### PR TITLE
Update default.conf.template

### DIFF
--- a/Nginx/default.conf.template
+++ b/Nginx/default.conf.template
@@ -127,11 +127,21 @@ server {
 
 
     location / {
-       return 301 https://$host$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://status-page;
     }
 
     location /status-page {
-       return 301 https://$host$request_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://status-page;
     }
 
     location /status-page-api/ {


### PR DESCRIPTION
### Fix custom domains status pages NGINX configuration.

Created PR to fix NGINX configurstion to handle custom domains attached to status pages for docker-compose installation.

I've faced redirect issue when trying to open custom domain which was configured to show status page of my installation.
The root domain was added to global configuration and sub domain attached to the status page as docs say. All DNS tests inside of deployment were marked as passed.

I've changed redirect to proxy_pass in nginx configuration under status-page block.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
