### PR TITLE
use overflow-x-scroll to stop nav bar from operlapping on mobile dashboard

### DIFF
--- a/StatusPage/src/Components/NavBar/NavBar.tsx
+++ b/StatusPage/src/Components/NavBar/NavBar.tsx
@@ -20,7 +20,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
     }
 
     return (
-        <NavBar className="bg-white flex justify-between py-2 mt-5 rounded-lg shadow px-5">
+        <NavBar className="bg-white flex justify-between py-2 mt-5 overflow-x-scroll rounded-lg shadow px-5">
             <NavBarItem
                 title="Overview"
                 icon={IconProp.CheckCircle}


### PR DESCRIPTION
### Title of this pull request?
use overflow-x-scroll to stop nav bar from operlapping on mobile dashboard
### Small Description?
On mobile, x overflow for the dashboard nav bar is not defined. Because of that, the navbar element will be extending over the screen.
### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropiate?

### Related Issue?
#451 
### Screenshots (if appropriate):
With this fix:
<img width="322" alt="Screenshot 2023-07-18 at 09 26 13" src="https://github.com/OneUptime/oneuptime/assets/39413320/bf8a0e8f-43e2-4419-9e45-9f2fa817593e">
Without the fix:
<img width="322" alt="Screenshot 2023-07-18 at 09 26 29" src="https://github.com/OneUptime/oneuptime/assets/39413320/9ed93c1d-2d14-4eaa-b41b-2658767b404b">
