### PR TITLE
feat(workflow): safer, clearer JSON inputs in the workflow builder

### DIFF
--- a/Common/Tests/UI/Components/Workflow/JSONArgumentInputUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/JSONArgumentInputUtils.test.ts
@@ -1,0 +1,85 @@
+import {
+  validateJson,
+  containsToken,
+  ValidationResult,
+} from "../../../../UI/Components/Workflow/JSONArgumentInputUtils";
+import { describe, expect, test } from "@jest/globals";
+
+describe("JSONArgumentInputUtils.validateJson", () => {
+  test("treats empty / whitespace-only content as empty (no error)", () => {
+    expect(validateJson("").status).toBe("empty");
+    expect(validateJson("   \n ").status).toBe("empty");
+    expect(validateJson("").hasVariables).toBe(false);
+  });
+
+  test("accepts well-formed JSON objects and arrays", () => {
+    expect(validateJson('{"a": 1}').status).toBe("valid");
+    expect(validateJson("[1, 2, 3]").status).toBe("valid");
+    expect(validateJson('{"nested": {"b": true}}').status).toBe("valid");
+    expect(validateJson('{"a": 1}').hasVariables).toBe(false);
+  });
+
+  test("flags malformed JSON as invalid with a message (the runtime footgun)", () => {
+    // Trailing comma: strict JSON.parse rejects it, and so does the runtime.
+    const trailingComma: ValidationResult = validateJson('{"a": 1,}');
+    expect(trailingComma.status).toBe("invalid");
+    expect(typeof trailingComma.message).toBe("string");
+    expect(trailingComma.message!.length).toBeGreaterThan(0);
+
+    expect(validateJson('{"a": }').status).toBe("invalid");
+    expect(validateJson("not json").status).toBe("invalid");
+    expect(validateJson('{"missing": "quote}').status).toBe("invalid");
+  });
+
+  test("treats JSON containing {{ tokens }} as valid (quoted and unquoted)", () => {
+    const quoted: ValidationResult = validateJson(
+      '{"url": "{{local.components.x.returnValues.y}}"}',
+    );
+    expect(quoted.status).toBe("valid");
+    expect(quoted.hasVariables).toBe(true);
+
+    // A token standing in for a whole value (unquoted) is also valid.
+    const unquoted: ValidationResult = validateJson(
+      '{"id": {{local.components.x.returnValues.y}}}',
+    );
+    expect(unquoted.status).toBe("valid");
+    expect(unquoted.hasVariables).toBe(true);
+
+    // A token embedded inside a larger string value.
+    expect(
+      validateJson('{"auth": "Bearer {{local.variables.token}}"}').status,
+    ).toBe("valid");
+  });
+
+  test("classifies a field that is exactly one token as a variable reference", () => {
+    const result: ValidationResult = validateJson("{{local.variables.foo}}");
+    expect(result.status).toBe("variable");
+    expect(result.hasVariables).toBe(true);
+  });
+
+  test("classifies {{#each}} block helpers as template logic, not invalid", () => {
+    const result: ValidationResult = validateJson(
+      "{{#each local.components.x.returnValues.list}}{{this}}{{/each}}",
+    );
+    expect(result.status).toBe("template");
+  });
+
+  test("invalid JSON without tokens stays invalid even near a valid mask", () => {
+    // Two bare concatenated tokens do not form valid JSON on their own.
+    expect(validateJson("{{a}}{{b}}").status).toBe("invalid");
+  });
+});
+
+describe("JSONArgumentInputUtils.containsToken", () => {
+  test("detects the presence of a {{ token }}", () => {
+    expect(containsToken('{"a": "{{x}}"}')).toBe(true);
+    expect(containsToken('{"a": 1}')).toBe(false);
+  });
+
+  test("is stateless across repeated calls (global-regex lastIndex reset)", () => {
+    const value: string = '{"a": "{{x}}"}';
+    expect(containsToken(value)).toBe(true);
+    expect(containsToken(value)).toBe(true);
+    expect(containsToken(value)).toBe(true);
+  });
+});

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -1,10 +1,10 @@
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
-import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import BasicForm, { FormProps } from "../Forms/BasicForm";
 import FormFieldSchemaType from "../Forms/Types/FormFieldSchemaType";
 import { CustomElementProps } from "../Forms/Types/Field";
 import FormValues from "../Forms/Types/FormValues";
 import ComponentValuePickerModal from "./ComponentValuePickerModal";
+import JSONArgumentInput from "./JSONArgumentInput";
 import ModelFieldPicker from "./ModelFieldPicker";
 import { componentInputTypeToFormFieldType } from "./Utils";
 import VariableModal from "./VariableModal";
@@ -27,6 +27,21 @@ import React, {
   useRef,
   useState,
 } from "react";
+
+/*
+ * Argument types that are edited as JSON. These used to render as a plain
+ * textarea; they now use the validating JSONArgumentInput. Select is included
+ * only when the component has no tableName (otherwise it uses ModelFieldPicker).
+ */
+const JSON_INPUT_TYPES: Array<ComponentInputType> = [
+  ComponentInputType.JSON,
+  ComponentInputType.JSONArray,
+  ComponentInputType.BaseModel,
+  ComponentInputType.BaseModelArray,
+  ComponentInputType.Query,
+  ComponentInputType.Select,
+  ComponentInputType.StringDictionary,
+];
 
 export interface ComponentProps {
   component: NodeDataProp;
@@ -51,6 +66,25 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
   >({});
 
   const [selectedArgId, setSelectedArgId] = useState<string>("");
+
+  /*
+   * Advanced arguments (Argument.isAdvanced) are hidden behind a toggle to
+   * keep the common configuration to a couple of fields. We start expanded
+   * only if an advanced field is required or already has a value, so nothing
+   * important is ever hidden.
+   */
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(() => {
+    const args: Array<Argument> = props.component.metadata.arguments || [];
+    return args.some((arg: Argument) => {
+      if (arg.isAdvanced !== true) {
+        return false;
+      }
+      const value: unknown = props.component.arguments
+        ? props.component.arguments[arg.id]
+        : undefined;
+      return arg.required === true || (value !== undefined && value !== "");
+    });
+  });
 
   /*
    * Workflows in the current project, used to populate dropdowns for any
@@ -142,21 +176,54 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
     props.onFormChange(component);
   }, [component]);
 
+  type SetJsonFieldErrorFunction = (argId: string, isInvalid: boolean) => void;
+
+  /*
+   * Each JSON argument reports whether its content is currently invalid. We
+   * track these under distinct "json:<argId>" keys so an invalid JSON body
+   * disables Save without clobbering the form's own validation state.
+   */
+  const setJsonFieldError: SetJsonFieldErrorFunction = (
+    argId: string,
+    isInvalid: boolean,
+  ): void => {
+    const key: string = `json:${argId}`;
+    setHasFormValidationErrors((prev: Dictionary<boolean>) => {
+      if (prev[key] === isInvalid) {
+        return prev;
+      }
+      return { ...prev, [key]: isInvalid };
+    });
+  };
+
+  const allArguments: Array<Argument> = component.metadata.arguments || [];
+  const advancedArguments: Array<Argument> = allArguments.filter(
+    (arg: Argument) => {
+      return arg.isAdvanced === true;
+    },
+  );
+  const hasAdvancedArguments: boolean = advancedArguments.length > 0;
+  const visibleArguments: Array<Argument> = allArguments.filter(
+    (arg: Argument) => {
+      return showAdvanced || arg.isAdvanced !== true;
+    },
+  );
+
   return (
     <div>
       <div>
-        {component.metadata.arguments &&
-          component.metadata.arguments.length === 0 && (
-            <ErrorMessage message={"This step does not need any settings."} />
-          )}
+        {allArguments.length === 0 && (
+          <div className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-500">
+            This step doesn&apos;t need any configuration.
+          </div>
+        )}
         {/*
           If any argument is a WorkflowSelect and we're still fetching the
           list of workflows, show a loader instead of the form. Otherwise
           the user briefly sees an empty dropdown which is confusing.
         */}
         {hasWorkflowSelectArg && isLoadingWorkflows && <ComponentLoader />}
-        {component.metadata.arguments &&
-          component.metadata.arguments.length > 0 &&
+        {allArguments.length > 0 &&
           !(hasWorkflowSelectArg && isLoadingWorkflows) && (
             <BasicForm
               hideSubmitButton={true}
@@ -174,122 +241,174 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                 });
               }}
               onFormValidationErrorChanged={(hasError: boolean) => {
-                if (hasFormValidationErrors["id"] !== hasError) {
-                  setHasFormValidationErrors({
-                    ...hasFormValidationErrors,
-                    id: hasError,
-                  });
-                }
-              }}
-              fields={
-                component.metadata.arguments &&
-                component.metadata.arguments.map((arg: Argument) => {
-                  const isWorkflowSelect: boolean =
-                    arg.type === ComponentInputType.WorkflowSelect;
-
-                  /*
-                   * Database Select args (the "Select Fields" / "Listen on"
-                   * trigger inputs) get a tree-style field picker backed by
-                   * the model's schema, instead of a raw JSON textarea. We
-                   * need a tableName on the component metadata to fetch the
-                   * column list; without it, fall back to the JSON editor.
-                   */
-                  const useFieldPicker: boolean =
-                    arg.type === ComponentInputType.Select &&
-                    Boolean(component.metadata.tableName);
-
-                  const baseField: {
-                    fieldType: import("../Forms/Types/FormFieldSchemaType").default;
-                    dropdownOptions?: Array<DropdownOption> | undefined;
-                    getCustomElement?: (
-                      values: FormValues<JSONObject>,
-                      customProps: CustomElementProps,
-                    ) => ReactElement | undefined;
-                  } = useFieldPicker
-                    ? {
-                        fieldType: FormFieldSchemaType.CustomComponent,
-                        getCustomElement: (
-                          _values: FormValues<JSONObject>,
-                          customProps: CustomElementProps,
-                        ): ReactElement => {
-                          return (
-                            <ModelFieldPicker
-                              tableName={component.metadata.tableName as string}
-                              initialValue={customProps.initialValue}
-                              onChange={(value: string) => {
-                                void customProps.onChange?.(value);
-                              }}
-                              placeholder={customProps.placeholder}
-                              error={customProps.error}
-                              tabIndex={customProps.tabIndex}
-                            />
-                          );
-                        },
-                      }
-                    : componentInputTypeToFormFieldType(
-                        arg.type,
-                        component.arguments && component.arguments[arg.id]
-                          ? component.arguments[arg.id]
-                          : null,
-                      );
-
-                  /*
-                   * For WorkflowSelect, inject the dynamically fetched list
-                   * of workflows as dropdown options.
-                   */
-                  if (isWorkflowSelect) {
-                    baseField.dropdownOptions = workflowDropdownOptions;
+                setHasFormValidationErrors((prev: Dictionary<boolean>) => {
+                  if (prev["arguments"] === hasError) {
+                    return prev;
                   }
+                  return { ...prev, arguments: hasError };
+                });
+              }}
+              fields={visibleArguments.map((arg: Argument) => {
+                const isWorkflowSelect: boolean =
+                  arg.type === ComponentInputType.WorkflowSelect;
 
-                  /*
-                   * The "pick from component / variable" footer doesn't
-                   * apply to the field picker (it edits a structured object,
-                   * not a free-text expression) or to WorkflowSelect.
-                   */
-                  const showVariableFooter: boolean =
-                    !isWorkflowSelect && !useFieldPicker;
+                /*
+                 * Database Select args (the "Select Fields" / "Listen on"
+                 * trigger inputs) get a tree-style field picker backed by
+                 * the model's schema, instead of a raw JSON textarea. We
+                 * need a tableName on the component metadata to fetch the
+                 * column list; without it, fall back to the JSON editor.
+                 */
+                const useFieldPicker: boolean =
+                  arg.type === ComponentInputType.Select &&
+                  Boolean(component.metadata.tableName);
 
-                  return {
-                    title: `${arg.name}`,
-                    footerElement: showVariableFooter ? (
-                      <div className="text-gray-500">
-                        <p className="text-sm">
-                          Pick this value from other{" "}
-                          <button
-                            className="underline text-blue-500 hover:text-blue-600 cursor-pointer"
-                            onClick={() => {
-                              setSelectedArgId(arg.id);
-                              setShowComponentPickerModal(true);
-                            }}
-                          >
-                            component
-                          </button>{" "}
-                          or from{" "}
-                          <button
-                            className="underline text-blue-500 hover:text-blue-600 cursor-pointer"
-                            onClick={() => {
-                              setSelectedArgId(arg.id);
-                              setShowVariableModal(true);
-                            }}
-                          >
-                            variable.
-                          </button>
-                        </p>
-                      </div>
-                    ) : undefined,
-                    description: `${
-                      arg.required ? "Required" : "Optional"
-                    }. ${arg.description}`,
-                    field: {
-                      [arg.id]: true,
+                /*
+                 * All structured/JSON-ish argument types render in the
+                 * validating JSONArgumentInput instead of a bare editor, so
+                 * syntax mistakes surface while editing rather than at run
+                 * time.
+                 */
+                const useJsonEditor: boolean =
+                  !useFieldPicker && JSON_INPUT_TYPES.includes(arg.type);
+
+                let baseField: {
+                  fieldType: import("../Forms/Types/FormFieldSchemaType").default;
+                  dropdownOptions?: Array<DropdownOption> | undefined;
+                  getCustomElement?: (
+                    values: FormValues<JSONObject>,
+                    customProps: CustomElementProps,
+                  ) => ReactElement | undefined;
+                };
+
+                if (useFieldPicker) {
+                  baseField = {
+                    fieldType: FormFieldSchemaType.CustomComponent,
+                    getCustomElement: (
+                      _values: FormValues<JSONObject>,
+                      customProps: CustomElementProps,
+                    ): ReactElement => {
+                      return (
+                        <ModelFieldPicker
+                          tableName={component.metadata.tableName as string}
+                          initialValue={customProps.initialValue}
+                          onChange={(value: string) => {
+                            void customProps.onChange?.(value);
+                          }}
+                          placeholder={customProps.placeholder}
+                          error={customProps.error}
+                          tabIndex={customProps.tabIndex}
+                        />
+                      );
                     },
-                    required: arg.required,
-                    placeholder: arg.placeholder,
-                    ...baseField,
                   };
-                })
-              }
+                } else if (useJsonEditor) {
+                  baseField = {
+                    fieldType: FormFieldSchemaType.CustomComponent,
+                    getCustomElement: (
+                      _values: FormValues<JSONObject>,
+                      customProps: CustomElementProps,
+                    ): ReactElement => {
+                      return (
+                        <JSONArgumentInput
+                          value={(customProps.initialValue as string) || ""}
+                          placeholder={arg.placeholder}
+                          error={customProps.error}
+                          tabIndex={customProps.tabIndex}
+                          onChange={(value: string) => {
+                            void customProps.onChange?.(value);
+                          }}
+                          onValidationChange={(isInvalid: boolean) => {
+                            setJsonFieldError(arg.id, isInvalid);
+                          }}
+                        />
+                      );
+                    },
+                  };
+                } else {
+                  baseField = componentInputTypeToFormFieldType(
+                    arg.type,
+                    component.arguments && component.arguments[arg.id]
+                      ? component.arguments[arg.id]
+                      : null,
+                  );
+                }
+
+                /*
+                 * For WorkflowSelect, inject the dynamically fetched list
+                 * of workflows as dropdown options.
+                 */
+                if (isWorkflowSelect) {
+                  baseField.dropdownOptions = workflowDropdownOptions;
+                }
+
+                /*
+                 * The "pick from component / variable" footer doesn't
+                 * apply to the field picker (it edits a structured object,
+                 * not a free-text expression) or to WorkflowSelect. JSON
+                 * editors keep it so authors can drop {{ tokens }} into a
+                 * request body or payload.
+                 */
+                const showVariableFooter: boolean =
+                  !isWorkflowSelect && !useFieldPicker;
+
+                return {
+                  title: `${arg.name}`,
+                  footerElement: showVariableFooter ? (
+                    <div className="text-gray-500">
+                      <p className="text-sm">
+                        Pick this value from other{" "}
+                        <button
+                          className="underline text-blue-500 hover:text-blue-600 cursor-pointer"
+                          onClick={() => {
+                            setSelectedArgId(arg.id);
+                            setShowComponentPickerModal(true);
+                          }}
+                        >
+                          component
+                        </button>{" "}
+                        or from{" "}
+                        <button
+                          className="underline text-blue-500 hover:text-blue-600 cursor-pointer"
+                          onClick={() => {
+                            setSelectedArgId(arg.id);
+                            setShowVariableModal(true);
+                          }}
+                        >
+                          variable.
+                        </button>
+                      </p>
+                    </div>
+                  ) : undefined,
+                  description: `${
+                    arg.required ? "Required" : "Optional"
+                  }. ${arg.description}`,
+                  field: {
+                    [arg.id]: true,
+                  },
+                  required: arg.required,
+                  placeholder: arg.placeholder,
+                  ...baseField,
+                };
+              })}
             />
+          )}
+
+        {hasAdvancedArguments &&
+          !(hasWorkflowSelectArg && isLoadingWorkflows) && (
+            <button
+              type="button"
+              onClick={() => {
+                setShowAdvanced((value: boolean) => {
+                  return !value;
+                });
+              }}
+              className="mt-3 text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+            >
+              {showAdvanced
+                ? "Hide advanced settings"
+                : `Show advanced settings (${advancedArguments.length})`}
+            </button>
           )}
       </div>
       {showVariableModal && (

--- a/Common/UI/Components/Workflow/ComponentValuePickerModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentValuePickerModal.tsx
@@ -47,12 +47,13 @@ const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
       return components;
     }
 
+    const query: string = searchText.toLowerCase();
     const searched: Array<NodeDataProp> = [];
 
     for (const component of components) {
       if (
-        component.metadata.title.includes(searchText) ||
-        component.metadata.description.includes(searchText)
+        component.metadata.title.toLowerCase().includes(query) ||
+        component.metadata.description.toLowerCase().includes(query)
       ) {
         searched.push(component);
         continue;
@@ -60,8 +61,8 @@ const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
 
       for (const returnVal of component.metadata.returnValues) {
         if (
-          returnVal.name.includes(searchText) ||
-          returnVal.description.includes(searchText)
+          returnVal.name.toLowerCase().includes(query) ||
+          returnVal.description.toLowerCase().includes(query)
         ) {
           searched.push(component);
           break;

--- a/Common/UI/Components/Workflow/JSONArgumentInput.tsx
+++ b/Common/UI/Components/Workflow/JSONArgumentInput.tsx
@@ -1,0 +1,179 @@
+import CodeEditor from "../CodeEditor/CodeEditor";
+import Icon from "../Icon/Icon";
+import CodeType from "../../../Types/Code/CodeType";
+import IconProp from "../../../Types/Icon/IconProp";
+import { validateJson, ValidationResult } from "./JSONArgumentInputUtils";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useState,
+} from "react";
+
+/*
+ * A JSON editor tailored for Workflow component arguments.
+ *
+ * Plain JSON arguments used to render as a bare Monaco editor with no
+ * feedback: authors only discovered a syntax mistake when the workflow ran
+ * and threw a cryptic "Invalid JSON provided for argument …" error (see
+ * App/FeatureSet/Workflow/Services/RunWorkflow.ts). This component validates
+ * the JSON as you type, is aware of {{ variable }} tokens (which are filled
+ * in at runtime and are therefore not literal JSON), and offers one-click
+ * formatting — so most mistakes are caught and fixed before the run.
+ *
+ * The pure validation logic lives in ./JSONArgumentInputUtils so it can be
+ * unit tested without a React/Monaco environment.
+ */
+
+export interface ComponentProps {
+  value: string;
+  placeholder?: string | undefined;
+  // Form-level error (e.g. "required"), surfaced by the surrounding form.
+  error?: string | undefined;
+  tabIndex?: number | undefined;
+  onChange: (value: string) => void;
+  // Reports whether the current content is syntactically invalid JSON.
+  onValidationChange?: ((isInvalid: boolean) => void) | undefined;
+}
+
+const JSONArgumentInput: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [validation, setValidation] = useState<ValidationResult>(() => {
+    return validateJson(props.value || "");
+  });
+
+  useEffect(() => {
+    const next: ValidationResult = validateJson(props.value || "");
+    setValidation(next);
+    props.onValidationChange?.(next.status === "invalid");
+  }, [props.value]);
+
+  /*
+   * When this field is removed from the tree (e.g. an advanced section is
+   * collapsed, or the settings panel closes), stop reporting an error so the
+   * surrounding form isn't blocked by a field the user can no longer see.
+   */
+  useEffect(() => {
+    return () => {
+      props.onValidationChange?.(false);
+    };
+  }, []);
+
+  const canFormat: boolean =
+    validation.status === "valid" && !validation.hasVariables;
+
+  type FormatJsonFunction = () => void;
+
+  const formatJson: FormatJsonFunction = (): void => {
+    try {
+      const formatted: string = JSON.stringify(
+        JSON.parse(props.value),
+        null,
+        2,
+      );
+      props.onChange(formatted);
+    } catch {
+      // Not valid JSON — nothing to format. Button is disabled in this case.
+    }
+  };
+
+  type StatusChip = {
+    label: string;
+    icon: IconProp;
+    className: string;
+  };
+
+  const getStatusChip: () => StatusChip | null = (): StatusChip | null => {
+    switch (validation.status) {
+      case "valid":
+        return {
+          label: validation.hasVariables
+            ? "Valid JSON · uses variables"
+            : "Valid JSON",
+          icon: IconProp.CheckCircle,
+          className: "text-green-600",
+        };
+      case "invalid":
+        return {
+          label: "Invalid JSON",
+          icon: IconProp.Error,
+          className: "text-red-600",
+        };
+      case "variable":
+        return {
+          label: "Variable",
+          icon: IconProp.Variable,
+          className: "text-indigo-500",
+        };
+      case "template":
+        return {
+          label: "Template logic",
+          icon: IconProp.Code,
+          className: "text-indigo-500",
+        };
+      case "empty":
+      default:
+        return null;
+    }
+  };
+
+  const chip: StatusChip | null = getStatusChip();
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1 min-h-[20px]">
+        <div>
+          {chip && (
+            <span
+              className={`inline-flex items-center gap-1 text-xs font-medium ${chip.className}`}
+            >
+              <Icon icon={chip.icon} className="h-3.5 w-3.5" />
+              {chip.label}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={formatJson}
+          disabled={!canFormat}
+          title={
+            validation.hasVariables
+              ? "Formatting is unavailable while variables are used."
+              : "Reformat the JSON with clean indentation."
+          }
+          className={
+            canFormat
+              ? "text-xs font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+              : "text-xs font-medium text-gray-300 cursor-not-allowed"
+          }
+        >
+          Format
+        </button>
+      </div>
+
+      <CodeEditor
+        type={CodeType.JSON}
+        showLineNumbers={true}
+        tabIndex={props.tabIndex}
+        value={props.value}
+        initialValue={props.value}
+        placeholder={props.placeholder}
+        error={
+          props.error ||
+          (validation.status === "invalid" ? validation.message : undefined)
+        }
+        onChange={(value: string) => {
+          props.onChange(value);
+        }}
+      />
+
+      {(validation.status === "variable" || validation.status === "template") &&
+        validation.message && (
+          <p className="mt-1 text-xs text-gray-500">{validation.message}</p>
+        )}
+    </div>
+  );
+};
+
+export default JSONArgumentInput;

--- a/Common/UI/Components/Workflow/JSONArgumentInputUtils.ts
+++ b/Common/UI/Components/Workflow/JSONArgumentInputUtils.ts
@@ -1,0 +1,93 @@
+/*
+ * Pure (React-free) validation helpers for JSONArgumentInput.
+ *
+ * Workflow JSON arguments may contain {{ variable }} tokens that are filled
+ * in at runtime and are therefore not literal JSON. These helpers validate
+ * the editor content while treating those tokens as valid placeholders, so
+ * syntax mistakes are caught while editing rather than surfacing as a cryptic
+ * runtime error (see App/FeatureSet/Workflow/Services/RunWorkflow.ts).
+ *
+ * Kept free of React/Monaco imports so it can be unit-tested directly.
+ */
+
+export type ValidationStatus =
+  | "empty"
+  | "valid"
+  | "invalid"
+  | "variable"
+  | "template";
+
+export interface ValidationResult {
+  status: ValidationStatus;
+  message?: string | undefined;
+  // Does the content contain at least one {{ token }} (but still parses)?
+  hasVariables: boolean;
+}
+
+// Matches a single {{ ... }} token.
+export const TOKEN_REGEX: RegExp = /\{\{(.*?)\}\}/g;
+
+// Matches {{#each}} / {{/each}} block helpers, which can't be validated statically.
+const BLOCK_HELPER_REGEX: RegExp = /\{\{\s*[#/]/;
+
+// Matches content that is exactly one {{ variable }} token.
+const SINGLE_TOKEN_REGEX: RegExp = /^\{\{[^{}]*\}\}$/;
+
+export type ContainsTokenFunction = (raw: string) => boolean;
+
+export const containsToken: ContainsTokenFunction = (raw: string): boolean => {
+  TOKEN_REGEX.lastIndex = 0;
+  return TOKEN_REGEX.test(raw);
+};
+
+export type ValidateJsonFunction = (raw: string) => ValidationResult;
+
+/*
+ * Validate the raw editor content as JSON, treating {{ tokens }} as valid
+ * placeholders. We mask each token with `0` (a value that is valid both on
+ * its own and inside a string) before parsing, mirroring how the runtime
+ * substitutes a real value in its place.
+ */
+export const validateJson: ValidateJsonFunction = (
+  raw: string,
+): ValidationResult => {
+  const trimmed: string = (raw || "").trim();
+
+  if (!trimmed) {
+    return { status: "empty", hasVariables: false };
+  }
+
+  // Block helpers like {{#each …}} / {{/each}} can't be validated statically.
+  if (BLOCK_HELPER_REGEX.test(trimmed)) {
+    return {
+      status: "template",
+      message: "Uses template logic — checked when the workflow runs.",
+      hasVariables: true,
+    };
+  }
+
+  // The whole field is a single variable reference — nothing to parse.
+  if (SINGLE_TOKEN_REGEX.test(trimmed)) {
+    return {
+      status: "variable",
+      message: "References a variable — resolved when the workflow runs.",
+      hasVariables: true,
+    };
+  }
+
+  const hasVariables: boolean = containsToken(trimmed);
+  const masked: string = trimmed.replace(TOKEN_REGEX, "0");
+
+  try {
+    JSON.parse(masked);
+    return { status: "valid", hasVariables: hasVariables };
+  } catch (err: unknown) {
+    const message: string =
+      err instanceof Error ? err.message : "Unexpected error.";
+    return {
+      status: "invalid",
+      message: message,
+      hasVariables: hasVariables,
+    };
+  }
+};


### PR DESCRIPTION
## Why

Configuring workflow components is hard to get right, and the **JSON-typed arguments are the sharpest edge**. Request bodies, HTTP headers, DB queries and payloads all rendered as a bare Monaco editor with **no validation**. A syntax slip — a trailing comma, a missing quote — was only discovered when the workflow *ran*, throwing a cryptic `Invalid JSON provided for argument …` (`App/FeatureSet/Workflow/Services/RunWorkflow.ts:596-607`). Template tokens made it worse: `{{ variable }}` references aren't literal JSON, so the editor couldn't tell "not valid yet" from "actually broken."

This PR makes JSON editing **validate-as-you-type** and blocks saving broken config — while keeping the **on-disk format byte-identical** (values are still stored as JSON strings and parsed at runtime, so existing workflows are unaffected and the executor is untouched).

## What changed

- **`JSONArgumentInput`** — a token-aware JSON editor with:
  - live validation + a clear inline **"Invalid JSON"** message (catches the trailing-comma / missing-quote footguns before the run),
  - a one-click **Format** button,
  - awareness of `{{ tokens }}` (masked before parsing), single-token variable references, and `{{#each}}` template blocks — so variable usage no longer reads as an error.
- **`JSONArgumentInputUtils`** — the pure validation logic, extracted React-free and covered by unit tests.
- **`ArgumentsForm`**:
  - routes `JSON` / `JSONArray` / `BaseModel` / `BaseModelArray` / `Query` / `StringDictionary` args (and `Select` without a `tableName`) through the validating editor;
  - **lifts each field's validity into the form** so an invalid JSON body disables **Save**;
  - honors the previously-**unused `Argument.isAdvanced` flag** — advanced fields collapse behind a **"Show advanced settings"** toggle so the common path is a couple of fields (auto-expands when an advanced field is required or already set, so nothing important is hidden);
  - fixes a **validation-key collision** — argument errors were reported under the same `"id"` key as the identifier field and could clobber it; now uses distinct `"arguments"` / `"json:<argId>"` keys;
  - replaces the misused **error-style empty state** ("This step does not need any settings") with a neutral note.
- **`ComponentValuePickerModal`** — case-insensitive search.

## Safety / compatibility

- **No storage or executor change.** JSON args remain strings; `RunWorkflow` / `API/Utils` still `JSON.parse` them at runtime. Verified the server reads these as `typeof === "string"` before parsing.
- Lands entirely in `Common/UI/Components/Workflow/*` — the path the workflow builder actually renders (`Dashboard/View/Builder.tsx` → `Common/UI/.../Workflow`). The separate `Dashboard/Canvas/*` copy (dashboard tiles) is untouched.

## Testing

- `tsc --noEmit` ✓ · `eslint` ✓
- New unit tests (9) for the validator: valid/invalid JSON, quoted & unquoted tokens, single-token variables, `{{#each}}` blocks, stateless token detection — all passing.

## Context / follow-ups

This is **Phase 0** of a larger workflow-builder simplification (validated via a multi-perspective design pass). Natural next steps, not in this PR: dock the config modal into a side **inspector**, turn `{{…}}` strings into **data chips** with upstream-only autocomplete, node-face config summaries, structured editors (key/value rows for headers, a filter builder for queries), labeled ports, and a template-gallery cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)