### PR TITLE
feat(ai): Sentinel live Investigation panel on the incident page

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -9,6 +9,7 @@ import MonitorGroupAPI from "Common/Server/API/MonitorGroupAPI";
 import NotificationAPI from "Common/Server/API/NotificationAPI";
 import AIBillingAPI from "Common/Server/API/AIBillingAPI";
 import AIChatAPI from "Common/Server/API/AIChatAPI";
+import AIInvestigationAPI from "Common/Server/API/AIInvestigationAPI";
 import AIConversation from "Common/Models/DatabaseModels/AIConversation";
 import AIConversationService, {
   Service as AIConversationServiceType,
@@ -4098,6 +4099,9 @@ const BaseAPIFeatureSet: FeatureSet = {
 
     // AI Observability Chat
     app.use(`/${APP_NAME.toLocaleLowerCase()}`, AIChatAPI);
+
+    // Sentinel — live incident investigation panel data
+    app.use(`/${APP_NAME.toLocaleLowerCase()}`, AIInvestigationAPI);
 
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentInvestigationPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentInvestigationPanel.tsx
@@ -1,0 +1,207 @@
+import ChatActivityFeed from "../AIChat/ChatActivityFeed";
+import AIRunEvent from "Common/Models/DatabaseModels/AIRunEvent";
+import AIRunStatus from "Common/Types/AI/AIRunStatus";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import URL from "Common/Types/API/URL";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import IconProp from "Common/Types/Icon/IconProp";
+import { APP_API_URL } from "Common/UI/Config";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import Card from "Common/UI/Components/Card/Card";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export interface ComponentProps {
+  incidentId: ObjectID;
+}
+
+const POLL_INTERVAL_MS: number = 2500;
+
+/*
+ * Sentinel's live "watch it think" panel on the incident page. It shows the
+ * autonomous investigation narrating its steps in real time (reusing
+ * ChatActivityFeed over the run's AIRunEvents) and its status. Renders nothing
+ * until an investigation exists for the incident, so it's invisible for projects
+ * that haven't enabled Sentinel. The full cited root cause lands in the incident
+ * timeline below; this panel is the reasoning trail.
+ */
+const IncidentInvestigationPanel: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [runStatus, setRunStatus] = useState<string | null>(null);
+  const [events, setEvents] = useState<Array<AIRunEvent>>([]);
+  const [stats, setStats] = useState<{
+    toolCallCount: number;
+    totalTokens: number;
+  } | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState<boolean>(false);
+  const signatureRef: React.MutableRefObject<string> = useRef<string>("");
+
+  const fetchData: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      try {
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.post<JSONObject>({
+            url: URL.fromString(
+              APP_API_URL.toString() + "/ai-investigation/incident",
+            ),
+            data: { incidentId: props.incidentId.toString() },
+            headers: ModelAPI.getCommonHeaders(),
+          });
+
+        if (response instanceof HTTPErrorResponse) {
+          setHasLoadedOnce(true);
+          return;
+        }
+
+        const data: JSONObject = response.data as JSONObject;
+        const runJson: JSONObject | null =
+          (data["run"] as JSONObject | null) || null;
+        const eventsJson: JSONArray = (data["events"] as JSONArray) || [];
+
+        const status: string | null =
+          (runJson?.["status"] as string | undefined) || null;
+
+        // Skip re-render when nothing changed (status + event count is enough).
+        const signature: string = `${status || "none"}:${eventsJson.length}`;
+        if (signature !== signatureRef.current) {
+          signatureRef.current = signature;
+          setRunStatus(status);
+          setEvents(
+            AIRunEvent.fromJSONArray(
+              eventsJson as Array<JSONObject>,
+              AIRunEvent,
+            ),
+          );
+          setStats(
+            runJson
+              ? {
+                  toolCallCount:
+                    (runJson["toolCallCount"] as number | undefined) || 0,
+                  totalTokens:
+                    (runJson["totalTokens"] as number | undefined) || 0,
+                }
+              : null,
+          );
+        }
+
+        setHasLoadedOnce(true);
+      } catch {
+        // Best-effort panel — never surface an error here.
+        setHasLoadedOnce(true);
+      }
+    }, [props.incidentId]);
+
+  useEffect(() => {
+    fetchData().catch(() => {
+      // handled inside fetchData
+    });
+  }, [fetchData]);
+
+  const isRunning: boolean = runStatus === AIRunStatus.Running;
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    const interval: ReturnType<typeof setInterval> = setInterval(() => {
+      fetchData().catch(() => {
+        // handled inside fetchData
+      });
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      return clearInterval(interval);
+    };
+  }, [isRunning, fetchData]);
+
+  // Nothing to show until an investigation exists for this incident.
+  if (!hasLoadedOnce || !runStatus) {
+    return <></>;
+  }
+
+  interface StatusMeta {
+    text: string;
+    className: string;
+    icon: IconProp;
+  }
+
+  let statusMeta: StatusMeta = {
+    text: "Investigation did not finish",
+    className: "text-red-600",
+    icon: IconProp.Alert,
+  };
+
+  if (runStatus === AIRunStatus.Running) {
+    statusMeta = {
+      text: "Investigating…",
+      className: "text-indigo-600",
+      icon: IconProp.Sparkles,
+    };
+  } else if (runStatus === AIRunStatus.Completed) {
+    statusMeta = {
+      text: "Investigation complete",
+      className: "text-green-600",
+      icon: IconProp.Check,
+    };
+  }
+
+  return (
+    <Card
+      title="AI Investigation"
+      description="Sentinel's live root-cause investigation for this incident."
+    >
+      <div className="-mt-4">
+        <div
+          className={`flex items-center gap-2 text-sm font-medium ${statusMeta.className}`}
+        >
+          <Icon icon={statusMeta.icon} className="h-4 w-4" />
+          <span>{statusMeta.text}</span>
+          {isRunning ? (
+            <span className="ml-1 inline-block h-2 w-2 animate-ping rounded-full bg-indigo-500" />
+          ) : (
+            <></>
+          )}
+        </div>
+
+        <div className="mt-3">
+          {events.length > 0 ? (
+            <ChatActivityFeed events={events} />
+          ) : (
+            <p className="text-sm text-gray-500">
+              {isRunning
+                ? "Starting investigation…"
+                : "No investigation steps were recorded."}
+            </p>
+          )}
+        </div>
+
+        {!isRunning && stats ? (
+          <p className="mt-3 text-xs text-gray-400">
+            {stats.toolCallCount} quer
+            {stats.toolCallCount === 1 ? "y" : "ies"} across your telemetry
+            {stats.totalTokens > 0
+              ? ` · ${stats.totalTokens.toLocaleString()} tokens`
+              : ""}
+            . The full cited root cause is in the incident timeline below.
+          </p>
+        ) : (
+          <></>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export default IncidentInvestigationPanel;

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -48,6 +48,7 @@ import HeaderAlert, {
 } from "Common/UI/Components/HeaderAlert/HeaderAlert";
 import ColorSwatch from "Common/Types/ColorSwatch";
 import IncidentFeedElement from "../../../Components/Incident/IncidentFeed";
+import IncidentInvestigationPanel from "../../../Components/Incident/IncidentInvestigationPanel";
 import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
 import IncidentAffectedResources from "./AffectedResources";
 import IncidentMemberRoleAssignment from "../../../Components/Incident/IncidentMemberRoleAssignment";
@@ -419,6 +420,8 @@ const IncidentView: FunctionComponent<
           <IncidentAffectedResources incidentId={modelId} />
 
           <EntityRunbooks incidentId={modelId} hideIfEmpty={true} />
+
+          <IncidentInvestigationPanel incidentId={modelId} />
 
           <IncidentFeedElement incidentId={modelId} />
         </div>

--- a/Common/Models/DatabaseModels/AIRun.ts
+++ b/Common/Models/DatabaseModels/AIRun.ts
@@ -293,6 +293,56 @@ export default class AIRun extends BaseModel {
     ],
     update: [],
   })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Triggered By Incident ID",
+    description:
+      "The incident that triggered this run (for autonomous investigations).",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public triggeredByIncidentId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Triggered By Alert ID",
+    description:
+      "The alert that triggered this run (for autonomous investigations).",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public triggeredByAlertId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
   @TableColumn({
     required: false,
     type: TableColumnType.Date,

--- a/Common/Models/DatabaseModels/Project.ts
+++ b/Common/Models/DatabaseModels/Project.ts
@@ -1433,6 +1433,36 @@ export default class Project extends TenantModel {
       Permission.UnAuthorizedSsoUser,
       Permission.ProjectUser,
     ],
+    update: [Permission.ProjectOwner, Permission.ProjectAdmin],
+  })
+  @TableColumn({
+    required: true,
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    title: "Enable Automatic Incident Investigation",
+    description:
+      "When enabled, OneUptime's AI SRE (Sentinel) automatically investigates every new incident and posts a cited root cause analysis to the incident timeline. Requires AI to be enabled and an LLM provider to be configured.",
+    defaultValue: false,
+    example: true,
+  })
+  @Column({
+    nullable: false,
+    default: false,
+    type: ColumnType.Boolean,
+  })
+  public enableAutomaticIncidentInvestigation?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadProject,
+      Permission.UnAuthorizedSsoUser,
+      Permission.ProjectUser,
+    ],
     update: [Permission.ProjectOwner, Permission.ManageProjectBilling],
   })
   @TableColumn({

--- a/Common/Server/API/AIInvestigationAPI.ts
+++ b/Common/Server/API/AIInvestigationAPI.ts
@@ -1,0 +1,148 @@
+import UserMiddleware from "../Middleware/UserAuthorization";
+import CommonAPI from "./CommonAPI";
+import Express, {
+  ExpressRequest,
+  ExpressResponse,
+  ExpressRouter,
+  NextFunction,
+} from "../Utils/Express";
+import Response from "../Utils/Response";
+import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import ObjectID from "../../Types/ObjectID";
+import BadDataException from "../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
+import { JSONArray, JSONObject } from "../../Types/JSON";
+import AIRunType from "../../Types/AI/AIRunType";
+import AIRun from "../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../Models/DatabaseModels/AIRunEvent";
+import Incident from "../../Models/DatabaseModels/Incident";
+import BaseModel from "../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import IncidentService from "../Services/IncidentService";
+import AIRunService from "../Services/AIRunService";
+import AIRunEventService from "../Services/AIRunEventService";
+
+const router: ExpressRouter = Express.getRouter();
+
+const MAX_EVENTS: number = 500;
+
+/*
+ * Returns the latest Sentinel investigation (the AIRun + its ordered
+ * AIRunEvents) for an incident, so the dashboard can render a live "watch it
+ * think" panel.
+ *
+ * Investigation runs are system-authored (userId = null) and are therefore
+ * hidden by the per-user privacy pin on the generic AIRun / AIRunEvent CRUD. So
+ * we gate access explicitly here: first confirm the caller can read the incident
+ * under THEIR permissions, then read the run + events as root.
+ */
+router.post(
+  "/ai-investigation/incident",
+  UserMiddleware.getUserMiddleware,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const props: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      if (!props.userId) {
+        throw new NotAuthorizedException(
+          "A logged-in user session is required.",
+        );
+      }
+
+      const incidentIdString: string | undefined = req.body["incidentId"] as
+        | string
+        | undefined;
+
+      if (!incidentIdString) {
+        throw new BadDataException("incidentId is required.");
+      }
+
+      const incidentId: ObjectID = new ObjectID(incidentIdString);
+
+      // Access check under the USER's permissions (null when not allowed).
+      const incident: Incident | null = await IncidentService.findOneById({
+        id: incidentId,
+        select: { _id: true },
+        props,
+      });
+
+      if (!incident) {
+        throw new BadDataException(
+          "Incident not found (or you do not have access to it).",
+        );
+      }
+
+      // Read the latest investigation run as root (bypasses the per-user pin).
+      const runs: Array<AIRun> = await AIRunService.findBy({
+        query: {
+          triggeredByIncidentId: incidentId,
+          runType: AIRunType.Investigation,
+        },
+        select: {
+          _id: true,
+          status: true,
+          startedAt: true,
+          completedAt: true,
+          errorMessage: true,
+          llmCallCount: true,
+          toolCallCount: true,
+          totalTokens: true,
+          createdAt: true,
+        },
+        sort: { createdAt: SortOrder.Descending },
+        limit: 1,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+      const run: AIRun | undefined = runs[0];
+
+      if (!run) {
+        Response.sendJsonObjectResponse(req, res, {
+          run: null,
+          events: [],
+        });
+        return;
+      }
+
+      const events: Array<AIRunEvent> = await AIRunEventService.findBy({
+        query: { aiRunId: run.id! },
+        select: {
+          _id: true,
+          sequence: true,
+          eventType: true,
+          toolName: true,
+          resultSummary: true,
+          createdAt: true,
+        },
+        sort: { sequence: SortOrder.Ascending },
+        limit: MAX_EVENTS,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+      const runJson: JSONObject | undefined = BaseModel.toJSONArray(
+        [run],
+        AIRun,
+      )[0];
+
+      const eventsJson: JSONArray = BaseModel.toJSONArray(events, AIRunEvent);
+
+      Response.sendJsonObjectResponse(req, res, {
+        run: runJson || null,
+        events: eventsJson,
+      });
+      return;
+    } catch (err) {
+      next(err);
+      return;
+    }
+  },
+);
+
+export default router;

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1783598145111-AddEnableAutomaticIncidentInvestigationToProject.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1783598145111-AddEnableAutomaticIncidentInvestigationToProject.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddEnableAutomaticIncidentInvestigationToProject1783598145111
+  implements MigrationInterface
+{
+  public name = "AddEnableAutomaticIncidentInvestigationToProject1783598145111";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Project" ADD "enableAutomaticIncidentInvestigation" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Project" DROP COLUMN "enableAutomaticIncidentInvestigation"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1783615884106-AddInvestigationSubjectToAIRun.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1783615884106-AddInvestigationSubjectToAIRun.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddInvestigationSubjectToAIRun1783615884106
+  implements MigrationInterface
+{
+  public name = "AddInvestigationSubjectToAIRun1783615884106";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "AIRun" ADD "triggeredByIncidentId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AIRun" ADD "triggeredByAlertId" uuid`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_AIRun_triggeredByIncidentId" ON "AIRun" ("triggeredByIncidentId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_AIRun_triggeredByAlertId" ON "AIRun" ("triggeredByAlertId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_AIRun_triggeredByAlertId"`);
+    await queryRunner.query(`DROP INDEX "IDX_AIRun_triggeredByIncidentId"`);
+    await queryRunner.query(
+      `ALTER TABLE "AIRun" DROP COLUMN "triggeredByAlertId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AIRun" DROP COLUMN "triggeredByIncidentId"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -418,6 +418,7 @@ import { FixNotNullForeignKeysOnDelete1783510935686 } from "./1783510935686-FixN
 import { MigrationName1783515836148 } from "./1783515836148-MigrationName";
 import { AddMigrationFailureTable1783523076215 } from "./1783523076215-AddMigrationFailureTable";
 import { AddEnableAutomaticIncidentInvestigationToProject1783598145111 } from "./1783598145111-AddEnableAutomaticIncidentInvestigationToProject";
+import { AddInvestigationSubjectToAIRun1783615884106 } from "./1783615884106-AddInvestigationSubjectToAIRun";
 
 export default [
   InitialMigration,
@@ -840,4 +841,5 @@ export default [
   MigrationName1783515836148,
   AddMigrationFailureTable1783523076215,
   AddEnableAutomaticIncidentInvestigationToProject1783598145111,
+  AddInvestigationSubjectToAIRun1783615884106,
 ];

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -417,6 +417,7 @@ import { AddIncomingCallPolicyRoutingPhoneNumberUnique1783470000000 } from "./17
 import { FixNotNullForeignKeysOnDelete1783510935686 } from "./1783510935686-FixNotNullForeignKeysOnDelete";
 import { MigrationName1783515836148 } from "./1783515836148-MigrationName";
 import { AddMigrationFailureTable1783523076215 } from "./1783523076215-AddMigrationFailureTable";
+import { AddEnableAutomaticIncidentInvestigationToProject1783598145111 } from "./1783598145111-AddEnableAutomaticIncidentInvestigationToProject";
 
 export default [
   InitialMigration,
@@ -838,4 +839,5 @@ export default [
   FixNotNullForeignKeysOnDelete1783510935686,
   MigrationName1783515836148,
   AddMigrationFailureTable1783523076215,
+  AddEnableAutomaticIncidentInvestigationToProject1783598145111,
 ];

--- a/Common/Server/Services/AlertService.ts
+++ b/Common/Server/Services/AlertService.ts
@@ -67,6 +67,7 @@ import AlertLabelRuleEngineService from "./AlertLabelRuleEngineService";
 import AlertOnCallRuleEngineService from "./AlertOnCallRuleEngineService";
 import AlertOwnerRuleEngineService from "./AlertOwnerRuleEngineService";
 import RunbookRuleEngineService from "./RunbookRuleEngineService";
+import SentinelAlertInvestigationRunner from "../Utils/AI/Sentinel/AlertInvestigationRunner";
 import AlertPrivacyRuleEngineService from "./AlertPrivacyRuleEngineService";
 import ProjectService from "./ProjectService";
 
@@ -551,6 +552,30 @@ export class Service extends DatabaseService<Model> {
         } catch (error) {
           logger.error(
             `Reminder scheduling failed in AlertService.onCreateSuccess: ${error}`,
+            {
+              projectId: createdItem.projectId?.toString(),
+              alertId: createdItem.id?.toString(),
+            } as LogAttributes,
+          );
+        }
+      })
+      .then(async () => {
+        /*
+         * Sentinel (AI SRE): automatically investigate the new alert and post a
+         * cited root cause analysis to the alert timeline + Slack/Teams. Runs
+         * last, is gated per project (opt-in) + requires an LLM provider, and is
+         * read-only.
+         */
+        try {
+          if (createdItem.projectId && createdItem.id) {
+            await SentinelAlertInvestigationRunner.investigateNewAlert({
+              alertId: createdItem.id,
+              projectId: createdItem.projectId,
+            });
+          }
+        } catch (error) {
+          logger.error(
+            `Sentinel alert investigation failed in AlertService.onCreateSuccess: ${error}`,
             {
               projectId: createdItem.projectId?.toString(),
               alertId: createdItem.id?.toString(),

--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -89,6 +89,7 @@ import LLMService, {
 } from "../Utils/LLM/LLMService";
 import LlmProviderService from "./LlmProviderService";
 import LlmProvider from "../../Models/DatabaseModels/LlmProvider";
+import SentinelIncidentInvestigationRunner from "../Utils/AI/Sentinel/IncidentInvestigationRunner";
 import IncidentAIContextBuilder, {
   AIGenerationContext,
   IncidentContextData,
@@ -1237,6 +1238,30 @@ export class Service extends DatabaseService<Model> {
               projectId: createdItem.projectId?.toString(),
               incidentId: createdItem.id?.toString(),
               userId: createdItem.createdByUserId?.toString(),
+            } as LogAttributes,
+          );
+        }
+      })
+      .then(async () => {
+        /*
+         * Sentinel (AI SRE): automatically investigate the new incident and post
+         * a cited root cause analysis to the incident timeline + Slack/Teams.
+         * Runs last so the workspace channels already exist, and is gated per
+         * project (opt-in) + requires a configured LLM provider. Read-only.
+         */
+        try {
+          if (createdItem.projectId && createdItem.id) {
+            await SentinelIncidentInvestigationRunner.investigateNewIncident({
+              incidentId: createdItem.id,
+              projectId: createdItem.projectId,
+            });
+          }
+        } catch (error) {
+          logger.error(
+            `Sentinel incident investigation failed in IncidentService.onCreateSuccess: ${error}`,
+            {
+              projectId: createdItem.projectId?.toString(),
+              incidentId: createdItem.id?.toString(),
             } as LogAttributes,
           );
         }

--- a/Common/Server/Services/IncidentStateTimelineService.ts
+++ b/Common/Server/Services/IncidentStateTimelineService.ts
@@ -27,6 +27,7 @@ import IncidentRole from "../../Models/DatabaseModels/IncidentRole";
 import { IsBillingEnabled } from "../EnvironmentConfig";
 import logger, { LogAttributes } from "../Utils/Logger";
 import IncidentFeedService from "./IncidentFeedService";
+import SentinelIncidentPostmortemRunner from "../Utils/AI/Sentinel/IncidentPostmortemRunner";
 import { IncidentFeedEventType } from "../../Models/DatabaseModels/IncidentFeed";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
@@ -555,6 +556,24 @@ ${createdItem.rootCause}`,
           createdItem.startsAt || undefined,
         );
       }
+
+      /*
+       * Sentinel: auto-draft a postmortem now that the incident is resolved
+       * (gated per project; never overwrites an existing postmortem).
+       */
+      SentinelIncidentPostmortemRunner.draftPostmortemOnResolve({
+        incidentId: createdItem.incidentId!,
+        projectId: createdItem.projectId!,
+      }).catch((error: Error) => {
+        logger.error(`Sentinel auto-postmortem failed on resolve:`, {
+          projectId: createdItem.projectId?.toString(),
+          incidentId: createdItem.incidentId?.toString(),
+        } as LogAttributes);
+        logger.error(error, {
+          projectId: createdItem.projectId?.toString(),
+          incidentId: createdItem.incidentId?.toString(),
+        } as LogAttributes);
+      });
     }
 
     if (onCreate.carryForward.publicNote) {

--- a/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
+++ b/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
@@ -44,6 +44,22 @@ export interface ObservabilityAssistantRequest {
   llmProviderId?: ObjectID | undefined;
   // Label recorded on LlmLog, e.g. "Slack ChatOps".
   feature: string;
+  /*
+   * Extra instructions appended to the base observability system prompt — used
+   * to give an autonomous run (e.g. Sentinel incident investigation) a distinct
+   * persona and task framing while keeping the same hard rules (citations, no
+   * fabrication, read-only). The base prompt's grounding rules always win.
+   */
+  systemInstructions?: string | undefined;
+  /*
+   * Optional budget overrides. Autonomous investigations get more room than an
+   * interactive chat-ops answer, which must return in a single quick message.
+   * Omitted values fall back to the interactive defaults.
+   */
+  maxLlmCalls?: number | undefined;
+  maxToolCalls?: number | undefined;
+  maxWallClockMs?: number | undefined;
+  maxOutputTokens?: number | undefined;
 }
 
 export interface ObservabilityAssistantResult {
@@ -70,19 +86,34 @@ export default class ObservabilityAssistant {
   ): Promise<ObservabilityAssistantResult> {
     const startedAtMs: number = Date.now();
 
+    const maxLlmCalls: number = request.maxLlmCalls ?? MAX_LLM_CALLS;
+    const maxToolCalls: number = request.maxToolCalls ?? MAX_TOOL_CALLS;
+    const maxWallClockMs: number = request.maxWallClockMs ?? MAX_WALL_CLOCK_MS;
+    const maxOutputTokens: number =
+      request.maxOutputTokens ?? MAX_OUTPUT_TOKENS;
+
     const toolContext: ToolContext = {
       projectId: request.projectId,
       props: request.props,
     };
 
+    let systemPromptContent: string = buildObservabilityChatSystemPrompt({
+      currentTime: OneUptimeDate.getCurrentDate(),
+      /*
+       * Slack/Teams and autonomous investigations have no approval UI, so this
+       * surface stays strictly read-only.
+       */
+      permissionMode: AIChatPermissionMode.ReadOnly,
+    });
+
+    if (request.systemInstructions) {
+      systemPromptContent += `\n\n${request.systemInstructions}`;
+    }
+
     const messages: Array<LLMMessage> = [
       {
         role: "system",
-        content: buildObservabilityChatSystemPrompt({
-          currentTime: OneUptimeDate.getCurrentDate(),
-          // Slack/Teams have no approval UI, so this surface stays read-only.
-          permissionMode: AIChatPermissionMode.ReadOnly,
-        }),
+        content: systemPromptContent,
       },
     ];
 
@@ -104,9 +135,9 @@ export default class ObservabilityAssistant {
 
     while (true) {
       const budgetExhausted: boolean =
-        llmCallCount >= MAX_LLM_CALLS - 1 ||
-        toolCallCount >= MAX_TOOL_CALLS ||
-        Date.now() - startedAtMs >= MAX_WALL_CLOCK_MS;
+        llmCallCount >= maxLlmCalls - 1 ||
+        toolCallCount >= maxToolCalls ||
+        Date.now() - startedAtMs >= maxWallClockMs;
 
       if (budgetExhausted) {
         messages.push({
@@ -125,7 +156,7 @@ export default class ObservabilityAssistant {
         tools: budgetExhausted
           ? undefined
           : AIToolbox.getLlmToolDefinitions(AIChatPermissionMode.ReadOnly),
-        maxTokens: MAX_OUTPUT_TOKENS,
+        maxTokens: maxOutputTokens,
         temperature: TEMPERATURE,
         // Chat-ops content is per-user — do not persist previews to LlmLog.
         storeContentPreviews: false,
@@ -152,8 +183,8 @@ export default class ObservabilityAssistant {
 
         for (const toolCall of response.toolCalls) {
           const overBudget: boolean =
-            toolCallCount >= MAX_TOOL_CALLS ||
-            Date.now() - startedAtMs >= MAX_WALL_CLOCK_MS;
+            toolCallCount >= maxToolCalls ||
+            Date.now() - startedAtMs >= maxWallClockMs;
 
           if (overBudget) {
             messages.push({

--- a/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
+++ b/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
@@ -1,6 +1,7 @@
 import DatabaseCommonInteractionProps from "../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import OneUptimeDate from "../../../../Types/Date";
 import ObjectID from "../../../../Types/ObjectID";
+import { JSONObject } from "../../../../Types/JSON";
 import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
 import AIService, { AILogResponse } from "../../../Services/AIService";
 import logger from "../../Logger";
@@ -32,6 +33,29 @@ export interface ObservabilityAssistantPriorTurn {
   content: string;
 }
 
+/*
+ * A single "thinking step" emitted live as the agent loop runs, so callers can
+ * narrate the investigation in real time ("Reading trace ✓ 0.4s"). This is the
+ * step-level narration the OneUptime UI renders by polling AIRunEvent rows.
+ */
+export type ObservabilityAssistantStepType =
+  | "llm_started"
+  | "llm_completed"
+  | "tool_started"
+  | "tool_completed"
+  | "tool_failed";
+
+export interface ObservabilityAssistantStep {
+  type: ObservabilityAssistantStepType;
+  toolName?: string | undefined;
+  toolArguments?: JSONObject | undefined;
+  rowCount?: number | undefined;
+  durationMs?: number | undefined;
+  citationId?: string | undefined;
+  totalTokens?: number | undefined;
+  errorMessage?: string | undefined;
+}
+
 export interface ObservabilityAssistantRequest {
   projectId: ObjectID;
   userId?: ObjectID | undefined;
@@ -60,6 +84,13 @@ export interface ObservabilityAssistantRequest {
   maxToolCalls?: number | undefined;
   maxWallClockMs?: number | undefined;
   maxOutputTokens?: number | undefined;
+  /*
+   * Optional live-narration hook, fired for each LLM/tool step as the loop runs.
+   * Used by autonomous runs to persist a per-step AIRunEvent trail so the UI can
+   * "watch it think". Best-effort — implementations must not throw; a slow or
+   * failing handler should not break the run.
+   */
+  onStep?: ((step: ObservabilityAssistantStep) => Promise<void>) | undefined;
 }
 
 export interface ObservabilityAssistantResult {
@@ -91,6 +122,22 @@ export default class ObservabilityAssistant {
     const maxWallClockMs: number = request.maxWallClockMs ?? MAX_WALL_CLOCK_MS;
     const maxOutputTokens: number =
       request.maxOutputTokens ?? MAX_OUTPUT_TOKENS;
+
+    // Best-effort live-narration emitter — never throws into the loop.
+    const emitStep: (
+      step: ObservabilityAssistantStep,
+    ) => Promise<void> = async (
+      step: ObservabilityAssistantStep,
+    ): Promise<void> => {
+      if (!request.onStep) {
+        return;
+      }
+      try {
+        await request.onStep(step);
+      } catch (err) {
+        logger.error(`ObservabilityAssistant onStep failed: ${err}`);
+      }
+    };
 
     const toolContext: ToolContext = {
       projectId: request.projectId,
@@ -147,6 +194,8 @@ export default class ObservabilityAssistant {
         });
       }
 
+      await emitStep({ type: "llm_started" });
+
       const response: AILogResponse = await AIService.executeWithLogging({
         projectId: request.projectId,
         userId: request.userId,
@@ -164,6 +213,11 @@ export default class ObservabilityAssistant {
 
       llmCallCount++;
       totalTokens += response.llmLog.totalTokens || 0;
+
+      await emitStep({
+        type: "llm_completed",
+        totalTokens: response.llmLog.totalTokens || 0,
+      });
 
       if (!providerName) {
         providerName = response.llmLog.llmProviderName;
@@ -207,6 +261,14 @@ export default class ObservabilityAssistant {
             continue;
           }
 
+          const toolStartedAtMs: number = Date.now();
+
+          await emitStep({
+            type: "tool_started",
+            toolName: toolCall.name,
+            toolArguments: toolCall.arguments,
+          });
+
           const outcome: ToolCallOutcome = await AIToolbox.executeTool({
             name: toolCall.name,
             args: toolCall.arguments,
@@ -214,6 +276,13 @@ export default class ObservabilityAssistant {
           });
 
           if (!outcome.success || !outcome.result) {
+            await emitStep({
+              type: "tool_failed",
+              toolName: toolCall.name,
+              durationMs: Date.now() - toolStartedAtMs,
+              errorMessage: outcome.errorMessage || outcome.textForLlm,
+            });
+
             messages.push({
               role: "tool",
               toolCallId: toolCall.id,
@@ -231,6 +300,14 @@ export default class ObservabilityAssistant {
             queryArguments: toolCall.arguments,
             rowCount: outcome.result.rowCount,
             target: outcome.result.citationTarget,
+          });
+
+          await emitStep({
+            type: "tool_completed",
+            toolName: toolCall.name,
+            durationMs: Date.now() - toolStartedAtMs,
+            rowCount: outcome.result.rowCount,
+            citationId: citationId,
           });
 
           const escapedText: string = escapeToolResultContent(

--- a/Common/Server/Utils/AI/Sentinel/AlertInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/AlertInvestigationRunner.ts
@@ -47,6 +47,7 @@ export default class SentinelAlertInvestigationRunner {
       await SentinelInvestigationEngine.investigate({
         projectId,
         feature: "Sentinel Alert Investigation",
+        subjectAlertId: alertId,
         contextSummary: this.buildAlertSummary(contextData),
         postAnalysis: async (postData: {
           analysisMarkdown: string;

--- a/Common/Server/Utils/AI/Sentinel/AlertInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/AlertInvestigationRunner.ts
@@ -1,0 +1,135 @@
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import { Blue500 } from "../../../../Types/BrandColors";
+import { AlertFeedEventType } from "../../../../Models/DatabaseModels/AlertFeed";
+import AlertFeedService from "../../../Services/AlertFeedService";
+import AlertAIContextBuilder, {
+  AlertContextData,
+} from "../AlertAIContextBuilder";
+import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import { ObservabilityAssistantResult } from "../Chat/ObservabilityAssistant";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — alert investigation.
+ *
+ * Alerts are the earlier, "left of boom" signal. When a new alert is declared,
+ * Sentinel investigates it (read-only) and posts a cited root-cause analysis to
+ * the alert timeline + Slack/Teams. Symmetric to incident investigation and
+ * built on the same shared SentinelInvestigationEngine.
+ *
+ * Gated by the same per-project opt-in as incidents. Alert volume can be higher
+ * than incidents, so severity / rate gating is a deliberate follow-up.
+ */
+export default class SentinelAlertInvestigationRunner {
+  /*
+   * Entry point called (fire-and-forget) from AlertService.onCreateSuccess.
+   * Never throws — all failures are logged and recorded on the AIRun.
+   */
+  @CaptureSpan()
+  public static async investigateNewAlert(data: {
+    alertId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    const { alertId, projectId } = data;
+
+    try {
+      if (!(await SentinelInvestigationEngine.isEnabledForProject(projectId))) {
+        return;
+      }
+
+      const contextData: AlertContextData =
+        await AlertAIContextBuilder.buildAlertContext({
+          alertId,
+        });
+
+      await SentinelInvestigationEngine.investigate({
+        projectId,
+        feature: "Sentinel Alert Investigation",
+        contextSummary: this.buildAlertSummary(contextData),
+        postAnalysis: async (postData: {
+          analysisMarkdown: string;
+          isConfident: boolean;
+          result: ObservabilityAssistantResult;
+        }): Promise<void> => {
+          await AlertFeedService.createAlertFeedItem({
+            alertId,
+            projectId,
+            alertFeedEventType: AlertFeedEventType.RootCause,
+            displayColor: Blue500,
+            feedInfoInMarkdown: postData.analysisMarkdown,
+            /*
+             * Quiet mode: an inconclusive investigation posts to the timeline
+             * but does NOT loudly ping the workspace / on-call.
+             */
+            workspaceNotification: {
+              sendWorkspaceNotification: postData.isConfident,
+            },
+          });
+        },
+      });
+    } catch (error) {
+      logger.error(
+        `Sentinel: unexpected error investigating alert ${alertId.toString()}: ${error}`,
+      );
+    }
+  }
+
+  // Build a compact alert record to seed the investigation.
+  private static buildAlertSummary(contextData: AlertContextData): string {
+    const { alert, internalNotes } = contextData;
+
+    const lines: Array<string> = [];
+    lines.push("# Alert");
+    lines.push(`Title: ${alert.title || "N/A"}`);
+
+    if (alert.description) {
+      lines.push(`Description: ${alert.description}`);
+    }
+
+    lines.push(`Severity: ${alert.alertSeverity?.name || "N/A"}`);
+    lines.push(`Current state: ${alert.currentAlertState?.name || "N/A"}`);
+    lines.push(
+      `Declared at: ${
+        alert.createdAt
+          ? OneUptimeDate.getDateAsFormattedString(alert.createdAt)
+          : "N/A"
+      }`,
+    );
+
+    if (alert.monitor?.name) {
+      lines.push(`Affected monitor: ${alert.monitor.name}`);
+    }
+
+    if (alert.labels && alert.labels.length > 0) {
+      lines.push(
+        `Labels: ${alert.labels
+          .map((l: { name?: string }) => {
+            return l.name;
+          })
+          .filter(Boolean)
+          .join(", ")}`,
+      );
+    }
+
+    if (alert.rootCause) {
+      lines.push(`Root cause (as recorded so far): ${alert.rootCause}`);
+    }
+
+    const recentNotes: Array<string> = (internalNotes || [])
+      .slice(-5)
+      .map((note: { note?: string }) => {
+        return note.note ? `- ${note.note}` : "";
+      })
+      .filter(Boolean);
+
+    if (recentNotes.length > 0) {
+      lines.push("");
+      lines.push("Recent internal notes:");
+      lines.push(...recentNotes);
+    }
+
+    return lines.join("\n");
+  }
+}

--- a/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
@@ -1,72 +1,29 @@
 import ObjectID from "../../../../Types/ObjectID";
 import OneUptimeDate from "../../../../Types/Date";
 import { Blue500 } from "../../../../Types/BrandColors";
-import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
-import AIRunType from "../../../../Types/AI/AIRunType";
-import AIRunStatus from "../../../../Types/AI/AIRunStatus";
-import AIRunEventType from "../../../../Types/AI/AIRunEventType";
-import AIRun from "../../../../Models/DatabaseModels/AIRun";
-import AIRunEvent from "../../../../Models/DatabaseModels/AIRunEvent";
-import Project from "../../../../Models/DatabaseModels/Project";
-import LlmProvider from "../../../../Models/DatabaseModels/LlmProvider";
 import { IncidentFeedEventType } from "../../../../Models/DatabaseModels/IncidentFeed";
-import AIRunService from "../../../Services/AIRunService";
-import AIRunEventService from "../../../Services/AIRunEventService";
-import ProjectService from "../../../Services/ProjectService";
-import LlmProviderService from "../../../Services/LlmProviderService";
 import IncidentFeedService from "../../../Services/IncidentFeedService";
 import IncidentAIContextBuilder, {
   IncidentContextData,
 } from "../IncidentAIContextBuilder";
-import ObservabilityAssistant, {
-  ObservabilityAssistantResult,
-} from "../Chat/ObservabilityAssistant";
+import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import { ObservabilityAssistantResult } from "../Chat/ObservabilityAssistant";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 
 /*
- * Sentinel — Phase 1 "Investigation Engine".
+ * Sentinel — incident investigation.
  *
- * When a new incident is declared, Sentinel (OneUptime's autonomous AI SRE)
- * wakes automatically, investigates the incident against the telemetry OneUptime
- * already owns (logs, metrics, traces, exceptions, recent changes) using the
- * existing read-only, tool-grounded, citation-minting agent loop
- * (ObservabilityAssistant), and posts a cited root-cause analysis into the
- * incident timeline + Slack/Teams — before the on-call engineer has finished
- * reading the page.
+ * When a new incident is declared, wakes Sentinel to investigate it (read-only)
+ * and post a cited root-cause analysis into the incident timeline + Slack/Teams
+ * — before the on-call engineer has finished reading the page. The heavy lifting
+ * (run lifecycle, the agent loop, confidence gating) lives in the shared
+ * SentinelInvestigationEngine; this file only assembles incident context and
+ * posts the result to the incident's feed.
  *
- * The run is recorded as an AIRun(Investigation) with AIRunEvents so it shows up
- * in the same audit/glass-box trail as chat runs. The investigation is strictly
- * READ-ONLY: it can never mutate anything.
- *
- * This is deliberately built on the fire-and-forget async pattern already used
- * throughout IncidentService.onCreateSuccess. The durable, restart-safe claimable
- * AIRun queue is a later phase (see Internal/Roadmap/AISentinelReliabilityBrain.md).
+ * Built on the fire-and-forget async pattern already used throughout
+ * IncidentService.onCreateSuccess. See Internal/Roadmap/AISentinelReliabilityBrain.md.
  */
-
-// Budgets — larger than an interactive chat-ops answer, small enough to stay cheap.
-const MAX_LLM_CALLS: number = 8;
-const MAX_TOOL_CALLS: number = 12;
-const MAX_WALL_CLOCK_MS: number = 150 * 1000;
-const MAX_OUTPUT_TOKENS: number = 2000;
-
-const FEATURE_LABEL: string = "Sentinel Incident Investigation";
-
-const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW incident was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
-
-Investigate like a senior on-call engineer:
-- Start from the affected monitors/services named in the incident.
-- Use your read tools to inspect the telemetry AROUND the incident's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
-- Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
-
-Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
-**Summary** — one or two sentences a paged engineer can read in five seconds.
-**Most likely root cause** — your hypothesis, with only the confidence the evidence actually supports, each factual claim carrying its [C#] citation. If you could not determine it, write "Inconclusive — insufficient signal" and explain what is missing.
-**Evidence** — the key findings that support or rule out the hypothesis, each cited.
-**Suggested next steps** — concrete actions for the on-call engineer.
-
-Keep it tight and skimmable. You are read-only: never claim to have changed anything.`;
-
 export default class SentinelIncidentInvestigationRunner {
   /*
    * Entry point called (fire-and-forget) from IncidentService.onCreateSuccess.
@@ -80,179 +37,44 @@ export default class SentinelIncidentInvestigationRunner {
     const { incidentId, projectId } = data;
 
     try {
-      /*
-       * Gate 1 — project opt-in. AI must be enabled AND the auto-investigation
-       * toggle must be explicitly on (it is off by default).
-       */
-      const project: Project | null = await ProjectService.findOneById({
-        id: projectId,
-        select: {
-          enableAi: true,
-          enableAutomaticIncidentInvestigation: true,
-        },
-        props: { isRoot: true },
-      });
-
-      if (!project) {
+      if (!(await SentinelInvestigationEngine.isEnabledForProject(projectId))) {
         return;
       }
 
-      if (project.enableAi === false) {
-        return;
-      }
-
-      if (project.enableAutomaticIncidentInvestigation !== true) {
-        // Feature not enabled for this project — nothing to do.
-        return;
-      }
-
-      // Gate 2 — an LLM provider must be configured for the project (or globally).
-      const llmProvider: LlmProvider | null =
-        await LlmProviderService.getLLMProviderForProject(projectId);
-
-      if (!llmProvider) {
-        logger.debug(
-          `Sentinel: skipping investigation for incident ${incidentId.toString()} — no LLM provider configured.`,
-        );
-        return;
-      }
-
-      await this.runInvestigation({ incidentId, projectId });
-    } catch (error) {
-      logger.error(
-        `Sentinel: unexpected error investigating incident ${incidentId.toString()}: ${error}`,
-      );
-    }
-  }
-
-  private static async runInvestigation(data: {
-    incidentId: ObjectID;
-    projectId: ObjectID;
-  }): Promise<void> {
-    const { incidentId, projectId } = data;
-
-    // Create the AIRun record up front so the run is auditable even if it fails.
-    const run: AIRun = new AIRun();
-    run.projectId = projectId;
-    run.runType = AIRunType.Investigation;
-    run.status = AIRunStatus.Running;
-    run.startedAt = OneUptimeDate.getCurrentDate();
-    run.lastHeartbeatAt = OneUptimeDate.getCurrentDate();
-
-    const createdRun: AIRun = await AIRunService.create({
-      data: run,
-      props: { isRoot: true },
-    });
-
-    const aiRunId: ObjectID = createdRun.id!;
-    let sequence: number = 0;
-
-    await this.emitEvent({
-      projectId,
-      aiRunId,
-      sequence: sequence++,
-      eventType: AIRunEventType.RunStarted,
-    });
-
-    try {
-      // Assemble the incident context (reuses the existing context builder).
       const contextData: IncidentContextData =
         await IncidentAIContextBuilder.buildIncidentContext({
           incidentId,
           includeWorkspaceMessages: false,
         });
 
-      const incidentSummary: string = this.buildIncidentSummary(contextData);
-
-      // Run the shared read-only, tool-grounded, cited agent loop as Sentinel.
-      const result: ObservabilityAssistantResult =
-        await ObservabilityAssistant.answerQuestion({
-          projectId,
-          // System run — full read access to the project's telemetry.
-          props: { isRoot: true },
-          feature: FEATURE_LABEL,
-          systemInstructions: INVESTIGATION_PERSONA,
-          question: `A new incident has just been declared and you have been woken to investigate it. Investigate now and produce your root cause analysis.\n\n${incidentSummary}`,
-          maxLlmCalls: MAX_LLM_CALLS,
-          maxToolCalls: MAX_TOOL_CALLS,
-          maxWallClockMs: MAX_WALL_CLOCK_MS,
-          maxOutputTokens: MAX_OUTPUT_TOKENS,
-        });
-
-      // Mark the run completed (status-guarded to avoid clobbering a terminal state).
-      await AIRunService.updateOneBy({
-        query: {
-          _id: aiRunId.toString(),
-          status: AIRunStatus.Running,
-        },
-        data: {
-          status: AIRunStatus.Completed,
-          completedAt: OneUptimeDate.getCurrentDate(),
-          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
-          llmCallCount: result.llmCallCount,
-          toolCallCount: result.toolCallCount,
-          totalTokens: result.totalTokens,
-        } as never,
-        props: { isRoot: true },
-      });
-
-      await this.emitEvent({
+      await SentinelInvestigationEngine.investigate({
         projectId,
-        aiRunId,
-        sequence: sequence++,
-        eventType: AIRunEventType.RunCompleted,
-      });
-
-      const analysisMarkdown: string = (result.contentInMarkdown || "").trim();
-
-      if (!analysisMarkdown) {
-        logger.debug(
-          `Sentinel: investigation for incident ${incidentId.toString()} produced no analysis; nothing posted.`,
-        );
-        return;
-      }
-
-      // Post the cited RCA to the incident timeline + Slack/Teams.
-      await IncidentFeedService.createIncidentFeedItem({
-        incidentId,
-        projectId,
-        incidentFeedEventType: IncidentFeedEventType.RootCause,
-        displayColor: Blue500,
-        feedInfoInMarkdown: this.buildFeedMarkdown(result, analysisMarkdown),
-        workspaceNotification: {
-          sendWorkspaceNotification: true,
+        feature: "Sentinel Incident Investigation",
+        contextSummary: this.buildIncidentSummary(contextData),
+        postAnalysis: async (postData: {
+          analysisMarkdown: string;
+          isConfident: boolean;
+          result: ObservabilityAssistantResult;
+        }): Promise<void> => {
+          await IncidentFeedService.createIncidentFeedItem({
+            incidentId,
+            projectId,
+            incidentFeedEventType: IncidentFeedEventType.RootCause,
+            displayColor: Blue500,
+            feedInfoInMarkdown: postData.analysisMarkdown,
+            /*
+             * Quiet mode: an inconclusive investigation posts to the timeline
+             * but does NOT loudly ping the workspace / on-call.
+             */
+            workspaceNotification: {
+              sendWorkspaceNotification: postData.isConfident,
+            },
+          });
         },
       });
-
-      logger.debug(
-        `Sentinel: posted root cause analysis for incident ${incidentId.toString()} (${result.llmCallCount} LLM calls, ${result.toolCallCount} tools, ${result.totalTokens} tokens).`,
-      );
     } catch (error) {
-      const message: string =
-        error instanceof Error ? error.message : String(error);
-
-      await AIRunService.updateOneBy({
-        query: {
-          _id: aiRunId.toString(),
-          status: AIRunStatus.Running,
-        },
-        data: {
-          status: AIRunStatus.Error,
-          completedAt: OneUptimeDate.getCurrentDate(),
-          errorMessage: message.substring(0, 480),
-        } as never,
-        props: { isRoot: true },
-      });
-
-      await this.emitEvent({
-        projectId,
-        aiRunId,
-        sequence: sequence++,
-        eventType: AIRunEventType.RunFailed,
-      });
-
       logger.error(
-        `Sentinel: investigation failed for incident ${incidentId.toString()}: ${message}`,
+        `Sentinel: unexpected error investigating incident ${incidentId.toString()}: ${error}`,
       );
     }
   }
@@ -309,7 +131,6 @@ export default class SentinelIncidentInvestigationRunner {
       lines.push(`Root cause (as recorded so far): ${incident.rootCause}`);
     }
 
-    // Include a few of the most recent internal notes for context.
     const recentNotes: Array<string> = (internalNotes || [])
       .slice(-5)
       .map((note: { note?: string }) => {
@@ -324,53 +145,5 @@ export default class SentinelIncidentInvestigationRunner {
     }
 
     return lines.join("\n");
-  }
-
-  // Wrap the agent's analysis with Sentinel branding + an evidence list.
-  private static buildFeedMarkdown(
-    result: ObservabilityAssistantResult,
-    analysisMarkdown: string,
-  ): string {
-    let markdown: string = `## 🧠 Sentinel — Automated Root Cause Analysis\n\n${analysisMarkdown}`;
-
-    const citations: Array<AIChatCitation> = result.citations || [];
-
-    if (citations.length > 0) {
-      markdown += `\n\n**Evidence checked**`;
-      for (const citation of citations.slice(0, 15)) {
-        markdown += `\n- **[${citation.id}]** ${citation.label} — ${citation.rowCount} row(s)`;
-      }
-    }
-
-    markdown += `\n\n---\n*Investigated automatically by OneUptime Sentinel — read-only, ${result.toolCallCount} quer${
-      result.toolCallCount === 1 ? "y" : "ies"
-    } run across your own telemetry${
-      result.modelName ? ` using ${result.modelName}` : ""
-    }. This is an AI-generated first pass; verify before acting.*`;
-
-    return markdown;
-  }
-
-  private static async emitEvent(data: {
-    projectId: ObjectID;
-    aiRunId: ObjectID;
-    sequence: number;
-    eventType: AIRunEventType;
-  }): Promise<void> {
-    try {
-      const event: AIRunEvent = new AIRunEvent();
-      event.projectId = data.projectId;
-      event.aiRunId = data.aiRunId;
-      event.sequence = data.sequence;
-      event.eventType = data.eventType;
-
-      await AIRunEventService.create({
-        data: event,
-        props: { isRoot: true },
-      });
-    } catch (error) {
-      // Events are best-effort telemetry — never fail the run because of them.
-      logger.error(`Sentinel: failed to emit AIRunEvent: ${error}`);
-    }
   }
 }

--- a/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
@@ -7,6 +7,7 @@ import IncidentAIContextBuilder, {
   IncidentContextData,
 } from "../IncidentAIContextBuilder";
 import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import SentinelMemory from "./SentinelMemory";
 import { ObservabilityAssistantResult } from "../Chat/ObservabilityAssistant";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
@@ -47,10 +48,32 @@ export default class SentinelIncidentInvestigationRunner {
           includeWorkspaceMessages: false,
         });
 
+      /*
+       * Recurrence memory: pull in past resolved incidents that share this
+       * incident's monitors/labels so Sentinel can recognise "I've seen this
+       * before" and reference the prior fix.
+       */
+      const priorCasesContext: string =
+        await SentinelMemory.getPriorSimilarIncidentsContext({
+          projectId,
+          currentIncidentId: incidentId,
+          monitorNames: (contextData.incident.monitors || [])
+            .map((m: { name?: string }) => {
+              return m.name || "";
+            })
+            .filter(Boolean),
+          labelNames: (contextData.incident.labels || [])
+            .map((l: { name?: string }) => {
+              return l.name || "";
+            })
+            .filter(Boolean),
+        });
+
       await SentinelInvestigationEngine.investigate({
         projectId,
         feature: "Sentinel Incident Investigation",
-        contextSummary: this.buildIncidentSummary(contextData),
+        contextSummary:
+          this.buildIncidentSummary(contextData) + priorCasesContext,
         postAnalysis: async (postData: {
           analysisMarkdown: string;
           isConfident: boolean;

--- a/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
@@ -1,0 +1,376 @@
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import { Blue500 } from "../../../../Types/BrandColors";
+import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
+import AIRunType from "../../../../Types/AI/AIRunType";
+import AIRunStatus from "../../../../Types/AI/AIRunStatus";
+import AIRunEventType from "../../../../Types/AI/AIRunEventType";
+import AIRun from "../../../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../../../Models/DatabaseModels/AIRunEvent";
+import Project from "../../../../Models/DatabaseModels/Project";
+import LlmProvider from "../../../../Models/DatabaseModels/LlmProvider";
+import { IncidentFeedEventType } from "../../../../Models/DatabaseModels/IncidentFeed";
+import AIRunService from "../../../Services/AIRunService";
+import AIRunEventService from "../../../Services/AIRunEventService";
+import ProjectService from "../../../Services/ProjectService";
+import LlmProviderService from "../../../Services/LlmProviderService";
+import IncidentFeedService from "../../../Services/IncidentFeedService";
+import IncidentAIContextBuilder, {
+  IncidentContextData,
+} from "../IncidentAIContextBuilder";
+import ObservabilityAssistant, {
+  ObservabilityAssistantResult,
+} from "../Chat/ObservabilityAssistant";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — Phase 1 "Investigation Engine".
+ *
+ * When a new incident is declared, Sentinel (OneUptime's autonomous AI SRE)
+ * wakes automatically, investigates the incident against the telemetry OneUptime
+ * already owns (logs, metrics, traces, exceptions, recent changes) using the
+ * existing read-only, tool-grounded, citation-minting agent loop
+ * (ObservabilityAssistant), and posts a cited root-cause analysis into the
+ * incident timeline + Slack/Teams — before the on-call engineer has finished
+ * reading the page.
+ *
+ * The run is recorded as an AIRun(Investigation) with AIRunEvents so it shows up
+ * in the same audit/glass-box trail as chat runs. The investigation is strictly
+ * READ-ONLY: it can never mutate anything.
+ *
+ * This is deliberately built on the fire-and-forget async pattern already used
+ * throughout IncidentService.onCreateSuccess. The durable, restart-safe claimable
+ * AIRun queue is a later phase (see Internal/Roadmap/AISentinelReliabilityBrain.md).
+ */
+
+// Budgets — larger than an interactive chat-ops answer, small enough to stay cheap.
+const MAX_LLM_CALLS: number = 8;
+const MAX_TOOL_CALLS: number = 12;
+const MAX_WALL_CLOCK_MS: number = 150 * 1000;
+const MAX_OUTPUT_TOKENS: number = 2000;
+
+const FEATURE_LABEL: string = "Sentinel Incident Investigation";
+
+const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW incident was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
+
+Investigate like a senior on-call engineer:
+- Start from the affected monitors/services named in the incident.
+- Use your read tools to inspect the telemetry AROUND the incident's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
+- Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
+
+Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
+**Summary** — one or two sentences a paged engineer can read in five seconds.
+**Most likely root cause** — your hypothesis, with only the confidence the evidence actually supports, each factual claim carrying its [C#] citation. If you could not determine it, write "Inconclusive — insufficient signal" and explain what is missing.
+**Evidence** — the key findings that support or rule out the hypothesis, each cited.
+**Suggested next steps** — concrete actions for the on-call engineer.
+
+Keep it tight and skimmable. You are read-only: never claim to have changed anything.`;
+
+export default class SentinelIncidentInvestigationRunner {
+  /*
+   * Entry point called (fire-and-forget) from IncidentService.onCreateSuccess.
+   * Never throws — all failures are logged and recorded on the AIRun.
+   */
+  @CaptureSpan()
+  public static async investigateNewIncident(data: {
+    incidentId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    const { incidentId, projectId } = data;
+
+    try {
+      /*
+       * Gate 1 — project opt-in. AI must be enabled AND the auto-investigation
+       * toggle must be explicitly on (it is off by default).
+       */
+      const project: Project | null = await ProjectService.findOneById({
+        id: projectId,
+        select: {
+          enableAi: true,
+          enableAutomaticIncidentInvestigation: true,
+        },
+        props: { isRoot: true },
+      });
+
+      if (!project) {
+        return;
+      }
+
+      if (project.enableAi === false) {
+        return;
+      }
+
+      if (project.enableAutomaticIncidentInvestigation !== true) {
+        // Feature not enabled for this project — nothing to do.
+        return;
+      }
+
+      // Gate 2 — an LLM provider must be configured for the project (or globally).
+      const llmProvider: LlmProvider | null =
+        await LlmProviderService.getLLMProviderForProject(projectId);
+
+      if (!llmProvider) {
+        logger.debug(
+          `Sentinel: skipping investigation for incident ${incidentId.toString()} — no LLM provider configured.`,
+        );
+        return;
+      }
+
+      await this.runInvestigation({ incidentId, projectId });
+    } catch (error) {
+      logger.error(
+        `Sentinel: unexpected error investigating incident ${incidentId.toString()}: ${error}`,
+      );
+    }
+  }
+
+  private static async runInvestigation(data: {
+    incidentId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    const { incidentId, projectId } = data;
+
+    // Create the AIRun record up front so the run is auditable even if it fails.
+    const run: AIRun = new AIRun();
+    run.projectId = projectId;
+    run.runType = AIRunType.Investigation;
+    run.status = AIRunStatus.Running;
+    run.startedAt = OneUptimeDate.getCurrentDate();
+    run.lastHeartbeatAt = OneUptimeDate.getCurrentDate();
+
+    const createdRun: AIRun = await AIRunService.create({
+      data: run,
+      props: { isRoot: true },
+    });
+
+    const aiRunId: ObjectID = createdRun.id!;
+    let sequence: number = 0;
+
+    await this.emitEvent({
+      projectId,
+      aiRunId,
+      sequence: sequence++,
+      eventType: AIRunEventType.RunStarted,
+    });
+
+    try {
+      // Assemble the incident context (reuses the existing context builder).
+      const contextData: IncidentContextData =
+        await IncidentAIContextBuilder.buildIncidentContext({
+          incidentId,
+          includeWorkspaceMessages: false,
+        });
+
+      const incidentSummary: string = this.buildIncidentSummary(contextData);
+
+      // Run the shared read-only, tool-grounded, cited agent loop as Sentinel.
+      const result: ObservabilityAssistantResult =
+        await ObservabilityAssistant.answerQuestion({
+          projectId,
+          // System run — full read access to the project's telemetry.
+          props: { isRoot: true },
+          feature: FEATURE_LABEL,
+          systemInstructions: INVESTIGATION_PERSONA,
+          question: `A new incident has just been declared and you have been woken to investigate it. Investigate now and produce your root cause analysis.\n\n${incidentSummary}`,
+          maxLlmCalls: MAX_LLM_CALLS,
+          maxToolCalls: MAX_TOOL_CALLS,
+          maxWallClockMs: MAX_WALL_CLOCK_MS,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+        });
+
+      // Mark the run completed (status-guarded to avoid clobbering a terminal state).
+      await AIRunService.updateOneBy({
+        query: {
+          _id: aiRunId.toString(),
+          status: AIRunStatus.Running,
+        },
+        data: {
+          status: AIRunStatus.Completed,
+          completedAt: OneUptimeDate.getCurrentDate(),
+          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
+          llmCallCount: result.llmCallCount,
+          toolCallCount: result.toolCallCount,
+          totalTokens: result.totalTokens,
+        } as never,
+        props: { isRoot: true },
+      });
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunCompleted,
+      });
+
+      const analysisMarkdown: string = (result.contentInMarkdown || "").trim();
+
+      if (!analysisMarkdown) {
+        logger.debug(
+          `Sentinel: investigation for incident ${incidentId.toString()} produced no analysis; nothing posted.`,
+        );
+        return;
+      }
+
+      // Post the cited RCA to the incident timeline + Slack/Teams.
+      await IncidentFeedService.createIncidentFeedItem({
+        incidentId,
+        projectId,
+        incidentFeedEventType: IncidentFeedEventType.RootCause,
+        displayColor: Blue500,
+        feedInfoInMarkdown: this.buildFeedMarkdown(result, analysisMarkdown),
+        workspaceNotification: {
+          sendWorkspaceNotification: true,
+        },
+      });
+
+      logger.debug(
+        `Sentinel: posted root cause analysis for incident ${incidentId.toString()} (${result.llmCallCount} LLM calls, ${result.toolCallCount} tools, ${result.totalTokens} tokens).`,
+      );
+    } catch (error) {
+      const message: string =
+        error instanceof Error ? error.message : String(error);
+
+      await AIRunService.updateOneBy({
+        query: {
+          _id: aiRunId.toString(),
+          status: AIRunStatus.Running,
+        },
+        data: {
+          status: AIRunStatus.Error,
+          completedAt: OneUptimeDate.getCurrentDate(),
+          errorMessage: message.substring(0, 480),
+        } as never,
+        props: { isRoot: true },
+      });
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunFailed,
+      });
+
+      logger.error(
+        `Sentinel: investigation failed for incident ${incidentId.toString()}: ${message}`,
+      );
+    }
+  }
+
+  // Build a compact incident record to seed the investigation.
+  private static buildIncidentSummary(
+    contextData: IncidentContextData,
+  ): string {
+    const { incident, internalNotes } = contextData;
+
+    const lines: Array<string> = [];
+    lines.push("# Incident");
+    lines.push(`Title: ${incident.title || "N/A"}`);
+
+    if (incident.description) {
+      lines.push(`Description: ${incident.description}`);
+    }
+
+    lines.push(`Severity: ${incident.incidentSeverity?.name || "N/A"}`);
+    lines.push(
+      `Current state: ${incident.currentIncidentState?.name || "N/A"}`,
+    );
+    lines.push(
+      `Declared at: ${
+        incident.createdAt
+          ? OneUptimeDate.getDateAsFormattedString(incident.createdAt)
+          : "N/A"
+      }`,
+    );
+
+    if (incident.monitors && incident.monitors.length > 0) {
+      lines.push(
+        `Affected monitors: ${incident.monitors
+          .map((m: { name?: string }) => {
+            return m.name;
+          })
+          .filter(Boolean)
+          .join(", ")}`,
+      );
+    }
+
+    if (incident.labels && incident.labels.length > 0) {
+      lines.push(
+        `Labels: ${incident.labels
+          .map((l: { name?: string }) => {
+            return l.name;
+          })
+          .filter(Boolean)
+          .join(", ")}`,
+      );
+    }
+
+    if (incident.rootCause) {
+      lines.push(`Root cause (as recorded so far): ${incident.rootCause}`);
+    }
+
+    // Include a few of the most recent internal notes for context.
+    const recentNotes: Array<string> = (internalNotes || [])
+      .slice(-5)
+      .map((note: { note?: string }) => {
+        return note.note ? `- ${note.note}` : "";
+      })
+      .filter(Boolean);
+
+    if (recentNotes.length > 0) {
+      lines.push("");
+      lines.push("Recent internal notes:");
+      lines.push(...recentNotes);
+    }
+
+    return lines.join("\n");
+  }
+
+  // Wrap the agent's analysis with Sentinel branding + an evidence list.
+  private static buildFeedMarkdown(
+    result: ObservabilityAssistantResult,
+    analysisMarkdown: string,
+  ): string {
+    let markdown: string = `## 🧠 Sentinel — Automated Root Cause Analysis\n\n${analysisMarkdown}`;
+
+    const citations: Array<AIChatCitation> = result.citations || [];
+
+    if (citations.length > 0) {
+      markdown += `\n\n**Evidence checked**`;
+      for (const citation of citations.slice(0, 15)) {
+        markdown += `\n- **[${citation.id}]** ${citation.label} — ${citation.rowCount} row(s)`;
+      }
+    }
+
+    markdown += `\n\n---\n*Investigated automatically by OneUptime Sentinel — read-only, ${result.toolCallCount} quer${
+      result.toolCallCount === 1 ? "y" : "ies"
+    } run across your own telemetry${
+      result.modelName ? ` using ${result.modelName}` : ""
+    }. This is an AI-generated first pass; verify before acting.*`;
+
+    return markdown;
+  }
+
+  private static async emitEvent(data: {
+    projectId: ObjectID;
+    aiRunId: ObjectID;
+    sequence: number;
+    eventType: AIRunEventType;
+  }): Promise<void> {
+    try {
+      const event: AIRunEvent = new AIRunEvent();
+      event.projectId = data.projectId;
+      event.aiRunId = data.aiRunId;
+      event.sequence = data.sequence;
+      event.eventType = data.eventType;
+
+      await AIRunEventService.create({
+        data: event,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      // Events are best-effort telemetry — never fail the run because of them.
+      logger.error(`Sentinel: failed to emit AIRunEvent: ${error}`);
+    }
+  }
+}

--- a/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentInvestigationRunner.ts
@@ -72,6 +72,7 @@ export default class SentinelIncidentInvestigationRunner {
       await SentinelInvestigationEngine.investigate({
         projectId,
         feature: "Sentinel Incident Investigation",
+        subjectIncidentId: incidentId,
         contextSummary:
           this.buildIncidentSummary(contextData) + priorCasesContext,
         postAnalysis: async (postData: {

--- a/Common/Server/Utils/AI/Sentinel/IncidentPostmortemRunner.ts
+++ b/Common/Server/Utils/AI/Sentinel/IncidentPostmortemRunner.ts
@@ -1,0 +1,100 @@
+import ObjectID from "../../../../Types/ObjectID";
+import { Blue500 } from "../../../../Types/BrandColors";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import { IncidentFeedEventType } from "../../../../Models/DatabaseModels/IncidentFeed";
+import IncidentService from "../../../Services/IncidentService";
+import IncidentFeedService from "../../../Services/IncidentFeedService";
+import SentinelInvestigationEngine from "./SentinelInvestigationEngine";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — auto-draft postmortem on resolve (Phase 3, "close the loop").
+ *
+ * When an incident moves to a resolved state, Sentinel drafts a postmortem from
+ * the incident timeline + telemetry (reusing the existing
+ * IncidentService.generatePostmortemFromAI) and saves it to the incident for a
+ * human to review and edit — turning a ~90-minute manual writeup into a review.
+ *
+ * It NEVER overwrites a postmortem that already exists (human work wins), is
+ * gated by the same per-project opt-in + LLM provider as investigations, and is
+ * fire-and-forget: failures are logged, never surfaced to the resolve flow.
+ */
+const MAX_FEED_PREVIEW_CHARS: number = 6000;
+
+export default class SentinelIncidentPostmortemRunner {
+  @CaptureSpan()
+  public static async draftPostmortemOnResolve(data: {
+    incidentId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<void> {
+    const { incidentId, projectId } = data;
+
+    try {
+      if (!(await SentinelInvestigationEngine.isEnabledForProject(projectId))) {
+        return;
+      }
+
+      const incident: Incident | null = await IncidentService.findOneById({
+        id: incidentId,
+        select: {
+          _id: true,
+          incidentNumber: true,
+          postmortemNote: true,
+        },
+        props: { isRoot: true },
+      });
+
+      if (!incident) {
+        return;
+      }
+
+      // Never clobber an existing postmortem (human or previously drafted).
+      if (
+        incident.postmortemNote &&
+        incident.postmortemNote.trim().length > 0
+      ) {
+        return;
+      }
+
+      const draft: string = await IncidentService.generatePostmortemFromAI({
+        incidentId,
+      });
+
+      if (!draft || !draft.trim()) {
+        return;
+      }
+
+      await IncidentService.updateOneById({
+        id: incidentId,
+        data: {
+          postmortemNote: draft,
+        },
+        props: { isRoot: true },
+      });
+
+      await IncidentFeedService.createIncidentFeedItem({
+        incidentId,
+        projectId,
+        incidentFeedEventType: IncidentFeedEventType.PostmortemNote,
+        displayColor: Blue500,
+        feedInfoInMarkdown: `## 🧠 Sentinel — Draft Postmortem\n\nSentinel drafted a postmortem for incident #${incident.incidentNumber} from the incident timeline and telemetry. It has been saved on the incident for you to review and edit.`,
+        moreInformationInMarkdown:
+          draft.length > MAX_FEED_PREVIEW_CHARS
+            ? `${draft.substring(0, MAX_FEED_PREVIEW_CHARS)}\n\n…(truncated — the full draft is saved on the incident.)`
+            : draft,
+        workspaceNotification: {
+          sendWorkspaceNotification: true,
+        },
+      });
+
+      logger.debug(
+        `Sentinel: drafted postmortem for incident ${incidentId.toString()}.`,
+      );
+    } catch (error) {
+      logger.error(
+        `Sentinel: failed to draft postmortem for incident ${incidentId.toString()}: ${error}`,
+      );
+    }
+  }
+}

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -1,0 +1,295 @@
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
+import AIRunType from "../../../../Types/AI/AIRunType";
+import AIRunStatus from "../../../../Types/AI/AIRunStatus";
+import AIRunEventType from "../../../../Types/AI/AIRunEventType";
+import AIRun from "../../../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../../../Models/DatabaseModels/AIRunEvent";
+import Project from "../../../../Models/DatabaseModels/Project";
+import LlmProvider from "../../../../Models/DatabaseModels/LlmProvider";
+import AIRunService from "../../../Services/AIRunService";
+import AIRunEventService from "../../../Services/AIRunEventService";
+import ProjectService from "../../../Services/ProjectService";
+import LlmProviderService from "../../../Services/LlmProviderService";
+import ObservabilityAssistant, {
+  ObservabilityAssistantResult,
+} from "../Chat/ObservabilityAssistant";
+import logger from "../../Logger";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+/*
+ * Sentinel — the shared autonomous-investigation engine.
+ *
+ * A single subject-agnostic core that powers "wake on signal" investigations
+ * for both incidents and alerts (and, later, anomalies). It:
+ *   1. records the run as an AIRun(Investigation) + AIRunEvents (audit trail),
+ *   2. runs the existing read-only, tool-grounded, citation-minting agent loop
+ *      (ObservabilityAssistant) with the Sentinel persona and a larger budget,
+ *   3. brands the cited analysis, judges confidence, and
+ *   4. hands the finished analysis back to the caller to post to the subject's
+ *      timeline.
+ *
+ * The investigation is strictly READ-ONLY: it can never mutate anything.
+ * Enablement + provider gating is shared via isEnabledForProject().
+ */
+
+// Budgets — larger than an interactive chat-ops answer, small enough to stay cheap.
+const MAX_LLM_CALLS: number = 8;
+const MAX_TOOL_CALLS: number = 12;
+const MAX_WALL_CLOCK_MS: number = 150 * 1000;
+const MAX_OUTPUT_TOKENS: number = 2000;
+
+/*
+ * Sentinel's own contract: it writes exactly this phrase when it cannot
+ * determine a cause. We match it deterministically to drive "quiet mode" —
+ * a non-answer should never loudly page the on-call.
+ */
+const INCONCLUSIVE_RE: RegExp = /inconclusive[^.\n]*insufficient signal/i;
+
+const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW signal (an incident or alert) was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
+
+Investigate like a senior on-call engineer:
+- Start from the affected monitors/services named in the signal.
+- Use your read tools to inspect the telemetry AROUND the signal's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
+- Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
+
+Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
+**Summary** — one or two sentences a paged engineer can read in five seconds.
+**Most likely root cause** — your hypothesis, with only the confidence the evidence actually supports, each factual claim carrying its [C#] citation. If you could not determine it, write "Inconclusive — insufficient signal" and explain what is missing.
+**Evidence** — the key findings that support or rule out the hypothesis, each cited.
+**Suggested next steps** — concrete actions for the on-call engineer.
+
+Keep it tight and skimmable. You are read-only: never claim to have changed anything.`;
+
+export interface InvestigationRequest {
+  projectId: ObjectID;
+  // Label recorded on LlmLog, e.g. "Sentinel Incident Investigation".
+  feature: string;
+  // A compact markdown summary of the subject that seeds the investigation.
+  contextSummary: string;
+  /*
+   * Called with the finished, branded, cited analysis so the caller can post it
+   * to the subject's timeline. `isConfident` is false when Sentinel reported it
+   * could not determine the cause — callers use it to post QUIETLY (no loud
+   * workspace ping) rather than paging a non-answer.
+   */
+  postAnalysis: (data: {
+    analysisMarkdown: string;
+    isConfident: boolean;
+    result: ObservabilityAssistantResult;
+  }) => Promise<void>;
+}
+
+export default class SentinelInvestigationEngine {
+  /*
+   * Shared gate: AI enabled, the auto-investigation opt-in on, and an LLM
+   * provider configured. Runs before any (subject-specific) context assembly.
+   */
+  @CaptureSpan()
+  public static async isEnabledForProject(
+    projectId: ObjectID,
+  ): Promise<boolean> {
+    const project: Project | null = await ProjectService.findOneById({
+      id: projectId,
+      select: {
+        enableAi: true,
+        enableAutomaticIncidentInvestigation: true,
+      },
+      props: { isRoot: true },
+    });
+
+    if (!project) {
+      return false;
+    }
+
+    if (project.enableAi === false) {
+      return false;
+    }
+
+    if (project.enableAutomaticIncidentInvestigation !== true) {
+      return false;
+    }
+
+    const llmProvider: LlmProvider | null =
+      await LlmProviderService.getLLMProviderForProject(projectId);
+
+    if (!llmProvider) {
+      logger.debug(
+        `Sentinel: skipping investigation for project ${projectId.toString()} — no LLM provider configured.`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /*
+   * Run one investigation end-to-end. Never throws — failures are logged and
+   * recorded on the AIRun.
+   */
+  @CaptureSpan()
+  public static async investigate(
+    request: InvestigationRequest,
+  ): Promise<void> {
+    const { projectId } = request;
+
+    // Record the run up front so it is auditable even if it fails.
+    const run: AIRun = new AIRun();
+    run.projectId = projectId;
+    run.runType = AIRunType.Investigation;
+    run.status = AIRunStatus.Running;
+    run.startedAt = OneUptimeDate.getCurrentDate();
+    run.lastHeartbeatAt = OneUptimeDate.getCurrentDate();
+
+    let createdRun: AIRun;
+    try {
+      createdRun = await AIRunService.create({
+        data: run,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      logger.error(`Sentinel: failed to create investigation run: ${error}`);
+      return;
+    }
+
+    const aiRunId: ObjectID = createdRun.id!;
+    let sequence: number = 0;
+
+    await this.emitEvent({
+      projectId,
+      aiRunId,
+      sequence: sequence++,
+      eventType: AIRunEventType.RunStarted,
+    });
+
+    try {
+      const result: ObservabilityAssistantResult =
+        await ObservabilityAssistant.answerQuestion({
+          projectId,
+          // System run — full read access to the project's telemetry.
+          props: { isRoot: true },
+          feature: request.feature,
+          systemInstructions: INVESTIGATION_PERSONA,
+          question: `A new signal has just been declared and you have been woken to investigate it. Investigate now and produce your root cause analysis.\n\n${request.contextSummary}`,
+          maxLlmCalls: MAX_LLM_CALLS,
+          maxToolCalls: MAX_TOOL_CALLS,
+          maxWallClockMs: MAX_WALL_CLOCK_MS,
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+        });
+
+      await AIRunService.updateOneBy({
+        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
+        data: {
+          status: AIRunStatus.Completed,
+          completedAt: OneUptimeDate.getCurrentDate(),
+          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
+          llmCallCount: result.llmCallCount,
+          toolCallCount: result.toolCallCount,
+          totalTokens: result.totalTokens,
+        } as never,
+        props: { isRoot: true },
+      });
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunCompleted,
+      });
+
+      const analysis: string = (result.contentInMarkdown || "").trim();
+
+      if (!analysis) {
+        logger.debug(
+          `Sentinel: investigation (run ${aiRunId.toString()}) produced no analysis; nothing posted.`,
+        );
+        return;
+      }
+
+      const isConfident: boolean = !INCONCLUSIVE_RE.test(analysis);
+
+      await request.postAnalysis({
+        analysisMarkdown: this.buildBrandedMarkdown(result, analysis),
+        isConfident,
+        result,
+      });
+
+      logger.debug(
+        `Sentinel: investigation complete (run ${aiRunId.toString()}, confident=${isConfident}, ${result.llmCallCount} LLM calls, ${result.toolCallCount} tools, ${result.totalTokens} tokens).`,
+      );
+    } catch (error) {
+      const message: string =
+        error instanceof Error ? error.message : String(error);
+
+      await AIRunService.updateOneBy({
+        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
+        data: {
+          status: AIRunStatus.Error,
+          completedAt: OneUptimeDate.getCurrentDate(),
+          errorMessage: message.substring(0, 480),
+        } as never,
+        props: { isRoot: true },
+      });
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunFailed,
+      });
+
+      logger.error(
+        `Sentinel: investigation failed (run ${aiRunId.toString()}): ${message}`,
+      );
+    }
+  }
+
+  // Wrap the agent's analysis with Sentinel branding + an evidence list.
+  private static buildBrandedMarkdown(
+    result: ObservabilityAssistantResult,
+    analysisMarkdown: string,
+  ): string {
+    let markdown: string = `## 🧠 Sentinel — Automated Root Cause Analysis\n\n${analysisMarkdown}`;
+
+    const citations: Array<AIChatCitation> = result.citations || [];
+
+    if (citations.length > 0) {
+      markdown += `\n\n**Evidence checked**`;
+      for (const citation of citations.slice(0, 15)) {
+        markdown += `\n- **[${citation.id}]** ${citation.label} — ${citation.rowCount} row(s)`;
+      }
+    }
+
+    markdown += `\n\n---\n*Investigated automatically by OneUptime Sentinel — read-only, ${result.toolCallCount} quer${
+      result.toolCallCount === 1 ? "y" : "ies"
+    } run across your own telemetry${
+      result.modelName ? ` using ${result.modelName}` : ""
+    }. This is an AI-generated first pass; verify before acting.*`;
+
+    return markdown;
+  }
+
+  private static async emitEvent(data: {
+    projectId: ObjectID;
+    aiRunId: ObjectID;
+    sequence: number;
+    eventType: AIRunEventType;
+  }): Promise<void> {
+    try {
+      const event: AIRunEvent = new AIRunEvent();
+      event.projectId = data.projectId;
+      event.aiRunId = data.aiRunId;
+      event.sequence = data.sequence;
+      event.eventType = data.eventType;
+
+      await AIRunEventService.create({
+        data: event,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      // Events are best-effort telemetry — never fail the run because of them.
+      logger.error(`Sentinel: failed to emit AIRunEvent: ${error}`);
+    }
+  }
+}

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -86,6 +86,12 @@ export interface InvestigationRequest {
   // A compact markdown summary of the subject that seeds the investigation.
   contextSummary: string;
   /*
+   * The subject that triggered this run — links the AIRun so the live panel can
+   * find "the investigation for this incident/alert". Exactly one is set.
+   */
+  subjectIncidentId?: ObjectID | undefined;
+  subjectAlertId?: ObjectID | undefined;
+  /*
    * Called with the finished, branded, cited analysis so the caller can post it
    * to the subject's timeline. `isConfident` is false when Sentinel reported it
    * could not determine the cause — callers use it to post QUIETLY (no loud
@@ -158,6 +164,13 @@ export default class SentinelInvestigationEngine {
     run.status = AIRunStatus.Running;
     run.startedAt = OneUptimeDate.getCurrentDate();
     run.lastHeartbeatAt = OneUptimeDate.getCurrentDate();
+
+    if (request.subjectIncidentId) {
+      run.triggeredByIncidentId = request.subjectIncidentId;
+    }
+    if (request.subjectAlertId) {
+      run.triggeredByAlertId = request.subjectAlertId;
+    }
 
     let createdRun: AIRun;
     try {

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -1,6 +1,10 @@
 import ObjectID from "../../../../Types/ObjectID";
 import OneUptimeDate from "../../../../Types/Date";
-import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import {
+  AIChatCitation,
+  AIRunEventResultSummary,
+} from "../../../../Types/AI/AIChatTypes";
 import AIRunType from "../../../../Types/AI/AIRunType";
 import AIRunStatus from "../../../../Types/AI/AIRunStatus";
 import AIRunEventType from "../../../../Types/AI/AIRunEventType";
@@ -14,6 +18,8 @@ import ProjectService from "../../../Services/ProjectService";
 import LlmProviderService from "../../../Services/LlmProviderService";
 import ObservabilityAssistant, {
   ObservabilityAssistantResult,
+  ObservabilityAssistantStep,
+  ObservabilityAssistantStepType,
 } from "../Chat/ObservabilityAssistant";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
@@ -46,6 +52,16 @@ const MAX_OUTPUT_TOKENS: number = 2000;
  * a non-answer should never loudly page the on-call.
  */
 const INCONCLUSIVE_RE: RegExp = /inconclusive[^.\n]*insufficient signal/i;
+
+// Maps a live agent step to the AIRunEvent type persisted for the glass-box trail.
+const STEP_EVENT_TYPE: Record<ObservabilityAssistantStepType, AIRunEventType> =
+  {
+    llm_started: AIRunEventType.LlmCallStarted,
+    llm_completed: AIRunEventType.LlmCallCompleted,
+    tool_started: AIRunEventType.ToolCallStarted,
+    tool_completed: AIRunEventType.ToolCallCompleted,
+    tool_failed: AIRunEventType.ToolCallFailed,
+  };
 
 const INVESTIGATION_PERSONA: string = `You are "Sentinel", OneUptime's autonomous AI Site Reliability Engineer. You have been woken automatically because a NEW signal (an incident or alert) was just declared in this project — no human has asked you a question yet. Investigate it proactively and produce a first-pass root cause analysis that the on-call engineer will read the moment they are paged.
 
@@ -164,6 +180,41 @@ export default class SentinelInvestigationEngine {
       eventType: AIRunEventType.RunStarted,
     });
 
+    /*
+     * Live narration: persist each LLM/tool step as an AIRunEvent so the UI can
+     * "watch it think" by polling the run's events. Best-effort, ordered.
+     */
+    const onStep: (step: ObservabilityAssistantStep) => Promise<void> = async (
+      step: ObservabilityAssistantStep,
+    ): Promise<void> => {
+      const resultSummary: AIRunEventResultSummary | undefined =
+        step.rowCount !== undefined ||
+        step.durationMs !== undefined ||
+        step.errorMessage !== undefined
+          ? {
+              rowCount: step.rowCount,
+              durationInMs: step.durationMs,
+              errorMessage: step.errorMessage,
+            }
+          : undefined;
+
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: STEP_EVENT_TYPE[step.type],
+        toolName: step.toolName,
+        toolArguments: step.toolArguments,
+        resultSummary,
+        citationId: step.citationId,
+      });
+
+      // Keep the run visibly alive for the stale-run sweeper + live UI.
+      if (step.type === "llm_started") {
+        await this.touchHeartbeat(aiRunId);
+      }
+    };
+
     try {
       const result: ObservabilityAssistantResult =
         await ObservabilityAssistant.answerQuestion({
@@ -177,6 +228,7 @@ export default class SentinelInvestigationEngine {
           maxToolCalls: MAX_TOOL_CALLS,
           maxWallClockMs: MAX_WALL_CLOCK_MS,
           maxOutputTokens: MAX_OUTPUT_TOKENS,
+          onStep,
         });
 
       await AIRunService.updateOneBy({
@@ -271,11 +323,30 @@ export default class SentinelInvestigationEngine {
     return markdown;
   }
 
+  // Refresh lastHeartbeatAt so a long-running investigation isn't swept as stale.
+  private static async touchHeartbeat(aiRunId: ObjectID): Promise<void> {
+    try {
+      await AIRunService.updateOneBy({
+        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
+        data: {
+          lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
+        } as never,
+        props: { isRoot: true },
+      });
+    } catch (error) {
+      logger.error(`Sentinel: heartbeat update failed: ${error}`);
+    }
+  }
+
   private static async emitEvent(data: {
     projectId: ObjectID;
     aiRunId: ObjectID;
     sequence: number;
     eventType: AIRunEventType;
+    toolName?: string | undefined;
+    toolArguments?: JSONObject | undefined;
+    resultSummary?: AIRunEventResultSummary | undefined;
+    citationId?: string | undefined;
   }): Promise<void> {
     try {
       const event: AIRunEvent = new AIRunEvent();
@@ -283,6 +354,19 @@ export default class SentinelInvestigationEngine {
       event.aiRunId = data.aiRunId;
       event.sequence = data.sequence;
       event.eventType = data.eventType;
+
+      if (data.toolName) {
+        event.toolName = data.toolName;
+      }
+      if (data.toolArguments) {
+        event.toolArguments = data.toolArguments;
+      }
+      if (data.resultSummary) {
+        event.resultSummary = data.resultSummary;
+      }
+      if (data.citationId) {
+        event.citationId = data.citationId;
+      }
 
       await AIRunEventService.create({
         data: event,

--- a/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelInvestigationEngine.ts
@@ -53,6 +53,7 @@ Investigate like a senior on-call engineer:
 - Start from the affected monitors/services named in the signal.
 - Use your read tools to inspect the telemetry AROUND the signal's creation time: recent exceptions and their trends, error/latency metrics versus their normal range, failing traces, relevant logs, and recent changes / deploys.
 - Form the single most likely root-cause hypothesis. If the evidence is inconclusive, say so plainly and list what you checked — do NOT guess a cause the data does not support.
+- If the context lists past resolved incidents, check whether this is a RECURRENCE. If the current signal matches one, say so explicitly, reference that incident number, and note how it was resolved before — but still verify against the current telemetry.
 
 Write your final answer as a concise incident-response note with exactly these sections (use these markdown headings):
 **Summary** — one or two sentences a paged engineer can read in five seconds.

--- a/Common/Server/Utils/AI/Sentinel/SentinelMemory.ts
+++ b/Common/Server/Utils/AI/Sentinel/SentinelMemory.ts
@@ -1,0 +1,167 @@
+import ObjectID from "../../../../Types/ObjectID";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import IncidentService from "../../../Services/IncidentService";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+import logger from "../../Logger";
+
+/*
+ * Sentinel — episodic memory (Phase 4, "I've seen this before").
+ *
+ * The first, no-new-storage cut of the recurrence short-circuit: instead of a
+ * vector store, retrieve past RESOLVED incidents in the same project that share
+ * monitors/labels with the current signal and carry a recorded root cause, then
+ * feed a compact digest into the investigation so the agent can recognise a
+ * recurrence and reference the prior fix.
+ *
+ * The full episodic store (pgvector embeddings over postmortems/runbooks + a
+ * temporal knowledge graph) is the deferred, larger build — this delivers the
+ * user-visible "this matches #123" behaviour on data we already own.
+ */
+
+// How many recent incidents to consider, and how many prior cases to surface.
+const CANDIDATE_LIMIT: number = 30;
+const MAX_CASES: number = 4;
+const MAX_ROOT_CAUSE_CHARS: number = 300;
+
+const SHARED_MONITOR_SCORE: number = 2;
+const SHARED_LABEL_SCORE: number = 1;
+
+export default class SentinelMemory {
+  /*
+   * Returns a markdown "past resolved incidents" section to append to the
+   * investigation context, or an empty string when there is nothing useful.
+   * Never throws — memory is a nice-to-have, not load-bearing.
+   */
+  @CaptureSpan()
+  public static async getPriorSimilarIncidentsContext(data: {
+    projectId: ObjectID;
+    currentIncidentId: ObjectID;
+    monitorNames: Array<string>;
+    labelNames: Array<string>;
+  }): Promise<string> {
+    try {
+      const candidates: Array<Incident> = await IncidentService.findBy({
+        query: {
+          projectId: data.projectId,
+        },
+        select: {
+          _id: true,
+          incidentNumber: true,
+          title: true,
+          rootCause: true,
+          createdAt: true,
+          currentIncidentState: {
+            isResolvedState: true,
+          },
+          monitors: {
+            name: true,
+          },
+          labels: {
+            name: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: CANDIDATE_LIMIT,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+      const currentIdString: string = data.currentIncidentId.toString();
+      const monitorSet: Set<string> = new Set(
+        data.monitorNames.map((n: string) => {
+          return n.toLowerCase();
+        }),
+      );
+      const labelSet: Set<string> = new Set(
+        data.labelNames.map((n: string) => {
+          return n.toLowerCase();
+        }),
+      );
+
+      const scored: Array<{ incident: Incident; score: number }> = candidates
+        .filter((incident: Incident) => {
+          return (
+            incident.id?.toString() !== currentIdString &&
+            incident.currentIncidentState?.isResolvedState === true &&
+            Boolean(incident.rootCause && incident.rootCause.trim().length > 0)
+          );
+        })
+        .map((incident: Incident) => {
+          let score: number = 0;
+
+          for (const monitor of incident.monitors || []) {
+            if (monitor.name && monitorSet.has(monitor.name.toLowerCase())) {
+              score += SHARED_MONITOR_SCORE;
+            }
+          }
+
+          for (const label of incident.labels || []) {
+            if (label.name && labelSet.has(label.name.toLowerCase())) {
+              score += SHARED_LABEL_SCORE;
+            }
+          }
+
+          return { incident, score };
+        });
+
+      /*
+       * Prefer cases that actually share a monitor/label; otherwise fall back to
+       * the most recent resolved incidents (V8's sort is stable, keeping recency).
+       */
+      const relevant: Array<{ incident: Incident; score: number }> = scored
+        .filter((item: { incident: Incident; score: number }) => {
+          return item.score > 0;
+        })
+        .sort(
+          (
+            a: { incident: Incident; score: number },
+            b: { incident: Incident; score: number },
+          ) => {
+            return b.score - a.score;
+          },
+        );
+
+      const chosen: Array<{ incident: Incident; score: number }> = (
+        relevant.length > 0 ? relevant : scored
+      ).slice(0, MAX_CASES);
+
+      if (chosen.length === 0) {
+        return "";
+      }
+
+      let markdown: string =
+        "\n\n# Past resolved incidents in this project (recurrence context)\n" +
+        "If the current signal matches one of these, this may be a recurrence — say so explicitly and reference the incident number and how it was resolved.\n";
+
+      for (const { incident } of chosen) {
+        const rootCause: string = (incident.rootCause || "").trim();
+        const shortRootCause: string =
+          rootCause.length > MAX_ROOT_CAUSE_CHARS
+            ? `${rootCause.substring(0, MAX_ROOT_CAUSE_CHARS)}…`
+            : rootCause;
+
+        markdown += `\n- **#${incident.incidentNumber} — ${incident.title || "Untitled"}**`;
+        markdown += `\n  Previously resolved. Root cause: ${shortRootCause}`;
+
+        const monitorNames: Array<string> = (incident.monitors || [])
+          .map((m: Monitor) => {
+            return m.name || "";
+          })
+          .filter(Boolean);
+
+        if (monitorNames.length > 0) {
+          markdown += `\n  Monitors: ${monitorNames.join(", ")}`;
+        }
+      }
+
+      return markdown;
+    } catch (error) {
+      logger.error(`Sentinel: failed to load recurrence context: ${error}`);
+      return "";
+    }
+  }
+}

--- a/Common/Server/Utils/AI/Toolbox/Index.ts
+++ b/Common/Server/Utils/AI/Toolbox/Index.ts
@@ -28,6 +28,12 @@ import {
   ResolveIncidentTool,
 } from "./IncidentWriteTools";
 import { AcknowledgeAlertTool, ResolveAlertTool } from "./AlertWriteTools";
+import {
+  PageOnCallPolicyTool,
+  RunRunbookTool,
+  PostIncidentStatusUpdateTool,
+  ChangeIncidentSeverityTool,
+} from "./SentinelActionTools";
 import AIChatPermissionMode from "../../../../Types/AI/AIChatPermissionMode";
 
 export interface ToolCallOutcome {
@@ -70,6 +76,11 @@ export default class AIToolbox {
     ResolveIncidentTool,
     AcknowledgeAlertTool,
     ResolveAlertTool,
+    // Sentinel action belt (Phase 0) — operate the platform, not just answer.
+    PageOnCallPolicyTool,
+    RunRunbookTool,
+    PostIncidentStatusUpdateTool,
+    ChangeIncidentSeverityTool,
   ];
 
   public static getTools(): Array<ObservabilityTool> {

--- a/Common/Server/Utils/AI/Toolbox/SentinelActionTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/SentinelActionTools.ts
@@ -1,0 +1,577 @@
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentSeverity from "../../../../Models/DatabaseModels/IncidentSeverity";
+import IncidentPublicNote from "../../../../Models/DatabaseModels/IncidentPublicNote";
+import Runbook from "../../../../Models/DatabaseModels/Runbook";
+import RunbookExecution from "../../../../Models/DatabaseModels/RunbookExecution";
+import OnCallDutyPolicy from "../../../../Models/DatabaseModels/OnCallDutyPolicy";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import OneUptimeDate from "../../../../Types/Date";
+import UserNotificationEventType from "../../../../Types/UserNotification/UserNotificationEventType";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import IncidentService from "../../../Services/IncidentService";
+import IncidentSeverityService from "../../../Services/IncidentSeverityService";
+import IncidentPublicNoteService from "../../../Services/IncidentPublicNoteService";
+import OnCallDutyPolicyService from "../../../Services/OnCallDutyPolicyService";
+import RunbookService from "../../../Services/RunbookService";
+import RunbookRuleEngineService from "../../../Services/RunbookRuleEngineService";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Sentinel "action belt" — Phase 0.
+ *
+ * Mutating tools that let the copilot OPERATE the platform (not just answer
+ * questions), each a thin wrapper over an already-RBAC-tested service method.
+ * They are gated twice: by the tool's requiredPermissions (RBAC) and by the
+ * conversation's permission mode (approval / auto-run / hidden in read-only).
+ * The acting user is always ctx.props.userId — never a tool argument.
+ *
+ * Permissions are resolved lazily (not at module load) because this module is
+ * pulled in through the service import graph before the model classes are fully
+ * wired up — calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool executes, every module is loaded.
+ */
+
+let cachedIncidentUpdatePermissions: Array<Permission> | null = null;
+const resolveIncidentUpdatePermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedIncidentUpdatePermissions) {
+      cachedIncidentUpdatePermissions = new Incident().getUpdatePermissions();
+    }
+    return cachedIncidentUpdatePermissions;
+  };
+
+let cachedPublicNoteCreatePermissions: Array<Permission> | null = null;
+const resolvePublicNoteCreatePermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedPublicNoteCreatePermissions) {
+      cachedPublicNoteCreatePermissions =
+        new IncidentPublicNote().getCreatePermissions();
+    }
+    return cachedPublicNoteCreatePermissions;
+  };
+
+let cachedRunbookUpdatePermissions: Array<Permission> | null = null;
+const resolveRunbookUpdatePermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedRunbookUpdatePermissions) {
+      cachedRunbookUpdatePermissions = new Runbook().getUpdatePermissions();
+    }
+    return cachedRunbookUpdatePermissions;
+  };
+
+/*
+ * ---------------------------------------------------------------------------
+ * page_on_call_policy — escalate an incident to its responders.
+ * ---------------------------------------------------------------------------
+ */
+export const PageOnCallPolicyTool: ObservabilityTool = {
+  name: "page_on_call_policy",
+  description:
+    "Page (trigger) an on-call duty policy so its responders are notified about an incident. Provide the on-call policy id and the incident id it relates to. Use query tools to find the on-call policy id and incident id first. This notifies real people — only do it when clearly asked.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      onCallDutyPolicyId: {
+        type: "string",
+        description: "The on-call duty policy's ID to trigger (required).",
+      },
+      incidentId: {
+        type: "string",
+        description:
+          "The incident's ID this page relates to (required). Find it with query_incidents first.",
+      },
+    },
+    required: ["onCallDutyPolicyId", "incidentId"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveIncidentUpdatePermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    return `Page on-call policy ${ToolArgs.getString(args, "onCallDutyPolicyId") || ""}`.trim();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const policyId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "onCallDutyPolicyId",
+    );
+    if (!policyId) {
+      throw new BadDataException(
+        "onCallDutyPolicyId is required. Use query tools to find it first.",
+      );
+    }
+
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    if (!incidentId) {
+      throw new BadDataException(
+        "incidentId is required. Use query_incidents to find it first.",
+      );
+    }
+
+    // Visibility checks under the user's RBAC (execution runs as root inside the service).
+    const policy: OnCallDutyPolicy | null =
+      await OnCallDutyPolicyService.findOneById({
+        id: policyId,
+        select: { _id: true, name: true },
+        props: ctx.props,
+      });
+    if (!policy) {
+      throw new BadDataException(
+        "On-call duty policy not found (or you do not have access to it).",
+      );
+    }
+
+    const incident: Incident | null = await IncidentService.findOneById({
+      id: incidentId,
+      select: { _id: true, incidentNumber: true, title: true },
+      props: ctx.props,
+    });
+    if (!incident) {
+      throw new BadDataException(
+        "Incident not found (or you do not have access to it).",
+      );
+    }
+
+    await OnCallDutyPolicyService.executePolicy(policyId, {
+      triggeredByIncidentId: incidentId,
+      userNotificationEventType: UserNotificationEventType.IncidentCreated,
+    });
+
+    const incidentIdString: string = incidentId.toString();
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        onCallPolicy: policy.name,
+        incidentNumber: incident.incidentNumber,
+        incidentTitle: incident.title,
+      },
+    ]);
+
+    return {
+      dataForLlm: `Paged on-call policy "${policy.name}" for incident #${incident.incidentNumber} ("${incident.title}"). Responders are being notified.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `Paged "${policy.name}" for incident #${incident.incidentNumber}`,
+      citationTarget: {
+        type: AIChatCitationTargetType.IncidentView,
+        params: { incidentId: incidentIdString },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "On-call paged",
+        resourceType: "OnCallDutyPolicy",
+        heading: policy.name || "On-call policy",
+        subheading: `Incident #${incident.incidentNumber}`,
+        fields: [
+          { label: "Policy", value: policy.name || "—" },
+          { label: "Incident", value: `#${incident.incidentNumber ?? ""}` },
+        ],
+        link: {
+          type: AIChatCitationTargetType.IncidentView,
+          params: { incidentId: incidentIdString },
+        },
+      }),
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * run_runbook — start an automated runbook.
+ * ---------------------------------------------------------------------------
+ */
+export const RunRunbookTool: ObservabilityTool = {
+  name: "run_runbook",
+  description:
+    "Start (execute) a runbook by its id, optionally linked to an incident. Use this to run a predefined remediation or diagnostic automation. Find the runbook id with query tools first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      runbookId: {
+        type: "string",
+        description: "The runbook's ID to execute (required).",
+      },
+      incidentId: {
+        type: "string",
+        description:
+          "Optional incident ID to link this runbook execution to. Find it with query_incidents first.",
+      },
+    },
+    required: ["runbookId"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveRunbookUpdatePermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    return `Run runbook ${ToolArgs.getString(args, "runbookId") || ""}`.trim();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const runbookId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "runbookId",
+    );
+    if (!runbookId) {
+      throw new BadDataException(
+        "runbookId is required. Use query tools to find it first.",
+      );
+    }
+
+    const userId: ObjectID | undefined = ctx.props.userId;
+    if (!userId) {
+      throw new BadDataException(
+        "No authenticated user in context; cannot run a runbook.",
+      );
+    }
+
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+
+    // Visibility check under the user's RBAC.
+    const runbook: Runbook | null = await RunbookService.findOneById({
+      id: runbookId,
+      select: { _id: true, name: true },
+      props: ctx.props,
+    });
+    if (!runbook) {
+      throw new BadDataException(
+        "Runbook not found (or you do not have access to it).",
+      );
+    }
+
+    const execution: RunbookExecution | null =
+      await RunbookRuleEngineService.startRunbookFor({
+        projectId: ctx.projectId,
+        runbookId: runbookId,
+        linkage: incidentId ? { incidentId: incidentId } : {},
+        triggeredByUserId: userId,
+      });
+
+    if (!execution) {
+      throw new BadDataException(
+        `Runbook "${runbook.name}" could not be started. It may be disabled, empty, or not part of this project.`,
+      );
+    }
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        runbook: runbook.name,
+        executionId: execution.id?.toString(),
+      },
+    ]);
+
+    const result: ToolExecutionResult = {
+      dataForLlm: `Started runbook "${runbook.name}". Execution is scheduled.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `Started runbook "${runbook.name}"`,
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "Runbook started",
+        resourceType: "Runbook",
+        heading: runbook.name || "Runbook",
+        subheading: "Execution scheduled",
+        fields: [{ label: "Runbook", value: runbook.name || "—" }],
+      }),
+    };
+
+    if (incidentId) {
+      result.citationTarget = {
+        type: AIChatCitationTargetType.IncidentView,
+        params: { incidentId: incidentId.toString() },
+      };
+    }
+
+    return result;
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * post_incident_status_update — customer-facing update on an incident.
+ * ---------------------------------------------------------------------------
+ */
+export const PostIncidentStatusUpdateTool: ObservabilityTool = {
+  name: "post_incident_status_update",
+  description:
+    "Post a customer-facing status update (public note) on an incident. It appears on the status page and, by default, notifies subscribers. Provide the incident id and the update text.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      incidentId: {
+        type: "string",
+        description: "The incident's ID (required).",
+      },
+      note: {
+        type: "string",
+        description: "The customer-facing update text in markdown (required).",
+      },
+      notifySubscribers: {
+        type: "boolean",
+        description:
+          "Whether to notify status page subscribers. Defaults to true.",
+      },
+    },
+    required: ["incidentId", "note"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolvePublicNoteCreatePermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    return `Post public status update on incident ${ToolArgs.getString(args, "incidentId") || ""}`.trim();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    if (!incidentId) {
+      throw new BadDataException(
+        "incidentId is required. Use query_incidents to find it first.",
+      );
+    }
+
+    const note: string | undefined = ToolArgs.getString(args, "note");
+    if (!note) {
+      throw new BadDataException("note is required (the update text).");
+    }
+
+    const userId: ObjectID | undefined = ctx.props.userId;
+    if (!userId) {
+      throw new BadDataException(
+        "No authenticated user in context; cannot post a status update.",
+      );
+    }
+
+    const notifySubscribers: boolean =
+      ToolArgs.getBoolean(args, "notifySubscribers") ?? true;
+
+    const incident: Incident | null = await IncidentService.findOneById({
+      id: incidentId,
+      select: { _id: true, incidentNumber: true, title: true },
+      props: ctx.props,
+    });
+    if (!incident) {
+      throw new BadDataException(
+        "Incident not found (or you do not have access to it).",
+      );
+    }
+
+    const publicNote: IncidentPublicNote = new IncidentPublicNote();
+    publicNote.incidentId = incidentId;
+    publicNote.projectId = ctx.projectId;
+    publicNote.note = note;
+    publicNote.postedAt = OneUptimeDate.getCurrentDate();
+    publicNote.createdByUserId = userId;
+    publicNote.shouldStatusPageSubscribersBeNotifiedOnNoteCreated =
+      notifySubscribers;
+
+    await IncidentPublicNoteService.create({
+      data: publicNote,
+      props: ctx.props,
+    });
+
+    const incidentIdString: string = incidentId.toString();
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        incidentNumber: incident.incidentNumber,
+        notifySubscribers: notifySubscribers,
+      },
+    ]);
+
+    return {
+      dataForLlm: `Posted a public status update on incident #${incident.incidentNumber}${
+        notifySubscribers ? " and notified subscribers" : ""
+      }.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `Status update on incident #${incident.incidentNumber}`,
+      citationTarget: {
+        type: AIChatCitationTargetType.IncidentView,
+        params: { incidentId: incidentIdString },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "Status update posted",
+        resourceType: "Incident",
+        heading: `#${incident.incidentNumber} · ${incident.title}`,
+        subheading: notifySubscribers
+          ? "Subscribers notified"
+          : "Subscribers not notified",
+        fields: [
+          {
+            label: "Update",
+            value: note.length > 200 ? `${note.substring(0, 200)}…` : note,
+          },
+        ],
+        link: {
+          type: AIChatCitationTargetType.IncidentView,
+          params: { incidentId: incidentIdString },
+        },
+      }),
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * change_incident_severity — re-classify an incident.
+ * ---------------------------------------------------------------------------
+ */
+export const ChangeIncidentSeverityTool: ObservabilityTool = {
+  name: "change_incident_severity",
+  description:
+    "Change the severity of an existing incident. Provide the incident id and the new severity name (must match an existing incident severity in this project, e.g. 'SEV1', 'Critical').",
+  inputSchema: {
+    type: "object",
+    properties: {
+      incidentId: {
+        type: "string",
+        description: "The incident's ID (required).",
+      },
+      severityName: {
+        type: "string",
+        description: "Name of an existing incident severity (required).",
+      },
+    },
+    required: ["incidentId", "severityName"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveIncidentUpdatePermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    return `Change incident ${ToolArgs.getString(args, "incidentId") || ""} severity to ${ToolArgs.getString(args, "severityName") || ""}`.trim();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    if (!incidentId) {
+      throw new BadDataException(
+        "incidentId is required. Use query_incidents to find it first.",
+      );
+    }
+
+    const severityName: string | undefined = ToolArgs.getString(
+      args,
+      "severityName",
+    );
+    if (!severityName) {
+      throw new BadDataException("severityName is required.");
+    }
+
+    const incident: Incident | null = await IncidentService.findOneById({
+      id: incidentId,
+      select: { _id: true, incidentNumber: true, title: true },
+      props: ctx.props,
+    });
+    if (!incident) {
+      throw new BadDataException(
+        "Incident not found (or you do not have access to it).",
+      );
+    }
+
+    const severities: Array<IncidentSeverity> =
+      await IncidentSeverityService.findBy({
+        query: {},
+        select: { _id: true, name: true, order: true },
+        sort: { order: SortOrder.Ascending },
+        limit: 50,
+        skip: 0,
+        props: ctx.props,
+      });
+
+    const severity: IncidentSeverity | undefined = severities.find(
+      (item: IncidentSeverity) => {
+        return item.name?.toLowerCase() === severityName.toLowerCase();
+      },
+    );
+
+    if (!severity) {
+      const available: string = severities
+        .map((s: IncidentSeverity) => {
+          return s.name;
+        })
+        .filter(Boolean)
+        .join(", ");
+      throw new BadDataException(
+        `No incident severity named "${severityName}". Available severities: ${available || "none configured"}.`,
+      );
+    }
+
+    await IncidentService.updateOneById({
+      id: incidentId,
+      data: {
+        incidentSeverityId: severity.id!,
+      },
+      props: ctx.props,
+    });
+
+    const incidentIdString: string = incidentId.toString();
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        incidentNumber: incident.incidentNumber,
+        newSeverity: severity.name,
+      },
+    ]);
+
+    return {
+      dataForLlm: `Changed incident #${incident.incidentNumber} severity to ${severity.name}.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `Incident #${incident.incidentNumber} → ${severity.name}`,
+      citationTarget: {
+        type: AIChatCitationTargetType.IncidentView,
+        params: { incidentId: incidentIdString },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "Severity changed",
+        resourceType: "Incident",
+        heading: `#${incident.incidentNumber} · ${incident.title}`,
+        subheading: `Severity: ${severity.name}`,
+        fields: [
+          { label: "Number", value: `#${incident.incidentNumber ?? ""}` },
+          { label: "New severity", value: severity.name || "—" },
+        ],
+        link: {
+          type: AIChatCitationTargetType.IncidentView,
+          params: { incidentId: incidentIdString },
+        },
+      }),
+    };
+  },
+};

--- a/Internal/Roadmap/AISentinelReliabilityBrain.md
+++ b/Internal/Roadmap/AISentinelReliabilityBrain.md
@@ -1,0 +1,218 @@
+# OneUptime AI — The Reliability Brain (codename: **Sentinel**)
+
+> The definitive product vision for overhauling OneUptime's AI agents.
+> Status: **Phase 0–1 in active development.** Read it, then let's go build it.
+
+---
+
+## 1. The North Star
+
+> **OneUptime becomes the open-source AI SRE that watches everything you own, tells you the root cause before you're paged — with a receipt for every claim — fixes the code, proves the fix held, and makes your software measurably more reliable every single week.**
+
+**The manifesto.** Monitoring told you *something is wrong*. Observability told you *where to look*. The Reliability Brain tells you *why it broke, what to do, and does it* — then closes the loop by turning every incident into a permanent improvement to your software. It never sleeps, it shows its work, it asks before it touches production, and it gets smarter every time it's corrected. It is not a chatbot bolted onto a dashboard. It is a senior on-call engineer that lives inside the one platform that already holds your monitors, logs, metrics, traces, exceptions, incidents, on-call schedules, status page, service catalog, and code repos — and because it's open-source and self-hostable, you can read its mind and run it air-gapped in your own cluster. We are not adding an AI feature. We are flipping OneUptime from *answers when asked* to *watches, decides, and improves on its own*.
+
+---
+
+## 2. Why now / why OneUptime wins
+
+The entire AI-SRE market has converged on one promise — **"root cause before you're paged"** — but every serious competitor is fighting with one hand tied behind their back:
+
+- **Cleric, Resolve, Traversal, incident.io** do sophisticated investigation but **own none of the observability data**. They federate read-only over your Datadog/Grafana/Prometheus, paying a cross-vendor correlation tax on every hop, inheriting each tool's sampling gaps, and burning ~15× the tokens stitching context across silos. Their citations are federated pointers that can rot.
+- **Datadog Bits** owns telemetry but **bolts code-fix on**, keeps its AI closed, and prices it as a metered add-on that triggers "tokenpocalypse" spend-shock. It has **no status page** — it structurally cannot close the customer-comms loop.
+- **Sentry Seer** owns errors and closes into PRs beautifully — but sees only errors, not full telemetry, on-call, or incidents.
+- **Every one of them is a closed box** you cannot audit and cannot run in-network.
+
+**OneUptime's advantage is structural, not incremental:**
+
+1. **It owns the entire data plane in ONE tenant-scoped model** — monitors, logs, metrics, traces, exceptions, incidents, alerts, on-call, runbooks, status pages, service catalog, *and linked GitHub/GitLab repos*. No connector cold-start. No correlation-across-vendors tax. Citations are **live deep-links to data we own**, not dead federated pointers. We can follow one unbroken causal chain: *metric spike → anomalous baseline → new exception fingerprint → the trace that threw it → the release that shipped it → the commit → the fix PR → the status-page post → the postmortem → the memory that short-circuits the next recurrence.* No competitor owns every link.
+
+2. **It's open-source, self-hostable, and BYO-LLM** — including keyless local Ollama already wired into `LLMService`. The reasoning trail is auditable; the LLM keys are yours; the whole thing runs air-gapped. That's a structural "**no third-party training on your data**" guarantee Datadog and Sentry cannot make — and a live-on-stage demo (*unplug the network, run full alert-to-RCA on a laptop*) that is **literally impossible for every named rival.**
+
+3. **The engine is already 80% built and dormant.** `AIRunType.Investigation` is a defined enum with **zero implementation**. `ChatAgentRunner` is a production-grade ReAct loop — budgets, heartbeats, server-minted citations, inline widgets, egress manifest, pause/resume approvals — that today only ever runs `AIRunType.Chat`. The single highest-leverage move in the codebase is giving that runner a non-conversational entrypoint and a wake-on-alert trigger. **We reach "root cause before you're paged" in weeks, not quarters.**
+
+The window is now: incumbents gate AI behind Enterprise paywalls, and **Opsgenie's forced EOL (data must migrate by April 2027)** is pushing teams to re-evaluate. An open-source, AI-native alternative that bundles monitoring + on-call + AI-SRE is a clean, time-boxed displacement wedge.
+
+---
+
+## 3. The core concept: the Reliability Brain
+
+The Reliability Brain is a single **always-on agent runtime** that runs one loop over the data OneUptime already owns:
+
+```
+   ┌─────────── WATCH ───────────┐
+   │  sensors fire on signal      │
+   ▼                              │
+HYPOTHESIZE → INVESTIGATE → ACT → VERIFY → LEARN
+   │  parallel,   grounded,  gated,  prove   memory +
+   │  glass-box   cited      by RBAC it held  runbooks
+   └──────────────── improves every incident ┘
+```
+
+It is **one runtime that swallows both of today's disconnected half-agents** — the reactive chat copilot and the narrow legacy code-fixer — not a third bolt-on.
+
+### How it reuses what already ships (the 80% head start)
+
+| Existing asset | Role in the Brain |
+|---|---|
+| `ChatAgentRunner` (ReAct loop, budgets, heartbeats, citations, widgets, egress manifest, pause/resume) | The per-agent engine. Add a **non-conversational entrypoint** + investigation prompt. No rewrite. |
+| `ObservabilityAssistant` (headless, read-only, cited agent loop for Slack/Teams) | The exact non-conversational entrypoint to build the Investigation Engine on. |
+| `AIService.executeWithLogging` + `LLMService` (7 providers, prompt-cache aware, gen_ai OTel spans) | The single metered gateway. Extend with model routing + streaming. |
+| `AIRun / AIRunEvent / AIConversation` + `TimeoutStuckRuns` sweeper | Durable run lifecycle + the glass-box reasoning trail. |
+| `AIChatPermissionMode` (ReadOnly / AskForApproval / AutoRun) + `ToolApprovalCard` + resume flow | The graduated-autonomy primitive. |
+| `AIToolbox` (curated tools) + MCP `ToolGenerator` (~155 model tools) | The tool belt — unified behind one `ObservabilityTool` interface (with a **hard allowlist** for autonomous agents, see §6). |
+| Server-minted `AIChatCitation` + `WidgetBuilder` + `stripFabricatedCitationMarkers` | The grounded-answer trust layer, reused for investigation reports. |
+| `IncidentAIContextBuilder`, `AlertAIContextBuilder`, `RecentChangesTool` | Zero-new-code context assembly. |
+| `MetricBaselineHourly` + `MetricBaselineService` (getBaseline, getBandSeries, sigmaForSensitivity) | Anomaly substrate — **already computed**, already used by anomaly monitors. |
+| Legacy `RepositoryManager` / `PullRequestCreator` / `WorkspaceManager` | Git plumbing for the code-fix loop — reuse; kill the OpenCode shell-out. |
+
+### The two genuinely new primitives
+
+- **A durable, checkpointed run substrate** — replace detached `runTurn().catch()` promises (which orphan on pod restart) with a **claimable AIRun queue with atomic claim** (fixing the legacy `get-pending-task` double-processing race), so long, unattended, restart-safe investigations become possible.
+- **Memory + a topology graph** — the "improve over time" engine, sequenced honestly:
+  1. **First-party topology graph, day-one, from data we already own.** Derive the service dependency graph from `Span` parent/child edges + `TelemetryEntity` relationships + service-catalog ownership. Gives **blast-radius** and turns correlation into causation *now*.
+  2. **Episodic case memory** — every resolved investigation persisted as a retrievable case (root cause + citations + the runbook/PR that fixed it). Recurrence short-circuit via similarity lookup — buildable *before* the full graph.
+  3. **pgvector RAG + temporal (valid_at/invalid_at) knowledge graph** — the net-new build, deferred but real, over postmortems/runbooks/service descriptions.
+
+---
+
+## 4. The agent capabilities — before / after
+
+Across the full lifecycle: **Detect → Correlate → Investigate → Remediate → Communicate → Verify → Learn.**
+
+1. **Proactive, pre-incident detection (*left of boom*).** *Before:* static thresholds miss slow regressions; `MetricBaselineHourly` is computed but never drives a proactive investigation. *After:* a scheduled sweep diffs live metrics against their per-hour-of-week band and **opens a cited incident before the alert even trips**.
+
+2. **Wake-on-signal autonomous investigation (headline).** *Before:* 100% of AI runs are human-typed `Chat`. *After:* the instant an incident/alert fires, an `AIRunType.Investigation` run assembles context via `IncidentAIContextBuilder`, runs the tool loop, and posts a **cited root-cause hypothesis into the incident timeline + Slack in 1–3 minutes**.
+
+3. **Glass-box parallel hypotheses.** An orchestrator spawns isolated sub-runs (deploy- / dependency- / resource- / data-caused), each labeled **VALIDATED / INVALIDATED / INCONCLUSIVE** by a **deterministic, server-verifiable check**, never free-form LLM judgment. Rendered as a HypothesisBoard + CausalChain widget.
+
+4. **Deterministic deploy correlation + one-click rollback.** Correlate `ExceptionInstance.release` to the exact deploy and offer **rollback of *that specific release*** — deterministic, not LLM-guessed.
+
+5. **Alert-storm collapse.** The on-call opens their phone to **ONE card: "47 alerts, 1 root cause."** Rule-based grouping plus AI root-cause grouping.
+
+6. **Confidence-gated escalation — "nobody gets woken at 3am."** Because OneUptime **owns on-call schedules**, when RCA confidence is high and blast-radius low, the Brain can **suppress the 3am page**, page the specific **service owner**, or hand a warm, diagnosed incident to the morning shift.
+
+7. **Full incident-command action belt.** ~10 new tools that are **thin wrappers over already-RBAC-tested service methods** — `page_on_call`, `run_runbook`, `set_incident_state/severity`, `change_monitor_status`, `post_status_update`, `draft_postmortem`.
+
+8. **Auto code-fix PR — evolving legacy FixException.** After RCA pins root cause, an **in-house `LLMService` coding sub-agent** reads surrounding logs/traces/spans, writes the fix *plus a regression test built from the real production error*, runs a **build/test/lint verify loop until green**, and opens a reviewable PR on GitHub *or* GitLab. **The biggest genuine engineering lift** — a per-repo CI sandbox is the hidden cost.
+
+9. **Auto customer-comms — the move no observability vendor can make.** Because OneUptime **owns the status page + subscribers**, the same run drafts the customer-facing announcement, queued for one-click human-approved publish.
+
+10. **Active verification — using our own probes as hands.** The Brain **re-runs the exact synthetic monitor/probe that failed** to confirm recovery in seconds, then watches SLO/error-budget + recurrence.
+
+11. **Learn — runbook-authoring flywheel + human-correction memory.** After a successful remediation, the Brain **drafts a versioned Runbook** (gated by human review). Every human correction (edited status update, rejected hypothesis, fixed PR) is captured as durable memory.
+
+12. **On-call copilot + ambient scribe.** Interactive Block Kit approval cards; rolling "catch-up" summaries; automated shift-handoff briefings.
+
+13. **Reliability-debt & cost report — "improve your software over time" made literal.** *"These 5 auto-remediations fired 200× this month → here are the permanent fixes, ranked by toil-hours saved"* — a CFO/eng-leader ROI artifact no observability competitor produces.
+
+---
+
+## 5. The wow moments
+
+**🏆 Flagship — the 60–90-second "holy grail" demo:** On stage, a presenter triggers a checkout error storm. The audience watches the **Investigation panel narrate live** — "Ranking exceptions ✓", "Reading trace ✓ 0.4s", "Checking recent changes ✓ deploy #4821" — and within a minute a **cited hypothesis** plus a **draft rollback** appears, *before anyone touched a dashboard.*
+
+1. **3am, nobody paged yet** — a Slack message that isn't an alert, it's a *diagnosis* with tap-to-approve buttons.
+2. **Click a citation, land on the proof** — every claim deep-links to the exact log line / trace span / metric spike.
+3. **The air-gapped mic-drop** — unplug the network, run full alert-to-RCA on a laptop with local Ollama.
+4. **"47 alerts, 1 root cause."**
+5. **The status page writes itself.**
+6. **"I've seen this before"** — a recurrence resolves in seconds.
+7. **Go to bed red, wake up to a merge-ready PR** with a regression test built from the real failure.
+8. **The honesty receipt** — a public **Agent Accuracy scorecard**.
+9. **The Friday digest.**
+10. **Sentinel watching Sentinel** — a public live dashboard of OneUptime's own production agent's accuracy/cost/traces.
+
+---
+
+## 6. Trust, safety & control
+
+Trust is the entire game — hallucinated overconfidence is the **#1 documented abandonment driver (>30% quit)**. We win it structurally:
+
+- **Show your work, always.** Citations minted server-side *only from executed tool calls*; fabricated `[C#]` markers are stripped. Hypothesis labels earned by deterministic checks, never free-form LLM assertion.
+- **Graduated autonomy, earned per problem-type.** ReadOnly → AskForApproval → AutoRun, and a type only graduates once **closed-loop accuracy scoring** crosses a threshold. **Autonomy never precedes measurement.**
+- **Reversible by design.** Every mutation ships with a paired **one-click Undo**; counterfactual dry-run previews before approval.
+- **The policy gateway ships before any mutation.** Per-action risk tier, per-team RBAC, blast-radius limits, a **circuit breaker that halts on a remediation storm**, capability-scoped tokens per sub-agent.
+- **Autonomous agents see a hard allowlist, not all 155 MCP tools.**
+- **Full audit trail** — `AIRun / AIRunEvent / LlmLog` + per-run **egress manifest** + `gen_ai.*` OTel spans.
+- **Honest uncertainty as an action** — when telemetry is insufficient, the Brain **refuses** and auto-opens an instrumentation-gap ticket.
+- **Eval harness dogfooding our own spans** — golden incidents, hallucination + tool-selection scoring, offline run replay.
+
+---
+
+## 7. Architecture & what to build vs reuse vs kill
+
+**REUSE (the 80% head start):** `ChatAgentRunner`, `ObservabilityAssistant`, `AIService`/`LLMService`, `AIRun`/`AIRunEvent`/`AIConversation`, `AIChatPermissionMode` + approval flow, `AIToolbox` + `ObservabilityTool` interface, citation minting + `WidgetBuilder`, all `AIContextBuilder`s, `MetricBaselineService`, the MCP `ToolGenerator`, and the legacy `RepositoryManager`/`PullRequestCreator`/`WorkspaceManager` git plumbing.
+
+**BUILD (net-new, sequenced):**
+1. Non-conversational `InvestigationRunner` entrypoint + investigation system prompt.
+2. Sensor/trigger layer — incident/alert create hooks + a scheduled anomaly/SLA-risk sweep. **Trigger off existing anomaly monitors — don't build a second uncoordinated anomaly cron.**
+3. **Durable claimable AIRun queue with atomic claim** (fix the `get-pending-task` race *first*) + checkpoint/resume; async long-running-tool contract.
+4. First-party **topology graph** from spans → episodic case memory → pgvector RAG (deferred).
+5. **SSE token streaming** through `LLMService`/`AIService` — a real refactor, load-bearing for the demo.
+6. Policy gateway + graduated-autonomy scoring + eval harness.
+7. Code-fix **CI sandbox + verify loop** (the largest hidden infra lift).
+
+**KILL / ABSORB — the legacy AIAgent FixException service.** Retire the standalone worker. **Keep** its git/PR/workspace plumbing folded into a `code_fix` tool inside the unified runtime. **Replace** the OpenCode CLI shell-out with in-house `LLMService` tool-calling. **Fix** the atomic-claim race. **Generalize** beyond GitHub (honor `CodeRepository.repositoryHostedAt`). No big-bang cutover.
+
+**Concurrency & cost guardrails (mandatory before autonomy):** dedicated autonomous-run pool + **per-feature budgets** + a storm circuit-breaker. Multi-agent fan-out (~15× tokens) needs planner/synthesizer model routing + prompt caching.
+
+---
+
+## 8. Phased roadmap
+
+**Phase 0 — Action belt + reframe (2–4 weeks, high wow / low risk).** Ship the ~10 mutating tools wrapping already-RBAC-tested service methods, entirely inside today's chat surface. Reframe the copilot as **"Sentinel."**
+
+**Phase 1 — The Investigation Engine (the missing half). ← IN PROGRESS.** Non-conversational entrypoint on `ChatAgentRunner`/`ObservabilityAssistant` + investigation prompt + incident/alert trigger → cited RCA in the incident timeline + Slack. Ship the **BYO-LLM / local-Ollama / air-gapped** GTM story and the `baseline_anomaly` tool.
+*Wow:* **"root cause before you're paged."**
+
+**Phase 2 — Trust UX + proactive detection.** Token streaming; the **HypothesisBoard + CausalChain widgets** with deterministic labels; the narrated living timeline; **confidence-gated quiet mode**; reversible Undo + counterfactual preview; the **pre-incident predictive sweep**; alert-storm collapse.
+
+**Phase 3 — Durability, active verify, close the code loop.** Durable checkpointed queue with atomic claim; **active verification** re-running failed probes; deterministic release rollback; the code-fix verify loop + regression tests + GitLab support; auto-postmortem on resolve; the **weekly "made your software better" digest.**
+
+**Phase 4 — Memory + multi-agent + graduated autonomy.** Topology graph → episodic memory → pgvector RAG; recurrence short-circuit; orchestrator-worker parallel hypotheses; **runbook-authoring flywheel** + human-correction memory; per-problem-type accuracy scoring gating AutoRun; the **public Agent Accuracy scorecard.**
+
+**Moonshot — the Reliability flywheel.** The **reliability-debt backlog** converting recurring firefights into ranked permanent PRs; a **community, AI-code-reviewed Runbook/Skill registry**; "Sentinel watching Sentinel" public accuracy dashboard; enterprise packaging (SOC2, air-gapped, SSO, per-team RBAC/audit).
+
+---
+
+## 9. Differentiation
+
+| Capability | **OneUptime Sentinel** | Datadog Bits AI | Cleric / Resolve / Traversal | incident.io AI |
+|---|---|---|---|---|
+| Owns full data plane (logs+metrics+traces+incidents+on-call+status+repos, one model) | ✅ **Wins** | ⚠️ Telemetry only, no status page | ❌ Federate read-only | ❌ Incident data only |
+| Wake-on-alert RCA | ✅ (ours on owned data) | ✅ | ✅ | ✅ |
+| Live deep-link citations (owned log line/span) | ✅ **Wins** | ⚠️ Opaque verdicts | ❌ Federated pointers rot | ⚠️ |
+| Close customer-comms loop (draft status-page update) | ✅ **Only us** | ❌ No status page | ❌ | ⚠️ Comms, no observability |
+| Active verify — re-run failed probe | ✅ **Only us** | ❌ Passive | ❌ Passive | ❌ |
+| Air-gapped / self-hosted / BYO-LLM | ✅ **Only us** | ❌ Closed SaaS | ❌ Closed SaaS | ❌ Closed SaaS |
+| Open-source & inspectable audit trail (egress manifest) | ✅ **Only us** | ❌ | ❌ | ❌ |
+| Public accuracy scorecard | ✅ **Wins** | ❌ | ❌ | ⚠️ Internal eval only |
+| Reliability-debt → permanent-fix backlog | ✅ **Only us** | ❌ | ❌ | ❌ |
+| Confidence-gated page suppression | ✅ **Only us** | ❌ | ❌ | ⚠️ |
+| Pricing | ✅ Free AI on self-host w/ own key | ❌ Metered add-on | ❌ Enterprise-only | ❌ Pro/Enterprise-gated |
+
+---
+
+## 10. The bumper-sticker
+
+> ## **OneUptime: the open-source AI SRE that finds the root cause before you're paged, fixes the code, proves the fix held — and makes your software more reliable every week. Self-hosted. Auditable. Yours.**
+
+**The three metrics that prove it's working:**
+
+1. **MTTR reduction** — median time-to-root-cause and time-to-resolve, before vs after Sentinel (target: RCA posted in 1–3 min; 30–60% MTTR cut).
+2. **Published RCA accuracy** — top-hypothesis precision, self-graded against documented postmortems, shown openly (target: 80%+, with the misses visible).
+3. **Reliability debt burned down** — recurring-incident classes eliminated and permanent-fix PRs merged per month.
+
+*Ship Phase 0–1 first. They're 80% built and dormant in the repo. The rest is how we win the category.*
+
+---
+
+## Appendix — Phase 1 build notes (Investigation Engine)
+
+Phase 1 delivers **wake-on-incident autonomous investigation**:
+
+- **Trigger:** when an incident is created (and the project has opted in), enqueue an `AIRunType.Investigation` run.
+- **Runner:** a non-conversational investigation entrypoint that builds incident context (`IncidentAIContextBuilder`) and runs the existing read-only, tool-grounded, cited agent loop (`ObservabilityAssistant`) with an investigation persona and a larger budget.
+- **Substrate:** the `AIRun` / `AIRunEvent` rows record the run lifecycle (Running → Completed/Error) and a glass-box event trail.
+- **Output:** the cited root-cause analysis is posted back to the incident as an internal note + incident feed item, and (when the incident posts to workspace channels) to Slack/Teams.
+- **Safety:** ReadOnly permission mode — the investigation can never mutate anything. Gated per-project by an opt-in flag and by AI/LLM-provider availability.


### PR DESCRIPTION
## Sentinel — the live Investigation panel (the visible payoff)

**Stacked on #2628 ("watch it think" → Phase 4 → 3 → 2 → 0 → 1).** Base branch is `sentinel-phase-2b-watch-it-think`.

This makes the "watch it think" work **visible**: on the incident page, the autonomous investigation now narrates its steps in real time — "Ranking exceptions ✓, Reading trace ✓ 0.4s, Checking recent changes ✓" — reusing the existing `ChatActivityFeed` over the run's `AIRunEvent`s.

### Backend
- **Link the run to its subject:** new `AIRun.triggeredByIncidentId` / `triggeredByAlertId` columns (+ migration + indexes), threaded through the engine (`InvestigationRequest.subjectIncidentId` / `subjectAlertId`) and both runners.
- **RBAC-safe read endpoint** `POST /api/ai-investigation/incident`: investigation runs are system-authored (`userId = null`) so they're hidden by the per-user privacy pin on the generic AIRun/AIRunEvent CRUD. The endpoint instead **confirms the caller can read the incident under *their* permissions**, then reads the run + ordered events **as root**, serialized with `BaseModel.toJSONArray`.

### Frontend
- **`IncidentInvestigationPanel`** polls the endpoint every 2.5s while the run is `Running`, renders `ChatActivityFeed` + a status pill (Investigating… / Complete / Did-not-finish), and shows a footer with query/token counts. Renders **nothing** until an investigation exists — invisible for projects not using Sentinel.
- Wired into the incident **Overview** page, above the timeline. The full cited RCA still lands in the feed below; this panel is the reasoning trail.

### Verification
- `tsc --noEmit` clean on **Common**, **App**, and **Dashboard** (0 errors each). `eslint` clean.
- ⚠️ **Front-end is not runtime-verified here** — I couldn't drive the dashboard in a browser in this environment. Built against the codebase's real patterns (`useAiChat`'s fetch/poll, `ChatActivityFeed`, `Card`), but please give it a click-through before merge.

### Deferred
- The symmetric **alert** panel (the endpoint/link already support alerts via `triggeredByAlertId`; just needs the alert-page wiring).
- Token-level text streaming — still gated behind wanting per-token rendering; the step-level narration is live now.
