### PR TITLE
docs: export env variables in a subshell

### DIFF
--- a/App/FeatureSet/Docs/Content/installation/docker-compose.md
+++ b/App/FeatureSet/Docs/Content/installation/docker-compose.md
@@ -47,7 +47,7 @@ If you don't like to use npm or do not have it installed, run this instead:
 
 ```
 # Read env vars from config.env file and run docker-compose up.
-export $(grep -v '^#' config.env | xargs) && docker compose up --remove-orphans -d
+(export $(grep -v '^#' config.env | xargs) && docker compose up --remove-orphans -d)
 ```
 
 To update: 


### PR DESCRIPTION
This PR is a small change to the documentation when installing OneUptime via docker compose without NPM.

It's preferrable to export the env variables in a subshell because otherwise certain variables such as `COMPOSE_PROJECT_NAME` will remain in the current shell, causing conflicts with other compose projects for the duration of the session.

For example, after installing OneUptime, I went to go bring up my GitLab compose project and it started using `oneuptime` as the project name based on the exported `COMPOSE_PROJECT_NAME` variable.

This had a series of negative consequences:
- The docker network was now `oneuptime_default` instead of `gitlab_default`
- All named volumes were switched from `gitlab_volume-name` to `oneuptime_volume-name`.

Afterwards, GitLab was unable to be reached via Caddy due to the network change and it was also detected as a fresh install and made new docker volumes that I now have to go and manually delete.