### PR TITLE
Polish dashboard model-list surfaces

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/MasterPage/MasterPage.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MasterPage/MasterPage.tsx
@@ -16,6 +16,10 @@ import Navigation from "Common/UI/Utils/Navigation";
 import Project from "Common/Models/DatabaseModels/Project";
 import React, { FunctionComponent, ReactElement } from "react";
 import ProjectUtil from "Common/UI/Utils/Project";
+import {
+  SurfaceStyle,
+  SurfaceStyleProvider,
+} from "Common/UI/Contexts/SurfaceStyleContext";
 
 export interface ComponentProps {
   children: ReactElement | Array<ReactElement>;
@@ -77,51 +81,53 @@ const DashboardMasterPage: FunctionComponent<ComponentProps> = (
   }
 
   return (
-    <div>
-      {BILLING_ENABLED && isSubscriptionInactiveOrOverdue && (
-        <TopAlert
-          alertType={TopAlertType.DANGER}
-          title={
-            isSubscriptionOverdue
-              ? "Your project will become inactive soon because some of the invoices are unpaid"
-              : "Your project is not active because some invoices are unpaid. If left unpaid, your project will be deleted."
-          }
-          description={
-            <AppLink
-              className="underline"
-              to={RouteUtil.populateRouteParams(
-                RouteMap[PageMap.SETTINGS_BILLING_INVOICES] as Route,
-              )}
-            >
-              Click here to pay your unpaid invoices.
-            </AppLink>
-          }
-        />
-      )}
-
-      <MasterPage
-        footer={<Footer />}
-        header={
-          <Header
-            projects={props.projects}
-            onProjectSelected={props.onProjectSelected}
-            showProjectModal={props.showProjectModal}
-            onProjectModalClose={props.onProjectModalClose}
-            selectedProject={props.selectedProject || null}
-            paymentMethodsCount={props.paymentMethodsCount}
+    <SurfaceStyleProvider style={SurfaceStyle.Quiet}>
+      <div>
+        {BILLING_ENABLED && isSubscriptionInactiveOrOverdue && (
+          <TopAlert
+            alertType={TopAlertType.DANGER}
+            title={
+              isSubscriptionOverdue
+                ? "Your project will become inactive soon because some of the invoices are unpaid"
+                : "Your project is not active because some invoices are unpaid. If left unpaid, your project will be deleted."
+            }
+            description={
+              <AppLink
+                className="underline"
+                to={RouteUtil.populateRouteParams(
+                  RouteMap[PageMap.SETTINGS_BILLING_INVOICES] as Route,
+                )}
+              >
+                Click here to pay your unpaid invoices.
+              </AppLink>
+            }
           />
-        }
-        navBar={
-          <NavBar show={props.projects.length > 0 && !isOnHideNavbarPage} />
-        }
-        isLoading={props.isLoading}
-        error={error}
-        className="flex min-h-screen flex-col bg-slate-50/60 text-slate-900 antialiased"
-        topSectionClassName="border-b border-slate-200/80 bg-white/90 text-slate-700 shadow-[0_1px_2px_rgba(15,23,42,0.04)] backdrop-blur-xl [&>div>div>nav]:!mt-0 [&>div>div>nav]:!bg-transparent"
-      >
-        {props.children}
-      </MasterPage>
-    </div>
+        )}
+
+        <MasterPage
+          footer={<Footer />}
+          header={
+            <Header
+              projects={props.projects}
+              onProjectSelected={props.onProjectSelected}
+              showProjectModal={props.showProjectModal}
+              onProjectModalClose={props.onProjectModalClose}
+              selectedProject={props.selectedProject || null}
+              paymentMethodsCount={props.paymentMethodsCount}
+            />
+          }
+          navBar={
+            <NavBar show={props.projects.length > 0 && !isOnHideNavbarPage} />
+          }
+          isLoading={props.isLoading}
+          error={error}
+          className="flex min-h-screen flex-col bg-slate-50/60 text-slate-900 antialiased"
+          topSectionClassName="border-b border-slate-200/80 bg-white/90 text-slate-700 shadow-[0_1px_2px_rgba(15,23,42,0.04)] backdrop-blur-xl [&>div>div>nav]:!mt-0 [&>div>div>nav]:!bg-transparent"
+        >
+          {props.children}
+        </MasterPage>
+      </div>
+    </SurfaceStyleProvider>
   );
 };
 

--- a/Common/Tests/UI/Components/Card.test.tsx
+++ b/Common/Tests/UI/Components/Card.test.tsx
@@ -3,11 +3,15 @@ import Card, {
   CardButtonSchema,
   ComponentProps,
 } from "../../../UI/Components/Card/Card";
-import "@testing-library/jest-dom/extend-expect";
+import {
+  SurfaceStyle,
+  SurfaceStyleProvider,
+} from "../../../UI/Contexts/SurfaceStyleContext";
+import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import IconProp from "../../../Types/Icon/IconProp";
 import React, { ReactElement } from "react";
-import { describe, expect, jest } from "@jest/globals";
+import { describe, jest } from "@jest/globals";
 
 describe("Card", () => {
   const props: ComponentProps = {
@@ -105,5 +109,34 @@ describe("Card", () => {
 
     expect(childComponent).toBeInTheDocument();
     expect(childComponent.parentElement).toHaveClass("mt-4");
+  });
+
+  test("should render the quiet dashboard surface without changing card behavior", () => {
+    const childElementText: string = "quiet card content";
+
+    render(
+      <SurfaceStyleProvider style={SurfaceStyle.Quiet}>
+        <Card {...props}>
+          <div>{childElementText}</div>
+        </Card>
+      </SurfaceStyleProvider>,
+    );
+
+    const card: HTMLElement = screen.getByTestId("card");
+    const cardSurface: HTMLElement = card.firstElementChild as HTMLElement;
+    const title: HTMLElement = screen.getByText(props.title as string);
+    const description: HTMLElement = screen.getByText(
+      props.description as string,
+    );
+
+    expect(cardSurface).toHaveClass(
+      "rounded-lg",
+      "border-slate-200",
+      "bg-white",
+    );
+    expect(cardSurface).not.toHaveClass("shadow-sm");
+    expect(title).toHaveClass("text-[15px]", "font-medium", "text-slate-900");
+    expect(description).toHaveClass("text-slate-500");
+    expect(screen.getByText(childElementText)).toBeInTheDocument();
   });
 });

--- a/Common/Tests/UI/Components/EmptyState/EmptyState.test.tsx
+++ b/Common/Tests/UI/Components/EmptyState/EmptyState.test.tsx
@@ -1,4 +1,8 @@
 import EmptyState from "../../../../UI/Components/EmptyState/EmptyState";
+import {
+  SurfaceStyle,
+  SurfaceStyleProvider,
+} from "../../../../UI/Contexts/SurfaceStyleContext";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import IconProp from "../../../../Types/Icon/IconProp";
@@ -41,5 +45,42 @@ describe("EmptyState", () => {
     const description: HTMLElement = screen.getByText("Description");
     expect(title).toBeInTheDocument();
     expect(description).toBeInTheDocument();
+  });
+
+  test("renders a compact quiet surface with its content intact", () => {
+    render(
+      <SurfaceStyleProvider style={SurfaceStyle.Quiet}>
+        <EmptyState
+          id="quiet-empty-state"
+          icon={IconProp.User}
+          title="Nothing here yet"
+          description="New items will appear here."
+          footer={<button type="button">Create item</button>}
+          showSolidBackground={true}
+        />
+      </SurfaceStyleProvider>,
+    );
+
+    const emptyState: HTMLElement = document.getElementById(
+      "quiet-empty-state",
+    ) as HTMLElement;
+
+    expect(emptyState).toHaveClass(
+      "min-h-64",
+      "px-6",
+      "py-16",
+      "rounded-lg",
+      "border",
+      "border-slate-200",
+      "bg-white",
+    );
+    expect(emptyState).not.toHaveClass("shadow");
+    expect(screen.getByText("Nothing here yet")).toHaveClass("text-slate-900");
+    expect(screen.getByText("New items will appear here.")).toHaveClass(
+      "text-slate-500",
+    );
+    expect(
+      screen.getByRole("button", { name: "Create item" }),
+    ).toBeInTheDocument();
   });
 });

--- a/Common/Tests/UI/Components/List.test.tsx
+++ b/Common/Tests/UI/Components/List.test.tsx
@@ -1,4 +1,8 @@
 import List, { ComponentProps } from "../../../UI/Components/List/List";
+import {
+  SurfaceStyle,
+  SurfaceStyleProvider,
+} from "../../../UI/Contexts/SurfaceStyleContext";
 import FieldType from "../../../UI/Components/Types/FieldType";
 import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
@@ -97,5 +101,23 @@ describe("List", () => {
     fireEvent.click(nextButtons[0]!);
 
     expect(defaultProps.onNavigateToPage).toHaveBeenCalledWith(2, 5);
+  });
+
+  it("uses card-safe spacing for the quiet dashboard surface", () => {
+    render(
+      <SurfaceStyleProvider style={SurfaceStyle.Quiet}>
+        <List {...defaultProps} />
+      </SurfaceStyleProvider>,
+    );
+
+    const listContainer: HTMLElement = screen.getByTestId("list-container");
+    const pagination: HTMLElement = screen.getByTestId("list-pagination");
+    const paginationWrapper: HTMLElement =
+      pagination.parentElement as HTMLElement;
+
+    expect(listContainer).toHaveAttribute("data-surface-style", "quiet");
+    expect(listContainer.firstElementChild).toHaveClass("mt-3");
+    expect(paginationWrapper).toHaveClass("-mb-4", "mt-4");
+    expect(pagination).toHaveClass("border-slate-200");
   });
 });

--- a/Common/Tests/UI/Components/Pagination.test.tsx
+++ b/Common/Tests/UI/Components/Pagination.test.tsx
@@ -1,8 +1,12 @@
 import Pagination, {
   ComponentProps,
 } from "../../../UI/Components/Pagination/Pagination";
-import { describe, expect, jest } from "@jest/globals";
-import "@testing-library/jest-dom/extend-expect";
+import {
+  SurfaceStyle,
+  SurfaceStyleProvider,
+} from "../../../UI/Contexts/SurfaceStyleContext";
+import { describe, jest } from "@jest/globals";
+import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import getJestMockFunction, { MockFunction } from "../../../Tests/MockType";
@@ -165,6 +169,50 @@ describe("Pagination", () => {
 
     await waitFor(() => {
       expect(mockOnNavigateToPage).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  it("renders compact quiet controls and keeps navigation working", async () => {
+    const mockOnNavigateToPage: MockFunction = getJestMockFunction();
+    const props: ComponentProps = {
+      currentPageNumber: 1,
+      totalItemsCount: 19,
+      itemsOnPage: 10,
+      onNavigateToPage: mockOnNavigateToPage,
+      isLoading: false,
+      isError: false,
+      singularLabel: "Item",
+      pluralLabel: "Items",
+    };
+
+    render(
+      <SurfaceStyleProvider style={SurfaceStyle.Quiet}>
+        <Pagination {...props} />
+      </SurfaceStyleProvider>,
+    );
+
+    const pagination: HTMLElement = screen.getByRole("navigation", {
+      name: "Pagination for Items",
+    });
+    const summary: HTMLElement = screen
+      .getByText(/Showing 1 to 10 on this page/i)
+      .closest("p") as HTMLElement;
+    const nextButton: HTMLElement = screen.getAllByRole("button", {
+      name: "Go to next page",
+    })[0]!;
+    const controls: HTMLElement = nextButton.closest(
+      ".shadow-none",
+    ) as HTMLElement;
+
+    expect(pagination).toHaveClass("min-h-12", "border-slate-200", "bg-white");
+    expect(summary).toHaveClass("text-xs", "text-slate-500");
+    expect(controls).toBeInTheDocument();
+    expect(nextButton).toHaveClass("text-xs", "text-slate-600");
+
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(mockOnNavigateToPage).toHaveBeenCalledWith(2, 10);
     });
   });
 });

--- a/Common/Tests/UI/Components/Table.test.tsx
+++ b/Common/Tests/UI/Components/Table.test.tsx
@@ -1,0 +1,104 @@
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import Table, { ComponentProps } from "../../../UI/Components/Table/Table";
+import {
+  SurfaceStyle,
+  SurfaceStyleProvider,
+} from "../../../UI/Contexts/SurfaceStyleContext";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { jest } from "@jest/globals";
+
+describe("Table", () => {
+  interface TableItem {
+    name: string;
+  }
+
+  const getProps: () => ComponentProps<TableItem> = () => {
+    return {
+      data: [{ name: "API service" }],
+      id: "services-table",
+      columns: [
+        {
+          title: "Name",
+          key: "name",
+          type: FieldType.Text,
+        },
+      ],
+      onNavigateToPage: jest.fn(),
+      currentPageNumber: 1,
+      totalItemsCount: 2,
+      itemsOnPage: 1,
+      error: "",
+      isLoading: false,
+      singularLabel: "Service",
+      pluralLabel: "Services",
+      sortOrder: SortOrder.Ascending,
+      sortBy: null,
+      onSortChanged: jest.fn(),
+    };
+  };
+
+  it("preserves the default table surface", () => {
+    render(<Table<TableItem> {...getProps()} />);
+
+    expect(screen.getByRole("table")).toHaveClass("divide-gray-200");
+    expect(screen.getByRole("columnheader", { name: "Name" })).toHaveClass(
+      "py-3",
+      "text-gray-900",
+    );
+    expect(screen.getByRole("cell", { name: "API service" })).toHaveClass(
+      "py-4",
+      "text-gray-500",
+    );
+  });
+
+  it("renders a quiet model table and keeps sorting and pagination working", () => {
+    const props: ComponentProps<TableItem> = getProps();
+
+    render(
+      <SurfaceStyleProvider style={SurfaceStyle.Quiet}>
+        <Table<TableItem> {...props} />
+      </SurfaceStyleProvider>,
+    );
+
+    const table: HTMLElement = screen.getByRole("table");
+    const tableHeader: HTMLElement = table.querySelector(
+      "thead",
+    ) as HTMLElement;
+    const tableBody: HTMLElement = table.querySelector("tbody") as HTMLElement;
+    const columnHeader: HTMLElement = screen.getByRole("columnheader", {
+      name: "Name",
+    });
+    const cell: HTMLElement = screen.getByRole("cell", {
+      name: "API service",
+    });
+    const row: HTMLElement = cell.closest("tr") as HTMLElement;
+    const tableContainer: HTMLElement = table.parentElement as HTMLElement;
+    const nextButton: HTMLElement = screen.getAllByRole("button", {
+      name: "Go to next page",
+    })[0]!;
+
+    expect(table).toHaveClass("divide-slate-200");
+    expect(tableHeader).toHaveClass("bg-slate-50");
+    expect(tableBody).toHaveClass("divide-slate-100");
+    expect(tableContainer).toHaveClass("border-t", "border-slate-200");
+    expect(tableContainer).not.toHaveClass("border-b", "border-y");
+    expect(row).toHaveClass("hover:bg-slate-50/70");
+    expect(columnHeader).toHaveClass("py-2.5", "text-slate-500");
+    expect(cell).toHaveClass("py-3", "text-slate-600");
+    expect(
+      screen.getByRole("navigation", { name: "Pagination for Services" }),
+    ).toHaveClass("min-h-12", "border-slate-200");
+
+    fireEvent.click(columnHeader);
+    expect(props.onSortChanged).toHaveBeenCalledWith(
+      "name",
+      SortOrder.Descending,
+    );
+
+    fireEvent.click(nextButton);
+    expect(props.onNavigateToPage).toHaveBeenCalledWith(2, 1);
+  });
+});

--- a/Common/UI/Components/Card/Card.tsx
+++ b/Common/UI/Components/Card/Card.tsx
@@ -2,6 +2,10 @@ import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
 import ShortcutKey from "../ShortcutKey/ShortcutKey";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface CardButtonSchema {
@@ -30,6 +34,8 @@ const Card: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const { translateValue } = useTranslateValue();
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   const noRightElementsOrButtons: boolean =
     !props.rightElement && (!props.buttons || props.buttons.length === 0);
   const translatedTitle: string | ReactElement | undefined = translateValue(
@@ -37,13 +43,37 @@ const Card: FunctionComponent<ComponentProps> = (
   );
   const translatedDescription: string | ReactElement | undefined =
     translateValue(props.description);
+  const cardClassName: string = isQuiet
+    ? "overflow-visible rounded-lg border border-slate-200 bg-white"
+    : "overflow-visible rounded-xl border border-gray-200 bg-white shadow-sm";
+  const contentClassName: string = isQuiet
+    ? "px-4 py-4 sm:px-5"
+    : "px-5 py-6 md:px-6";
+  const titleClassName: string = isQuiet
+    ? "text-[15px] font-medium leading-6 tracking-[-0.01em] text-slate-900"
+    : "text-lg font-semibold leading-6 text-gray-900";
+  const descriptionClassName: string = isQuiet
+    ? "mt-1 w-full text-sm leading-5 text-slate-500"
+    : "mt-1.5 hidden w-full text-sm leading-relaxed text-gray-500 md:block";
+  const bodyClassName: string =
+    props.bodyClassName || (isQuiet ? "mt-3" : "mt-4");
 
   return (
     <React.Fragment>
-      <div data-testid="card" className={`mb-5 ${props.className || ""}`}>
-        <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-visible">
-          <div className="py-6 px-5 md:px-6">
-            <div className="flex flex-col md:flex-row md:justify-between md:items-start">
+      <div
+        data-testid="card"
+        data-surface-style={surfaceStyle}
+        className={`${isQuiet ? "mb-4" : "mb-5"} ${props.className || ""}`}
+      >
+        <div data-testid="card-surface" className={cardClassName}>
+          <div className={contentClassName}>
+            <div
+              className={`flex flex-col ${
+                isQuiet
+                  ? "gap-3 sm:flex-row sm:items-start sm:justify-between"
+                  : "md:flex-row md:items-start md:justify-between"
+              }`}
+            >
               <div
                 className={`${noRightElementsOrButtons ? "w-full" : "flex-1 min-w-0"}`}
               >
@@ -51,7 +81,7 @@ const Card: FunctionComponent<ComponentProps> = (
                   <h2
                     data-testid="card-details-heading"
                     id="card-details-heading"
-                    className="text-lg font-semibold leading-6 text-gray-900"
+                    className={titleClassName}
                   >
                     {translatedTitle}
                   </h2>
@@ -59,7 +89,7 @@ const Card: FunctionComponent<ComponentProps> = (
                 {translatedDescription && (
                   <p
                     data-testid="card-description"
-                    className="mt-1.5 text-sm text-gray-500 w-full hidden md:block leading-relaxed"
+                    className={descriptionClassName}
                   >
                     {translatedDescription}
                   </p>
@@ -67,7 +97,13 @@ const Card: FunctionComponent<ComponentProps> = (
               </div>
               {(props.rightElement ||
                 (props.buttons && props.buttons.length > 0)) && (
-                <div className="flex flex-col md:flex-row md:items-center md:w-fit mt-4 md:mt-0 md:ml-4 gap-2 md:gap-0 flex-shrink-0 items-center">
+                <div
+                  className={`flex flex-shrink-0 flex-col items-center gap-2 md:w-fit md:flex-row md:items-center ${
+                    isQuiet
+                      ? "sm:ml-4 sm:mt-0"
+                      : "mt-4 md:ml-4 md:mt-0 md:gap-0"
+                  }`}
+                >
                   {props.rightElement && (
                     <div className="mb-2 md:mb-0 md:mr-3">
                       {props.rightElement}
@@ -125,9 +161,7 @@ const Card: FunctionComponent<ComponentProps> = (
             </div>
 
             {props.children && (
-              <div className={props.bodyClassName || "mt-4"}>
-                {props.children}
-              </div>
+              <div className={bodyClassName}>{props.children}</div>
             )}
           </div>
         </div>

--- a/Common/UI/Components/EmptyState/EmptyState.tsx
+++ b/Common/UI/Components/EmptyState/EmptyState.tsx
@@ -1,4 +1,8 @@
 import Icon from "../Icon/Icon";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
 import React, { FunctionComponent, ReactElement } from "react";
@@ -17,31 +21,64 @@ const EmptyState: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const { translateValue } = useTranslateValue();
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
+  const rootClassName: string = isQuiet
+    ? `flex min-h-64 px-6 py-16 ${
+        props.showSolidBackground
+          ? "rounded-lg border border-slate-200 bg-white"
+          : ""
+      }`
+    : `flex pb-52 pt-52 ${
+        props.showSolidBackground ? "rounded bg-white shadow" : ""
+      }`;
+
   return (
     <React.Fragment>
       <div
         id={props.id}
-        className={`flex pt-52 pb-52 ${
-          props.showSolidBackground ? "bg-white rounded shadow" : ""
-        }`}
+        data-testid="empty-state"
+        data-surface-style={surfaceStyle}
+        className={rootClassName}
       >
-        <div className="m-auto text-center">
+        <div
+          className={
+            isQuiet ? "m-auto max-w-md text-center" : "m-auto text-center"
+          }
+        >
           {props.icon && (
             <Icon
               icon={props.icon}
               className={
-                props.iconClassName || `mx-auto h-12 w-12 text-gray-400`
+                props.iconClassName ||
+                (isQuiet
+                  ? "mx-auto h-10 w-10 text-slate-400"
+                  : "mx-auto h-12 w-12 text-gray-400")
               }
             />
           )}
 
-          <h3 className="mt-2 text-sm font-medium text-gray-900">
+          <h3
+            className={
+              isQuiet
+                ? "mt-3 text-[15px] font-medium text-slate-900"
+                : "mt-2 text-sm font-medium text-gray-900"
+            }
+          >
             {translateValue(props.title)}
           </h3>
-          <p className="mt-1 text-sm text-gray-500">
+          <p
+            className={
+              isQuiet
+                ? "mt-1 text-sm leading-5 text-slate-500"
+                : "mt-1 text-sm text-gray-500"
+            }
+          >
             {translateValue(props.description)}
           </p>
-          {props.footer && <div className="mt-6">{props.footer}</div>}
+          {props.footer && (
+            <div className={isQuiet ? "mt-5" : "mt-6"}>{props.footer}</div>
+          )}
         </div>
       </div>
     </React.Fragment>

--- a/Common/UI/Components/List/List.tsx
+++ b/Common/UI/Components/List/List.tsx
@@ -1,4 +1,8 @@
 import { GetReactElementFunction } from "../../Types/FunctionTypes";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import ActionButtonSchema from "../ActionButton/ActionButtonSchema";
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
 import Field from "../Detail/Field";
@@ -60,6 +64,9 @@ type ListFunction = <T extends GenericObject>(
 const List: ListFunction = <T extends GenericObject>(
   props: ComponentProps<T>,
 ): ReactElement => {
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
+
   const getListbody: GetReactElementFunction = (): ReactElement => {
     if (props.isLoading) {
       return <ComponentLoader />;
@@ -107,9 +114,11 @@ const List: ListFunction = <T extends GenericObject>(
   };
 
   return (
-    <div data-testid="list-container">
-      <div className="mt-6">
-        <div className="bg-white pr-6 pl-6">
+    <div data-testid="list-container" data-surface-style={surfaceStyle}>
+      <div className={isQuiet ? "mt-3" : "mt-6"}>
+        <div
+          className={isQuiet ? "bg-white px-4 sm:px-5" : "bg-white pl-6 pr-6"}
+        >
           <FilterViewer
             id={`${props.id}-filter`}
             showFilterModal={props.showFilterModal || false}
@@ -140,7 +149,7 @@ const List: ListFunction = <T extends GenericObject>(
             {getListbody()}
           </DragDropContext>
           {!props.disablePagination && (
-            <div className="mt-5 -mb-6">
+            <div className={isQuiet ? "-mb-4 mt-4" : "-mb-6 mt-5"}>
               <Pagination
                 singularLabel={props.singularLabel}
                 pluralLabel={props.pluralLabel}

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -5,6 +5,10 @@ import { GetReactElementFunction } from "../../Types/FunctionTypes";
 import SelectEntityField from "../../Types/SelectEntityField";
 import API from "../../Utils/API/API";
 import useTranslateValue from "../../Utils/Translation";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 
 import Query from "../../../Types/BaseDatabase/Query";
 import GroupBy from "../../../Types/BaseDatabase/GroupBy";
@@ -301,6 +305,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 ) => ReactElement = <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   props: ComponentProps<TBaseModel>,
 ): ReactElement => {
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   const { translateValue, translateString } = useTranslateValue();
   const tx: (value: string) => string = (value: string): string => {
     return translateString(value) ?? value;
@@ -3152,7 +3158,9 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               buttons={headerButtons}
               bodyClassName={
                 showAs === ShowAs.List
-                  ? "-ml-6 -mr-6 bg-gray-50 border-top"
+                  ? isQuiet
+                    ? "-mx-4 border-t border-slate-200 bg-slate-50 sm:-mx-5"
+                    : "-ml-6 -mr-6 bg-gray-50 border-top"
                   : ""
               }
               title={getCardHeaderTitle(

--- a/Common/UI/Components/Pagination/Pagination.tsx
+++ b/Common/UI/Components/Pagination/Pagination.tsx
@@ -1,4 +1,8 @@
 import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import BasicFormModal from "../FormModal/BasicFormModal";
 import FormFieldSchemaType from "../Forms/Types/FormFieldSchemaType";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -36,6 +40,8 @@ export interface ComponentProps {
 const Pagination: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   const isHasMoreMode: boolean = props.hasMore !== undefined;
 
   const [minPageNumber, setMinPageNumber] = useState<number>(1);
@@ -76,16 +82,59 @@ const Pagination: FunctionComponent<ComponentProps> = (
 
   const [showPaginationModel, setShowPaginationModel] =
     useState<boolean>(false);
+  const navClassName: string = isQuiet
+    ? "flex min-h-12 items-center justify-between border-t border-slate-200 bg-white px-4 sm:px-5"
+    : "flex items-center justify-between border-t border-gray-200 bg-white px-4";
+  const controlGroupClassName: string = isQuiet
+    ? "inline-flex -space-x-px rounded-md shadow-none"
+    : "inline-flex -space-x-px rounded-md shadow-sm";
+  const listClassName: string = isQuiet ? "flex py-2" : "flex py-3";
+  const previousButtonClassName: string = isQuiet
+    ? `inline-flex items-center rounded-l-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
+        isPreviousDisabled
+          ? "cursor-not-allowed bg-slate-50 text-slate-300"
+          : "cursor-pointer hover:bg-slate-50"
+      }`
+    : `inline-flex items-center rounded-l-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
+        isPreviousDisabled
+          ? "cursor-not-allowed bg-gray-100"
+          : "cursor-pointer hover:bg-gray-50"
+      }`;
+  const currentButtonClassName: string = isQuiet
+    ? `z-10 inline-flex items-center border border-x-0 border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
+        isCurrentPageButtonDisabled
+          ? "cursor-not-allowed bg-slate-50 text-slate-300"
+          : "cursor-pointer bg-slate-50 hover:bg-slate-100"
+      }`
+    : `z-10 inline-flex cursor-pointer items-center border border-x-0 border-gray-300 px-4 py-2 text-sm font-medium text-text-600 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
+        isCurrentPageButtonDisabled ? "bg-gray-100" : ""
+      }`;
+  const nextButtonClassName: string = isQuiet
+    ? `inline-flex items-center rounded-r-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
+        isNextDisabled
+          ? "cursor-not-allowed bg-slate-50 text-slate-300"
+          : "cursor-pointer hover:bg-slate-50"
+      }`
+    : `inline-flex items-center rounded-r-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
+        isNextDisabled
+          ? "cursor-not-allowed bg-gray-100"
+          : "cursor-pointer hover:bg-gray-50"
+      }`;
 
   return (
     <nav
-      className="flex items-center justify-between border-t border-gray-200 bg-white px-4"
+      className={navClassName}
       data-testid={props.dataTestId}
+      data-surface-style={surfaceStyle}
       aria-label={`Pagination for ${props.pluralLabel}`}
     >
       {/* Desktop layout: Description on left, all controls on right */}
       <div className="hidden md:block">
-        <p className="text-sm text-gray-500">
+        <p
+          className={
+            isQuiet ? "text-xs text-slate-500" : "text-sm text-gray-500"
+          }
+        >
           {!props.isLoading && isHasMoreMode && (
             <span>
               {`Showing ${
@@ -118,11 +167,11 @@ const Pagination: FunctionComponent<ComponentProps> = (
 
       {/* Desktop layout: All controls together on right */}
       <div className="hidden md:flex">
-        <div className="inline-flex -space-x-px rounded-md shadow-sm">
-          <div className="my-2">
+        <div className={controlGroupClassName}>
+          <div className={isQuiet ? "my-1" : "my-2"}>
             <Button
               dataTestId="show-pagination-modal-button"
-              className="mx-2 my-2"
+              className={isQuiet ? "mx-1 my-1" : "mx-2 my-2"}
               buttonSize={ButtonSize.ExtraSmall}
               icon={IconProp.AdjustmentHorizontal}
               buttonStyle={ButtonStyleType.ICON_LIGHT}
@@ -133,7 +182,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
             />
           </div>
 
-          <ul className="flex py-3" role="list">
+          <ul className={listClassName} role="list">
             <li className="flex">
               <button
                 type="button"
@@ -153,11 +202,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
                     );
                   }
                 }}
-                className={` inline-flex items-center rounded-l-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500   ${
-                  isPreviousDisabled
-                    ? "bg-gray-100 cursor-not-allowed"
-                    : "hover:bg-gray-50 cursor-pointer"
-                }`}
+                className={previousButtonClassName}
               >
                 <span className="page-link">Previous</span>
               </button>
@@ -169,9 +214,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
                 aria-current="page"
                 aria-label={`Page ${props.currentPageNumber}, current page. Select to jump to another page.`}
                 data-testid="current-page-link"
-                className={` z-10 inline-flex items-center border border-x-0 border-gray-300 hover:bg-gray-50 px-4 py-2 text-sm font-medium text-text-600 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
-                  isCurrentPageButtonDisabled ? "bg-gray-100" : ""
-                }`}
+                className={currentButtonClassName}
                 onClick={() => {
                   if (!isHasMoreMode) {
                     setShowPaginationModel(true);
@@ -200,11 +243,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
                     );
                   }
                 }}
-                className={` inline-flex items-center rounded-r-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500  ${
-                  isNextDisabled
-                    ? "bg-gray-100 cursor-not-allowed"
-                    : " hover:bg-gray-50 cursor-pointer"
-                }`}
+                className={nextButtonClassName}
               >
                 <span>Next</span>
               </button>
@@ -214,10 +253,10 @@ const Pagination: FunctionComponent<ComponentProps> = (
       </div>
 
       {/* Mobile layout: Navigate button on left, pagination controls on right */}
-      <div className="md:hidden my-2">
+      <div className={isQuiet ? "my-1 md:hidden" : "my-2 md:hidden"}>
         <Button
           dataTestId="show-pagination-modal-button-mobile"
-          className="my-2"
+          className={isQuiet ? "my-1" : "my-2"}
           buttonSize={ButtonSize.ExtraSmall}
           icon={IconProp.AdjustmentHorizontal}
           buttonStyle={ButtonStyleType.ICON_LIGHT}
@@ -229,7 +268,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
       </div>
 
       <div className="md:hidden">
-        <div className="inline-flex -space-x-px rounded-md shadow-sm">
+        <div className={controlGroupClassName}>
           <ul className="flex" role="list">
             <li className="flex">
               <button
@@ -250,11 +289,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
                     );
                   }
                 }}
-                className={` inline-flex items-center rounded-l-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500   ${
-                  isPreviousDisabled
-                    ? "bg-gray-100 cursor-not-allowed"
-                    : "hover:bg-gray-50 cursor-pointer"
-                }`}
+                className={previousButtonClassName}
               >
                 <span className="page-link">Previous</span>
               </button>
@@ -266,9 +301,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
                 aria-current="page"
                 aria-label={`Page ${props.currentPageNumber}, current page. Select to jump to another page.`}
                 data-testid="current-page-link-mobile"
-                className={` z-10 inline-flex items-center border border-x-0 border-gray-300 hover:bg-gray-50 px-4 py-2 text-sm font-medium text-text-600 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 ${
-                  isCurrentPageButtonDisabled ? "bg-gray-100" : ""
-                }`}
+                className={currentButtonClassName}
                 onClick={() => {
                   if (!isHasMoreMode) {
                     setShowPaginationModel(true);
@@ -297,11 +330,7 @@ const Pagination: FunctionComponent<ComponentProps> = (
                     );
                   }
                 }}
-                className={` inline-flex items-center rounded-r-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500  ${
-                  isNextDisabled
-                    ? "bg-gray-100 cursor-not-allowed"
-                    : " hover:bg-gray-50 cursor-pointer"
-                }`}
+                className={nextButtonClassName}
               >
                 <span>Next</span>
               </button>

--- a/Common/UI/Components/Table/Table.tsx
+++ b/Common/UI/Components/Table/Table.tsx
@@ -1,4 +1,8 @@
 import { GetReactElementFunction } from "../../Types/FunctionTypes";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import useTranslateValue from "../../Utils/Translation";
 import ActionButtonSchema from "../ActionButton/ActionButtonSchema";
 import BulkUpdateForm, {
@@ -91,6 +95,8 @@ const Table: TableFunction = <T extends GenericObject>(
   props: ComponentProps<T>,
 ): ReactElement => {
   const { translateString } = useTranslateValue();
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   const translatedSingularLabel: string =
     translateString(props.singularLabel) ?? props.singularLabel;
   const translatedPluralLabel: string =
@@ -242,7 +248,11 @@ const Table: TableFunction = <T extends GenericObject>(
   });
 
   return (
-    <div className={props.className}>
+    <div
+      className={`${props.className || ""} ${isQuiet ? "min-w-0" : ""}`}
+      data-testid="table"
+      data-surface-style={surfaceStyle}
+    >
       <FilterViewer
         id={`${props.id}-filter`}
         showFilterModal={props.showFilterModal || false}
@@ -289,23 +299,47 @@ const Table: TableFunction = <T extends GenericObject>(
           }
         }}
       >
-        <div className="-my-2 overflow-x-auto md:-mx-6">
-          <div className="inline-block min-w-full py-2 align-middle">
+        <div
+          className={
+            isQuiet
+              ? "-mx-4 -my-1 overflow-x-auto sm:-mx-5"
+              : "-my-2 overflow-x-auto md:-mx-6"
+          }
+        >
+          <div
+            className={
+              isQuiet
+                ? "inline-block min-w-full py-1 align-middle"
+                : "inline-block min-w-full py-2 align-middle"
+            }
+          >
             <div
               className={
                 props.tableContainerClassName
                   ? props.tableContainerClassName
-                  : "overflow-hidden border-t border-gray-200"
+                  : isQuiet
+                    ? `overflow-hidden border-t border-slate-200 ${
+                        props.disablePagination ? "border-b" : ""
+                      }`
+                    : "overflow-hidden border-t border-gray-200"
               }
             >
               {isMobile ? (
                 // Mobile view: render as list
-                <div className="min-w-full divide-y divide-gray-200">
+                <div
+                  className={`min-w-full divide-y ${
+                    isQuiet ? "divide-slate-100" : "divide-gray-200"
+                  }`}
+                >
                   {getTablebody()}
                 </div>
               ) : (
                 // Desktop view: render as table
-                <table className="min-w-full divide-y divide-gray-200">
+                <table
+                  className={`min-w-full divide-y ${
+                    isQuiet ? "divide-slate-200" : "divide-gray-200"
+                  }`}
+                >
                   <TableHeader
                     id={`${props.id}-header`}
                     columns={props.columns}
@@ -332,7 +366,13 @@ const Table: TableFunction = <T extends GenericObject>(
             </div>
           </div>
         </div>
-        <div className="bg-gray-50 text-right md:-mx-6 -mb-6 rounded-b-xl">
+        <div
+          className={
+            isQuiet
+              ? "-mx-4 -mb-4 rounded-b-lg bg-white text-right sm:-mx-5"
+              : "-mb-6 rounded-b-xl bg-gray-50 text-right md:-mx-6"
+          }
+        >
           {!props.disablePagination && (
             <Pagination
               singularLabel={translatedSingularLabel}

--- a/Common/UI/Components/Table/TableBody.tsx
+++ b/Common/UI/Components/Table/TableBody.tsx
@@ -1,4 +1,8 @@
 import ActionButtonSchema from "../ActionButton/ActionButtonSchema";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import TableRow from "./TableRow";
 import Columns from "./Types/Columns";
 import GenericObject from "../../../Types/GenericObject";
@@ -33,6 +37,8 @@ type TableBodyFunction = <T extends GenericObject>(
 const TableBody: TableBodyFunction = <T extends GenericObject>(
   props: ComponentProps<T>,
 ): ReactElement => {
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   type GetBodyFunction = (provided?: DroppableProvided) => ReactElement;
 
   const getBody: GetBodyFunction = (
@@ -45,7 +51,9 @@ const TableBody: TableBodyFunction = <T extends GenericObject>(
           id={props.id}
           ref={provided?.innerRef}
           {...provided?.droppableProps}
-          className="divide-y divide-gray-200 bg-white"
+          className={`divide-y bg-white ${
+            isQuiet ? "divide-slate-100" : "divide-gray-200"
+          }`}
         >
           {props.data &&
             props.data.map((item: T, i: number) => {
@@ -91,7 +99,9 @@ const TableBody: TableBodyFunction = <T extends GenericObject>(
         id={props.id}
         ref={provided?.innerRef}
         {...provided?.droppableProps}
-        className="divide-y divide-gray-200 bg-white"
+        className={`divide-y bg-white ${
+          isQuiet ? "divide-slate-100" : "divide-gray-200"
+        }`}
       >
         {props.data &&
           props.data.map((item: T, i: number) => {

--- a/Common/UI/Components/Table/TableHeader.tsx
+++ b/Common/UI/Components/Table/TableHeader.tsx
@@ -1,4 +1,8 @@
 import CheckboxElement from "../Checkbox/Checkbox";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import Icon, { ThickProp } from "../Icon/Icon";
 import FieldType from "../Types/FieldType";
 import Column from "./Types/Column";
@@ -33,6 +37,8 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
   props: ComponentProps<T>,
 ): ReactElement => {
   const { translateString } = useTranslateValue();
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   // Track mobile view for responsive behavior
   const [isMobile, setIsMobile] = useState<boolean>(false);
 
@@ -54,7 +60,7 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
   );
 
   return (
-    <thead className="bg-gray-50" id={props.id}>
+    <thead className={isQuiet ? "bg-slate-50" : "bg-gray-50"} id={props.id}>
       <tr>
         {props.enableDragAndDrop && (
           <th scope="col">
@@ -68,7 +74,7 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
             <span className="sr-only">
               {translateString("Select all items")}
             </span>
-            <div className="ml-5">
+            <div className={isQuiet ? "ml-4 sm:ml-5" : "ml-5"}>
               <CheckboxElement
                 disabled={!props.hasTableItems}
                 value={selectBulkSelectCheckbox}
@@ -105,9 +111,11 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
                 key={i}
                 scope="col"
                 aria-sort={ariaSort}
-                className={`px-6 py-3 text-left text-sm font-semibold text-gray-900 ${
-                  canSort ? "cursor-pointer" : ""
-                }`}
+                className={`text-left ${
+                  isQuiet
+                    ? "px-4 py-2.5 text-xs font-medium text-slate-500 sm:px-5"
+                    : "px-6 py-3 text-sm font-semibold text-gray-900"
+                } ${canSort ? "cursor-pointer" : ""}`}
                 onClick={() => {
                   if (!column.key) {
                     return;
@@ -141,7 +149,11 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
                       <Icon
                         icon={IconProp.ChevronUp}
                         thick={ThickProp.Thick}
-                        className="ml-2  p-1 flex-none rounded bg-gray-200 text-gray-500 group-hover:bg-gray-300 h-4 w-4"
+                        className={
+                          isQuiet
+                            ? "ml-1.5 h-3.5 w-3.5 flex-none text-slate-400"
+                            : "ml-2 h-4 w-4 flex-none rounded bg-gray-200 p-1 text-gray-500 group-hover:bg-gray-300"
+                        }
                       />
                     )}
                   {canSort &&
@@ -150,7 +162,11 @@ const TableHeader: TableHeaderFunction = <T extends GenericObject>(
                       <Icon
                         icon={IconProp.ChevronDown}
                         thick={ThickProp.Thick}
-                        className="ml-2 p-1 flex-none rounded bg-gray-200 text-gray-500 group-hover:bg-gray-300 h-4 w-4"
+                        className={
+                          isQuiet
+                            ? "ml-1.5 h-3.5 w-3.5 flex-none text-slate-400"
+                            : "ml-2 h-4 w-4 flex-none rounded bg-gray-200 p-1 text-gray-500 group-hover:bg-gray-300"
+                        }
                       />
                     )}
                 </div>

--- a/Common/UI/Components/Table/TableRow.tsx
+++ b/Common/UI/Components/Table/TableRow.tsx
@@ -1,4 +1,8 @@
 import ActionButtonSchema from "../ActionButton/ActionButtonSchema";
+import {
+  SurfaceStyle,
+  useSurfaceStyle,
+} from "../../Contexts/SurfaceStyleContext";
 import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
 import CheckboxElement from "../Checkbox/Checkbox";
 import ColorInput from "../ColorViewer/ColorViewer";
@@ -41,6 +45,8 @@ type TableRowFunction = <T extends GenericObject>(
 const TableRow: TableRowFunction = <T extends GenericObject>(
   props: ComponentProps<T>,
 ): ReactElement => {
+  const surfaceStyle: SurfaceStyle = useSurfaceStyle();
+  const isQuiet: boolean = surfaceStyle === SurfaceStyle.Quiet;
   // Helper function to get nested property values using dot notation
   const getNestedValue: (obj: any, path: string) => any = (
     obj: any,
@@ -89,7 +95,12 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
           <div
             {...provided?.draggableProps}
             ref={provided?.innerRef}
-            className="p-4 bg-white border-b border-gray-200"
+            className={
+              isQuiet
+                ? "border-b border-slate-100 bg-white px-4 py-3"
+                : "border-b border-gray-200 bg-white p-4"
+            }
+            data-surface-style={surfaceStyle}
           >
             {props.enableDragAndDrop ? (
               <div
@@ -122,7 +133,7 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
               <></>
             )}
 
-            <div className="space-y-3">
+            <div className={isQuiet ? "space-y-2.5" : "space-y-3"}>
               {props.columns.map((column: Column<T>, i: number) => {
                 if (column.type === FieldType.Actions) {
                   return (
@@ -271,17 +282,35 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
                 return (
                   <div
                     key={i}
-                    className="flex flex-col space-y-1"
+                    className={
+                      isQuiet
+                        ? "flex flex-col space-y-0.5"
+                        : "flex flex-col space-y-1"
+                    }
                     onClick={() => {
                       if (column.tooltipText) {
                         setTooltipModalText(column.tooltipText(props.item));
                       }
                     }}
                   >
-                    <div className="text-sm font-medium text-gray-500">
+                    <div
+                      className={
+                        isQuiet
+                          ? "text-xs font-medium text-slate-500"
+                          : "text-sm font-medium text-gray-500"
+                      }
+                    >
                       {column.title}
                     </div>
-                    <div className="text-sm text-gray-900">{value}</div>
+                    <div
+                      className={
+                        isQuiet
+                          ? "text-sm text-slate-700"
+                          : "text-sm text-gray-900"
+                      }
+                    >
+                      {value}
+                    </div>
                   </div>
                 );
               })}
@@ -305,24 +334,39 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
     // Desktop view: render as table row
     return (
       <>
-        <tr {...provided?.draggableProps} ref={provided?.innerRef}>
+        <tr
+          {...provided?.draggableProps}
+          ref={provided?.innerRef}
+          data-surface-style={surfaceStyle}
+          className={
+            isQuiet ? "transition-colors hover:bg-slate-50/70" : undefined
+          }
+        >
           {props.enableDragAndDrop && (
             <td
-              className="ml-5 py-4 w-10 align-top"
+              className={
+                isQuiet ? "w-10 py-3 align-middle" : "ml-5 w-10 py-4 align-top"
+              }
               {...provided?.dragHandleProps}
             >
               <Icon
                 icon={IconProp.ArrowUpDown}
-                className="ml-6 h-5 w-5 text-gray-500 hover:text-indigo-800 m-auto cursor-ns-resize"
+                className={
+                  isQuiet
+                    ? "m-auto h-4 w-4 cursor-ns-resize text-slate-400 hover:text-indigo-700"
+                    : "m-auto ml-6 h-5 w-5 cursor-ns-resize text-gray-500 hover:text-indigo-800"
+                }
               />
             </td>
           )}
           {props.isBulkActionsEnabled && (
             <td
-              className="w-10 py-3.5  align-top"
+              className={
+                isQuiet ? "w-10 py-3 align-middle" : "w-10 py-3.5 align-top"
+              }
               {...provided?.dragHandleProps}
             >
-              <div className="ml-5">
+              <div className={isQuiet ? "ml-4 sm:ml-5" : "ml-5"}>
                 <CheckboxElement
                   value={props.isItemSelected}
                   onChange={(value: boolean) => {
@@ -344,11 +388,13 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
                 return !(column.hideOnMobile && isMobile);
               })
               .map((column: Column<T>, i: number) => {
-                let className: string =
-                  "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+                let className: string = isQuiet
+                  ? "whitespace-nowrap px-4 py-3 text-sm font-normal text-slate-600 align-middle sm:px-5"
+                  : "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
                 if (i === props.columns.length - 1) {
-                  className =
-                    "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+                  className = isQuiet
+                    ? "whitespace-nowrap px-4 py-3 text-sm font-normal text-slate-600 align-middle sm:px-5"
+                    : "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
                 }
 
                 let columnContent: React.ReactNode = null;

--- a/Common/UI/Contexts/SurfaceStyleContext.tsx
+++ b/Common/UI/Contexts/SurfaceStyleContext.tsx
@@ -1,0 +1,36 @@
+import React, {
+  Context,
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  useContext,
+} from "react";
+
+export enum SurfaceStyle {
+  Default = "default",
+  Quiet = "quiet",
+}
+
+const SurfaceStyleContext: Context<SurfaceStyle> =
+  React.createContext<SurfaceStyle>(SurfaceStyle.Default);
+
+export interface SurfaceStyleProviderProps {
+  children: ReactNode;
+  style: SurfaceStyle;
+}
+
+export const SurfaceStyleProvider: FunctionComponent<
+  SurfaceStyleProviderProps
+> = (props: SurfaceStyleProviderProps): ReactElement => {
+  return (
+    <SurfaceStyleContext.Provider value={props.style}>
+      {props.children}
+    </SurfaceStyleContext.Provider>
+  );
+};
+
+export const useSurfaceStyle: () => SurfaceStyle = (): SurfaceStyle => {
+  return useContext(SurfaceStyleContext);
+};
+
+export default SurfaceStyleContext;


### PR DESCRIPTION
## Summary

- add a Dashboard-only quiet surface context while preserving legacy styling in other apps
- refine shared cards, model tables, list layouts, table headers and rows, pagination, and empty states
- align responsive list/table gutters with the tighter card spacing and remove doubled pagination seams
- cover both default and quiet rendering plus sort and pagination behavior

## Stack

- depends on #2635
- #2635 depends on #2632

## Validation

- 27 focused UI tests pass across Card, List, Table, Pagination, and EmptyState
- targeted ESLint passes
- Dashboard development build passes
- read-only code and responsive UI reviews report no actionable findings
- Common compile reaches only the repository's existing ioredis/BullMQ and AreaChart/LineChart type errors
- root `npm run fix` reaches only the two existing missing `react-hooks/exhaustive-deps` rule definitions