### PR TITLE
feat(workflow): read-only Outline view

### DIFF
--- a/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
@@ -2,10 +2,14 @@ import {
   getUpstreamComponentIds,
   getComponentSummary,
   getNodeStatus,
+  buildOutline,
+  WorkflowOutline,
 } from "../../../../UI/Components/Workflow/GraphUtils";
 import {
   ComponentInputType,
+  ComponentType,
   NodeDataProp,
+  NodeType,
 } from "../../../../Types/Workflow/Component";
 import { describe, expect, test } from "@jest/globals";
 import { Edge, Node } from "reactflow";
@@ -291,5 +295,148 @@ describe("GraphUtils.getNodeStatus", () => {
       arguments: {},
     } as unknown as NodeDataProp;
     expect(getNodeStatus(data)).toBe("ready");
+  });
+});
+
+describe("GraphUtils.buildOutline", () => {
+  const wfNode: (
+    rfId: string,
+    dataId: string,
+    title: string,
+    componentType: ComponentType,
+    outPorts: Array<{ id: string; title: string }>,
+  ) => Node = (
+    rfId: string,
+    dataId: string,
+    title: string,
+    componentType: ComponentType,
+    outPorts: Array<{ id: string; title: string }>,
+  ): Node => {
+    return {
+      id: rfId,
+      position: { x: 0, y: 0 },
+      data: {
+        id: dataId,
+        nodeType: NodeType.Node,
+        componentType: componentType,
+        metadata: {
+          title: title,
+          outPorts: outPorts.map((p: { id: string; title: string }) => {
+            return { id: p.id, title: p.title, description: "" };
+          }),
+          arguments: [],
+        },
+        arguments: {},
+      },
+    } as unknown as Node;
+  };
+
+  const edge: (source: string, target: string, handle: string) => Edge = (
+    source: string,
+    target: string,
+    handle: string,
+  ): Edge => {
+    return {
+      id: `${source}->${target}`,
+      source: source,
+      target: target,
+      sourceHandle: handle,
+    };
+  };
+
+  test("returns hasTrigger=false with no trigger", () => {
+    const nodes: Array<Node> = [
+      wfNode("n1", "log-1", "Log", ComponentType.Component, []),
+    ];
+    const outline: WorkflowOutline = buildOutline(nodes, []);
+    expect(outline.hasTrigger).toBe(false);
+    expect(outline.entries).toHaveLength(0);
+  });
+
+  test("linearises a simple chain with increasing depth", () => {
+    const nodes: Array<Node> = [
+      wfNode("t", "schedule-1", "Schedule", ComponentType.Trigger, [
+        { id: "execute", title: "Execute" },
+      ]),
+      wfNode("a", "slack-1", "Slack", ComponentType.Component, [
+        { id: "success", title: "Success" },
+      ]),
+      wfNode("b", "log-1", "Log", ComponentType.Component, []),
+    ];
+    const edges: Array<Edge> = [
+      edge("t", "a", "execute"),
+      edge("a", "b", "success"),
+    ];
+
+    const outline: WorkflowOutline = buildOutline(nodes, edges);
+    expect(outline.hasTrigger).toBe(true);
+    expect(
+      outline.entries.map((e: { title: string; depth: number }) => {
+        return `${e.depth}:${e.title}`;
+      }),
+    ).toEqual(["0:Schedule", "1:Slack", "2:Log"]);
+    expect(outline.hasMultiplePaths).toBe(false);
+  });
+
+  test("labels branches by their out-port when a step has multiple ports", () => {
+    const nodes: Array<Node> = [
+      wfNode("t", "schedule-1", "Schedule", ComponentType.Trigger, [
+        { id: "execute", title: "Execute" },
+      ]),
+      wfNode("if", "if-else-1", "If / Else", ComponentType.Component, [
+        { id: "yes", title: "Yes" },
+        { id: "no", title: "No" },
+      ]),
+      wfNode("x", "slack-1", "Slack", ComponentType.Component, []),
+      wfNode("y", "log-1", "Log", ComponentType.Component, []),
+    ];
+    const edges: Array<Edge> = [
+      edge("t", "if", "execute"),
+      edge("if", "x", "yes"),
+      edge("if", "y", "no"),
+    ];
+
+    const outline: WorkflowOutline = buildOutline(nodes, edges);
+    const branchLabels: Record<string, string | undefined> = {};
+    for (const entry of outline.entries) {
+      branchLabels[entry.title] = entry.branchLabel;
+    }
+    expect(branchLabels["Slack"]).toBe("Yes");
+    expect(branchLabels["Log"]).toBe("No");
+    // The trigger's single out-port doesn't get a branch label.
+    expect(branchLabels["If / Else"]).toBeUndefined();
+  });
+
+  test("marks a merge/loop step as repeated and flags multiple paths", () => {
+    // t -> a -> c, t -> b -> c  (c is a fan-in)
+    const nodes: Array<Node> = [
+      wfNode("t", "schedule-1", "Schedule", ComponentType.Trigger, [
+        { id: "execute", title: "Execute" },
+      ]),
+      wfNode("a", "slack-1", "Slack", ComponentType.Component, [
+        { id: "out", title: "Out" },
+      ]),
+      wfNode("b", "email-1", "Email", ComponentType.Component, [
+        { id: "out", title: "Out" },
+      ]),
+      wfNode("c", "log-1", "Log", ComponentType.Component, []),
+    ];
+    const edges: Array<Edge> = [
+      edge("t", "a", "execute"),
+      edge("t", "b", "execute"),
+      edge("a", "c", "out"),
+      edge("b", "c", "out"),
+    ];
+
+    const outline: WorkflowOutline = buildOutline(nodes, edges);
+    expect(outline.hasMultiplePaths).toBe(true);
+    const logEntries: Array<{ repeated: boolean }> = outline.entries.filter(
+      (e: { title: string }) => {
+        return e.title === "Log";
+      },
+    );
+    expect(logEntries).toHaveLength(2);
+    expect(logEntries[0]!.repeated).toBe(false);
+    expect(logEntries[1]!.repeated).toBe(true);
   });
 });

--- a/Common/Tests/UI/Components/Workflow/WorkflowOutline.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/WorkflowOutline.test.tsx
@@ -1,0 +1,109 @@
+import WorkflowOutline from "../../../../UI/Components/Workflow/WorkflowOutline";
+import { ComponentType, NodeType } from "../../../../Types/Workflow/Component";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Edge, Node } from "reactflow";
+import React from "react";
+
+const wfNode: (
+  rfId: string,
+  dataId: string,
+  title: string,
+  componentType: ComponentType,
+  outPortId?: string,
+) => Node = (
+  rfId: string,
+  dataId: string,
+  title: string,
+  componentType: ComponentType,
+  outPortId?: string,
+): Node => {
+  return {
+    id: rfId,
+    position: { x: 0, y: 0 },
+    data: {
+      id: dataId,
+      nodeType: NodeType.Node,
+      componentType: componentType,
+      metadata: {
+        title: title,
+        outPorts: outPortId
+          ? [{ id: outPortId, title: "Out", description: "" }]
+          : [],
+        arguments: [],
+      },
+      arguments: {},
+    },
+  } as unknown as Node;
+};
+
+describe("WorkflowOutline", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the ordered steps from the trigger", () => {
+    const nodes: Array<Node> = [
+      wfNode("t", "schedule-1", "Schedule", ComponentType.Trigger, "execute"),
+      wfNode("a", "slack-1", "Send to Slack", ComponentType.Component),
+    ];
+    const edges: Array<Edge> = [
+      {
+        id: "t->a",
+        source: "t",
+        target: "a",
+        sourceHandle: "execute",
+      },
+    ];
+
+    render(
+      <WorkflowOutline
+        nodes={nodes}
+        edges={edges}
+        onClose={getJestMockFunction()}
+      />,
+    );
+
+    expect(screen.getByText("Schedule")).toBeTruthy();
+    expect(screen.getByText("Send to Slack")).toBeTruthy();
+  });
+
+  it("shows a hint when there is no trigger", () => {
+    const nodes: Array<Node> = [
+      wfNode("a", "slack-1", "Send to Slack", ComponentType.Component),
+    ];
+
+    render(
+      <WorkflowOutline
+        nodes={nodes}
+        edges={[]}
+        onClose={getJestMockFunction()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Add a trigger to see what this workflow does."),
+    ).toBeTruthy();
+  });
+
+  it("closes when the close button is clicked", () => {
+    const onClose: MockFunction = getJestMockFunction();
+    render(<WorkflowOutline nodes={[]} edges={[]} onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText("Close outline"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/UI/Components/Workflow/GraphUtils.ts
+++ b/Common/UI/Components/Workflow/GraphUtils.ts
@@ -1,7 +1,10 @@
 import {
   Argument,
   ComponentInputType,
+  ComponentType,
   NodeDataProp,
+  NodeType,
+  Port,
 } from "../../../Types/Workflow/Component";
 import { JSONObject } from "../../../Types/JSON";
 import { Edge, Node } from "reactflow";
@@ -284,4 +287,140 @@ export const getNodeStatus: GetNodeStatusFunction = (
   });
 
   return hasMissingRequired ? "incomplete" : "ready";
+};
+
+export interface OutlineEntry {
+  // The component's human id (NodeDataProp.id), stable per node.
+  nodeId: string;
+  title: string;
+  summary: string | null;
+  // Indentation level; the trigger is 0.
+  depth: number;
+  // The out-port that led here, shown only when the parent branches.
+  branchLabel?: string | undefined;
+  /*
+   * True when this step was already listed (a loop or a merge/fan-in) — it's
+   * a reference back, not re-expanded.
+   */
+  repeated: boolean;
+}
+
+export interface WorkflowOutline {
+  hasTrigger: boolean;
+  entries: Array<OutlineEntry>;
+  // A step is reached from more than one path (fan-in or loop).
+  hasMultiplePaths: boolean;
+}
+
+/*
+ * Linearise the graph into an ordered, indented list of steps for the
+ * read-only Outline — a plain "read back what this workflow does" view. It
+ * walks forward from the trigger following edges; branches nest under their
+ * port label, and a step reached twice (loop / merge) is listed once more as a
+ * reference rather than re-expanded, so this always terminates.
+ */
+export type BuildOutlineFunction = (
+  nodes: Array<Node>,
+  edges: Array<Edge>,
+) => WorkflowOutline;
+
+export const buildOutline: BuildOutlineFunction = (
+  nodes: Array<Node>,
+  edges: Array<Edge>,
+): WorkflowOutline => {
+  const nodeById: Map<string, Node> = new Map<string, Node>();
+  for (const node of nodes) {
+    nodeById.set(node.id, node);
+  }
+
+  const adjacency: Map<
+    string,
+    Array<{ port: string | null | undefined; target: string }>
+  > = new Map();
+  for (const edge of edges) {
+    if (!edge.source || !edge.target) {
+      continue;
+    }
+    const list: Array<{ port: string | null | undefined; target: string }> =
+      adjacency.get(edge.source) || [];
+    list.push({ port: edge.sourceHandle, target: edge.target });
+    adjacency.set(edge.source, list);
+  }
+
+  const trigger: Node | undefined = nodes.find((node: Node) => {
+    const data: NodeDataProp = node.data as NodeDataProp;
+    return (
+      data &&
+      data.nodeType === NodeType.Node &&
+      data.componentType === ComponentType.Trigger
+    );
+  });
+
+  if (!trigger) {
+    return { hasTrigger: false, entries: [], hasMultiplePaths: false };
+  }
+
+  const entries: Array<OutlineEntry> = [];
+  const visited: Set<string> = new Set<string>();
+  let hasMultiplePaths: boolean = false;
+
+  type VisitFunction = (
+    reactFlowId: string,
+    depth: number,
+    branchLabel: string | undefined,
+  ) => void;
+
+  const visit: VisitFunction = (
+    reactFlowId: string,
+    depth: number,
+    branchLabel: string | undefined,
+  ): void => {
+    const node: Node | undefined = nodeById.get(reactFlowId);
+    if (!node) {
+      return;
+    }
+
+    const data: NodeDataProp = node.data as NodeDataProp;
+    const alreadySeen: boolean = visited.has(reactFlowId);
+    if (alreadySeen) {
+      hasMultiplePaths = true;
+    }
+
+    entries.push({
+      nodeId: data.id,
+      title: data.metadata?.title || data.id,
+      summary: getComponentSummary(data),
+      depth: depth,
+      branchLabel: branchLabel,
+      repeated: alreadySeen,
+    });
+
+    if (alreadySeen) {
+      return;
+    }
+    visited.add(reactFlowId);
+
+    const outPorts: Array<Port> = data.metadata?.outPorts || [];
+    const branches: boolean = outPorts.length > 1;
+    const outEdges: Array<{ port: string | null | undefined; target: string }> =
+      adjacency.get(reactFlowId) || [];
+
+    for (const outEdge of outEdges) {
+      const port: Port | undefined = outPorts.find((p: Port) => {
+        return p.id === outEdge.port;
+      });
+      const label: string | undefined = branches
+        ? port?.title || outEdge.port || undefined
+        : undefined;
+      visit(outEdge.target, depth + 1, label);
+    }
+  };
+
+  visit(trigger.id, 0, undefined);
+
+  return {
+    hasTrigger: true,
+    entries: entries,
+    hasMultiplePaths: hasMultiplePaths,
+  };
 };

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -3,6 +3,7 @@ import ComponentSettingsPanel from "./ComponentSettingsPanel";
 import ComponentsModal from "./ComponentsModal";
 import RunModal from "./RunModal";
 import WorkflowTemplateGallery from "./WorkflowTemplateGallery";
+import WorkflowOutline from "./WorkflowOutline";
 import {
   WorkflowTemplate,
   WorkflowTemplates,
@@ -333,6 +334,8 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
   // Dismissed once the user picks a template or chooses to start from scratch.
   const [templatesDismissed, setTemplatesDismissed] = useState<boolean>(false);
 
+  const [showOutline, setShowOutline] = useState<boolean>(false);
+
   type LoadTemplateFunction = (template: WorkflowTemplate) => void;
 
   const loadTemplate: LoadTemplateFunction = (
@@ -582,6 +585,56 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
             }}
           />
         )}
+
+      {/*
+        Outline: a read-only "what does this workflow do" panel. The toggle
+        appears once there is at least one real step; the panel docks on the
+        left so it doesn't collide with the right-side settings inspector.
+      */}
+      {!showOutline &&
+        nodes.some((node: Node) => {
+          return (node.data as NodeDataProp).nodeType === NodeType.Node;
+        }) && (
+          <button
+            type="button"
+            onClick={() => {
+              setShowOutline(true);
+            }}
+            style={{
+              position: "absolute",
+              top: "12px",
+              left: "12px",
+              zIndex: 5,
+            }}
+            className="rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 cursor-pointer"
+          >
+            Outline
+          </button>
+        )}
+
+      {showOutline && (
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            bottom: 0,
+            width: "min(360px, 100%)",
+            zIndex: 6,
+            backgroundColor: "#ffffff",
+            borderRight: "1px solid #e2e8f0",
+            boxShadow: "4px 0 12px -6px rgba(0, 0, 0, 0.15)",
+          }}
+        >
+          <WorkflowOutline
+            nodes={nodes}
+            edges={edges}
+            onClose={() => {
+              setShowOutline(false);
+            }}
+          />
+        </div>
+      )}
 
       {showComponentsModal && (
         <ComponentsModal

--- a/Common/UI/Components/Workflow/WorkflowOutline.tsx
+++ b/Common/UI/Components/Workflow/WorkflowOutline.tsx
@@ -1,0 +1,97 @@
+import Icon from "../Icon/Icon";
+import {
+  OutlineEntry,
+  WorkflowOutline as OutlineData,
+  buildOutline,
+} from "./GraphUtils";
+import IconProp from "../../../Types/Icon/IconProp";
+import { Edge, Node } from "reactflow";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/*
+ * A read-only, plain-English "read back what this workflow does" panel. It
+ * never edits the graph — it only renders the outline produced by
+ * buildOutline(nodes, edges).
+ */
+
+export interface ComponentProps {
+  nodes: Array<Node>;
+  edges: Array<Edge>;
+  onClose: () => void;
+}
+
+const WorkflowOutline: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const outline: OutlineData = buildOutline(props.nodes, props.edges);
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900">Outline</h2>
+          <p className="text-xs text-gray-500">
+            What this workflow does, in order.
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="Close outline"
+          onClick={props.onClose}
+          className="shrink-0 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 cursor-pointer"
+        >
+          <Icon icon={IconProp.Close} className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {!outline.hasTrigger ? (
+          <p className="text-sm text-gray-500">
+            Add a trigger to see what this workflow does.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {outline.entries.map((entry: OutlineEntry, index: number) => {
+              return (
+                <li
+                  key={`${entry.nodeId}-${index}`}
+                  style={{ marginLeft: `${entry.depth}rem` }}
+                  className="text-sm"
+                >
+                  {entry.branchLabel && (
+                    <span className="mr-1.5 rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-500">
+                      {entry.branchLabel}
+                    </span>
+                  )}
+                  <span className="font-medium text-gray-900">
+                    {entry.title}
+                  </span>
+                  {entry.repeated ? (
+                    <span className="ml-1 text-xs text-gray-400">
+                      (runs again here)
+                    </span>
+                  ) : (
+                    entry.summary && (
+                      <span className="ml-1 text-gray-500">
+                        — {entry.summary}
+                      </span>
+                    )
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+        )}
+
+        {outline.hasMultiplePaths && (
+          <p className="mt-4 text-xs text-gray-400">
+            Some steps run from more than one path — the canvas shows the full
+            shape.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowOutline;


### PR DESCRIPTION
A read-only "read back what this workflow does" view for non-technical authors. **Stacked on #2607.**

## What

Understanding a workflow meant tracing boxes and arrows on the canvas. This adds an **Outline** panel: a plain, ordered, indented list of the steps, walking forward from the trigger.

- **Pure `buildOutline(nodes, edges)`** linearises the graph: branches **nest under their out-port label** (Yes / No, Success / Error), and a step reached from more than one path (a loop or merge) is listed once more as a **reference** rather than re-expanded — so it always terminates and never invents a shape the graph doesn't have.
- **`WorkflowOutline`** renders it (or an honest "add a trigger" hint) and notes when steps run from multiple paths.
- **Strictly read-only** — no `graphToSteps` / auto-wiring, so it can never clobber a hand-built graph (this was the explicit reason the design chose a read-only outline over an editable "simple mode"). Wired into `Workflow.tsx` as an **"Outline" toggle** (shown once there's a real step) opening a **left-docked** panel, clear of the right-side settings inspector.

## Verification

- **`buildOutline` (in GraphUtils.test.ts):** no-trigger → `hasTrigger:false`; linear chain → increasing depth; multi-port step → branch labels ("Yes"/"No"); merge/loop → the step is `repeated` and `hasMultiplePaths` is set.
- **`WorkflowOutline.test.tsx` (RTL):** renders the ordered steps, shows the no-trigger hint, close button fires `onClose`.
- **69 workflow tests pass**; `tsc` ✓, `eslint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
