### PR TITLE
fix: Remove automatic default injection in MonitorStep.fromJSON

### DIFF
--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -448,24 +448,6 @@ export default class MonitorStep extends DatabaseProperty {
         : undefined,
     }) as any;
 
-    if (monitorStep.data && !monitorStep.data?.logMonitor) {
-      monitorStep.data.logMonitor = MonitorStepLogMonitorUtil.getDefault();
-    }
-
-    if (monitorStep.data && !monitorStep.data?.traceMonitor) {
-      monitorStep.data.traceMonitor = MonitorStepTraceMonitorUtil.getDefault();
-    }
-
-    if (monitorStep.data && !monitorStep.data?.metricMonitor) {
-      monitorStep.data.metricMonitor =
-        MonitorStepMetricMonitorUtil.getDefault();
-    }
-
-    if (monitorStep.data && !monitorStep.data?.exceptionMonitor) {
-      monitorStep.data.exceptionMonitor =
-        MonitorStepExceptionMonitorUtil.getDefault();
-    }
-
     return monitorStep;
   }
 


### PR DESCRIPTION
## Summary

- 🔧 Remove automatic population of `logMonitor`, `traceMonitor`, `metricMonitor`, `exceptionMonitor` defaults in `fromJSON()` method
- 🐛 Fixes Terraform provider "inconsistent result after apply" errors
- 📝 API was injecting defaults not present in original request, breaking round-trip consistency

## Problem

When creating monitors via the Terraform provider, the API response included default values for optional fields (`exceptionMonitor`, `logMonitor`, etc.) that were not present in the original request. This caused Terraform to report:

```
Provider produced inconsistent result after apply

.monitor_steps: was cty.StringVal("...no exceptionMonitor...")
but now cty.StringVal("...\"exceptionMonitor\":{\"exceptionTypes\":[],...}...")
```

## Root Cause

`Common/Types/Monitor/MonitorStep.ts` lines 451-467 explicitly injected defaults during JSON deserialisation:

```typescript
if (monitorStep.data && !monitorStep.data?.exceptionMonitor) {
  monitorStep.data.exceptionMonitor = MonitorStepExceptionMonitorUtil.getDefault();
}
```

## Solution

Removed the automatic default injection blocks in `fromJSON()`. The fields remain `undefined` when not provided, preserving round-trip consistency.

## Testing

- ✅ Monitor creation succeeds without "inconsistent result" error
- ✅ No state drift on re-plan (`No changes. Your infrastructure matches the configuration.`)
- ✅ Dashboard uses fallback patterns at render time (unaffected)
- ✅ Worker validates presence explicitly (unchanged behaviour)

## Test Plan

- [x] Verified fix with local OneUptime instance
- [x] Terraform apply/plan cycle produces consistent state
- [x] Published provider v9.3.22 works with this fix (server-side only change)

Fixes #2226

🤖 Generated with [Claude Code](https://claude.com/claude-code)