### PR TITLE
Refactor Analytics SQL generation to use query params

### DIFF
--- a/CommonServer/API/BaseAnalyticsAPI.ts
+++ b/CommonServer/API/BaseAnalyticsAPI.ts
@@ -333,7 +333,7 @@ export default class BaseAnalyticsAPI<
         await this.onBeforeDelete(req, res);
         const objectId: ObjectID = new ObjectID(req.params['id'] as string);
 
-        await this.service.deleteOneBy({
+        await this.service.deleteBy({
             query: {
                 _id: objectId.toString(),
             },

--- a/CommonServer/API/BaseAnalyticsAPI.ts
+++ b/CommonServer/API/BaseAnalyticsAPI.ts
@@ -362,7 +362,7 @@ export default class BaseAnalyticsAPI<
         delete (item as any)['createdAt'];
         delete (item as any)['updatedAt'];
 
-        await this.service.updateOneBy({
+        await this.service.updateBy({
             query: {
                 _id: objectIdString,
             },

--- a/CommonServer/Services/AnalyticsDatabaseService.ts
+++ b/CommonServer/Services/AnalyticsDatabaseService.ts
@@ -45,7 +45,6 @@ import OneUptimeDate from 'Common/Types/Date';
 import CreateManyBy from '../Types/AnalyticsDatabase/CreateManyBy';
 import StatementGenerator from '../Utils/AnalyticsDatabase/StatementGenerator';
 import CountBy from '../Types/AnalyticsDatabase/CountBy';
-import DeleteOneBy from '../Types/AnalyticsDatabase/DeleteOneBy';
 import Realtime from '../Utils/Realtime';
 import { ModelEventType } from 'Common/Utils/Realtime';
 import { SQL, Statement } from '../Utils/AnalyticsDatabase/Statement';
@@ -354,24 +353,6 @@ export default class AnalyticsDatabaseService<
             DELETE WHERE TRUE `.append(whereStatement);
         /* eslint-enable prettier/prettier */
 
-        if (deleteBy.limit) {
-            statement.append(SQL`
-            LIMIT ${{
-                value: Number(deleteBy.limit),
-                type: TableColumnType.Number,
-            }}
-            `);
-        }
-
-        if (deleteBy.skip) {
-            statement.append(SQL`
-            OFFSET ${{
-                value: Number(deleteBy.skip),
-                type: TableColumnType.Number,
-            }}
-            `);
-        }
-
         logger.info(`${this.model.tableName} Delete Statement`);
         logger.info(statement);
 
@@ -391,14 +372,6 @@ export default class AnalyticsDatabaseService<
             return documents[0];
         }
         return null;
-    }
-
-    public async deleteOneBy(deleteBy: DeleteOneBy<TBaseModel>): Promise<void> {
-        return await this._deleteBy({
-            ...deleteBy,
-            limit: 1,
-            skip: 0,
-        });
     }
 
     public async deleteBy(deleteBy: DeleteBy<TBaseModel>): Promise<void> {

--- a/CommonServer/Services/AnalyticsDatabaseService.ts
+++ b/CommonServer/Services/AnalyticsDatabaseService.ts
@@ -46,7 +46,6 @@ import CreateManyBy from '../Types/AnalyticsDatabase/CreateManyBy';
 import StatementGenerator from '../Utils/AnalyticsDatabase/StatementGenerator';
 import CountBy from '../Types/AnalyticsDatabase/CountBy';
 import DeleteOneBy from '../Types/AnalyticsDatabase/DeleteOneBy';
-import UpdateOneBy from '../Types/AnalyticsDatabase/UpdateOneBy';
 import Realtime from '../Utils/Realtime';
 import { ModelEventType } from 'Common/Utils/Realtime';
 import { SQL, Statement } from '../Utils/AnalyticsDatabase/Statement';
@@ -449,15 +448,6 @@ export default class AnalyticsDatabaseService<
             },
             select: findOneById.select || {},
             props: findOneById.props,
-        });
-    }
-
-    public async updateOneBy(
-        updateOneBy: UpdateOneBy<TBaseModel>
-    ): Promise<void> {
-        return await this._updateBy({
-            ...updateOneBy,
-            limit: 1,
         });
     }
 

--- a/CommonServer/Services/AnalyticsDatabaseService.ts
+++ b/CommonServer/Services/AnalyticsDatabaseService.ts
@@ -49,6 +49,8 @@ import DeleteOneBy from '../Types/AnalyticsDatabase/DeleteOneBy';
 import UpdateOneBy from '../Types/AnalyticsDatabase/UpdateOneBy';
 import Realtime from '../Utils/Realtime';
 import { ModelEventType } from 'Common/Utils/Realtime';
+import { SQL, Statement } from '../Utils/AnalyticsDatabase/Statement';
+import TableColumnType from 'Common/Types/AnalyticsDatabase/TableColumnType';
 
 export default class AnalyticsDatabaseService<
     TBaseModel extends AnalyticsBaseModel
@@ -94,7 +96,7 @@ export default class AnalyticsDatabaseService<
 
             countBy.query = checkReadPermissionType.query;
 
-            const countStatement: string = this.toCountStatement(countBy);
+            const countStatement: Statement = this.toCountStatement(countBy);
 
             const dbResult: ExecResult<Stream> = await this.execute(
                 countStatement
@@ -170,8 +172,10 @@ export default class AnalyticsDatabaseService<
                 onBeforeFind.limit = new PositiveNumber(onBeforeFind.limit);
             }
 
-            const findStatement: { statement: string; columns: Array<string> } =
-                this.toFindStatement(onBeforeFind);
+            const findStatement: {
+                statement: Statement;
+                columns: Array<string>;
+            } = this.toFindStatement(onBeforeFind);
 
             const dbResult: ExecResult<Stream> = await this.execute(
                 findStatement.statement
@@ -192,8 +196,6 @@ export default class AnalyticsDatabaseService<
                     jsonItems,
                     this.modelType
                 );
-
-            items = this.sanitizeFindByItems(items, onBeforeFind);
 
             if (!findBy.props.ignoreHooks) {
                 items = await (
@@ -234,18 +236,6 @@ export default class AnalyticsDatabaseService<
         return jsonItems;
     }
 
-    private sanitizeFindByItems(
-        items: Array<TBaseModel>,
-        findBy: FindBy<TBaseModel>
-    ): Array<TBaseModel> {
-        // if there's no select then there's nothing to do.
-        if (!findBy.select) {
-            return items;
-        }
-
-        return items;
-    }
-
     protected async onBeforeDelete(
         deleteBy: DeleteBy<TBaseModel>
     ): Promise<OnDelete<TBaseModel>> {
@@ -267,29 +257,40 @@ export default class AnalyticsDatabaseService<
         return Promise.resolve({ findBy, carryForward: null });
     }
 
-    public toCountStatement(countBy: CountBy<TBaseModel>): string {
+    public toCountStatement(countBy: CountBy<TBaseModel>): Statement {
         if (!this.database) {
             this.useDefaultDatabase();
         }
 
-        let statement: string = `SELECT count() FROM ${
-            this.database.getDatasourceOptions().database
-        }.${this.model.tableName} 
-        ${
-            Object.keys(countBy.query).length > 0 ? 'WHERE' : ''
-        } ${this.statementGenerator.toWhereStatement(countBy.query)}
-        `;
+        const databaseName: string =
+            this.database.getDatasourceOptions().database!;
+        const whereStatement: Statement =
+            this.statementGenerator.toWhereStatement(countBy.query);
+
+        /* eslint-disable prettier/prettier */
+        const statement: Statement = SQL`
+            SELECT
+                count()
+            FROM ${databaseName}.${this.model.tableName}
+            WHERE TRUE `.append(whereStatement);
+        /* eslint-enable prettier/prettier */
 
         if (countBy.limit) {
-            statement += `
-            LIMIT ${countBy.limit.toString()}
-            `;
+            statement.append(SQL`
+            LIMIT ${{
+                value: Number(countBy.limit),
+                type: TableColumnType.Number,
+            }}
+            `);
         }
 
         if (countBy.skip) {
-            statement += `
-            OFFSET ${countBy.skip.toString()}
-            `;
+            statement.append(SQL`
+            OFFSET ${{
+                value: Number(countBy.skip),
+                type: TableColumnType.Number,
+            }}
+            `);
         }
         logger.info(`${this.model.tableName} Count Statement`);
         logger.info(statement);
@@ -298,26 +299,39 @@ export default class AnalyticsDatabaseService<
     }
 
     public toFindStatement(findBy: FindBy<TBaseModel>): {
-        statement: string;
+        statement: Statement;
         columns: Array<string>;
     } {
         if (!this.database) {
             this.useDefaultDatabase();
         }
 
-        const select: { statement: string; columns: Array<string> } =
+        const databaseName: string =
+            this.database.getDatasourceOptions().database!;
+        const select: { statement: Statement; columns: Array<string> } =
             this.statementGenerator.toSelectStatement(findBy.select!);
 
-        const statement: string = `SELECT ${select.statement} FROM ${
-            this.database.getDatasourceOptions().database
-        }.${this.model.tableName} 
-        ${
-            Object.keys(findBy.query).length > 0 ? 'WHERE' : ''
-        } ${this.statementGenerator.toWhereStatement(findBy.query)}
-        ORDER BY ${this.statementGenerator.toSortStatemennt(findBy.sort!)}
-        LIMIT ${findBy.limit.toString()}
-        OFFSET ${findBy.skip.toString()}
-        `;
+        const whereStatement: Statement =
+            this.statementGenerator.toWhereStatement(findBy.query);
+        const sortStatement: Statement =
+            this.statementGenerator.toSortStatement(findBy.sort!);
+
+        /* eslint-disable prettier/prettier */
+        const statement: Statement = SQL`
+            SELECT `.append(select.statement).append(SQL`
+            FROM ${databaseName}.${this.model.tableName}
+            WHERE TRUE `).append(whereStatement).append(SQL`
+            ORDER BY `).append(sortStatement).append(SQL`
+            LIMIT ${{
+                value: Number(findBy.limit),
+                type: TableColumnType.Number,
+            }}
+            OFFSET ${{
+                value: Number(findBy.skip),
+                type: TableColumnType.Number,
+            }}
+        `);
+        /* eslint-enable prettier/prettier */
 
         logger.info(`${this.model.tableName} Find Statement`);
         logger.info(statement);
@@ -325,29 +339,38 @@ export default class AnalyticsDatabaseService<
         return { statement, columns: select.columns };
     }
 
-    public toDeleteStatement(deleteBy: DeleteBy<TBaseModel>): string {
+    public toDeleteStatement(deleteBy: DeleteBy<TBaseModel>): Statement {
         if (!this.database) {
             this.useDefaultDatabase();
         }
 
-        let statement: string = `ALTER TABLE ${
-            this.database.getDatasourceOptions().database
-        }.${this.model.tableName} 
-            DELETE ${
-                Object.keys(deleteBy.query).length > 0 ? 'WHERE' : 'WHERE 1=1'
-            } ${this.statementGenerator.toWhereStatement(deleteBy.query)}
-        `;
+        const databaseName: string =
+            this.database.getDatasourceOptions().database!;
+        const whereStatement: Statement =
+            this.statementGenerator.toWhereStatement(deleteBy.query);
+
+        /* eslint-disable prettier/prettier */
+        const statement: Statement = SQL`
+            ALTER TABLE ${databaseName}.${this.model.tableName}
+            DELETE WHERE TRUE `.append(whereStatement);
+        /* eslint-enable prettier/prettier */
 
         if (deleteBy.limit) {
-            statement += `
-            LIMIT ${deleteBy.limit.toString()}
-            `;
+            statement.append(SQL`
+            LIMIT ${{
+                value: Number(deleteBy.limit),
+                type: TableColumnType.Number,
+            }}
+            `);
         }
 
         if (deleteBy.skip) {
-            statement += `
-            OFFSET ${deleteBy.skip.toString()}
-            `;
+            statement.append(SQL`
+            OFFSET ${{
+                value: Number(deleteBy.skip),
+                type: TableColumnType.Number,
+            }}
+            `);
         }
 
         logger.info(`${this.model.tableName} Delete Statement`);
@@ -496,14 +519,20 @@ export default class AnalyticsDatabaseService<
         this.databaseClient = this.database.getDataSource() as ClickhouseClient;
     }
 
-    public async execute(query: string): Promise<ExecResult<Stream>> {
+    public async execute(
+        statement: Statement | string
+    ): Promise<ExecResult<Stream>> {
         if (!this.databaseClient) {
             this.useDefaultDatabase();
         }
 
-        return await this.databaseClient.exec({
-            query: query,
-        });
+        return await this.databaseClient.exec(
+            statement instanceof Statement
+                ? statement
+                : {
+                      query: statement, // TODO remove and only accept Statements
+                  }
+        );
     }
 
     protected async onUpdateSuccess(

--- a/CommonServer/Tests/Services/AnalyticsDatabaseService.test.ts
+++ b/CommonServer/Tests/Services/AnalyticsDatabaseService.test.ts
@@ -1,0 +1,297 @@
+import '../TestingUtils/Init';
+import AnalyticsBaseModel from 'Common/AnalyticsModels/BaseModel';
+import Route from 'Common/Types/API/Route';
+import AnalyticsTableEngine from 'Common/Types/AnalyticsDatabase/AnalyticsTableEngine';
+import AnalyticsTableColumn from 'Common/Types/AnalyticsDatabase/TableColumn';
+import TableColumnType from 'Common/Types/AnalyticsDatabase/TableColumnType';
+import AnalyticsDatabaseService from '../../Services/AnalyticsDatabaseService';
+import { SQL, Statement } from '../../Utils/AnalyticsDatabase/Statement';
+import logger from '../../Utils/Logger';
+
+describe('AnalyticsDatabaseService', () => {
+    class TestModel extends AnalyticsBaseModel {
+        public constructor() {
+            super({
+                tableName: '<table-name>',
+                singularName: '<singular-name>',
+                pluralName: '<plural-name>',
+                tableColumns: [
+                    new AnalyticsTableColumn({
+                        key: `column_ObjectID`,
+                        title: '<title>',
+                        description: '<description>',
+                        required: true,
+                        type: TableColumnType.ObjectID,
+                    }),
+                    new AnalyticsTableColumn({
+                        key: `column_1`,
+                        title: '<title>',
+                        description: '<description>',
+                        required: false,
+                        type: TableColumnType.Text,
+                    }),
+                    new AnalyticsTableColumn({
+                        key: `column_2`,
+                        title: '<title>',
+                        description: '<description>',
+                        required: false,
+                        type: TableColumnType.Number,
+                    }),
+                ],
+                crudApiPath: new Route('route'),
+                primaryKeys: ['column_ObjectID'],
+                tableEngine: AnalyticsTableEngine.MergeTree,
+            });
+        }
+    }
+
+    let service: AnalyticsDatabaseService<TestModel>;
+    beforeEach(() => {
+        service = new AnalyticsDatabaseService({
+            modelType: TestModel,
+        });
+    });
+
+    describe('toCountStatement', () => {
+        beforeEach(() => {
+            service.statementGenerator.toWhereStatement = jest.fn(() => {
+                return SQL`<where-statement>`;
+            });
+            jest.spyOn(logger, 'info').mockImplementation(() => {
+                return undefined!;
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should return count statement', () => {
+            const statement: Statement = service.toCountStatement({
+                query: '<query>' as {},
+                props: '<props>' as {},
+            });
+
+            expect(service.statementGenerator.toWhereStatement).toBeCalledWith(
+                '<query>'
+            );
+
+            expect(jest.mocked(logger.info)).toHaveBeenCalledTimes(2);
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                1,
+                '<table-name> Count Statement'
+            );
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                2,
+                statement
+            );
+
+            expect(statement.query).toBe(
+                'SELECT\n' +
+                    '    count()\n' +
+                    'FROM {p0:Identifier}.{p1:Identifier}\n' +
+                    'WHERE TRUE <where-statement>'
+            );
+            expect(statement.query_params).toStrictEqual({
+                p0: 'oneuptime',
+                p1: '<table-name>',
+            });
+        });
+
+        test('optionally adds LIMIT', () => {
+            const statement: Statement = service.toCountStatement({
+                query: '<query>' as {},
+                props: '<props>' as {},
+                limit: 123,
+            });
+
+            expect(statement.query).toBe(
+                'SELECT\n' +
+                    '    count()\n' +
+                    'FROM {p0:Identifier}.{p1:Identifier}\n' +
+                    'WHERE TRUE <where-statement>\n' +
+                    'LIMIT {p2:Int32}'
+            );
+            expect(statement.query_params).toStrictEqual({
+                p0: 'oneuptime',
+                p1: '<table-name>',
+                p2: 123,
+            });
+        });
+
+        test('optionally adds OFFSET', () => {
+            const statement: Statement = service.toCountStatement({
+                query: '<query>' as {},
+                props: '<props>' as {},
+                skip: 123,
+            });
+
+            expect(statement.query).toBe(
+                'SELECT\n' +
+                    '    count()\n' +
+                    'FROM {p0:Identifier}.{p1:Identifier}\n' +
+                    'WHERE TRUE <where-statement>\n' +
+                    'OFFSET {p2:Int32}'
+            );
+            expect(statement.query_params).toStrictEqual({
+                p0: 'oneuptime',
+                p1: '<table-name>',
+                p2: 123,
+            });
+        });
+    });
+
+    describe('toFindStatement', () => {
+        beforeEach(() => {
+            service.statementGenerator.toSelectStatement = jest.fn(() => {
+                return {
+                    statement: SQL`<select-statement>`,
+                    columns: ['<column-1>', '<column-2>'],
+                };
+            });
+            service.statementGenerator.toWhereStatement = jest.fn(() => {
+                return SQL`<where-statement>`;
+            });
+            service.statementGenerator.toSortStatement = jest.fn(() => {
+                return SQL`<sort-statement>`;
+            });
+            jest.spyOn(logger, 'info').mockImplementation(() => {
+                return undefined!;
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should return find statement', () => {
+            const { statement, columns } = service.toFindStatement({
+                select: '<select>' as {},
+                query: '<query>' as {},
+                props: '<props>' as {},
+                sort: '<sort>' as {},
+                limit: 123,
+                skip: 234,
+            });
+
+            expect(service.statementGenerator.toSelectStatement).toBeCalledWith(
+                '<select>'
+            );
+            expect(service.statementGenerator.toWhereStatement).toBeCalledWith(
+                '<query>'
+            );
+            expect(service.statementGenerator.toSortStatement).toBeCalledWith(
+                '<sort>'
+            );
+
+            expect(jest.mocked(logger.info)).toHaveBeenCalledTimes(2);
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                1,
+                '<table-name> Find Statement'
+            );
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                2,
+                statement
+            );
+
+            expect(statement.query).toBe(
+                'SELECT <select-statement>\n' +
+                    'FROM {p0:Identifier}.{p1:Identifier}\n' +
+                    'WHERE TRUE <where-statement>\n' +
+                    'ORDER BY <sort-statement>\n' +
+                    'LIMIT {p2:Int32}\n' +
+                    'OFFSET {p3:Int32}'
+            );
+            expect(statement.query_params).toStrictEqual({
+                p0: 'oneuptime',
+                p1: '<table-name>',
+                p2: 123, // limit
+                p3: 234, // offset
+            });
+            expect(columns).toStrictEqual(['<column-1>', '<column-2>']);
+        });
+
+        describe('toDeleteStatement', () => {
+            beforeEach(() => {
+                service.statementGenerator.toWhereStatement = jest.fn(() => {
+                    return SQL`<where-statement>`;
+                });
+                jest.spyOn(logger, 'info').mockImplementation(() => {
+                    return undefined!;
+                });
+            });
+
+            afterEach(() => {
+                jest.restoreAllMocks();
+            });
+
+            test('should return delete statement', () => {
+                const statement: Statement = service.toDeleteStatement({
+                    query: '<query>' as {},
+                    props: '<props>' as {},
+                });
+
+                expect(
+                    service.statementGenerator.toWhereStatement
+                ).toBeCalledWith('<query>');
+
+                expect(jest.mocked(logger.info)).toHaveBeenCalledTimes(2);
+                expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                    1,
+                    '<table-name> Delete Statement'
+                );
+                expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                    2,
+                    statement
+                );
+
+                expect(statement.query).toBe(
+                    'ALTER TABLE {p0:Identifier}.{p1:Identifier}\n' +
+                        'DELETE WHERE TRUE <where-statement>'
+                );
+                expect(statement.query_params).toStrictEqual({
+                    p0: 'oneuptime',
+                    p1: '<table-name>',
+                });
+            });
+
+            test('optionally adds LIMIT', () => {
+                const statement: Statement = service.toDeleteStatement({
+                    query: '<query>' as {},
+                    props: '<props>' as {},
+                    limit: 123,
+                });
+
+                expect(statement.query).toBe(
+                    'ALTER TABLE {p0:Identifier}.{p1:Identifier}\n' +
+                        'DELETE WHERE TRUE <where-statement>\n' +
+                        'LIMIT {p2:Int32}'
+                );
+                expect(statement.query_params).toStrictEqual({
+                    p0: 'oneuptime',
+                    p1: '<table-name>',
+                    p2: 123,
+                });
+            });
+
+            test('optionally adds OFFSET', () => {
+                const statement: Statement = service.toDeleteStatement({
+                    query: '<query>' as {},
+                    props: '<props>' as {},
+                    skip: 123,
+                });
+
+                expect(statement.query).toBe(
+                    'ALTER TABLE {p0:Identifier}.{p1:Identifier}\n' +
+                        'DELETE WHERE TRUE <where-statement>\n' +
+                        'OFFSET {p2:Int32}'
+                );
+                expect(statement.query_params).toStrictEqual({
+                    p0: 'oneuptime',
+                    p1: '<table-name>',
+                    p2: 123,
+                });
+            });
+        });
+    });
+});

--- a/CommonServer/Tests/Services/AnalyticsDatabaseService.test.ts
+++ b/CommonServer/Tests/Services/AnalyticsDatabaseService.test.ts
@@ -254,44 +254,6 @@ describe('AnalyticsDatabaseService', () => {
                     p1: '<table-name>',
                 });
             });
-
-            test('optionally adds LIMIT', () => {
-                const statement: Statement = service.toDeleteStatement({
-                    query: '<query>' as {},
-                    props: '<props>' as {},
-                    limit: 123,
-                });
-
-                expect(statement.query).toBe(
-                    'ALTER TABLE {p0:Identifier}.{p1:Identifier}\n' +
-                        'DELETE WHERE TRUE <where-statement>\n' +
-                        'LIMIT {p2:Int32}'
-                );
-                expect(statement.query_params).toStrictEqual({
-                    p0: 'oneuptime',
-                    p1: '<table-name>',
-                    p2: 123,
-                });
-            });
-
-            test('optionally adds OFFSET', () => {
-                const statement: Statement = service.toDeleteStatement({
-                    query: '<query>' as {},
-                    props: '<props>' as {},
-                    skip: 123,
-                });
-
-                expect(statement.query).toBe(
-                    'ALTER TABLE {p0:Identifier}.{p1:Identifier}\n' +
-                        'DELETE WHERE TRUE <where-statement>\n' +
-                        'OFFSET {p2:Int32}'
-                );
-                expect(statement.query_params).toStrictEqual({
-                    p0: 'oneuptime',
-                    p1: '<table-name>',
-                    p2: 123,
-                });
-            });
         });
     });
 });

--- a/CommonServer/Tests/Utils/AnalyticsDatabase/Statement.test.ts
+++ b/CommonServer/Tests/Utils/AnalyticsDatabase/Statement.test.ts
@@ -1,0 +1,102 @@
+import '../../TestingUtils/Init';
+import TableColumnType from 'Common/Types/AnalyticsDatabase/TableColumnType';
+import { SQL, Statement } from '../../../Utils/AnalyticsDatabase/Statement';
+
+describe('Statement', () => {
+    describe('constructor', () => {
+        test('Should default to empty', () => {
+            const statement: Statement = new Statement();
+            expect(statement.query).toBe('');
+            expect(statement.query_params).toStrictEqual({});
+        });
+    });
+
+    describe('SQL', () => {
+        test('should produce ClickHouse query params', () => {
+            const statement: Statement = SQL`SELECT * FROM table`;
+            expect(statement.query).toBe('SELECT * FROM table');
+            expect(statement.query_params).toStrictEqual({});
+        });
+
+        test('should use ClickHouse query param substitution', () => {
+            const statement: Statement = SQL`
+                SELECT
+                    *
+                FROM
+                    ${'table'}
+                WHERE TRUE
+                    AND number_col = ${{
+                        value: 123,
+                        type: TableColumnType.Number,
+                    }}
+                    AND text_col = ${{
+                        value: '<text>',
+                        type: TableColumnType.Text,
+                    }}
+            `;
+            expect(statement.query).toBe(
+                'SELECT\n' +
+                    '    *\n' +
+                    'FROM\n' +
+                    '    {p0:Identifier}\n' +
+                    'WHERE TRUE\n' +
+                    '    AND number_col = {p1:Int32}\n' +
+                    '    AND text_col = {p2:String}'
+            );
+            expect(statement.query_params).toStrictEqual({
+                p0: 'table',
+                p1: 123,
+                p2: '<text>',
+            });
+        });
+
+        describe('append', () => {
+            test('should append a Statement', () => {
+                const statement: Statement = SQL`
+                    SELECT
+                        *
+                    FROM
+                        ${'table'}
+                    WHERE TRUE
+                        AND number_col = ${{
+                            value: 123,
+                            type: TableColumnType.Number,
+                        }}
+                        AND text_col = ${{
+                            value: '<text>',
+                            type: TableColumnType.Text,
+                        }}
+                    `.append(SQL`
+                        AND boolean_col = ${{
+                            value: false,
+                            type: TableColumnType.Boolean,
+                        }}
+                        AND decimal_col = ${{
+                            value: 234.5,
+                            type: TableColumnType.Decimal,
+                        }}
+                `);
+
+                expect(statement.query).toBe(
+                    'SELECT\n' +
+                        '    *\n' +
+                        'FROM\n' +
+                        '    {p0:Identifier}\n' +
+                        'WHERE TRUE\n' +
+                        '    AND number_col = {p1:Int32}\n' +
+                        '    AND text_col = {p2:String}\n' +
+                        '\n' +
+                        '    AND boolean_col = {p3:Bool}\n' +
+                        '    AND decimal_col = {p4:Double}'
+                );
+                expect(statement.query_params).toStrictEqual({
+                    p0: 'table',
+                    p1: 123,
+                    p2: '<text>',
+                    p3: false,
+                    p4: 234.5,
+                });
+            });
+        });
+    });
+});

--- a/CommonServer/Tests/Utils/AnalyticsDatabase/StatementGenerator.test.ts
+++ b/CommonServer/Tests/Utils/AnalyticsDatabase/StatementGenerator.test.ts
@@ -4,8 +4,17 @@ import AnalyticsTableColumn from 'Common/Types/AnalyticsDatabase/TableColumn';
 import TableColumnType from 'Common/Types/AnalyticsDatabase/TableColumnType';
 import StatementGenerator from '../../../Utils/AnalyticsDatabase/StatementGenerator';
 import { ClickhouseAppInstance } from '../../../Infrastructure/ClickhouseDatabase';
-import ObjectID from 'Common/Types/ObjectID';
 import Route from 'Common/Types/API/Route';
+import { SQL, Statement } from '../../../Utils/AnalyticsDatabase/Statement';
+import UpdateBy from '../../../Types/AnalyticsDatabase/UpdateBy';
+import logger from '../../../Utils/Logger';
+import NestedModel from 'Common/AnalyticsModels/NestedModel';
+import AnalyticsTableEngine from 'Common/Types/AnalyticsDatabase/AnalyticsTableEngine';
+
+function expectStatement(actual: Statement, expected: Statement): void {
+    expect(actual.query).toBe(expected.query);
+    expect(actual.query_params).toStrictEqual(expected.query_params);
+}
 
 describe('StatementGenerator', () => {
     class TestModel extends AnalyticsBaseModel {
@@ -14,24 +23,32 @@ describe('StatementGenerator', () => {
                 tableName: '<table-name>',
                 singularName: '<singular-name>',
                 pluralName: '<plural-name>',
-                tableColumns: Object.keys(TableColumnType)
-                    .filter((tableColumnType: string) => {
-                        // NestedModel not supported?
-                        return tableColumnType !== 'NestedModel';
-                    })
-                    .map((tableColumnType: string) => {
-                        return new AnalyticsTableColumn({
-                            key: `column_${tableColumnType}`,
-                            title: '<title>',
-                            description: '<description>',
-                            required: tableColumnType === 'ObjectID',
-                            type: TableColumnType[
-                                tableColumnType as keyof typeof TableColumnType
-                            ],
-                        });
+                tableColumns: [
+                    new AnalyticsTableColumn({
+                        key: `column_ObjectID`,
+                        title: '<title>',
+                        description: '<description>',
+                        required: true,
+                        type: TableColumnType.ObjectID,
                     }),
+                    new AnalyticsTableColumn({
+                        key: `column_1`,
+                        title: '<title>',
+                        description: '<description>',
+                        required: false,
+                        type: TableColumnType.Text,
+                    }),
+                    new AnalyticsTableColumn({
+                        key: `column_2`,
+                        title: '<title>',
+                        description: '<description>',
+                        required: false,
+                        type: TableColumnType.Number,
+                    }),
+                ],
                 crudApiPath: new Route('route'),
                 primaryKeys: ['column_ObjectID'],
+                tableEngine: AnalyticsTableEngine.MergeTree,
             });
         }
     }
@@ -44,6 +61,72 @@ describe('StatementGenerator', () => {
         });
     });
 
+    describe('toUpdateStatement', () => {
+        let updateBy: UpdateBy<TestModel>;
+        beforeEach(() => {
+            updateBy = {
+                data: new TestModel(),
+                query: '<query>' as {},
+                props: '<props>' as {},
+            };
+            generator.toSetStatement = jest.fn(() => {
+                return SQL`<set-statement>`;
+            });
+            generator.toWhereStatement = jest.fn(() => {
+                return SQL`<where-statement>`;
+            });
+            jest.spyOn(logger, 'info').mockImplementation(() => {
+                return undefined!;
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should return ALTER TABLE UPDATE statement', () => {
+            const statement: Statement = generator.toUpdateStatement(updateBy);
+
+            expect(generator.toSetStatement).toBeCalledWith(updateBy.data);
+            expect(generator.toWhereStatement).toBeCalledWith('<query>');
+
+            expect(jest.mocked(logger.info)).toHaveBeenCalledTimes(2);
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                1,
+                '<table-name> Update Statement'
+            );
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                2,
+                statement
+            );
+
+            /* eslint-disable prettier/prettier */
+            expectStatement(statement, SQL`
+                ALTER TABLE ${'oneuptime'}.${'<table-name>'}
+                UPDATE <set-statement>
+                WHERE TRUE <where-statement>
+            `);
+            /* eslint-enable prettier/prettier */
+        });
+
+        test('optionally adds a LIMIT', () => {
+            updateBy.limit = 123;
+            const statement: Statement = generator.toUpdateStatement(updateBy);
+
+            /* eslint-disable prettier/prettier */
+            expectStatement(statement, SQL`
+                ALTER TABLE ${'oneuptime'}.${'<table-name>'}
+                UPDATE <set-statement>
+                WHERE TRUE <where-statement>
+                LIMIT ${{
+                    value: 123,
+                    type: TableColumnType.Number,
+                }}
+            `);
+            /* eslint-enable prettier/prettier */
+        });
+    });
+
     describe('toSetStatement', () => {
         let model: TestModel;
         beforeEach(() => {
@@ -51,65 +134,245 @@ describe('StatementGenerator', () => {
         });
 
         test('should return the contents of a SET statement', () => {
-            model.setColumnValue('column_ObjectID', new ObjectID('<value>'));
-            model.setColumnValue('column_Date', new Date(9876543210));
-            model.setColumnValue('column_Number', 123);
-            model.setColumnValue('column_Text', '<value>');
-            model.setColumnValue('column_JSON', { key: '<value>' });
-            model.setColumnValue('column_Decimal', 234.56);
-            model.setColumnValue('column_ArrayNumber', [3, 4, 5]);
-            model.setColumnValue('column_ArrayText', [
-                '<value-1>',
-                '<value-2>',
-            ]);
-            model.setColumnValue('column_LongNumber', '12345678901234567890');
-            expect(generator.toSetStatement(model)).toEqual(
-                "column_ObjectID = '<value>', " +
-                    "column_Date = parseDateTimeBestEffortOrNull('1970-04-25T07:29:03.210Z'), " +
-                    'column_Number = 123, ' +
-                    "column_Text = '<value>', " +
-                    'column_JSON = \'{"key":"<value>"}\', ' +
-                    'column_Decimal = 234.56, ' +
-                    'column_ArrayNumber = [3, 4, 5], ' +
-                    "column_ArrayText = ['<value-1>', '<value-2>'], " +
-                    "column_LongNumber = CAST('12345678901234567890' AS Int128)"
-            );
+            model.setColumnValue('column_1', '<value>');
+            const statement: Statement = generator.toSetStatement(model);
+            expect(statement.query).toBe('column_1 = {p0:String}');
+            expect(statement.query_params).toStrictEqual({
+                p0: '<value>',
+            });
         });
 
-        test('should sanitize column values', () => {
-            const unsafeString: string = "Robert'; DROP TABLE Students;--";
-            model.setColumnValue('column_ObjectID', new ObjectID(unsafeString));
-            // model.setColumnValue('column_Date', unsafeString); // throws error
-            model.setColumnValue('column_Number', unsafeString);
-            model.setColumnValue('column_Text', unsafeString);
-            model.setColumnValue('column_JSON', { key: unsafeString });
-            model.setColumnValue('column_Decimal', unsafeString);
-            model.setColumnValue('column_ArrayNumber', [
-                ']; DROP TABLE Students;--',
-            ]);
-            model.setColumnValue('column_ArrayText', [
-                "Robert']; DROP TABLE Students;--",
-            ]);
-            model.setColumnValue(
-                'column_LongNumber',
-                '0; DROP TABLE Students;--'
+        test('should set multiple columns', () => {
+            model.setColumnValue('column_1', '<value>');
+            model.setColumnValue('column_2', 123);
+            const statement: Statement = generator.toSetStatement(model);
+            expect(statement.query).toBe(
+                'column_1 = {p0:String}, column_2 = {p1:Int32}'
             );
-            expect(generator.toSetStatement(model)).toEqual(
-                "column_ObjectID = 'Robert\\'; DROP TABLE Students;--', " +
-                    'column_Number = NULL, ' +
-                    "column_Text = 'Robert\\'; DROP TABLE Students;--', " +
-                    'column_JSON = \'{"key":"Robert\\\'; DROP TABLE Students;--"}\', ' +
-                    'column_Decimal = NULL, ' +
-                    'column_ArrayNumber = [NULL], ' +
-                    "column_ArrayText = ['Robert\\']; DROP TABLE Students;--'], " +
-                    "column_LongNumber = CAST('0; DROP TABLE Students;--' AS Int128)"
-            );
+            expect(statement.query_params).toStrictEqual({
+                p0: '<value>',
+                p1: 123,
+            });
         });
 
         test('should set column to NULL', () => {
-            model.setColumnValue('column_Text', null);
-            expect(generator.toSetStatement(model)).toEqual(
-                'column_Text = NULL'
+            model.setColumnValue('column_1', null);
+            const statement: Statement = generator.toSetStatement(model);
+            expect(statement.query).toBe('column_1 = {p0:String}');
+            expect(statement.query_params).toStrictEqual({
+                p0: null,
+            });
+        });
+    });
+
+    describe('toWhereStatement', () => {
+        test('should return the contents of a WHERE statement', () => {
+            const statement: Statement = generator.toWhereStatement({
+                _id: '<value>',
+            });
+            expect(statement.query).toBe('AND {p0:Identifier} = {p1:String}');
+            expect(statement.query_params).toStrictEqual({
+                p0: '_id',
+                p1: '<value>',
+            });
+        });
+
+        test('should check multiple columns', () => {
+            const statement: Statement = generator.toWhereStatement({
+                _id: '<value>',
+                updatedAt: new Date(9876543210),
+            });
+            expect(statement.query).toBe(
+                'AND {p0:Identifier} = {p1:String} AND {p2:Identifier} = {p3:DateTime}'
+            );
+            expect(statement.query_params).toStrictEqual({
+                p0: '_id',
+                p1: '<value>',
+                p2: 'updatedAt',
+                p3: new Date(9876543210),
+            });
+        });
+    });
+
+    describe('toSelectStatement', () => {
+        test('should return the contents of a SELECT statement', () => {
+            const { statement, columns } = generator.toSelectStatement({
+                _id: true,
+            });
+            expect(statement.query).toBe('{p0:Identifier}');
+            expect(statement.query_params).toStrictEqual({
+                p0: '_id',
+            });
+            expect(columns).toStrictEqual(['_id']);
+        });
+
+        test('should SELECT multiple columns', () => {
+            const { statement, columns } = generator.toSelectStatement({
+                _id: true,
+                createdAt: false,
+                updatedAt: true,
+            });
+            expect(statement.query).toBe('{p0:Identifier}, {p1:Identifier}');
+            expect(statement.query_params).toStrictEqual({
+                p0: '_id',
+                p1: 'updatedAt',
+            });
+            expect(columns).toStrictEqual(['_id', 'updatedAt']);
+        });
+    });
+
+    describe('toColumnsCreateStatement', () => {
+        test('should return the columns of a CREATE TABLE statement', () => {
+            const statement: Statement = generator.toColumnsCreateStatement([
+                new AnalyticsTableColumn({
+                    key: 'column_1',
+                    title: '<title>',
+                    description: '<description>',
+                    required: true,
+                    type: TableColumnType.Text,
+                }),
+                new AnalyticsTableColumn({
+                    key: 'column_2',
+                    title: '<title>',
+                    description: '<description>',
+                    required: false,
+                    type: TableColumnType.Number,
+                }),
+            ]);
+
+            /* eslint-disable prettier/prettier */
+            expectStatement(statement, SQL`
+                column_1 String NOT NULL,
+                column_2 Int32 NULL
+            `);
+            /* eslint-enable prettier/prettier */
+        });
+
+        test('should support nested models', () => {
+            class TestNestedModel extends NestedModel {
+                public constructor() {
+                    super({
+                        tableColumns: [
+                            new AnalyticsTableColumn({
+                                key: 'nested_column_1',
+                                title: '<title>',
+                                description: '<description>',
+                                required: true,
+                                type: TableColumnType.Text,
+                            }),
+                            new AnalyticsTableColumn({
+                                key: 'nested_column_2',
+                                title: '<title>',
+                                description: '<description>',
+                                required: false,
+                                type: TableColumnType.Number,
+                            }),
+                        ],
+                    });
+                }
+            }
+
+            const statement: Statement = generator.toColumnsCreateStatement([
+                new AnalyticsTableColumn({
+                    key: 'column_1',
+                    title: '<title>',
+                    description: '<description>',
+                    required: true,
+                    type: TableColumnType.Text,
+                }),
+                new AnalyticsTableColumn({
+                    key: 'column_2',
+                    title: '<title>',
+                    description: '<description>',
+                    required: false,
+                    type: TableColumnType.NestedModel,
+                    nestedModelType: TestNestedModel,
+                }),
+            ]);
+
+            /* eslint-disable prettier/prettier */
+            expectStatement(statement, SQL`
+                column_1 String NOT NULL,
+                column_2 Nested (
+                    nested_column_1 String,
+                    nested_column_2 Int32
+                )
+            `);
+            /* eslint-enable prettier/prettier */
+        });
+
+        test('should not add NULL|NOT NULL to Array types', () => {
+            const statement: Statement = generator.toColumnsCreateStatement([
+                new AnalyticsTableColumn({
+                    key: 'column_1',
+                    title: '<title>',
+                    description: '<description>',
+                    required: true,
+                    type: TableColumnType.ArrayText,
+                }),
+                new AnalyticsTableColumn({
+                    key: 'column_2',
+                    title: '<title>',
+                    description: '<description>',
+                    required: false,
+                    type: TableColumnType.ArrayNumber,
+                }),
+            ]);
+
+            /* eslint-disable prettier/prettier */
+            expectStatement(statement, SQL`
+                column_1 Array(String),
+                column_2 Array(Int32)
+            `);
+            /* eslint-enable prettier/prettier */
+        });
+    });
+
+    describe('toTableCreateStatement', () => {
+        beforeEach(() => {
+            generator.toColumnsCreateStatement = jest.fn(() => {
+                return SQL`                <columns-create-statement>`;
+            });
+            jest.spyOn(logger, 'info').mockImplementation(() => {
+                return undefined!;
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should return CREATE TABLE statement', () => {
+            const statement: Statement = generator.toTableCreateStatement();
+
+            expect(generator.toColumnsCreateStatement).toBeCalledWith(
+                generator.model.tableColumns
+            );
+
+            expect(jest.mocked(logger.info)).toHaveBeenCalledTimes(2);
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                1,
+                '<table-name> Table Create Statement'
+            );
+            expect(jest.mocked(logger.info)).toHaveBeenNthCalledWith(
+                2,
+                statement
+            );
+
+            /* eslint-disable prettier/prettier */
+            const expectedStatement: Statement = SQL`
+                CREATE TABLE IF NOT EXISTS ${'oneuptime'}.${'<table-name>'}
+                (
+                    <columns-create-statement>
+                )
+                ENGINE = MergeTree
+                PRIMARY KEY (${'column_ObjectID'})
+            `;
+            /* eslint-enable prettier/prettier */
+
+            expect(statement.query).toBe(expectedStatement.query);
+            expect(statement.query_params).toStrictEqual(
+                expectedStatement.query_params
             );
         });
     });

--- a/CommonServer/Tests/Utils/AnalyticsDatabase/StatementGenerator.test.ts
+++ b/CommonServer/Tests/Utils/AnalyticsDatabase/StatementGenerator.test.ts
@@ -108,23 +108,6 @@ describe('StatementGenerator', () => {
             `);
             /* eslint-enable prettier/prettier */
         });
-
-        test('optionally adds a LIMIT', () => {
-            updateBy.limit = 123;
-            const statement: Statement = generator.toUpdateStatement(updateBy);
-
-            /* eslint-disable prettier/prettier */
-            expectStatement(statement, SQL`
-                ALTER TABLE ${'oneuptime'}.${'<table-name>'}
-                UPDATE <set-statement>
-                WHERE TRUE <where-statement>
-                LIMIT ${{
-                    value: 123,
-                    type: TableColumnType.Number,
-                }}
-            `);
-            /* eslint-enable prettier/prettier */
-        });
     });
 
     describe('toSetStatement', () => {

--- a/CommonServer/Types/AnalyticsDatabase/DeleteBy.ts
+++ b/CommonServer/Types/AnalyticsDatabase/DeleteBy.ts
@@ -1,9 +1,8 @@
+import Query from './Query';
 import BaseModel from 'Common/AnalyticsModels/BaseModel';
-import PositiveNumber from 'Common/Types/PositiveNumber';
-import DeleteOneBy from './DeleteOneBy';
+import DatabaseCommonInteractionProps from 'Common/Types/BaseDatabase/DatabaseCommonInteractionProps';
 
-export default interface DeleteBy<TBaseModel extends BaseModel>
-    extends DeleteOneBy<TBaseModel> {
-    limit?: PositiveNumber | number | undefined;
-    skip?: PositiveNumber | number | undefined;
+export default interface DeleteBy<TBaseModel extends BaseModel> {
+    query: Query<TBaseModel>;
+    props: DatabaseCommonInteractionProps;
 }

--- a/CommonServer/Types/AnalyticsDatabase/DeleteOneBy.ts
+++ b/CommonServer/Types/AnalyticsDatabase/DeleteOneBy.ts
@@ -1,8 +1,0 @@
-import Query from './Query';
-import BaseModel from 'Common/AnalyticsModels/BaseModel';
-import DatabaseCommonInteractionProps from 'Common/Types/BaseDatabase/DatabaseCommonInteractionProps';
-
-export default interface DeleteOneBy<TBaseModel extends BaseModel> {
-    query: Query<TBaseModel>;
-    props: DatabaseCommonInteractionProps;
-}

--- a/CommonServer/Types/AnalyticsDatabase/UpdateBy.ts
+++ b/CommonServer/Types/AnalyticsDatabase/UpdateBy.ts
@@ -1,8 +1,9 @@
 import BaseModel from 'Common/AnalyticsModels/BaseModel';
-import UpdateOneBy from './UpdateOneBy';
-import PositiveNumber from 'Common/Types/PositiveNumber';
+import DatabaseCommonInteractionProps from 'Common/Types/BaseDatabase/DatabaseCommonInteractionProps';
+import Query from './Query';
 
-export default interface UpdateBy<TBaseModel extends BaseModel>
-    extends UpdateOneBy<TBaseModel> {
-    limit?: PositiveNumber | number | undefined;
+export default interface UpdateBy<TBaseModel extends BaseModel> {
+    query: Query<TBaseModel>;
+    data: TBaseModel;
+    props: DatabaseCommonInteractionProps;
 }

--- a/CommonServer/Types/AnalyticsDatabase/UpdateOneBy.ts
+++ b/CommonServer/Types/AnalyticsDatabase/UpdateOneBy.ts
@@ -1,9 +1,0 @@
-import BaseModel from 'Common/AnalyticsModels/BaseModel';
-import DatabaseCommonInteractionProps from 'Common/Types/BaseDatabase/DatabaseCommonInteractionProps';
-import Query from './Query';
-
-export default interface UpdateOneBy<TBaseModel extends BaseModel> {
-    query: Query<TBaseModel>;
-    data: TBaseModel;
-    props: DatabaseCommonInteractionProps;
-}

--- a/CommonServer/Utils/AnalyticsDatabase/Statement.ts
+++ b/CommonServer/Utils/AnalyticsDatabase/Statement.ts
@@ -1,0 +1,109 @@
+import { BaseQueryParams } from '@clickhouse/client';
+import { integer } from '@elastic/elasticsearch/lib/api/types';
+import { RecordValue } from 'Common/AnalyticsModels/CommonModel';
+import TableColumnType from 'Common/Types/AnalyticsDatabase/TableColumnType';
+import { inspect } from 'util';
+
+/**
+ * This file based on the sql-template-strings package, adapted for ClickHouse
+ */
+
+export type StatementParameter = {
+    type: TableColumnType;
+    value: RecordValue;
+};
+
+export class Statement implements BaseQueryParams {
+    public constructor(
+        private strings: string[] = [''],
+        private values: Array<StatementParameter | string> = []
+    ) {}
+
+    public get query(): string {
+        let query: string = this.strings.reduce(
+            (prev: string, curr: string, i: integer) => {
+                const param: StatementParameter | string = this.values[i - 1]!;
+                const dataType: string =
+                    typeof param === 'string'
+                        ? 'Identifier'
+                        : Statement.toColumnType(param.type);
+                return prev + `{p${i - 1}:${dataType}}` + curr;
+            }
+        );
+
+        // dedent lines
+        query = query.trimEnd();
+        const minIndent: number =
+            query
+                .match(/\n( *)/g)
+                ?.reduce((minIndent: number, indent: string) => {
+                    return Math.min(minIndent, indent.length - 1);
+                }, Infinity) ?? 0;
+        query = query.replace(new RegExp(`\n {${minIndent}}`, 'g'), '\n');
+        query = query.trimStart();
+
+        return query;
+    }
+
+    public get query_params(): Record<string, unknown> {
+        return Object.fromEntries(
+            this.values.map((v: StatementParameter | string, i: integer) => {
+                return [`p${i}`, typeof v === 'string' ? v : v.value];
+            })
+        );
+    }
+
+    /**
+     * Append an escaped SQL fragment. If you pass a raw String
+     * it is appended as trusted SQL!
+     */
+    public append(statement: Statement | String): Statement {
+        if (statement instanceof Statement) {
+            this.strings[this.strings.length - 1] += statement.strings[0];
+            this.strings.push(...statement.strings.slice(1));
+            this.values.push(...statement.values);
+        } else {
+            this.strings[this.strings.length - 1] += statement;
+        }
+        return this;
+    }
+
+    // custom inspect for logging
+    public [Symbol.for('nodejs.util.inspect.custom')](): string {
+        return `Statement ${inspect({
+            query: this.query,
+            query_params: this.query_params,
+        })}`;
+    }
+
+    private static toColumnType(type: TableColumnType): string {
+        // ensure we have a mapping for all types (a missing mapping will
+        // be a compile error)
+        return {
+            [TableColumnType.Text]: 'String',
+            [TableColumnType.ObjectID]: 'String',
+            [TableColumnType.Boolean]: 'Bool',
+            [TableColumnType.Number]: 'Int32',
+            [TableColumnType.Decimal]: 'Double',
+            [TableColumnType.Date]: 'DateTime',
+            [TableColumnType.JSON]: 'JSON',
+            [TableColumnType.NestedModel]: 'Nested',
+            [TableColumnType.ArrayNumber]: 'Array(Int32)',
+            [TableColumnType.ArrayText]: 'Array(String)',
+            [TableColumnType.LongNumber]: 'Int128',
+        }[type];
+    }
+}
+
+/**
+ * ClickHouse SQL template literal tag.
+ *
+ * String substitution values are interpereted as Identifiers (e.g. table or column names),
+ * other substitution values must be StatementParameters.
+ */
+export function SQL(
+    strings: TemplateStringsArray,
+    ...values: Array<StatementParameter | string>
+): Statement {
+    return new Statement(strings.slice(0), values.slice(0));
+}

--- a/CommonServer/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/CommonServer/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -43,17 +43,6 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
             WHERE TRUE `).append(whereStatement);
         /* eslint-enable prettier/prettier */
 
-        // TODO is this right? the ClickHouse docco doesn't mention LIMIT on ALTER UPDATE
-        // https://clickhouse.com/docs/en/sql-reference/statements/alter/update
-        if (updateBy.limit) {
-            statement.append(SQL`
-            LIMIT ${{
-                value: Number(updateBy.limit),
-                type: TableColumnType.Number,
-            }}
-            `);
-        }
-
         logger.info(`${this.model.tableName} Update Statement`);
         logger.info(statement);
 


### PR DESCRIPTION
### Title of this pull request?
Refactor Analytics SQL generation to use query params

### Small Description?
SQL is generated using the Statement class which guards
against accidental SQL injection using a special "SQL"
template literal tag.

INSERT functionality is not using the new Statement class
pending resolution of Nested column type functionality.

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [X] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
