### PR TITLE
feat: add hostAliases config to helm chart

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -662,6 +662,10 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $.hostAliases }}
+      hostAliases:
+        {{- toYaml $.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if $.Values.affinity }}
       affinity: {{- $.Values.affinity | toYaml | nindent 8 }}
       {{- end }}

--- a/HelmChart/Public/oneuptime/templates/ai-agent.yaml
+++ b/HelmChart/Public/oneuptime/templates/ai-agent.yaml
@@ -44,6 +44,13 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $.Values.aiAgent.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.aiAgent.hostAliases | nindent 8 }}
+      {{- else if $.Values.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if $.Values.affinity }}
       affinity: {{- $.Values.affinity | toYaml | nindent 8 }}
       {{- end }}

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -47,6 +47,13 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $.Values.app.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.app.hostAliases | nindent 8 }}
+      {{- else if $.Values.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if $.Values.affinity }}
       affinity: {{- $.Values.affinity | toYaml | nindent 8 }}
       {{- end }}

--- a/HelmChart/Public/oneuptime/templates/home.yaml
+++ b/HelmChart/Public/oneuptime/templates/home.yaml
@@ -45,6 +45,13 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $.Values.home.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.home.hostAliases | nindent 8 }}
+      {{- else if $.Values.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if $.Values.affinity }}
       affinity: {{- $.Values.affinity | toYaml | nindent 8 }}
       {{- end }}

--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -58,6 +58,13 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $.Values.nginx.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.nginx.hostAliases | nindent 8 }}
+      {{- else if $.Values.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml $.Values.imagePullSecrets | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/probe.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe.yaml
@@ -46,6 +46,13 @@ spec:
       securityContext:
         {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- if $.Values.probe.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.probe.hostAliases | nindent 8 }}
+      {{- else if $.Values.hostAliases }}
+      hostAliases:
+        {{- toYaml $.Values.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if $.Values.affinity }}
       affinity: {{- $.Values.affinity | toYaml | nindent 8 }}
       {{- end }}

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -318,6 +318,9 @@
                 },
                 "containerSecurityContext": {
                     "type": "object"
+                },
+                "hostAliases": {
+                    "type": "object"
                 }
             },
             "additionalProperties": false
@@ -1130,6 +1133,9 @@
                         "containerSecurityContext": {
                             "type": "object"
                         },
+                        "hostAliases": {
+                            "type": "object"
+                        },
                         "additionalContainers": {
                             "type": "array"
                         },
@@ -1716,6 +1722,9 @@
                 "podSecurityContext": {
                     "type": "object"
                 },
+                "hostAliases": {
+                    "type": "object"
+                },
                 "containerSecurityContext": {
                     "type": "object"
                 },
@@ -1811,6 +1820,9 @@
                     "type": "object"
                 },
                 "podSecurityContext": {
+                    "type": "object"
+                },
+                "hostAliases": {
                     "type": "object"
                 },
                 "containerSecurityContext": {
@@ -2060,6 +2072,9 @@
                     "type": "object"
                 },
                 "containerSecurityContext": {
+                    "type": "object"
+                },
+                "hostAliases": {
                     "type": "object"
                 },
                 "keda": {

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -493,6 +493,7 @@ podSecurityContext:
 affinity:
 tolerations:
 nodeSelector:
+hostAliases:
 
 # This can be one of the following: DEBUG, INFO, WARN, ERROR, OFF
 # Please do not set this to DEBUG in production. This is only for development / debugging purposes.

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -99,6 +99,7 @@ nginx:
   resources: {}
   nodeSelector: {}
   podSecurityContext: {}
+  hostAliases: {}
   containerSecurityContext: {}
 
 postgresql:
@@ -433,6 +434,7 @@ probes:
     resources: {}
     nodeSelector: {}
     podSecurityContext: {}
+    hostAliases: {}
     containerSecurityContext: {}
 #   additionalContainers:
 # two:
@@ -648,6 +650,7 @@ home:
   resources:
   nodeSelector: {}
   podSecurityContext: {}
+  hostAliases: {}
   containerSecurityContext: {}
 
 
@@ -666,6 +669,7 @@ app:
   resources:
   nodeSelector: {}
   podSecurityContext: {}
+  hostAliases: {}
   containerSecurityContext: {}
   # KEDA autoscaling configuration based on combined queue metrics (worker + workflow + telemetry)
   keda:
@@ -703,6 +707,7 @@ aiAgent:
   resources:
   nodeSelector: {}
   podSecurityContext: {}
+  hostAliases: {}
   containerSecurityContext: {}
   # KEDA autoscaling configuration based on queue metrics
   keda:


### PR DESCRIPTION
Add support for configuring `hostAliases` in the Helm chart.

This allows injecting custom hostname-to-IP mappings into the pod’s `/etc/hosts`,
useful for internal testing, mock services, or overriding DNS resolution when needed.