### PR TITLE
fix(telemetry): make service find/create race-safe with case-insensitive retry

### DIFF
--- a/Common/Server/Services/OpenTelemetryIngestService.ts
+++ b/Common/Server/Services/OpenTelemetryIngestService.ts
@@ -9,6 +9,8 @@ import ServiceService from "../../Server/Services/ServiceService";
 import { DEFAULT_RETENTION_IN_DAYS } from "../../Models/DatabaseModels/TelemetryUsageBilling";
 import TelemetryUtil from "../../Server/Utils/Telemetry/Telemetry";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import QueryHelper from "../Types/Database/QueryHelper";
+import Sleep from "../../Types/Sleep";
 
 export enum OtelAggregationTemporality {
   Cumulative = "AGGREGATION_TEMPORALITY_CUMULATIVE",
@@ -30,10 +32,23 @@ export default class OTelIngestService {
     serviceId: ObjectID;
     dataRententionInDays: number;
   }> {
+    /*
+     * Case-insensitive + whitespace-trimmed match is used consistently in
+     * both the initial lookup and the post-conflict re-fetch. The
+     * `DatabaseService.checkUniqueColumnBy` pre-create hook rejects
+     * duplicates with a LOWER(name) = LOWER(?) comparison, so a previous
+     * worker may have inserted a row whose stored case differs from the
+     * OTLP attribute we just received. An exact-match re-fetch would then
+     * miss the existing row and the handler would throw "Failed to create
+     * or find service", dropping the entire OTLP batch.
+     */
+    const nameMatcher: ReturnType<typeof QueryHelper.findWithSameText> =
+      QueryHelper.findWithSameText(data.serviceName);
+
     const service: Service | null = await ServiceService.findOneBy({
       query: {
         projectId: data.projectId,
-        name: data.serviceName,
+        name: nameMatcher,
       },
       select: {
         _id: true,
@@ -44,43 +59,61 @@ export default class OTelIngestService {
       },
     });
 
-    if (!service) {
-      try {
-        const newService: Service = new Service();
-        newService.projectId = data.projectId;
-        newService.name = data.serviceName;
-        newService.description = data.serviceName;
-        newService.retainTelemetryDataForDays = DEFAULT_RETENTION_IN_DAYS;
+    if (service) {
+      return {
+        serviceId: service.id!,
+        dataRententionInDays:
+          service.retainTelemetryDataForDays || DEFAULT_RETENTION_IN_DAYS,
+      };
+    }
 
-        const createdService: Service = await ServiceService.create({
-          data: newService,
-          props: {
-            isRoot: true,
-          },
-        });
+    try {
+      const newService: Service = new Service();
+      newService.projectId = data.projectId;
+      newService.name = data.serviceName;
+      newService.description = data.serviceName;
+      newService.retainTelemetryDataForDays = DEFAULT_RETENTION_IN_DAYS;
 
-        return {
-          serviceId: createdService.id!,
-          dataRententionInDays: DEFAULT_RETENTION_IN_DAYS,
-        };
-      } catch {
-        /*
-         * Race condition: another request created the service concurrently.
-         * Re-fetch the existing service.
-         */
-        const existingService: Service | null = await ServiceService.findOneBy({
-          query: {
-            projectId: data.projectId,
-            name: data.serviceName,
+      const createdService: Service = await ServiceService.create({
+        data: newService,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      return {
+        serviceId: createdService.id!,
+        dataRententionInDays: DEFAULT_RETENTION_IN_DAYS,
+      };
+    } catch {
+      /*
+       * Race condition: another worker created the same service between
+       * our lookup and our create. Re-fetch with bounded retry to cover
+       * the brief window where the winning worker's transaction is still
+       * committing and its row is not yet visible to our session under
+       * read-committed isolation. Total worst-case wait is ~375ms spread
+       * across 5 attempts. If all retries fail, bubble the original
+       * "Failed to create or find" error.
+       */
+      const maxAttempts: number = 5;
+      const baseDelayMs: number = 25;
+
+      for (let attempt: number = 0; attempt < maxAttempts; attempt++) {
+        const existingService: Service | null = await ServiceService.findOneBy(
+          {
+            query: {
+              projectId: data.projectId,
+              name: nameMatcher,
+            },
+            select: {
+              _id: true,
+              retainTelemetryDataForDays: true,
+            },
+            props: {
+              isRoot: true,
+            },
           },
-          select: {
-            _id: true,
-            retainTelemetryDataForDays: true,
-          },
-          props: {
-            isRoot: true,
-          },
-        });
+        );
 
         if (existingService) {
           return {
@@ -91,17 +124,14 @@ export default class OTelIngestService {
           };
         }
 
-        throw new Error(
-          "Failed to create or find service: " + data.serviceName,
-        );
+        // Exponential-ish backoff: 25ms, 50ms, 75ms, 100ms, 125ms
+        await Sleep.sleep(baseDelayMs * (attempt + 1));
       }
-    }
 
-    return {
-      serviceId: service.id!,
-      dataRententionInDays:
-        service.retainTelemetryDataForDays || DEFAULT_RETENTION_IN_DAYS,
-    };
+      throw new Error(
+        "Failed to create or find service: " + data.serviceName,
+      );
+    }
   }
   @CaptureSpan()
   public static getMetricFromDatapoint(data: {


### PR DESCRIPTION
## Summary

`OTelIngestService.telemetryServiceFromName` can throw `Failed to create or find service: X` when two OTLP batches for the same service name arrive concurrently and differ in case or whitespace. The handler's initial lookup and the post-conflict re-fetch use an exact string match, while `DatabaseService.checkUniqueColumnBy` rejects duplicates case-insensitively. That mismatch causes the re-fetch to miss the row the winning worker just committed, and the whole OTLP batch is dropped.

## Root cause

\`\`\`typescript
// Initial lookup (current code) — exact match
await ServiceService.findOneBy({
  query: { projectId, name: data.serviceName },
});

// Pre-create hook in DatabaseService.checkUniqueColumnBy
// uses QueryHelper.findWithSameText which matches LOWER(name) = LOWER(?)
\`\`\`

The race:

1. Worker A receives OTLP with `service.name = "Service-Acesso"`, exact-match `findOneBy` returns null.
2. Worker B receives OTLP with `service.name = "service-acesso"` simultaneously, exact-match also returns null.
3. Worker A calls `ServiceService.create` — pre-create hook's `countBy` finds no existing row via `LOWER(?)`, commit succeeds with `"Service-Acesso"`.
4. Worker B calls `ServiceService.create` — pre-create hook's `countBy` finds Worker A's row via `LOWER(?)`, throws `BadDataException("Service with the same name already exists")`.
5. Worker B catches and re-fetches via exact-match on `"service-acesso"` — misses because the stored value is `"Service-Acesso"`.
6. Worker B throws `Failed to create or find service`, losing the entire OTLP batch.

A second, briefer failure mode exists even when cases match: under read-committed isolation, Worker B's re-fetch can run inside the commit window of Worker A's winning transaction and return null on a row that is about to be visible.

## Change

- Use `QueryHelper.findWithSameText` consistently for both the initial lookup and the post-conflict re-fetch, so Worker B reliably sees the row Worker A just committed regardless of case/whitespace variations.
- Add a bounded retry loop (5 attempts, 25/50/75/100/125ms backoff = ~375ms worst case) around the post-conflict re-fetch to cover the commit-propagation window under read-committed isolation.
- Early-return when the initial lookup succeeds to simplify the control flow and drop a level of nesting.
- Bubble the `Failed to create or find` error only after every retry has missed.

## Test plan

- [x] Manual: deployed to a production OneUptime 10.0.55 instance where a .NET service's OTLP pipeline ships `service.name` in mixed case across pods. Pre-fix: **~251 errors per 10 minutes** dropping full OTLP batches. Post-fix: **0 errors** across 10-minute windows, with throughput increasing 10–75% across Log/Metric/Span tables because previously-dropped batches now succeed.