### PR TITLE
fix(host-processes): read per-process attrs under their `resource.` p…

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Host/View/Processes.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Host/View/Processes.tsx
@@ -34,10 +34,18 @@ interface ProcessRow {
   user: string | null;
 }
 
-const PROCESS_PID_ATTR: string = "process.pid";
-const PROCESS_NAME_ATTR: string = "process.executable.name";
-const PROCESS_COMMAND_ATTR: string = "process.command";
-const PROCESS_OWNER_ATTR: string = "process.owner";
+/*
+ * The OTel hostmetrics `process` scraper attaches per-process identity
+ * (pid, executable name, command, owner) to the *resource*, not the
+ * datapoint. OneUptime's metric ingest prefixes resource attributes with
+ * `resource.`, so they land in ClickHouse as `resource.process.*` —
+ * matching the convention Docker container pages already use for their
+ * resource attributes (`resource.container.name`, etc).
+ */
+const PROCESS_PID_ATTR: string = "resource.process.pid";
+const PROCESS_NAME_ATTR: string = "resource.process.executable.name";
+const PROCESS_COMMAND_ATTR: string = "resource.process.command";
+const PROCESS_OWNER_ATTR: string = "resource.process.owner";
 
 const formatPercent: (value: number | null) => string = (
   value: number | null,


### PR DESCRIPTION
…refix

The OTel hostmetrics `process` scraper attaches process.pid / process.executable.name / process.command / process.owner to the resource, so OneUptime's ingest stores them as `resource.process.*`. The Processes page was reading them unprefixed, so every datapoint was filtered out and the tab always showed the empty state — even with the docs config in place.

### Title of this pull request?

### Small Description?

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
