### PR TITLE
Add startupProbe to deployments with healthchecks

### DIFF
--- a/HelmChart/Public/oneuptime/templates/api-reference.yaml
+++ b/HelmChart/Public/oneuptime/templates/api-reference.yaml
@@ -41,15 +41,26 @@ spec:
       containers:
         - image: {{ printf "%s/%s/%s:%s" $.Values.image.registry $.Values.image.repository "api-reference" $.Values.image.tag }}
           name: {{ printf "%s-%s" $.Release.Name "api-reference"  }}
+          {{- if $.Values.startupProbes.enabled }}
+          # Startup probe
+          startupProbe:
+            httpGet:
+              path: /status/live
+              port: {{ $.Values.port.apiReference }}
+            periodSeconds: {{ $.Values.startupProbes.periodSeconds }}
+            failureThreshold: {{ $.Values.startupProbes.failureThreshold }}
+          {{- end }}
           {{- if $.Values.enableLivenessProbe }}
           # Liveness probe
           livenessProbe:
             httpGet:
               path: /status/live
               port: {{ $.Values.port.apiReference }}
-            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 30
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
           {{- end }}
           {{- if $.Values.enableReadinessProbe }}
           # Readyness Probe
@@ -57,8 +68,10 @@ spec:
             httpGet:
               path: /status/ready
               port: {{ $.Values.port.apiReference }}
-            initialDelaySeconds: 60
             periodSeconds: 10
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             timeoutSeconds: 30
           {{- end }}
           {{- if $.Values.containerSecurityContext }}

--- a/HelmChart/Public/oneuptime/templates/docs.yaml
+++ b/HelmChart/Public/oneuptime/templates/docs.yaml
@@ -41,14 +41,24 @@ spec:
       containers:
         - image: {{ printf "%s/%s/%s:%s" $.Values.image.registry $.Values.image.repository "docs" $.Values.image.tag }}
           name: {{ printf "%s-%s" $.Release.Name "docs"  }}
-          # Liveness probe
+          {{- if $.Values.startupProbes.enabled }}
+          # Startup probe
+          startupProbe:
+            httpGet:
+              path: /status/live
+              port: {{ $.Values.port.docs }}
+            periodSeconds: {{ $.Values.startupProbes.periodSeconds }}
+            failureThreshold: {{ $.Values.startupProbes.failureThreshold }}
+          {{- end }}
           {{- if $.Values.enableLivenessProbe }}
           # Liveness probe
           livenessProbe:
             httpGet:
               path: /status/live
               port: {{ $.Values.port.docs }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}
@@ -58,7 +68,9 @@ spec:
             httpGet:
               path: /status/ready
               port: {{ $.Values.port.docs }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}

--- a/HelmChart/Public/oneuptime/templates/home.yaml
+++ b/HelmChart/Public/oneuptime/templates/home.yaml
@@ -41,14 +41,24 @@ spec:
       containers:
         - image: {{ printf "%s/%s/%s:%s" $.Values.image.registry $.Values.image.repository "home" $.Values.image.tag }}
           name: {{ printf "%s-%s" $.Release.Name "home"  }}
-          # Liveness probe
+          {{- if $.Values.startupProbes.enabled }}
+          # Startup probe
+          startupProbe:
+            httpGet:
+              path: /status/live
+              port: {{ $.Values.port.home }}
+            periodSeconds: {{ $.Values.startupProbes.periodSeconds }}
+            failureThreshold: {{ $.Values.startupProbes.failureThreshold }}
+          {{- end }}
           {{- if $.Values.enableLivenessProbe }}
           # Liveness probe
           livenessProbe:
             httpGet:
               path: /status/live
               port: {{ $.Values.port.home }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}
@@ -58,7 +68,9 @@ spec:
             httpGet:
               path: /status/ready
               port: {{ $.Values.port.home }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}

--- a/HelmChart/Public/oneuptime/templates/ingestor.yaml
+++ b/HelmChart/Public/oneuptime/templates/ingestor.yaml
@@ -50,14 +50,24 @@ spec:
       containers:
         - image: {{ printf "%s/%s/%s:%s" $.Values.image.registry $.Values.image.repository "ingestor" $.Values.image.tag }}
           name: {{ printf "%s-%s" $.Release.Name "ingestor"  }}
-          # Liveness probe
+          {{- if $.Values.startupProbes.enabled }}
+          # Startup probe
+          startupProbe:
+            httpGet:
+              path: /status/live
+              port: {{ $.Values.port.ingestor }}
+            periodSeconds: {{ $.Values.startupProbes.periodSeconds }}
+            failureThreshold: {{ $.Values.startupProbes.failureThreshold }}
+          {{- end }}
           {{- if $.Values.enableLivenessProbe }}
           # Liveness probe
           livenessProbe:
             httpGet:
               path: /status/live
               port: {{ $.Values.port.ingestor }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}
@@ -67,7 +77,9 @@ spec:
             httpGet:
               path: /status/ready
               port: {{ $.Values.port.ingestor }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}

--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -55,14 +55,24 @@ spec:
       containers:
         - image: {{ printf "%s/%s/%s:%s" $.Values.image.registry $.Values.image.repository "nginx" $.Values.image.tag }}
           name: {{ printf "%s-%s" $.Release.Name "nginx"  }}
-          # Liveness probe
+          {{- if $.Values.startupProbes.enabled }}
+          # Startup probe
+          startupProbe:
+            httpGet:
+              path: /status/live
+              port: 7851
+            periodSeconds: {{ $.Values.startupProbes.periodSeconds }}
+            failureThreshold: {{ $.Values.startupProbes.failureThreshold }}
+          {{- end }}
           {{- if $.Values.enableLivenessProbe }}
           # Liveness probe
           livenessProbe:
             httpGet:
               path: /status/live
               port: 7851
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}
@@ -72,7 +82,9 @@ spec:
             httpGet:
               path: /status/ready
               port: 7851
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}

--- a/HelmChart/Public/oneuptime/templates/workflow.yaml
+++ b/HelmChart/Public/oneuptime/templates/workflow.yaml
@@ -41,13 +41,24 @@ spec:
       containers:
         - image: {{ printf "%s/%s/%s:%s" $.Values.image.registry $.Values.image.repository "workflow" $.Values.image.tag }}
           name: {{ printf "%s-%s" $.Release.Name "workflow"  }}
+          {{- if $.Values.startupProbes.enabled }}
+          # Startup probe
+          startupProbe:
+            httpGet:
+              path: /status/live
+              port: {{ $.Values.port.workflow }}
+            periodSeconds: {{ $.Values.startupProbes.periodSeconds }}
+            failureThreshold: {{ $.Values.startupProbes.failureThreshold }}
+          {{- end }}
           {{- if $.Values.enableLivenessProbe }}
           # Liveness probe
           livenessProbe:
             httpGet:
               path: /status/live
               port: {{ $.Values.port.workflow }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}
@@ -57,7 +68,9 @@ spec:
             httpGet:
               path: /status/ready
               port: {{ $.Values.port.workflow }}
-            initialDelaySeconds: 60
+            {{- if not $.Values.startupProbes.enabled }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            {{- end }}
             periodSeconds: 10
             timeoutSeconds: 30
           {{- end }}

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -378,3 +378,9 @@ notifications:
 
 enableLivenessProbe: true
 enableReadinessProbe: true
+
+initialDelaySeconds: 60 # Initial delay for probes if startup probe is disabled
+startupProbes: # Startup probe configuration
+  enabled: true
+  periodSeconds: 10
+  failureThreshold: 18


### PR DESCRIPTION
Added startupProbe to deployments with healthchecks, replacing initialDelaySeconds.

Additionally made startup probes configurable (periodSeconds and failureThreshold can be set in values.yaml), and added a fallback to initialDelaySeconds if startup probes are disabled.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?
