### PR TITLE
fix(ai-chat): close the trust-gate cluster (exfil, authz, billing, redaction)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIChat/SafeChatMarkdown.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/SafeChatMarkdown.tsx
@@ -6,45 +6,20 @@ export interface ComponentProps {
 }
 
 /*
- * Renders assistant markdown with the exfiltration channels removed: every
- * form of link/image markdown is stripped down to its text, and bare URLs
- * are wrapped in code spans so remark-gfm's autolink-literal extension does
- * not turn them into clickable anchors. Telemetry content is
- * attacker-influenceable, so a prompt-injected answer must not be able to
- * render a tracking pixel or a clickable exfil URL. Navigation happens only
- * through server-minted citation chips.
+ * Renders assistant markdown with the exfiltration channels removed. The
+ * assistant's answer is derived from attacker-influenceable telemetry, so a
+ * prompt-injected response must not be able to render a tracking pixel or a
+ * clickable exfil URL. Neutralization happens inside MarkdownViewer on the
+ * PARSED markdown tree (safeMode): links become plain text and images are
+ * never fetched. Doing it there — rather than regex-stripping the raw string
+ * here — is what makes it robust: no CommonMark syntax edge case can slip a
+ * link or image past the parser. Navigation happens only through the
+ * server-minted citation chips rendered alongside the message.
  */
 const SafeChatMarkdown: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  let text: string = props.text;
-
-  // Reference definitions: [ref]: https://url "title" -> removed entirely.
-  text = text.replace(/^[ \t]{0,3}\[[^\]]+\]:[ \t]+\S+.*$/gm, "");
-
-  // Images, inline or reference-style: ![alt](url) / ![alt][ref] -> alt
-  text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
-  text = text.replace(/!\[([^\]]*)\]\[[^\]]*\]/g, "$1");
-
-  // Links, inline or reference-style: [text](url) / [text][ref] -> text
-  text = text.replace(/\[([^\]]*)\]\(([^)]*)\)/g, "$1");
-  text = text.replace(/\[([^\]]*)\]\[[^\]]*\]/g, "$1");
-
-  // Autolinks: <https://example.com> -> bare text (neutralized below).
-  text = text.replace(/<(https?:\/\/[^>]+)>/g, "$1");
-
-  /*
-   * Bare URLs and www. literals: remark-gfm autolinks them. Wrap in code
-   * spans (unless already inside backticks) so they render as plain text.
-   */
-  text = text.replace(
-    /(^|[^`])((?:https?:\/\/|www\.)[^\s`<>"')\]]+)/g,
-    (_full: string, prefix: string, url: string): string => {
-      return `${prefix}\`${url}\``;
-    },
-  );
-
-  return <MarkdownViewer text={text} />;
+  return <MarkdownViewer text={props.text} safeMode={true} />;
 };
 
 export default SafeChatMarkdown;

--- a/Common/Server/Services/AIService.ts
+++ b/Common/Server/Services/AIService.ts
@@ -200,26 +200,15 @@ export class Service extends BaseService {
 
         // Deduct from project balance
         if (totalCost > 0) {
-          const project: Project | null = await ProjectService.findOneById({
-            id: request.projectId,
-            select: { aiCurrentBalanceInUSDCents: true },
-            props: { isRoot: true },
+          /*
+           * Atomic decrement — concurrent LLM calls within and across chat
+           * turns must not lose each other's deductions (a read-modify-write
+           * here silently forgave overlapping spend).
+           */
+          await ProjectService.deductAiBalanceInUSDCents({
+            projectId: request.projectId,
+            amountInUSDCents: totalCost,
           });
-
-          if (project) {
-            const newBalance: number = Math.max(
-              0,
-              (project.aiCurrentBalanceInUSDCents || 0) - totalCost,
-            );
-
-            await ProjectService.updateOneById({
-              id: request.projectId,
-              data: {
-                aiCurrentBalanceInUSDCents: newBalance,
-              },
-              props: { isRoot: true },
-            });
-          }
 
           // Check if auto-recharge is needed (do this async, don't wait)
           AIBillingService.rechargeIfBalanceIsLow(request.projectId).catch(

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -2106,6 +2106,25 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     );
   }
 
+  /*
+   * Atomically subtract `value` from a numeric column in a single UPDATE
+   * (SET col = col - value) so concurrent callers never lose each other's
+   * writes the way a read-modify-write would. The column can go negative;
+   * callers that gate on a non-negative balance simply reject the next
+   * request rather than silently forgiving the overage.
+   */
+  protected async atomicDecrementColumnValueBy(data: {
+    id: ObjectID;
+    columnName: keyof TBaseModel;
+    value: number;
+  }): Promise<void> {
+    await this.getRepository().decrement(
+      { _id: data.id.toString() } as any,
+      data.columnName as string,
+      data.value,
+    );
+  }
+
   @CaptureSpan()
   public async searchBy({
     skip,

--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -1916,6 +1916,30 @@ export class ProjectService extends DatabaseService<Model> {
   }
 
   @CaptureSpan()
+  /*
+   * Atomically deduct AI spend from the project's balance. A single
+   * SET aiCurrentBalanceInUSDCents = aiCurrentBalanceInUSDCents - amount
+   * so concurrent AI runs (many LLM calls per turn, several turns per
+   * project) can't clobber each other's deductions the way a
+   * read-then-write would. No-op for non-positive amounts.
+   */
+  @CaptureSpan()
+  public async deductAiBalanceInUSDCents(data: {
+    projectId: ObjectID;
+    amountInUSDCents: number;
+  }): Promise<void> {
+    if (!data.amountInUSDCents || data.amountInUSDCents <= 0) {
+      return;
+    }
+
+    await this.atomicDecrementColumnValueBy({
+      id: data.projectId,
+      columnName: "aiCurrentBalanceInUSDCents",
+      value: data.amountInUSDCents,
+    });
+  }
+
+  @CaptureSpan()
   public async incrementAndGetIncidentCounter(
     projectId: ObjectID,
   ): Promise<{ counter: number; prefix: string | undefined }> {

--- a/Common/Server/Types/AnalyticsDatabase/ModelPermission.ts
+++ b/Common/Server/Types/AnalyticsDatabase/ModelPermission.ts
@@ -703,18 +703,31 @@ export default class ModelPermission {
    * scale to telemetry volume; one Postgres roundtrip + one indexed
    * predicate does. See Internal/Docs/PermissionsSimplification.md.
    */
-  private static async addOwnedScopeToQuery<TBaseModel extends BaseModel>(
+  /*
+   * Resolves the owned-scope decision for an analytics model without touching
+   * a query. Returns `null` when no ownership filter applies (root/master,
+   * creates, models without @OwnedThrough, no applicable permission rows, or
+   * an unrestricted grant) — i.e. the caller has full access. Otherwise
+   * returns the FK column plus the exact set of parent resource IDs the user
+   * may read (possibly empty, meaning "access to nothing").
+   *
+   * This is the single source of truth for owned-scope resolution:
+   * addOwnedScopeToQuery injects it into a ClickHouse query, and
+   * getAccessibleServiceIdsForAnalyticsModel exposes it to callers that build
+   * their own aggregation SQL (e.g. the AI toolbox), so the two can never
+   * drift apart.
+   */
+  private static async resolveOwnedScope<TBaseModel extends BaseModel>(
     modelType: { new (): TBaseModel },
-    query: Query<TBaseModel>,
     props: DatabaseCommonInteractionProps,
     type: DatabaseRequestType,
-  ): Promise<Query<TBaseModel>> {
+  ): Promise<{ fkColumn: string; allowedResourceIds: Set<string> } | null> {
     if (props.isRoot || props.isMasterAdmin) {
-      return query;
+      return null;
     }
 
     if (type === DatabaseRequestType.Create) {
-      return query;
+      return null;
     }
 
     /*
@@ -725,7 +738,7 @@ export default class ModelPermission {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const model: any = new modelType();
     if (!model.ownedThrough) {
-      return query;
+      return null;
     }
 
     const modelPermissions: Array<Permission> = this.getModelPermissions(
@@ -748,7 +761,7 @@ export default class ModelPermission {
     );
 
     if (applicableRows.length === 0) {
-      return query;
+      return null;
     }
 
     /*
@@ -771,7 +784,7 @@ export default class ModelPermission {
       },
     );
     if (hasUnrestrictedGrant) {
-      return query;
+      return null;
     }
 
     const allowedResourceIds: Set<string> = new Set<string>();
@@ -831,7 +844,59 @@ export default class ModelPermission {
       allowedResourceIds.add(props.tenantId.toString());
     }
 
-    const fkColumn: string = model.ownedThrough.fkColumn;
+    return { fkColumn: model.ownedThrough.fkColumn, allowedResourceIds };
+  }
+
+  /*
+   * The set of parent resource (Service) IDs the user may read for an analytics
+   * model, for callers that bypass findBy() and build aggregation SQL directly
+   * (e.g. the AI toolbox's log_histogram / query_traces, which call the
+   * aggregation services with a raw projectId). Pass the result as the
+   * aggregation's `serviceIds` filter.
+   *
+   * `null` means no ownership restriction applies — do NOT constrain (the user
+   * has project-wide access). A returned array (even empty) means the user is
+   * label/owned-restricted: constrain to exactly these IDs, and treat an empty
+   * array as "no accessible services" (match nothing), NEVER as "no filter".
+   */
+  public static async getAccessibleServiceIdsForAnalyticsModel<
+    TBaseModel extends BaseModel,
+  >(
+    modelType: { new (): TBaseModel },
+    props: DatabaseCommonInteractionProps,
+    type: DatabaseRequestType,
+  ): Promise<Array<ObjectID> | null> {
+    const scope: {
+      fkColumn: string;
+      allowedResourceIds: Set<string>;
+    } | null = await this.resolveOwnedScope(modelType, props, type);
+
+    if (!scope) {
+      return null;
+    }
+
+    return Array.from(scope.allowedResourceIds).map((id: string) => {
+      return new ObjectID(id);
+    });
+  }
+
+  private static async addOwnedScopeToQuery<TBaseModel extends BaseModel>(
+    modelType: { new (): TBaseModel },
+    query: Query<TBaseModel>,
+    props: DatabaseCommonInteractionProps,
+    type: DatabaseRequestType,
+  ): Promise<Query<TBaseModel>> {
+    const scope: {
+      fkColumn: string;
+      allowedResourceIds: Set<string>;
+    } | null = await this.resolveOwnedScope(modelType, props, type);
+
+    if (!scope) {
+      return query;
+    }
+
+    const fkColumn: string = scope.fkColumn;
+    const allowedResourceIds: Set<string> = scope.allowedResourceIds;
     const sentinelNoMatch: Array<string> = [
       ObjectID.getZeroObjectID().toString(),
     ];

--- a/Common/Server/Utils/AI/Toolbox/LogTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/LogTools.ts
@@ -1,4 +1,6 @@
 import Log from "../../../../Models/AnalyticsModels/Log";
+import DatabaseRequestType from "../../../Types/BaseDatabase/DatabaseRequestType";
+import ModelPermission from "../../../Types/AnalyticsDatabase/ModelPermission";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../../Types/BaseDatabase/Includes";
 import Search from "../../../../Types/BaseDatabase/Search";
@@ -200,6 +202,18 @@ export const LogHistogramTool: ObservabilityTool = {
       "serviceId",
     );
 
+    /*
+     * getHistogram builds raw aggregation SQL and skips the model layer's
+     * owned-scope filter, so a label-restricted user would otherwise see
+     * project-wide volume. Constrain to the services this user may read.
+     */
+    const accessibleServiceIds: Array<ObjectID> | null =
+      await ModelPermission.getAccessibleServiceIdsForAnalyticsModel(
+        Log,
+        ctx.props,
+        DatabaseRequestType.Read,
+      );
+
     const buckets: Array<HistogramBucket> =
       await LogAggregationService.getHistogram({
         projectId: ctx.projectId,
@@ -208,7 +222,7 @@ export const LogHistogramTool: ObservabilityTool = {
         bucketSizeInMinutes: bucketSizeInMinutes,
         severityTexts: ToolArgs.getStringArray(args, "severityTexts"),
         bodySearchText: ToolArgs.getString(args, "bodySearchText"),
-        serviceIds: serviceId ? [serviceId] : undefined,
+        serviceIds: ToolArgs.scopeServiceIds(accessibleServiceIds, serviceId),
       });
 
     const rows: Array<JSONObject> = buckets.map((bucket: HistogramBucket) => {

--- a/Common/Server/Utils/AI/Toolbox/Serializer.ts
+++ b/Common/Server/Utils/AI/Toolbox/Serializer.ts
@@ -43,8 +43,18 @@ const REDACTION_RULES: Array<RedactionRule> = [
     replacement: "[redacted-ip]",
   },
   {
+    /*
+     * Long hex blobs are usually secrets (SHA-256 digests, 40+ char API
+     * keys). But W3C/OTel trace IDs are exactly 32 hex chars and span IDs
+     * exactly 16 — redacting those would break the documented
+     * search_logs → get_trace pivot, since the model would never see the ID
+     * it needs to pass back. So only redact runs of 33+ hex chars, which
+     * preserves both ID lengths while still catching typical hash-length
+     * secrets. Labeled secrets of any length are still caught by
+     * key-value-secret below.
+     */
     name: "hex-secret",
-    regex: /\b[0-9a-fA-F]{32,}\b/g,
+    regex: /\b[0-9a-fA-F]{33,}\b/g,
     replacement: "[redacted-hex]",
   },
   {

--- a/Common/Server/Utils/AI/Toolbox/ToolTypes.ts
+++ b/Common/Server/Utils/AI/Toolbox/ToolTypes.ts
@@ -116,6 +116,40 @@ export class ToolArgs {
   }
 
   /*
+   * Combines the caller's optional serviceId filter with the user's owned-scope
+   * access (from ModelPermission.getAccessibleServiceIdsForAnalyticsModel) into
+   * the `serviceIds` filter to hand an aggregation service.
+   *
+   * `allowed === null` means the user has project-wide access: pass only the
+   * caller's own filter (or undefined for no filter). Otherwise the user is
+   * label/owned-restricted: intersect with any requested service and NEVER
+   * return undefined or an empty array — an empty result is forced to a
+   * no-match sentinel, because the aggregation services treat a missing/empty
+   * serviceIds as "no filter" (which would leak the whole project).
+   */
+  public static scopeServiceIds(
+    allowed: Array<ObjectID> | null,
+    requested: ObjectID | undefined,
+  ): Array<ObjectID> | undefined {
+    if (allowed === null) {
+      return requested ? [requested] : undefined;
+    }
+
+    let effective: Array<ObjectID> = allowed;
+    if (requested) {
+      effective = allowed.filter((id: ObjectID) => {
+        return id.toString() === requested.toString();
+      });
+    }
+
+    if (effective.length === 0) {
+      return [ObjectID.getZeroObjectID()];
+    }
+
+    return effective;
+  }
+
+  /*
    * Time range for a tool call: explicit ISO startTime/endTime arguments,
    * clamped to a maximum window, defaulting to the last hour.
    */

--- a/Common/Server/Utils/AI/Toolbox/TraceTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/TraceTools.ts
@@ -1,4 +1,6 @@
 import Span from "../../../../Models/AnalyticsModels/Span";
+import DatabaseRequestType from "../../../Types/BaseDatabase/DatabaseRequestType";
+import ModelPermission from "../../../Types/AnalyticsDatabase/ModelPermission";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import { JSONObject } from "../../../../Types/JSON";
@@ -135,6 +137,19 @@ export const QueryTracesTool: ObservabilityTool = {
     const windowMinutes: number =
       (endTime.getTime() - startTime.getTime()) / (60 * 1000);
 
+    /*
+     * getAnalyticsTable builds raw aggregation SQL and skips the model layer's
+     * owned-scope filter, so a label-restricted user would otherwise see
+     * project-wide trace analytics. Constrain to the services this user may
+     * read (spans are owned through Service, same as logs).
+     */
+    const accessibleServiceIds: Array<ObjectID> | null =
+      await ModelPermission.getAccessibleServiceIdsForAnalyticsModel(
+        Span,
+        ctx.props,
+        DatabaseRequestType.Read,
+      );
+
     const tableRows: Array<TraceAnalyticsTableRow> =
       await TraceAggregationService.getAnalyticsTable({
         projectId: ctx.projectId,
@@ -146,7 +161,7 @@ export const QueryTracesTool: ObservabilityTool = {
         groupBy: [groupBy],
         limit: limit,
         nameSearchText: ToolArgs.getString(args, "nameSearchText"),
-        serviceIds: serviceId ? [serviceId] : undefined,
+        serviceIds: ToolArgs.scopeServiceIds(accessibleServiceIds, serviceId),
         hasException: ToolArgs.getBoolean(args, "hasException"),
         rootOnly: ToolArgs.getBoolean(args, "rootOnly"),
       });

--- a/Common/Tests/Server/Utils/AI/ToolArgsScopeServiceIds.test.ts
+++ b/Common/Tests/Server/Utils/AI/ToolArgsScopeServiceIds.test.ts
@@ -1,0 +1,79 @@
+import { ToolArgs } from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import ObjectID from "../../../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * scopeServiceIds decides the `serviceIds` filter the aggregation tools hand to
+ * the raw-SQL aggregation services. The aggregation services treat a
+ * missing/empty serviceIds as "no filter" (whole project), so for a
+ * label-restricted user this helper must NEVER return undefined or []. These
+ * tests pin that invariant.
+ */
+describe("ToolArgs.scopeServiceIds", () => {
+  test("unrestricted user, no requested service → no filter", () => {
+    expect(ToolArgs.scopeServiceIds(null, undefined)).toBeUndefined();
+  });
+
+  test("unrestricted user with a requested service → just that service", () => {
+    const requested: ObjectID = ObjectID.generate();
+    const result: Array<ObjectID> | undefined = ToolArgs.scopeServiceIds(
+      null,
+      requested,
+    );
+    expect(
+      result?.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([requested.toString()]);
+  });
+
+  test("restricted user, no requested service → the accessible set", () => {
+    const a: ObjectID = ObjectID.generate();
+    const b: ObjectID = ObjectID.generate();
+    const result: Array<ObjectID> | undefined = ToolArgs.scopeServiceIds(
+      [a, b],
+      undefined,
+    );
+    expect(
+      result?.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([a.toString(), b.toString()]);
+  });
+
+  test("restricted user requesting an accessible service → intersection", () => {
+    const a: ObjectID = ObjectID.generate();
+    const b: ObjectID = ObjectID.generate();
+    const result: Array<ObjectID> | undefined = ToolArgs.scopeServiceIds(
+      [a, b],
+      b,
+    );
+    expect(
+      result?.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([b.toString()]);
+  });
+
+  test("restricted user requesting a forbidden service → no-match sentinel, never empty", () => {
+    const accessible: ObjectID = ObjectID.generate();
+    const forbidden: ObjectID = ObjectID.generate();
+    const result: Array<ObjectID> | undefined = ToolArgs.scopeServiceIds(
+      [accessible],
+      forbidden,
+    );
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.toString()).toBe(ObjectID.getZeroObjectID().toString());
+  });
+
+  test("restricted user with no accessible services → no-match sentinel, never empty", () => {
+    const result: Array<ObjectID> | undefined = ToolArgs.scopeServiceIds(
+      [],
+      undefined,
+    );
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(1);
+    expect(result?.[0]?.toString()).toBe(ObjectID.getZeroObjectID().toString());
+  });
+});

--- a/Common/Tests/Server/Utils/AI/ToolResultSerializer.test.ts
+++ b/Common/Tests/Server/Utils/AI/ToolResultSerializer.test.ts
@@ -45,6 +45,31 @@ describe("ToolResultSerializer.redact", () => {
     expect(result.text).toContain("[redacted-hex]");
   });
 
+  test("preserves 32-char OTel trace IDs and 16-char span IDs", () => {
+    /*
+     * Exactly 32 hex = W3C/OTel trace ID; exactly 16 hex = span ID. Both must
+     * survive so the model can pivot search_logs -> get_trace.
+     */
+    const traceId: string = "4bf92f3577b34da6a3ce929d0e0e4736";
+    const spanId: string = "00f067aa0ba902b7";
+    const result: { text: string; count: number } = ToolResultSerializer.redact(
+      `traceId=${traceId} spanId=${spanId}`,
+    );
+    expect(result.text).toContain(traceId);
+    expect(result.text).toContain(spanId);
+    expect(result.text).not.toContain("[redacted-hex]");
+    expect(result.count).toBe(0);
+  });
+
+  test("still redacts hex secrets longer than a trace ID (33+ chars)", () => {
+    const sha256: string = "a".repeat(64);
+    const result: { text: string; count: number } = ToolResultSerializer.redact(
+      `digest ${sha256} verified`,
+    );
+    expect(result.text).toContain("[redacted-hex]");
+    expect(result.text).not.toContain(sha256);
+  });
+
   test("redacts key=value secrets and keeps the key via capture groups", () => {
     const result: { text: string; count: number } = ToolResultSerializer.redact(
       "config: password=supersecretvalue retries=3",

--- a/Common/UI/Components/Markdown.tsx/MarkdownViewer.tsx
+++ b/Common/UI/Components/Markdown.tsx/MarkdownViewer.tsx
@@ -144,6 +144,14 @@ const MermaidDiagram: FunctionComponent<{ chart: string }> = ({
 
 export interface ComponentProps {
   text: string;
+  /*
+   * Hardened rendering for untrusted / LLM-generated content. When true, links
+   * render as non-clickable text and images are never fetched — both are
+   * neutralized on react-markdown's PARSED tree, so (unlike pre-processing the
+   * raw markdown with regexes) no CommonMark syntax trick can smuggle a
+   * clickable exfil link or a zero-click tracking pixel through.
+   */
+  safeMode?: boolean;
 }
 
 // Language display names
@@ -348,6 +356,9 @@ const extractTextFromChildren: (children: unknown) => string = (
 const MarkdownViewer: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  // Captured here because the component overrides below shadow `props`.
+  const safeMode: boolean = props.safeMode === true;
+
   return (
     <div className="max-w-none">
       <ReactMarkdown
@@ -409,19 +420,40 @@ const MarkdownViewer: FunctionComponent<ComponentProps> = (
               />
             );
           },
-          a: ({ ...props }: any) => {
+          a: ({ children, ...props }: any) => {
+            if (safeMode) {
+              // Keep the link text, drop the href: no navigation, no exfil.
+              return (
+                <span className="underline decoration-dotted text-gray-700 font-medium">
+                  {children}
+                </span>
+              );
+            }
             return (
               <a
                 className="underline text-blue-600 hover:text-blue-800 font-medium transition-colors"
                 {...props}
-              />
+              >
+                {children}
+              </a>
             );
           },
-          img: ({ ...props }: any) => {
+          img: ({ alt, ...props }: any) => {
+            if (safeMode) {
+              /*
+               * Never emit an <img> for untrusted content — the browser would
+               * fetch its src on render (a zero-click exfil channel). Show the
+               * alt text (already plain, React-escaped) instead.
+               */
+              return alt ? (
+                <span className="text-gray-500 italic">{`[image: ${alt}]`}</span>
+              ) : null;
+            }
             return (
               <img
                 className="max-w-full h-auto rounded-md border border-gray-200 my-3"
                 loading="lazy"
+                alt={alt}
                 {...props}
               />
             );


### PR DESCRIPTION
Fixes the four ship-blocking trust bugs found in the **Ask AI chat-ops** audit. Each attacks the trust the assistant depends on; none is individually large, but together they should gate further feature work.

## What's fixed

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | Critical | **Zero-click exfiltration** via prompt-injected markdown | Neutralize links/images on react-markdown's parsed AST (`MarkdownViewer` `safeMode`) instead of the bypassable regex |
| 2 | High | **Label-scope authz bypass** — `log_histogram`/`query_traces` aggregated project-wide for label-restricted users | Apply the model layer's owned-scope filter to the aggregation calls |
| 3 | Critical | **Non-atomic credit deduction** — concurrent runs lost deductions | Atomic SQL decrement |
| 4 | High | **Redaction corrupted OTel trace IDs**, breaking the `search_logs → get_trace` pivot | Only redact 33+ char hex, preserving 32-char trace / 16-char span IDs |

## Approach notes

- **(1)** The old `SafeChatMarkdown` regex-stripped link/image *syntax*, which CommonMark can slip past (multi-line constructs, autolink literals). Moving neutralization into `MarkdownViewer.safeMode` operates on the parsed tree — links render as plain text, images never emit an `<img>` (no `src` fetch). Removing the regex also fixes the code-block-corruption bug it caused.
- **(2)** Extracted the owned-scope resolver out of `ModelPermission.addOwnedScopeToQuery` into `getAccessibleServiceIdsForAnalyticsModel` so the query path and the toolbox share one implementation and can't drift. `ToolArgs.scopeServiceIds` guarantees a label-restricted user never produces an empty/undefined `serviceIds` filter (which the aggregation services treat as "whole project"). Normal project-wide readers are unaffected.
- **(3)** `ProjectService.deductAiBalanceInUSDCents` → new `atomicDecrementColumnValueBy` base-service method (`SET col = col - value`). Balance may go slightly negative on genuine overage, which correctly blocks the next request rather than forgiving it.

## Testing

- New regression tests: trace/span-ID preservation + long-hex redaction (`ToolResultSerializer`); `ToolArgs.scopeServiceIds` suite pinning the never-empty-when-restricted invariant.
- All 37 Common AI tests pass; Common and Dashboard typecheck clean; ESLint clean.

## Not in this PR (documented follow-ups from the audit)

`query_metrics` missing time filter, `log_histogram` dropping recent buckets, `get_trace` 100-span truncation, the realtime-ping/streaming gap, no stop/cancel, and the eval harness — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)