### PR TITLE
feat(identity): clarify SAML SSO setup and validate assertion Audience

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalSSO/View.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalSSO/View.tsx
@@ -14,6 +14,7 @@ import {
 import IconProp from "Common/Types/Icon/IconProp";
 import EnterpriseFeatureUpgrade from "../../../Components/EnterpriseEdition/EnterpriseFeatureUpgrade";
 import Card from "Common/UI/Components/Card/Card";
+import IdentityProviderUrls from "Common/UI/Components/SSO/IdentityProviderUrls";
 import Link from "Common/UI/Components/Link/Link";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import CardModelDetail from "Common/UI/Components/ModelDetail/CardModelDetail";
@@ -243,6 +244,15 @@ const GlobalSSOView: FunctionComponent = (): ReactElement => {
             },
             {
               field: {
+                enforceAudienceValidation: true,
+              },
+              title: "Enforce Audience Validation",
+              description:
+                "Reject SAML assertions whose Audience does not exactly match this provider's Entity ID. Leave off if you use the Azure AD GUID Sign-On-URL override.",
+              fieldType: FormFieldSchemaType.Toggle,
+            },
+            {
+              field: {
                 isEnabled: true,
               },
               title: "Enabled",
@@ -305,6 +315,14 @@ const GlobalSSOView: FunctionComponent = (): ReactElement => {
               },
               {
                 field: {
+                  enforceAudienceValidation: true,
+                },
+                title: "Enforce Audience Validation",
+                fieldType: FieldType.Boolean,
+                placeholder: t("common.no"),
+              },
+              {
+                field: {
                   isEnabled: true,
                 },
                 title: "Enabled",
@@ -316,26 +334,12 @@ const GlobalSSOView: FunctionComponent = (): ReactElement => {
           }}
         />
 
-        <Card
-          title={"Identity Provider URLs"}
-          description={
-            <div>
-              <div className="mb-3">
-                Paste these values into your SAML identity provider (Okta, Azure
-                AD, OneLogin, JumpCloud and more).
-              </div>
-              <div className="mb-3">
-                <div className="font-semibold">
-                  ACS URL (Assertion Consumer Service / Reply URL):
-                </div>
-                <div className="break-all">{acsURL}</div>
-              </div>
-              <div>
-                <div className="font-semibold">Issuer (Entity ID):</div>
-                <div className="break-all">{issuerURL}</div>
-              </div>
-            </div>
-          }
+        <IdentityProviderUrls
+          renderInCard={true}
+          acsUrl={acsURL}
+          entityId={issuerURL}
+          acsLabel="ACS URL (Assertion Consumer Service / Reply URL)"
+          entityIdLabel="Issuer (Entity ID)"
         />
 
         <Card

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/SSO.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/SSO.tsx
@@ -8,7 +8,7 @@ import IconProp from "Common/Types/Icon/IconProp";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
-import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
+import IdentityProviderUrls from "Common/UI/Components/SSO/IdentityProviderUrls";
 import CardModelDetail from "Common/UI/Components/ModelDetail/CardModelDetail";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
@@ -231,6 +231,16 @@ const SSOPage: FunctionComponent<PageComponentProps> = (
             },
             {
               field: {
+                enforceAudienceValidation: true,
+              },
+              title: "Enforce Audience Validation",
+              description:
+                "Reject SAML assertions whose Audience does not exactly match this provider's Entity ID. Leave off if you use the Azure AD GUID Sign-On-URL override.",
+              fieldType: FormFieldSchemaType.Toggle,
+              stepId: "more",
+            },
+            {
+              field: {
                 teams: true,
               },
               title: "Teams",
@@ -379,34 +389,14 @@ const SSOPage: FunctionComponent<PageComponentProps> = (
         />
 
         {showSingleSignOnUrlId && (
-          <ConfirmModal
-            title={`SSO Configuration`}
-            description={
-              <div>
-                <div>
-                  <div className="font-semibold">Identifier (Entity ID): </div>
-
-                  <div>{`${HTTP_PROTOCOL}${HOST}/${props.currentProject?._id}/${showSingleSignOnUrlId}`}</div>
-                  <br />
-                </div>
-                <div>
-                  <div className="font-semibold">
-                    Reply URL (Assertion Consumer Service URL):
-                  </div>
-                  <div>
-                    {`${URL.fromString(IDENTITY_URL.toString()).addRoute(
-                      `/idp-login/${props.currentProject?._id}/${showSingleSignOnUrlId}`,
-                    )}`}
-                  </div>
-                  <br />
-                </div>
-              </div>
-            }
-            submitButtonText={"Close"}
-            onSubmit={() => {
-              setShowSingleSignOnUrlId("");
-            }}
-            submitButtonType={ButtonStyleType.NORMAL}
+          <IdentityProviderUrls
+            renderInCard={true}
+            entityId={`${HTTP_PROTOCOL}${HOST}/${props.currentProject?._id}/${showSingleSignOnUrlId}`}
+            acsUrl={`${URL.fromString(IDENTITY_URL.toString()).addRoute(
+              `/idp-login/${props.currentProject?._id}/${showSingleSignOnUrlId}`,
+            )}`}
+            acsLabel="Reply URL (Assertion Consumer Service URL)"
+            entityIdLabel="Identifier (Entity ID)"
           />
         )}
       </>

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SSO.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SSO.tsx
@@ -9,7 +9,7 @@ import SignatureMethod from "Common/Types/SSO/SignatureMethod";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
-import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
+import IdentityProviderUrls from "Common/UI/Components/SSO/IdentityProviderUrls";
 import CardModelDetail from "Common/UI/Components/ModelDetail/CardModelDetail";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
@@ -242,6 +242,16 @@ const SSOPage: FunctionComponent<PageComponentProps> = (
               fieldType: FormFieldSchemaType.Toggle,
               stepId: "more",
             },
+            {
+              field: {
+                enforceAudienceValidation: true,
+              },
+              title: "Enforce Audience Validation",
+              description:
+                "Reject SAML assertions whose Audience does not exactly match this provider's Entity ID. Leave off if you use the Azure AD GUID Sign-On-URL override.",
+              fieldType: FormFieldSchemaType.Toggle,
+              stepId: "more",
+            },
           ]}
           showRefreshButton={true}
           actionButtons={[
@@ -365,34 +375,14 @@ const SSOPage: FunctionComponent<PageComponentProps> = (
         />
 
         {showSingleSignOnUrlId && (
-          <ConfirmModal
-            title={`SSO Configuration`}
-            description={
-              <div>
-                <div>
-                  <div className="font-semibold">Identifier (Entity ID):</div>
-
-                  <div>{`${HTTP_PROTOCOL}${HOST}/${modelId.toString()}/${showSingleSignOnUrlId}`}</div>
-                  <br />
-                </div>
-                <div>
-                  <div className="font-semibold">
-                    Reply URL (Assertion Consumer Service URL):
-                  </div>
-                  <div>
-                    {`${URL.fromString(IDENTITY_URL.toString()).addRoute(
-                      `/status-page-idp-login/${modelId.toString()}/${showSingleSignOnUrlId}`,
-                    )}`}
-                  </div>
-                  <br />
-                </div>
-              </div>
-            }
-            submitButtonText={"Close"}
-            onSubmit={() => {
-              setShowSingleSignOnUrlId("");
-            }}
-            submitButtonType={ButtonStyleType.NORMAL}
+          <IdentityProviderUrls
+            renderInCard={true}
+            entityId={`${HTTP_PROTOCOL}${HOST}/${modelId.toString()}/${showSingleSignOnUrlId}`}
+            acsUrl={`${URL.fromString(IDENTITY_URL.toString()).addRoute(
+              `/status-page-idp-login/${modelId.toString()}/${showSingleSignOnUrlId}`,
+            )}`}
+            acsLabel="Reply URL (Assertion Consumer Service URL)"
+            entityIdLabel="Identifier (Entity ID)"
           />
         )}
       </>

--- a/App/FeatureSet/Identity/API/GlobalSSO.ts
+++ b/App/FeatureSet/Identity/API/GlobalSSO.ts
@@ -1,5 +1,5 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
-import SSOUtil from "../Utils/SSO";
+import SSOUtil, { type AudienceValidationResult } from "../Utils/SSO";
 import { DashboardRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
 import Protocol from "Common/Types/API/Protocol";
@@ -253,6 +253,7 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
         issuerURL: true,
         publicCertificate: true,
         disableSignUpWithSso: true,
+        enforceAudienceValidation: true,
       },
       props: { isRoot: true },
     });
@@ -322,6 +323,40 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
         req,
         res,
         new BadRequestException("Issuer URL does not match"),
+      );
+    }
+
+    /*
+     * Validate the assertion Audience against the SP Entity ID we advertise (the
+     * same value stamped into the outbound AuthnRequest Issuer). A mismatch is
+     * surfaced loudly so a misconfigured IdP Identifier no longer silently
+     * "works" via IdP-initiated login. Default is warn-only; the provider's
+     * enforceAudienceValidation toggle upgrades it to a hard block.
+     */
+    const expectedAudience: string = `${HttpProtocol}${Host}/global-sso/${globalSsoId.toString()}`;
+
+    const audienceValidation: AudienceValidationResult =
+      SSOUtil.validateAudience({
+        payload: response,
+        expectedAudience,
+      });
+
+    if (audienceValidation.isMismatch) {
+      if (globalSso.enforceAudienceValidation) {
+        logger.error(
+          audienceValidation.message,
+          getLogAttributesFromRequest(req as RequestLike),
+        );
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadRequestException(audienceValidation.message),
+        );
+      }
+
+      logger.warn(
+        audienceValidation.message,
+        getLogAttributesFromRequest(req as RequestLike),
       );
     }
 

--- a/App/FeatureSet/Identity/API/SSO.ts
+++ b/App/FeatureSet/Identity/API/SSO.ts
@@ -1,5 +1,5 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
-import SSOUtil from "../Utils/SSO";
+import SSOUtil, { type AudienceValidationResult } from "../Utils/SSO";
 import { DashboardRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
 import Protocol from "Common/Types/API/Protocol";
@@ -361,6 +361,7 @@ const loginUserWithSso: LoginUserWithSsoFunction = async (
         signOnURL: true,
         issuerURL: true,
         publicCertificate: true,
+        enforceAudienceValidation: true,
         teams: {
           _id: true,
         },
@@ -443,6 +444,38 @@ const loginUserWithSso: LoginUserWithSsoFunction = async (
         req,
         res,
         new BadRequestException("Issuer URL does not match"),
+      );
+    }
+
+    /*
+     * Validate the assertion Audience against the SP Entity ID we advertise (the
+     * same value stamped into the outbound AuthnRequest Issuer). Default is
+     * warn-only; the provider's enforceAudienceValidation toggle hard-blocks.
+     */
+    const expectedAudience: string = `${HttpProtocol}${Host}/${req.params["projectId"]}/${req.params["projectSsoId"]}`;
+
+    const audienceValidation: AudienceValidationResult =
+      SSOUtil.validateAudience({
+        payload: response,
+        expectedAudience,
+      });
+
+    if (audienceValidation.isMismatch) {
+      if (projectSSO.enforceAudienceValidation) {
+        logger.error(
+          audienceValidation.message,
+          getLogAttributesFromRequest(req as RequestLike),
+        );
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadRequestException(audienceValidation.message),
+        );
+      }
+
+      logger.warn(
+        audienceValidation.message,
+        getLogAttributesFromRequest(req as RequestLike),
       );
     }
 

--- a/App/FeatureSet/Identity/API/StatusPageSSO.ts
+++ b/App/FeatureSet/Identity/API/StatusPageSSO.ts
@@ -1,4 +1,4 @@
-import SSOUtil from "../Utils/SSO";
+import SSOUtil, { type AudienceValidationResult } from "../Utils/SSO";
 import URL from "Common/Types/API/URL";
 import Email from "Common/Types/Email";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
@@ -172,6 +172,7 @@ router.post(
             issuerURL: true,
             publicCertificate: true,
             projectId: true,
+            enforceAudienceValidation: true,
           },
           props: {
             isRoot: true,
@@ -256,6 +257,38 @@ router.post(
 
           res,
           new BadRequestException("Issuer URL does not match"),
+        );
+      }
+
+      /*
+       * Validate the assertion Audience against the SP Entity ID we advertise
+       * (the same value stamped into the outbound AuthnRequest Issuer). Default
+       * is warn-only; the provider's enforceAudienceValidation toggle hard-blocks.
+       */
+      const expectedAudience: string = `${HttpProtocol}${Host}/${statusPageId.toString()}/${req.params["statusPageSsoId"]}`;
+
+      const audienceValidation: AudienceValidationResult =
+        SSOUtil.validateAudience({
+          payload: response,
+          expectedAudience,
+        });
+
+      if (audienceValidation.isMismatch) {
+        if (statusPageSSO.enforceAudienceValidation) {
+          logger.error(
+            audienceValidation.message,
+            getLogAttributesFromRequest(req as RequestLike),
+          );
+          return Response.sendErrorResponse(
+            req,
+            res,
+            new BadRequestException(audienceValidation.message),
+          );
+        }
+
+        logger.warn(
+          audienceValidation.message,
+          getLogAttributesFromRequest(req as RequestLike),
         );
       }
 

--- a/App/FeatureSet/Identity/Utils/SSO.ts
+++ b/App/FeatureSet/Identity/Utils/SSO.ts
@@ -14,6 +14,17 @@ import {
 import zlib from "zlib";
 import Name from "Common/Types/Name";
 
+export interface AudienceValidationResult {
+  // True when validation passed (match) or was skipped (no AudienceRestriction).
+  isOk: boolean;
+  // True only when an Audience was present and did not match the expected value.
+  isMismatch: boolean;
+  receivedAudiences: Array<string>;
+  expectedAudience: string;
+  // Human-readable detail, reused for both the warn log and the thrown error.
+  message: string;
+}
+
 export default class SSOUtil {
   public static createSAMLRequestUrl(data: {
     acsUrl: URL;
@@ -324,5 +335,162 @@ export default class SSOUtil {
     }
 
     return issuerUrl.trim();
+  }
+
+  /*
+   * Returns every <Audience> string declared under the assertion's
+   * <Conditions><AudienceRestriction>. Mirrors the defensive, namespace-prefix
+   * tolerant navigation used by getIssuer/getEmail. Never throws: returns an
+   * empty array when there are no Conditions/AudienceRestriction (some IdPs omit
+   * them), so callers can treat "absent" as "skip" rather than "fail".
+   */
+  public static getAudiences(payload: JSONObject): Array<string> {
+    const response: JSONObject =
+      (payload["saml2p:Response"] as JSONObject) ||
+      (payload["samlp:Response"] as JSONObject) ||
+      (payload["Response"] as JSONObject);
+
+    if (!response) {
+      return [];
+    }
+
+    const samlAssertion: JSONArray =
+      (response["saml2:Assertion"] as JSONArray) ||
+      (response["saml:Assertion"] as JSONArray) ||
+      (response["Assertion"] as JSONArray);
+
+    if (!samlAssertion || samlAssertion.length === 0) {
+      return [];
+    }
+
+    const assertion: JSONObject = samlAssertion[0] as JSONObject;
+
+    const conditions: JSONArray =
+      (assertion["saml2:Conditions"] as JSONArray) ||
+      (assertion["saml:Conditions"] as JSONArray) ||
+      (assertion["Conditions"] as JSONArray);
+
+    if (!conditions || conditions.length === 0) {
+      return [];
+    }
+
+    const audiences: Array<string> = [];
+
+    for (const condition of conditions) {
+      const conditionObject: JSONObject = condition as JSONObject;
+
+      // The spec allows multiple <AudienceRestriction> under <Conditions>.
+      const audienceRestrictions: JSONArray =
+        (conditionObject["saml2:AudienceRestriction"] as JSONArray) ||
+        (conditionObject["saml:AudienceRestriction"] as JSONArray) ||
+        (conditionObject["AudienceRestriction"] as JSONArray);
+
+      if (!audienceRestrictions || audienceRestrictions.length === 0) {
+        continue;
+      }
+
+      for (const restriction of audienceRestrictions) {
+        const restrictionObject: JSONObject = restriction as JSONObject;
+
+        // And multiple <Audience> under a single <AudienceRestriction>.
+        const audienceList: JSONArray =
+          (restrictionObject["saml2:Audience"] as JSONArray) ||
+          (restrictionObject["saml:Audience"] as JSONArray) ||
+          (restrictionObject["Audience"] as JSONArray);
+
+        if (!audienceList || audienceList.length === 0) {
+          continue;
+        }
+
+        for (const audience of audienceList) {
+          let audienceValue: string | undefined = undefined;
+
+          if (typeof audience === "string") {
+            audienceValue = audience;
+          } else if (audience && typeof audience === "object") {
+            audienceValue = (audience as JSONObject)["_"] as string;
+          }
+
+          if (audienceValue && audienceValue.trim()) {
+            audiences.push(audienceValue.trim());
+          }
+        }
+      }
+    }
+
+    return audiences;
+  }
+
+  /*
+   * Validates that the SP Entity ID OneUptime advertises (the same value it
+   * stamps into the outbound AuthnRequest Issuer) appears among the assertion's
+   * audiences. Absent audiences => skip (isOk:true). Present-but-no-match =>
+   * isMismatch:true. The caller decides whether a mismatch is a hard error
+   * (enforce) or just a warning, but the message names both values either way.
+   */
+  public static validateAudience(data: {
+    payload: JSONObject;
+    expectedAudience: string;
+  }): AudienceValidationResult {
+    const receivedAudiences: Array<string> = SSOUtil.getAudiences(data.payload);
+
+    if (receivedAudiences.length === 0) {
+      return {
+        isOk: true,
+        isMismatch: false,
+        receivedAudiences,
+        expectedAudience: data.expectedAudience,
+        message:
+          "SAML assertion contained no AudienceRestriction; audience validation skipped.",
+      };
+    }
+
+    const isMatch: boolean = receivedAudiences.some((audience: string) => {
+      return SSOUtil.audienceEquals(audience, data.expectedAudience);
+    });
+
+    if (isMatch) {
+      return {
+        isOk: true,
+        isMismatch: false,
+        receivedAudiences,
+        expectedAudience: data.expectedAudience,
+        message: "",
+      };
+    }
+
+    const message: string =
+      `SAML assertion Audience does not match this OneUptime SSO endpoint. ` +
+      `Received Audience(s): [${receivedAudiences.join(", ")}]. ` +
+      `Expected (Service Provider Entity ID / Identifier): "${data.expectedAudience}". ` +
+      `Fix: in your Identity Provider, set the application Identifier / Audience / Entity ID to exactly "${data.expectedAudience}". ` +
+      `(If you intentionally use the Azure AD GUID Sign-On-URL override, leave this provider's "Enforce Audience Validation" setting OFF.)`;
+
+    return {
+      isOk: false,
+      isMismatch: true,
+      receivedAudiences,
+      expectedAudience: data.expectedAudience,
+      message,
+    };
+  }
+
+  /*
+   * Entity IDs are case-sensitive URIs, so we do NOT lowercase. The only
+   * tolerated divergence is a trailing slash, because OneUptime builds its
+   * AuthnRequest Issuer without one while some IdPs append it.
+   */
+  private static audienceEquals(a: string, b: string): boolean {
+    if (a === b) {
+      return true;
+    }
+
+    const stripTrailingSlash: (value: string) => string = (
+      value: string,
+    ): string => {
+      return value.replace(/\/+$/, "");
+    };
+
+    return stripTrailingSlash(a) === stripTrailingSlash(b);
   }
 }

--- a/App/Tests/Identity/SSOAudienceValidation.test.ts
+++ b/App/Tests/Identity/SSOAudienceValidation.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Logger pulls in server logging infra that is irrelevant to these pure SAML
+ * parsing/comparison helpers; replace it so the suite stays light and isolated.
+ */
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+    getLogAttributesFromRequest: jest.fn(),
+  };
+});
+
+import SSOUtil, {
+  AudienceValidationResult,
+} from "../../FeatureSet/Identity/Utils/SSO";
+import { JSONObject } from "Common/Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+import xml2js from "xml2js";
+
+const EXPECTED: string = "https://oneuptime.example.com/global-sso/abc-123";
+
+const parseXml: (xml: string) => Promise<JSONObject> = async (
+  xml: string,
+): Promise<JSONObject> => {
+  return (await xml2js.parseStringPromise(xml)) as JSONObject;
+};
+
+/*
+ * Wrap an arbitrary <Conditions> body inside a minimal Response/Assertion using
+ * the requested namespace prefix ("saml2", "saml", or "" for no prefix).
+ */
+const buildResponse: (data: {
+  conditionsXml: string;
+  prefix?: string;
+}) => string = (data: { conditionsXml: string; prefix?: string }): string => {
+  const prefix: string = data.prefix ?? "saml2";
+  const p: string = prefix ? `${prefix}:` : "";
+  const protoNs: string = prefix
+    ? `xmlns:${prefix}="urn:oasis:names:tc:SAML:2.0:assertion"`
+    : `xmlns="urn:oasis:names:tc:SAML:2.0:assertion"`;
+
+  return (
+    `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ${protoNs}>` +
+    `<${p}Assertion><${p}Issuer>idp</${p}Issuer>${data.conditionsXml}</${p}Assertion>` +
+    `</samlp:Response>`
+  );
+};
+
+const audienceConditions: (data: {
+  audiences: Array<string>;
+  prefix?: string;
+}) => string = (data: {
+  audiences: Array<string>;
+  prefix?: string;
+}): string => {
+  const p: string = (data.prefix ?? "saml2") ? `${data.prefix ?? "saml2"}:` : "";
+  const audienceXml: string = data.audiences
+    .map((a: string) => {
+      return `<${p}Audience>${a}</${p}Audience>`;
+    })
+    .join("");
+  return `<${p}Conditions><${p}AudienceRestriction>${audienceXml}</${p}AudienceRestriction></${p}Conditions>`;
+};
+
+describe("SSOUtil.getAudiences", () => {
+  test("extracts a single audience (saml2 prefix)", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({ conditionsXml: audienceConditions({ audiences: [EXPECTED] }) }),
+    );
+    expect(SSOUtil.getAudiences(payload)).toEqual([EXPECTED]);
+  });
+
+  test("extracts audiences with the saml: prefix", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({
+        prefix: "saml",
+        conditionsXml: audienceConditions({ audiences: [EXPECTED], prefix: "saml" }),
+      }),
+    );
+    expect(SSOUtil.getAudiences(payload)).toEqual([EXPECTED]);
+  });
+
+  test("extracts audiences with no namespace prefix", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({
+        prefix: "",
+        conditionsXml: audienceConditions({ audiences: [EXPECTED], prefix: "" }),
+      }),
+    );
+    expect(SSOUtil.getAudiences(payload)).toEqual([EXPECTED]);
+  });
+
+  test("reads audience text even when the element carries attributes", async () => {
+    const conditionsXml: string =
+      `<saml2:Conditions><saml2:AudienceRestriction>` +
+      `<saml2:Audience xmlns:extra="urn:x">${EXPECTED}</saml2:Audience>` +
+      `</saml2:AudienceRestriction></saml2:Conditions>`;
+    const payload: JSONObject = await parseXml(buildResponse({ conditionsXml }));
+    expect(SSOUtil.getAudiences(payload)).toEqual([EXPECTED]);
+  });
+
+  test("collects multiple audiences across multiple AudienceRestrictions", async () => {
+    const conditionsXml: string =
+      `<saml2:Conditions>` +
+      `<saml2:AudienceRestriction><saml2:Audience>first</saml2:Audience></saml2:AudienceRestriction>` +
+      `<saml2:AudienceRestriction><saml2:Audience>second</saml2:Audience><saml2:Audience>third</saml2:Audience></saml2:AudienceRestriction>` +
+      `</saml2:Conditions>`;
+    const payload: JSONObject = await parseXml(buildResponse({ conditionsXml }));
+    expect(SSOUtil.getAudiences(payload)).toEqual(["first", "second", "third"]);
+  });
+
+  test("returns [] when there is no Conditions / AudienceRestriction", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({ conditionsXml: "" }),
+    );
+    expect(SSOUtil.getAudiences(payload)).toEqual([]);
+  });
+
+  test("returns [] for a payload with no Response", async () => {
+    const payload: JSONObject = await parseXml(`<Other></Other>`);
+    expect(SSOUtil.getAudiences(payload)).toEqual([]);
+  });
+});
+
+describe("SSOUtil.validateAudience", () => {
+  test("passes when the expected audience is present", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({ conditionsXml: audienceConditions({ audiences: [EXPECTED] }) }),
+    );
+    const result: AudienceValidationResult = SSOUtil.validateAudience({
+      payload,
+      expectedAudience: EXPECTED,
+    });
+    expect(result.isOk).toBe(true);
+    expect(result.isMismatch).toBe(false);
+  });
+
+  test("passes when expected appears among several audiences", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({
+        conditionsXml: audienceConditions({
+          audiences: ["api://other", EXPECTED, "spn:xyz"],
+        }),
+      }),
+    );
+    const result: AudienceValidationResult = SSOUtil.validateAudience({
+      payload,
+      expectedAudience: EXPECTED,
+    });
+    expect(result.isOk).toBe(true);
+    expect(result.isMismatch).toBe(false);
+  });
+
+  test("flags a mismatch and names both values in the message", async () => {
+    const received: string = "api://0000-1111-2222";
+    const payload: JSONObject = await parseXml(
+      buildResponse({ conditionsXml: audienceConditions({ audiences: [received] }) }),
+    );
+    const result: AudienceValidationResult = SSOUtil.validateAudience({
+      payload,
+      expectedAudience: EXPECTED,
+    });
+    expect(result.isOk).toBe(false);
+    expect(result.isMismatch).toBe(true);
+    expect(result.message).toContain(EXPECTED);
+    expect(result.message).toContain(received);
+  });
+
+  test("is case-sensitive (a case-only difference is a mismatch)", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({
+        conditionsXml: audienceConditions({ audiences: [EXPECTED.toUpperCase()] }),
+      }),
+    );
+    const result: AudienceValidationResult = SSOUtil.validateAudience({
+      payload,
+      expectedAudience: EXPECTED,
+    });
+    expect(result.isMismatch).toBe(true);
+  });
+
+  test("tolerates a single trailing slash difference", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({
+        conditionsXml: audienceConditions({ audiences: [`${EXPECTED}/`] }),
+      }),
+    );
+    const result: AudienceValidationResult = SSOUtil.validateAudience({
+      payload,
+      expectedAudience: EXPECTED,
+    });
+    expect(result.isOk).toBe(true);
+    expect(result.isMismatch).toBe(false);
+  });
+
+  test("skips (isOk, not mismatch) when no AudienceRestriction is present", async () => {
+    const payload: JSONObject = await parseXml(
+      buildResponse({ conditionsXml: "" }),
+    );
+    const result: AudienceValidationResult = SSOUtil.validateAudience({
+      payload,
+      expectedAudience: EXPECTED,
+    });
+    expect(result.isOk).toBe(true);
+    expect(result.isMismatch).toBe(false);
+    expect(result.message).toContain("skipped");
+  });
+});

--- a/Common/Models/DatabaseModels/GlobalSso.ts
+++ b/Common/Models/DatabaseModels/GlobalSso.ts
@@ -204,6 +204,26 @@ export default class GlobalSSO extends BaseModel {
   @TableColumn({
     isDefaultValueColumn: true,
     type: TableColumnType.Boolean,
+    title: "Enforce Audience Validation",
+    description:
+      "When enabled, OneUptime rejects a SAML assertion whose Audience does not exactly match this provider's Entity ID (instead of only warning). Leave OFF if you intentionally use the Azure AD GUID Sign-On-URL override.",
+    defaultValue: false,
+    example: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: false,
+  })
+  public enforceAudienceValidation?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
     title: "Enabled",
     description: "Is this SSO provider enabled?",
     defaultValue: false,

--- a/Common/Models/DatabaseModels/ProjectSso.ts
+++ b/Common/Models/DatabaseModels/ProjectSso.ts
@@ -629,6 +629,45 @@ export default class ProjectSSO extends BaseModel {
   })
   public isEnabled?: boolean = undefined;
 
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectSSO,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectUser,
+      Permission.UnAuthorizedSsoUser,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.SettingsViewer,
+      Permission.ReadProjectSSO,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectSSO,
+    ],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    title: "Enforce Audience Validation",
+    description:
+      "When enabled, OneUptime rejects a SAML assertion whose Audience does not exactly match this provider's Entity ID (instead of only warning). Leave OFF if you intentionally use the Azure AD GUID Sign-On-URL override.",
+    defaultValue: false,
+    example: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: false,
+  })
+  public enforceAudienceValidation?: boolean = undefined;
+
   // Is this integration tested?
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/StatusPageSso.ts
+++ b/Common/Models/DatabaseModels/StatusPageSso.ts
@@ -596,6 +596,40 @@ export default class StatusPageSSO extends BaseModel {
   })
   public isEnabled?: boolean = undefined;
 
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateStatusPageSSO,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectUser,
+      Permission.Public,
+      Permission.ReadStatusPageSSO,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditStatusPageSSO,
+    ],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    title: "Enforce Audience Validation",
+    description:
+      "When enabled, OneUptime rejects a SAML assertion whose Audience does not exactly match this provider's Entity ID (instead of only warning). Leave OFF if you intentionally use the Azure AD GUID Sign-On-URL override.",
+    defaultValue: false,
+    example: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: false,
+  })
+  public enforceAudienceValidation?: boolean = undefined;
+
   // Is this integration tested?
   @ColumnAccessControl({
     create: [

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1782600000000-AddEnforceAudienceValidationToSso.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1782600000000-AddEnforceAudienceValidationToSso.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddEnforceAudienceValidationToSso1782600000000
+  implements MigrationInterface
+{
+  public name = "AddEnforceAudienceValidationToSso1782600000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "GlobalSSO" ADD "enforceAudienceValidation" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProjectSSO" ADD "enforceAudienceValidation" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "StatusPageSSO" ADD "enforceAudienceValidation" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "StatusPageSSO" DROP COLUMN "enforceAudienceValidation"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProjectSSO" DROP COLUMN "enforceAudienceValidation"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GlobalSSO" DROP COLUMN "enforceAudienceValidation"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -397,6 +397,7 @@ import { MoveRequireSsoForLoginToGlobalConfig1782300000000 } from "./17823000000
 import { MigrationName1782310000000 } from "./1782310000000-MigrationName";
 import { RemoveIsTestedFromGlobalSsoAndOidc1782400000000 } from "./1782400000000-RemoveIsTestedFromGlobalSsoAndOidc";
 import { OptimizeTelemetryExceptionWritePath1782500000000 } from "./1782500000000-OptimizeTelemetryExceptionWritePath";
+import { AddEnforceAudienceValidationToSso1782600000000 } from "./1782600000000-AddEnforceAudienceValidationToSso";
 
 export default [
   InitialMigration,
@@ -798,4 +799,5 @@ export default [
   MigrationName1782310000000,
   RemoveIsTestedFromGlobalSsoAndOidc1782400000000,
   OptimizeTelemetryExceptionWritePath1782500000000,
+  AddEnforceAudienceValidationToSso1782600000000,
 ];

--- a/Common/UI/Components/SSO/IdentityProviderUrls.tsx
+++ b/Common/UI/Components/SSO/IdentityProviderUrls.tsx
@@ -1,0 +1,119 @@
+import Card from "../Card/Card";
+import AlertBanner, { AlertBannerType } from "../AlertBanner/AlertBanner";
+import CodeBlock from "../CodeBlock/CodeBlock";
+import CollapsibleSection from "../CollapsibleSection/CollapsibleSection";
+import InlineCode from "../InlineCode/InlineCode";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  // Fully computed ACS / Reply URL (already includes the /identity segment).
+  acsUrl: string;
+  // Fully computed Entity ID / Issuer (does NOT include /identity).
+  entityId: string;
+  // Label overrides so each screen can keep its own wording.
+  acsLabel?: string | undefined;
+  entityIdLabel?: string | undefined;
+  // When true (default) the body is wrapped in its own titled Card.
+  renderInCard?: boolean | undefined;
+  className?: string | undefined;
+}
+
+/*
+ * Shared presentational block that shows the ACS URL and Entity ID an admin must
+ * paste into their SAML identity provider, plus the exact-match rules and the
+ * Azure AADSTS700016 workaround. It intentionally takes precomputed strings:
+ * Global / Project / Status Page SSO each build these URLs with different
+ * formulas, so the component must not try to construct them.
+ */
+const IdentityProviderUrls: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const acsLabel: string =
+    props.acsLabel || "ACS URL (Reply URL / Assertion Consumer Service)";
+  const entityIdLabel: string =
+    props.entityIdLabel || "Entity ID (Issuer / Identifier)";
+
+  const body: ReactElement = (
+    <div className={props.className}>
+      <AlertBanner title="Enter these values exactly" type={AlertBannerType.Warning}>
+        <ul className="list-disc space-y-1 pl-5 text-sm text-amber-900">
+          <li>
+            Copy and paste each value — do not retype it. The values are
+            case-sensitive and must have no trailing slash and no extra spaces.
+          </li>
+          <li>
+            The Entity ID does not contain <InlineCode text="/identity" />, but
+            the ACS URL does. Do not swap them — pasting one into the other&apos;s
+            field is the most common cause of failed SSO.
+          </li>
+          <li>
+            Your provider&apos;s app tile / &quot;My Apps&quot; (IdP-initiated)
+            login can succeed even when the &quot;Sign in with SSO&quot; button
+            (SP-initiated) is broken — they are validated separately by the
+            identity provider. A working tile does not mean the button works.
+            Always finish by testing the SSO button itself.
+          </li>
+        </ul>
+      </AlertBanner>
+
+      <div className="mt-4">
+        <div className="mb-1 text-sm font-semibold text-gray-900">
+          {acsLabel}
+        </div>
+        <CodeBlock code={props.acsUrl} language="plaintext" />
+      </div>
+
+      <div className="mt-4">
+        <div className="mb-1 text-sm font-semibold text-gray-900">
+          {entityIdLabel}
+        </div>
+        <CodeBlock code={props.entityId} language="plaintext" />
+      </div>
+
+      <div className="mt-4">
+        <CollapsibleSection
+          title="Using Azure AD / Entra ID? Fixing error AADSTS700016"
+          variant="bordered"
+          defaultCollapsed={true}
+        >
+          <div className="space-y-3 text-sm text-gray-600">
+            <p>
+              Azure validates the Entity ID exactly. If SP-initiated sign-in
+              fails with &quot;AADSTS700016: Application not found in the
+              directory&quot; even though the values above look correct, set the
+              Sign On URL field above to the form below. OneUptime sends
+              unsigned SAML AuthnRequests, so this tenant-scoped endpoint is a
+              valid and supported workaround.
+            </p>
+            <CodeBlock
+              code="https://login.microsoftonline.com/{tenant}/saml2/{servicePrincipalGuid}"
+              language="plaintext"
+            />
+            <p>
+              Replace <InlineCode text="{tenant}" /> with your Azure tenant ID
+              (or domain) and <InlineCode text="{servicePrincipalGuid}" /> with
+              the Object ID of the OneUptime Enterprise Application in Azure
+              (Enterprise applications → your app → Overview → Object ID). Then
+              test the &quot;Sign in with SSO&quot; button again.
+            </p>
+          </div>
+        </CollapsibleSection>
+      </div>
+    </div>
+  );
+
+  if (props.renderInCard === false) {
+    return body;
+  }
+
+  return (
+    <Card
+      title="Identity Provider URLs"
+      description="Paste these values into your SAML identity provider (Okta, Azure AD, OneLogin, JumpCloud and more)."
+    >
+      {body}
+    </Card>
+  );
+};
+
+export default IdentityProviderUrls;


### PR DESCRIPTION
## Why

An admin lost hours to an Azure **AADSTS700016** failure where **SP-initiated** SSO (the "Login with SSO" button) failed while **IdP-initiated** (Microsoft MyApps) login worked. Two OneUptime-side gaps made this hard to diagnose:

1. The SSO setup screens print the ACS URL and Entity ID as bare text — no copy buttons, no warning that the Entity ID must match **exactly** (case-sensitive, no trailing slash), and no callout that the Entity ID has **no** `/identity` segment while the ACS does.
2. OneUptime **never validated the SAML assertion `Audience`** — only signature + response Issuer. So a wrong/missing SP Entity ID was invisible: IdP-initiated login succeeded and masked the misconfiguration, surfacing only later at the IdP where OneUptime can't see the error.

## What changed

**1. Self-explanatory setup UI** — new shared `Common/UI/Components/SSO/IdentityProviderUrls.tsx`, mounted on the Global, Project, and Status Page SSO screens:
- ACS URL + Entity ID rendered as **copy-button code blocks** (no error-prone hand-selection).
- A warning callout: paste exactly (case-sensitive, no trailing slash); the Entity ID has no `/identity` but the ACS does; **a working IdP/MyApps tile does NOT mean the SSO button works** (they're validated separately — always test the button).
- A collapsible **Azure AADSTS700016 tip** documenting the `saml2/{servicePrincipalGuid}` Sign-On-URL workaround (valid because OneUptime sends unsigned AuthnRequests).
- Project/Status Page values now show in a **persistent card** instead of an ephemeral modal.

**2. SAML assertion Audience validation** — `SSOUtil.getAudiences` / `validateAudience`, wired into all three SAML login handlers (Global / Project / Status Page):
- A mismatch between the assertion Audience and the SP Entity ID is **warned by default** and **hard-blocked** when the new per-provider `enforceAudienceValidation` toggle is enabled.
- **Warn-by-default** intentionally does not break setups relying on the Azure GUID Sign-On-URL override (where Azure stamps a different Audience).
- Absent `AudienceRestriction` is treated as skip (some IdPs omit it). Matching is case-sensitive with single-trailing-slash tolerance; the message names both received and expected values.

Adds `enforceAudienceValidation` boolean to `GlobalSso` / `ProjectSso` / `StatusPageSso` (additive migration `1782600000000`, default `false`), exposes the toggle in each SSO config form, and adds unit tests.

## Verification

- `App/Tests/Identity/SSOAudienceValidation.test.ts` — **13/13 passing** (real `xml2js` parsing: namespace variants, attribute form, multi-audience, case-sensitivity, trailing-slash, skip-on-absent, mismatch messaging).
- `tsc --noEmit` on the App project — **0 errors**.
- Migration is additive (`NOT NULL DEFAULT false`), default preserves current behavior; warn-by-default means no existing login is blocked on upgrade.
