### PR TITLE
chore(seo): clarify homepage title and description

### DIFF
--- a/Home/Utils/PageSEO.ts
+++ b/Home/Utils/PageSEO.ts
@@ -65,9 +65,9 @@ export const createDefaultSEO: (
 export const PageSEOConfig: Record<string, PageSEOData> = {
   // Homepage
   "/": {
-    title: "OneUptime | Complete Monitoring & Observability Platform",
+    title: "OneUptime | Open-Source Monitoring, Status Pages & Incident Management",
     description:
-      "OneUptime is an open-source complete observability platform. Monitor websites, APIs, and servers. Get alerts, manage incidents, and keep customers informed with status pages. Free tier available.",
+      "Monitor your websites, APIs, and servers. Create status pages for customers. Manage incidents and on-call schedules. Open-source and self-hostable.",
     canonicalPath: "/",
     ogType: "website",
     twitterCard: "summary_large_image",

--- a/Home/Views/Partials/hero.ejs
+++ b/Home/Views/Partials/hero.ejs
@@ -134,12 +134,12 @@
 
         <!-- Main headline -->
         <h1 class="text-4xl font-medium tracking-tight text-gray-900 sm:text-5xl lg:text-[3.5rem] lg:leading-[1.15]">
-          The Open-Source <br class="hidden sm:block" />Observability Platform
+          Open-Source Monitoring, Status Pages <br class="hidden sm:block" />& Incident Management
         </h1>
 
         <!-- Subheadline -->
         <p class="mt-6 text-base leading-7 text-gray-600 sm:text-lg sm:leading-8 max-w-xl mx-auto">
-          Your complete reliability stack unified: infrastructure monitoring, incident management, status pages, and APM. Open-source and self-hostable.
+          Monitor services. Keep customers informed with status pages. Manage incidents when things go wrong.
         </p>
 
         <!-- CTA buttons -->

--- a/Home/Views/index.ejs
+++ b/Home/Views/index.ejs
@@ -4,9 +4,9 @@
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 
 <head>
-  <title>OneUptime | The Open-Source Observability Platform</title>
+  <title>OneUptime | Open-Source Monitoring, Status Pages & Incident Management</title>
   <meta name="description"
-    content="The open-source observability platform. Infrastructure monitoring, incident management, status pages, and APM — unified and self-hostable.">
+    content="Monitor your websites, APIs, and servers. Create status pages for customers. Manage incidents and on-call schedules. Open-source and self-hostable.">
   <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>


### PR DESCRIPTION
## Summary

Subtle SEO improvement for the homepage. No keyword stuffing, no salesy language — just clearer communication about what OneUptime does.

## Changes

**Title:**
- Before: `OneUptime | The Open-Source Observability Platform`
- After: `OneUptime | Open-Source Monitoring, Status Pages & Incident Management`

**Meta description:**
- Before: `The open-source observability platform. Infrastructure monitoring, incident management, status pages, and APM — unified and self-hostable.`
- After: `Monitor your websites, APIs, and servers. Create status pages for customers. Manage incidents and on-call schedules. Open-source and self-hostable.`

**H1:**
- Before: `The Open-Source Observability Platform`
- After: `Open-Source Monitoring, Status Pages & Incident Management`

## Why

- "Observability Platform" is vague for someone searching for monitoring tools
- The new title clearly states what you can *do* with OneUptime
- Meta description now speaks to the user, not to Google
- Aligns title, H1, and PageSEO.ts for consistency

No power words, no forced numbers, no SEO template garbage. Just honest, clear copy.