### PR TITLE
fix(workflow): follow identifier renames through downstream references

### DIFF
--- a/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
@@ -4,6 +4,7 @@ import {
   getNodeStatus,
   buildOutline,
   WorkflowOutline,
+  renameComponentReferences,
 } from "../../../../UI/Components/Workflow/GraphUtils";
 import {
   ComponentInputType,
@@ -438,5 +439,99 @@ describe("GraphUtils.buildOutline", () => {
     expect(logEntries).toHaveLength(2);
     expect(logEntries[0]!.repeated).toBe(false);
     expect(logEntries[1]!.repeated).toBe(true);
+  });
+});
+
+describe("GraphUtils.renameComponentReferences", () => {
+  const nodeWithArgs: (
+    dataId: string,
+    args: Record<string, unknown>,
+  ) => Node = (dataId: string, args: Record<string, unknown>): Node => {
+    return {
+      id: `rf-${dataId}`,
+      position: { x: 0, y: 0 },
+      data: { id: dataId, arguments: args },
+    } as unknown as Node;
+  };
+
+  const argsOf: (node: Node) => Record<string, unknown> = (
+    node: Node,
+  ): Record<string, unknown> => {
+    return (node.data as { arguments: Record<string, unknown> }).arguments;
+  };
+
+  test("rewrites a downstream reference to the renamed step", () => {
+    const nodes: Array<Node> = [
+      nodeWithArgs("slack-1", {}),
+      nodeWithArgs("log-1", {
+        text: "Error was {{local.components.slack-1.returnValues.error}}",
+      }),
+    ];
+
+    const result: Array<Node> = renameComponentReferences(
+      nodes,
+      "slack-1",
+      "notify-slack",
+    );
+
+    expect(argsOf(result[1]!)["text"]).toBe(
+      "Error was {{local.components.notify-slack.returnValues.error}}",
+    );
+  });
+
+  test("does not rewrite a step whose id is only a prefix of the renamed one", () => {
+    const nodes: Array<Node> = [
+      nodeWithArgs("log-1", {
+        a: "{{local.components.slack-1.returnValues.x}}",
+        b: "{{local.components.slack-10.returnValues.y}}",
+      }),
+    ];
+
+    const result: Array<Node> = renameComponentReferences(
+      nodes,
+      "slack-1",
+      "NEW",
+    );
+
+    expect(argsOf(result[0]!)["a"]).toBe(
+      "{{local.components.NEW.returnValues.x}}",
+    );
+    // slack-10 must be untouched.
+    expect(argsOf(result[0]!)["b"]).toBe(
+      "{{local.components.slack-10.returnValues.y}}",
+    );
+  });
+
+  test("rewrites every occurrence within a value", () => {
+    const nodes: Array<Node> = [
+      nodeWithArgs("log-1", {
+        text:
+          "{{local.components.a-1.returnValues.x}} and " +
+          "{{local.components.a-1.returnValues.y}}",
+      }),
+    ];
+
+    const result: Array<Node> = renameComponentReferences(nodes, "a-1", "b-1");
+    expect(argsOf(result[0]!)["text"]).toBe(
+      "{{local.components.b-1.returnValues.x}} and " +
+        "{{local.components.b-1.returnValues.y}}",
+    );
+  });
+
+  test("is a no-op (same reference) when id is unchanged or empty", () => {
+    const nodes: Array<Node> = [nodeWithArgs("slack-1", { text: "hi" })];
+    expect(renameComponentReferences(nodes, "slack-1", "slack-1")).toBe(nodes);
+    expect(renameComponentReferences(nodes, "", "x")).toBe(nodes);
+  });
+
+  test("leaves unaffected nodes as the same object", () => {
+    const untouched: Node = nodeWithArgs("log-1", { text: "no refs here" });
+    const nodes: Array<Node> = [untouched];
+    const result: Array<Node> = renameComponentReferences(
+      nodes,
+      "slack-1",
+      "x",
+    );
+    expect(result[0]).toBe(untouched);
   });
 });

--- a/Common/UI/Components/Workflow/GraphUtils.ts
+++ b/Common/UI/Components/Workflow/GraphUtils.ts
@@ -424,3 +424,58 @@ export const buildOutline: BuildOutlineFunction = (
     hasMultiplePaths: hasMultiplePaths,
   };
 };
+
+/*
+ * Rewrite every downstream reference to a renamed step. Data references are
+ * stored as {{local.components.<id>.returnValues.<rv>}} tokens inside argument
+ * strings; when a step's identifier changes, those tokens must follow or they
+ * silently break. Matching includes the trailing ".returnValues." so an id
+ * that is a prefix of another (slack-1 vs slack-10) is never mis-rewritten.
+ * Returns new node objects only where something changed.
+ */
+export type RenameComponentReferencesFunction = (
+  nodes: Array<Node>,
+  oldId: string,
+  newId: string,
+) => Array<Node>;
+
+export const renameComponentReferences: RenameComponentReferencesFunction = (
+  nodes: Array<Node>,
+  oldId: string,
+  newId: string,
+): Array<Node> => {
+  if (!oldId || !newId || oldId === newId) {
+    return nodes;
+  }
+
+  const needle: string = `{{local.components.${oldId}.returnValues.`;
+  const replacement: string = `{{local.components.${newId}.returnValues.`;
+
+  return nodes.map((node: Node) => {
+    const data: NodeDataProp = node.data as NodeDataProp;
+    const args: JSONObject | undefined = data?.arguments as
+      | JSONObject
+      | undefined;
+    if (!args) {
+      return node;
+    }
+
+    let changed: boolean = false;
+    const nextArgs: JSONObject = {};
+    for (const key of Object.keys(args)) {
+      const value: unknown = args[key];
+      if (typeof value === "string" && value.includes(needle)) {
+        nextArgs[key] = value.split(needle).join(replacement);
+        changed = true;
+      } else {
+        nextArgs[key] = args[key];
+      }
+    }
+
+    if (!changed) {
+      return node;
+    }
+
+    return { ...node, data: { ...data, arguments: nextArgs } };
+  });
+};

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -10,7 +10,10 @@ import {
   buildTemplateGraph,
   TemplateGraph,
 } from "./WorkflowTemplates";
-import { getUpstreamComponentIds } from "./GraphUtils";
+import {
+  getUpstreamComponentIds,
+  renameComponentReferences,
+} from "./GraphUtils";
 import { loadComponentsAndCategories } from "./Utils";
 import { VoidFunction } from "../../../Types/FunctionTypes";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -734,16 +737,22 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
               setShowComponentSettingsModal(false);
             }}
             onSave={(componentData: NodeDataProp) => {
-              // Update the node.
+              // Update the node, then follow any identifier rename downstream.
+              const previousId: string = selectedNodeData.id;
 
               setNodes((nds: Array<Node>) => {
-                return nds.map((n: Node) => {
+                const updated: Array<Node> = nds.map((n: Node) => {
                   if (n.data.internalId === componentData.internalId) {
-                    n.data = componentData;
+                    return { ...n, data: componentData };
                   }
-
                   return n;
                 });
+
+                return renameComponentReferences(
+                  updated,
+                  previousId,
+                  componentData.id,
+                );
               });
 
               setShowComponentSettingsModal(false);


### PR DESCRIPTION
A correctness fix: renaming a step no longer silently breaks references to it. **Stacked on #2611.**

## Problem

Renaming a step's identifier left every downstream `{{local.components.<id>.returnValues.<rv>}}` token pointing at the **old** id — a silent breakage (now visible as the red "broken reference" chips from #2604, but still broken).

## Fix

Renames now cascade automatically on save.

- **Pure `renameComponentReferences(nodes, oldId, newId)`** rewrites the tokens in every argument string. Matching includes the trailing **`.returnValues.`** so an id that's a **prefix of another** (`slack-1` vs `slack-10`) is never mis-rewritten; unchanged nodes are returned **by reference**; it's a no-op when the id is unchanged/empty.
- **Wired into the settings-panel save path** in `Workflow.tsx`: when the saved id differs from the one the panel opened with, the cascade runs across the graph (and autosaves).

## Verification

- **`renameComponentReferences` (5 tests):** rewrites a downstream ref; **prefix-collision safety** (`slack-1` rename leaves `slack-10` alone); multiple occurrences in one value; no-op for unchanged/empty id; untouched nodes kept by reference.
- **87 workflow tests pass**; `tsc` ✓, `eslint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
