### PR TITLE
fix: workflow crash on manually run

### DIFF
--- a/CommonUI/src/Components/Workflow/RunModal.tsx
+++ b/CommonUI/src/Components/Workflow/RunModal.tsx
@@ -78,6 +78,7 @@ const RunModal: FunctionComponent<ComponentProps> = (
                                             ComponentInputType.Select ||
                                         args.type ===
                                             ComponentInputType.StringDictionary) &&
+                                    component.returnValues &&
                                     component.returnValues[args.id] &&
                                     typeof component.returnValues[args.id] ===
                                         'string'


### PR DESCRIPTION
### Run workflow manually crashes when we don't input the optional request headers

close #963 

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
After:

https://github.com/OneUptime/oneuptime/assets/20983608/9f169c80-8817-4b84-a9c8-0cd84591b5cc

