### PR TITLE
Fix processing of teams response

### DIFF
--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -3082,14 +3082,12 @@ All monitoring checks are passing normally.`;
           isRoot: true,
         },
       });
-      
       if (!user || !user.email) {
         logger.error("User or user email not found");
         throw new BadDataException(
           "User email not found for Microsoft Teams integration",
         );
       }
-      
       const userEmail: string = user.email.toString();
       logger.debug(`Retrieved user email: ${userEmail}`);
 


### PR DESCRIPTION
### Fix processing of teams response

### Fixed the double processing of the teams response when user-scoped teams were retrieved

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [X] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
