### PR TITLE
feat(on-call): timezone bubble + modal picker with explicit save

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/Layers.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/Layers.tsx
@@ -1,5 +1,6 @@
 import LayerCard from "./LayerCard";
 import LayersPreview from "./LayersPreview";
+import TimezoneSelectButton from "./TimezoneSelectButton";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
@@ -15,10 +16,6 @@ import RestrictionTimes from "Common/Types/OnCallDutyPolicy/RestrictionTimes";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
-import Dropdown, {
-  DropdownOption,
-  DropdownValue,
-} from "Common/UI/Components/Dropdown/Dropdown";
 import EmptyState from "Common/UI/Components/EmptyState/EmptyState";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import Icon from "Common/UI/Components/Icon/Icon";
@@ -26,18 +23,10 @@ import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
 import { GetReactElementFunction } from "Common/UI/Types/FunctionTypes";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
-import TimezoneUtil from "Common/UI/Utils/Timezone";
 import OnCallDutyPolicyScheduleLayer from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayer";
 import OnCallDutyPolicyScheduleLayerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
 import OnCallDutyPolicySchedule from "Common/Models/DatabaseModels/OnCallDutyPolicySchedule";
 import React, { FunctionComponent, ReactElement, useEffect } from "react";
-
-/*
- * Timezone options are static and expensive to sort (every IANA zone by GMT
- * offset), so compute them once at module load rather than per render.
- */
-const timezoneDropdownOptions: Array<DropdownOption> =
-  TimezoneUtil.getTimezoneDropdownOptions();
 
 export interface ComponentProps {
   onCallDutyPolicyScheduleId: ObjectID;
@@ -547,38 +536,38 @@ const Layers: FunctionComponent<ComponentProps> = (
   };
 
   const timezoneCard: GetReactElementFunction = (): ReactElement => {
-    const selectedOption: DropdownOption | undefined = scheduleTimezone
-      ? timezoneDropdownOptions.find((option: DropdownOption) => {
-          return option.value === scheduleTimezone;
-        })
-      : undefined;
-
     return (
       <div className="mb-5">
         <Card
           title="Schedule timezone"
           description={
-            "Every layer in this schedule — rotation start, hand-off and active-hour restrictions — is entered and enforced in this timezone. Leave empty to use the server's local timezone."
+            "Every layer in this schedule — rotation start, hand-off and active-hour restrictions — is entered and enforced in this timezone."
           }
         >
-          <div className="max-w-md">
-            <Dropdown
-              options={timezoneDropdownOptions}
-              value={selectedOption}
-              placeholder="Select timezone"
-              onChange={(
-                value: DropdownValue | Array<DropdownValue> | null,
-              ) => {
-                const timezone: string | undefined =
-                  value && !Array.isArray(value) ? value.toString() : undefined;
-
+          <div className="flex items-center gap-3">
+            <TimezoneSelectButton
+              value={scheduleTimezone}
+              saving={isSavingTimezone}
+              icon={IconProp.Globe}
+              placeholder="Not set — using server local time"
+              modalTitle="Set schedule timezone"
+              modalDescription="All rotation start, hand-off and active-hour times in this schedule are interpreted in this timezone. Changing it re-interprets the existing times in the new zone."
+              submitButtonText="Save timezone"
+              dataTestId="schedule-timezone-button"
+              onChange={(timezone: string | undefined) => {
                 saveScheduleTimezone(timezone).catch((err: Error) => {
                   setError(API.getFriendlyMessage(err));
                 });
               }}
             />
-            {isSavingTimezone && (
-              <p className="mt-2 text-xs text-gray-400">Saving timezone…</p>
+            {scheduleTimezone ? (
+              <span className="text-xs text-gray-500">
+                Click to change. Everything below is in this zone.
+              </span>
+            ) : (
+              <span className="text-xs text-amber-600">
+                No timezone set yet — click to choose one.
+              </span>
             )}
           </div>
         </Card>

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
@@ -1,7 +1,9 @@
 import FinalScheduleSummary from "./FinalScheduleSummary";
 import { getColorForUserId } from "./LayerUserColors";
+import TimezoneSelectButton from "./TimezoneSelectButton";
 import CalendarEvent from "Common/Types/Calendar/CalendarEvent";
 import OneUptimeDate from "Common/Types/Date";
+import IconProp from "Common/Types/Icon/IconProp";
 import Dictionary from "Common/Types/Dictionary";
 import LayerUtil, { LayerProps } from "Common/Types/OnCallDutyPolicy/Layer";
 import ScheduleShiftUtil, {
@@ -18,14 +20,9 @@ import IsNull from "Common/Types/BaseDatabase/IsNull";
 import LessThanOrEqual from "Common/Types/BaseDatabase/LessThanOrEqual";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import Calendar from "Common/UI/Components/Calendar/Calendar";
-import Dropdown, {
-  DropdownOption,
-  DropdownValue,
-} from "Common/UI/Components/Dropdown/Dropdown";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
-import TimezoneUtil from "Common/UI/Utils/Timezone";
 import OnCallDutyPolicyScheduleLayer from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayer";
 import OnCallDutyPolicyScheduleLayerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
 import OnCallDutyPolicyUserOverride from "Common/Models/DatabaseModels/OnCallDutyPolicyUserOverride";
@@ -45,13 +42,6 @@ import React, {
  * that happen to fall in the calendar's currently-visible range.
  */
 const SUMMARY_WINDOW_DAYS: number = 42;
-
-/*
- * Timezone options are static and expensive to sort (every IANA zone by GMT
- * offset), so compute them once at module load rather than per render.
- */
-const timezoneDropdownOptions: Array<DropdownOption> =
-  TimezoneUtil.getTimezoneDropdownOptions();
 
 export interface ComponentProps {
   layers: Array<OnCallDutyPolicyScheduleLayer>;
@@ -494,11 +484,6 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     );
   }, [viewAsTimezone]);
 
-  const selectedViewOption: DropdownOption | undefined =
-    timezoneDropdownOptions.find((option: DropdownOption) => {
-      return option.value === viewAsTimezone;
-    });
-
   /*
    * Explain which zone the grid/summary below are rendered in, and — when the
    * viewer has switched away from the schedule's own zone — that these times are
@@ -585,18 +570,20 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
         person actually paged by a given policy may differ.
       </div>
 
-      {/* View-as timezone control + note above the calendar grid. */}
-      <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div className="w-full sm:w-72">
-          <FieldLabelElement title="View as timezone" />
-          <Dropdown
-            options={timezoneDropdownOptions}
-            value={selectedViewOption}
-            placeholder="Select timezone"
-            onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
-              const timezone: string | undefined =
-                value && !Array.isArray(value) ? value.toString() : undefined;
-
+      {/* View-as timezone bubble + note above the calendar grid. */}
+      <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+            View as
+          </span>
+          <TimezoneSelectButton
+            value={viewAsTimezone}
+            icon={IconProp.Clock}
+            modalTitle="View schedule in timezone"
+            modalDescription="Change the timezone this preview is shown in — for example, to see how an India schedule lands in your US working hours. This only changes what you see; it does not affect who is on call or when."
+            submitButtonText="Apply"
+            dataTestId="view-as-timezone-button"
+            onChange={(timezone: string | undefined) => {
               if (timezone) {
                 setViewAsTimezone(timezone);
               }

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/TimezoneSelectButton.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/TimezoneSelectButton.tsx
@@ -1,0 +1,117 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import TimezoneUtil from "Common/UI/Utils/Timezone";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+
+/*
+ * Timezone options are static and expensive to sort (every IANA zone by GMT
+ * offset), so compute them once at module load rather than per render.
+ */
+const timezoneDropdownOptions: Array<DropdownOption> =
+  TimezoneUtil.getTimezoneDropdownOptions();
+
+export interface ComponentProps {
+  value?: string | undefined;
+  onChange: (value: string | undefined) => void;
+  modalTitle: string;
+  modalDescription?: string | undefined;
+  // Text on the modal's confirm button (e.g. "Save timezone", "Apply").
+  submitButtonText?: string | undefined;
+  // Bubble text shown when no value is set.
+  placeholder?: string | undefined;
+  icon?: IconProp | undefined;
+  // Shows a transient "Saving…" state on the bubble (for async persistence).
+  saving?: boolean | undefined;
+  dataTestId?: string | undefined;
+}
+
+/*
+ * A compact "bubble" that shows the current timezone and, on click, opens a
+ * modal with a searchable timezone picker and an explicit confirm button. Used
+ * for both the schedule's timezone (persisted, "Save") and the preview's
+ * "View as" display zone (ephemeral, "Apply"). The pending selection is held in
+ * a draft so closing the modal without confirming discards it.
+ */
+const TimezoneSelectButton: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [draft, setDraft] = useState<string | undefined>(props.value);
+
+  const openModal: () => void = (): void => {
+    setDraft(props.value);
+    setIsModalOpen(true);
+  };
+
+  const selectedDraftOption: DropdownOption | undefined = draft
+    ? timezoneDropdownOptions.find((option: DropdownOption) => {
+        return option.value === draft;
+      })
+    : undefined;
+
+  const bubbleText: string = props.saving
+    ? "Saving…"
+    : props.value || props.placeholder || "Select timezone";
+
+  return (
+    <React.Fragment>
+      <button
+        type="button"
+        data-testid={props.dataTestId}
+        onClick={openModal}
+        className="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:border-indigo-400 hover:bg-indigo-50 hover:text-indigo-700"
+      >
+        <Icon
+          icon={props.icon || IconProp.Globe}
+          className="h-4 w-4 text-gray-400"
+        />
+        <span className={props.value || props.saving ? "" : "text-gray-400"}>
+          {bubbleText}
+        </span>
+        <Icon icon={IconProp.ChevronDown} className="h-3 w-3 text-gray-400" />
+      </button>
+
+      {isModalOpen && (
+        <Modal
+          title={props.modalTitle}
+          description={props.modalDescription}
+          icon={props.icon || IconProp.Globe}
+          modalWidth={ModalWidth.Normal}
+          submitButtonText={props.submitButtonText || "Save"}
+          submitButtonStyleType={ButtonStyleType.PRIMARY}
+          onSubmit={() => {
+            props.onChange(draft);
+            setIsModalOpen(false);
+          }}
+          onClose={() => {
+            setIsModalOpen(false);
+          }}
+        >
+          {/* Give the searchable menu room; it portals to <body> so it never clips. */}
+          <div className="min-h-[16rem]">
+            <Dropdown
+              options={timezoneDropdownOptions}
+              value={selectedDraftOption}
+              placeholder="Search and select a timezone"
+              onChange={(
+                value: DropdownValue | Array<DropdownValue> | null,
+              ) => {
+                setDraft(
+                  value && !Array.isArray(value) ? value.toString() : undefined,
+                );
+              }}
+            />
+          </div>
+        </Modal>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default TimezoneSelectButton;


### PR DESCRIPTION
## What & why

Follow-up UI polish on the on-call schedule timezone controls. Previously the schedule timezone and the preview **View as** control were inline dropdowns that auto-saved on change — users couldn't tell **how to save** (no visible Save button).

Now both are compact **clickable bubbles** that open a **modal with a searchable timezone picker and an explicit confirm button**:
- **Schedule timezone** → modal titled "Set schedule timezone" with a **Save timezone** button that persists to the schedule (optimistic update + rollback on failure).
- **Preview "View as"** → modal titled "View schedule in timezone" with an **Apply** button that re-renders the preview + calendar in any zone. Display only — never affects who is paged or when.

The pending selection is held as a draft, so cancelling the modal discards it.

## Files
- `.../OnCallScheduleLayer/TimezoneSelectButton.tsx` (new, reusable bubble+modal)
- `.../OnCallScheduleLayer/Layers.tsx`
- `.../OnCallScheduleLayer/LayersPreview.tsx`

## Verification
- `tsc` clean (App), `eslint` clean.
- Modal renders its footer Save/Apply button wired to `onSubmit` (confirmed in `Common/UI/Components/Modal/Modal.tsx`); the searchable Dropdown portals its menu to `document.body` so it doesn't clip in the modal.