### PR TITLE
test(Common): add tests for Types/Database/ColorField

### DIFF
--- a/Common/Tests/Types/Database/ColorField.test.ts
+++ b/Common/Tests/Types/Database/ColorField.test.ts
@@ -1,0 +1,69 @@
+import ColorField, {
+  getColorFieldColumns,
+  getFirstColorFieldColumn,
+  isColorFieldColumn,
+} from "../../../Types/Database/ColorField";
+import "reflect-metadata";
+
+class ModelWithColorFields {
+  @ColorField()
+  public primaryColor: string = "";
+
+  public name: string = "";
+
+  @ColorField()
+  public secondaryColor: string = "";
+}
+
+class ModelWithoutColorFields {
+  public name: string = "";
+
+  public count: number = 0;
+}
+
+describe("ColorField", () => {
+  describe("isColorFieldColumn", () => {
+    test("returns true for a column decorated with @ColorField", () => {
+      const model: ModelWithColorFields = new ModelWithColorFields();
+      expect(isColorFieldColumn(model as any, "primaryColor")).toBe(true);
+      expect(isColorFieldColumn(model as any, "secondaryColor")).toBe(true);
+    });
+
+    test("returns false for a column that is not decorated", () => {
+      const model: ModelWithColorFields = new ModelWithColorFields();
+      expect(isColorFieldColumn(model as any, "name")).toBe(false);
+    });
+
+    test("returns false for an unknown column", () => {
+      const model: ModelWithColorFields = new ModelWithColorFields();
+      expect(isColorFieldColumn(model as any, "doesNotExist")).toBe(false);
+    });
+  });
+
+  describe("getColorFieldColumns", () => {
+    test("returns every column decorated with @ColorField", () => {
+      const model: ModelWithColorFields = new ModelWithColorFields();
+      expect(getColorFieldColumns(model as any)).toEqual([
+        "primaryColor",
+        "secondaryColor",
+      ]);
+    });
+
+    test("returns an empty array when no column is decorated", () => {
+      const model: ModelWithoutColorFields = new ModelWithoutColorFields();
+      expect(getColorFieldColumns(model as any)).toEqual([]);
+    });
+  });
+
+  describe("getFirstColorFieldColumn", () => {
+    test("returns the first column decorated with @ColorField", () => {
+      const model: ModelWithColorFields = new ModelWithColorFields();
+      expect(getFirstColorFieldColumn(model as any)).toEqual("primaryColor");
+    });
+
+    test("returns null when no column is decorated", () => {
+      const model: ModelWithoutColorFields = new ModelWithoutColorFields();
+      expect(getFirstColorFieldColumn(model as any)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for `Common/Types/Database/ColorField.ts`, which previously had no test coverage.

The tests cover the `@ColorField()` decorator and its three reflection helper functions:

- **`isColorFieldColumn`** — returns `true` for decorated columns, `false` for non-decorated and unknown columns.
- **`getColorFieldColumns`** — returns all `@ColorField`-decorated columns, and an empty array when none exist.
- **`getFirstColorFieldColumn`** — returns the first decorated column, and `null` when none exist.

## Why

Contributes to #210 (Write tests for `Common/Types/Database`).

## Testing

```
node node_modules/.bin/jest --runInBand ./Tests/Types/Database/ColorField.test.ts
```

All 7 tests pass. The file is Prettier-clean (`prettier --check`).