### PR TITLE
Fix externalClickhouse password secret

### DIFF
--- a/HelmChart/Public/oneuptime/templates/secrets.yaml
+++ b/HelmChart/Public/oneuptime/templates/secrets.yaml
@@ -123,26 +123,26 @@ metadata:
   annotations:
     "helm.sh/resource-policy": "keep"
 type: Opaque
-data:
+stringData:
   key: "clickhouse"
 
   {{- if $.Values.externalClickhouse.password }}
   ## Add secret here for clickhousePassword
-  password: {{ $.Values.externalClickhouse.password | b64enc | quote }}
+  password: {{ $.Values.externalClickhouse.password | quote }}
   {{- end }}
 
   ## Add TLS secret here for clickhouse
   {{- if $.Values.externalClickhouse.tls.enabled -}}
   {{- if $.Values.externalClickhouse.tls.ca }}
-  tls-ca: {{ printf "%s" $.Values.externalClickhouse.tls.ca | b64enc | quote }}
+  tls-ca: {{ printf "%s" $.Values.externalClickhouse.tls.ca | quote }}
   {{- end }}
 
   {{- if $.Values.externalClickhouse.tls.cert }}
-  tls-cert: {{ printf "%s" $.Values.externalClickhouse.tls.cert | b64enc | quote }}
+  tls-cert: {{ printf "%s" $.Values.externalClickhouse.tls.cert | quote }}
   {{- end }}
 
   {{- if $.Values.externalClickhouse.tls.key }}
-  tls-key: {{ printf "%s" $.Values.externalClickhouse.tls.key | quote | b64enc | quote }}
+  tls-key: {{ printf "%s" $.Values.externalClickhouse.tls.key | quote }}
   {{- end }}
 
   {{- end -}}


### PR DESCRIPTION
### Title of this pull request?
Fix Helm Chart Deployment Fails when using External Clickhouse

### Small Description?
According to issue #1713, the following error occurs when using an external clickhouse:
`Error from server (BadRequest): error when creating "secret.yaml": Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 8.` 

Unfortunately I could not determine the root cause of the issue—please leave a comment if you know why this happens. Even doing some debug the generated yaml was with the right value. However I was able to get rid of the error by replacing the base64-encoded `data` to a plain-text `stringData`, which lets k8s take care of the base64 encoding and maintains the same level of obfuscation.
### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?
closes #1713

### Screenshots (if appropriate):