### PR TITLE
feat: Add GA4 CTA click tracking across all pages

### DIFF
--- a/Home/Views/Blog/List.ejs
+++ b/Home/Views/Blog/List.ejs
@@ -82,6 +82,7 @@
 
     <%- include('./Partials/BlogCta') -%>
       <%- include('../footer') -%>
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/Blog/ListByTag.ejs
+++ b/Home/Views/Blog/ListByTag.ejs
@@ -47,6 +47,7 @@
 
     <%- include('./Partials/BlogCta') -%>
       <%- include('../footer') -%>
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/Blog/Post.ejs
+++ b/Home/Views/Blog/Post.ejs
@@ -720,6 +720,7 @@
                     } catch(e) {}
                 })();
             </script>
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/Partials/cta-tracking.ejs
+++ b/Home/Views/Partials/cta-tracking.ejs
@@ -1,0 +1,43 @@
+<!-- GA4 CTA Click Tracking -->
+<script>
+(function() {
+  // Track clicks on all CTA links (register + demo)
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a');
+    if (!link) return;
+
+    var href = link.getAttribute('href') || '';
+    var eventName = null;
+    var eventLabel = '';
+
+    if (href.indexOf('/accounts/register') !== -1) {
+      eventName = 'cta_get_started';
+      eventLabel = link.textContent.trim();
+    } else if (href.indexOf('/enterprise/demo') !== -1) {
+      eventName = 'cta_request_demo';
+      eventLabel = link.textContent.trim();
+    }
+
+    if (eventName) {
+      // GA4 via gtag
+      if (typeof gtag !== 'undefined') {
+        gtag('event', eventName, {
+          event_category: 'conversion',
+          event_label: eventLabel,
+          link_url: href
+        });
+      }
+      // GTM dataLayer (backup)
+      if (typeof dataLayer !== 'undefined') {
+        dataLayer.push({
+          event: eventName,
+          eventCategory: 'conversion',
+          eventAction: eventName,
+          eventLabel: eventLabel,
+          linkUrl: href
+        });
+      }
+    }
+  });
+})();
+</script>

--- a/Home/Views/demo.ejs
+++ b/Home/Views/demo.ejs
@@ -811,6 +811,7 @@
   </main>
 
   <%- include('footer') -%>
+  <%- include("./Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/index.ejs
+++ b/Home/Views/index.ejs
@@ -42,6 +42,7 @@
   <%- include('footer') -%>
 
   <%- include('./Partials/video-script') -%>
+  <%- include('./Partials/cta-tracking') -%>
 
 </body>
 

--- a/Home/Views/industries/fintech.ejs
+++ b/Home/Views/industries/fintech.ejs
@@ -386,6 +386,7 @@
   </main>
   <%- include('../footer') -%>
 
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/industries/government.ejs
+++ b/Home/Views/industries/government.ejs
@@ -386,6 +386,7 @@
   </main>
   <%- include('../footer') -%>
 
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/industries/media.ejs
+++ b/Home/Views/industries/media.ejs
@@ -385,6 +385,7 @@
   </main>
   <%- include('../footer') -%>
 
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/industries/saas.ejs
+++ b/Home/Views/industries/saas.ejs
@@ -378,6 +378,7 @@
   </main>
   <%- include('../footer') -%>
 
+  <%- include("../Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/pricing.ejs
+++ b/Home/Views/pricing.ejs
@@ -1953,6 +1953,7 @@ Coinbase:      "The Times 03/Jan/2009 Chancellor on brink of second bailout for 
             })();
           </script>
 
+  <%- include("./Partials/cta-tracking") -%>
 </body>
 
 </html>

--- a/Home/Views/status-page.ejs
+++ b/Home/Views/status-page.ejs
@@ -1350,6 +1350,7 @@
       })();
     </script>
 
+  <%- include("./Partials/cta-tracking") -%>
 </body>
 
 </html>


### PR DESCRIPTION
## What

Adds GA4 event tracking for CTA clicks ("Get started free" and "Request demo" buttons) across all pages.

## Why

GA weekly audit found **zero conversion events** configured. While `sign_up` and `demo_request` events fire after form submission, we had no tracking on the CTA clicks themselves. This means we couldn't measure:
- Which pages drive the most CTA clicks
- Click-through rate from landing pages to registration
- Which CTA copy/placement performs best

## How

New partial `cta-tracking.ejs` uses event delegation to track all links to `/accounts/register` and `/enterprise/demo`:
- Fires `cta_get_started` event for registration CTAs
- Fires `cta_request_demo` event for demo CTAs
- Pushes to both gtag and dataLayer (GTM backup)
- Captures link text and URL for analysis

Added to: homepage, pricing, demo, blog posts, blog list, status page, and all industry pages.

## Next Step

After merge, mark `cta_get_started`, `cta_request_demo`, `sign_up`, and `demo_request` as **Key Events** in GA4 Admin.