### PR TITLE
feat(ai): Sentinel Phase 2 — alert investigation + confidence-gated quiet mode

### DIFF
--- a/Common/Server/Services/AlertService.ts
+++ b/Common/Server/Services/AlertService.ts
@@ -67,6 +67,7 @@ import AlertLabelRuleEngineService from "./AlertLabelRuleEngineService";
 import AlertOnCallRuleEngineService from "./AlertOnCallRuleEngineService";
 import AlertOwnerRuleEngineService from "./AlertOwnerRuleEngineService";
 import RunbookRuleEngineService from "./RunbookRuleEngineService";
+import SentinelAlertInvestigationRunner from "../Utils/AI/Sentinel/AlertInvestigationRunner";
 import AlertPrivacyRuleEngineService from "./AlertPrivacyRuleEngineService";
 import ProjectService from "./ProjectService";
 
@@ -551,6 +552,30 @@ export class Service extends DatabaseService<Model> {
         } catch (error) {
           logger.error(
             `Reminder scheduling failed in AlertService.onCreateSuccess: ${error}`,
+            {
+              projectId: createdItem.projectId?.toString(),
+              alertId: createdItem.id?.toString(),
+            } as LogAttributes,
+          );
+        }
+      })
+      .then(async () => {
+        /*
+         * Sentinel (AI SRE): automatically investigate the new alert and post a
+         * cited root cause analysis to the alert timeline + Slack/Teams. Runs
+         * last, is gated per project (opt-in) + requires an LLM provider, and is
+         * read-only.
+         */
+        try {
+          if (createdItem.projectId && createdItem.id) {
+            await SentinelAlertInvestigationRunner.investigateNewAlert({
+              alertId: createdItem.id,
+              projectId: createdItem.projectId,
+            });
+          }
+        } catch (error) {
+          logger.error(
+            `Sentinel alert investigation failed in AlertService.onCreateSuccess: ${error}`,
             {
               projectId: createdItem.projectId?.toString(),
               alertId: createdItem.id?.toString(),

--- a/Common/Server/Utils/AI/Sentinel/AlertInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/AlertInvestigationRunner.ts
@@ -1,0 +1,135 @@
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import { Blue500 } from "../../../../Types/BrandColors";
+import { AlertFeedEventType } from "../../../../Models/DatabaseModels/AlertFeed";
+import AlertFeedService from "../../../Services/AlertFeedService";
+import AlertAIContextBuilder, {
+  AlertContextData,
+} from "../AlertAIContextBuilder";
+import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import { ObservabilityAssistantResult } from "../Chat/ObservabilityAssistant";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — alert investigation.
+ *
+ * Alerts are the earlier, "left of boom" signal. When a new alert is declared,
+ * Sentinel investigates it (read-only) and posts a cited root-cause analysis to
+ * the alert timeline + Slack/Teams. Symmetric to incident investigation and
+ * built on the same shared SentinelInvestigationEngine.
+ *
+ * Gated by the same per-project opt-in as incidents. Alert volume can be higher
+ * than incidents, so severity / rate gating is a deliberate follow-up.
+ */
+export default class SentinelAlertInvestigationRunner {
+  /*
+   * Entry point called (fire-and-forget) from AlertService.onCreateSuccess.
+   * Never throws — all failures are logged and recorded on the AIRun.
+   */
+  @CaptureSpan()
+  public static async investigateNewAlert(data: {
+    alertId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    const { alertId, projectId } = data;
+
+    try {
+      if (!(await SentinelInvestigationEngine.isEnabledForProject(projectId))) {
+        return;
+      }
+
+      const contextData: AlertContextData =
+        await AlertAIContextBuilder.buildAlertContext({
+          alertId,
+        });
+
+      await SentinelInvestigationEngine.investigate({
+        projectId,
+        feature: "Sentinel Alert Investigation",
+        contextSummary: this.buildAlertSummary(contextData),
+        postAnalysis: async (postData: {
+          analysisMarkdown: string;
+          isConfident: boolean;
+          result: ObservabilityAssistantResult;
+        }): Promise<void> => {
+          await AlertFeedService.createAlertFeedItem({
+            alertId,
+            projectId,
+            alertFeedEventType: AlertFeedEventType.RootCause,
+            displayColor: Blue500,
+            feedInfoInMarkdown: postData.analysisMarkdown,
+            /*
+             * Quiet mode: an inconclusive investigation posts to the timeline
+             * but does NOT loudly ping the workspace / on-call.
+             */
+            workspaceNotification: {
+              sendWorkspaceNotification: postData.isConfident,
+            },
+          });
+        },
+      });
+    } catch (error) {
+      logger.error(
+        `Sentinel: unexpected error investigating alert ${alertId.toString()}: ${error}`,
+      );
+    }
+  }
+
+  // Build a compact alert record to seed the investigation.
+  private static buildAlertSummary(contextData: AlertContextData): string {
+    const { alert, internalNotes } = contextData;
+
+    const lines: Array<string> = [];
+    lines.push("# Alert");
+    lines.push(`Title: ${alert.title || "N/A"}`);
+
+    if (alert.description) {
+      lines.push(`Description: ${alert.description}`);
+    }
+
+    lines.push(`Severity: ${alert.alertSeverity?.name || "N/A"}`);
+    lines.push(`Current state: ${alert.currentAlertState?.name || "N/A"}`);
+    lines.push(
+      `Declared at: ${
+        alert.createdAt
+          ? OneUptimeDate.getDateAsFormattedString(alert.createdAt)
+          : "N/A"
+      }`,
+    );
+
+    if (alert.monitor?.name) {
+      lines.push(`Affected monitor: ${alert.monitor.name}`);
+    }
+
+    if (alert.labels && alert.labels.length > 0) {
+      lines.push(
+        `Labels: ${alert.labels
+          .map((l: { name?: string }) => {
+            return l.name;
+          })
+          .filter(Boolean)
+          .join(", ")}`,
+      );
+    }
+
+    if (alert.rootCause) {
+      lines.push(`Root cause (as recorded so far): ${alert.rootCause}`);
+    }
+
+    const recentNotes: Array<string> = (internalNotes || [])
+      .slice(-5)
+      .map((note: { note?: string }) => {
+        return note.note ? `- ${note.note}` : "";
+      })
+      .filter(Boolean);
+
+    if (recentNotes.length > 0) {
+      lines.push("");
+      lines.push("Recent internal notes:");
+      lines.push(...recentNotes);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
@@ -1,72 +1,29 @@
 import ObjectID from "../../../../Types/ObjectID";
 import OneUptimeDate from "../../../../Types/Date";
 import { Blue500 } from "../../../../Types/BrandColors";
-import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
-import AIRunType from "../../../../Types/AI/AIRunType";
-import AIRunStatus from "../../../../Types/AI/AIRunStatus";
-import AIRunEventType from "../../../../Types/AI/AIRunEventType";
-import AIRun from "../../../../Models/DatabaseModels/AIRun";
-import AIRunEvent from "../../../../Models/DatabaseModels/AIRunEvent";
-import Project from "../../../../Models/DatabaseModels/Project";
-import LlmProvider from "../../../../Models/DatabaseModels/LlmProvider";
 import { IncidentFeedEventType } from "../../../../Models/DatabaseModels/IncidentFeed";
-import AIRunService from "../../../Services/AIRunService";
-import AIRunEventService from "../../../Services/AIRunEventService";
-import ProjectService from "../../../Services/ProjectService";
-import LlmProviderService from "../../../Services/LlmProviderService";
 import IncidentFeedService from "../../../Services/IncidentFeedService";
 import IncidentAIContextBuilder, {
   IncidentContextData,
 } from "../IncidentAIContextBuilder";
-import ObservabilityAssistant, {
-  ObservabilityAssistantResult,
-} from "../Chat/ObservabilityAssistant";
+import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import { ObservabilityAssistantResult } from "../Chat/ObservabilityAssistant";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 
 /*
- * Sentinel — Phase 1 "Investigation Engine".
+ * Sentinel — incident investigation.
  *
- * When a new incident is declared, Sentinel (OneUptime's autonomous AI SRE)
- * wakes automatically, investigates the incident against the telemetry OneUptime
- * already owns (logs, metrics, traces, exceptions, recent changes) using the
- * existing read-only, tool-grounded, citation-minting agent loop
- * (ObservabilityAssistant), and posts a cited root-cause analysis into the
- * incident timeline + Slack/Teams — before the on-call engineer has finished
- * reading the page.
+ * When a new incident is declared, wakes Sentinel to investigate it (read-only)
+ * and post a cited root-cause analysis into the incident timeline + Slack/Teams
+ * — before the on-call engineer has finished reading the page. The heavy lifting
+ * (run lifecycle, the agent loop, confidence gating) lives in the shared
+ * SentinelInvestigationEngine; this file only assembles incident context and
+ * posts the result to the incident's feed.
  *
- * The run is recorded as an AIRun(Investigation) with AIRunEvents so it shows up
- * in the same audit/glass-box trail as chat runs. The investigation is strictly
- * READ-ONLY: it can never mutate anything.
- *
- * This is deliberately built on the fire-and-forget async pattern already used
- * throughout IncidentService.onCreateSuccess. The durable, restart-safe claimable
- * AIRun queue is a later phase (see Internal/Roadmap/AISentinelReliabilityBrain.md).
+ * Built on the fire-and-forget async pattern already used throughout
+ * IncidentService.onCreateSuccess. See Internal/Roadmap/AISentinelReliabilityBrain.md.
  */
-
-// Budgets — larger than an interactive chat-ops answer, small enough to stay cheap.
-const MAX_LLM_CALLS: number = 8;
-const MAX_TOOL_CALLS: number = 12;
-const MAX_WALL_CLOCK_MS: number = 150 * 1000;
-const MAX_OUTPUT_TOKENS: number = 2000;
-
-const FEATURE_LABEL: string = "Sentinel Incident Investigation";
-
-const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW incident was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
-
-Investigate like a senior on-call engineer:
-- Start from the affected monitors/services named in the incident.
-- Use your read tools to inspect the telemetry AROUND the incident's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
-- Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
-
-Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
-**Summary** — one or two sentences a paged engineer can read in five seconds.
-**Most likely root cause** — your hypothesis, with only the confidence the evidence actually supports, each factual claim carrying its [C#] citation. If you could not determine it, write "Inconclusive — insufficient signal" and explain what is missing.
-**Evidence** — the key findings that support or rule out the hypothesis, each cited.
-**Suggested next steps** — concrete actions for the on-call engineer.
-
-Keep it tight and skimmable. You are read-only: never claim to have changed anything.`;
-
 export default class SentinelIncidentInvestigationRunner {
   /*
    * Entry point called (fire-and-forget) from IncidentService.onCreateSuccess.
@@ -80,179 +37,44 @@ export default class SentinelIncidentInvestigationRunner {
     const { incidentId, projectId } = data;
 
     try {
-      /*
-       * Gate 1 — project opt-in. AI must be enabled AND the auto-investigation
-       * toggle must be explicitly on (it is off by default).
-       */
-      const project: Project | null = await ProjectService.findOneById({
-        id: projectId,
-        select: {
-          enableAi: true,
-          enableAutomaticIncidentInvestigation: true,
-        },
-        props: { isRoot: true },
-      });
-
-      if (!project) {
+      if (!(await SentinelInvestigationEngine.isEnabledForProject(projectId))) {
         return;
       }
 
-      if (project.enableAi === false) {
-        return;
-      }
-
-      if (project.enableAutomaticIncidentInvestigation !== true) {
-        // Feature not enabled for this project — nothing to do.
-        return;
-      }
-
-      // Gate 2 — an LLM provider must be configured for the project (or globally).
-      const llmProvider: LlmProvider | null =
-        await LlmProviderService.getLLMProviderForProject(projectId);
-
-      if (!llmProvider) {
-        logger.debug(
-          `Sentinel: skipping investigation for incident ${incidentId.toString()} — no LLM provider configured.`,
-        );
-        return;
-      }
-
-      await this.runInvestigation({ incidentId, projectId });
-    } catch (error) {
-      logger.error(
-        `Sentinel: unexpected error investigating incident ${incidentId.toString()}: ${error}`,
-      );
-    }
-  }
-
-  private static async runInvestigation(data: {
-    incidentId: ObjectID;
-    projectId: ObjectID;
-  }): Promise<void> {
-    const { incidentId, projectId } = data;
-
-    // Create the AIRun record up front so the run is auditable even if it fails.
-    const run: AIRun = new AIRun();
-    run.projectId = projectId;
-    run.runType = AIRunType.Investigation;
-    run.status = AIRunStatus.Running;
-    run.startedAt = OneUptimeDate.getCurrentDate();
-    run.lastHeartbeatAt = OneUptimeDate.getCurrentDate();
-
-    const createdRun: AIRun = await AIRunService.create({
-      data: run,
-      props: { isRoot: true },
-    });
-
-    const aiRunId: ObjectID = createdRun.id!;
-    let sequence: number = 0;
-
-    await this.emitEvent({
-      projectId,
-      aiRunId,
-      sequence: sequence++,
-      eventType: AIRunEventType.RunStarted,
-    });
-
-    try {
-      // Assemble the incident context (reuses the existing context builder).
       const contextData: IncidentContextData =
         await IncidentAIContextBuilder.buildIncidentContext({
           incidentId,
           includeWorkspaceMessages: false,
         });
 
-      const incidentSummary: string = this.buildIncidentSummary(contextData);
-
-      // Run the shared read-only, tool-grounded, cited agent loop as Sentinel.
-      const result: ObservabilityAssistantResult =
-        await ObservabilityAssistant.answerQuestion({
-          projectId,
-          // System run — full read access to the project's telemetry.
-          props: { isRoot: true },
-          feature: FEATURE_LABEL,
-          systemInstructions: INVESTIGATION_PERSONA,
-          question: `A new incident has just been declared and you have been woken to investigate it. Investigate now and produce your root cause analysis.\n\n${incidentSummary}`,
-          maxLlmCalls: MAX_LLM_CALLS,
-          maxToolCalls: MAX_TOOL_CALLS,
-          maxWallClockMs: MAX_WALL_CLOCK_MS,
-          maxOutputTokens: MAX_OUTPUT_TOKENS,
-        });
-
-      // Mark the run completed (status-guarded to avoid clobbering a terminal state).
-      await AIRunService.updateOneBy({
-        query: {
-          _id: aiRunId.toString(),
-          status: AIRunStatus.Running,
-        },
-        data: {
-          status: AIRunStatus.Completed,
-          completedAt: OneUptimeDate.getCurrentDate(),
-          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
-          llmCallCount: result.llmCallCount,
-          toolCallCount: result.toolCallCount,
-          totalTokens: result.totalTokens,
-        } as never,
-        props: { isRoot: true },
-      });
-
-      await this.emitEvent({
+      await SentinelInvestigationEngine.investigate({
         projectId,
-        aiRunId,
-        sequence: sequence++,
-        eventType: AIRunEventType.RunCompleted,
-      });
-
-      const analysisMarkdown: string = (result.contentInMarkdown || "").trim();
-
-      if (!analysisMarkdown) {
-        logger.debug(
-          `Sentinel: investigation for incident ${incidentId.toString()} produced no analysis; nothing posted.`,
-        );
-        return;
-      }
-
-      // Post the cited RCA to the incident timeline + Slack/Teams.
-      await IncidentFeedService.createIncidentFeedItem({
-        incidentId,
-        projectId,
-        incidentFeedEventType: IncidentFeedEventType.RootCause,
-        displayColor: Blue500,
-        feedInfoInMarkdown: this.buildFeedMarkdown(result, analysisMarkdown),
-        workspaceNotification: {
-          sendWorkspaceNotification: true,
+        feature: "Sentinel Incident Investigation",
+        contextSummary: this.buildIncidentSummary(contextData),
+        postAnalysis: async (postData: {
+          analysisMarkdown: string;
+          isConfident: boolean;
+          result: ObservabilityAssistantResult;
+        }): Promise<void> => {
+          await IncidentFeedService.createIncidentFeedItem({
+            incidentId,
+            projectId,
+            incidentFeedEventType: IncidentFeedEventType.RootCause,
+            displayColor: Blue500,
+            feedInfoInMarkdown: postData.analysisMarkdown,
+            /*
+             * Quiet mode: an inconclusive investigation posts to the timeline
+             * but does NOT loudly ping the workspace / on-call.
+             */
+            workspaceNotification: {
+              sendWorkspaceNotification: postData.isConfident,
+            },
+          });
         },
       });
-
-      logger.debug(
-        `Sentinel: posted root cause analysis for incident ${incidentId.toString()} (${result.llmCallCount} LLM calls, ${result.toolCallCount} tools, ${result.totalTokens} tokens).`,
-      );
     } catch (error) {
-      const message: string =
-        error instanceof Error ? error.message : String(error);
-
-      await AIRunService.updateOneBy({
-        query: {
-          _id: aiRunId.toString(),
-          status: AIRunStatus.Running,
-        },
-        data: {
-          status: AIRunStatus.Error,
-          completedAt: OneUptimeDate.getCurrentDate(),
-          errorMessage: message.substring(0, 480),
-        } as never,
-        props: { isRoot: true },
-      });
-
-      await this.emitEvent({
-        projectId,
-        aiRunId,
-        sequence: sequence++,
-        eventType: AIRunEventType.RunFailed,
-      });
-
       logger.error(
-        `Sentinel: investigation failed for incident ${incidentId.toString()}: ${message}`,
+        `Sentinel: unexpected error investigating incident ${incidentId.toString()}: ${error}`,
       );
     }
   }
@@ -309,7 +131,6 @@ export default class SentinelIncidentInvestigationRunner {
       lines.push(`Root cause (as recorded so far): ${incident.rootCause}`);
     }
 
-    // Include a few of the most recent internal notes for context.
     const recentNotes: Array<string> = (internalNotes || [])
       .slice(-5)
       .map((note: { note?: string }) => {
@@ -324,53 +145,5 @@ export default class SentinelIncidentInvestigationRunner {
     }
 
     return lines.join("\n");
-  }
-
-  // Wrap the agent's analysis with Sentinel branding + an evidence list.
-  private static buildFeedMarkdown(
-    result: ObservabilityAssistantResult,
-    analysisMarkdown: string,
-  ): string {
-    let markdown: string = `## 🧠 Sentinel — Automated Root Cause Analysis\n\n${analysisMarkdown}`;
-
-    const citations: Array<AIChatCitation> = result.citations || [];
-
-    if (citations.length > 0) {
-      markdown += `\n\n**Evidence checked**`;
-      for (const citation of citations.slice(0, 15)) {
-        markdown += `\n- **[${citation.id}]** ${citation.label} — ${citation.rowCount} row(s)`;
-      }
-    }
-
-    markdown += `\n\n---\n*Investigated automatically by OneUptime Sentinel — read-only, ${result.toolCallCount} quer${
-      result.toolCallCount === 1 ? "y" : "ies"
-    } run across your own telemetry${
-      result.modelName ? ` using ${result.modelName}` : ""
-    }. This is an AI-generated first pass; verify before acting.*`;
-
-    return markdown;
-  }
-
-  private static async emitEvent(data: {
-    projectId: ObjectID;
-    aiRunId: ObjectID;
-    sequence: number;
-    eventType: AIRunEventType;
-  }): Promise<void> {
-    try {
-      const event: AIRunEvent = new AIRunEvent();
-      event.projectId = data.projectId;
-      event.aiRunId = data.aiRunId;
-      event.sequence = data.sequence;
-      event.eventType = data.eventType;
-
-      await AIRunEventService.create({
-        data: event,
-        props: { isRoot: true },
-      });
-    } catch (error) {
-      // Events are best-effort telemetry — never fail the run because of them.
-      logger.error(`Sentinel: failed to emit AIRunEvent: ${error}`);
-    }
   }
 }

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -1,0 +1,295 @@
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
+import AIRunType from "../../../../Types/AI/AIRunType";
+import AIRunStatus from "../../../../Types/AI/AIRunStatus";
+import AIRunEventType from "../../../../Types/AI/AIRunEventType";
+import AIRun from "../../../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../../../Models/DatabaseModels/AIRunEvent";
+import Project from "../../../../Models/DatabaseModels/Project";
+import LlmProvider from "../../../../Models/DatabaseModels/LlmProvider";
+import AIRunService from "../../../Services/AIRunService";
+import AIRunEventService from "../../../Services/AIRunEventService";
+import ProjectService from "../../../Services/ProjectService";
+import LlmProviderService from "../../../Services/LlmProviderService";
+import ObservabilityAssistant, {
+  ObservabilityAssistantResult,
+} from "../Chat/ObservabilityAssistant";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — the shared autonomous-investigation engine.
+ *
+ * A single subject-agnostic core that powers "wake on signal" investigations
+ * for both incidents and alerts (and, later, anomalies). It:
+ *   1. records the run as an AIRun(Investigation) + AIRunEvents (audit trail),
+ *   2. runs the existing read-only, tool-grounded, citation-minting agent loop
+ *      (ObservabilityAssistant) with the Sentinel persona and a larger budget,
+ *   3. brands the cited analysis, judges confidence, and
+ *   4. hands the finished analysis back to the caller to post to the subject's
+ *      timeline.
+ *
+ * The investigation is strictly READ-ONLY: it can never mutate anything.
+ * Enablement + provider gating is shared via isEnabledForProject().
+ */
+
+// Budgets — larger than an interactive chat-ops answer, small enough to stay cheap.
+const MAX_LLM_CALLS: number = 8;
+const MAX_TOOL_CALLS: number = 12;
+const MAX_WALL_CLOCK_MS: number = 150 * 1000;
+const MAX_OUTPUT_TOKENS: number = 2000;
+
+/*
+ * Sentinel's own contract: it writes exactly this phrase when it cannot
+ * determine a cause. We match it deterministically to drive "quiet mode" —
+ * a non-answer should never loudly page the on-call.
+ */
+const INCONCLUSIVE_RE: RegExp = /inconclusive[^.\n]*insufficient signal/i;
+
+const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW signal (an incident or alert) was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
+
+Investigate like a senior on-call engineer:
+- Start from the affected monitors/services named in the signal.
+- Use your read tools to inspect the telemetry AROUND the signal's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
+- Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
+
+Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
+**Summary** — one or two sentences a paged engineer can read in five seconds.
+**Most likely root cause** — your hypothesis, with only the confidence the evidence actually supports, each factual claim carrying its [C#] citation. If you could not determine it, write "Inconclusive — insufficient signal" and explain what is missing.
+**Evidence** — the key findings that support or rule out the hypothesis, each cited.
+**Suggested next steps** — concrete actions for the on-call engineer.
+
+Keep it tight and skimmable. You are read-only: never claim to have changed anything.`;
+
+export interface InvestigationRequest {
+  projectId: ObjectID;
+  // Label recorded on LlmLog, e.g. "Sentinel Incident Investigation".
+  feature: string;
+  // A compact markdown summary of the subject that seeds the investigation.
+  contextSummary: string;
+  /*
+   * Called with the finished, branded, cited analysis so the caller can post it
+   * to the subject's timeline. `isConfident` is false when Sentinel reported it
+   * could not determine the cause — callers use it to post QUIETLY (no loud
+   * workspace ping) rather than paging a non-answer.
+   */
+  postAnalysis: (data: {
+    analysisMarkdown: string;
+    isConfident: boolean;
+    result: ObservabilityAssistantResult;
+  }) => Promise<void>;
+}
+
+export default class SentinelInvestigationEngine {
+  /*
+   * Shared gate: AI enabled, the auto-investigation opt-in on, and an LLM
+   * provider configured. Runs before any (subject-specific) context assembly.
+   */
+  @CaptureSpan()
+  public static async isEnabledForProject(
+    projectId: ObjectID,
+  ): Promise<boolean> {
+    const project: Project | null = await ProjectService.findOneById({
+      id: projectId,
+      select: {
+        enableAi: true,
+        enableAutomaticIncidentInvestigation: true,
+      },
+      props: { isRoot: true },
+    });
+
+    if (!project) {
+      return false;
+    }
+
+    if (project.enableAi === false) {
+      return false;
+    }
+
+    if (project.enableAutomaticIncidentInvestigation !== true) {
+      return false;
+    }
+
+    const llmProvider: LlmProvider | null =
+      await LlmProviderService.getLLMProviderForProject(projectId);
+
+    if (!llmProvider) {
+      logger.debug(
+        `Sentinel: skipping investigation for project ${projectId.toString()} — no LLM provider configured.`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /*
+   * Run one investigation end-to-end. Never throws — failures are logged and
+   * recorded on the AIRun.
+   */
+  @CaptureSpan()
+  public static async investigate(
+    request: InvestigationRequest,
+  ): Promise<void> {
+    const { projectId } = request;
+
+    // Record the run up front so it is auditable even if it fails.
+    const run: AIRun = new AIRun();
+    run.projectId = projectId;
+    run.runType = AIRunType.Investigation;
+    run.status = AIRunStatus.Running;
+    run.startedAt = OneUptimeDate.getCurrentDate();
+    run.lastHeartbeatAt = OneUptimeDate.getCurrentDate();
+
+    let createdRun: AIRun;
+    try {
+      createdRun = await AIRunService.create({
+        data: run,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      logger.error(`Sentinel: failed to create investigation run: ${error}`);
+      return;
+    }
+
+    const aiRunId: ObjectID = createdRun.id!;
+    let sequence: number = 0;
+
+    await this.emitEvent({
+      projectId,
+      aiRunId,
+      sequence: sequence++,
+      eventType: AIRunEventType.RunStarted,
+    });
+
+    try {
+      const result: ObservabilityAssistantResult =
+        await ObservabilityAssistant.answerQuestion({
+          projectId,
+          // System run — full read access to the project's telemetry.
+          props: { isRoot: true },
+          feature: request.feature,
+          systemInstructions: INVESTIGATION_PERSONA,
+          question: `A new signal has just been declared and you have been woken to investigate it. Investigate now and produce your root cause analysis.\n\n${request.contextSummary}`,
+          maxLlmCalls: MAX_LLM_CALLS,
+          maxToolCalls: MAX_TOOL_CALLS,
+          maxWallClockMs: MAX_WALL_CLOCK_MS,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+        });
+
+      await AIRunService.updateOneBy({
+        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
+        data: {
+          status: AIRunStatus.Completed,
+          completedAt: OneUptimeDate.getCurrentDate(),
+          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
+          llmCallCount: result.llmCallCount,
+          toolCallCount: result.toolCallCount,
+          totalTokens: result.totalTokens,
+        } as never,
+        props: { isRoot: true },
+      });
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunCompleted,
+      });
+
+      const analysis: string = (result.contentInMarkdown || "").trim();
+
+      if (!analysis) {
+        logger.debug(
+          `Sentinel: investigation (run ${aiRunId.toString()}) produced no analysis; nothing posted.`,
+        );
+        return;
+      }
+
+      const isConfident: boolean = !INCONCLUSIVE_RE.test(analysis);
+
+      await request.postAnalysis({
+        analysisMarkdown: this.buildBrandedMarkdown(result, analysis),
+        isConfident,
+        result,
+      });
+
+      logger.debug(
+        `Sentinel: investigation complete (run ${aiRunId.toString()}, confident=${isConfident}, ${result.llmCallCount} LLM calls, ${result.toolCallCount} tools, ${result.totalTokens} tokens).`,
+      );
+    } catch (error) {
+      const message: string =
+        error instanceof Error ? error.message : String(error);
+
+      await AIRunService.updateOneBy({
+        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
+        data: {
+          status: AIRunStatus.Error,
+          completedAt: OneUptimeDate.getCurrentDate(),
+          errorMessage: message.substring(0, 480),
+        } as never,
+        props: { isRoot: true },
+      });
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunFailed,
+      });
+
+      logger.error(
+        `Sentinel: investigation failed (run ${aiRunId.toString()}): ${message}`,
+      );
+    }
+  }
+
+  // Wrap the agent's analysis with Sentinel branding + an evidence list.
+  private static buildBrandedMarkdown(
+    result: ObservabilityAssistantResult,
+    analysisMarkdown: string,
+  ): string {
+    let markdown: string = `## 🧠 Sentinel — Automated Root Cause Analysis\n\n${analysisMarkdown}`;
+
+    const citations: Array<AIChatCitation> = result.citations || [];
+
+    if (citations.length > 0) {
+      markdown += `\n\n**Evidence checked**`;
+      for (const citation of citations.slice(0, 15)) {
+        markdown += `\n- **[${citation.id}]** ${citation.label} — ${citation.rowCount} row(s)`;
+      }
+    }
+
+    markdown += `\n\n---\n*Investigated automatically by OneUptime Sentinel — read-only, ${result.toolCallCount} quer${
+      result.toolCallCount === 1 ? "y" : "ies"
+    } run across your own telemetry${
+      result.modelName ? ` using ${result.modelName}` : ""
+    }. This is an AI-generated first pass; verify before acting.*`;
+
+    return markdown;
+  }
+
+  private static async emitEvent(data: {
+    projectId: ObjectID;
+    aiRunId: ObjectID;
+    sequence: number;
+    eventType: AIRunEventType;
+  }): Promise<void> {
+    try {
+      const event: AIRunEvent = new AIRunEvent();
+      event.projectId = data.projectId;
+      event.aiRunId = data.aiRunId;
+      event.sequence = data.sequence;
+      event.eventType = data.eventType;
+
+      await AIRunEventService.create({
+        data: event,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      // Events are best-effort telemetry — never fail the run because of them.
+      logger.error(`Sentinel: failed to emit AIRunEvent: ${error}`);
+    }
+  }
+}


### PR DESCRIPTION
## Sentinel — Phase 2: earlier signal + trust

**Stacked on #2624 (Phase 0 → Phase 1).** Base branch is `sentinel-phase-0-action-belt`.

Two things: extend "wake on signal" to the **earlier** signal (alerts), and make the output **trustworthy** with confidence-gating.

### 1. Shared engine + alert investigation
- Extracted `SentinelInvestigationEngine` — the subject-agnostic core (AIRun lifecycle + events, the read-only cited agent loop, branding, provider/opt-in gating). The Phase 1 incident runner now sits on it (no behaviour change).
- New `SentinelAlertInvestigationRunner` + a trigger in `AlertService.onCreateSuccess`: a **new alert** is now auto-investigated and a cited RCA is posted to the **alert timeline + Slack/Teams**, symmetric to incidents.

### 2. Confidence-gated "quiet mode" (trust)
Sentinel's persona writes exactly `Inconclusive — insufficient signal` when it can't determine a cause. The engine detects that deterministically and posts the analysis to the timeline **quietly** — no loud workspace ping. **We never page the on-call with a non-answer.** A confident RCA still notifies loudly.

### Files
- `SentinelInvestigationEngine.ts` (new — shared core)
- `IncidentInvestigationRunner.ts` (refactored onto the engine)
- `AlertInvestigationRunner.ts` (new)
- `AlertService.ts` (trigger)

### Verification
- `tsc --noEmit` on `Common`: clean. `eslint`: clean.

### Deliberately deferred (honest scope)
- **The `MetricBaselineHourly` predictive sweep** ("catch it before the alert fires") — a Worker cron over the already-computed baselines; sequenced after the durable queue (Phase 3) so always-on scanning is restart-safe and rate-limited.
- **Rendered HypothesisBoard / CausalChain widgets** and **SSE token streaming** ("watch it think") — these need dashboard/front-end work + a real streaming refactor across the 7 provider branches; tracked for a dedicated PR.
- **Alert-volume cost gating** (severity threshold / rate limit) — alerts can be higher-volume than incidents; the opt-in currently covers both. A severity/rate gate is a small follow-up.
