### PR TITLE
Fix user ID handling in MicrosoftTeams service

### DIFF
--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -3076,7 +3076,7 @@ All monitoring checks are passing normally.`;
 
     try {
       // Fetch user email from UserService
-      const user: User = await UserService.findOneById({
+      const user: User | null = await UserService.findOneById({
         id: data.userId,
         select: {
           email: true,


### PR DESCRIPTION
### Fix user ID handling in MicrosoftTeams service

### User-ID was internal oneuptime ID. Switched to using email with MS-graph API.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
