### PR TITLE
fix: show uptime history bar chart on mobile status page

### DIFF
--- a/App/FeatureSet/StatusPage/src/Components/Monitor/MonitorOverview.tsx
+++ b/App/FeatureSet/StatusPage/src/Components/Monitor/MonitorOverview.tsx
@@ -123,9 +123,9 @@ const MonitorOverview: FunctionComponent<ComponentProps> = (
         </div>
       </div>
 
-      {/* Uptime graph: Hidden on mobile, visible on larger screens */}
+      {/* Uptime graph: Scrollable on mobile, full width on larger screens */}
       {props.showHistoryChart && (
-        <div className="w-full overflow-hidden hidden sm:block">
+        <div className="w-full overflow-x-auto">
           <MonitorUptimeGraph
             error={undefined}
             barColorRules={props.statusPageHistoryChartBarColorRules}
@@ -140,9 +140,9 @@ const MonitorOverview: FunctionComponent<ComponentProps> = (
         </div>
       )}
 
-      {/* Time labels: Hidden on mobile, visible on larger screens */}
+      {/* Time labels: Visible on all screen sizes */}
       {props.showHistoryChart && (
-        <div className="text-xs sm:text-sm text-gray-400 mt-1 justify-between hidden sm:flex">
+        <div className="text-xs sm:text-sm text-gray-400 mt-1 justify-between flex">
           <div>90 days ago</div>
           <div>Today</div>
         </div>


### PR DESCRIPTION
Fixes #2049

## Summary
- The uptime history bar chart was hidden on mobile view of the status page due to `hidden sm:block` responsive classes
- The "90 days ago / Today" time labels were similarly hidden with `hidden sm:flex`
- Replaced with `overflow-x-auto` and `flex` so the chart and labels are visible on all screen sizes, with horizontal scrolling on small screens

## Changes
- `MonitorOverview.tsx`: Removed `hidden sm:block` from the chart container, replaced `overflow-hidden` with `overflow-x-auto`
- `MonitorOverview.tsx`: Removed `hidden sm:flex` from the time labels container, replaced with `flex`

---
Developed with AI assistance (Claude Code)