### PR TITLE
feat(workflow): guided-canvas — docked inspector, upstream picker, self-documenting nodes

### DIFF
--- a/Common/Tests/UI/Components/Workflow/ComponentSettingsPanel.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/ComponentSettingsPanel.test.tsx
@@ -1,0 +1,198 @@
+import ComponentSettingsPanel from "../../../../UI/Components/Workflow/ComponentSettingsPanel";
+import {
+  ComponentInputType,
+  ComponentType,
+  NodeDataProp,
+  NodeType,
+} from "../../../../Types/Workflow/Component";
+import IconProp from "../../../../Types/Icon/IconProp";
+import ObjectID from "../../../../Types/ObjectID";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+/*
+ * Mock the Monaco-backed editor so the import chain stays light in jsdom
+ * (this test uses a plain Text argument, so the code editor is never
+ * rendered). RTL getBy* queries throw when an element is missing, so they
+ * double as presence assertions — we avoid jest-dom matchers, which aren't
+ * typed for @jest/globals' expect.
+ */
+jest.mock("../../../../UI/Components/CodeEditor/CodeEditor", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return null;
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Navigation", () => {
+  return {
+    __esModule: true,
+    default: { navigate: jest.fn() },
+  };
+});
+
+type MakeComponentFunction = () => NodeDataProp;
+
+const makeComponent: MakeComponentFunction = (): NodeDataProp => {
+  return {
+    error: "",
+    id: "log-1",
+    nodeType: NodeType.Node,
+    isPreview: false,
+    metadataId: "log",
+    internalId: "internal-1",
+    arguments: {},
+    returnValues: {},
+    componentType: ComponentType.Component,
+    metadata: {
+      id: "log",
+      title: "Log to Console",
+      category: "Utility",
+      description: "Logs a message",
+      iconProp: IconProp.Bolt,
+      componentType: ComponentType.Component,
+      arguments: [
+        {
+          id: "text",
+          name: "Message",
+          description: "The message to log.",
+          required: false,
+          type: ComponentInputType.Text,
+        },
+      ],
+      returnValues: [],
+      inPorts: [{ id: "in", title: "In", description: "Where it starts." }],
+      outPorts: [],
+    },
+  } as NodeDataProp;
+};
+
+type RenderPanelResult = {
+  onClose: MockFunction;
+  onSave: MockFunction;
+  onDelete: MockFunction;
+  component: NodeDataProp;
+};
+
+type RenderPanelFunction = () => RenderPanelResult;
+
+const renderPanel: RenderPanelFunction = (): RenderPanelResult => {
+  const onClose: MockFunction = getJestMockFunction();
+  const onSave: MockFunction = getJestMockFunction();
+  const onDelete: MockFunction = getJestMockFunction();
+  const component: NodeDataProp = makeComponent();
+
+  render(
+    <ComponentSettingsPanel
+      title="Log to Console"
+      description="Logs a message"
+      onClose={onClose}
+      onSave={onSave}
+      onDelete={onDelete}
+      component={component}
+      graphComponents={[component]}
+      workflowId={ObjectID.generate()}
+    />,
+  );
+
+  return { onClose, onSave, onDelete, component };
+};
+
+describe("ComponentSettingsPanel (docked inspector)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the step title and its settings", async () => {
+    renderPanel();
+
+    expect(
+      screen.getByRole("heading", { name: "Log to Console" }),
+    ).toBeTruthy();
+
+    // The argument field renders (ArgumentsForm builds it asynchronously).
+    await waitFor(() => {
+      expect(screen.getByText("Message")).toBeTruthy();
+    });
+  });
+
+  it("saves the step when Save is clicked", () => {
+    const { onSave } = renderPanel();
+
+    fireEvent.click(screen.getByTestId("workflow-step-save"));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0]![0]).toMatchObject({ id: "log-1" });
+  });
+
+  it("closes when the close button is clicked", () => {
+    const { onClose } = renderPanel();
+
+    fireEvent.click(screen.getByLabelText("Close settings"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the technical Identifier until Advanced is expanded", async () => {
+    renderPanel();
+
+    expect(screen.queryByText("Identifier")).toBeNull();
+
+    fireEvent.click(screen.getByText("Show advanced (identifier)"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Identifier")).toBeTruthy();
+    });
+  });
+
+  it("deletes the step only after confirmation", async () => {
+    const { onDelete, onClose } = renderPanel();
+
+    // Opening the panel does not delete anything.
+    expect(onDelete).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("workflow-step-delete"));
+
+    // A confirmation dialog appears.
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Are you sure you want to delete this component? This action is not recoverable.",
+        ),
+      ).toBeTruthy();
+    });
+
+    /*
+     * Confirm the deletion (the dialog's submit button, distinct from the
+     * footer's Delete trigger).
+     */
+    const deleteButtons: Array<HTMLElement> = screen.getAllByRole("button", {
+      name: "Delete",
+    });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1] as HTMLElement);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
@@ -1,0 +1,234 @@
+import {
+  getUpstreamComponentIds,
+  getComponentSummary,
+} from "../../../../UI/Components/Workflow/GraphUtils";
+import {
+  ComponentInputType,
+  NodeDataProp,
+} from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+import { Edge, Node } from "reactflow";
+
+type MakeNodeFunction = (nodeId: string, dataId: string) => Node;
+
+const makeNode: MakeNodeFunction = (nodeId: string, dataId: string): Node => {
+  return {
+    id: nodeId,
+    position: { x: 0, y: 0 },
+    data: { id: dataId } as NodeDataProp,
+  };
+};
+
+type MakeEdgeFunction = (source: string, target: string) => Edge;
+
+const makeEdge: MakeEdgeFunction = (source: string, target: string): Edge => {
+  return { id: `${source}->${target}`, source: source, target: target };
+};
+
+describe("GraphUtils.getUpstreamComponentIds", () => {
+  test("returns all ancestors in a linear chain A -> B -> C", () => {
+    const nodes: Array<Node> = [
+      makeNode("nA", "a-1"),
+      makeNode("nB", "b-1"),
+      makeNode("nC", "c-1"),
+    ];
+    const edges: Array<Edge> = [makeEdge("nA", "nB"), makeEdge("nB", "nC")];
+
+    const upstreamOfC: Set<string> = getUpstreamComponentIds(
+      "nC",
+      nodes,
+      edges,
+    );
+    expect(upstreamOfC).toEqual(new Set(["a-1", "b-1"]));
+  });
+
+  test("a root node has no upstream", () => {
+    const nodes: Array<Node> = [makeNode("nA", "a-1"), makeNode("nB", "b-1")];
+    const edges: Array<Edge> = [makeEdge("nA", "nB")];
+
+    expect(getUpstreamComponentIds("nA", nodes, edges)).toEqual(
+      new Set<string>(),
+    );
+  });
+
+  test("collects all ancestors across a diamond and does not include self", () => {
+    // A -> B, A -> C, B -> D, C -> D
+    const nodes: Array<Node> = [
+      makeNode("nA", "a-1"),
+      makeNode("nB", "b-1"),
+      makeNode("nC", "c-1"),
+      makeNode("nD", "d-1"),
+    ];
+    const edges: Array<Edge> = [
+      makeEdge("nA", "nB"),
+      makeEdge("nA", "nC"),
+      makeEdge("nB", "nD"),
+      makeEdge("nC", "nD"),
+    ];
+
+    const upstreamOfD: Set<string> = getUpstreamComponentIds(
+      "nD",
+      nodes,
+      edges,
+    );
+    expect(upstreamOfD).toEqual(new Set(["a-1", "b-1", "c-1"]));
+    expect(upstreamOfD.has("d-1")).toBe(false);
+  });
+
+  test("terminates on a cycle instead of looping forever", () => {
+    // A -> B -> A (pathological), asking upstream of B
+    const nodes: Array<Node> = [makeNode("nA", "a-1"), makeNode("nB", "b-1")];
+    const edges: Array<Edge> = [makeEdge("nA", "nB"), makeEdge("nB", "nA")];
+
+    const upstreamOfB: Set<string> = getUpstreamComponentIds(
+      "nB",
+      nodes,
+      edges,
+    );
+    expect(upstreamOfB).toEqual(new Set(["a-1"]));
+  });
+});
+
+type MakeDataFunction = (
+  args: Array<{ id: string; name: string; type: ComponentInputType }>,
+  values: Record<string, unknown>,
+) => NodeDataProp;
+
+const makeData: MakeDataFunction = (
+  args: Array<{ id: string; name: string; type: ComponentInputType }>,
+  values: Record<string, unknown>,
+): NodeDataProp => {
+  return {
+    metadata: {
+      arguments: args.map(
+        (a: { id: string; name: string; type: ComponentInputType }) => {
+          return {
+            id: a.id,
+            name: a.name,
+            type: a.type,
+            description: "",
+            required: false,
+          };
+        },
+      ),
+    },
+    arguments: values,
+  } as unknown as NodeDataProp;
+};
+
+describe("GraphUtils.getComponentSummary", () => {
+  test("returns null when nothing is configured", () => {
+    const data: NodeDataProp = makeData(
+      [{ id: "text", name: "Message", type: ComponentInputType.Text }],
+      {},
+    );
+    expect(getComponentSummary(data)).toBeNull();
+  });
+
+  test("summarizes up to two configured values", () => {
+    const data: NodeDataProp = makeData(
+      [
+        { id: "channel", name: "Channel", type: ComponentInputType.Text },
+        { id: "text", name: "Message", type: ComponentInputType.Text },
+        { id: "extra", name: "Extra", type: ComponentInputType.Text },
+      ],
+      { channel: "#alerts", text: "Incident is down", extra: "ignored" },
+    );
+    expect(getComponentSummary(data)).toBe(
+      "Channel: #alerts · Message: Incident is down",
+    );
+  });
+
+  test("redacts secret-typed and secret-named fields", () => {
+    const data: NodeDataProp = makeData(
+      [
+        {
+          id: "webhook-url",
+          name: "Slack Webhook URL",
+          type: ComponentInputType.URL,
+        },
+      ],
+      { "webhook-url": "https://hooks.slack.com/services/TOKEN" },
+    );
+    expect(getComponentSummary(data)).toBe("Slack Webhook URL: ••••");
+
+    const pwd: NodeDataProp = makeData(
+      [{ id: "pw", name: "Password", type: ComponentInputType.Password }],
+      { pw: "hunter2" },
+    );
+    expect(getComponentSummary(pwd)).toBe("Password: ••••");
+  });
+
+  test("truncates long values", () => {
+    const longText: string = "x".repeat(100);
+    const data: NodeDataProp = makeData(
+      [{ id: "text", name: "Msg", type: ComponentInputType.Text }],
+      { text: longText },
+    );
+    const summary: string | null = getComponentSummary(data);
+    expect(summary).not.toBeNull();
+    expect(summary!.endsWith("…")).toBe(true);
+    // "Msg: " + 40 chars max
+    expect(summary!.length).toBeLessThanOrEqual("Msg: ".length + 40);
+  });
+
+  test("redacts structured/opaque types (JSON, headers) that may hold secrets", () => {
+    const headers: NodeDataProp = makeData(
+      [
+        {
+          id: "request-headers",
+          name: "Request Headers",
+          type: ComponentInputType.StringDictionary,
+        },
+      ],
+      { "request-headers": '{"Authorization":"Bearer eyJsecrettoken"}' },
+    );
+    expect(getComponentSummary(headers)).toBe("Request Headers: ••••");
+
+    const body: NodeDataProp = makeData(
+      [{ id: "request-body", name: "Body", type: ComponentInputType.JSON }],
+      { "request-body": '{"apiKey":"sk-live-123"}' },
+    );
+    expect(getComponentSummary(body)).toBe("Body: ••••");
+  });
+
+  test("masks credentials and query string from URL values", () => {
+    const withCreds: NodeDataProp = makeData(
+      [{ id: "endpoint", name: "Endpoint", type: ComponentInputType.URL }],
+      { endpoint: "https://user:p@ssw0rd@internal.host/path?sig=secret" },
+    );
+    // userinfo and query dropped, host + path kept.
+    expect(getComponentSummary(withCreds)).toBe(
+      "Endpoint: https://internal.host/path",
+    );
+
+    const plain: NodeDataProp = makeData(
+      [{ id: "endpoint", name: "Endpoint", type: ComponentInputType.URL }],
+      { endpoint: "https://api.example.com/v1" },
+    );
+    expect(getComponentSummary(plain)).toBe(
+      "Endpoint: https://api.example.com/v1",
+    );
+  });
+
+  test("humanizes {{ tokens }} into friendly names", () => {
+    const data: NodeDataProp = makeData(
+      [{ id: "text", name: "Message", type: ComponentInputType.Text }],
+      {
+        text: "Incident {{local.components.incident-1.returnValues.title}} is down",
+      },
+    );
+    expect(getComponentSummary(data)).toBe("Message: Incident {title} is down");
+  });
+
+  test("skips a value that is only whitespace (no dangling label)", () => {
+    const data: NodeDataProp = makeData(
+      [
+        { id: "a", name: "A", type: ComponentInputType.Text },
+        { id: "b", name: "B", type: ComponentInputType.Text },
+      ],
+      { a: "   ", b: "real" },
+    );
+    expect(getComponentSummary(data)).toBe("B: real");
+  });
+});

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -48,6 +48,8 @@ export interface ComponentProps {
   onHasFormValidationErrors: (values: Dictionary<boolean>) => void;
   workflowId: ObjectID;
   graphComponents: Array<NodeDataProp>;
+  // Component data ids upstream of this step (their output is referenceable).
+  upstreamComponentIds?: Set<string> | undefined;
   onFormChange: (value: NodeDataProp) => void;
 }
 
@@ -432,6 +434,8 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
       {showComponentPickerModal && (
         <ComponentValuePickerModal
           components={props.graphComponents}
+          upstreamComponentIds={props.upstreamComponentIds}
+          currentComponentId={component.id}
           onClose={() => {
             setShowComponentPickerModal(false);
           }}

--- a/Common/UI/Components/Workflow/Component.tsx
+++ b/Common/UI/Components/Workflow/Component.tsx
@@ -1,5 +1,6 @@
 import Icon, { ThickProp } from "../Icon/Icon";
 import Tooltip from "../Tooltip/Tooltip";
+import { getComponentSummary } from "./GraphUtils";
 import IconProp from "../../../Types/Icon/IconProp";
 import {
   ComponentType,
@@ -472,7 +473,11 @@ const Node: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
           </div>
         )}
 
-        {/* Description */}
+        {/*
+          Show a summary of the step's configured values so the canvas is
+          self-documenting; fall back to the static description when nothing
+          is configured yet (and always in the components-picker preview).
+        */}
         <p
           style={{
             color: "#64748b",
@@ -483,9 +488,11 @@ const Node: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
             WebkitLineClamp: 2,
             WebkitBoxOrient: "vertical",
             overflow: "hidden",
+            overflowWrap: "anywhere",
           }}
         >
-          {props.data.metadata.description}
+          {(!props.data.isPreview && getComponentSummary(props.data)) ||
+            props.data.metadata.description}
         </p>
       </div>
 

--- a/Common/UI/Components/Workflow/ComponentSettingsModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentSettingsModal.tsx
@@ -24,6 +24,8 @@ export interface ComponentProps {
   onDelete: (component: NodeDataProp) => void;
   component: NodeDataProp;
   graphComponents: Array<NodeDataProp>;
+  // Component data ids that run before this step (their output is referenceable).
+  upstreamComponentIds?: Set<string> | undefined;
   workflowId: ObjectID;
   webhookSecretKey?: string | undefined;
 }
@@ -68,10 +70,18 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
   const [showDeleteConfirmation, setShowDeleteConfirmation] =
     useState<boolean>(false);
 
+  /*
+   * The Identifier is a technical detail most authors never touch (it's used
+   * to reference this step from others). It's tucked behind an "Advanced"
+   * disclosure so the panel stays focused on the actual settings.
+   */
+  const [showIdentifier, setShowIdentifier] = useState<boolean>(false);
+
   const settingsSection: ReactElement = (
     <SectionCard icon={IconProp.Settings} title="Settings">
       <ArgumentsForm
         graphComponents={props.graphComponents}
+        upstreamComponentIds={props.upstreamComponentIds}
         workflowId={props.workflowId}
         component={component}
         onFormChange={(c: NodeDataProp) => {
@@ -224,11 +234,23 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div className="md:col-span-2 space-y-4">{settingsSection}</div>
           <div className="md:col-span-1 space-y-4">
-            {idSection}
             {documentationSection}
             {inputsSection}
             {outputsSection}
             {returnsSection}
+            {showIdentifier ? (
+              idSection
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setShowIdentifier(true);
+                }}
+                className="text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+              >
+                Show advanced (identifier)
+              </button>
+            )}
           </div>
         </div>
       </>

--- a/Common/UI/Components/Workflow/ComponentSettingsPanel.tsx
+++ b/Common/UI/Components/Workflow/ComponentSettingsPanel.tsx
@@ -3,7 +3,7 @@ import BasicForm from "../Forms/BasicForm";
 import FormFieldSchemaType from "../Forms/Types/FormFieldSchemaType";
 import FormValues from "../Forms/Types/FormValues";
 import ConfirmModal from "../Modal/ConfirmModal";
-import Modal, { ModalWidth } from "../Modal/Modal";
+import Icon from "../Icon/Icon";
 import ArgumentsForm from "./ArgumentsForm";
 import ComponentPortViewer from "./ComponentPortViewer";
 import ComponentReturnValueViewer from "./ComponentReturnValueViewer";
@@ -14,7 +14,13 @@ import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import { NodeDataProp } from "../../../Types/Workflow/Component";
 import React, { FunctionComponent, ReactElement, useState } from "react";
-import Icon from "../Icon/Icon";
+
+/*
+ * The step configuration surface, rendered as a docked panel beside the
+ * canvas (see Workflow.tsx) instead of a full-screen modal — so the graph
+ * stays visible while you configure a step. It overlays the right edge of the
+ * canvas, leaving the React Flow layout untouched.
+ */
 
 export interface ComponentProps {
   title: string;
@@ -60,7 +66,7 @@ const SectionCard: FunctionComponent<SectionCardProps> = (
   );
 };
 
-const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
+const ComponentSettingsPanel: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const [component, setComponent] = useState<NodeDataProp>(props.component);
@@ -137,7 +143,7 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
 
   /*
    * Each connection/output card is only rendered if there's something to
-   * show — keeps the sidebar lean for triggers (no inputs) and components
+   * show — keeps the panel lean for triggers (no inputs) and components
    * that don't return any data.
    */
   const hasInputs: boolean =
@@ -187,75 +193,91 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
   );
 
   return (
-    <Modal
-      title={props.title}
-      description={props.description}
-      onClose={props.onClose}
-      onSubmit={() => {
-        return component && props.onSave(component);
-      }}
-      submitButtonText="Save"
-      modalWidth={ModalWidth.Large}
-      disableSubmitButton={hasErrors}
-      leftFooterElement={
+    <div className="flex h-full flex-col bg-white">
+      {/* Header */}
+      <div className="flex items-start justify-between border-b border-gray-200 px-4 py-3">
+        <div className="min-w-0 pr-2">
+          <h2 className="truncate text-sm font-semibold text-gray-900">
+            {props.title}
+          </h2>
+          {props.description && (
+            <p className="truncate text-xs text-gray-500">
+              {props.description}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          aria-label="Close settings"
+          onClick={props.onClose}
+          className="shrink-0 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 cursor-pointer"
+        >
+          <Icon icon={IconProp.Close} className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 space-y-4 overflow-y-auto p-4">
+        {settingsSection}
+        {documentationSection}
+        {inputsSection}
+        {outputsSection}
+        {returnsSection}
+        {showIdentifier ? (
+          idSection
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setShowIdentifier(true);
+            }}
+            className="text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+          >
+            Show advanced (identifier)
+          </button>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between border-t border-gray-200 px-4 py-3">
         <Button
           title="Delete"
           icon={IconProp.Trash}
           buttonStyle={ButtonStyleType.DANGER_OUTLINE}
+          dataTestId="workflow-step-delete"
           onClick={() => {
             setShowDeleteConfirmation(true);
           }}
         />
-      }
-    >
-      <>
-        {showDeleteConfirmation && (
-          <ConfirmModal
-            title={`Delete ${component.metadata.componentType}`}
-            description={`Are you sure you want to delete this ${component.metadata.componentType.toLowerCase()}? This action is not recoverable.`}
-            onClose={() => {
-              setShowDeleteConfirmation(false);
-            }}
-            submitButtonText="Delete"
-            onSubmit={() => {
-              props.onDelete(component);
-              setShowDeleteConfirmation(false);
-              props.onClose();
-            }}
-            submitButtonType={ButtonStyleType.DANGER}
-          />
-        )}
+        <Button
+          title="Save"
+          buttonStyle={ButtonStyleType.PRIMARY}
+          disabled={hasErrors}
+          dataTestId="workflow-step-save"
+          onClick={() => {
+            props.onSave(component);
+          }}
+        />
+      </div>
 
-        {/*
-         * Two-column layout: arguments take the main column (2/3 width on
-         * md+), metadata sits in a narrower sidebar. Collapses to one
-         * column below md.
-         */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="md:col-span-2 space-y-4">{settingsSection}</div>
-          <div className="md:col-span-1 space-y-4">
-            {documentationSection}
-            {inputsSection}
-            {outputsSection}
-            {returnsSection}
-            {showIdentifier ? (
-              idSection
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setShowIdentifier(true);
-                }}
-                className="text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
-              >
-                Show advanced (identifier)
-              </button>
-            )}
-          </div>
-        </div>
-      </>
-    </Modal>
+      {showDeleteConfirmation && (
+        <ConfirmModal
+          title={`Delete ${component.metadata.componentType}`}
+          description={`Are you sure you want to delete this ${component.metadata.componentType.toLowerCase()}? This action is not recoverable.`}
+          onClose={() => {
+            setShowDeleteConfirmation(false);
+          }}
+          submitButtonText="Delete"
+          onSubmit={() => {
+            props.onDelete(component);
+            setShowDeleteConfirmation(false);
+            props.onClose();
+          }}
+          submitButtonType={ButtonStyleType.DANGER}
+        />
+      )}
+    </div>
   );
 };
 
-export default ComponentSettingsModal;
+export default ComponentSettingsPanel;

--- a/Common/UI/Components/Workflow/ComponentValuePickerModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentValuePickerModal.tsx
@@ -4,17 +4,20 @@ import Modal, { ModalWidth } from "../Modal/Modal";
 import Pill from "../Pill/Pill";
 import { Black } from "../../../Types/BrandColors";
 import { NodeDataProp, ReturnValue } from "../../../Types/Workflow/Component";
-import React, {
-  FunctionComponent,
-  ReactElement,
-  useEffect,
-  useState,
-} from "react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 
 export interface ComponentProps {
   onClose: () => void;
   onSave: (componentValueId: string) => void;
   components: Array<NodeDataProp>;
+  /*
+   * Data ids of steps upstream of the one being edited. When provided, only
+   * these are offered by default — you can't reference data that won't exist
+   * at runtime. Undefined means "no graph context, show everything".
+   */
+  upstreamComponentIds?: Set<string> | undefined;
+  // The step being edited — never offer it as a source of its own value.
+  currentComponentId?: string | undefined;
 }
 
 const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
@@ -24,15 +27,11 @@ const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
     useState<ReturnValue | null>(null);
   const [selectedComponent, setSelectedComponent] =
     useState<NodeDataProp | null>(null);
-  const [searchedComponents, setSearchedComponents] = useState<
-    Array<NodeDataProp>
-  >([]);
 
   const [searchText, setSearchText] = useState<string>("");
 
-  useEffect(() => {
-    setSearchedComponents(searchReturnValues(props.components, searchText));
-  }, [props.components, searchText]);
+  // When true, ignore the upstream filter and list every step in the graph.
+  const [showAllSteps, setShowAllSteps] = useState<boolean>(false);
 
   type SearchReturnValuesFunction = (
     components: Array<NodeDataProp>,
@@ -59,7 +58,7 @@ const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
         continue;
       }
 
-      for (const returnVal of component.metadata.returnValues) {
+      for (const returnVal of component.metadata.returnValues || []) {
         if (
           returnVal.name.toLowerCase().includes(query) ||
           returnVal.description.toLowerCase().includes(query)
@@ -73,12 +72,41 @@ const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
     return searched;
   };
 
+  /*
+   * Restrict the choices to steps whose output actually exists when this step
+   * runs: the upstream set, minus the step itself. "Show all steps" lifts the
+   * restriction for loops / fan-out where a strict backward walk isn't enough.
+   */
+  const canFilterUpstream: boolean = Boolean(props.upstreamComponentIds);
+
+  const availableComponents: Array<NodeDataProp> = props.components.filter(
+    (component: NodeDataProp) => {
+      // Skip the placeholder trigger node (empty id, no return values).
+      if (!component.id) {
+        return false;
+      }
+      if (component.id === props.currentComponentId) {
+        return false;
+      }
+      if (!canFilterUpstream || showAllSteps) {
+        return true;
+      }
+      return props.upstreamComponentIds!.has(component.id);
+    },
+  );
+
+  // Derived during render — no effect/state, so no blank first frame or churn.
+  const searchedComponents: Array<NodeDataProp> = searchReturnValues(
+    availableComponents,
+    searchText,
+  );
+
   return (
     <Modal
       modalWidth={ModalWidth.Large}
-      title={"Select return value from another component"}
+      title={"Use a value from an earlier step"}
       description={
-        "Select a return value from the component this component is connected to."
+        "Pick an output from a step that runs before this one. Its value is filled in when the workflow runs."
       }
       onClose={props.onClose}
       disableSubmitButton={!selectedReturnValue}
@@ -108,9 +136,57 @@ const ComponentValuePickerModal: FunctionComponent<ComponentProps> = (
           </div>
         )}
 
+        {canFilterUpstream && (
+          <div className="px-2 pb-1 flex items-center justify-between">
+            <p className="text-xs text-gray-400">
+              {showAllSteps
+                ? "Showing every step in this workflow."
+                : "Showing steps that run before this one."}
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setShowAllSteps((value: boolean) => {
+                  return !value;
+                });
+              }}
+              className="text-xs font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+            >
+              {showAllSteps ? "Show upstream only" : "Show all steps"}
+            </button>
+          </div>
+        )}
+
         <div className="max-h-96 mt-5 mb-5 overflow-y-auto">
           {props.components.length === 0 ? (
             <ErrorMessage message={"No components in this workflow."} />
+          ) : (
+            <></>
+          )}
+
+          {props.components.length > 0 &&
+          !searchText &&
+          availableComponents.length === 0 ? (
+            <div className="p-3 text-sm text-gray-500">
+              {canFilterUpstream && !showAllSteps ? (
+                <span>
+                  No earlier steps are connected to this one yet. Connect it to
+                  a previous step, or{" "}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowAllSteps(true);
+                    }}
+                    className="font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+                  >
+                    show all steps
+                  </button>
+                  .
+                </span>
+              ) : (
+                "There are no other steps in this workflow yet."
+              )}
+            </div>
           ) : (
             <></>
           )}

--- a/Common/UI/Components/Workflow/GraphUtils.ts
+++ b/Common/UI/Components/Workflow/GraphUtils.ts
@@ -1,0 +1,256 @@
+import {
+  Argument,
+  ComponentInputType,
+  NodeDataProp,
+} from "../../../Types/Workflow/Component";
+import { JSONObject } from "../../../Types/JSON";
+import { Edge, Node } from "reactflow";
+
+/*
+ * Pure graph/presentation helpers for the workflow builder.
+ *
+ * Kept free of React and of the heavy catalog loader (Utils.ts pulls in every
+ * database model) so these can be unit-tested cheaply and reused widely.
+ */
+
+/*
+ * Return the set of component ids (NodeDataProp.id — the human "slack-1"
+ * identifier, NOT the React Flow node id) that are UPSTREAM of the given
+ * React Flow node, i.e. steps that run before it and whose output therefore
+ * actually exists when this step runs.
+ *
+ * Edges connect React Flow node ids (node.id); tokens reference the data id
+ * (node.data.id), so we walk the graph on node.id and translate the result
+ * back to data ids.
+ */
+export type GetUpstreamComponentIdsFunction = (
+  selectedNodeId: string,
+  nodes: Array<Node>,
+  edges: Array<Edge>,
+) => Set<string>;
+
+export const getUpstreamComponentIds: GetUpstreamComponentIdsFunction = (
+  selectedNodeId: string,
+  nodes: Array<Node>,
+  edges: Array<Edge>,
+): Set<string> => {
+  // target node id -> list of source node ids feeding into it.
+  const incoming: Map<string, Array<string>> = new Map<string, Array<string>>();
+  for (const edge of edges) {
+    if (!edge.source || !edge.target) {
+      continue;
+    }
+    const list: Array<string> = incoming.get(edge.target) || [];
+    list.push(edge.source);
+    incoming.set(edge.target, list);
+  }
+
+  // Breadth-first walk backwards from the selected node.
+  const visitedNodeIds: Set<string> = new Set<string>();
+  const queue: Array<string> = [...(incoming.get(selectedNodeId) || [])];
+
+  while (queue.length > 0) {
+    const current: string = queue.shift() as string;
+    if (visitedNodeIds.has(current) || current === selectedNodeId) {
+      continue;
+    }
+    visitedNodeIds.add(current);
+    for (const source of incoming.get(current) || []) {
+      if (!visitedNodeIds.has(source)) {
+        queue.push(source);
+      }
+    }
+  }
+
+  // Translate upstream React Flow node ids -> component data ids.
+  const dataIds: Set<string> = new Set<string>();
+  for (const node of nodes) {
+    if (visitedNodeIds.has(node.id)) {
+      const dataId: string | undefined = (node.data as NodeDataProp | undefined)
+        ?.id;
+      if (dataId) {
+        dataIds.add(dataId);
+      }
+    }
+  }
+
+  return dataIds;
+};
+
+// Field names/types whose values must never be printed on the canvas.
+const SECRET_NAME_REGEX: RegExp =
+  /webhook|token|secret|password|api[_-]?key|authorization|bearer|credential/i;
+
+const MAX_SUMMARY_VALUE_LENGTH: number = 40;
+
+const REDACTED: string = "••••";
+
+/*
+ * Only these input types are safe to print verbatim on the always-visible
+ * canvas. Structured/opaque types (JSON, StringDictionary/headers, DB queries,
+ * URLs with embedded credentials, JavaScript, …) can carry secrets, so their
+ * values are redacted rather than rendered — the node face is a shareable
+ * surface (screenshots, screen-shares).
+ */
+const SAFE_DISPLAY_TYPES: Set<ComponentInputType> = new Set<ComponentInputType>(
+  [
+    ComponentInputType.Text,
+    ComponentInputType.LongText,
+    ComponentInputType.Markdown,
+    ComponentInputType.HTML,
+    ComponentInputType.Number,
+    ComponentInputType.Decimal,
+    ComponentInputType.Boolean,
+    ComponentInputType.Date,
+    ComponentInputType.DateTime,
+    ComponentInputType.Email,
+    ComponentInputType.CronTab,
+    ComponentInputType.Operator,
+    ComponentInputType.ValueType,
+    ComponentInputType.WorkflowSelect,
+  ],
+);
+
+type IsSecretArgumentFunction = (arg: Argument) => boolean;
+
+const isSecretArgument: IsSecretArgumentFunction = (arg: Argument): boolean => {
+  if (arg.type === ComponentInputType.Password) {
+    return true;
+  }
+  return SECRET_NAME_REGEX.test(arg.id) || SECRET_NAME_REGEX.test(arg.name);
+};
+
+/*
+ * Turn {{ tokens }} into friendly names so the node face reads like a
+ * sentence ("Post {title}") instead of showing raw plumbing that also risks
+ * being sliced mid-token by truncation.
+ */
+type HumanizeTokensFunction = (text: string) => string;
+
+const humanizeTokens: HumanizeTokensFunction = (text: string): string => {
+  return text
+    .replace(
+      /\{\{\s*local\.components\.[^.}]+\.returnValues\.([^}]+?)\s*\}\}/g,
+      "{$1}",
+    )
+    .replace(/\{\{\s*(?:local|global)\.variables\.([^}]+?)\s*\}\}/g, "{$1}")
+    .replace(/\{\{[^}]*\}\}/g, "{…}");
+};
+
+// Strip credentials and query/fragment from a URL before displaying it.
+type MaskUrlFunction = (value: string) => string;
+
+const maskUrl: MaskUrlFunction = (value: string): string => {
+  /*
+   * Strip userinfo: greedily consume up to the last "@" before the path so a
+   * password containing "@" is fully removed.
+   */
+  let masked: string = value.replace(
+    /^([a-z][a-z0-9+.-]*:\/\/)[^/?#\s]*@/i,
+    "$1",
+  );
+  masked = masked.split("?")[0] as string;
+  masked = masked.split("#")[0] as string;
+  return masked;
+};
+
+type CollapseAndTruncateFunction = (text: string) => string;
+
+const collapseAndTruncate: CollapseAndTruncateFunction = (
+  text: string,
+): string => {
+  let result: string = text.replace(/\s+/g, " ").trim();
+  if (result.length > MAX_SUMMARY_VALUE_LENGTH) {
+    result = `${result.slice(0, MAX_SUMMARY_VALUE_LENGTH - 1).trimEnd()}…`;
+  }
+  return result;
+};
+
+/*
+ * Produce the display string for one argument value, or null to skip it.
+ * Secret and structured/opaque types are redacted; safe types are shown with
+ * tokens humanized and long values truncated.
+ */
+type DisplayArgumentValueFunction = (
+  arg: Argument,
+  value: unknown,
+) => string | null;
+
+const displayArgumentValue: DisplayArgumentValueFunction = (
+  arg: Argument,
+  value: unknown,
+): string | null => {
+  if (isSecretArgument(arg)) {
+    return REDACTED;
+  }
+
+  if (arg.type === ComponentInputType.URL) {
+    return collapseAndTruncate(maskUrl(humanizeTokens(String(value))));
+  }
+
+  if (!SAFE_DISPLAY_TYPES.has(arg.type)) {
+    return REDACTED;
+  }
+
+  let text: string;
+  if (typeof value === "string") {
+    text = value;
+  } else if (typeof value === "object") {
+    try {
+      text = JSON.stringify(value);
+    } catch {
+      text = String(value);
+    }
+  } else {
+    text = String(value);
+  }
+
+  const display: string = collapseAndTruncate(humanizeTokens(text));
+  /*
+   * A value that was only whitespace collapses to "" — skip it so the node
+   * never shows a dangling "Name: " label.
+   */
+  return display.length > 0 ? display : null;
+};
+
+/*
+ * Build a short, human-readable summary of what a configured step actually
+ * does, from its argument values — so the canvas is self-documenting instead
+ * of showing the same static description on every node. Secret and structured
+ * values are redacted. Returns null when nothing meaningful is configured (the
+ * caller falls back to the static description).
+ */
+export type GetComponentSummaryFunction = (data: NodeDataProp) => string | null;
+
+export const getComponentSummary: GetComponentSummaryFunction = (
+  data: NodeDataProp,
+): string | null => {
+  const args: Array<Argument> = data.metadata?.arguments || [];
+  const values: JSONObject = (data.arguments as JSONObject) || {};
+
+  const parts: Array<string> = [];
+
+  for (const arg of args) {
+    if (parts.length >= 2) {
+      break;
+    }
+
+    const value: unknown = values[arg.id];
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+
+    const display: string | null = displayArgumentValue(arg, value);
+    if (!display) {
+      continue;
+    }
+
+    parts.push(`${arg.name}: ${display}`);
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return parts.join(" · ");
+};

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -2,6 +2,7 @@ import WorkflowComponent from "./Component";
 import ComponentSettingsModal from "./ComponentSettingsModal";
 import ComponentsModal from "./ComponentsModal";
 import RunModal from "./RunModal";
+import { getUpstreamComponentIds } from "./GraphUtils";
 import { loadComponentsAndCategories } from "./Utils";
 import { VoidFunction } from "../../../Types/FunctionTypes";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -562,6 +563,18 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
           graphComponents={nodes.map((node: Node) => {
             return node.data as NodeDataProp;
           })}
+          upstreamComponentIds={getUpstreamComponentIds(
+            (
+              nodes.find((node: Node) => {
+                return (
+                  (node.data as NodeDataProp).internalId ===
+                  selectedNodeData.internalId
+                );
+              }) || { id: "" }
+            ).id,
+            nodes,
+            edges,
+          )}
           workflowId={props.workflowId}
           webhookSecretKey={props.webhookSecretKey}
           component={selectedNodeData}

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -1,5 +1,5 @@
 import WorkflowComponent from "./Component";
-import ComponentSettingsModal from "./ComponentSettingsModal";
+import ComponentSettingsPanel from "./ComponentSettingsPanel";
 import ComponentsModal from "./ComponentsModal";
 import RunModal from "./RunModal";
 import { getUpstreamComponentIds } from "./GraphUtils";
@@ -408,6 +408,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
   return (
     <div
       style={{
+        position: "relative",
         height: "calc(100vh - 220px)",
         minHeight: "600px",
         borderRadius: "8px",
@@ -559,57 +560,83 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
       )}
 
       {showComponentSettingsModal && selectedNodeData && (
-        <ComponentSettingsModal
-          graphComponents={nodes.map((node: Node) => {
-            return node.data as NodeDataProp;
-          })}
-          upstreamComponentIds={getUpstreamComponentIds(
-            (
-              nodes.find((node: Node) => {
-                return (
-                  (node.data as NodeDataProp).internalId ===
-                  selectedNodeData.internalId
-                );
-              }) || { id: "" }
-            ).id,
-            nodes,
-            edges,
-          )}
-          workflowId={props.workflowId}
-          webhookSecretKey={props.webhookSecretKey}
-          component={selectedNodeData}
-          title={
-            selectedNodeData && selectedNodeData.metadata.title
-              ? selectedNodeData.metadata.title
-              : "Component Properties"
-          }
-          onDelete={(component: NodeDataProp) => {
-            deleteNode(component.id);
+        <div
+          /*
+           * Docked inspector: overlays the right edge of the canvas so the
+           * graph stays visible while you configure a step. Positioned
+           * absolutely so the React Flow layout underneath is untouched. On
+           * narrow viewports it spans the full width as a drawer.
+           */
+          style={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            bottom: 0,
+            width: "min(400px, 100%)",
+            zIndex: 5,
+            backgroundColor: "#ffffff",
+            borderLeft: "1px solid #e2e8f0",
+            boxShadow: "-4px 0 12px -6px rgba(0, 0, 0, 0.15)",
           }}
-          description={
-            selectedNodeData && selectedNodeData.metadata.description
-              ? selectedNodeData.metadata.description
-              : "Edit Component Properties and variables here."
-          }
-          onClose={() => {
-            setShowComponentSettingsModal(false);
-          }}
-          onSave={(componentData: NodeDataProp) => {
-            // Update the node.
+        >
+          <ComponentSettingsPanel
+            /*
+             * Remount when the selected node changes so the panel's internal
+             * form state re-initialises to the newly selected step (the canvas
+             * stays clickable behind the docked panel).
+             */
+            key={selectedNodeData.internalId}
+            graphComponents={nodes.map((node: Node) => {
+              return node.data as NodeDataProp;
+            })}
+            upstreamComponentIds={getUpstreamComponentIds(
+              (
+                nodes.find((node: Node) => {
+                  return (
+                    (node.data as NodeDataProp).internalId ===
+                    selectedNodeData.internalId
+                  );
+                }) || { id: "" }
+              ).id,
+              nodes,
+              edges,
+            )}
+            workflowId={props.workflowId}
+            webhookSecretKey={props.webhookSecretKey}
+            component={selectedNodeData}
+            title={
+              selectedNodeData && selectedNodeData.metadata.title
+                ? selectedNodeData.metadata.title
+                : "Component Properties"
+            }
+            onDelete={(component: NodeDataProp) => {
+              deleteNode(component.id);
+            }}
+            description={
+              selectedNodeData && selectedNodeData.metadata.description
+                ? selectedNodeData.metadata.description
+                : "Edit Component Properties and variables here."
+            }
+            onClose={() => {
+              setShowComponentSettingsModal(false);
+            }}
+            onSave={(componentData: NodeDataProp) => {
+              // Update the node.
 
-            setNodes((nds: Array<Node>) => {
-              return nds.map((n: Node) => {
-                if (n.data.internalId === componentData.internalId) {
-                  n.data = componentData;
-                }
+              setNodes((nds: Array<Node>) => {
+                return nds.map((n: Node) => {
+                  if (n.data.internalId === componentData.internalId) {
+                    n.data = componentData;
+                  }
 
-                return n;
+                  return n;
+                });
               });
-            });
 
-            setShowComponentSettingsModal(false);
-          }}
-        />
+              setShowComponentSettingsModal(false);
+            }}
+          />
+        </div>
       )}
 
       {showRunModal && (


### PR DESCRIPTION
Continues the workflow-builder simplification. **Stacked on #2601** (base is that branch, so this diff is only the new work; GitHub retargets it to `master` once #2601 merges).

All changes are in `Common/UI/Components/Workflow/*` (+ a new pure-logic `GraphUtils.ts`). **No storage or executor changes** — existing workflows are unaffected.

## What changed

**1. Docked inspector panel.** Configuring a step used to open a full-screen modal that hid the whole graph. It's now a **docked panel on the right edge of the canvas**, so you see the graph and the step's settings together. `ComponentSettingsModal` → **`ComponentSettingsPanel`**: same sections + `ArgumentsForm`, rendered with its own header (title + close) and footer (Delete + Save, Save disabled on validation errors). It overlays the canvas absolutely, so **React Flow's layout is untouched** (no canvas-sizing regression), and remounts (`key={internalId}`) when you select a different node.

**2. Upstream-only data picker.** Inserting "a value from another step" now offers only steps that run **before** the current one (backward graph walk). A **"Show all steps"** escape covers loops/fan-out, plus a helpful empty state when the step isn't connected yet.

**3. Self-documenting node faces.** Each node shows what it's configured to do (`Channel: #alerts · Message: …`) instead of the same static description. **Secret-safe by construction:** safe-type allowlist shown; **URL** creds + query stripped; JSON / headers / DB queries and secret-named/typed fields → `••••`; `{{ tokens }}` humanized to `{title}`.

**4. Tidier config.** The technical **Identifier** field is tucked behind an "Advanced" disclosure.

## Verification

Per the reviewer's suggestion, components are exercised directly with **React Testing Library (jsdom)** — no full-app run needed:
- **`ComponentSettingsPanel.test.tsx` (5 tests):** renders title + settings; Save/Close/Delete call their callbacks; delete requires confirmation; Advanced reveals the Identifier.
- **`GraphUtils.test.ts` (12 tests):** graph traversal (chains, diamonds, cycles, roots) + summary redaction / URL-masking / token-humanizing / whitespace-skip.
- **26 workflow tests total pass.** `tsc --noEmit` ✓ · `eslint` ✓.

## Adversarial review hardening (earlier pass)

A multi-agent adversarial review (3 lenses → per-finding verification) caught 5 confirmed findings I fixed before pushing, notably:
- **Secret leak (major):** node summary printed URL/header/JSON values verbatim (basic-auth URLs, `Authorization` headers). → redact by type + mask URLs.
- **Blank-frame anti-pattern (major):** picker list held in `useState`+`useEffect`. → compute during render.
- **Placeholder crash (major):** "Show all steps" surfaced the empty-id placeholder and crashed search on `undefined` return values. → exclude empty-id + guard the loop.

## Deferred (next)

Inline data **chips** replacing the `{{…}}` string-append (highest-risk — needs a token-input with golden round-trip serialization tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
