### PR TITLE
feat: Add API Reference link to documentation

### DIFF
--- a/Docs/Content/api-reference/API Reference.md
+++ b/Docs/Content/api-reference/API Reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+[OneUptime API Reference](/reference)

--- a/Docs/Utils/Nav.ts
+++ b/Docs/Utils/Nav.ts
@@ -115,6 +115,15 @@ const DocsNav: NavGroup[] = [
       { title: "Deploy LLM Server", url: "/docs/copilot/deploy-llm-server" },
     ],
   },
+  {
+    title: "API Reference",
+    links: [
+      {
+        title: "OneUptime API Reference",
+        url: "/docs/api-reference/api-reference",
+      },
+    ],
+  },
 ];
 
 // Is self hosted install, then...


### PR DESCRIPTION
This commit introduces a new "API Reference" section in the documentation navigation.

- A new navigation group "API Reference" is added to `Docs/Utils/Nav.ts`.
- This group links to a new page `/docs/api-reference/api-reference`.
- The new page `Docs/Content/api-reference/API Reference.md` is created and contains a link to the main OneUptime API Reference at `/reference`.

### Title of this pull request?

### Small Description?

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
