### PR TITLE
fix(logs): preserve custom IN filter values

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/FilterQueryBuilder/FilterQueryParser.ts
+++ b/App/FeatureSet/Dashboard/src/Components/FilterQueryBuilder/FilterQueryParser.ts
@@ -31,7 +31,10 @@ export function parseFilterQuery(
   const conditions: Array<FilterConditionData> = [];
 
   for (const part of parts) {
-    const trimmed: string = part.trim().replace(/^\(|\)$/g, "");
+    let trimmed: string = part.trim();
+    if (trimmed.startsWith("(") && trimmed.endsWith(")")) {
+      trimmed = trimmed.slice(1, -1).trim();
+    }
 
     const likeMatch: RegExpMatchArray | null = trimmed.match(
       /^(\S+)\s+(LIKE)\s+'([^']*)'$/i,

--- a/App/Tests/Dashboard/FilterQueryParser.test.ts
+++ b/App/Tests/Dashboard/FilterQueryParser.test.ts
@@ -1,4 +1,5 @@
 import LogFilterConfig from "../../FeatureSet/Dashboard/src/Components/FilterQueryBuilder/LogFilterConfig";
+import TraceFilterConfig from "../../FeatureSet/Dashboard/src/Components/FilterQueryBuilder/TraceFilterConfig";
 import {
   buildFilterQuery,
   parseFilterQuery,
@@ -47,6 +48,115 @@ describe("FilterQueryParser", () => {
           value: "prod, staging",
         },
       ],
+    });
+  });
+
+  test("round-trips a multi-condition AND query across =, !=, LIKE and IN", () => {
+    /*
+     * Exercises the per-part split-then-strip path with more than one
+     * condition and an IN clause in the LAST position. A regression that
+     * stripped the IN clause's own trailing ')' (the original bug) would
+     * drop that condition and fail this test.
+     */
+    const query: string = buildFilterQuery(
+      [
+        { field: "severityText", operator: "=", value: "ERROR" },
+        { field: "body", operator: "LIKE", value: "%timeout%" },
+        { field: "primaryEntityId", operator: "!=", value: "svc-123" },
+        {
+          field: "attributes.k8s.object.kind",
+          operator: "IN",
+          value: "Pod, Deployment",
+        },
+      ],
+      "AND",
+      LogFilterConfig,
+    );
+
+    expect(query).toBe(
+      "severityText = 'ERROR' AND body LIKE '%timeout%' AND " +
+        "primaryEntityId != 'svc-123' AND " +
+        "attributes.k8s.object.kind IN ('Pod', 'Deployment')",
+    );
+
+    expect(parseFilterQuery(query, LogFilterConfig)).toEqual({
+      connector: "AND",
+      conditions: [
+        { field: "severityText", operator: "=", value: "ERROR" },
+        { field: "body", operator: "LIKE", value: "%timeout%" },
+        { field: "primaryEntityId", operator: "!=", value: "svc-123" },
+        {
+          field: "attributes.k8s.object.kind",
+          operator: "IN",
+          value: "Pod, Deployment",
+        },
+      ],
+    });
+  });
+
+  test("round-trips a multi-condition OR query with an IN clause", () => {
+    const query: string = buildFilterQuery(
+      [
+        { field: "severityText", operator: "=", value: "ERROR" },
+        {
+          field: "attributes.k8s.namespace.name",
+          operator: "IN",
+          value: "prod, staging",
+        },
+      ],
+      "OR",
+      LogFilterConfig,
+    );
+
+    expect(query).toBe(
+      "severityText = 'ERROR' OR " +
+        "attributes.k8s.namespace.name IN ('prod', 'staging')",
+    );
+
+    expect(parseFilterQuery(query, LogFilterConfig)).toEqual({
+      connector: "OR",
+      conditions: [
+        { field: "severityText", operator: "=", value: "ERROR" },
+        {
+          field: "attributes.k8s.namespace.name",
+          operator: "IN",
+          value: "prod, staging",
+        },
+      ],
+    });
+  });
+
+  test("round-trips IN filters for the trace filter config", () => {
+    const query: string = buildFilterQuery(
+      [
+        {
+          field: "attributes.http.request.method",
+          operator: "IN",
+          value: "GET, POST",
+        },
+      ],
+      "AND",
+      TraceFilterConfig,
+    );
+
+    expect(query).toBe("attributes.http.request.method IN ('GET', 'POST')");
+
+    expect(parseFilterQuery(query, TraceFilterConfig)).toEqual({
+      connector: "AND",
+      conditions: [
+        {
+          field: "attributes.http.request.method",
+          operator: "IN",
+          value: "GET, POST",
+        },
+      ],
+    });
+  });
+
+  test("returns the default condition for an empty query", () => {
+    expect(parseFilterQuery("", LogFilterConfig)).toEqual({
+      connector: "AND",
+      conditions: [{ field: "severityText", operator: "=", value: "" }],
     });
   });
 });

--- a/App/Tests/Dashboard/FilterQueryParser.test.ts
+++ b/App/Tests/Dashboard/FilterQueryParser.test.ts
@@ -1,0 +1,52 @@
+import LogFilterConfig from "../../FeatureSet/Dashboard/src/Components/FilterQueryBuilder/LogFilterConfig";
+import {
+  buildFilterQuery,
+  parseFilterQuery,
+} from "../../FeatureSet/Dashboard/src/Components/FilterQueryBuilder/FilterQueryParser";
+
+describe("FilterQueryParser", () => {
+  test("round-trips custom attribute IN filters", () => {
+    const query: string = buildFilterQuery(
+      [
+        {
+          field: "attributes.k8s.object.kind",
+          operator: "IN",
+          value: "Pod, Deployment, ReplicaSet",
+        },
+      ],
+      "AND",
+      LogFilterConfig,
+    );
+
+    expect(query).toBe(
+      "attributes.k8s.object.kind IN ('Pod', 'Deployment', 'ReplicaSet')",
+    );
+
+    expect(parseFilterQuery(query, LogFilterConfig)).toEqual({
+      connector: "AND",
+      conditions: [
+        {
+          field: "attributes.k8s.object.kind",
+          operator: "IN",
+          value: "Pod, Deployment, ReplicaSet",
+        },
+      ],
+    });
+  });
+
+  test("keeps IN filters when wrapped in grouping parentheses", () => {
+    const query: string =
+      "(attributes.k8s.namespace.name IN ('prod', 'staging'))";
+
+    expect(parseFilterQuery(query, LogFilterConfig)).toEqual({
+      connector: "AND",
+      conditions: [
+        {
+          field: "attributes.k8s.namespace.name",
+          operator: "IN",
+          value: "prod, staging",
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Why
- the logs drop-filter builder exposed `is one of` for custom attributes, but any saved `IN (...)` clause was immediately broken when the builder reparsed it
- users would type comma-separated values such as `Pod, Deployment, ReplicaSet`, save the rule, and then see the value disappear because the parser stripped the closing `)` from the `IN (...)` clause and fell back to the default empty condition
- this made custom-attribute drop filters look flaky in the UI even though the ingest-side evaluator already supports `IN`

## Summary
- keep `IN (...)` clauses intact when the filter-query builder reparses grouped conditions
- add a regression test for custom-attribute `is one of` filters so comma-separated values survive round-trips

## Testing
- `cd App && node node_modules/.bin/jest --runInBand ./Tests/Dashboard/FilterQueryParser.test.ts --detectOpenHandles`

- After (Before, it was not possible to set conditions.)
<img width="1437" height="366" alt="image" src="https://github.com/user-attachments/assets/ee0c85a9-5df0-496c-bcaf-2b6c9bcce6ef" />

