### PR TITLE
feat(ai): Sentinel Phase 3 — auto-draft postmortem on incident resolve

### DIFF
--- a/Common/Server/Services/IncidentStateTimelineService.ts
+++ b/Common/Server/Services/IncidentStateTimelineService.ts
@@ -27,6 +27,7 @@ import IncidentRole from "../../Models/DatabaseModels/IncidentRole";
 import { IsBillingEnabled } from "../EnvironmentConfig";
 import logger, { LogAttributes } from "../Utils/Logger";
 import IncidentFeedService from "./IncidentFeedService";
+import SentinelIncidentPostmortemRunner from "../Utils/AI/Sentinel/IncidentPostmortemRunner";
 import { IncidentFeedEventType } from "../../Models/DatabaseModels/IncidentFeed";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
@@ -555,6 +556,24 @@ ${createdItem.rootCause}`,
           createdItem.startsAt || undefined,
         );
       }
+
+      /*
+       * Sentinel: auto-draft a postmortem now that the incident is resolved
+       * (gated per project; never overwrites an existing postmortem).
+       */
+      SentinelIncidentPostmortemRunner.draftPostmortemOnResolve({
+        incidentId: createdItem.incidentId!,
+        projectId: createdItem.projectId!,
+      }).catch((error: Error) => {
+        logger.error(`Sentinel auto-postmortem failed on resolve:`, {
+          projectId: createdItem.projectId?.toString(),
+          incidentId: createdItem.incidentId?.toString(),
+        } as LogAttributes);
+        logger.error(error, {
+          projectId: createdItem.projectId?.toString(),
+          incidentId: createdItem.incidentId?.toString(),
+        } as LogAttributes);
+      });
     }
 
     if (onCreate.carryForward.publicNote) {

--- a/Common/Server/Utils/AI/Sentinel/IncidentPostmortemRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentPostmortemRunner.ts
@@ -1,0 +1,100 @@
+import ObjectID from "../../../../Types/ObjectID";
+import { Blue500 } from "../../../../Types/BrandColors";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import { IncidentFeedEventType } from "../../../../Models/DatabaseModels/IncidentFeed";
+import IncidentService from "../../../Services/IncidentService";
+import IncidentFeedService from "../../../Services/IncidentFeedService";
+import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — auto-draft postmortem on resolve (Phase 3, "close the loop").
+ *
+ * When an incident moves to a resolved state, Sentinel drafts a postmortem from
+ * the incident timeline + telemetry (reusing the existing
+ * IncidentService.generatePostmortemFromAI) and saves it to the incident for a
+ * human to review and edit — turning a ~90-minute manual writeup into a review.
+ *
+ * It NEVER overwrites a postmortem that already exists (human work wins), is
+ * gated by the same per-project opt-in + LLM provider as investigations, and is
+ * fire-and-forget: failures are logged, never surfaced to the resolve flow.
+ */
+const MAX_FEED_PREVIEW_CHARS: number = 6000;
+
+export default class SentinelIncidentPostmortemRunner {
+  @CaptureSpan()
+  public static async draftPostmortemOnResolve(data: {
+    incidentId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    const { incidentId, projectId } = data;
+
+    try {
+      if (!(await SentinelInvestigationEngine.isEnabledForProject(projectId))) {
+        return;
+      }
+
+      const incident: Incident | null = await IncidentService.findOneById({
+        id: incidentId,
+        select: {
+          _id: true,
+          incidentNumber: true,
+          postmortemNote: true,
+        },
+        props: { isRoot: true },
+      });
+
+      if (!incident) {
+        return;
+      }
+
+      // Never clobber an existing postmortem (human or previously drafted).
+      if (
+        incident.postmortemNote &&
+        incident.postmortemNote.trim().length > 0
+      ) {
+        return;
+      }
+
+      const draft: string = await IncidentService.generatePostmortemFromAI({
+        incidentId,
+      });
+
+      if (!draft || !draft.trim()) {
+        return;
+      }
+
+      await IncidentService.updateOneById({
+        id: incidentId,
+        data: {
+          postmortemNote: draft,
+        },
+        props: { isRoot: true },
+      });
+
+      await IncidentFeedService.createIncidentFeedItem({
+        incidentId,
+        projectId,
+        incidentFeedEventType: IncidentFeedEventType.PostmortemNote,
+        displayColor: Blue500,
+        feedInfoInMarkdown: `## 🧠 Sentinel — Draft Postmortem\n\nSentinel drafted a postmortem for incident #${incident.incidentNumber} from the incident timeline and telemetry. It has been saved on the incident for you to review and edit.`,
+        moreInformationInMarkdown:
+          draft.length > MAX_FEED_PREVIEW_CHARS
+            ? `${draft.substring(0, MAX_FEED_PREVIEW_CHARS)}\n\n…(truncated — the full draft is saved on the incident.)`
+            : draft,
+        workspaceNotification: {
+          sendWorkspaceNotification: true,
+        },
+      });
+
+      logger.debug(
+        `Sentinel: drafted postmortem for incident ${incidentId.toString()}.`,
+      );
+    } catch (error) {
+      logger.error(
+        `Sentinel: failed to draft postmortem for incident ${incidentId.toString()}: ${error}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Sentinel — Phase 3: close the loop (auto-postmortem)

**Stacked on #2625 (Phase 2 → 0 → 1).** Base branch is `sentinel-phase-2-proactive-detection`.

When an incident moves to a **resolved** state, Sentinel drafts a postmortem from the incident timeline + telemetry (reusing the existing `IncidentService.generatePostmortemFromAI`), **saves it to the incident** for a human to review/edit, and posts a feed note. A ~90-minute manual writeup becomes a review.

### Behaviour
- Triggers from the `isResolvedState` branch of `IncidentStateTimelineService` (fire-and-forget, `.catch()`ed like the sibling side effects).
- **Never overwrites** an existing postmortem — human/earlier-drafted work wins.
- Gated by the same per-project opt-in + LLM provider as investigations.
- Full draft saved to `Incident.postmortemNote`; a truncated preview goes to the feed + workspace.

### Files
- `Common/Server/Utils/AI/Sentinel/IncidentPostmortemRunner.ts` (new)
- `Common/Server/Services/IncidentStateTimelineService.ts` (trigger)

### Verification
- `tsc --noEmit` on `Common`: clean. `eslint`: clean.

### Deliberately deferred (the rest of Phase 3 — honest scope)
These are the larger, higher-risk items I did **not** fake-complete; each deserves its own PR:
- **Durable, restart-safe claimable AIRun queue** (atomic claim; investigations survive a pod restart). Needs a new `AIRun` status + a `triggeredBy*` column + a Worker cron + an engine refactor to run against an existing run. Real migration + worker surface.
- **Active verification** — re-run the exact failed synthetic monitor/probe on resolve to *prove* recovery. Needs the monitor/probe re-run API.
- **Auto code-fix verify loop** (regression test + build/test/lint until green + GitLab) — the big one; needs a per-repo CI sandbox.
- **Weekly "made your software better" digest.**
