### PR TITLE
fix: Update Dropdown (react-select) style

### DIFF
--- a/CommonUI/src/Components/Dropdown/Dropdown.tsx
+++ b/CommonUI/src/Components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import Select from 'react-select';
+import Select, { ControlProps, GroupBase, OptionProps } from 'react-select';
 import React, {
     FunctionComponent,
     ReactElement,
@@ -125,6 +125,29 @@ const Dropdown: FunctionComponent<ComponentProps> = (
                 value={value}
                 onFocus={() => {
                     props.onFocus && props.onFocus();
+                }}
+                classNames={{
+                    control: (
+                        state: ControlProps<any, boolean, GroupBase<any>>
+                    ): string => {
+                        return state.isFocused
+                            ? '!border-indigo-500'
+                            : 'border-grey-300';
+                    },
+                    option: (
+                        state: OptionProps<any, boolean, GroupBase<any>>
+                    ): string => {
+                        if (state.isDisabled) {
+                            return 'bg-gray-100';
+                        }
+                        if (state.isSelected) {
+                            return '!bg-indigo-500';
+                        }
+                        if (state.isFocused) {
+                            return '!bg-indigo-100';
+                        }
+                        return '';
+                    },
                 }}
                 isClearable={true}
                 isSearchable={true}


### PR DESCRIPTION
### Update dropdown (react-select) style to match the primary color

For the dropdown component, when the component is focused the border color is the default color of react-select which is inconsistent with our primary color. Also the option of the dropdown selected background color and option hover (focus) background color don't match the primary color.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):

#### Before
![Screenshot 2023-11-25 at 11 22 00 at night](https://github.com/OneUptime/oneuptime/assets/20983608/7bcc9697-b7cf-4186-8957-66d0b16b98e0)

#### After
![Screenshot 2023-11-25 at 11 25 36 at night](https://github.com/OneUptime/oneuptime/assets/20983608/455e6517-e358-4ed7-b6b6-3402d94bb457)
