### PR TITLE
fix: unbreak master CI (recharts v3 types, uuid ESM, Probe mocks, expo-doctor)

### DIFF
--- a/Common/UI/Components/LogsViewer/components/LogsAnalyticsView.tsx
+++ b/Common/UI/Components/LogsViewer/components/LogsAnalyticsView.tsx
@@ -685,13 +685,13 @@ const LogsAnalyticsView: FunctionComponent<LogsAnalyticsViewProps> = (
                 />
                 <Area
                   dataKey={seriesKeys[0] || "count"}
-                  stroke={CHART_COLORS[0]}
+                  stroke={CHART_COLORS[0]!}
                   strokeWidth={2}
                   fill="url(#areaGradient0)"
                   dot={false}
                   activeDot={{
                     r: 4,
-                    fill: CHART_COLORS[0],
+                    fill: CHART_COLORS[0]!,
                     stroke: "#fff",
                     strokeWidth: 2,
                   }}

--- a/Common/Utils/UUID.ts
+++ b/Common/Utils/UUID.ts
@@ -1,7 +1,7 @@
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "crypto";
 
 export default class UUID {
   public static generate(): string {
-    return uuidv4();
+    return randomUUID();
   }
 }

--- a/Common/package-lock.json
+++ b/Common/package-lock.json
@@ -43,7 +43,6 @@
         "@types/qrcode": "^1.5.5",
         "@types/react-highlight": "^0.12.8",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "@types/uuid": "^8.3.4",
         "@types/web-push": "^3.6.4",
         "acme-client": "^5.3.0",
         "airtable": "^0.12.2",
@@ -100,7 +99,7 @@
         "react-syntax-highlighter": "^16.0.0",
         "react-toggle": "^4.1.3",
         "reactflow": "^11.11.4",
-        "recharts": "^3.0.0",
+        "recharts": "^3.8.1",
         "redis-semaphore": "^5.5.1",
         "reflect-metadata": "^0.2.2",
         "remark-gfm": "^4.0.0",
@@ -116,7 +115,6 @@
         "typeorm-extension": "^2.2.13",
         "universal-cookie": "^7.2.1",
         "use-async-effect": "^2.2.6",
-        "uuid": "^14.0.0",
         "web-push": "^3.6.7",
         "zod": "^3.25.76"
       },
@@ -5891,12 +5889,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "license": "MIT"
     },
     "node_modules/@types/warning": {
@@ -15953,12 +15945,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.0.0.tgz",
-      "integrity": "sha512-GODedlXZEOQ/KN15puHqaEk9JaiUvFr+Wef/nSagi7g9wHPFLB7prH1/J8vyEBtA2Es6r8qGY1t2OqkuAIpgBg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
       "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
@@ -16010,14 +16005,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/recharts/node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/recharts/node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -18794,19 +18781,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/Common/package.json
+++ b/Common/package.json
@@ -82,7 +82,6 @@
     "@types/qrcode": "^1.5.5",
     "@types/react-highlight": "^0.12.8",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/uuid": "^8.3.4",
     "@types/web-push": "^3.6.4",
     "acme-client": "^5.3.0",
     "airtable": "^0.12.2",
@@ -155,7 +154,6 @@
     "typeorm-extension": "^2.2.13",
     "universal-cookie": "^7.2.1",
     "use-async-effect": "^2.2.6",
-    "uuid": "^14.0.0",
     "web-push": "^3.6.7",
     "zod": "^3.25.76"
   }

--- a/MobileApp/package-lock.json
+++ b/MobileApp/package-lock.json
@@ -30,7 +30,7 @@
         "expo-splash-screen": "^31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-system-ui": "~6.0.9",
-        "expo-web-browser": "~15.0.10",
+        "expo-web-browser": "~15.0.11",
         "nativewind": "^4.2.1",
         "postcss": "^8.5.6",
         "react": "19.1.0",
@@ -5718,9 +5718,9 @@
       }
     },
     "node_modules/expo-web-browser": {
-      "version": "15.0.10",
-      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.10.tgz",
-      "integrity": "sha512-fvDhW4bhmXAeWFNFiInmsGCK83PAqAcQaFyp/3pE/jbdKmFKoRCWr46uZGIfN4msLK/OODhaQ/+US7GSJNDHJg==",
+      "version": "15.0.11",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.11.tgz",
+      "integrity": "sha512-r2LS4Ro6DgUPZkcaEfgt8mp9eJuoA93x11Jh7S6utFe0FEzvUNn2yFhxg8XVwESaaHGt2k5V8LuK36rsp0BeIw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/MobileApp/package.json
+++ b/MobileApp/package.json
@@ -42,7 +42,7 @@
     "expo-splash-screen": "^31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-system-ui": "~6.0.9",
-    "expo-web-browser": "~15.0.10",
+    "expo-web-browser": "~15.0.11",
     "nativewind": "^4.2.1",
     "postcss": "^8.5.6",
     "react": "19.1.0",

--- a/Probe/jest.config.json
+++ b/Probe/jest.config.json
@@ -1,10 +1,12 @@
 {
-   
+
  "preset": "ts-jest",
 "testPathIgnorePatterns": [
         "node_modules",
-        "dist"
+        "dist",
+        "<rootDir>/build/"
     ],
+    "modulePathIgnorePatterns": ["<rootDir>/build/"],
     "verbose": true,
     "globals": {
         "ts-jest": {


### PR DESCRIPTION
## Summary

Master is currently red on four workflows. None are caused by recent feature work — they're the side effects of a recent dependency refresh. This PR fixes all four.

| Workflow | Failure | Fix |
|---|---|---|
| `Compile` (compile-dashboard) | `LogsAnalyticsView.tsx:692` — recharts v3 `Area.stroke` / `activeDot.fill` reject `string \| undefined` under `exactOptionalPropertyTypes` | Non-null assert `CHART_COLORS[0]!` (matches the pattern used elsewhere in the same file) |
| `CLI Test` & `Probe Test` | `uuid@14` is ESM-only; jest under ts-jest can't transform it (`SyntaxError: Unexpected token 'export'`) | Replace `uuid.v4()` with Node's built-in `crypto.randomUUID()`. Drop `uuid` + `@types/uuid` from `Common/package.json` (it was the only consumer) |
| `Probe Test` (compounding) | Probe's jest config has no `modulePathIgnorePatterns`, so stale compiled mocks under `Probe/build/dist/Tests/__mocks__/` shadow the `.ts` source mocks | Add `modulePathIgnorePatterns: ["<rootDir>/build/"]` and ignore `<rootDir>/build/` in `testPathIgnorePatterns` |
| `MobileApp Test` (expo-doctor) | `expo-web-browser` pinned at `~15.0.10`, Expo SDK 54 expects `~15.0.11` | Bump to `~15.0.11` |

## Test plan

- [x] `cd Common && npm run compile`
- [x] `cd App/FeatureSet/Dashboard && npm run compile`
- [x] `cd App/FeatureSet/AdminDashboard && npm run compile`
- [x] `cd CLI && npm run test` — 163 passed
- [x] `cd Probe && npm run test` — 9 passed
- [x] `cd MobileApp && npx expo-doctor@latest` — 17/17 passed
- [x] `npm run fix` (repo-wide eslint) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)