### PR TITLE
chore(ci): [terraform] Add Missing arm64 Targets

### DIFF
--- a/Scripts/TerraformProvider/Core/TerraformProviderGenerator.ts
+++ b/Scripts/TerraformProvider/Core/TerraformProviderGenerator.ts
@@ -39,17 +39,29 @@ release:
 	mkdir -p ./builds
 	GOOS=darwin GOARCH=amd64 go build -o ./builds/\${BINARY}_darwin_amd64
 	GOOS=darwin GOARCH=arm go build -o ./builds/\${BINARY}_darwin_arm
+	GOOS=darwin GOARCH=arm64 go build -o ./builds/\${BINARY}_darwin_arm64
+
 	GOOS=freebsd GOARCH=386 go build -o ./builds/\${BINARY}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./builds/\${BINARY}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./builds/\${BINARY}_freebsd_arm
+	GOOS=freebsd GOARCH=arm64 go build -o ./builds/\${BINARY}_freebsd_arm64
+
 	GOOS=linux GOARCH=386 go build -o ./builds/\${BINARY}_linux_386
 	GOOS=linux GOARCH=amd64 go build -o ./builds/\${BINARY}_linux_amd64
 	GOOS=linux GOARCH=arm go build -o ./builds/\${BINARY}_linux_arm
+	GOOS=linux GOARCH=arm64 go build -o ./builds/\${BINARY}_linux_arm64
+
 	GOOS=openbsd GOARCH=386 go build -o ./builds/\${BINARY}_openbsd_386
 	GOOS=openbsd GOARCH=amd64 go build -o ./builds/\${BINARY}_openbsd_amd64
+	GOOS=openbsd GOARCH=arm go build -o ./builds/\${BINARY}_openbsd_arm
+	GOOS=openbsd GOARCH=arm64 go build -o ./builds/\${BINARY}_openbsd_arm64
+
 	GOOS=solaris GOARCH=amd64 go build -o ./builds/\${BINARY}_solaris_amd64
+
 	GOOS=windows GOARCH=386 go build -o ./builds/\${BINARY}_windows_386.exe
 	GOOS=windows GOARCH=amd64 go build -o ./builds/\${BINARY}_windows_amd64.exe
+	GOOS=windows GOARCH=arm go build -o ./builds/\${BINARY}_windows_arm.exe
+	GOOS=windows GOARCH=arm64 go build -o ./builds/\${BINARY}_windows_arm64.exe
 
 install: build
 	mkdir -p ~/.terraform.d/plugins/\${HOSTNAME}/\${NAMESPACE}/\${NAME}/\${VERSION}/\${OS_ARCH}

--- a/Scripts/TerraformProvider/GenerateProvider.ts
+++ b/Scripts/TerraformProvider/GenerateProvider.ts
@@ -143,16 +143,23 @@ async function main(): Promise<void> {
         }> = [
           { os: "darwin", arch: "amd64" },
           { os: "darwin", arch: "arm" },
+          { os: "darwin", arch: "arm64" },
           { os: "linux", arch: "amd64" },
           { os: "linux", arch: "386" },
           { os: "linux", arch: "arm" },
+          { os: "linux", arch: "arm64" },
           { os: "windows", arch: "amd64", ext: ".exe" },
           { os: "windows", arch: "386", ext: ".exe" },
+          { os: "windows", arch: "arm", ext: ".exe" },
+          { os: "windows", arch: "arm64", ext: ".exe" },
           { os: "freebsd", arch: "amd64" },
           { os: "freebsd", arch: "386" },
           { os: "freebsd", arch: "arm" },
+          { os: "freebsd", arch: "arm64" },
           { os: "openbsd", arch: "amd64" },
           { os: "openbsd", arch: "386" },
+          { os: "openbsd", arch: "arm" },
+          { os: "openbsd", arch: "arm64" },
           { os: "solaris", arch: "amd64" },
         ];
 


### PR DESCRIPTION
### Title of this pull request?

chore(ci): [terraform] Add Missing arm64 Targets

### Small Description?

A previous commit added `arm` targets, which is 32-bit ARM. We also need `arm64` targets (64-bit ARM.)

This commit also adds `arm`/`arm64` for other `GOOS` targets.

### Pull Request Checklist: 

- [X] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

#1967 was originally meant to do this.

### Screenshots (if appropriate):
N/A