### PR TITLE
fix(kubernetes): load specs for volume autoscaler lists

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/HPAs.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/HPAs.tsx
@@ -52,6 +52,7 @@ const KubernetesClusterHPAs: FunctionComponent<
         await KubernetesResourceUtils.fetchInventoryResources({
           kubernetesClusterId: modelId,
           kind: "HorizontalPodAutoscaler",
+          selectFullSpec: true,
           transform: (
             resource: KubernetesResource,
             row: KubernetesResourceModel,

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/PersistentVolumeClaims.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/PersistentVolumeClaims.tsx
@@ -52,6 +52,7 @@ const KubernetesClusterPVCs: FunctionComponent<
         await KubernetesResourceUtils.fetchInventoryResources({
           kubernetesClusterId: modelId,
           kind: "PersistentVolumeClaim",
+          selectFullSpec: true,
           transform: (
             resource: KubernetesResource,
             row: KubernetesResourceModel,

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/PersistentVolumes.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/PersistentVolumes.tsx
@@ -49,6 +49,7 @@ const KubernetesClusterPVs: FunctionComponent<
         await KubernetesResourceUtils.fetchInventoryResources({
           kubernetesClusterId: modelId,
           kind: "PersistentVolume",
+          selectFullSpec: true,
           transform: (
             resource: KubernetesResource,
             row: KubernetesResourceModel,

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/VPAs.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/VPAs.tsx
@@ -52,6 +52,7 @@ const KubernetesClusterVPAs: FunctionComponent<
         await KubernetesResourceUtils.fetchInventoryResources({
           kubernetesClusterId: modelId,
           kind: "VerticalPodAutoscaler",
+          selectFullSpec: true,
           transform: (
             resource: KubernetesResource,
             row: KubernetesResourceModel,


### PR DESCRIPTION
## Summary
- Include Kubernetes `spec` and `status` fields when loading PersistentVolumeClaim, PersistentVolume, HorizontalPodAutoscaler, and VerticalPodAutoscaler inventory lists.
- Fixes list/table columns that derive from `spec` or `status`, such as volume capacity, storage class, access modes, HPA targets, and VPA recommendations.

|before|after|
|---|---|
|<img width="1487" height="590" alt="before" src="https://github.com/user-attachments/assets/613045e4-51e5-4ddd-9567-dca6a9a41fb3" />|<img width="1501" height="621" alt="after" src="https://github.com/user-attachments/assets/6c46f9df-ca7c-4a44-9b58-730e79b97dca" />|

## Testing
- `npm run compile` from `App/FeatureSet/Dashboard`