### PR TITLE
Modify API call to retrieve user's team memberships

### DIFF
--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -53,6 +53,7 @@ import AlertService from "../../../Services/AlertService";
 import ScheduledMaintenanceService from "../../../Services/ScheduledMaintenanceService";
 import IncidentStateService from "../../../Services/IncidentStateService";
 import AlertStateService from "../../../Services/AlertStateService";
+import UserService from "../../../Services/UserService";
 
 // Import database utilities
 import QueryHelper from "../../../Types/Database/QueryHelper";
@@ -2938,7 +2939,7 @@ All monitoring checks are passing normally.`;
           logger.debug("Using app-scoped token to fetch joined teams for user");
           const userTeams: Record<string, { id: string; name: string }> =
             await this.getUserJoinedTeams({
-              userId: data.userId.toString(),
+              userId: data.userId,
               projectId: data.projectId,
             });
           allTeams = Object.values(userTeams) as any;
@@ -3063,14 +3064,33 @@ All monitoring checks are passing normally.`;
   // Method to get user's joined teams using app-scoped token
   @CaptureSpan()
   public static async getUserJoinedTeams(data: {
-    userId: string;
+    userId: ObjectID;
     projectId: ObjectID;
   }): Promise<Record<string, { id: string; name: string }>> {
     logger.debug("=== getUserJoinedTeams called ===");
-    logger.debug(`User ID: ${data.userId}`);
+    logger.debug(`User ID: ${data.userId.toString()}`);
     logger.debug(`Project ID: ${data.projectId.toString()}`);
 
     try {
+      // Fetch user email from UserService
+      const user = await UserService.findOneById({
+        id: data.userId,
+        select: {
+          email: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+      
+      if (!user || !user.email) {
+        logger.error("User or user email not found");
+        throw new BadDataException("User email not found for Microsoft Teams integration");
+      }
+      
+      const userEmail: string = user.email.toString();
+      logger.debug(`Retrieved user email: ${userEmail}`);
+
       // Get a valid app access token (refreshed if needed)
       logger.debug("Refreshing app access token before fetching teams");
       const accessToken: string = await this.getValidAccessToken({
@@ -3083,7 +3103,7 @@ All monitoring checks are passing normally.`;
       const teamsResponse: HTTPErrorResponse | HTTPResponse<JSONObject> =
         await API.get<JSONObject>({
           url: URL.fromString(
-            `https://graph.microsoft.com/v1.0/users/${data.userId}/memberOf/$/microsoft.graph.group?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')`,
+            `https://graph.microsoft.com/v1.0/users/${userEmail}/joinedTeams`,
           ),
           headers: {
             Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
### Switch to membersof instead of joinedTeams

### Due to false behaviour in MS Entra Graph API the /v1.0/users/{userId}/joinedTeams is wrongly redirect to https://graph.microsoft.com/edu/users/{userId}/memberOf. Fixing by directly using the memberOf endpoint with needed filter

### Pull Request Checklist: 

- [X] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
