### PR TITLE
Support existing secrets for Redis & ClickHouse

### DIFF
--- a/HelmChart/Public/oneuptime/templates/clickhouse-statefulset.yaml
+++ b/HelmChart/Public/oneuptime/templates/clickhouse-statefulset.yaml
@@ -92,8 +92,13 @@ spec:
         - name: CLICKHOUSE_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.clickhouse.auth.existingSecret.name }}
+              name: {{ .Values.clickhouse.auth.existingSecret.name }}
+              key: {{ .Values.clickhouse.auth.existingSecret.passwordKey }}
+              {{- else }}
               name: {{ .Release.Name }}-clickhouse
               key: admin-password
+              {{- end }}
         - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
           value: "1"
         livenessProbe:

--- a/HelmChart/Public/oneuptime/templates/redis-statefulset.yaml
+++ b/HelmChart/Public/oneuptime/templates/redis-statefulset.yaml
@@ -79,8 +79,13 @@ spec:
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.redis.auth.existingSecret.name }}
+              name: {{ .Values.redis.auth.existingSecret.name }}
+              key: {{ .Values.redis.auth.existingSecret.passwordKey }}
+              {{- else }}
               name: {{ .Release.Name }}-redis
               key: redis-password
+              {{- end }}
         livenessProbe:
           exec:
             command:

--- a/HelmChart/Public/oneuptime/templates/secrets.yaml
+++ b/HelmChart/Public/oneuptime/templates/secrets.yaml
@@ -64,7 +64,7 @@ stringData:
 
 ---
 
-{{- if .Values.redis.enabled }}
+{{- if and .Values.redis.enabled (not .Values.redis.auth.existingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -217,7 +217,7 @@ stringData:
 
 ---
 
-{{- if .Values.clickhouse.enabled }}
+{{- if and .Values.clickhouse.enabled (not .Values.clickhouse.auth.existingSecret.name) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -349,6 +349,18 @@
             },
             "password": {
               "type": ["string", "null"]
+            },
+            "existingSecret": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": ["string", "null"]
+                },
+                "passwordKey": {
+                  "type": ["string", "null"]
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -450,6 +462,18 @@
           "properties": {
             "password": {
               "type": ["string", "null"]
+            },
+            "existingSecret": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": ["string", "null"]
+                },
+                "passwordKey": {
+                  "type": ["string", "null"]
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -132,6 +132,10 @@ clickhouse:
     username: oneuptime
     # Will be auto-generated if not provided
     password:
+    # Use an existing secret for the ClickHouse password
+    existingSecret:
+      name:
+      passwordKey:
   image:
     repository: clickhouse/clickhouse-server
     tag: latest
@@ -197,6 +201,10 @@ redis:
   auth:
     # Will be auto-generated if not provided
     password:
+    # Use an existing secret for the Redis password
+    existingSecret:
+      name:
+      passwordKey:
   image:
     repository: redis
     tag: latest


### PR DESCRIPTION
### Description

Allows referencing existing Kubernetes secrets for ClickHouse and Redis passwords (compatible with already in-place auto-generated passwords).

## Usage

**ClickHouse:**
```yaml
clickhouse:
  auth:
    existingSecret:
      name: my-clickhouse-secret
      passwordKey: admin-password
```

**Redis:**
```yaml
redis:
  auth:
    existingSecret:
      name: my-redis-secret
      passwordKey: password
```

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?
