### PR TITLE
feat: add Azure OpenAI, Groq, and Mistral as LLM provider types

### DIFF
--- a/AIAgent/CodeAgents/OpenCodeAgent.ts
+++ b/AIAgent/CodeAgents/OpenCodeAgent.ts
@@ -282,7 +282,9 @@ export default class OpenCodeAgent implements CodeAgent {
       case LlmType.Ollama:
         return "ollama";
       default:
-        throw new BadDataException("Unsupported LLM type for OpenCode agent");
+        throw new BadDataException(
+          `LLM provider "${this.config.llmType}" is not supported by the OpenCode AI agent. Configure an Anthropic, OpenAI, or Ollama provider for code agent tasks.`,
+        );
     }
   }
 
@@ -300,7 +302,9 @@ export default class OpenCodeAgent implements CodeAgent {
       case LlmType.Ollama:
         return "llama2";
       default:
-        throw new BadDataException("Unsupported LLM type for OpenCode agent");
+        throw new BadDataException(
+          `LLM provider "${this.config.llmType}" is not supported by the OpenCode AI agent. Configure an Anthropic, OpenAI, or Ollama provider for code agent tasks.`,
+        );
     }
   }
 
@@ -318,7 +322,9 @@ export default class OpenCodeAgent implements CodeAgent {
       case LlmType.Ollama:
         return "llama2";
       default:
-        throw new BadDataException("Unsupported LLM type for OpenCode agent");
+        throw new BadDataException(
+          `LLM provider "${this.config.llmType}" is not supported by the OpenCode AI agent. Configure an Anthropic, OpenAI, or Ollama provider for code agent tasks.`,
+        );
     }
   }
 

--- a/App/FeatureSet/AdminDashboard/src/Locales/en.json
+++ b/App/FeatureSet/AdminDashboard/src/Locales/en.json
@@ -276,7 +276,7 @@
         "bannerTitle": "Need help with setting up LLM Providers?",
         "bannerDescription": "LLM Providers enable AI features. You can configure global LLM Providers that are available to all projects.",
         "cardTitle": "Global LLM Providers",
-        "cardDescription": "Global LLM Providers are available to all projects for AI features. Configure OpenAI, Anthropic, Ollama, or other LLM providers.",
+        "cardDescription": "Global LLM Providers are available to all projects for AI features. Configure OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, or other LLM providers.",
         "noItems": "No LLM Providers configured. Add an LLM Provider to enable AI features.",
         "stepBasicInfo": "Basic Info",
         "stepProviderSettings": "Provider Settings",

--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/LlmProviders/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/LlmProviders/Index.tsx
@@ -138,7 +138,7 @@ const Settings: FunctionComponent = (): ReactElement => {
             required: false,
             placeholder: "sk-...",
             description:
-              "Required for OpenAI and Anthropic. Not required for Ollama if self-hosted.",
+              "Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral. Not required for Ollama if self-hosted.",
           },
           {
             field: {
@@ -148,9 +148,9 @@ const Settings: FunctionComponent = (): ReactElement => {
             stepId: "provider-settings",
             fieldType: FormFieldSchemaType.Text,
             required: false,
-            placeholder: "gpt-4, claude-3-opus, llama2",
+            placeholder: "gpt-4o, gpt-5.4-mini, claude-3-opus, llama2",
             description:
-              "The specific model to use (e.g., gpt-4, claude-3-opus, llama2).",
+              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq).",
           },
           {
             field: {
@@ -162,7 +162,7 @@ const Settings: FunctionComponent = (): ReactElement => {
             required: false,
             placeholder: "http://localhost:11434",
             description:
-              "Required for Ollama. Optional for others to use custom endpoints.",
+              "Required for Azure OpenAI and Ollama. For Azure OpenAI use your endpoint (e.g. https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1). Optional for others to override the default endpoint.",
           },
           ...(BILLING_ENABLED
             ? [

--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/LlmProviders/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/LlmProviders/Index.tsx
@@ -148,9 +148,9 @@ const Settings: FunctionComponent = (): ReactElement => {
             stepId: "provider-settings",
             fieldType: FormFieldSchemaType.Text,
             required: false,
-            placeholder: "gpt-4o, gpt-5.4-mini, claude-3-opus, llama2",
+            placeholder: "gpt-4o, claude-3-opus, llama-3.3-70b-versatile",
             description:
-              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq).",
+              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral).",
           },
           {
             field: {
@@ -162,7 +162,7 @@ const Settings: FunctionComponent = (): ReactElement => {
             required: false,
             placeholder: "http://localhost:11434",
             description:
-              "Required for Azure OpenAI and Ollama. For Azure OpenAI use your endpoint (e.g. https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1). Optional for others to override the default endpoint.",
+              "Required for Azure OpenAI and Ollama. For Azure OpenAI use your deployment endpoint (e.g. https://<resource>.openai.azure.com/openai/deployments/<deployment>). The api-version query parameter is added automatically if you don't include one. Optional for others to override the default endpoint.",
           },
           ...(BILLING_ENABLED
             ? [

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviderView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviderView.tsx
@@ -101,9 +101,9 @@ const LlmProviderView: FunctionComponent<PageComponentProps> = (
             stepId: "provider-settings",
             fieldType: FormFieldSchemaType.Text,
             required: false,
-            placeholder: "gpt-4o, gpt-5.4-mini, claude-3-opus, llama2",
+            placeholder: "gpt-4o, claude-3-opus, llama-3.3-70b-versatile",
             description:
-              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq).",
+              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral).",
           },
           {
             field: {
@@ -115,7 +115,7 @@ const LlmProviderView: FunctionComponent<PageComponentProps> = (
             required: false,
             placeholder: "http://localhost:11434",
             description:
-              "Required for Azure OpenAI and Ollama. For Azure OpenAI use your endpoint (e.g. https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1). Optional for others to override the default endpoint.",
+              "Required for Azure OpenAI and Ollama. For Azure OpenAI use your deployment endpoint (e.g. https://<resource>.openai.azure.com/openai/deployments/<deployment>). The api-version query parameter is added automatically if you don't include one. Optional for others to override the default endpoint.",
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviderView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviderView.tsx
@@ -91,7 +91,7 @@ const LlmProviderView: FunctionComponent<PageComponentProps> = (
             required: false,
             placeholder: "sk-...",
             description:
-              "Required for OpenAI and Anthropic. Not required for Ollama if self-hosted.",
+              "Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral. Not required for Ollama if self-hosted.",
           },
           {
             field: {
@@ -101,9 +101,9 @@ const LlmProviderView: FunctionComponent<PageComponentProps> = (
             stepId: "provider-settings",
             fieldType: FormFieldSchemaType.Text,
             required: false,
-            placeholder: "gpt-4, claude-3-opus, llama2",
+            placeholder: "gpt-4o, gpt-5.4-mini, claude-3-opus, llama2",
             description:
-              "The specific model to use (e.g., gpt-4, claude-3-opus, llama2).",
+              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq).",
           },
           {
             field: {
@@ -115,7 +115,7 @@ const LlmProviderView: FunctionComponent<PageComponentProps> = (
             required: false,
             placeholder: "http://localhost:11434",
             description:
-              "Required for Ollama. Optional for others to use custom endpoints.",
+              "Required for Azure OpenAI and Ollama. For Azure OpenAI use your endpoint (e.g. https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1). Optional for others to override the default endpoint.",
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviders.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviders.tsx
@@ -185,8 +185,8 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
           cardProps={{
             title: "Bring Your Own Large Language Model",
             description: BILLING_ENABLED
-              ? "Configure LLM Providers for AI features. Connect to OpenAI, Anthropic, Ollama, or other providers. You will not be charged for AI usage when you bring your own models."
-              : "Configure LLM Providers for AI features. Connect to OpenAI, Anthropic, Ollama, or other providers.",
+              ? "Configure LLM Providers for AI features. Connect to OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, or other providers. You will not be charged for AI usage when you bring your own models."
+              : "Configure LLM Providers for AI features. Connect to OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, or other providers.",
           }}
           documentationLink={Route.fromString("/docs/ai/llm-provider")}
           selectMoreFields={{
@@ -251,7 +251,7 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
               required: false,
               placeholder: "sk-...",
               description:
-                "Required for OpenAI and Anthropic. Not required for Ollama if self-hosted.",
+                "Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral. Not required for Ollama if self-hosted.",
             },
             {
               field: {
@@ -261,9 +261,9 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
               stepId: "provider-settings",
               fieldType: FormFieldSchemaType.Text,
               required: false,
-              placeholder: "gpt-4, claude-3-opus, llama2",
+              placeholder: "gpt-4o, gpt-5.4-mini, claude-3-opus, llama2",
               description:
-                "The specific model to use (e.g., gpt-4, claude-3-opus, llama2).",
+                "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq).",
             },
             {
               field: {
@@ -275,7 +275,7 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
               required: false,
               placeholder: "http://localhost:11434",
               description:
-                "Required for Ollama. Optional for others to use custom endpoints.",
+                "Required for Azure OpenAI and Ollama. For Azure OpenAI use your endpoint (e.g. https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1). Optional for others to override the default endpoint.",
             },
             {
               field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviders.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviders.tsx
@@ -261,9 +261,9 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
               stepId: "provider-settings",
               fieldType: FormFieldSchemaType.Text,
               required: false,
-              placeholder: "gpt-4o, gpt-5.4-mini, claude-3-opus, llama2",
+              placeholder: "gpt-4o, claude-3-opus, llama-3.3-70b-versatile",
               description:
-                "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq).",
+                "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral).",
             },
             {
               field: {
@@ -275,7 +275,7 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
               required: false,
               placeholder: "http://localhost:11434",
               description:
-                "Required for Azure OpenAI and Ollama. For Azure OpenAI use your endpoint (e.g. https://<resource>.services.ai.azure.com/api/projects/<project>/openai/v1). Optional for others to override the default endpoint.",
+                "Required for Azure OpenAI and Ollama. For Azure OpenAI use your deployment endpoint (e.g. https://<resource>.openai.azure.com/openai/deployments/<deployment>). The api-version query parameter is added automatically if you don't include one. Optional for others to override the default endpoint.",
             },
             {
               field: {

--- a/Common/Models/DatabaseModels/LlmLog.ts
+++ b/Common/Models/DatabaseModels/LlmLog.ts
@@ -217,7 +217,8 @@ export default class LlmLog extends BaseModel {
     required: false,
     type: TableColumnType.ShortText,
     title: "LLM Type",
-    description: "Type of LLM (OpenAI, Anthropic, Ollama)",
+    description:
+      "Type of LLM (OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama)",
     canReadOnRelationQuery: false,
   })
   @Column({

--- a/Common/Models/DatabaseModels/LlmProvider.ts
+++ b/Common/Models/DatabaseModels/LlmProvider.ts
@@ -42,7 +42,7 @@ import LlmType from "../../Types/LLM/LlmType";
   pluralName: "LLM Providers",
   icon: IconProp.Bolt,
   tableDescription:
-    "Manage LLM Provider configurations. Connect to OpenAI, Anthropic, Ollama, or other LLM providers to enable AI features.",
+    "Manage LLM Provider configurations. Connect to OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, or other LLM providers to enable AI features.",
 })
 @TableAccessControl({
   create: [
@@ -179,7 +179,8 @@ export default class LlmProvider extends BaseModel {
     required: true,
     type: TableColumnType.ShortText,
     title: "LLM Type",
-    description: "The type of LLM provider (OpenAI, Anthropic, Ollama, etc.)",
+    description:
+      "The type of LLM provider (OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, etc.)",
   })
   @Column({
     nullable: false,
@@ -214,7 +215,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.LongText,
     title: "API Key",
     description:
-      "The API key for the LLM provider. Required for OpenAI and Anthropic.",
+      "The API key for the LLM provider. Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral.",
     encrypted: true,
   })
   @Column({
@@ -276,7 +277,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.ShortURL,
     title: "Base URL",
     description:
-      "The base URL for the LLM API. Required for Ollama, optional for others.",
+      "The base URL for the LLM API. Required for Azure OpenAI and Ollama, optional for others.",
   })
   @Column({
     nullable: true,

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -46,7 +46,11 @@ export default class LLMService {
 
     switch (config.llmType) {
       case LlmType.OpenAI:
-        return await this.getOpenAICompletion(config, request);
+      case LlmType.Groq:
+      case LlmType.Mistral:
+        return await this.getOpenAICompatibleCompletion(config, request);
+      case LlmType.AzureOpenAI:
+        return await this.getAzureOpenAICompletion(config, request);
       case LlmType.Anthropic:
         return await this.getAnthropicCompletion(config, request);
       case LlmType.Ollama:
@@ -57,17 +61,32 @@ export default class LLMService {
   }
 
   @CaptureSpan()
-  private static async getOpenAICompletion(
+  private static async getOpenAICompatibleCompletion(
     config: LLMProviderConfig,
     request: LLMCompletionRequest,
   ): Promise<LLMCompletionResponse> {
     if (!config.apiKey) {
-      throw new BadDataException("OpenAI API key is required");
+      throw new BadDataException(`${config.llmType} API key is required`);
     }
 
-    const baseUrl: string = config.baseUrl || "https://api.openai.com/v1";
-    const modelName: string = config.modelName || "gpt-4o";
+    const defaultBaseUrls: Record<string, string> = {
+      [LlmType.OpenAI]: "https://api.openai.com/v1",
+      [LlmType.Groq]: "https://api.groq.com/openai/v1",
+      [LlmType.Mistral]: "https://api.mistral.ai/v1",
+    };
 
+    const defaultModels: Record<string, string> = {
+      [LlmType.OpenAI]: "gpt-4o",
+      [LlmType.Groq]: "llama-3.3-70b-versatile",
+      [LlmType.Mistral]: "mistral-large-latest",
+    };
+
+    const baseUrl: string =
+      config.baseUrl ||
+      defaultBaseUrls[config.llmType] ||
+      "https://api.openai.com/v1";
+    const modelName: string =
+      config.modelName || defaultModels[config.llmType] || "gpt-4o";
     const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await API.post<JSONObject>({
         url: URL.fromString(`${baseUrl}/chat/completions`),
@@ -88,20 +107,20 @@ export default class LLMService {
         options: {
           retries: 2,
           exponentialBackoff: true,
-          timeout: 120000, // 2 minutes timeout for LLM calls
+          timeout: 120000,
         },
       });
 
-    const openAILogAttributes: LogAttributes = {
+    const logAttributes: LogAttributes = {
       llmType: config.llmType,
       modelName: modelName,
     };
 
     if (response instanceof HTTPErrorResponse) {
-      logger.error("Error from OpenAI API:", openAILogAttributes);
-      logger.error(response, openAILogAttributes);
+      logger.error(`Error from ${config.llmType} API:`, logAttributes);
+      logger.error(response, logAttributes);
       throw new BadDataException(
-        `OpenAI API error: ${JSON.stringify(response.jsonData)}`,
+        `${config.llmType} API error: ${JSON.stringify(response.jsonData)}`,
       );
     }
 
@@ -109,7 +128,83 @@ export default class LLMService {
     const choices: Array<JSONObject> = jsonData["choices"] as Array<JSONObject>;
 
     if (!choices || choices.length === 0) {
-      throw new BadDataException("No response from OpenAI");
+      throw new BadDataException(`No response from ${config.llmType}`);
+    }
+
+    const message: JSONObject = choices[0]!["message"] as JSONObject;
+    const usage: JSONObject = jsonData["usage"] as JSONObject;
+
+    return {
+      content: message["content"] as string,
+      usage: usage
+        ? {
+            promptTokens: usage["prompt_tokens"] as number,
+            completionTokens: usage["completion_tokens"] as number,
+            totalTokens: usage["total_tokens"] as number,
+          }
+        : undefined,
+    };
+  }
+
+  @CaptureSpan()
+  private static async getAzureOpenAICompletion(
+    config: LLMProviderConfig,
+    request: LLMCompletionRequest,
+  ): Promise<LLMCompletionResponse> {
+    if (!config.apiKey) {
+      throw new BadDataException("Azure OpenAI API key is required");
+    }
+
+    if (!config.baseUrl) {
+      throw new BadDataException(
+        "Azure OpenAI Base URL is required (e.g. https://<resource>.openai.azure.com/openai/deployments/<deployment>/)",
+      );
+    }
+
+    const modelName: string = config.modelName || "gpt-4o";
+
+    const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
+      await API.post<JSONObject>({
+        url: URL.fromString(`${config.baseUrl}/chat/completions`),
+        data: {
+          model: modelName,
+          messages: request.messages.map((msg: LLMMessage) => {
+            return {
+              role: msg.role,
+              content: msg.content,
+            };
+          }),
+          temperature: request.temperature ?? 0.7,
+        },
+        headers: {
+          "api-key": config.apiKey,
+          "Content-Type": "application/json",
+        },
+        options: {
+          retries: 2,
+          exponentialBackoff: true,
+          timeout: 120000,
+        },
+      });
+
+    const logAttributes: LogAttributes = {
+      llmType: config.llmType,
+      modelName: modelName,
+    };
+
+    if (response instanceof HTTPErrorResponse) {
+      logger.error("Error from Azure OpenAI API:", logAttributes);
+      logger.error(response, logAttributes);
+      throw new BadDataException(
+        `Azure OpenAI API error: ${JSON.stringify(response.jsonData)}`,
+      );
+    }
+
+    const jsonData: JSONObject = response.jsonData as JSONObject;
+    const choices: Array<JSONObject> = jsonData["choices"] as Array<JSONObject>;
+
+    if (!choices || choices.length === 0) {
+      throw new BadDataException("No response from Azure OpenAI");
     }
 
     const message: JSONObject = choices[0]!["message"] as JSONObject;

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -146,6 +146,29 @@ export default class LLMService {
     };
   }
 
+  /*
+   * Default Azure OpenAI API version. Users can override by including
+   * ?api-version=... in their configured base URL.
+   */
+  private static readonly AZURE_OPENAI_DEFAULT_API_VERSION: string =
+    "2024-10-21";
+
+  private static buildAzureOpenAIChatCompletionsUrl(baseUrl: string): string {
+    const trimmed: string = baseUrl.replace(/\/+$/, "");
+    const queryIndex: number = trimmed.indexOf("?");
+    const pathPart: string =
+      queryIndex >= 0 ? trimmed.substring(0, queryIndex) : trimmed;
+    const queryPart: string =
+      queryIndex >= 0 ? trimmed.substring(queryIndex + 1) : "";
+
+    const params: URLSearchParams = new URLSearchParams(queryPart);
+    if (!params.has("api-version")) {
+      params.set("api-version", LLMService.AZURE_OPENAI_DEFAULT_API_VERSION);
+    }
+
+    return `${pathPart}/chat/completions?${params.toString()}`;
+  }
+
   @CaptureSpan()
   private static async getAzureOpenAICompletion(
     config: LLMProviderConfig,
@@ -157,15 +180,18 @@ export default class LLMService {
 
     if (!config.baseUrl) {
       throw new BadDataException(
-        "Azure OpenAI Base URL is required (e.g. https://<resource>.openai.azure.com/openai/deployments/<deployment>/)",
+        "Azure OpenAI Base URL is required (e.g. https://<resource>.openai.azure.com/openai/deployments/<deployment>)",
       );
     }
 
     const modelName: string = config.modelName || "gpt-4o";
+    const requestUrl: string = LLMService.buildAzureOpenAIChatCompletionsUrl(
+      config.baseUrl,
+    );
 
     const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await API.post<JSONObject>({
-        url: URL.fromString(`${config.baseUrl}/chat/completions`),
+        url: URL.fromString(requestUrl),
         data: {
           model: modelName,
           messages: request.messages.map((msg: LLMMessage) => {

--- a/Common/Types/LLM/LlmType.ts
+++ b/Common/Types/LLM/LlmType.ts
@@ -1,6 +1,9 @@
 enum LlmType {
   OpenAI = "OpenAI",
+  AzureOpenAI = "AzureOpenAI",
   Anthropic = "Anthropic",
+  Groq = "Groq",
+  Mistral = "Mistral",
   Ollama = "Ollama",
 }
 


### PR DESCRIPTION
## Summary

- Adds **Azure OpenAI**, **Groq**, and **Mistral** as first-class LLM provider options alongside the existing OpenAI, Anthropic, and Ollama
- Refactors `getOpenAICompletion` into a shared `getOpenAICompatibleCompletion` method with per-provider default base URLs and models, reducing duplication
- Adds a dedicated `getAzureOpenAICompletion` method that uses the `api-key` header required by Azure (instead of `Authorization: Bearer`), fixing the `{"data":""}` error users see when configuring Azure OpenAI
- Updates all UI form descriptions and placeholders in both the Dashboard and AdminDashboard to document the new providers

## Provider details

| Provider | Default Base URL | Default Model | Auth Header |
|----------|-----------------|---------------|-------------|
| OpenAI | `https://api.openai.com/v1` | `gpt-4o` | `Authorization: Bearer` |
| Azure OpenAI | User-provided (required) | `gpt-4o` | `api-key` |
| Groq | `https://api.groq.com/openai/v1` | `llama-3.3-70b-versatile` | `Authorization: Bearer` |
| Mistral | `https://api.mistral.ai/v1` | `mistral-large-latest` | `Authorization: Bearer` |

## Test plan

- [ ] Select Azure OpenAI as provider type, enter API key and base URL — AI features should work
- [ ] Select Groq, enter API key — should default to `api.groq.com` without needing a base URL
- [ ] Select Mistral, enter API key — should default to `api.mistral.ai` without needing a base URL
- [ ] Existing OpenAI, Anthropic, Ollama providers continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)