### PR TITLE
fix: restore open source access to identity integrationsfirst commit

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Settings/OIDC.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/OIDC.tsx
@@ -2,7 +2,6 @@ import TeamsElement from "../../Components/Team/TeamsElement";
 import ProjectUtil from "Common/UI/Utils/Project";
 import PageComponentProps from "../PageComponentProps";
 import URL from "Common/Types/API/URL";
-import IconProp from "Common/Types/Icon/IconProp";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
@@ -18,14 +17,10 @@ import {
 import Navigation from "Common/UI/Utils/Navigation";
 import ProjectOIDC from "Common/Models/DatabaseModels/ProjectOidc";
 import Team from "Common/Models/DatabaseModels/Team";
-import EnterpriseFeatureUpgrade, {
-  isEnterpriseFeatureEligible,
-} from "../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
-  useMemo,
   useState,
 } from "react";
 import Link from "Common/UI/Components/Link/Link";
@@ -34,47 +29,6 @@ const OIDCPage: FunctionComponent<PageComponentProps> = (
   _props: PageComponentProps,
 ): ReactElement => {
   const [showOidcConfigId, setShowOidcConfigId] = useState<string>("");
-
-  const isEnterpriseEligible: boolean = useMemo(() => {
-    return isEnterpriseFeatureEligible();
-  }, []);
-
-  if (!isEnterpriseEligible) {
-    return (
-      <EnterpriseFeatureUpgrade
-        title="OpenID Connect (OIDC)"
-        description="Configure OIDC sign-on for your project."
-        featureName="OIDC Single Sign On"
-        featureDescription="Authenticate team members through any OIDC provider — Google Workspace, Auth0, Keycloak, Microsoft Entra ID and more."
-        benefits={[
-          {
-            icon: IconProp.Lock,
-            title: "Modern OAuth2 flow",
-            subtitle:
-              "Use any OIDC-compliant identity provider to manage who can sign in.",
-          },
-          {
-            icon: IconProp.ShieldCheck,
-            title: "Enforce SSO",
-            subtitle:
-              "Require OIDC login for everyone in the project — no shared passwords.",
-          },
-          {
-            icon: IconProp.User,
-            title: "Auto team assignment",
-            subtitle:
-              "Map signed-in users into the right teams the moment they log in.",
-          },
-          {
-            icon: IconProp.ClipboardDocumentList,
-            title: "Audit trail",
-            subtitle:
-              "Every OIDC sign-in is recorded alongside the rest of your audit events.",
-          },
-        ]}
-      />
-    );
-  }
 
   return (
     <Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/SCIM.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/SCIM.tsx
@@ -18,16 +18,12 @@ import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
-  useMemo,
   useState,
 } from "react";
 import IconProp from "Common/Types/Icon/IconProp";
 import Route from "Common/Types/API/Route";
 import Tabs from "Common/UI/Components/Tabs/Tabs";
 import ProjectSCIMLogsTable from "../../Components/SCIMLogs/ProjectSCIMLogsTable";
-import EnterpriseFeatureUpgrade, {
-  isEnterpriseFeatureEligible,
-} from "../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 
 const SCIMPage: FunctionComponent<PageComponentProps> = (
   _props: PageComponentProps,
@@ -43,46 +39,6 @@ const SCIMPage: FunctionComponent<PageComponentProps> = (
   const [showResetErrorModal, setShowResetErrorModal] =
     useState<boolean>(false);
 
-  const isEnterpriseEligible: boolean = useMemo(() => {
-    return isEnterpriseFeatureEligible();
-  }, []);
-
-  if (!isEnterpriseEligible) {
-    return (
-      <EnterpriseFeatureUpgrade
-        title="SCIM User Provisioning"
-        description="Automate user provisioning via SCIM."
-        featureName="SCIM User Provisioning"
-        featureDescription="Provision and deprovision users automatically from your identity provider — Okta, Azure AD, OneLogin and any other SCIM 2.0 system."
-        benefits={[
-          {
-            icon: IconProp.User,
-            title: "Automatic provisioning",
-            subtitle:
-              "Users created in your IdP are added to OneUptime without manual invites.",
-          },
-          {
-            icon: IconProp.Lock,
-            title: "Automatic deprovisioning",
-            subtitle:
-              "Disable a user in your IdP and access here is removed at the same time.",
-          },
-          {
-            icon: IconProp.ShieldCheck,
-            title: "Group sync",
-            subtitle:
-              "Map IdP groups to teams to keep on-call rosters and permissions accurate.",
-          },
-          {
-            icon: IconProp.ClipboardDocumentList,
-            title: "SCIM activity logs",
-            subtitle:
-              "See every provisioning event so you can debug sync issues quickly.",
-          },
-        ]}
-      />
-    );
-  }
   const [showResetSuccessModal, setShowResetSuccessModal] =
     useState<boolean>(false);
   const [newBearerToken, setNewBearerToken] = useState<string>("");

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/SSO.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/SSO.tsx
@@ -4,7 +4,6 @@ import PageComponentProps from "../PageComponentProps";
 import URL from "Common/Types/API/URL";
 import DigestMethod from "Common/Types/SSO/DigestMethod";
 import SignatureMethod from "Common/Types/SSO/SignatureMethod";
-import IconProp from "Common/Types/Icon/IconProp";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
@@ -23,14 +22,10 @@ import Navigation from "Common/UI/Utils/Navigation";
 import Project from "Common/Models/DatabaseModels/Project";
 import ProjectSSO from "Common/Models/DatabaseModels/ProjectSso";
 import Team from "Common/Models/DatabaseModels/Team";
-import EnterpriseFeatureUpgrade, {
-  isEnterpriseFeatureEligible,
-} from "../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
-  useMemo,
   useState,
 } from "react";
 import Link from "Common/UI/Components/Link/Link";
@@ -40,47 +35,6 @@ const SSOPage: FunctionComponent<PageComponentProps> = (
 ): ReactElement => {
   const [showSingleSignOnUrlId, setShowSingleSignOnUrlId] =
     useState<string>("");
-
-  const isEnterpriseEligible: boolean = useMemo(() => {
-    return isEnterpriseFeatureEligible();
-  }, []);
-
-  if (!isEnterpriseEligible) {
-    return (
-      <EnterpriseFeatureUpgrade
-        title="Single Sign On (SSO)"
-        description="Configure SAML SSO for your project."
-        featureName="SAML Single Sign On"
-        featureDescription="Let team members authenticate into this project using your SAML identity provider (Okta, Azure AD, OneLogin, JumpCloud and more)."
-        benefits={[
-          {
-            icon: IconProp.Lock,
-            title: "Centralized auth",
-            subtitle:
-              "Federate sign-in to your IdP and revoke access from one place.",
-          },
-          {
-            icon: IconProp.ShieldCheck,
-            title: "Enforce SSO",
-            subtitle:
-              "Require SSO for everyone in the project — no shared passwords.",
-          },
-          {
-            icon: IconProp.User,
-            title: "Auto team assignment",
-            subtitle:
-              "Map signed-in users into the right teams the moment they log in.",
-          },
-          {
-            icon: IconProp.ClipboardDocumentList,
-            title: "Audit trail",
-            subtitle:
-              "Every SSO sign-in is recorded alongside the rest of your audit events.",
-          },
-        ]}
-      />
-    );
-  }
 
   return (
     <Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/OIDC.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/OIDC.tsx
@@ -3,7 +3,6 @@ import URL from "Common/Types/API/URL";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import { VoidFunction } from "Common/Types/FunctionTypes";
 import ObjectID from "Common/Types/ObjectID";
-import IconProp from "Common/Types/Icon/IconProp";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
@@ -18,14 +17,10 @@ import {
 } from "Common/UI/Config";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPageOIDC from "Common/Models/DatabaseModels/StatusPageOidc";
-import EnterpriseFeatureUpgrade, {
-  isEnterpriseFeatureEligible,
-} from "../../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
-  useMemo,
   useState,
 } from "react";
 import Link from "Common/UI/Components/Link/Link";
@@ -37,46 +32,6 @@ const OIDCPage: FunctionComponent<PageComponentProps> = (
   const modelId: ObjectID = Navigation.getLastParamAsObjectID(1);
 
   const [showOidcConfigId, setShowOidcConfigId] = useState<string>("");
-
-  const isEnterpriseEligible: boolean = useMemo(() => {
-    return isEnterpriseFeatureEligible();
-  }, []);
-
-  if (!isEnterpriseEligible) {
-    return (
-      <EnterpriseFeatureUpgrade
-        title="Status Page OIDC"
-        description="Configure OIDC sign-on for this private status page."
-        featureName="Status Page OIDC SSO"
-        featureDescription="Restrict access to this status page using any OIDC provider — Google Workspace, Auth0, Keycloak and more."
-        benefits={[
-          {
-            icon: IconProp.Lock,
-            title: "Private status pages",
-            subtitle:
-              "Only OIDC-authenticated users can view this status page.",
-          },
-          {
-            icon: IconProp.ShieldCheck,
-            title: "Centralized control",
-            subtitle:
-              "Revoke a user in your IdP and they lose access immediately.",
-          },
-          {
-            icon: IconProp.User,
-            title: "Per-status-page identity",
-            subtitle:
-              "Run distinct IdPs for different audiences (internal vs partner).",
-          },
-          {
-            icon: IconProp.ClipboardDocumentList,
-            title: "Audit trail",
-            subtitle: "See who signed in to your status page and when.",
-          },
-        ]}
-      />
-    );
-  }
 
   return (
     <Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SCIM.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SCIM.tsx
@@ -16,16 +16,12 @@ import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
-  useMemo,
   useState,
 } from "react";
 import IconProp from "Common/Types/Icon/IconProp";
 import Route from "Common/Types/API/Route";
 import Tabs from "Common/UI/Components/Tabs/Tabs";
 import StatusPageSCIMLogsTable from "../../../Components/SCIMLogs/StatusPageSCIMLogsTable";
-import EnterpriseFeatureUpgrade, {
-  isEnterpriseFeatureEligible,
-} from "../../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 
 const SCIMPage: FunctionComponent<PageComponentProps> = (
   _props: PageComponentProps,
@@ -44,46 +40,6 @@ const SCIMPage: FunctionComponent<PageComponentProps> = (
   const [showResetSuccessModal, setShowResetSuccessModal] =
     useState<boolean>(false);
   const [newBearerToken, setNewBearerToken] = useState<string>("");
-
-  const isEnterpriseEligible: boolean = useMemo(() => {
-    return isEnterpriseFeatureEligible();
-  }, []);
-
-  if (!isEnterpriseEligible) {
-    return (
-      <EnterpriseFeatureUpgrade
-        title="Status Page SCIM"
-        description="Automate user provisioning for this status page."
-        featureName="Status Page SCIM Provisioning"
-        featureDescription="Provision and deprovision viewers of this status page directly from your identity provider — Okta, Azure AD and any SCIM 2.0 system."
-        benefits={[
-          {
-            icon: IconProp.User,
-            title: "Automatic provisioning",
-            subtitle: "Status page viewers are added when granted in your IdP.",
-          },
-          {
-            icon: IconProp.Lock,
-            title: "Automatic deprovisioning",
-            subtitle:
-              "Disable access in your IdP and they lose access here in sync.",
-          },
-          {
-            icon: IconProp.ShieldCheck,
-            title: "Group sync",
-            subtitle:
-              "Map IdP groups to status page viewers without manual upkeep.",
-          },
-          {
-            icon: IconProp.ClipboardDocumentList,
-            title: "SCIM activity logs",
-            subtitle:
-              "Every provisioning event is recorded for troubleshooting.",
-          },
-        ]}
-      />
-    );
-  }
 
   const resetBearerToken: () => Promise<void> = async (): Promise<void> => {
     setIsResetLoading(true);

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SSO.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SSO.tsx
@@ -3,7 +3,6 @@ import URL from "Common/Types/API/URL";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import { VoidFunction } from "Common/Types/FunctionTypes";
 import ObjectID from "Common/Types/ObjectID";
-import IconProp from "Common/Types/Icon/IconProp";
 import DigestMethod from "Common/Types/SSO/DigestMethod";
 import SignatureMethod from "Common/Types/SSO/SignatureMethod";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
@@ -23,14 +22,10 @@ import DropdownUtil from "Common/UI/Utils/Dropdown";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPage from "Common/Models/DatabaseModels/StatusPage";
 import StatusPageSSO from "Common/Models/DatabaseModels/StatusPageSso";
-import EnterpriseFeatureUpgrade, {
-  isEnterpriseFeatureEligible,
-} from "../../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
-  useMemo,
   useState,
 } from "react";
 import Link from "Common/UI/Components/Link/Link";
@@ -43,46 +38,6 @@ const SSOPage: FunctionComponent<PageComponentProps> = (
 
   const [showSingleSignOnUrlId, setShowSingleSignOnUrlId] =
     useState<string>("");
-
-  const isEnterpriseEligible: boolean = useMemo(() => {
-    return isEnterpriseFeatureEligible();
-  }, []);
-
-  if (!isEnterpriseEligible) {
-    return (
-      <EnterpriseFeatureUpgrade
-        title="Status Page SSO"
-        description="Configure SAML SSO for this private status page."
-        featureName="Status Page SAML SSO"
-        featureDescription="Restrict access to this status page using your SAML identity provider — Okta, Azure AD, OneLogin and more."
-        benefits={[
-          {
-            icon: IconProp.Lock,
-            title: "Private status pages",
-            subtitle:
-              "Only signed-in members of your IdP can view this status page.",
-          },
-          {
-            icon: IconProp.ShieldCheck,
-            title: "Centralized control",
-            subtitle:
-              "Revoke a user in your IdP and they lose access to the status page immediately.",
-          },
-          {
-            icon: IconProp.User,
-            title: "Per-status-page identity",
-            subtitle:
-              "Run distinct identity providers for different audiences (internal vs partner).",
-          },
-          {
-            icon: IconProp.ClipboardDocumentList,
-            title: "Audit trail",
-            subtitle: "See who signed in to your status page and when.",
-          },
-        ]}
-      />
-    );
-  }
 
   return (
     <Fragment>

--- a/Common/Models/DatabaseModels/ProjectOidc.ts
+++ b/Common/Models/DatabaseModels/ProjectOidc.ts
@@ -8,7 +8,6 @@ import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
-import TableEditionAccessControl from "../../Types/Database/AccessControl/TableEditionAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -30,9 +29,6 @@ import {
   ManyToOne,
 } from "typeorm";
 
-@TableEditionAccessControl({
-  requiresEnterprise: true,
-})
 @TableBillingAccessControl({
   create: PlanType.Scale,
   read: PlanType.Scale,

--- a/Common/Models/DatabaseModels/ProjectSCIM.ts
+++ b/Common/Models/DatabaseModels/ProjectSCIM.ts
@@ -7,7 +7,6 @@ import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
-import TableEditionAccessControl from "../../Types/Database/AccessControl/TableEditionAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -29,9 +28,6 @@ import {
   ManyToOne,
 } from "typeorm";
 
-@TableEditionAccessControl({
-  requiresEnterprise: true,
-})
 @TableBillingAccessControl({
   create: PlanType.Scale,
   read: PlanType.Scale,

--- a/Common/Models/DatabaseModels/ProjectSso.ts
+++ b/Common/Models/DatabaseModels/ProjectSso.ts
@@ -8,7 +8,6 @@ import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
-import TableEditionAccessControl from "../../Types/Database/AccessControl/TableEditionAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -32,9 +31,6 @@ import {
   ManyToOne,
 } from "typeorm";
 
-@TableEditionAccessControl({
-  requiresEnterprise: true,
-})
 @TableBillingAccessControl({
   create: PlanType.Scale,
   read: PlanType.Scale,

--- a/Common/Models/DatabaseModels/StatusPageOidc.ts
+++ b/Common/Models/DatabaseModels/StatusPageOidc.ts
@@ -9,7 +9,6 @@ import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccess
 import OwnedThrough from "../../Types/Database/AccessControl/OwnedThrough";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
-import TableEditionAccessControl from "../../Types/Database/AccessControl/TableEditionAccessControl";
 import CanAccessIfCanReadOn from "../../Types/Database/CanAccessIfCanReadOn";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
@@ -25,9 +24,6 @@ import Permission from "../../Types/Permission";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
 @CanAccessIfCanReadOn("statusPage")
-@TableEditionAccessControl({
-  requiresEnterprise: true,
-})
 @TableBillingAccessControl({
   create: PlanType.Scale,
   read: PlanType.Scale,

--- a/Common/Models/DatabaseModels/StatusPageSCIM.ts
+++ b/Common/Models/DatabaseModels/StatusPageSCIM.ts
@@ -8,7 +8,6 @@ import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccess
 import OwnedThrough from "../../Types/Database/AccessControl/OwnedThrough";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
-import TableEditionAccessControl from "../../Types/Database/AccessControl/TableEditionAccessControl";
 import CanAccessIfCanReadOn from "../../Types/Database/CanAccessIfCanReadOn";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
@@ -25,9 +24,6 @@ import Permission from "../../Types/Permission";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
 @EnableDocumentation()
-@TableEditionAccessControl({
-  requiresEnterprise: true,
-})
 @TableBillingAccessControl({
   create: PlanType.Scale,
   read: PlanType.Scale,

--- a/Common/Models/DatabaseModels/StatusPageSso.ts
+++ b/Common/Models/DatabaseModels/StatusPageSso.ts
@@ -9,7 +9,6 @@ import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccess
 import OwnedThrough from "../../Types/Database/AccessControl/OwnedThrough";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
-import TableEditionAccessControl from "../../Types/Database/AccessControl/TableEditionAccessControl";
 import CanAccessIfCanReadOn from "../../Types/Database/CanAccessIfCanReadOn";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
@@ -29,9 +28,6 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
 @EnableDocumentation()
 @CanAccessIfCanReadOn("statusPage")
-@TableEditionAccessControl({
-  requiresEnterprise: true,
-})
 @TableBillingAccessControl({
   create: PlanType.Scale,
   read: PlanType.Scale,


### PR DESCRIPTION
### Title of this pull request?

Restore OSS access to SSO, OIDC, and SCIM settings

### Small Description?

This PR removes Enterprise Edition gating from SSO, OIDC, and SCIM settings for both Project Settings and Status Page settings.

These identity integrations remain protected by the existing billing plan access controls, but are no longer blocked by `requiresEnterprise` checks in open-source/self-hosted deployments.

Closes #2518

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

Closes #2518

### Screenshots (if appropriate):


---
The Terraform Provider E2E job is failing before Terraform tests run.

It fails during `npm run status-check` because the local OneUptime app keeps returning HTTP 502 while waiting for the dev stack to boot. This appears unrelated to this PR, which only removes Enterprise Edition gating from SSO/OIDC/SCIM settings.

Relevant checks for this change have passed:
- Changed files ESLint
- Common compile
- Dashboard compile
- Common/Dashboard dep-check
- Package version sync check
