### PR TITLE
test(Common): add tests for Types/BaseDatabase/AggregationIntervalUtil

### DIFF
--- a/Common/Tests/Types/BaseDatabase/AggregationIntervalUtil.test.ts
+++ b/Common/Tests/Types/BaseDatabase/AggregationIntervalUtil.test.ts
@@ -1,0 +1,127 @@
+import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
+import AggregationIntervalUtil from "../../../Types/BaseDatabase/AggregationIntervalUtil";
+
+describe("AggregationIntervalUtil", () => {
+  const SECOND: number = 1000;
+  const HOUR: number = SECOND * 60 * 60;
+  const DAY: number = HOUR * 24;
+
+  const windowOf: (durationMs: number) => { startDate: Date; endDate: Date } = (
+    durationMs: number,
+  ): { startDate: Date; endDate: Date } => {
+    const startDate: Date = new Date(Date.UTC(2020, 0, 1, 0, 0, 0));
+    const endDate: Date = new Date(startDate.getTime() + durationMs);
+    return { startDate, endDate };
+  };
+
+  describe("getAggregationIntervalForWindow", () => {
+    const cases: Array<[string, number, AggregationInterval]> = [
+      ["2 hours -> Minute", 2 * HOUR, AggregationInterval.Minute],
+      [
+        "exactly 3 hours -> Minute (inclusive bound)",
+        3 * HOUR,
+        AggregationInterval.Minute,
+      ],
+      ["3 hours + 1ms -> Hour", 3 * HOUR + 1, AggregationInterval.Hour],
+      ["1 day -> Hour", DAY, AggregationInterval.Hour],
+      [
+        "exactly 7 days -> Hour (inclusive bound)",
+        7 * DAY,
+        AggregationInterval.Hour,
+      ],
+      ["7 days + 1ms -> Day", 7 * DAY + 1, AggregationInterval.Day],
+      ["14 days -> Day", 14 * DAY, AggregationInterval.Day],
+      [
+        "exactly 6 weeks -> Day (inclusive bound)",
+        42 * DAY,
+        AggregationInterval.Day,
+      ],
+      ["6 weeks + 1ms -> Week", 42 * DAY + 1, AggregationInterval.Week],
+      ["60 days -> Week", 60 * DAY, AggregationInterval.Week],
+      ["200 days -> Month", 200 * DAY, AggregationInterval.Month],
+      ["8 years -> Year", 8 * 365 * DAY, AggregationInterval.Year],
+    ];
+
+    test.each(cases)(
+      "%s",
+      (_label: string, durationMs: number, expected: AggregationInterval) => {
+        expect(
+          AggregationIntervalUtil.getAggregationIntervalForWindow(
+            windowOf(durationMs),
+          ),
+        ).toBe(expected);
+      },
+    );
+
+    test("returns the widest interval as the window grows", () => {
+      const order: Array<AggregationInterval> = [
+        AggregationInterval.Minute,
+        AggregationInterval.Hour,
+        AggregationInterval.Day,
+        AggregationInterval.Week,
+        AggregationInterval.Month,
+        AggregationInterval.Year,
+      ];
+      const durations: Array<number> = [
+        HOUR,
+        2 * DAY,
+        30 * DAY,
+        90 * DAY,
+        365 * DAY,
+        10 * 365 * DAY,
+      ];
+
+      const results: Array<AggregationInterval> = durations.map(
+        (d: number): AggregationInterval => {
+          return AggregationIntervalUtil.getAggregationIntervalForWindow(
+            windowOf(d),
+          );
+        },
+      );
+
+      // Each larger window is at least as wide an interval as the previous.
+      for (let i: number = 1; i < results.length; i++) {
+        expect(order.indexOf(results[i]!)).toBeGreaterThanOrEqual(
+          order.indexOf(results[i - 1]!),
+        );
+      }
+    });
+  });
+
+  describe("getAggregationIntervalMs", () => {
+    test.each([
+      [AggregationInterval.Minute, 1000 * 60],
+      [AggregationInterval.Hour, 1000 * 60 * 60],
+      [AggregationInterval.Day, 1000 * 60 * 60 * 24],
+      [AggregationInterval.Week, 1000 * 60 * 60 * 24 * 7],
+      [AggregationInterval.Month, 1000 * 60 * 60 * 24 * 30],
+      [AggregationInterval.Year, 1000 * 60 * 60 * 24 * 365],
+    ])(
+      "maps %s to its nominal width",
+      (interval: AggregationInterval, expectedMs: number) => {
+        expect(AggregationIntervalUtil.getAggregationIntervalMs(interval)).toBe(
+          expectedMs,
+        );
+      },
+    );
+
+    test("intervals are strictly increasing in width", () => {
+      const ordered: Array<AggregationInterval> = [
+        AggregationInterval.Minute,
+        AggregationInterval.Hour,
+        AggregationInterval.Day,
+        AggregationInterval.Week,
+        AggregationInterval.Month,
+        AggregationInterval.Year,
+      ];
+
+      for (let i: number = 1; i < ordered.length; i++) {
+        expect(
+          AggregationIntervalUtil.getAggregationIntervalMs(ordered[i]!),
+        ).toBeGreaterThan(
+          AggregationIntervalUtil.getAggregationIntervalMs(ordered[i - 1]!),
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for `AggregationIntervalUtil` in `Common/Types/BaseDatabase/AggregationIntervalUtil.ts`, which previously had no test coverage. This util is the single source of truth for which time-bucket size the analytics aggregate API uses for a given query window (shared by the server statement generator and browser chart code).

Covered:

- **`getAggregationIntervalForWindow`** — the full threshold ladder with **inclusive-boundary** checks: ≤3h → Minute, ≤7d → Hour, ≤6w → Day, ≤6mo → Week, ≤6y → Month, else Year. Includes the exact-boundary cases (3h, 7d, 6w) and just-over-boundary cases, plus a monotonicity check that the interval only widens as the window grows.
- **`getAggregationIntervalMs`** — each interval maps to its nominal millisecond width, and the widths are strictly increasing.

## Why

Improves test coverage for the `Common/Types` utilities (part of the broader test-coverage effort). The boundary tests pin down the exact `<=` cut-offs so a future refactor can't silently shift a bucket size.

## Testing

```
node node_modules/.bin/jest --runInBand ./Tests/Types/BaseDatabase/AggregationIntervalUtil.test.ts
```

All 20 tests pass. The file is Prettier-clean.