### PR TITLE
fix: sideover content overflow cannot scroll

### DIFF
--- a/CommonUI/src/Components/SideOver/SideOver.tsx
+++ b/CommonUI/src/Components/SideOver/SideOver.tsx
@@ -30,47 +30,45 @@ const SideOver: FunctionComponent<ComponentProps> = (
                 <div className="absolute inset-0 overflow-hidden">
                     <div className="pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10 sm:pl-16">
                         <div className="pointer-events-auto w-screen max-w-2xl">
-                            <div className="flex h-full flex-col overflow-y-auto bg-white shadow-xl">
-                                <div className="flex-1 flex flex-col overflow-hidden">
-                                    <div className="bg-gray-50 px-4 py-6 sm:px-6">
-                                        <div className="flex items-start justify-between space-x-3">
-                                            <div className="space-y-1">
-                                                <h2
-                                                    className="text-lg font-medium text-gray-900"
-                                                    id="slide-over-title"
-                                                >
-                                                    {props.title}
-                                                </h2>
-                                                <p className="text-sm text-gray-500">
-                                                    {props.description}
-                                                </p>
-                                            </div>
-                                            <div className="flex h-7 items-center">
-                                                <button
-                                                    onClick={() => {
-                                                        props.onClose();
-                                                    }}
-                                                    type="button"
-                                                    className="text-gray-400 hover:text-gray-500"
-                                                >
-                                                    <span className="sr-only">
-                                                        Close panel
-                                                    </span>
+                            <div className="flex h-full flex-col bg-white shadow-xl">
+                                <div className="flex-shink-0 flex flex-col bg-gray-50 px-4 py-6 sm:px-6">
+                                    <div className="flex items-start justify-between space-x-3">
+                                        <div className="space-y-1">
+                                            <h2
+                                                className="text-lg font-medium text-gray-900"
+                                                id="slide-over-title"
+                                            >
+                                                {props.title}
+                                            </h2>
+                                            <p className="text-sm text-gray-500">
+                                                {props.description}
+                                            </p>
+                                        </div>
+                                        <div className="flex h-7 items-center">
+                                            <button
+                                                onClick={() => {
+                                                    props.onClose();
+                                                }}
+                                                type="button"
+                                                className="text-gray-400 hover:text-gray-500"
+                                            >
+                                                <span className="sr-only">
+                                                    Close panel
+                                                </span>
 
-                                                    <Icon
-                                                        className="h-6 w-6"
-                                                        icon={IconProp.Close}
-                                                    />
-                                                </button>
-                                            </div>
+                                                <Icon
+                                                    className="h-6 w-6"
+                                                    icon={IconProp.Close}
+                                                />
+                                            </button>
                                         </div>
                                     </div>
-
-                                    <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0 p-5 overflow-hidden">
+                                </div>
+                                <div className="flex flex-1 h-full overflow-y-scroll">
+                                    <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0 p-5">
                                         {props.children}
                                     </div>
                                 </div>
-
                                 <div className="flex-shrink-0 border-t border-gray-200 px-4 py-5 sm:px-6 flex justify-between">
                                     <div className="flex justify-start space-x-3">
                                         {props.leftFooterElement}


### PR DESCRIPTION
### Workflow Sideover (drawer) panel content is hidden when overflows and cannot scroll.

closes #962 

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
