### PR TITLE
fix: duplicate api call in ModelForm

### DIFF
--- a/CommonUI/src/Components/Forms/ModelForm.tsx
+++ b/CommonUI/src/Components/Forms/ModelForm.tsx
@@ -272,11 +272,6 @@ const ModelForm: <TBaseModel extends BaseModel>(
     useAsyncEffect(async () => {
         // set fields.
         await setFormFields();
-    }, []);
-
-    useAsyncEffect(async () => {
-        // set fields.
-        await setFormFields();
     }, [props.fields]);
 
     const fetchItem: () => Promise<void> = async (): Promise<void> => {


### PR DESCRIPTION
### Fix duplicate API calls in ModelForm

While exploring the dashboard with its features I noticed the loading state in ModelForm when I tried to create something new like Incident, Monitor, etc. I opened the developer tools to Inspect the Network calls and saw a bunch of API calls that were duplicated.

The ModelForm accepts props `fields`, an array of form fields.  Looks like there's a duplicate calls for `setFormFields` function. The first one is `useAsyncEffect` for the component mount life cycle and another `useAsyncEffect` for `props.fields` changes.

I removed the first since the `setFormFields` only makes sense when `props.fields` value has been passed to the component or changed.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):

#### Before
![image](https://github.com/OneUptime/oneuptime/assets/20983608/15aa4b8a-0fc5-4fae-b12c-c8f544779221)
![Screenshot 2023-11-22 at 10 52 03 at night](https://github.com/OneUptime/oneuptime/assets/20983608/d717c4a9-47ae-4d4a-bbc3-8250da64292a)

#### After
![Screenshot 2023-11-22 at 11 07 46 at night](https://github.com/OneUptime/oneuptime/assets/20983608/efffa5e8-829f-4ade-989e-15911fc5724a)

