### PR TITLE
fix: probe types in test file

### DIFF
--- a/Probe/Tests/Utils/PingMonitor.test.ts
+++ b/Probe/Tests/Utils/PingMonitor.test.ts
@@ -4,7 +4,6 @@ import PositiveNumber from 'Common/Types/PositiveNumber';
 import Ping, {
     PingResponse,
 } from '../../Utils/Monitors/MonitorTypes/PingMonitor';
-import '@types/jest';
 
 describe('Ping', () => {
     jest.setTimeout(10000);

--- a/Probe/tsconfig.json
+++ b/Probe/tsconfig.json
@@ -38,8 +38,8 @@
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         "typeRoots": [
-         
-        ], /* Specify multiple folders that act like `./node_modules/@types`. */
+            "./node_modules/@types"
+        ] /* Specify multiple folders that act like `./node_modules/@types`. */,
         "types": ["node", "jest"],                                      /* Specify type package names to be included without being referenced in a source file. */
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
         // "resolveJsonModule": true,                        /* Enable importing .json files */


### PR DESCRIPTION
### Fix Probe

Fixes the below bug:

```
> probe@1.0.0 test
> jest --passWithNoTests

ts-jest[versions] (WARN) Version 5.0.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=4.3.0 <5.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
FAIL Tests/Utils/PingMonitor.test.ts
  ● Test suite failed to run

    Tests/Utils/PingMonitor.test.ts:7:8 - error TS6137: Cannot import type declaration files. Consider importing 'jest' instead of '@types/jest'.

    7 import '@types/jest';
```

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
