### PR TITLE
docs(telemetry): add mute_process_user_error to host OTel collector config

### DIFF
--- a/App/FeatureSet/Docs/Content/en/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/host-otel-collector.md
@@ -135,6 +135,7 @@ receivers:
       processes:
       process:
         mute_process_name_error: true
+        mute_process_user_error: true
 ```
 
 > On Linux, the collector reads `/proc` and `/sys`. When the collector runs in a container, mount the host's `/proc` and `/sys` and set the `HOST_PROC` / `HOST_SYS` environment variables. When it runs directly as a systemd service (as installed above), no extra setup is needed.
@@ -259,6 +260,9 @@ receivers:
       load:
       paging:
       processes:
+      process:
+        mute_process_name_error: true
+        mute_process_user_error: true
 
   filelog/syslog:
     include:
@@ -316,6 +320,9 @@ receivers:
       load:
       paging:
       processes:
+      process:
+        mute_process_name_error: true
+        mute_process_user_error: true
 
   filelog/system:
     include:
@@ -368,6 +375,9 @@ receivers:
       load:
       paging:
       processes:
+      process:
+        mute_process_name_error: true
+        mute_process_user_error: true
 
   windowseventlog/system:
     channel: System


### PR DESCRIPTION
## Summary

- Adds `mute_process_user_error: true` to the `process` scraper block in the host OTel Collector documentation (reference snippet + all three complete OS examples: Linux, macOS, Windows)
- Suppresses the `/etc/passwd` read error that spams logs when the collector runs on a host where usernames cannot be resolved from the proc filesystem (common on container hosts and hardened systems)

## Root cause

The doc already had `mute_process_name_error: true` but was missing `mute_process_user_error: true`. Users who copy the provided config verbatim see repeated `scraperhelper` errors.

## Test plan

- [x] Copy the Linux complete example config → start `otelcol-contrib` → confirm no `/etc/passwd` error spam in logs
- [ ] Verify collector still reports process metrics normally

Closes #2474