### PR TITLE
Refactor the use app-scoped token for fetching teams per user

### DIFF
--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -2935,9 +2935,7 @@ All monitoring checks are passing normally.`;
       try {
         // Fetch joined teams using app-scoped token
         if (data.userId) {
-          logger.debug(
-            "Using app-scoped token to fetch joined teams for user",
-          );
+          logger.debug("Using app-scoped token to fetch joined teams for user");
           const userTeams: Record<string, { id: string; name: string }> =
             await this.getUserJoinedTeams({
               userId: data.userId.toString(),


### PR DESCRIPTION
### Refactor the use app-scoped token for fetching teams per user

### Previous approach to fetch only the teams that the user who created the MSTeams integration did not work. Switchign back to app-scoped token but using the users/{user-id}/joinedTeams Graph endpoint.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
