### PR TITLE
feat(workflow): browse database steps by model (catalog drill-down)

### DIFF
--- a/Common/Tests/UI/Components/Workflow/DatabaseStepPicker.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/DatabaseStepPicker.test.tsx
@@ -1,0 +1,111 @@
+import DatabaseStepPicker from "../../../../UI/Components/Workflow/DatabaseStepPicker";
+import IconProp from "../../../../Types/Icon/IconProp";
+import ComponentMetadata, {
+  ComponentType,
+} from "../../../../Types/Workflow/Component";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const comp: (
+  id: string,
+  title: string,
+  tableName: string,
+  category: string,
+) => ComponentMetadata = (
+  id: string,
+  title: string,
+  tableName: string,
+  category: string,
+): ComponentMetadata => {
+  return {
+    id: id,
+    title: title,
+    description: "",
+    tableName: tableName,
+    category: category,
+    iconProp: IconProp.Database,
+    componentType: ComponentType.Component,
+  } as unknown as ComponentMetadata;
+};
+
+const catalog: Array<ComponentMetadata> = [
+  comp("incident-find-one", "Find One Incident", "Incident", "Incident"),
+  comp("incident-create-one", "Create Incident", "Incident", "Incident"),
+  comp("monitor-find-one", "Find One Monitor", "Monitor", "Monitor"),
+];
+
+describe("DatabaseStepPicker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("lists the available models", () => {
+    render(
+      <DatabaseStepPicker
+        components={catalog}
+        componentType={ComponentType.Component}
+        onSelect={getJestMockFunction()}
+      />,
+    );
+
+    expect(screen.getByText("Incident")).toBeTruthy();
+    expect(screen.getByText("Monitor")).toBeTruthy();
+  });
+
+  it("drills into a model and selects an operation", () => {
+    const onSelect: MockFunction = getJestMockFunction();
+    render(
+      <DatabaseStepPicker
+        components={catalog}
+        componentType={ComponentType.Component}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Open the Incident model.
+    fireEvent.click(screen.getByText("Incident"));
+
+    // Its operations are shown.
+    expect(screen.getByText("Find One Incident")).toBeTruthy();
+    expect(screen.getByText("Create Incident")).toBeTruthy();
+    // Monitor's operation is not shown here.
+    expect(screen.queryByText("Find One Monitor")).toBeNull();
+
+    fireEvent.click(screen.getByText("Create Incident"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]![0]).toMatchObject({
+      id: "incident-create-one",
+    });
+  });
+
+  it("can go back to the model list", () => {
+    render(
+      <DatabaseStepPicker
+        components={catalog}
+        componentType={ComponentType.Component}
+        onSelect={getJestMockFunction()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Incident"));
+    expect(screen.getByText("Find One Incident")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("All records"));
+    // Back to models: the operation is gone, the model card is back.
+    expect(screen.queryByText("Find One Incident")).toBeNull();
+    expect(screen.getByText("Monitor")).toBeTruthy();
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/DatabaseStepUtils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/DatabaseStepUtils.test.ts
@@ -1,0 +1,95 @@
+import {
+  ModelGroup,
+  filterModelGroups,
+  groupComponentsByModel,
+} from "../../../../UI/Components/Workflow/DatabaseStepUtils";
+import ComponentMetadata, {
+  ComponentType,
+} from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+const comp: (
+  id: string,
+  tableName: string | undefined,
+  category: string,
+  componentType: ComponentType,
+) => ComponentMetadata = (
+  id: string,
+  tableName: string | undefined,
+  category: string,
+  componentType: ComponentType,
+): ComponentMetadata => {
+  return {
+    id: id,
+    tableName: tableName,
+    category: category,
+    componentType: componentType,
+  } as unknown as ComponentMetadata;
+};
+
+const catalog: Array<ComponentMetadata> = [
+  comp("monitor-find-one", "Monitor", "Monitor", ComponentType.Component),
+  comp("incident-find-one", "Incident", "Incident", ComponentType.Component),
+  comp("incident-find-many", "Incident", "Incident", ComponentType.Component),
+  comp("slack", undefined, "Slack", ComponentType.Component), // static, no table
+  comp("incident-on-create", "Incident", "Incident", ComponentType.Trigger),
+];
+
+describe("DatabaseStepUtils.groupComponentsByModel", () => {
+  test("groups model-backed components of the type, sorted by name", () => {
+    const groups: Array<ModelGroup> = groupComponentsByModel(
+      catalog,
+      ComponentType.Component,
+    );
+
+    expect(
+      groups.map((g: ModelGroup) => {
+        return g.name;
+      }),
+    ).toEqual(["Incident", "Monitor"]);
+
+    const incident: ModelGroup = groups[0]!;
+    expect(
+      incident.components.map((c: ComponentMetadata) => {
+        return c.id;
+      }),
+    ).toEqual(["incident-find-one", "incident-find-many"]);
+  });
+
+  test("excludes static components without a tableName", () => {
+    const groups: Array<ModelGroup> = groupComponentsByModel(
+      catalog,
+      ComponentType.Component,
+    );
+    const allIds: Array<string> = groups.flatMap((g: ModelGroup) => {
+      return g.components.map((c: ComponentMetadata) => {
+        return c.id;
+      });
+    });
+    expect(allIds).not.toContain("slack");
+  });
+
+  test("separates triggers from components", () => {
+    const triggerGroups: Array<ModelGroup> = groupComponentsByModel(
+      catalog,
+      ComponentType.Trigger,
+    );
+    expect(triggerGroups).toHaveLength(1);
+    expect(triggerGroups[0]!.components[0]!.id).toBe("incident-on-create");
+  });
+});
+
+describe("DatabaseStepUtils.filterModelGroups", () => {
+  test("filters model groups by name, case-insensitively", () => {
+    const groups: Array<ModelGroup> = groupComponentsByModel(
+      catalog,
+      ComponentType.Component,
+    );
+    expect(
+      filterModelGroups(groups, "mon").map((g: ModelGroup) => {
+        return g.name;
+      }),
+    ).toEqual(["Monitor"]);
+    expect(filterModelGroups(groups, "")).toHaveLength(2);
+  });
+});

--- a/Common/UI/Components/Workflow/ComponentsModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentsModal.tsx
@@ -7,6 +7,8 @@ import {
   COMMON_CATEGORY_NAME,
   getCommonComponents,
 } from "./CommonComponents";
+import DatabaseStepPicker from "./DatabaseStepPicker";
+import { groupComponentsByModel } from "./DatabaseStepUtils";
 import IconProp from "../../../Types/Icon/IconProp";
 import ComponentMetadata, {
   ComponentCategory,
@@ -86,6 +88,9 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
   >([]);
   const [selectedComponentMetadata, setSelectedComponentMetadata] =
     useState<ComponentMetadata | null>(null);
+
+  // When on, browse database records by model → operation instead of the list.
+  const [databaseMode, setDatabaseMode] = useState<boolean>(false);
 
   useEffect(() => {
     setComponents(props.components);
@@ -193,6 +198,8 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
   };
   const hasCommonComponents: boolean =
     getCommonComponents(components, props.componentsType).length > 0;
+  const hasModelComponents: boolean =
+    groupComponentsByModel(components, props.componentsType).length > 0;
   const displayCategories: Array<ComponentCategory> =
     hasSearchTerm || !hasCommonComponents
       ? categories
@@ -376,235 +383,282 @@ const ComponentsModal: FunctionComponent<ComponentProps> = (
                   })}
                 </div>
               )}
+
+              {hasModelComponents && (
+                <div className="mt-3">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDatabaseMode((value: boolean) => {
+                        return !value;
+                      });
+                    }}
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors duration-150 ${
+                      databaseMode
+                        ? "border-indigo-200 bg-indigo-50 text-indigo-700"
+                        : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
+                    }`}
+                  >
+                    <Icon icon={IconProp.Database} className="h-3 w-3" />
+                    {databaseMode
+                      ? "Back to all steps"
+                      : "Work with database records"}
+                  </button>
+                </div>
+              )}
             </div>
           </div>
 
           <div className="overflow-y-auto overflow-x-hidden flex-1">
-            {!componentsToShow ||
-              (componentsToShow.length === 0 && (
-                <div className="mt-20 flex w-full flex-col items-center justify-center gap-4 px-4">
-                  <div className="max-w-2xl">
-                    <ErrorMessage message="No components that match your search. If you are looking for an integration that does not exist currently - you can use Custom Code or API component to build anything you like." />
-                  </div>
-                  {hasSearchTerm && (
-                    <button
-                      type="button"
-                      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition-colors duration-150 hover:bg-slate-50 hover:text-slate-800"
-                      onClick={() => {
-                        setSearch("");
-                        searchInputRef.current?.focus();
-                      }}
-                    >
-                      <Icon icon={IconProp.Close} className="h-3.5 w-3.5" />
-                      Reset search
-                    </button>
-                  )}
-                </div>
-              ))}
-
-            {displayCategories &&
-              displayCategories.length > 0 &&
-              displayCategories.map(
-                (category: ComponentCategory, i: number) => {
-                  const categoryComponents: Array<ComponentMetadata> =
-                    category.name === COMMON_CATEGORY_NAME
-                      ? getCommonComponents(
-                          componentsToShow,
-                          props.componentsType,
-                        )
-                      : componentsToShow.filter(
-                          (componentMetadata: ComponentMetadata) => {
-                            return componentMetadata.category === category.name;
-                          },
-                        );
-
-                  if (categoryComponents.length === 0) {
-                    return <div key={i}></div>;
-                  }
-
-                  return (
-                    <div key={i} className="mb-6">
-                      {/* Category header */}
-                      <div className="flex items-center gap-2 mb-3 px-1">
-                        <div
-                          className="flex items-center justify-center rounded-md"
-                          style={{
-                            width: "28px",
-                            height: "28px",
-                            backgroundColor: "#f1f5f9",
+            {databaseMode ? (
+              <div className="p-1">
+                <DatabaseStepPicker
+                  components={components}
+                  componentType={props.componentsType}
+                  selectedComponentId={selectedComponentMetadata?.id}
+                  onSelect={(component: ComponentMetadata) => {
+                    setSelectedComponentMetadata(component);
+                  }}
+                />
+              </div>
+            ) : (
+              <>
+                {!componentsToShow ||
+                  (componentsToShow.length === 0 && (
+                    <div className="mt-20 flex w-full flex-col items-center justify-center gap-4 px-4">
+                      <div className="max-w-2xl">
+                        <ErrorMessage message="No components that match your search. If you are looking for an integration that does not exist currently - you can use Custom Code or API component to build anything you like." />
+                      </div>
+                      {hasSearchTerm && (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition-colors duration-150 hover:bg-slate-50 hover:text-slate-800"
+                          onClick={() => {
+                            setSearch("");
+                            searchInputRef.current?.focus();
                           }}
                         >
-                          <Icon
-                            icon={category.icon}
-                            className="h-4 w-4 text-gray-500"
-                          />
-                        </div>
-                        <div>
-                          <h4 className="text-sm font-semibold text-gray-700 leading-tight">
-                            {category.name}
-                          </h4>
-                          <p className="text-xs text-gray-400 leading-tight">
-                            {category.description}
-                          </p>
-                        </div>
-                      </div>
+                          <Icon icon={IconProp.Close} className="h-3.5 w-3.5" />
+                          Reset search
+                        </button>
+                      )}
+                    </div>
+                  ))}
 
-                      {/* Component cards grid */}
-                      <div className="grid grid-cols-1 gap-2">
-                        {categoryComponents.map(
-                          (componentMetadata: ComponentMetadata, j: number) => {
-                            const isSelected: boolean =
-                              selectedComponentMetadata !== null &&
-                              selectedComponentMetadata.id ===
-                                componentMetadata.id;
+                {displayCategories &&
+                  displayCategories.length > 0 &&
+                  displayCategories.map(
+                    (category: ComponentCategory, i: number) => {
+                      const categoryComponents: Array<ComponentMetadata> =
+                        category.name === COMMON_CATEGORY_NAME
+                          ? getCommonComponents(
+                              componentsToShow,
+                              props.componentsType,
+                            )
+                          : componentsToShow.filter(
+                              (componentMetadata: ComponentMetadata) => {
+                                return (
+                                  componentMetadata.category === category.name
+                                );
+                              },
+                            );
 
-                            return (
-                              <div
-                                key={j}
-                                onClick={() => {
-                                  setSelectedComponentMetadata(
-                                    componentMetadata,
-                                  );
-                                }}
-                                className="cursor-pointer transition-all duration-150"
-                                style={{
-                                  padding: "0.75rem",
-                                  borderRadius: "10px",
-                                  border: isSelected
-                                    ? "2px solid #6366f1"
-                                    : "1px solid #e2e8f0",
-                                  backgroundColor: isSelected
-                                    ? "#eef2ff"
-                                    : "#ffffff",
-                                  display: "flex",
-                                  alignItems: "flex-start",
-                                  gap: "0.75rem",
-                                  boxShadow: isSelected
-                                    ? "0 0 0 3px rgba(99, 102, 241, 0.1)"
-                                    : "0 1px 2px 0 rgba(0, 0, 0, 0.03)",
-                                }}
-                              >
-                                {/* Icon */}
-                                <div
-                                  style={{
-                                    width: "36px",
-                                    height: "36px",
-                                    borderRadius: "8px",
-                                    backgroundColor: isSelected
-                                      ? "#6366f1"
-                                      : "#f1f5f9",
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    flexShrink: 0,
-                                    transition: "all 0.15s ease",
-                                  }}
-                                >
-                                  <Icon
-                                    icon={componentMetadata.iconProp}
-                                    style={{
-                                      color: isSelected ? "#ffffff" : "#64748b",
-                                      width: "1rem",
-                                      height: "1rem",
+                      if (categoryComponents.length === 0) {
+                        return <div key={i}></div>;
+                      }
+
+                      return (
+                        <div key={i} className="mb-6">
+                          {/* Category header */}
+                          <div className="flex items-center gap-2 mb-3 px-1">
+                            <div
+                              className="flex items-center justify-center rounded-md"
+                              style={{
+                                width: "28px",
+                                height: "28px",
+                                backgroundColor: "#f1f5f9",
+                              }}
+                            >
+                              <Icon
+                                icon={category.icon}
+                                className="h-4 w-4 text-gray-500"
+                              />
+                            </div>
+                            <div>
+                              <h4 className="text-sm font-semibold text-gray-700 leading-tight">
+                                {category.name}
+                              </h4>
+                              <p className="text-xs text-gray-400 leading-tight">
+                                {category.description}
+                              </p>
+                            </div>
+                          </div>
+
+                          {/* Component cards grid */}
+                          <div className="grid grid-cols-1 gap-2">
+                            {categoryComponents.map(
+                              (
+                                componentMetadata: ComponentMetadata,
+                                j: number,
+                              ) => {
+                                const isSelected: boolean =
+                                  selectedComponentMetadata !== null &&
+                                  selectedComponentMetadata.id ===
+                                    componentMetadata.id;
+
+                                return (
+                                  <div
+                                    key={j}
+                                    onClick={() => {
+                                      setSelectedComponentMetadata(
+                                        componentMetadata,
+                                      );
                                     }}
-                                  />
-                                </div>
-
-                                {/* Text */}
-                                <div style={{ minWidth: 0, flex: 1 }}>
-                                  <div className="flex items-start justify-between gap-2">
-                                    <p
+                                    className="cursor-pointer transition-all duration-150"
+                                    style={{
+                                      padding: "0.75rem",
+                                      borderRadius: "10px",
+                                      border: isSelected
+                                        ? "2px solid #6366f1"
+                                        : "1px solid #e2e8f0",
+                                      backgroundColor: isSelected
+                                        ? "#eef2ff"
+                                        : "#ffffff",
+                                      display: "flex",
+                                      alignItems: "flex-start",
+                                      gap: "0.75rem",
+                                      boxShadow: isSelected
+                                        ? "0 0 0 3px rgba(99, 102, 241, 0.1)"
+                                        : "0 1px 2px 0 rgba(0, 0, 0, 0.03)",
+                                    }}
+                                  >
+                                    {/* Icon */}
+                                    <div
                                       style={{
-                                        fontSize: "0.8125rem",
-                                        fontWeight: 600,
-                                        color: isSelected
-                                          ? "#4338ca"
-                                          : "#1e293b",
-                                        margin: 0,
-                                        lineHeight: "1.25rem",
+                                        width: "36px",
+                                        height: "36px",
+                                        borderRadius: "8px",
+                                        backgroundColor: isSelected
+                                          ? "#6366f1"
+                                          : "#f1f5f9",
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        flexShrink: 0,
+                                        transition: "all 0.15s ease",
                                       }}
                                     >
-                                      {renderHighlightedText(
-                                        componentMetadata.title,
-                                        isSelected
-                                          ? "rounded bg-white/80 px-0.5 text-current"
-                                          : "rounded bg-amber-100 px-0.5 text-current",
-                                      )}
-                                    </p>
+                                      <Icon
+                                        icon={componentMetadata.iconProp}
+                                        style={{
+                                          color: isSelected
+                                            ? "#ffffff"
+                                            : "#64748b",
+                                          width: "1rem",
+                                          height: "1rem",
+                                        }}
+                                      />
+                                    </div>
 
-                                    {hasSearchTerm && (
-                                      <span
-                                        className={`mt-0.5 inline-flex flex-shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                                          isSelected
-                                            ? "bg-white/80 text-indigo-700"
-                                            : "bg-slate-100 text-slate-500"
-                                        }`}
+                                    {/* Text */}
+                                    <div style={{ minWidth: 0, flex: 1 }}>
+                                      <div className="flex items-start justify-between gap-2">
+                                        <p
+                                          style={{
+                                            fontSize: "0.8125rem",
+                                            fontWeight: 600,
+                                            color: isSelected
+                                              ? "#4338ca"
+                                              : "#1e293b",
+                                            margin: 0,
+                                            lineHeight: "1.25rem",
+                                          }}
+                                        >
+                                          {renderHighlightedText(
+                                            componentMetadata.title,
+                                            isSelected
+                                              ? "rounded bg-white/80 px-0.5 text-current"
+                                              : "rounded bg-amber-100 px-0.5 text-current",
+                                          )}
+                                        </p>
+
+                                        {hasSearchTerm && (
+                                          <span
+                                            className={`mt-0.5 inline-flex flex-shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                                              isSelected
+                                                ? "bg-white/80 text-indigo-700"
+                                                : "bg-slate-100 text-slate-500"
+                                            }`}
+                                          >
+                                            {renderHighlightedText(
+                                              componentMetadata.category,
+                                              isSelected
+                                                ? "rounded bg-indigo-100 px-0.5 text-current"
+                                                : "rounded bg-white px-0.5 text-current",
+                                            )}
+                                          </span>
+                                        )}
+                                      </div>
+                                      <p
+                                        style={{
+                                          fontSize: "0.75rem",
+                                          color: isSelected
+                                            ? "#6366f1"
+                                            : "#94a3b8",
+                                          margin: 0,
+                                          marginTop: "2px",
+                                          lineHeight: "1rem",
+                                          display: "-webkit-box",
+                                          WebkitLineClamp: 2,
+                                          WebkitBoxOrient: "vertical",
+                                          overflow: "hidden",
+                                        }}
                                       >
                                         {renderHighlightedText(
-                                          componentMetadata.category,
+                                          componentMetadata.description,
                                           isSelected
-                                            ? "rounded bg-indigo-100 px-0.5 text-current"
-                                            : "rounded bg-white px-0.5 text-current",
+                                            ? "rounded bg-white/80 px-0.5 text-current"
+                                            : "rounded bg-amber-100 px-0.5 text-current",
                                         )}
-                                      </span>
-                                    )}
-                                  </div>
-                                  <p
-                                    style={{
-                                      fontSize: "0.75rem",
-                                      color: isSelected ? "#6366f1" : "#94a3b8",
-                                      margin: 0,
-                                      marginTop: "2px",
-                                      lineHeight: "1rem",
-                                      display: "-webkit-box",
-                                      WebkitLineClamp: 2,
-                                      WebkitBoxOrient: "vertical",
-                                      overflow: "hidden",
-                                    }}
-                                  >
-                                    {renderHighlightedText(
-                                      componentMetadata.description,
-                                      isSelected
-                                        ? "rounded bg-white/80 px-0.5 text-current"
-                                        : "rounded bg-amber-100 px-0.5 text-current",
-                                    )}
-                                  </p>
-                                </div>
+                                      </p>
+                                    </div>
 
-                                {/* Selection indicator */}
-                                {isSelected && (
-                                  <div
-                                    style={{
-                                      width: "20px",
-                                      height: "20px",
-                                      borderRadius: "50%",
-                                      backgroundColor: "#6366f1",
-                                      display: "flex",
-                                      alignItems: "center",
-                                      justifyContent: "center",
-                                      flexShrink: 0,
-                                      marginTop: "2px",
-                                    }}
-                                  >
-                                    <Icon
-                                      icon={IconProp.Check}
-                                      style={{
-                                        color: "#ffffff",
-                                        width: "0.625rem",
-                                        height: "0.625rem",
-                                      }}
-                                    />
+                                    {/* Selection indicator */}
+                                    {isSelected && (
+                                      <div
+                                        style={{
+                                          width: "20px",
+                                          height: "20px",
+                                          borderRadius: "50%",
+                                          backgroundColor: "#6366f1",
+                                          display: "flex",
+                                          alignItems: "center",
+                                          justifyContent: "center",
+                                          flexShrink: 0,
+                                          marginTop: "2px",
+                                        }}
+                                      >
+                                        <Icon
+                                          icon={IconProp.Check}
+                                          style={{
+                                            color: "#ffffff",
+                                            width: "0.625rem",
+                                            height: "0.625rem",
+                                          }}
+                                        />
+                                      </div>
+                                    )}
                                   </div>
-                                )}
-                              </div>
-                            );
-                          },
-                        )}
-                      </div>
-                    </div>
-                  );
-                },
-              )}
+                                );
+                              },
+                            )}
+                          </div>
+                        </div>
+                      );
+                    },
+                  )}
+              </>
+            )}
           </div>
         </div>
       </>

--- a/Common/UI/Components/Workflow/DatabaseStepPicker.tsx
+++ b/Common/UI/Components/Workflow/DatabaseStepPicker.tsx
@@ -1,0 +1,152 @@
+import Icon from "../Icon/Icon";
+import Input from "../Input/Input";
+import {
+  ModelGroup,
+  filterModelGroups,
+  groupComponentsByModel,
+} from "./DatabaseStepUtils";
+import IconProp from "../../../Types/Icon/IconProp";
+import ComponentMetadata, {
+  ComponentType,
+} from "../../../Types/Workflow/Component";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+
+/*
+ * A model → operation drill-down for database-record steps: pick a model
+ * (searchable), then pick the operation (Find / Create / Update / Delete, or
+ * the On-Create/Update/Delete triggers). It hands back the real component
+ * object, so nothing is reconstructed.
+ */
+
+export interface ComponentProps {
+  components: Array<ComponentMetadata>;
+  componentType: ComponentType;
+  selectedComponentId?: string | undefined;
+  onSelect: (component: ComponentMetadata) => void;
+}
+
+const DatabaseStepPicker: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [search, setSearch] = useState<string>("");
+  const [selectedTableName, setSelectedTableName] = useState<string | null>(
+    null,
+  );
+
+  const groups: Array<ModelGroup> = groupComponentsByModel(
+    props.components,
+    props.componentType,
+  );
+
+  const selectedGroup: ModelGroup | undefined = groups.find(
+    (group: ModelGroup) => {
+      return group.tableName === selectedTableName;
+    },
+  );
+
+  if (selectedGroup) {
+    return (
+      <div>
+        <button
+          type="button"
+          className="mb-3 inline-flex items-center gap-1 text-sm font-medium text-blue-500 hover:text-blue-600 cursor-pointer"
+          onClick={() => {
+            setSelectedTableName(null);
+          }}
+        >
+          <Icon icon={IconProp.ChevronLeft} className="h-3.5 w-3.5" />
+          All records
+        </button>
+
+        <h4 className="mb-2 text-sm font-semibold text-gray-700">
+          {selectedGroup.name}
+        </h4>
+
+        <div className="grid grid-cols-1 gap-2">
+          {selectedGroup.components.map((component: ComponentMetadata) => {
+            const isSelected: boolean =
+              props.selectedComponentId === component.id;
+            return (
+              <button
+                key={component.id}
+                type="button"
+                onClick={() => {
+                  props.onSelect(component);
+                }}
+                className={`flex items-start gap-3 rounded-lg border p-3 text-left cursor-pointer ${
+                  isSelected
+                    ? "border-indigo-400 bg-indigo-50"
+                    : "border-gray-200 hover:border-indigo-300 hover:bg-indigo-50/40"
+                }`}
+              >
+                <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-500">
+                  <Icon icon={component.iconProp} className="h-4 w-4" />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium text-gray-900">
+                    {component.title}
+                  </span>
+                  <span className="block text-xs text-gray-500">
+                    {component.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  const filteredGroups: Array<ModelGroup> = filterModelGroups(groups, search);
+
+  return (
+    <div>
+      <div className="mb-3">
+        <Input
+          placeholder="Search records (e.g. Incident, Monitor)…"
+          onChange={(value: string) => {
+            setSearch(value);
+          }}
+        />
+      </div>
+
+      {filteredGroups.length === 0 ? (
+        <p className="p-2 text-sm text-gray-500">
+          No records match your search.
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {filteredGroups.map((group: ModelGroup) => {
+            return (
+              <button
+                key={group.tableName}
+                type="button"
+                onClick={() => {
+                  setSelectedTableName(group.tableName);
+                }}
+                className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 p-3 text-left hover:border-indigo-300 hover:bg-indigo-50/40 cursor-pointer"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-medium text-gray-900">
+                    {group.name}
+                  </span>
+                  <span className="block text-xs text-gray-400">
+                    {group.components.length} action
+                    {group.components.length === 1 ? "" : "s"}
+                  </span>
+                </span>
+                <Icon
+                  icon={IconProp.ChevronRight}
+                  className="h-4 w-4 shrink-0 text-gray-300"
+                />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DatabaseStepPicker;

--- a/Common/UI/Components/Workflow/DatabaseStepUtils.ts
+++ b/Common/UI/Components/Workflow/DatabaseStepUtils.ts
@@ -1,0 +1,79 @@
+import ComponentMetadata, {
+  ComponentType,
+} from "../../../Types/Workflow/Component";
+
+/*
+ * Helpers for the "database records" drill-down in the component picker.
+ *
+ * Every database model that enables workflows contributes ~11 near-identical
+ * components (Find/Create/Update/Delete + On-Create/Update/Delete). Listing
+ * them all is overwhelming, but they can be grouped: each such component
+ * carries the model's tableName. We group the REAL catalog components by model
+ * — no ids are reconstructed or morphed, so there's zero fidelity risk; the
+ * picker still hands back the exact component object the engine executes.
+ */
+
+export interface ModelGroup {
+  tableName: string;
+  name: string;
+  components: Array<ComponentMetadata>;
+}
+
+export type GroupComponentsByModelFunction = (
+  components: Array<ComponentMetadata>,
+  componentType: ComponentType,
+) => Array<ModelGroup>;
+
+/*
+ * Group the model-backed components (those with a tableName) of the given type
+ * by model, sorted by display name. Static components (no tableName) are
+ * excluded — they're listed directly in the picker.
+ */
+export const groupComponentsByModel: GroupComponentsByModelFunction = (
+  components: Array<ComponentMetadata>,
+  componentType: ComponentType,
+): Array<ModelGroup> => {
+  const byTable: Map<string, ModelGroup> = new Map<string, ModelGroup>();
+
+  for (const component of components) {
+    if (component.componentType !== componentType) {
+      continue;
+    }
+    if (!component.tableName) {
+      continue;
+    }
+
+    let group: ModelGroup | undefined = byTable.get(component.tableName);
+    if (!group) {
+      group = {
+        tableName: component.tableName,
+        name: component.category,
+        components: [],
+      };
+      byTable.set(component.tableName, group);
+    }
+    group.components.push(component);
+  }
+
+  return Array.from(byTable.values()).sort((a: ModelGroup, b: ModelGroup) => {
+    return a.name.localeCompare(b.name);
+  });
+};
+
+export type FilterModelGroupsFunction = (
+  groups: Array<ModelGroup>,
+  search: string,
+) => Array<ModelGroup>;
+
+export const filterModelGroups: FilterModelGroupsFunction = (
+  groups: Array<ModelGroup>,
+  search: string,
+): Array<ModelGroup> => {
+  const query: string = search.trim().toLowerCase();
+  if (!query) {
+    return groups;
+  }
+  return groups.filter((group: ModelGroup) => {
+    return group.name.toLowerCase().includes(query);
+  });
+};


### PR DESCRIPTION
Tames the catalog for good — a **model → operation** drill-down for database steps. The verifiable, zero-morph version of the "block collapse". **Stacked on #2615.**

## What

Every database model that enables workflows adds ~11 near-identical components (Find/Create/Update/Delete + On-Create/Update/Delete). With hundreds of models the picker is an enormous flat list. This adds a **"Work with database records"** mode: pick a model, then pick the operation.

- **Pure `groupComponentsByModel(components, type)`** groups the **real** catalog components by their `tableName` (sorted by model name); `filterModelGroups` searches them.
- **`DatabaseStepPicker`** is the model → operation drill-down (searchable model grid, back nav, operation cards).
- **`ComponentsModal`** gets a **"Work with database records"** toggle (shown only when model-backed components exist for the current type); selecting an operation flows into the existing "Add to Workflow" selection — nothing else in the picker changes.

## Why this is safe (vs the block-morph collapse)

**No id is reconstructed or morphed.** The picker hands back the **exact component object** the engine already knows (grouped by the real `tableName` those components carry). So there's **zero fidelity risk** — the failure mode the full block-collapse carried (a morphed id that doesn't resolve → a broken step) simply can't happen here.

## Verification

- **`DatabaseStepUtils.test.ts`:** grouping by model, sort by name, static-component exclusion, trigger-vs-component separation, case-insensitive search.
- **`DatabaseStepPicker.test.tsx` (RTL):** lists models, drills into a model, selects an operation (returns the real component), back navigation.
- **114 workflow tests pass**; `tsc` ✓, `eslint` ✓.
- Worth a 30-sec manual smoke-test: the toggle lives inside the existing `ComponentsModal` (a `SideOver`), which isn't exercised end-to-end in jsdom; the drill-down + grouping are unit/RTL-tested in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
