### PR TITLE
feat(analytics): add GA4 sign_up and page view tracking

### DIFF
--- a/Accounts/src/Pages/Register.tsx
+++ b/Accounts/src/Pages/Register.tsx
@@ -330,6 +330,7 @@ const RegisterPage: () => JSX.Element = () => {
               if (value && value.email) {
                 UiAnalytics.userAuth(value.email);
                 UiAnalytics.capture("accounts/register");
+                UiAnalytics.capture("sign_up");
               }
 
               LoginUtil.login({

--- a/Home/Views/demo.ejs
+++ b/Home/Views/demo.ejs
@@ -191,6 +191,17 @@
           layout: "month_view"
         });
         Cal("ui", { "styles": { "branding": { "brandColor": "#4f46e5" } }, "hideEventTypeDetails": false, "layout": "month_view" });
+        
+        // GA4: Track demo page view as key event
+        if (typeof dataLayer !== 'undefined') {
+          dataLayer.push({
+            'event': 'page_view_demo',
+            'eventCategory': 'page_view',
+            'eventAction': 'page_view_demo',
+            'eventLabel': window.location.pathname
+          });
+        }
+        
         Cal("on", {
           action: "bookingSuccessful",
           callback: (e) => {

--- a/Home/Views/pricing.ejs
+++ b/Home/Views/pricing.ejs
@@ -1665,6 +1665,15 @@
       </div>
 
       <script>
+        // GA4: Track pricing page view as key event
+        if (typeof dataLayer !== 'undefined') {
+          dataLayer.push({
+            'event': 'page_view_pricing',
+            'eventCategory': 'page_view',
+            'eventAction': 'page_view_pricing',
+            'eventLabel': window.location.pathname
+          });
+        }
 
         function switchToYearlyBilling() {
           document.getElementById("yearly-billing-btn").classList = "relative w-1/2 whitespace-nowrap rounded-md border-gray-200 bg-white py-2 text-sm font-medium text-gray-900 shadow-sm focus:z-10 focus:outline-none focus:ring-2 focus:ring-gray-500 sm:w-auto sm:px-8"


### PR DESCRIPTION
Adds GA4 key event tracking: sign_up on registration, page_view_pricing on pricing page, page_view_demo on demo page. All use dataLayer.push for GTM/GA4 compatibility.