### PR TITLE
feat(ai): Sentinel "watch it think" — live per-step investigation narration

### DIFF
--- a/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
+++ b/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
@@ -1,6 +1,7 @@
 import DatabaseCommonInteractionProps from "../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import OneUptimeDate from "../../../../Types/Date";
 import ObjectID from "../../../../Types/ObjectID";
+import { JSONObject } from "../../../../Types/JSON";
 import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
 import AIService, { AILogResponse } from "../../../Services/AIService";
 import logger from "../../Logger";
@@ -32,6 +33,29 @@ export interface ObservabilityAssistantPriorTurn {
   content: string;
 }
 
+/*
+ * A single "thinking step" emitted live as the agent loop runs, so callers can
+ * narrate the investigation in real time ("Reading trace ✓ 0.4s"). This is the
+ * step-level narration the OneUptime UI renders by polling AIRunEvent rows.
+ */
+export type ObservabilityAssistantStepType =
+  | "llm_started"
+  | "llm_completed"
+  | "tool_started"
+  | "tool_completed"
+  | "tool_failed";
+
+export interface ObservabilityAssistantStep {
+  type: ObservabilityAssistantStepType;
+  toolName?: string | undefined;
+  toolArguments?: JSONObject | undefined;
+  rowCount?: number | undefined;
+  durationMs?: number | undefined;
+  citationId?: string | undefined;
+  totalTokens?: number | undefined;
+  errorMessage?: string | undefined;
+}
+
 export interface ObservabilityAssistantRequest {
   projectId: ObjectID;
   userId?: ObjectID | undefined;
@@ -60,6 +84,13 @@ export interface ObservabilityAssistantRequest {
   maxToolCalls?: number | undefined;
   maxWallClockMs?: number | undefined;
   maxOutputTokens?: number | undefined;
+  /*
+   * Optional live-narration hook, fired for each LLM/tool step as the loop runs.
+   * Used by autonomous runs to persist a per-step AIRunEvent trail so the UI can
+   * "watch it think". Best-effort — implementations must not throw; a slow or
+   * failing handler should not break the run.
+   */
+  onStep?: ((step: ObservabilityAssistantStep) => Promise<void>) | undefined;
 }
 
 export interface ObservabilityAssistantResult {
@@ -91,6 +122,22 @@ export default class ObservabilityAssistant {
     const maxWallClockMs: number = request.maxWallClockMs ?? MAX_WALL_CLOCK_MS;
     const maxOutputTokens: number =
       request.maxOutputTokens ?? MAX_OUTPUT_TOKENS;
+
+    // Best-effort live-narration emitter — never throws into the loop.
+    const emitStep: (
+      step: ObservabilityAssistantStep,
+    ) => Promise<void> = async (
+      step: ObservabilityAssistantStep,
+    ): Promise<void> => {
+      if (!request.onStep) {
+        return;
+      }
+      try {
+        await request.onStep(step);
+      } catch (err) {
+        logger.error(`ObservabilityAssistant onStep failed: ${err}`);
+      }
+    };
 
     const toolContext: ToolContext = {
       projectId: request.projectId,
@@ -147,6 +194,8 @@ export default class ObservabilityAssistant {
         });
       }
 
+      await emitStep({ type: "llm_started" });
+
       const response: AILogResponse = await AIService.executeWithLogging({
         projectId: request.projectId,
         userId: request.userId,
@@ -164,6 +213,11 @@ export default class ObservabilityAssistant {
 
       llmCallCount++;
       totalTokens += response.llmLog.totalTokens || 0;
+
+      await emitStep({
+        type: "llm_completed",
+        totalTokens: response.llmLog.totalTokens || 0,
+      });
 
       if (!providerName) {
         providerName = response.llmLog.llmProviderName;
@@ -207,6 +261,14 @@ export default class ObservabilityAssistant {
             continue;
           }
 
+          const toolStartedAtMs: number = Date.now();
+
+          await emitStep({
+            type: "tool_started",
+            toolName: toolCall.name,
+            toolArguments: toolCall.arguments,
+          });
+
           const outcome: ToolCallOutcome = await AIToolbox.executeTool({
             name: toolCall.name,
             args: toolCall.arguments,
@@ -214,6 +276,13 @@ export default class ObservabilityAssistant {
           });
 
           if (!outcome.success || !outcome.result) {
+            await emitStep({
+              type: "tool_failed",
+              toolName: toolCall.name,
+              durationMs: Date.now() - toolStartedAtMs,
+              errorMessage: outcome.errorMessage || outcome.textForLlm,
+            });
+
             messages.push({
               role: "tool",
               toolCallId: toolCall.id,
@@ -231,6 +300,14 @@ export default class ObservabilityAssistant {
             queryArguments: toolCall.arguments,
             rowCount: outcome.result.rowCount,
             target: outcome.result.citationTarget,
+          });
+
+          await emitStep({
+            type: "tool_completed",
+            toolName: toolCall.name,
+            durationMs: Date.now() - toolStartedAtMs,
+            rowCount: outcome.result.rowCount,
+            citationId: citationId,
           });
 
           const escapedText: string = escapeToolResultContent(

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -1,6 +1,10 @@
 import ObjectID from "../../../../Types/ObjectID";
 import OneUptimeDate from "../../../../Types/Date";
-import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import {
+  AIChatCitation,
+  AIRunEventResultSummary,
+} from "../../../../Types/AI/AIChatTypes";
 import AIRunType from "../../../../Types/AI/AIRunType";
 import AIRunStatus from "../../../../Types/AI/AIRunStatus";
 import AIRunEventType from "../../../../Types/AI/AIRunEventType";
@@ -14,6 +18,8 @@ import ProjectService from "../../../Services/ProjectService";
 import LlmProviderService from "../../../Services/LlmProviderService";
 import ObservabilityAssistant, {
   ObservabilityAssistantResult,
+  ObservabilityAssistantStep,
+  ObservabilityAssistantStepType,
 } from "../Chat/ObservabilityAssistant";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
@@ -46,6 +52,16 @@ const MAX_OUTPUT_TOKENS: number = 2000;
  * a non-answer should never loudly page the on-call.
  */
 const INCONCLUSIVE_RE: RegExp = /inconclusive[^.\n]*insufficient signal/i;
+
+// Maps a live agent step to the AIRunEvent type persisted for the glass-box trail.
+const STEP_EVENT_TYPE: Record<ObservabilityAssistantStepType, AIRunEventType> =
+  {
+    llm_started: AIRunEventType.LlmCallStarted,
+    llm_completed: AIRunEventType.LlmCallCompleted,
+    tool_started: AIRunEventType.ToolCallStarted,
+    tool_completed: AIRunEventType.ToolCallCompleted,
+    tool_failed: AIRunEventType.ToolCallFailed,
+  };
 
 const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW signal (an incident or alert) was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
 
@@ -164,6 +180,41 @@ export default class SentinelInvestigationEngine {
       eventType: AIRunEventType.RunStarted,
     });
 
+    /*
+     * Live narration: persist each LLM/tool step as an AIRunEvent so the UI can
+     * "watch it think" by polling the run's events. Best-effort, ordered.
+     */
+    const onStep: (step: ObservabilityAssistantStep) => Promise<void> = async (
+      step: ObservabilityAssistantStep,
+    ): Promise<void> => {
+      const resultSummary: AIRunEventResultSummary | undefined =
+        step.rowCount !== undefined ||
+        step.durationMs !== undefined ||
+        step.errorMessage !== undefined
+          ? {
+              rowCount: step.rowCount,
+              durationInMs: step.durationMs,
+              errorMessage: step.errorMessage,
+            }
+          : undefined;
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: STEP_EVENT_TYPE[step.type],
+        toolName: step.toolName,
+        toolArguments: step.toolArguments,
+        resultSummary,
+        citationId: step.citationId,
+      });
+
+      // Keep the run visibly alive for the stale-run sweeper + live UI.
+      if (step.type === "llm_started") {
+        await this.touchHeartbeat(aiRunId);
+      }
+    };
+
     try {
       const result: ObservabilityAssistantResult =
         await ObservabilityAssistant.answerQuestion({
@@ -177,6 +228,7 @@ export default class SentinelInvestigationEngine {
           maxToolCalls: MAX_TOOL_CALLS,
           maxWallClockMs: MAX_WALL_CLOCK_MS,
           maxOutputTokens: MAX_OUTPUT_TOKENS,
+          onStep,
         });
 
       await AIRunService.updateOneBy({
@@ -271,11 +323,30 @@ export default class SentinelInvestigationEngine {
     return markdown;
   }
 
+  // Refresh lastHeartbeatAt so a long-running investigation isn't swept as stale.
+  private static async touchHeartbeat(aiRunId: ObjectID): Promise<void> {
+    try {
+      await AIRunService.updateOneBy({
+        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
+        data: {
+          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
+        } as never,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      logger.error(`Sentinel: heartbeat update failed: ${error}`);
+    }
+  }
+
   private static async emitEvent(data: {
     projectId: ObjectID;
     aiRunId: ObjectID;
     sequence: number;
     eventType: AIRunEventType;
+    toolName?: string | undefined;
+    toolArguments?: JSONObject | undefined;
+    resultSummary?: AIRunEventResultSummary | undefined;
+    citationId?: string | undefined;
   }): Promise<void> {
     try {
       const event: AIRunEvent = new AIRunEvent();
@@ -283,6 +354,19 @@ export default class SentinelInvestigationEngine {
       event.aiRunId = data.aiRunId;
       event.sequence = data.sequence;
       event.eventType = data.eventType;
+
+      if (data.toolName) {
+        event.toolName = data.toolName;
+      }
+      if (data.toolArguments) {
+        event.toolArguments = data.toolArguments;
+      }
+      if (data.resultSummary) {
+        event.resultSummary = data.resultSummary;
+      }
+      if (data.citationId) {
+        event.citationId = data.citationId;
+      }
 
       await AIRunEventService.create({
         data: event,


### PR DESCRIPTION
## Sentinel — "watch it think" (live step narration)

**Stacked on #2627 (Phase 4 → 3 → 2 → 0 → 1).** Base branch is `sentinel-phase-4-recurrence-memory`.

Makes an autonomous investigation **narrate its steps in real time** — "Ranking exceptions ✓, Reading trace ✓ 0.4s, Checking recent changes ✓" — the flagship demo moment.

### An honest note on the mechanism
The option was framed as "SSE token streaming." But OneUptime's copilot UI is **poll-based** — it already renders progress by reading `AIRunEvent` rows. So the correct, idiomatic, low-risk way to deliver "watch it think" here is a **rich per-step `AIRunEvent` trail**, not a net-new SSE token pipeline bolted onto the shared LLM path (which I couldn't verify at runtime and which risks the most critical code path). This is the real substrate the live view renders; token-level SSE would be a *second* live mechanism.

### What it does
- **`ObservabilityAssistant`** gains an optional, best-effort `onStep` hook that fires for each step: `llm_started` / `llm_completed`, and per tool `tool_started` / `tool_completed` / `tool_failed` — carrying tool name, row count, duration, and citation id. Backward compatible: omit `onStep` and chat-ops behaves exactly as before.
- **`SentinelInvestigationEngine`** persists each step as a rich `AIRunEvent` (`LlmCallStarted/Completed`, `ToolCallStarted/Completed/Failed` with `resultSummary.rowCount` + `durationInMs` + `citationId`) and refreshes the run **heartbeat**, so the investigation's `AIRun` is now a live, ordered, glass-box "thinking" trail.

### Files
- `Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts`
- `Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts`

### Verification
- `tsc --noEmit` on `Common`: clean. `eslint`: clean.

### Deliberately deferred
- **The dashboard live "Investigation" panel** that renders these events for an incident (front-end + the RBAC to surface a system-run's events, which are currently `userId`-pinned). This is the visible consumer; the events it needs now exist.
- **Token-level text streaming** (per-provider SSE) — only worth it once that live panel exists; a large, unverifiable-here refactor of the shared LLM path.
