### PR TITLE
fix(monitor): return null when evaluateOverTime window has no data yet

### DIFF
--- a/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
@@ -40,7 +40,8 @@ export default class APIRequestCriteria {
         });
 
         if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+          // No historical data yet — don't evaluate until the window fills up.
+          return null;
         }
       } catch (err) {
         logger.error(

--- a/Common/Server/Utils/Monitor/Criteria/DnsMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DnsMonitorCriteria.ts
@@ -42,7 +42,7 @@ export default class DnsMonitorCriteria {
         });
 
         if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+          return null;
         }
       } catch (err) {
         logger.error(

--- a/Common/Server/Utils/Monitor/Criteria/ExternalStatusPageMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ExternalStatusPageMonitorCriteria.ts
@@ -42,7 +42,7 @@ export default class ExternalStatusPageMonitorCriteria {
         });
 
         if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+          return null;
         }
       } catch (err) {
         logger.error(

--- a/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
@@ -43,7 +43,7 @@ export default class ServerMonitorCriteria {
         });
 
         if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+          return null;
         }
       } catch (err) {
         logger.error(

--- a/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
@@ -42,7 +42,7 @@ export default class ServerMonitorCriteria {
         });
 
         if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+          return null;
         }
       } catch (err) {
         logger.error(


### PR DESCRIPTION
When evaluateOverTime is enabled but no historical metric data exists yet, criteria returned null (no match) instead of falling back to the current probe value via ||. This ensures monitors wait for the evaluation window to fill before triggering. Affected: APIRequest, DNS, SSL, ExternalStatusPage, Server criteria. Closes #2321