### PR TITLE
fix: Handle null monitor in workspace notification rules

### DIFF
--- a/Common/Server/Services/WorkspaceNotificationRuleService.ts
+++ b/Common/Server/Services/WorkspaceNotificationRuleService.ts
@@ -2065,7 +2065,7 @@ export class Service extends DatabaseService<WorkspaceNotificationRule> {
         [NotificationRuleConditionCheckOn.ScheduledMaintenanceLabels]:
           undefined,
         [NotificationRuleConditionCheckOn.Monitors]: [
-          alert.monitor!.id!.toString() || "",
+          alert.monitor?.id ? alert.monitor.id.toString() : "",
         ],
 
         [NotificationRuleConditionCheckOn.OnCallDutyPolicyName]: undefined,


### PR DESCRIPTION
Fixes #2348

## Problem

Alerts without monitors were causing workspace notifications (Slack/Teams) to crash with:

```
TypeError: Cannot read properties of null (reading 'id')
    at Service.getValuesBasedOnNotificationFor (WorkspaceNotificationRuleService.ts:2068:26)
```

## Root Cause

Regression introduced in commit 76ab3a8cd6 which removed optional chaining:

```diff
-          alert.monitor?.id!.toString() || "",
+          alert.monitor!.id!.toString() || "",
```

## Solution

Restore proper null handling:

```typescript
alert.monitor?.id ? alert.monitor.id.toString() : ""
```

## Testing

1. Create an alert without a monitor
2. Confirm workspace notifications are sent without errors