### PR TITLE
feat(workflow): one clear condition editor for If/Else

### DIFF
--- a/Common/Tests/UI/Components/Workflow/ConditionBuilder.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/ConditionBuilder.test.tsx
@@ -1,0 +1,131 @@
+import ConditionBuilder from "../../../../UI/Components/Workflow/ConditionBuilder";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// The chip helper is tested separately; stub it to keep this test focused.
+jest.mock("../../../../UI/Components/Workflow/DataReferenceInput", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return null;
+    },
+  };
+});
+
+const BASE_ARGS: JSONObject = {
+  "input-1": "5",
+  "input-1-type": "number",
+  operator: ">",
+  "input-2": "3",
+  "input-2-type": "number",
+};
+
+type RenderResult = { onChange: MockFunction; onValidity: MockFunction };
+
+type RenderBuilderFunction = (args: JSONObject) => RenderResult;
+
+const renderBuilder: RenderBuilderFunction = (
+  args: JSONObject,
+): RenderResult => {
+  const onChange: MockFunction = getJestMockFunction();
+  const onValidity: MockFunction = getJestMockFunction();
+  render(
+    <ConditionBuilder
+      arguments={args}
+      onArgumentsChange={onChange}
+      onValidityChange={onValidity}
+      components={[]}
+      workflowId={ObjectID.generate()}
+    />,
+  );
+  return { onChange, onValidity };
+};
+
+describe("ConditionBuilder (If/Else)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the current condition values", () => {
+    renderBuilder(BASE_ARGS);
+
+    expect((screen.getByLabelText("Value") as HTMLInputElement).value).toBe(
+      "5",
+    );
+    expect(
+      (screen.getByLabelText("Compare with") as HTMLInputElement).value,
+    ).toBe("3");
+    expect(
+      (screen.getByLabelText("Condition") as HTMLSelectElement).value,
+    ).toBe(">");
+  });
+
+  it("writes the legacy input-1 / input-2 / operator ids on change", () => {
+    const { onChange } = renderBuilder(BASE_ARGS);
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "7" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ "input-1": "7" });
+
+    fireEvent.change(screen.getByLabelText("Condition"), {
+      target: { value: "==" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ operator: "==" });
+
+    fireEvent.change(screen.getByLabelText("Compare with"), {
+      target: { value: "9" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ "input-2": "9" });
+  });
+
+  it("writes the value-type id from the 'treated as' selector", () => {
+    const { onChange } = renderBuilder(BASE_ARGS);
+
+    fireEvent.change(screen.getByLabelText("Value treated as"), {
+      target: { value: "text" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ "input-1-type": "text" });
+  });
+
+  it("defaults the value-type selector to Text when unset", () => {
+    renderBuilder({ "input-1": "a", operator: "==", "input-2": "b" });
+
+    expect(
+      (screen.getByLabelText("Value treated as") as HTMLSelectElement).value,
+    ).toBe("text");
+  });
+
+  it("reports invalid while a required value is empty, valid once filled", () => {
+    const { onValidity } = renderBuilder({
+      "input-1": "",
+      operator: "==",
+      "input-2": "b",
+    });
+    expect(onValidity).toHaveBeenLastCalledWith(true);
+
+    cleanup();
+
+    const filled: RenderResult = renderBuilder({
+      "input-1": "a",
+      operator: "==",
+      "input-2": "b",
+    });
+    expect(filled.onValidity).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -4,6 +4,7 @@ import FormFieldSchemaType from "../Forms/Types/FormFieldSchemaType";
 import { CustomElementProps } from "../Forms/Types/Field";
 import FormValues from "../Forms/Types/FormValues";
 import ComponentValuePickerModal from "./ComponentValuePickerModal";
+import ConditionBuilder from "./ConditionBuilder";
 import DataReferenceInput from "./DataReferenceInput";
 import JSONArgumentInput from "./JSONArgumentInput";
 import ModelFieldPicker from "./ModelFieldPicker";
@@ -12,6 +13,7 @@ import VariableModal from "./VariableModal";
 import Dictionary from "../../../Types/Dictionary";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
+import ComponentID from "../../../Types/Workflow/ComponentID";
 import {
   Argument,
   ComponentInputType,
@@ -199,6 +201,13 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
     });
   };
 
+  /*
+   * The If / Else step gets a purpose-built condition editor instead of the
+   * five generic fields (its ValueType/Operator inputs are used nowhere else).
+   */
+  const isConditionComponent: boolean =
+    component.metadata.id === ComponentID.IfElse;
+
   const allArguments: Array<Argument> = component.metadata.arguments || [];
   const advancedArguments: Array<Argument> = allArguments.filter(
     (arg: Argument) => {
@@ -226,7 +235,36 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
           the user briefly sees an empty dropdown which is confusing.
         */}
         {hasWorkflowSelectArg && isLoadingWorkflows && <ComponentLoader />}
-        {allArguments.length > 0 &&
+
+        {isConditionComponent && (
+          <ConditionBuilder
+            arguments={(component.arguments as JSONObject) || {}}
+            components={props.graphComponents}
+            upstreamComponentIds={props.upstreamComponentIds}
+            currentComponentId={component.id}
+            workflowId={props.workflowId}
+            onArgumentsChange={(patch: JSONObject) => {
+              setComponent({
+                ...component,
+                arguments: {
+                  ...((component.arguments as JSONObject) || {}),
+                  ...patch,
+                },
+              });
+            }}
+            onValidityChange={(hasError: boolean) => {
+              setHasFormValidationErrors((prev: Dictionary<boolean>) => {
+                if (prev["condition"] === hasError) {
+                  return prev;
+                }
+                return { ...prev, condition: hasError };
+              });
+            }}
+          />
+        )}
+
+        {!isConditionComponent &&
+          allArguments.length > 0 &&
           !(hasWorkflowSelectArg && isLoadingWorkflows) && (
             <BasicForm
               hideSubmitButton={true}

--- a/Common/UI/Components/Workflow/ConditionBuilder.tsx
+++ b/Common/UI/Components/Workflow/ConditionBuilder.tsx
@@ -1,0 +1,212 @@
+import DataReferenceInput from "./DataReferenceInput";
+import {
+  ConditionOperator,
+  ConditionValueType,
+} from "../../../Types/Workflow/Components/Condition";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { NodeDataProp } from "../../../Types/Workflow/Component";
+import React, { FunctionComponent, ReactElement, useEffect } from "react";
+
+/*
+ * A single, readable condition editor for the If / Else step. It replaces the
+ * five stacked fields (Input 1 Type / Input 1 / Operator / Input 2 Type /
+ * Input 2) with one card, but writes exactly those same argument ids — so the
+ * server evaluator (Common/Server/Types/Workflow/Components/Conditions/IfElse)
+ * is untouched. The value-type selectors are demoted to a compact "treated as"
+ * dropdown (defaulting to Text, matching the server default).
+ */
+
+export interface ComponentProps {
+  arguments: JSONObject;
+  onArgumentsChange: (patch: JSONObject) => void;
+  onValidityChange?: ((hasError: boolean) => void) | undefined;
+  components: Array<NodeDataProp>;
+  upstreamComponentIds?: Set<string> | undefined;
+  currentComponentId?: string | undefined;
+  workflowId: ObjectID;
+}
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+const VALUE_TYPE_OPTIONS: Array<Option> = [
+  { label: "Text", value: ConditionValueType.Text },
+  { label: "Number", value: ConditionValueType.Number },
+  { label: "True / False", value: ConditionValueType.Boolean },
+  { label: "Null", value: ConditionValueType.Null },
+  { label: "Undefined", value: ConditionValueType.Undefined },
+];
+
+const OPERATOR_OPTIONS: Array<Option> = [
+  { label: "is equal to", value: ConditionOperator.EqualTo },
+  { label: "is not equal to", value: ConditionOperator.NotEqualTo },
+  { label: "is greater than", value: ConditionOperator.GreaterThan },
+  {
+    label: "is greater than or equal to",
+    value: ConditionOperator.GreaterThanOrEqualTo,
+  },
+  { label: "is less than", value: ConditionOperator.LessThan },
+  {
+    label: "is less than or equal to",
+    value: ConditionOperator.LessThanOrEqualTo,
+  },
+  { label: "contains", value: ConditionOperator.Contains },
+  { label: "does not contain", value: ConditionOperator.DoesNotContain },
+  { label: "starts with", value: ConditionOperator.StartsWith },
+  { label: "ends with", value: ConditionOperator.EndsWith },
+];
+
+const inputClass: string =
+  "block w-full rounded-md border border-gray-300 py-2 px-3 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500";
+const selectClass: string =
+  "rounded-md border border-gray-300 py-2 px-2 text-sm text-gray-700 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500";
+
+const ConditionBuilder: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  type GetArgFunction = (key: string) => string;
+
+  const getArg: GetArgFunction = (key: string): string => {
+    return props.arguments && props.arguments[key]
+      ? String(props.arguments[key])
+      : "";
+  };
+
+  const input1: string = getArg("input-1");
+  const input2: string = getArg("input-2");
+  const operator: string = getArg("operator") || ConditionOperator.EqualTo;
+  const input1Type: string = getArg("input-1-type") || ConditionValueType.Text;
+  const input2Type: string = getArg("input-2-type") || ConditionValueType.Text;
+
+  // Required inputs must be filled for the condition to be valid.
+  useEffect(() => {
+    props.onValidityChange?.(input1.trim() === "" || input2.trim() === "");
+  }, [input1, input2]);
+
+  // Clear the error if this editor unmounts (e.g. the panel closes).
+  useEffect(() => {
+    return () => {
+      props.onValidityChange?.(false);
+    };
+  }, []);
+
+  type UpdateFunction = (key: string, value: string) => void;
+
+  const update: UpdateFunction = (key: string, value: string): void => {
+    props.onArgumentsChange({ [key]: value });
+  };
+
+  type ValueRowProps = {
+    label: string;
+    valueKey: string;
+    typeKey: string;
+    value: string;
+    valueType: string;
+    placeholder: string;
+  };
+
+  const renderValueRow: (rowProps: ValueRowProps) => ReactElement = (
+    rowProps: ValueRowProps,
+  ): ReactElement => {
+    return (
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">
+          {rowProps.label}
+        </label>
+        <div className="flex gap-2">
+          <input
+            className={inputClass}
+            value={rowProps.value}
+            placeholder={rowProps.placeholder}
+            aria-label={rowProps.label}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              update(rowProps.valueKey, e.target.value);
+            }}
+          />
+          <select
+            className={selectClass}
+            value={rowProps.valueType}
+            title="Treated as"
+            aria-label={`${rowProps.label} treated as`}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+              update(rowProps.typeKey, e.target.value);
+            }}
+          >
+            {VALUE_TYPE_OPTIONS.map((option: Option) => {
+              return (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+        <DataReferenceInput
+          value={rowProps.value}
+          components={props.components}
+          upstreamComponentIds={props.upstreamComponentIds}
+          currentComponentId={props.currentComponentId}
+          workflowId={props.workflowId}
+          onChange={(newValue: string) => {
+            update(rowProps.valueKey, newValue);
+          }}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-gray-500">
+        Runs the <span className="font-medium text-green-600">Yes</span> branch
+        when the condition is true, otherwise the{" "}
+        <span className="font-medium text-gray-600">No</span> branch.
+      </p>
+
+      {renderValueRow({
+        label: "Value",
+        valueKey: "input-1",
+        typeKey: "input-1-type",
+        value: input1,
+        valueType: input1Type,
+        placeholder: "A value, or insert data from a step",
+      })}
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">
+          Condition
+        </label>
+        <select
+          className={`${selectClass} w-full`}
+          value={operator}
+          aria-label="Condition"
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+            update("operator", e.target.value);
+          }}
+        >
+          {OPERATOR_OPTIONS.map((option: Option) => {
+            return (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+
+      {renderValueRow({
+        label: "Compare with",
+        valueKey: "input-2",
+        typeKey: "input-2-type",
+        value: input2,
+        valueType: input2Type,
+        placeholder: "A value, or insert data from a step",
+      })}
+    </div>
+  );
+};
+
+export default ConditionBuilder;


### PR DESCRIPTION
Another named "worst friction" from the design pass: **If/Else's five stacked, manually-type-synced fields**. **Stacked on #2604** (retargets up the stack as each merges).

## Before

Configuring an If/Else step meant filling five generic fields — `Input 1 Type`, `Input 1`, `Operator`, `Input 2 Type`, `Input 2` — where the value field's own description read *"This fields takes number, text, boolean, null, undefined as values."* You had to think like the evaluator and keep type + value in sync by hand.

## After

For the **If/Else step only**, one readable condition card:
- **Value** → **Condition** (plain-English: "is greater than", "contains", …) → **Compare with**
- each value has a compact **"treated as"** type selector (defaulting to **Text**) and the **data-reference chip** helper
- a one-line note: a true condition runs the **Yes** branch, otherwise **No**.

## Byte-compatibility (server untouched)

The editor writes exactly the same argument ids — `input-1`, `input-1-type`, `operator`, `input-2`, `input-2-type` — so `Conditions/IfElse` is unchanged. Confirmed against the server: it already **defaults an unset `operator` to `==` and unset types to `Text`** (IfElse.ts:66-69, 164), which match the editor's defaults — so leaving the sensible defaults writes nothing and evaluates identically. (This is actually an improvement: the old flow *forced* an explicit operator pick.) `ValueType`/`Operator` input types are used by **no other component**, so the special-case is fully self-contained.

## Verification

- **`ConditionBuilder.test.tsx` (5, RTL/jsdom):** shows current values; changing the value / operator / compare-with writes the legacy `input-1`/`operator`/`input-2` ids; the "treated as" selector writes `input-1-type`; the type defaults to Text when unset; required-value validity is reported (blocks Save while empty).
- **49 workflow tests pass**; `tsc` ✓, `eslint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
