### PR TITLE
Fix workflow breadcrumbs and avoid self links

### DIFF
--- a/CommonServer/Tests/Services/TeamMemberService.test.ts
+++ b/CommonServer/Tests/Services/TeamMemberService.test.ts
@@ -26,6 +26,8 @@ import UserNotificationRuleService from '../../Services/UserNotificationRuleServ
 import Errors from '../../Utils/Errors';
 import CreateBy from '../../Types/Database/CreateBy';
 
+jest.setTimeout(60000); // Increase test timeout to 60 seconds becuase GitHub runners are slow
+
 const testDatabase: Database = new Database();
 
 // mock PostgresDatabase because we need it across all services

--- a/CommonUI/src/Components/Breadcrumbs/Breadcrumbs.tsx
+++ b/CommonUI/src/Components/Breadcrumbs/Breadcrumbs.tsx
@@ -3,6 +3,8 @@ import React, { FunctionComponent, ReactElement } from 'react';
 import Icon from '../Icon/Icon';
 import IconProp from 'Common/Types/Icon/IconProp';
 import UILink from '../Link/Link';
+import Route from 'Common/Types/API/Route';
+import URL from 'Common/Types/API/URL';
 
 interface ComponentProps {
     links: Array<Link>;
@@ -39,7 +41,11 @@ const Breadcrumbs: FunctionComponent<ComponentProps> = ({
                                             icon={IconProp.ChevronRight}
                                         />
                                         <UILink
-                                            to={link.to}
+                                            to={
+                                                isCurrentPage(link.to)
+                                                    ? null // Avoid linking to current page
+                                                    : link.to
+                                            }
                                             className="ml-1 text-sm font-medium text-gray-500 hover:text-gray-700 -mt-1"
                                         >
                                             {link.title}
@@ -53,5 +59,9 @@ const Breadcrumbs: FunctionComponent<ComponentProps> = ({
         </nav>
     );
 };
+
+function isCurrentPage(linkTo: Route | URL): boolean {
+    return linkTo.toString() === window.location.pathname;
+}
 
 export default Breadcrumbs;

--- a/CommonUI/src/Components/Link/Link.tsx
+++ b/CommonUI/src/Components/Link/Link.tsx
@@ -38,10 +38,14 @@ const Link: FunctionComponent<ComponentProps> = (
         linkProps['href'] = props.to?.toString();
     }
 
+    const cursorClassName: string = props.to
+        ? 'cursor-pointer'
+        : 'cursor-default';
+
     return (
         <a
             id={props.id}
-            className={`cursor-pointer  ${props.className || ''}`}
+            className={`${cursorClassName} ${props.className || ''}`}
             onMouseOver={props.onMouseOver}
             onMouseOut={props.onMouseOut}
             onMouseLeave={props.onMouseLeave}

--- a/CommonUI/src/Tests/Components/Breadcrumbs.test.tsx
+++ b/CommonUI/src/Tests/Components/Breadcrumbs.test.tsx
@@ -7,6 +7,7 @@ import renderer, {
 } from 'react-test-renderer';
 import Breadcrumbs from '../../Components/Breadcrumbs/Breadcrumbs';
 import Link from 'Common/Types/Link';
+import Navigation from '../../Utils/Navigation';
 describe('Breadcrumbs', () => {
     test('Should render correctly and also contain "Home" and "Projects" string', () => {
         const links: Array<Link> = [
@@ -41,5 +42,41 @@ describe('Breadcrumbs', () => {
                 'children'
             ]
         ).toEqual('Projects');
+    });
+
+    test('Should avoid linking to the current page', () => {
+        // Mock `window.location.pathname`
+        Object.defineProperty(window, 'location', {
+            get() {
+                return { pathname: '/projects' };
+            },
+        });
+        // Render component
+        const links: Array<Link> = [
+            {
+                title: 'Home',
+                to: new Route('/'),
+            },
+            {
+                title: 'Projects',
+                to: new Route('/projects'),
+            },
+        ];
+        const testRenderer: ReactTestRenderer = renderer.create(
+            <Breadcrumbs links={links} />
+        );
+        const testInstance: ReactTestInstance = testRenderer.root;
+        // Assert cursor style
+        const anchors: ReactTestInstance[] = testInstance.findAllByType('a');
+        expect(anchors[0]?.props['className']).toContain('cursor-pointer');
+        expect(anchors[1]?.props['className']).toContain('cursor-default');
+        // Set up spy on navigation
+        jest.spyOn(Navigation, 'navigate');
+        // Assert the second link does not navigate
+        anchors[1]?.props['onClick']();
+        expect(Navigation.navigate).not.toHaveBeenCalled();
+        // Assert the first link navigates
+        anchors[0]?.props['onClick']();
+        expect(Navigation.navigate).toHaveBeenCalledTimes(1);
     });
 });

--- a/Dashboard/src/Components/Workflow/WorkflowElement.tsx
+++ b/Dashboard/src/Components/Workflow/WorkflowElement.tsx
@@ -27,7 +27,7 @@ const WorkflowElement: FunctionComponent<ComponentProps> = (
                 className="hover:underline"
                 to={
                     new Route(
-                        `/dashboard/${projectId}/workflows/workflow/${props.workflow._id}`
+                        `/dashboard/${projectId}/workflows/${props.workflow._id}`
                     )
                 }
             >

--- a/Dashboard/src/Pages/Workflow/View/Settings.tsx
+++ b/Dashboard/src/Pages/Workflow/View/Settings.tsx
@@ -26,9 +26,7 @@ const Settings: FunctionComponent<PageComponentProps> = (
                     labels: true,
                 }}
                 navigateToOnSuccess={RouteUtil.populateRouteParams(
-                    new Route(RouteMap[PageMap.WORKFLOWS]?.toString()).addRoute(
-                        '/workflow'
-                    )
+                    new Route(RouteMap[PageMap.WORKFLOWS]?.toString())
                 )}
                 fieldsToChange={[
                     {

--- a/Dashboard/src/Pages/Workflow/Workflows.tsx
+++ b/Dashboard/src/Pages/Workflow/Workflows.tsx
@@ -1,4 +1,3 @@
-import Route from 'Common/Types/API/Route';
 import React, { Fragment, FunctionComponent, ReactElement } from 'react';
 import PageComponentProps from '../PageComponentProps';
 import ModelTable from 'CommonUI/src/Components/ModelTable/ModelTable';
@@ -135,9 +134,7 @@ const Workflows: FunctionComponent<PageComponentProps> = (
                     ]}
                     showRefreshButton={true}
                     showFilterButton={true}
-                    viewPageRoute={Navigation.getCurrentRoute().addRoute(
-                        new Route('/workflow')
-                    )}
+                    viewPageRoute={Navigation.getCurrentRoute()}
                     columns={[
                         {
                             field: {

--- a/Dashboard/src/Utils/RouteMap.ts
+++ b/Dashboard/src/Utils/RouteMap.ts
@@ -26,12 +26,12 @@ export const MonitorsRoutePath: Dictionary<string> = {
 export const WorkflowRoutePath: Dictionary<string> = {
     [PageMap.WORKFLOWS_LOGS]: 'logs',
     [PageMap.WORKFLOWS_VARIABLES]: 'variables',
-    [PageMap.WORKFLOW_VARIABLES]: `workflow/${RouteParams.ModelID}/variables`,
-    [PageMap.WORKFLOW_BUILDER]: `workflow/${RouteParams.ModelID}/builder`,
-    [PageMap.WORKFLOW_VIEW]: `workflow/${RouteParams.ModelID}`,
-    [PageMap.WORKFLOW_LOGS]: `workflow/${RouteParams.ModelID}/logs`,
-    [PageMap.WORKFLOW_DELETE]: `workflow/${RouteParams.ModelID}/delete`,
-    [PageMap.WORKFLOW_VIEW_SETTINGS]: `workflow/${RouteParams.ModelID}/settings`,
+    [PageMap.WORKFLOW_VARIABLES]: `${RouteParams.ModelID}/variables`,
+    [PageMap.WORKFLOW_BUILDER]: `${RouteParams.ModelID}/builder`,
+    [PageMap.WORKFLOW_VIEW]: `${RouteParams.ModelID}`,
+    [PageMap.WORKFLOW_LOGS]: `${RouteParams.ModelID}/logs`,
+    [PageMap.WORKFLOW_DELETE]: `${RouteParams.ModelID}/delete`,
+    [PageMap.WORKFLOW_VIEW_SETTINGS]: `${RouteParams.ModelID}/settings`,
 };
 
 export const TelemetryRouthPath: Dictionary<string> = {


### PR DESCRIPTION
## Fix Workflow Breadcrumbs and Avoid Self Links

### Diagnosis

The cause for #1252 is incorrect paths. Instead of the correct path `dashboard/some-uuid/workflows/workflow/another-uuid`, an incorrect path of `dashboard/some-uuid/workflows/workflow` is being used.

Upon investigation, the path generation algorithm is naive - breaking up `pathname` by `/` and assigning a portion of `pathname` based on the array index. https://github.com/OneUptime/oneuptime/blob/b8fcc4c40c071b68545fa902e06297a63e23c647/CommonUI/src/Utils/Navigation.ts#L41-L44

In addition, readers with a keen eye would've noticed that Workflow routes do not follow the convention set by other routes such as Incidents. Workflow routes have an additional `/workflow` in its path. Thus Workflow routes break the assumption made by the path generation algorithm.

Lastly, self links are widely considered bad UX. #1253 has more details on this.

### The Fix

Three approaches were considered.

1. Make path generation algorithm more complex, handing the convention-breaking Workflow routes.
2. Make Workflow routes consistent with other routes.
3. Remove the self link from breadcrumbs, which is usually (but not always) the last link.

This PR implements approach 2 (573e3a0e6af75eb437e97d4b648b9523c9da2b53) and 3 (0342233117a272d7ce7941dbdcc37e6e32cbcf7f).

Approach 2 is chosen for improved code consistency and approach 3 is chosen for better UX. I believe the marginal benefits of approach 1 do not outweigh its increased complexity.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issues

Closes #1252 
Closes #1253 

### Screenshots (if appropriate):

The screen recording below shows that
1. The self link in breadcrumbs is disabled, with the proper cursor style.
5. The rest of the breadcrumbs continues to work as expected.

https://github.com/OneUptime/oneuptime/assets/1525352/01580cd3-6586-4078-9331-dc31e6bdd6f3

