### PR TITLE
fix(status-page): use internal service hostname for StatusPageApiInternalUrl

### DIFF
--- a/Common/Server/EnvironmentConfig.ts
+++ b/Common/Server/EnvironmentConfig.ts
@@ -457,13 +457,18 @@ export const StatusPageApiClientUrl: URL = new URL(
 );
 
 /*
- *Internal URL for server-to-server communication (uses internal Docker hostname)
+ *Internal URL for server-to-server communication (uses internal service hostname)
  *Note: The internal path is /api/status-page (not /status-page-api) because
  * /status-page-api is the external route that Nginx rewrites to /api/status-page
+ *Uses AppApiHostname (SERVER_APP_HOSTNAME:APP_PORT) over plain HTTP so the
+ * call stays within the cluster and does not depend on the public HOST or
+ * HTTP_PROTOCOL env vars.
  */
-export const StatusPageApiInternalUrl: URL = URL.fromString(
-  AppApiClientUrl.toString(),
-).addRoute(new Route("/status-page"));
+export const StatusPageApiInternalUrl: URL = new URL(
+  Protocol.HTTP,
+  AppApiHostname,
+  new Route(`${AppApiRoute.toString()}/status-page`),
+);
 
 export const DashboardClientUrl: URL = new URL(
   HttpProtocol,


### PR DESCRIPTION
## Summary

- Changes `StatusPageApiInternalUrl` in `Common/Server/EnvironmentConfig.ts` to use `AppApiHostname` (`SERVER_APP_HOSTNAME:APP_PORT`) over plain `Protocol.HTTP` instead of deriving it from `AppApiClientUrl` (which uses the public `HOST` and `HTTP_PROTOCOL` env vars)

## Root cause

`AppApiClientUrl` is the public-facing URL. Using it for internal server-to-server calls inside the cluster causes the app pod to call its own public ingress, which can be unreachable (ETIMEDOUT) or route incorrectly:

```
APIException: connect ETIMEDOUT 10.10.10.10:443
url: http://my_domain/api/status-page/seo/oneuptime-app.cluster.local
```

`AppApiHostname` already exists for exactly this use-case (built from `SERVER_APP_HOSTNAME` + `APP_PORT` env vars).

## Test plan

- [x] Self-hosted Kubernetes: status page SEO requests succeed without ETIMEDOUT
- [x] Docker Compose: `SERVER_APP_HOSTNAME=localhost`, `APP_PORT=3002` → `StatusPageApiInternalUrl` resolves to `http://localhost:3002/api/status-page`
- [x] Status page custom domain still loads correctly end-to-end

Closes #2475