### PR TITLE
Fix Incident Number Concatenating instead of incrementing

### DIFF
--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -302,7 +302,9 @@ export class Service extends DatabaseService<Model> {
       return 0;
     }
 
-    return lastIncident.incidentNumber ? Number(lastIncident.incidentNumber) : 0;
+    return lastIncident.incidentNumber
+      ? Number(lastIncident.incidentNumber)
+      : 0;
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -302,7 +302,7 @@ export class Service extends DatabaseService<Model> {
       return 0;
     }
 
-    return lastIncident.incidentNumber || 0;
+    return lastIncident.incidentNumber ? Number(lastIncident.incidentNumber) : 0;
   }
 
   @CaptureSpan()


### PR DESCRIPTION
In some instances, database ORM is returning a string instead of a number. This commit ensures that a number is returned by this function.

### Title of this pull request?
Fix Incident Number Concatenating instead of incrementing

### Small Description?
Simple fix to ensure that function is returning a number instead of a string

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission? - No
- [X] Did you write tests where appropriate?

### Related Issue?
No related issue raised, direct fix as similar to issue #1854

### Screenshots (if appropriate):
