### PR TITLE
fix(metrics): drop non-finite numeric values when parsing OTLP strings

### DIFF
--- a/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
@@ -594,7 +594,20 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
 
     if (typeof value === "string") {
       const parsed: number = Number.parseFloat(value);
-      return isNaN(parsed) ? null : parsed;
+      /*
+       * `Number.isFinite` is stricter than `!isNaN`: it rejects both NaN
+       * and +/-Infinity. OTLP histograms routinely contain "+Inf" as the
+       * trailing explicitBound value when the histogram has an unbounded
+       * final bucket; `parseFloat("Infinity")` returns `Infinity`, which
+       * `isNaN` would accept and which then fails to serialize into the
+       * ClickHouse JSONEachRow format with:
+       *   Cannot read array from text, expected comma or end of array,
+       *   found 'e': (while reading the value of key explicitBounds)
+       * dropping the entire metrics batch. Filter non-finite values here
+       * so they are coerced to null and then dropped by the caller's
+       * `.filter(entry !== null)` step.
+       */
+      return Number.isFinite(parsed) ? parsed : null;
     }
 
     return null;


### PR DESCRIPTION
## Summary

`OtelMetricsIngestService.toNumberOrNull` correctly filters NaN/±Infinity when the input is already a JS number, but accepts any string that `parseFloat` can consume — including `"Infinity"` and `"-Infinity"`, which `parseFloat` returns unchanged and `isNaN` reports as valid.

## Root cause

\`\`\`typescript
private static toNumberOrNull(value: unknown): number | null {
  if (typeof value === "number") {
    return Number.isFinite(value) ? value : null;
  }
  if (typeof value === "string") {
    const parsed = Number.parseFloat(value);
    return isNaN(parsed) ? null : parsed;  // ← accepts Infinity
  }
  return null;
}
\`\`\`

OTLP histograms routinely serialize unbounded bucket boundaries as string literals `"Infinity"` / `"-Infinity"` on the JSON transport. These hit the string branch, parse back to `Infinity`, and are then placed into the row that the worker ships to ClickHouse via JSONEachRow.

## Change

One-line change: use `Number.isFinite(parsed)` instead of `!isNaN(parsed)` in the string branch. `Number.isFinite` rejects NaN AND ±Infinity, causing `toNumberOrNull` to return null for non-finite strings, which the caller's `.filter(entry !== null)` then drops.

This applies transparently to every numeric field that flows through `toNumberOrNull` — `valueFromInt`, `valueFromDouble`, `count`, `sum`, `min`, `max`, `bucketCounts` entries and `explicitBounds` entries — not just the field that triggered the visible error.

## Test plan

- [x] Manual: confirmed that JS `parseFloat("Infinity") === Infinity` and `isNaN(Infinity) === false`, reproducing the bug in isolation, then verified the fix correctly returns `null` for the same input.

## Notes

This fix addresses one source of ClickHouse parse errors but there may be others — `OtelMetricsIngestService` also has other codepaths that serialize histograms without routing through `toNumberOrNull` (e.g. if OTLP delivers values as native JS numbers via gRPC). A broader audit of the metrics serialization layer would be a good follow-up, but this patch is the minimal fix for the string-branch regression.