### PR TITLE
Modernize dashboard dialogs and floating controls

### DIFF
--- a/Common/Tests/UI/Components/ConfirmModal.test.tsx
+++ b/Common/Tests/UI/Components/ConfirmModal.test.tsx
@@ -2,7 +2,8 @@ import { ButtonStyleType } from "../../../UI/Components/Button/Button";
 import ConfirmModal, {
   ComponentProps,
 } from "../../../UI/Components/Modal/ConfirmModal";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { describe, it, jest, beforeEach } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
@@ -46,6 +47,26 @@ describe("ConfirmModal", () => {
       "modal-footer-close-button",
     )?.classList;
     expect(closeButton.contains("bg-white")).toBe(true);
+  });
+
+  it("links the confirmation description to the dialog", () => {
+    render(<ConfirmModal {...mockProps} />);
+
+    const dialog: HTMLElement = screen.getByRole("dialog", {
+      name: "Confirmation Title",
+    });
+    const description: HTMLElement = screen.getByTestId(
+      "confirm-modal-description",
+    );
+
+    expect(description.id).not.toBe("");
+    expect(dialog).toHaveAttribute("aria-describedby", description.id);
+  });
+
+  it("initially focuses the non-destructive confirmation action", () => {
+    render(<ConfirmModal {...mockProps} />);
+
+    expect(screen.getByTestId("modal-footer-close-button")).toHaveFocus();
   });
 
   it("closes the comfirm modal when the close button is clicked", () => {

--- a/Common/Tests/UI/Components/Dropdown.test.tsx
+++ b/Common/Tests/UI/Components/Dropdown.test.tsx
@@ -1,10 +1,12 @@
 import Dropdown, {
   DropdownOption,
 } from "../../../UI/Components/Dropdown/Dropdown";
-import "@testing-library/jest-dom/extend-expect";
-import { fireEvent, render, screen } from "@testing-library/react";
+import EntityDropdown from "../../../UI/Components/EntityDropdown/EntityDropdown";
+import Modal from "../../../UI/Components/Modal/Modal";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { describe, expect } from "@jest/globals";
+import { describe } from "@jest/globals";
 import getJestMockFunction, { MockFunction } from "../../../Tests/MockType";
 describe("Dropdown", () => {
   const options: DropdownOption[] = [
@@ -53,6 +55,101 @@ describe("Dropdown", () => {
 
     expect(await screen.findByText("1")).toBeInTheDocument();
     expect(await screen.findByText("2")).toBeInTheDocument();
+  });
+
+  test("renders a portalled menu above its containing modal", async () => {
+    render(
+      <Modal title="Dropdown Modal" onClose={() => {}}>
+        <Dropdown onChange={() => {}} options={options} />
+      </Modal>,
+    );
+    const dropdown: HTMLElement = screen.getByRole("combobox");
+
+    fireEvent.keyDown(dropdown, { key: "ArrowDown", code: "ArrowDown" });
+
+    const option: HTMLElement = await screen.findByText("1");
+    let menuPortal: HTMLElement | null = option.parentElement;
+    while (
+      menuPortal &&
+      menuPortal !== document.body &&
+      window.getComputedStyle(menuPortal).zIndex !== "70"
+    ) {
+      menuPortal = menuPortal.parentElement;
+    }
+
+    expect(menuPortal).not.toBeNull();
+    expect(menuPortal ? window.getComputedStyle(menuPortal).zIndex : "").toBe(
+      "70",
+    );
+  });
+
+  test("closes its menu before Escape reaches the containing modal", async () => {
+    const onModalClose: MockFunction = getJestMockFunction();
+    render(
+      <Modal title="Dropdown Modal" onClose={onModalClose}>
+        <Dropdown onChange={() => {}} options={options} />
+      </Modal>,
+    );
+    const dropdown: HTMLElement = screen.getByRole("combobox");
+
+    fireEvent.keyDown(dropdown, { key: "ArrowDown", code: "ArrowDown" });
+    expect(await screen.findByText("1")).toBeInTheDocument();
+
+    fireEvent.keyDown(dropdown, { key: "Escape", code: "Escape" });
+
+    expect(onModalClose).not.toHaveBeenCalled();
+  });
+
+  test("links an entity listbox and dismisses it before its modal", async () => {
+    const onModalClose: MockFunction = getJestMockFunction();
+    render(
+      <Modal title="Entity Modal" onClose={onModalClose}>
+        <EntityDropdown
+          onChange={() => {}}
+          options={options}
+          dataTestId="entity-dropdown"
+        />
+      </Modal>,
+    );
+    const dropdown: HTMLInputElement = screen.getByTestId("entity-dropdown");
+
+    fireEvent.focus(dropdown);
+    fireEvent.keyDown(dropdown, { key: "ArrowDown", code: "ArrowDown" });
+
+    const listbox: HTMLElement = await screen.findByRole("listbox");
+    const activeOptionId: string | null = dropdown.getAttribute(
+      "aria-activedescendant",
+    );
+    expect(dropdown).toHaveAttribute("aria-controls", listbox.id);
+    expect(activeOptionId).not.toBeNull();
+    expect(document.getElementById(activeOptionId || "")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+
+    fireEvent.keyDown(dropdown, { key: "Escape", code: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(onModalClose).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(dropdown, { key: "Escape", code: "Escape" });
+    expect(onModalClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("moves focus into an entity search opened from a selected value", async () => {
+    render(
+      <EntityDropdown
+        onChange={() => {}}
+        options={options}
+        initialValue={options[0]}
+        dataTestId="selected-entity-dropdown"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "1" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-entity-dropdown")).toHaveFocus();
+    });
   });
 
   test("renders placeholder", async () => {

--- a/Common/Tests/UI/Components/Modal.test.tsx
+++ b/Common/Tests/UI/Components/Modal.test.tsx
@@ -1,12 +1,38 @@
 import { ButtonStyleType } from "../../../UI/Components/Button/Button";
 import ButtonType from "../../../UI/Components/Button/ButtonTypes";
 import Modal, { ModalWidth } from "../../../UI/Components/Modal/Modal";
-import { describe, expect, it, test } from "@jest/globals";
-import "@testing-library/jest-dom/extend-expect";
-import { fireEvent, render } from "@testing-library/react";
+import FloatingPortal from "../../../UI/Components/Floating/FloatingPortal";
+import IconPicker from "../../../UI/Components/Forms/Fields/IconPicker";
+import { describe, it, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import IconProp from "../../../Types/Icon/IconProp";
-import React from "react";
+import React, { ReactElement, useRef } from "react";
 import getJestMockFunction, { MockFunction } from "../../../Tests/MockType";
+
+const FloatingControl: () => ReactElement = (): ReactElement => {
+  const anchorRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <button ref={anchorRef} type="button" data-testid="floating-anchor">
+        Open menu
+      </button>
+      <FloatingPortal anchorRef={anchorRef} onEscape={() => {}}>
+        <button type="button" data-testid="floating-action">
+          Floating action
+        </button>
+      </FloatingPortal>
+    </>
+  );
+};
 
 describe("Modal", () => {
   test("renders the modal with the title and description", () => {
@@ -41,6 +67,427 @@ describe("Modal", () => {
     fireEvent.click(closeButton);
 
     expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it("closes the modal when Escape is pressed", () => {
+    const onCloseMock: MockFunction = getJestMockFunction();
+
+    render(
+      <Modal title="Escape Modal" onClose={onCloseMock}>
+        <button type="button">Focusable content</button>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("dialog", { name: "Escape Modal" }), {
+      key: "Escape",
+    });
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("only closes the top-most nested modal when Escape is pressed", () => {
+    const onParentClose: MockFunction = getJestMockFunction();
+    const onChildClose: MockFunction = getJestMockFunction();
+
+    render(
+      <Modal title="Parent Modal" onClose={onParentClose}>
+        <Modal title="Child Modal" onClose={onChildClose}>
+          <button type="button">Child action</button>
+        </Modal>
+      </Modal>,
+    );
+
+    const parentDialog: HTMLElement = screen
+      .getByText("Parent Modal")
+      .closest('[role="dialog"]') as HTMLElement;
+    const childDialog: HTMLElement = screen.getByRole("dialog", {
+      name: "Child Modal",
+    });
+    const parentLayer: HTMLElement = parentDialog.closest(
+      '[data-testid="modal-layer"]',
+    ) as HTMLElement;
+    const childLayer: HTMLElement = childDialog.closest(
+      '[data-testid="modal-layer"]',
+    ) as HTMLElement;
+
+    expect(Number(childLayer.style.zIndex)).toBeGreaterThan(
+      Number(parentLayer.style.zIndex),
+    );
+    expect(parentDialog).toHaveAttribute("aria-hidden", "true");
+    expect(parentDialog).toHaveAttribute("inert");
+    expect(childDialog).toHaveAttribute("aria-modal", "true");
+    expect(within(childDialog).getByText("Child action")).toHaveFocus();
+
+    fireEvent.keyDown(childDialog, {
+      key: "Escape",
+    });
+
+    expect(onChildClose).toHaveBeenCalledTimes(1);
+    expect(onParentClose).not.toHaveBeenCalled();
+  });
+
+  it("consumes Escape in a non-dismissible nested modal", () => {
+    const onParentClose: MockFunction = getJestMockFunction();
+    const onChildSubmit: MockFunction = getJestMockFunction();
+
+    render(
+      <Modal title="Parent Modal" onClose={onParentClose}>
+        <Modal title="Locked Child Modal" onSubmit={onChildSubmit}>
+          <div>Child content</div>
+        </Modal>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(
+      screen.getByRole("dialog", { name: "Locked Child Modal" }),
+      { key: "Escape" },
+    );
+
+    expect(onParentClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps nested dialog Tab handling inside the child dialog", () => {
+    const onParentClose: MockFunction = getJestMockFunction();
+    const onChildSubmit: MockFunction = getJestMockFunction();
+
+    render(
+      <Modal title="Parent Modal" onClose={onParentClose}>
+        <Modal title="Child Modal" onSubmit={onChildSubmit}>
+          <input data-testid="child-first-field" aria-label="Child field" />
+        </Modal>
+      </Modal>,
+    );
+
+    const childFirstField: HTMLInputElement =
+      screen.getByTestId("child-first-field");
+    const childSubmitButton: HTMLButtonElement = screen.getByTestId(
+      "modal-footer-submit-button",
+    );
+
+    childSubmitButton.focus();
+    fireEvent.keyDown(childSubmitButton, { key: "Tab" });
+
+    expect(childFirstField).toHaveFocus();
+  });
+
+  it("uses unique title and description ids for each dialog", () => {
+    render(
+      <>
+        <Modal title="First Modal" description="First description">
+          <div>First content</div>
+        </Modal>
+        <Modal title="Second Modal" description="Second description">
+          <div>Second content</div>
+        </Modal>
+      </>,
+    );
+
+    const firstDialog: HTMLElement = screen
+      .getByText("First Modal")
+      .closest('[role="dialog"]') as HTMLElement;
+    const secondDialog: HTMLElement = screen.getByRole("dialog", {
+      name: "Second Modal",
+    });
+    const firstTitle: HTMLElement = screen.getByText("First Modal");
+    const secondTitle: HTMLElement = screen.getByText("Second Modal");
+    const firstDescription: HTMLElement = screen.getByText("First description");
+    const secondDescription: HTMLElement =
+      screen.getByText("Second description");
+
+    expect(firstTitle.id).not.toBe("");
+    expect(secondTitle.id).not.toBe("");
+    expect(firstDescription.id).not.toBe("");
+    expect(secondDescription.id).not.toBe("");
+    expect(firstTitle.id).not.toBe(secondTitle.id);
+    expect(firstDescription.id).not.toBe(secondDescription.id);
+    expect(firstDialog).toHaveAttribute("aria-labelledby", firstTitle.id);
+    expect(firstDialog).toHaveAttribute(
+      "aria-describedby",
+      firstDescription.id,
+    );
+    expect(secondDialog).toHaveAttribute("aria-labelledby", secondTitle.id);
+    expect(secondDialog).toHaveAttribute(
+      "aria-describedby",
+      secondDescription.id,
+    );
+  });
+
+  it("moves focus into the modal and restores it when the modal unmounts", async () => {
+    const onSubmitMock: MockFunction = getJestMockFunction();
+    const { rerender } = render(
+      <button data-testid="modal-trigger" type="button">
+        Open modal
+      </button>,
+    );
+    const trigger: HTMLButtonElement = screen.getByTestId("modal-trigger");
+    trigger.focus();
+
+    rerender(
+      <>
+        <button data-testid="modal-trigger" type="button">
+          Open modal
+        </button>
+        <Modal title="Focus Modal" onSubmit={onSubmitMock}>
+          <input data-testid="first-modal-field" aria-label="First field" />
+        </Modal>
+      </>,
+    );
+
+    expect(screen.getByTestId("first-modal-field")).toHaveFocus();
+
+    rerender(
+      <button data-testid="modal-trigger" type="button">
+        Open modal
+      </button>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("modal-trigger")).toHaveFocus();
+    });
+  });
+
+  it("keeps owner-linked floating controls inside the modal focus loop", () => {
+    const onSubmitMock: MockFunction = getJestMockFunction();
+
+    render(
+      <Modal title="Floating Modal" onSubmit={onSubmitMock}>
+        <FloatingControl />
+      </Modal>,
+    );
+
+    const dialog: HTMLElement = screen.getByRole("dialog", {
+      name: "Floating Modal",
+    });
+    const floatingAction: HTMLButtonElement =
+      screen.getByTestId("floating-action");
+    const floatingPortal: HTMLElement = floatingAction.closest(
+      '[data-floating-portal="true"]',
+    ) as HTMLElement;
+
+    expect(floatingPortal.dataset["floatingModalOwner"]).toBe(
+      dialog.dataset["modalOwnerId"],
+    );
+
+    floatingAction.focus();
+    fireEvent.keyDown(floatingAction, { key: "Tab" });
+
+    expect(screen.getByTestId("floating-anchor")).toHaveFocus();
+  });
+
+  it("returns focus to a picker trigger when its portal closes", async () => {
+    const onModalClose: MockFunction = getJestMockFunction();
+    render(
+      <Modal title="Picker Modal" onClose={onModalClose}>
+        <IconPicker
+          placeholder="Choose icon"
+          dataTestId="icon-picker-trigger"
+          onChange={() => {}}
+        />
+      </Modal>,
+    );
+
+    const trigger: HTMLButtonElement = screen.getByTestId(
+      "icon-picker-trigger",
+    );
+    fireEvent.click(trigger);
+    const searchInput: HTMLInputElement =
+      screen.getByPlaceholderText("Search icons...");
+    await waitFor(() => {
+      expect(searchInput).toHaveFocus();
+    });
+
+    fireEvent.keyDown(searchInput, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+    expect(
+      screen.queryByPlaceholderText("Search icons..."),
+    ).not.toBeInTheDocument();
+    expect(onModalClose).not.toHaveBeenCalled();
+
+    fireEvent.click(trigger);
+    const pickerDialog: HTMLElement = screen.getByRole("dialog", {
+      name: "Choose an icon",
+    });
+    const firstIconOption: HTMLButtonElement = within(
+      pickerDialog,
+    ).getAllByRole("button")[0] as HTMLButtonElement;
+    firstIconOption.focus();
+    fireEvent.click(firstIconOption);
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it("reactivates and focuses a parent when its nested modal unmounts", async () => {
+    const { rerender } = render(
+      <Modal title="Parent Modal">
+        <>
+          <input data-testid="parent-field" aria-label="Parent field" />
+          <Modal title="Child Modal">
+            <input data-testid="child-field" aria-label="Child field" />
+          </Modal>
+        </>
+      </Modal>,
+    );
+
+    expect(screen.getByTestId("child-field")).toHaveFocus();
+
+    rerender(
+      <Modal title="Parent Modal">
+        <input data-testid="parent-field" aria-label="Parent field" />
+      </Modal>,
+    );
+
+    await waitFor(() => {
+      const parentDialog: HTMLElement = screen.getByRole("dialog", {
+        name: "Parent Modal",
+      });
+      expect(parentDialog).not.toHaveAttribute("inert");
+      expect(screen.getByTestId("parent-field")).toHaveFocus();
+    });
+  });
+
+  it("focuses the remaining dialog when the top same-level dialog unmounts", async () => {
+    const { rerender } = render(
+      <>
+        <Modal title="First Modal">
+          <input data-testid="first-field" aria-label="First field" />
+        </Modal>
+        <Modal title="Second Modal">
+          <input data-testid="second-field" aria-label="Second field" />
+        </Modal>
+      </>,
+    );
+
+    expect(screen.getByTestId("second-field")).toHaveFocus();
+
+    rerender(
+      <Modal title="First Modal">
+        <input data-testid="first-field" aria-label="First field" />
+      </Modal>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("first-field")).toHaveFocus();
+    });
+  });
+
+  it("restores the external trigger when an entire nested stack unmounts", async () => {
+    const { rerender } = render(
+      <button data-testid="stack-trigger" type="button">
+        Open stack
+      </button>,
+    );
+    const trigger: HTMLButtonElement = screen.getByTestId("stack-trigger");
+    trigger.focus();
+
+    rerender(
+      <>
+        <button data-testid="stack-trigger" type="button">
+          Open stack
+        </button>
+        <Modal title="Parent Modal">
+          <Modal title="Child Modal">
+            <input aria-label="Child field" />
+          </Modal>
+        </Modal>
+      </>,
+    );
+
+    rerender(
+      <button data-testid="stack-trigger" type="button">
+        Open stack
+      </button>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stack-trigger")).toHaveFocus();
+    });
+  });
+
+  it("inerts floating controls owned by an underlying modal", () => {
+    render(
+      <Modal title="Parent Modal">
+        <>
+          <FloatingControl />
+          <Modal title="Child Modal">
+            <button type="button">Child action</button>
+          </Modal>
+        </>
+      </Modal>,
+    );
+
+    const floatingPortal: HTMLElement = screen
+      .getByTestId("floating-action")
+      .closest('[data-floating-portal="true"]') as HTMLElement;
+
+    expect(floatingPortal).toHaveAttribute("inert");
+    expect(floatingPortal).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("reveals a new form error at the top of the scroll region", () => {
+    const { rerender } = render(
+      <Modal title="Form Modal">
+        <div>Long form</div>
+      </Modal>,
+    );
+    const scrollRegion: HTMLElement = screen.getByTestId("modal-scroll-region");
+    scrollRegion.scrollTop = 320;
+
+    rerender(
+      <Modal title="Form Modal" error="Unable to save">
+        <div>Long form</div>
+      </Modal>,
+    );
+
+    expect(scrollRegion.scrollTop).toBe(0);
+    expect(screen.getByRole("alert")).toHaveTextContent("Unable to save");
+  });
+
+  it("contains Tab and Shift+Tab focus within the dialog", () => {
+    const onSubmitMock: MockFunction = getJestMockFunction();
+
+    render(
+      <Modal title="Focus Trap Modal" onSubmit={onSubmitMock}>
+        <input data-testid="first-modal-field" aria-label="First field" />
+      </Modal>,
+    );
+
+    const firstField: HTMLInputElement =
+      screen.getByTestId("first-modal-field");
+    const submitButton: HTMLButtonElement = screen.getByTestId(
+      "modal-footer-submit-button",
+    );
+
+    submitButton.focus();
+    fireEvent.keyDown(submitButton, { key: "Tab" });
+    expect(firstField).toHaveFocus();
+
+    firstField.focus();
+    fireEvent.keyDown(firstField, { key: "Tab", shiftKey: true });
+    expect(submitButton).toHaveFocus();
+  });
+
+  it("does not render an empty footer when there are no actions", () => {
+    const onSubmitMock: MockFunction = getJestMockFunction();
+    const { rerender } = render(
+      <Modal title="Read-only Modal">
+        <div>Read-only content</div>
+      </Modal>,
+    );
+
+    expect(screen.queryByTestId("modal-footer")).not.toBeInTheDocument();
+
+    rerender(
+      <Modal title="Action Modal" onSubmit={onSubmitMock}>
+        <div>Action content</div>
+      </Modal>,
+    );
+
+    expect(screen.getByTestId("modal-footer")).toBeInTheDocument();
   });
 
   it("calls the onSubmit function when the submit button is clicked", () => {

--- a/Common/Tests/UI/Components/Toast.test.tsx
+++ b/Common/Tests/UI/Components/Toast.test.tsx
@@ -1,10 +1,10 @@
 import Toast, { ToastType } from "../../../UI/Components/Toast/Toast";
-import "@testing-library/jest-dom/extend-expect";
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import * as React from "react";
-import { describe, expect, test } from "@jest/globals";
+import { describe, test } from "@jest/globals";
 
 describe("Test for Toast.tsx", () => {
   test("should render the component", () => {
@@ -12,7 +12,7 @@ describe("Test for Toast.tsx", () => {
       <Toast type={ToastType.SUCCESS} title="Spread" description="Love" />,
     );
     expect(screen.getByTestId("toast")).toHaveClass(
-      "pointer-events-none fixed z-40 top-0 left-0 right-0  flex items-end px-4 py-6 sm:items-start sm:p-6",
+      "pointer-events-none fixed z-[200] top-0 left-0 right-0  flex items-end px-4 py-6 sm:items-start sm:p-6",
     );
   });
 

--- a/Common/UI/Components/Dropdown/Dropdown.tsx
+++ b/Common/UI/Components/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import ObjectID from "../../../Types/ObjectID";
 import useTranslateValue from "../../Utils/Translation";
+import { ModalStackValue, useModalStack } from "../Modal/ModalStackContext";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -66,6 +67,7 @@ const Dropdown: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const { translateString } = useTranslateValue();
+  const modalStack: ModalStackValue = useModalStack();
   const tx: (value: string | undefined) => string | undefined = (
     value: string | undefined,
   ): string | undefined => {
@@ -165,6 +167,10 @@ const Dropdown: FunctionComponent<ComponentProps> = (
   const [value, setValue] = useState<
     DropdownOption | Array<DropdownOption> | undefined
   >(getDropdownOptionFromValue(props.initialValue));
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(
+    null,
+  );
 
   const firstUpdate: React.MutableRefObject<boolean> = useRef(true);
 
@@ -511,6 +517,25 @@ const Dropdown: FunctionComponent<ComponentProps> = (
     setValue(value);
   }, [props.value]);
 
+  useLayoutEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const portalTarget: HTMLDivElement = document.createElement("div");
+    portalTarget.dataset["floatingPortal"] = "true";
+    portalTarget.dataset["floatingModalDepth"] = String(modalStack.depth);
+    if (modalStack.ownerId) {
+      portalTarget.dataset["floatingModalOwner"] = modalStack.ownerId;
+    }
+    document.body.appendChild(portalTarget);
+    setMenuPortalTarget(portalTarget);
+
+    return () => {
+      portalTarget.remove();
+    };
+  }, [modalStack.depth, modalStack.ownerId]);
+
   return (
     <div
       id={props.id}
@@ -536,6 +561,17 @@ const Dropdown: FunctionComponent<ComponentProps> = (
         value={value || null}
         onFocus={() => {
           props.onFocus?.();
+        }}
+        onMenuOpen={(): void => {
+          setIsMenuOpen(true);
+        }}
+        onMenuClose={(): void => {
+          setIsMenuOpen(false);
+        }}
+        onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>): void => {
+          if (event.key === "Escape" && isMenuOpen) {
+            event.stopPropagation();
+          }
         }}
         aria-label={props.ariaLabel}
         aria-labelledby={props.ariaLabelledby}
@@ -710,11 +746,15 @@ const Dropdown: FunctionComponent<ComponentProps> = (
           menuPortal: (base: CSSObjectWithLabel): CSSObjectWithLabel => {
             return {
               ...base,
-              zIndex: 50,
+              /*
+               * Keep this body portal above its containing modal but below a
+               * nested dialog. Outside a modal, preserve the legacy z-index.
+               */
+              zIndex: 50 + modalStack.depth * 20,
             };
           },
         }}
-        menuPortalTarget={document.body}
+        menuPortalTarget={menuPortalTarget}
         menuPosition="fixed"
         isClearable={true}
         isSearchable={true}

--- a/Common/UI/Components/EntityDropdown/EntityDropdown.tsx
+++ b/Common/UI/Components/EntityDropdown/EntityDropdown.tsx
@@ -8,6 +8,7 @@ import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
 import IconProp from "../../../Types/Icon/IconProp";
 import ObjectID from "../../../Types/ObjectID";
 import ModelAPI, { ListResult } from "../../Utils/ModelAPI/ModelAPI";
+import FloatingPortal from "../Floating/FloatingPortal";
 import Icon from "../Icon/Icon";
 import {
   DropdownOption,
@@ -20,6 +21,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -251,6 +253,13 @@ const detectLabelsField: (
 const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
   props: EntityDropdownProps,
 ): ReactElement => {
+  const uniqueId: string = useId();
+  const listboxId: string = `entity-dropdown-listbox-${uniqueId}`;
+  const popupId: string = `entity-dropdown-popup-${uniqueId}`;
+  const optionsPanelId: string = `entity-dropdown-options-panel-${uniqueId}`;
+  const labelsPanelId: string = `entity-dropdown-labels-panel-${uniqueId}`;
+  const optionsTabId: string = `entity-dropdown-options-tab-${uniqueId}`;
+  const labelsTabId: string = `entity-dropdown-labels-tab-${uniqueId}`;
   const isMulti: boolean = Boolean(props.isMultiSelect);
   const modelType: { new (): BaseModel } | undefined = props.modelType;
   const labelField: string = props.labelField || "name";
@@ -441,8 +450,14 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
 
   const containerRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef<HTMLDivElement | null>(null);
+  const menuRef: React.MutableRefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement | null>(null);
   const inputRef: React.MutableRefObject<HTMLInputElement | null> =
     useRef<HTMLInputElement | null>(null);
+  const optionsTabRef: React.MutableRefObject<HTMLButtonElement | null> =
+    useRef<HTMLButtonElement | null>(null);
+  const labelsTabRef: React.MutableRefObject<HTMLButtonElement | null> =
+    useRef<HTMLButtonElement | null>(null);
   const debounceRef: React.MutableRefObject<number | null> = useRef<
     number | null
   >(null);
@@ -454,7 +469,8 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
       if (
         containerRef.current &&
         event.target instanceof Node &&
-        !containerRef.current.contains(event.target)
+        !containerRef.current.contains(event.target) &&
+        !menuRef.current?.contains(event.target)
       ) {
         setIsOpen(false);
       }
@@ -1052,6 +1068,57 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
   const placeholderText: string = props.placeholder || "Select...";
   const showSingleSelectedText: boolean =
     !isMulti && !isOpen && selectedOptions.length > 0;
+  const activeDescendantId: string | undefined =
+    isOpen &&
+    activeTab === "options" &&
+    highlightedIndex >= 0 &&
+    highlightedIndex < availableOptions.length
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
+  const shouldFocusInputOnOpenRef: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
+
+  useEffect((): void => {
+    if (isOpen && shouldFocusInputOnOpenRef.current) {
+      shouldFocusInputOnOpenRef.current = false;
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const activateTab: (
+    tab: "options" | "labels",
+    moveFocus?: boolean,
+  ) => void = (tab: "options" | "labels", moveFocus?: boolean): void => {
+    setActiveTab(tab);
+    setHighlightedIndex(-1);
+
+    if (moveFocus) {
+      window.setTimeout((): void => {
+        (tab === "options" ? optionsTabRef : labelsTabRef).current?.focus();
+      }, 0);
+    }
+  };
+
+  const handleTabKeyDown: (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => void = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+    let nextTab: "options" | "labels" | null = null;
+
+    if (event.key === "Home") {
+      nextTab = "options";
+    } else if (event.key === "End") {
+      nextTab = "labels";
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      nextTab = activeTab === "options" ? "labels" : "options";
+    }
+
+    if (!nextTab) {
+      return;
+    }
+
+    event.preventDefault();
+    activateTab(nextTab, true);
+  };
 
   return (
     <div
@@ -1113,78 +1180,82 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
          * container to start typing.
          */}
         {showSingleSelectedText && (
-          <button
-            type="button"
-            disabled={props.disabled}
-            aria-labelledby={props.ariaLabelledby}
-            onClick={(): void => {
-              if (props.disabled) {
-                return;
-              }
-              setIsOpen(true);
-              inputRef.current?.focus();
-            }}
-            onFocus={() => {
-              props.onFocus?.();
-            }}
-            className={`flex w-full items-center justify-between rounded-lg border bg-white px-3 py-2 text-left text-sm shadow-sm transition-colors ${
-              props.error
-                ? "border-red-400"
-                : "border-gray-300 hover:border-indigo-300"
-            } ${
-              props.disabled
-                ? "cursor-not-allowed bg-gray-100 text-gray-400"
-                : ""
-            }`}
-          >
-            <span className="flex items-center gap-2">
-              {(() => {
-                const colorStr: string | undefined = optionColorString(
-                  selectedOptions[0]!,
-                );
-                if (!colorStr) {
-                  return null;
+          <div className="relative flex items-center">
+            <button
+              type="button"
+              disabled={props.disabled}
+              aria-labelledby={props.ariaLabelledby}
+              aria-haspopup={activeTab === "options" ? "listbox" : "dialog"}
+              aria-expanded="false"
+              onClick={(): void => {
+                if (props.disabled) {
+                  return;
                 }
-                return (
-                  <span
-                    aria-hidden="true"
-                    className="inline-block h-2.5 w-2.5 rounded-full border border-gray-200"
-                    style={{ backgroundColor: colorStr }}
-                  />
-                );
-              })()}
-              <span className="font-medium text-gray-900">
-                {selectedOptions[0]!.label}
-              </span>
-            </span>
-            <div className="flex items-center gap-1 text-gray-400">
-              {!props.disabled && (
-                <button
-                  type="button"
-                  aria-label="Clear selection"
-                  onClick={(e: React.MouseEvent<HTMLButtonElement>): void => {
-                    e.stopPropagation();
-                    clearAll();
-                  }}
-                  className="rounded p-0.5 hover:bg-gray-100 hover:text-red-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                >
-                  <svg
-                    className="h-3.5 w-3.5"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                      clipRule="evenodd"
+                shouldFocusInputOnOpenRef.current = true;
+                setIsOpen(true);
+              }}
+              onFocus={() => {
+                props.onFocus?.();
+              }}
+              className={`flex w-full items-center justify-between rounded-lg border bg-white px-3 py-2 pr-16 text-left text-sm shadow-sm transition-colors ${
+                props.error
+                  ? "border-red-400"
+                  : "border-gray-300 hover:border-indigo-300"
+              } ${
+                props.disabled
+                  ? "cursor-not-allowed bg-gray-100 text-gray-400"
+                  : ""
+              }`}
+            >
+              <span className="flex items-center gap-2">
+                {(() => {
+                  const colorStr: string | undefined = optionColorString(
+                    selectedOptions[0]!,
+                  );
+                  if (!colorStr) {
+                    return null;
+                  }
+                  return (
+                    <span
+                      aria-hidden="true"
+                      className="inline-block h-2.5 w-2.5 rounded-full border border-gray-200"
+                      style={{ backgroundColor: colorStr }}
                     />
-                  </svg>
-                </button>
-              )}
-              <Icon icon={IconProp.ChevronDown} className="h-4 w-4" />
-            </div>
-          </button>
+                  );
+                })()}
+                <span className="font-medium text-gray-900">
+                  {selectedOptions[0]!.label}
+                </span>
+              </span>
+              <Icon
+                icon={IconProp.ChevronDown}
+                className="h-4 w-4 text-gray-400"
+              />
+            </button>
+            {!props.disabled && (
+              <button
+                type="button"
+                aria-label="Clear selection"
+                onClick={(): void => {
+                  clearAll();
+                }}
+                className="absolute right-8 rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-red-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              >
+                <svg
+                  className="h-3.5 w-3.5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
         )}
 
         {!showSingleSelectedText && (
@@ -1204,6 +1275,15 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
               disabled={props.disabled}
               tabIndex={props.tabIndex}
               aria-autocomplete="list"
+              aria-activedescendant={activeDescendantId}
+              aria-haspopup={activeTab === "options" ? "listbox" : "dialog"}
+              aria-controls={
+                isOpen
+                  ? activeTab === "options"
+                    ? listboxId
+                    : popupId
+                  : undefined
+              }
               aria-expanded={isOpen}
               aria-label={props.ariaLabel}
               aria-labelledby={props.ariaLabelledby}
@@ -1281,8 +1361,12 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
                   return;
                 }
                 if (event.key === "Escape") {
-                  setIsOpen(false);
-                  setHighlightedIndex(-1);
+                  if (isOpen) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setIsOpen(false);
+                    setHighlightedIndex(-1);
+                  }
                   return;
                 }
                 if (
@@ -1328,24 +1412,43 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
       </div>
 
       {isOpen && !props.disabled && (
-        <div
-          className="absolute z-20 mt-1 flex max-h-96 w-full flex-col overflow-hidden rounded-md border border-gray-200 bg-white text-sm shadow-lg"
-          role="listbox"
+        <FloatingPortal
+          anchorRef={containerRef}
+          floatingRef={menuRef}
+          id={popupId}
+          matchAnchorWidth={true}
+          maxHeight={384}
+          className="flex flex-col overflow-hidden rounded-md border border-gray-200 bg-white text-sm shadow-lg"
+          role="dialog"
+          ariaLabel="Choose entries"
+          onEscape={(): void => {
+            setIsOpen(false);
+            setHighlightedIndex(-1);
+            inputRef.current?.focus();
+          }}
         >
           {labelsTabEnabled && (
-            <div className="flex flex-shrink-0 items-center gap-1 border-b border-gray-100 bg-gray-50 px-1.5 py-1">
+            <div
+              role="tablist"
+              aria-label="Entry source"
+              className="flex flex-shrink-0 items-center gap-1 border-b border-gray-100 bg-gray-50 px-1.5 py-1"
+            >
               <button
+                ref={optionsTabRef}
+                id={optionsTabId}
                 type="button"
                 role="tab"
                 aria-selected={activeTab === "options"}
+                aria-controls={optionsPanelId}
+                tabIndex={activeTab === "options" ? 0 : -1}
                 onMouseDown={(
                   event: React.MouseEvent<HTMLButtonElement>,
                 ): void => {
                   event.preventDefault();
                 }}
+                onKeyDown={handleTabKeyDown}
                 onClick={(): void => {
-                  setActiveTab("options");
-                  setHighlightedIndex(-1);
+                  activateTab("options");
                 }}
                 className={`rounded px-2.5 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-1 focus:ring-indigo-500 ${
                   activeTab === "options"
@@ -1356,17 +1459,21 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
                 Results
               </button>
               <button
+                ref={labelsTabRef}
+                id={labelsTabId}
                 type="button"
                 role="tab"
                 aria-selected={activeTab === "labels"}
+                aria-controls={labelsPanelId}
+                tabIndex={activeTab === "labels" ? 0 : -1}
                 onMouseDown={(
                   event: React.MouseEvent<HTMLButtonElement>,
                 ): void => {
                   event.preventDefault();
                 }}
+                onKeyDown={handleTabKeyDown}
                 onClick={(): void => {
-                  setActiveTab("labels");
-                  setHighlightedIndex(-1);
+                  activateTab("labels");
                 }}
                 className={`inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-1 focus:ring-indigo-500 ${
                   activeTab === "labels"
@@ -1391,122 +1498,141 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
           )}
 
           {activeTab === "options" && (
-            <div className="flex-1 overflow-auto py-1">
-              {isLoading && (
-                <div className="flex items-center px-3 py-2 text-gray-500">
-                  <svg
-                    className="animate-spin -ml-0.5 mr-2 h-4 w-4 text-indigo-500"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-                    ></path>
-                  </svg>
-                  <span>Searching...</span>
-                </div>
-              )}
-              {!isLoading && availableOptions.length === 0 && (
-                <div className="px-3 py-2 text-gray-500">
-                  {searchQuery.trim() === ""
-                    ? "No options."
-                    : "No matching entries."}
-                </div>
-              )}
-              {!isLoading &&
-                availableOptions.map(
-                  (opt: DropdownOption, idx: number): ReactElement => {
-                    const key: string = valueKey(opt.value);
-                    const isHighlighted: boolean = idx === highlightedIndex;
-                    const isCurrentSelection: boolean =
-                      !isMulti && selectedKeys[0] === key;
-                    const colorStr: string | undefined = optionColorString(opt);
-                    return (
-                      <button
-                        key={key}
-                        type="button"
-                        role="option"
-                        aria-selected={isCurrentSelection || isHighlighted}
-                        onMouseEnter={(): void => {
-                          setHighlightedIndex(idx);
-                        }}
-                        onMouseDown={(
-                          event: React.MouseEvent<HTMLButtonElement>,
-                        ): void => {
-                          event.preventDefault();
-                        }}
-                        onClick={(): void => {
-                          addOption(opt);
-                        }}
-                        className={`flex w-full items-center gap-2 px-3 py-2 text-left ${
-                          isHighlighted
-                            ? "bg-indigo-600 text-white"
-                            : isCurrentSelection
-                              ? "bg-indigo-50 text-indigo-900"
-                              : "text-gray-700 hover:bg-indigo-50"
-                        }`}
-                      >
-                        {colorStr && (
-                          <span
-                            aria-hidden="true"
-                            className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full border border-gray-200"
-                            style={{ backgroundColor: colorStr }}
-                          />
-                        )}
-                        <span className="truncate">{opt.label}</span>
-                        {opt.description && (
-                          <span
-                            className={`ml-auto truncate text-xs ${
-                              isHighlighted
-                                ? "text-indigo-100"
-                                : "text-gray-500"
-                            }`}
-                          >
-                            {opt.description}
-                          </span>
-                        )}
-                        {/*
-                         * Trailing check for the current single-select value
-                         * — same visual cue react-select uses to flag the
-                         * active option without taking it out of the list.
-                         */}
-                        {isCurrentSelection && (
-                          <svg
-                            className={`ml-auto h-4 w-4 flex-shrink-0 ${
-                              isHighlighted ? "text-white" : "text-indigo-600"
-                            }`}
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                            aria-hidden="true"
-                          >
-                            <path
-                              fillRule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clipRule="evenodd"
-                            />
-                          </svg>
-                        )}
-                      </button>
-                    );
-                  },
+            <div
+              id={labelsTabEnabled ? optionsPanelId : undefined}
+              role={labelsTabEnabled ? "tabpanel" : undefined}
+              aria-labelledby={labelsTabEnabled ? optionsTabId : undefined}
+              className="min-h-0 flex-1"
+            >
+              <div
+                id={listboxId}
+                role="listbox"
+                className="h-full overflow-auto py-1"
+              >
+                {isLoading && (
+                  <div className="flex items-center px-3 py-2 text-gray-500">
+                    <svg
+                      className="animate-spin -ml-0.5 mr-2 h-4 w-4 text-indigo-500"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      ></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                      ></path>
+                    </svg>
+                    <span>Searching...</span>
+                  </div>
                 )}
+                {!isLoading && availableOptions.length === 0 && (
+                  <div className="px-3 py-2 text-gray-500">
+                    {searchQuery.trim() === ""
+                      ? "No options."
+                      : "No matching entries."}
+                  </div>
+                )}
+                {!isLoading &&
+                  availableOptions.map(
+                    (opt: DropdownOption, idx: number): ReactElement => {
+                      const key: string = valueKey(opt.value);
+                      const isHighlighted: boolean = idx === highlightedIndex;
+                      const isCurrentSelection: boolean =
+                        !isMulti && selectedKeys[0] === key;
+                      const colorStr: string | undefined =
+                        optionColorString(opt);
+                      return (
+                        <button
+                          key={key}
+                          id={`${listboxId}-option-${idx}`}
+                          type="button"
+                          role="option"
+                          tabIndex={-1}
+                          aria-selected={isCurrentSelection}
+                          onMouseEnter={(): void => {
+                            setHighlightedIndex(idx);
+                          }}
+                          onMouseDown={(
+                            event: React.MouseEvent<HTMLButtonElement>,
+                          ): void => {
+                            event.preventDefault();
+                          }}
+                          onClick={(): void => {
+                            addOption(opt);
+                          }}
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left ${
+                            isHighlighted
+                              ? "bg-indigo-600 text-white"
+                              : isCurrentSelection
+                                ? "bg-indigo-50 text-indigo-900"
+                                : "text-gray-700 hover:bg-indigo-50"
+                          }`}
+                        >
+                          {colorStr && (
+                            <span
+                              aria-hidden="true"
+                              className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full border border-gray-200"
+                              style={{ backgroundColor: colorStr }}
+                            />
+                          )}
+                          <span className="truncate">{opt.label}</span>
+                          {opt.description && (
+                            <span
+                              className={`ml-auto truncate text-xs ${
+                                isHighlighted
+                                  ? "text-indigo-100"
+                                  : "text-gray-500"
+                              }`}
+                            >
+                              {opt.description}
+                            </span>
+                          )}
+                          {/*
+                           * Trailing check for the current single-select value
+                           * — same visual cue react-select uses to flag the
+                           * active option without taking it out of the list.
+                           */}
+                          {isCurrentSelection && (
+                            <svg
+                              className={`ml-auto h-4 w-4 flex-shrink-0 ${
+                                isHighlighted ? "text-white" : "text-indigo-600"
+                              }`}
+                              viewBox="0 0 20 20"
+                              fill="currentColor"
+                              aria-hidden="true"
+                            >
+                              <path
+                                fillRule="evenodd"
+                                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                                clipRule="evenodd"
+                              />
+                            </svg>
+                          )}
+                        </button>
+                      );
+                    },
+                  )}
+              </div>
             </div>
           )}
 
           {activeTab === "labels" && (
-            <div className="flex-1 overflow-auto py-1">
+            <div
+              id={labelsPanelId}
+              role="tabpanel"
+              aria-labelledby={labelsTabId}
+              className="flex-1 overflow-auto py-1"
+            >
               {isLoadingLabels && (
                 <div className="flex items-center px-3 py-2 text-gray-500">
                   <svg
@@ -1609,8 +1735,7 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
                           </button>
                           <button
                             type="button"
-                            role="option"
-                            aria-selected={isChecked}
+                            aria-pressed={isChecked}
                             onMouseDown={(
                               event: React.MouseEvent<HTMLButtonElement>,
                             ): void => {
@@ -1788,7 +1913,7 @@ const EntityDropdown: FunctionComponent<EntityDropdownProps> = (
               </button>
             </div>
           )}
-        </div>
+        </FloatingPortal>
       )}
 
       {props.error && (

--- a/Common/UI/Components/Floating/FloatingPortal.tsx
+++ b/Common/UI/Components/Floating/FloatingPortal.tsx
@@ -1,0 +1,140 @@
+import { ModalStackValue, useModalStack } from "../Modal/ModalStackContext";
+import React, {
+  CSSProperties,
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  RefObject,
+  useLayoutEffect,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface FloatingPosition {
+  bottom?: number;
+  left: number;
+  maxHeight: number;
+  top?: number;
+  width: number;
+}
+
+export interface ComponentProps {
+  anchorRef: RefObject<HTMLElement>;
+  ariaLabel?: string | undefined;
+  children: ReactNode;
+  className?: string | undefined;
+  floatingRef?: RefObject<HTMLDivElement> | undefined;
+  id?: string | undefined;
+  matchAnchorWidth?: boolean | undefined;
+  maxHeight?: number | undefined;
+  onEscape?: (() => void) | undefined;
+  role?: React.AriaRole | undefined;
+  width?: number | undefined;
+}
+
+const viewportMargin: number = 8;
+
+const FloatingPortal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const modalStack: ModalStackValue = useModalStack();
+  const [position, setPosition] = useState<FloatingPosition | null>(null);
+
+  useLayoutEffect(() => {
+    const updatePosition: () => void = (): void => {
+      const anchor: HTMLElement | null = props.anchorRef.current;
+      if (!anchor) {
+        return;
+      }
+
+      const anchorRect: DOMRect = anchor.getBoundingClientRect();
+      const requestedWidth: number = props.matchAnchorWidth
+        ? anchorRect.width
+        : props.width || anchorRect.width;
+      const width: number = Math.min(
+        requestedWidth,
+        window.innerWidth - viewportMargin * 2,
+      );
+      const left: number = Math.min(
+        Math.max(viewportMargin, anchorRect.left),
+        window.innerWidth - width - viewportMargin,
+      );
+      const availableBelow: number =
+        window.innerHeight - anchorRect.bottom - viewportMargin;
+      const availableAbove: number = anchorRect.top - viewportMargin;
+      const desiredMaxHeight: number = props.maxHeight || 384;
+      const shouldOpenAbove: boolean =
+        availableBelow < Math.min(desiredMaxHeight, 240) &&
+        availableAbove > availableBelow;
+      const availableHeight: number = shouldOpenAbove
+        ? availableAbove
+        : availableBelow;
+      const maxHeight: number = Math.max(
+        80,
+        Math.min(desiredMaxHeight, availableHeight),
+      );
+
+      setPosition({
+        ...(shouldOpenAbove
+          ? { bottom: window.innerHeight - anchorRect.top + 4 }
+          : { top: anchorRect.bottom + 4 }),
+        left,
+        maxHeight,
+        width,
+      });
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [props.anchorRef, props.matchAnchorWidth, props.maxHeight, props.width]);
+
+  const style: CSSProperties = {
+    position: "fixed",
+    zIndex: 50 + modalStack.depth * 20,
+    ...(position || {
+      left: 0,
+      maxHeight: 0,
+      top: 0,
+      visibility: "hidden",
+      width: 0,
+    }),
+  };
+  const floatingElement: ReactElement = (
+    <div
+      ref={props.floatingRef}
+      id={props.id}
+      role={props.role}
+      aria-label={props.ariaLabel}
+      className={props.className}
+      style={style}
+      data-floating-portal="true"
+      data-floating-modal-depth={modalStack.depth}
+      data-floating-modal-owner={modalStack.ownerId || undefined}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>): void => {
+        if (event.key !== "Escape" || !props.onEscape) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        props.onEscape();
+      }}
+    >
+      {props.children}
+    </div>
+  );
+
+  if (typeof document === "undefined") {
+    return floatingElement;
+  }
+
+  return createPortal(floatingElement, document.body);
+};
+
+export default FloatingPortal;

--- a/Common/UI/Components/FormModal/BasicFormModal.tsx
+++ b/Common/UI/Components/FormModal/BasicFormModal.tsx
@@ -1,7 +1,5 @@
 import { ButtonStyleType } from "../Button/Button";
 import ButtonType from "../Button/ButtonTypes";
-import ComponentLoader from "../ComponentLoader/ComponentLoader";
-import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import BasicForm, {
   BaseComponentProps as BasicFormComponentProps,
 } from "../Forms/BasicForm";
@@ -38,29 +36,22 @@ const BasicFormModal: <T extends GenericObject>(
       {...props}
       submitButtonType={ButtonType.Submit}
       isLoading={isLoading}
+      isBodyLoading={Boolean(props.isLoading)}
       onSubmit={() => {
-        formRef.current.submitForm();
+        formRef.current?.submitForm();
       }}
     >
-      <>
-        {isLoading && <ComponentLoader />}
-
-        {props.error && <ErrorMessage message={props.error} />}
-
-        {!isLoading && (
-          <BasicForm
-            {...props.formProps}
-            hideSubmitButton={true}
-            ref={formRef}
-            onLoadingChange={(isFormLoading: boolean) => {
-              setIsLoading(isFormLoading);
-            }}
-            onSubmit={(data: T) => {
-              props.onSubmit?.(data);
-            }}
-          />
-        )}
-      </>
+      <BasicForm
+        {...props.formProps}
+        hideSubmitButton={true}
+        ref={formRef}
+        onLoadingChange={(isFormLoading: boolean) => {
+          setIsLoading(isFormLoading);
+        }}
+        onSubmit={(data: T) => {
+          props.onSubmit?.(data);
+        }}
+      />
     </Modal>
   );
 };

--- a/Common/UI/Components/Forms/Fields/ColorPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/ColorPicker.tsx
@@ -1,12 +1,14 @@
 import useComponentOutsideClick from "../../../Types/UseComponentOutsideClick";
+import FloatingPortal from "../../Floating/FloatingPortal";
 import Icon from "../../Icon/Icon";
-import Input, { InputType } from "../../Input/Input";
 import Color from "../../../../Types/Color";
 import IconProp from "../../../../Types/Icon/IconProp";
 import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useId,
+  useRef,
   useState,
 } from "react";
 import { ChromePicker, ColorResult } from "react-color";
@@ -33,6 +35,11 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
   const [color, setColor] = useState<string>("");
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentOutsideClick(false);
+  const anchorRef: React.RefObject<HTMLDivElement> =
+    useRef<HTMLDivElement>(null);
+  const triggerRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null);
+  const popoverId: string = `color-picker-${useId()}`;
 
   const [isInitialValuesInitialized, setIsInitialValuesInitialized] =
     useState<boolean>(false);
@@ -44,6 +51,24 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
     }
   }, [props.initialValue]);
 
+  useEffect(() => {
+    if (!isComponentVisible) {
+      return;
+    }
+
+    const focusTimeout: number = window.setTimeout((): void => {
+      const initialControl: HTMLElement | null =
+        (ref.current as HTMLElement | null)?.querySelector<HTMLElement>(
+          "input:not([disabled]), button:not([disabled])",
+        ) || null;
+      initialControl?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(focusTimeout);
+    };
+  }, [isComponentVisible]);
+
   type HandleChangeFunction = (color: string) => void;
 
   const handleChange: HandleChangeFunction = (color: string): void => {
@@ -54,61 +79,86 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
     props.onChange(new Color(color));
   };
 
+  const closeAndRestoreFocus: () => void = (): void => {
+    setIsComponentVisible(false);
+    window.setTimeout((): void => {
+      triggerRef.current?.focus();
+    }, 0);
+  };
+
   return (
     <div>
-      <div className="flex block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
-        <div
-          onClick={() => {
-            if (!props.readOnly) {
-              setIsComponentVisible(!isComponentVisible);
-            }
-          }}
-          className="rounded h-5 w-5 border border-gray-200 cursor-pointer"
-          style={{ backgroundColor: color.toString() }}
-        ></div>
-
-        <Input
-          onClick={() => {
-            if (!props.readOnly) {
-              setIsComponentVisible(!isComponentVisible);
-            }
-          }}
-          disabled={props.disabled}
-          dataTestId={props.dataTestId}
-          onBlur={props.onBlur}
-          onEnterPress={props.onEnterPress}
-          className="border-none focus:outline-none w-full pl-2 text-gray-500 cursor-pointer"
-          outerDivClassName='className="border-none focus:outline-none w-full pl-2 text-gray-500 cursor-pointer"'
-          placeholder={props.placeholder}
-          value={color || props.value}
-          readOnly={true}
-          type={InputType.TEXT}
+      <div
+        ref={anchorRef}
+        onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>): void => {
+          if (event.key === "Escape" && isComponentVisible) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeAndRestoreFocus();
+          }
+        }}
+        className="relative flex w-full items-center rounded-lg border border-gray-300 bg-white text-sm shadow-sm transition-colors hover:border-indigo-300 focus-within:border-indigo-400 focus-within:ring-2 focus-within:ring-indigo-100"
+      >
+        <button
+          ref={triggerRef}
+          type="button"
+          disabled={props.disabled || props.readOnly}
           tabIndex={props.tabIndex}
-          ariaLabelledby={props.ariaLabelledby}
-          onChange={(value: string) => {
-            if (!value) {
-              return handleChange("");
+          data-testid={props.dataTestId}
+          aria-labelledby={props.ariaLabelledby}
+          aria-haspopup="dialog"
+          aria-expanded={isComponentVisible}
+          aria-controls={isComponentVisible ? popoverId : undefined}
+          onFocus={props.onFocus}
+          onBlur={props.onBlur}
+          onClick={(): void => {
+            setIsComponentVisible(!isComponentVisible);
+          }}
+          onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>): void => {
+            if (event.key === "Enter") {
+              props.onEnterPress?.();
             }
           }}
-          onFocus={props.onFocus || undefined}
-        />
-        {color && !props.disabled && (
-          <Icon
-            icon={IconProp.Close}
-            className="text-gray-400 h-5 w-5 cursor-pointer hover:text-gray-600"
-            onClick={() => {
-              setColor("#FFFFFF");
-              if (props.onChange) {
-                props.onChange(null);
-              }
-            }}
+          className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-3 py-2 text-left text-gray-700 outline-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
+        >
+          <span
+            aria-hidden="true"
+            className="h-4 w-4 shrink-0 rounded border border-gray-200"
+            style={{ backgroundColor: color || "transparent" }}
           />
+          <span className="min-w-0 flex-1 truncate">
+            {color || props.value || props.placeholder}
+          </span>
+          <Icon
+            icon={IconProp.ChevronDown}
+            className="h-4 w-4 shrink-0 text-gray-400"
+          />
+        </button>
+        {color && !props.disabled && !props.readOnly && (
+          <button
+            type="button"
+            aria-label="Clear color"
+            className="mr-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            onClick={(): void => {
+              setColor("");
+              props.onChange(null);
+            }}
+          >
+            <Icon icon={IconProp.Close} className="h-4 w-4" />
+          </button>
         )}
         {isComponentVisible ? (
-          <div
-            ref={ref}
-            style={{
-              position: "absolute",
+          <FloatingPortal
+            anchorRef={anchorRef}
+            floatingRef={ref}
+            width={227}
+            maxHeight={360}
+            className="overflow-x-hidden overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg"
+            id={popoverId}
+            role="dialog"
+            ariaLabel="Choose a color"
+            onEscape={(): void => {
+              closeAndRestoreFocus();
             }}
           >
             <ChromePicker
@@ -120,7 +170,7 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
                 return handleChange(color.hex);
               }}
             />
-          </div>
+          </FloatingPortal>
         ) : (
           <></>
         )}

--- a/Common/UI/Components/Forms/Fields/IconPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/IconPicker.tsx
@@ -1,4 +1,5 @@
 import useComponentOutsideClick from "../../../Types/UseComponentOutsideClick";
+import FloatingPortal from "../../Floating/FloatingPortal";
 import Icon from "../../Icon/Icon";
 import Input, { InputType } from "../../Input/Input";
 import IconProp from "../../../../Types/Icon/IconProp";
@@ -6,6 +7,8 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useId,
+  useRef,
   useState,
 } from "react";
 
@@ -32,6 +35,11 @@ const IconPicker: FunctionComponent<ComponentProps> = (
   const [searchQuery, setSearchQuery] = useState<string>("");
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentOutsideClick(false);
+  const anchorRef: React.RefObject<HTMLDivElement> =
+    useRef<HTMLDivElement>(null);
+  const triggerRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null);
+  const popoverId: string = `icon-picker-${useId()}`;
 
   const [isInitialValuesInitialized, setIsInitialValuesInitialized] =
     useState<boolean>(false);
@@ -43,12 +51,40 @@ const IconPicker: FunctionComponent<ComponentProps> = (
     }
   }, [props.initialValue]);
 
+  useEffect(() => {
+    if (!isComponentVisible) {
+      return;
+    }
+
+    const focusTimeout: number = window.setTimeout((): void => {
+      const initialControl: HTMLElement | null =
+        (ref.current as HTMLElement | null)?.querySelector<HTMLElement>(
+          "input:not([disabled]), button:not([disabled])",
+        ) || null;
+      initialControl?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(focusTimeout);
+    };
+  }, [isComponentVisible]);
+
   type HandleChangeFunction = (icon: IconProp | null) => void;
 
   const handleChange: HandleChangeFunction = (icon: IconProp | null): void => {
     setSelectedIcon(icon);
     props.onChange(icon);
     setIsComponentVisible(false);
+    window.setTimeout((): void => {
+      triggerRef.current?.focus();
+    }, 0);
+  };
+
+  const closeAndRestoreFocus: () => void = (): void => {
+    setIsComponentVisible(false);
+    window.setTimeout((): void => {
+      triggerRef.current?.focus();
+    }, 0);
   };
 
   // Get all icons from IconProp enum
@@ -61,60 +97,80 @@ const IconPicker: FunctionComponent<ComponentProps> = (
 
   return (
     <div>
-      <div className="flex block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
-        <div
-          onClick={() => {
-            if (!props.readOnly && !props.disabled) {
-              setIsComponentVisible(!isComponentVisible);
+      <div
+        ref={anchorRef}
+        onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>): void => {
+          if (event.key === "Escape" && isComponentVisible) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeAndRestoreFocus();
+          }
+        }}
+        className="relative flex w-full items-center rounded-lg border border-gray-300 bg-white text-sm shadow-sm transition-colors hover:border-indigo-300 focus-within:border-indigo-400 focus-within:ring-2 focus-within:ring-indigo-100"
+      >
+        <button
+          ref={triggerRef}
+          type="button"
+          disabled={props.disabled || props.readOnly}
+          tabIndex={props.tabIndex}
+          data-testid={props.dataTestId}
+          aria-labelledby={props.ariaLabelledby}
+          aria-haspopup="dialog"
+          aria-expanded={isComponentVisible}
+          aria-controls={isComponentVisible ? popoverId : undefined}
+          onFocus={props.onFocus}
+          onBlur={props.onBlur}
+          onClick={(): void => {
+            setIsComponentVisible(!isComponentVisible);
+          }}
+          onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>): void => {
+            if (event.key === "Enter") {
+              props.onEnterPress?.();
             }
           }}
-          className="flex items-center justify-center h-5 w-5 cursor-pointer"
+          className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-3 py-2 text-left text-gray-700 outline-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400"
         >
           {selectedIcon ? (
-            <Icon icon={selectedIcon} className="h-5 w-5 text-gray-600" />
+            <Icon
+              icon={selectedIcon}
+              className="h-4 w-4 shrink-0 text-gray-600"
+            />
           ) : (
-            <div className="h-5 w-5 border border-dashed border-gray-300 rounded"></div>
+            <span className="h-4 w-4 shrink-0 rounded border border-dashed border-gray-300" />
           )}
-        </div>
-
-        <Input
-          onClick={() => {
-            if (!props.readOnly && !props.disabled) {
-              setIsComponentVisible(!isComponentVisible);
-            }
-          }}
-          disabled={props.disabled}
-          dataTestId={props.dataTestId}
-          onBlur={props.onBlur}
-          onEnterPress={props.onEnterPress}
-          className="border-none focus:outline-none w-full pl-2 text-gray-500 cursor-pointer"
-          outerDivClassName='className="border-none focus:outline-none w-full pl-2 text-gray-500 cursor-pointer"'
-          placeholder={props.placeholder}
-          value={selectedIcon || props.value || ""}
-          readOnly={true}
-          type={InputType.TEXT}
-          tabIndex={props.tabIndex}
-          ariaLabelledby={props.ariaLabelledby}
-          onChange={() => {}}
-          onFocus={props.onFocus || undefined}
-        />
-        {selectedIcon && !props.disabled && (
+          <span className="min-w-0 flex-1 truncate">
+            {selectedIcon || props.value || props.placeholder}
+          </span>
           <Icon
-            icon={IconProp.Close}
-            className="text-gray-400 h-5 w-5 cursor-pointer hover:text-gray-600"
-            onClick={() => {
+            icon={IconProp.ChevronDown}
+            className="h-4 w-4 shrink-0 text-gray-400"
+          />
+        </button>
+        {selectedIcon && !props.disabled && !props.readOnly && (
+          <button
+            type="button"
+            aria-label="Clear icon"
+            className="mr-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            onClick={(): void => {
               setSelectedIcon(null);
               props.onChange(null);
             }}
-          />
+          >
+            <Icon icon={IconProp.Close} className="h-4 w-4" />
+          </button>
         )}
         {isComponentVisible ? (
-          <div
-            ref={ref}
-            className="absolute z-50 mt-8 bg-white border border-gray-200 rounded-lg shadow-lg p-3"
-            style={{
-              width: "320px",
-              maxHeight: "400px",
+          <FloatingPortal
+            anchorRef={anchorRef}
+            floatingRef={ref}
+            width={320}
+            maxHeight={400}
+            className="overflow-y-auto rounded-lg border border-gray-200 bg-white p-3 shadow-lg"
+            id={popoverId}
+            role="dialog"
+            ariaLabel="Choose an icon"
+            onEscape={(): void => {
+              closeAndRestoreFocus();
             }}
           >
             {/* Search input */}
@@ -137,12 +193,14 @@ const IconPicker: FunctionComponent<ComponentProps> = (
             >
               {filteredIcons.map((icon: IconProp) => {
                 return (
-                  <div
+                  <button
                     key={icon}
-                    onClick={() => {
+                    type="button"
+                    aria-label={icon}
+                    onClick={(): void => {
                       handleChange(icon);
                     }}
-                    className={`flex items-center justify-center p-2 rounded cursor-pointer hover:bg-gray-100 ${
+                    className={`flex items-center justify-center rounded p-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
                       selectedIcon === icon
                         ? "bg-indigo-100 ring-2 ring-indigo-500"
                         : ""
@@ -150,7 +208,7 @@ const IconPicker: FunctionComponent<ComponentProps> = (
                     title={icon}
                   >
                     <Icon icon={icon} className="h-5 w-5 text-gray-600" />
-                  </div>
+                  </button>
                 );
               })}
             </div>
@@ -160,7 +218,7 @@ const IconPicker: FunctionComponent<ComponentProps> = (
                 No icons found
               </div>
             )}
-          </div>
+          </FloatingPortal>
         ) : (
           <></>
         )}

--- a/Common/UI/Components/Modal/ConfirmModal.tsx
+++ b/Common/UI/Components/Modal/ConfirmModal.tsx
@@ -1,7 +1,7 @@
 import { ButtonStyleType } from "../Button/Button";
 import Modal from "./Modal";
 import useTranslateValue from "../../Utils/Translation";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useId } from "react";
 
 export interface ComponentProps {
   title: string;
@@ -23,9 +23,12 @@ const ConfirmModal: FunctionComponent<ComponentProps> = (
   const { translateValue } = useTranslateValue();
   const translatedDescription: string | ReactElement | undefined =
     translateValue(props.description);
+  const descriptionId: string = `confirm-modal-description-${useId()}`;
+
   return (
     <Modal
       title={props.title}
+      ariaDescribedBy={descriptionId}
       isLoading={props.isLoading}
       onSubmit={props.onSubmit}
       onClose={props.onClose ? props.onClose : undefined}
@@ -47,8 +50,9 @@ const ConfirmModal: FunctionComponent<ComponentProps> = (
       error={props.error}
     >
       <div
+        id={descriptionId}
         data-testid="confirm-modal-description"
-        className="text-gray-500 mt-5 text-sm whitespace-pre-wrap break-words max-h-96 overflow-y-auto pr-1"
+        className="max-h-96 whitespace-pre-wrap break-words pr-1 text-sm leading-6 text-slate-600"
       >
         {translatedDescription}
       </div>

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -1,9 +1,14 @@
-import Button, { ButtonStyleType } from "../Button/Button";
+import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
 import ButtonType from "../Button/ButtonTypes";
 import Icon, { IconType, SizeProp, ThickProp } from "../Icon/Icon";
 import Loader, { LoaderType } from "../Loader/Loader";
 import ModalBody from "./ModalBody";
 import ModalFooter from "./ModalFooter";
+import {
+  ModalStackContext,
+  ModalStackValue,
+  useModalStackDepth,
+} from "./ModalStackContext";
 import { VeryLightGray } from "../../../Types/BrandColors";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
@@ -11,8 +16,11 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useId,
+  useMemo,
   useRef,
 } from "react";
+import { createPortal } from "react-dom";
 
 export enum ModalWidth {
   Normal,
@@ -40,7 +48,185 @@ export interface ComponentProps {
   rightElement?: ReactElement | undefined;
   closeButtonText?: string | undefined;
   leftFooterElement?: ReactElement | undefined;
+  ariaDescribedBy?: string | undefined;
 }
+
+const focusableElementSelector: string = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(", ");
+
+const getTopmostModal: () => HTMLElement | null = (): HTMLElement | null => {
+  const modals: Array<HTMLElement> = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-modal-stack-depth]"),
+  );
+  let topmostModal: HTMLElement | null = null;
+  let topmostDepth: number = -1;
+
+  for (const modal of modals) {
+    const depth: number = Number(modal.dataset["modalStackDepth"] || 0);
+    if (depth >= topmostDepth) {
+      topmostDepth = depth;
+      topmostModal = modal;
+    }
+  }
+
+  return topmostModal;
+};
+
+const modalOwnershipRefs: Map<
+  HTMLElement,
+  React.MutableRefObject<boolean>
+> = new Map<HTMLElement, React.MutableRefObject<boolean>>();
+
+const getOwnedFloatingPortals: (modal: HTMLElement) => Array<HTMLElement> = (
+  modal: HTMLElement,
+): Array<HTMLElement> => {
+  const ownerId: string | undefined = modal.dataset["modalOwnerId"];
+  if (!ownerId) {
+    return [];
+  }
+
+  return Array.from(
+    document.querySelectorAll<HTMLElement>("[data-floating-modal-owner]"),
+  ).filter((portal: HTMLElement): boolean => {
+    return portal.dataset["floatingModalOwner"] === ownerId;
+  });
+};
+
+const elementBelongsToModal: (
+  modal: HTMLElement,
+  element: Element | null,
+) => boolean = (modal: HTMLElement, element: Element | null): boolean => {
+  if (!element) {
+    return false;
+  }
+
+  return (
+    modal.contains(element) ||
+    getOwnedFloatingPortals(modal).some((portal: HTMLElement): boolean => {
+      return portal.contains(element);
+    })
+  );
+};
+
+const getModalFocusableElements: (modal: HTMLElement) => Array<HTMLElement> = (
+  modal: HTMLElement,
+): Array<HTMLElement> => {
+  const modalElements: Array<HTMLElement> = Array.from(
+    modal.querySelectorAll<HTMLElement>(focusableElementSelector),
+  );
+  const portalElements: Array<HTMLElement> = getOwnedFloatingPortals(
+    modal,
+  ).flatMap((portal: HTMLElement): Array<HTMLElement> => {
+    return Array.from(
+      portal.querySelectorAll<HTMLElement>(focusableElementSelector),
+    );
+  });
+
+  return [...modalElements, ...portalElements].filter(
+    (element: HTMLElement): boolean => {
+      return !element.closest("[inert]");
+    },
+  );
+};
+
+const getPreferredModalFocus: (modal: HTMLElement) => HTMLElement = (
+  modal: HTMLElement,
+): HTMLElement => {
+  return (
+    modal.querySelector<HTMLElement>("[autofocus]") ||
+    modal.querySelector<HTMLElement>(
+      ".modal-body input:not([disabled]), .modal-body select:not([disabled]), .modal-body textarea:not([disabled]), .modal-body button:not([disabled])",
+    ) ||
+    modal.querySelector<HTMLElement>(
+      '[data-testid="modal-footer-close-button"]',
+    ) ||
+    getModalFocusableElements(modal)[0] ||
+    modal
+  );
+};
+
+const syncModalAccessibility: () => void = (): void => {
+  const topmostModal: HTMLElement | null = getTopmostModal();
+  const modals: Array<HTMLElement> = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-modal-stack-depth]"),
+  );
+
+  for (const modal of modals) {
+    const ownershipRef: React.MutableRefObject<boolean> | undefined =
+      modalOwnershipRefs.get(modal);
+    if (ownershipRef) {
+      ownershipRef.current = modal === topmostModal;
+    }
+
+    if (modal === topmostModal) {
+      modal.setAttribute("aria-modal", "true");
+      modal.removeAttribute("aria-hidden");
+      modal.removeAttribute("inert");
+    } else {
+      modal.setAttribute("aria-modal", "false");
+      modal.setAttribute("inert", "");
+      modal.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  const topmostOwnerId: string | undefined =
+    topmostModal?.dataset["modalOwnerId"];
+  const floatingPortals: Array<HTMLElement> = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-floating-modal-owner]"),
+  );
+
+  for (const portal of floatingPortals) {
+    if (portal.dataset["floatingModalOwner"] === topmostOwnerId) {
+      portal.removeAttribute("aria-hidden");
+      portal.removeAttribute("inert");
+    } else {
+      portal.setAttribute("inert", "");
+      portal.setAttribute("aria-hidden", "true");
+    }
+  }
+};
+
+let openModalCount: number = 0;
+let bodyOverflowBeforeFirstModal: string = "";
+let bodyPaddingRightBeforeFirstModal: string = "";
+
+const lockBodyScroll: () => void = (): void => {
+  if (openModalCount === 0) {
+    bodyOverflowBeforeFirstModal = document.body.style.overflow;
+    bodyPaddingRightBeforeFirstModal = document.body.style.paddingRight;
+
+    const documentWidth: number = document.documentElement.clientWidth;
+    const scrollbarWidth: number =
+      documentWidth > 0 ? window.innerWidth - documentWidth : 0;
+
+    if (scrollbarWidth > 0) {
+      const currentPaddingRight: number =
+        Number.parseFloat(
+          window.getComputedStyle(document.body).paddingRight,
+        ) || 0;
+      document.body.style.paddingRight = `${currentPaddingRight + scrollbarWidth}px`;
+    }
+  }
+
+  openModalCount += 1;
+  document.body.style.overflow = "hidden";
+};
+
+const unlockBodyScroll: () => void = (): void => {
+  openModalCount = Math.max(0, openModalCount - 1);
+
+  if (openModalCount === 0) {
+    document.body.style.overflow = bodyOverflowBeforeFirstModal;
+    document.body.style.paddingRight = bodyPaddingRightBeforeFirstModal;
+  }
+};
 
 const Modal: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -58,200 +244,324 @@ const Modal: FunctionComponent<ComponentProps> = (
   );
   const modalRef: React.RefObject<HTMLDivElement> =
     useRef<HTMLDivElement>(null);
-
-  // Handle Escape key to close modal
-  useEffect(() => {
-    const handleEscapeKey: (event: KeyboardEvent) => void = (
-      event: KeyboardEvent,
-    ): void => {
-      if (event.key === "Escape" && props.onClose) {
-        props.onClose();
-      }
+  const modalBodyScrollRef: React.RefObject<HTMLDivElement> =
+    useRef<HTMLDivElement>(null);
+  const ownsTopmostRef: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
+  const previouslyFocusedElementRef: React.MutableRefObject<HTMLElement | null> =
+    useRef<HTMLElement | null>(null);
+  const modalId: string = useId();
+  const modalStackDepth: number = useModalStackDepth();
+  const titleId: string = `modal-title-${modalId}`;
+  const descriptionId: string = `modal-description-${modalId}`;
+  const modalStackValue: ModalStackValue = useMemo((): ModalStackValue => {
+    return {
+      depth: modalStackDepth + 1,
+      ownerId: modalId,
     };
+  }, [modalId, modalStackDepth]);
 
-    document.addEventListener("keydown", handleEscapeKey);
-    return () => {
-      document.removeEventListener("keydown", handleEscapeKey);
-    };
-  }, [props.onClose]);
-
-  // Focus trap and initial focus
   useEffect(() => {
     const modal: HTMLDivElement | null = modalRef.current;
-    if (modal) {
-      // Focus the first focusable element in the modal, excluding the close button
-      const focusableElements: NodeListOf<Element> = modal.querySelectorAll(
-        'button:not([data-testid="close-button"]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
-      const firstFocusable: HTMLElement | undefined = focusableElements[0] as
-        | HTMLElement
-        | undefined;
-      if (firstFocusable) {
-        firstFocusable.focus();
-      }
+
+    if (!modal) {
+      return;
     }
+
+    previouslyFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    modalOwnershipRefs.set(modal, ownsTopmostRef);
+    lockBodyScroll();
+
+    if (getTopmostModal() === modal) {
+      getPreferredModalFocus(modal).focus();
+    }
+    syncModalAccessibility();
+
+    return () => {
+      const wasTopmost: boolean = ownsTopmostRef.current;
+      modalOwnershipRefs.delete(modal);
+      unlockBodyScroll();
+
+      window.setTimeout((): void => {
+        syncModalAccessibility();
+        const remainingTopmostModal: HTMLElement | null = getTopmostModal();
+        const previouslyFocusedElement: HTMLElement | null =
+          previouslyFocusedElementRef.current;
+
+        if (!wasTopmost) {
+          if (!remainingTopmostModal && previouslyFocusedElement?.isConnected) {
+            previouslyFocusedElement.focus();
+          }
+          return;
+        }
+
+        if (
+          previouslyFocusedElement?.isConnected &&
+          (!remainingTopmostModal ||
+            elementBelongsToModal(
+              remainingTopmostModal,
+              previouslyFocusedElement,
+            ))
+        ) {
+          previouslyFocusedElement.focus();
+          return;
+        }
+
+        if (remainingTopmostModal) {
+          getPreferredModalFocus(remainingTopmostModal).focus();
+        }
+      }, 0);
+    };
   }, []);
 
-  let iconBgColor: string = "bg-indigo-100";
-  let iconColor: string = "text-indigo-600";
+  useEffect((): void => {
+    if (props.error && modalBodyScrollRef.current) {
+      modalBodyScrollRef.current.scrollTop = 0;
+    }
+  }, [props.error]);
 
-  if (props.iconType === IconType.Info) {
-    iconBgColor = "bg-indigo-100";
-    iconColor = "text-indigo-600";
-  } else if (props.iconType === IconType.Warning) {
-    iconBgColor = "bg-yellow-100";
-    iconColor = "text-yellow-600";
+  const handleKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      props.onClose?.();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    /*
+     * React events continue through portal boundaries. Keep a nested dialog's
+     * focus loop from being handled again by its parent dialog.
+     */
+    event.stopPropagation();
+
+    const modal: HTMLDivElement | null = modalRef.current;
+    if (!modal) {
+      return;
+    }
+
+    const focusableElements: Array<HTMLElement> =
+      getModalFocusableElements(modal);
+
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      modal.focus();
+      return;
+    }
+
+    const firstFocusableElement: HTMLElement = focusableElements[0]!;
+    const lastFocusableElement: HTMLElement =
+      focusableElements[focusableElements.length - 1]!;
+    const activeElement: Element | null = document.activeElement;
+
+    if (
+      event.shiftKey &&
+      (activeElement === firstFocusableElement ||
+        !elementBelongsToModal(modal, activeElement))
+    ) {
+      event.preventDefault();
+      lastFocusableElement.focus();
+      return;
+    }
+
+    if (
+      !event.shiftKey &&
+      (activeElement === lastFocusableElement ||
+        !elementBelongsToModal(modal, activeElement))
+    ) {
+      event.preventDefault();
+      firstFocusableElement.focus();
+    }
+  };
+
+  let iconBackgroundClassName: string = "bg-indigo-50 ring-indigo-100";
+  let iconClassName: string = "text-indigo-600";
+
+  if (props.iconType === IconType.Warning) {
+    iconBackgroundClassName = "bg-amber-50 ring-amber-100";
+    iconClassName = "text-amber-600";
   } else if (props.iconType === IconType.Success) {
-    iconBgColor = "bg-green-100";
-    iconColor = "text-green-600";
+    iconBackgroundClassName = "bg-emerald-50 ring-emerald-100";
+    iconClassName = "text-emerald-600";
   } else if (props.iconType === IconType.Danger) {
-    iconBgColor = "bg-red-100";
-    iconColor = "text-red-600";
+    iconBackgroundClassName = "bg-rose-50 ring-rose-100";
+    iconClassName = "text-rose-600";
   }
 
-  return (
-    <div
-      ref={modalRef}
-      className="relative z-20"
-      aria-labelledby="modal-title"
-      aria-describedby={props.description ? "modal-description" : undefined}
-      role="dialog"
-      aria-modal="true"
-    >
-      <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+  let modalWidthClassName: string = "sm:max-w-lg md:max-w-lg";
+  if (props.modalWidth === ModalWidth.Medium) {
+    modalWidthClassName = "sm:max-w-3xl md:max-w-3xl";
+  } else if (props.modalWidth === ModalWidth.Large) {
+    modalWidthClassName = "sm:max-w-7xl md:max-w-7xl";
+  }
 
-      <div className="fixed inset-0 z-20 overflow-y-auto">
-        <div className="flex min-h-screen items-end justify-center p-0 text-center md:items-center md:p-4">
+  const hasFooter: boolean = Boolean(
+    props.onSubmit || props.onClose || props.leftFooterElement,
+  );
+  const modalZIndex: number = 60 + modalStackDepth * 20;
+
+  const modalElement: ReactElement = (
+    <div
+      className="fixed inset-0"
+      style={{ zIndex: modalZIndex }}
+      onKeyDown={handleKeyDown}
+      data-testid="modal-layer"
+    >
+      <div className="absolute inset-0 bg-slate-950/35" aria-hidden="true" />
+
+      <div className="absolute inset-0 overflow-y-auto overscroll-contain">
+        <div className="flex min-h-full items-end justify-center pt-3 text-left sm:items-center sm:p-6">
           <div
-            className={`relative transform bg-white text-left shadow-xl transition-all w-full h-full md:rounded-lg md:my-8 ${
-              props.modalWidth && props.modalWidth === ModalWidth.Large
-                ? "md:max-w-7xl"
-                : ""
-            } ${
-              props.modalWidth && props.modalWidth === ModalWidth.Medium
-                ? "md:max-w-3xl"
-                : ""
-            } ${!props.modalWidth ? "md:max-w-lg" : ""} `}
+            ref={modalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={
+              props.ariaDescribedBy ||
+              (translatedDescription ? descriptionId : undefined)
+            }
+            tabIndex={-1}
+            className={`relative flex w-full max-h-[calc(100dvh-0.75rem)] flex-col overflow-hidden rounded-t-2xl border border-slate-200/90 bg-white text-left shadow-[0_24px_80px_-24px_rgba(15,23,42,0.38),0_8px_24px_-12px_rgba(15,23,42,0.18)] ring-1 ring-slate-950/5 sm:max-h-[calc(100dvh-3rem)] sm:rounded-xl ${modalWidthClassName}`}
             data-testid="modal"
+            data-modal-stack-depth={modalStackDepth}
+            data-modal-owner-id={modalId}
           >
-            {props.onClose && (
-              <div className="absolute top-0 right-0 z-10 pt-4 pr-4 md:hidden lg:block">
-                <Button
-                  buttonStyle={ButtonStyleType.ICON}
-                  icon={IconProp.Close}
-                  iconSize={SizeProp.Large}
-                  title="Close"
-                  dataTestId="close-button"
-                  onClick={props.onClose}
-                />
-              </div>
-            )}
-            <div className="p-4 md:p-6">
-              {props.icon && (
-                <div
-                  className={`mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full ${iconBgColor} md:mx-0 md:h-10 md:w-10`}
-                  data-testid="icon"
-                >
-                  <Icon
-                    thick={ThickProp.Thick}
-                    type={
-                      props.iconType === undefined
-                        ? IconType.Info
-                        : props.iconType
-                    }
-                    className={`${iconColor} h-6 w-6 stroke-2`}
-                    icon={props.icon}
-                    size={SizeProp.Large}
-                  />
-                </div>
-              )}
-              <div className="text-left md:mt-0 md:ml-4 md:mr-4">
-                <div className="flex flex-col md:flex-row md:justify-between">
-                  <div className="flex-1">
+            <div className="shrink-0 border-b border-slate-200/80 bg-white px-5 py-4 sm:px-6">
+              <div className="flex items-start gap-3">
+                {props.icon && (
+                  <div
+                    className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset ${iconBackgroundClassName}`}
+                    data-testid="icon"
+                  >
+                    <Icon
+                      thick={ThickProp.Thick}
+                      type={props.iconType || IconType.Info}
+                      className={`h-4 w-4 stroke-2 ${iconClassName}`}
+                      icon={props.icon}
+                      size={SizeProp.Regular}
+                    />
+                  </div>
+                )}
+
+                <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 flex-1">
                     <h3
                       data-testid="modal-title"
-                      className={`text-lg font-medium leading-6 text-gray-900 ${
-                        props.icon ? "mt-4 md:ml-10 md:-mt-8 md:mb-5" : ""
-                      }`}
-                      id="modal-title"
+                      className="break-words text-base font-semibold leading-6 tracking-tight text-slate-950"
+                      id={titleId}
                     >
                       {translatedTitle}
                     </h3>
                     {translatedDescription && (
                       <p
-                        id="modal-description"
+                        id={descriptionId}
                         data-testid="modal-description"
-                        className="text-sm leading-6 text-gray-500 mt-2"
+                        className="mt-1 break-words text-sm leading-5 text-slate-500"
                       >
                         {translatedDescription}
                       </p>
                     )}
                   </div>
+
                   {props.rightElement && (
                     <div
                       data-testid="right-element"
-                      className="mt-4 md:mt-0 lg:mr-4"
+                      className="shrink-0 self-start"
                     >
                       {props.rightElement}
                     </div>
                   )}
                 </div>
-                <div className="mt-2">
-                  <ModalBody error={props.error}>
-                    {!props.isBodyLoading ? (
-                      props.children
-                    ) : (
-                      <div className="modal-body mt-20 mb-20 flex justify-center">
-                        <Loader
-                          loaderType={LoaderType.Bar}
-                          color={VeryLightGray}
-                          size={200}
-                        />
-                      </div>
-                    )}
-                  </ModalBody>
-                </div>
+
+                {props.onClose && (
+                  <Button
+                    buttonStyle={ButtonStyleType.ICON}
+                    buttonSize={ButtonSize.ExtraSmall}
+                    icon={IconProp.Close}
+                    iconSize={SizeProp.Regular}
+                    title="Close"
+                    dataTestId="close-button"
+                    className="!m-0 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 sm:h-8 sm:w-8"
+                    onClick={props.onClose}
+                  />
+                )}
               </div>
             </div>
-            <ModalFooter
-              submitButtonType={
-                props.submitButtonType
-                  ? props.submitButtonType
-                  : ButtonType.Button
-              }
-              submitButtonStyleType={
-                props.submitButtonStyleType
-                  ? props.submitButtonStyleType
-                  : ButtonStyleType.PRIMARY
-              }
-              closeButtonStyleType={
-                props.closeButtonStyleType
-                  ? props.closeButtonStyleType
-                  : ButtonStyleType.NORMAL
-              }
-              submitButtonText={
-                translatedSubmitButtonText
-                  ? translatedSubmitButtonText
-                  : translateString("Save") || "Save"
-              }
-              closeButtonText={
-                translatedCloseButtonText
-                  ? translatedCloseButtonText
-                  : translateString("Cancel") || "Cancel"
-              }
-              onSubmit={props.onSubmit}
-              onClose={props.onClose ? props.onClose : undefined}
-              isLoading={props.isLoading || false}
-              disableSubmitButton={
-                props.isBodyLoading || props.disableSubmitButton
-              }
-              leftFooterElement={props.leftFooterElement}
-            />
+
+            <div
+              ref={modalBodyScrollRef}
+              data-testid="modal-scroll-region"
+              className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-5 sm:px-6"
+            >
+              <ModalBody error={props.error}>
+                {!props.isBodyLoading ? (
+                  props.children
+                ) : (
+                  <div className="flex min-h-48 items-center justify-center py-8">
+                    <Loader
+                      loaderType={LoaderType.Bar}
+                      color={VeryLightGray}
+                      size={200}
+                    />
+                  </div>
+                )}
+              </ModalBody>
+            </div>
+
+            {hasFooter && (
+              <ModalFooter
+                submitButtonType={props.submitButtonType || ButtonType.Button}
+                submitButtonStyleType={
+                  props.submitButtonStyleType || ButtonStyleType.PRIMARY
+                }
+                closeButtonStyleType={
+                  props.closeButtonStyleType || ButtonStyleType.NORMAL
+                }
+                submitButtonText={
+                  translatedSubmitButtonText ||
+                  translateString("Save") ||
+                  "Save"
+                }
+                closeButtonText={
+                  translatedCloseButtonText ||
+                  translateString("Cancel") ||
+                  "Cancel"
+                }
+                onSubmit={props.onSubmit}
+                onClose={props.onClose}
+                isLoading={props.isLoading || false}
+                disableSubmitButton={
+                  props.isBodyLoading || props.disableSubmitButton
+                }
+                leftFooterElement={props.leftFooterElement}
+              />
+            )}
           </div>
         </div>
       </div>
     </div>
   );
+
+  const modalWithStackContext: ReactElement = (
+    <ModalStackContext.Provider value={modalStackValue}>
+      {modalElement}
+    </ModalStackContext.Provider>
+  );
+
+  if (typeof document === "undefined") {
+    return modalWithStackContext;
+  }
+
+  return createPortal(modalWithStackContext, document.body);
 };
 
 export default Modal;

--- a/Common/UI/Components/Modal/ModalBody.tsx
+++ b/Common/UI/Components/Modal/ModalBody.tsx
@@ -1,4 +1,6 @@
-import Alert, { AlertType } from "../Alerts/Alert";
+import Icon from "../Icon/Icon";
+import IconProp from "../../../Types/Icon/IconProp";
+import useTranslateValue from "../../Utils/Translation";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
@@ -9,9 +11,25 @@ export interface ComponentProps {
 const ModalBody: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const { translateString } = useTranslateValue();
+
   return (
     <div className="modal-body">
-      {props.error && <Alert title={props.error} type={AlertType.DANGER} />}
+      {props.error && (
+        <div
+          className="mb-4 flex items-start gap-2.5 rounded-lg border border-rose-200 bg-rose-50 px-3.5 py-3 text-sm leading-5 text-rose-700"
+          role="alert"
+          aria-live="polite"
+          tabIndex={-1}
+          data-testid="modal-error"
+        >
+          <Icon
+            icon={IconProp.ErrorSolid}
+            className="mt-0.5 h-4 w-4 shrink-0 text-rose-500"
+          />
+          <span>{translateString(props.error) || props.error}</span>
+        </div>
+      )}
       {props.children}
     </div>
   );

--- a/Common/UI/Components/Modal/ModalFooter.tsx
+++ b/Common/UI/Components/Modal/ModalFooter.tsx
@@ -19,13 +19,41 @@ const ModalFooter: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   return (
-    <div className="bg-gray-50 px-4 py-3 flex flex-row gap-3 md:px-6 md:justify-between">
+    <div
+      className="flex shrink-0 flex-col gap-3 border-t border-slate-200/80 bg-white px-5 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6"
+      data-testid="modal-footer"
+      style={{
+        paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))",
+      }}
+    >
       {props.leftFooterElement ? (
-        <div className="flex flex-row gap-3">{props.leftFooterElement}</div>
+        <div className="flex min-w-0 flex-wrap items-center gap-2 [&_button]:!ml-0 [&_button]:!w-auto">
+          {props.leftFooterElement}
+        </div>
       ) : (
-        <div />
+        <div className="hidden sm:block" />
       )}
-      <div className="flex flex-row gap-3 md:flex-row-reverse">
+
+      <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+        {props.onClose ? (
+          <Button
+            buttonStyle={
+              props.closeButtonStyleType
+                ? props.closeButtonStyleType
+                : ButtonStyleType.NORMAL
+            }
+            title={props.closeButtonText ? props.closeButtonText : "Cancel"}
+            className="!ml-0 sm:!w-auto"
+            data-dismiss="modal"
+            onClick={() => {
+              props.onClose?.();
+            }}
+            dataTestId="modal-footer-close-button"
+          />
+        ) : (
+          <></>
+        )}
+
         {props.onSubmit ? (
           <Button
             buttonStyle={
@@ -36,6 +64,7 @@ const ModalFooter: FunctionComponent<ComponentProps> = (
             title={
               props.submitButtonText ? props.submitButtonText : "Save Changes"
             }
+            className="!ml-0 sm:!w-auto"
             onClick={() => {
               props.onSubmit?.();
             }}
@@ -47,24 +76,6 @@ const ModalFooter: FunctionComponent<ComponentProps> = (
                 : ButtonType.Button
             }
             dataTestId="modal-footer-submit-button"
-          />
-        ) : (
-          <></>
-        )}
-
-        {props.onClose ? (
-          <Button
-            buttonStyle={
-              props.closeButtonStyleType
-                ? props.closeButtonStyleType
-                : ButtonStyleType.NORMAL
-            }
-            title={props.closeButtonText ? props.closeButtonText : "Cancel"}
-            data-dismiss="modal"
-            onClick={() => {
-              props.onClose?.();
-            }}
-            dataTestId="modal-footer-close-button"
           />
         ) : (
           <></>

--- a/Common/UI/Components/Modal/ModalStackContext.tsx
+++ b/Common/UI/Components/Modal/ModalStackContext.tsx
@@ -1,0 +1,27 @@
+import React, { Context, useContext } from "react";
+
+export interface ModalStackValue {
+  depth: number;
+  ownerId: string | null;
+}
+
+const defaultModalStackValue: ModalStackValue = {
+  depth: 0,
+  ownerId: null,
+};
+
+/*
+ * Tracks how many modal surfaces contain the current component. React context
+ * is preserved through portals, which lets nested dialogs and their floating
+ * controls share one deterministic overlay scale.
+ */
+export const ModalStackContext: Context<ModalStackValue> =
+  React.createContext<ModalStackValue>(defaultModalStackValue);
+
+export const useModalStack: () => ModalStackValue = (): ModalStackValue => {
+  return useContext(ModalStackContext);
+};
+
+export const useModalStackDepth: () => number = (): number => {
+  return useModalStack().depth;
+};

--- a/Common/UI/Components/ModelFormModal/ModelFormModal.tsx
+++ b/Common/UI/Components/ModelFormModal/ModelFormModal.tsx
@@ -1,5 +1,4 @@
 import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
-import Alert, { AlertType } from "../Alerts/Alert";
 import { ButtonStyleType } from "../Button/Button";
 import ButtonType from "../Button/ButtonTypes";
 import { FormProps } from "../Forms/BasicForm";
@@ -61,10 +60,10 @@ const ModelFormModal: <TBaseModel extends BaseModel>(
 
   const [error, setError] = useState<string>("");
 
-  let modalWidth: ModalWidth = props.modalWidth || ModalWidth.Normal;
+  let modalWidth: ModalWidth = props.modalWidth ?? ModalWidth.Normal;
 
   if (props.formProps.steps && props.formProps.steps.length > 0) {
-    modalWidth = props.modalWidth || ModalWidth.Medium;
+    modalWidth = props.modalWidth ?? ModalWidth.Medium;
   }
 
   return (
@@ -77,51 +76,46 @@ const ModelFormModal: <TBaseModel extends BaseModel>(
       description={props.description}
       disableSubmitButton={isFormLoading}
       onSubmit={async () => {
+        setError("");
         await formRef.current?.submitForm();
       }}
       error={error}
     >
-      {!error ? (
-        <>
-          <ModelForm<TBaseModel>
-            {...props.formProps}
-            name={props.name}
-            modelAPI={props.modelAPI}
-            modelType={props.modelType}
-            onIsLastFormStep={(isLastFormStep: boolean) => {
-              if (isLastFormStep) {
-                setSubmitButtonText(props.submitButtonText || "Save");
-              } else {
-                setSubmitButtonText("Next");
-              }
-            }}
-            modelIdToEdit={props.modelIdToEdit}
-            hideSubmitButton={true}
-            formRef={formRef}
-            onLoadingChange={(isFormLoading: boolean) => {
-              setIsFormLoading(isFormLoading);
-            }}
-            initialValues={props.initialValues}
-            onSuccess={(data: TBaseModel) => {
-              if (props.onSuccess) {
-                props.onSuccess(
-                  BaseModel.fromJSONObject(data as TBaseModel, props.modelType),
-                );
-              }
-            }}
-            onError={(error: string) => {
-              setError(error);
-            }}
-            onBeforeCreate={props.onBeforeCreate}
-          />
+      <>
+        <ModelForm<TBaseModel>
+          {...props.formProps}
+          name={props.name}
+          modelAPI={props.modelAPI}
+          modelType={props.modelType}
+          onIsLastFormStep={(isLastFormStep: boolean) => {
+            if (isLastFormStep) {
+              setSubmitButtonText(props.submitButtonText || "Save");
+            } else {
+              setSubmitButtonText("Next");
+            }
+          }}
+          modelIdToEdit={props.modelIdToEdit}
+          hideSubmitButton={true}
+          formRef={formRef}
+          onLoadingChange={(isFormLoading: boolean) => {
+            setIsFormLoading(isFormLoading);
+          }}
+          initialValues={props.initialValues}
+          onSuccess={(data: TBaseModel) => {
+            if (props.onSuccess) {
+              props.onSuccess(
+                BaseModel.fromJSONObject(data as TBaseModel, props.modelType),
+              );
+            }
+          }}
+          onError={(error: string) => {
+            setError(error);
+          }}
+          onBeforeCreate={props.onBeforeCreate}
+        />
 
-          {props.footer}
-        </>
-      ) : (
-        <></>
-      )}
-
-      {error ? <Alert title={error} type={AlertType.DANGER} /> : <></>}
+        {props.footer}
+      </>
     </Modal>
   );
 };

--- a/Common/UI/Components/Toast/Toast.tsx
+++ b/Common/UI/Components/Toast/Toast.tsx
@@ -64,7 +64,7 @@ const Component: FunctionComponent<ComponentProps> = (
       <div
         data-testid="toast"
         aria-live="assertive"
-        className={`pointer-events-none fixed z-40 top-${top} left-0 right-0  flex items-end px-4 py-6 sm:items-start sm:p-6`}
+        className={`pointer-events-none fixed z-[200] top-${top} left-0 right-0  flex items-end px-4 py-6 sm:items-start sm:p-6`}
       >
         <div className="flex w-full flex-col items-center space-y-4 sm:items-end">
           <div className="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-black ring-opacity-5">


### PR DESCRIPTION
## Summary

- redesign shared dialogs with a quieter, responsive Linear × Notion visual system
- add nested-modal stacking, scroll locking, focus containment/restoration, and accessible descriptions
- keep long forms mounted through validation errors and reveal errors at the top of the scroll region
- make dropdowns, entity pickers, icon pickers, and color pickers portal-safe, keyboard accessible, and correctly layered
- raise toast notifications above nested dialog stacks

## Stack

- Depends on #2632
- This is PR 2 of the dashboard polish stack

## Validation

- 72 focused Common UI tests pass
- Dashboard development build passes
- Targeted ESLint passes
- `npm run fix` completes formatting and reports only the two existing missing `react-hooks/exhaustive-deps` rule definitions
- Common compile reaches only pre-existing Queue/ioredis and chart generic errors; no touched-file errors