### PR TITLE
feat(logs): allow viewing and editing LogPipeline processors

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/LogPipeline/ProcessorForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/LogPipeline/ProcessorForm.tsx
@@ -23,9 +23,35 @@ import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 
 export interface ComponentProps {
   pipelineId: ObjectID;
-  onProcessorCreated: () => void;
+  // When provided, the form opens in edit mode pre-filled from this processor.
+  initialProcessor?: LogPipelineProcessor | undefined;
+  onProcessorSaved: () => void;
   onCancel: () => void;
 }
+
+/*
+ * Processor configuration is a polymorphic JSONB blob. It is usually handed
+ * back as an object, but some persistence paths store it as a JSON string
+ * literal, so accept either shape when pre-filling the edit form.
+ */
+const parseConfiguration: (raw: JSONValue | undefined) => JSONObject = (
+  raw: JSONValue | undefined,
+): JSONObject => {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as JSONObject;
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed: JSONValue = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as JSONObject;
+      }
+    } catch {
+      // fall through to empty config
+    }
+  }
+  return {};
+};
 
 type ProcessorType =
   | "SeverityRemapper"
@@ -62,29 +88,70 @@ interface CategoryRule {
 const ProcessorForm: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const isEditMode: boolean = Boolean(props.initialProcessor?.id);
+  const initialType: ProcessorType =
+    (props.initialProcessor?.processorType as ProcessorType) || "";
+  const initialConfig: JSONObject = parseConfiguration(
+    props.initialProcessor?.configuration as JSONValue | undefined,
+  );
+
   // Common fields
-  const [name, setName] = useState<string>("");
-  const [processorType, setProcessorType] = useState<ProcessorType>("");
-  const [isEnabled, setIsEnabled] = useState<boolean>(true);
+  const [name, setName] = useState<string>(props.initialProcessor?.name || "");
+  const [processorType, setProcessorType] =
+    useState<ProcessorType>(initialType);
+  const [isEnabled, setIsEnabled] = useState<boolean>(
+    props.initialProcessor?.isEnabled ?? true,
+  );
 
   // Severity Remapper fields
-  const [severitySourceKey, setSeveritySourceKey] = useState<string>("level");
+  const [severitySourceKey, setSeveritySourceKey] = useState<string>(
+    initialType === "SeverityRemapper"
+      ? (initialConfig["sourceKey"] as string) || "level"
+      : "level",
+  );
   const [severityMappings, setSeverityMappings] = useState<
     Array<SeverityMapping>
-  >([{ matchValue: "", severityText: "", severityNumber: 0 }]);
+  >(
+    initialType === "SeverityRemapper" &&
+      Array.isArray(initialConfig["mappings"])
+      ? (initialConfig["mappings"] as unknown as Array<SeverityMapping>)
+      : [{ matchValue: "", severityText: "", severityNumber: 0 }],
+  );
 
   // Attribute Remapper fields
-  const [attrSourceKey, setAttrSourceKey] = useState<string>("");
-  const [attrTargetKey, setAttrTargetKey] = useState<string>("");
-  const [preserveSource, setPreserveSource] = useState<boolean>(false);
-  const [overrideOnConflict, setOverrideOnConflict] = useState<boolean>(true);
+  const [attrSourceKey, setAttrSourceKey] = useState<string>(
+    initialType === "AttributeRemapper"
+      ? (initialConfig["sourceKey"] as string) || ""
+      : "",
+  );
+  const [attrTargetKey, setAttrTargetKey] = useState<string>(
+    initialType === "AttributeRemapper"
+      ? (initialConfig["targetKey"] as string) || ""
+      : "",
+  );
+  const [preserveSource, setPreserveSource] = useState<boolean>(
+    initialType === "AttributeRemapper"
+      ? Boolean(initialConfig["preserveSource"])
+      : false,
+  );
+  const [overrideOnConflict, setOverrideOnConflict] = useState<boolean>(
+    initialType === "AttributeRemapper"
+      ? initialConfig["overrideOnConflict"] !== false
+      : true,
+  );
 
   // Category Processor fields
-  const [categoryTargetKey, setCategoryTargetKey] =
-    useState<string>("category");
-  const [categories, setCategories] = useState<Array<CategoryRule>>([
-    { name: "", filterQuery: "" },
-  ]);
+  const [categoryTargetKey, setCategoryTargetKey] = useState<string>(
+    initialType === "CategoryProcessor"
+      ? (initialConfig["targetKey"] as string) || "category"
+      : "category",
+  );
+  const [categories, setCategories] = useState<Array<CategoryRule>>(
+    initialType === "CategoryProcessor" &&
+      Array.isArray(initialConfig["categories"])
+      ? (initialConfig["categories"] as unknown as Array<CategoryRule>)
+      : [{ name: "", filterQuery: "" }],
+  );
 
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
@@ -178,22 +245,40 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
     setError("");
 
     try {
-      const processor: LogPipelineProcessor = new LogPipelineProcessor();
-      processor.name = name;
-      processor.processorType = processorType;
-      processor.configuration = buildConfiguration();
-      processor.isEnabled = isEnabled;
-      processor.logPipelineId = props.pipelineId;
-      processor.sortOrder = 1;
+      if (isEditMode && props.initialProcessor?.id) {
+        // Edit: update the existing processor, preserving its sortOrder.
+        await ModelAPI.updateById({
+          modelType: LogPipelineProcessor,
+          id: props.initialProcessor.id,
+          data: {
+            name,
+            processorType,
+            configuration: buildConfiguration(),
+            isEnabled,
+          },
+        });
+      } else {
+        const processor: LogPipelineProcessor = new LogPipelineProcessor();
+        processor.name = name;
+        processor.processorType = processorType;
+        processor.configuration = buildConfiguration();
+        processor.isEnabled = isEnabled;
+        processor.logPipelineId = props.pipelineId;
+        processor.sortOrder = 1;
 
-      await ModelAPI.create({
-        model: processor,
-        modelType: LogPipelineProcessor,
-      });
+        await ModelAPI.create({
+          model: processor,
+          modelType: LogPipelineProcessor,
+        });
+      }
 
-      props.onProcessorCreated();
+      props.onProcessorSaved();
     } catch {
-      setError("Failed to create processor. Please try again.");
+      setError(
+        isEditMode
+          ? "Failed to update processor. Please try again."
+          : "Failed to create processor. Please try again.",
+      );
     } finally {
       setIsSaving(false);
     }
@@ -201,10 +286,10 @@ const ProcessorForm: FunctionComponent<ComponentProps> = (
 
   return (
     <Modal
-      title="Add Processor"
+      title={isEditMode ? "Edit Processor" : "Add Processor"}
       description="Processors transform logs as they flow through the pipeline. They run in order after the filter conditions match. Each processor modifies the log before it is stored."
       modalWidth={ModalWidth.Large}
-      submitButtonText="Create Processor"
+      submitButtonText={isEditMode ? "Save Changes" : "Create Processor"}
       onSubmit={handleSave}
       isLoading={isSaving}
       onClose={props.onCancel}

--- a/App/FeatureSet/Dashboard/src/Pages/Logs/Settings/PipelineView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Logs/Settings/PipelineView.tsx
@@ -100,6 +100,9 @@ const LogPipelineView: FunctionComponent<PageComponentProps> = (
 ): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID();
   const [showProcessorForm, setShowProcessorForm] = useState<boolean>(false);
+  const [processorToEdit, setProcessorToEdit] = useState<
+    LogPipelineProcessor | undefined
+  >(undefined);
   const [refreshProcessorToggle, setRefreshProcessorToggle] =
     useState<string>("initial");
 
@@ -206,6 +209,26 @@ const LogPipelineView: FunctionComponent<PageComponentProps> = (
         isDeleteable={true}
         isEditable={false}
         isCreateable={false}
+        selectMoreFields={{
+          configuration: true,
+          isEnabled: true,
+          sortOrder: true,
+        }}
+        actionButtons={[
+          {
+            title: "Edit",
+            buttonStyleType: ButtonStyleType.NORMAL,
+            icon: IconProp.Edit,
+            onClick: (
+              item: LogPipelineProcessor,
+              onCompleteAction: () => void,
+            ) => {
+              setProcessorToEdit(item);
+              setShowProcessorForm(true);
+              onCompleteAction();
+            },
+          },
+        ]}
         sortBy="sortOrder"
         sortOrder={SortOrder.Ascending}
         enableDragAndDrop={true}
@@ -219,6 +242,7 @@ const LogPipelineView: FunctionComponent<PageComponentProps> = (
               title: "Add Processor",
               buttonStyle: ButtonStyleType.NORMAL,
               onClick: () => {
+                setProcessorToEdit(undefined);
                 setShowProcessorForm(true);
               },
               icon: IconProp.Add,
@@ -280,12 +304,15 @@ const LogPipelineView: FunctionComponent<PageComponentProps> = (
       {showProcessorForm && (
         <ProcessorForm
           pipelineId={modelId}
-          onProcessorCreated={() => {
+          initialProcessor={processorToEdit}
+          onProcessorSaved={() => {
             setShowProcessorForm(false);
+            setProcessorToEdit(undefined);
             setRefreshProcessorToggle(Date.now().toString());
           }}
           onCancel={() => {
             setShowProcessorForm(false);
+            setProcessorToEdit(undefined);
           }}
         />
       )}


### PR DESCRIPTION
## What

On the LogPipeline detail page, the Processors table only allowed **delete** — `isEditable` was hardcoded `false`. There was no way to view or change an existing processor's configuration short of deleting and recreating it.

`isEditable` was off for a real reason: a processor's `configuration` is **polymorphic per type** (SeverityRemapper / AttributeRemapper / CategoryProcessor), so the generic `ModelForm` edit can't render it. Creation already uses a custom `ProcessorForm` for that reason.

This adds **view + edit** by reusing that same custom form in edit mode:

**`ProcessorForm`**
- New optional `initialProcessor` prop. When provided, the form opens pre-filled from the processor's saved `configuration` (the inverse of `buildConfiguration`), and on save calls `ModelAPI.updateById` instead of `create`, **preserving `sortOrder`**.
- A small `parseConfiguration` helper accepts the config as either an object or a JSON-string literal (both shapes occur in storage).
- Modal title and submit label switch between "Add Processor" / "Create Processor" and "Edit Processor" / "Save Changes".

**`PipelineView`**
- Fetches `configuration` / `isEnabled` / `sortOrder` via `selectMoreFields` so the row item is complete.
- Adds an **Edit** action button per row that opens the form for that processor; the "Add Processor" button clears any edit state first.

Opening a processor for edit also covers the **"view configuration"** ask from the issue, since the form shows the full current config.

## Why

Resolves the "cannot view or edit processor config" problem in #2516 — users no longer have to delete and recreate a processor to change it.

## Testing

- `npx tsc --noEmit` — clean for both changed files.
- `eslint` + Prettier — clean.

> Note: this is a UI change and I don't currently have the full local stack running, so it has **not yet been verified in a browser**. The logic is type-checked and lint-clean; happy to record a quick screen capture once I have the dashboard up, or if a maintainer can sanity-check the edit flow.

Refs #2516