### PR TITLE
test(Common): add tests for Types/Billing/SubscriptionStatusUtil

### DIFF
--- a/Common/Tests/Types/Billing/SubscriptionStatus.test.ts
+++ b/Common/Tests/Types/Billing/SubscriptionStatus.test.ts
@@ -1,0 +1,127 @@
+import SubscriptionStatus, {
+  SubscriptionStatusUtil,
+} from "../../../Types/Billing/SubscriptionStatus";
+
+describe("SubscriptionStatusUtil", () => {
+  describe("isSubscriptionActive", () => {
+    test("treats a missing status as active", () => {
+      expect(SubscriptionStatusUtil.isSubscriptionActive(undefined)).toBe(true);
+    });
+
+    test.each([
+      SubscriptionStatus.Active,
+      SubscriptionStatus.Trialing,
+      SubscriptionStatus.PastDue,
+    ])("returns true for %s", (status: SubscriptionStatus) => {
+      expect(SubscriptionStatusUtil.isSubscriptionActive(status)).toBe(true);
+    });
+
+    test.each([
+      SubscriptionStatus.Incomplete,
+      SubscriptionStatus.IncompleteExpired,
+      SubscriptionStatus.Canceled,
+      SubscriptionStatus.Unpaid,
+      SubscriptionStatus.Expired,
+      SubscriptionStatus.Paused,
+    ])("returns false for %s", (status: SubscriptionStatus) => {
+      expect(SubscriptionStatusUtil.isSubscriptionActive(status)).toBe(false);
+    });
+  });
+
+  describe("isSubscriptionInactive", () => {
+    test("is the inverse of isSubscriptionActive", () => {
+      const statuses: Array<SubscriptionStatus | undefined> = [
+        undefined,
+        ...Object.values(SubscriptionStatus),
+      ];
+
+      for (const status of statuses) {
+        expect(SubscriptionStatusUtil.isSubscriptionInactive(status)).toBe(
+          !SubscriptionStatusUtil.isSubscriptionActive(status),
+        );
+      }
+    });
+
+    test("treats a missing status as active (not inactive)", () => {
+      expect(SubscriptionStatusUtil.isSubscriptionInactive(undefined)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isSubscriptionOverdue", () => {
+    test("returns false for a missing status", () => {
+      expect(SubscriptionStatusUtil.isSubscriptionOverdue(undefined)).toBe(
+        false,
+      );
+    });
+
+    test("returns true only for PastDue", () => {
+      expect(
+        SubscriptionStatusUtil.isSubscriptionOverdue(
+          SubscriptionStatus.PastDue,
+        ),
+      ).toBe(true);
+      expect(
+        SubscriptionStatusUtil.isSubscriptionOverdue(SubscriptionStatus.Active),
+      ).toBe(false);
+      expect(
+        SubscriptionStatusUtil.isSubscriptionOverdue(
+          SubscriptionStatus.Canceled,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("isSubscriptionCancelled", () => {
+    test("returns false for a missing status", () => {
+      expect(SubscriptionStatusUtil.isSubscriptionCancelled(undefined)).toBe(
+        false,
+      );
+    });
+
+    test.each([
+      SubscriptionStatus.Canceled,
+      SubscriptionStatus.Unpaid,
+      SubscriptionStatus.Expired,
+      SubscriptionStatus.IncompleteExpired,
+    ])("returns true for %s", (status: SubscriptionStatus) => {
+      expect(SubscriptionStatusUtil.isSubscriptionCancelled(status)).toBe(true);
+    });
+
+    test.each([
+      SubscriptionStatus.Active,
+      SubscriptionStatus.Trialing,
+      SubscriptionStatus.PastDue,
+      SubscriptionStatus.Incomplete,
+      SubscriptionStatus.Paused,
+    ])("returns false for %s", (status: SubscriptionStatus) => {
+      expect(SubscriptionStatusUtil.isSubscriptionCancelled(status)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("status relationships", () => {
+    test("PastDue is both active and overdue", () => {
+      expect(
+        SubscriptionStatusUtil.isSubscriptionActive(SubscriptionStatus.PastDue),
+      ).toBe(true);
+      expect(
+        SubscriptionStatusUtil.isSubscriptionOverdue(
+          SubscriptionStatus.PastDue,
+        ),
+      ).toBe(true);
+    });
+
+    test("active and cancelled statuses never overlap", () => {
+      for (const status of Object.values(SubscriptionStatus)) {
+        const active: boolean =
+          SubscriptionStatusUtil.isSubscriptionActive(status);
+        const cancelled: boolean =
+          SubscriptionStatusUtil.isSubscriptionCancelled(status);
+        expect(active && cancelled).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the `SubscriptionStatusUtil` class in `Common/Types/Billing/SubscriptionStatus.ts`, which previously had no test coverage.

Covered:

- **`isSubscriptionActive`** — treats a missing status as active; true for `Active` / `Trialing` / `PastDue`; false for the rest.
- **`isSubscriptionInactive`** — verified to be the exact inverse of `isSubscriptionActive` across every status (including `undefined`).
- **`isSubscriptionOverdue`** — false for a missing status; true only for `PastDue`.
- **`isSubscriptionCancelled`** — false for a missing status; true for `Canceled` / `Unpaid` / `Expired` / `IncompleteExpired`; false otherwise.
- **Relationship invariants** — `PastDue` is both active and overdue, and the active / cancelled sets never overlap.

## Why

Improves test coverage for the `Common/Types` utilities (part of the broader test-coverage effort).

## Testing

```
node node_modules/.bin/jest --runInBand ./Tests/Types/Billing/SubscriptionStatus.test.ts
```

All 26 tests pass. The file is Prettier-clean.