### PR TITLE
fix: setting header buttons in BaseModelTable

### DIFF
--- a/CommonUI/src/Components/ModelTable/BaseModelTable.tsx
+++ b/CommonUI/src/Components/ModelTable/BaseModelTable.tsx
@@ -579,6 +579,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
                         ) as Array<ClassicFilterType<TBaseModel>>;
 
                 setClassicTableFilters(classicFilters);
+
+                setHeaderButtons();
             } catch (err) {
                 setTableFilterError(API.getFriendlyMessage(err));
             }


### PR DESCRIPTION
### Title of this pull request?
Button disabled state render incorrectly

### Small Description?
When click on filter button in monitors page, It cannot click any header button such as refresh or close filter bar. so normally it should be disable only data fetching or loading. 
### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
