### PR TITLE
fix(seo): unique meta descriptions for product pages

### DIFF
--- a/Home/Views/about.ejs
+++ b/Home/Views/about.ejs
@@ -5,11 +5,11 @@
 
 <head>
     <title>About OneUptime | Open Source Observability Platform</title>
-    <meta name="description" content="Learn about OneUptime's mission to democratize observability. We're building an open-source platform that helps teams monitor, debug, and resolve issues faster.">
+    <meta name="description" content="OneUptime is the open source observability platform replacing Datadog, PagerDuty, and Statuspage. Apache 2.0 licensed. Built by developers, for developers. Join 6,000+ GitHub stars.">
 
     <!-- Open Graph -->
     <meta property="og:title" content="About OneUptime | Open Source Observability Platform">
-    <meta property="og:description" content="Learn about OneUptime's mission to democratize observability. We're building an open-source platform that helps teams monitor, debug, and resolve issues faster.">
+    <meta property="og:description" content="OneUptime is the open source observability platform replacing Datadog, PagerDuty, and Statuspage. Apache 2.0 licensed. Built by developers, for developers.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://oneuptime.com/about">
     <meta property="og:image" content="https://oneuptime.com/img/og-image.png">

--- a/Home/Views/incident-management.ejs
+++ b/Home/Views/incident-management.ejs
@@ -6,7 +6,7 @@
 <head>
     <title>OneUptime | Incident Management and Response. </title>
     <meta name="description"
-        content="OneUptime monitors websites, APIs, and servers and alerts your team if something goes wrong. It also keeps your customers updated about any downtime.">
+        content="Streamline incident response with timelines, collaboration, and postmortems. Integrates with Slack, Teams, and PagerDuty. Open source incident management platform.">
         <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>

--- a/Home/Views/monitoring.ejs
+++ b/Home/Views/monitoring.ejs
@@ -6,7 +6,7 @@
 <head>
     <title>OneUptime | Monitor any resource in real-time. </title>
     <meta name="description"
-        content="OneUptime monitors websites, APIs, and servers and alerts your team if something goes wrong. It also keeps your customers updated about any downtime.">
+        content="Monitor websites, APIs, servers, and containers from 7+ global locations. Get alerts via SMS, email, Slack, and phone. Free tier available. Open source Datadog alternative.">
         <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>

--- a/Home/Views/on-call.ejs
+++ b/Home/Views/on-call.ejs
@@ -6,7 +6,7 @@
 <head>
     <title>OneUptime | On-Call Policies and Alerts. </title>
     <meta name="description"
-        content="OneUptime monitors websites, APIs, and servers and alerts your team if something goes wrong. It also keeps your customers updated about any downtime.">
+        content="On-call scheduling with rotations, escalations, and multi-channel alerts (SMS, phone, Slack, Teams). Free tier includes unlimited schedules. Open source PagerDuty alternative.">
         <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>

--- a/Home/Views/status-page.ejs
+++ b/Home/Views/status-page.ejs
@@ -4,9 +4,9 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 
 <head>
-  <title>OneUptime | Unlimited Public or Private Status Page. </title>
+  <title>Free Status Page | Public & Private | Unlimited Subscribers | OneUptime</title>
   <meta name="description"
-    content="OneUptime monitors websites, APIs, and servers and alerts your team if something goes wrong. It also keeps your customers updated about any downtime.">
+    content="Create beautiful public or private status pages for free. Unlimited subscribers, custom domains, automatic updates from monitoring. Open source alternative to Atlassian Statuspage.">
   <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>


### PR DESCRIPTION
## Problem

Multiple product pages have **identical generic meta descriptions**:

```
OneUptime monitors websites, APIs, and servers and alerts your team if something goes wrong...
```

This kills CTR because Google shows the same snippet for:
- /product/status-page (8,186 impressions, 0.39% CTR)
- /product/monitoring (2,007 impressions, 0.70% CTR)
- /product/incident-management (1,437 impressions, 0.56% CTR)
- /product/on-call (1,979 impressions, 1.01% CTR)

## Solution

Unique, keyword-rich meta descriptions for each page:

| Page | New Description |
|------|----------------|
| **/product/status-page** | Create beautiful public or private status pages for free. Unlimited subscribers, custom domains, automatic updates from monitoring. Open source alternative to Atlassian Statuspage. |
| **/product/monitoring** | Monitor websites, APIs, servers, and containers from 7+ global locations. Get alerts via SMS, email, Slack, and phone. Free tier available. Open source Datadog alternative. |
| **/product/incident-management** | Streamline incident response with timelines, collaboration, and postmortems. Integrates with Slack, Teams, and PagerDuty. Open source incident management platform. |
| **/product/on-call** | On-call scheduling with rotations, escalations, and multi-channel alerts. Free tier includes unlimited schedules. Open source PagerDuty alternative. |
| **/about** | OneUptime is the open source observability platform replacing Datadog, PagerDuty, and Statuspage. Apache 2.0 licensed. Built by developers, for developers. |

## Why This Matters

- **Better CTR** = More organic traffic from same impressions
- **Keyword targeting** = Rank for "free status page", "PagerDuty alternative", etc.
- **User intent** = Descriptions match what searchers are looking for

## Files Changed

- `Home/Views/status-page.ejs`
- `Home/Views/monitoring.ejs`
- `Home/Views/incident-management.ejs`
- `Home/Views/on-call.ejs`
- `Home/Views/about.ejs`