### PR TITLE
fix(dashboard): improve metric and chart layout

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -911,7 +911,7 @@ const MetricView: FunctionComponent<ComponentProps> = (
                * Give each metric result ~20rem of height (matching the
                * chart's previous fixed h-80 / 320px height).
                */
-              height: metricResults.length * 20 + "rem",
+              minHeight: metricResults.length * 20 + "rem",
             }}
           >
             <MetricCharts

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -276,13 +276,15 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
 
   // When showing cards, use the grid layout
   const gridCols: string =
-    props.charts.length > 1 ? "lg:grid-cols-2" : "lg:grid-cols-1";
+    props.charts.length > 1
+      ? "lg:grid-cols-2 min-h-96"
+      : "lg:grid-cols-1 min-h-80";
 
   return (
     <>
       {renderMetricInfoModal()}
       <div
-        className={`grid grid-cols-1 ${gridCols} gap-4 space-y-4 lg:space-y-0 min-h-80`}
+        className={`grid grid-cols-1 ${gridCols} gap-4 space-y-4 lg:space-y-0`}
       >
         {props.charts.map((chart: Chart, index: number) => {
           return (

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -282,13 +282,13 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
     <>
       {renderMetricInfoModal()}
       <div
-        className={`grid grid-cols-1 ${gridCols} gap-4 space-y-4 lg:space-y-0`}
+        className={`grid grid-cols-1 ${gridCols} gap-4 space-y-4 lg:space-y-0 min-h-80`}
       >
         {props.charts.map((chart: Chart, index: number) => {
           return (
             <div
               key={index}
-              className={`p-5 rounded-lg border border-gray-200 bg-white shadow-sm ${props.chartCssClass || ""}`}
+              className={`p-5 rounded-lg border border-gray-200 bg-white shadow-sm flex flex-col ${props.chartCssClass || ""}`}
             >
               <div className="flex items-center">
                 <h2

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -276,9 +276,7 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
 
   // When showing cards, use the grid layout
   const gridCols: string =
-    props.charts.length > 1
-      ? "lg:grid-cols-2 min-h-96"
-      : "lg:grid-cols-1 min-h-80";
+    props.charts.length > 1 ? "lg:grid-cols-2" : "lg:grid-cols-1";
 
   return (
     <>
@@ -290,7 +288,7 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
           return (
             <div
               key={index}
-              className={`p-5 rounded-lg border border-gray-200 bg-white shadow-sm flex flex-col ${props.chartCssClass || ""}`}
+              className={`p-5 rounded-lg border border-gray-200 bg-white shadow-sm flex flex-col gap-3 ${props.chartCssClass || ""}`}
             >
               <div className="flex items-center">
                 <h2
@@ -310,10 +308,10 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
                   {chart.description}
                 </p>
               )}
-              {chart.seriesControls ? (
-                <div className="mt-3">{chart.seriesControls}</div>
-              ) : null}
-              {getChartContent(chart, index)}
+              {chart.seriesControls ? chart.seriesControls : null}
+              <div className="flex-1 flex flex-col min-h-80">
+                {getChartContent(chart, index)}
+              </div>
             </div>
           );
         })}

--- a/Common/UI/Components/Page/Page.tsx
+++ b/Common/UI/Components/Page/Page.tsx
@@ -47,8 +47,7 @@ const Page: FunctionComponent<ComponentProps> = (
   return (
     <div
       className={
-        props.className ||
-        "mb-auto max-w-full px-4 sm:px-6 lg:px-8 mt-5 mb-20 h-max"
+        props.className || "max-w-full px-4 sm:px-6 lg:px-8 mt-5 mb-20 h-max"
       }
     >
       {((props.breadcrumbLinks && props.breadcrumbLinks.length > 0) ||

--- a/Common/UI/Components/Page/Page.tsx
+++ b/Common/UI/Components/Page/Page.tsx
@@ -47,7 +47,7 @@ const Page: FunctionComponent<ComponentProps> = (
   return (
     <div
       className={
-        props.className || "max-w-full px-4 sm:px-6 lg:px-8 mt-5 mb-20 h-max"
+        props.className || "mb-auto max-w-full px-4 sm:px-6 lg:px-8 mt-5 h-max"
       }
     >
       {((props.breadcrumbLinks && props.breadcrumbLinks.length > 0) ||


### PR DESCRIPTION
## Summary
- use `minHeight` for metric result containers so dashboards can grow with content
- align `ChartGroup` layout sizing so chart cards stop fighting fixed-height constraints
- simplify `Page` sizing so dashboard pages stretch correctly with the updated chart layout

|before|after|
|---|---|
|<img width="1022" height="612" alt="image" src="https://github.com/user-attachments/assets/a3410be8-d8da-4584-805d-c11ce852b243" />|<img width="1020" height="868" alt="image" src="https://github.com/user-attachments/assets/e3ed6251-63ce-4b59-9223-bde18b0f057b" />|
