### PR TITLE
fix: NavbarItem is active only for the specific route

### DIFF
--- a/CommonUI/src/Components/Navbar/NavBarItem.tsx
+++ b/CommonUI/src/Components/Navbar/NavBarItem.tsx
@@ -11,6 +11,8 @@ export interface ComponentProps {
     title: string;
     icon?: undefined | IconProp;
     route?: undefined | Route;
+    activeRoute?: undefined | Route;
+    exact?: boolean;
     children?: undefined | ReactElement | Array<ReactElement>;
     isRenderedOnMobile?: boolean;
     onMouseOver?: (() => void) | undefined;
@@ -22,8 +24,12 @@ export interface ComponentProps {
 const NavBarItem: FunctionComponent<ComponentProps> = (
     props: ComponentProps
 ): ReactElement => {
+    const activeRoute: Route | undefined = props.activeRoute || props.route;
     const isActive: boolean = Boolean(
-        props.route && Navigation.isOnThisPage(props.route)
+        activeRoute &&
+            (props.exact
+                ? Navigation.isOnThisPage(activeRoute)
+                : Navigation.isStartWith(activeRoute))
     );
 
     let classNames: string =

--- a/CommonUI/src/Utils/Navigation.ts
+++ b/CommonUI/src/Utils/Navigation.ts
@@ -115,6 +115,37 @@ abstract class Navigation {
         return window.location.pathname.includes(text);
     }
 
+    public static isStartWith(route: Route): boolean {
+        const current: Route = this.getCurrentRoute();
+        const routeItems: Array<string> = route.toString().split('/');
+        let anotherRouteItems: Array<string> = current.toString().split('/');
+
+        if (routeItems.length > anotherRouteItems.length) {
+            return false;
+        }
+
+        anotherRouteItems = anotherRouteItems.splice(0, routeItems.length);
+
+        let start: number = 0;
+        let startsWith: boolean = true;
+        for (const item of anotherRouteItems) {
+            if (routeItems[start]?.startsWith(':') && item) {
+                start++;
+                continue;
+            }
+
+            if (routeItems[start]?.toString() !== item.toString()) {
+                startsWith = false;
+                break;
+            }
+
+            start++;
+        }
+        console.log(route, current, startsWith);
+
+        return startsWith;
+    }
+
     public static isOnThisPage(route: Route | URL): boolean {
         if (route instanceof Route) {
             const current: Route = this.getCurrentRoute();

--- a/CommonUI/src/Utils/Navigation.ts
+++ b/CommonUI/src/Utils/Navigation.ts
@@ -141,8 +141,6 @@ abstract class Navigation {
 
             start++;
         }
-        console.log(route, current, startsWith);
-
         return startsWith;
     }
 

--- a/Dashboard/src/Components/NavBar/NavBar.tsx
+++ b/Dashboard/src/Components/NavBar/NavBar.tsx
@@ -60,6 +60,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
             <NavBarItem
                 title="Home"
                 icon={IconProp.Home}
+                activeRoute={RouteMap[PageMap.HOME]}
                 route={RouteUtil.populateRouteParams(
                     RouteMap[PageMap.HOME] as Route
                 )}
@@ -67,6 +68,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
 
             <NavBarItem
                 title="Monitors"
+                activeRoute={RouteMap[PageMap.MONITORS]}
                 route={RouteUtil.populateRouteParams(
                     RouteMap[PageMap.MONITORS] as Route
                 )}
@@ -75,6 +77,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
 
             <NavBarItem
                 title="Incidents"
+                activeRoute={RouteMap[PageMap.INCIDENTS]}
                 route={RouteUtil.populateRouteParams(
                     RouteMap[PageMap.INCIDENTS] as Route
                 )}
@@ -83,6 +86,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
 
             <NavBarItem
                 title="Scheduled Maintenance"
+                activeRoute={RouteMap[PageMap.SCHEDULED_MAINTENANCE_EVENTS]}
                 route={RouteUtil.populateRouteParams(
                     RouteMap[PageMap.SCHEDULED_MAINTENANCE_EVENTS] as Route
                 )}
@@ -91,6 +95,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
 
             <NavBarItem
                 title="Status Pages"
+                activeRoute={RouteMap[PageMap.STATUS_PAGES]}
                 icon={IconProp.CheckCircle}
                 route={RouteUtil.populateRouteParams(
                     RouteMap[PageMap.STATUS_PAGES] as Route

--- a/StatusPage/src/Components/NavBar/NavBar.tsx
+++ b/StatusPage/src/Components/NavBar/NavBar.tsx
@@ -26,6 +26,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
                 id="overview-nav-bar-item"
                 title="Overview"
                 icon={IconProp.CheckCircle}
+                exact={true}
                 route={RouteUtil.populateRouteParams(
                     props.isPreview
                         ? (RouteMap[PageMap.PREVIEW_OVERVIEW] as Route)
@@ -37,6 +38,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
                 id="incidents-nav-bar-item"
                 title="Incidents"
                 icon={IconProp.Alert}
+                exact={true}
                 route={RouteUtil.populateRouteParams(
                     props.isPreview
                         ? (RouteMap[PageMap.PREVIEW_INCIDENT_LIST] as Route)
@@ -48,6 +50,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
                 id="announcements-nav-bar-item"
                 title="Announcements"
                 icon={IconProp.Announcement}
+                exact={true}
                 route={RouteUtil.populateRouteParams(
                     props.isPreview
                         ? (RouteMap[PageMap.PREVIEW_ANNOUNCEMENT_LIST] as Route)
@@ -59,6 +62,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
                 id="scheduled-events-nav-bar-item"
                 title="Scheduled Events"
                 icon={IconProp.Clock}
+                exact={true}
                 route={RouteUtil.populateRouteParams(
                     props.isPreview
                         ? (RouteMap[
@@ -73,6 +77,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
                     id="subscribe-nav-bar-item"
                     title="Subscribe"
                     icon={IconProp.Email}
+                    exact={true}
                     route={RouteUtil.populateRouteParams(
                         props.isPreview
                             ? (RouteMap[
@@ -90,6 +95,7 @@ const DashboardNavbar: FunctionComponent<ComponentProps> = (
                     id="logout-nav-bar-item"
                     title="Logout"
                     icon={IconProp.Logout}
+                    exact={true}
                     route={RouteUtil.populateRouteParams(
                         props.isPreview
                             ? (RouteMap[PageMap.PREVIEW_LOGOUT] as Route)


### PR DESCRIPTION
### NavbarItem is active only for the specific route

If you look at the navigation bar (header) of the dashboard and you navigate around pages. Example: Monitors page, there are 4 levels: All, Inoperational, Disabled, and Monitor Detail View. You will notice that NavBarItem is only in active state if it's in All Page which is a props `route` pass to the component.

The NavBarItem should be in the active state even if we navigate around the `monitors` page.

- `../monitors`
- `../monitors/:id`
- `../monitors/inoperational`
- `../monitors/disabled`

Conceptually, any route starts with `../minitors`, the NavbarItem should be in the active state.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
#### Before:
https://github.com/OneUptime/oneuptime/assets/20983608/3cf85d87-3d45-4a58-8879-ad471d50292a

#### After:
https://github.com/OneUptime/oneuptime/assets/20983608/6ad08b05-e5a2-4c12-bb92-f45ba57c71ae

