### PR TITLE
On-call summaries: human-readable schedule, escalation & policy overviews

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx
@@ -1,4 +1,8 @@
 import ProjectUser from "../../../Utils/ProjectUser";
+import EscalationSummary, {
+  EscalationLevelSummary,
+  EscalationResponder,
+} from "./EscalationSummary";
 import Route from "Common/Types/API/Route";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
@@ -28,6 +32,7 @@ import ProjectUtil from "Common/UI/Utils/Project";
 import UserUtil from "Common/UI/Utils/User";
 import BlankProfilePic from "Common/UI/Images/users/blank-profile.svg";
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
 import OnCallDutyEscalationRule from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRule";
 import OnCallDutyPolicyEscalationRuleSchedule from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRuleSchedule";
 import OnCallDutyPolicyEscalationRuleTeam from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRuleTeam";
@@ -309,6 +314,10 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>("");
 
+  // Repeat-policy config, surfaced in the escalation summary's terminator node.
+  const [repeatEnabled, setRepeatEnabled] = useState<boolean>(false);
+  const [repeatCount, setRepeatCount] = useState<number>(0);
+
   const [showCreateModal, setShowCreateModal] = useState<boolean>(false);
   const [ruleToEdit, setRuleToEdit] = useState<OnCallDutyEscalationRule | null>(
     null,
@@ -350,6 +359,20 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
             order: SortOrder.Ascending,
           },
         });
+
+      // Repeat behavior, so the summary can describe what happens after the
+      // final level with no acknowledgement.
+      const policy: OnCallDutyPolicy | null =
+        await ModelAPI.getItem<OnCallDutyPolicy>({
+          modelType: OnCallDutyPolicy,
+          id: props.onCallDutyPolicyId,
+          select: {
+            repeatPolicyIfNoOneAcknowledges: true,
+            repeatPolicyIfNoOneAcknowledgesNoOfTimes: true,
+          },
+        });
+      setRepeatEnabled(Boolean(policy?.repeatPolicyIfNoOneAcknowledges));
+      setRepeatCount(policy?.repeatPolicyIfNoOneAcknowledgesNoOfTimes || 0);
 
       const [userJoins, teamJoins, scheduleJoins]: [
         ListResult<OnCallDutyPolicyEscalationRuleUser>,
@@ -1008,8 +1031,70 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
       })()
     : undefined;
 
+  /*
+   * Flatten the loaded rules + join rows into the lightweight shape the
+   * escalation summary renders. Recomputed on every render so the summary stays
+   * in lockstep with add / edit / delete / reorder of the rules below it.
+   */
+  const summaryLevels: Array<EscalationLevelSummary> = rules.map(
+    (rule: OnCallDutyEscalationRule, index: number): EscalationLevelSummary => {
+      const members: RuleMembers =
+        membersByRuleId[rule.id?.toString() || ""] || emptyRuleMembers();
+
+      const responders: Array<EscalationResponder> = [];
+
+      for (const join of members.scheduleJoins) {
+        if (join.onCallDutyPolicySchedule) {
+          responders.push({
+            type: "schedule",
+            label:
+              join.onCallDutyPolicySchedule.name?.toString() ||
+              "On-call schedule",
+          });
+        }
+      }
+      for (const join of members.teamJoins) {
+        if (join.team) {
+          responders.push({
+            type: "team",
+            label: join.team.name?.toString() || "Team",
+          });
+        }
+      }
+      for (const join of members.userJoins) {
+        if (join.user) {
+          responders.push({
+            type: "user",
+            label:
+              join.user.name?.toString() ||
+              join.user.email?.toString() ||
+              "User",
+          });
+        }
+      }
+
+      return {
+        name: rule.name?.toString() || `Escalation Level ${index + 1}`,
+        escalateAfterInMinutes: rule.escalateAfterInMinutes || 0,
+        responders,
+      };
+    },
+  );
+
   return (
     <Fragment>
+      {!isLoading && !error && rules.length > 0 ? (
+        <div className="mb-6">
+          <EscalationSummary
+            levels={summaryLevels}
+            repeatEnabled={repeatEnabled}
+            repeatCount={repeatCount}
+          />
+        </div>
+      ) : (
+        <></>
+      )}
+
       <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
         {/* Header */}
         <div className="flex flex-col gap-4 border-b border-gray-100 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationSummary.tsx
@@ -1,0 +1,291 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { Fragment, FunctionComponent, ReactElement } from "react";
+
+/*
+ * A concise, plain-english overview of how an on-call policy escalates — the
+ * "read it in five seconds" companion to the detailed, editable rule cards
+ * below it. It answers: who is paged first, how the alert climbs the ladder over
+ * time, and what happens if nobody ever acknowledges.
+ */
+
+export type ResponderType = "schedule" | "team" | "user";
+
+export interface EscalationResponder {
+  label: string;
+  type: ResponderType;
+}
+
+export interface EscalationLevelSummary {
+  name: string;
+  escalateAfterInMinutes: number;
+  responders: Array<EscalationResponder>;
+}
+
+export interface ComponentProps {
+  levels: Array<EscalationLevelSummary>;
+  repeatEnabled: boolean;
+  repeatCount: number;
+}
+
+// Compact human duration, e.g. "immediately", "5 min", "1 hr 30 min".
+const formatDuration: (minutes: number) => string = (
+  minutes: number,
+): string => {
+  if (!minutes || minutes <= 0) {
+    return "0 min";
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours: number = Math.floor(minutes / 60);
+  const remaining: number = minutes % 60;
+  if (remaining === 0) {
+    return hours === 1 ? "1 hr" : `${hours} hrs`;
+  }
+  return `${hours} hr ${remaining} min`;
+};
+
+const responderIcon: (type: ResponderType) => IconProp = (
+  type: ResponderType,
+): IconProp => {
+  if (type === "schedule") {
+    return IconProp.Calendar;
+  }
+  if (type === "team") {
+    return IconProp.Team;
+  }
+  return IconProp.User;
+};
+
+const responderIconColor: (type: ResponderType) => string = (
+  type: ResponderType,
+): string => {
+  if (type === "schedule") {
+    return "text-indigo-500";
+  }
+  if (type === "team") {
+    return "text-violet-500";
+  }
+  return "text-gray-500";
+};
+
+const EscalationSummary: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const levels: Array<EscalationLevelSummary> = props.levels;
+
+  // Cumulative minutes from the moment the incident triggers to each level.
+  // Level 1 fires immediately; level i fires after the sum of the wait times of
+  // all preceding levels.
+  const cumulativeOffsets: Array<number> = [];
+  let runningTotal: number = 0;
+  for (let i: number = 0; i < levels.length; i++) {
+    cumulativeOffsets.push(runningTotal);
+    runningTotal += Math.max(0, levels[i]!.escalateAfterInMinutes || 0);
+  }
+  // Time from trigger until the final level is engaged.
+  const timeToFinalLevel: number =
+    cumulativeOffsets[cumulativeOffsets.length - 1] || 0;
+
+  const distinctResponders: number = ((): number => {
+    const seen: Set<string> = new Set<string>();
+    for (const level of levels) {
+      for (const responder of level.responders) {
+        seen.add(`${responder.type}:${responder.label}`);
+      }
+    }
+    return seen.size;
+  })();
+
+  const getStatTile: (params: {
+    icon: IconProp;
+    label: string;
+    value: string;
+  }) => ReactElement = (params: {
+    icon: IconProp;
+    label: string;
+    value: string;
+  }): ReactElement => {
+    return (
+      <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-50">
+          <Icon icon={params.icon} className="h-4 w-4 text-indigo-600" />
+        </div>
+        <div className="min-w-0">
+          <div className="truncate text-lg font-semibold leading-tight text-gray-900">
+            {params.value}
+          </div>
+          <div className="truncate text-xs text-gray-500">{params.label}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const getResponderChips: (level: EscalationLevelSummary) => ReactElement = (
+    level: EscalationLevelSummary,
+  ): ReactElement => {
+    if (level.responders.length === 0) {
+      return (
+        <span className="inline-flex items-center gap-1 rounded-md bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+          <Icon icon={IconProp.Alert} className="h-3 w-3 text-amber-500" />
+          No responders
+        </span>
+      );
+    }
+
+    return (
+      <span className="flex flex-wrap items-center gap-1.5">
+        {level.responders.map((responder: EscalationResponder, i: number) => {
+          return (
+            <span
+              key={`r-${i}`}
+              className="inline-flex items-center gap-1 rounded-md bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200"
+            >
+              <Icon
+                icon={responderIcon(responder.type)}
+                className={`h-3 w-3 ${responderIconColor(responder.type)}`}
+              />
+              {responder.label}
+            </span>
+          );
+        })}
+      </span>
+    );
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+      {/* Header */}
+      <div className="flex items-start gap-3 border-b border-gray-100 px-6 py-5">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-50 ring-1 ring-inset ring-indigo-200">
+          <Icon icon={IconProp.List} className="h-5 w-5 text-indigo-600" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Escalation summary
+          </h2>
+          <p className="mt-0.5 text-sm text-gray-500">
+            A plain-english walkthrough of who gets paged, and when, after an
+            incident is triggered.
+          </p>
+        </div>
+      </div>
+
+      <div className="p-6">
+        {/* Stat tiles */}
+        <div className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {getStatTile({
+            icon: IconProp.List,
+            label:
+              levels.length === 1 ? "Escalation level" : "Escalation levels",
+            value: `${levels.length}`,
+          })}
+          {getStatTile({
+            icon: IconProp.User,
+            label: distinctResponders === 1 ? "Responder" : "Responders",
+            value: `${distinctResponders}`,
+          })}
+          {getStatTile({
+            icon: IconProp.Clock,
+            label: "To final level",
+            value:
+              timeToFinalLevel > 0
+                ? formatDuration(timeToFinalLevel)
+                : "Instant",
+          })}
+          {getStatTile({
+            icon: IconProp.Reload,
+            label: "Repeats if unacked",
+            value:
+              props.repeatEnabled && props.repeatCount > 0
+                ? `${props.repeatCount}×`
+                : "None",
+          })}
+        </div>
+
+        {/* Condensed escalation timeline */}
+        <div>
+          {/* Trigger node */}
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+            <Icon icon={IconProp.Alert} className="h-3.5 w-3.5 text-red-400" />
+            Incident triggered
+          </div>
+
+          <ol className="mt-2 space-y-0">
+            {levels.map((level: EscalationLevelSummary, index: number) => {
+              const offset: number = cumulativeOffsets[index] || 0;
+              const timingLabel: string =
+                offset <= 0 ? "Immediately" : `After ${formatDuration(offset)}`;
+
+              return (
+                <Fragment key={`level-${index}`}>
+                  {/* Connector line from the previous node */}
+                  <div className="ml-3 h-4 w-px bg-gray-200" />
+
+                  <li className="flex items-start gap-3">
+                    <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 text-xs font-semibold text-white">
+                      {index + 1}
+                    </span>
+                    <div className="min-w-0 flex-1 pb-1">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                        <span className="text-sm font-semibold text-gray-900">
+                          {level.name}
+                        </span>
+                        <span className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-500 ring-1 ring-inset ring-gray-200">
+                          <Icon
+                            icon={IconProp.Clock}
+                            className="h-2.5 w-2.5 text-gray-400"
+                          />
+                          {timingLabel}
+                        </span>
+                      </div>
+                      <div className="mt-1.5 flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                        <span className="text-xs text-gray-500">Notifies</span>
+                        {getResponderChips(level)}
+                      </div>
+                    </div>
+                  </li>
+                </Fragment>
+              );
+            })}
+
+            {/* Terminator node */}
+            <div className="ml-3 h-4 w-px bg-gray-200" />
+            <li className="flex items-start gap-3">
+              <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 ring-1 ring-inset ring-gray-200">
+                <Icon
+                  icon={
+                    props.repeatEnabled && props.repeatCount > 0
+                      ? IconProp.Reload
+                      : IconProp.CheckCircle
+                  }
+                  className="h-3.5 w-3.5 text-gray-500"
+                />
+              </span>
+              <div className="min-w-0 flex-1 pt-0.5 text-sm text-gray-600">
+                {props.repeatEnabled && props.repeatCount > 0 ? (
+                  <>
+                    If still unacknowledged, the entire policy repeats{" "}
+                    <span className="font-semibold text-gray-900">
+                      up to {props.repeatCount} more{" "}
+                      {props.repeatCount === 1 ? "time" : "times"}
+                    </span>
+                    , then stops.
+                  </>
+                ) : (
+                  <>
+                    If no one acknowledges after the final level, escalation
+                    stops here.
+                  </>
+                )}
+              </div>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EscalationSummary;

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicySummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicySummary.tsx
@@ -1,0 +1,474 @@
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import IconProp from "Common/Types/Icon/IconProp";
+import ObjectID from "Common/Types/ObjectID";
+import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import Icon from "Common/UI/Components/Icon/Icon";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
+import OnCallDutyPolicyEscalationRule from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRule";
+import OnCallDutyPolicyEscalationRuleSchedule from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRuleSchedule";
+import OnCallDutyPolicyEscalationRuleTeam from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRuleTeam";
+import OnCallDutyPolicyEscalationRuleUser from "Common/Models/DatabaseModels/OnCallDutyPolicyEscalationRuleUser";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+import useAsyncEffect from "use-async-effect";
+
+export interface ComponentProps {
+  onCallDutyPolicyId: ObjectID;
+  projectId: ObjectID;
+}
+
+interface PolicyOverview {
+  levels: number;
+  timeToFinalLevelMinutes: number;
+  repeatEnabled: boolean;
+  repeatCount: number;
+  scheduleNames: Array<string>;
+  teamNames: Array<string>;
+  userNames: Array<string>;
+  levelsWithNoResponders: number;
+}
+
+// Compact human duration, e.g. "immediately", "5 min", "1 hr 30 min".
+const formatDuration: (minutes: number) => string = (
+  minutes: number,
+): string => {
+  if (!minutes || minutes <= 0) {
+    return "0 min";
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours: number = Math.floor(minutes / 60);
+  const remaining: number = minutes % 60;
+  if (remaining === 0) {
+    return hours === 1 ? "1 hr" : `${hours} hrs`;
+  }
+  return `${hours} hr ${remaining} min`;
+};
+
+const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>("");
+  const [overview, setOverview] = useState<PolicyOverview | null>(null);
+
+  const loadData: () => Promise<void> = async (): Promise<void> => {
+    try {
+      setIsLoading(true);
+      setError("");
+
+      const [rulesResult, userJoins, teamJoins, scheduleJoins, policy]: [
+        ListResult<OnCallDutyPolicyEscalationRule>,
+        ListResult<OnCallDutyPolicyEscalationRuleUser>,
+        ListResult<OnCallDutyPolicyEscalationRuleTeam>,
+        ListResult<OnCallDutyPolicyEscalationRuleSchedule>,
+        OnCallDutyPolicy | null,
+      ] = await Promise.all([
+        ModelAPI.getList<OnCallDutyPolicyEscalationRule>({
+          modelType: OnCallDutyPolicyEscalationRule,
+          query: {
+            onCallDutyPolicyId: props.onCallDutyPolicyId,
+            projectId: props.projectId,
+          },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          select: {
+            _id: true,
+            escalateAfterInMinutes: true,
+            order: true,
+          },
+          sort: { order: SortOrder.Ascending },
+        }),
+        ModelAPI.getList<OnCallDutyPolicyEscalationRuleUser>({
+          modelType: OnCallDutyPolicyEscalationRuleUser,
+          query: { onCallDutyPolicyId: props.onCallDutyPolicyId },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          select: {
+            _id: true,
+            onCallDutyPolicyEscalationRuleId: true,
+            user: { _id: true, name: true, email: true },
+          },
+          sort: {},
+        }),
+        ModelAPI.getList<OnCallDutyPolicyEscalationRuleTeam>({
+          modelType: OnCallDutyPolicyEscalationRuleTeam,
+          query: { onCallDutyPolicyId: props.onCallDutyPolicyId },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          select: {
+            _id: true,
+            onCallDutyPolicyEscalationRuleId: true,
+            team: { _id: true, name: true },
+          },
+          sort: {},
+        }),
+        ModelAPI.getList<OnCallDutyPolicyEscalationRuleSchedule>({
+          modelType: OnCallDutyPolicyEscalationRuleSchedule,
+          query: { onCallDutyPolicyId: props.onCallDutyPolicyId },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          select: {
+            _id: true,
+            onCallDutyPolicyEscalationRuleId: true,
+            onCallDutyPolicySchedule: { _id: true, name: true },
+          },
+          sort: {},
+        }),
+        ModelAPI.getItem<OnCallDutyPolicy>({
+          modelType: OnCallDutyPolicy,
+          id: props.onCallDutyPolicyId,
+          select: {
+            repeatPolicyIfNoOneAcknowledges: true,
+            repeatPolicyIfNoOneAcknowledgesNoOfTimes: true,
+          },
+        }),
+      ]);
+
+      // Time from trigger until the final level is engaged: the sum of the wait
+      // times of every level except the last (the last level's wait governs the
+      // repeat, not another level).
+      const orderedRules: Array<OnCallDutyPolicyEscalationRule> =
+        rulesResult.data;
+      let timeToFinalLevelMinutes: number = 0;
+      for (let i: number = 0; i < orderedRules.length - 1; i++) {
+        timeToFinalLevelMinutes += Math.max(
+          0,
+          orderedRules[i]!.escalateAfterInMinutes || 0,
+        );
+      }
+
+      // Distinct responders per type, plus the set of rules that have at least
+      // one responder (to flag levels that would notify no one).
+      const scheduleNamesById: Record<string, string> = {};
+      const teamNamesById: Record<string, string> = {};
+      const userNamesById: Record<string, string> = {};
+      const rulesWithResponders: Set<string> = new Set<string>();
+
+      for (const join of scheduleJoins.data) {
+        const id: string = join.onCallDutyPolicySchedule?.id?.toString() || "";
+        if (id) {
+          scheduleNamesById[id] =
+            join.onCallDutyPolicySchedule?.name?.toString() ||
+            "On-call schedule";
+        }
+        const ruleId: string =
+          join.onCallDutyPolicyEscalationRuleId?.toString() || "";
+        if (ruleId) {
+          rulesWithResponders.add(ruleId);
+        }
+      }
+      for (const join of teamJoins.data) {
+        const id: string = join.team?.id?.toString() || "";
+        if (id) {
+          teamNamesById[id] = join.team?.name?.toString() || "Team";
+        }
+        const ruleId: string =
+          join.onCallDutyPolicyEscalationRuleId?.toString() || "";
+        if (ruleId) {
+          rulesWithResponders.add(ruleId);
+        }
+      }
+      for (const join of userJoins.data) {
+        const id: string = join.user?.id?.toString() || "";
+        if (id) {
+          userNamesById[id] =
+            join.user?.name?.toString() ||
+            join.user?.email?.toString() ||
+            "User";
+        }
+        const ruleId: string =
+          join.onCallDutyPolicyEscalationRuleId?.toString() || "";
+        if (ruleId) {
+          rulesWithResponders.add(ruleId);
+        }
+      }
+
+      const levelsWithNoResponders: number = orderedRules.filter(
+        (rule: OnCallDutyPolicyEscalationRule) => {
+          return !rulesWithResponders.has(rule.id?.toString() || "");
+        },
+      ).length;
+
+      setOverview({
+        levels: orderedRules.length,
+        timeToFinalLevelMinutes,
+        repeatEnabled: Boolean(policy?.repeatPolicyIfNoOneAcknowledges),
+        repeatCount: policy?.repeatPolicyIfNoOneAcknowledgesNoOfTimes || 0,
+        scheduleNames: Object.values(scheduleNamesById),
+        teamNames: Object.values(teamNamesById),
+        userNames: Object.values(userNamesById),
+        levelsWithNoResponders,
+      });
+    } catch (err) {
+      setError(API.getFriendlyMessage(err));
+    }
+
+    setIsLoading(false);
+  };
+
+  useAsyncEffect(async () => {
+    await loadData();
+  }, []);
+
+  const getStatTile: (params: {
+    icon: IconProp;
+    label: string;
+    value: string;
+  }) => ReactElement = (params: {
+    icon: IconProp;
+    label: string;
+    value: string;
+  }): ReactElement => {
+    return (
+      <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-50">
+          <Icon icon={params.icon} className="h-4 w-4 text-indigo-600" />
+        </div>
+        <div className="min-w-0">
+          <div className="truncate text-lg font-semibold leading-tight text-gray-900">
+            {params.value}
+          </div>
+          <div className="truncate text-xs text-gray-500">{params.label}</div>
+        </div>
+      </div>
+    );
+  };
+
+  const getResponderGroup: (params: {
+    icon: IconProp;
+    iconColor: string;
+    label: string;
+    names: Array<string>;
+  }) => ReactElement = (params: {
+    icon: IconProp;
+    iconColor: string;
+    label: string;
+    names: Array<string>;
+  }): ReactElement => {
+    return (
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400">
+          <Icon
+            icon={params.icon}
+            className={`h-3.5 w-3.5 ${params.iconColor}`}
+          />
+          {params.label}
+        </span>
+        {params.names.map((name: string, i: number) => {
+          return (
+            <span
+              key={`${params.label}-${i}`}
+              className="inline-flex items-center rounded-md bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200"
+            >
+              {name}
+            </span>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const getBody: () => ReactElement = (): ReactElement => {
+    if (isLoading) {
+      return (
+        <div className="flex w-full justify-center py-10">
+          <ComponentLoader />
+        </div>
+      );
+    }
+
+    if (error) {
+      return <ErrorMessage message={error} onRefreshClick={loadData} />;
+    }
+
+    if (!overview) {
+      return <></>;
+    }
+
+    const totalResponders: number =
+      overview.scheduleNames.length +
+      overview.teamNames.length +
+      overview.userNames.length;
+
+    if (overview.levels === 0) {
+      return (
+        <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/60 px-4 py-6 text-center">
+          <p className="text-sm text-gray-600">
+            This policy has no escalation rules yet, so triggering it will not
+            page anyone. Open the{" "}
+            <span className="font-semibold text-gray-900">Escalation</span> tab
+            to add the first level.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        {/* Narrative */}
+        <p className="mb-5 text-sm leading-relaxed text-gray-600">
+          When this policy is triggered, it works through{" "}
+          <span className="font-semibold text-gray-900">
+            {overview.levels}{" "}
+            {overview.levels === 1 ? "escalation level" : "escalation levels"}
+          </span>{" "}
+          and can reach{" "}
+          <span className="font-semibold text-gray-900">
+            {totalResponders}{" "}
+            {totalResponders === 1 ? "responder" : "responders"}
+          </span>
+          . The first level is paged immediately;{" "}
+          {overview.levels > 1 ? (
+            overview.timeToFinalLevelMinutes > 0 ? (
+              <>
+                if no one acknowledges, the alert climbs to the final level
+                after{" "}
+                <span className="font-semibold text-gray-900">
+                  {formatDuration(overview.timeToFinalLevelMinutes)}
+                </span>
+                .{" "}
+              </>
+            ) : (
+              <>
+                if no one acknowledges, every level is engaged{" "}
+                <span className="font-semibold text-gray-900">right away</span>.{" "}
+              </>
+            )
+          ) : (
+            <>there are no further levels to escalate to. </>
+          )}
+          {overview.repeatEnabled && overview.repeatCount > 0 ? (
+            <>
+              If it is still unacknowledged, the whole policy repeats up to{" "}
+              <span className="font-semibold text-gray-900">
+                {overview.repeatCount} more{" "}
+                {overview.repeatCount === 1 ? "time" : "times"}
+              </span>
+              .
+            </>
+          ) : (
+            <>If it is still unacknowledged after the final level, it stops.</>
+          )}
+        </p>
+
+        {/* Stat tiles */}
+        <div className="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {getStatTile({
+            icon: IconProp.List,
+            label:
+              overview.levels === 1 ? "Escalation level" : "Escalation levels",
+            value: `${overview.levels}`,
+          })}
+          {getStatTile({
+            icon: IconProp.User,
+            label: totalResponders === 1 ? "Responder" : "Responders",
+            value: `${totalResponders}`,
+          })}
+          {getStatTile({
+            icon: IconProp.Clock,
+            label: "To final level",
+            value:
+              overview.timeToFinalLevelMinutes > 0
+                ? formatDuration(overview.timeToFinalLevelMinutes)
+                : "Instant",
+          })}
+          {getStatTile({
+            icon: IconProp.Reload,
+            label: "Repeats if unacked",
+            value:
+              overview.repeatEnabled && overview.repeatCount > 0
+                ? `${overview.repeatCount}×`
+                : "None",
+          })}
+        </div>
+
+        {/* Responder breakdown */}
+        {totalResponders > 0 ? (
+          <div className="space-y-3 rounded-xl border border-gray-200 bg-gray-50/60 p-4">
+            {overview.scheduleNames.length > 0 &&
+              getResponderGroup({
+                icon: IconProp.Calendar,
+                iconColor: "text-indigo-500",
+                label: "On-call schedules",
+                names: overview.scheduleNames,
+              })}
+            {overview.teamNames.length > 0 &&
+              getResponderGroup({
+                icon: IconProp.Team,
+                iconColor: "text-violet-500",
+                label: "Teams",
+                names: overview.teamNames,
+              })}
+            {overview.userNames.length > 0 &&
+              getResponderGroup({
+                icon: IconProp.User,
+                iconColor: "text-gray-500",
+                label: "Users",
+                names: overview.userNames,
+              })}
+          </div>
+        ) : (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            <Icon
+              icon={IconProp.Alert}
+              className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500"
+            />
+            <span>
+              No responders are assigned to any level, so this policy will not
+              page anyone. Add responders on the Escalation tab.
+            </span>
+          </div>
+        )}
+
+        {/* Coverage warning for levels with nobody assigned */}
+        {overview.levelsWithNoResponders > 0 && totalResponders > 0 ? (
+          <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            <Icon
+              icon={IconProp.Alert}
+              className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500"
+            />
+            <span>
+              <span className="font-semibold">
+                {overview.levelsWithNoResponders}{" "}
+                {overview.levelsWithNoResponders === 1 ? "level" : "levels"}
+              </span>{" "}
+              have no responders and will notify no one when reached.
+            </span>
+          </div>
+        ) : (
+          <></>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="mb-6 rounded-xl border border-gray-200 bg-white shadow-sm">
+      {/* Header */}
+      <div className="flex items-start gap-3 border-b border-gray-100 px-6 py-5">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-50 ring-1 ring-inset ring-indigo-200">
+          <Icon icon={IconProp.Bell} className="h-5 w-5 text-indigo-600" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Policy at a glance
+          </h2>
+          <p className="mt-0.5 text-sm text-gray-500">
+            A quick snapshot of how this on-call policy responds when it is
+            triggered.
+          </p>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="p-6">{getBody()}</div>
+    </div>
+  );
+};
+
+export default OnCallPolicySummary;

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/FinalScheduleSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/FinalScheduleSummary.tsx
@@ -1,0 +1,257 @@
+import { getColorForUserId, getUserInitials } from "./LayerUserColors";
+import {
+  formatRelativeStart,
+  formatShiftDuration,
+  formatShiftInstant,
+} from "./LayerSummary";
+import Dictionary from "Common/Types/Dictionary";
+import IconProp from "Common/Types/Icon/IconProp";
+import ScheduleShiftUtil, {
+  CoverageGap,
+  CurrentAndNextShift,
+  OnCallShift,
+} from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface UserInfo {
+  name: string;
+  email: string;
+}
+
+export interface ComponentProps {
+  // Coverage shifts of the combined schedule (already override-applied),
+  // sorted by start, computed over [now, windowEnd].
+  shifts: Array<OnCallShift>;
+  now: Date;
+  windowEnd: Date;
+  timezone?: string | undefined;
+  // userId -> display info for everyone who can appear (schedule users +
+  // override substitutes).
+  userById: Dictionary<UserInfo>;
+}
+
+const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const getName: (userId: string) => string = (userId: string): string => {
+    const info: UserInfo | undefined = props.userById[userId];
+    return info?.name || info?.email || "Unknown user";
+  };
+
+  const getInitials: (userId: string) => string = (userId: string): string => {
+    const info: UserInfo | undefined = props.userById[userId];
+    return getUserInitials(info?.name || "", info?.email || "");
+  };
+
+  const { current, next }: CurrentAndNextShift =
+    ScheduleShiftUtil.getCurrentAndNextShift(props.shifts, props.now);
+
+  const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+    props.shifts,
+    props.now,
+    props.windowEnd,
+  );
+
+  const upcoming: Array<OnCallShift> = props.shifts
+    .filter((shift: OnCallShift) => {
+      // future shifts only (the current one is already shown in the hero card)
+      return props.now.getTime() < shift.start.getTime();
+    })
+    /*
+     * Drop the first future shift: it is exactly what the "Up next" hero card
+     * already shows (getCurrentAndNextShift picks the earliest future shift as
+     * `next`), so listing it again here would render the same hand-off twice.
+     */
+    .slice(1, 7);
+
+  const getAvatar: (userId: string, sizeClass: string) => ReactElement = (
+    userId: string,
+    sizeClass: string,
+  ): ReactElement => {
+    return (
+      <span
+        className={`inline-flex flex-shrink-0 items-center justify-center rounded-full font-semibold text-white ${sizeClass}`}
+        style={{ backgroundColor: getColorForUserId(userId) }}
+      >
+        {getInitials(userId)}
+      </span>
+    );
+  };
+
+  const getNowCard: () => ReactElement = (): ReactElement => {
+    if (!current) {
+      return (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+          <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-amber-700">
+            <Icon icon={IconProp.Alert} className="h-3.5 w-3.5" />
+            On call right now
+          </div>
+          <div className="mt-2 text-sm font-medium text-amber-800">
+            No one is currently on call in this schedule.
+          </div>
+          <p className="mt-1 text-xs text-amber-700">
+            Add a 24/7 fallback layer, or widen a layer&apos;s active hours, to
+            close this gap.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="rounded-xl border border-indigo-200 bg-indigo-50/60 p-4">
+        <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-indigo-700">
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-indigo-400 opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-indigo-500" />
+          </span>
+          On call right now
+        </div>
+        <div className="mt-2.5 flex items-center gap-3">
+          {getAvatar(current.userId, "h-10 w-10 text-sm")}
+          <div className="min-w-0">
+            <div className="truncate text-base font-semibold text-gray-900">
+              {getName(current.userId)}
+            </div>
+            <div className="text-xs text-gray-500">
+              Until {formatShiftInstant(current.end, props.timezone)}
+              <span className="ml-1 text-gray-400">
+                ({formatShiftDuration(props.now, current.end)} left)
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const getNextCard: () => ReactElement = (): ReactElement => {
+    if (!next) {
+      return (
+        <div className="rounded-xl border border-gray-200 bg-white p-4">
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            Up next
+          </div>
+          <div className="mt-2 text-sm text-gray-500">
+            No further hand-offs scheduled in the coming weeks.
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+          Up next
+        </div>
+        <div className="mt-2.5 flex items-center gap-3">
+          {getAvatar(next.userId, "h-10 w-10 text-sm")}
+          <div className="min-w-0">
+            <div className="truncate text-base font-semibold text-gray-900">
+              {getName(next.userId)}
+            </div>
+            <div className="text-xs text-gray-500">
+              Starts {formatShiftInstant(next.start, props.timezone)}
+              <span className="ml-1 text-gray-400">
+                ({formatRelativeStart(next.start, props.now)})
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const getGapWarnings: () => ReactElement = (): ReactElement => {
+    // Show only the nearest couple of gaps so a heavily-restricted schedule
+    // does not produce a wall of warnings.
+    const shownGaps: Array<CoverageGap> = gaps.slice(0, 2);
+    const remaining: number = gaps.length - shownGaps.length;
+
+    return (
+      <div className="space-y-2">
+        {shownGaps.map((gap: CoverageGap, i: number) => {
+          return (
+            <div
+              key={`gap-${i}`}
+              className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+            >
+              <Icon
+                icon={IconProp.Alert}
+                className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500"
+              />
+              <span>
+                <span className="font-semibold">Coverage gap:</span> no one is
+                on call from {formatShiftInstant(gap.start, props.timezone)} to{" "}
+                {formatShiftInstant(gap.end, props.timezone)}.
+              </span>
+            </div>
+          );
+        })}
+        {remaining > 0 && (
+          <div className="text-xs text-amber-700">
+            + {remaining} more coverage {remaining === 1 ? "gap" : "gaps"} in
+            the coming weeks.
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const getUpcomingList: () => ReactElement = (): ReactElement => {
+    return (
+      <div>
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+          Upcoming hand-offs
+        </div>
+        <ol className="space-y-2">
+          {upcoming.map((shift: OnCallShift, index: number) => {
+            return (
+              <li
+                key={`upcoming-${index}`}
+                className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5"
+              >
+                {getAvatar(shift.userId, "h-7 w-7 text-[10px]")}
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-semibold text-gray-900">
+                    {getName(shift.userId)}
+                  </div>
+                  <div className="mt-0.5 text-xs text-gray-500">
+                    {formatShiftInstant(shift.start, props.timezone)}
+                    <span className="mx-1 text-gray-300">&rarr;</span>
+                    {formatShiftInstant(shift.end, props.timezone)}
+                  </div>
+                </div>
+                <div className="flex flex-shrink-0 flex-col items-end gap-0.5">
+                  <span className="rounded-md bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-inset ring-gray-200">
+                    {formatShiftDuration(shift.start, shift.end)}
+                  </span>
+                  <span className="text-[11px] font-medium text-gray-400">
+                    {formatRelativeStart(shift.start, props.now)}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    );
+  };
+
+  const hasAnyShifts: boolean = props.shifts.length > 0;
+
+  return (
+    <div className="mb-4 space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {getNowCard()}
+        {getNextCard()}
+      </div>
+
+      {gaps.length > 0 && getGapWarnings()}
+
+      {hasAnyShifts && upcoming.length > 0 && getUpcomingList()}
+    </div>
+  );
+};
+
+export default FinalScheduleSummary;

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerCard.tsx
@@ -1,14 +1,24 @@
 import LayerConfigForm from "./LayerConfigForm";
+import LayerRotationSummary from "./LayerRotationSummary";
+import { getLayerPreviewEvents, LayerPreviewResult } from "./LayerShiftPreview";
 import LayerUser from "./LayerUser";
 import { getColorForUserId, getUserInitials } from "./LayerUserColors";
-import { summarizeRestriction, summarizeRotation } from "./LayerSummary";
+import {
+  formatRelativeStart,
+  summarizeRestriction,
+  summarizeRotation,
+} from "./LayerSummary";
 import IconProp from "Common/Types/Icon/IconProp";
+import ScheduleShiftUtil, {
+  CurrentAndNextShift,
+  OnCallShift,
+} from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
 import Icon from "Common/UI/Components/Icon/Icon";
 import Tooltip from "Common/UI/Components/Tooltip/Tooltip";
 import OnCallDutyPolicyScheduleLayer from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayer";
 import OnCallDutyPolicyScheduleLayerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
 import User from "Common/Models/DatabaseModels/User";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useMemo } from "react";
 
 export interface ComponentProps {
   layer: OnCallDutyPolicyScheduleLayer;
@@ -60,6 +70,58 @@ const LayerCard: FunctionComponent<ComponentProps> = (
     layer.restrictionTimes,
     props.timezone,
   );
+
+  /*
+   * A cheap client-side rotation preview (using the SAME LayerUtil the server
+   * and the calendar use) powers both the collapsed "on call now" line and the
+   * expanded rotation summary. Memoized on the fields that actually affect the
+   * schedule so it does not recompute on unrelated re-renders (expanding a
+   * sibling layer, editing another card). The layer object is mutated in place
+   * on save, so a reference-based dependency would go stale — key on the values.
+   */
+  const previewKey: string = [
+    layer.startsAt?.toString() || "",
+    layer.handOffTime?.toString() || "",
+    JSON.stringify(layer.rotation || null),
+    JSON.stringify(layer.restrictionTimes || null),
+    props.users
+      .map((u: OnCallDutyPolicyScheduleLayerUser) => {
+        return u.user?.id?.toString() || "";
+      })
+      .join(","),
+    props.timezone || "",
+  ].join("|");
+
+  const preview: LayerPreviewResult = useMemo(() => {
+    return getLayerPreviewEvents({
+      layer,
+      users: props.users,
+      timezone: props.timezone,
+      numberOfShifts: 6,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewKey]);
+
+  /*
+   * The person literally on call at this instant (null during off-hours or a
+   * coverage gap) and who is up next. Computed from raw coverage (no across-gap
+   * merging) so the header line is honest for restricted layers.
+   */
+  const coverageShifts: Array<OnCallShift> =
+    ScheduleShiftUtil.groupEventsIntoShifts(preview.events);
+  const currentAndNext: CurrentAndNextShift =
+    ScheduleShiftUtil.getCurrentAndNextShift(coverageShifts, preview.now);
+
+  const nameById: Record<string, string> = {};
+  for (const layerUser of props.users) {
+    const id: string = layerUser.user?.id?.toString() || "";
+    if (id && !nameById[id]) {
+      nameById[id] =
+        layerUser.user?.name?.toString() ||
+        layerUser.user?.email?.toString() ||
+        "Unknown user";
+    }
+  }
 
   const userCount: number = props.users.length;
   const shownUsers: Array<OnCallDutyPolicyScheduleLayerUser> =
@@ -204,6 +266,45 @@ const LayerCard: FunctionComponent<ComponentProps> = (
             <SummaryChip icon={IconProp.Refresh} text={rotationSummary} />
             <SummaryChip icon={IconProp.Clock} text={restrictionSummary} />
           </div>
+
+          {/* Live "who is on call right now" line, derived from the rotation. */}
+          {userCount > 0 && (
+            <div className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-500">
+              <span
+                className="inline-block h-2 w-2 flex-shrink-0 rounded-full"
+                style={{
+                  backgroundColor: currentAndNext.current
+                    ? getColorForUserId(currentAndNext.current.userId)
+                    : "#d1d5db",
+                }}
+              />
+              {currentAndNext.current ? (
+                <span>
+                  <span className="font-semibold text-gray-700">
+                    {nameById[currentAndNext.current.userId] || "Unknown user"}
+                  </span>{" "}
+                  on call now
+                </span>
+              ) : (
+                <span>No one on call in this layer right now</span>
+              )}
+              {currentAndNext.next && (
+                <>
+                  <span className="text-gray-300">&middot;</span>
+                  <span>
+                    Up next{" "}
+                    <span className="font-medium text-gray-700">
+                      {nameById[currentAndNext.next.userId] || "Unknown user"}
+                    </span>{" "}
+                    {formatRelativeStart(
+                      currentAndNext.next.start,
+                      preview.now,
+                    )}
+                  </span>
+                </>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Actions */}
@@ -264,6 +365,18 @@ const LayerCard: FunctionComponent<ComponentProps> = (
       {/* Body */}
       {props.isExpanded && (
         <div className="border-t border-gray-200 px-4 py-5 md:px-5">
+          {userCount > 0 && (
+            <div className="mb-6">
+              <LayerRotationSummary
+                layer={layer}
+                users={props.users}
+                timezone={props.timezone}
+                events={preview.events}
+                now={preview.now}
+              />
+            </div>
+          )}
+
           <div className="mb-6">
             <h4 className="text-sm font-semibold text-gray-900">
               On-call users

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerRotationSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerRotationSummary.tsx
@@ -1,0 +1,317 @@
+import { getColorForUserId, getUserInitials } from "./LayerUserColors";
+import {
+  formatDurationFromSeconds,
+  formatRelativeStart,
+  formatShiftInstant,
+  summarizeRestriction,
+  summarizeRotation,
+} from "./LayerSummary";
+import CalendarEvent from "Common/Types/Calendar/CalendarEvent";
+import IconProp from "Common/Types/Icon/IconProp";
+import RestrictionTimes, {
+  RestrictionType,
+} from "Common/Types/OnCallDutyPolicy/RestrictionTimes";
+import ScheduleShiftUtil, {
+  OnCallShift,
+} from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
+import Icon from "Common/UI/Components/Icon/Icon";
+import OnCallDutyPolicyScheduleLayer from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayer";
+import OnCallDutyPolicyScheduleLayerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
+import User from "Common/Models/DatabaseModels/User";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  layer: OnCallDutyPolicyScheduleLayer;
+  users: Array<OnCallDutyPolicyScheduleLayerUser>;
+  timezone?: string | undefined;
+  // Pre-computed events + reference instant, so the parent runs LayerUtil once.
+  events: Array<CalendarEvent>;
+  now: Date;
+  // How many upcoming turns to list. Defaults to 5.
+  numberOfShifts?: number | undefined;
+}
+
+interface UserDisplay {
+  name: string;
+  color: string;
+  initials: string;
+}
+
+const LayerRotationSummary: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const numberOfShifts: number = props.numberOfShifts || 5;
+
+  /*
+   * usersById is keyed by user id (deduplicated) for name/color lookup by a
+   * shift's userId. orderedUsers keeps ONE entry per assignment row, in rotation
+   * order — including a user listed twice — because the engine rotates through
+   * every row, and because this keeps the count consistent with the collapsed
+   * header's row count (a distinct-person count would disagree with it).
+   */
+  const usersById: Record<string, UserDisplay> = {};
+  const orderedUsers: Array<UserDisplay> = [];
+  for (const layerUser of props.users) {
+    const user: User | undefined = layerUser.user;
+    const userId: string = user?.id?.toString() || "";
+    if (!userId) {
+      continue;
+    }
+    const name: string =
+      user?.name?.toString() || user?.email?.toString() || "Unknown user";
+    if (!usersById[userId]) {
+      usersById[userId] = {
+        name,
+        color: getColorForUserId(userId),
+        initials: getUserInitials(
+          user?.name?.toString() || "",
+          user?.email?.toString() || "",
+        ),
+      };
+    }
+    orderedUsers.push(usersById[userId]!);
+  }
+
+  const getUserDisplay: (userId: string) => UserDisplay = (
+    userId: string,
+  ): UserDisplay => {
+    return (
+      usersById[userId] || {
+        name: "Unknown user",
+        color: getColorForUserId(userId),
+        initials: "?",
+      }
+    );
+  };
+
+  const restrictionTimes: RestrictionTimes | undefined =
+    props.layer.restrictionTimes;
+  const hasRestriction: boolean = Boolean(
+    restrictionTimes &&
+      restrictionTimes.restictionType &&
+      restrictionTimes.restictionType !== RestrictionType.None,
+  );
+
+  const rotationSummary: string = summarizeRotation(props.layer.rotation);
+  const restrictionSummary: string = summarizeRestriction(
+    restrictionTimes,
+    props.timezone,
+  );
+
+  /*
+   * No renderable users (parent shows its own "add users" prompt, or every row
+   * is missing a user id) -> render nothing rather than a nonsensical
+   * "rotates through 0 people".
+   */
+  if (orderedUsers.length === 0) {
+    return <></>;
+  }
+
+  // Group raw coverage into rotation turns (absorb within-turn off-hours gaps).
+  const turns: Array<OnCallShift> = ScheduleShiftUtil.groupEventsIntoShifts(
+    props.events,
+    { mergeAcrossGaps: true },
+  );
+
+  const { current }: { current: OnCallShift | null } =
+    ScheduleShiftUtil.getCurrentAndNextShift(turns, props.now);
+
+  /*
+   * Whether SOMEONE is actively on call in this layer right now, from raw
+   * coverage (no across-gap merging). During a restricted layer's off-hours this
+   * is null even though a rotation turn is "current" — so the current-turn row
+   * can label itself "off-hours" instead of "on call now", staying consistent
+   * with the collapsed header (which uses the same raw-coverage signal).
+   */
+  const rawCurrent: OnCallShift | null =
+    ScheduleShiftUtil.getCurrentAndNextShift(
+      ScheduleShiftUtil.groupEventsIntoShifts(props.events),
+      props.now,
+    ).current;
+  const isActiveNow: boolean = rawCurrent !== null;
+
+  // Current turn + upcoming turns (drop turns that already ended).
+  const upcomingTurns: Array<OnCallShift> = turns
+    .filter((turn: OnCallShift) => {
+      return props.now.getTime() < turn.end.getTime();
+    })
+    .slice(0, numberOfShifts);
+
+  const isSingleUser: boolean = orderedUsers.length === 1;
+
+  const getRotationOrderRow: () => ReactElement = (): ReactElement => {
+    return (
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+          Order
+        </span>
+        {orderedUsers.map((user: UserDisplay, i: number) => {
+          return (
+            <React.Fragment key={`order-${i}`}>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-white py-0.5 pl-0.5 pr-2 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200">
+                <span
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-full text-[8px] font-semibold text-white"
+                  style={{ backgroundColor: user.color }}
+                >
+                  {user.initials}
+                </span>
+                {user.name}
+              </span>
+              {i < orderedUsers.length - 1 && (
+                <Icon
+                  icon={IconProp.ArrowRight}
+                  className="h-3 w-3 text-gray-300"
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const getShiftRow: (turn: OnCallShift, index: number) => ReactElement = (
+    turn: OnCallShift,
+    index: number,
+  ): ReactElement => {
+    const user: UserDisplay = getUserDisplay(turn.userId);
+    const isCurrent: boolean = Boolean(
+      current &&
+        current.userId === turn.userId &&
+        current.start.getTime() === turn.start.getTime(),
+    );
+
+    return (
+      <li
+        key={`shift-${index}`}
+        className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 ${
+          isCurrent
+            ? "border-indigo-200 bg-indigo-50/50"
+            : "border-gray-200 bg-white"
+        }`}
+      >
+        <span
+          className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
+          style={{ backgroundColor: user.color }}
+        >
+          {user.initials}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <span className="truncate text-sm font-semibold text-gray-900">
+              {user.name}
+            </span>
+            {isCurrent &&
+              (isActiveNow ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-indigo-700">
+                  <span className="h-1.5 w-1.5 rounded-full bg-indigo-500" />
+                  On call now
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-600">
+                  <span className="h-1.5 w-1.5 rounded-full bg-gray-400" />
+                  Current turn · off-hours
+                </span>
+              ))}
+          </div>
+          <div className="mt-0.5 text-xs text-gray-500">
+            {formatShiftInstant(turn.start, props.timezone)}
+            <span className="mx-1 text-gray-300">&rarr;</span>
+            {formatShiftInstant(turn.end, props.timezone)}
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 flex-col items-end gap-0.5">
+          <span className="rounded-md bg-gray-50 px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-inset ring-gray-200">
+            {formatDurationFromSeconds(turn.coverageSeconds)}
+            {hasRestriction ? " on call" : ""}
+          </span>
+          <span className="text-[11px] font-medium text-gray-400">
+            {formatRelativeStart(turn.start, props.now)}
+          </span>
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50/60 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h4 className="text-sm font-semibold text-gray-900">
+          Who is on call, and when
+        </h4>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-white px-2.5 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-200">
+          <Icon icon={IconProp.Refresh} className="h-3 w-3 text-gray-400" />
+          {rotationSummary}
+        </span>
+      </div>
+
+      {/* Plain-english framing of the rotation */}
+      <p className="mb-3 text-sm leading-relaxed text-gray-600">
+        {isSingleUser ? (
+          <>
+            <span className="font-semibold text-gray-900">
+              {orderedUsers[0]?.name}
+            </span>{" "}
+            is always on call for this layer — there is no rotation.
+          </>
+        ) : (
+          <>
+            On-call duty rotates through{" "}
+            <span className="font-semibold text-gray-900">
+              {orderedUsers.length} people
+            </span>
+            , {rotationSummary.toLowerCase()}. Each person is on call until the
+            next hand-off, then it passes to the next person in order.
+          </>
+        )}
+        {hasRestriction && (
+          <>
+            {" "}
+            Coverage is limited to{" "}
+            <span className="font-semibold text-gray-900">
+              {restrictionSummary.toLowerCase()}
+            </span>
+            ; outside those hours, lower-priority layers take over.
+          </>
+        )}
+      </p>
+
+      {!isSingleUser && <div className="mb-3">{getRotationOrderRow()}</div>}
+
+      {/*
+       * The upcoming-shifts list only makes sense for a real rotation. With a
+       * single user, every period is theirs, so mergeAcrossGaps collapses the
+       * whole window into one meaningless span — the "always on call" narrative
+       * above already says everything there is to say.
+       */}
+      {!isSingleUser &&
+        (upcomingTurns.length > 0 ? (
+          <>
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
+              Upcoming shifts
+            </div>
+            <ol className="space-y-2">
+              {upcomingTurns.map((turn: OnCallShift, index: number) => {
+                return getShiftRow(turn, index);
+              })}
+            </ol>
+            {hasRestriction && (
+              <p className="mt-2 text-[11px] leading-relaxed text-gray-400">
+                Each row shows a person&apos;s full rotation turn; the duration
+                counts only active on-call hours (
+                {restrictionSummary.toLowerCase()}). Outside those hours,
+                lower-priority layers take over.
+              </p>
+            )}
+          </>
+        ) : (
+          <div className="rounded-lg border border-dashed border-gray-200 bg-white px-3 py-4 text-center text-sm text-gray-500">
+            No upcoming shifts in the near future. Check the rotation start and
+            hand-off time above.
+          </div>
+        ))}
+    </div>
+  );
+};
+
+export default LayerRotationSummary;

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerShiftPreview.ts
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerShiftPreview.ts
@@ -1,0 +1,163 @@
+import CalendarEvent from "Common/Types/Calendar/CalendarEvent";
+import OneUptimeDate from "Common/Types/Date";
+import EventInterval from "Common/Types/Events/EventInterval";
+import Recurring from "Common/Types/Events/Recurring";
+import LayerUtil, { LayerProps } from "Common/Types/OnCallDutyPolicy/Layer";
+import OnCallDutyPolicyScheduleLayer from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayer";
+import OnCallDutyPolicyScheduleLayerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
+import User from "Common/Models/DatabaseModels/User";
+
+/*
+ * Client-side glue that turns the stored layer models into the concrete
+ * CalendarEvents the summaries read, using the SAME LayerUtil the calendar
+ * preview and the server use. Keeping this in one place means the textual
+ * rotation summary can never drift from the calendar it sits next to.
+ */
+
+export interface LayerPreviewResult {
+  events: Array<CalendarEvent>;
+  now: Date;
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+/*
+ * Advance (or, with a negative count, rewind) a date by `count` rotation periods
+ * of the given recurrence. A period is intervalCount units of intervalType, so
+ * "every 2 days" advances 2 days per period. This lets the preview window scale
+ * to the rotation cadence: an hourly rotation only needs a few hours of window,
+ * a monthly rotation needs months.
+ */
+const addRotationPeriods: (
+  date: Date,
+  rotation: Recurring,
+  count: number,
+) => Date = (date: Date, rotation: Recurring, count: number): Date => {
+  const rawInterval: number = rotation.intervalCount?.toNumber
+    ? rotation.intervalCount.toNumber()
+    : 1;
+  const interval: number =
+    Number.isFinite(rawInterval) && rawInterval >= 1
+      ? Math.floor(rawInterval)
+      : 1;
+  const units: number = interval * count;
+
+  switch (rotation.intervalType) {
+    case EventInterval.Hour:
+      return OneUptimeDate.addRemoveHours(date, units);
+    case EventInterval.Day:
+      return OneUptimeDate.addRemoveDays(date, units);
+    case EventInterval.Week:
+      return OneUptimeDate.addRemoveWeeks(date, units);
+    case EventInterval.Month:
+      return OneUptimeDate.addRemoveMonths(date, units);
+    case EventInterval.Year:
+      return OneUptimeDate.addRemoveYears(date, units);
+    default:
+      return OneUptimeDate.addRemoveDays(date, units);
+  }
+};
+
+const toLayerUsers: (
+  users: Array<OnCallDutyPolicyScheduleLayerUser>,
+) => Array<User> = (
+  users: Array<OnCallDutyPolicyScheduleLayerUser>,
+): Array<User> => {
+  return users
+    .map((layerUser: OnCallDutyPolicyScheduleLayerUser) => {
+      return layerUser.user;
+    })
+    .filter((user: User | undefined): user is User => {
+      return Boolean(user);
+    });
+};
+
+/*
+ * Compute the rotation events for a single layer over a window sized to show the
+ * current turn plus roughly `numberOfShifts` upcoming turns. The window starts a
+ * couple of rotation periods in the past so the CURRENT turn is captured with
+ * its true (un-clamped) start rather than starting at "now".
+ */
+export const getLayerPreviewEvents: (params: {
+  layer: OnCallDutyPolicyScheduleLayer;
+  users: Array<OnCallDutyPolicyScheduleLayerUser>;
+  timezone?: string | undefined;
+  numberOfShifts?: number | undefined;
+}) => LayerPreviewResult = (params: {
+  layer: OnCallDutyPolicyScheduleLayer;
+  users: Array<OnCallDutyPolicyScheduleLayerUser>;
+  timezone?: string | undefined;
+  numberOfShifts?: number | undefined;
+}): LayerPreviewResult => {
+  const now: Date = OneUptimeDate.getCurrentDate();
+  const numberOfShifts: number = params.numberOfShifts || 6;
+
+  /*
+   * Used only to size the preview window to the rotation cadence. Guard against
+   * a missing or non-canonical rotation so a bad value degrades to a sensible
+   * default window instead of throwing during render — the events themselves are
+   * still expanded from the layer's real rotation by LayerUtil below.
+   */
+  let rotation: Recurring;
+  try {
+    rotation =
+      params.layer.rotation instanceof Recurring
+        ? params.layer.rotation
+        : Recurring.fromJSON(params.layer.rotation as never);
+  } catch {
+    rotation = Recurring.getDefault();
+  }
+
+  /*
+   * A little history so the in-progress turn shows its real start; a little
+   * extra future (numberOfShifts + 2) so the requested count survives any
+   * fully-restricted periods that produce no coverage.
+   *
+   * The window is ALSO floored to a minimum span (2 days back, 14 days forward)
+   * so a fine rotation combined with a coarser restriction still shows upcoming
+   * coverage during off-hours. Without the floor, an hourly rotation with a
+   * daily 9-5 restriction would size the forward window to ~8 hours; asked at
+   * 18:00, that whole window is off-hours and the preview would wrongly show
+   * "no upcoming shifts" even though coverage resumes at 09:00 tomorrow.
+   * OneUptime restrictions are at most weekly, so a 14-day floor always spans
+   * the largest possible off-hours gap.
+   */
+  const cadenceStart: Date = addRotationPeriods(now, rotation, -2);
+  const cadenceEnd: Date = addRotationPeriods(
+    now,
+    rotation,
+    numberOfShifts + 2,
+  );
+  const minStart: Date = OneUptimeDate.addRemoveDays(now, -2);
+  const minEnd: Date = OneUptimeDate.addRemoveDays(now, 14);
+
+  const windowStart: Date = OneUptimeDate.isBefore(cadenceStart, minStart)
+    ? cadenceStart
+    : minStart;
+  const windowEnd: Date = OneUptimeDate.isAfter(cadenceEnd, minEnd)
+    ? cadenceEnd
+    : minEnd;
+
+  const layerUsers: Array<User> = toLayerUsers(params.users);
+
+  if (layerUsers.length === 0 || !params.layer.startsAt) {
+    return { events: [], now, windowStart, windowEnd };
+  }
+
+  const layerProps: LayerProps = {
+    users: layerUsers,
+    startDateTimeOfLayer: params.layer.startsAt,
+    handOffTime: params.layer.handOffTime!,
+    rotation: params.layer.rotation!,
+    restrictionTimes: params.layer.restrictionTimes!,
+    timezone: params.timezone,
+  };
+
+  const events: Array<CalendarEvent> = new LayerUtil().getEvents({
+    ...layerProps,
+    calendarStartDate: windowStart,
+    calendarEndDate: windowEnd,
+  });
+
+  return { events, now, windowStart, windowEnd };
+};

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerSummary.ts
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerSummary.ts
@@ -157,3 +157,87 @@ export function summarizeStartsAt(startsAt: Date | undefined): string {
 
   return `Starts ${OneUptimeDate.getDateAsLocalFormattedString(startsAt, false)}`;
 }
+
+/*
+ * The following helpers format the concrete rotation SHIFTS the summaries list
+ * ("Alice is on call from Mon 9:00 AM to Tue 9:00 AM"). They format the shift's
+ * absolute instants in the schedule's timezone when one is set — the same zone
+ * the engine pages people in — so the summary can never disagree with who is
+ * actually on call. When no timezone is set they fall back to the viewer's
+ * local zone.
+ */
+
+// e.g. "Mon, Jul 7, 2025, 9:00 AM EDT"
+export function formatShiftInstant(
+  date: Date,
+  timezone?: string | undefined,
+): string {
+  return OneUptimeDate.getDateAsFormattedStringInTimezone({
+    date,
+    timezone,
+    showWeekday: true,
+  });
+}
+
+// Compact human duration from a raw seconds count, e.g. "24h", "8h 30m",
+// "5d 12h", "45m".
+export function formatDurationFromSeconds(totalSeconds: number): string {
+  if (totalSeconds <= 0) {
+    return "0m";
+  }
+
+  const days: number = Math.floor(totalSeconds / 86400);
+  const hours: number = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes: number = Math.floor((totalSeconds % 3600) / 60);
+
+  if (days > 0) {
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes || 1}m`;
+}
+
+// Compact human duration of a shift's wall-clock span (start -> end).
+export function formatShiftDuration(start: Date, end: Date): string {
+  return formatDurationFromSeconds(
+    OneUptimeDate.getDifferenceInSeconds(end, start),
+  );
+}
+
+/*
+ * A short "when does this start relative to now" label for an upcoming shift:
+ * "Now" for a shift already in progress, otherwise "in 45 min" / "in 3 hours" /
+ * "in 2 days" / "in 3 weeks".
+ */
+export function formatRelativeStart(start: Date, now: Date): string {
+  if (OneUptimeDate.isOnOrBefore(start, now)) {
+    return "Now";
+  }
+
+  const seconds: number = OneUptimeDate.getDifferenceInSeconds(start, now);
+  const minutes: number = Math.round(seconds / 60);
+
+  if (minutes < 60) {
+    return `in ${Math.max(1, minutes)} min`;
+  }
+
+  const hours: number = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `in ${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+
+  const days: number = Math.round(hours / 24);
+  if (days < 7) {
+    return `in ${days} ${days === 1 ? "day" : "days"}`;
+  }
+
+  const weeks: number = Math.round(days / 7);
+  if (weeks < 5) {
+    return `in ${weeks} ${weeks === 1 ? "week" : "weeks"}`;
+  }
+
+  const months: number = Math.round(days / 30);
+  return `in ${months} ${months === 1 ? "month" : "months"}`;
+}

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
@@ -1,8 +1,12 @@
+import FinalScheduleSummary from "./FinalScheduleSummary";
 import { getColorForUserId } from "./LayerUserColors";
 import CalendarEvent from "Common/Types/Calendar/CalendarEvent";
 import OneUptimeDate from "Common/Types/Date";
 import Dictionary from "Common/Types/Dictionary";
 import LayerUtil, { LayerProps } from "Common/Types/OnCallDutyPolicy/Layer";
+import ScheduleShiftUtil, {
+  OnCallShift,
+} from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
 import UserOverrideUtil, {
   OverrideEventMeta,
   UserOverrideRecord,
@@ -28,6 +32,14 @@ import React, {
   useMemo,
   useState,
 } from "react";
+
+/*
+ * Forward window (from "now") the textual schedule summary looks ahead over.
+ * The user-override fetch is widened to at least this window too, so the summary
+ * reflects the same substitutions the server would page — not just overrides
+ * that happen to fall in the calendar's currently-visible range.
+ */
+const SUMMARY_WINDOW_DAYS: number = 42;
 
 export interface ComponentProps {
   layers: Array<OnCallDutyPolicyScheduleLayer>;
@@ -149,6 +161,26 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
 
     let isCancelled: boolean = false;
 
+    /*
+     * Fetch overrides overlapping BOTH the visible calendar range AND the
+     * summary's forward window [now, now + SUMMARY_WINDOW_DAYS]. Widening it to
+     * the summary window means a substitution that lands weeks ahead is applied
+     * to the "upcoming hand-offs" summary too, instead of only appearing once
+     * the user navigates the calendar to that week (which previously made the
+     * summary contradict the calendar and the actual paging).
+     */
+    const summaryNow: Date = OneUptimeDate.getCurrentDate();
+    const summaryEnd: Date = OneUptimeDate.addRemoveDays(
+      summaryNow,
+      SUMMARY_WINDOW_DAYS,
+    );
+    const fetchStart: Date = OneUptimeDate.isBefore(startTime, summaryNow)
+      ? startTime
+      : summaryNow;
+    const fetchEnd: Date = OneUptimeDate.isAfter(endTime, summaryEnd)
+      ? endTime
+      : summaryEnd;
+
     const fetchOverrides: () => Promise<void> = async (): Promise<void> => {
       try {
         const result: ListResult<OnCallDutyPolicyUserOverride> =
@@ -156,8 +188,8 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
             modelType: OnCallDutyPolicyUserOverride,
             query: {
               projectId: ProjectUtil.getCurrentProjectId()!,
-              startsAt: new LessThanOrEqual<Date>(endTime),
-              endsAt: new GreaterThanOrEqual<Date>(startTime),
+              startsAt: new LessThanOrEqual<Date>(fetchEnd),
+              endsAt: new GreaterThanOrEqual<Date>(fetchStart),
               onCallDutyPolicyId: new IsNull(),
             },
             limit: LIMIT_PER_PROJECT,
@@ -263,10 +295,13 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     return result;
   }, [scheduleUsersById, overrides, overrideUserInfo]);
 
-  useEffect(() => {
-    const layerUtil: LayerUtil = new LayerUtil();
+  /*
+   * Build the LayerProps array once from the current layers/users. Shared by
+   * both the calendar (visible range) and the textual summary (a fixed forward
+   * window), so the two are always computed from identical inputs.
+   */
+  const buildLayerProps: () => Array<LayerProps> = (): Array<LayerProps> => {
     const layerProps: Array<LayerProps> = [];
-
     for (const layer of props.layers) {
       const layerUsers: Array<OnCallDutyPolicyScheduleLayerUser> =
         props.allLayerUsers[layer.id?.toString() || ""] || [];
@@ -284,6 +319,65 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
         timezone: props.timezone,
       });
     }
+    return layerProps;
+  };
+
+  const overrideRecords: Array<UserOverrideRecord> = useMemo(() => {
+    return overrides.map(
+      (o: OnCallDutyPolicyUserOverride): UserOverrideRecord => {
+        return {
+          overrideUserId: o.overrideUserId?.toString() || "",
+          routeAlertsToUserId: o.routeAlertsToUserId?.toString() || "",
+          startsAt: o.startsAt!,
+          endsAt: o.endsAt!,
+          onCallDutyPolicyId: o.onCallDutyPolicyId?.toString() || null,
+        };
+      },
+    );
+  }, [overrides]);
+
+  /*
+   * The combined-schedule shifts for the summary. Computed over a fixed forward
+   * window from "now" (independent of where the user has navigated the calendar)
+   * so "on call now / up next / upcoming hand-offs" stays stable and meaningful.
+   * Uses the same LayerUtil + override application as the calendar, so the
+   * summary never contradicts the grid below it.
+   */
+  const summaryData: {
+    shifts: Array<OnCallShift>;
+    now: Date;
+    windowEnd: Date;
+  } = useMemo(() => {
+    const now: Date = OneUptimeDate.getCurrentDate();
+    const windowEnd: Date = OneUptimeDate.addRemoveDays(
+      now,
+      SUMMARY_WINDOW_DAYS,
+    );
+
+    let events: Array<CalendarEvent> = new LayerUtil().getMultiLayerEvents({
+      calendarStartDate: now,
+      calendarEndDate: windowEnd,
+      layers: buildLayerProps(),
+    });
+
+    if (overrideRecords.length > 0) {
+      events = UserOverrideUtil.applyOverridesToEvents({
+        events,
+        overrides: overrideRecords,
+      });
+    }
+
+    return {
+      shifts: ScheduleShiftUtil.groupEventsIntoShifts(events),
+      now,
+      windowEnd,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.layers, props.allLayerUsers, props.timezone, overrideRecords]);
+
+  useEffect(() => {
+    const layerUtil: LayerUtil = new LayerUtil();
+    const layerProps: Array<LayerProps> = buildLayerProps();
 
     let events: Array<CalendarEvent> = layerUtil.getMultiLayerEvents({
       calendarEndDate: endTime,
@@ -291,19 +385,7 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
       layers: layerProps,
     });
 
-    if (overrides.length > 0) {
-      const overrideRecords: Array<UserOverrideRecord> = overrides.map(
-        (o: OnCallDutyPolicyUserOverride): UserOverrideRecord => {
-          return {
-            overrideUserId: o.overrideUserId?.toString() || "",
-            routeAlertsToUserId: o.routeAlertsToUserId?.toString() || "",
-            startsAt: o.startsAt!,
-            endsAt: o.endsAt!,
-            onCallDutyPolicyId: o.onCallDutyPolicyId?.toString() || null,
-          };
-        },
-      );
-
+    if (overrideRecords.length > 0) {
       events = UserOverrideUtil.applyOverridesToEvents({
         events,
         overrides: overrideRecords,
@@ -344,7 +426,7 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     props.timezone,
     startTime,
     endTime,
-    overrides,
+    overrideRecords,
     overrideUserInfo,
     scheduleUsersById,
   ]);
@@ -364,6 +446,20 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
               : "Here is a preview of who is on call and when. This is based on your local timezone - " +
                 OneUptimeDate.getCurrentTimezoneString()
           }
+        />
+      )}
+
+      {/*
+       * Textual "who is on call now / next / upcoming" summary of the combined
+       * schedule, above the calendar grid it is derived from.
+       */}
+      {uniqueUsers.length > 0 && (
+        <FinalScheduleSummary
+          shifts={summaryData.shifts}
+          now={summaryData.now}
+          windowEnd={summaryData.windowEnd}
+          timezone={props.timezone}
+          userById={{ ...scheduleUsersById, ...overrideUserInfo }}
         />
       )}
 

--- a/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutyPolicy/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutyPolicy/Index.tsx
@@ -7,8 +7,10 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import Label from "Common/Models/DatabaseModels/Label";
 import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
+import ProjectUtil from "Common/UI/Utils/Project";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
 import OnCallDutyPolicyFeedElement from "../../../Components/OnCallPolicy/OnCallDutyPolicyFeed";
+import OnCallPolicySummary from "../../../Components/OnCallPolicy/OnCallPolicySummary";
 
 const OnCallDutyPolicyView: FunctionComponent<
   PageComponentProps
@@ -17,6 +19,12 @@ const OnCallDutyPolicyView: FunctionComponent<
 
   return (
     <Fragment>
+      {/* At-a-glance overview of how this policy escalates. */}
+      <OnCallPolicySummary
+        onCallDutyPolicyId={modelId}
+        projectId={ProjectUtil.getCurrentProjectId()!}
+      />
+
       {/* OnCallDutyPolicy View  */}
       <CardModelDetail<OnCallDutyPolicy>
         name="On-Call Policy > On-Call Policy Details"

--- a/Common/Tests/Types/OnCallDutyPolicy/ScheduleShiftUtil.test.ts
+++ b/Common/Tests/Types/OnCallDutyPolicy/ScheduleShiftUtil.test.ts
@@ -1,0 +1,246 @@
+import CalendarEvent from "../../../Types/Calendar/CalendarEvent";
+import OneUptimeDate from "../../../Types/Date";
+import ScheduleShiftUtil, {
+  CoverageGap,
+  CurrentAndNextShift,
+  OnCallShift,
+} from "../../../Types/OnCallDutyPolicy/ScheduleShiftUtil";
+
+/*
+ * These tests pin the pure event -> shift transformation the on-call schedule
+ * summaries depend on. They deliberately do NOT re-test LayerUtil (covered by
+ * its own exhaustive suites) — they only cover the grouping / gap / current-next
+ * logic layered on top of its output.
+ */
+
+// Build a CalendarEvent the way LayerUtil emits one: user id in `title`.
+const event: (userId: string, start: Date, end: Date) => CalendarEvent = (
+  userId: string,
+  start: Date,
+  end: Date,
+): CalendarEvent => {
+  return {
+    id: 0,
+    title: userId,
+    allDay: false,
+    start,
+    end,
+  };
+};
+
+const at: (iso: string) => Date = (iso: string): Date => {
+  return OneUptimeDate.fromString(iso);
+};
+
+// Build an OnCallShift literal for the resolver/gap tests (coverageSeconds is
+// irrelevant to those, so default it to the wall-clock span).
+const mkShift: (userId: string, start: Date, end: Date) => OnCallShift = (
+  userId: string,
+  start: Date,
+  end: Date,
+): OnCallShift => {
+  return {
+    userId,
+    start,
+    end,
+    coverageSeconds: OneUptimeDate.getDifferenceInSeconds(end, start),
+  };
+};
+
+describe("ScheduleShiftUtil", () => {
+  describe("groupEventsIntoShifts", () => {
+    test("returns empty array for no events", () => {
+      expect(ScheduleShiftUtil.groupEventsIntoShifts([])).toEqual([]);
+    });
+
+    test("keeps distinct users as separate shifts (24/7 rotation)", () => {
+      const events: Array<CalendarEvent> = [
+        event("A", at("2024-01-01T09:00:00Z"), at("2024-01-02T09:00:00Z")),
+        event("B", at("2024-01-02T09:00:01Z"), at("2024-01-03T09:00:00Z")),
+        event("A", at("2024-01-03T09:00:01Z"), at("2024-01-04T09:00:00Z")),
+      ];
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+      expect(shifts).toHaveLength(3);
+      expect(shifts.map((s: OnCallShift) => s.userId)).toEqual(["A", "B", "A"]);
+      expect(shifts[0]!.end).toEqual(at("2024-01-02T09:00:00Z"));
+    });
+
+    test("merges touching same-user segments into one contiguous shift", () => {
+      // Two segments one second apart -> a single shift.
+      const events: Array<CalendarEvent> = [
+        event("A", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        event("A", at("2024-01-01T17:00:01Z"), at("2024-01-02T09:00:00Z")),
+      ];
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+      expect(shifts).toHaveLength(1);
+      expect(shifts[0]!.start).toEqual(at("2024-01-01T09:00:00Z"));
+      expect(shifts[0]!.end).toEqual(at("2024-01-02T09:00:00Z"));
+    });
+
+    test("does NOT merge same-user segments across a real gap by default", () => {
+      // Daily 9-5 restriction: same user, but a 16h nightly gap between days.
+      const events: Array<CalendarEvent> = [
+        event("A", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        event("A", at("2024-01-02T09:00:00Z"), at("2024-01-02T17:00:00Z")),
+      ];
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+      expect(shifts).toHaveLength(2);
+    });
+
+    test("merges same-user segments across gaps when mergeAcrossGaps=true", () => {
+      const events: Array<CalendarEvent> = [
+        event("A", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        event("A", at("2024-01-02T09:00:00Z"), at("2024-01-02T17:00:00Z")),
+        event("B", at("2024-01-03T09:00:00Z"), at("2024-01-03T17:00:00Z")),
+      ];
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events, {
+          mergeAcrossGaps: true,
+        });
+
+      expect(shifts).toHaveLength(2);
+      expect(shifts[0]!.userId).toBe("A");
+      expect(shifts[0]!.start).toEqual(at("2024-01-01T09:00:00Z"));
+      // Turn end is the last covered instant of that user's run.
+      expect(shifts[0]!.end).toEqual(at("2024-01-02T17:00:00Z"));
+      /*
+       * coverageSeconds is the REAL active time (two 8h days = 16h), not the
+       * ~32h wall-clock span across the overnight gap.
+       */
+      expect(shifts[0]!.coverageSeconds).toBe(16 * 3600);
+      expect(shifts[1]!.userId).toBe("B");
+    });
+
+    test("sorts unsorted input by start time and never mutates the caller array", () => {
+      const events: Array<CalendarEvent> = [
+        event("B", at("2024-01-02T09:00:00Z"), at("2024-01-03T09:00:00Z")),
+        event("A", at("2024-01-01T09:00:00Z"), at("2024-01-02T09:00:00Z")),
+      ];
+      const snapshot: Array<string> = events.map((e: CalendarEvent) => {
+        return e.title;
+      });
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+      expect(shifts.map((s: OnCallShift) => s.userId)).toEqual(["A", "B"]);
+      // input order preserved (we copy before sorting)
+      expect(events.map((e: CalendarEvent) => e.title)).toEqual(snapshot);
+    });
+  });
+
+  describe("getCurrentAndNextShift", () => {
+    const shifts: Array<OnCallShift> = [
+      mkShift("A", at("2024-01-01T09:00:00Z"), at("2024-01-02T09:00:00Z")),
+      mkShift("B", at("2024-01-02T09:00:00Z"), at("2024-01-03T09:00:00Z")),
+    ];
+
+    test("resolves the current and next shift when now is inside a shift", () => {
+      const result: CurrentAndNextShift =
+        ScheduleShiftUtil.getCurrentAndNextShift(
+          shifts,
+          at("2024-01-01T12:00:00Z"),
+        );
+
+      expect(result.current?.userId).toBe("A");
+      expect(result.next?.userId).toBe("B");
+    });
+
+    test("current is null inside a coverage gap but next is still found", () => {
+      const gapped: Array<OnCallShift> = [
+        mkShift("A", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        mkShift("A", at("2024-01-02T09:00:00Z"), at("2024-01-02T17:00:00Z")),
+      ];
+
+      const result: CurrentAndNextShift =
+        ScheduleShiftUtil.getCurrentAndNextShift(
+          gapped,
+          at("2024-01-01T20:00:00Z"),
+        );
+
+      expect(result.current).toBeNull();
+      expect(result.next?.start).toEqual(at("2024-01-02T09:00:00Z"));
+    });
+
+    test("next is null when now is past the last shift", () => {
+      const result: CurrentAndNextShift =
+        ScheduleShiftUtil.getCurrentAndNextShift(
+          shifts,
+          at("2024-01-05T00:00:00Z"),
+        );
+
+      expect(result.current).toBeNull();
+      expect(result.next).toBeNull();
+    });
+  });
+
+  describe("getCoverageGaps", () => {
+    test("reports a leading gap before the first shift", () => {
+      const shifts: Array<OnCallShift> = [
+        mkShift("A", at("2024-01-01T12:00:00Z"), at("2024-01-01T18:00:00Z")),
+      ];
+
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shifts,
+        at("2024-01-01T09:00:00Z"),
+        at("2024-01-01T20:00:00Z"),
+      );
+
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]!.start).toEqual(at("2024-01-01T09:00:00Z"));
+      expect(gaps[0]!.end).toEqual(at("2024-01-01T12:00:00Z"));
+    });
+
+    test("reports gaps between shifts but not trailing time after the last", () => {
+      const shifts: Array<OnCallShift> = [
+        mkShift("A", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        mkShift("A", at("2024-01-02T09:00:00Z"), at("2024-01-02T17:00:00Z")),
+      ];
+
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shifts,
+        at("2024-01-01T09:00:00Z"),
+        at("2024-01-03T00:00:00Z"),
+      );
+
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]!.start).toEqual(at("2024-01-01T17:00:00Z"));
+      expect(gaps[0]!.end).toEqual(at("2024-01-02T09:00:00Z"));
+    });
+
+    test("treats the whole window as a gap when there are no shifts", () => {
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        [],
+        at("2024-01-01T09:00:00Z"),
+        at("2024-01-02T09:00:00Z"),
+      );
+
+      expect(gaps).toHaveLength(1);
+    });
+
+    test("ignores the one-second boundaries between touching segments", () => {
+      const shifts: Array<OnCallShift> = [
+        mkShift("A", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        mkShift("B", at("2024-01-01T17:00:01Z"), at("2024-01-02T09:00:00Z")),
+      ];
+
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shifts,
+        at("2024-01-01T09:00:00Z"),
+        at("2024-01-02T09:00:00Z"),
+      );
+
+      expect(gaps).toHaveLength(0);
+    });
+  });
+});

--- a/Common/Types/Date.ts
+++ b/Common/Types/Date.ts
@@ -287,6 +287,52 @@ export default class OneUptimeDate {
   }
 
   /**
+   * Format a single instant as a human-readable "weekday, month day, time"
+   * string resolved in a specific IANA timezone (e.g. "America/New_York").
+   *
+   * Used by the on-call schedule summaries to render each shift's start / end in
+   * the SAME zone the rotation engine schedules people in, with a DST-aware zone
+   * abbreviation appended so the reader is never in doubt which wall clock the
+   * time refers to. When `timezone` is omitted the instant is formatted in the
+   * viewer's local zone (matching the rest of the local-time UI).
+   */
+  public static getDateAsFormattedStringInTimezone(data: {
+    date: Date | string;
+    timezone?: string | undefined;
+    onlyShowDate?: boolean | undefined;
+    showWeekday?: boolean | undefined;
+    use12HourFormat?: boolean | undefined;
+  }): string {
+    const date: Date = this.fromString(data.date);
+    const use12HourFormat: boolean =
+      data.use12HourFormat ?? this.getUserPrefers12HourFormat();
+
+    const timePart: string = use12HourFormat ? "h:mm A" : "HH:mm";
+    const datePart: string = data.showWeekday
+      ? "ddd, MMM D, YYYY"
+      : "MMM D, YYYY";
+    const formatString: string = data.onlyShowDate
+      ? datePart
+      : `${datePart}, ${timePart}`;
+
+    if (!data.timezone) {
+      const local: moment.Moment = moment(date).local();
+      return (
+        local.format(formatString) +
+        (data.onlyShowDate ? "" : " " + this.getCurrentTimezoneString())
+      ).trim();
+    }
+
+    const zoned: moment.Moment = moment(date).tz(data.timezone);
+    return (
+      zoned.format(formatString) +
+      (data.onlyShowDate
+        ? ""
+        : " " + this.getZoneAbbrByTimezone(data.timezone as Timezone, date))
+    ).trim();
+  }
+
+  /**
    * Reinterpret the wall-clock components of `date` — read in the process /
    * browser local zone — as the SAME wall-clock in `timezone`, and return that
    * instant. Used to store a time the user typed for the schedule's timezone

--- a/Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts
+++ b/Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts
@@ -1,0 +1,251 @@
+import CalendarEvent from "../Calendar/CalendarEvent";
+import OneUptimeDate from "../Date";
+
+/*
+ * Turns the low-level calendar events produced by LayerUtil into the
+ * human-readable "shifts" the on-call schedule summaries render — e.g.
+ * "Alice is on call from Mon 9:00 AM to Tue 9:00 AM".
+ *
+ * LayerUtil emits one CalendarEvent per contiguous coverage segment. A single
+ * rotation turn can therefore be split into several events (a daily 9-5
+ * restriction produces one event per day), and the merged multi-layer schedule
+ * interleaves events from different users/layers. These helpers collapse those
+ * raw segments back into the shifts a human thinks in, and surface the gaps
+ * where nobody is on call.
+ *
+ * Everything here is pure and timezone-agnostic: it operates on the absolute
+ * instants already resolved by LayerUtil (which itself resolves restriction
+ * wall-clock windows in the schedule's timezone). Rendering code decides which
+ * timezone to display those instants in.
+ */
+
+// The identity of the on-call person for an event. LayerUtil stores the user id
+// in CalendarEvent.title before the UI relabels it, so callers pass the events
+// straight through from getEvents/getMultiLayerEvents.
+export interface OnCallShift {
+  userId: string;
+  start: Date;
+  end: Date;
+  /*
+   * Total ACTIVE on-call seconds inside this shift, i.e. the sum of the covered
+   * segments' durations. For a contiguous shift this equals end - start. For a
+   * turn merged across off-hours (mergeAcrossGaps), it is the real time on call,
+   * which is smaller than the wall-clock span — so the summary can show honest
+   * coverage ("40h across the week") instead of the misleading span ("4d 8h").
+   */
+  coverageSeconds: number;
+}
+
+export interface CoverageGap {
+  start: Date;
+  end: Date;
+}
+
+export interface CurrentAndNextShift {
+  current: OnCallShift | null;
+  next: OnCallShift | null;
+}
+
+/*
+ * Two coverage segments are considered part of the same continuous shift when
+ * the gap between them is below this threshold. LayerUtil starts each following
+ * segment exactly one second after the previous one ends, so anything within a
+ * couple of minutes is "touching"; anything larger is a genuine off-hours gap
+ * (a restriction window closing, a rotation with no fallback layer, etc.).
+ */
+const CONTIGUITY_TOLERANCE_SECONDS: number = 90;
+
+export default class ScheduleShiftUtil {
+  /*
+   * Collapse raw coverage events into shifts.
+   *
+   * - mergeAcrossGaps = false (default): only merges segments that actually
+   *   touch, so genuine off-hours gaps remain visible. This is what the "final
+   *   schedule" summary uses so it can honestly show when nobody is on call.
+   * - mergeAcrossGaps = true: merges every consecutive run of the same user
+   *   into a single turn, absorbing the within-turn off-hours gaps. This is what
+   *   the per-layer rotation summary uses so "Alice: Mon -> Fri" reads as one
+   *   rotation turn instead of five separate day rows. The turn's coverageSeconds
+   *   still reflects only the real active on-call time (e.g. 5x8h, not the full
+   *   Mon->Fri wall-clock span), and the summary shows the layer's active-hours
+   *   window as context.
+   */
+  public static groupEventsIntoShifts(
+    events: Array<CalendarEvent>,
+    options?: { mergeAcrossGaps?: boolean | undefined } | undefined,
+  ): Array<OnCallShift> {
+    if (!events || events.length === 0) {
+      return [];
+    }
+
+    const mergeAcrossGaps: boolean = Boolean(options?.mergeAcrossGaps);
+
+    // Work on a copy sorted by start time; never mutate the caller's array.
+    const sorted: Array<CalendarEvent> = [...events]
+      .filter((event: CalendarEvent) => {
+        return (
+          Boolean(event.title) && Boolean(event.start) && Boolean(event.end)
+        );
+      })
+      .sort((a: CalendarEvent, b: CalendarEvent) => {
+        if (OneUptimeDate.isBefore(a.start, b.start)) {
+          return -1;
+        }
+        if (OneUptimeDate.isAfter(a.start, b.start)) {
+          return 1;
+        }
+        return 0;
+      });
+
+    const shifts: Array<OnCallShift> = [];
+
+    for (const event of sorted) {
+      const userId: string = event.title;
+      const eventSeconds: number = OneUptimeDate.getDifferenceInSeconds(
+        event.end,
+        event.start,
+      );
+      const last: OnCallShift | undefined = shifts[shifts.length - 1];
+
+      const sameUser: boolean = Boolean(last) && last!.userId === userId;
+
+      const isContiguous: boolean =
+        Boolean(last) &&
+        OneUptimeDate.getDifferenceInSeconds(last!.end, event.start) <=
+          CONTIGUITY_TOLERANCE_SECONDS &&
+        OneUptimeDate.isOnOrBefore(last!.end, event.end);
+
+      /*
+       * Extend the previous shift when it belongs to the same user AND either we
+       * are merging whole turns, or the two segments physically touch. Only
+       * extend the end forward — never pull it backwards — so overlapping
+       * segments (possible after the multi-layer priority merge) can't shrink a
+       * shift. Accumulate each merged segment's own duration into coverageSeconds
+       * so a turn merged across off-hours reports its real active time on call.
+       */
+      if (last && sameUser && (mergeAcrossGaps || isContiguous)) {
+        if (OneUptimeDate.isAfter(event.end, last.end)) {
+          last.end = event.end;
+        }
+        last.coverageSeconds += eventSeconds;
+        continue;
+      }
+
+      shifts.push({
+        userId,
+        start: event.start,
+        end: event.end,
+        coverageSeconds: eventSeconds,
+      });
+    }
+
+    return shifts;
+  }
+
+  /*
+   * The shift that contains `now` (the person on call right now) and the first
+   * shift that starts after `now` (up next). Either can be null: `current` is
+   * null when nobody is on call at this instant (a coverage gap), and `next` is
+   * null when the computed window does not reach far enough to include another
+   * shift.
+   */
+  public static getCurrentAndNextShift(
+    shifts: Array<OnCallShift>,
+    now: Date,
+  ): CurrentAndNextShift {
+    let current: OnCallShift | null = null;
+    let next: OnCallShift | null = null;
+
+    for (const shift of shifts) {
+      const hasStarted: boolean = OneUptimeDate.isOnOrBefore(shift.start, now);
+      const hasNotEnded: boolean = OneUptimeDate.isAfter(shift.end, now);
+
+      if (hasStarted && hasNotEnded) {
+        current = shift;
+        continue;
+      }
+
+      if (OneUptimeDate.isAfter(shift.start, now)) {
+        if (!next || OneUptimeDate.isBefore(shift.start, next.start)) {
+          next = shift;
+        }
+      }
+    }
+
+    return { current, next };
+  }
+
+  /*
+   * Periods inside [windowStart, windowEnd] during which no shift provides
+   * coverage. Includes a leading gap (from windowStart until the first shift
+   * begins) and gaps between consecutive shifts. Trailing time after the last
+   * shift is intentionally NOT reported as a gap: the summary window is finite,
+   * so "nothing scheduled past the window" is an artifact of the window, not a
+   * real coverage hole.
+   *
+   * `shifts` are assumed sorted by start (as returned by groupEventsIntoShifts).
+   */
+  public static getCoverageGaps(
+    shifts: Array<OnCallShift>,
+    windowStart: Date,
+    windowEnd: Date,
+  ): Array<CoverageGap> {
+    const gaps: Array<CoverageGap> = [];
+
+    if (OneUptimeDate.isOnOrAfter(windowStart, windowEnd)) {
+      return gaps;
+    }
+
+    // A gap only "counts" when it is longer than the contiguity tolerance, so
+    // the one-second boundaries LayerUtil leaves between segments never show up
+    // as spurious coverage holes.
+    const isRealGap: (start: Date, end: Date) => boolean = (
+      start: Date,
+      end: Date,
+    ): boolean => {
+      return (
+        OneUptimeDate.isAfter(end, start) &&
+        OneUptimeDate.getDifferenceInSeconds(end, start) >
+          CONTIGUITY_TOLERANCE_SECONDS
+      );
+    };
+
+    if (shifts.length === 0) {
+      if (isRealGap(windowStart, windowEnd)) {
+        gaps.push({ start: windowStart, end: windowEnd });
+      }
+      return gaps;
+    }
+
+    // Leading gap: nobody on call from the window start until the first shift.
+    const firstShift: OnCallShift = shifts[0]!;
+    if (
+      OneUptimeDate.isAfter(firstShift.start, windowStart) &&
+      isRealGap(windowStart, firstShift.start)
+    ) {
+      gaps.push({ start: windowStart, end: firstShift.start });
+    }
+
+    // `coveredUntil` tracks the furthest point covered so far. Shifts can
+    // overlap (multi-layer merges), so we advance it monotonically and only
+    // record a gap when the next shift starts strictly after it.
+    let coveredUntil: Date = firstShift.end;
+
+    for (let i: number = 1; i < shifts.length; i++) {
+      const shift: OnCallShift = shifts[i]!;
+
+      if (
+        OneUptimeDate.isAfter(shift.start, coveredUntil) &&
+        isRealGap(coveredUntil, shift.start)
+      ) {
+        gaps.push({ start: coveredUntil, end: shift.start });
+      }
+
+      if (OneUptimeDate.isAfter(shift.end, coveredUntil)) {
+        coveredUntil = shift.end;
+      }
+    }
+
+    return gaps;
+  }
+}


### PR DESCRIPTION
## What & why

On-call schedules and policies were configurable but hard to *read at a glance*: the schedule editor showed a calendar grid but no plain-english "who is on call from when to when", and the escalation/policy pages gave only a basic list. This PR adds human-readable **summaries** across the on-call product, and polishes the UI to match.

All summaries are derived from the **same `LayerUtil` rotation engine** the server and the calendar use (timezone-aware, restriction/override-aware), so they can never disagree with who actually gets paged.

## What's new

### 1. Per-layer rotation summary (schedule layers)
- Each layer card now shows **"Who is on call, and when"** when expanded: the rotation order (User 1 → User 2 → …), a plain-english framing, and a list of upcoming **shifts** — `Alice · Mon, Jul 7, 9:00 AM → Tue, Jul 8, 9:00 AM`, with duration and a relative "in 2 days" label. The current turn is highlighted.
- The collapsed layer header gets a live **"● Alice on call now · Up next Bob in 3 hours"** line (honest for restricted layers — shows "No one on call in this layer right now" during off-hours).

### 2. Final schedule summary
- Above the combined "Final schedule" calendar: **On call right now** and **Up next** hero cards, an **Upcoming hand-offs** list, and **coverage-gap warnings** ("no one is on call from … to …") — surfacing holes a restricted schedule with no fallback would otherwise hide.

### 3. Escalation summary (escalation policy)
- A new **Escalation summary** card at the top of the escalation view: stat tiles (levels, responders, time to final level, repeats) plus a condensed, cumulative-timed timeline: *Incident triggered → Level 1 immediately → Level 2 after 5 min → … → repeats ×N / stops.* Stays in lockstep with rule add/edit/delete/reorder.

### 4. Policy overview (on-call policy)
- A **"Policy at a glance"** card on the policy page: a one-paragraph narrative of how the policy responds, the same stat tiles, a responder breakdown (schedules / teams / users), and warnings for levels with no responders.

## Implementation notes
- New pure util `Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts` turns `LayerUtil` events into shifts (per-turn grouping for a single layer; contiguous grouping + coverage-gap detection for the merged schedule) — fully unit-tested (`ScheduleShiftUtil.test.ts`, 13 tests).
- New `Date.getDateAsFormattedStringInTimezone(...)` renders a weekday + date + time in a given IANA timezone with a DST-aware zone abbreviation, so shift times are shown in the schedule's own timezone (matching the restriction chips and the paging engine).
- All new UI matches the existing indigo/gray card design language.

## Testing
- `ScheduleShiftUtil.test.ts` — 13 unit tests, all passing.
- `npm run compile` in `Common` and `App/FeatureSet/Dashboard`.
- Existing `LayerUtil` / override test suites unchanged and green.
