### PR TITLE
Fix policy-scoped on-call user overrides

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
@@ -13,6 +13,7 @@ import StartAndEndTime from "Common/Types/Time/StartAndEndTime";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
 import LessThanOrEqual from "Common/Types/BaseDatabase/LessThanOrEqual";
+import ObjectID from "Common/Types/ObjectID";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import Calendar from "Common/UI/Components/Calendar/Calendar";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
@@ -34,6 +35,7 @@ export interface ComponentProps {
   layers: Array<OnCallDutyPolicyScheduleLayer>;
   allLayerUsers: Dictionary<Array<OnCallDutyPolicyScheduleLayerUser>>;
   showFieldLabel?: boolean;
+  onCallDutyPolicyId?: ObjectID | undefined;
   id?: string | undefined;
 }
 
@@ -181,9 +183,38 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
           return;
         }
 
+        const filteredOverrideRecords: Array<UserOverrideRecord> =
+          UserOverrideUtil.getOverridesForPolicy({
+            overrides: result.data.map(
+              (o: OnCallDutyPolicyUserOverride): UserOverrideRecord => {
+                return {
+                  overrideUserId: o.overrideUserId?.toString() || "",
+                  routeAlertsToUserId: o.routeAlertsToUserId?.toString() || "",
+                  startsAt: o.startsAt!,
+                  endsAt: o.endsAt!,
+                  onCallDutyPolicyId: o.onCallDutyPolicyId?.toString() || null,
+                };
+              },
+            ),
+            onCallDutyPolicyId: props.onCallDutyPolicyId?.toString() || null,
+          }).filter((override: UserOverrideRecord) => {
+            return scheduleUserIds.has(override.overrideUserId);
+          });
+
         const filtered: Array<OnCallDutyPolicyUserOverride> =
           result.data.filter((o: OnCallDutyPolicyUserOverride) => {
-            return scheduleUserIds.has(o.overrideUserId?.toString() || "");
+            const overrideUserId: string = o.overrideUserId?.toString() || "";
+            const overridePolicyId: string | null =
+              o.onCallDutyPolicyId?.toString() || null;
+
+            return filteredOverrideRecords.some(
+              (override: UserOverrideRecord) => {
+                return (
+                  override.overrideUserId === overrideUserId &&
+                  override.onCallDutyPolicyId === overridePolicyId
+                );
+              },
+            );
           });
 
         const userMap: Dictionary<UserInfo> = {};
@@ -219,7 +250,7 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     return () => {
       isCancelled = true;
     };
-  }, [startTime, endTime, scheduleUserIds]);
+  }, [startTime, endTime, scheduleUserIds, props.onCallDutyPolicyId]);
 
   const uniqueUsers: Array<UserColorAssignment> = useMemo(() => {
     const seen: Set<string> = new Set<string>();
@@ -286,17 +317,21 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     });
 
     if (overrides.length > 0) {
-      const overrideRecords: Array<UserOverrideRecord> = overrides.map(
-        (o: OnCallDutyPolicyUserOverride): UserOverrideRecord => {
-          return {
-            overrideUserId: o.overrideUserId?.toString() || "",
-            routeAlertsToUserId: o.routeAlertsToUserId?.toString() || "",
-            startsAt: o.startsAt!,
-            endsAt: o.endsAt!,
-            onCallDutyPolicyId: o.onCallDutyPolicyId?.toString() || null,
-          };
-        },
-      );
+      const overrideRecords: Array<UserOverrideRecord> =
+        UserOverrideUtil.getOverridesForPolicy({
+          overrides: overrides.map(
+            (o: OnCallDutyPolicyUserOverride): UserOverrideRecord => {
+              return {
+                overrideUserId: o.overrideUserId?.toString() || "",
+                routeAlertsToUserId: o.routeAlertsToUserId?.toString() || "",
+                startsAt: o.startsAt!,
+                endsAt: o.endsAt!,
+                onCallDutyPolicyId: o.onCallDutyPolicyId?.toString() || null,
+              };
+            },
+          ),
+          onCallDutyPolicyId: props.onCallDutyPolicyId?.toString() || null,
+        });
 
       events = UserOverrideUtil.applyOverridesToEvents({
         events,
@@ -340,6 +375,7 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     overrides,
     overrideUserInfo,
     scheduleUsersById,
+    props.onCallDutyPolicyId,
   ]);
 
   const hasActiveOverrides: boolean = overrides.length > 0;

--- a/Common/Server/Services/OnCallDutyPolicyEscalationRuleScheduleService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyEscalationRuleScheduleService.ts
@@ -43,6 +43,7 @@ export class Service extends DatabaseService<Model> {
       select: {
         projectId: true,
         onCallDutyPolicyScheduleId: true,
+        onCallDutyPolicyId: true,
         onCallDutyPolicySchedule: {
           name: true,
         },
@@ -77,6 +78,9 @@ export class Service extends DatabaseService<Model> {
     const userOnSchedule: ObjectID | null =
       await OnCallDutyPolicyScheduleService.getCurrentUserIdInSchedule(
         createdModel.onCallDutyPolicyScheduleId,
+        {
+          onCallDutyPolicyId: createdModel.onCallDutyPolicyId,
+        },
       );
 
     if (!userOnSchedule) {
@@ -207,6 +211,7 @@ export class Service extends DatabaseService<Model> {
       select: {
         projectId: true,
         onCallDutyPolicyScheduleId: true,
+        onCallDutyPolicyId: true,
         onCallDutyPolicySchedule: {
           name: true,
           _id: true,
@@ -277,6 +282,9 @@ export class Service extends DatabaseService<Model> {
       const userOnSchedule: ObjectID | null =
         await OnCallDutyPolicyScheduleService.getCurrentUserIdInSchedule(
           deletedItem.onCallDutyPolicyScheduleId!,
+          {
+            onCallDutyPolicyId: deletedItem.onCallDutyPolicyId,
+          },
         );
 
       if (!userOnSchedule) {

--- a/Common/Server/Services/OnCallDutyPolicyEscalationRuleService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyEscalationRuleService.ts
@@ -460,6 +460,9 @@ export class Service extends DatabaseService<Model> {
       const userIdInSchedule: ObjectID | null =
         await OnCallDutyPolicyScheduleService.getCurrentUserIdInSchedule(
           scheduleRule.onCallDutyPolicyScheduleId!,
+          {
+            onCallDutyPolicyId: options.onCallPolicyId,
+          },
         );
 
       if (!userIdInSchedule) {

--- a/Common/Server/Services/OnCallDutyPolicyScheduleService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyScheduleService.ts
@@ -1052,6 +1052,7 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
     scheduleUserIds: Array<ObjectID>;
     windowStart: Date;
     windowEnd: Date;
+    onCallDutyPolicyId?: ObjectID | undefined;
   }): Promise<Array<UserOverrideRecord>> {
     if (data.scheduleUserIds.length === 0) {
       return [];
@@ -1087,7 +1088,7 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
       }),
     );
 
-    return overrides
+    const overrideRecords: Array<UserOverrideRecord> = overrides
       .filter((o: OnCallDutyPolicyUserOverride) => {
         const overrideUserId: string = o.overrideUserId?.toString() || "";
         return scheduleUserIdSet.has(overrideUserId);
@@ -1101,11 +1102,17 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
           onCallDutyPolicyId: o.onCallDutyPolicyId?.toString() || null,
         };
       });
+
+    return UserOverrideUtil.getOverridesForPolicy({
+      overrides: overrideRecords,
+      onCallDutyPolicyId: data.onCallDutyPolicyId?.toString() || null,
+    });
   }
 
   public async getEventByIndexInSchedule(data: {
     scheduleId: ObjectID;
     getNumberOfEvents: number; // which event would you like to get. First event, second event, etc.
+    onCallDutyPolicyId?: ObjectID | undefined;
   }): Promise<Array<CalendarEvent>> {
     logger.debug(
       "getEventByIndexInSchedule called with data: " + JSON.stringify(data),
@@ -1169,6 +1176,7 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
           scheduleUserIds,
           windowStart: currentStartTime,
           windowEnd: currentEndTime,
+          onCallDutyPolicyId: data.onCallDutyPolicyId,
         });
 
       if (overrides.length > 0) {
@@ -1189,6 +1197,9 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
   @CaptureSpan()
   public async getCurrentUserIdInSchedule(
     scheduleId: ObjectID,
+    options?: {
+      onCallDutyPolicyId?: ObjectID | undefined;
+    },
   ): Promise<ObjectID | null> {
     const { layerProps, projectId, scheduleUserIds } =
       await this.getScheduleLayerProps({
@@ -1223,6 +1234,7 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
           scheduleUserIds,
           windowStart: currentStartTime,
           windowEnd: currentEndTime,
+          onCallDutyPolicyId: options?.onCallDutyPolicyId,
         });
 
       if (overrides.length > 0) {

--- a/Common/Tests/Types/OnCallDutyPolicy/UserOverrideUtil.test.ts
+++ b/Common/Tests/Types/OnCallDutyPolicy/UserOverrideUtil.test.ts
@@ -1,0 +1,149 @@
+import CalendarEvent from "../../../Types/Calendar/CalendarEvent";
+import UserOverrideUtil, {
+  UserOverrideRecord,
+} from "../../../Types/OnCallDutyPolicy/UserOverrideUtil";
+
+function event(data: { title: string; start: Date; end: Date }): CalendarEvent {
+  return {
+    id: 1,
+    title: data.title,
+    start: data.start,
+    end: data.end,
+  };
+}
+
+function override(data: {
+  overrideUserId?: string;
+  routeAlertsToUserId: string;
+  startsAt: Date;
+  endsAt: Date;
+  onCallDutyPolicyId?: string | null;
+}): UserOverrideRecord {
+  return {
+    overrideUserId: data.overrideUserId || "user-a",
+    routeAlertsToUserId: data.routeAlertsToUserId,
+    startsAt: data.startsAt,
+    endsAt: data.endsAt,
+    onCallDutyPolicyId: data.onCallDutyPolicyId || null,
+  };
+}
+
+describe("UserOverrideUtil", () => {
+  test("filters policy-specific overrides to the active policy", () => {
+    const startsAt: Date = new Date("2026-01-01T00:00:00.000Z");
+    const endsAt: Date = new Date("2026-01-02T00:00:00.000Z");
+
+    const globalOverride: UserOverrideRecord = override({
+      routeAlertsToUserId: "global-substitute",
+      startsAt,
+      endsAt,
+    });
+    const policyAOverride: UserOverrideRecord = override({
+      routeAlertsToUserId: "policy-a-substitute",
+      startsAt,
+      endsAt,
+      onCallDutyPolicyId: "policy-a",
+    });
+    const policyBOverride: UserOverrideRecord = override({
+      routeAlertsToUserId: "policy-b-substitute",
+      startsAt,
+      endsAt,
+      onCallDutyPolicyId: "policy-b",
+    });
+
+    const policyBOverrides: Array<UserOverrideRecord> =
+      UserOverrideUtil.getOverridesForPolicy({
+        overrides: [globalOverride, policyAOverride, policyBOverride],
+        onCallDutyPolicyId: "policy-b",
+      });
+
+    expect(policyBOverrides).toEqual([globalOverride, policyBOverride]);
+
+    const scheduleOnlyOverrides: Array<UserOverrideRecord> =
+      UserOverrideUtil.getOverridesForPolicy({
+        overrides: [globalOverride, policyAOverride, policyBOverride],
+      });
+
+    expect(scheduleOnlyOverrides).toEqual([globalOverride]);
+  });
+
+  test("does not apply another policy's user override to schedule events", () => {
+    const startsAt: Date = new Date("2026-01-01T00:00:00.000Z");
+    const endsAt: Date = new Date("2026-01-02T00:00:00.000Z");
+    const events: Array<CalendarEvent> = [
+      event({
+        title: "user-a",
+        start: startsAt,
+        end: endsAt,
+      }),
+    ];
+
+    const policyAOverride: UserOverrideRecord = override({
+      routeAlertsToUserId: "policy-a-substitute",
+      startsAt,
+      endsAt,
+      onCallDutyPolicyId: "policy-a",
+    });
+
+    const policyBOverrides: Array<UserOverrideRecord> =
+      UserOverrideUtil.getOverridesForPolicy({
+        overrides: [policyAOverride],
+        onCallDutyPolicyId: "policy-b",
+      });
+
+    const overriddenEvents: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events,
+        overrides: policyBOverrides,
+      });
+
+    expect(overriddenEvents).toHaveLength(1);
+    expect(overriddenEvents[0]!.title).toBe("user-a");
+  });
+
+  test("lets policy-specific override take precedence over global override", () => {
+    const startsAt: Date = new Date("2026-01-01T00:00:00.000Z");
+    const localStartsAt: Date = new Date("2026-01-01T12:00:00.000Z");
+    const localEndsAt: Date = new Date("2026-01-01T13:00:00.000Z");
+    const endsAt: Date = new Date("2026-01-02T00:00:00.000Z");
+    const events: Array<CalendarEvent> = [
+      event({
+        title: "user-a",
+        start: startsAt,
+        end: endsAt,
+      }),
+    ];
+
+    const globalOverride: UserOverrideRecord = override({
+      routeAlertsToUserId: "global-substitute",
+      startsAt,
+      endsAt,
+    });
+    const policyOverride: UserOverrideRecord = override({
+      routeAlertsToUserId: "policy-substitute",
+      startsAt: localStartsAt,
+      endsAt: localEndsAt,
+      onCallDutyPolicyId: "policy-a",
+    });
+
+    const policyOverrides: Array<UserOverrideRecord> =
+      UserOverrideUtil.getOverridesForPolicy({
+        overrides: [policyOverride, globalOverride],
+        onCallDutyPolicyId: "policy-a",
+      });
+
+    const overriddenEvents: Array<CalendarEvent> =
+      UserOverrideUtil.applyOverridesToEvents({
+        events,
+        overrides: policyOverrides,
+      });
+
+    expect(
+      overriddenEvents.map((item: CalendarEvent) => {
+        return item.title;
+      }),
+    ).toEqual(["global-substitute", "policy-substitute", "global-substitute"]);
+    expect(overriddenEvents[1]!.start).toEqual(localStartsAt);
+    expect(overriddenEvents[1]!.end).toEqual(localEndsAt);
+  });
+});

--- a/Common/Types/OnCallDutyPolicy/UserOverrideUtil.ts
+++ b/Common/Types/OnCallDutyPolicy/UserOverrideUtil.ts
@@ -27,21 +27,56 @@ export const OVERRIDE_META_KEY: string = "_override";
 
 export default class UserOverrideUtil {
   /**
-   * Returns true when this override should be applied on top of the schedule
-   * events. Global overrides always apply; policy-scoped overrides apply to
-   * any schedule, since a schedule's calendar shows coverage information for
-   * every user who could potentially be paged through it.
+   * Returns overrides that can apply in the supplied policy context.
+   * A missing policy context means the schedule is being rendered outside any
+   * policy, so only global overrides are valid.
    */
-  public static isOverrideApplicable(_override: UserOverrideRecord): boolean {
-    return true;
+  public static getOverridesForPolicy(data: {
+    overrides: Array<UserOverrideRecord>;
+    onCallDutyPolicyId?: string | null | undefined;
+  }): Array<UserOverrideRecord> {
+    const onCallDutyPolicyId: string | null = data.onCallDutyPolicyId || null;
+
+    return data.overrides
+      .filter((override: UserOverrideRecord) => {
+        const overridePolicyId: string | null =
+          override.onCallDutyPolicyId || null;
+
+        if (!onCallDutyPolicyId) {
+          return !overridePolicyId;
+        }
+
+        return !overridePolicyId || overridePolicyId === onCallDutyPolicyId;
+      })
+      .sort((a: UserOverrideRecord, b: UserOverrideRecord) => {
+        const specificityDiff: number =
+          UserOverrideUtil.getOverrideSpecificity(a) -
+          UserOverrideUtil.getOverrideSpecificity(b);
+
+        if (specificityDiff !== 0) {
+          return specificityDiff;
+        }
+
+        return a.startsAt.getTime() - b.startsAt.getTime();
+      });
   }
 
   public static applyOverridesToEvents(data: {
     events: Array<CalendarEvent>;
     overrides: Array<UserOverrideRecord>;
   }): Array<CalendarEvent> {
-    const applicable: Array<UserOverrideRecord> = data.overrides.filter(
-      UserOverrideUtil.isOverrideApplicable,
+    const applicable: Array<UserOverrideRecord> = [...data.overrides].sort(
+      (a: UserOverrideRecord, b: UserOverrideRecord) => {
+        const specificityDiff: number =
+          UserOverrideUtil.getOverrideSpecificity(a) -
+          UserOverrideUtil.getOverrideSpecificity(b);
+
+        if (specificityDiff !== 0) {
+          return specificityDiff;
+        }
+
+        return a.startsAt.getTime() - b.startsAt.getTime();
+      },
     );
 
     if (applicable.length === 0) {
@@ -65,7 +100,12 @@ export default class UserOverrideUtil {
     event: CalendarEvent,
     override: UserOverrideRecord,
   ): Array<CalendarEvent> {
-    if (event.title !== override.overrideUserId) {
+    const existingOverrideMeta: OverrideEventMeta | null =
+      UserOverrideUtil.getOverrideMeta(event);
+    const originalUserId: string =
+      existingOverrideMeta?.originalUserId || event.title;
+
+    if (originalUserId !== override.overrideUserId) {
       return [event];
     }
 
@@ -103,7 +143,7 @@ export default class UserOverrideUtil {
     // Override window — substitute user takes over.
     const meta: OverrideEventMeta = {
       isOverride: true,
-      originalUserId: override.overrideUserId,
+      originalUserId: originalUserId,
       overrideUserId: override.routeAlertsToUserId,
       overrideStartsAt: override.startsAt,
       overrideEndsAt: override.endsAt,
@@ -126,6 +166,10 @@ export default class UserOverrideUtil {
     }
 
     return segments;
+  }
+
+  private static getOverrideSpecificity(override: UserOverrideRecord): number {
+    return override.onCallDutyPolicyId ? 1 : 0;
   }
 
   private static reassignEventIds(


### PR DESCRIPTION
## Summary
- Scope schedule-level user override application to the active on-call policy.
- Keep global overrides applying across policies, while policy-specific overrides only apply to their own policy.
- Preserve policy-specific precedence over global overrides when both overlap.
- Apply the same filtering in the dashboard schedule preview and add regression coverage.

Closes #2445

## Testing
- `npm run fix`
- `cd Common && npm run compile`
- `cd App/FeatureSet/Dashboard && npm run compile`
- `cd Common && npm run test-file -- Tests/Types/OnCallDutyPolicy/UserOverrideUtil.test.ts`
