### PR TITLE
fix(ai-chat): correct silent data errors in the observability tool belt

### DIFF
--- a/Common/Server/Utils/AI/Toolbox/LogTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/LogTools.ts
@@ -22,6 +22,9 @@ import {
   ToolExecutionResult,
 } from "./ToolTypes";
 
+// Keep pivoted histogram rows under the serializer's 50-row cap.
+const MAX_HISTOGRAM_BUCKETS: number = 48;
+
 const LOG_READ_PERMISSIONS: Array<Permission> = [
   Permission.ProjectOwner,
   Permission.ProjectAdmin,
@@ -192,9 +195,16 @@ export const LogHistogramTool: ObservabilityTool = {
 
     const windowMinutes: number =
       (endTime.getTime() - startTime.getTime()) / (60 * 1000);
+    /*
+     * Bound the number of time buckets. getHistogram returns one row per
+     * (bucket, severity); after we pivot to one row per bucket that is at most
+     * MAX_HISTOGRAM_BUCKETS rows, which stays under the serializer's row cap so
+     * the most recent buckets are never dropped (spike detection reads the tail
+     * of the window).
+     */
     const bucketSizeInMinutes: number = Math.max(
       1,
-      Math.round(windowMinutes / 60),
+      Math.ceil(windowMinutes / MAX_HISTOGRAM_BUCKETS),
     );
 
     const serviceId: ObjectID | undefined = ToolArgs.getObjectID(
@@ -225,9 +235,27 @@ export const LogHistogramTool: ObservabilityTool = {
         serviceIds: ToolArgs.scopeServiceIds(accessibleServiceIds, serviceId),
       });
 
-    const rows: Array<JSONObject> = buckets.map((bucket: HistogramBucket) => {
-      return bucket as unknown as JSONObject;
-    });
+    /*
+     * Pivot (time, severity, count) rows into one row per time bucket with a
+     * column per severity, e.g. "time=… | Error=12 | Warn=3". This is both more
+     * compact for the model and collapses the row count from
+     * buckets×severities down to just buckets.
+     */
+    const rowsByTime: Map<string, JSONObject> = new Map();
+    for (const bucket of buckets) {
+      let row: JSONObject | undefined = rowsByTime.get(bucket.time);
+      if (!row) {
+        row = { time: bucket.time };
+        rowsByTime.set(bucket.time, row);
+      }
+      row[bucket.severity || "Unspecified"] = bucket.count;
+    }
+
+    const rows: Array<JSONObject> = Array.from(rowsByTime.values()).sort(
+      (a: JSONObject, b: JSONObject) => {
+        return String(a["time"]).localeCompare(String(b["time"]));
+      },
+    );
 
     const serialized: SerializedResult =
       ToolResultSerializer.serializeRows(rows);

--- a/Common/Server/Utils/AI/Toolbox/MetricTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/MetricTools.ts
@@ -1,5 +1,6 @@
 import Metric from "../../../../Models/AnalyticsModels/Metric";
 import AggregationType from "../../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
 import Permission from "../../../../Types/Permission";
@@ -92,8 +93,15 @@ export const QueryMetricsTool: ObservabilityTool = {
       );
     }
 
+    /*
+     * The time filter must be part of the query's WHERE clause. aggregateBy's
+     * startTimestamp/endTimestamp only define the bucket grid — without an
+     * explicit `time` filter the percentile/aggregate scans the metric's whole
+     * retention and mixes in data outside the requested window.
+     */
     const query: JSONObject = {
       name: metricName,
+      time: new InBetween(startTime, endTime),
     };
 
     const entityId: ObjectID | undefined = ToolArgs.getObjectID(

--- a/Common/Server/Utils/AI/Toolbox/Serializer.ts
+++ b/Common/Server/Utils/AI/Toolbox/Serializer.ts
@@ -210,6 +210,15 @@ export default class ToolResultSerializer {
       text = "(no rows found)";
     }
 
+    /*
+     * Tell the model when it is only seeing a slice. Without this marker a
+     * capped result looks complete, and the model reports partial data as if it
+     * were the whole picture.
+     */
+    if (rows.length > MAX_ROWS) {
+      text = `${text}\n… [showing the first ${MAX_ROWS} of ${rowCount} rows; narrow the query — a shorter time range or more filters — to see the rest]`;
+    }
+
     return {
       text,
       rowCount,

--- a/Common/Server/Utils/AI/Toolbox/ToolTypes.ts
+++ b/Common/Server/Utils/AI/Toolbox/ToolTypes.ts
@@ -166,12 +166,21 @@ export class ToolArgs {
       "startTime",
     );
 
+    /*
+     * Reject unparseable timestamps instead of silently falling back to the
+     * default window — a silent fallback answers a different question than the
+     * one asked. Throwing lets the model see the error and retry with a valid
+     * ISO 8601 value.
+     */
     let endTime: Date = OneUptimeDate.getCurrentDate();
     if (endTimeString) {
       const parsed: Date = new Date(endTimeString);
-      if (!isNaN(parsed.getTime())) {
-        endTime = parsed;
+      if (isNaN(parsed.getTime())) {
+        throw new BadDataException(
+          `endTime "${endTimeString}" is not a valid ISO 8601 timestamp (e.g. 2024-01-31T14:00:00Z).`,
+        );
       }
+      endTime = parsed;
     }
 
     let startTime: Date = OneUptimeDate.addRemoveHours(
@@ -180,9 +189,12 @@ export class ToolArgs {
     );
     if (startTimeString) {
       const parsed: Date = new Date(startTimeString);
-      if (!isNaN(parsed.getTime())) {
-        startTime = parsed;
+      if (isNaN(parsed.getTime())) {
+        throw new BadDataException(
+          `startTime "${startTimeString}" is not a valid ISO 8601 timestamp (e.g. 2024-01-31T13:00:00Z).`,
+        );
       }
+      startTime = parsed;
     }
 
     if (startTime.getTime() >= endTime.getTime()) {

--- a/Common/Server/Utils/AI/Toolbox/TraceTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/TraceTools.ts
@@ -51,6 +51,14 @@ const VALID_GROUP_BY: Array<string> = [
   "isRootSpan",
 ];
 
+/*
+ * Upper bound on spans fetched for a single trace waterfall. High enough for
+ * almost every real trace; when a trace exceeds it we say so explicitly rather
+ * than silently dropping spans (which also orphans their children into fake
+ * roots).
+ */
+const MAX_TRACE_SPANS: number = 500;
+
 export const QueryTracesTool: ObservabilityTool = {
   name: "query_traces",
   description:
@@ -243,10 +251,12 @@ export const GetTraceTool: ObservabilityTool = {
       sort: {
         startTimeUnixNano: SortOrder.Ascending,
       } as never,
-      limit: 100,
+      limit: MAX_TRACE_SPANS,
       skip: 0,
       props: ctx.props,
     });
+
+    const isSpanLimitHit: boolean = spans.length >= MAX_TRACE_SPANS;
 
     // Build the tree.
     const nodesBySpanId: Map<string, SpanTreeNode> = new Map();
@@ -292,6 +302,12 @@ export const GetTraceTool: ObservabilityTool = {
       renderNode(root, 0);
     }
 
+    if (isSpanLimitHit) {
+      lines.push(
+        `… trace truncated at ${MAX_TRACE_SPANS} spans; deeper spans are omitted and some shown here may appear as roots because their parent was cut off.`,
+      );
+    }
+
     const serialized: SerializedResult = ToolResultSerializer.serializeText(
       lines.join("\n"),
       spans.length,
@@ -300,13 +316,13 @@ export const GetTraceTool: ObservabilityTool = {
     return {
       dataForLlm: serialized.text,
       rowCount: serialized.rowCount,
-      citationLabel: `Trace ${traceId} (${spans.length} spans)`,
+      citationLabel: `Trace ${traceId} (${spans.length}${isSpanLimitHit ? "+" : ""} spans)`,
       citationTarget: {
         type: AIChatCitationTargetType.TraceView,
         params: { traceId: traceId },
       },
       redactionCount: serialized.redactionCount,
-      isTruncated: serialized.isTruncated,
+      isTruncated: serialized.isTruncated || isSpanLimitHit,
     };
   },
 };

--- a/Common/Tests/Server/Utils/AI/ToolArgsGetTimeRange.test.ts
+++ b/Common/Tests/Server/Utils/AI/ToolArgsGetTimeRange.test.ts
@@ -1,0 +1,62 @@
+import { ToolArgs } from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * getTimeRange turns untrusted LLM-supplied time arguments into a concrete
+ * window. It must reject garbage rather than silently answer for the default
+ * window (which would answer a different question than the user asked).
+ */
+describe("ToolArgs.getTimeRange", () => {
+  test("uses explicit ISO 8601 start and end", () => {
+    const args: JSONObject = {
+      startTime: "2024-01-31T13:00:00Z",
+      endTime: "2024-01-31T14:00:00Z",
+    };
+    const { startTime, endTime } = ToolArgs.getTimeRange(args, {
+      defaultHours: 1,
+      maxDays: 30,
+    });
+    expect(startTime.toISOString()).toBe("2024-01-31T13:00:00.000Z");
+    expect(endTime.toISOString()).toBe("2024-01-31T14:00:00.000Z");
+  });
+
+  test("throws on an unparseable endTime instead of falling back", () => {
+    expect(() => {
+      ToolArgs.getTimeRange({ endTime: "yesterday 2am" }, { defaultHours: 1 });
+    }).toThrow(BadDataException);
+  });
+
+  test("throws on an unparseable startTime instead of falling back", () => {
+    expect(() => {
+      ToolArgs.getTimeRange(
+        { startTime: "last tuesday", endTime: "2024-01-31T14:00:00Z" },
+        { defaultHours: 1 },
+      );
+    }).toThrow(BadDataException);
+  });
+
+  test("defaults the window when no timestamps are supplied", () => {
+    const { startTime, endTime } = ToolArgs.getTimeRange(
+      {},
+      { defaultHours: 2 },
+    );
+    const spanHours: number =
+      (endTime.getTime() - startTime.getTime()) / (60 * 60 * 1000);
+    expect(spanHours).toBeCloseTo(2, 5);
+  });
+
+  test("clamps a window wider than maxDays", () => {
+    const { startTime, endTime } = ToolArgs.getTimeRange(
+      {
+        startTime: "2024-01-01T00:00:00Z",
+        endTime: "2024-06-01T00:00:00Z",
+      },
+      { defaultHours: 1, maxDays: 30 },
+    );
+    const spanDays: number =
+      (endTime.getTime() - startTime.getTime()) / (24 * 60 * 60 * 1000);
+    expect(spanDays).toBeLessThanOrEqual(30);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/ToolResultSerializer.test.ts
+++ b/Common/Tests/Server/Utils/AI/ToolResultSerializer.test.ts
@@ -101,6 +101,23 @@ describe("ToolResultSerializer.serializeRows", () => {
     expect(result.text.split("\n").length).toBeLessThanOrEqual(51);
   });
 
+  test("tells the model how many rows were hidden when capped", () => {
+    const rows: Array<JSONObject> = [];
+    for (let i: number = 0; i < 80; i++) {
+      rows.push({ index: i, value: `row-${i}` });
+    }
+
+    const result: SerializedResult = ToolResultSerializer.serializeRows(rows);
+    expect(result.text).toContain("first 50 of 80 rows");
+  });
+
+  test("does not add a truncation marker when rows fit", () => {
+    const rows: Array<JSONObject> = [{ index: 1 }, { index: 2 }];
+    const result: SerializedResult = ToolResultSerializer.serializeRows(rows);
+    expect(result.isTruncated).toBe(false);
+    expect(result.text).not.toContain("showing the first");
+  });
+
   test("truncates long field values", () => {
     const result: SerializedResult = ToolResultSerializer.serializeRows([
       { body: "x".repeat(2000) },


### PR DESCRIPTION
Second batch from the Ask AI audit: five confirmed correctness bugs where a tool quietly returned **wrong or partial data** — the worst failure mode for an assistant meant to be trusted.

> **Stacked on #2595** (trust-gate). Review/merge that first; this PR is based on it so the diff shows only the correctness fixes. Re-target to `master` once #2595 merges.

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | High | `query_metrics` aggregate had **no time predicate** → percentiles scanned full retention and mixed in out-of-window data | Add explicit `time` InBetween to the query |
| 2 | High | `log_histogram` **dropped the newest buckets** (one row per bucket×severity overflowed the 50-row cap, which kept the oldest) → missed recent spikes | Pivot to one row per bucket + bound bucket count |
| 3 | Medium | `get_trace` **silently truncated at 100 spans**, rendering orphaned subtrees as roots | Raise limit; append explicit truncation note + flag when hit |
| 4 | Medium | `getTimeRange` **silently ignored unparseable timestamps** and used the default window | Throw `BadDataException` so the model self-corrects |
| 5 | Medium | Row-cap truncation was **invisible to the model** — a slice looked complete | Append a "showing the first 50 of N rows" marker |

## Why these matter

Each one causes the assistant to state something false with full confidence — an out-of-window p99, a "no recent error spike" when there was one, a partial trace presented as whole, an answer for the wrong time window, or a partial table reported as complete. Citations don't help if the cited data is silently wrong.

## Notable design choices

- **(2)** The histogram is now pivoted (`time | Error=12 | Warn=3`), which is both more compact for the model and collapses the row count from *buckets × severities* to just *buckets*; `MAX_HISTOGRAM_BUCKETS = 48` keeps it under the serializer cap so nothing is dropped.
- **(3)** Raised to `MAX_TRACE_SPANS = 500`; the 16KB payload cap still applies (and is now visible via the truncation flag).

## Testing

- New `getTimeRange` suite (valid ISO, throws on garbage, defaults when omitted, clamps > maxDays).
- New serializer truncation-marker cases.
- All 44 Common AI tests pass; Common typechecks clean; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)