### PR TITLE
fix(telemetry): guard escapeStringLiteral against undefined/null input

### DIFF
--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -193,8 +193,11 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
     return record;
   }
 
-  private escapeStringLiteral(raw: string): string {
+  private escapeStringLiteral(raw: string | undefined | null): string {
     // escape String literal based on https://clickhouse.com/docs/en/sql-reference/syntax#string
+    if (raw === undefined || raw === null) {
+      return "''";
+    }
     return `'${raw.replace(/'|\\/g, "\\$&")}'`;
   }
 

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
@@ -633,6 +633,81 @@ describe("StatementGenerator", () => {
     });
   });
 
+  describe("toCreateStatement", () => {
+    /*
+     * Regression test for the escapeStringLiteral undefined/null guard.
+     * An ArrayText (Array(String)) column whose value array carried
+     * undefined/null members at runtime used to throw
+     * "TypeError: Cannot read properties of undefined (reading 'replace')"
+     * inside escapeStringLiteral while building the INSERT. The member is
+     * now rendered as the empty string literal '' so the statement still
+     * serializes to a valid ClickHouse Array(String).
+     */
+    class ArrayTextModel extends AnalyticsBaseModel {
+      public constructor() {
+        super({
+          tableName: "<array-create-table>",
+          singularName: "<singular>",
+          pluralName: "<plural>",
+          tableColumns: [
+            new AnalyticsTableColumn({
+              key: "_id",
+              title: "<title>",
+              description: "<description>",
+              required: true,
+              type: TableColumnType.ObjectID,
+            }),
+            new AnalyticsTableColumn({
+              key: "entityKeys",
+              title: "<title>",
+              description: "<description>",
+              required: true,
+              defaultValue: [],
+              type: TableColumnType.ArrayText,
+            }),
+          ],
+          crudApiPath: new Route("route"),
+          primaryKeys: ["_id"],
+          sortKeys: ["_id"],
+          partitionKey: "_id",
+          tableEngine: AnalyticsTableEngine.MergeTree,
+        });
+      }
+    }
+
+    let arrayTextGenerator: StatementGenerator<ArrayTextModel>;
+    beforeEach(() => {
+      arrayTextGenerator = new StatementGenerator<ArrayTextModel>({
+        modelType: ArrayTextModel,
+        database: ClickhouseAppInstance,
+      });
+    });
+
+    test("renders undefined/null ArrayText elements as '' instead of throwing", () => {
+      const item: ArrayTextModel = new ArrayTextModel();
+      item.setColumnValue("_id", "210dac24142f1baa");
+      /*
+       * Simulate runtime data where the Array(String) column carries
+       * undefined/null members. The type system models the column as
+       * string[], hence the cast — this is exactly what crashed before
+       * the guard was added.
+       */
+      item.setColumnValue("entityKeys", [
+        "alpha",
+        undefined,
+        null,
+        "beta",
+      ] as unknown as Array<string>);
+
+      let statement: string = "";
+      expect(() => {
+        statement = arrayTextGenerator.toCreateStatement({ item: [item] });
+      }).not.toThrow();
+
+      expect(statement).toContain("['alpha', '', '', 'beta']");
+    });
+  });
+
   describe("toSelectStatement", () => {
     test("should return the contents of a SELECT statement", () => {
       const { statement, columns } = generator.toSelectStatement({


### PR DESCRIPTION
escapeStringLiteral crashed with TypeError when an ArrayText column contained undefined elements at runtime. Returns empty string literal ('') for undefined/null instead of calling .replace() on them.

Added a regression test (`StatementGenerator.test.ts` -> `toCreateStatement`) that reproduces the crash on an ArrayText value containing undefined/null members and asserts they now serialize to ''.

Related to #2355. Note: this does NOT fully resolve #2355 -- that report's white-page is caused by gRPC trace IDs reaching the frontend as bytes rather than hex-encoded strings (a separate ingest/UI concern), whereas this PR hardens the analytics INSERT path. Leaving #2355 open for the byte-vs-hex root cause.