### PR TITLE
Adds tests for Common/Types/Database

### DIFF
--- a/Common/Models/BaseModel.ts
+++ b/Common/Models/BaseModel.ts
@@ -122,7 +122,7 @@ export default class BaseModel extends BaseEntity {
     public totalItemsNumber!: number | null;
     public totalItemsErrorMessage!: string | null;
 
-    public isPermissionIf: Dictionary<JSONObject> = {};
+    public isPermissionIf!: Dictionary<JSONObject>;
 
     public isMultiTenantRequestAllowed!: boolean | null;
     public allowUserQueryWithoutTenant!: boolean | null;
@@ -146,6 +146,9 @@ export default class BaseModel extends BaseEntity {
         super();
         if (id) {
             this.id = id;
+        }
+        if (!this.isPermissionIf) {
+            this.isPermissionIf = {};
         }
     }
 

--- a/Common/Tests/Types/Database/AccessControl/ColumnAccessControl.test.ts
+++ b/Common/Tests/Types/Database/AccessControl/ColumnAccessControl.test.ts
@@ -1,0 +1,102 @@
+import BaseModel from '../../../../Models/BaseModel';
+import Permission from '../../../../Types/Permission';
+import { ColumnAccessControl as ColumnAccessControlType } from '../../../../Types/BaseDatabase/AccessControl';
+import ColumnAccessControl, {
+    getColumnAccessControl,
+    getColumnAccessControlForAllColumns,
+} from '../../../../Types/Database/AccessControl/ColumnAccessControl';
+
+describe('ColumnAccessControl', () => {
+    describe('getColumnAccessControl', () => {
+        it('should return nothing if no AccessControl is set', () => {
+            class Test extends BaseModel {
+                public testColumn?: string = undefined;
+            }
+            const test: Test = new Test();
+            expect(getColumnAccessControl(test, 'testColumn')).toBe(undefined);
+        });
+        it('should return ColumnAccessControl', () => {
+            const permissions: ColumnAccessControlType = {
+                create: [
+                    Permission.ProjectOwner,
+                    Permission.ProjectAdmin,
+                    Permission.ProjectMember,
+                    Permission.CanCreateProjectMonitor,
+                ],
+                read: [
+                    Permission.ProjectOwner,
+                    Permission.ProjectAdmin,
+                    Permission.ProjectMember,
+                    Permission.CanReadProjectMonitor,
+                ],
+                update: [],
+            };
+
+            class Test extends BaseModel {
+                @ColumnAccessControl(permissions)
+                public testColumn?: string = undefined;
+            }
+            const test: Test = new Test();
+            expect(getColumnAccessControl(test, 'testColumn')).toBe(
+                permissions
+            );
+        });
+    });
+
+    describe('getColumnAccessControlForAllColumns', () => {
+        it('should return nothing if no AccessControl is set', () => {
+            class Test extends BaseModel {
+                public testColumn?: string = undefined;
+            }
+            const test: Test = new Test();
+            expect(getColumnAccessControl(test, 'testColumn')).toBe(undefined);
+        });
+        it('should return ColumnAccessControl for all columns', () => {
+            const fooPermissions: ColumnAccessControlType = {
+                create: [
+                    Permission.ProjectOwner,
+                    Permission.ProjectAdmin,
+                    Permission.ProjectMember,
+                    Permission.CanCreateProjectMonitor,
+                ],
+                read: [
+                    Permission.ProjectOwner,
+                    Permission.ProjectAdmin,
+                    Permission.ProjectMember,
+                    Permission.CanReadProjectMonitor,
+                ],
+                update: [],
+            };
+
+            const barPermissions: ColumnAccessControlType = {
+                create: [
+                    Permission.ProjectOwner,
+                    Permission.ProjectAdmin,
+                    Permission.CanCreateProjectMonitor,
+                ],
+                read: [
+                    Permission.ProjectOwner,
+                    Permission.ProjectAdmin,
+                    Permission.ProjectMember,
+                    Permission.CanReadProjectMonitor,
+                ],
+                update: [Permission.ProjectOwner, Permission.ProjectAdmin],
+            };
+
+            class Test extends BaseModel {
+                @ColumnAccessControl(fooPermissions)
+                public foo?: string = undefined;
+
+                @ColumnAccessControl(barPermissions)
+                public bar?: string = undefined;
+
+                public foobar?: string = undefined;
+            }
+            const test: Test = new Test();
+            expect(getColumnAccessControlForAllColumns(test)).toStrictEqual({
+                foo: fooPermissions,
+                bar: barPermissions,
+            });
+        });
+    });
+});

--- a/Common/Tests/Types/Database/AccessControlColumn.test.ts
+++ b/Common/Tests/Types/Database/AccessControlColumn.test.ts
@@ -1,0 +1,17 @@
+import BaseModel from '../../../Models/BaseModel';
+import AccessControlColumn from '../../../Types/Database/AccessControlColumn';
+
+describe('AccessControlColumn', () => {
+    it('should not set accessControlColumn', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().accessControlColumn).toBe(undefined);
+    });
+
+    it('should set accessControlColumn', () => {
+        @AccessControlColumn('labels')
+        class Test extends BaseModel{};
+
+        expect(new Test().accessControlColumn).toBe('labels');
+    });
+});

--- a/Common/Tests/Types/Database/AccessControlColumn.test.ts
+++ b/Common/Tests/Types/Database/AccessControlColumn.test.ts
@@ -3,14 +3,14 @@ import AccessControlColumn from '../../../Types/Database/AccessControlColumn';
 
 describe('AccessControlColumn', () => {
     it('should not set accessControlColumn', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().accessControlColumn).toBe(undefined);
     });
 
     it('should set accessControlColumn', () => {
         @AccessControlColumn('labels')
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().accessControlColumn).toBe('labels');
     });

--- a/Common/Tests/Types/Database/AllowUserQueryWithoutTenant.test.ts
+++ b/Common/Tests/Types/Database/AllowUserQueryWithoutTenant.test.ts
@@ -3,21 +3,21 @@ import AllowUserQueryWithoutTenant from '../../../Types/Database/AllowUserQueryW
 
 describe('AllowUserQueryWithoutTenant', () => {
     it('should not define user query without tenant', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().allowUserQueryWithoutTenant).toBe(undefined);
     });
 
     it('should allow user query without tenant', () => {
         @AllowUserQueryWithoutTenant(true)
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().allowUserQueryWithoutTenant).toBe(true);
     });
 
     it('should disallow user query without tenant', () => {
         @AllowUserQueryWithoutTenant(false)
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().allowUserQueryWithoutTenant).toBe(false);
     });

--- a/Common/Tests/Types/Database/AllowUserQueryWithoutTenant.test.ts
+++ b/Common/Tests/Types/Database/AllowUserQueryWithoutTenant.test.ts
@@ -1,0 +1,24 @@
+import BaseModel from '../../../Models/BaseModel';
+import AllowUserQueryWithoutTenant from '../../../Types/Database/AllowUserQueryWithoutTenant';
+
+describe('AllowUserQueryWithoutTenant', () => {
+    it('should not define user query without tenant', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().allowUserQueryWithoutTenant).toBe(undefined);
+    });
+
+    it('should allow user query without tenant', () => {
+        @AllowUserQueryWithoutTenant(true)
+        class Test extends BaseModel{};
+
+        expect(new Test().allowUserQueryWithoutTenant).toBe(true);
+    });
+
+    it('should disallow user query without tenant', () => {
+        @AllowUserQueryWithoutTenant(false)
+        class Test extends BaseModel{};
+
+        expect(new Test().allowUserQueryWithoutTenant).toBe(false);
+    });
+});

--- a/Common/Tests/Types/Database/CanAccessIfCanReadOn.test.ts
+++ b/Common/Tests/Types/Database/CanAccessIfCanReadOn.test.ts
@@ -1,0 +1,17 @@
+import BaseModel from '../../../Models/BaseModel';
+import CanAccessIfCanReadOn from '../../../Types/Database/CanAccessIfCanReadOn';
+
+describe('CanAccessIfCanReadOn', () => {
+    it('should not set canAccessIfCanReadOn', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().canAccessIfCanReadOn).toBe(undefined);
+    });
+
+    it('should set canAccessIfCanReadOn', () => {
+        @CanAccessIfCanReadOn('statusPage')
+        class Test extends BaseModel{};
+
+        expect(new Test().canAccessIfCanReadOn).toBe('statusPage');
+    });
+});

--- a/Common/Tests/Types/Database/CanAccessIfCanReadOn.test.ts
+++ b/Common/Tests/Types/Database/CanAccessIfCanReadOn.test.ts
@@ -3,14 +3,14 @@ import CanAccessIfCanReadOn from '../../../Types/Database/CanAccessIfCanReadOn';
 
 describe('CanAccessIfCanReadOn', () => {
     it('should not set canAccessIfCanReadOn', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().canAccessIfCanReadOn).toBe(undefined);
     });
 
     it('should set canAccessIfCanReadOn', () => {
         @CanAccessIfCanReadOn('statusPage')
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().canAccessIfCanReadOn).toBe('statusPage');
     });

--- a/Common/Tests/Types/Database/ColumnLength.test.ts
+++ b/Common/Tests/Types/Database/ColumnLength.test.ts
@@ -1,55 +1,27 @@
-import ColumnLength from '../../../Types/Database/ColumnLength';
+import { getMaxLengthFromTableColumnType } from '../../../Types/Database/ColumnLength';
+import TableColumnType from '../../../Types/Database/TableColumnType';
 
 describe('enum ColumnLength', () => {
-    test('ColumnLength.Version', () => {
-        expect(ColumnLength.Version).toEqual(30);
-    });
+    test.each([
+        [TableColumnType.Version, 30],
+        [TableColumnType.Slug, 100],
+        [TableColumnType.Email, 100],
+        [TableColumnType.Domain, 100],
+        [TableColumnType.Color, 7],
+        [TableColumnType.Name, 50],
+        [TableColumnType.Description, 500],
+        [TableColumnType.LongText, 500],
+        [TableColumnType.Password, 500],
+        [TableColumnType.ShortURL, 100],
+        [TableColumnType.ShortText, 100],
+        [TableColumnType.HashedString, 64],
+        [TableColumnType.Phone, 30],
+        [TableColumnType.OTP, 8],
 
-    test('ColumnLength.Slug', () => {
-        expect(ColumnLength.Slug).toEqual(100);
-    });
+        [TableColumnType.Date, undefined],
+        ['Random', undefined],
 
-    test('ColumnLength.Email', () => {
-        expect(ColumnLength.Email).toEqual(100);
-    });
-
-    test('ColumnLength.Color', () => {
-        expect(ColumnLength.Color).toEqual(7);
-    });
-
-    test('ColumnLength.Name', () => {
-        expect(ColumnLength.Name).toEqual(50);
-    });
-
-    test('ColumnLength.Description', () => {
-        expect(ColumnLength.Description).toEqual(500);
-    });
-
-    test('ColumnLength.LongText', () => {
-        expect(ColumnLength.LongText).toEqual(500);
-    });
-
-    test('ColumnLength.Password', () => {
-        expect(ColumnLength.Password).toEqual(500);
-    });
-
-    test('ColumnLength.ShortURL', () => {
-        expect(ColumnLength.ShortURL).toEqual(100);
-    });
-
-    test('ColumnLength.ShortText', () => {
-        expect(ColumnLength.ShortText).toEqual(100);
-    });
-
-    test('ColumnLength.HashedString', () => {
-        expect(ColumnLength.HashedString).toEqual(64);
-    });
-
-    test('ColumnLength.Phone', () => {
-        expect(ColumnLength.Phone).toEqual(30);
-    });
-
-    test('ColumnLength.OTP', () => {
-        expect(ColumnLength.OTP).toEqual(8);
+    ])('length for column %s is %d ', (columnType, expected) => {
+        expect(getMaxLengthFromTableColumnType(columnType)).toBe(expected);
     });
 });

--- a/Common/Tests/Types/Database/ColumnLength.test.ts
+++ b/Common/Tests/Types/Database/ColumnLength.test.ts
@@ -2,7 +2,7 @@ import { getMaxLengthFromTableColumnType } from '../../../Types/Database/ColumnL
 import TableColumnType from '../../../Types/Database/TableColumnType';
 
 describe('enum ColumnLength', () => {
-    test.each([
+    const testCases: [TableColumnType, number | undefined][] = [
         [TableColumnType.Version, 30],
         [TableColumnType.Slug, 100],
         [TableColumnType.Email, 100],
@@ -19,9 +19,12 @@ describe('enum ColumnLength', () => {
         [TableColumnType.OTP, 8],
 
         [TableColumnType.Date, undefined],
-        ['Random', undefined],
+    ];
 
-    ])('length for column %s is %d ', (columnType, expected) => {
-        expect(getMaxLengthFromTableColumnType(columnType)).toBe(expected);
-    });
+    test.each(testCases)(
+        'length for column %s is %d ',
+        (columnType: TableColumnType, expected: number | undefined) => {
+            expect(getMaxLengthFromTableColumnType(columnType)).toBe(expected);
+        }
+    );
 });

--- a/Common/Tests/Types/Database/CompareBase.test.ts
+++ b/Common/Tests/Types/Database/CompareBase.test.ts
@@ -3,9 +3,15 @@ import BadDataException from '../../../Types/Exception/BadDataException';
 
 describe('CompareBase', () => {
     describe('toString', () => {
-        it('should return string representation of value', () => {
+        it('should return string representation of value if it is a number', () => {
             const compareBase: CompareBase = new CompareBase(10);
             expect(compareBase.toString()).toBe('10');
+        });
+
+        it('should return string representation of value if it is a date', () => {
+            const now = new Date();
+            const compareBase: CompareBase = new CompareBase(now);
+            expect(compareBase.toString()).toBe(now.toJSON());
         });
     });
 

--- a/Common/Tests/Types/Database/CompareBase.test.ts
+++ b/Common/Tests/Types/Database/CompareBase.test.ts
@@ -9,7 +9,7 @@ describe('CompareBase', () => {
         });
 
         it('should return string representation of value if it is a date', () => {
-            const now = new Date();
+            const now: Date = new Date();
             const compareBase: CompareBase = new CompareBase(now);
             expect(compareBase.toString()).toBe(now.toJSON());
         });

--- a/Common/Tests/Types/Database/CrudApiEndpoint.test.ts
+++ b/Common/Tests/Types/Database/CrudApiEndpoint.test.ts
@@ -4,15 +4,15 @@ import CrudApiEndpoint from '../../../Types/Database/CrudApiEndpoint';
 
 describe('CrudApiEndpoint', () => {
     it('should not set crudApiPath', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().crudApiPath).toBe(undefined);
     });
 
     it('should set crudApiPath', () => {
-        const testRoute = new Route('/test');
+        const testRoute: Route = new Route('/test');
         @CrudApiEndpoint(testRoute)
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().crudApiPath).toBe(testRoute);
     });

--- a/Common/Tests/Types/Database/CrudApiEndpoint.test.ts
+++ b/Common/Tests/Types/Database/CrudApiEndpoint.test.ts
@@ -1,0 +1,19 @@
+import BaseModel from '../../../Models/BaseModel';
+import Route from '../../../Types/API/Route';
+import CrudApiEndpoint from '../../../Types/Database/CrudApiEndpoint';
+
+describe('CrudApiEndpoint', () => {
+    it('should not set crudApiPath', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().crudApiPath).toBe(undefined);
+    });
+
+    it('should set crudApiPath', () => {
+        const testRoute = new Route('/test');
+        @CrudApiEndpoint(testRoute)
+        class Test extends BaseModel{};
+
+        expect(new Test().crudApiPath).toBe(testRoute);
+    });
+});

--- a/Common/Tests/Types/Database/CurrentUserCanAccessRecordBy.test.ts
+++ b/Common/Tests/Types/Database/CurrentUserCanAccessRecordBy.test.ts
@@ -1,0 +1,17 @@
+import BaseModel from '../../../Models/BaseModel';
+import CurrentUserCanAccessRecordBy from '../../../Types/Database/CurrentUserCanAccessRecordBy';
+
+describe('CurrentUserCanAccessRecordBy', () => {
+    it('should not set currentUserCanAccessColumnBy', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().currentUserCanAccessColumnBy).toBe(undefined);
+    });
+
+    it('should set currentUserCanAccessColumnBy', () => {
+        @CurrentUserCanAccessRecordBy('userId')
+        class Test extends BaseModel{};
+
+        expect(new Test().currentUserCanAccessColumnBy).toBe('userId');
+    });
+});

--- a/Common/Tests/Types/Database/CurrentUserCanAccessRecordBy.test.ts
+++ b/Common/Tests/Types/Database/CurrentUserCanAccessRecordBy.test.ts
@@ -3,14 +3,14 @@ import CurrentUserCanAccessRecordBy from '../../../Types/Database/CurrentUserCan
 
 describe('CurrentUserCanAccessRecordBy', () => {
     it('should not set currentUserCanAccessColumnBy', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().currentUserCanAccessColumnBy).toBe(undefined);
     });
 
     it('should set currentUserCanAccessColumnBy', () => {
         @CurrentUserCanAccessRecordBy('userId')
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().currentUserCanAccessColumnBy).toBe('userId');
     });

--- a/Common/Tests/Types/Database/EnableDocumentation.test.ts
+++ b/Common/Tests/Types/Database/EnableDocumentation.test.ts
@@ -1,9 +1,11 @@
 import BaseModel from '../../../Models/BaseModel';
-import EnableDocumentation from '../../../Types/Database/EnableDocumentation';
+import EnableDocumentation, {
+    EnableDocumentationProps,
+} from '../../../Types/Database/EnableDocumentation';
 
 describe('EnableDocumentation', () => {
     test('without EnableDocumentation', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().enableDocumentation).toBe(undefined);
         expect(new Test().isMasterAdminApiDocs).toBe(undefined);
@@ -11,21 +13,35 @@ describe('EnableDocumentation', () => {
 
     test('enableDocumentation no props', () => {
         @EnableDocumentation()
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().enableDocumentation).toBe(true);
         expect(new Test().isMasterAdminApiDocs).toBe(false);
     });
 
-    test.each([
-        [{isMasterAdminApiDocs: true}, {isMasterAdminApiDocs: true}],
-        [{isMasterAdminApiDocs: false}, {isMasterAdminApiDocs: false}],
-        [{isMasterAdminApiDocs: undefined}, {isMasterAdminApiDocs: false}],
-    ])('enableDocumentation with props = %o', (props, expected) => {
-        @EnableDocumentation(props)
-        class Test extends BaseModel{};
+    const testCases: [EnableDocumentationProps, { [key: string]: boolean }][] =
+        [
+            [{ isMasterAdminApiDocs: true }, { isMasterAdminApiDocs: true }],
+            [{ isMasterAdminApiDocs: false }, { isMasterAdminApiDocs: false }],
+            [
+                { isMasterAdminApiDocs: undefined },
+                { isMasterAdminApiDocs: false },
+            ],
+        ];
 
-        expect(new Test().enableDocumentation).toBe(true);
-        expect(new Test().isMasterAdminApiDocs).toBe(expected.isMasterAdminApiDocs);
-    });
+    test.each(testCases)(
+        'enableDocumentation with props = %o',
+        (
+            props: EnableDocumentationProps,
+            expected: { [key: string]: boolean }
+        ) => {
+            @EnableDocumentation(props)
+            class Test extends BaseModel {}
+
+            expect(new Test().enableDocumentation).toBe(true);
+            expect(new Test().isMasterAdminApiDocs).toBe(
+                expected.isMasterAdminApiDocs
+            );
+        }
+    );
 });

--- a/Common/Tests/Types/Database/EnableDocumentation.test.ts
+++ b/Common/Tests/Types/Database/EnableDocumentation.test.ts
@@ -1,0 +1,31 @@
+import BaseModel from '../../../Models/BaseModel';
+import EnableDocumentation from '../../../Types/Database/EnableDocumentation';
+
+describe('EnableDocumentation', () => {
+    test('without EnableDocumentation', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().enableDocumentation).toBe(undefined);
+        expect(new Test().isMasterAdminApiDocs).toBe(undefined);
+    });
+
+    test('enableDocumentation no props', () => {
+        @EnableDocumentation()
+        class Test extends BaseModel{};
+
+        expect(new Test().enableDocumentation).toBe(true);
+        expect(new Test().isMasterAdminApiDocs).toBe(false);
+    });
+
+    test.each([
+        [{isMasterAdminApiDocs: true}, {isMasterAdminApiDocs: true}],
+        [{isMasterAdminApiDocs: false}, {isMasterAdminApiDocs: false}],
+        [{isMasterAdminApiDocs: undefined}, {isMasterAdminApiDocs: false}],
+    ])('enableDocumentation with props = %o', (props, expected) => {
+        @EnableDocumentation(props)
+        class Test extends BaseModel{};
+
+        expect(new Test().enableDocumentation).toBe(true);
+        expect(new Test().isMasterAdminApiDocs).toBe(expected.isMasterAdminApiDocs);
+    });
+});

--- a/Common/Tests/Types/Database/EnableDocumentation.test.ts
+++ b/Common/Tests/Types/Database/EnableDocumentation.test.ts
@@ -33,7 +33,7 @@ describe('EnableDocumentation', () => {
         'enableDocumentation with props = %o',
         (
             props: EnableDocumentationProps,
-            expected: { [key: string]: boolean }
+            expected: EnableDocumentationProps
         ) => {
             @EnableDocumentation(props)
             class Test extends BaseModel {}

--- a/Common/Tests/Types/Database/EnableWorkflow.test.ts
+++ b/Common/Tests/Types/Database/EnableWorkflow.test.ts
@@ -1,0 +1,42 @@
+import BaseModel from '../../../Models/BaseModel';
+import EnableWorkflow from '../../../Types/Database/EnableWorkflow';
+
+describe('EnableWorkflow', () => {
+    test('without EnableWorkflow', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().enableWorkflowOn).toBe(undefined);
+    });
+
+    test.each([
+        [
+            {read: true}, {read: true}
+        ],
+        [{
+            create: true,
+            update: false,
+            delete: true,
+            read: true,
+        }, {
+            create: true,
+            update: false,
+            delete: true,
+            read: true,
+        }],
+        [{
+            create: true,
+            update: true,
+            read: true,
+        }, {
+            create: true,
+            update: true,
+            delete: undefined,
+            read: true,
+        }],
+    ])('EnableWorkflow with options = %o', (props, expected) => {
+        @EnableWorkflow(props)
+        class Test extends BaseModel{};
+
+        expect(new Test().enableWorkflowOn).toEqual(expected);
+    });
+});

--- a/Common/Tests/Types/Database/EnableWorkflow.test.ts
+++ b/Common/Tests/Types/Database/EnableWorkflow.test.ts
@@ -1,42 +1,52 @@
 import BaseModel from '../../../Models/BaseModel';
 import EnableWorkflow from '../../../Types/Database/EnableWorkflow';
+import EnableWorkflowOn from '../../../Types/BaseDatabase/EnableWorkflowOn';
 
 describe('EnableWorkflow', () => {
     test('without EnableWorkflow', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().enableWorkflowOn).toBe(undefined);
     });
 
-    test.each([
+    const testCases: [EnableWorkflowOn, EnableWorkflowOn][] = [
+        [{ read: true }, { read: true }],
         [
-            {read: true}, {read: true}
+            {
+                create: true,
+                update: false,
+                delete: true,
+                read: true,
+            },
+            {
+                create: true,
+                update: false,
+                delete: true,
+                read: true,
+            },
         ],
-        [{
-            create: true,
-            update: false,
-            delete: true,
-            read: true,
-        }, {
-            create: true,
-            update: false,
-            delete: true,
-            read: true,
-        }],
-        [{
-            create: true,
-            update: true,
-            read: true,
-        }, {
-            create: true,
-            update: true,
-            delete: undefined,
-            read: true,
-        }],
-    ])('EnableWorkflow with options = %o', (props, expected) => {
-        @EnableWorkflow(props)
-        class Test extends BaseModel{};
+        [
+            {
+                create: true,
+                update: true,
+                read: true,
+            },
+            {
+                create: true,
+                update: true,
+                delete: undefined,
+                read: true,
+            },
+        ],
+    ];
 
-        expect(new Test().enableWorkflowOn).toEqual(expected);
-    });
+    test.each(testCases)(
+        'EnableWorkflow with options = %o',
+        (props: EnableWorkflowOn, expected: EnableWorkflowOn) => {
+            @EnableWorkflow(props)
+            class Test extends BaseModel {}
+
+            expect(new Test().enableWorkflowOn).toEqual(expected);
+        }
+    );
 });

--- a/Common/Tests/Types/Database/GreaterThan.test.ts
+++ b/Common/Tests/Types/Database/GreaterThan.test.ts
@@ -1,0 +1,77 @@
+import GreaterThan from '../../../Types/Database/GreaterThan';
+import BadDataException from '../../../Types/Exception/BadDataException';
+import { JSONObject } from '../../../Types/JSON';
+
+describe('GreaterThan', () => {
+    describe('toJSON', () => {
+        it('number - should generate the correct JSON representation', () => {
+            const greaterThan = new GreaterThan(2023);
+            const expectedJSON: JSONObject = {
+                _type: 'GreaterThan',
+                value: 2023,
+            };
+            expect(greaterThan.toJSON()).toEqual(expectedJSON);
+        });
+
+        it('date - should generate the correct JSON representation', () => {
+            const now = new Date();
+            const greaterThan = new GreaterThan(now);
+            const expectedJSON: JSONObject = {
+                _type: 'GreaterThan',
+                value: now.toJSON(),
+            };
+            expect(greaterThan.toJSON()).toEqual(expectedJSON);
+        });
+    });
+
+    describe('fromJSON', () => {
+        it('number - should create an GreaterThan object from valid JSON input', () => {
+            const jsonInput: JSONObject = {
+                _type: 'GreaterThan',
+                value: 2023,
+            };
+            const greaterThan: GreaterThan = GreaterThan.fromJSON(jsonInput);
+            expect(greaterThan.value).toBe(2023);
+        });
+
+        it('date - should create an GreaterThan object from valid JSON input', () => {
+            const now = new Date();
+            const jsonInput: JSONObject = {
+                _type: 'GreaterThan',
+                value: now.toJSON(),
+            };
+            const greaterThan: GreaterThan = GreaterThan.fromJSON(jsonInput);
+            expect(greaterThan.value).toEqual(now);
+        });
+
+        it('should throw a BadDataException when using invalid JSON input - type', () => {
+            const jsonInput: JSONObject = {
+                _type: 'InvalidType',
+                value: 42,
+            };
+            expect(() => {
+                return GreaterThan.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+
+        it('should throw a BadDataException when using invalid JSON input - value', () => {
+            const jsonInput: JSONObject = {
+                _type: 'GreaterThan',
+                value: '123string',
+            };
+            expect(() => {
+                return GreaterThan.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+
+        it('should throw a BadDataException when using invalid JSON input - date', () => {
+            const jsonInput: JSONObject = {
+                _type: 'GreaterThan',
+                value: '2023-13-35',
+            };
+            expect(() => {
+                return GreaterThan.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+    });
+});

--- a/Common/Tests/Types/Database/GreaterThan.test.ts
+++ b/Common/Tests/Types/Database/GreaterThan.test.ts
@@ -5,7 +5,7 @@ import { JSONObject } from '../../../Types/JSON';
 describe('GreaterThan', () => {
     describe('toJSON', () => {
         it('number - should generate the correct JSON representation', () => {
-            const greaterThan = new GreaterThan(2023);
+            const greaterThan: GreaterThan = new GreaterThan(2023);
             const expectedJSON: JSONObject = {
                 _type: 'GreaterThan',
                 value: 2023,
@@ -14,8 +14,8 @@ describe('GreaterThan', () => {
         });
 
         it('date - should generate the correct JSON representation', () => {
-            const now = new Date();
-            const greaterThan = new GreaterThan(now);
+            const now: Date = new Date();
+            const greaterThan: GreaterThan = new GreaterThan(now);
             const expectedJSON: JSONObject = {
                 _type: 'GreaterThan',
                 value: now.toJSON(),
@@ -35,7 +35,7 @@ describe('GreaterThan', () => {
         });
 
         it('date - should create an GreaterThan object from valid JSON input', () => {
-            const now = new Date();
+            const now: Date = new Date();
             const jsonInput: JSONObject = {
                 _type: 'GreaterThan',
                 value: now.toJSON(),

--- a/Common/Tests/Types/Database/IsNull.test.ts
+++ b/Common/Tests/Types/Database/IsNull.test.ts
@@ -5,14 +5,14 @@ import { JSONObject } from '../../../Types/JSON';
 describe('IsNull', () => {
     describe('toString', () => {
         it('should return the correct string representation', () => {
-            const isNull = new IsNull();
+            const isNull: IsNull = new IsNull();
             expect(isNull.toString()).toEqual('');
         });
     });
 
     describe('toJSON', () => {
         it('should generate the correct JSON representation', () => {
-            const isNull = new IsNull();
+            const isNull: IsNull = new IsNull();
             const expectedJSON: JSONObject = {
                 _type: 'IsNull',
                 value: null,

--- a/Common/Tests/Types/Database/IsNull.test.ts
+++ b/Common/Tests/Types/Database/IsNull.test.ts
@@ -1,0 +1,44 @@
+import IsNull from '../../../Types/Database/IsNull';
+import BadDataException from '../../../Types/Exception/BadDataException';
+import { JSONObject } from '../../../Types/JSON';
+
+describe('IsNull', () => {
+    describe('toString', () => {
+        it('should return the correct string representation', () => {
+            const isNull = new IsNull();
+            expect(isNull.toString()).toEqual('');
+        });
+    });
+
+    describe('toJSON', () => {
+        it('should generate the correct JSON representation', () => {
+            const isNull = new IsNull();
+            const expectedJSON: JSONObject = {
+                _type: 'IsNull',
+                value: null,
+            };
+            expect(isNull.toJSON()).toEqual(expectedJSON);
+        });
+    });
+
+    describe('fromJSON', () => {
+        it('should create an IsNull object from valid JSON input', () => {
+            const jsonInput: JSONObject = {
+                _type: 'IsNull',
+                value: null,
+            };
+            const isNull: IsNull = IsNull.fromJSON(jsonInput);
+            expect(isNull.toString()).toBe('');
+        });
+
+        it('should throw a BadDataException when using invalid JSON input', () => {
+            const jsonInput: JSONObject = {
+                _type: 'InvalidType',
+                value: null,
+            };
+            expect(() => {
+                return IsNull.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+    });
+});

--- a/Common/Tests/Types/Database/IsPermissionIf.test.ts
+++ b/Common/Tests/Types/Database/IsPermissionIf.test.ts
@@ -4,7 +4,7 @@ import IsPermissionsIf from '../../../Types/Database/IsPermissionsIf';
 
 describe('IsPermissionsIf', () => {
     it('should not set isPermissionIf', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().isPermissionIf).toEqual({});
     });
@@ -12,15 +12,15 @@ describe('IsPermissionsIf', () => {
     it('should set isPermissionIf', () => {
         @IsPermissionsIf(Permission.Public, 'projectId', null)
         @IsPermissionsIf(Permission.ProjectUser, 'userId', true)
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().isPermissionIf).toEqual({
             [Permission.Public]: {
-                'projectId': null,
+                projectId: null,
             },
             [Permission.ProjectUser]: {
-                'userId': true,
-            }
+                userId: true,
+            },
         });
     });
 });

--- a/Common/Tests/Types/Database/IsPermissionIf.test.ts
+++ b/Common/Tests/Types/Database/IsPermissionIf.test.ts
@@ -1,0 +1,26 @@
+import BaseModel from '../../../Models/BaseModel';
+import Permission from '../../../Types/Permission';
+import IsPermissionsIf from '../../../Types/Database/IsPermissionsIf';
+
+describe('IsPermissionsIf', () => {
+    it('should not set isPermissionIf', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().isPermissionIf).toEqual({});
+    });
+
+    it('should set isPermissionIf', () => {
+        @IsPermissionsIf(Permission.Public, 'projectId', null)
+        @IsPermissionsIf(Permission.ProjectUser, 'userId', true)
+        class Test extends BaseModel{};
+
+        expect(new Test().isPermissionIf).toEqual({
+            [Permission.Public]: {
+                'projectId': null,
+            },
+            [Permission.ProjectUser]: {
+                'userId': true,
+            }
+        });
+    });
+});

--- a/Common/Tests/Types/Database/LabelsColumn.test.ts
+++ b/Common/Tests/Types/Database/LabelsColumn.test.ts
@@ -3,16 +3,15 @@ import LabelsColumn from '../../../Types/Database/LabelsColumn';
 
 describe('LabelsColumn', () => {
     it('should not set labelsColumn', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().labelsColumn).toBe(undefined);
     });
 
     it('should set labelsColumn', () => {
         @LabelsColumn('test')
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().labelsColumn).toBe('test');
     });
 });
-

--- a/Common/Tests/Types/Database/LabelsColumn.test.ts
+++ b/Common/Tests/Types/Database/LabelsColumn.test.ts
@@ -1,0 +1,18 @@
+import BaseModel from '../../../Models/BaseModel';
+import LabelsColumn from '../../../Types/Database/LabelsColumn';
+
+describe('LabelsColumn', () => {
+    it('should not set labelsColumn', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().labelsColumn).toBe(undefined);
+    });
+
+    it('should set labelsColumn', () => {
+        @LabelsColumn('test')
+        class Test extends BaseModel{};
+
+        expect(new Test().labelsColumn).toBe('test');
+    });
+});
+

--- a/Common/Tests/Types/Database/LessThan.test.ts
+++ b/Common/Tests/Types/Database/LessThan.test.ts
@@ -5,7 +5,7 @@ import { JSONObject } from '../../../Types/JSON';
 describe('LessThan', () => {
     describe('toJSON', () => {
         it('number - should generate the correct JSON representation', () => {
-            const lessThan = new LessThan(2023);
+            const lessThan: LessThan = new LessThan(2023);
             const expectedJSON: JSONObject = {
                 _type: 'LessThan',
                 value: 2023,
@@ -14,8 +14,8 @@ describe('LessThan', () => {
         });
 
         it('date - should generate the correct JSON representation', () => {
-            const now = new Date();
-            const lessThan = new LessThan(now);
+            const now: Date = new Date();
+            const lessThan: LessThan = new LessThan(now);
             const expectedJSON: JSONObject = {
                 _type: 'LessThan',
                 value: now.toJSON(),
@@ -35,7 +35,7 @@ describe('LessThan', () => {
         });
 
         it('date - should create an LessThan object from valid JSON input', () => {
-            const now = new Date();
+            const now: Date = new Date();
             const jsonInput: JSONObject = {
                 _type: 'LessThan',
                 value: now.toJSON(),
@@ -75,4 +75,3 @@ describe('LessThan', () => {
         });
     });
 });
-

--- a/Common/Tests/Types/Database/LessThan.test.ts
+++ b/Common/Tests/Types/Database/LessThan.test.ts
@@ -1,0 +1,78 @@
+import LessThan from '../../../Types/Database/LessThan';
+import BadDataException from '../../../Types/Exception/BadDataException';
+import { JSONObject } from '../../../Types/JSON';
+
+describe('LessThan', () => {
+    describe('toJSON', () => {
+        it('number - should generate the correct JSON representation', () => {
+            const lessThan = new LessThan(2023);
+            const expectedJSON: JSONObject = {
+                _type: 'LessThan',
+                value: 2023,
+            };
+            expect(lessThan.toJSON()).toEqual(expectedJSON);
+        });
+
+        it('date - should generate the correct JSON representation', () => {
+            const now = new Date();
+            const lessThan = new LessThan(now);
+            const expectedJSON: JSONObject = {
+                _type: 'LessThan',
+                value: now.toJSON(),
+            };
+            expect(lessThan.toJSON()).toEqual(expectedJSON);
+        });
+    });
+
+    describe('fromJSON', () => {
+        it('number - should create an LessThan object from valid JSON input', () => {
+            const jsonInput: JSONObject = {
+                _type: 'LessThan',
+                value: 2023,
+            };
+            const lessThan: LessThan = LessThan.fromJSON(jsonInput);
+            expect(lessThan.value).toBe(2023);
+        });
+
+        it('date - should create an LessThan object from valid JSON input', () => {
+            const now = new Date();
+            const jsonInput: JSONObject = {
+                _type: 'LessThan',
+                value: now.toJSON(),
+            };
+            const lessThan: LessThan = LessThan.fromJSON(jsonInput);
+            expect(lessThan.value).toEqual(now);
+        });
+
+        it('should throw a BadDataException when using invalid JSON input - type', () => {
+            const jsonInput: JSONObject = {
+                _type: 'InvalidType',
+                value: 42,
+            };
+            expect(() => {
+                return LessThan.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+
+        it('should throw a BadDataException when using invalid JSON input - value', () => {
+            const jsonInput: JSONObject = {
+                _type: 'LessThan',
+                value: '123string',
+            };
+            expect(() => {
+                return LessThan.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+
+        it('should throw a BadDataException when using invalid JSON input - date', () => {
+            const jsonInput: JSONObject = {
+                _type: 'LessThan',
+                value: '2023-13-35',
+            };
+            expect(() => {
+                return LessThan.fromJSON(jsonInput);
+            }).toThrow(BadDataException);
+        });
+    });
+});
+

--- a/Common/Tests/Types/Database/MultiTenentQueryAllowed.test.ts
+++ b/Common/Tests/Types/Database/MultiTenentQueryAllowed.test.ts
@@ -1,0 +1,24 @@
+import BaseModel from '../../../Models/BaseModel';
+import MultiTenentQueryAllowed from '../../../Types/Database/MultiTenentQueryAllowed';
+
+describe('MultiTenentQueryAllowed', () => {
+    it('should not define isMultiTenantRequestAllowed', () => {
+        class Test extends BaseModel{};
+
+        expect(new Test().isMultiTenantRequestAllowed).toBe(undefined);
+    });
+
+    it('should allow multi tenent query', () => {
+        @MultiTenentQueryAllowed(true)
+        class Test extends BaseModel{};
+
+        expect(new Test().isMultiTenantRequestAllowed).toBe(true);
+    });
+
+    it('should disallow multi tenant query', () => {
+        @MultiTenentQueryAllowed(false)
+        class Test extends BaseModel{};
+
+        expect(new Test().isMultiTenantRequestAllowed).toBe(false);
+    });
+});

--- a/Common/Tests/Types/Database/MultiTenentQueryAllowed.test.ts
+++ b/Common/Tests/Types/Database/MultiTenentQueryAllowed.test.ts
@@ -3,21 +3,21 @@ import MultiTenentQueryAllowed from '../../../Types/Database/MultiTenentQueryAll
 
 describe('MultiTenentQueryAllowed', () => {
     it('should not define isMultiTenantRequestAllowed', () => {
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().isMultiTenantRequestAllowed).toBe(undefined);
     });
 
     it('should allow multi tenent query', () => {
         @MultiTenentQueryAllowed(true)
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().isMultiTenantRequestAllowed).toBe(true);
     });
 
     it('should disallow multi tenant query', () => {
         @MultiTenentQueryAllowed(false)
-        class Test extends BaseModel{};
+        class Test extends BaseModel {}
 
         expect(new Test().isMultiTenantRequestAllowed).toBe(false);
     });

--- a/Common/Types/Database/CompareBase.ts
+++ b/Common/Types/Database/CompareBase.ts
@@ -16,12 +16,23 @@ export default class CompareBase extends SerializableObject {
         this.value = value;
     }
 
+    public isNumber(): boolean {
+        return Typeof.Number === typeof this.value;
+    }
+
+    public isDate(): boolean {
+        return this.value instanceof Date;
+    }
+
     public override toString(): string {
+        if (this.isDate()) {
+            return this.toDate().toJSON();
+        }
         return this.value.toString();
     }
 
     public toNumber(): number {
-        if (Typeof.Number === typeof this.value) {
+        if (this.isNumber()) {
             return this.value as number;
         }
 
@@ -29,7 +40,7 @@ export default class CompareBase extends SerializableObject {
     }
 
     public toDate(): Date {
-        if (this.value instanceof Date) {
+        if (this.isDate()) {
             return this.value as Date;
         }
 

--- a/Common/Types/Database/GreaterThan.ts
+++ b/Common/Types/Database/GreaterThan.ts
@@ -8,17 +8,30 @@ export default class GreaterThan extends CompareBase {
     }
 
     public override toJSON(): JSONObject {
+        let value: number | string;
+        try {
+            value = (this as GreaterThan).toNumber();
+        } catch {
+            value = (this as GreaterThan).toString();
+        }
         return {
             _type: ObjectType.GreaterThan,
-            value: (this as GreaterThan).toString(),
+            value,
         };
     }
 
     public static override fromJSON(json: JSONObject): GreaterThan {
         if (json['_type'] === ObjectType.GreaterThan) {
-            return new GreaterThan(json['value'] as number | Date);
+            if (isNaN(Number(json['value']))) {
+                const date = new Date(json['value'] as string);
+                if (isNaN(date.getTime())) {
+                    throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
+                }
+                return new GreaterThan(date);
+            } else {
+                return new GreaterThan(Number(json['value']));
+            }
         }
-
         throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
     }
 }

--- a/Common/Types/Database/GreaterThan.ts
+++ b/Common/Types/Database/GreaterThan.ts
@@ -23,14 +23,15 @@ export default class GreaterThan extends CompareBase {
     public static override fromJSON(json: JSONObject): GreaterThan {
         if (json['_type'] === ObjectType.GreaterThan) {
             if (isNaN(Number(json['value']))) {
-                const date = new Date(json['value'] as string);
+                const date: Date = new Date(json['value'] as string);
                 if (isNaN(date.getTime())) {
-                    throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
+                    throw new BadDataException(
+                        'Invalid JSON: ' + JSON.stringify(json)
+                    );
                 }
                 return new GreaterThan(date);
-            } else {
-                return new GreaterThan(Number(json['value']));
             }
+            return new GreaterThan(Number(json['value']));
         }
         throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
     }

--- a/Common/Types/Database/GreaterThan.ts
+++ b/Common/Types/Database/GreaterThan.ts
@@ -9,9 +9,9 @@ export default class GreaterThan extends CompareBase {
 
     public override toJSON(): JSONObject {
         let value: number | string;
-        try {
+        if (this.isNumber()) {
             value = (this as GreaterThan).toNumber();
-        } catch {
+        } else {
             value = (this as GreaterThan).toString();
         }
         return {
@@ -22,7 +22,8 @@ export default class GreaterThan extends CompareBase {
 
     public static override fromJSON(json: JSONObject): GreaterThan {
         if (json['_type'] === ObjectType.GreaterThan) {
-            if (isNaN(Number(json['value']))) {
+            const numValue: number = Number(json['value']);
+            if (isNaN(numValue)) {
                 const date: Date = new Date(json['value'] as string);
                 if (isNaN(date.getTime())) {
                     throw new BadDataException(
@@ -31,7 +32,7 @@ export default class GreaterThan extends CompareBase {
                 }
                 return new GreaterThan(date);
             }
-            return new GreaterThan(Number(json['value']));
+            return new GreaterThan(numValue);
         }
         throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
     }

--- a/Common/Types/Database/LessThan.ts
+++ b/Common/Types/Database/LessThan.ts
@@ -23,14 +23,15 @@ export default class LessThan extends CompareBase {
     public static override fromJSON(json: JSONObject): LessThan {
         if (json['_type'] === ObjectType.LessThan) {
             if (isNaN(Number(json['value']))) {
-                const date = new Date(json['value'] as string);
+                const date: Date = new Date(json['value'] as string);
                 if (isNaN(date.getTime())) {
-                    throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
+                    throw new BadDataException(
+                        'Invalid JSON: ' + JSON.stringify(json)
+                    );
                 }
                 return new LessThan(date);
-            } else {
-                return new LessThan(Number(json['value']));
             }
+            return new LessThan(Number(json['value']));
         }
 
         throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));

--- a/Common/Types/Database/LessThan.ts
+++ b/Common/Types/Database/LessThan.ts
@@ -9,9 +9,9 @@ export default class LessThan extends CompareBase {
 
     public override toJSON(): JSONObject {
         let value: number | string;
-        try {
+        if (this.isNumber()) {
             value = (this as LessThan).toNumber();
-        } catch {
+        } else {
             value = (this as LessThan).toString();
         }
         return {
@@ -22,7 +22,8 @@ export default class LessThan extends CompareBase {
 
     public static override fromJSON(json: JSONObject): LessThan {
         if (json['_type'] === ObjectType.LessThan) {
-            if (isNaN(Number(json['value']))) {
+            const numValue: number = Number(json['value']);
+            if (isNaN(numValue)) {
                 const date: Date = new Date(json['value'] as string);
                 if (isNaN(date.getTime())) {
                     throw new BadDataException(
@@ -31,7 +32,7 @@ export default class LessThan extends CompareBase {
                 }
                 return new LessThan(date);
             }
-            return new LessThan(Number(json['value']));
+            return new LessThan(numValue);
         }
 
         throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));

--- a/Common/Types/Database/LessThan.ts
+++ b/Common/Types/Database/LessThan.ts
@@ -8,15 +8,29 @@ export default class LessThan extends CompareBase {
     }
 
     public override toJSON(): JSONObject {
+        let value: number | string;
+        try {
+            value = (this as LessThan).toNumber();
+        } catch {
+            value = (this as LessThan).toString();
+        }
         return {
             _type: ObjectType.LessThan,
-            value: (this as LessThan).toString(),
+            value,
         };
     }
 
     public static override fromJSON(json: JSONObject): LessThan {
         if (json['_type'] === ObjectType.LessThan) {
-            return new LessThan(json['value'] as number | Date);
+            if (isNaN(Number(json['value']))) {
+                const date = new Date(json['value'] as string);
+                if (isNaN(date.getTime())) {
+                    throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));
+                }
+                return new LessThan(date);
+            } else {
+                return new LessThan(Number(json['value']));
+            }
         }
 
         throw new BadDataException('Invalid JSON: ' + JSON.stringify(json));


### PR DESCRIPTION
### Adds tests for Common/Types/Database.

Adds new tests for some of the files in `Common/Types/Database` directory.
Refactored one test (`ColumnLength`) to increase test coverage and simplicity.

Upon writing the tests I noticed a couple of issues.

1. `IsPermissionsIf` decorator didn't seem to set the property due to the initial property value in the `BaseModel`, at least upon testing. Moved the initialization to the constructor and to set only if there isn't a value, to fix this.
2. Classes that extend `CompareBase`, AKA classes that take either a number or a Date as value, "fail" serialization and de-serialization. The value in the end object ends up a `string`. This commit attempts to fix that as well.

PS: I used `Date.toJSON()` as it is the method that `JSON.stringify` would call on a date.

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue

#210
