### PR TITLE
fix: Change form field from description to rootCause

### DIFF
--- a/Dashboard/src/Pages/Incidents/View/RootCause.tsx
+++ b/Dashboard/src/Pages/Incidents/View/RootCause.tsx
@@ -28,7 +28,7 @@ const IncidentDelete: FunctionComponent<
       formFields={[
         {
           field: {
-            description: true,
+            rootCause: true,
           },
           title: "Root Cause",
 


### PR DESCRIPTION


### [Title of this pull request?](fix: Change form field from description to rootCause)

### RootCause Edit Modal wrongly fetched the Incident description in the form and also updates the wrong field.

### Pull Request Checklist: 

- [X] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
