### PR TITLE
feat(workflow): starter templates for the blank-canvas cold start

### DIFF
--- a/Common/Tests/UI/Components/Workflow/WorkflowTemplateGallery.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/WorkflowTemplateGallery.test.tsx
@@ -1,0 +1,87 @@
+import WorkflowTemplateGallery from "../../../../UI/Components/Workflow/WorkflowTemplateGallery";
+import { WorkflowTemplate } from "../../../../UI/Components/Workflow/WorkflowTemplates";
+import IconProp from "../../../../Types/Icon/IconProp";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const templates: Array<WorkflowTemplate> = [
+  {
+    id: "a",
+    name: "Scheduled Slack message",
+    description: "Post to Slack on a schedule.",
+    icon: IconProp.Slack,
+    steps: [],
+    connections: [],
+  },
+  {
+    id: "b",
+    name: "Webhook to Slack",
+    description: "Post to Slack from a webhook.",
+    icon: IconProp.SendMessage,
+    steps: [],
+    connections: [],
+  },
+];
+
+describe("WorkflowTemplateGallery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("lists the available templates", () => {
+    render(
+      <WorkflowTemplateGallery
+        templates={templates}
+        onSelect={getJestMockFunction()}
+        onDismiss={getJestMockFunction()}
+      />,
+    );
+
+    expect(screen.getByText("Scheduled Slack message")).toBeTruthy();
+    expect(screen.getByText("Webhook to Slack")).toBeTruthy();
+  });
+
+  it("selects a template when its card is clicked", () => {
+    const onSelect: MockFunction = getJestMockFunction();
+    render(
+      <WorkflowTemplateGallery
+        templates={templates}
+        onSelect={onSelect}
+        onDismiss={getJestMockFunction()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Webhook to Slack"));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]![0]).toMatchObject({ id: "b" });
+  });
+
+  it("dismisses when 'Start from scratch' is clicked", () => {
+    const onDismiss: MockFunction = getJestMockFunction();
+    render(
+      <WorkflowTemplateGallery
+        templates={templates}
+        onSelect={getJestMockFunction()}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Start from scratch"));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/WorkflowTemplates.test.ts
+++ b/Common/Tests/UI/Components/Workflow/WorkflowTemplates.test.ts
@@ -1,0 +1,141 @@
+import {
+  WorkflowTemplate,
+  WorkflowTemplates,
+  buildTemplateGraph,
+  TemplateGraph,
+} from "../../../../UI/Components/Workflow/WorkflowTemplates";
+import StaticComponents from "../../../../Types/Workflow/Components";
+import IconProp from "../../../../Types/Icon/IconProp";
+import ComponentMetadata, {
+  ComponentType,
+  NodeType,
+} from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+const catalog: Array<ComponentMetadata> = [
+  {
+    id: "schedule",
+    title: "Schedule",
+    category: "Schedule",
+    description: "",
+    iconProp: IconProp.Clock,
+    componentType: ComponentType.Trigger,
+    arguments: [],
+    returnValues: [],
+    inPorts: [],
+    outPorts: [{ id: "execute", title: "Execute", description: "" }],
+  },
+  {
+    id: "slack-send-message-to-channel",
+    title: "Send to Slack",
+    category: "Slack",
+    description: "",
+    iconProp: IconProp.Slack,
+    componentType: ComponentType.Component,
+    arguments: [],
+    returnValues: [],
+    inPorts: [{ id: "in", title: "In", description: "" }],
+    outPorts: [
+      { id: "success", title: "Success", description: "" },
+      { id: "error", title: "Error", description: "" },
+    ],
+  },
+];
+
+const template: WorkflowTemplate = {
+  id: "t",
+  name: "Test",
+  description: "",
+  icon: IconProp.Slack,
+  steps: [
+    { key: "trigger", metadataId: "schedule", position: { x: 0, y: 0 } },
+    {
+      key: "slack",
+      metadataId: "slack-send-message-to-channel",
+      position: { x: 0, y: 100 },
+    },
+  ],
+  connections: [{ from: "trigger", to: "slack" }],
+};
+
+describe("WorkflowTemplates.buildTemplateGraph", () => {
+  test("builds nodes in the same shape as addToGraph", () => {
+    const graph: TemplateGraph | null = buildTemplateGraph(template, catalog);
+    expect(graph).not.toBeNull();
+
+    expect(graph!.nodes).toHaveLength(2);
+    const trigger: { data: Record<string, unknown> } = graph!
+      .nodes[0] as unknown as { data: Record<string, unknown> };
+    expect(trigger.data["nodeType"]).toBe(NodeType.Node);
+    expect(trigger.data["metadataId"]).toBe("schedule");
+    expect(trigger.data["componentType"]).toBe(ComponentType.Trigger);
+    expect(trigger.data["id"]).toBe("schedule-1");
+    expect(typeof trigger.data["internalId"]).toBe("string");
+  });
+
+  test("connects the first out-port to the first in-port", () => {
+    const graph: TemplateGraph | null = buildTemplateGraph(template, catalog);
+    expect(graph!.edges).toHaveLength(1);
+    expect(graph!.edges[0]!.source).toBe(graph!.nodes[0]!.id);
+    expect(graph!.edges[0]!.target).toBe(graph!.nodes[1]!.id);
+    expect(graph!.edges[0]!.sourceHandle).toBe("execute");
+    expect(graph!.edges[0]!.targetHandle).toBe("in");
+  });
+
+  test("gives duplicate components distinct data ids", () => {
+    const dupTemplate: WorkflowTemplate = {
+      ...template,
+      steps: [
+        { key: "a", metadataId: "schedule", position: { x: 0, y: 0 } },
+        { key: "b", metadataId: "schedule", position: { x: 0, y: 100 } },
+      ],
+      connections: [],
+    };
+    const graph: TemplateGraph | null = buildTemplateGraph(
+      dupTemplate,
+      catalog,
+    );
+    const ids: Array<string> = graph!.nodes.map((n: unknown) => {
+      return (n as { data: { id: string } }).data.id;
+    });
+    expect(ids).toEqual(["schedule-1", "schedule-2"]);
+  });
+
+  test("returns null when a referenced component is missing", () => {
+    const broken: WorkflowTemplate = {
+      ...template,
+      steps: [
+        {
+          key: "trigger",
+          metadataId: "does-not-exist",
+          position: { x: 0, y: 0 },
+        },
+      ],
+      connections: [],
+    };
+    expect(buildTemplateGraph(broken, catalog)).toBeNull();
+  });
+});
+
+describe("WorkflowTemplates definitions", () => {
+  test("every shipped template resolves against the real static catalog", () => {
+    const realCatalog: Array<ComponentMetadata> =
+      StaticComponents as Array<ComponentMetadata>;
+
+    for (const shippedTemplate of WorkflowTemplates) {
+      const graph: TemplateGraph | null = buildTemplateGraph(
+        shippedTemplate,
+        realCatalog,
+      );
+      // A null result means a metadataId doesn't exist — a broken template.
+      expect(graph).not.toBeNull();
+      expect(graph!.nodes).toHaveLength(shippedTemplate.steps.length);
+      expect(graph!.edges).toHaveLength(shippedTemplate.connections.length);
+      // Every connection resolved to real port handles.
+      for (const edge of graph!.edges) {
+        expect(edge.sourceHandle).toBeTruthy();
+        expect(edge.targetHandle).toBeTruthy();
+      }
+    }
+  });
+});

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -2,6 +2,13 @@ import WorkflowComponent from "./Component";
 import ComponentSettingsPanel from "./ComponentSettingsPanel";
 import ComponentsModal from "./ComponentsModal";
 import RunModal from "./RunModal";
+import WorkflowTemplateGallery from "./WorkflowTemplateGallery";
+import {
+  WorkflowTemplate,
+  WorkflowTemplates,
+  buildTemplateGraph,
+  TemplateGraph,
+} from "./WorkflowTemplates";
 import { getUpstreamComponentIds } from "./GraphUtils";
 import { loadComponentsAndCategories } from "./Utils";
 import { VoidFunction } from "../../../Types/FunctionTypes";
@@ -323,6 +330,38 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
 
   const [showRunModal, setShowRunModal] = useState<boolean>(false);
 
+  // Dismissed once the user picks a template or chooses to start from scratch.
+  const [templatesDismissed, setTemplatesDismissed] = useState<boolean>(false);
+
+  type LoadTemplateFunction = (template: WorkflowTemplate) => void;
+
+  const loadTemplate: LoadTemplateFunction = (
+    template: WorkflowTemplate,
+  ): void => {
+    const graph: TemplateGraph | null = buildTemplateGraph(
+      template,
+      allComponentMetadata,
+    );
+
+    setTemplatesDismissed(true);
+
+    if (!graph) {
+      return;
+    }
+
+    setNodes(
+      graph.nodes.map((node: Node) => {
+        node.data.onClick = onNodeClick;
+        return node;
+      }),
+    );
+    setEdges(
+      graph.edges.map((edge: Edge) => {
+        return { ...edge, ...getEdgeDefaultProps(edge.selected || false) };
+      }),
+    );
+  };
+
   useEffect(() => {
     props.onComponentPickerModalUpdate(showComponentsModal);
   }, [showComponentsModal]);
@@ -522,6 +561,27 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
           color="#cbd5e1"
         />
       </ReactFlow>
+
+      {/*
+        Blank-canvas cold start: when the graph has no real steps yet (only the
+        placeholder trigger), offer starter templates. Shown until the user
+        picks one or dismisses it.
+      */}
+      {!templatesDismissed &&
+        allComponentMetadata.length > 0 &&
+        !nodes.some((node: Node) => {
+          return (node.data as NodeDataProp).nodeType === NodeType.Node;
+        }) && (
+          <WorkflowTemplateGallery
+            templates={WorkflowTemplates}
+            onSelect={(template: WorkflowTemplate) => {
+              loadTemplate(template);
+            }}
+            onDismiss={() => {
+              setTemplatesDismissed(true);
+            }}
+          />
+        )}
 
       {showComponentsModal && (
         <ComponentsModal

--- a/Common/UI/Components/Workflow/WorkflowTemplateGallery.tsx
+++ b/Common/UI/Components/Workflow/WorkflowTemplateGallery.tsx
@@ -1,0 +1,86 @@
+import Icon from "../Icon/Icon";
+import { WorkflowTemplate } from "./WorkflowTemplates";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/*
+ * The blank-canvas cold start: instead of an empty graph with a lone
+ * placeholder trigger, offer a few pre-wired starter workflows. Selecting one
+ * drops a ready graph the author just fills in; "Start from scratch" dismisses
+ * the gallery.
+ */
+
+export interface ComponentProps {
+  templates: Array<WorkflowTemplate>;
+  onSelect: (template: WorkflowTemplate) => void;
+  onDismiss: () => void;
+}
+
+const WorkflowTemplateGallery: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 6,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "rgba(248, 250, 252, 0.85)",
+        padding: "1.5rem",
+      }}
+    >
+      <div className="w-full max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg">
+        <h2 className="text-base font-semibold text-gray-900">
+          Start with a template
+        </h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Pick a starting point and fill in the details, or start from an empty
+          canvas.
+        </p>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {props.templates.map((template: WorkflowTemplate) => {
+            return (
+              <button
+                key={template.id}
+                type="button"
+                className="flex items-start gap-3 rounded-lg border border-gray-200 p-3 text-left hover:border-indigo-300 hover:bg-indigo-50/40 cursor-pointer"
+                onClick={() => {
+                  props.onSelect(template);
+                }}
+              >
+                <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-indigo-50 text-indigo-500">
+                  <Icon icon={template.icon} className="h-4 w-4" />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium text-gray-900">
+                    {template.name}
+                  </span>
+                  <span className="block text-xs text-gray-500">
+                    {template.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-5 flex justify-end">
+          <button
+            type="button"
+            className="text-sm font-medium text-gray-500 hover:text-gray-700 cursor-pointer"
+            onClick={() => {
+              props.onDismiss();
+            }}
+          >
+            Start from scratch
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowTemplateGallery;

--- a/Common/UI/Components/Workflow/WorkflowTemplates.ts
+++ b/Common/UI/Components/Workflow/WorkflowTemplates.ts
@@ -1,0 +1,202 @@
+import IconProp from "../../../Types/Icon/IconProp";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import ComponentID from "../../../Types/Workflow/ComponentID";
+import ComponentMetadata, {
+  NodeDataProp,
+  NodeType,
+  Port,
+} from "../../../Types/Workflow/Component";
+import { Edge, Node } from "reactflow";
+
+/*
+ * Starter templates for the blank-canvas cold start. A template is an
+ * engine-agnostic recipe (which components, where, and how they connect);
+ * buildTemplateGraph turns it into the exact node/edge shape the builder
+ * already produces in addToGraph (Workflow.tsx), by looking each component up
+ * in the live catalog. Only static components are used, so there's no
+ * per-model id-fidelity risk.
+ */
+
+export interface TemplateStep {
+  key: string;
+  metadataId: string;
+  position: { x: number; y: number };
+  arguments?: JSONObject | undefined;
+}
+
+export interface TemplateConnection {
+  from: string;
+  to: string;
+  // Defaults to the source's first out-port / target's first in-port.
+  fromPort?: string | undefined;
+  toPort?: string | undefined;
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  icon: IconProp;
+  steps: Array<TemplateStep>;
+  connections: Array<TemplateConnection>;
+}
+
+export const WorkflowTemplates: Array<WorkflowTemplate> = [
+  {
+    id: "scheduled-slack",
+    name: "Scheduled Slack message",
+    description: "On a schedule, post a message to a Slack channel.",
+    icon: IconProp.Slack,
+    steps: [
+      {
+        key: "trigger",
+        metadataId: ComponentID.Schedule,
+        position: { x: 150, y: 60 },
+        arguments: { schedule: "0 9 * * *" },
+      },
+      {
+        key: "slack",
+        metadataId: ComponentID.SlackSendMessageToChannel,
+        position: { x: 150, y: 300 },
+      },
+    ],
+    connections: [{ from: "trigger", to: "slack" }],
+  },
+  {
+    id: "scheduled-email",
+    name: "Scheduled email",
+    description: "On a schedule, send an email.",
+    icon: IconProp.Email,
+    steps: [
+      {
+        key: "trigger",
+        metadataId: ComponentID.Schedule,
+        position: { x: 150, y: 60 },
+        arguments: { schedule: "0 9 * * *" },
+      },
+      {
+        key: "email",
+        metadataId: ComponentID.SendEmail,
+        position: { x: 150, y: 300 },
+      },
+    ],
+    connections: [{ from: "trigger", to: "email" }],
+  },
+  {
+    id: "webhook-to-slack",
+    name: "Webhook to Slack",
+    description: "When your webhook is called, post a message to Slack.",
+    icon: IconProp.SendMessage,
+    steps: [
+      {
+        key: "trigger",
+        metadataId: ComponentID.Webhook,
+        position: { x: 150, y: 60 },
+      },
+      {
+        key: "slack",
+        metadataId: ComponentID.SlackSendMessageToChannel,
+        position: { x: 150, y: 300 },
+      },
+    ],
+    connections: [{ from: "trigger", to: "slack" }],
+  },
+];
+
+type FirstPortIdFunction = (
+  ports: Array<Port> | undefined,
+) => string | undefined;
+
+const firstPortId: FirstPortIdFunction = (
+  ports: Array<Port> | undefined,
+): string | undefined => {
+  return ports && ports.length > 0 ? ports[0]!.id : undefined;
+};
+
+export interface TemplateGraph {
+  nodes: Array<Node>;
+  edges: Array<Edge>;
+}
+
+export type BuildTemplateGraphFunction = (
+  template: WorkflowTemplate,
+  catalog: Array<ComponentMetadata>,
+) => TemplateGraph | null;
+
+/*
+ * Build the concrete graph for a template. Returns null if any referenced
+ * component isn't in the catalog (so we never drop a broken template onto the
+ * canvas). Node shape mirrors addToGraph exactly.
+ */
+export const buildTemplateGraph: BuildTemplateGraphFunction = (
+  template: WorkflowTemplate,
+  catalog: Array<ComponentMetadata>,
+): TemplateGraph | null => {
+  const keyToNodeId: Record<string, string> = {};
+  const keyToMetadata: Record<string, ComponentMetadata> = {};
+  const idCounters: Record<string, number> = {};
+  const nodes: Array<Node> = [];
+
+  for (const step of template.steps) {
+    const metadata: ComponentMetadata | undefined = catalog.find(
+      (c: ComponentMetadata) => {
+        return c.id === step.metadataId;
+      },
+    );
+
+    if (!metadata) {
+      return null;
+    }
+
+    idCounters[step.metadataId] = (idCounters[step.metadataId] || 0) + 1;
+    const reactFlowId: string = ObjectID.generate().toString();
+    keyToNodeId[step.key] = reactFlowId;
+    keyToMetadata[step.key] = metadata;
+
+    const data: NodeDataProp = {
+      nodeType: NodeType.Node,
+      id: `${step.metadataId}-${idCounters[step.metadataId]}`,
+      error: "",
+      metadata: { ...metadata },
+      metadataId: metadata.id,
+      internalId: ObjectID.generate().toString(),
+      componentType: metadata.componentType,
+      arguments: step.arguments || {},
+      returnValues: {},
+    };
+
+    nodes.push({
+      id: reactFlowId,
+      type: "node",
+      position: step.position,
+      selected: false,
+      data: data,
+    });
+  }
+
+  const edges: Array<Edge> = [];
+  for (const connection of template.connections) {
+    const source: string | undefined = keyToNodeId[connection.from];
+    const target: string | undefined = keyToNodeId[connection.to];
+    if (!source || !target) {
+      continue;
+    }
+
+    edges.push({
+      id: ObjectID.generate().toString(),
+      source: source,
+      target: target,
+      sourceHandle:
+        connection.fromPort ||
+        firstPortId(keyToMetadata[connection.from]?.outPorts) ||
+        null,
+      targetHandle:
+        connection.toPort ||
+        firstPortId(keyToMetadata[connection.to]?.inPorts) ||
+        null,
+    });
+  }
+
+  return { nodes: nodes, edges: edges };
+};


### PR DESCRIPTION
Fixes the intimidating blank-canvas cold start the design flagged. **Stacked on #2606.**

## What

A brand-new workflow opened to an empty canvas with a lone placeholder trigger — a "now what?" moment. This offers a few **pre-wired starter workflows** instead; picking one drops a ready graph you just fill in, and **"Start from scratch"** keeps the empty canvas.

- **`WorkflowTemplates`** — engine-agnostic recipes (which components, where, how they connect). Uses **only static components**, so there's no per-model id-fidelity risk. `buildTemplateGraph` resolves each against the live catalog and produces the **exact node/edge shape `addToGraph` already creates** (returns `null` rather than dropping a broken graph if a component is missing).
- **`WorkflowTemplateGallery`** — the cards + "Start from scratch" overlay.
- **Wired into `Workflow.tsx`** — shown only when the graph has **no real steps yet** (every node is a placeholder), gated on the catalog being loaded, dismissed once the user picks a template or opts out. Existing workflows (which have real nodes) never see it.

Ships 3 templates: Scheduled Slack message, Scheduled email, Webhook → Slack.

## Verification

- **`WorkflowTemplates.test.ts`:** `buildTemplateGraph` shape matches `addToGraph`; connects first out-port → first in-port; disambiguates duplicate data ids; returns `null` on a missing component; **and a guard that every shipped template resolves against the real static catalog** (so no broken `metadataId` can ship).
- **`WorkflowTemplateGallery.test.tsx` (RTL):** lists templates, select fires `onSelect(template)`, "Start from scratch" fires `onDismiss`.
- **62 workflow tests pass**; `tsc` ✓, `eslint` ✓.

**One caveat:** loaded-template *canvas rendering* goes through the same node shape as manually-added components (unit-verified), but ReactFlow rendering isn't exercised in jsdom — worth a 30-second manual smoke-test when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
