### PR TITLE
fix(database): include sort columns in select to fix DISTINCT subquery crash

### DIFF
--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1445,6 +1445,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
   ): Promise<Array<TBaseModel>> {
     try {
       let automaticallyAddedCreatedAtInSelect: boolean = false;
+      const automaticallyAddedSortColumnsInSelect: Array<string> = [];
 
       if (!findBy.sort || Object.keys(findBy.sort).length === 0) {
         findBy.sort = {
@@ -1458,6 +1459,21 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
         if (!(findBy.select as any)["createdAt"]) {
           (findBy.select as any)["createdAt"] = true;
           automaticallyAddedCreatedAtInSelect = true;
+        }
+      } else {
+        // Ensure every sort column is present in select. When TypeORM
+        // paginates a query that uses relations (which triggers a DISTINCT
+        // subquery), each ORDER BY column must appear in the inner SELECT or
+        // Postgres raises "column does not exist" on the outer query.
+        if (!findBy.select) {
+          findBy.select = {} as any;
+        }
+
+        for (const sortKey of Object.keys(findBy.sort)) {
+          if (!(findBy.select as any)[sortKey]) {
+            (findBy.select as any)[sortKey] = true;
+            automaticallyAddedSortColumnsInSelect.push(sortKey);
+          }
         }
       }
 
@@ -1528,6 +1544,10 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       for (const item of decryptedItems) {
         if (automaticallyAddedCreatedAtInSelect) {
           delete (item as any).createdAt;
+        }
+
+        for (const sortKey of automaticallyAddedSortColumnsInSelect) {
+          delete (item as any)[sortKey];
         }
       }
 

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1461,10 +1461,12 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
           automaticallyAddedCreatedAtInSelect = true;
         }
       } else {
-        // Ensure every sort column is present in select. When TypeORM
-        // paginates a query that uses relations (which triggers a DISTINCT
-        // subquery), each ORDER BY column must appear in the inner SELECT or
-        // Postgres raises "column does not exist" on the outer query.
+        /*
+         * Ensure every sort column is present in select. When TypeORM
+         * paginates a query that uses relations (which triggers a DISTINCT
+         * subquery), each ORDER BY column must appear in the inner SELECT or
+         * Postgres raises "column does not exist" on the outer query.
+         */
         if (!findBy.select) {
           findBy.select = {} as any;
         }


### PR DESCRIPTION
## Summary

- In `DatabaseService._findBy`, auto-adds any sort key that is absent from `select` before calling `repository.find()`
- Strips the auto-added sort keys from result items afterward so the response shape is unchanged
- Mirrors the existing pattern already used for the default `createdAt` sort

## Root cause

When TypeORM paginates a query that involves relations (triggered on models decorated with `@CanAccessIfCanReadOn`), it wraps the inner SELECT in a `distinctAlias` subquery. Any column referenced in the outer `ORDER BY` must be present in the inner SELECT, otherwise Postgres raises:

```
column distinctAlias.AlertStateTimeline_startsAt does not exist
```

This manifested on `IncidentStateTimeline` and `AlertStateTimeline` when the client sorts by `startsAt` — a common sort for timeline views.

## Test plan

- [x] Query `GET /api/incident-state-timeline/get-list` with `sort: {"startsAt":"ASC"}` as a team member with `ReadIncidentStateTimeline` permission → should return results, not a 500 error
- [x] Query `GET /api/alert-state-timeline/get-list` with `sort: {"startsAt":"ASC"}` → same
- [x] Default (no explicit sort) queries are unaffected — the `createdAt DESC` path is unchanged
- [x] Result items do not include the auto-added sort column if it was not in the original `select`

Closes #2476