### PR TITLE
Fix undefined as domain name when saving custom SSL-Certs

### DIFF
--- a/Nginx/Jobs/WriteCustomCertsToDisk.ts
+++ b/Nginx/Jobs/WriteCustomCertsToDisk.ts
@@ -58,12 +58,12 @@ export default class Jobs {
 
           // Write to disk.
           await LocalFile.write(
-            `/etc/nginx/certs/StatusPageCerts/${cert.domain}.crt`,
+            `/etc/nginx/certs/StatusPageCerts/${cert.fullDomain}.crt`,
             cert.customCertificate?.toString() || "",
           );
 
           await LocalFile.write(
-            `/etc/nginx/certs/StatusPageCerts/${cert.domain}.key`,
+            `/etc/nginx/certs/StatusPageCerts/${cert.fullDomain}.key`,
             cert.customCertificateKey?.toString() || "",
           );
 


### PR DESCRIPTION

### Small Description?

This pull request includes a small but important change to the `WriteCustomCertsToDisk` job in the `Nginx/Jobs/WriteCustomCertsToDisk.ts` file. The change updates the file paths used when writing custom certificates to disk to use `cert.fullDomain` instead of `cert.domain`.

* [`Nginx/Jobs/WriteCustomCertsToDisk.ts`](diffhunk://#diff-b92bdb33e5d129d5f1c9f0182ee3c6e4b18100be36d2aea4b9351edb7a06ef81L61-R66): Updated file paths for writing `.crt` and `.key` files to use `cert.fullDomain` for better accuracy and consistency

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
<img width="921" alt="Bildschirmfoto 2025-05-20 um 14 20 10" src="https://github.com/user-attachments/assets/e40c00fb-e58f-4081-80e7-5562d1d4df91" />
