### PR TITLE
Exclude parameter "replicas" in Deployments, if autoscaling.enabled = true

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -552,7 +552,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name $.ServiceName  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/api-reference.yaml
+++ b/HelmChart/Public/oneuptime/templates/api-reference.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "api-reference"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "app"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/docs.yaml
+++ b/HelmChart/Public/oneuptime/templates/docs.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "docs"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/fluent-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/fluent-ingest.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if $.Values.deployment.fluentIngest.replicaCount }}
   replicas: {{ $.Values.deployment.fluentIngest.replicaCount }}
   {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/home.yaml
+++ b/HelmChart/Public/oneuptime/templates/home.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "home"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/incoming-request-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/incoming-request-ingest.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if $.Values.deployment.incomingRequestIngest.replicaCount }}
   replicas: {{ $.Values.deployment.incomingRequestIngest.replicaCount }}
   {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/isolated-vm.yaml
+++ b/HelmChart/Public/oneuptime/templates/isolated-vm.yaml
@@ -15,7 +15,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "isolated-vm"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -15,7 +15,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "nginx"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/open-telemetry-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/open-telemetry-ingest.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if $.Values.deployment.openTelemetryIngest.replicaCount }}
   replicas: {{ $.Values.deployment.openTelemetryIngest.replicaCount }}
   {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/otel-collector.yaml
+++ b/HelmChart/Public/oneuptime/templates/otel-collector.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if $.Values.deployment.otelCollector.replicaCount }}
   replicas: {{ $.Values.deployment.otelCollector.replicaCount }}
   {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/probe-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe-ingest.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if $.Values.deployment.probeIngest.replicaCount }}
   replicas: {{ $.Values.deployment.probeIngest.replicaCount }}
   {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/probe.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe.yaml
@@ -14,7 +14,13 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name (printf "probe-%s" $key)  }}
+  {{- if $val.replicaCount }}
   replicas: {{ $val.replicaCount }}
+  {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/server-monitor-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/server-monitor-ingest.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if $.Values.deployment.serverMonitorIngest.replicaCount }}
   replicas: {{ $.Values.deployment.serverMonitorIngest.replicaCount }}
   {{- else }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/worker.yaml
+++ b/HelmChart/Public/oneuptime/templates/worker.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "worker"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/workflow.yaml
+++ b/HelmChart/Public/oneuptime/templates/workflow.yaml
@@ -14,7 +14,9 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-%s" $.Release.Name "workflow"  }}
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ $.Values.deployment.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
In the Helm chart, when autoscaling.enabled = true is set in values.yaml, a HorizontalPodAutoscaler takes care of managing the number of replicas. For this reason, the replicas field should be omitted in the Deployment to avoid it being reset to 1 on every helm upgrade