### PR TITLE
feat(workflow): 'needs setup' status dot on nodes

### DIFF
--- a/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   getUpstreamComponentIds,
   getComponentSummary,
+  getNodeStatus,
 } from "../../../../UI/Components/Workflow/GraphUtils";
 import {
   ComponentInputType,
@@ -230,5 +231,65 @@ describe("GraphUtils.getComponentSummary", () => {
       { a: "   ", b: "real" },
     );
     expect(getComponentSummary(data)).toBe("B: real");
+  });
+});
+
+describe("GraphUtils.getNodeStatus", () => {
+  const requiredArgData: (values: Record<string, unknown>) => NodeDataProp = (
+    values: Record<string, unknown>,
+  ): NodeDataProp => {
+    return {
+      error: "",
+      metadata: {
+        arguments: [
+          {
+            id: "url",
+            name: "URL",
+            type: ComponentInputType.URL,
+            description: "",
+            required: true,
+          },
+          {
+            id: "note",
+            name: "Note",
+            type: ComponentInputType.Text,
+            description: "",
+            required: false,
+          },
+        ],
+      },
+      arguments: values,
+    } as unknown as NodeDataProp;
+  };
+
+  test("is 'error' when the node reported an error", () => {
+    const data: NodeDataProp = requiredArgData({ url: "https://x" });
+    (data as { error: string }).error = "boom";
+    expect(getNodeStatus(data)).toBe("error");
+  });
+
+  test("is 'incomplete' when a required argument is empty", () => {
+    expect(getNodeStatus(requiredArgData({}))).toBe("incomplete");
+    expect(getNodeStatus(requiredArgData({ url: "" }))).toBe("incomplete");
+  });
+
+  test("is 'ready' when all required arguments are filled", () => {
+    expect(getNodeStatus(requiredArgData({ url: "https://x" }))).toBe("ready");
+  });
+
+  test("ignores optional arguments", () => {
+    // note is optional and empty, url is filled -> still ready.
+    expect(getNodeStatus(requiredArgData({ url: "https://x", note: "" }))).toBe(
+      "ready",
+    );
+  });
+
+  test("is 'ready' for a step with no arguments", () => {
+    const data: NodeDataProp = {
+      error: "",
+      metadata: { arguments: [] },
+      arguments: {},
+    } as unknown as NodeDataProp;
+    expect(getNodeStatus(data)).toBe("ready");
   });
 });

--- a/Common/UI/Components/Workflow/Component.tsx
+++ b/Common/UI/Components/Workflow/Component.tsx
@@ -1,6 +1,6 @@
 import Icon, { ThickProp } from "../Icon/Icon";
 import Tooltip from "../Tooltip/Tooltip";
-import { getComponentSummary } from "./GraphUtils";
+import { getComponentSummary, getNodeStatus } from "./GraphUtils";
 import IconProp from "../../../Types/Icon/IconProp";
 import {
   ComponentType,
@@ -281,6 +281,8 @@ const Node: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
 
   // Regular node
   const hasError: boolean = Boolean(props.data.error);
+  const needsSetup: boolean =
+    !hasError && getNodeStatus(props.data) === "incomplete";
 
   return (
     <div
@@ -353,6 +355,25 @@ const Node: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
               })}
           </div>
         )}
+
+      {/* Needs-setup indicator (a required field is still empty) */}
+      {!props.data.isPreview && needsSetup && (
+        <div
+          title="Needs setup — a required field is empty"
+          style={{
+            position: "absolute",
+            top: "10px",
+            right: "10px",
+            zIndex: 10,
+            width: "12px",
+            height: "12px",
+            borderRadius: "50%",
+            backgroundColor: "#f59e0b",
+            border: "2px solid #ffffff",
+            boxShadow: "0 0 0 1px #fde68a",
+          }}
+        />
+      )}
 
       {/* Error indicator */}
       {!props.data.isPreview && hasError && (

--- a/Common/UI/Components/Workflow/GraphUtils.ts
+++ b/Common/UI/Components/Workflow/GraphUtils.ts
@@ -254,3 +254,34 @@ export const getComponentSummary: GetComponentSummaryFunction = (
 
   return parts.join(" · ");
 };
+
+export type NodeStatus = "error" | "incomplete" | "ready";
+
+/*
+ * Classify a node for the at-a-glance status indicator on its face:
+ *  - "error"      → the last run reported an error on this step.
+ *  - "incomplete" → a required argument is still empty (needs setup).
+ *  - "ready"      → everything required is filled in.
+ */
+export type GetNodeStatusFunction = (data: NodeDataProp) => NodeStatus;
+
+export const getNodeStatus: GetNodeStatusFunction = (
+  data: NodeDataProp,
+): NodeStatus => {
+  if (data.error) {
+    return "error";
+  }
+
+  const args: Array<Argument> = data.metadata?.arguments || [];
+  const values: JSONObject = (data.arguments as JSONObject) || {};
+
+  const hasMissingRequired: boolean = args.some((arg: Argument) => {
+    if (!arg.required) {
+      return false;
+    }
+    const value: unknown = values[arg.id];
+    return value === undefined || value === null || value === "";
+  });
+
+  return hasMissingRequired ? "incomplete" : "ready";
+};


### PR DESCRIPTION
Small node-face polish completing the "self-documenting canvas" theme. **Stacked on #2605.**

## What

The canvas already shows a red badge when a step **errored** on its last run, but nothing flagged a step that simply **isn't configured yet**. On a graph with several steps you couldn't tell at a glance which ones still need attention.

This adds a small **amber "needs setup" dot** to a node's corner when a **required argument is still empty** (mutually exclusive with the existing error badge).

Backed by a pure helper:
```
getNodeStatus(data) → "error" | "incomplete" | "ready"
```
so the logic is unit-tested; the node face just renders the indicator.

## Verification

- **`getNodeStatus` (5 tests):** error / incomplete / ready / ignores optional args / no-args step.
- **54 workflow tests pass**; `tsc` ✓, `eslint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
