### PR TITLE
fix: use api-key header for Azure OpenAI authentication

### DIFF
--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -68,6 +68,11 @@ export default class LLMService {
     const baseUrl: string = config.baseUrl || "https://api.openai.com/v1";
     const modelName: string = config.modelName || "gpt-4o";
 
+    const isAzure: boolean = baseUrl.includes(".azure.com");
+    const authHeaders: { [key: string]: string } = isAzure
+      ? { "api-key": config.apiKey }
+      : { Authorization: `Bearer ${config.apiKey}` };
+
     const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await API.post<JSONObject>({
         url: URL.fromString(`${baseUrl}/chat/completions`),
@@ -82,7 +87,7 @@ export default class LLMService {
           temperature: request.temperature ?? 0.7,
         },
         headers: {
-          Authorization: `Bearer ${config.apiKey}`,
+          ...authHeaders,
           "Content-Type": "application/json",
         },
         options: {


### PR DESCRIPTION
## Summary

- Azure OpenAI requires the `api-key` request header for authentication, not `Authorization: Bearer` used by standard OpenAI
- `LLMService.getOpenAICompletion()` was sending the wrong header when an Azure endpoint is configured, causing a 401 error with an empty response body (`{"data":""}`)
- Fix detects Azure endpoints by checking for `.azure.com` in the base URL and switches the header accordingly

## Root Cause

In `Common/Server/Utils/LLM/LLMService.ts`, the OpenAI completion method hardcodes `Authorization: Bearer <key>` for all providers. Azure OpenAI (both classic `.openai.azure.com` and AI Foundry `.services.ai.azure.com`) requires `api-key: <key>` instead.

## Test plan

- [ ] Configure an Azure OpenAI LLM provider with a `.azure.com` base URL
- [ ] Verify AI features (Copilot, incident notes, etc.) work correctly
- [ ] Verify standard OpenAI providers still work with `Authorization: Bearer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)