### PR TITLE
Fix flaky tests

### DIFF
--- a/CommonServer/Tests/Services/TeamMemberService.test.ts
+++ b/CommonServer/Tests/Services/TeamMemberService.test.ts
@@ -26,6 +26,8 @@ import UserNotificationRuleService from '../../Services/UserNotificationRuleServ
 import Errors from '../../Utils/Errors';
 import CreateBy from '../../Types/Database/CreateBy';
 
+jest.setTimeout(60000); // Increase test timeout to 60 seconds becuase GitHub runners are slow
+
 const testDatabase: Database = new Database();
 
 // mock PostgresDatabase because we need it across all services


### PR DESCRIPTION
## Fix Flaky Tests

### Diagnosis

`TeamMemberService.test.ts` contains flaky tests. The flakiness can be observed in both #1251 and #1252. Tests in both PRs fail, yet the failed tests have nothing to do with the code changes. I cannot reproduce the failed tests locally.

Upon investigation, the cause seems to be the slowness of GitHub Action runners, leading to tests exceeding Jest's default 5-second-long timeout.

### The Fix

This PR increases the test timeout to 60 seconds for `TeamMemberService.test.ts`.

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue

https://github.com/OneUptime/oneuptime/pull/1254#issuecomment-1999121156

### Screenshots (if appropriate):

N/A