### PR TITLE
feat: add optional TLS skip verification via env var

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -83,8 +83,8 @@ Usage:
 - name: NODE_ENV
   value: {{ $.Values.nodeEnvironment }}
 {{- if $.Values.skipVerifyTLS }}
-  - name: NODE_TLS_REJECT_UNAUTHORIZED
-    value: "0"
+- name: NODE_TLS_REJECT_UNAUTHORIZED
+  value: "0"
 {{- end }} 
 - name: BILLING_ENABLED
   value: {{ $.Values.billing.enabled | squote }}

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -81,10 +81,10 @@ Usage:
 - name: HTTP_PROTOCOL
   value: {{ $.Values.httpProtocol }}
 - name: NODE_ENV
-  value: {{ $.Values.skipVerifyTLS }}
-{{- if $.Values.allow--- }}
-- name: NODE_TLS_REJECT_UNAUTHORIZED
-  value: "0"
+  value: {{ $.Values.nodeEnvironment }}
+{{- if $.Values.skipVerifyTLS }}
+  - name: NODE_TLS_REJECT_UNAUTHORIZED
+    value: "0"
 {{- end }} 
 - name: BILLING_ENABLED
   value: {{ $.Values.billing.enabled | squote }}

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -81,7 +81,11 @@ Usage:
 - name: HTTP_PROTOCOL
   value: {{ $.Values.httpProtocol }}
 - name: NODE_ENV
-  value: {{ $.Values.nodeEnvironment }}
+  value: {{ $.Values.skipVerifyTLS }}
+{{- if $.Values.allow--- }}
+- name: NODE_TLS_REJECT_UNAUTHORIZED
+  value: "0"
+{{- end }} 
 - name: BILLING_ENABLED
   value: {{ $.Values.billing.enabled | squote }}
 - name: BILLING_PUBLIC_KEY

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -763,6 +763,9 @@
         "nodeEnvironment": {
             "type": "string"
         },
+        "skipVerifyTLS": {
+            "type": "boolean"
+        },
         "billing": {
             "type": "object",
             "properties": {

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -311,6 +311,11 @@ autoscaling:
 
 nodeEnvironment: production
 
+# Disable TLS certificate verification for outbound HTTPS requests.
+# Useful for self-signed certs or testing setups.
+# Not safe for production (risk of MITM attacks)!
+skipVerifyTLS: false
+
 billing:
   enabled: false
   publicKey:


### PR DESCRIPTION
Introduce `skipVerifyTLS` flag to control TLS certificate validation.

When enabled, sets `NODE_TLS_REJECT_UNAUTHORIZED=0` to allow connections to endpoints with self-signed or invalid certificates. This is useful for testing and internal environments.