### PR TITLE
Add docker network to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,3 +115,11 @@ services:
        extends:
             file: ./docker-compose.base.yml
             service: nginx
+
+volumes:
+    postgres:
+    clickhouse:
+
+networks:
+  oneuptime:
+    driver: bridge


### PR DESCRIPTION
### Title of this pull request?
Add docker network to docker-compose.yml
### Small Description?
The network appears to not be carried of docker-compose.yml from the docker-compose.base.yml. This causes an error because of the missing network.
### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropiate?

### Related Issue?

### Screenshots (if appropriate):
