### PR TITLE
fix(config): use internal app hostname for StatusPageApiInternalUrl

### DIFF
--- a/Common/Server/EnvironmentConfig.ts
+++ b/Common/Server/EnvironmentConfig.ts
@@ -501,9 +501,11 @@ export const StatusPageApiClientUrl: URL = new URL(
  *Note: The internal path is /api/status-page (not /status-page-api) because
  * /status-page-api is the external route that Nginx rewrites to /api/status-page
  */
-export const StatusPageApiInternalUrl: URL = URL.fromString(
-  AppApiClientUrl.toString(),
-).addRoute(new Route("/status-page"));
+export const StatusPageApiInternalUrl: URL = new URL(
+  Protocol.HTTP,
+  AppApiHostname,
+  new Route(`${AppApiRoute.toString()}/status-page`),
+);
 
 export const DashboardClientUrl: URL = new URL(
   HttpProtocol,

--- a/Common/Tests/Server/EnvironmentConfig.test.ts
+++ b/Common/Tests/Server/EnvironmentConfig.test.ts
@@ -1,0 +1,56 @@
+/*
+ * StatusPageApiInternalUrl is used for server-to-server (in-cluster) calls,
+ * e.g. the status page SEO lookup the app makes about itself. It must target
+ * the internal app service hostname (SERVER_APP_HOSTNAME:APP_PORT) rather than
+ * the public ingress HOST — otherwise, in Kubernetes/multi-host deployments the
+ * pod calls its own public URL and times out (ETIMEDOUT).
+ *
+ * EnvironmentConfig computes its exports from process.env at import time, so we
+ * re-import the module with controlled env via jest.resetModules() + import().
+ */
+describe("EnvironmentConfig.StatusPageApiInternalUrl", () => {
+  const originalEnv: NodeJS.ProcessEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  const loadInternalUrl: (
+    env: Record<string, string>,
+  ) => Promise<string> = async (
+    env: Record<string, string>,
+  ): Promise<string> => {
+    jest.resetModules();
+    process.env = { ...originalEnv, ...env };
+    const config: typeof import("../../Server/EnvironmentConfig") =
+      await import("../../Server/EnvironmentConfig");
+    return config.StatusPageApiInternalUrl.toString();
+  };
+
+  const publicAndInternalEnv: Record<string, string> = {
+    SERVER_APP_HOSTNAME: "oneuptime-app",
+    APP_PORT: "3002",
+    HOST: "status.example.com",
+    HTTP_PROTOCOL: "https",
+  };
+
+  test("uses the internal app service hostname, not the public ingress host", async () => {
+    const url: string = await loadInternalUrl(publicAndInternalEnv);
+
+    expect(url).toContain("oneuptime-app:3002");
+    expect(url).not.toContain("status.example.com");
+  });
+
+  test("targets the /api/status-page internal route", async () => {
+    const url: string = await loadInternalUrl(publicAndInternalEnv);
+
+    expect(url).toContain("/api/status-page");
+  });
+
+  test("stays on http for in-cluster traffic even when the public protocol is https", async () => {
+    const url: string = await loadInternalUrl(publicAndInternalEnv);
+
+    expect(url.startsWith("http://")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`StatusPageApiInternalUrl` is used for **server-to-server (in-cluster)** calls — e.g. the status page SEO lookup the app makes about itself. It was built from `AppApiClientUrl`, which uses the **public** `HOST` and `HTTP_PROTOCOL`:

```ts
export const StatusPageApiInternalUrl: URL = URL.fromString(
  AppApiClientUrl.toString(),         // <- public HOST + HTTP_PROTOCOL
).addRoute(new Route("/status-page"));
```

In Kubernetes / any multi-host deployment, the pod then tries to reach its own public ingress from the inside:

```
APIException: Request failed to https://my_domain/api/status-page/seo/...
connect ETIMEDOUT 10.10.10.10:443
```

## Fix

Build it from `AppApiHostname` (`SERVER_APP_HOSTNAME:APP_PORT`) over `http`, matching the internal-URL pattern already used by `MailService`, `SmsService`, `StatusPageCertificateService`, etc.:

```ts
export const StatusPageApiInternalUrl: URL = new URL(
  Protocol.HTTP,
  AppApiHostname,
  new Route(`${AppApiRoute.toString()}/status-page`),
);
```

The path stays `/api/status-page` — only the host and protocol move from public to internal, which is exactly what the existing comment on this constant already claimed it did.

## Tests

New `Common/Tests/Server/EnvironmentConfig.test.ts` (re-imports `EnvironmentConfig` with controlled env via `jest.resetModules()` + `import()`):

1. The internal URL uses the internal hostname (`oneuptime-app:3002`), not the public `HOST`.
2. It targets the `/api/status-page` internal route.
3. It stays on `http://` even when `HTTP_PROTOCOL=https` (in-cluster traffic shouldn't go through TLS/ingress).

Tests 1 and 3 fail without the source change, confirming they are real regression guards. Prettier-clean and type-checks pass.

```
node node_modules/.bin/jest --runInBand ./Tests/Server/EnvironmentConfig.test.ts
# 3 passed
```

Fixes #2475