### PR TITLE
feat(workflow): curated 'Common steps' section in the component picker

### DIFF
--- a/Common/Tests/UI/Components/Workflow/CommonComponents.test.ts
+++ b/Common/Tests/UI/Components/Workflow/CommonComponents.test.ts
@@ -1,0 +1,75 @@
+import { getCommonComponents } from "../../../../UI/Components/Workflow/CommonComponents";
+import ComponentMetadata, {
+  ComponentType,
+} from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+const meta: (id: string, componentType: ComponentType) => ComponentMetadata = (
+  id: string,
+  componentType: ComponentType,
+): ComponentMetadata => {
+  return {
+    id: id,
+    componentType: componentType,
+  } as unknown as ComponentMetadata;
+};
+
+const catalog: Array<ComponentMetadata> = [
+  meta("schedule", ComponentType.Trigger),
+  meta("webhook", ComponentType.Trigger),
+  meta("slack-send-message-to-channel", ComponentType.Component),
+  meta("log", ComponentType.Component),
+  meta("if-else", ComponentType.Component),
+  meta("some-model-find-one", ComponentType.Component), // not curated
+];
+
+describe("CommonComponents.getCommonComponents", () => {
+  test("returns curated components of the Component type in curated order", () => {
+    const result: Array<ComponentMetadata> = getCommonComponents(
+      catalog,
+      ComponentType.Component,
+    );
+    /*
+     * Curated order is slack, email, apiGet, apiPost, ifElse, ... log ...
+     * Only slack, if-else and log are present, in that order.
+     */
+    expect(
+      result.map((c: ComponentMetadata) => {
+        return c.id;
+      }),
+    ).toEqual(["slack-send-message-to-channel", "if-else", "log"]);
+  });
+
+  test("returns curated triggers when asked for triggers", () => {
+    const result: Array<ComponentMetadata> = getCommonComponents(
+      catalog,
+      ComponentType.Trigger,
+    );
+    expect(
+      result.map((c: ComponentMetadata) => {
+        return c.id;
+      }),
+    ).toEqual(["schedule", "webhook"]);
+  });
+
+  test("never surfaces a non-curated component", () => {
+    const result: Array<ComponentMetadata> = getCommonComponents(
+      catalog,
+      ComponentType.Component,
+    );
+    expect(
+      result.some((c: ComponentMetadata) => {
+        return c.id === "some-model-find-one";
+      }),
+    ).toBe(false);
+  });
+
+  test("is empty when none of the curated ids are present", () => {
+    expect(
+      getCommonComponents(
+        [meta("some-model-find-one", ComponentType.Component)],
+        ComponentType.Component,
+      ),
+    ).toHaveLength(0);
+  });
+});

--- a/Common/UI/Components/Workflow/CommonComponents.ts
+++ b/Common/UI/Components/Workflow/CommonComponents.ts
@@ -1,0 +1,73 @@
+import ComponentID from "../../../Types/Workflow/ComponentID";
+import ComponentMetadata, {
+  ComponentType,
+} from "../../../Types/Workflow/Component";
+
+/*
+ * A small curated set of the steps most authors reach for, surfaced as a
+ * "Common steps" section at the top of the component picker. This is purely a
+ * shortcut over the full catalog (which still lists everything) — no component
+ * is removed or renamed, so there's no morph/fidelity risk.
+ */
+
+export const COMMON_CATEGORY_NAME: string = "Common steps";
+export const COMMON_CATEGORY_DESCRIPTION: string =
+  "Popular steps to get you started.";
+
+const COMMON_TRIGGER_IDS: Array<string> = [
+  ComponentID.Schedule,
+  ComponentID.Webhook,
+  ComponentID.Manual,
+];
+
+const COMMON_COMPONENT_IDS: Array<string> = [
+  ComponentID.SlackSendMessageToChannel,
+  ComponentID.SendEmail,
+  ComponentID.ApiGet,
+  ComponentID.ApiPost,
+  ComponentID.IfElse,
+  ComponentID.JavaScriptCode,
+  ComponentID.Log,
+  ComponentID.WorkflowRun,
+  ComponentID.Sleep,
+];
+
+export type GetCommonComponentsFunction = (
+  components: Array<ComponentMetadata>,
+  componentType: ComponentType,
+) => Array<ComponentMetadata>;
+
+/*
+ * Return the curated components of the given type that exist in the catalog,
+ * in curated order. Unknown ids are skipped, so this never surfaces a broken
+ * entry.
+ */
+export const getCommonComponents: GetCommonComponentsFunction = (
+  components: Array<ComponentMetadata>,
+  componentType: ComponentType,
+): Array<ComponentMetadata> => {
+  const curatedIds: Array<string> =
+    componentType === ComponentType.Trigger
+      ? COMMON_TRIGGER_IDS
+      : COMMON_COMPONENT_IDS;
+
+  const byId: Map<string, ComponentMetadata> = new Map<
+    string,
+    ComponentMetadata
+  >();
+  for (const component of components) {
+    if (component.componentType === componentType) {
+      byId.set(component.id, component);
+    }
+  }
+
+  const result: Array<ComponentMetadata> = [];
+  for (const id of curatedIds) {
+    const component: ComponentMetadata | undefined = byId.get(id);
+    if (component) {
+      result.push(component);
+    }
+  }
+
+  return result;
+};

--- a/Common/UI/Components/Workflow/ComponentsModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentsModal.tsx
@@ -2,6 +2,11 @@
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import Icon from "../Icon/Icon";
 import SideOver from "../SideOver/SideOver";
+import {
+  COMMON_CATEGORY_DESCRIPTION,
+  COMMON_CATEGORY_NAME,
+  getCommonComponents,
+} from "./CommonComponents";
 import IconProp from "../../../Types/Icon/IconProp";
 import ComponentMetadata, {
   ComponentCategory,
@@ -176,6 +181,22 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
       });
     })
     .slice(0, 4);
+
+  /*
+   * Lead the list with a curated "Common steps" section (a shortcut over the
+   * full catalog, hidden while searching so search stays a flat ranked list).
+   */
+  const commonCategory: ComponentCategory = {
+    name: COMMON_CATEGORY_NAME,
+    description: COMMON_CATEGORY_DESCRIPTION,
+    icon: IconProp.Star,
+  };
+  const hasCommonComponents: boolean =
+    getCommonComponents(components, props.componentsType).length > 0;
+  const displayCategories: Array<ComponentCategory> =
+    hasSearchTerm || !hasCommonComponents
+      ? categories
+      : [commonCategory, ...categories];
 
   const renderHighlightedText: (
     text: string,
@@ -381,198 +402,209 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
                 </div>
               ))}
 
-            {categories &&
-              categories.length > 0 &&
-              categories.map((category: ComponentCategory, i: number) => {
-                const categoryComponents: Array<ComponentMetadata> =
-                  componentsToShow.filter(
-                    (componentMetadata: ComponentMetadata) => {
-                      return componentMetadata.category === category.name;
-                    },
-                  );
+            {displayCategories &&
+              displayCategories.length > 0 &&
+              displayCategories.map(
+                (category: ComponentCategory, i: number) => {
+                  const categoryComponents: Array<ComponentMetadata> =
+                    category.name === COMMON_CATEGORY_NAME
+                      ? getCommonComponents(
+                          componentsToShow,
+                          props.componentsType,
+                        )
+                      : componentsToShow.filter(
+                          (componentMetadata: ComponentMetadata) => {
+                            return componentMetadata.category === category.name;
+                          },
+                        );
 
-                if (categoryComponents.length === 0) {
-                  return <div key={i}></div>;
-                }
+                  if (categoryComponents.length === 0) {
+                    return <div key={i}></div>;
+                  }
 
-                return (
-                  <div key={i} className="mb-6">
-                    {/* Category header */}
-                    <div className="flex items-center gap-2 mb-3 px-1">
-                      <div
-                        className="flex items-center justify-center rounded-md"
-                        style={{
-                          width: "28px",
-                          height: "28px",
-                          backgroundColor: "#f1f5f9",
-                        }}
-                      >
-                        <Icon
-                          icon={category.icon}
-                          className="h-4 w-4 text-gray-500"
-                        />
+                  return (
+                    <div key={i} className="mb-6">
+                      {/* Category header */}
+                      <div className="flex items-center gap-2 mb-3 px-1">
+                        <div
+                          className="flex items-center justify-center rounded-md"
+                          style={{
+                            width: "28px",
+                            height: "28px",
+                            backgroundColor: "#f1f5f9",
+                          }}
+                        >
+                          <Icon
+                            icon={category.icon}
+                            className="h-4 w-4 text-gray-500"
+                          />
+                        </div>
+                        <div>
+                          <h4 className="text-sm font-semibold text-gray-700 leading-tight">
+                            {category.name}
+                          </h4>
+                          <p className="text-xs text-gray-400 leading-tight">
+                            {category.description}
+                          </p>
+                        </div>
                       </div>
-                      <div>
-                        <h4 className="text-sm font-semibold text-gray-700 leading-tight">
-                          {category.name}
-                        </h4>
-                        <p className="text-xs text-gray-400 leading-tight">
-                          {category.description}
-                        </p>
-                      </div>
-                    </div>
 
-                    {/* Component cards grid */}
-                    <div className="grid grid-cols-1 gap-2">
-                      {categoryComponents.map(
-                        (componentMetadata: ComponentMetadata, j: number) => {
-                          const isSelected: boolean =
-                            selectedComponentMetadata !== null &&
-                            selectedComponentMetadata.id ===
-                              componentMetadata.id;
+                      {/* Component cards grid */}
+                      <div className="grid grid-cols-1 gap-2">
+                        {categoryComponents.map(
+                          (componentMetadata: ComponentMetadata, j: number) => {
+                            const isSelected: boolean =
+                              selectedComponentMetadata !== null &&
+                              selectedComponentMetadata.id ===
+                                componentMetadata.id;
 
-                          return (
-                            <div
-                              key={j}
-                              onClick={() => {
-                                setSelectedComponentMetadata(componentMetadata);
-                              }}
-                              className="cursor-pointer transition-all duration-150"
-                              style={{
-                                padding: "0.75rem",
-                                borderRadius: "10px",
-                                border: isSelected
-                                  ? "2px solid #6366f1"
-                                  : "1px solid #e2e8f0",
-                                backgroundColor: isSelected
-                                  ? "#eef2ff"
-                                  : "#ffffff",
-                                display: "flex",
-                                alignItems: "flex-start",
-                                gap: "0.75rem",
-                                boxShadow: isSelected
-                                  ? "0 0 0 3px rgba(99, 102, 241, 0.1)"
-                                  : "0 1px 2px 0 rgba(0, 0, 0, 0.03)",
-                              }}
-                            >
-                              {/* Icon */}
+                            return (
                               <div
+                                key={j}
+                                onClick={() => {
+                                  setSelectedComponentMetadata(
+                                    componentMetadata,
+                                  );
+                                }}
+                                className="cursor-pointer transition-all duration-150"
                                 style={{
-                                  width: "36px",
-                                  height: "36px",
-                                  borderRadius: "8px",
+                                  padding: "0.75rem",
+                                  borderRadius: "10px",
+                                  border: isSelected
+                                    ? "2px solid #6366f1"
+                                    : "1px solid #e2e8f0",
                                   backgroundColor: isSelected
-                                    ? "#6366f1"
-                                    : "#f1f5f9",
+                                    ? "#eef2ff"
+                                    : "#ffffff",
                                   display: "flex",
-                                  alignItems: "center",
-                                  justifyContent: "center",
-                                  flexShrink: 0,
-                                  transition: "all 0.15s ease",
+                                  alignItems: "flex-start",
+                                  gap: "0.75rem",
+                                  boxShadow: isSelected
+                                    ? "0 0 0 3px rgba(99, 102, 241, 0.1)"
+                                    : "0 1px 2px 0 rgba(0, 0, 0, 0.03)",
                                 }}
                               >
-                                <Icon
-                                  icon={componentMetadata.iconProp}
+                                {/* Icon */}
+                                <div
                                   style={{
-                                    color: isSelected ? "#ffffff" : "#64748b",
-                                    width: "1rem",
-                                    height: "1rem",
+                                    width: "36px",
+                                    height: "36px",
+                                    borderRadius: "8px",
+                                    backgroundColor: isSelected
+                                      ? "#6366f1"
+                                      : "#f1f5f9",
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    flexShrink: 0,
+                                    transition: "all 0.15s ease",
                                   }}
-                                />
-                              </div>
+                                >
+                                  <Icon
+                                    icon={componentMetadata.iconProp}
+                                    style={{
+                                      color: isSelected ? "#ffffff" : "#64748b",
+                                      width: "1rem",
+                                      height: "1rem",
+                                    }}
+                                  />
+                                </div>
 
-                              {/* Text */}
-                              <div style={{ minWidth: 0, flex: 1 }}>
-                                <div className="flex items-start justify-between gap-2">
+                                {/* Text */}
+                                <div style={{ minWidth: 0, flex: 1 }}>
+                                  <div className="flex items-start justify-between gap-2">
+                                    <p
+                                      style={{
+                                        fontSize: "0.8125rem",
+                                        fontWeight: 600,
+                                        color: isSelected
+                                          ? "#4338ca"
+                                          : "#1e293b",
+                                        margin: 0,
+                                        lineHeight: "1.25rem",
+                                      }}
+                                    >
+                                      {renderHighlightedText(
+                                        componentMetadata.title,
+                                        isSelected
+                                          ? "rounded bg-white/80 px-0.5 text-current"
+                                          : "rounded bg-amber-100 px-0.5 text-current",
+                                      )}
+                                    </p>
+
+                                    {hasSearchTerm && (
+                                      <span
+                                        className={`mt-0.5 inline-flex flex-shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                                          isSelected
+                                            ? "bg-white/80 text-indigo-700"
+                                            : "bg-slate-100 text-slate-500"
+                                        }`}
+                                      >
+                                        {renderHighlightedText(
+                                          componentMetadata.category,
+                                          isSelected
+                                            ? "rounded bg-indigo-100 px-0.5 text-current"
+                                            : "rounded bg-white px-0.5 text-current",
+                                        )}
+                                      </span>
+                                    )}
+                                  </div>
                                   <p
                                     style={{
-                                      fontSize: "0.8125rem",
-                                      fontWeight: 600,
-                                      color: isSelected ? "#4338ca" : "#1e293b",
+                                      fontSize: "0.75rem",
+                                      color: isSelected ? "#6366f1" : "#94a3b8",
                                       margin: 0,
-                                      lineHeight: "1.25rem",
+                                      marginTop: "2px",
+                                      lineHeight: "1rem",
+                                      display: "-webkit-box",
+                                      WebkitLineClamp: 2,
+                                      WebkitBoxOrient: "vertical",
+                                      overflow: "hidden",
                                     }}
                                   >
                                     {renderHighlightedText(
-                                      componentMetadata.title,
+                                      componentMetadata.description,
                                       isSelected
                                         ? "rounded bg-white/80 px-0.5 text-current"
                                         : "rounded bg-amber-100 px-0.5 text-current",
                                     )}
                                   </p>
-
-                                  {hasSearchTerm && (
-                                    <span
-                                      className={`mt-0.5 inline-flex flex-shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                                        isSelected
-                                          ? "bg-white/80 text-indigo-700"
-                                          : "bg-slate-100 text-slate-500"
-                                      }`}
-                                    >
-                                      {renderHighlightedText(
-                                        componentMetadata.category,
-                                        isSelected
-                                          ? "rounded bg-indigo-100 px-0.5 text-current"
-                                          : "rounded bg-white px-0.5 text-current",
-                                      )}
-                                    </span>
-                                  )}
                                 </div>
-                                <p
-                                  style={{
-                                    fontSize: "0.75rem",
-                                    color: isSelected ? "#6366f1" : "#94a3b8",
-                                    margin: 0,
-                                    marginTop: "2px",
-                                    lineHeight: "1rem",
-                                    display: "-webkit-box",
-                                    WebkitLineClamp: 2,
-                                    WebkitBoxOrient: "vertical",
-                                    overflow: "hidden",
-                                  }}
-                                >
-                                  {renderHighlightedText(
-                                    componentMetadata.description,
-                                    isSelected
-                                      ? "rounded bg-white/80 px-0.5 text-current"
-                                      : "rounded bg-amber-100 px-0.5 text-current",
-                                  )}
-                                </p>
-                              </div>
 
-                              {/* Selection indicator */}
-                              {isSelected && (
-                                <div
-                                  style={{
-                                    width: "20px",
-                                    height: "20px",
-                                    borderRadius: "50%",
-                                    backgroundColor: "#6366f1",
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    flexShrink: 0,
-                                    marginTop: "2px",
-                                  }}
-                                >
-                                  <Icon
-                                    icon={IconProp.Check}
+                                {/* Selection indicator */}
+                                {isSelected && (
+                                  <div
                                     style={{
-                                      color: "#ffffff",
-                                      width: "0.625rem",
-                                      height: "0.625rem",
+                                      width: "20px",
+                                      height: "20px",
+                                      borderRadius: "50%",
+                                      backgroundColor: "#6366f1",
+                                      display: "flex",
+                                      alignItems: "center",
+                                      justifyContent: "center",
+                                      flexShrink: 0,
+                                      marginTop: "2px",
                                     }}
-                                  />
-                                </div>
-                              )}
-                            </div>
-                          );
-                        },
-                      )}
+                                  >
+                                    <Icon
+                                      icon={IconProp.Check}
+                                      style={{
+                                        color: "#ffffff",
+                                        width: "0.625rem",
+                                        height: "0.625rem",
+                                      }}
+                                    />
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          },
+                        )}
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
+                  );
+                },
+              )}
           </div>
         </div>
       </>


### PR DESCRIPTION
Tames the overwhelming component picker — the safe slice of the "catalog collapse". **Stacked on #2613.**

## What

Opening the picker means facing a very long list: the static components **plus up to eleven database operations for every model** that enables workflows (hundreds of near-identical entries). This surfaces the ~dozen steps most authors actually reach for at the top.

- **Pure `getCommonComponents(components, componentType)`** returns a curated, ordered subset — Slack, Email, API GET/POST, If/Else, JavaScript, Log, Run Workflow, Sleep (components); Schedule, Webhook, Manual (triggers) — skipping any id not present, so it can never surface a broken entry.
- **`ComponentsModal`** renders it as a **"Common steps"** section at the top, hidden while searching (search stays a flat ranked list).

## Why this and not the full block-collapse

It's a **pure shortcut** — the full catalog still lists everything below, so **no component is removed, renamed, or morphed.** That means **zero fidelity risk**, unlike the ~15-block collapse (which would have to reproduce the exact id/args/ports of every model permutation and keep a legacy loader). This delivers most of the "don't drown in hundreds of entries" value safely; the full morph-based collapse remains a larger, app-QA follow-up.

## Verification

- **`getCommonComponents` (4 tests):** curated order preserved; trigger vs component filtering; never surfaces a non-curated component; empty when none present.
- **95 workflow tests pass**; `tsc` ✓, `eslint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
