### PR TITLE
fix(seo): improve compare page title tags for better CTR

### DIFF
--- a/Home/Views/product-compare.ejs
+++ b/Home/Views/product-compare.ejs
@@ -4,9 +4,9 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 
 <head>
-    <title>OneUptime vs <%= productConfig.productName %>: Open-Source Alternative | 2026 Comparison</title>
+    <title><%= productConfig.productName %> Alternative - OneUptime | Open Source | 2026 Comparison</title>
     <meta name="description"
-        content="Looking for a <%= productConfig.productName %> alternative? OneUptime is the open-source observability platform with monitoring, status pages, incident management & APM in one. Compare features and pricing.">
+        content="Compare <%= productConfig.productName %> vs OneUptime. Free open-source alternative with unlimited monitors, status pages & on-call. See pricing, features & migration guide.">
     <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>


### PR DESCRIPTION
## Problem

`/compare/better-uptime` ranks position 13.5 with 803 impressions but only 0.37% CTR.

Current title: `OneUptime vs Better Stack: Open-Source Alternative | 2026 Comparison`

## Solution

New title pattern: `[Product] Alternative - OneUptime | Open Source | 2026 Comparison`

Example: `Better Stack (Better Uptime) Alternative - OneUptime | Open Source | 2026 Comparison`

### Why This Works

1. **Competitor name first** - Matches search intent ("better uptime alternative")
2. **"Alternative" prominent** - High-intent keyword users search for
3. **Shorter & scannable** - Better for SERP display

### Also Improved Meta Description

From:
> Looking for a [Product] alternative? OneUptime is the open-source observability platform...

To:
> Compare [Product] vs OneUptime. Free open-source alternative with unlimited monitors, status pages & on-call. See pricing, features & migration guide.

## Expected Impact

- Higher CTR from compare-intent searches
- Better rankings for "[product] alternative" queries
- More qualified traffic (comparison shoppers)