### PR TITLE
fix: "All Values" over time could fire on a single probe (#2321)

### DIFF
--- a/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
@@ -52,7 +52,7 @@ For **Response Time**:
 - **Less Than or Equal To** — Response time is at or below a threshold
 - **Equal To** — Response time matches exactly
 - **Not Equal To** — Response time does not match
-- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window
+- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 ### Example Criteria
 

--- a/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
@@ -53,7 +53,7 @@ For **Response Time**, **Packet Loss**, and **Jitter**:
 - **Greater Than or Equal To** — Value is at or above a threshold
 - **Less Than or Equal To** — Value is at or below a threshold
 
-**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
+**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 ### Example Criteria
 

--- a/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
@@ -52,7 +52,7 @@ For **Response Time**:
 - **Less Than or Equal To** — Response time is at or below a threshold
 - **Equal To** — Response time matches exactly
 - **Not Equal To** — Response time does not match
-- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window
+- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 ### Example Criteria
 

--- a/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
@@ -53,7 +53,7 @@ For **Response Time**, **Packet Loss**, and **Jitter**:
 - **Greater Than or Equal To** — Value is at or above a threshold
 - **Less Than or Equal To** — Value is at or below a threshold
 
-**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
+**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 ### Example Criteria
 

--- a/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
@@ -67,7 +67,7 @@ For **Response Time**:
 - **Less Than or Equal To** — Response time is at or below a threshold
 - **Equal To** — Response time matches exactly
 - **Not Equal To** — Response time does not match
-- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window
+- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 ### Example Criteria
 

--- a/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
@@ -79,7 +79,7 @@ For **Total Connection Time (DNS + TCP)**, **Port DNS Lookup Time**, and **Port 
 - **Greater Than or Equal To** — Response time is at or above a threshold
 - **Less Than or Equal To** — Response time is at or below a threshold
 
-**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
+**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 DNS lookup criteria have no value to evaluate when the target is already an IP address. Use the total or TCP connection time for criteria that must work with both hostnames and IP addresses.
 

--- a/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
@@ -133,7 +133,7 @@ For numeric metrics (CPU, memory, disk):
 - **Less Than** — Value is below a threshold
 - **Greater Than or Equal To** — Value is at or above a threshold
 - **Less Than or Equal To** — Value is at or below a threshold
-- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window
+- **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 For process checks:
 

--- a/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
@@ -139,7 +139,7 @@ For numeric metrics (CPU, memory, disk, swap, CPU IO wait, load average):
 - **Greater Than or Equal To** — Value is at or above a threshold
 - **Less Than or Equal To** — Value is at or below a threshold
 
-**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check.
+**Evaluate this criteria over a period of time** is a separate checkbox on the criteria form rather than a filter condition. Turn it on to compare an aggregate — chosen under **Evaluate** (Average, Sum, Maximum Value, Minimum Value, All Values, Any Value) over the window set by **For the last (in minutes)** — instead of the value from the latest check. **All Values** and the aggregates (**Average/Sum/Maximum/Minimum**) only evaluate once the window is actually covered by data, so the criterion will not fire on a single result (a brand-new or just-restarted monitor waits until it has collected enough of the window). **Any Value** is the exception — a single matching result is enough. When the window has no data the criterion does not fire by default — configurable via `onNoDataPolicy` (Terraform/API).
 
 For process checks:
 

--- a/Common/Server/Utils/CronTab.ts
+++ b/Common/Server/Utils/CronTab.ts
@@ -15,4 +15,26 @@ export default class CronTab {
       throw new BadDataException(`Invalid cron expression: ${crontab}`);
     }
   }
+
+  /**
+   * Best-effort probe interval (in minutes) for a monitoring cron
+   * expression, computed as the gap between the next two executions.
+   * Returns null for invalid crons or non-positive gaps so callers can
+   * fall back gracefully. For irregular schedules this is the local
+   * interval at the current time, which is a reasonable approximation.
+   */
+  @CaptureSpan()
+  public static getIntervalInMinutes(crontab: string): number | null {
+    try {
+      const interval: CronExpression = CronParser.parseExpression(crontab);
+      const first: Date = interval.next().toDate();
+      const second: Date = interval.next().toDate();
+      const diffInMinutes: number =
+        (second.getTime() - first.getTime()) / (1000 * 60);
+      return diffInMinutes > 0 ? diffInMinutes : null;
+    } catch (error) {
+      logger.error(error);
+      return null;
+    }
+  }
 }

--- a/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
@@ -1,6 +1,6 @@
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import { JSONObject } from "../../../../Types/JSON";
 import {
   CheckOn,
@@ -10,13 +10,14 @@ import {
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import Typeof from "../../../../Types/Typeof";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class APIRequestCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
@@ -30,25 +31,28 @@ export default class APIRequestCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
           miscData: input.criteriaFilter.serverMonitorOptions as JSONObject,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {

--- a/Common/Server/Utils/Monitor/Criteria/DnsMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DnsMonitorCriteria.ts
@@ -7,15 +7,16 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import DnsMonitorResponse from "../../../../Types/Monitor/DnsMonitor/DnsMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class DnsMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -33,24 +34,27 @@ export default class DnsMonitorCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     // Check if DNS is online

--- a/Common/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.ts
@@ -8,14 +8,15 @@ import {
 import DomainMonitorResponse from "../../../../Types/Monitor/DomainMonitor/DomainMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import EvaluateOverTime from "./EvaluateOverTime";
-import logger from "../../Logger";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 
 export default class DomainMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -33,24 +34,27 @@ export default class DomainMonitorCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: dataToProcess.projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     /*

--- a/Common/Server/Utils/Monitor/Criteria/EvaluateOverTime.ts
+++ b/Common/Server/Utils/Monitor/Criteria/EvaluateOverTime.ts
@@ -6,6 +6,7 @@ import {
   CheckOn,
   EvaluateOverTimeOptions,
   EvaluateOverTimeType,
+  NoDataPolicy,
 } from "../../../../Types/Monitor/CriteriaFilter";
 import ObjectID from "../../../../Types/ObjectID";
 import Metric from "../../../../Models/AnalyticsModels/Metric";
@@ -13,16 +14,220 @@ import MonitorMetricTypeUtil from "../../../../Utils/Monitor/MonitorMetricType";
 import MetricService from "../../../Services/MetricService";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import CronTab from "../../CronTab";
+import logger from "../../Logger";
+
+interface OverTimeSample {
+  value: number | boolean;
+  time: Date;
+}
+
+/*
+ * Outcome of resolving an evaluate-over-time filter:
+ * - "compare": there is enough data; `value` should be compared to the threshold.
+ * - "not-met": the filter does not fire. Either the configured NoDataPolicy says
+ *   a data-less window does not fire, or (for windowed types) the window is not
+ *   yet covered by enough observations to assert the condition. `reason` explains
+ *   which, and is surfaced in the evaluation summary.
+ * - "trigger": the configured NoDataPolicy says a data-less window is itself a breach.
+ */
+export type EvaluateOverTimeResult =
+  | {
+      decision: "compare";
+      value: number | boolean | Array<number | boolean>;
+    }
+  | { decision: "not-met"; reason: string }
+  | { decision: "trigger"; reason: string };
 
 export default class EvaluateOverTime {
+  /*
+   * Resolve an evaluate-over-time filter into a decision, honoring the
+   * configured NoDataPolicy. It refuses to report a match for windowed types
+   * ("All Values" and the aggregates average/sum/min/max) unless the window is
+   * actually covered by data — so a single fresh sample cannot satisfy `.every()`
+   * or become an "average/max over N minutes" all by itself (see issue #2321) —
+   * and it never falls back to the instantaneous probe value. "Any Value" is
+   * exempt: one observed breach is a legitimate match regardless of coverage.
+   */
   @CaptureSpan()
-  public static async getValueOverTime(data: {
+  public static async resolveFilterOverTime(data: {
+    projectId: ObjectID;
+    monitorId: ObjectID;
+    evaluateOverTimeOptions: EvaluateOverTimeOptions;
+    metricType: CheckOn;
+    monitoringInterval?: string | undefined;
+    miscData?: JSONObject | undefined;
+  }): Promise<EvaluateOverTimeResult> {
+    let samples: Array<OverTimeSample> = [];
+
+    try {
+      samples = await this.getSamples(data);
+    } catch (err) {
+      logger.error(`Error getting over-time samples for ${data.metricType}`);
+      logger.error(err);
+
+      // Treat an evaluation error as "no data" so we never fire on a failed query.
+      return this.applyNoDataPolicy({
+        evaluateOverTimeOptions: data.evaluateOverTimeOptions,
+        reason: `No usable data for ${data.metricType} in the evaluation window (query failed).`,
+      });
+    }
+
+    const evaluateOverTimeType: EvaluateOverTimeType | undefined =
+      data.evaluateOverTimeOptions.evaluateOverTimeType;
+
+    // No data at all in the window -> honor the configured NoDataPolicy.
+    if (samples.length === 0) {
+      return this.applyNoDataPolicy({
+        evaluateOverTimeOptions: data.evaluateOverTimeOptions,
+        reason: `No data was received for ${data.metricType} in the last ${data.evaluateOverTimeOptions.timeValueInMinutes} minutes.`,
+      });
+    }
+
+    /*
+     * Windowed types ("All Values" and the aggregates) claim something about the
+     * ENTIRE window, which we can only assert when the window is actually covered
+     * by observations. Otherwise a single fresh sample would make `.every()`
+     * trivially true (or an average/max equal to that one spike) and the criteria
+     * would fire on the first failed probe. "Any Value" is exempt — one observed
+     * breach is a legitimate match.
+     *
+     * Unlike genuine no-data, "not enough history yet" is never itself a breach,
+     * so it ALWAYS resolves to not-met regardless of NoDataPolicy: a warming-up
+     * or just-restarted monitor must not trigger an incident just because its
+     * window has not filled yet.
+     */
+    if (
+      evaluateOverTimeType !== EvaluateOverTimeType.AnyValue &&
+      !this.hasSufficientWindowCoverage({
+        sampleTimes: samples.map((sample: OverTimeSample) => {
+          return sample.time;
+        }),
+        timeValueInMinutes: Number(
+          data.evaluateOverTimeOptions.timeValueInMinutes,
+        ),
+        monitoringInterval: data.monitoringInterval,
+      })
+    ) {
+      return {
+        decision: "not-met",
+        reason: `Not enough data yet to evaluate ${data.metricType} across the full ${data.evaluateOverTimeOptions.timeValueInMinutes}-minute window.`,
+      };
+    }
+
+    return {
+      decision: "compare",
+      value: this.computeValue({
+        values: samples.map((sample: OverTimeSample) => {
+          return sample.value;
+        }),
+        evaluateOverTimeType: evaluateOverTimeType,
+      }),
+    };
+  }
+
+  /*
+   * True when the observed samples plausibly cover the whole evaluation window.
+   * When the probe interval is known (from the monitor's cron) we require
+   * roughly the expected number of samples; otherwise we fall back to requiring
+   * at least two observations whose oldest reaches back to (almost) the start of
+   * the window. Either way a single sample can never cover a multi-sample window.
+   *
+   * Public so it can be unit-tested directly without a database.
+   */
+  public static hasSufficientWindowCoverage(data: {
+    sampleTimes: Array<Date>;
+    timeValueInMinutes: number;
+    monitoringInterval?: string | undefined;
+  }): boolean {
+    if (data.sampleTimes.length === 0) {
+      return false;
+    }
+
+    if (!data.timeValueInMinutes || data.timeValueInMinutes <= 0) {
+      // No meaningful window configured — any data counts.
+      return true;
+    }
+
+    // Preferred: derive the expected sample count from the probe interval.
+    if (data.monitoringInterval) {
+      const intervalInMinutes: number | null = CronTab.getIntervalInMinutes(
+        data.monitoringInterval,
+      );
+
+      if (intervalInMinutes && intervalInMinutes > 0) {
+        const expectedSamples: number = Math.floor(
+          data.timeValueInMinutes / intervalInMinutes,
+        );
+        /*
+         * When two or more samples fit in the window we must observe at least
+         * two — a single sample can never represent a sliding window (#2321).
+         * For larger windows we still tolerate one missing sample for scheduling
+         * jitter. When the interval is as coarse as the window (expected <= 1),
+         * a single sample legitimately IS the whole window.
+         */
+        const requiredSamples: number =
+          expectedSamples <= 1 ? 1 : Math.max(2, expectedSamples - 1);
+        return data.sampleTimes.length >= requiredSamples;
+      }
+    }
+
+    /*
+     * Fallback (unknown/irregular interval): require at least two samples AND the
+     * oldest one to reach back to (almost) the window start, so neither a single
+     * recent sample nor a single stale sample counts as full coverage.
+     */
+    if (data.sampleTimes.length < 2) {
+      return false;
+    }
+
+    const earliestSampleTime: Date | undefined = data.sampleTimes.reduce(
+      (earliest: Date | undefined, current: Date) => {
+        return !earliest || OneUptimeDate.isBefore(current, earliest)
+          ? current
+          : earliest;
+      },
+      undefined as Date | undefined,
+    );
+
+    if (!earliestSampleTime) {
+      return false;
+    }
+
+    const requiredOldestSampleTime: Date = OneUptimeDate.getSomeMinutesAgo(
+      Math.max(0, data.timeValueInMinutes - 1),
+    );
+
+    return !OneUptimeDate.isAfter(earliestSampleTime, requiredOldestSampleTime);
+  }
+
+  private static applyNoDataPolicy(data: {
+    evaluateOverTimeOptions: EvaluateOverTimeOptions;
+    reason: string;
+  }): EvaluateOverTimeResult {
+    const policy: NoDataPolicy =
+      data.evaluateOverTimeOptions.onNoDataPolicy || NoDataPolicy.Ignore;
+
+    if (policy === NoDataPolicy.Trigger) {
+      return { decision: "trigger", reason: data.reason };
+    }
+
+    /*
+     * Ignore (default) and TreatAsZero both resolve to "do not fire" here.
+     * TreatAsZero is a counter-oriented policy with no meaningful
+     * interpretation for boolean/status over-time checks, so we treat it as
+     * Ignore rather than inventing a value.
+     */
+    return { decision: "not-met", reason: data.reason };
+  }
+
+  private static async getSamples(data: {
     projectId: ObjectID;
     monitorId: ObjectID;
     evaluateOverTimeOptions: EvaluateOverTimeOptions;
     metricType: CheckOn;
     miscData?: JSONObject | undefined;
-  }): Promise<number | boolean | Array<number | boolean>> {
+  }): Promise<Array<OverTimeSample>> {
     // get values over time
 
     const lastMinutesDate: Date = OneUptimeDate.getSomeMinutesAgo(
@@ -53,37 +258,44 @@ export default class EvaluateOverTime {
       },
       select: {
         value: true,
+        time: true,
       },
     });
 
-    const values: Array<number | boolean> = monitorMetricsItems
-      .map((item: Metric) => {
-        if (
-          data.metricType === CheckOn.IsOnline ||
-          data.metricType === CheckOn.IsRequestTimeout
-        ) {
-          return item.value === 1;
-        }
+    const samples: Array<OverTimeSample> = [];
 
-        return item.value;
-      })
-      .filter((value: number | boolean | undefined) => {
-        return value !== undefined;
-      }) as Array<number | boolean>;
+    for (const item of monitorMetricsItems) {
+      if (item.value === undefined) {
+        continue;
+      }
 
+      const value: number | boolean =
+        data.metricType === CheckOn.IsOnline ||
+        data.metricType === CheckOn.IsRequestTimeout
+          ? item.value === 1
+          : item.value;
+
+      samples.push({ value: value, time: item.time || now });
+    }
+
+    return samples;
+  }
+
+  private static computeValue(data: {
+    values: Array<number | boolean>;
+    evaluateOverTimeType: EvaluateOverTimeType | undefined;
+  }): number | boolean | Array<number | boolean> {
     if (
-      data.evaluateOverTimeOptions.evaluateOverTimeType ===
-        EvaluateOverTimeType.AnyValue ||
-      data.evaluateOverTimeOptions.evaluateOverTimeType ===
-        EvaluateOverTimeType.AllValues
+      data.evaluateOverTimeType === EvaluateOverTimeType.AnyValue ||
+      data.evaluateOverTimeType === EvaluateOverTimeType.AllValues
     ) {
-      // if its any or all then return the values. Otherwise compute the value based on the type
-      return values;
+      // For any/all, hand back the raw values; the comparator applies some/every.
+      return data.values;
     }
 
     return this.getValueByEvaluationType({
-      values: values as Array<number>,
-      evaluateOverTimeType: data.evaluateOverTimeOptions.evaluateOverTimeType!,
+      values: data.values as Array<number>,
+      evaluateOverTimeType: data.evaluateOverTimeType!,
     });
   }
 

--- a/Common/Server/Utils/Monitor/Criteria/ExternalStatusPageMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ExternalStatusPageMonitorCriteria.ts
@@ -6,15 +6,16 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import ExternalStatusPageMonitorResponse from "../../../../Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class ExternalStatusPageMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -33,24 +34,27 @@ export default class ExternalStatusPageMonitorCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     // Check if external status page is online

--- a/Common/Server/Utils/Monitor/Criteria/IncomingRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/IncomingRequestCriteria.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import IncomingMonitorRequest from "../../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import Typeof from "../../../../Types/Typeof";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import CompareCriteria from "./CompareCriteria";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
@@ -19,6 +19,8 @@ export default class IncomingRequestCriteria {
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
@@ -44,24 +46,27 @@ export default class IncomingRequestCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as IncomingMonitorRequest).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {

--- a/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
@@ -8,15 +8,16 @@ import {
 } from "../../../../Types/Monitor/CriteriaFilter";
 import SslMonitorResponse from "../../../../Types/Monitor/SSLMonitor/SslMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
-import logger from "../../Logger";
 
 export default class ServerMonitorCriteria {
   @CaptureSpan()
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -34,24 +35,27 @@ export default class ServerMonitorCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {

--- a/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/ServerMonitorCriteria.ts
@@ -1,6 +1,6 @@
 import DataToProcess from "../DataToProcess";
 import CompareCriteria from "./CompareCriteria";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import OneUptimeDate from "../../../../Types/Date";
 import { BasicDiskMetrics } from "../../../../Types/Infrastructure/BasicMetrics";
 import { JSONObject } from "../../../../Types/JSON";
@@ -20,6 +20,8 @@ export default class ServerMonitorCriteria {
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     // Server Monitoring Checks
 
@@ -32,25 +34,28 @@ export default class ServerMonitorCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as ServerMonitorResponse).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
           miscData: input.criteriaFilter.serverMonitorOptions as JSONObject,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     const lastCheckTime: Date = (input.dataToProcess as ServerMonitorResponse)

--- a/Common/Server/Utils/Monitor/Criteria/SnmpMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SnmpMonitorCriteria.ts
@@ -16,7 +16,7 @@ import SnmpMonitorResponse, {
 } from "../../../../Types/Monitor/SnmpMonitor/SnmpMonitorResponse";
 import SnmpTrap from "../../../../Types/Monitor/SnmpMonitor/SnmpTrap";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
-import EvaluateOverTime from "./EvaluateOverTime";
+import EvaluateOverTime, { EvaluateOverTimeResult } from "./EvaluateOverTime";
 import MetricBaselineService, {
   BaselineSummary,
   MetricBaselineService as MetricBaselineServiceClass,
@@ -173,6 +173,8 @@ export default class SnmpMonitorCriteria {
   public static async isMonitorInstanceCriteriaFilterMet(input: {
     dataToProcess: DataToProcess;
     criteriaFilter: CriteriaFilter;
+    monitoringInterval?: string | undefined;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     let threshold: number | string | undefined | null =
       input.criteriaFilter.value;
@@ -247,24 +249,27 @@ export default class SnmpMonitorCriteria {
       input.criteriaFilter.evaluateOverTime &&
       input.criteriaFilter.evaluateOverTimeOptions
     ) {
-      try {
-        overTimeValue = await EvaluateOverTime.getValueOverTime({
+      const overTimeDecision: EvaluateOverTimeResult =
+        await EvaluateOverTime.resolveFilterOverTime({
           projectId: (input.dataToProcess as ProbeMonitorResponse).projectId,
           monitorId: input.dataToProcess.monitorId!,
           evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
           metricType: input.criteriaFilter.checkOn,
+          monitoringInterval: input.monitoringInterval,
         });
 
-        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
-          overTimeValue = undefined;
+      if (overTimeDecision.decision === "not-met") {
+        if (input.overTimeContext) {
+          input.overTimeContext.notMetReason = overTimeDecision.reason;
         }
-      } catch (err) {
-        logger.error(
-          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
-        );
-        logger.error(err);
-        overTimeValue = undefined;
+        return null;
       }
+
+      if (overTimeDecision.decision === "trigger") {
+        return overTimeDecision.reason;
+      }
+
+      overTimeValue = overTimeDecision.value;
     }
 
     // Check if SNMP device is online

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -440,6 +440,8 @@ ${contextBlock}
     let allFiltersMet: boolean = true;
 
     for (const criteriaFilter of input.criteriaInstance.data?.filters || []) {
+      const overTimeContext: { notMetReason?: string } = {};
+
       const rootCause: string | null =
         await MonitorCriteriaEvaluator.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
@@ -448,19 +450,28 @@ ${contextBlock}
           probeApiIngestResponse: input.probeApiIngestResponse,
           criteriaInstance: input.criteriaInstance,
           criteriaFilter: criteriaFilter,
+          overTimeContext: overTimeContext,
         });
 
       const didMeetCriteria: boolean = Boolean(rootCause);
 
+      /*
+       * When an evaluate-over-time filter does not fire because its window is
+       * not yet covered (or has no data), surface that reason in the summary
+       * instead of the generic "expected ..." message, so the timeline explains
+       * why nothing happened (#2321).
+       */
       const filterMessage: string =
-        MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
-          monitor: input.monitor,
-          criteriaFilter: criteriaFilter,
-          dataToProcess: input.dataToProcess,
-          monitorStep: input.monitorStep,
-          didMeetCriteria: didMeetCriteria,
-          matchMessage: rootCause,
-        });
+        !didMeetCriteria && overTimeContext.notMetReason
+          ? overTimeContext.notMetReason
+          : MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
+              monitor: input.monitor,
+              criteriaFilter: criteriaFilter,
+              dataToProcess: input.dataToProcess,
+              monitorStep: input.monitorStep,
+              didMeetCriteria: didMeetCriteria,
+              matchMessage: rootCause,
+            });
 
       const filterSummary: MonitorEvaluationFilterResult = {
         checkOn: criteriaFilter.checkOn,
@@ -534,6 +545,7 @@ ${contextBlock}
     probeApiIngestResponse: ProbeApiIngestResponse;
     criteriaInstance: MonitorCriteriaInstance;
     criteriaFilter: CriteriaFilter;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     if (input.criteriaFilter.checkOn === CheckOn.JavaScriptExpression) {
       let storageMap: JSONObject = {};
@@ -637,6 +649,8 @@ ${contextBlock}
         await APIRequestCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (apiRequestCriteriaResult) {
@@ -682,6 +696,8 @@ ${contextBlock}
         await IncomingRequestCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (incomingRequestResult) {
@@ -706,6 +722,8 @@ ${contextBlock}
         await SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (sslMonitorResult) {
@@ -718,6 +736,8 @@ ${contextBlock}
         await ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (serverMonitorResult) {
@@ -801,6 +821,8 @@ ${contextBlock}
         await SnmpMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (snmpMonitorResult) {
@@ -813,6 +835,8 @@ ${contextBlock}
         await DnsMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (dnsMonitorResult) {
@@ -862,6 +886,8 @@ ${contextBlock}
           {
             dataToProcess: input.dataToProcess,
             criteriaFilter: input.criteriaFilter,
+            monitoringInterval: input.monitor.monitoringInterval,
+            overTimeContext: input.overTimeContext,
           },
         );
 

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -457,6 +457,8 @@ ${contextBlock}
     let allFiltersMet: boolean = true;
 
     for (const criteriaFilter of input.criteriaInstance.data?.filters || []) {
+      const overTimeContext: { notMetReason?: string } = {};
+
       const rootCause: string | null =
         await MonitorCriteriaEvaluator.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
@@ -465,19 +467,28 @@ ${contextBlock}
           probeApiIngestResponse: input.probeApiIngestResponse,
           criteriaInstance: input.criteriaInstance,
           criteriaFilter: criteriaFilter,
+          overTimeContext: overTimeContext,
         });
 
       const didMeetCriteria: boolean = Boolean(rootCause);
 
+      /*
+       * When an evaluate-over-time filter does not fire because its window is
+       * not yet covered (or has no data), surface that reason in the summary
+       * instead of the generic "expected ..." message, so the timeline explains
+       * why nothing happened (#2321).
+       */
       const filterMessage: string =
-        MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
-          monitor: input.monitor,
-          criteriaFilter: criteriaFilter,
-          dataToProcess: input.dataToProcess,
-          monitorStep: input.monitorStep,
-          didMeetCriteria: didMeetCriteria,
-          matchMessage: rootCause,
-        });
+        !didMeetCriteria && overTimeContext.notMetReason
+          ? overTimeContext.notMetReason
+          : MonitorCriteriaMessageBuilder.buildCriteriaFilterMessage({
+              monitor: input.monitor,
+              criteriaFilter: criteriaFilter,
+              dataToProcess: input.dataToProcess,
+              monitorStep: input.monitorStep,
+              didMeetCriteria: didMeetCriteria,
+              matchMessage: rootCause,
+            });
 
       const filterSummary: MonitorEvaluationFilterResult = {
         checkOn: criteriaFilter.checkOn,
@@ -551,6 +562,7 @@ ${contextBlock}
     probeApiIngestResponse: ProbeApiIngestResponse;
     criteriaInstance: MonitorCriteriaInstance;
     criteriaFilter: CriteriaFilter;
+    overTimeContext?: { notMetReason?: string } | undefined;
   }): Promise<string | null> {
     if (input.criteriaFilter.checkOn === CheckOn.JavaScriptExpression) {
       let storageMap: JSONObject = {};
@@ -666,6 +678,8 @@ ${contextBlock}
         await APIRequestCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (apiRequestCriteriaResult) {
@@ -711,6 +725,8 @@ ${contextBlock}
         await IncomingRequestCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (incomingRequestResult) {
@@ -735,6 +751,8 @@ ${contextBlock}
         await SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (sslMonitorResult) {
@@ -747,6 +765,8 @@ ${contextBlock}
         await ServerMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (serverMonitorResult) {
@@ -830,6 +850,8 @@ ${contextBlock}
         await SnmpMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (snmpMonitorResult) {
@@ -842,6 +864,8 @@ ${contextBlock}
         await DnsMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (dnsMonitorResult) {
@@ -854,6 +878,8 @@ ${contextBlock}
         await DomainMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
           dataToProcess: input.dataToProcess,
           criteriaFilter: input.criteriaFilter,
+          monitoringInterval: input.monitor.monitoringInterval,
+          overTimeContext: input.overTimeContext,
         });
 
       if (domainMonitorResult) {
@@ -891,6 +917,8 @@ ${contextBlock}
           {
             dataToProcess: input.dataToProcess,
             criteriaFilter: input.criteriaFilter,
+            monitoringInterval: input.monitor.monitoringInterval,
+            overTimeContext: input.overTimeContext,
           },
         );
 

--- a/Common/Tests/Server/Utils/CronTab.test.ts
+++ b/Common/Tests/Server/Utils/CronTab.test.ts
@@ -41,4 +41,20 @@ describe("CronTab", () => {
       CronTab.getNextExecutionTime(crontab);
     }).toThrowError(`Invalid cron expression: ${crontab}`);
   });
+
+  it("should return the interval in minutes for an every-minute cron", () => {
+    expect(CronTab.getIntervalInMinutes("* * * * *")).toBe(1);
+  });
+
+  it("should return the interval in minutes for an every-5-minutes cron", () => {
+    expect(CronTab.getIntervalInMinutes("*/5 * * * *")).toBe(5);
+  });
+
+  it("should return the interval in minutes for an every-15-minutes cron", () => {
+    expect(CronTab.getIntervalInMinutes("*/15 * * * *")).toBe(15);
+  });
+
+  it("should return null for an invalid cron expression interval", () => {
+    expect(CronTab.getIntervalInMinutes("not-a-cron")).toBeNull();
+  });
 });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/EvaluateOverTime.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/EvaluateOverTime.test.ts
@@ -1,0 +1,303 @@
+import EvaluateOverTime, {
+  EvaluateOverTimeResult,
+} from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
+import MetricService from "../../../../../Server/Services/MetricService";
+import ObjectID from "../../../../../Types/ObjectID";
+import {
+  CheckOn,
+  EvaluateOverTimeType,
+  NoDataPolicy,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+
+const minutesAgo: (minutes: number) => Date = (minutes: number): Date => {
+  return new Date(Date.now() - minutes * 60 * 1000);
+};
+
+describe("EvaluateOverTime.hasSufficientWindowCoverage", () => {
+  test("an empty sample set is never sufficient", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [],
+        timeValueInMinutes: 5,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(false);
+  });
+
+  test("with a 1-minute interval, a single sample does NOT cover a 5-minute window (issue #2321)", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0)],
+        timeValueInMinutes: 5,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(false);
+  });
+
+  test("with a 1-minute interval, a single sample does NOT cover a 2-minute window (the INC-12 case)", () => {
+    // window fits 2 samples -> we must observe 2; one spike can never be "all values over 2 minutes"
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0)],
+        timeValueInMinutes: 2,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(false);
+  });
+
+  test("with a 1-minute interval, two samples DO cover a 2-minute window", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0), minutesAgo(1)],
+        timeValueInMinutes: 2,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(true);
+  });
+
+  test("with a 1-minute interval, a 3-minute window still needs at least two samples", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0)],
+        timeValueInMinutes: 3,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(false);
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0), minutesAgo(1)],
+        timeValueInMinutes: 3,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(true);
+  });
+
+  test("with a 1-minute interval, a full window of samples is sufficient", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [
+          minutesAgo(0),
+          minutesAgo(1),
+          minutesAgo(2),
+          minutesAgo(3),
+          minutesAgo(4),
+        ],
+        timeValueInMinutes: 5,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(true);
+  });
+
+  test("allows one missing sample for scheduling jitter (4 of an expected 5)", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [
+          minutesAgo(0),
+          minutesAgo(1),
+          minutesAgo(2),
+          minutesAgo(3),
+        ],
+        timeValueInMinutes: 5,
+        monitoringInterval: "* * * * *",
+      }),
+    ).toBe(true);
+  });
+
+  test("with a coarse interval (>= window), a single sample IS full coverage", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0)],
+        timeValueInMinutes: 5,
+        monitoringInterval: "*/10 * * * *",
+      }),
+    ).toBe(true);
+  });
+
+  test("without a known interval, only-recent samples do not cover the window", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0), minutesAgo(1)],
+        timeValueInMinutes: 5,
+      }),
+    ).toBe(false);
+  });
+
+  test("without a known interval, a single stale sample is NOT enough (need at least two)", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(5)],
+        timeValueInMinutes: 5,
+      }),
+    ).toBe(false);
+  });
+
+  test("without a known interval, two samples reaching back to the window start cover it", () => {
+    expect(
+      EvaluateOverTime.hasSufficientWindowCoverage({
+        sampleTimes: [minutesAgo(0), minutesAgo(5)],
+        timeValueInMinutes: 5,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("EvaluateOverTime.resolveFilterOverTime", () => {
+  const projectId: ObjectID = new ObjectID(
+    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  );
+  const monitorId: ObjectID = new ObjectID(
+    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  );
+
+  const mockSamples: (values: Array<number>) => void = (
+    values: Array<number>,
+  ): void => {
+    jest.spyOn(MetricService, "findBy").mockResolvedValue(
+      values.map((value: number, index: number) => {
+        return { value: value, time: minutesAgo(index) };
+      }) as never,
+    );
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("All Values fires not-met (with a reason) on a single sample in a 2-minute window", async () => {
+    mockSamples([9171]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("not-met");
+    expect(
+      (result as { decision: "not-met"; reason: string }).reason,
+    ).toContain("Not enough data");
+  });
+
+  test("aggregates (Average) are also gated: a single sample is not-met", async () => {
+    mockSamples([9171]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.Average,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("not-met");
+  });
+
+  test("Any Value is exempt from the coverage gate: a single sample is compared", async () => {
+    mockSamples([9171]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.AnyValue,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("compare");
+  });
+
+  test("All Values compares once the window is covered by two samples", async () => {
+    mockSamples([9171, 9200]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("compare");
+    expect(
+      (result as { decision: "compare"; value: Array<number> }).value,
+    ).toEqual([9171, 9200]);
+  });
+
+  test("no data honors the NoDataPolicy: default Ignore -> not-met", async () => {
+    mockSamples([]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("not-met");
+    expect(
+      (result as { decision: "not-met"; reason: string }).reason,
+    ).toContain("No data");
+  });
+
+  test("no data with NoDataPolicy Trigger -> trigger", async () => {
+    mockSamples([]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          onNoDataPolicy: NoDataPolicy.Trigger,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("trigger");
+  });
+
+  test("insufficient coverage never triggers, even with NoDataPolicy Trigger (only true no-data does)", async () => {
+    // One sample in a 2-minute window is under-covered, NOT no-data: must stay not-met.
+    mockSamples([9171]);
+
+    const result: EvaluateOverTimeResult =
+      await EvaluateOverTime.resolveFilterOverTime({
+        projectId: projectId,
+        monitorId: monitorId,
+        evaluateOverTimeOptions: {
+          timeValueInMinutes: 2,
+          evaluateOverTimeType: EvaluateOverTimeType.AllValues,
+          onNoDataPolicy: NoDataPolicy.Trigger,
+        },
+        metricType: CheckOn.ResponseTime,
+        monitoringInterval: "* * * * *",
+      });
+
+    expect(result.decision).toBe("not-met");
+  });
+});

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -222,6 +222,13 @@ export enum EvaluateOverTimeMinutes {
 export interface EvaluateOverTimeOptions {
   timeValueInMinutes: number | undefined;
   evaluateOverTimeType: EvaluateOverTimeType | undefined;
+  /*
+   * Governs how the evaluator handles an evaluation window that has no data
+   * - or, for "All Values", not enough history to span the configured window.
+   * Defaults to Ignore (do not fire) when unset. Mirrors the metric monitor's
+   * MetricMonitorOptions.onNoDataPolicy.
+   */
+  onNoDataPolicy?: NoDataPolicy | undefined;
 }
 
 export interface CriteriaFilter {
@@ -445,5 +452,6 @@ export const CriteriaFilterSchema: ZodSchema = Zod.object({
   evaluateOverTimeOptions: Zod.object({
     timeValueInMinutes: Zod.number().optional(),
     evaluateOverTimeType: Zod.string().optional(),
+    onNoDataPolicy: Zod.string().optional(),
   }).optional(),
 });

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -224,6 +224,13 @@ export enum EvaluateOverTimeMinutes {
 export interface EvaluateOverTimeOptions {
   timeValueInMinutes: number | undefined;
   evaluateOverTimeType: EvaluateOverTimeType | undefined;
+  /*
+   * Governs how the evaluator handles an evaluation window that has no data
+   * - or, for "All Values", not enough history to span the configured window.
+   * Defaults to Ignore (do not fire) when unset. Mirrors the metric monitor's
+   * MetricMonitorOptions.onNoDataPolicy.
+   */
+  onNoDataPolicy?: NoDataPolicy | undefined;
 }
 
 export interface CriteriaFilter {
@@ -449,5 +456,6 @@ export const CriteriaFilterSchema: ZodSchema = Zod.object({
   evaluateOverTimeOptions: Zod.object({
     timeValueInMinutes: Zod.number().optional(),
     evaluateOverTimeType: Zod.string().optional(),
+    onNoDataPolicy: Zod.string().optional(),
   }).optional(),
 });


### PR DESCRIPTION
### Fix: "All Values" / over-time criteria could fire on a single probe (#2321)


### Small Description
Evaluate-over-time criteria could fire on a single probe: `every()` on a one-element array is trivially true, the aggregates (Average/Sum/Maximum/Minimum) equalled that one sample, and an empty window fell back to the current probe value — so one failing/slow probe opened an incident instead of waiting the configured minutes. This PR gates windowed types (All Values + aggregates) on real window coverage (≥ 2 samples for any window wider than one interval), never falls back to the instantaneous value, keeps "insufficient history" as not-met regardless of `onNoDataPolicy`, and surfaces the reason in the evaluation summary. "Any Value" stays exempt. Scope: evaluate-over-time logic only.

### Pull Request Checklist:
- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

> **CI note:** every job is green **except `js-lint`**, which fails on a pre-existing, master-side tooling error — the `docs:check-anchors` step (`Scripts/Docs/CheckAnchors.ts`) crashes on `Cannot find module 'Common/Server/Types/Markdown'` before it checks anything. It is unrelated to this PR (other open PRs, e.g. #2508, fail the same job identically). This PR's own ESLint is clean (`npm run fix` produces no changes) and `compile-common` + `test` are green.

### Related Issue
closes #2321

### Screenshots (if appropriate):
N/A — backend criteria-evaluation logic + unit tests.

---

<details>
<summary>Details — Problem / Fix / Behavior change / Scope / Testing</summary>

## Problem

Evaluate-over-time criteria could fire on a single probe. With "All Values", `every()` on a one-element array is trivially true; the aggregates (Average/Sum/Maximum/Minimum) over a one-sample window equalled that single sample; and an empty window fell back to the current probe value. So one failing/slow probe could open an incident (or flip monitor status) instead of waiting the configured minutes. Reported in #2321 — still reproducible on 11.5.x with a 2-minute window at a 1-minute interval (≈2 expected samples, so a lone spike must not match).

## Fix (evaluate-over-time logic only)

- **Window coverage is required before a windowed type can match.** `EvaluateOverTime.resolveFilterOverTime` returns a decision (`compare` / `not-met` / `trigger`) and only compares once the window is actually covered. Coverage needs at least two samples for any window wider than one interval: `required = expected <= 1 ? 1 : Math.max(2, expected - 1)` (expected = ⌊window / probe-interval⌋ from the monitor cron). The unknown/irregular-interval fallback likewise needs ≥ 2 samples reaching back to the window start. A single sample can never satisfy a multi-sample window.
- **The gate covers "All Values" AND the aggregates** (Average/Sum/Maximum/Minimum) — a one-sample average/max "over N minutes" is the same bug. **"Any Value" stays exempt** (one observed breach is a legitimate match).
- **"Not enough history yet" is never a breach** — it always resolves to `not-met` regardless of policy, so a warming-up or just-restarted monitor never triggers an incident. `onNoDataPolicy` (new; reuses `NoDataPolicy`, default `Ignore`) governs only genuine no-data (empty window / failed query) for heartbeat-style "absence of data is the problem" cases.
- **Never fall back to the instantaneous probe value.**
- **The evaluation summary now explains a not-met over-time filter** ("Not enough data yet to evaluate … across the full N-minute window") instead of a generic message.
- Removed the now-unused `getValueOverTime`.

## Behavior change

Criteria that previously fired on a single sample (or on an empty window via the instantaneous fallback) now wait for the window to be covered — the intended fix. With the default `onNoDataPolicy: Ignore`, no-data no longer fires unless you opt into `Trigger`.

## Scope

Evaluate-over-time logic only; `checkProbeAgreement` is intentionally unchanged. The reported "two evaluations disagree" symptom is resolved as a consequence: a single-sample match is now impossible in **both** the summary pass and the `checkProbeAgreement` re-evaluation, so it can no longer surface as an incident.

## Testing

- `hasSufficientWindowCoverage`: empty set; 2-min/1-min (1 insufficient, 2 sufficient); 3-min; full window; one-missing jitter; coarse interval; unknown-interval fallback (single stale insufficient, two spanning sufficient).
- `resolveFilterOverTime` (mocked `MetricService`): All Values not-met + reason on one sample; aggregates gated; Any Value exempt; compare once covered; no-data honors `onNoDataPolicy`; insufficient coverage never triggers even with `Trigger`.
- Cron interval helper tests; `tsc --noEmit` clean; full Monitor + CronTab suites green (100 tests).

</details>