### PR TITLE
chore(ci): [terraform] Add darwin/arm Build Target

### DIFF
--- a/Scripts/TerraformProvider/Core/TerraformProviderGenerator.ts
+++ b/Scripts/TerraformProvider/Core/TerraformProviderGenerator.ts
@@ -38,6 +38,7 @@ build:
 release:
 	mkdir -p ./builds
 	GOOS=darwin GOARCH=amd64 go build -o ./builds/\${BINARY}_darwin_amd64
+	GOOS=darwin GOARCH=arm go build -o ./builds/\${BINARY}_darwin_arm
 	GOOS=freebsd GOARCH=386 go build -o ./builds/\${BINARY}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./builds/\${BINARY}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./builds/\${BINARY}_freebsd_arm

--- a/Scripts/TerraformProvider/GenerateProvider.ts
+++ b/Scripts/TerraformProvider/GenerateProvider.ts
@@ -142,6 +142,7 @@ async function main(): Promise<void> {
           ext?: string;
         }> = [
           { os: "darwin", arch: "amd64" },
+          { os: "darwin", arch: "arm" },
           { os: "linux", arch: "amd64" },
           { os: "linux", arch: "386" },
           { os: "linux", arch: "arm" },


### PR DESCRIPTION
### Title of this pull request?

chore(ci): [terraform] Add darwin/arm Build Target

### Small Description?

The Terraform provider wasn't releasing with a `darwin/arm` target, so you couldn't use it on Apple Silicon Macs. This adds that target to the build process.

### Pull Request Checklist: 

- [X] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

Was originally over at OneUptime/terraform-provider-oneuptime#1 but didn't realize that this is the place to put it!

### Screenshots (if appropriate):

N/A