### PR TITLE
Feat: add authenticated status endpoint for monitors

### DIFF
--- a/Common/Utils/UUID.ts
+++ b/Common/Utils/UUID.ts
@@ -1,7 +1,15 @@
-import { v1 as uuidv1 } from 'uuid';
+import {
+    v1 as uuidv1,
+    validate as uuidValidate,
+    version as uuidVersion,
+} from 'uuid';
 
 export default class UUID {
     public static generate(): string {
         return uuidv1();
+    }
+
+    public static validate(uuid: string, version: number = 1): boolean {
+        return uuidValidate(uuid) && uuidVersion(uuid) === version;
     }
 }

--- a/CommonServer/API/MonitorAPI.ts
+++ b/CommonServer/API/MonitorAPI.ts
@@ -1,7 +1,7 @@
 import BaseAPI from './BaseAPI';
-import Monitor from 'Model/Models/Monitor';
+import Monitor from '../../Model/Models/Monitor';
 import Select from '../Types/Database/Select';
-import UUID from '../Utils/UUID';
+import UUID from '../../Common/Utils/UUID';
 import MonitorService, {
     Service as MonitorServiceType,
 } from '../Services/MonitorService';
@@ -33,9 +33,7 @@ export default class MonitorAPI extends BaseAPI<Monitor, MonitorServiceType> {
                 }
 
                 const select: Select<Monitor> = {
-                    _id: true,
                     name: true,
-                    createdAt: true,
                     monitorType: true,
                     monitoringInterval: true,
                     disableActiveMonitoring: true,

--- a/CommonServer/API/MonitorAPI.ts
+++ b/CommonServer/API/MonitorAPI.ts
@@ -1,0 +1,71 @@
+import BaseAPI from './BaseAPI';
+import Monitor from 'Model/Models/Monitor';
+import Select from '../Types/Database/Select';
+import UUID from '../Utils/UUID';
+import MonitorService, {
+    Service as MonitorServiceType,
+} from '../Services/MonitorService';
+import { ExpressRequest, ExpressResponse } from '../Utils/Express';
+import Response from '../Utils/Response';
+import BadDataException from 'Common/Types/Exception/BadDataException';
+import NotFoundException from 'Common/Types/Exception/NotFoundException';
+import NotAuthenticatedException from 'Common/Types/Exception/NotAuthenticatedException';
+
+export default class MonitorAPI extends BaseAPI<Monitor, MonitorServiceType> {
+    public constructor() {
+        super(Monitor, MonitorService);
+
+        // Fetch monitor status
+        this.router.get(
+            `${new this.entityType().getCrudApiPath()?.toString()}/status/:id`,
+            async (req: ExpressRequest, res: ExpressResponse) => {
+                const id: string = req.params['id'] as string;
+                if (!id) {
+                    throw new BadDataException('Monitor ID was not provided.');
+                }
+
+                const key: string = req.params['key'] as string;
+                const isUUIDv1: boolean = UUID.validate(key);
+                if (!key || !isUUIDv1) {
+                    throw new BadDataException(
+                        'You must provide a valid monitor key with this request.'
+                    );
+                }
+
+                const select: Select<Monitor> = {
+                    _id: true,
+                    name: true,
+                    createdAt: true,
+                    monitorType: true,
+                    monitoringInterval: true,
+                    disableActiveMonitoring: true,
+                    currentMonitorStatusId: true,
+                    incomingRequestReceivedAt: true,
+                    embeddedStatusKey: true,
+                };
+
+                const monitorStatus: Monitor | null =
+                    await MonitorService.findOneById({
+                        id,
+                        select,
+                        props: {
+                            isRoot: true,
+                        },
+                    });
+
+                if (!monitorStatus) {
+                    throw new NotFoundException('Monitor does not exist.');
+                }
+
+                if (monitorStatus.embeddedStatusKey !== key) {
+                    throw new NotAuthenticatedException(
+                        'You are not authenticated to access this status page'
+                    );
+                }
+
+                delete monitorStatus.embeddedStatusKey;
+                return Response.sendJsonObjectResponse(req, res, monitorStatus);
+            }
+        );
+    }
+}

--- a/CommonServer/Services/MonitorService.ts
+++ b/CommonServer/Services/MonitorService.ts
@@ -117,6 +117,8 @@ export class Service extends DatabaseService<Model> {
 
         createBy.data.currentMonitorStatusId = monitorStatus.id;
 
+        createBy.data.embeddedStatusKey = ObjectID.generate()
+
         return { createBy, carryForward: null };
     }
 

--- a/CommonServer/Services/MonitorService.ts
+++ b/CommonServer/Services/MonitorService.ts
@@ -117,7 +117,7 @@ export class Service extends DatabaseService<Model> {
 
         createBy.data.currentMonitorStatusId = monitorStatus.id;
 
-        createBy.data.embeddedStatusKey = ObjectID.generate()
+        createBy.data.embeddedStatusKey = ObjectID.generate();
 
         return { createBy, carryForward: null };
     }

--- a/Dashboard/src/Pages/Monitor/View/EmbeddedMonitorKey.tsx
+++ b/Dashboard/src/Pages/Monitor/View/EmbeddedMonitorKey.tsx
@@ -1,0 +1,59 @@
+import URL from 'Common/Types/API/URL';
+import ObjectID from 'Common/Types/ObjectID';
+import Card from 'CommonUI/src/Components/Card/Card';
+import Link from 'CommonUI/src/Components/Link/Link';
+import IconProp from 'Common/Types/Icon/IconProp';
+import { ButtonStyleType } from 'CommonUI/src/Component/Button/Button';
+import { HOST, HTTP_PROTOCOL } from 'CommonUI/src/Config';
+import React, { FunctionComponent, ReactElement } from 'react';
+
+export interface ComponentProps {
+    modelId: ObjectID;
+    monitorKey?: ObjectID;
+}
+
+const EmbeddedMonitorKey: FunctionComponent<ComponentProps> = (
+    props: ComponentProps
+): ReactElement => {
+    return (
+        <>
+            <Card
+                title={`Embedded Monitor Key`}
+                description={
+                    <span>
+                        You can fetch the status of this monitor at any time
+                        using this monitor key:{' '}
+                        <Link
+                            openInNewTab={true}
+                            to={new URL(HTTP_PROTOCOL, HOST)
+                                .addRoute('/heartbeat')
+                                .addRoute(`/${props.modelId.toString()}`)
+                                .append('key', props.monitorKey.toString())
+                                .toString()}
+                        >
+                            <span>
+                                {new URL(HTTP_PROTOCOL, HOST)
+                                    .addRoute('/heartbeat')
+                                    .addRoute(`/${props.modelId.toString()}`)
+                                    .append('key', props.monitorKey.toString())
+                                    .toString()}
+                            </span>
+                        </Link>
+                    </span>
+                }
+                buttons={[
+                    {
+                        title: 'Reset Key',
+                        buttonStyle: ButtonStyleType.NORMAL,
+                        icon: IconProp.Refresh,
+                        onClick: () => {
+                            
+                        }
+                    },
+                ]}
+            />
+        </>
+    );
+};
+
+export default EmbeddedMonitorKey;

--- a/Dashboard/src/Pages/Monitor/View/Settings.tsx
+++ b/Dashboard/src/Pages/Monitor/View/Settings.tsx
@@ -19,6 +19,7 @@ import FieldType from 'CommonUI/src/Components/Types/FieldType';
 import DisabledWarning from '../../../Components/Monitor/DisabledWarning';
 import useAsyncEffect from 'use-async-effect';
 import DuplicateModel from 'CommonUI/src/Components/DuplicateModel/DuplicateModel';
+import EmbeddedMonitorKey from './EmbeddedMonitorKey';
 
 const MonitorCriteria: FunctionComponent<PageComponentProps> = (
     _props: PageComponentProps
@@ -153,6 +154,14 @@ const MonitorCriteria: FunctionComponent<PageComponentProps> = (
                     />
                 </div>
             </div>
+                            title: 'Disable Active Monitoring',
+                            fieldType: FieldType.Boolean,
+                        },
+                    ],
+                    modelId: modelId,
+                }}
+            />
+            <EmbeddedMonitorKey modelId={modelId}  />
         );
     };
 

--- a/Model/Models/Monitor.ts
+++ b/Model/Models/Monitor.ts
@@ -761,4 +761,37 @@ export default class Monitor extends BaseModel {
         default: false,
     })
     public disableActiveMonitoringBecauseOfManualIncident?: boolean = undefined;
+
+    @ColumnAccessControl({
+        create: [
+            Permission.ProjectOwner,
+            Permission.ProjectAdmin,
+            Permission.ProjectMember,
+            Permission.CanCreateProjectMonitor,
+        ],
+        read: [
+            Permission.ProjectOwner,
+            Permission.ProjectAdmin,
+            Permission.ProjectMember,
+            Permission.CanReadProjectMonitor,
+        ],
+        update: [
+            Permission.ProjectOwner,
+            Permission.ProjectAdmin,
+            Permission.ProjectMember,
+            Permission.CanEditProjectMonitor,
+        ],
+    })
+    @TableColumn({
+        type: TableColumnType.ObjectID,
+        required: true,
+        title: 'Monitor Key',
+        description: 'Key of your OneUptime Monitor in which this is used to fetch statuses',
+    })
+    @Column({
+        type: ColumnType.ObjectID,
+        nullable: false,
+        transformer: ObjectID.getDatabaseTransformer(),
+    })
+    public embeddedStatusKey?: ObjectID = undefined;
 }

--- a/Model/Models/Monitor.ts
+++ b/Model/Models/Monitor.ts
@@ -786,7 +786,8 @@ export default class Monitor extends BaseModel {
         type: TableColumnType.ObjectID,
         required: true,
         title: 'Monitor Key',
-        description: 'Key of your OneUptime Monitor in which this is used to fetch statuses',
+        description:
+            'Key of your OneUptime Monitor in which this is used to fetch statuses',
     })
     @Column({
         type: ColumnType.ObjectID,


### PR DESCRIPTION
### Feat: add authenticated status endpoint for monitors

### Adds support for fetching the singular status of a monitor with its key.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?
