### PR TITLE
fix(llm): send max_tokens on Anthropic completion requests

### DIFF
--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -157,6 +157,11 @@ export default class LLMService {
     const requestData: JSONObject = {
       model: modelName,
       messages: userMessages,
+      // Anthropic's Messages API requires max_tokens. Without it the server
+      // rejects the request with `max_tokens: Field required` (400). 4096 is
+      // a conservative default that fits every current Claude model's output
+      // window and is enough for long-form generations like postmortems.
+      max_tokens: 4096,
       temperature: request.temperature ?? 0.7,
     };
 


### PR DESCRIPTION
## Summary

The Anthropic Messages API requires `max_tokens` on every request. `getAnthropicCompletion` in `Common/Server/Utils/LLM/LLMService.ts` was building the request body without it, so every Anthropic call was rejected with:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: Field required"}}
```

In the UI this surfaces as "Generate Postmortem with AI" (and any other Anthropic-backed feature) failing with:

> Error - Anthropic API error: `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: Field required"},"request_id":"req_..."}`

## Root cause

`max_tokens` was added and then removed a couple of times on the same day during a refactor:

- `5eca1a5` (2025-12-16 11:21) — refactor: Remove maxTokens from LLMCompletionRequest and related usages
- `bdd894f` (2025-12-16 15:33) — feat: Add maxTokens parameter to LLMCompletionRequest and update related methods
- `8d79a38` (2025-12-16 15:39) — refactor: Remove maxTokens parameter from LLMCompletionRequest and related methods

The final removal left the Anthropic path broken in every release since then. OpenAI and Ollama are unaffected because they treat the field as optional.

## Change

Default to `max_tokens: 4096` on the Anthropic request. 4096 fits inside the output window of every Claude model currently exposed (including the default `claude-sonnet-4-20250514`) and is enough for long-form generations like postmortems.

I kept the change minimal and intentionally did not re-add `maxTokens` to `LLMCompletionRequest` — that broader refactor is what caused the regression in the first place, and this PR is aimed at unblocking users today. If maintainers want `max_tokens` to be caller-configurable, that's a reasonable follow-up on top of this fix.

## Test plan

- [x] Manual: before the fix, "Generate Postmortem with AI" against Anthropic returns `400 max_tokens: Field required`. After the fix, the request is accepted and a postmortem is generated.
- [ ] Unit: there are no existing tests around `LLMService` in the repo; I did not add one to keep the PR minimal, but happy to add one if maintainers prefer.