### PR TITLE
refactor: optimize tree-shaking for lodash to reduce bundle size

### DIFF
--- a/CommonUI/src/Components/Detail/Detail.tsx
+++ b/CommonUI/src/Components/Detail/Detail.tsx
@@ -5,7 +5,7 @@ import OneUptimeDate from 'Common/Types/Date';
 import FieldType from '../Types/FieldType';
 import HiddenText from '../HiddenText/HiddenText';
 import { JSONObject } from 'Common/Types/JSON';
-import _, { Dictionary } from 'lodash';
+import get from 'lodash/get';
 import MarkdownViewer from '../Markdown.tsx/MarkdownViewer';
 import CodeEditor from '../CodeEditor/CodeEditor';
 import CodeType from 'Common/Types/Code/CodeType';
@@ -18,6 +18,7 @@ import DictionaryOfStringsViewer from '../Dictionary/DictionaryOfStingsViewer';
 import { DropdownOption } from '../Dropdown/Dropdown';
 import FieldLabelElement from './FieldLabel';
 import DatabaseProperty from 'Common/Types/Database/DatabaseProperty';
+import Dictionary from 'Common/Types/Dictionary';
 
 export interface ComponentProps {
     item: JSONObject;
@@ -96,8 +97,8 @@ const Detail: (props: ComponentProps) => ReactElement = (
 
         let data: string | ReactElement = '';
 
-        if (_.get(props.item, fieldKey)) {
-            data = (_.get(props.item, fieldKey, '') as any) || '';
+        if (get(props.item, fieldKey)) {
+            data = (get(props.item, fieldKey, '') as any) || '';
         }
 
         if (field.fieldType === FieldType.Date) {

--- a/CommonUI/src/Components/Dictionary/DictionaryOfStingsViewer.tsx
+++ b/CommonUI/src/Components/Dictionary/DictionaryOfStingsViewer.tsx
@@ -1,4 +1,4 @@
-import { Dictionary } from 'lodash';
+import Dictionary from 'Common/Types/Dictionary';
 import React, {
     FunctionComponent,
     ReactElement,

--- a/CommonUI/src/Components/Dictionary/DictionaryOfStrings.tsx
+++ b/CommonUI/src/Components/Dictionary/DictionaryOfStrings.tsx
@@ -1,4 +1,4 @@
-import { Dictionary } from 'lodash';
+import Dictionary from 'Common/Types/Dictionary';
 import React, {
     FunctionComponent,
     ReactElement,

--- a/CommonUI/src/Components/Graphs/DayUptimeGraph.tsx
+++ b/CommonUI/src/Components/Graphs/DayUptimeGraph.tsx
@@ -1,7 +1,7 @@
 import { Green } from 'Common/Types/BrandColors';
 import Color from 'Common/Types/Color';
 import OneUptimeDate from 'Common/Types/Date';
-import { Dictionary } from 'lodash';
+import Dictionary from 'Common/Types/Dictionary';
 import React, {
     FunctionComponent,
     ReactElement,

--- a/CommonUI/src/Components/Table/TableRow.tsx
+++ b/CommonUI/src/Components/Table/TableRow.tsx
@@ -8,7 +8,7 @@ import ActionButtonSchema from '../ActionButton/ActionButtonSchema';
 import Column from './Types/Column';
 import Columns from './Types/Columns';
 import FieldType from '../Types/FieldType';
-import _ from 'lodash';
+import get from 'lodash/get';
 import ConfirmModal from '../Modal/ConfirmModal';
 import { Draggable, DraggableProvided } from 'react-beautiful-dnd';
 
@@ -131,7 +131,7 @@ const TableRow: FunctionComponent<ComponentProps> = (
                                                 />
                                             )
                                         ) : (
-                                            _.get(
+                                            get(
                                                 props.item,
                                                 column.key,
                                                 ''

--- a/CommonUI/src/Tests/Components/DictionaryOfStrings.test.tsx
+++ b/CommonUI/src/Tests/Components/DictionaryOfStrings.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { Dictionary } from 'lodash';
+import Dictionary from 'Common/Types/Dictionary';
 
 // Custom components
 import DictionaryOfStrings, {

--- a/CommonUI/src/Utils/LocalStorage.ts
+++ b/CommonUI/src/Utils/LocalStorage.ts
@@ -3,7 +3,7 @@ import Email from 'Common/Types/Email';
 import { JSONObject, JSONValue } from 'Common/Types/JSON';
 import Typeof from 'Common/Types/Typeof';
 import JSONFunctions from 'Common/Types/JSONFunctions';
-import { Dictionary } from 'lodash';
+import Dictionary from 'Common/Types/Dictionary';
 
 export default class LocalStorage {
     public static setItem(key: string, value: JSONValue | Email | URL): void {

--- a/CommonUI/src/Utils/Navigation.ts
+++ b/CommonUI/src/Utils/Navigation.ts
@@ -4,7 +4,7 @@ import URL from 'Common/Types/API/URL';
 import BadDataException from 'Common/Types/Exception/BadDataException';
 import Hostname from 'Common/Types/API/Hostname';
 import ObjectID from 'Common/Types/ObjectID';
-import { Dictionary } from 'lodash';
+import Dictionary from 'Common/Types/Dictionary';
 
 abstract class Navigation {
     private static navigateHook: NavigateFunction;

--- a/Dashboard/package.json
+++ b/Dashboard/package.json
@@ -25,6 +25,7 @@
     "scripts": {
         "dev": "npx nodemon",
         "build": "webpack build --mode=production",
+        "analyze": "cross-env analyze=true webpack build --mode=production",
         "test": "react-app-rewired test",
         "eject": "webpack eject",
         "compile": "tsc",
@@ -55,6 +56,7 @@
         "@types/react": "^18.2.38",
         "@types/react-dom": "^18.0.4",
         "@types/react-router-dom": "^5.3.3",
+        "cross-env": "^7.0.3",
         "css-loader": "^6.7.1",
         "customize-cra": "^1.0.0",
         "nodemon": "^2.0.20",
@@ -64,6 +66,7 @@
         "ts-loader": "^9.3.0",
         "ts-node": "^10.9.1",
         "webpack": "^5.76.0",
+        "webpack-bundle-analyzer": "^4.10.1",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.0"
     }

--- a/Dashboard/webpack.config.js
+++ b/Dashboard/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const webpack = require("webpack");
 const dotenv = require('dotenv');
 const express = require('express');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const readEnvFile = (pathToFile) => {
 
@@ -42,6 +43,7 @@ module.exports = {
                 }
             }
         }),
+        process.env.analyze === 'true' ? new BundleAnalyzerPlugin() : () => {},
     ],
     module: {
         rules: [

--- a/StatusPage/package.json
+++ b/StatusPage/package.json
@@ -15,12 +15,12 @@
     "react-icons": "^4.11.0",
     "react-router": "^6.19.0",
     "react-router-dom": "^6.18.0",
-    
     "use-async-effect": "^2.2.6"
   },
   "scripts": {
     "dev": "npx nodemon",
     "build": "webpack build --mode=production",
+    "analyze": "cross-env analyze=true webpack build --mode=production",
     "test": "",
     "compile": "tsc",
     "clear-modules": "rm -rf node_modules && rm package-lock.json && npm install",
@@ -50,6 +50,7 @@
     "@types/react": "^18.2.38",
     "@types/react-dom": "^18.0.4",
     "@types/react-router-dom": "^5.3.3",
+    "cross-env": "^7.0.3",
     "css-loader": "^6.7.1",
     "customize-cra": "^1.0.0",
     "nodemon": "^2.0.20",
@@ -59,6 +60,7 @@
     "ts-loader": "^9.3.0",
     "ts-node": "^10.9.1",
     "webpack": "^5.76.0",
+    "webpack-bundle-analyzer": "^4.10.1",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.0"
   }

--- a/StatusPage/webpack.config.js
+++ b/StatusPage/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const webpack = require("webpack");
 const dotenv = require('dotenv');
 const express = require('express');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const readEnvFile = (pathToFile) => {
 
@@ -41,6 +42,7 @@ module.exports = {
                 }
             }
         }),
+        process.env.analyze === 'true' ? new BundleAnalyzerPlugin() : () => { }
     ],
     module: {
         rules: [


### PR DESCRIPTION
### Optimize tree-shaking for lodash to reduce bundle size

As Dictionary type is not necessarily needed from lodash and there's an existing type for that in Common. So we can use that instead. 

Note that to achieve this we need to stop using `import _ from 'lodash';`

We saved 300kb for gzip compression.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):

#### Before:

![Screenshot 2023-12-05 at 7 37 00 in the evening](https://github.com/OneUptime/oneuptime/assets/20983608/a954892d-9e3d-4a39-a24e-8b235d7f3f99)

#### After:
<img width="1230" alt="Screenshot 2023-12-05 at 7 38 58 in the evening" src="https://github.com/OneUptime/oneuptime/assets/20983608/11b0304d-ba19-4e55-b6b5-d0df2b15b90d">
