### PR TITLE
Fix alert name links opening invalid/broken page

### DIFF
--- a/Dashboard/src/Components/Alert/Alert.tsx
+++ b/Dashboard/src/Components/Alert/Alert.tsx
@@ -20,7 +20,7 @@ const AlertElement: FunctionComponent<ComponentProps> = (
         onNavigateComplete={props.onNavigateComplete}
         className="hover:underline"
         to={RouteUtil.populateRouteParams(
-          RouteMap[PageMap.INCIDENT_VIEW] as Route,
+          RouteMap[PageMap.ALERT_VIEW] as Route,
           {
             modelId: new ObjectID(props.alert._id as string),
           },


### PR DESCRIPTION
Fix route on Alert name link in list of alerts

originally clicking the alert name would attempt to open an incident page for the alert's ID - resulting in an error page being shown
