### PR TITLE
fix: schedule ongoing error

### DIFF
--- a/Dashboard/src/Utils/RouteMap.ts
+++ b/Dashboard/src/Utils/RouteMap.ts
@@ -81,6 +81,7 @@ export const IncidentsRoutePath: Dictionary<string> = {
 };
 
 export const ScheduledMaintenanceEventsRoutePath: Dictionary<string> = {
+    [PageMap.ONGOING_SCHEDULED_MAINTENANCE_EVENTS]: 'ongoing',
     [PageMap.SCHEDULED_MAINTENANCE_VIEW]: `${RouteParams.ModelID}`,
     [PageMap.SCHEDULED_MAINTENANCE_VIEW_OWNERS]: `${RouteParams.ModelID}/owners`,
     [PageMap.SCHEDULED_MAINTENANCE_VIEW_STATE_TIMELINE]: `${RouteParams.ModelID}/state-timeline`,
@@ -340,7 +341,11 @@ const RouteMap: Dictionary<Route> = {
     ),
 
     [PageMap.ONGOING_SCHEDULED_MAINTENANCE_EVENTS]: new Route(
-        `/dashboard/${RouteParams.ProjectID}/scheduled-maintenance-events/ongoing`
+        `/dashboard/${RouteParams.ProjectID}/scheduled-maintenance-events/${
+            ScheduledMaintenanceEventsRoutePath[
+                PageMap.ONGOING_SCHEDULED_MAINTENANCE_EVENTS
+            ]
+        }`
     ),
 
     [PageMap.SCHEDULED_MAINTENANCE_VIEW]: new Route(


### PR DESCRIPTION
### Scheduled Maintenance Ongoing Page Error

There's a missing route path for that page so it renders schedule maintenance page by default and cause API to get the wrong params for projectId and cause the error.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
#### Before
![image](https://github.com/OneUptime/oneuptime/assets/20983608/58939b06-5959-4586-9a5b-6aa7eeaa29a8)

### After
![image](https://github.com/OneUptime/oneuptime/assets/20983608/1bb66360-2795-465a-928e-bedb2aa37131)
