### PR TITLE
fix(docker): register DockerResource CRUD API route in BaseAPI

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -413,6 +413,9 @@ import DockerHostOwnerTeamService, {
 import DockerHostOwnerUserService, {
   Service as DockerHostOwnerUserServiceType,
 } from "Common/Server/Services/DockerHostOwnerUserService";
+import DockerResourceService, {
+  Service as DockerResourceServiceType,
+} from "Common/Server/Services/DockerResourceService";
 import HostService, {
   Service as HostServiceType,
 } from "Common/Server/Services/HostService";
@@ -817,6 +820,7 @@ import KubernetesClusterOwnerUser from "Common/Models/DatabaseModels/KubernetesC
 import DockerHost from "Common/Models/DatabaseModels/DockerHost";
 import DockerHostOwnerTeam from "Common/Models/DatabaseModels/DockerHostOwnerTeam";
 import DockerHostOwnerUser from "Common/Models/DatabaseModels/DockerHostOwnerUser";
+import DockerResource from "Common/Models/DatabaseModels/DockerResource";
 import Host from "Common/Models/DatabaseModels/Host";
 import HostOwnerTeam from "Common/Models/DatabaseModels/HostOwnerTeam";
 import HostOwnerUser from "Common/Models/DatabaseModels/HostOwnerUser";
@@ -2795,6 +2799,14 @@ const BaseAPIFeatureSet: FeatureSet = {
       new BaseAPI<DockerHostOwnerUser, DockerHostOwnerUserServiceType>(
         DockerHostOwnerUser,
         DockerHostOwnerUserService,
+      ).getRouter(),
+    );
+
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new BaseAPI<DockerResource, DockerResourceServiceType>(
+        DockerResource,
+        DockerResourceService,
       ).getRouter(),
     );
 


### PR DESCRIPTION
### Title of this pull request?

fix(docker): register DockerResource CRUD API route in BaseAPI

### Small Description?

`DockerResource` was missing its `app.use` registration in `BaseAPI/Index.ts`, causing every request to `/api/docker-resource/get-list` (and all other CRUD endpoints on this model) to return 404. The model, service, `@CrudApiEndpoint` decorator, and all frontend components were in place — only the server-side route registration was absent.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #2469` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

closes #2469

### Screenshots (if appropriate):

Before fix — Dashboard Docker container widget network request:
```
404 Page not found - /api/docker-resource/get-list?limit=25&skip=0
```

After fix:
```
200 OK — returns DockerResource list
```