### PR TITLE
Fix installation command to ensure it can follow the redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ By using OneUptime Cloud, you also support the continued development of the open
 
 ```bash
 # Quick start with one command
-curl https://oneuptime.com/install.sh | bash
+curl -L https://oneuptime.com/install.sh | bash
 ```
 
 For detailed installation guides, see:


### PR DESCRIPTION
The install.The URL is a redirect, for curl to follow it, you must use the -L option, otherwise you get an error.

EG:

root@inf1:~# curl https://oneuptime.com/install.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   107  100   107    0     0    242      0 --:--:-- --:--:-- --:--:--   243
bash: line 1: Found.: command not found

### Title of this pull request?
Install command throws error due to redirect.

### Small Description?
Fixes install command to follow the redirect for install.sh

### Pull Request Checklist: 

- [ Y] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [Y] Have you lint your code locally before submission?
- [Y] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
