### PR TITLE
feat(workflow): 'Show data flow' overlay

### DIFF
--- a/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphUtils.test.ts
@@ -5,6 +5,7 @@ import {
   buildOutline,
   WorkflowOutline,
   renameComponentReferences,
+  deriveDataEdges,
 } from "../../../../UI/Components/Workflow/GraphUtils";
 import {
   ComponentInputType,
@@ -533,5 +534,64 @@ describe("GraphUtils.renameComponentReferences", () => {
       "x",
     );
     expect(result[0]).toBe(untouched);
+  });
+});
+
+describe("GraphUtils.deriveDataEdges", () => {
+  const refNode: (
+    rfId: string,
+    dataId: string,
+    args: Record<string, unknown>,
+  ) => Node = (
+    rfId: string,
+    dataId: string,
+    args: Record<string, unknown>,
+  ): Node => {
+    return {
+      id: rfId,
+      position: { x: 0, y: 0 },
+      data: { id: dataId, arguments: args },
+    } as unknown as Node;
+  };
+
+  test("draws a ghost edge from the referenced step to the consumer", () => {
+    const nodes: Array<Node> = [
+      refNode("rf-slack", "slack-1", {}),
+      refNode("rf-log", "log-1", {
+        text: "Was {{local.components.slack-1.returnValues.error}}",
+      }),
+    ];
+
+    const ghosts: Array<Edge> = deriveDataEdges(nodes);
+    expect(ghosts).toHaveLength(1);
+    expect(ghosts[0]!.source).toBe("rf-slack");
+    expect(ghosts[0]!.target).toBe("rf-log");
+    expect(ghosts[0]!.id).toBe("data-ghost-rf-slack->rf-log");
+  });
+
+  test("dedupes multiple references between the same pair", () => {
+    const nodes: Array<Node> = [
+      refNode("rf-slack", "slack-1", {}),
+      refNode("rf-log", "log-1", {
+        a: "{{local.components.slack-1.returnValues.error}}",
+        b: "{{local.components.slack-1.returnValues.text}}",
+      }),
+    ];
+    expect(deriveDataEdges(nodes)).toHaveLength(1);
+  });
+
+  test("ignores references to unknown steps and self-references", () => {
+    const nodes: Array<Node> = [
+      refNode("rf-log", "log-1", {
+        a: "{{local.components.ghost-9.returnValues.x}}",
+        b: "{{local.components.log-1.returnValues.self}}",
+      }),
+    ];
+    expect(deriveDataEdges(nodes)).toHaveLength(0);
+  });
+
+  test("returns nothing when there are no references", () => {
+    const nodes: Array<Node> = [refNode("rf-a", "a-1", { text: "plain text" })];
+    expect(deriveDataEdges(nodes)).toHaveLength(0);
   });
 });

--- a/Common/UI/Components/Workflow/GraphUtils.ts
+++ b/Common/UI/Components/Workflow/GraphUtils.ts
@@ -479,3 +479,87 @@ export const renameComponentReferences: RenameComponentReferencesFunction = (
     return { ...node, data: { ...data, arguments: nextArgs } };
   });
 };
+
+// Captures the source component's data id from a data-reference token.
+const COMPONENT_TOKEN_SOURCE_REGEX: RegExp =
+  /\{\{local\.components\.([^.}]+)\.returnValues\.[^}]+\}\}/g;
+
+/*
+ * Derive "ghost" edges that visualise the data flow: for every
+ * {{local.components.<id>.returnValues.…}} reference in a step's arguments,
+ * draw a faint dashed edge from the referenced (source) step to the step that
+ * consumes it. These are display-only — they are never added to the persisted
+ * edges state — so they can't leak into a saved graph. Ids are deterministic
+ * so React Flow doesn't churn across renders.
+ */
+export type DeriveDataEdgesFunction = (nodes: Array<Node>) => Array<Edge>;
+
+export const deriveDataEdges: DeriveDataEdgesFunction = (
+  nodes: Array<Node>,
+): Array<Edge> => {
+  const dataIdToNodeId: Map<string, string> = new Map<string, string>();
+  for (const node of nodes) {
+    const data: NodeDataProp = node.data as NodeDataProp;
+    if (data?.id) {
+      dataIdToNodeId.set(data.id, node.id);
+    }
+  }
+
+  const ghostEdges: Array<Edge> = [];
+  const seen: Set<string> = new Set<string>();
+
+  for (const node of nodes) {
+    const data: NodeDataProp = node.data as NodeDataProp;
+    const args: JSONObject | undefined = data?.arguments as
+      | JSONObject
+      | undefined;
+    if (!args) {
+      continue;
+    }
+
+    for (const key of Object.keys(args)) {
+      const value: unknown = args[key];
+      if (typeof value !== "string") {
+        continue;
+      }
+
+      COMPONENT_TOKEN_SOURCE_REGEX.lastIndex = 0;
+      let match: RegExpExecArray | null = null;
+      while ((match = COMPONENT_TOKEN_SOURCE_REGEX.exec(value)) !== null) {
+        const sourceDataId: string | undefined = match[1];
+        if (!sourceDataId) {
+          continue;
+        }
+        const sourceNodeId: string | undefined =
+          dataIdToNodeId.get(sourceDataId);
+        // Skip unknown sources and self-references.
+        if (!sourceNodeId || sourceNodeId === node.id) {
+          continue;
+        }
+
+        const pairKey: string = `${sourceNodeId}->${node.id}`;
+        if (seen.has(pairKey)) {
+          continue;
+        }
+        seen.add(pairKey);
+
+        ghostEdges.push({
+          id: `data-ghost-${pairKey}`,
+          source: sourceNodeId,
+          target: node.id,
+          type: "smoothstep",
+          animated: true,
+          deletable: false,
+          style: {
+            stroke: "#a5b4fc",
+            strokeWidth: 1.5,
+            strokeDasharray: "4 4",
+            opacity: 0.7,
+          },
+        });
+      }
+    }
+  }
+
+  return ghostEdges;
+};

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -13,6 +13,7 @@ import {
 import {
   getUpstreamComponentIds,
   renameComponentReferences,
+  deriveDataEdges,
 } from "./GraphUtils";
 import { loadComponentsAndCategories } from "./Utils";
 import { VoidFunction } from "../../../Types/FunctionTypes";
@@ -339,6 +340,8 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
 
   const [showOutline, setShowOutline] = useState<boolean>(false);
 
+  const [showDataFlow, setShowDataFlow] = useState<boolean>(false);
+
   type LoadTemplateFunction = (template: WorkflowTemplate) => void;
 
   const loadTemplate: LoadTemplateFunction = (
@@ -513,7 +516,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
       </style>
       <ReactFlow
         nodes={nodes}
-        edges={edges}
+        edges={showDataFlow ? edges.concat(deriveDataEdges(nodes)) : edges}
         fitView={true}
         onEdgeClick={() => {
           refreshEdges();
@@ -590,29 +593,49 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
         )}
 
       {/*
-        Outline: a read-only "what does this workflow do" panel. The toggle
-        appears once there is at least one real step; the panel docks on the
-        left so it doesn't collide with the right-side settings inspector.
+        Canvas toolbar (top-left): the read-only Outline and the "Show data
+        flow" overlay. Both appear once there's at least one real step and are
+        hidden while the Outline panel is open (it docks over this corner).
       */}
       {!showOutline &&
         nodes.some((node: Node) => {
           return (node.data as NodeDataProp).nodeType === NodeType.Node;
         }) && (
-          <button
-            type="button"
-            onClick={() => {
-              setShowOutline(true);
-            }}
+          <div
             style={{
               position: "absolute",
               top: "12px",
               left: "12px",
               zIndex: 5,
+              display: "flex",
+              gap: "6px",
             }}
-            className="rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 cursor-pointer"
           >
-            Outline
-          </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowOutline(true);
+              }}
+              className="rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 cursor-pointer"
+            >
+              Outline
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowDataFlow((value: boolean) => {
+                  return !value;
+                });
+              }}
+              className={
+                showDataFlow
+                  ? "rounded-md border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-xs font-medium text-indigo-600 shadow-sm cursor-pointer"
+                  : "rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 cursor-pointer"
+              }
+            >
+              {showDataFlow ? "Hide data flow" : "Data flow"}
+            </button>
+          </div>
         )}
 
       {showOutline && (


### PR DESCRIPTION
Makes the invisible data flow visible on the canvas. **Stacked on #2612.**

## What

Edges show **execution order**, but the **data flow** — which step's output feeds which step's input via `{{ tokens }}` — was invisible. This adds a **"Data flow"** toggle that draws faint dashed edges from each referenced step to the step that consumes it.

- **Pure `deriveDataEdges(nodes)`** scans argument strings for `{{local.components.<id>.returnValues.…}}` references and produces ghost edges (source → consumer), **deduped**, ignoring unknown sources and self-references.

## Safe by construction (the design's flagged footgun)

The synthesis warned that ghost edges must never leak into the saved graph. Here they can't: the ghost edges are **concatenated onto the `edges` passed to React Flow but are never added to the `edges` state** — so `onWorkflowUpdated` / autosave only ever persist real edges. The overlay is also **off by default**, non-deletable, with deterministic ids so React Flow doesn't churn. Worst case if the visual is imperfect is cosmetic; state and saving are untouched.

Added alongside the Outline toggle in a small top-left canvas toolbar.

## Verification

- **`deriveDataEdges` (4 tests):** draws a source→consumer ghost edge; dedupes multiple refs between a pair; ignores unknown-source and self references; empty when there are no references.
- **91 workflow tests pass**; `tsc` ✓, `eslint` ✓.
- Note: the ReactFlow *rendering* of the overlay isn't exercised in jsdom, but the derivation is unit-tested and the integration is render-only/off-by-default, so a visual imperfection can't affect data or saving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
