### PR TITLE
Fix Schedule Maintence Event Number Concatenating instead of incrementing

### DIFF
--- a/Common/Server/Services/ScheduledMaintenanceService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceService.ts
@@ -90,7 +90,7 @@ export class Service extends DatabaseService<Model> {
       return 0;
     }
 
-    return lastScheduledMaintenance.scheduledMaintenanceNumber || 0;
+    return Number(lastScheduledMaintenance.scheduledMaintenanceNumber) || 0;
   }
 
   @CaptureSpan()


### PR DESCRIPTION
In some instances ORM/Database doesn't appear to return the correct type

### Title of this pull request?
Fix Schedule Maintence Event Number Concatenating instead of incrementing

### Small Description?
Simple fix to ensure that function is adding numbers instead of possibly combining a string with a number.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission? - No
- [x] Did you write tests where appropriate?

### Related Issue?
closes #1854 

### Screenshots (if appropriate):
