### PR TITLE
feat: allow admins to configure default subscription checkbox state

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SubscriberSettings.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SubscriberSettings.tsx
@@ -272,6 +272,26 @@ const StatusPageSubscriberSettings: FunctionComponent<
           },
           {
             field: {
+              defaultSubscribeToAllResources: true,
+            },
+            title: "Subscribe to All Resources by Default",
+            fieldType: FormFieldSchemaType.Toggle,
+            required: false,
+            placeholder:
+              "Should the 'Subscribe to All Resources' checkbox be checked by default for new subscribers?",
+          },
+          {
+            field: {
+              defaultSubscribeToAllEventTypes: true,
+            },
+            title: "Subscribe to All Event Types by Default",
+            fieldType: FormFieldSchemaType.Toggle,
+            required: false,
+            placeholder:
+              "Should the 'Subscribe to All Event Types' checkbox be checked by default for new subscribers?",
+          },
+          {
+            field: {
               subscriberTimezones: true,
             },
             title: "Subscriber Timezones",
@@ -305,6 +325,24 @@ const StatusPageSubscriberSettings: FunctionComponent<
               title: "Allow Subscribers to Choose Event Types",
               description:
                 "Can subscribers choose which event types they want to subscribe to (like Incidents, Announcements or Scheduled Events)?",
+            },
+            {
+              field: {
+                defaultSubscribeToAllResources: true,
+              },
+              fieldType: FieldType.Boolean,
+              title: "Subscribe to All Resources by Default",
+              description:
+                "Should the 'Subscribe to All Resources' checkbox be checked by default for new subscribers?",
+            },
+            {
+              field: {
+                defaultSubscribeToAllEventTypes: true,
+              },
+              fieldType: FieldType.Boolean,
+              title: "Subscribe to All Event Types by Default",
+              description:
+                "Should the 'Subscribe to All Event Types' checkbox be checked by default for new subscribers?",
             },
             {
               field: {

--- a/App/FeatureSet/StatusPage/src/App.tsx
+++ b/App/FeatureSet/StatusPage/src/App.tsx
@@ -202,6 +202,16 @@ const App: () => JSX.Element = () => {
     setAllowSubscriberToChooseEventTypes,
   ] = useState<boolean>(false);
 
+  const [
+    defaultSubscribeToAllResources,
+    setDefaultSubscribeToAllResources,
+  ] = useState<boolean>(true);
+
+  const [
+    defaultSubscribeToAllEventTypes,
+    setDefaultSubscribeToAllEventTypes,
+  ] = useState<boolean>(true);
+
   const [enableSMSSubscribers, setenableSMSSubscribers] =
     useState<boolean>(false);
   const [enableSlackSubscribers, setenableSlackSubscribers] =
@@ -313,10 +323,24 @@ const App: () => JSX.Element = () => {
             "statusPage.allowSubscribersToChooseEventTypes",
           ) as boolean;
 
+        const defaultSubscribeToAllResources: boolean =
+          (JSONFunctions.getJSONValueInPath(
+            masterpage || {},
+            "statusPage.defaultSubscribeToAllResources",
+          ) as boolean) ?? true;
+
+        const defaultSubscribeToAllEventTypes: boolean =
+          (JSONFunctions.getJSONValueInPath(
+            masterpage || {},
+            "statusPage.defaultSubscribeToAllEventTypes",
+          ) as boolean) ?? true;
+
         setAllowSubscribersToChooseResources(allowSubscribersToChooseResources);
         setAllowSubscriberToChooseEventTypes(
           allowSubscribersToChooseEventTypes,
         );
+        setDefaultSubscribeToAllResources(defaultSubscribeToAllResources);
+        setDefaultSubscribeToAllEventTypes(defaultSubscribeToAllEventTypes);
 
         setenableSMSSubscribers(enableSMSSubscribers);
         setenableSlackSubscribers(enableSlackSubscribers);
@@ -533,6 +557,12 @@ const App: () => JSX.Element = () => {
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
                 }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
+                }
               />
             }
           />
@@ -557,6 +587,12 @@ const App: () => JSX.Element = () => {
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
                 }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
+                }
               />
             }
           />
@@ -580,6 +616,12 @@ const App: () => JSX.Element = () => {
                 enableSlackSubscribers={enableSlackSubscribers}
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
+                }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
                 }
               />
             }
@@ -617,6 +659,12 @@ const App: () => JSX.Element = () => {
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
                 }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
+                }
               />
             }
           />
@@ -640,6 +688,12 @@ const App: () => JSX.Element = () => {
                 enableSlackSubscribers={enableSlackSubscribers}
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
+                }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
                 }
               />
             }
@@ -679,6 +733,12 @@ const App: () => JSX.Element = () => {
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
                 }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
+                }
               />
             }
           />
@@ -707,6 +767,12 @@ const App: () => JSX.Element = () => {
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
                 }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
+                }
               />
             }
           />
@@ -731,6 +797,12 @@ const App: () => JSX.Element = () => {
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
                 }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
+                }
               />
             }
           />
@@ -754,6 +826,12 @@ const App: () => JSX.Element = () => {
                 enableSlackSubscribers={enableSlackSubscribers}
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
+                }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
                 }
               />
             }
@@ -783,6 +861,12 @@ const App: () => JSX.Element = () => {
                 enableSlackSubscribers={enableSlackSubscribers}
                 enableMicrosoftTeamsSubscribers={
                   enableMicrosoftTeamsSubscribers
+                }
+                defaultSubscribeToAllResources={
+                  defaultSubscribeToAllResources
+                }
+                defaultSubscribeToAllEventTypes={
+                  defaultSubscribeToAllEventTypes
                 }
               />
             }

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/EmailSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/EmailSubscribe.tsx
@@ -106,7 +106,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
         "Select this option if you want to subscribe to all resources.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllResources,
     });
 
     fields.push({
@@ -134,7 +134,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
         "Select this option if you want to subscribe to all event types.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllEventTypes,
     });
 
     fields.push({

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/MicrosoftTeamsSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/MicrosoftTeamsSubscribe.tsx
@@ -119,7 +119,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
         "Select this option if you want to subscribe to all resources.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllResources,
     });
 
     fields.push({
@@ -147,7 +147,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
         "Select this option if you want to subscribe to all event types.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllEventTypes,
     });
 
     fields.push({

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/SlackSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/SlackSubscribe.tsx
@@ -119,7 +119,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
         "Select this option if you want to subscribe to all resources.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllResources,
     });
 
     fields.push({
@@ -147,7 +147,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
         "Select this option if you want to subscribe to all event types.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllEventTypes,
     });
 
     fields.push({

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/SmsSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/SmsSubscribe.tsx
@@ -106,7 +106,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
         "Select this option if you want to subscribe to all resources.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllResources,
     });
 
     fields.push({
@@ -134,7 +134,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
         "Select this option if you want to subscribe to all event types.",
       fieldType: FormFieldSchemaType.Checkbox,
       required: false,
-      defaultValue: true,
+      defaultValue: props.defaultSubscribeToAllEventTypes,
     });
 
     fields.push({

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/SubscribePageUtils.ts
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/SubscribePageUtils.ts
@@ -7,4 +7,6 @@ export interface SubscribePageProps extends PageComponentProps {
   enableMicrosoftTeamsSubscribers: boolean;
   allowSubscribersToChooseResources: boolean;
   allowSubscribersToChooseEventTypes: boolean;
+  defaultSubscribeToAllResources: boolean;
+  defaultSubscribeToAllEventTypes: boolean;
 }

--- a/Common/Models/DatabaseModels/StatusPage.ts
+++ b/Common/Models/DatabaseModels/StatusPage.ts
@@ -1238,6 +1238,86 @@ export default class StatusPage extends BaseModel {
   @TableColumn({
     isDefaultValueColumn: true,
     type: TableColumnType.Boolean,
+    title: "Subscribe to All Resources by Default",
+    description:
+      "Should the 'Subscribe to All Resources' checkbox be checked by default for new subscribers?",
+    defaultValue: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: true,
+  })
+  @ColumnBillingAccessControl({
+    read: PlanType.Free,
+    update: PlanType.Scale,
+    create: PlanType.Free,
+  })
+  public defaultSubscribeToAllResources?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.CreateProjectStatusPage,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.ReadProjectStatusPage,
+      Permission.ReadAllProjectResources,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.EditProjectStatusPage,
+    ],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    title: "Subscribe to All Event Types by Default",
+    description:
+      "Should the 'Subscribe to All Event Types' checkbox be checked by default for new subscribers?",
+    defaultValue: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: true,
+  })
+  @ColumnBillingAccessControl({
+    read: PlanType.Free,
+    update: PlanType.Scale,
+    create: PlanType.Free,
+  })
+  public defaultSubscribeToAllEventTypes?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.CreateProjectStatusPage,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.ReadProjectStatusPage,
+      Permission.ReadAllProjectResources,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.EditProjectStatusPage,
+    ],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
     title: "Enable SMS Subscribers",
     description: "Can SMS subscribers subscribe to this Status Page?",
     defaultValue: false,


### PR DESCRIPTION
 Closes #2178

  ## Summary
  Adds two new StatusPage admin settings that control whether the "Subscribe to All Resources" and "Subscribe to All
  Event Types" checkboxes are checked by default for new subscribers. Previously hardcoded to `true`, causing
  subscribers to receive excessive notifications.

  ## New Settings
  | Setting | Default | Description |
  |---------|---------|-------------|
  | `defaultSubscribeToAllResources` | `true` | Default state of "Subscribe to All Resources" checkbox |
  | `defaultSubscribeToAllEventTypes` | `true` | Default state of "Subscribe to All Event Types" checkbox |

  Defaults are `true` for backward compatibility — existing behavior is unchanged unless admins explicitly configure it.

  ## Changes
  - **StatusPage model** — two new boolean columns with access control and billing annotations
  - **Dashboard admin UI** — two new toggles in Subscriber Settings
  - **Subscribe forms** — all four channels (Email, SMS, Slack, Microsoft Teams) use configurable defaults instead of
  hardcoded `true`
  - **App.tsx** — fetches and passes new settings to all subscribe page components
  - **SubscribePageUtils** — extended props interface

  ## Files Changed (8)
  - `Common/Models/DatabaseModels/StatusPage.ts`
  - `App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SubscriberSettings.tsx`
  - `App/FeatureSet/StatusPage/src/App.tsx`
  - `App/FeatureSet/StatusPage/src/Pages/Subscribe/SubscribePageUtils.ts`
  - `App/FeatureSet/StatusPage/src/Pages/Subscribe/EmailSubscribe.tsx`
  - `App/FeatureSet/StatusPage/src/Pages/Subscribe/SmsSubscribe.tsx`
  - `App/FeatureSet/StatusPage/src/Pages/Subscribe/SlackSubscribe.tsx`
  - `App/FeatureSet/StatusPage/src/Pages/Subscribe/MicrosoftTeamsSubscribe.tsx`