### PR TITLE
fix(on-call): size timezone modal to content (standard labeled field)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/TimezoneSelectButton.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/TimezoneSelectButton.tsx
@@ -4,6 +4,7 @@ import Dropdown, {
   DropdownOption,
   DropdownValue,
 } from "Common/UI/Components/Dropdown/Dropdown";
+import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import Icon from "Common/UI/Components/Icon/Icon";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import TimezoneUtil from "Common/UI/Utils/Timezone";
@@ -93,8 +94,9 @@ const TimezoneSelectButton: FunctionComponent<ComponentProps> = (
             setIsModalOpen(false);
           }}
         >
-          {/* Give the searchable menu room; it portals to <body> so it never clips. */}
-          <div className="min-h-[16rem]">
+          {/* Standard labeled field; the searchable menu portals to <body> so it never clips. */}
+          <div className="mt-1">
+            <FieldLabelElement title="Timezone" required={true} />
             <Dropdown
               options={timezoneDropdownOptions}
               value={selectedDraftOption}


### PR DESCRIPTION
Follow-up polish. The timezone picker modal (schedule timezone / "View as") had a fixed `min-h-[16rem]` on its body that left a large empty gap below the dropdown, making it look non-standard.

- Remove the reserved min-height — the searchable menu portals to `document.body`, so it never needed the space.
- Render a standard **"Timezone"** labeled field so the modal sizes to its content like other OneUptime modals.

`tsc` + `eslint` clean. Single-file change.