### PR TITLE
Update SubscribedToStatusPage.hbs

### DIFF
--- a/App/FeatureSet/Notification/Templates/SubscribedToStatusPage.hbs
+++ b/App/FeatureSet/Notification/Templates/SubscribedToStatusPage.hbs
@@ -3,7 +3,6 @@
 {{> CustomLogo this}}
 {{> EmailTitle title=(concat "You have been subscribed to status page - " statusPageName) }}
 
-{{> InfoBlock info=(concat "You have been subscribed to status page - " statusPageName)}}
 {{> InfoBlock info="You will be the first to hear from us when there are any incidents, announcements or scheduled maintenance events."}}
 
 {{> ButtonBlock buttonUrl=statusPageUrl buttonText="Go to Status Page"}}


### PR DESCRIPTION
Remove InfoBlock which is identical to EmailTitle and thus messing up the template when send to the new subscriber.

### Title of this pull request?

### Small Description?
Looking at the email that is send to the new subscriber, this looks like a duplication of that sentence.
I've removed the InfoBlock, which seems appropriate as the text contained i already in the EmailTitle.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/06111e74-fe2c-41b1-8553-65de5e2b6a81)
