### PR TITLE
fix: Double window opening on image selection

### DIFF
--- a/CommonUI/src/Components/FilePicker/FilePicker.tsx
+++ b/CommonUI/src/Components/FilePicker/FilePicker.tsx
@@ -84,6 +84,7 @@ const FilePicker: FunctionComponent<ComponentProps> = (
     const { getRootProps, getInputProps } = useDropzone({
         accept: acceptTypes,
         multiple: props.isMultiFilePicker,
+        noClick: true,
         onDrop: async (acceptedFiles: Array<File>) => {
             setIsLoading(true);
             try {


### PR DESCRIPTION
### Fix double window opening on image selection

This issue occurs due to a bug in useDropzone - https://github.com/react-dropzone/react-dropzone/issues/1107.

In the documentation for useDropzone, it is mentioned that `{noClick: true}` should be used if `label` is root element - https://react-dropzone.js.org/#:~:text=Using%20%3Clabel%3E%20as%20Root.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?
closes #956 

### Screenshots (if appropriate):
