### PR TITLE
Fix format for Helm Chart documentation

### DIFF
--- a/HelmChart/Public/oneuptime/README.md
+++ b/HelmChart/Public/oneuptime/README.md
@@ -77,10 +77,8 @@ The following table lists the configurable parameters of the OneUptime chart and
 | `global.storageClass` | Storage class to be used for all persistent volumes | `nil` | 🚨 |
 | `host` | Hostname for the ingress | `localhost` | 🚨 |
 | `httpProtocol` | If the server is hosted with SSL/TLS cert then change this value to https | `http` | 🚨 |
-
 | `oneuptimeSecret` | Value used to define ONEUPTIME_SECRET | `nil` | |
 | `encryptionSecret` | Value used to define ENCRYPTION_SECRET | `nil` | |
-
 | `global.clusterDomain` | Kubernetes Cluster Domain | `cluster.local` |  |
 | `image.registry` | Docker image registry | `docker.io` |  |
 | `image.repository` | Docker image repository | `oneuptime` | |


### PR DESCRIPTION
### Small Description?
Some extra spaces breaks the format of a table in Helm chart documentation


### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):

AFTER

![image](https://github.com/user-attachments/assets/39ed04d5-75e7-4dd0-ab1f-0eafbf799de0)


BEFORE
![image](https://github.com/user-attachments/assets/2e490f08-550d-4f64-8684-7ed98bbc6c18)
