### PR TITLE
fix(seo): noindex tag pages and remove from sitemap

### DIFF
--- a/Home/Utils/Sitemap.ts
+++ b/Home/Utils/Sitemap.ts
@@ -327,14 +327,8 @@ export async function generateSitemapIndexXml(): Promise<string> {
     lastmod: timestamp,
   });
 
-  // Blog tags sitemaps (paginated)
-  const tagsPageCount: number = await getTagsSitemapPageCount();
-  for (let i: number = 1; i <= tagsPageCount; i++) {
-    sitemaps.push({
-      loc: `${baseUrlString}/sitemap-tags-${i}.xml`,
-      lastmod: timestamp,
-    });
-  }
+  // Note: Blog tag sitemaps removed - tag pages are noindex to improve
+  // site quality signals and crawl budget efficiency
 
   // Blog post sitemaps (paginated)
   const blogPageCount: number = await getBlogSitemapPageCount();

--- a/Home/Views/Blog/ListByTag.ejs
+++ b/Home/Views/Blog/ListByTag.ejs
@@ -6,6 +6,7 @@
 <head>
   <title>Latest Posts on <%= tagName %> - OneUptime Blog</title>
   <meta name="description" content="Read our latest posts on <%= tagName %>.">
+  <meta name="robots" content="noindex, follow">
   <%- include('../head') -%>
 
 


### PR DESCRIPTION
## Problem

Google Search Console shows **0 out of 10,519 pages indexed**. 

Root cause: 5,000+ thin tag pages are:
- Diluting site quality signals
- Consuming crawl budget
- Signaling to Google that the site has low-quality content

## Solution

### 1. Add `noindex` to tag pages
```html
<meta name="robots" content="noindex, follow">
```

This tells Google:
- ❌ Do NOT index this page
- ✅ DO follow links to discover real content

### 2. Remove tag sitemaps from index

Stop submitting 5,000 low-value URLs to Google.

## Expected Impact

| Before | After |
|--------|-------|
| 10,519 URLs submitted | ~5,500 URLs submitted |
| 0 indexed | Gradual improvement |
| Crawl budget wasted on tags | Focused on valuable content |

## Files Changed

- `Home/Views/Blog/ListByTag.ejs` - Added noindex meta tag
- `Home/Utils/Sitemap.ts` - Removed tag sitemaps from index

## Note

This is a critical SEO fix. Google will need time to re-crawl and update its index (2-4 weeks typical).