### PR TITLE
helm: add deployment update strategy

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -573,6 +573,7 @@ spec:
   {{- if or (not $.Values.autoscaling.enabled) ($.DisableAutoscaler) }}
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/HelmChart/Public/oneuptime/templates/api-reference.yaml
+++ b/HelmChart/Public/oneuptime/templates/api-reference.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/docs.yaml
+++ b/HelmChart/Public/oneuptime/templates/docs.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/fluent-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/fluent-ingest.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/home.yaml
+++ b/HelmChart/Public/oneuptime/templates/home.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/incoming-request-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/incoming-request-ingest.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/isolated-vm.yaml
+++ b/HelmChart/Public/oneuptime/templates/isolated-vm.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/open-telemetry-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/open-telemetry-ingest.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/otel-collector.yaml
+++ b/HelmChart/Public/oneuptime/templates/otel-collector.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/probe-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe-ingest.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/probe.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/server-monitor-ingest.yaml
+++ b/HelmChart/Public/oneuptime/templates/server-monitor-ingest.yaml
@@ -22,6 +22,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/worker.yaml
+++ b/HelmChart/Public/oneuptime/templates/worker.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/templates/workflow.yaml
+++ b/HelmChart/Public/oneuptime/templates/workflow.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ $.Values.deployment.replicaCount }}
   {{- end }}
   {{- end }}
+  strategy: {{- toYaml $.Values.deployment.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -29,7 +29,10 @@ fluentdHost:
 
 deployment:
   # Default replica count for all deployments
-  replicaCount: 1 
+  replicaCount: 1
+  # Update strategy type for all deployments
+  updateStrategy:
+    type: RollingUpdate
 
 metalLb:
   enabled: false


### PR DESCRIPTION
### Title of this pull request?

helm: add deployment update strategy

### Small Description?

makes all the helm chart deployments update strategy to be configurable. 

set to `RollingUpdate` in the chart values, which is the default value for all deployments.

i would like to use `Recreate` on my cluster as it has limited resources and cannot create two pods for all OneUptime components. I am already at 90% CPU and memory.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
