### PR TITLE
feat(workflow): key/value editor for headers & query params

### DIFF
--- a/Common/Tests/UI/Components/Workflow/KeyValueInput.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/KeyValueInput.test.tsx
@@ -1,0 +1,102 @@
+import KeyValueInput from "../../../../UI/Components/Workflow/KeyValueInput";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// JSON-mode uses the Monaco-backed editor; stub it (rows mode is under test).
+jest.mock("../../../../UI/Components/Workflow/JSONArgumentInput", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return null;
+    },
+  };
+});
+
+describe("KeyValueInput", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a row per key/value pair", () => {
+    render(
+      <KeyValueInput
+        value='{"Accept":"application/json"}'
+        onChange={getJestMockFunction()}
+      />,
+    );
+
+    const keys: Array<HTMLInputElement> = screen.getAllByLabelText(
+      "Key",
+    ) as Array<HTMLInputElement>;
+    const values: Array<HTMLInputElement> = screen.getAllByLabelText(
+      "Value",
+    ) as Array<HTMLInputElement>;
+    expect(keys[0]!.value).toBe("Accept");
+    expect(values[0]!.value).toBe("application/json");
+  });
+
+  it("serializes edits back to a JSON object string", () => {
+    const onChange: MockFunction = getJestMockFunction();
+    render(<KeyValueInput value='{"Accept":"x"}' onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "application/json" },
+    });
+
+    const last: string = onChange.mock.calls[
+      onChange.mock.calls.length - 1
+    ]![0] as string;
+    expect(JSON.parse(last)).toEqual({ Accept: "application/json" });
+  });
+
+  it("adds and removes rows", () => {
+    const onChange: MockFunction = getJestMockFunction();
+    render(<KeyValueInput value="" onChange={onChange} />);
+
+    fireEvent.click(screen.getByText("+ Add"));
+    fireEvent.change(screen.getByLabelText("Key"), {
+      target: { value: "X-Api-Key" },
+    });
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "secret" },
+    });
+
+    let last: string = onChange.mock.calls[
+      onChange.mock.calls.length - 1
+    ]![0] as string;
+    expect(JSON.parse(last)).toEqual({ "X-Api-Key": "secret" });
+
+    fireEvent.click(screen.getByLabelText("Remove row"));
+    last = onChange.mock.calls[onChange.mock.calls.length - 1]![0] as string;
+    expect(last).toBe("");
+  });
+
+  it("starts in JSON mode when the value can't be shown as rows", () => {
+    render(
+      <KeyValueInput
+        value='{"nested":{"a":1}}'
+        onChange={getJestMockFunction()}
+      />,
+    );
+
+    /*
+     * No key/value rows are rendered; the "Edit as JSON" toggle is absent
+     * because we're already in JSON mode (the JSON editor is stubbed to null).
+     */
+    expect(screen.queryByLabelText("Key")).toBeNull();
+    expect(screen.getByText("Switch to fields")).toBeTruthy();
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/KeyValueUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/KeyValueUtils.test.ts
@@ -1,0 +1,78 @@
+import {
+  KeyValueRow,
+  parseKeyValue,
+  serializeKeyValue,
+} from "../../../../UI/Components/Workflow/KeyValueUtils";
+import { describe, expect, test } from "@jest/globals";
+
+describe("KeyValueUtils.parseKeyValue", () => {
+  test("empty value parses to no rows", () => {
+    expect(parseKeyValue("")).toEqual([]);
+    expect(parseKeyValue("   ")).toEqual([]);
+  });
+
+  test("a flat object parses to rows", () => {
+    expect(
+      parseKeyValue('{"Authorization":"Bearer x","Accept":"application/json"}'),
+    ).toEqual([
+      { key: "Authorization", value: "Bearer x" },
+      { key: "Accept", value: "application/json" },
+    ]);
+  });
+
+  test("keeps a {{ token }} inside a value verbatim", () => {
+    expect(
+      parseKeyValue('{"Authorization":"Bearer {{local.variables.token}}"}'),
+    ).toEqual([
+      { key: "Authorization", value: "Bearer {{local.variables.token}}" },
+    ]);
+  });
+
+  test("coerces non-string scalar values to strings", () => {
+    expect(parseKeyValue('{"Retries":3,"Enabled":true}')).toEqual([
+      { key: "Retries", value: "3" },
+      { key: "Enabled", value: "true" },
+    ]);
+  });
+
+  test("returns null for invalid JSON, arrays, or nested objects", () => {
+    expect(parseKeyValue("{not json")).toBeNull();
+    expect(parseKeyValue('["a","b"]')).toBeNull();
+    expect(parseKeyValue('{"nested":{"a":1}}')).toBeNull();
+  });
+});
+
+describe("KeyValueUtils.serializeKeyValue", () => {
+  test("serializes rows to a JSON object string", () => {
+    const rows: Array<KeyValueRow> = [
+      { key: "Authorization", value: "Bearer x" },
+      { key: "Accept", value: "application/json" },
+    ];
+    expect(JSON.parse(serializeKeyValue(rows))).toEqual({
+      Authorization: "Bearer x",
+      Accept: "application/json",
+    });
+  });
+
+  test("drops rows with an empty key", () => {
+    const rows: Array<KeyValueRow> = [
+      { key: "", value: "ignored" },
+      { key: "Accept", value: "application/json" },
+    ];
+    expect(JSON.parse(serializeKeyValue(rows))).toEqual({
+      Accept: "application/json",
+    });
+  });
+
+  test("serializes to an empty string when there are no real entries", () => {
+    expect(serializeKeyValue([])).toBe("");
+    expect(serializeKeyValue([{ key: "  ", value: "x" }])).toBe("");
+  });
+
+  test("round-trips a flat object to the same parsed value", () => {
+    const original: string = '{"A":"1","B":"two"}';
+    const rows: Array<KeyValueRow> | null = parseKeyValue(original);
+    expect(rows).not.toBeNull();
+    expect(JSON.parse(serializeKeyValue(rows!))).toEqual(JSON.parse(original));
+  });
+});

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -7,6 +7,7 @@ import ComponentValuePickerModal from "./ComponentValuePickerModal";
 import ConditionBuilder from "./ConditionBuilder";
 import DataReferenceInput from "./DataReferenceInput";
 import JSONArgumentInput from "./JSONArgumentInput";
+import KeyValueInput from "./KeyValueInput";
 import ModelFieldPicker from "./ModelFieldPicker";
 import { componentInputTypeToFormFieldType } from "./Utils";
 import VariableModal from "./VariableModal";
@@ -35,6 +36,7 @@ import React, {
  * Argument types that are edited as JSON. These used to render as a plain
  * textarea; they now use the validating JSONArgumentInput. Select is included
  * only when the component has no tableName (otherwise it uses ModelFieldPicker).
+ * StringDictionary is handled separately (key/value rows, see KeyValueInput).
  */
 const JSON_INPUT_TYPES: Array<ComponentInputType> = [
   ComponentInputType.JSON,
@@ -43,7 +45,6 @@ const JSON_INPUT_TYPES: Array<ComponentInputType> = [
   ComponentInputType.BaseModelArray,
   ComponentInputType.Query,
   ComponentInputType.Select,
-  ComponentInputType.StringDictionary,
 ];
 
 export interface ComponentProps {
@@ -313,6 +314,13 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                 const useJsonEditor: boolean =
                   !useFieldPicker && JSON_INPUT_TYPES.includes(arg.type);
 
+                /*
+                 * StringDictionary args (HTTP headers, query params) are
+                 * edited as key/value rows rather than raw JSON.
+                 */
+                const useKeyValueEditor: boolean =
+                  arg.type === ComponentInputType.StringDictionary;
+
                 let baseField: {
                   fieldType: import("../Forms/Types/FormFieldSchemaType").default;
                   dropdownOptions?: Array<DropdownOption> | undefined;
@@ -366,6 +374,28 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                       );
                     },
                   };
+                } else if (useKeyValueEditor) {
+                  baseField = {
+                    fieldType: FormFieldSchemaType.CustomComponent,
+                    getCustomElement: (
+                      _values: FormValues<JSONObject>,
+                      customProps: CustomElementProps,
+                    ): ReactElement => {
+                      return (
+                        <KeyValueInput
+                          value={(customProps.initialValue as string) || ""}
+                          placeholder={arg.placeholder}
+                          error={customProps.error}
+                          onChange={(value: string) => {
+                            void customProps.onChange?.(value);
+                          }}
+                          onValidationChange={(isInvalid: boolean) => {
+                            setJsonFieldError(arg.id, isInvalid);
+                          }}
+                        />
+                      );
+                    },
+                  };
                 } else {
                   baseField = componentInputTypeToFormFieldType(
                     arg.type,
@@ -389,7 +419,7 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                  * expression) or to WorkflowSelect.
                  */
                 const showVariableFooter: boolean =
-                  !isWorkflowSelect && !useFieldPicker;
+                  !isWorkflowSelect && !useFieldPicker && !useKeyValueEditor;
 
                 /*
                  * Plain text fields get the inline chip helper: existing

--- a/Common/UI/Components/Workflow/KeyValueInput.tsx
+++ b/Common/UI/Components/Workflow/KeyValueInput.tsx
@@ -1,0 +1,193 @@
+import JSONArgumentInput from "./JSONArgumentInput";
+import { KeyValueRow, parseKeyValue, serializeKeyValue } from "./KeyValueUtils";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useRef,
+  useState,
+} from "react";
+
+/*
+ * Edit a StringDictionary argument (HTTP headers, query params, …) as
+ * key/value rows instead of hand-written JSON — far harder to get wrong. The
+ * value stays a JSON string (see KeyValueUtils), so storage/execution are
+ * unchanged. An "Edit as JSON" escape covers values that aren't simple pairs.
+ */
+
+interface Row extends KeyValueRow {
+  id: number;
+}
+
+export interface ComponentProps {
+  value: string;
+  onChange: (value: string) => void;
+  onValidationChange?: ((isInvalid: boolean) => void) | undefined;
+  placeholder?: string | undefined;
+  error?: string | undefined;
+}
+
+const inputClass: string =
+  "block w-full rounded-md border border-gray-300 py-2 px-3 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500";
+
+const KeyValueInput: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const idRef: React.MutableRefObject<number> = useRef<number>(0);
+
+  type MakeRowFunction = (key: string, value: string) => Row;
+  const makeRow: MakeRowFunction = (key: string, value: string): Row => {
+    idRef.current += 1;
+    return { id: idRef.current, key: key, value: value };
+  };
+
+  const parsedInitial: Array<KeyValueRow> | null = parseKeyValue(props.value);
+
+  const [rows, setRows] = useState<Array<Row>>(() => {
+    return (parsedInitial || []).map((r: KeyValueRow) => {
+      return makeRow(r.key, r.value);
+    });
+  });
+  const [mode, setMode] = useState<"fields" | "json">(
+    parsedInitial === null ? "json" : "fields",
+  );
+
+  type CommitFunction = (nextRows: Array<Row>) => void;
+  const commit: CommitFunction = (nextRows: Array<Row>): void => {
+    setRows(nextRows);
+    props.onChange(serializeKeyValue(nextRows));
+    // Rows always serialize to valid JSON.
+    props.onValidationChange?.(false);
+  };
+
+  if (mode === "json") {
+    const canSwitchToFields: boolean = parseKeyValue(props.value) !== null;
+    return (
+      <div>
+        <JSONArgumentInput
+          value={props.value}
+          placeholder={props.placeholder}
+          error={props.error}
+          onChange={(value: string) => {
+            props.onChange(value);
+          }}
+          onValidationChange={props.onValidationChange}
+        />
+        <button
+          type="button"
+          disabled={!canSwitchToFields}
+          className={
+            canSwitchToFields
+              ? "mt-1 text-xs font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+              : "mt-1 text-xs font-medium text-gray-300 cursor-not-allowed"
+          }
+          title={
+            canSwitchToFields
+              ? "Show as key/value fields"
+              : "Can't show as fields while the JSON is invalid or nested."
+          }
+          onClick={() => {
+            const parsed: Array<KeyValueRow> | null = parseKeyValue(
+              props.value,
+            );
+            if (!parsed) {
+              return;
+            }
+            setRows(
+              parsed.map((r: KeyValueRow) => {
+                return makeRow(r.key, r.value);
+              }),
+            );
+            setMode("fields");
+            props.onValidationChange?.(false);
+          }}
+        >
+          Switch to fields
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {rows.length === 0 && (
+        <p className="mb-2 text-sm text-gray-400">No entries yet.</p>
+      )}
+
+      <div className="space-y-2">
+        {rows.map((row: Row) => {
+          return (
+            <div key={row.id} className="flex items-center gap-2">
+              <input
+                className={inputClass}
+                placeholder="Key"
+                aria-label="Key"
+                value={row.key}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  commit(
+                    rows.map((r: Row) => {
+                      return r.id === row.id
+                        ? { ...r, key: e.target.value }
+                        : r;
+                    }),
+                  );
+                }}
+              />
+              <input
+                className={inputClass}
+                placeholder="Value"
+                aria-label="Value"
+                value={row.value}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  commit(
+                    rows.map((r: Row) => {
+                      return r.id === row.id
+                        ? { ...r, value: e.target.value }
+                        : r;
+                    }),
+                  );
+                }}
+              />
+              <button
+                type="button"
+                aria-label="Remove row"
+                className="shrink-0 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 cursor-pointer"
+                onClick={() => {
+                  commit(
+                    rows.filter((r: Row) => {
+                      return r.id !== row.id;
+                    }),
+                  );
+                }}
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          type="button"
+          className="text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+          onClick={() => {
+            setRows([...rows, makeRow("", "")]);
+          }}
+        >
+          + Add
+        </button>
+        <button
+          type="button"
+          className="text-xs font-medium text-gray-400 hover:text-gray-600 cursor-pointer"
+          onClick={() => {
+            setMode("json");
+          }}
+        >
+          Edit as JSON
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default KeyValueInput;

--- a/Common/UI/Components/Workflow/KeyValueUtils.ts
+++ b/Common/UI/Components/Workflow/KeyValueUtils.ts
@@ -1,0 +1,80 @@
+/*
+ * Pure (React-free) helpers for editing a StringDictionary argument (HTTP
+ * headers, query params, …) as key/value rows instead of raw JSON. The stored
+ * value stays a JSON string — the server JSON-parses it either way — so a
+ * workflow round-trips to the same parsed object and nothing about execution
+ * changes.
+ */
+
+export interface KeyValueRow {
+  key: string;
+  value: string;
+}
+
+export type ParseKeyValueFunction = (
+  value: string,
+) => Array<KeyValueRow> | null;
+
+/*
+ * Parse the stored JSON string into rows. Returns null when the value can't be
+ * shown as simple key/value pairs (invalid JSON, an array, or a nested
+ * object) — the caller then falls back to the raw JSON editor.
+ */
+export const parseKeyValue: ParseKeyValueFunction = (
+  value: string,
+): Array<KeyValueRow> | null => {
+  const trimmed: string = (value || "").trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const rows: Array<KeyValueRow> = [];
+  for (const key of Object.keys(parsed as Record<string, unknown>)) {
+    const raw: unknown = (parsed as Record<string, unknown>)[key];
+    if (raw !== null && typeof raw === "object") {
+      // Nested object/array — can't represent as a flat row.
+      return null;
+    }
+    rows.push({
+      key: key,
+      value: raw === null || raw === undefined ? "" : String(raw),
+    });
+  }
+
+  return rows;
+};
+
+export type SerializeKeyValueFunction = (rows: Array<KeyValueRow>) => string;
+
+/*
+ * Serialize rows back to a JSON string. Rows with an empty key are dropped;
+ * an empty result serializes to "" (an unset optional argument).
+ */
+export const serializeKeyValue: SerializeKeyValueFunction = (
+  rows: Array<KeyValueRow>,
+): string => {
+  const object: Record<string, string> = {};
+  for (const row of rows) {
+    if (row.key.trim() === "") {
+      continue;
+    }
+    object[row.key] = row.value;
+  }
+
+  if (Object.keys(object).length === 0) {
+    return "";
+  }
+
+  return JSON.stringify(object, null, 2);
+};


### PR DESCRIPTION
Kills the biggest remaining raw-JSON footgun: **HTTP headers / query params**. **Stacked on #2610.**

## What

`StringDictionary` arguments (headers and query params on the API & Webhook components) were hand-written JSON — a `{"Authorization": "Bearer x"}` blob that's easy to get wrong. They're now edited as **key/value rows**: add, remove, type a name and a value.

- **Pure `KeyValueUtils`** (`parseKeyValue` / `serializeKeyValue`): the value **stays a JSON string on disk**, so the server parses it to the same object and execution is unchanged. Values keep any `{{ tokens }}` verbatim.
- **`KeyValueInput`** renders the rows, with an **"Edit as JSON" escape** — and it starts in JSON mode automatically when the value is nested/invalid, so nothing strands the user.
- **`ArgumentsForm`** routes `StringDictionary` to it (removed from the JSON-editor set) and suppresses the data-reference footer for it, since editing is inline.

## Verification

- **`KeyValueUtils.test.ts`:** flat object → rows; token-in-value preserved; scalar coercion; array / nested / invalid → `null` (→ JSON fallback); empty → `[]`; serialize drops empty-key rows, empty → `""`, and round-trips to the same parsed object.
- **`KeyValueInput.test.tsx` (RTL):** renders a row per pair, serializes edits back to a JSON object, add/remove rows, and starts in JSON mode for nested values.
- **82 workflow tests pass**; `tsc` ✓, `eslint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
