### PR TITLE
refactor(dashboard): simplify chart layout and clean up dashboard spacing

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardChartComponent.tsx
@@ -157,26 +157,6 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
     fetchAggregatedResults,
   ]);
 
-  const numberOfCharts: number =
-    queryConfigs.length + formulaConfigs.length || 1;
-  // Account for widget-level header and per-chart overhead (title + legend + padding)
-  const hasWidgetHeader: boolean = Boolean(
-    props.component.arguments.chartTitle ||
-      props.component.arguments.chartDescription,
-  );
-  const widgetHeaderHeight: number = hasWidgetHeader ? 50 : 0;
-  // Each chart section: pt-5(20) + title(20) + legend(24) + pb-4(16) = ~80px overhead
-  const perChartOverhead: number = 80;
-  let heightOfChart: number | undefined =
-    ((props.dashboardComponentHeightInPx || 0) -
-      widgetHeaderHeight -
-      numberOfCharts * perChartOverhead) /
-    numberOfCharts;
-
-  if (heightOfChart < 50) {
-    heightOfChart = undefined;
-  }
-
   const getMetricChartType: () => MetricChartType = useCallback(() => {
     if (props.component.arguments.chartType === DashboardChartType.Bar) {
       return MetricChartType.BAR;
@@ -274,13 +254,12 @@ const DashboardChartComponentElement: FunctionComponent<ComponentProps> = (
           )}
         </div>
       )}
-      <div className="flex-1 min-h-0 overflow-hidden">
+      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
         <MetricCharts
           metricResults={metricResults}
           metricTypes={props.metricTypes}
           metricViewData={chartMetricViewData}
           hideCard={true}
-          heightInPx={heightOfChart}
         />
       </div>
     </div>

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -57,6 +57,7 @@ export interface ComponentProps {
   metricResults: Array<AggregatedResult>;
   metricTypes: Array<MetricType>;
   hideCard?: boolean | undefined;
+  heightInPx?: number | undefined;
   chartCssClass?: string | undefined;
 }
 
@@ -1109,6 +1110,7 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     <ChartGroup
       charts={getCharts()}
       hideCard={props.hideCard}
+      heightInPx={props.heightInPx}
       chartCssClass={props.chartCssClass}
     />
   );

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -275,7 +275,7 @@ function renderSeriesControls(input: {
         </div>
       ) : null}
 
-      <div className="flex flex-wrap gap-1 max-h-24 overflow-y-auto">
+      <div className="flex flex-wrap gap-1 max-h-16 overflow-y-auto">
         {visibleForChips.length === 0 ? (
           <div className="py-1 text-xs italic text-gray-400">
             No series match &ldquo;{controls.searchQuery}&rdquo;
@@ -1110,7 +1110,6 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
     <ChartGroup
       charts={getCharts()}
       hideCard={props.hideCard}
-      heightInPx={props.heightInPx}
       chartCssClass={props.chartCssClass}
     />
   );

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -57,7 +57,6 @@ export interface ComponentProps {
   metricResults: Array<AggregatedResult>;
   metricTypes: Array<MetricType>;
   hideCard?: boolean | undefined;
-  heightInPx?: number | undefined;
   chartCssClass?: string | undefined;
 }
 

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -771,9 +771,13 @@ const MetricView: FunctionComponent<ComponentProps> = (
           <div
             className={
               props.hideCardInCharts
-                ? "pt-4 mt-2 border-t border-gray-200"
+                ? "pt-4 mt-2 border-t border-gray-200 flex flex-col flex-1 w-full"
                 : "grid grid-cols-1 gap-4"
             }
+            style={{
+              // set height to the number of metric results * h-20
+              height: metricResults.length * 20 + "rem",
+            }}
           >
             <MetricCharts
               hideCard={props.hideCardInCharts}

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -37,7 +37,6 @@ export interface ComponentProps {
   yAxis: YAxis;
   curve: ChartCurve;
   sync: boolean;
-  heightInPx?: number | undefined;
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   exemplarPoints?: Array<ExemplarPoint> | undefined;
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
@@ -108,11 +107,6 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
     });
   }, [props.exemplarPoints, props.xAxis]);
 
-  const className: string = props.heightInPx ? `` : "h-80";
-  const style: React.CSSProperties = props.heightInPx
-    ? { height: `${props.heightInPx}px` }
-    : {};
-
   const hasNoData: boolean =
     !props.data ||
     props.data.length === 0 ||
@@ -134,10 +128,8 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
     typeof yAxisMaxOption === "number" ? { maxValue: yAxisMaxOption } : {};
 
   return (
-    <div className="relative">
+    <div className="relative flex flex-1">
       <AreaChart
-        className={className}
-        style={style}
         data={records}
         tickGap={1}
         index={"Time"}

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -37,6 +37,7 @@ export interface ComponentProps {
   yAxis: YAxis;
   curve: ChartCurve;
   sync: boolean;
+  heightInPx?: number | undefined;
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   exemplarPoints?: Array<ExemplarPoint> | undefined;
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
@@ -128,7 +129,10 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
     typeof yAxisMaxOption === "number" ? { maxValue: yAxisMaxOption } : {};
 
   return (
-    <div className="relative flex flex-1">
+    <div
+      className="relative flex flex-1"
+      style={props.heightInPx ? { height: `${props.heightInPx}px` } : undefined}
+    >
       <AreaChart
         data={records}
         tickGap={1}

--- a/Common/UI/Components/Charts/Bar/BarChart.tsx
+++ b/Common/UI/Components/Charts/Bar/BarChart.tsx
@@ -26,6 +26,7 @@ export interface ComponentProps {
   xAxis: XAxis;
   yAxis: YAxis;
   sync: boolean;
+  heightInPx?: number | undefined;
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   showLegend?: boolean | undefined;
 }
@@ -61,7 +62,10 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
     });
 
   return (
-    <div className="relative flex flex-1">
+    <div
+      className="relative flex flex-1"
+      style={props.heightInPx ? { height: `${props.heightInPx}px` } : undefined}
+    >
       <BarChart
         data={records}
         tickGap={1}

--- a/Common/UI/Components/Charts/Bar/BarChart.tsx
+++ b/Common/UI/Components/Charts/Bar/BarChart.tsx
@@ -26,7 +26,6 @@ export interface ComponentProps {
   xAxis: XAxis;
   yAxis: YAxis;
   sync: boolean;
-  heightInPx?: number | undefined;
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   showLegend?: boolean | undefined;
 }
@@ -54,11 +53,6 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
     setRecords(records);
   }, [props.data]);
 
-  const className: string = props.heightInPx ? `` : "h-80";
-  const style: React.CSSProperties = props.heightInPx
-    ? { height: `${props.heightInPx}px` }
-    : {};
-
   const hasNoData: boolean =
     !props.data ||
     props.data.length === 0 ||
@@ -67,10 +61,8 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
     });
 
   return (
-    <div className="relative">
+    <div className="relative flex flex-1">
       <BarChart
-        className={className}
-        style={style}
         data={records}
         tickGap={1}
         index={"Time"}

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -49,6 +49,7 @@ export interface Chart {
 export interface ComponentProps {
   charts: Array<Chart>;
   hideCard?: boolean | undefined;
+  heightInPx?: number | undefined;
   chartCssClass?: string | undefined;
 }
 

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -49,7 +49,6 @@ export interface Chart {
 export interface ComponentProps {
   charts: Array<Chart>;
   hideCard?: boolean | undefined;
-  heightInPx?: number | undefined;
   chartCssClass?: string | undefined;
 }
 
@@ -80,7 +79,6 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
             key={index}
             {...(chart.props as LineChartProps)}
             syncid={syncId}
-            heightInPx={props.heightInPx}
             exemplarPoints={chart.exemplarPoints}
             onExemplarClick={chart.onExemplarClick}
             showLegend={showLegend}
@@ -92,7 +90,6 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
             key={index}
             {...(chart.props as BarChartProps)}
             syncid={syncId}
-            heightInPx={props.heightInPx}
             showLegend={showLegend}
           />
         );
@@ -102,7 +99,6 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
             key={index}
             {...(chart.props as AreaChartProps)}
             syncid={syncId}
-            heightInPx={props.heightInPx}
             exemplarPoints={chart.exemplarPoints}
             onExemplarClick={chart.onExemplarClick}
             showLegend={showLegend}
@@ -244,14 +240,14 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
     return (
       <>
         {renderMetricInfoModal()}
-        <div className="space-y-3">
+        <div className="space-y-3 flex-col flex flex-1 w-full">
           {props.charts.map((chart: Chart, index: number) => {
             return (
               <div
                 key={index}
-                className={`bg-white ${props.chartCssClass || ""}`}
+                className={`bg-white ${props.chartCssClass || ""} flex-1 flex-col flex w-full`}
               >
-                <div className="px-5 pt-4 pb-4">
+                <div className="px-5 pt-4 pb-4 flex flex-col flex-1">
                   <div className="mb-3 pb-3 border-b border-gray-100">
                     <div className="flex items-center">
                       <h3 className="text-sm font-semibold text-gray-800 tracking-tight">
@@ -265,10 +261,10 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
                       </p>
                     )}
                   </div>
+                  {getChartContent(chart, index)}
                   {chart.seriesControls ? (
                     <div className="mb-3">{chart.seriesControls}</div>
                   ) : null}
-                  {getChartContent(chart, index)}
                 </div>
               </div>
             );

--- a/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/AreaChart/AreaChart.tsx
@@ -689,7 +689,7 @@ const AreaChart: React.ForwardRefExoticComponent<
     }
 
     return (
-      <div ref={ref} className={cx("h-80 w-full", className)} {...other}>
+      <div ref={ref} className={cx("flex-1 w-full", className)} {...other}>
         <ResponsiveContainer>
           <RechartsAreaChart
             data={data}

--- a/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/BarChart/BarChart.tsx
@@ -780,7 +780,7 @@ const BarChart: React.ForwardRefExoticComponent<
     return (
       <div
         ref={forwardedRef}
-        className={cx("h-80 w-full", className)}
+        className={cx("flex-1 w-full", className)}
         data-tremor-id="tremor-raw"
         {...other}
       >

--- a/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
+++ b/Common/UI/Components/Charts/ChartLibrary/LineChart/LineChart.tsx
@@ -695,7 +695,7 @@ const LineChart: React.ForwardRefExoticComponent<
     }
 
     return (
-      <div ref={ref} className={cx("h-80 w-full", className)} {...other}>
+      <div ref={ref} className={cx("flex-1 w-full", className)} {...other}>
         <ResponsiveContainer>
           <RechartsLineChart
             data={data}

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -36,6 +36,7 @@ export interface ComponentProps {
   yAxis: YAxis;
   curve: ChartCurve;
   sync: boolean;
+  heightInPx?: number | undefined;
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   exemplarPoints?: Array<ExemplarPoint> | undefined;
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
@@ -108,7 +109,10 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
     typeof yAxisMaxOption === "number" ? { maxValue: yAxisMaxOption } : {};
 
   return (
-    <div className="relative flex flex-1">
+    <div
+      className="relative flex flex-1"
+      style={props.heightInPx ? { height: `${props.heightInPx}px` } : undefined}
+    >
       <LineChart
         data={records}
         tickGap={1}

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -36,7 +36,6 @@ export interface ComponentProps {
   yAxis: YAxis;
   curve: ChartCurve;
   sync: boolean;
-  heightInPx?: number | undefined;
   referenceLines?: Array<ChartReferenceLineProps> | undefined;
   exemplarPoints?: Array<ExemplarPoint> | undefined;
   onExemplarClick?: ((exemplar: ExemplarPoint) => void) | undefined;
@@ -86,11 +85,6 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
     });
   }, [props.exemplarPoints, props.xAxis]);
 
-  const className: string = props.heightInPx ? `` : "h-80";
-  const style: React.CSSProperties = props.heightInPx
-    ? { height: `${props.heightInPx}px` }
-    : {};
-
   const hasNoData: boolean =
     !props.data ||
     props.data.length === 0 ||
@@ -114,10 +108,8 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
     typeof yAxisMaxOption === "number" ? { maxValue: yAxisMaxOption } : {};
 
   return (
-    <div className="relative">
+    <div className="relative flex flex-1">
       <LineChart
-        className={className}
-        style={style}
         data={records}
         tickGap={1}
         index={"Time"}

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -188,7 +188,7 @@ const Modal: FunctionComponent<ComponentProps> = (
                     )}
                   </div>
                   {props.rightElement && (
-                    <div data-testid="right-element" className="mt-4 md:mt-0">
+                    <div data-testid="right-element" className="mt-4 md:mt-0 lg:mr-2">
                       {props.rightElement}
                     </div>
                   )}

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -188,7 +188,10 @@ const Modal: FunctionComponent<ComponentProps> = (
                     )}
                   </div>
                   {props.rightElement && (
-                    <div data-testid="right-element" className="mt-4 md:mt-0 lg:mr-2">
+                    <div
+                      data-testid="right-element"
+                      className="mt-4 md:mt-0 lg:mr-2"
+                    >
                       {props.rightElement}
                     </div>
                   )}

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -190,7 +190,7 @@ const Modal: FunctionComponent<ComponentProps> = (
                   {props.rightElement && (
                     <div
                       data-testid="right-element"
-                      className="mt-4 md:mt-0 lg:mr-2"
+                      className="mt-4 md:mt-0 lg:mr-4"
                     >
                       {props.rightElement}
                     </div>


### PR DESCRIPTION
### Related Issue?

N/A

### Screenshots (if appropriate):

| Before | After |
| --- | --- |
|<img width="597" height="474" alt="before-1" src="https://github.com/user-attachments/assets/7810aad2-e963-40b5-ab7d-5259ba7c2829" /> | <img width="598" height="480" alt="after-1" src="https://github.com/user-attachments/assets/c7672ef7-5905-41db-ba1b-936538dae9e1" />|
|<img width="1111" height="563" alt="before-2" src="https://github.com/user-attachments/assets/b3c97435-1e37-47bb-8d63-e381290d43f5" /> | <img width="1129" height="588" alt="after-2" src="https://github.com/user-attachments/assets/be60297e-ea20-48e6-b9fc-689665ddd0dc" />|
|<img width="1120" height="618" alt="before-3" src="https://github.com/user-attachments/assets/608af9c6-f43b-4d7a-bbc0-1cd0fcf400e8" />|<img width="1121" height="594" alt="after-3" src="https://github.com/user-attachments/assets/e9695da1-337f-444f-8b38-d4b08f2a0d6a" />|
|<img width="1138" height="592" alt="before-4" src="https://github.com/user-attachments/assets/b28b2591-b0b9-442b-8f0a-94c5a63d4444" /> | <img width="1132" height="605" alt="after-4" src="https://github.com/user-attachments/assets/c34e9739-1bbe-4211-a86e-13c5ed725fd5" />|

### Additional Context

#### Why this change?

The previous dashboard chart path was carrying height-related props through several components even though the layout was already primarily controlled by flex containers.

That made the chart layout harder to reason about and increased component-level sizing complexity without much value.

This refactor reduces that plumbing so the chart structure is simpler and easier to maintain, while also cleaning up a couple of dashboard-adjacent layout details.

#### What changed?

- removed unused height calculations from dashboard chart rendering
- reduced chart height prop plumbing across dashboard chart components
- simplified chart wrapper layout behavior
- updated spark chart container sizing so it can expand with available space
- cleaned up follow-up lint issues in the refactor
- increased modal right-element spacing on large screens for better layout balance

#### Verification

- `npm run dev-build` in `App/FeatureSet/Dashboard`
- targeted ESLint pass on touched chart/layout files
