### PR TITLE
fix(database): add sort columns to select to avoid DISTINCT subquery error

### DIFF
--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1515,20 +1515,38 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     try {
       this.setTelemetryContextFromProps(findBy.props);
 
-      let automaticallyAddedCreatedAtInSelect: boolean = false;
+      // Columns we add to the select purely to satisfy the ORDER BY, and which
+      // must be stripped from the returned items so the caller only gets back
+      // what it asked for.
+      const automaticallyAddedSortKeysInSelect: Array<string> = [];
 
       if (!findBy.sort || Object.keys(findBy.sort).length === 0) {
         findBy.sort = {
           createdAt: SortOrder.Descending,
         };
+      }
 
-        if (!findBy.select) {
-          findBy.select = {} as any;
+      /*
+       * Ensure every column we sort by is also selected. When a query loads
+       * relations (e.g. via @CanAccessIfCanReadOn), TypeORM paginates with a
+       * DISTINCT subquery and references the sort columns in the outer ORDER BY.
+       * If a sort column is not part of the select, it is absent from the inner
+       * subquery and Postgres fails with "column ... does not exist". This also
+       * covers the default createdAt sort added above.
+       */
+      if (!findBy.select) {
+        findBy.select = {} as any;
+      }
+
+      for (const sortKey of Object.keys(findBy.sort)) {
+        // Only scalar columns need to be selected; skip nested/relation sorts.
+        if (typeof (findBy.sort as any)[sortKey] === Typeof.Object) {
+          continue;
         }
 
-        if (!(findBy.select as any)["createdAt"]) {
-          (findBy.select as any)["createdAt"] = true;
-          automaticallyAddedCreatedAtInSelect = true;
+        if (!(findBy.select as any)[sortKey]) {
+          (findBy.select as any)[sortKey] = true;
+          automaticallyAddedSortKeysInSelect.push(sortKey);
         }
       }
 
@@ -1597,8 +1615,8 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       decryptedItems = this.sanitizeFindByItems(decryptedItems, onBeforeFind);
 
       for (const item of decryptedItems) {
-        if (automaticallyAddedCreatedAtInSelect) {
-          delete (item as any).createdAt;
+        for (const sortKey of automaticallyAddedSortKeysInSelect) {
+          delete (item as any)[sortKey];
         }
       }
 

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1515,9 +1515,11 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     try {
       this.setTelemetryContextFromProps(findBy.props);
 
-      // Columns we add to the select purely to satisfy the ORDER BY, and which
-      // must be stripped from the returned items so the caller only gets back
-      // what it asked for.
+      /*
+       * Columns we add to the select purely to satisfy the ORDER BY, and which
+       * must be stripped from the returned items so the caller only gets back
+       * what it asked for.
+       */
       const automaticallyAddedSortKeysInSelect: Array<string> = [];
 
       if (!findBy.sort || Object.keys(findBy.sort).length === 0) {

--- a/Common/Tests/Server/Services/DatabaseService.test.ts
+++ b/Common/Tests/Server/Services/DatabaseService.test.ts
@@ -1,0 +1,131 @@
+import AlertStateTimeline from "../../../Models/DatabaseModels/AlertStateTimeline";
+import AlertStateTimelineService from "../../../Server/Services/AlertStateTimelineService";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * Regression tests for DatabaseService._findBy sort/select handling.
+ *
+ * When a query loads relations, TypeORM paginates with a DISTINCT subquery and
+ * references the sort columns in the outer ORDER BY. If a sort column is not in
+ * the select, Postgres fails with "column ... does not exist". _findBy must add
+ * every sort column to the select and strip the auto-added ones from the result.
+ */
+describe("DatabaseService._findBy sort columns", () => {
+  type FindMock = jest.Mock;
+
+  const makeItem: (fields: Record<string, unknown>) => AlertStateTimeline = (
+    fields: Record<string, unknown>,
+  ): AlertStateTimeline => {
+    return Object.assign(new AlertStateTimeline(), fields);
+  };
+
+  const mockRepositoryFind: (items: Array<unknown>) => FindMock = (
+    items: Array<unknown>,
+  ): FindMock => {
+    const find: FindMock = jest.fn().mockResolvedValue(items);
+    getJestSpyOn(AlertStateTimelineService, "getRepository").mockReturnValue({
+      find,
+    } as never);
+    return find;
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("adds a sorted-but-unselected column to the select passed to the repository", async () => {
+    const find: FindMock = mockRepositoryFind([]);
+
+    await AlertStateTimelineService.findBy({
+      query: {},
+      select: { alertStateId: true } as never,
+      sort: { startsAt: SortOrder.Ascending } as never,
+      skip: 0,
+      limit: 10,
+      props: { isRoot: true, ignoreHooks: true },
+    });
+
+    const select: Record<string, unknown> = find.mock.calls[0]![0].select;
+
+    // The explicitly requested column stays selected.
+    expect(select["alertStateId"]).toBe(true);
+    // The sort column was added so the ORDER BY can resolve it.
+    expect(select["startsAt"]).toBe(true);
+  });
+
+  test("strips the auto-added sort column from returned items", async () => {
+    mockRepositoryFind([
+      makeItem({
+        _id: "1",
+        alertStateId: "state-1",
+        startsAt: new Date("2020-01-01"),
+      }),
+    ]);
+
+    const items: Array<unknown> = await AlertStateTimelineService.findBy({
+      query: {},
+      select: { alertStateId: true } as never,
+      sort: { startsAt: SortOrder.Ascending } as never,
+      skip: 0,
+      limit: 10,
+      props: { isRoot: true, ignoreHooks: true },
+    });
+
+    const item: Record<string, unknown> = items[0] as Record<string, unknown>;
+    expect(item["alertStateId"]).toBe("state-1");
+    // startsAt was only added internally for the ORDER BY, so it is removed.
+    expect(item).not.toHaveProperty("startsAt");
+  });
+
+  test("keeps a sort column that the caller explicitly selected", async () => {
+    mockRepositoryFind([
+      makeItem({
+        _id: "1",
+        alertStateId: "state-1",
+        startsAt: new Date("2020-01-01"),
+      }),
+    ]);
+
+    const items: Array<unknown> = await AlertStateTimelineService.findBy({
+      query: {},
+      select: { alertStateId: true, startsAt: true } as never,
+      sort: { startsAt: SortOrder.Ascending } as never,
+      skip: 0,
+      limit: 10,
+      props: { isRoot: true, ignoreHooks: true },
+    });
+
+    const item: Record<string, unknown> = items[0] as Record<string, unknown>;
+    // Explicitly selected, so it must survive in the result.
+    expect(item).toHaveProperty("startsAt");
+  });
+
+  test("defaults to createdAt sort and strips it when no sort is given", async () => {
+    const find: FindMock = mockRepositoryFind([
+      makeItem({
+        _id: "1",
+        alertStateId: "state-1",
+        createdAt: new Date("2020-01-01"),
+      }),
+    ]);
+
+    const items: Array<unknown> = await AlertStateTimelineService.findBy({
+      query: {},
+      select: { alertStateId: true } as never,
+      skip: 0,
+      limit: 10,
+      props: { isRoot: true, ignoreHooks: true },
+    });
+
+    // Default sort is applied and its column is selected for the ORDER BY.
+    expect(find.mock.calls[0]![0].order).toEqual({
+      createdAt: SortOrder.Descending,
+    });
+    expect(find.mock.calls[0]![0].select["createdAt"]).toBe(true);
+
+    // ...but the auto-added createdAt is stripped from the returned item.
+    const item: Record<string, unknown> = items[0] as Record<string, unknown>;
+    expect(item).not.toHaveProperty("createdAt");
+  });
+});


### PR DESCRIPTION
## What

Fixes a 500 error when querying a model by a sort column that was not explicitly listed in `select`, on models that load relations.

`GET /api/incident-state-timeline/get-list` (or `alert-state-timeline`) with `sort: {"startsAt": "ASC"}` currently fails with:

```
QueryFailedError: column "distinctAlias.AlertStateTimeline_startsAt" does not exist
```

## Root cause

These models load relations (via `@CanAccessIfCanReadOn`), so TypeORM paginates with a DISTINCT subquery and references the sort columns in the outer `ORDER BY`:

```sql
SELECT DISTINCT "distinctAlias"."AlertStateTimeline__id",
                "distinctAlias"."AlertStateTimeline_startsAt"
FROM ( SELECT "AlertStateTimeline"."_id", "AlertStateTimeline"."alertStateId" ... ) "distinctAlias"
ORDER BY "distinctAlias"."AlertStateTimeline_startsAt" ASC
```

`startsAt` is in the outer `ORDER BY` but not in the inner `SELECT`, so Postgres cannot resolve it.

## Fix

In `DatabaseService._findBy`, ensure **every scalar sort column** is present in the `select` map before calling `repository.find()`, and strip the auto-added columns from the returned items so callers only get back what they requested.

- Generalizes the existing `createdAt`-only handling — the default `createdAt` sort now flows through the same path.
- Skips nested/relation sorts.
- No change to the API contract: auto-added columns are removed from results.

```diff
- let automaticallyAddedCreatedAtInSelect: boolean = false;
+ const automaticallyAddedSortKeysInSelect: Array<string> = [];
  ...
- if (!(findBy.select as any)["createdAt"]) {
-   (findBy.select as any)["createdAt"] = true;
-   automaticallyAddedCreatedAtInSelect = true;
- }
+ for (const sortKey of Object.keys(findBy.sort)) {
+   if (typeof (findBy.sort as any)[sortKey] === Typeof.Object) { continue; }
+   if (!(findBy.select as any)[sortKey]) {
+     (findBy.select as any)[sortKey] = true;
+     automaticallyAddedSortKeysInSelect.push(sortKey);
+   }
+ }
```

## Tests

New `Common/Tests/Server/Services/DatabaseService.test.ts` with 4 cases:

1. A sorted-but-unselected column is added to the `select` passed to the repository.
2. That auto-added column is stripped from returned items.
3. A sort column the caller explicitly selected is preserved.
4. The default `createdAt` sort is applied and stripped (no regression).

The two bug-specific tests fail without the source change, confirming they are real regression guards.

```
node node_modules/.bin/jest --runInBand ./Tests/Server/Services/DatabaseService.test.ts
# 4 passed
```

Prettier-clean and type-checks pass.

Fixes #2476