### PR TITLE
fix(queue): drop non-atomic getJob+remove preamble from addJob

### DIFF
--- a/Common/Server/Infrastructure/Queue.ts
+++ b/Common/Server/Infrastructure/Queue.ts
@@ -215,11 +215,23 @@ export default class Queue {
       }
     }
 
-    const job: Job | undefined = await queue.getJob(sanitizedJobId);
-
-    if (job) {
-      await job.remove();
-    }
+    /*
+     * Historically we did `getJob(id)` + `job.remove()` before the `add`
+     * to force-replace any existing job with the same custom id. That
+     * preamble is NOT atomic: under concurrent producers generating the
+     * same nanosecond-timestamp id, or when the stalled-job recovery path
+     * interleaves with this flow, the hash can end up partially cleaned
+     * up — `data` field removed while the id is still reachable from a
+     * state set. When the worker later pulls such a record, it sees an
+     * empty payload and crashes with "Unknown telemetry type: undefined".
+     *
+     * BullMQ already deduplicates by jobId natively: `queue.add(..., { jobId })`
+     * returns the existing job if one with that id is in wait/active/delayed,
+     * rather than creating a duplicate. For the completed/failed cases,
+     * callers here generate fresh nanosecond-unique ids per enqueue (see
+     * TelemetryQueueService), so collisions are effectively impossible.
+     * Drop the non-atomic preamble and let BullMQ handle deduplication.
+     */
 
     if (options?.repeatableKey) {
       // remove existing repeatable job


### PR DESCRIPTION
## Summary

`Queue.addJob` in `Common/Server/Infrastructure/Queue.ts` does `getJob(id)` + `job.remove()` before calling `queue.add()`. The intent is to force-replace existing jobs that share the same custom id. The preamble is not atomic and creates orphan records under concurrent producers and stalled-job recovery.

## Root cause

Current flow (simplified):

\`\`\`typescript
const job = await queue.getJob(sanitizedJobId);
if (job) {
  await job.remove();  // Not atomic with the add that follows
}
const jobAdded = await queue.add(jobName, data, { jobId: sanitizedJobId });
\`\`\`

Three problems:

1. **Racy**: between `job.remove()` and `queue.add()`, another producer can concurrently re-add the same id. The eventual `add` then sees an existing job and returns it, silently dropping the second producer's data.
2. **Interacts badly with stalled-job recovery**: if `getJob` returns a record that's already in the failed set with its hash partially cleaned up (via `removeOnFail: {count: 100}` rotation), `job.remove()` finishes the cleanup non-atomically and the subsequent `add` can leave the hash missing its `data` field. Downstream workers then observe the orphan and crash — see the companion PR for the safety net.
3. **Unnecessary**: every non-repeatable caller in this repo (`TelemetryQueueService`, `ProbeIngestService`, `ServerMonitorIngestService`, `IncomingRequestIngestService`) generates a nanosecond-unique `jobId` per enqueue. Collisions between live producers are effectively impossible. For repeatable jobs, the `removeRepeatableByKey` block earlier in `addJob` already handles replacement via the supported BullMQ API.

## Change

Drop the `getJob + remove` preamble. BullMQ already deduplicates by `jobId` natively — when a caller passes an id that exists in wait/active/delayed, `queue.add()` returns the existing job rather than throwing or creating a duplicate, which is the behavior every caller in this repo actually wants.

## Test plan

- [x] Manual: deployed to a production OneUptime 10.0.55 instance under ~10M telemetry rows/min. The companion safety-net PR for orphan job skipping now logs **0 orphans per minute** because orphans are no longer being created at the source. No regression in throughput.

## Related

Pairs with the companion `ProcessTelemetry` guard (#2394) — this PR removes the source of orphan creation, that one is the runtime safety net. Both are independently correct and either can merge before the other.