### PR TITLE
Fix(tests): Correct EnvironmentConfig mock in BaseAPI.test.ts

### DIFF
--- a/Common/Tests/Server/API/BaseAPI.test.ts
+++ b/Common/Tests/Server/API/BaseAPI.test.ts
@@ -102,8 +102,17 @@ jest.mock("../../../Server/Services/ProjectService", () => {
 });
 
 jest.mock("../../../Server/EnvironmentConfig", () => {
+  enum ConfigLogLevel {
+    DEBUG = "debug",
+    INFO = "info",
+    WARN = "warn",
+    ERROR = "error",
+  }
   return {
     IsBillingEnabled: true,
+    LogLevel: ConfigLogLevel.INFO, // Or any other appropriate default for tests
+    ConfigLogLevel: ConfigLogLevel,
+    DisableTelemetry: true,
   };
 });
 


### PR DESCRIPTION
I've updated the Jest mock for 'Common/Server/EnvironmentConfig' in 'Common/Tests/Server/API/BaseAPI.test.ts' to include 'LogLevel' and 'ConfigLogLevel'. This resolves a TypeError (Cannot read properties of undefined (reading 'INFO')) that occurred when the logger was invoked during test execution.

The error was caused by an incomplete mock that did not provide the logging configuration, leading to a crash in 'Logger.getLogLevel()'.

Additionally, I've added 'DisableTelemetry: true' to the mock to prevent unnecessary telemetry initialization during these specific API tests.

### Title of this pull request?

### Small Description?

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
