### PR TITLE
Add option to configure ENCRYPTION_SECRET and ONEUPTIME_SECRET using external secrets

### DIFF
--- a/HelmChart/Public/oneuptime/README.md
+++ b/HelmChart/Public/oneuptime/README.md
@@ -77,6 +77,10 @@ The following table lists the configurable parameters of the OneUptime chart and
 | `global.storageClass` | Storage class to be used for all persistent volumes | `nil` | 🚨 |
 | `host` | Hostname for the ingress | `localhost` | 🚨 |
 | `httpProtocol` | If the server is hosted with SSL/TLS cert then change this value to https | `http` | 🚨 |
+
+| `oneuptimeSecret` | Value used to define ONEUPTIME_SECRET | `nil` | |
+| `encryptionSecret` | Value used to define ENCRYPTION_SECRET | `nil` | |
+
 | `global.clusterDomain` | Kubernetes Cluster Domain | `cluster.local` |  |
 | `image.registry` | Docker image registry | `docker.io` |  |
 | `image.repository` | Docker image repository | `oneuptime` | |
@@ -307,7 +311,7 @@ Please do the same for Redis and Clickhouse.
 
 - [ ] Please make sure you have a backups enabled for your PVCs. This is outside the scope of this chart. Please refer to your cloud provider's documentation on how to enable backups for PVCs.
 - [ ] Please make sure you have static passwords for your database passswords (for redis, clickhouse and postgres). You can refer to Bitnami documentation on how to set static passwords for these databases. 
-- [ ] Please set `oneuptimeSecret` and `encryptionSecret` to a long random string. You can use a password generator to generate these strings.
+- [ ] Please set `oneuptimeSecret` and `encryptionSecret` (or setup in `externalSecrets` section) to a long random string. You can use a password generator to generate these strings.
 - [ ] Please set `probes.<key>.key` to a long random string. This is used to secure your probes.
 - [ ] Please regularly update OneUptime. We release updates every day. We recommend you to update the software aleast once a week if you're running OneUptime production. 
 

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -97,10 +97,18 @@ Usage:
   {{- if $.Values.oneuptimeSecret }}
   value: {{ $.Values.oneuptimeSecret }}
   {{- else }}
+  
+  {{- if $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
+  valueFrom:
+    secretKeyRef:
+        name: {{ printf "%s" $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
+        key: {{ $.Values.externalSecrets.oneuptimeSecret.existingSecret.passwordKey }}
+  {{- else }}
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s-%s" $.Release.Name "secrets"  }}
       key: oneuptime-secret
+  {{- end }}
   {{- end }}
 {{- end }}
 
@@ -124,10 +132,17 @@ Usage:
   {{- if $.Values.encryptionSecret }}
   value: {{ $.Values.encryptionSecret }}
   {{- else }}
+  {{- if $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
+  valueFrom:
+    secretKeyRef:
+        name: {{ printf "%s" $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
+        key: {{ $.Values.externalSecrets.encryptionSecret.existingSecret.passwordKey }}
+  {{- else }}
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s-%s" $.Release.Name "secrets"  }}
       key: encryption-secret
+  {{- end }}
   {{- end }}
 
 - name: CLICKHOUSE_USER

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -97,11 +97,10 @@ Usage:
   {{- if $.Values.oneuptimeSecret }}
   value: {{ $.Values.oneuptimeSecret }}
   {{- else }}
-  
   {{- if $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
   valueFrom:
     secretKeyRef:
-        name: {{ printf "%s" $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
+        name: {{ $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
         key: {{ $.Values.externalSecrets.oneuptimeSecret.existingSecret.passwordKey }}
   {{- else }}
   valueFrom:
@@ -135,7 +134,7 @@ Usage:
   {{- if $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
   valueFrom:
     secretKeyRef:
-        name: {{ printf "%s" $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
+        name: {{ $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
         key: {{ $.Values.externalSecrets.encryptionSecret.existingSecret.passwordKey }}
   {{- else }}
   valueFrom:

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -11,6 +11,18 @@ httpProtocol: http
 oneuptimeSecret:
 encryptionSecret:
 
+# External Secrets
+# You need to leave blank oneuptimeSecret and encryptionSecret to use this section
+externalSecrets:
+  oneuptimeSecret:
+    existingSecret:
+      name:
+      passwordKey:
+  encryptionSecret:
+    existingSecret:
+      name:
+      passwordKey:
+
 # (Optional): You usually do not need to set this if you're self hosting.
 openTelemetryCollectorHost:
 fluentdHost:


### PR DESCRIPTION
### Title of this pull request?

Configure ENCRYPTION_SECRET and ONEUPTIME_SECRET with external secrets instead plain text values in _values_ file Helm chart
### Small Description?

Add configuration in the `_helpers.tpl` file of the Helm chart to configure some secrets using external secrets, instead plain text values in _values_ file.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

https://github.com/OneUptime/oneuptime/issues/1675

### Screenshots (if appropriate):
