### PR TITLE
feat(ai): Sentinel Phase 4 — recurrence memory ("I've seen this before")

### DIFF
--- a/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
@@ -7,6 +7,7 @@ import IncidentAIContextBuilder, {
   IncidentContextData,
 } from "../IncidentAIContextBuilder";
 import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import SentinelMemory from "./SentinelMemory";
 import { ObservabilityAssistantResult } from "../Chat/ObservabilityAssistant";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
@@ -47,10 +48,32 @@ export default class SentinelIncidentInvestigationRunner {
           includeWorkspaceMessages: false,
         });
 
+      /*
+       * Recurrence memory: pull in past resolved incidents that share this
+       * incident's monitors/labels so Sentinel can recognise "I've seen this
+       * before" and reference the prior fix.
+       */
+      const priorCasesContext: string =
+        await SentinelMemory.getPriorSimilarIncidentsContext({
+          projectId,
+          currentIncidentId: incidentId,
+          monitorNames: (contextData.incident.monitors || [])
+            .map((m: { name?: string }) => {
+              return m.name || "";
+            })
+            .filter(Boolean),
+          labelNames: (contextData.incident.labels || [])
+            .map((l: { name?: string }) => {
+              return l.name || "";
+            })
+            .filter(Boolean),
+        });
+
       await SentinelInvestigationEngine.investigate({
         projectId,
         feature: "Sentinel Incident Investigation",
-        contextSummary: this.buildIncidentSummary(contextData),
+        contextSummary:
+          this.buildIncidentSummary(contextData) + priorCasesContext,
         postAnalysis: async (postData: {
           analysisMarkdown: string;
           isConfident: boolean;

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -53,6 +53,7 @@ Investigate like a senior on-call engineer:
 - Start from the affected monitors/services named in the signal.
 - Use your read tools to inspect the telemetry AROUND the signal's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
 - Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
+- If the context lists past resolved incidents, check whether this is a RECURRENCE. If the current signal matches one, say so explicitly, reference that incident number, and note how it was resolved before — but still verify against the current telemetry.
 
 Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
 **Summary** — one or two sentences a paged engineer can read in five seconds.

--- a/Common/Server/Utils/AI/Sentinel/SentinelMemory.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelMemory.ts
@@ -1,0 +1,167 @@
+import ObjectID from "../../../../Types/ObjectID";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import IncidentService from "../../../Services/IncidentService";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+import logger from "../../Logger";
+
+/*
+ * Sentinel — episodic memory (Phase 4, "I've seen this before").
+ *
+ * The first, no-new-storage cut of the recurrence short-circuit: instead of a
+ * vector store, retrieve past RESOLVED incidents in the same project that share
+ * monitors/labels with the current signal and carry a recorded root cause, then
+ * feed a compact digest into the investigation so the agent can recognise a
+ * recurrence and reference the prior fix.
+ *
+ * The full episodic store (pgvector embeddings over postmortems/runbooks + a
+ * temporal knowledge graph) is the deferred, larger build — this delivers the
+ * user-visible "this matches #123" behaviour on data we already own.
+ */
+
+// How many recent incidents to consider, and how many prior cases to surface.
+const CANDIDATE_LIMIT: number = 30;
+const MAX_CASES: number = 4;
+const MAX_ROOT_CAUSE_CHARS: number = 300;
+
+const SHARED_MONITOR_SCORE: number = 2;
+const SHARED_LABEL_SCORE: number = 1;
+
+export default class SentinelMemory {
+  /*
+   * Returns a markdown "past resolved incidents" section to append to the
+   * investigation context, or an empty string when there is nothing useful.
+   * Never throws — memory is a nice-to-have, not load-bearing.
+   */
+  @CaptureSpan()
+  public static async getPriorSimilarIncidentsContext(data: {
+    projectId: ObjectID;
+    currentIncidentId: ObjectID;
+    monitorNames: Array<string>;
+    labelNames: Array<string>;
+  }): Promise<string> {
+    try {
+      const candidates: Array<Incident> = await IncidentService.findBy({
+        query: {
+          projectId: data.projectId,
+        },
+        select: {
+          _id: true,
+          incidentNumber: true,
+          title: true,
+          rootCause: true,
+          createdAt: true,
+          currentIncidentState: {
+            isResolvedState: true,
+          },
+          monitors: {
+            name: true,
+          },
+          labels: {
+            name: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: CANDIDATE_LIMIT,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+      const currentIdString: string = data.currentIncidentId.toString();
+      const monitorSet: Set<string> = new Set(
+        data.monitorNames.map((n: string) => {
+          return n.toLowerCase();
+        }),
+      );
+      const labelSet: Set<string> = new Set(
+        data.labelNames.map((n: string) => {
+          return n.toLowerCase();
+        }),
+      );
+
+      const scored: Array<{ incident: Incident; score: number }> = candidates
+        .filter((incident: Incident) => {
+          return (
+            incident.id?.toString() !== currentIdString &&
+            incident.currentIncidentState?.isResolvedState === true &&
+            Boolean(incident.rootCause && incident.rootCause.trim().length > 0)
+          );
+        })
+        .map((incident: Incident) => {
+          let score: number = 0;
+
+          for (const monitor of incident.monitors || []) {
+            if (monitor.name && monitorSet.has(monitor.name.toLowerCase())) {
+              score += SHARED_MONITOR_SCORE;
+            }
+          }
+
+          for (const label of incident.labels || []) {
+            if (label.name && labelSet.has(label.name.toLowerCase())) {
+              score += SHARED_LABEL_SCORE;
+            }
+          }
+
+          return { incident, score };
+        });
+
+      /*
+       * Prefer cases that actually share a monitor/label; otherwise fall back to
+       * the most recent resolved incidents (V8's sort is stable, keeping recency).
+       */
+      const relevant: Array<{ incident: Incident; score: number }> = scored
+        .filter((item: { incident: Incident; score: number }) => {
+          return item.score > 0;
+        })
+        .sort(
+          (
+            a: { incident: Incident; score: number },
+            b: { incident: Incident; score: number },
+          ) => {
+            return b.score - a.score;
+          },
+        );
+
+      const chosen: Array<{ incident: Incident; score: number }> = (
+        relevant.length > 0 ? relevant : scored
+      ).slice(0, MAX_CASES);
+
+      if (chosen.length === 0) {
+        return "";
+      }
+
+      let markdown: string =
+        "\n\n# Past resolved incidents in this project (recurrence context)\n" +
+        "If the current signal matches one of these, this may be a recurrence — say so explicitly and reference the incident number and how it was resolved.\n";
+
+      for (const { incident } of chosen) {
+        const rootCause: string = (incident.rootCause || "").trim();
+        const shortRootCause: string =
+          rootCause.length > MAX_ROOT_CAUSE_CHARS
+            ? `${rootCause.substring(0, MAX_ROOT_CAUSE_CHARS)}…`
+            : rootCause;
+
+        markdown += `\n- **#${incident.incidentNumber} — ${incident.title || "Untitled"}**`;
+        markdown += `\n  Previously resolved. Root cause: ${shortRootCause}`;
+
+        const monitorNames: Array<string> = (incident.monitors || [])
+          .map((m: Monitor) => {
+            return m.name || "";
+          })
+          .filter(Boolean);
+
+        if (monitorNames.length > 0) {
+          markdown += `\n  Monitors: ${monitorNames.join(", ")}`;
+        }
+      }
+
+      return markdown;
+    } catch (error) {
+      logger.error(`Sentinel: failed to load recurrence context: ${error}`);
+      return "";
+    }
+  }
+}


### PR DESCRIPTION
## Sentinel — Phase 4: it remembers

**Stacked on #2626 (Phase 3 → 2 → 0 → 1).** Base branch is `sentinel-phase-3-auto-postmortem`.

The first cut of **episodic memory** — the recurrence short-circuit — **without** standing up a vector store. When investigating a new incident, Sentinel retrieves past **resolved** incidents in the project that share its monitors/labels and carry a recorded root cause, ranks them by overlap, and feeds a compact digest into the investigation. The persona now recognises a recurrence and references the prior incident + its fix.

> *"This matches #231 from last month — connection-pool exhaustion, resolved by raising the pool size. Verifying against current telemetry…"*

### How it works (data we already own)
- `SentinelMemory.getPriorSimilarIncidentsContext` pulls the 30 most recent incidents, keeps the resolved ones with a root cause, scores by shared monitors (×2) / labels (×1), and surfaces the top matches (recency fallback when nothing overlaps).
- The incident runner appends that context to the investigation prompt.
- The shared persona gains a rule: detect recurrences, cite the prior incident, **still verify against current telemetry** (memory informs, it doesn't decide).

### Files
- `SentinelMemory.ts` (new)
- `IncidentInvestigationRunner.ts` (wire it in)
- `SentinelInvestigationEngine.ts` (persona: recurrence awareness)

### Verification
- `tsc --noEmit` on `Common`: clean. `eslint`: clean.

### Deliberately deferred (the real memory moat)
- **pgvector embeddings** over postmortems/runbooks/service descriptions for semantic recall beyond monitor/label overlap.
- **Temporal knowledge graph** (`valid_at`/`invalid_at`) of services/deps/ownership from spans + `TelemetryEntity`.
- **Human-correction memory** (learn from edited status updates / rejected hypotheses) and the runbook-authoring flywheel.
- Recurrence context for **alerts** (currently incidents only).
