### PR TITLE
fix(home): repair broken footer logo image

### DIFF
--- a/Home/Views/footer.ejs
+++ b/Home/Views/footer.ejs
@@ -43,7 +43,7 @@
         <!-- Brand Section -->
         <div class="space-y-6">
           <a href="/" class="inline-block">
-            <img class="h-8 w-auto" src="/img/4-gray.svg" alt="OneUptime" width="140" height="32" loading="lazy">
+            <img class="h-8 w-auto" src="/img/3-transparent.svg" alt="OneUptime" width="140" height="32" loading="lazy">
           </a>
           <p class="text-sm text-gray-600 leading-relaxed max-w-xs">
             The complete open-source observability platform. Monitor, debug, and improve your entire stack in one place.


### PR DESCRIPTION
## What

Fixes the broken brand logo in the homepage footer on oneuptime.com.

The footer referenced `/img/4-gray.svg`, which fails to load on the live site — the browser shows the `alt` text ("OneUptime") instead of the logo image.

This change points the footer at `/img/3-transparent.svg`, the same OneUptime wordmark the top navigation already uses and serves correctly:

- `Home/Views/nav.ejs` — uses `/img/3-transparent.svg` (renders fine)
- `Home/Views/footer.ejs` — now uses the same asset

```diff
- <img class="h-8 w-auto" src="/img/4-gray.svg" alt="OneUptime" width="140" height="32" loading="lazy">
+ <img class="h-8 w-auto" src="/img/3-transparent.svg" alt="OneUptime" width="140" height="32" loading="lazy">
```

## Why

Using the asset already proven to load on the same page guarantees the footer logo renders, and keeps the header and footer branding consistent. The `width`/`height`/`class` are unchanged, so layout is unaffected.

## Testing

Verified `Home/Static/img/3-transparent.svg` exists and is the OneUptime wordmark used by the nav. Single-line template change; no behavior beyond the image source is affected.

Fixes #2558