### PR TITLE
Fix missing Redis & ClickHouse existing secrets

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -277,8 +277,13 @@ Usage:
   {{- if $.Values.clickhouse.enabled }}
   valueFrom:
     secretKeyRef:
+        {{- if .Values.clickhouse.auth.existingSecret.name }}
+        name: {{ .Values.clickhouse.auth.existingSecret.name }}
+        key: {{ .Values.clickhouse.auth.existingSecret.passwordKey }}
+        {{- else }}
         name: {{ printf "%s-%s" $.Release.Name "clickhouse"  }}
         key: admin-password
+        {{- end }}
   {{- else }}
   {{- if $.Values.externalClickhouse.password }}
   valueFrom:


### PR DESCRIPTION
### Small Description

Following this PR https://github.com/OneUptime/oneuptime/pull/2251 to support existing secrets for Redis & ClickHouse. I've missed two modifications.

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
