### PR TITLE
Change Enterprise Edition URL in AuditLogsEnterpriseUpgrade

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AuditLogs/AuditLogsEnterpriseUpgrade.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AuditLogs/AuditLogsEnterpriseUpgrade.tsx
@@ -69,7 +69,7 @@ const AuditLogsEnterpriseUpgrade: FunctionComponent<ComponentProps> = (
   const ctaIcon: IconProp = isCloud ? IconProp.Billing : IconProp.Info;
   const ctaUrl: string = isCloud
     ? "https://oneuptime.com/pricing"
-    : "https://oneuptime.com/enterprise";
+    : "https://oneuptime.com/enterprise/overview";
 
   const pitchLine: string = isCloud
     ? "Audit Logs are available on the Enterprise plan. Upgrade to turn on audit logging for this project."


### PR DESCRIPTION
### Title of this pull request?
Change Enterprise Edition URL in AuditLogsEnterpriseUpgrade

### Small Description?
The Modal, showing the Button to learn more about the Enterprise Plan, links to an 404 Page. Same goes for the Documentation (no real link found). Might be an Issue for Conversion.
### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?
/none
### Screenshots (if appropriate):
/none