### PR TITLE
Fix accidental workflow triggering

### DIFF
--- a/CommonServer/Tests/Services/ScheduledMaintenanceService.test.ts
+++ b/CommonServer/Tests/Services/ScheduledMaintenanceService.test.ts
@@ -1,0 +1,89 @@
+import '../TestingUtils/Init';
+import ScheduledMaintenanceService from '../../Services/ScheduledMaintenanceService';
+import ScheduledMaintenance from 'Model/Models/ScheduledMaintenance';
+import Database from '../TestingUtils/Database';
+import Project from 'Model/Models/Project';
+import User from 'Model/Models/User';
+import UserServiceHelper from '../TestingUtils/Services/UserServiceHelper';
+import ProjectServiceHelper from '../TestingUtils/Services/ProjectServiceHelper';
+import ScheduledMaintenanceState from 'Model/Models/ScheduledMaintenanceState';
+import ScheduledMaintenanceServiceHelper from '../TestingUtils/Services/ScheduledMaintenanceServiceHelper';
+import ScheduledMaintenanceStateServiceHelper from '../TestingUtils/Services/ScheduledMaintenanceStateServiceHelper';
+
+// mock PostgresDatabase
+const testDatabase: Database = new Database();
+jest.mock('../../Infrastructure/PostgresDatabase', () => {
+    const actualModule: any = jest.requireActual(
+        '../../Infrastructure/PostgresDatabase'
+    );
+    return {
+        __esModule: true,
+        default: actualModule.default,
+        PostgresAppInstance: {
+            getDataSource: () => {
+                return testDatabase.getDatabase().getDataSource();
+            },
+            isConnected: () => {
+                return testDatabase.getDatabase().isConnected();
+            },
+        },
+    };
+});
+
+describe('ScheduledMaintenanceService', () => {
+    beforeEach(async () => {
+        await testDatabase.createAndConnect();
+    });
+
+    afterEach(async () => {
+        await testDatabase.disconnectAndDropDatabase();
+        jest.resetAllMocks();
+    });
+
+    describe('changeScheduledMaintenanceState', () => {
+        it('should trigger workflows only once', async () => {
+            // Prepare scheduled maintenance
+            const user: User = UserServiceHelper.generateRandomUser().data;
+            await user.save();
+            const project: Project = ProjectServiceHelper.generateRandomProject(
+                user.id!
+            ).data;
+            await project.save();
+            const scheduledState: ScheduledMaintenanceState =
+                ScheduledMaintenanceStateServiceHelper.generateScheduledState(
+                    project.id!
+                ).data;
+            await scheduledState.save();
+            const maintenance: ScheduledMaintenance =
+                ScheduledMaintenanceServiceHelper.generateRandomScheduledMaintenance(
+                    project.id!,
+                    scheduledState.id!
+                ).data;
+            await maintenance.save();
+            // Change state
+            const ongoingState: ScheduledMaintenanceState =
+                ScheduledMaintenanceStateServiceHelper.generateOngoingState(
+                    project.id!
+                ).data;
+            await ongoingState.save();
+            jest.spyOn(ScheduledMaintenanceService, 'onTrigger');
+            await ScheduledMaintenanceService.changeScheduledMaintenanceState({
+                projectId: project.id!,
+                scheduledMaintenanceId: maintenance.id!,
+                scheduledMaintenanceStateId: ongoingState.id!,
+                shouldNotifyStatusPageSubscribers: Boolean(
+                    maintenance.shouldStatusPageSubscribersBeNotifiedWhenEventChangedToEnded
+                ),
+                isSubscribersNotified: false,
+                notifyOwners: true,
+                props: {
+                    isRoot: true,
+                },
+            });
+            // Assert triggering workflows only once
+            expect(ScheduledMaintenanceService.onTrigger).toHaveBeenCalledTimes(
+                1
+            );
+        });
+    });
+});

--- a/CommonServer/Tests/TestingUtils/Services/ScheduledMaintenanceServiceHelper.ts
+++ b/CommonServer/Tests/TestingUtils/Services/ScheduledMaintenanceServiceHelper.ts
@@ -1,0 +1,30 @@
+import ObjectID from 'Common/Types/ObjectID';
+import CreateBy from '../../../Types/Database/CreateBy';
+import ScheduledMaintenance from 'Model/Models/ScheduledMaintenance';
+import Faker from 'Common/Utils/Faker';
+import faker from '@faker-js/faker';
+
+export default class ScheduledMaintenanceTestService {
+    public static generateRandomScheduledMaintenance(
+        projectId: ObjectID,
+        currentScheduledMaintenanceStateId: ObjectID
+    ): CreateBy<ScheduledMaintenance> {
+        const maintenance: ScheduledMaintenance = new ScheduledMaintenance();
+
+        // required fields
+        maintenance.projectId = projectId;
+        maintenance.currentScheduledMaintenanceStateId =
+            currentScheduledMaintenanceStateId;
+        maintenance.title = Faker.generateName();
+        maintenance.description = Faker.generateName();
+        maintenance.startsAt = faker.date.soon(1);
+        maintenance.endsAt = faker.date.soon(2);
+        maintenance.isOwnerNotifiedOfResourceCreation = false;
+        maintenance.slug = maintenance.title;
+
+        return {
+            data: maintenance,
+            props: { isRoot: true },
+        };
+    }
+}

--- a/CommonServer/Tests/TestingUtils/Services/ScheduledMaintenanceStateServiceHelper.ts
+++ b/CommonServer/Tests/TestingUtils/Services/ScheduledMaintenanceStateServiceHelper.ts
@@ -1,0 +1,50 @@
+import ObjectID from 'Common/Types/ObjectID';
+import ScheduledMaintenanceState from 'Model/Models/ScheduledMaintenanceState';
+import CreateBy from '../../../Types/Database/CreateBy';
+import { Black, Yellow } from 'Common/Types/BrandColors';
+
+export default class ScheduledMaintenanceStateTestService {
+    public static generateScheduledState(
+        projectId: ObjectID
+    ): CreateBy<ScheduledMaintenanceState> {
+        const scheduledState: ScheduledMaintenanceState =
+            new ScheduledMaintenanceState();
+
+        // required fields
+        scheduledState.name = 'Scheduled';
+        scheduledState.description =
+            'When an event is scheduled, it belongs to this state';
+        scheduledState.color = Black;
+        scheduledState.isScheduledState = true;
+        scheduledState.projectId = projectId;
+        scheduledState.order = 1;
+        scheduledState.slug = scheduledState.name;
+
+        return {
+            data: scheduledState,
+            props: { isRoot: true },
+        };
+    }
+
+    public static generateOngoingState(
+        projectId: ObjectID
+    ): CreateBy<ScheduledMaintenanceState> {
+        const ongoingState: ScheduledMaintenanceState =
+            new ScheduledMaintenanceState();
+
+        // required fields
+        ongoingState.name = 'Ongoing';
+        ongoingState.description =
+            'When an event is ongoing, it belongs to this state.';
+        ongoingState.color = Yellow;
+        ongoingState.isOngoingState = true;
+        ongoingState.projectId = projectId;
+        ongoingState.order = 2;
+        ongoingState.slug = ongoingState.name;
+
+        return {
+            data: ongoingState,
+            props: { isRoot: true },
+        };
+    }
+}


### PR DESCRIPTION
## Fix Accidental Workflow Triggering

### Diagnosis

@koroglumert reported multiple workflow triggers with a single state change. Upon investigation, there are at least two code paths independently triggering workflows for the same change to `currentScheduledMaintenanceStateId`.

1. `changeScheduledMaintenanceState` in ScheduledMaintenanceService.ts https://github.com/OneUptime/oneuptime/blob/64e0d3e7fa803a6e961bbbcc4ed97ac4ec61fa8c/CommonServer/Services/ScheduledMaintenanceService.ts#L424-L428

1. `onCreateSuccess` in ScheduledMaintenanceStateTimelineService.ts https://github.com/OneUptime/oneuptime/blob/64e0d3e7fa803a6e961bbbcc4ed97ac4ec61fa8c/CommonServer/Services/ScheduledMaintenanceStateTimelineService.ts#L128-L135

In addition, the same error is reported to also happen to the "On Update Incident" trigger. Therefore, there may be quite a few similar bugs with other resources in the code base.

### The Fix

The easy fix is to remove one of the aforementioned code paths. However, this only addresses the issue for `ScheduledMaintenance` and fails to address other existing issues let alone guarding against similar bugs in the future.

Instead, this PR adds a check before workflow triggers, ensuring that multiple identical updates (e.g. updating `currentScheduledMaintenanceStateId` twice to the same value) only trigger workflow once. The goal is to fix a *category* of bugs, both existing one and ones that may pop up in the future.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue

Closes #1113

### Screenshots (if appropriate):

I reproduced the scenario in #1113 with `Listen on` set to `{ "currentScheduledMaintenanceStateId": true }`.

The screenshot below shows that only two workflow triggers during the lifecycle of a scheduled maintenance. One for transitioning from `Scheduled` to `Ongoing`, and the other for `Ongoing` to `Ended`. No more unexpected triggers.
<img width="1506" alt="Screenshot 2024-03-14 at 4 46 08 PM" src="https://github.com/OneUptime/oneuptime/assets/1525352/298ae66c-f230-4510-85e0-442af574d51f">

The details of the two triggers are as follows.
<img width="1141" alt="Screenshot 2024-03-14 at 4 46 41 PM" src="https://github.com/OneUptime/oneuptime/assets/1525352/f3468783-7a3c-4953-bea2-1fa2f88b8778">
<img width="1141" alt="Screenshot 2024-03-14 at 4 46 46 PM" src="https://github.com/OneUptime/oneuptime/assets/1525352/4ec873fb-5185-4546-b62c-9cfc0f7887ec">