### PR TITLE
fix(status-page): default new subscribers to all resources and event types

### DIFF
--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -3872,13 +3872,15 @@ export default class StatusPageAPI extends BaseAPI<
     statusPageSubscriber.statusPageId = objectId;
     statusPageSubscriber.sendYouHaveSubscribedMessage = true;
     statusPageSubscriber.projectId = statusPage.projectId!;
-    statusPageSubscriber.isSubscribedToAllResources = Boolean(
-      req.body.data["isSubscribedToAllResources"],
-    );
+    statusPageSubscriber.isSubscribedToAllResources =
+      req.body.data["isSubscribedToAllResources"] !== undefined
+        ? Boolean(req.body.data["isSubscribedToAllResources"])
+        : true;
 
-    statusPageSubscriber.isSubscribedToAllEventTypes = Boolean(
-      req.body.data["isSubscribedToAllEventTypes"],
-    );
+    statusPageSubscriber.isSubscribedToAllEventTypes =
+      req.body.data["isSubscribedToAllEventTypes"] !== undefined
+        ? Boolean(req.body.data["isSubscribedToAllEventTypes"])
+        : true;
 
     if (
       req.body.data["statusPageResources"] &&


### PR DESCRIPTION
When a new subscriber signs up, isSubscribedToAllResources and isSubscribedToAllEventTypes now default to true instead of false (Boolean(undefined)). Explicit false values from the form are still respected. Closes #2178