### PR TITLE
feat(workflow): data-reference chips (upstream-scoped, byte-safe)

### DIFF
--- a/Common/Tests/UI/Components/Workflow/DataReferenceInput.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/DataReferenceInput.test.tsx
@@ -1,0 +1,133 @@
+import DataReferenceInput from "../../../../UI/Components/Workflow/DataReferenceInput";
+import { NodeDataProp } from "../../../../Types/Workflow/Component";
+import ObjectID from "../../../../Types/ObjectID";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// VariableModal pulls in the whole model-list stack; stub it (not under test).
+jest.mock("../../../../UI/Components/Workflow/VariableModal", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return null;
+    },
+  };
+});
+
+const slack: NodeDataProp = {
+  id: "slack-1",
+  metadata: {
+    title: "Send to Slack",
+    returnValues: [
+      { id: "error", name: "Error", description: "", required: false },
+    ],
+  },
+} as unknown as NodeDataProp;
+
+const log: NodeDataProp = {
+  id: "log-1",
+  metadata: {
+    title: "Log",
+    returnValues: [
+      { id: "output", name: "Output", description: "", required: false },
+    ],
+  },
+} as unknown as NodeDataProp;
+
+const VALUE_WITH_TWO_REFS: string =
+  "Hi {{local.components.slack-1.returnValues.error}} and " +
+  "{{local.components.gone-1.returnValues.x}}";
+
+type RenderResult = { onChange: MockFunction };
+
+type RenderInputFunction = (value: string) => RenderResult;
+
+const renderInput: RenderInputFunction = (value: string): RenderResult => {
+  const onChange: MockFunction = getJestMockFunction();
+  render(
+    <DataReferenceInput
+      value={value}
+      onChange={onChange}
+      components={[slack, log]}
+      upstreamComponentIds={new Set(["slack-1"])}
+      currentComponentId="current-1"
+      workflowId={ObjectID.generate()}
+    />,
+  );
+  return { onChange };
+};
+
+describe("DataReferenceInput (chips)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders each token as a chip and flags a broken reference", () => {
+    renderInput(VALUE_WITH_TWO_REFS);
+
+    // Resolvable reference shows a friendly label.
+    expect(screen.getByText("Error · from Send to Slack")).toBeTruthy();
+
+    /*
+     * A reference to a missing step is flagged (the ⚠ marker is only rendered
+     * for broken chips).
+     */
+    expect(screen.getByText("⚠")).toBeTruthy();
+  });
+
+  it("removes exactly the chosen reference when its chip is dismissed", () => {
+    const { onChange } = renderInput(VALUE_WITH_TWO_REFS);
+
+    fireEvent.click(
+      screen.getByLabelText("Remove reference Error · from Send to Slack"),
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next: string = onChange.mock.calls[0]![0] as string;
+    expect(next.includes("slack-1")).toBe(false);
+    // The other reference is untouched.
+    expect(next.includes("gone-1")).toBe(true);
+  });
+
+  it("inserts an upstream step's output from the menu", () => {
+    const { onChange } = renderInput("Message: ");
+
+    fireEvent.click(screen.getByTestId("insert-data-toggle"));
+
+    // Upstream step is offered; its output can be inserted.
+    expect(screen.getByText("Send to Slack")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Error" }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]![0]).toBe(
+      "Message: {{local.components.slack-1.returnValues.error}}",
+    );
+  });
+
+  it("hides non-upstream steps until 'Show all steps' is toggled", () => {
+    renderInput("");
+
+    fireEvent.click(screen.getByTestId("insert-data-toggle"));
+
+    // 'Log' is downstream/unconnected — not offered by default.
+    expect(screen.getByText("Send to Slack")).toBeTruthy();
+    expect(screen.queryByText("Log")).toBeNull();
+
+    fireEvent.click(screen.getByText("Show all steps"));
+
+    expect(screen.getByText("Log")).toBeTruthy();
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/TokenUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/TokenUtils.test.ts
@@ -1,0 +1,149 @@
+import {
+  appendToken,
+  buildComponentToken,
+  classifyToken,
+  describeToken,
+  parseTokens,
+  removeTokenOccurrence,
+  ParsedToken,
+} from "../../../../UI/Components/Workflow/TokenUtils";
+import { NodeDataProp } from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+const components: Array<NodeDataProp> = [
+  {
+    id: "slack-1",
+    metadata: {
+      title: "Send to Slack",
+      returnValues: [
+        { id: "error", name: "Error", description: "", required: false },
+      ],
+    },
+  } as unknown as NodeDataProp,
+];
+
+describe("TokenUtils.classifyToken", () => {
+  test("classifies a component return-value token", () => {
+    expect(
+      classifyToken("{{local.components.slack-1.returnValues.error}}"),
+    ).toEqual({
+      kind: "component",
+      raw: "{{local.components.slack-1.returnValues.error}}",
+      componentId: "slack-1",
+      returnValueId: "error",
+    });
+  });
+
+  test("classifies local and global variable tokens", () => {
+    expect(classifyToken("{{local.variables.apiKey}}")).toMatchObject({
+      kind: "variable",
+      scope: "local",
+      name: "apiKey",
+    });
+    expect(classifyToken("{{global.variables.region}}")).toMatchObject({
+      kind: "variable",
+      scope: "global",
+      name: "region",
+    });
+  });
+
+  test("falls back to unknown for anything else", () => {
+    expect(classifyToken("{{something.else}}").kind).toBe("unknown");
+  });
+});
+
+describe("TokenUtils.parseTokens", () => {
+  test("returns tokens in order with correct offsets and occurrence index", () => {
+    const value: string =
+      "Hi {{local.components.slack-1.returnValues.error}} and {{local.variables.x}}";
+    const tokens: Array<ParsedToken> = parseTokens(value);
+
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]!.occurrence).toBe(0);
+    expect(tokens[0]!.token.kind).toBe("component");
+    expect(value.slice(tokens[0]!.start, tokens[0]!.end)).toBe(
+      "{{local.components.slack-1.returnValues.error}}",
+    );
+    expect(tokens[1]!.occurrence).toBe(1);
+    expect(tokens[1]!.token.kind).toBe("variable");
+  });
+
+  test("returns nothing for empty or token-free values", () => {
+    expect(parseTokens("")).toHaveLength(0);
+    expect(parseTokens("just some text")).toHaveLength(0);
+  });
+});
+
+describe("TokenUtils.describeToken", () => {
+  test("gives a friendly label for a resolvable component token", () => {
+    const token: ParsedToken = parseTokens(
+      "{{local.components.slack-1.returnValues.error}}",
+    )[0]!;
+    expect(describeToken(token.token, components)).toEqual({
+      label: "Error · from Send to Slack",
+      isBroken: false,
+    });
+  });
+
+  test("marks a token whose source step is missing as broken", () => {
+    const token: ParsedToken = parseTokens(
+      "{{local.components.deleted-9.returnValues.error}}",
+    )[0]!;
+    const described: { isBroken: boolean } = describeToken(
+      token.token,
+      components,
+    );
+    expect(described.isBroken).toBe(true);
+  });
+
+  test("marks a token whose output is missing as broken", () => {
+    const token: ParsedToken = parseTokens(
+      "{{local.components.slack-1.returnValues.gone}}",
+    )[0]!;
+    expect(describeToken(token.token, components).isBroken).toBe(true);
+  });
+
+  test("labels variables and never marks them broken", () => {
+    const token: ParsedToken = parseTokens("{{global.variables.region}}")[0]!;
+    expect(describeToken(token.token, components)).toEqual({
+      label: "region · global variable",
+      isBroken: false,
+    });
+  });
+});
+
+describe("TokenUtils.buildComponentToken / appendToken", () => {
+  test("builds the exact stored token format", () => {
+    expect(buildComponentToken("slack-1", "error")).toBe(
+      "{{local.components.slack-1.returnValues.error}}",
+    );
+  });
+
+  test("appends a token to the existing value verbatim", () => {
+    expect(appendToken("Hello", "{{x}}")).toBe("Hello{{x}}");
+    expect(appendToken("", "{{x}}")).toBe("{{x}}");
+  });
+});
+
+describe("TokenUtils.removeTokenOccurrence", () => {
+  test("removes exactly the chosen occurrence, leaving the rest byte-identical", () => {
+    const value: string = "a {{local.variables.x}} b {{local.variables.y}} c";
+    expect(removeTokenOccurrence(value, 0)).toBe(
+      "a  b {{local.variables.y}} c",
+    );
+    expect(removeTokenOccurrence(value, 1)).toBe(
+      "a {{local.variables.x}} b  c",
+    );
+  });
+
+  test("distinguishes two identical tokens by position", () => {
+    const value: string = "{{local.variables.x}}{{local.variables.x}}";
+    expect(removeTokenOccurrence(value, 0)).toBe("{{local.variables.x}}");
+    expect(removeTokenOccurrence(value, 1)).toBe("{{local.variables.x}}");
+  });
+
+  test("is a no-op for an out-of-range occurrence", () => {
+    const value: string = "{{local.variables.x}}";
+    expect(removeTokenOccurrence(value, 5)).toBe(value);
+  });
+});

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -4,6 +4,7 @@ import FormFieldSchemaType from "../Forms/Types/FormFieldSchemaType";
 import { CustomElementProps } from "../Forms/Types/Field";
 import FormValues from "../Forms/Types/FormValues";
 import ComponentValuePickerModal from "./ComponentValuePickerModal";
+import DataReferenceInput from "./DataReferenceInput";
 import JSONArgumentInput from "./JSONArgumentInput";
 import ModelFieldPicker from "./ModelFieldPicker";
 import { componentInputTypeToFormFieldType } from "./Utils";
@@ -345,18 +346,23 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                 }
 
                 /*
-                 * The "pick from component / variable" footer doesn't
-                 * apply to the field picker (it edits a structured object,
-                 * not a free-text expression) or to WorkflowSelect. JSON
-                 * editors keep it so authors can drop {{ tokens }} into a
-                 * request body or payload.
+                 * The data-reference footer doesn't apply to the field
+                 * picker (it edits a structured object, not a free-text
+                 * expression) or to WorkflowSelect.
                  */
                 const showVariableFooter: boolean =
                   !isWorkflowSelect && !useFieldPicker;
 
-                return {
-                  title: `${arg.name}`,
-                  footerElement: showVariableFooter ? (
+                /*
+                 * Plain text fields get the inline chip helper: existing
+                 * {{ tokens }} render as friendly, removable chips and new
+                 * references are inserted from an upstream-scoped menu. JSON
+                 * editors keep the modal-based picker (inserting into a raw
+                 * body is better served by the full picker for now).
+                 */
+                let footerElement: ReactElement | undefined = undefined;
+                if (showVariableFooter && useJsonEditor) {
+                  footerElement = (
                     <div className="text-gray-500">
                       <p className="text-sm">
                         Pick this value from other{" "}
@@ -381,7 +387,29 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                         </button>
                       </p>
                     </div>
-                  ) : undefined,
+                  );
+                } else if (showVariableFooter) {
+                  footerElement = (
+                    <DataReferenceInput
+                      value={
+                        component.arguments && component.arguments[arg.id]
+                          ? String(component.arguments[arg.id])
+                          : ""
+                      }
+                      components={props.graphComponents}
+                      upstreamComponentIds={props.upstreamComponentIds}
+                      currentComponentId={component.id}
+                      workflowId={props.workflowId}
+                      onChange={(newValue: string) => {
+                        formRef.current?.setFieldValue(arg.id, newValue);
+                      }}
+                    />
+                  );
+                }
+
+                return {
+                  title: `${arg.name}`,
+                  footerElement: footerElement,
                   description: `${
                     arg.required ? "Required" : "Optional"
                   }. ${arg.description}`,

--- a/Common/UI/Components/Workflow/DataReferenceInput.tsx
+++ b/Common/UI/Components/Workflow/DataReferenceInput.tsx
@@ -1,0 +1,229 @@
+import VariableModal from "./VariableModal";
+import {
+  ParsedToken,
+  appendToken,
+  buildComponentToken,
+  describeToken,
+  parseTokens,
+  removeTokenOccurrence,
+  TokenDescription,
+} from "./TokenUtils";
+import ObjectID from "../../../Types/ObjectID";
+import { NodeDataProp, ReturnValue } from "../../../Types/Workflow/Component";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+
+/*
+ * The data-reference helper shown beneath a text argument. It renders the
+ * {{ … }} tokens already in the value as friendly, removable chips (red when
+ * the referenced step/output no longer exists), and lets you insert a new
+ * reference from an inline menu scoped to UPSTREAM steps — the ones whose
+ * output actually exists when this step runs.
+ *
+ * The value stays a plain string (tokens are appended / spliced), so the
+ * workflow round-trips byte-for-byte. All parsing lives in TokenUtils.
+ */
+
+export interface ComponentProps {
+  value: string;
+  onChange: (value: string) => void;
+  components: Array<NodeDataProp>;
+  upstreamComponentIds?: Set<string> | undefined;
+  currentComponentId?: string | undefined;
+  workflowId: ObjectID;
+}
+
+const DataReferenceInput: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [showInsertMenu, setShowInsertMenu] = useState<boolean>(false);
+  const [showAllSteps, setShowAllSteps] = useState<boolean>(false);
+  const [showVariableModal, setShowVariableModal] = useState<boolean>(false);
+
+  const canFilterUpstream: boolean = Boolean(props.upstreamComponentIds);
+
+  const parsedTokens: Array<ParsedToken> = parseTokens(props.value || "");
+
+  /*
+   * Steps that can be referenced: those with outputs, minus this step, scoped
+   * to upstream unless "Show all steps" is toggled on.
+   */
+  const availableComponents: Array<NodeDataProp> = props.components.filter(
+    (component: NodeDataProp) => {
+      if (!component.id || component.id === props.currentComponentId) {
+        return false;
+      }
+      if (
+        !component.metadata.returnValues ||
+        component.metadata.returnValues.length === 0
+      ) {
+        return false;
+      }
+      if (!canFilterUpstream || showAllSteps) {
+        return true;
+      }
+      return props.upstreamComponentIds!.has(component.id);
+    },
+  );
+
+  type InsertReferenceFunction = (token: string) => void;
+
+  const insertReference: InsertReferenceFunction = (token: string): void => {
+    props.onChange(appendToken(props.value || "", token));
+  };
+
+  return (
+    <div className="mt-1">
+      {parsedTokens.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {parsedTokens.map((parsed: ParsedToken) => {
+            const described: TokenDescription = describeToken(
+              parsed.token,
+              props.components,
+            );
+            const chipClass: string = described.isBroken
+              ? "border-red-200 bg-red-50 text-red-700"
+              : "border-indigo-200 bg-indigo-50 text-indigo-700";
+
+            return (
+              <span
+                key={parsed.occurrence}
+                className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium ${chipClass}`}
+                title={
+                  described.isBroken
+                    ? "This reference points to a step or output that no longer exists."
+                    : described.label
+                }
+              >
+                {described.isBroken && <span aria-hidden="true">⚠</span>}
+                <span className="max-w-[16rem] truncate">
+                  {described.label}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Remove reference ${described.label}`}
+                  className="ml-0.5 text-current opacity-60 hover:opacity-100 cursor-pointer"
+                  onClick={() => {
+                    props.onChange(
+                      removeTokenOccurrence(
+                        props.value || "",
+                        parsed.occurrence,
+                      ),
+                    );
+                  }}
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="relative flex items-center gap-3">
+        <button
+          type="button"
+          data-testid="insert-data-toggle"
+          className="text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+          onClick={() => {
+            setShowInsertMenu((open: boolean) => {
+              return !open;
+            });
+          }}
+        >
+          + Insert data from a step
+        </button>
+        <button
+          type="button"
+          className="text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+          onClick={() => {
+            setShowVariableModal(true);
+          }}
+        >
+          Use a variable
+        </button>
+
+        {showInsertMenu && (
+          <div className="absolute left-0 top-7 z-10 max-h-72 w-80 overflow-y-auto rounded-md border border-gray-200 bg-white p-2 shadow-lg">
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-xs text-gray-400">
+                {showAllSteps
+                  ? "All steps in this workflow"
+                  : "Steps that run before this one"}
+              </span>
+              {canFilterUpstream && (
+                <button
+                  type="button"
+                  className="text-xs font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+                  onClick={() => {
+                    setShowAllSteps((all: boolean) => {
+                      return !all;
+                    });
+                  }}
+                >
+                  {showAllSteps ? "Upstream only" : "Show all steps"}
+                </button>
+              )}
+            </div>
+
+            {availableComponents.length === 0 ? (
+              <p className="p-2 text-sm text-gray-500">
+                {canFilterUpstream && !showAllSteps
+                  ? "No earlier steps are connected yet."
+                  : "No other steps produce data yet."}
+              </p>
+            ) : (
+              availableComponents.map((component: NodeDataProp) => {
+                return (
+                  <div key={component.id} className="mb-2">
+                    <p className="text-xs font-semibold text-gray-600">
+                      {component.metadata.title}
+                    </p>
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {(component.metadata.returnValues || []).map(
+                        (returnValue: ReturnValue) => {
+                          return (
+                            <button
+                              key={returnValue.id}
+                              type="button"
+                              className="rounded border border-gray-200 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 cursor-pointer"
+                              onClick={() => {
+                                insertReference(
+                                  buildComponentToken(
+                                    component.id,
+                                    returnValue.id,
+                                  ),
+                                );
+                                setShowInsertMenu(false);
+                              }}
+                            >
+                              {returnValue.name}
+                            </button>
+                          );
+                        },
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        )}
+      </div>
+
+      {showVariableModal && (
+        <VariableModal
+          workflowId={props.workflowId}
+          onClose={() => {
+            setShowVariableModal(false);
+          }}
+          onSave={(variableToken: string) => {
+            insertReference(variableToken);
+            setShowVariableModal(false);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DataReferenceInput;

--- a/Common/UI/Components/Workflow/TokenUtils.ts
+++ b/Common/UI/Components/Workflow/TokenUtils.ts
@@ -1,0 +1,205 @@
+import { NodeDataProp, ReturnValue } from "../../../Types/Workflow/Component";
+
+/*
+ * Pure (React-free) helpers for the {{ … }} data-reference tokens used in
+ * workflow arguments. These power the chip UI in DataReferenceInput while
+ * keeping the stored value a plain string — so a workflow round-trips
+ * byte-for-byte and nothing about storage or execution changes.
+ *
+ * Token formats (produced by the pickers today):
+ *   {{local.components.<componentId>.returnValues.<returnValueId>}}
+ *   {{local.variables.<name>}}  /  {{global.variables.<name>}}
+ */
+
+export interface ComponentToken {
+  kind: "component";
+  raw: string;
+  componentId: string;
+  returnValueId: string;
+}
+
+export interface VariableToken {
+  kind: "variable";
+  raw: string;
+  scope: "local" | "global";
+  name: string;
+}
+
+export interface UnknownToken {
+  kind: "unknown";
+  raw: string;
+}
+
+export type TokenValue = ComponentToken | VariableToken | UnknownToken;
+
+export interface ParsedToken {
+  token: TokenValue;
+  start: number;
+  end: number;
+  // 0-based position among all tokens in the value (its occurrence order).
+  occurrence: number;
+}
+
+// Matches a single {{ … }} token (no nested braces).
+const TOKEN_REGEX: RegExp = /\{\{[^{}]*\}\}/g;
+const COMPONENT_INNER_REGEX: RegExp =
+  /^local\.components\.(.+)\.returnValues\.(.+)$/;
+const VARIABLE_INNER_REGEX: RegExp = /^(local|global)\.variables\.(.+)$/;
+
+export type ClassifyTokenFunction = (raw: string) => TokenValue;
+
+export const classifyToken: ClassifyTokenFunction = (
+  raw: string,
+): TokenValue => {
+  const inner: string = raw.slice(2, -2).trim();
+
+  const component: RegExpExecArray | null = COMPONENT_INNER_REGEX.exec(inner);
+  if (component && component[1] && component[2]) {
+    return {
+      kind: "component",
+      raw: raw,
+      componentId: component[1],
+      returnValueId: component[2],
+    };
+  }
+
+  const variable: RegExpExecArray | null = VARIABLE_INNER_REGEX.exec(inner);
+  if (variable && variable[1] && variable[2]) {
+    return {
+      kind: "variable",
+      raw: raw,
+      scope: variable[1] === "global" ? "global" : "local",
+      name: variable[2],
+    };
+  }
+
+  return { kind: "unknown", raw: raw };
+};
+
+export type ParseTokensFunction = (value: string) => Array<ParsedToken>;
+
+export const parseTokens: ParseTokensFunction = (
+  value: string,
+): Array<ParsedToken> => {
+  const result: Array<ParsedToken> = [];
+  if (!value) {
+    return result;
+  }
+
+  TOKEN_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+  let occurrence: number = 0;
+
+  while ((match = TOKEN_REGEX.exec(value)) !== null) {
+    result.push({
+      token: classifyToken(match[0]),
+      start: match.index,
+      end: match.index + match[0].length,
+      occurrence: occurrence,
+    });
+    occurrence++;
+  }
+
+  return result;
+};
+
+export interface TokenDescription {
+  label: string;
+  // A reference whose source step/output can't be found in the graph.
+  isBroken: boolean;
+}
+
+export type DescribeTokenFunction = (
+  token: TokenValue,
+  components: Array<NodeDataProp>,
+) => TokenDescription;
+
+export const describeToken: DescribeTokenFunction = (
+  token: TokenValue,
+  components: Array<NodeDataProp>,
+): TokenDescription => {
+  if (token.kind === "variable") {
+    return {
+      label: `${token.name} · ${token.scope} variable`,
+      isBroken: false,
+    };
+  }
+
+  if (token.kind === "unknown") {
+    const inner: string = token.raw.slice(2, -2).trim();
+    return { label: inner || "reference", isBroken: true };
+  }
+
+  const component: NodeDataProp | undefined = components.find(
+    (c: NodeDataProp) => {
+      return c.id === token.componentId;
+    },
+  );
+
+  if (!component) {
+    return {
+      label: `${token.returnValueId} · from ${token.componentId}`,
+      isBroken: true,
+    };
+  }
+
+  const returnValue: ReturnValue | undefined = (
+    component.metadata.returnValues || []
+  ).find((r: ReturnValue) => {
+    return r.id === token.returnValueId;
+  });
+
+  return {
+    label: `${returnValue ? returnValue.name : token.returnValueId} · from ${
+      component.metadata.title
+    }`,
+    isBroken: !returnValue,
+  };
+};
+
+export type BuildComponentTokenFunction = (
+  componentId: string,
+  returnValueId: string,
+) => string;
+
+export const buildComponentToken: BuildComponentTokenFunction = (
+  componentId: string,
+  returnValueId: string,
+): string => {
+  return `{{local.components.${componentId}.returnValues.${returnValueId}}}`;
+};
+
+export type AppendTokenFunction = (value: string, token: string) => string;
+
+/*
+ * Append a token to the current value. Kept identical to the existing
+ * "string append" behaviour of the pickers so nothing changes on disk.
+ */
+export const appendToken: AppendTokenFunction = (
+  value: string,
+  token: string,
+): string => {
+  return (value || "") + token;
+};
+
+export type RemoveTokenOccurrenceFunction = (
+  value: string,
+  occurrence: number,
+) => string;
+
+export const removeTokenOccurrence: RemoveTokenOccurrenceFunction = (
+  value: string,
+  occurrence: number,
+): string => {
+  const target: ParsedToken | undefined = parseTokens(value).find(
+    (t: ParsedToken) => {
+      return t.occurrence === occurrence;
+    },
+  );
+
+  if (!target) {
+    return value;
+  }
+
+  return value.slice(0, target.start) + value.slice(target.end);
+};


### PR DESCRIPTION
The last and highest-risk piece of the workflow-builder simplification: turning the raw `{{…}}` data references into **chips**. **Stacked on #2602** (GitHub retargets to `master` once the stack merges).

## The problem

Referencing another step's output meant opening a full-screen modal that **string-appended** a raw token like `{{local.components.slack-1.returnValues.error}}` into the field — which you then had to read and manage by hand. No readability, no removal, no validation that the referenced step actually runs before this one.

## What changed

For text arguments, the footer is now an inline **data-reference helper**:
- **Existing tokens render as friendly, removable chips** — `Error · from Send to Slack` — that turn **red** when the referenced step or output no longer exists.
- **Insert from an inline menu scoped to upstream steps** (with a "Show all steps" escape), so you can't reference data that won't exist at runtime.
- Variables still use the existing `VariableModal`.

## Why this design (and not contentEditable)

The stored value **stays a plain string** — tokens are appended / index-spliced — so a workflow **round-trips byte-for-byte** and the executor is untouched. A rich `contentEditable` chip editor was deliberately avoided: it risks corrupting saved workflows and, critically, **jsdom can't test it**, so it couldn't be verified with the component-testing approach used here. Keeping the string as the source of truth makes all the logic pure and fully testable.

- Only **text-like fields** get the chip footer; **JSON editors keep** the existing modal picker.
- **The set of fields that show a data-reference footer is unchanged** — only the footer's UI changed.
- `buildComponentToken` / variable tokens are **byte-identical** to what `ComponentValuePickerModal` / `VariableModal` already produce.

## Verification

- **`TokenUtils.test.ts` (14):** parse/classify/describe/append + **byte-exact `removeTokenOccurrence`** (correct occurrence among adjacent duplicates, surrounding text preserved, out-of-range no-op).
- **`DataReferenceInput.test.tsx` (4, RTL/jsdom):** chips render, broken-reference flagged, precise removal, upstream-scoped insert + show-all.
- **48 workflow tests pass**; `tsc` ✓, `eslint` ✓.
- **Adversarial review pass** (dedicated agent) traced the full value-sync chain (`setFieldValue → onChange → setComponent → props.fields → useAsyncEffect`), confirmed the token formats byte-for-byte against the pickers and executor, and found **no real bug or regression** — only two theoretical nits that match pre-existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
