### PR TITLE
Add eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,7 +79,6 @@
         // https://www.npmjs.com/package/eslint-plugin-unused-imports
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        // turn on to error if needed to activate
         "@typescript-eslint/await-thenable":"error",
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,6 +79,7 @@
         // https://www.npmjs.com/package/eslint-plugin-unused-imports
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/await-thenable":"error",
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,6 +79,7 @@
         // https://www.npmjs.com/package/eslint-plugin-unused-imports
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": "off",
+        // turn on to error if needed to activate
         "@typescript-eslint/await-thenable":"off",
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,7 +79,7 @@
         // https://www.npmjs.com/package/eslint-plugin-unused-imports
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/await-thenable":"error",
+        "@typescript-eslint/await-thenable":"off",
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,7 @@
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": "off",
         // turn on to error if needed to activate
-        "@typescript-eslint/await-thenable":"off",
+        "@typescript-eslint/await-thenable":"error",
         "unused-imports/no-unused-imports": "error",
         "unused-imports/no-unused-vars": [
             "error",

--- a/AdminDashboard/src/Actions/auditLogs.ts
+++ b/AdminDashboard/src/Actions/auditLogs.ts
@@ -149,7 +149,7 @@ export const deleteAuditLogs: $TSFixMe = () => {
         dispatch(deleteAuditLogsRequest());
 
         try {
-            const response: $TSFixMe = await delete `audit-logs`;
+            const response: $TSFixMe = delete `audit-logs`;
 
             const message: $TSFixMe = response.data.message;
 

--- a/AdminDashboard/src/Actions/callLogs.ts
+++ b/AdminDashboard/src/Actions/callLogs.ts
@@ -149,7 +149,7 @@ export const deleteCallLogs: $TSFixMe = () => {
         dispatch(deleteCallLogsRequest());
 
         try {
-            const response: $TSFixMe = await delete `call-logs`;
+            const response: $TSFixMe = delete `call-logs`;
 
             const message: $TSFixMe = response.data.message;
 

--- a/AdminDashboard/src/Actions/emailLogs.ts
+++ b/AdminDashboard/src/Actions/emailLogs.ts
@@ -150,7 +150,7 @@ export const deleteEmailLogs: $TSFixMe = () => {
         dispatch(deleteEmailLogsRequest());
 
         try {
-            const response: $TSFixMe = await delete `email-logs`;
+            const response: $TSFixMe = delete `email-logs`;
 
             const message: $TSFixMe = response.data.message;
 

--- a/AdminDashboard/src/Actions/probe.ts
+++ b/AdminDashboard/src/Actions/probe.ts
@@ -90,7 +90,7 @@ export const deleteProbe: $TSFixMe = (probeId: $TSFixMe) => {
         dispatch(deleteProbeRequest());
 
         try {
-            const response: $TSFixMe = await delete `probe/${probeId}`;
+            const response: $TSFixMe = delete `probe/${probeId}`;
             dispatch(deleteProbeSuccess(probeId));
             return response;
         } catch (error) {

--- a/AdminDashboard/src/Actions/project.ts
+++ b/AdminDashboard/src/Actions/project.ts
@@ -498,7 +498,7 @@ export const deleteProject: $TSFixMe = (projectId: ObjectID) => {
 
         try {
             const response: $TSFixMe =
-                await delete `project/${projectId}/deleteProject`;
+                delete `project/${projectId}/deleteProject`;
 
             const data: $TSFixMe = response.data;
 

--- a/AdminDashboard/src/Actions/smsLogs.ts
+++ b/AdminDashboard/src/Actions/smsLogs.ts
@@ -149,7 +149,7 @@ export const deleteSmsLogs: $TSFixMe = () => {
         dispatch(deleteSmsLogsRequest());
 
         try {
-            const response: $TSFixMe = await delete `sms-logs`;
+            const response: $TSFixMe = delete `sms-logs`;
 
             const message: $TSFixMe = response.data.message;
 

--- a/AdminDashboard/src/Actions/sso.ts
+++ b/AdminDashboard/src/Actions/sso.ts
@@ -123,7 +123,7 @@ export const deleteSso: $TSFixMe = (ssoId: $TSFixMe) => {
     return async (dispatch: Dispatch): void => {
         dispatch(deleteSsoRequest());
         try {
-            await delete `sso/${ssoId}`;
+            delete `sso/${ssoId}`;
             dispatch(deleteSsoSuccess());
         } catch (error) {
             let errorMsg: $TSFixMe;

--- a/AdminDashboard/src/Actions/ssoDefaultRoles.ts
+++ b/AdminDashboard/src/Actions/ssoDefaultRoles.ts
@@ -136,7 +136,7 @@ export const deleteSsoDefaultRole: $TSFixMe = (ssoId: $TSFixMe) => {
     return async (dispatch: Dispatch) => {
         dispatch(deleteSsoDefaultRoleRequest());
         try {
-            const response: $TSFixMe = await delete `ssoDefaultRoles/${ssoId}`;
+            const response: $TSFixMe = delete `ssoDefaultRoles/${ssoId}`;
 
             dispatch(deleteSsoDefaultRoleSuccess(response.data));
 

--- a/AdminDashboard/src/Actions/user.ts
+++ b/AdminDashboard/src/Actions/user.ts
@@ -290,7 +290,7 @@ export const deleteUser: $TSFixMe = (userId: ObjectID) => {
         dispatch(deleteUserRequest());
 
         try {
-            const response: $TSFixMe = await delete `user/${userId}`;
+            const response: $TSFixMe = delete `user/${userId}`;
 
             const data: $TSFixMe = response.data;
 

--- a/ApplicationScanner/utils/applicationService.ts
+++ b/ApplicationScanner/utils/applicationService.ts
@@ -28,9 +28,7 @@ export default {
             security.gitCredential.gitUsername &&
             security.gitCredential.gitPassword
         ) {
-            const decryptedSecurity: $TSFixMe = await this.decryptPassword(
-                security
-            );
+            const decryptedSecurity: $TSFixMe = this.decryptPassword(security);
             await this.scanApplicationSecurity(decryptedSecurity);
         }
         if (
@@ -81,7 +79,7 @@ export default {
     sshScanApplicationSecurity: async (security: $TSFixMe) => {
         let securityDir: $TSFixMe = 'application_security_dir';
 
-        securityDir = await createDir(securityDir);
+        securityDir = createDir(securityDir);
         const cloneDirectory: string = `${uuidv1()}security`; // Always create unique paths
         const repoPath: $TSFixMe = Path.resolve(securityDir, cloneDirectory);
         const conn: $TSFixMe = new Client();
@@ -190,7 +188,7 @@ export default {
                                 await updateApplicationSecurityScanTime({
                                     _id: security._id,
                                 });
-                                await deleteFolderRecursive(repoPath);
+                                deleteFolderRecursive(repoPath);
                                 return resolve(resolvedLog);
                             });
                         });
@@ -204,7 +202,7 @@ export default {
                             error
                         );
 
-                        await deleteFolderRecursive(repoPath);
+                        deleteFolderRecursive(repoPath);
                         return reject(error);
                     });
             });
@@ -219,7 +217,7 @@ export default {
     scanApplicationSecurity: async (security: $TSFixMe) => {
         let securityDir: $TSFixMe = 'application_security_dir';
 
-        securityDir = await createDir(securityDir);
+        securityDir = createDir(securityDir);
 
         const USER: $TSFixMe = security.gitCredential.gitUsername;
         const PASS: $TSFixMe = security.gitCredential.gitPassword;
@@ -332,7 +330,7 @@ export default {
                             await updateApplicationSecurityScanTime({
                                 _id: security._id,
                             });
-                            await deleteFolderRecursive(repoPath);
+                            deleteFolderRecursive(repoPath);
                             return resolve(resolvedLog);
                         });
                     });
@@ -346,7 +344,7 @@ export default {
                         error
                     );
 
-                    await deleteFolderRecursive(repoPath);
+                    deleteFolderRecursive(repoPath);
                     return reject(error);
                 });
         });

--- a/ApplicationScanner/worker/applicationSecurity.ts
+++ b/ApplicationScanner/worker/applicationSecurity.ts
@@ -2,6 +2,6 @@ import ApplicationService from '../Utils/applicationService';
 
 export default {
     scan: async (security: $TSFixMe) => {
-        await ApplicationService.scan(security);
+        ApplicationService.scan(security);
     },
 };

--- a/ContainerScanner/utils/containerService.ts
+++ b/ContainerScanner/utils/containerService.ts
@@ -19,9 +19,7 @@ import flattenArray from './flattenArray';
 
 export default {
     scan: async function (security: $TSFixMe): void {
-        const decryptedSecurity: $TSFixMe = await this.decryptPassword(
-            security
-        );
+        const decryptedSecurity: $TSFixMe = this.decryptPassword(security);
         await this.scanContainerSecurity(decryptedSecurity);
     },
 
@@ -70,7 +68,7 @@ export default {
         const outputFile: string = `${uuidv1()}result.json`;
         let securityDir: $TSFixMe = 'container_security_dir';
 
-        securityDir = await createDir(securityDir);
+        securityDir = createDir(securityDir);
         const exactFilePath: $TSFixMe = Path.resolve(securityDir, outputFile);
         /*
          * Update container security to scanning true
@@ -112,7 +110,7 @@ export default {
             });
 
             output.on('close', async () => {
-                let auditLogs: $TSFixMe = await readFileContent(exactFilePath);
+                let auditLogs: $TSFixMe = readFileContent(exactFilePath);
                 /*
                  * If auditLogs is empty, then scanning was unsuccessful
                  * The provided credentials or image path must have been wrong

--- a/ContainerScanner/worker/containerSecurity.ts
+++ b/ContainerScanner/worker/containerSecurity.ts
@@ -2,6 +2,6 @@ import ContainerService from '../Utils/containerService';
 
 export default {
     scan: async (security: $TSFixMe) => {
-        await ContainerService.scan(security);
+        ContainerService.scan(security);
     },
 };

--- a/Dashboard/src/Actions/Base/base.ts
+++ b/Dashboard/src/Actions/Base/base.ts
@@ -149,7 +149,7 @@ class BaseAction {
                     }
 
                     if (this.actionType === 'delete') {
-                        response = await delete (path, data);
+                        response = delete (path, data);
                     }
 
                     const data: $TSFixMe = response.data;

--- a/Dashboard/src/Actions/credential.ts
+++ b/Dashboard/src/Actions/credential.ts
@@ -185,7 +185,7 @@ export const deleteGitCredential: $TSFixMe = ({
 
         try {
             const response: $TSFixMe =
-                await delete `credential/${projectId}/gitCredential/${credentialId}`;
+                delete `credential/${projectId}/gitCredential/${credentialId}`;
 
             dispatch(deleteGitCredentialSuccess(response.data));
         } catch (error) {
@@ -444,7 +444,7 @@ export const deleteDockerCredential: $TSFixMe = ({
 
         try {
             const response: $TSFixMe =
-                await delete `credential/${projectId}/dockerCredential/${credentialId}`;
+                delete `credential/${projectId}/dockerCredential/${credentialId}`;
 
             dispatch(deleteDockerCredentialSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/customField.ts
+++ b/Dashboard/src/Actions/customField.ts
@@ -190,7 +190,7 @@ export const deleteCustomField: $TSFixMe = (
             dispatch(deleteCustomFieldRequest());
 
             const response: $TSFixMe =
-                await delete `customField/${projectId}/${customFieldId}`;
+                delete `customField/${projectId}/${customFieldId}`;
 
             dispatch(deleteCustomFieldSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/domain.ts
+++ b/Dashboard/src/Actions/domain.ts
@@ -139,7 +139,7 @@ export const deleteDomain: Function = ({
         dispatch(deleteDomainRequest());
         try {
             const response: $TSFixMe =
-                await delete `StatusPage/${projectId}/${statusPageId}/${domainId}`;
+                delete `StatusPage/${projectId}/${statusPageId}/${domainId}`;
 
             dispatch(deleteDomainSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/group.ts
+++ b/Dashboard/src/Actions/group.ts
@@ -231,8 +231,7 @@ export const deleteGroup: $TSFixMe = (
         dispatch(deleteGroupRequest());
 
         try {
-            const response: $TSFixMe =
-                await delete `group/${projectId}/${groupId}`;
+            const response: $TSFixMe = delete `group/${projectId}/${groupId}`;
 
             dispatch(deleteGroupSuccess(response.data));
             dispatch(getGroups());

--- a/Dashboard/src/Actions/incidentCommunicationSla.ts
+++ b/Dashboard/src/Actions/incidentCommunicationSla.ts
@@ -200,7 +200,7 @@ export const deleteCommunicationSla: $TSFixMe = (
             dispatch(deleteCommunicationSlaRequest());
 
             const response: $TSFixMe =
-                await delete `incidentSla/${projectId}/${incidentSlaId}`;
+                delete `incidentSla/${projectId}/${incidentSlaId}`;
 
             dispatch(deleteCommunicationSlaSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/incomingRequest.ts
+++ b/Dashboard/src/Actions/incomingRequest.ts
@@ -142,7 +142,7 @@ export const deleteIncomingRequest: $TSFixMe = (
             dispatch(deleteIncomingRequestRequest());
 
             const response: $TSFixMe =
-                await delete `incoming-request/${projectId}/remove/${requestId}`;
+                delete `incoming-request/${projectId}/remove/${requestId}`;
 
             dispatch(deleteIncomingRequestSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/monitorCustomField.ts
+++ b/Dashboard/src/Actions/monitorCustomField.ts
@@ -192,7 +192,7 @@ export const deleteCustomField: $TSFixMe = (
             dispatch(deleteCustomFieldRequest());
 
             const response: $TSFixMe =
-                await delete `monitorCustomField/${projectId}/${customFieldId}`;
+                delete `monitorCustomField/${projectId}/${customFieldId}`;
 
             dispatch(deleteCustomFieldSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/monitorSla.ts
+++ b/Dashboard/src/Actions/monitorSla.ts
@@ -189,7 +189,7 @@ export const deleteMonitorSla: $TSFixMe = (
             dispatch(deleteMonitorSlaRequest());
 
             const response: $TSFixMe =
-                await delete `monitorSla/${projectId}/${monitorSlaId}`;
+                delete `monitorSla/${projectId}/${monitorSlaId}`;
 
             dispatch(deleteMonitorSlaSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/project.ts
+++ b/Dashboard/src/Actions/project.ts
@@ -1463,7 +1463,7 @@ export const deleteProjectDomain: Function = ({
 
         try {
             const response: $TSFixMe =
-                await delete `domainVerificationToken/${projectId}/domain/${domainId}`;
+                delete `domainVerificationToken/${projectId}/domain/${domainId}`;
 
             dispatch(deleteProjectDomainSuccess(response.data));
 

--- a/Dashboard/src/Actions/scheduledEvent.ts
+++ b/Dashboard/src/Actions/scheduledEvent.ts
@@ -334,7 +334,7 @@ export const deleteScheduledEvent: $TSFixMe = (
             dispatch(deleteScheduledEventRequest());
 
             const response: $TSFixMe =
-                await delete `scheduledEvent/${projectId}/${scheduledEventId}`;
+                delete `scheduledEvent/${projectId}/${scheduledEventId}`;
 
             dispatch(deleteScheduledEventSuccess(response.data));
         } catch (error) {
@@ -758,7 +758,7 @@ export const deleteScheduledEventNote: $TSFixMe = (
             dispatch(deleteScheduledEventNoteRequest());
 
             const response: $TSFixMe =
-                await delete `scheduledEvent/${projectId}/${scheduledEventId}/notes/${scheduledEventNoteId}`;
+                delete `scheduledEvent/${projectId}/${scheduledEventId}/notes/${scheduledEventNoteId}`;
 
             dispatch(deleteScheduledEventNoteSuccess(response.data));
         } catch (error) {

--- a/Dashboard/src/Actions/security.ts
+++ b/Dashboard/src/Actions/security.ts
@@ -230,7 +230,7 @@ export const deleteContainerSecurity: $TSFixMe = ({
 
         try {
             const response: $TSFixMe =
-                await delete `security/${projectId}/${componentId}/container/${containerSecurityId}`;
+                delete `security/${projectId}/${componentId}/container/${containerSecurityId}`;
 
             dispatch(deleteContainerSecuritySuccess(response.data));
 
@@ -721,7 +721,7 @@ export const deleteApplicationSecurity: $TSFixMe = ({
 
         try {
             const response: $TSFixMe =
-                await delete `security/${projectId}/${componentId}/application/${applicationSecurityId}`;
+                delete `security/${projectId}/${componentId}/application/${applicationSecurityId}`;
 
             dispatch(deleteApplicationSecuritySuccess(response.data));
 

--- a/Dashboard/src/useNotification.ts
+++ b/Dashboard/src/useNotification.ts
@@ -8,7 +8,7 @@ export async function askUserPermission(): void {
 }
 
 export async function getUserAgent(): void {
-    return await navigator.userAgent;
+    return navigator.userAgent;
 }
 
 export async function getTheSubscription(): void {

--- a/DashboardAPI/api/StatusPage.ts
+++ b/DashboardAPI/api/StatusPage.ts
@@ -2425,16 +2425,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const ongoingEvents: $TSFixMe = await getOngoingScheduledEvents(
+            const ongoingEvents: $TSFixMe = getOngoingScheduledEvents(
                 req,
 
                 statusPage.slug
@@ -2456,16 +2453,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const futureEvents: $TSFixMe = await getFutureEvents(
+            const futureEvents: $TSFixMe = getFutureEvents(
                 req,
                 statusPage.slug
             );
@@ -2486,19 +2480,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const pastEvents: $TSFixMe = await getPastEvents(
-                req,
-                statusPage.slug
-            );
+            const pastEvents: $TSFixMe = getPastEvents(req, statusPage.slug);
 
             return sendItemResponse(req, res, pastEvents);
         } catch (error) {
@@ -2516,16 +2504,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const probes: $TSFixMe = await getProbes(req);
+            const probes: $TSFixMe = getProbes(req);
 
             return sendItemResponse(req, res, probes);
         } catch (error) {
@@ -2543,16 +2528,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const monitorLogs: $TSFixMe = await getMonitorLogs(
+            const monitorLogs: $TSFixMe = getMonitorLogs(
                 req,
                 statusPage.monitors
             );
@@ -2573,10 +2555,7 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
@@ -2584,7 +2563,7 @@ router.get(
 
             const { _id: statusPageId, projectId } = statusPage;
 
-            const announcements: $TSFixMe = await getAnnouncements(
+            const announcements: $TSFixMe = getAnnouncements(
                 req,
                 statusPageId,
                 projectId
@@ -2606,18 +2585,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const announcementLogs: $TSFixMe = await getAnnouncementLogs(
-                statusPage
-            );
+            const announcementLogs: $TSFixMe = getAnnouncementLogs(statusPage);
 
             return sendItemResponse(req, res, announcementLogs);
         } catch (error) {
@@ -2635,18 +2609,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const timelines: $TSFixMe = await getMonitorTimelines(
-                statusPage.slug
-            );
+            const timelines: $TSFixMe = getMonitorTimelines(statusPage.slug);
 
             return sendItemResponse(req, res, timelines);
         } catch (error) {
@@ -2664,16 +2633,13 @@ router.get(
             const { statusPageSlug }: $TSFixMe = req.params;
 
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
             }
 
-            const statusPageNote: $TSFixMe = await getStatusPageNote(
+            const statusPageNote: $TSFixMe = getStatusPageNote(
                 req,
 
                 statusPage.slug,
@@ -2698,10 +2664,7 @@ router.get(
             const { range }: $TSFixMe = req.query;
             const response: $TSFixMe = {};
             //Get status pages
-            const statusPage: $TSFixMe = await getStatusPage(
-                req,
-                statusPageSlug
-            );
+            const statusPage: $TSFixMe = getStatusPage(req, statusPageSlug);
 
             if (statusPage.error) {
                 return sendErrorResponse(req, res, statusPage.data);
@@ -2709,10 +2672,7 @@ router.get(
 
             const { monitors }: $TSFixMe = statusPage;
 
-            const monitorStatus: $TSFixMe = await getMonitorStatuses(
-                req,
-                monitors
-            );
+            const monitorStatus: $TSFixMe = getMonitorStatuses(req, monitors);
 
             response.monitorStatus = monitorStatus || {};
 
@@ -2723,9 +2683,9 @@ router.get(
 
             response.statusPages = statusPage;
 
-            const probes: $TSFixMe = await getProbes(req);
+            const probes: $TSFixMe = getProbes(req);
 
-            const time: $TSFixMe = await calculateTime(
+            const time: $TSFixMe = calculateTime(
                 statusPage,
                 monitorStatus,
                 probes,

--- a/DashboardAPI/test/adminCredentials.test.ts
+++ b/DashboardAPI/test/adminCredentials.test.ts
@@ -22,13 +22,13 @@ describe('Admin process.env.login API', function (): void {
     before(async function (): void {
         this.timeout(40000);
         await UserService.hardDeleteBy({});
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
     });
 
     after(async (): void => {
         await UserService.hardDeleteBy({});
         await AirtableService.deleteAll({ tableName: 'User' });
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await AuditLogsService.hardDeleteBy({});
     });
 

--- a/DashboardAPI/test/alert.test.ts
+++ b/DashboardAPI/test/alert.test.ts
@@ -131,7 +131,7 @@ describe('Alert API', (): void => {
             await StatusPageService.hardDeleteBy({ projectId: projectId });
             await NotificationService.hardDeleteBy({ projectId: projectId });
             await AlertService.hardDeleteBy({ _id: alertId });
-            await GlobalConfig.removeTestConfig();
+            GlobalConfig.removeTestConfig();
             await AirtableService.deleteAll({ tableName: 'User' });
             await UserService.hardDeleteBy({
                 email: userData.user.email,
@@ -303,7 +303,7 @@ describe('Alert API', (): void => {
             await MonitorService.hardDeleteBy({ _id: monitorId });
             await IncidentService.hardDeleteBy({ _id: incidentId });
             await AlertService.hardDeleteBy({ _id: alertId });
-            await GlobalConfig.removeTestConfig();
+            GlobalConfig.removeTestConfig();
         });
 
         it('should not create alert for user not in the project.', (done: $TSFixMe): void => {

--- a/DashboardAPI/test/applicationLog.test.ts
+++ b/DashboardAPI/test/applicationLog.test.ts
@@ -600,7 +600,7 @@ describe('Application Log API', function (): void {
     // Yet to figure out how thi works
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await ApplicationLogService.hardDeleteBy({
             _id: { $in: [applicationLog._id] },

--- a/DashboardAPI/test/applicationSecurity.test.ts
+++ b/DashboardAPI/test/applicationSecurity.test.ts
@@ -107,7 +107,7 @@ describe('Application Security API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email,

--- a/DashboardAPI/test/auditLogs.test.ts
+++ b/DashboardAPI/test/auditLogs.test.ts
@@ -74,7 +74,7 @@ describe('Audit Logs API', function (): void {
             },
         });
         await AirtableService.deleteAll({ tableName: 'User' });
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         /*
          * Deleting any auditLogs created between this test suite.

--- a/DashboardAPI/test/component.test.ts
+++ b/DashboardAPI/test/component.test.ts
@@ -470,7 +470,7 @@ describe('Component API with Sub-Projects', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: {
                 $in: [projectId, newProjectId, otherProjectId, subProjectId],

--- a/DashboardAPI/test/containerSecurity.test.ts
+++ b/DashboardAPI/test/containerSecurity.test.ts
@@ -107,7 +107,7 @@ describe('Container Security API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email,

--- a/DashboardAPI/test/customField.test.ts
+++ b/DashboardAPI/test/customField.test.ts
@@ -79,7 +79,7 @@ describe('Incident Custom Field API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email.toLowerCase(),

--- a/DashboardAPI/test/disableSignup.test.ts
+++ b/DashboardAPI/test/disableSignup.test.ts
@@ -24,10 +24,10 @@ describe('Disable Sign up test', function (): void {
 
     this.beforeAll(async function (): void {
         this.timeout(400000);
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({});
         await AirtableService.deleteAll({ tableName: 'User' });
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const user: $TSFixMe = await createUser(request, data.adminUser);
         await UserService.updateBy(
             { _id: user.body.id },
@@ -42,7 +42,7 @@ describe('Disable Sign up test', function (): void {
     });
 
     this.afterAll(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({});
         await AirtableService.deleteAll({ tableName: 'User' });
         process.env['DISABLE_SIGNUP'] = undefined;

--- a/DashboardAPI/test/dockerCredential.test.ts
+++ b/DashboardAPI/test/dockerCredential.test.ts
@@ -32,7 +32,7 @@ describe('Docker Credential API', function (): void {
     this.timeout(timeout);
 
     before(async (): void => {
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         const project: $TSFixMe = res.body.project;
         projectId = project._id;
@@ -52,7 +52,7 @@ describe('Docker Credential API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email,

--- a/DashboardAPI/test/emailAuthorization.test.ts
+++ b/DashboardAPI/test/emailAuthorization.test.ts
@@ -49,7 +49,7 @@ describe('Email verification API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/emailLogs.test.ts
+++ b/DashboardAPI/test/emailLogs.test.ts
@@ -75,7 +75,7 @@ describe('Email Logs API', function (): void {
             },
         });
         await AirtableService.deleteAll({ tableName: 'User' });
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         /*
          * Deleting any emailLogs created between this test suite.
@@ -172,7 +172,7 @@ describe('Email Logs API', function (): void {
         const authorization: string = `Basic ${token}`;
 
         // Creating Email Logs.
-        await GlobalConfig.enableEmailLog();
+        GlobalConfig.enableEmailLog();
         await createUser(request, userData.newUser);
         await createUser(request, userData.anotherUser);
         const res: $TSFixMe = await request
@@ -195,7 +195,7 @@ describe('Email Logs API', function (): void {
         const authorization: string = `Basic ${token}`;
 
         // Creating Email Logs.
-        await GlobalConfig.enableEmailLog();
+        GlobalConfig.enableEmailLog();
         await createUser(request, userData.newUser);
         await createUser(request, userData.anotherUser);
 

--- a/DashboardAPI/test/emailSmtp.test.ts
+++ b/DashboardAPI/test/emailSmtp.test.ts
@@ -26,7 +26,7 @@ describe('Email SMTP Api Test', function (): void {
 
     before(async function (): void {
         this.timeout(400000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, data.user);
 
         const project: $TSFixMe = res.body.project;
@@ -51,7 +51,7 @@ describe('Email SMTP Api Test', function (): void {
     });
 
     after(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [data.user.email.toLowerCase()],

--- a/DashboardAPI/test/emailTemplate.test.ts
+++ b/DashboardAPI/test/emailTemplate.test.ts
@@ -27,7 +27,7 @@ describe('Email Template API', function (): void {
 
     before(async function (): void {
         this.timeout(40000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
 
         const res: $TSFixMe = await createUser(request, userData.user);
         const project: $TSFixMe = res.body.project;
@@ -50,7 +50,7 @@ describe('Email Template API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/enterpriseAlert.test.ts
+++ b/DashboardAPI/test/enterpriseAlert.test.ts
@@ -73,7 +73,7 @@ describe('Enterprise Alert API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await MonitorService.hardDeleteBy({ _id: monitorId });
         await UserService.hardDeleteBy({

--- a/DashboardAPI/test/enterpriseComponent.test.ts
+++ b/DashboardAPI/test/enterpriseComponent.test.ts
@@ -48,7 +48,7 @@ describe('Enterprise Component API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, newProjectId] },
         });

--- a/DashboardAPI/test/enterpriseDisableSignup.test.ts
+++ b/DashboardAPI/test/enterpriseDisableSignup.test.ts
@@ -17,9 +17,9 @@ describe('Disable Sign up test', function (): void {
     let token: $TSFixMe = null;
     this.beforeAll(async function (): void {
         this.timeout(400000);
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({});
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         await createUser(request, data.adminUser);
         const res: $TSFixMe = await request.post('/user/login').send({
             email: data.adminUser.email,
@@ -30,7 +30,7 @@ describe('Disable Sign up test', function (): void {
     });
 
     this.afterAll(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({});
         await ProjectService.hardDeleteBy({});
         process.env['DISABLE_SIGNUP'] = undefined;

--- a/DashboardAPI/test/enterpriseIncidentAlerts.test.ts
+++ b/DashboardAPI/test/enterpriseIncidentAlerts.test.ts
@@ -164,7 +164,7 @@ describe('Incident Alerts', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await OnCallScheduleStatusService.hardDeleteBy({ project: projectId });
         await SubscriberService.hardDeleteBy({ projectId });
         await SubscriberAlertService.hardDeleteBy({ projectId });

--- a/DashboardAPI/test/enterpriseMonitor.test.ts
+++ b/DashboardAPI/test/enterpriseMonitor.test.ts
@@ -50,7 +50,7 @@ describe('Enterprise Monitor API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, newProjectId] },
         });

--- a/DashboardAPI/test/enterpriseProject.test.ts
+++ b/DashboardAPI/test/enterpriseProject.test.ts
@@ -44,7 +44,7 @@ describe('Enterprise Project API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, newProjectId] },
         });

--- a/DashboardAPI/test/enterpriseTeam.test.ts
+++ b/DashboardAPI/test/enterpriseTeam.test.ts
@@ -46,7 +46,7 @@ describe('Enterprise Team API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, newProjectId] },
         });

--- a/DashboardAPI/test/enterpriseUser.test.ts
+++ b/DashboardAPI/test/enterpriseUser.test.ts
@@ -48,7 +48,7 @@ describe('Enterprise User API', function (): void {
     });
 
     after(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/feedback.test.ts
+++ b/DashboardAPI/test/feedback.test.ts
@@ -73,7 +73,7 @@ describe('Feedback API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/gitCredential.test.ts
+++ b/DashboardAPI/test/gitCredential.test.ts
@@ -67,7 +67,7 @@ describe('Git Credential API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email.toLowerCase(),

--- a/DashboardAPI/test/globalConfig.test.ts
+++ b/DashboardAPI/test/globalConfig.test.ts
@@ -65,7 +65,7 @@ describe('Global Config API', function (): void {
     });
 
     after(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: data.user.email.toLowerCase(),
         });

--- a/DashboardAPI/test/incident.test.ts
+++ b/DashboardAPI/test/incident.test.ts
@@ -75,7 +75,7 @@ describe('Incident API', function (): void {
 
     before(async function (): void {
         this.timeout(90000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         projectId = res.body.project._id;
         userId = res.body.id;
@@ -148,7 +148,7 @@ describe('Incident API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await NotificationService.hardDeleteBy({ projectId: projectId });
         await AirtableService.deleteAll({ tableName: 'User' });
         await IntegrationService.hardDeleteBy({
@@ -712,7 +712,7 @@ describe('Incident API with Sub-Projects', function (): void {
 
         const authorization: string = `Basic ${token}`;
         // Create a subproject for parent project
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await request
             .post(`/project/${projectId}/subProject`)
             .set('Authorization', authorization)

--- a/DashboardAPI/test/incidentAlerts.test.ts
+++ b/DashboardAPI/test/incidentAlerts.test.ts
@@ -84,7 +84,7 @@ describe('SMS/Calls Incident Alerts', function (): void {
 
     before(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const user: $TSFixMe = await createUser(request, userData.user);
         const project: $TSFixMe = user.body.project;
         projectId = project._id;
@@ -202,7 +202,7 @@ describe('SMS/Calls Incident Alerts', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await OnCallScheduleStatusService.hardDeleteBy({ project: projectId });
         await SubscriberService.hardDeleteBy({ projectId });
         await SubscriberAlertService.hardDeleteBy({ projectId });
@@ -922,8 +922,10 @@ describe('SMS/Calls Incident Alerts', function (): void {
                 },
             ];
 
-            let updatedProject: $TSFixMe =
-                await TeamMembers.addTeamMembersToProject(projectId, members);
+            let updatedProject: $TSFixMe = TeamMembers.addTeamMembersToProject(
+                projectId,
+                members
+            );
 
             // A user was added when creating the project, so we expect a total of 2 members
             expect(updatedProject.users).to.have.lengthOf(2);
@@ -1028,7 +1030,7 @@ describe('SMS/Calls Incident Alerts', function (): void {
             });
 
             // Remove the added team members
-            updatedProject = await TeamMembers.removeTeamMembersFromProject(
+            updatedProject = TeamMembers.removeTeamMembersFromProject(
                 projectId,
                 updatedProject.users.filter((user: $TSFixMe) => {
                     return user.userId === newUserId;
@@ -1071,8 +1073,10 @@ describe('SMS/Calls Incident Alerts', function (): void {
                 },
             ];
 
-            let updatedProject: $TSFixMe =
-                await TeamMembers.addTeamMembersToProject(projectId, members);
+            let updatedProject: $TSFixMe = TeamMembers.addTeamMembersToProject(
+                projectId,
+                members
+            );
 
             // A user was added when creating the project, so we expect a total of 2 members
             expect(updatedProject.users).to.have.lengthOf(2);
@@ -1190,7 +1194,7 @@ describe('SMS/Calls Incident Alerts', function (): void {
             });
 
             // Remove the added team members
-            updatedProject = await TeamMembers.removeTeamMembersFromProject(
+            updatedProject = TeamMembers.removeTeamMembersFromProject(
                 projectId,
                 updatedProject.users.filter((user: $TSFixMe) => {
                     return user.userId === newUserId;
@@ -1240,8 +1244,10 @@ describe('SMS/Calls Incident Alerts', function (): void {
                 },
             ];
 
-            let updatedProject: $TSFixMe =
-                await TeamMembers.addTeamMembersToProject(projectId, members);
+            let updatedProject: $TSFixMe = TeamMembers.addTeamMembersToProject(
+                projectId,
+                members
+            );
 
             // A user was added when creating the project, so we expect a total of 2 members
             expect(updatedProject.users).to.have.lengthOf(2);
@@ -1341,7 +1347,7 @@ describe('SMS/Calls Incident Alerts', function (): void {
             });
 
             // Remove the added team members
-            updatedProject = await TeamMembers.removeTeamMembersFromProject(
+            updatedProject = TeamMembers.removeTeamMembersFromProject(
                 projectId,
                 updatedProject.users.filter((user: $TSFixMe) => {
                     return user.userId === newUserId;
@@ -2732,7 +2738,7 @@ describe('Email Incident Alerts', (): void => {
 
     after(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await OnCallScheduleStatusService.hardDeleteBy({ project: projectId });
         await SubscriberService.hardDeleteBy({ projectId });
         await SubscriberAlertService.hardDeleteBy({ projectId });
@@ -3471,7 +3477,7 @@ describe('Webhook Incident Alerts', function (): void {
 
     after(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await OnCallScheduleStatusService.hardDeleteBy({ project: projectId });
         await SubscriberService.hardDeleteBy({ projectId });
         await SubscriberAlertService.hardDeleteBy({ projectId });

--- a/DashboardAPI/test/incidentCommunicationSla.test.ts
+++ b/DashboardAPI/test/incidentCommunicationSla.test.ts
@@ -36,7 +36,7 @@ describe('Incident Communication SLA', function (): void {
     this.timeout(timeout);
 
     before(async (): void => {
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         projectId = res.body.project._id;
         userId = res.body.id;
@@ -56,7 +56,7 @@ describe('Incident Communication SLA', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email.toLowerCase(),

--- a/DashboardAPI/test/incidentPriority.test.ts
+++ b/DashboardAPI/test/incidentPriority.test.ts
@@ -64,7 +64,7 @@ describe('Incident Priority API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await IncidentSettings.hardDeleteBy({ projectId: projectId });
         await UserService.hardDeleteBy({ _id: userId });
         await ProjectService.hardDeleteBy({ _id: projectId });

--- a/DashboardAPI/test/incidentSettings.test.ts
+++ b/DashboardAPI/test/incidentSettings.test.ts
@@ -126,7 +126,7 @@ describe('Incident Settings API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await IncidentService.hardDeleteBy({ _id: incidentId });
         await IncidentSettings.hardDeleteBy({ projectId });
         await IncidentPrioritiesService.hardDeleteBy({ projectId });

--- a/DashboardAPI/test/incomingHttpRequest.test.ts
+++ b/DashboardAPI/test/incomingHttpRequest.test.ts
@@ -161,7 +161,7 @@ describe('Incoming HTTP Request API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email.toLowerCase(),

--- a/DashboardAPI/test/invoice.test.ts
+++ b/DashboardAPI/test/invoice.test.ts
@@ -28,7 +28,7 @@ describe('Invoice API', function (): void {
 
     before(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const checkCardData: $TSFixMe = await request
             .post('/stripe/checkCard')
             .send({
@@ -99,7 +99,7 @@ describe('Invoice API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/jwttoken.test.ts
+++ b/DashboardAPI/test/jwttoken.test.ts
@@ -66,7 +66,7 @@ describe('Jwt Token API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/lead.test.ts
+++ b/DashboardAPI/test/lead.test.ts
@@ -28,11 +28,11 @@ describe('Lead API', function (): void {
 
     before(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
     });
 
     it('should add lead when requested for type demo or whitepaper', (done: $TSFixMe): void => {

--- a/DashboardAPI/test/monitor.test.ts
+++ b/DashboardAPI/test/monitor.test.ts
@@ -137,7 +137,7 @@ describe('Monitor API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await MonitorService.hardDeleteBy({ projectId });
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
@@ -541,7 +541,7 @@ describe('API Monitor API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await MonitorService.hardDeleteBy({ _id: monitorId });
         await UserService.hardDeleteBy({
             email: userData.user.email,
@@ -751,7 +751,7 @@ describe('IncomingHttpRequest Monitor', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await MonitorService.hardDeleteBy({ _id: monitorId });
         await MonitorService.hardDeleteBy({ _id: monitor2Id });
         await UserService.hardDeleteBy({
@@ -949,7 +949,7 @@ describe('Monitor API with resource Category', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ResourceCategoryService.hardDeleteBy({ _id: resourceCategoryId });
         await MonitorService.hardDeleteBy({ _id: monitorId });
         await AirtableService.deleteAll({ tableName: 'User' });
@@ -1062,7 +1062,7 @@ describe('Monitor API with Sub-Projects', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await MonitorService.hardDeleteBy({ _id: monitorId });
         await MonitorService.hardDeleteBy({ _id: subProjectMonitorId });
     });
@@ -1310,7 +1310,7 @@ describe('Monitor API - Tests Project Seats With SubProjects', function (): void
 
     before(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const authorization: string = `Basic ${token}`;
 
         await MonitorService.hardDeleteBy({ projectId });
@@ -1326,7 +1326,7 @@ describe('Monitor API - Tests Project Seats With SubProjects', function (): void
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, subProjectId] },
         });

--- a/DashboardAPI/test/monitorCriteria.test.ts
+++ b/DashboardAPI/test/monitorCriteria.test.ts
@@ -60,7 +60,7 @@ describe('Monitor Criteria API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/monitorCustomField.test.ts
+++ b/DashboardAPI/test/monitorCustomField.test.ts
@@ -79,7 +79,7 @@ describe('Monitor Custom Field API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email.toLowerCase(),

--- a/DashboardAPI/test/monitorSla.test.ts
+++ b/DashboardAPI/test/monitorSla.test.ts
@@ -36,7 +36,7 @@ describe('Monitor SLA', function (): void {
     this.timeout(timeout);
 
     before(async (): void => {
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         projectId = res.body.project._id;
         userId = res.body.id;
@@ -56,7 +56,7 @@ describe('Monitor SLA', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: userData.user.email.toLowerCase(),

--- a/DashboardAPI/test/notification.test.ts
+++ b/DashboardAPI/test/notification.test.ts
@@ -63,7 +63,7 @@ describe('Notification API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/probe.test.ts
+++ b/DashboardAPI/test/probe.test.ts
@@ -61,7 +61,7 @@ describe('Probe API', function (): void {
 
     before(async function (): void {
         this.timeout(40000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         // Remove every monitor in DB
         await MonitorService.hardDeleteBy({});
 
@@ -94,7 +94,7 @@ describe('Probe API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProbeService.hardDeleteBy({ _id: probeId });
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({

--- a/DashboardAPI/test/project.test.ts
+++ b/DashboardAPI/test/project.test.ts
@@ -81,7 +81,7 @@ describe('Project API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({

--- a/DashboardAPI/test/reports.test.ts
+++ b/DashboardAPI/test/reports.test.ts
@@ -102,7 +102,7 @@ describe('Reports API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/resourceCategory.test.ts
+++ b/DashboardAPI/test/resourceCategory.test.ts
@@ -82,7 +82,7 @@ describe('Resource Category API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
@@ -243,7 +243,7 @@ describe('User from other project have access to read / write and delete API.', 
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
@@ -461,7 +461,7 @@ describe('Non-admin user access to create, delete and access resource category.'
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await ProjectService.hardDeleteBy({ _id: projectId });
         await ProjectService.hardDeleteBy({ _id: projectIdSecondUser });
@@ -545,7 +545,7 @@ describe('Resource Category APIs accesible through API key', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
@@ -632,7 +632,7 @@ describe('Resource Category API - Check pagination for 12 resource categories', 
 
     before(async function (): void {
         this.timeout(60000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const checkCardData: $TSFixMe = await request
             .post('/stripe/checkCard')
             .send({
@@ -689,7 +689,7 @@ describe('Resource Category API - Check pagination for 12 resource categories', 
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({

--- a/DashboardAPI/test/schedule.test.ts
+++ b/DashboardAPI/test/schedule.test.ts
@@ -65,7 +65,7 @@ describe('Schedule API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ScheduleService.hardDeleteBy({ _id: scheduleId });
         await AirtableService.deleteAll({ tableName: 'User' });
     });
@@ -249,7 +249,7 @@ describe('Schedule API with Sub-Projects', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, subProjectId] },
         });

--- a/DashboardAPI/test/scheduledEvent.test.ts
+++ b/DashboardAPI/test/scheduledEvent.test.ts
@@ -172,7 +172,7 @@ describe('Scheduled event API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {
@@ -450,7 +450,7 @@ describe('User from other project have access to read / write and delete API.', 
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/scheduledEventNote.test.ts
+++ b/DashboardAPI/test/scheduledEventNote.test.ts
@@ -210,7 +210,7 @@ describe('Scheduled Event Note', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/slack.test.ts
+++ b/DashboardAPI/test/slack.test.ts
@@ -40,7 +40,7 @@ describe('Slack API', function (): void {
     });
 
     this.afterAll(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/smsTemplate.test.ts
+++ b/DashboardAPI/test/smsTemplate.test.ts
@@ -28,7 +28,7 @@ describe('SMS Template API', function (): void {
 
     before(async function (): void {
         this.timeout(40000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         const project: $TSFixMe = res.body.project;
         projectId = project._id;
@@ -48,7 +48,7 @@ describe('SMS Template API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/sso.test.ts
+++ b/DashboardAPI/test/sso.test.ts
@@ -74,7 +74,7 @@ describe('SSO API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ 'users.userId': userId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/ssoDefaultRoles.test.ts
+++ b/DashboardAPI/test/ssoDefaultRoles.test.ts
@@ -81,7 +81,7 @@ describe('SSO DEFAULT ROLES API', function (): void {
 
     before(async function (): void {
         this.timeout(40000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const response: $TSFixMe = await createUser(
             request,
             userData.adminUser
@@ -127,7 +127,7 @@ describe('SSO DEFAULT ROLES API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ 'users.userId': userId });
         await UserService.hardDeleteBy({
             _id: {

--- a/DashboardAPI/test/statusPage.test.ts
+++ b/DashboardAPI/test/statusPage.test.ts
@@ -183,7 +183,7 @@ describe('Status API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await MonitorService.hardDeleteBy({ _id: monitorId });
         await ScheduledEventService.hardDeleteBy({ _id: scheduledEventId });
         await StatusService.hardDeleteBy({ projectId: projectId });

--- a/DashboardAPI/test/stripe.test.ts
+++ b/DashboardAPI/test/stripe.test.ts
@@ -65,7 +65,7 @@ describe('Stripe payment API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/subscriber.test.ts
+++ b/DashboardAPI/test/subscriber.test.ts
@@ -168,7 +168,7 @@ describe('Subscriber API', function (): void {
     });
 
     after(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/subscriberAlert.test.ts
+++ b/DashboardAPI/test/subscriberAlert.test.ts
@@ -130,7 +130,7 @@ describe('Subcriber Alert API', function (): void {
     });
 
     after(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/team.test.ts
+++ b/DashboardAPI/test/team.test.ts
@@ -33,7 +33,7 @@ describe('Team API', function (): void {
 
     before(async function (): void {
         this.timeout(40000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         const project: $TSFixMe = res.body.project;
         projectId = project._id;
@@ -54,7 +54,7 @@ describe('Team API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
 
         await NotificationService.hardDeleteBy({ projectId: projectId });
         await AirtableService.deleteAll({ tableName: 'User' });
@@ -217,7 +217,7 @@ describe('Team API with Sub-Projects', async function (): void {
 
     before(async function (): void {
         this.timeout(30000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
 
         const authorization: string = `Basic ${token}`;
         // Create a subproject for parent project
@@ -264,7 +264,7 @@ describe('Team API with Sub-Projects', async function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({
             _id: { $in: [projectId, subProjectId] },
         });

--- a/DashboardAPI/test/tutorial.test.ts
+++ b/DashboardAPI/test/tutorial.test.ts
@@ -25,7 +25,7 @@ describe('Tutorial API', function (): void {
 
     before(async function (): void {
         this.timeout(120000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         const res: $TSFixMe = await createUser(request, userData.user);
         const project: $TSFixMe = res.body.project;
         projectId = project._id;
@@ -47,7 +47,7 @@ describe('Tutorial API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/twilio.test.ts
+++ b/DashboardAPI/test/twilio.test.ts
@@ -34,7 +34,7 @@ describe('Twilio API', function (): void {
 
     before(async function (): void {
         this.timeout(40000);
-        await GlobalConfig.initTestConfig();
+        GlobalConfig.initTestConfig();
         let res: $TSFixMe = await createUser(request, userData.user);
         expect(res).to.have.status(200);
         projectId = res.body.project._id;
@@ -76,7 +76,7 @@ describe('Twilio API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/user.test.ts
+++ b/DashboardAPI/test/user.test.ts
@@ -81,7 +81,7 @@ describe('User API', function (): void {
     });
 
     after(async () => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/test/webhook.test.ts
+++ b/DashboardAPI/test/webhook.test.ts
@@ -125,7 +125,7 @@ describe('Webhook API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await ProjectService.hardDeleteBy({ _id: projectId });
         await UserService.hardDeleteBy({
             email: {

--- a/DashboardAPI/test/zapier.test.ts
+++ b/DashboardAPI/test/zapier.test.ts
@@ -124,7 +124,7 @@ describe('Zapier API', function (): void {
     });
 
     after(async (): void => {
-        await GlobalConfig.removeTestConfig();
+        GlobalConfig.removeTestConfig();
         await UserService.hardDeleteBy({
             email: {
                 $in: [

--- a/DashboardAPI/workers/certOrder.ts
+++ b/DashboardAPI/workers/certOrder.ts
@@ -38,7 +38,7 @@ async function handleFetchingDomains(): void {
 }
 
 export default async function (): void {
-    const domains: $TSFixMe = await handleFetchingDomains();
+    const domains: $TSFixMe = handleFetchingDomains();
 
     const greenlock: $TSFixMe = global.greenlock;
     if (greenlock) {

--- a/DataIngestor/api/probe.ts
+++ b/DataIngestor/api/probe.ts
@@ -41,13 +41,13 @@ router.post(
             let matchedCriterion: $TSFixMe;
 
             if (type === 'incomingHttpRequest') {
-                const newMonitor: $TSFixMe = await MonitorService.findOneBy({
+                const newMonitor: $TSFixMe = MonitorService.findOneBy({
                     query: { _id: ObjectId(monitor._id) },
                 });
 
                 const probeId: $TSFixMe =
                     req.probe && req.probe.id ? req.probe.id : null;
-                log = await ProbeService.probeHttpRequest(newMonitor, probeId);
+                log = ProbeService.probeHttpRequest(newMonitor, probeId);
             } else {
                 if (type === 'api' || type === 'url') {
                     const {
@@ -591,10 +591,7 @@ router.post(
 
                 data.matchedCriterion = matchedCriterion;
                 // Update monitor to save the last matched criterion
-                await MonitorService.updateCriterion(
-                    monitor._id,
-                    matchedCriterion
-                );
+                MonitorService.updateCriterion(monitor._id, matchedCriterion);
 
                 data.monitorId = monitorId || monitor._id;
 
@@ -637,7 +634,7 @@ router.post(
                         ]);
                     } else {
                         // When this is scanned success or failed.
-                        await MonitorService.updateLighthouseScanStatus(
+                        MonitorService.updateLighthouseScanStatus(
                             data.monitorId,
 
                             data.lighthouseScanStatus,
@@ -647,7 +644,7 @@ router.post(
                     }
                 } else if (data.lighthouseData) {
                     data.scanning = false;
-                    log = await ProbeService.saveLighthouseLog(data);
+                    log = ProbeService.saveLighthouseLog(data);
                 } else {
                     data.matchedUpCriterion =
                         monitor && monitor.criteria && monitor.criteria.up;
@@ -660,10 +657,10 @@ router.post(
                         monitor.criteria &&
                         monitor.criteria.degraded;
 
-                    log = await ProbeService.saveMonitorLog(data);
+                    log = ProbeService.saveMonitorLog(data);
 
                     if (type === 'script') {
-                        await MonitorService.updateScriptStatus(
+                        MonitorService.updateScriptStatus(
                             monitorId,
                             'completed',
                             req.probe.id
@@ -686,7 +683,7 @@ router.post(
             const data: $TSFixMe = req.body;
             data.probeId = req.probe.id;
             data.monitorId = req.params['monitorId'];
-            const log: $TSFixMe = await ProbeService.saveMonitorLog(data);
+            const log: $TSFixMe = ProbeService.saveMonitorLog(data);
             return sendItemResponse(req, res, log);
         } catch (error) {
             return sendErrorResponse(req, res, error as Exception);
@@ -702,7 +699,7 @@ router.post(
             const data: $TSFixMe = req.body;
             data.probeId = req.probe.id;
             data.monitorId = req.params['monitorId'];
-            const log: $TSFixMe = await ProbeService.getMonitorLog(data);
+            const log: $TSFixMe = ProbeService.getMonitorLog(data);
             return sendItemResponse(req, res, log);
         } catch (error) {
             return sendErrorResponse(req, res, error as Exception);
@@ -716,7 +713,7 @@ router.post(
     async (req: ExpressRequest, res: ExpressResponse) => {
         try {
             const { monitorIds, scanning }: $TSFixMe = req.body;
-            await MonitorService.updateScanStatus(monitorIds, scanning);
+            MonitorService.updateScanStatus(monitorIds, scanning);
 
             return sendEmptyResponse(req, res);
         } catch (error) {
@@ -731,7 +728,7 @@ router.post(
     async (req: ExpressRequest, res: ExpressResponse) => {
         try {
             const { monitorIds }: $TSFixMe = req.body;
-            await MonitorService.addProbeScanning(monitorIds, req.probe.id);
+            MonitorService.addProbeScanning(monitorIds, req.probe.id);
 
             return sendEmptyResponse(req, res);
         } catch (error) {
@@ -746,7 +743,7 @@ router.post(
     async (req: ExpressRequest, res: ExpressResponse) => {
         try {
             const { monitorIds }: $TSFixMe = req.body;
-            await MonitorService.removeProbeScanning(monitorIds, req.probe.id);
+            MonitorService.removeProbeScanning(monitorIds, req.probe.id);
 
             return sendEmptyResponse(req, res);
         } catch (error) {

--- a/DataIngestor/middlewares/probeAuthorization.ts
+++ b/DataIngestor/middlewares/probeAuthorization.ts
@@ -103,7 +103,7 @@ export default {
             if (global.probes[probeName]) {
                 probeId = global.probes[probeName]._id;
             } else {
-                const probe: $TSFixMe = await ProbeService.findOneBy({
+                const probe: $TSFixMe = ProbeService.findOneBy({
                     probeName,
                 });
 
@@ -120,7 +120,7 @@ export default {
         } else if (global.probes[probeName]) {
             probeId = global.probes[probeName]._id;
         } else {
-            const probe: $TSFixMe = await ProbeService.findOneBy({
+            const probe: $TSFixMe = ProbeService.findOneBy({
                 probeKey,
                 probeName,
             });
@@ -146,7 +146,7 @@ export default {
 
         if (!probeId) {
             //Create a new probe.
-            const probe: $TSFixMe = await ProbeService.create({
+            const probe: $TSFixMe = ProbeService.create({
                 probeKey,
                 probeName,
                 probeVersion,
@@ -163,14 +163,14 @@ export default {
 
         if (global.probes[probeName].probeKey !== probeKey) {
             //Update probe key becasue it does not match.
-            await ProbeService.updateOneBy(
+            ProbeService.updateOneBy(
                 {
                     probeName,
                 },
                 { probeKey }
             );
 
-            const probe: $TSFixMe = await ProbeService.findOneBy({
+            const probe: $TSFixMe = ProbeService.findOneBy({
                 probeKey,
                 probeName,
             });
@@ -195,7 +195,7 @@ export default {
             (!global.probes[probeName].version ||
                 global.probes[probeName].version !== probeVersion)
         ) {
-            await ProbeService.updateOneBy(
+            ProbeService.updateOneBy(
                 {
                     probeName,
                 },

--- a/DataIngestor/services/automatedScriptService.ts
+++ b/DataIngestor/services/automatedScriptService.ts
@@ -41,7 +41,7 @@ export default {
         scriptLog.deleted = false;
 
         const result: $TSFixMe = await scriptLogCollection.insertOne(scriptLog);
-        const newScriptLog: $TSFixMe = await this.findOneBy({
+        const newScriptLog: $TSFixMe = this.findOneBy({
             _id: ObjectId(result.insertedId),
         });
 
@@ -104,7 +104,7 @@ export default {
                         return null;
                 }
 
-                await this.createLog(resource.automatedScript, data);
+                this.createLog(resource.automatedScript, data);
             }
         }
 
@@ -145,7 +145,7 @@ export default {
         stackSize,
     }: $TSFixMe): void {
         const { script, scriptType, successEvent, failureEvent }: $TSFixMe =
-            await this.findOneBy({
+            this.findOneBy({
                 _id: ObjectId(automatedScriptId),
             });
         let data: $TSFixMe = null;
@@ -192,7 +192,7 @@ export default {
             : null;
 
         if (data.success && successEvent.length > 0) {
-            await this.runResource({
+            this.runResource({
                 triggeredId: automatedScriptId,
                 resources: successEvent,
                 stackSize,
@@ -200,17 +200,17 @@ export default {
         }
 
         if (!data.success && failureEvent.length > 0) {
-            await this.runResource({
+            this.runResource({
                 triggeredId: automatedScriptId,
                 resources: failureEvent,
                 stackSize,
             });
         }
-        const automatedScriptLog: $TSFixMe = await this.createLog(
+        const automatedScriptLog: $TSFixMe = this.createLog(
             automatedScriptId,
             data
         );
-        await this.updateOne(
+        this.updateOne(
             { _id: ObjectId(automatedScriptId) },
             { updatedAt: new Date(moment().format()) }
         );

--- a/DataIngestor/services/incidentService.ts
+++ b/DataIngestor/services/incidentService.ts
@@ -52,7 +52,7 @@ export default {
             query.$or = [{ deleted: false }, { deleted: { $exists: false } }];
         }
 
-        const oldIncident: $TSFixMe = await this.findOneBy({
+        const oldIncident: $TSFixMe = this.findOneBy({
             query: { _id: ObjectId(query._id), deleted: { $ne: null } },
         });
 
@@ -80,7 +80,7 @@ export default {
             }
         );
 
-        updatedIncident = await this.findOneBy({
+        updatedIncident = this.findOneBy({
             query,
         });
         /*
@@ -307,7 +307,7 @@ export default {
             }
         }
 
-        const project: $TSFixMe = await ProjectService.findOneBy({
+        const project: $TSFixMe = ProjectService.findOneBy({
             query: {
                 _id: ObjectId(
                     updatedIncident.projectId._id || updatedIncident.projectId

--- a/DataIngestor/services/lighthouseLogService.ts
+++ b/DataIngestor/services/lighthouseLogService.ts
@@ -28,11 +28,11 @@ export default {
             scanning: data.scanning,
             createdAt: new Date(moment().format()),
         });
-        const savedLog: $TSFixMe = await this.findOneBy({
+        const savedLog: $TSFixMe = this.findOneBy({
             _id: ObjectId(result.insertedId),
         });
 
-        await this.sendLighthouseLog(savedLog);
+        this.sendLighthouseLog(savedLog);
 
         if (data.probeId && data.monitorId) {
             await probeService.sendProbe(data.probeId, data.monitorId);
@@ -56,12 +56,12 @@ export default {
     },
 
     async sendLighthouseLog(data: $TSFixMe): void {
-        const monitor: $TSFixMe = await MonitorService.findOneBy({
+        const monitor: $TSFixMe = MonitorService.findOneBy({
             query: { _id: ObjectId(data.monitorId) },
         });
 
         if (monitor && monitor.projectId) {
-            const project: $TSFixMe = await ProjectService.findOneBy({
+            const project: $TSFixMe = ProjectService.findOneBy({
                 query: {
                     _id: ObjectId(monitor.projectId._id || monitor.projectId),
                 },
@@ -108,6 +108,6 @@ export default {
     },
 
     async updateAllLighthouseLogs(monitorId: $TSFixMe, query: Query): void {
-        await this.updateManyBy({ monitorId: monitorId }, query);
+        this.updateManyBy({ monitorId: monitorId }, query);
     },
 };

--- a/DataIngestor/services/monitorLogByDayService.ts
+++ b/DataIngestor/services/monitorLogByDayService.ts
@@ -57,7 +57,7 @@ export default {
         const result: $TSFixMe = await monitorLogByDayCollection.insertOne(
             LogDay
         );
-        const savedLogDay: $TSFixMe = await this.findOneBy({
+        const savedLogDay: $TSFixMe = this.findOneBy({
             _id: ObjectId(result.insertedId),
         });
 

--- a/DataIngestor/services/monitorLogByHourService.ts
+++ b/DataIngestor/services/monitorLogByHourService.ts
@@ -57,7 +57,7 @@ export default {
         const result: $TSFixMe = await monitorLogByHourCollection.insertOne(
             LogHour
         );
-        const savedLogHour: $TSFixMe = await this.findOneBy({
+        const savedLogHour: $TSFixMe = this.findOneBy({
             _id: ObjectId(result.insertedId),
         });
 

--- a/DataIngestor/services/monitorLogByWeekService.ts
+++ b/DataIngestor/services/monitorLogByWeekService.ts
@@ -57,7 +57,7 @@ export default {
         const result: $TSFixMe = await monitorLogByWeekCollection.insertOne(
             LogWeek
         );
-        const savedLogWeek: $TSFixMe = await this.findOneBy({
+        const savedLogWeek: $TSFixMe = this.findOneBy({
             _id: ObjectId(result.insertedId),
         });
 

--- a/DataIngestor/services/monitorLogService.ts
+++ b/DataIngestor/services/monitorLogService.ts
@@ -77,7 +77,7 @@ export default {
         Log.scriptMetadata = data.scriptMetadata;
 
         const result: $TSFixMe = await monitorLogCollection.insertOne(Log);
-        const savedLog: $TSFixMe = await this.findOneBy({
+        const savedLog: $TSFixMe = this.findOneBy({
             _id: ObjectId(result.insertedId),
         });
 
@@ -115,7 +115,7 @@ export default {
         ]);
 
         if (logByHour) {
-            await MonitorLogByHourService.updateOneBy(
+            MonitorLogByHourService.updateOneBy(
                 { _id: ObjectId(logByHour._id) },
                 {
                     ...data,
@@ -143,13 +143,13 @@ export default {
                 }
             );
         } else {
-            await MonitorLogByHourService.create({
+            MonitorLogByHourService.create({
                 ...data,
                 intervalDate: intervalHourDate,
             });
         }
         if (logByDay) {
-            await MonitorLogByDayService.updateOneBy(
+            MonitorLogByDayService.updateOneBy(
                 { _id: ObjectId(logByDay._id) },
                 {
                     ...data,
@@ -177,13 +177,13 @@ export default {
                 }
             );
         } else {
-            await MonitorLogByDayService.create({
+            MonitorLogByDayService.create({
                 ...data,
                 intervalDate: intervalDayDate,
             });
         }
         if (logByWeek) {
-            await MonitorLogByWeekService.updateOneBy(
+            MonitorLogByWeekService.updateOneBy(
                 { _id: ObjectId(logByWeek._id) },
                 {
                     ...data,
@@ -211,7 +211,7 @@ export default {
                 }
             );
         } else {
-            await MonitorLogByWeekService.create({
+            MonitorLogByWeekService.create({
                 ...data,
                 intervalDate: intervalWeekDate,
             });
@@ -226,7 +226,7 @@ export default {
         await monitorLogCollection.updateOne(query, {
             $set: data,
         });
-        const monitorLog: $TSFixMe = await this.findOneBy(query);
+        const monitorLog: $TSFixMe = this.findOneBy(query);
 
         return monitorLog;
     },
@@ -276,7 +276,7 @@ export default {
         ]);
 
         if (monitor && monitor.projectId) {
-            const project: $TSFixMe = await ProjectService.findOneBy({
+            const project: $TSFixMe = ProjectService.findOneBy({
                 query: {
                     _id: ObjectId(monitor.projectId._id || monitor.projectId),
                 },

--- a/DataIngestor/services/monitorStatusService.ts
+++ b/DataIngestor/services/monitorStatusService.ts
@@ -23,7 +23,7 @@ export default {
             query.probeId = data.probeId;
         }
 
-        let previousMonitorStatus: $TSFixMe = await this.findBy({
+        let previousMonitorStatus: $TSFixMe = this.findBy({
             query,
             limit: 1,
         });
@@ -48,7 +48,7 @@ export default {
                 ) {
                     data.status = previousMonitorStatus.lastStatus;
                 }
-                await this.updateOneBy(
+                this.updateOneBy(
                     {
                         _id: ObjectId(previousMonitorStatus._id),
                     },
@@ -75,11 +75,11 @@ export default {
             const result: $TSFixMe = await monitorStatusCollection.insertOne(
                 monitorStatusData
             );
-            const savedMonitorStatus: $TSFixMe = await this.findOneBy({
+            const savedMonitorStatus: $TSFixMe = this.findOneBy({
                 _id: ObjectId(result.insertedId),
             });
 
-            await this.sendMonitorStatus(savedMonitorStatus);
+            this.sendMonitorStatus(savedMonitorStatus);
 
             return savedMonitorStatus;
         }
@@ -131,7 +131,7 @@ export default {
     },
 
     async sendMonitorStatus(data: $TSFixMe): void {
-        const monitor: $TSFixMe = await MonitorService.findOneBy({
+        const monitor: $TSFixMe = MonitorService.findOneBy({
             query: { _id: ObjectId(data.monitorId) },
             /*
              * Select: 'projectId',
@@ -139,7 +139,7 @@ export default {
              */
         });
         if (monitor && monitor.projectId) {
-            const project: $TSFixMe = await ProjectService.findOneBy({
+            const project: $TSFixMe = ProjectService.findOneBy({
                 query: {
                     _id: ObjectId(monitor.projectId._id || monitor.projectId),
                 },

--- a/DataIngestor/services/probeService.ts
+++ b/DataIngestor/services/probeService.ts
@@ -27,7 +27,7 @@ export default {
         } else {
             probeKey = uuidv1();
         }
-        const storedProbe: $TSFixMe = await this.findOneBy({
+        const storedProbe: $TSFixMe = this.findOneBy({
             probeName: data.probeName,
         });
         if (storedProbe && storedProbe.probeName) {
@@ -54,7 +54,7 @@ export default {
             probe.deleted = false;
 
             const result: $TSFixMe = await probeCollection.insertOne(probe);
-            const savedProbe: $TSFixMe = await this.findOneBy({
+            const savedProbe: $TSFixMe = this.findOneBy({
                 _id: ObjectId(result.insertedId),
             });
             return savedProbe;
@@ -84,17 +84,17 @@ export default {
         }
 
         await probeCollection.updateOne(query, { $set: data });
-        const probe: $TSFixMe = await this.findOneBy(query);
+        const probe: $TSFixMe = this.findOneBy(query);
         return probe;
     },
 
     saveLighthouseLog: async function (data: $TSFixMe): void {
-        const log: $TSFixMe = await LighthouseLogService.create(data);
+        const log: $TSFixMe = LighthouseLogService.create(data);
         return log;
     },
 
     createMonitorDisabledStatus: async function (data: $TSFixMe): void {
-        let monitorStatus: $TSFixMe = await MonitorStatusService.findBy({
+        let monitorStatus: $TSFixMe = MonitorStatusService.findBy({
             query: {
                 monitorId: data.monitorId,
             },
@@ -107,7 +107,7 @@ export default {
 
         if (!lastStatus || (lastStatus && lastStatus !== data.status)) {
             data.lastStatus = lastStatus ? lastStatus : null;
-            monitorStatus = await MonitorStatusService.create({
+            monitorStatus = MonitorStatusService.create({
                 ...data,
                 deleted: false,
             });
@@ -116,7 +116,7 @@ export default {
     },
 
     saveMonitorLog: async function (data: $TSFixMe): void {
-        let monitorStatus: $TSFixMe = await MonitorStatusService.findBy({
+        let monitorStatus: $TSFixMe = MonitorStatusService.findBy({
             query: {
                 monitorId: data.monitorId,
                 probeId: data.probeId,
@@ -128,10 +128,10 @@ export default {
         const lastStatus: $TSFixMe =
             monitorStatus && monitorStatus.status ? monitorStatus.status : null;
 
-        let log: $TSFixMe = await MonitorLogService.create(data);
+        let log: $TSFixMe = MonitorLogService.create(data);
 
         if (!data.stopPingTimeUpdate) {
-            await MonitorService.updateMonitorPingTime(data.monitorId);
+            MonitorService.updateMonitorPingTime(data.monitorId);
         }
 
         // Grab all the criteria in a monitor
@@ -169,11 +169,11 @@ export default {
                     return { retry: true, retryCount: data.retryCount };
                 }
 
-                await this.incidentResolveOrAcknowledge(data, allCriteria);
+                this.incidentResolveOrAcknowledge(data, allCriteria);
             }
 
             const incidentIdsOrRetry: $TSFixMe =
-                await this.incidentCreateOrUpdate(data);
+                this.incidentCreateOrUpdate(data);
 
             if (incidentIdsOrRetry.retry) {
                 return incidentIdsOrRetry;
@@ -186,10 +186,10 @@ export default {
                 data.incidentId = incidentIdsOrRetry[0];
             }
 
-            await MonitorStatusService.create({ ...data, deleted: false });
+            MonitorStatusService.create({ ...data, deleted: false });
 
             if (incidentIdsOrRetry && incidentIdsOrRetry.length) {
-                log = await MonitorLogService.updateOneBy(
+                log = MonitorLogService.updateOneBy(
                     { _id: ObjectId(log._id) },
                     { incidentIds: incidentIdsOrRetry }
                 );
@@ -197,10 +197,10 @@ export default {
         } else {
             // Should make sure all unresolved incidents for the monitor is resolved
             if (data.status === 'online') {
-                await this.incidentResolveOrAcknowledge(data, allCriteria);
+                this.incidentResolveOrAcknowledge(data, allCriteria);
             }
 
-            const incidents: $TSFixMe = await IncidentService.findBy({
+            const incidents: $TSFixMe = IncidentService.findBy({
                 query: {
                     'monitors.monitorId': ObjectId(data.monitorId),
                     incidentType: data.status,
@@ -215,7 +215,7 @@ export default {
             );
 
             if (incidentIds && incidentIds.length) {
-                log = await MonitorLogService.updateOneBy(
+                log = MonitorLogService.updateOneBy(
                     { _id: ObjectId(log._id) },
                     { incidentIds }
                 );
@@ -226,7 +226,7 @@ export default {
 
     getMonitorLog: async function (data: $TSFixMe): void {
         const date: $TSFixMe = new Date(moment().format());
-        const log: $TSFixMe = await MonitorLogService.findOneBy({
+        const log: $TSFixMe = MonitorLogService.findOneBy({
             monitorId: data.monitorId,
             probeId: data.probeId,
             createdAt: { $lt: data.date || date },
@@ -284,7 +284,7 @@ export default {
                                 };
                             }
                         );
-                        incident = await IncidentService.updateOneBy(
+                        incident = IncidentService.updateOneBy(
                             {
                                 _id: ObjectId(incident._id),
                             },
@@ -302,7 +302,7 @@ export default {
                         );
                     }
 
-                    await IncidentTimelineService.create({
+                    IncidentTimelineService.create({
                         incidentId: incident._id,
                         probeId: data.probeId,
                         status: data.status,
@@ -368,7 +368,7 @@ export default {
                                 };
                             }
                         );
-                        incident = await IncidentService.updateOneBy(
+                        incident = IncidentService.updateOneBy(
                             {
                                 _id: ObjectId(incident._id),
                             },
@@ -386,7 +386,7 @@ export default {
                         );
                     }
 
-                    await IncidentTimelineService.create({
+                    IncidentTimelineService.create({
                         incidentId: incident._id.toString(),
                         probeId: data.probeId,
                         status: data.status,
@@ -451,7 +451,7 @@ export default {
                                 };
                             }
                         );
-                        incident = await IncidentService.updateOneBy(
+                        incident = IncidentService.updateOneBy(
                             {
                                 _id: ObjectId(incident._id),
                             },
@@ -469,7 +469,7 @@ export default {
                         );
                     }
 
-                    await IncidentTimelineService.create({
+                    IncidentTimelineService.create({
                         incidentId: incident._id.toString(),
                         probeId: data.probeId,
                         status: data.status,
@@ -700,7 +700,7 @@ export default {
             },
             { $set: { lastAlive: now } }
         );
-        const probe: $TSFixMe = await this.findOneBy({
+        const probe: $TSFixMe = this.findOneBy({
             _id: ObjectId(probeId),
         });
 

--- a/JavaScriptSDK/src/logger.ts
+++ b/JavaScriptSDK/src/logger.ts
@@ -36,7 +36,7 @@ class Logger {
         }
         const logType: string = 'info';
         // Make api request to the server to save a log with the key, id and content
-        return await this._makeApiRequest(data, logType, tags);
+        return this._makeApiRequest(data, logType, tags);
     }
     public async warning(data: $TSFixMe, tags = null): void {
         const type: $TSFixMe = typeof data;
@@ -52,7 +52,7 @@ class Logger {
         }
         const logType: string = 'warning';
         // Make api request to the server to save a log with the key, id and content
-        return await this._makeApiRequest(data, logType, tags);
+        return this._makeApiRequest(data, logType, tags);
     }
     public async error(data: $TSFixMe, tags = null): void {
         const type: $TSFixMe = typeof data;
@@ -68,7 +68,7 @@ class Logger {
         }
         const logType: string = 'error';
         // Make api request to the server to save a log with the key, id and content
-        return await this._makeApiRequest(data, logType, tags);
+        return this._makeApiRequest(data, logType, tags);
     }
 
     private _makeApiRequest(

--- a/JavaScriptSDK/src/util.ts
+++ b/JavaScriptSDK/src/util.ts
@@ -87,7 +87,7 @@ class Util {
          */
 
         if (readFile && this.options.captureCodeSnippet) {
-            obj = await this._getErrorCodeSnippet(obj);
+            obj = this._getErrorCodeSnippet(obj);
         }
         return obj;
     }
@@ -137,9 +137,8 @@ class Util {
                 }
             } else {
                 // Try to read the file content and save to cache
-                const currentContent: $TSFixMe = await this._readFileFromSource(
-                    fileName
-                );
+                const currentContent: $TSFixMe =
+                    this._readFileFromSource(fileName);
                 if (currentContent !== null) {
                     frames[i].sourceFile = currentContent;
                 }

--- a/JavaScriptSDK/src/utils/dataStore.ts
+++ b/JavaScriptSDK/src/utils/dataStore.ts
@@ -112,7 +112,7 @@ class DataStore {
             mongoose: Object.fromEntries(this.mongoose),
             sentAt: Date.now(),
         };
-        await this._makeApiRequest(data);
+        this._makeApiRequest(data);
         this.clearData();
     }
     public async processDataOnExit(): void {
@@ -127,7 +127,7 @@ class DataStore {
                 mongoose: Object.fromEntries(this.mongoose),
                 sentAt: Date.now(),
             };
-            await this._makeApiRequest(data);
+            this._makeApiRequest(data);
             this.clearData();
             process.exit(1);
         }

--- a/LighthouseRunner/workers/urlMonitors.ts
+++ b/LighthouseRunner/workers/urlMonitors.ts
@@ -25,7 +25,7 @@ export default {
                         (!monitor.lighthouseScanStatus ||
                             monitor.lighthouseScanStatus !== 'scanning'))
                 ) {
-                    await UrlService.ping(monitor._id, {
+                    UrlService.ping(monitor._id, {
                         monitor,
                         resp: { lighthouseScanStatus: 'scanning' },
                     });
@@ -35,7 +35,7 @@ export default {
                     for (const url of sites) {
                         const resp: $TSFixMe = await lighthouseFetch(url);
 
-                        await UrlService.ping(monitor._id, {
+                        UrlService.ping(monitor._id, {
                             monitor,
                             resp,
                         });
@@ -50,7 +50,7 @@ const lighthouseFetch: Function = (url: URL): void => {
     return new Promise((resolve: Function, reject: Function) => {
         const lighthouseWorker: $TSFixMe = fork('./utils/lighthouse');
         const timeoutHandler: $TSFixMe = setTimeout(async (): $TSFixMe => {
-            await processLighthouseScan({
+            processLighthouseScan({
                 data: { url },
                 error: { message: 'TIMEOUT' },
             });
@@ -58,7 +58,7 @@ const lighthouseFetch: Function = (url: URL): void => {
 
         lighthouseWorker.send(url);
         lighthouseWorker.on('message', async (result: $TSFixMe) => {
-            await processLighthouseScan(result);
+            processLighthouseScan(result);
         });
 
         async function processLighthouseScan(result: $TSFixMe): void {

--- a/Probe/Workers/Index.ts
+++ b/Probe/Workers/Index.ts
@@ -77,7 +77,7 @@ const _this: $TSFixMe = {
                 logger.info(
                     `Monitor ID ${monitor._id}: Start monitoring Kubernetes monitor`
                 );
-                await KubernetesMonitors.run({ monitor });
+                KubernetesMonitors.run({ monitor });
                 logger.info(
                     `Monitor ID ${monitor._id}: End monitoring Kubernetes monitor`
                 );

--- a/ScriptRunner/workers/scriptMonitors.ts
+++ b/ScriptRunner/workers/scriptMonitors.ts
@@ -26,7 +26,7 @@ export default {
                     consoleLogs,
                 };
 
-                await ApiService.ping(monitor._id, {
+                ApiService.ping(monitor._id, {
                     monitor,
                     resp,
                 });


### PR DESCRIPTION
### Disallows awaiting a value that is not a Thenable

### This means you will not be able to await codes like:
`await 'Hello World'`

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [x] Assign yourself to the PR
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Label it as "needs-review"
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropiate?

### Related Issue?
#43 
### Screenshots (if appropriate):
