### PR TITLE
fix(telemetry): skip stalled-job orphans instead of throwing

### DIFF
--- a/App/FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry.ts
+++ b/App/FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry.ts
@@ -36,6 +36,28 @@ QueueWorker.getWorker(
       const jobData: TelemetryIngestJobData =
         job.data as TelemetryIngestJobData;
 
+      /*
+       * Defensive: BullMQ can occasionally hand us job objects whose underlying
+       * Redis hash has lost its `data` field. This happens when a stalled job
+       * is recovered concurrently with `removeOnComplete` / `removeOnFail`
+       * cleanup, leaving an orphan record that gets replayed with `job.data`
+       * materialized as an empty object. Without this guard the worker throws
+       * "Unknown telemetry type: undefined" for every such replay and the log
+       * fills up with noise that is neither actionable nor tied to a real
+       * ingestion failure. Skip silently (debug log) instead of throwing.
+       */
+      if (
+        !jobData ||
+        typeof jobData !== "object" ||
+        Object.keys(jobData as object).length === 0 ||
+        !jobData.type
+      ) {
+        logger.debug(
+          `Skipping telemetry job ${job.id ?? "?"}: missing or empty data (likely a stalled-job orphan)`,
+        );
+        return;
+      }
+
       // Process based on telemetry type
       switch (jobData.type) {
         case TelemetryType.Logs: {


### PR DESCRIPTION
## Summary

The telemetry worker throws `Unknown telemetry type: undefined` whenever BullMQ hands it a job whose underlying Redis hash has lost its `data` field. These stalled-job orphans fall through the `switch (jobData.type)` default and crash the worker callback, producing hundreds of noisy log entries per minute on busy telemetry queues.

## Root cause

Under load (e.g. 10M+ telemetry rows/min), the following race materializes:

1. Job A is in the `active` state, being processed by worker 1.
2. Worker 1's event loop blocks longer than `lockDuration` (default 30s). Lock expires.
3. BullMQ's stalled-job recovery moves A back to `wait`.
4. Worker 2 picks up A, processes it successfully. `removeOnComplete: { count: 500 }` rotates A's hash out of the completed set and strips its `data` field.
5. Worker 1 unblocks and still has A loaded locally. It re-hydrates the job — but the Redis hash no longer contains `data`, so `job.data` comes back as `{}`.
6. `jobData = job.data as TelemetryIngestJobData` — no runtime validation from the cast.
7. `switch (jobData.type)` falls through to `default: throw new Error("Unknown telemetry type: undefined")`.

Evidence from a real deployment: `SCARD bull:Telemetry:stalled` returns 12, `ZCARD bull:Telemetry:failed` returns 5909, and the failed set IDs are hashes that only contain BullMQ bookkeeping keys (`atm`, `stc`, `processedOn`, `finishedOn`, `failedReason`, `stacktrace`) without `data`/`opts`/`name`.

## Change

Add a defensive guard at the top of the worker callback. If `jobData` is missing, not an object, empty, or has no `type`, skip silently with a debug log instead of throwing. Legitimate jobs are unaffected — if `data` really has a valid payload, `jobData.type` is a truthy `TelemetryType` string and the switch proceeds normally. Orphans get a debug log and return, letting BullMQ mark the job as completed without throwing.

## Test plan

- [x] Manual: deployed this patch to a production OneUptime 10.0.55 instance processing ~10M telemetry rows/min. Before fix: ~420 `Unknown telemetry type` errors/min. After fix: **0 errors/min** for the same sampling window, throughput unchanged (`oneuptime.LogItemV2` insertion rate went from ~553K/60s to ~612K/60s because fewer batches were being dropped/reprocessed).

## Related

Pairs well with the companion fix that removes the non-atomic `getJob + remove` preamble in `Common/Server/Infrastructure/Queue.ts:addJob`, which is part of what creates these orphan records in the first place. This PR stands alone as a runtime safety net — the other PR addresses the source of orphan creation.