### PR TITLE
Feature: Nginx: Allow to specify listen options

### DIFF
--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -101,6 +101,10 @@ spec:
             {{- include "oneuptime.env.common" . | nindent 12 }}
             {{- include "oneuptime.env.commonServer" . | nindent 12 }}
             {{- include "oneuptime.env.oneuptimeSecret" . | nindent 12 }}
+            - name: NGINX_LISTEN_ADDRESS
+              value: {{ $.Values.nginx.listenAddress | quote }}
+            - name: NGINX_LISTEN_OPTIONS
+              value: {{ $.Values.nginx.listenOptions | quote }}
             - name: ONEUPTIME_HTTP_PORT
               value: {{ $.Values.port.nginxHttp | quote }}
             - name: OPENTELEMETRY_EXPORTER_OTLP_HEADERS

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -49,6 +49,8 @@ metalLb:
 
 nginx:
   disableTelemetryCollection: false
+  listenAddress: ""
+  listenOptions: ""
   service:
     loadBalancerIP:
     type: LoadBalancer

--- a/Nginx/default.conf.template
+++ b/Nginx/default.conf.template
@@ -119,7 +119,7 @@ server {
     gzip_proxied    no-cache no-store private expired auth;
     gzip_min_length 1000;
    
-    listen 7849;
+    listen ${NGINX_LISTEN_ADDRESS}7849 ${NGINX_LISTEN_OPTIONS};
     http2  on;
 
     server_name oneuptime-fluentd-collector ${FLUENTD_HOST};
@@ -157,7 +157,7 @@ server {
     gzip_proxied    no-cache no-store private expired auth;
     gzip_min_length 1000;
    
-    listen 7849 default_server;
+    listen ${NGINX_LISTEN_ADDRESS}7849 default_server ${NGINX_LISTEN_OPTIONS};
 
     server_name  _; # All domains. 
 
@@ -282,7 +282,7 @@ server {
     gzip_proxied    no-cache no-store private expired auth;
     gzip_min_length 1000;
 
-    listen 7850 ssl default_server; # Port HTTPS
+    listen ${NGINX_LISTEN_ADDRESS}7850 ssl default_server ${NGINX_LISTEN_OPTIONS}; # Port HTTPS
 
 
     ssl_certificate /etc/nginx/certs/StatusPageCerts/$ssl_server_name.crt; 
@@ -388,7 +388,7 @@ server {
     gzip_proxied    no-cache no-store private expired auth;
     gzip_min_length 1000;
     
-    listen 7849;
+    listen ${NGINX_LISTEN_ADDRESS}7849 ${NGINX_LISTEN_OPTIONS};
     http2  on;
 
     server_name localhost ingress ${HOST}; #All domains

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -541,6 +541,8 @@ services:
         environment:
             <<: *common-server-variables
             ONEUPTIME_HTTP_PORT: ${ONEUPTIME_HTTP_PORT}
+            NGINX_LISTEN_ADDRESS: ${NGINX_LISTEN_ADDRESS}
+            NGINX_LISTEN_OPTIONS: ${NGINX_LISTEN_OPTIONS}
             DISABLE_TELEMETRY: ${DISABLE_TELEMETRY_FOR_INGRESS}
         ports:
             - '${ONEUPTIME_HTTP_PORT}:7849'


### PR DESCRIPTION
### Motivation

All OneUptime's services are now ipv6 friendly except Nginx that still listen only on IPv4. This PR finish the work done on #1773 and #1807.

### Description

This PR allow to modify nginx's listen address and options to be able to listen on dual and ipv6 only network stack.

It introduce the `NGINX_LISTEN_ADDRESS` and `NGINX_LISTEN_OPTIONS` environmental variable inside the nginx configuration template so modify both parameter.

This PR don't change the current behaviors.

### Example

IPv6 only:

```env
NGINX_LISTEN_ADDRESS=[::]:
NGINX_LISTEN_OPTIONS=
```

dual stack:

```env
NGINX_LISTEN_ADDRESS=[::]:
NGINX_LISTEN_OPTIONS=ipv6only=off
```

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [X] Did you write tests where appropriate?

### Related Issues

#1348
#1773
#1807

