### PR TITLE
Modify clone instructions for release branch

### DIFF
--- a/Docs/Content/installation/docker-compose.md
+++ b/Docs/Content/installation/docker-compose.md
@@ -31,12 +31,9 @@ Before you start the deployment process, please make sure you have:
 To install OneUptime: 
 
 ```
-# Clone this repo and cd into it.
-git clone https://github.com/OneUptime/oneuptime.git
+# Clone this repo with just the release branch and cd into it.
+git clone --depth 1 --single-branch --branch release https://github.com/OneUptime/oneuptime.git
 cd oneuptime
-
-# Please make sure you're on release branch.
-git checkout release
 
 # Copy config.example.env to config.env
 cp config.example.env config.env


### PR DESCRIPTION
Updated the instructions to clone the repository to the release branch only.

This will save significant bandwidth and disk space by cloning only the release branch, as it exists now, rather than the entire repository with its full history.

### Title of this pull request?

### Small Description?

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
