### PR TITLE
Network monitoring phase 1: ping statistics, auto-traceroute on failure, HTTP phase timings

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/HttpTimingsView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/HttpTimingsView.tsx
@@ -1,0 +1,94 @@
+import HttpPhaseTimings from "Common/Types/Monitor/HttpPhaseTimings";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  httpTimings: HttpPhaseTimings;
+}
+
+interface TimingPhase {
+  label: string;
+  valueInMs: number;
+  colorClassName: string;
+}
+
+/*
+ * Waterfall of the HTTP(S) request phases: DNS → TCP → TLS → waiting (TTFB)
+ * → download. Bar widths are proportional to each phase's share of the total.
+ */
+const HttpTimingsView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement | null => {
+  const timings: HttpPhaseTimings = props.httpTimings;
+
+  const phases: Array<TimingPhase> = [
+    {
+      label: "DNS Lookup",
+      valueInMs: timings.dnsLookupInMs ?? -1,
+      colorClassName: "bg-indigo-400",
+    },
+    {
+      label: "TCP Connect",
+      valueInMs: timings.tcpConnectInMs ?? -1,
+      colorClassName: "bg-sky-400",
+    },
+    {
+      label: "TLS Handshake",
+      valueInMs: timings.tlsHandshakeInMs ?? -1,
+      colorClassName: "bg-teal-400",
+    },
+    {
+      label: "Waiting (TTFB)",
+      valueInMs: timings.timeToFirstByteInMs ?? -1,
+      colorClassName: "bg-amber-400",
+    },
+    {
+      label: "Download",
+      valueInMs: timings.downloadInMs ?? -1,
+      colorClassName: "bg-emerald-400",
+    },
+  ].filter((phase: TimingPhase) => {
+    return phase.valueInMs >= 0;
+  });
+
+  if (phases.length === 0) {
+    return null;
+  }
+
+  const totalInMs: number = phases.reduce((sum: number, phase: TimingPhase) => {
+    return sum + phase.valueInMs;
+  }, 0);
+
+  return (
+    <div className="rounded-md border-2 border-gray-100 p-4">
+      <div className="text-sm font-medium text-gray-900 mb-1">
+        Request Phase Breakdown
+      </div>
+      <div className="text-xs text-gray-500 mb-3">
+        Where this check spent its time, from DNS lookup to the last byte.
+      </div>
+      <div className="space-y-2">
+        {phases.map((phase: TimingPhase) => {
+          const percent: number =
+            totalInMs > 0 ? (phase.valueInMs / totalInMs) * 100 : 0;
+
+          return (
+            <div key={phase.label} className="flex items-center text-sm">
+              <div className="w-36 shrink-0 text-gray-700">{phase.label}</div>
+              <div className="flex-1 mx-2">
+                <div
+                  className={`h-3 rounded ${phase.colorClassName}`}
+                  style={{ width: `${Math.max(percent, 1)}%` }}
+                ></div>
+              </div>
+              <div className="w-24 shrink-0 text-right text-gray-700 font-mono">
+                {Math.round(phase.valueInMs * 100) / 100} ms
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default HttpTimingsView;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/NetworkPathView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/NetworkPathView.tsx
@@ -1,0 +1,108 @@
+import NetworkPathTrace, {
+  TraceRouteHop,
+} from "Common/Types/Monitor/NetworkMonitor/NetworkPathTrace";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  networkPathTrace: NetworkPathTrace;
+}
+
+/*
+ * Renders the traceroute + DNS lookup the probe captured when a network
+ * check failed — the path evidence for "where did it break?".
+ */
+const NetworkPathView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement | null => {
+  const trace: NetworkPathTrace = props.networkPathTrace;
+
+  if (!trace.dnsLookup && !trace.traceRoute) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border-2 border-gray-100 p-4">
+      <div className="text-sm font-medium text-gray-900 mb-1">
+        Network Path at Time of Failure
+      </div>
+      <div className="text-xs text-gray-500 mb-3">
+        Traceroute captured by the probe when this check failed.
+      </div>
+
+      {trace.dnsLookup && (
+        <div className="mb-3 text-sm text-gray-700">
+          <span className="font-medium">DNS:</span>{" "}
+          {trace.dnsLookup.isSuccess ? (
+            <span>
+              {trace.dnsLookup.hostName} resolved to{" "}
+              <span className="font-mono">
+                {trace.dnsLookup.resolvedAddresses.join(", ")}
+              </span>{" "}
+              in {trace.dnsLookup.resolvedInMS} ms
+            </span>
+          ) : (
+            <span className="text-red-700">
+              Lookup for {trace.dnsLookup.hostName} failed
+              {trace.dnsLookup.errorMessage
+                ? ` — ${trace.dnsLookup.errorMessage}`
+                : ""}
+            </span>
+          )}
+        </div>
+      )}
+
+      {trace.traceRoute && trace.traceRoute.hops.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm text-gray-700">
+            <thead>
+              <tr className="text-left text-xs text-gray-500">
+                <th className="pr-4 pb-2 font-medium">Hop</th>
+                <th className="pr-4 pb-2 font-medium">Host</th>
+                <th className="pb-2 font-medium">RTT</th>
+              </tr>
+            </thead>
+            <tbody>
+              {trace.traceRoute.hops.map((hop: TraceRouteHop) => {
+                return (
+                  <tr
+                    key={hop.hopNumber}
+                    className={hop.isTimeout ? "text-red-700" : ""}
+                  >
+                    <td className="pr-4 py-1 font-mono">{hop.hopNumber}</td>
+                    <td className="pr-4 py-1 font-mono break-all">
+                      {hop.isTimeout
+                        ? "* * *"
+                        : `${hop.hostName ? hop.hostName + " " : ""}${
+                            hop.address ? `(${hop.address})` : ""
+                          }`}
+                    </td>
+                    <td className="py-1">
+                      {hop.roundTripTimeInMS !== undefined
+                        ? `${hop.roundTripTimeInMS} ms`
+                        : "-"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {trace.traceRoute && (
+        <div className="mt-2 text-xs text-gray-500">
+          {trace.traceRoute.isComplete
+            ? "Route reached the destination."
+            : trace.traceRoute.failedHop !== undefined
+              ? `Route broke at hop ${trace.traceRoute.failedHop}.`
+              : "Route did not reach the destination."}
+          {trace.traceRoute.failureMessage
+            ? ` ${trace.traceRoute.failureMessage}`
+            : ""}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NetworkPathView;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/PingMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/PingMonitorView.tsx
@@ -1,8 +1,10 @@
 import OneUptimeDate from "Common/Types/Date";
+import PingMonitorResponse from "Common/Types/Monitor/PingMonitor/PingMonitorResponse";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
 import InfoCard from "Common/UI/Components/InfoCard/InfoCard";
 import React, { FunctionComponent, ReactElement } from "react";
+import NetworkPathView from "./NetworkPathView";
 import ProbeAttemptsView from "./ProbeAttemptsView";
 
 export interface ComponentProps {
@@ -24,6 +26,9 @@ const PingMonitorView: FunctionComponent<ComponentProps> = (
   const hasErrorDetails: boolean = Boolean(
     props.probeMonitorResponse.requestFailedDetails,
   );
+
+  const pingResponse: PingMonitorResponse | undefined =
+    props.probeMonitorResponse.pingResponse;
 
   const probeAttempts: Array<ProbeAttempt> =
     props.probeMonitorResponse.probeAttempts || [];
@@ -75,6 +80,43 @@ const PingMonitorView: FunctionComponent<ComponentProps> = (
         />
       </div>
 
+      {pingResponse && (
+        <div className="flex space-x-3">
+          <InfoCard
+            className="w-1/4 shadow-none border-2 border-gray-100 "
+            title="Packet Loss"
+            value={`${pingResponse.packetLossPercent}% (${pingResponse.packetsReceived}/${pingResponse.packetsSent} received)`}
+          />
+          <InfoCard
+            className="w-1/4 shadow-none border-2 border-gray-100 "
+            title="Jitter"
+            value={
+              pingResponse.jitterInMs !== undefined
+                ? pingResponse.jitterInMs + " ms"
+                : "-"
+            }
+          />
+          <InfoCard
+            className="w-1/4 shadow-none border-2 border-gray-100 "
+            title="Min RTT"
+            value={
+              pingResponse.minRoundTripTimeInMs !== undefined
+                ? pingResponse.minRoundTripTimeInMs + " ms"
+                : "-"
+            }
+          />
+          <InfoCard
+            className="w-1/4 shadow-none border-2 border-gray-100 "
+            title="Max RTT"
+            value={
+              pingResponse.maxRoundTripTimeInMs !== undefined
+                ? pingResponse.maxRoundTripTimeInMs + " ms"
+                : "-"
+            }
+          />
+        </div>
+      )}
+
       {props.probeMonitorResponse.failureCause && (
         <div className="flex space-x-3">
           <InfoCard
@@ -117,6 +159,12 @@ const PingMonitorView: FunctionComponent<ComponentProps> = (
             />
           </div>
         </div>
+      )}
+
+      {props.probeMonitorResponse.networkPathTrace && (
+        <NetworkPathView
+          networkPathTrace={props.probeMonitorResponse.networkPathTrace}
+        />
       )}
 
       {hadRetries && (

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/WebsiteMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/WebsiteMonitorView.tsx
@@ -7,6 +7,7 @@ import Field from "Common/UI/Components/Detail/Field";
 import InfoCard from "Common/UI/Components/InfoCard/InfoCard";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import React, { FunctionComponent, ReactElement } from "react";
+import HttpTimingsView from "./HttpTimingsView";
 import ProbeAttemptsView from "./ProbeAttemptsView";
 
 export interface ComponentProps {
@@ -96,6 +97,10 @@ const WebsiteMonitorSummaryView: FunctionComponent<ComponentProps> = (
           }
         />
       </div>
+
+      {props.probeMonitorResponse.httpTimings && (
+        <HttpTimingsView httpTimings={props.probeMonitorResponse.httpTimings} />
+      )}
 
       {props.probeMonitorResponse.failureCause && (
         <div className="flex space-x-3">

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -43,10 +43,12 @@ export default class CriteriaFilterUtil {
       criteriaFilter?.checkOn === CheckOn.DiskUsagePercent ||
       criteriaFilter?.checkOn === CheckOn.MemoryUsagePercent ||
       criteriaFilter?.checkOn === CheckOn.SwapUsagePercent ||
-      criteriaFilter?.checkOn === CheckOn.CPUIoWaitPercent;
+      criteriaFilter?.checkOn === CheckOn.CPUIoWaitPercent ||
+      criteriaFilter?.checkOn === CheckOn.PacketLossPercent;
 
     const isMilliseconds: boolean =
-      criteriaFilter?.checkOn === CheckOn.ResponseTime;
+      criteriaFilter?.checkOn === CheckOn.ResponseTime ||
+      criteriaFilter?.checkOn === CheckOn.Jitter;
 
     // check evaluation over time values.
     if (
@@ -182,11 +184,19 @@ export default class CriteriaFilterUtil {
     let options: Array<DropdownOption> =
       DropdownUtil.getDropdownOptionsFromEnum(CheckOn);
 
-    if (
-      monitorType === MonitorType.Ping ||
-      monitorType === MonitorType.IP ||
-      monitorType === MonitorType.Port
-    ) {
+    if (monitorType === MonitorType.Ping || monitorType === MonitorType.IP) {
+      options = options.filter((i: DropdownOption) => {
+        return (
+          i.value === CheckOn.IsOnline ||
+          i.value === CheckOn.ResponseTime ||
+          i.value === CheckOn.PacketLossPercent ||
+          i.value === CheckOn.Jitter ||
+          i.value === CheckOn.IsRequestTimeout
+        );
+      });
+    }
+
+    if (monitorType === MonitorType.Port) {
       options = options.filter((i: DropdownOption) => {
         return (
           i.value === CheckOn.IsOnline ||
@@ -393,7 +403,12 @@ export default class CriteriaFilterUtil {
       return [];
     }
 
-    if (checkOn === CheckOn.ResponseTime || checkOn === CheckOn.ExecutionTime) {
+    if (
+      checkOn === CheckOn.ResponseTime ||
+      checkOn === CheckOn.ExecutionTime ||
+      checkOn === CheckOn.PacketLossPercent ||
+      checkOn === CheckOn.Jitter
+    ) {
       options = options.filter((i: DropdownOption) => {
         return (
           i.value === FilterType.GreaterThan ||
@@ -823,6 +838,14 @@ export default class CriteriaFilterUtil {
 
     if (checkOn === CheckOn.ResponseTime) {
       return "5000";
+    }
+
+    if (checkOn === CheckOn.PacketLossPercent) {
+      return "2";
+    }
+
+    if (checkOn === CheckOn.Jitter) {
+      return "30";
     }
 
     if (checkOn === CheckOn.ServerProcessPID) {

--- a/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
@@ -88,6 +88,50 @@ export default class APIRequestCriteria {
       });
     }
 
+    // check packet loss (Ping/IP monitors with multi-packet checks)
+    if (input.criteriaFilter.checkOn === CheckOn.PacketLossPercent) {
+      const packetLossPercent: number | undefined = (
+        input.dataToProcess as ProbeMonitorResponse
+      ).pingResponse?.packetLossPercent;
+
+      const value: Array<number> | number | undefined =
+        (overTimeValue as Array<number>) || packetLossPercent;
+
+      if (value === undefined) {
+        return null;
+      }
+
+      threshold = CompareCriteria.convertToNumber(threshold);
+
+      return CompareCriteria.compareCriteriaNumbers({
+        value: value,
+        threshold: threshold as number,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    // check jitter (Ping/IP monitors with multi-packet checks)
+    if (input.criteriaFilter.checkOn === CheckOn.Jitter) {
+      const jitterInMs: number | undefined = (
+        input.dataToProcess as ProbeMonitorResponse
+      ).pingResponse?.jitterInMs;
+
+      const value: Array<number> | number | undefined =
+        (overTimeValue as Array<number>) || jitterInMs;
+
+      if (value === undefined) {
+        return null;
+      }
+
+      threshold = CompareCriteria.convertToNumber(threshold);
+
+      return CompareCriteria.compareCriteriaNumbers({
+        value: value,
+        threshold: threshold as number,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
     //check response code
     if (
       input.criteriaFilter.checkOn === CheckOn.ResponseStatusCode &&

--- a/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
@@ -14,7 +14,9 @@ import BasicInfrastructureMetrics, {
 import Dictionary from "../../../Types/Dictionary";
 import { JSONObject } from "../../../Types/JSON";
 import CapturedMetric from "../../../Types/Monitor/CustomCodeMonitor/CapturedMetric";
+import HttpPhaseTimings from "../../../Types/Monitor/HttpPhaseTimings";
 import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
+import PingMonitorResponse from "../../../Types/Monitor/PingMonitor/PingMonitorResponse";
 import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
 import ServerMonitorResponse from "../../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
 import SyntheticMonitorResponse from "../../../Types/Monitor/SyntheticMonitors/SyntheticMonitorResponse";
@@ -23,8 +25,12 @@ import ObjectID from "../../../Types/ObjectID";
 import OneUptimeDate from "../../../Types/Date";
 
 export default class MonitorMetricUtil {
-  // Default retention in days if GlobalConfig is not set
-  private static readonly DEFAULT_RETENTION_DAYS: number = 1;
+  /*
+   * Default retention in days if GlobalConfig is not set. 30 days keeps
+   * enough history for trend analysis and evaluate-over-time criteria;
+   * one day made week-over-week charts impossible out of the box.
+   */
+  private static readonly DEFAULT_RETENTION_DAYS: number = 30;
 
   // Cached retention value to avoid querying GlobalConfig on every monitor check
   private static cachedRetentionDays: number | null = null;
@@ -881,6 +887,106 @@ export default class MonitorMetricUtil {
       metricType.unit = "ms";
 
       metricNameServiceNameMap[MonitorMetricType.ResponseTime] = metricType;
+    }
+
+    if ((data.dataToProcess as ProbeMonitorResponse).httpTimings) {
+      const httpTimings: HttpPhaseTimings = (
+        data.dataToProcess as ProbeMonitorResponse
+      ).httpTimings!;
+
+      const extraAttributes: JSONObject = {
+        probeId: (
+          data.dataToProcess as ProbeMonitorResponse
+        ).probeId.toString(),
+      };
+
+      const phaseMetrics: Array<{
+        metricName: MonitorMetricType;
+        value: number | undefined;
+        description: string;
+      }> = [
+        {
+          metricName: MonitorMetricType.DnsLookupTime,
+          value: httpTimings.dnsLookupInMs,
+          description: "DNS lookup time for this monitor",
+        },
+        {
+          metricName: MonitorMetricType.TcpConnectTime,
+          value: httpTimings.tcpConnectInMs,
+          description: "TCP connect time for this monitor",
+        },
+        {
+          metricName: MonitorMetricType.TlsHandshakeTime,
+          value: httpTimings.tlsHandshakeInMs,
+          description: "TLS handshake time for this monitor",
+        },
+        {
+          metricName: MonitorMetricType.TimeToFirstByte,
+          value: httpTimings.timeToFirstByteInMs,
+          description: "Time to first byte for this monitor",
+        },
+        {
+          metricName: MonitorMetricType.DownloadTime,
+          value: httpTimings.downloadInMs,
+          description: "Response download time for this monitor",
+        },
+      ];
+
+      for (const phaseMetric of phaseMetrics) {
+        await this.pushMonitorMetric({
+          projectId: data.projectId,
+          monitorId: data.monitorId,
+          monitorName: data.monitorName,
+          probeName: data.probeName,
+          metricName: phaseMetric.metricName,
+          value: phaseMetric.value,
+          description: phaseMetric.description,
+          unit: "ms",
+          extraAttributes: extraAttributes,
+          metricRows: metricRows,
+          metricNameServiceNameMap: metricNameServiceNameMap,
+        });
+      }
+    }
+
+    if ((data.dataToProcess as ProbeMonitorResponse).pingResponse) {
+      const pingResponse: PingMonitorResponse = (
+        data.dataToProcess as ProbeMonitorResponse
+      ).pingResponse!;
+
+      const extraAttributes: JSONObject = {
+        probeId: (
+          data.dataToProcess as ProbeMonitorResponse
+        ).probeId.toString(),
+      };
+
+      await this.pushMonitorMetric({
+        projectId: data.projectId,
+        monitorId: data.monitorId,
+        monitorName: data.monitorName,
+        probeName: data.probeName,
+        metricName: MonitorMetricType.PacketLossPercent,
+        value: pingResponse.packetLossPercent,
+        description: CheckOn.PacketLossPercent + " for this monitor",
+        unit: "%",
+        extraAttributes: extraAttributes,
+        metricRows: metricRows,
+        metricNameServiceNameMap: metricNameServiceNameMap,
+      });
+
+      await this.pushMonitorMetric({
+        projectId: data.projectId,
+        monitorId: data.monitorId,
+        monitorName: data.monitorName,
+        probeName: data.probeName,
+        metricName: MonitorMetricType.Jitter,
+        value: pingResponse.jitterInMs,
+        description: CheckOn.Jitter + " for this monitor",
+        unit: "ms",
+        extraAttributes: extraAttributes,
+        metricRows: metricRows,
+        metricNameServiceNameMap: metricNameServiceNameMap,
+      });
     }
 
     if ((data.dataToProcess as ProbeMonitorResponse).isOnline !== undefined) {

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -3,6 +3,8 @@ import MetricCriteriaContext from "./MetricMonitor/MetricCriteriaContext";
 
 export enum CheckOn {
   ResponseTime = "Response Time (in ms)",
+  PacketLossPercent = "Packet Loss (in %)",
+  Jitter = "Jitter (in ms)",
   ResponseStatusCode = "Response Status Code",
   ResponseHeader = "Response Header",
   ResponseHeaderValue = "Response Header Value",
@@ -374,6 +376,8 @@ export class CriteriaFilterUtil {
     return (
       checkOn === CheckOn.ResponseStatusCode ||
       checkOn === CheckOn.ResponseTime ||
+      checkOn === CheckOn.PacketLossPercent ||
+      checkOn === CheckOn.Jitter ||
       checkOn === CheckOn.DiskUsagePercent ||
       checkOn === CheckOn.CPUUsagePercent ||
       checkOn === CheckOn.MemoryUsagePercent ||

--- a/Common/Types/Monitor/HttpPhaseTimings.ts
+++ b/Common/Types/Monitor/HttpPhaseTimings.ts
@@ -1,0 +1,16 @@
+/*
+ * Per-phase breakdown of an HTTP(S) check, all in milliseconds. Captured by
+ * the probe from socket events on the initial connection of the request.
+ * Every field is optional: phases are absent when they don't apply (no TLS
+ * on plain HTTP, no DNS lookup when the target is an IP address) or when the
+ * request went through a proxy, where per-phase timing would be misleading.
+ * When the check follows redirects, the phases describe the first connection
+ * and the download phase absorbs the rest of the exchange.
+ */
+export default interface HttpPhaseTimings {
+  dnsLookupInMs?: number | undefined;
+  tcpConnectInMs?: number | undefined;
+  tlsHandshakeInMs?: number | undefined;
+  timeToFirstByteInMs?: number | undefined;
+  downloadInMs?: number | undefined;
+}

--- a/Common/Types/Monitor/MonitorMetricType.ts
+++ b/Common/Types/Monitor/MonitorMetricType.ts
@@ -8,6 +8,23 @@ enum MonitorMetricType {
   ExecutionTime = "oneuptime.monitor.execution.time",
 
   /*
+   * Packet-level network metrics. Emitted by Ping/IP monitors when the
+   * probe sends multiple echo requests per check; absent for older probes.
+   */
+  PacketLossPercent = "oneuptime.monitor.ping.packet.loss.percent",
+  Jitter = "oneuptime.monitor.ping.jitter",
+
+  /*
+   * HTTP(S) phase breakdown. Emitted by Website/API monitors when the probe
+   * captured socket-level timings; absent behind proxies and on older probes.
+   */
+  DnsLookupTime = "oneuptime.monitor.http.dns.lookup.time",
+  TcpConnectTime = "oneuptime.monitor.http.tcp.connect.time",
+  TlsHandshakeTime = "oneuptime.monitor.http.tls.handshake.time",
+  TimeToFirstByte = "oneuptime.monitor.http.time.to.first.byte",
+  DownloadTime = "oneuptime.monitor.http.download.time",
+
+  /*
    * Extended server/VM metrics. Emitted when the agent payload contains them;
    * absent for older agents, which keeps the pipeline backwards-compatible.
    */

--- a/Common/Types/Monitor/PingMonitor/PingMonitorResponse.ts
+++ b/Common/Types/Monitor/PingMonitor/PingMonitorResponse.ts
@@ -1,0 +1,20 @@
+/*
+ * Packet-level statistics captured by the Ping/IP monitor. Populated when
+ * the probe sends multiple ICMP echo requests per check. All RTT values
+ * are in milliseconds. Absent on older probes (single-echo pings) and when
+ * ICMP is blocked and the probe falls back to TCP port checks, which keeps
+ * the pipeline backwards-compatible.
+ */
+export default interface PingMonitorResponse {
+  packetsSent: number;
+  packetsReceived: number;
+  packetLossPercent: number;
+  minRoundTripTimeInMs?: number | undefined;
+  maxRoundTripTimeInMs?: number | undefined;
+  avgRoundTripTimeInMs?: number | undefined;
+  /*
+   * Jitter is the standard deviation of round-trip times across the
+   * packets sent in this check.
+   */
+  jitterInMs?: number | undefined;
+}

--- a/Common/Types/Probe/ProbeMonitorResponse.ts
+++ b/Common/Types/Probe/ProbeMonitorResponse.ts
@@ -8,10 +8,13 @@ import SslMonitorResponse from "../Monitor/SSLMonitor/SslMonitorResponse";
 import SyntheticMonitorResponse from "../Monitor/SyntheticMonitors/SyntheticMonitorResponse";
 import SnmpMonitorResponse from "../Monitor/SnmpMonitor/SnmpMonitorResponse";
 import DnsMonitorResponse from "../Monitor/DnsMonitor/DnsMonitorResponse";
+import PingMonitorResponse from "../Monitor/PingMonitor/PingMonitorResponse";
 import DomainMonitorResponse from "../Monitor/DomainMonitor/DomainMonitorResponse";
 import DnssecMonitorResponse from "../Monitor/DnssecMonitor/DnssecMonitorResponse";
 import ExternalStatusPageMonitorResponse from "../Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
+import HttpPhaseTimings from "../Monitor/HttpPhaseTimings";
 import MonitorEvaluationSummary from "../Monitor/MonitorEvaluationSummary";
+import NetworkPathTrace from "../Monitor/NetworkMonitor/NetworkPathTrace";
 import ObjectID from "../ObjectID";
 import Port from "../Port";
 import ProbeAttempt from "./ProbeAttempt";
@@ -35,6 +38,17 @@ export default interface ProbeMonitorResponse {
   syntheticMonitorResponse?: Array<SyntheticMonitorResponse> | undefined;
   customCodeMonitorResponse?: CustomCodeMonitorResponse | undefined;
   snmpResponse?: SnmpMonitorResponse | undefined;
+  pingResponse?: PingMonitorResponse | undefined;
+  /*
+   * Traceroute + DNS lookup captured by the probe when a Ping/IP/Port check
+   * fails — path evidence from the moment of failure.
+   */
+  networkPathTrace?: NetworkPathTrace | undefined;
+  /*
+   * DNS / TCP / TLS / TTFB / download phase breakdown for Website and API
+   * checks. Absent when the request went through a proxy.
+   */
+  httpTimings?: HttpPhaseTimings | undefined;
   dnsResponse?: DnsMonitorResponse | undefined;
   domainResponse?: DomainMonitorResponse | undefined;
   dnssecResponse?: DnssecMonitorResponse | undefined;

--- a/Common/Utils/Monitor/MonitorMetricType.ts
+++ b/Common/Utils/Monitor/MonitorMetricType.ts
@@ -33,6 +33,16 @@ class MonitorMetricTypeUtil {
         return AggregationType.Avg;
       case MonitorMetricType.ExecutionTime:
         return AggregationType.Avg;
+      case MonitorMetricType.PacketLossPercent:
+        return AggregationType.Avg;
+      case MonitorMetricType.Jitter:
+        return AggregationType.Avg;
+      case MonitorMetricType.DnsLookupTime:
+      case MonitorMetricType.TcpConnectTime:
+      case MonitorMetricType.TlsHandshakeTime:
+      case MonitorMetricType.TimeToFirstByte:
+      case MonitorMetricType.DownloadTime:
+        return AggregationType.Avg;
 
       /*
        * Extended server/VM metrics. Cumulative counters (bytes/packets/ops since
@@ -79,6 +89,10 @@ class MonitorMetricTypeUtil {
     switch (checkOn) {
       case CheckOn.ResponseTime:
         return MonitorMetricType.ResponseTime;
+      case CheckOn.PacketLossPercent:
+        return MonitorMetricType.PacketLossPercent;
+      case CheckOn.Jitter:
+        return MonitorMetricType.Jitter;
       case CheckOn.ResponseStatusCode:
         return MonitorMetricType.ResponseStatusCode;
       case CheckOn.IsOnline:
@@ -117,6 +131,11 @@ class MonitorMetricTypeUtil {
         MonitorMetricType.IsOnline,
         MonitorMetricType.ResponseTime,
         MonitorMetricType.ResponseStatusCode,
+        MonitorMetricType.DnsLookupTime,
+        MonitorMetricType.TcpConnectTime,
+        MonitorMetricType.TlsHandshakeTime,
+        MonitorMetricType.TimeToFirstByte,
+        MonitorMetricType.DownloadTime,
       ];
     }
 
@@ -165,9 +184,20 @@ class MonitorMetricTypeUtil {
       return [MonitorMetricType.ExecutionTime];
     }
 
+    if (monitorType === MonitorType.Ping || monitorType === MonitorType.IP) {
+      /*
+       * Ping/IP checks send multiple echo requests, so they get packet-level
+       * network metrics on top of availability and response time.
+       */
+      return [
+        MonitorMetricType.IsOnline,
+        MonitorMetricType.ResponseTime,
+        MonitorMetricType.PacketLossPercent,
+        MonitorMetricType.Jitter,
+      ];
+    }
+
     if (
-      monitorType === MonitorType.Ping ||
-      monitorType === MonitorType.IP ||
       monitorType === MonitorType.Port ||
       monitorType === MonitorType.SNMP ||
       monitorType === MonitorType.DNS ||
@@ -288,6 +318,20 @@ class MonitorMetricTypeUtil {
         return "Memory Usage Percent";
       case MonitorMetricType.ExecutionTime:
         return "Execution Time";
+      case MonitorMetricType.PacketLossPercent:
+        return "Packet Loss";
+      case MonitorMetricType.Jitter:
+        return "Jitter";
+      case MonitorMetricType.DnsLookupTime:
+        return "DNS Lookup Time";
+      case MonitorMetricType.TcpConnectTime:
+        return "TCP Connect Time";
+      case MonitorMetricType.TlsHandshakeTime:
+        return "TLS Handshake Time";
+      case MonitorMetricType.TimeToFirstByte:
+        return "Time to First Byte";
+      case MonitorMetricType.DownloadTime:
+        return "Download Time";
       case MonitorMetricType.LoadAverage1Min:
         return "Load Average (1 minute)";
       case MonitorMetricType.LoadAverage5Min:
@@ -370,6 +414,16 @@ class MonitorMetricTypeUtil {
         return "%";
       case MonitorMetricType.ExecutionTime:
         return "ms";
+      case MonitorMetricType.PacketLossPercent:
+        return "%";
+      case MonitorMetricType.Jitter:
+        return "ms";
+      case MonitorMetricType.DnsLookupTime:
+      case MonitorMetricType.TcpConnectTime:
+      case MonitorMetricType.TlsHandshakeTime:
+      case MonitorMetricType.TimeToFirstByte:
+      case MonitorMetricType.DownloadTime:
+        return "ms";
       case MonitorMetricType.LoadAverage1Min:
       case MonitorMetricType.LoadAverage5Min:
       case MonitorMetricType.LoadAverage15Min:
@@ -426,6 +480,20 @@ class MonitorMetricTypeUtil {
         return "Memory usage percent is the percentage of memory that is currently being used on a server. It is a measure of how much of the server's memory is being used.";
       case MonitorMetricType.ExecutionTime:
         return "Execution time is the time taken for a custom JavaScript code or a synthetic monitor to execute.";
+      case MonitorMetricType.PacketLossPercent:
+        return "Percentage of ICMP echo requests that received no reply during this check. Sustained loss above 1-2% typically indicates congestion, faulty hardware, or routing problems on the path.";
+      case MonitorMetricType.Jitter:
+        return "Variation in round-trip time across the packets sent in each check (standard deviation). High jitter degrades real-time traffic like VoIP and video even when average latency looks healthy.";
+      case MonitorMetricType.DnsLookupTime:
+        return "Time spent resolving the hostname to an IP address. Spikes here point at the DNS provider, not the monitored service.";
+      case MonitorMetricType.TcpConnectTime:
+        return "Time spent establishing the TCP connection after DNS resolution — a proxy for raw network latency to the target.";
+      case MonitorMetricType.TlsHandshakeTime:
+        return "Time spent negotiating TLS after the TCP connection was established. Regressions here often follow certificate or cipher configuration changes.";
+      case MonitorMetricType.TimeToFirstByte:
+        return "Time from the end of connection setup until the first byte of the response arrived — the server-side processing time.";
+      case MonitorMetricType.DownloadTime:
+        return "Time spent receiving the response body after the first byte arrived.";
       case MonitorMetricType.LoadAverage1Min:
         return "Average number of runnable or uninterruptible processes over the last 1 minute. Values persistently above the number of CPU cores indicate CPU saturation.";
       case MonitorMetricType.LoadAverage5Min:

--- a/Probe/Utils/HttpTimingAgents.ts
+++ b/Probe/Utils/HttpTimingAgents.ts
@@ -1,0 +1,148 @@
+import HttpPhaseTimings from "Common/Types/Monitor/HttpPhaseTimings";
+import http from "http";
+import https from "https";
+import net from "net";
+
+/*
+ * Records HTTP(S) phase timings by listening to socket events on the first
+ * connection an agent opens: 'lookup' (DNS), 'connect' (TCP), 'secureConnect'
+ * (TLS), and the first 'data' chunk (time to first byte). Download time is
+ * derived by the caller as total minus the instrumented phases.
+ *
+ * Only the first socket is instrumented — redirects open new connections
+ * whose phases would overwrite the numbers users care about (the initial
+ * connection to the monitored target).
+ */
+export class HttpTimingCollector {
+  private startedAt: number | undefined;
+  private dnsDoneAt: number | undefined;
+  private connectDoneAt: number | undefined;
+  private secureDoneAt: number | undefined;
+  private firstByteAt: number | undefined;
+  private isAttached: boolean = false;
+
+  private static nowInMs(): number {
+    const hrtime: [number, number] = process.hrtime();
+    return hrtime[0] * 1000 + hrtime[1] / 1000000;
+  }
+
+  public reset(): void {
+    this.startedAt = undefined;
+    this.dnsDoneAt = undefined;
+    this.connectDoneAt = undefined;
+    this.secureDoneAt = undefined;
+    this.firstByteAt = undefined;
+    this.isAttached = false;
+  }
+
+  public attach(socket: net.Socket): void {
+    if (this.isAttached) {
+      return;
+    }
+
+    this.isAttached = true;
+    this.startedAt = HttpTimingCollector.nowInMs();
+
+    socket.once("lookup", () => {
+      this.dnsDoneAt = HttpTimingCollector.nowInMs();
+    });
+
+    socket.once("connect", () => {
+      this.connectDoneAt = HttpTimingCollector.nowInMs();
+    });
+
+    socket.once("secureConnect", () => {
+      this.secureDoneAt = HttpTimingCollector.nowInMs();
+    });
+
+    socket.once("data", () => {
+      this.firstByteAt = HttpTimingCollector.nowInMs();
+    });
+  }
+
+  public getTimings(totalTimeInMs?: number | undefined): HttpPhaseTimings {
+    const timings: HttpPhaseTimings = {};
+
+    if (this.startedAt === undefined) {
+      return timings;
+    }
+
+    const round: (value: number) => number = (value: number) => {
+      return Math.max(0, Math.round(value * 100) / 100);
+    };
+
+    if (this.dnsDoneAt !== undefined) {
+      timings.dnsLookupInMs = round(this.dnsDoneAt - this.startedAt);
+    }
+
+    if (this.connectDoneAt !== undefined) {
+      timings.tcpConnectInMs = round(
+        this.connectDoneAt - (this.dnsDoneAt ?? this.startedAt),
+      );
+    }
+
+    if (this.secureDoneAt !== undefined && this.connectDoneAt !== undefined) {
+      timings.tlsHandshakeInMs = round(this.secureDoneAt - this.connectDoneAt);
+    }
+
+    const readyAt: number | undefined = this.secureDoneAt ?? this.connectDoneAt;
+
+    if (this.firstByteAt !== undefined && readyAt !== undefined) {
+      timings.timeToFirstByteInMs = round(this.firstByteAt - readyAt);
+    }
+
+    if (
+      totalTimeInMs !== undefined &&
+      this.firstByteAt !== undefined &&
+      this.startedAt !== undefined
+    ) {
+      timings.downloadInMs = round(
+        totalTimeInMs - (this.firstByteAt - this.startedAt),
+      );
+    }
+
+    return timings;
+  }
+}
+
+export interface TimedAgents {
+  httpAgent: http.Agent;
+  httpsAgent: https.Agent;
+}
+
+export class HttpTimingAgents {
+  /*
+   * Wraps fresh keep-alive-free agents so every request opens a new socket
+   * the collector can instrument. `createConnection` is a documented
+   * override point on http.Agent; @types/node does not declare it, hence
+   * the casts.
+   */
+  public static create(
+    collector: HttpTimingCollector,
+    httpsAgentOptions?: https.AgentOptions | undefined,
+  ): TimedAgents {
+    const httpAgent: http.Agent = new http.Agent({ keepAlive: false });
+    const httpsAgent: https.Agent = new https.Agent({
+      keepAlive: false,
+      ...(httpsAgentOptions || {}),
+    });
+
+    for (const agent of [httpAgent, httpsAgent]) {
+      const originalCreateConnection: (
+        options: unknown,
+        callback?: unknown,
+      ) => net.Socket = (agent as any).createConnection.bind(agent);
+
+      (agent as any).createConnection = (
+        options: unknown,
+        callback?: unknown,
+      ): net.Socket => {
+        const socket: net.Socket = originalCreateConnection(options, callback);
+        collector.attach(socket);
+        return socket;
+      };
+    }
+
+    return { httpAgent, httpsAgent };
+  }
+}

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -3,6 +3,7 @@ import ProbeUtil from "../Probe";
 import ProbeAPIRequest from "../ProbeAPIRequest";
 import ApiMonitor, { APIResponse } from "./MonitorTypes/ApiMonitor";
 import CustomCodeMonitor from "./MonitorTypes/CustomCodeMonitor";
+import NetworkPathMonitor from "./MonitorTypes/NetworkPathMonitor";
 import PingMonitor, { PingResponse } from "./MonitorTypes/PingMonitor";
 import PortMonitor, { PortMonitorResponse } from "./MonitorTypes/PortMonitor";
 import SSLMonitor, { SslResponse } from "./MonitorTypes/SslMonitor";
@@ -404,6 +405,7 @@ export default class MonitorUtil {
         result.failureCause = response.failureCause;
         result.probeAttempts = response.probeAttempts;
         result.totalAttempts = response.totalAttempts;
+        result.pingResponse = response.pingResponse;
       }
     }
 
@@ -444,6 +446,35 @@ export default class MonitorUtil {
       result.isTimeout = response.isTimeout;
       result.probeAttempts = response.probeAttempts;
       result.totalAttempts = response.totalAttempts;
+    }
+
+    /*
+     * When a network check fails, capture the path (traceroute + DNS lookup)
+     * at the moment of failure. It is attached to the response as diagnostic
+     * evidence, so whoever gets paged sees where the route broke — not just
+     * that the target is down.
+     */
+    if (
+      (monitorType === MonitorType.Ping ||
+        monitorType === MonitorType.IP ||
+        monitorType === MonitorType.Port) &&
+      result.isOnline === false &&
+      monitorStep.data?.monitorDestination
+    ) {
+      try {
+        result.networkPathTrace = await NetworkPathMonitor.trace(
+          monitorStep.data.monitorDestination,
+          {
+            timeout: 20000,
+            maxHops: 20,
+          },
+        );
+      } catch (err) {
+        // Diagnostics must never turn a completed check into a failed one.
+        logger.error(
+          `Failed to capture network path for monitor ${monitorId.toString()}: ${err}`,
+        );
+      }
     }
 
     if (monitorType === MonitorType.SyntheticMonitor) {
@@ -571,6 +602,7 @@ export default class MonitorUtil {
       result.requestFailedDetails = response.requestFailedDetails;
       result.probeAttempts = response.probeAttempts;
       result.totalAttempts = response.totalAttempts;
+      result.httpTimings = response.httpTimings;
     }
 
     if (monitorType === MonitorType.API) {
@@ -625,6 +657,7 @@ export default class MonitorUtil {
       result.requestFailedDetails = response.requestFailedDetails;
       result.probeAttempts = response.probeAttempts;
       result.totalAttempts = response.totalAttempts;
+      result.httpTimings = response.httpTimings;
     }
 
     if (monitorType === MonitorType.SNMP) {

--- a/Probe/Utils/Monitors/MonitorTypes/ApiMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/ApiMonitor.ts
@@ -12,8 +12,14 @@ import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import RequestFailedDetails from "Common/Types/Probe/RequestFailedDetails";
 import Sleep from "Common/Types/Sleep";
 import API from "Common/Utils/API";
+import HttpPhaseTimings from "Common/Types/Monitor/HttpPhaseTimings";
 import logger from "Common/Server/Utils/Logger";
 import ProxyConfig, { ProxyAgents } from "../../ProxyConfig";
+import {
+  HttpTimingAgents,
+  HttpTimingCollector,
+  TimedAgents,
+} from "../../HttpTimingAgents";
 import https from "https";
 
 export interface APIResponse {
@@ -31,6 +37,7 @@ export interface APIResponse {
   isTimeout?: boolean;
   probeAttempts?: Array<ProbeAttempt> | undefined;
   totalAttempts?: number | undefined;
+  httpTimings?: HttpPhaseTimings | undefined;
 }
 
 export default class ApiMonitor {
@@ -84,6 +91,8 @@ export default class ApiMonitor {
     const tlsClientKeyPassphrase: string | undefined =
       options.tlsClientKeyPassphrase || undefined;
 
+    const timingCollector: HttpTimingCollector = new HttpTimingCollector();
+
     const buildAgents: () => ProxyAgents = (): ProxyAgents => {
       const proxyOptions: {
         rejectUnauthorized?: boolean;
@@ -106,21 +115,34 @@ export default class ApiMonitor {
         ...ProxyConfig.getRequestProxyAgents(url, proxyOptions),
       };
 
-      if (
+      const agentOptions: https.AgentOptions = {};
+      if (allowSelfSignedCertificates) {
+        agentOptions.rejectUnauthorized = false;
+      }
+      if (hasClientCert && tlsClientCertificate && tlsClientKey) {
+        agentOptions.cert = tlsClientCertificate;
+        agentOptions.key = tlsClientKey;
+        if (tlsClientKeyPassphrase) {
+          agentOptions.passphrase = tlsClientKeyPassphrase;
+        }
+      }
+
+      if (!proxyAgents.httpAgent && !proxyAgents.httpsAgent) {
+        /*
+         * No proxy in the way — use timing-instrumented agents so the check
+         * captures a DNS / TCP / TLS / TTFB phase breakdown.
+         */
+        timingCollector.reset();
+        const timedAgents: TimedAgents = HttpTimingAgents.create(
+          timingCollector,
+          agentOptions,
+        );
+        proxyAgents.httpAgent = timedAgents.httpAgent;
+        proxyAgents.httpsAgent = timedAgents.httpsAgent;
+      } else if (
         (allowSelfSignedCertificates || hasClientCert) &&
         !proxyAgents.httpsAgent
       ) {
-        const agentOptions: https.AgentOptions = {};
-        if (allowSelfSignedCertificates) {
-          agentOptions.rejectUnauthorized = false;
-        }
-        if (hasClientCert && tlsClientCertificate && tlsClientKey) {
-          agentOptions.cert = tlsClientCertificate;
-          agentOptions.key = tlsClientKey;
-          if (tlsClientKeyPassphrase) {
-            agentOptions.passphrase = tlsClientKeyPassphrase;
-          }
-        }
         proxyAgents.httpsAgent = new https.Agent(agentOptions);
       }
 
@@ -225,6 +247,10 @@ export default class ApiMonitor {
         return await this.ping(url, options);
       }
 
+      const httpTimings: HttpPhaseTimings = timingCollector.getTimings(
+        responseTimeInMS.toNumber(),
+      );
+
       const apiResponse: APIResponse = {
         url: url,
         requestHeaders: options.requestHeaders || {},
@@ -240,6 +266,8 @@ export default class ApiMonitor {
         isTimeout: false,
         probeAttempts: options.attempts,
         totalAttempts: options.attempts!.length,
+        httpTimings:
+          Object.keys(httpTimings).length > 0 ? httpTimings : undefined,
       };
 
       logger.debug(

--- a/Probe/Utils/Monitors/MonitorTypes/PingMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/PingMonitor.ts
@@ -6,11 +6,18 @@ import UnableToReachServer from "Common/Types/Exception/UnableToReachServer";
 import IPv4 from "Common/Types/IP/IPv4";
 import IPv6 from "Common/Types/IP/IPv6";
 import ObjectID from "Common/Types/ObjectID";
+import PingMonitorResponse from "Common/Types/Monitor/PingMonitor/PingMonitorResponse";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import Sleep from "Common/Types/Sleep";
 import logger from "Common/Server/Utils/Logger";
 import ping from "ping";
+
+/*
+ * Echo requests sent per check. Multiple packets turn a reachability probe
+ * into a measurement: packet loss %, jitter, and min/avg/max RTT.
+ */
+export const PING_PACKET_COUNT: number = 5;
 
 // TODO - make sure it works for the IPV6
 export interface PingResponse {
@@ -20,6 +27,7 @@ export interface PingResponse {
   isTimeout?: boolean | undefined;
   probeAttempts?: Array<ProbeAttempt> | undefined;
   totalAttempts?: number | undefined;
+  pingResponse?: PingMonitorResponse | undefined;
 }
 
 export interface PingOptions {
@@ -32,6 +40,65 @@ export interface PingOptions {
 }
 
 export default class PingMonitor {
+  /*
+   * Builds packet-level statistics from the ping library result. The library
+   * parses the OS ping summary into strings (min/max/avg/stddev/packetLoss,
+   * "unknown" when unavailable) and collects per-packet RTTs in `times`, so
+   * every stat is recomputed from `times` when the parsed value is missing.
+   */
+  public static getPacketStatistics(
+    res: ping.PingResponse,
+  ): PingMonitorResponse {
+    const times: Array<number> = (res.times || []).filter((time: number) => {
+      return typeof time === "number" && isFinite(time);
+    });
+
+    const parseStat: (value: string | undefined) => number | undefined = (
+      value: string | undefined,
+    ) => {
+      const parsed: number = parseFloat(value as string);
+      return isFinite(parsed) ? parsed : undefined;
+    };
+
+    const packetsReceived: number = times.length;
+    const packetLossPercent: number =
+      parseStat(res.packetLoss) ??
+      ((PING_PACKET_COUNT - packetsReceived) / PING_PACKET_COUNT) * 100;
+
+    const avg: number | undefined =
+      parseStat(res.avg) ??
+      (times.length > 0
+        ? times.reduce((sum: number, time: number) => {
+            return sum + time;
+          }, 0) / times.length
+        : undefined);
+
+    let jitter: number | undefined = parseStat(res.stddev);
+
+    if (jitter === undefined && times.length > 0 && avg !== undefined) {
+      const variance: number =
+        times.reduce((sum: number, time: number) => {
+          return sum + Math.pow(time - avg, 2);
+        }, 0) / times.length;
+      jitter = Math.sqrt(variance);
+    }
+
+    return {
+      packetsSent: PING_PACKET_COUNT,
+      packetsReceived: packetsReceived,
+      packetLossPercent: Math.round(packetLossPercent * 100) / 100,
+      minRoundTripTimeInMs:
+        parseStat(res.min) ??
+        (times.length > 0 ? Math.min(...times) : undefined),
+      maxRoundTripTimeInMs:
+        parseStat(res.max) ??
+        (times.length > 0 ? Math.max(...times) : undefined),
+      avgRoundTripTimeInMs: avg,
+      jitterInMs:
+        jitter !== undefined ? Math.round(jitter * 100) / 100 : undefined,
+    };
+  }
+
   public static async ping(
     host: Hostname | IPv4 | IPv6 | URL,
     pingOptions?: PingOptions,
@@ -71,6 +138,7 @@ export default class PingMonitor {
     try {
       const res: ping.PingResponse = await ping.promise.probe(hostAddress, {
         timeout: Math.ceil((pingOptions?.timeout?.toNumber() || 5000) / 1000),
+        min_reply: PING_PACKET_COUNT, // maps to -c on Linux/macOS and -n on Windows
       });
 
       logger.debug(
@@ -84,9 +152,23 @@ export default class PingMonitor {
         );
       }
 
-      const responseTime: PositiveNumber | undefined = res.time
-        ? new PositiveNumber(Math.ceil(res.time as any))
-        : undefined;
+      const packetStatistics: PingMonitorResponse =
+        this.getPacketStatistics(res);
+
+      /*
+       * Prefer the average RTT across all packets over the first packet's
+       * RTT — it is the more honest single number for a multi-packet check.
+       */
+      const rttForResponse: number | undefined =
+        packetStatistics.avgRoundTripTimeInMs ??
+        (res.time !== "unknown" && res.time !== undefined
+          ? (res.time as number)
+          : undefined);
+
+      const responseTime: PositiveNumber | undefined =
+        rttForResponse !== undefined
+          ? new PositiveNumber(Math.ceil(rttForResponse))
+          : undefined;
       const responseReceivedAt: Date = new Date();
 
       pingOptions.attempts!.push({
@@ -115,6 +197,7 @@ export default class PingMonitor {
         failureCause: "",
         probeAttempts: pingOptions.attempts,
         totalAttempts: pingOptions.attempts!.length,
+        pingResponse: packetStatistics,
       };
     } catch (err: unknown) {
       logger.debug(

--- a/Probe/Utils/Monitors/MonitorTypes/WebsiteMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/WebsiteMonitor.ts
@@ -10,10 +10,16 @@ import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import RequestFailedDetails from "Common/Types/Probe/RequestFailedDetails";
 import Sleep from "Common/Types/Sleep";
 import WebsiteRequest, { WebsiteResponse } from "Common/Types/WebsiteRequest";
+import HttpPhaseTimings from "Common/Types/Monitor/HttpPhaseTimings";
 import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
 import { AxiosError } from "axios";
 import ProxyConfig, { ProxyAgents } from "../../ProxyConfig";
+import {
+  HttpTimingAgents,
+  HttpTimingCollector,
+  TimedAgents,
+} from "../../HttpTimingAgents";
 import https from "https";
 
 export interface ProbeWebsiteResponse {
@@ -30,6 +36,7 @@ export interface ProbeWebsiteResponse {
   isTimeout?: boolean;
   probeAttempts?: Array<ProbeAttempt> | undefined;
   totalAttempts?: number | undefined;
+  httpTimings?: HttpPhaseTimings | undefined;
 }
 
 export default class WebsiteMonitor {
@@ -85,6 +92,8 @@ export default class WebsiteMonitor {
     const tlsClientKeyPassphrase: string | undefined =
       options.tlsClientKeyPassphrase || undefined;
 
+    const timingCollector: HttpTimingCollector = new HttpTimingCollector();
+
     const buildAgents: () => ProxyAgents = (): ProxyAgents => {
       const proxyOptions: {
         rejectUnauthorized?: boolean;
@@ -107,21 +116,34 @@ export default class WebsiteMonitor {
         ...ProxyConfig.getRequestProxyAgents(url, proxyOptions),
       };
 
-      if (
+      const agentOptions: https.AgentOptions = {};
+      if (allowSelfSignedCertificates) {
+        agentOptions.rejectUnauthorized = false;
+      }
+      if (hasClientCert && tlsClientCertificate && tlsClientKey) {
+        agentOptions.cert = tlsClientCertificate;
+        agentOptions.key = tlsClientKey;
+        if (tlsClientKeyPassphrase) {
+          agentOptions.passphrase = tlsClientKeyPassphrase;
+        }
+      }
+
+      if (!proxyAgents.httpAgent && !proxyAgents.httpsAgent) {
+        /*
+         * No proxy in the way — use timing-instrumented agents so the check
+         * captures a DNS / TCP / TLS / TTFB phase breakdown.
+         */
+        timingCollector.reset();
+        const timedAgents: TimedAgents = HttpTimingAgents.create(
+          timingCollector,
+          agentOptions,
+        );
+        proxyAgents.httpAgent = timedAgents.httpAgent;
+        proxyAgents.httpsAgent = timedAgents.httpsAgent;
+      } else if (
         (allowSelfSignedCertificates || hasClientCert) &&
         !proxyAgents.httpsAgent
       ) {
-        const agentOptions: https.AgentOptions = {};
-        if (allowSelfSignedCertificates) {
-          agentOptions.rejectUnauthorized = false;
-        }
-        if (hasClientCert && tlsClientCertificate && tlsClientKey) {
-          agentOptions.cert = tlsClientCertificate;
-          agentOptions.key = tlsClientKey;
-          if (tlsClientKeyPassphrase) {
-            agentOptions.passphrase = tlsClientKeyPassphrase;
-          }
-        }
         proxyAgents.httpsAgent = new https.Agent(agentOptions);
       }
 
@@ -184,6 +206,10 @@ export default class WebsiteMonitor {
         return await this.ping(url, options);
       }
 
+      const httpTimings: HttpPhaseTimings = timingCollector.getTimings(
+        responseTimeInMS.toNumber(),
+      );
+
       const probeWebsiteResponse: ProbeWebsiteResponse = {
         url: url,
         requestHeaders: {},
@@ -197,6 +223,8 @@ export default class WebsiteMonitor {
         isTimeout: false,
         probeAttempts: options.attempts,
         totalAttempts: options.attempts!.length,
+        httpTimings:
+          Object.keys(httpTimings).length > 0 ? httpTimings : undefined,
       };
 
       logger.debug(


### PR DESCRIPTION
## What this does

Phase 1 of the network monitoring roadmap: turn existing checks from "is it up?" into real network measurements. Everything rides pipeline that already existed (ClickHouse monitor metrics, criteria engine, summary views).

### 1. Ping/IP packet statistics
- Ping/IP monitors send **5 ICMP echo requests per check** (`min_reply` → `ping -c 5`) instead of one.
- New `PingMonitorResponse` captures **packet loss %, jitter (RTT stddev), min/avg/max RTT**; `responseTimeInMs` is now the average across packets.
- New metrics `oneuptime.monitor.ping.packet.loss.percent` and `oneuptime.monitor.ping.jitter` auto-render on the monitor Metrics tab with per-probe series.
- New alertable criteria **Packet Loss (in %)** and **Jitter (in ms)** for Ping/IP monitors, including evaluate-over-time support — e.g. "create incident when average packet loss over 5 minutes > 2%".
- Summary view shows loss, jitter, and min/max RTT cards.

### 2. Auto-traceroute on failure (wires previously dead code)
- `NetworkPathMonitor.ts` (complete traceroute implementation that had zero imports) is now wired into the probe dispatcher.
- When a **Ping/IP/Port check fails**, the probe captures traceroute + DNS lookup at the moment of failure and attaches it to the probe response (`networkPathTrace`).
- The monitor summary view renders the hop table with per-hop RTTs and highlights where the route broke. Degrades gracefully when the `traceroute` binary is absent (recorded as a failure message; the probe Docker image already installs it).

### 3. HTTP/TLS phase timings for Website/API monitors
- New timing-instrumented HTTP agents capture **DNS lookup → TCP connect → TLS handshake → TTFB → download** from socket events (`lookup`/`connect`/`secureConnect`/first `data`).
- Skipped when the request goes through a proxy (phase timing would be misleading); with redirects, phases describe the initial connection.
- Five new `oneuptime.monitor.http.*` metrics, plus a phase waterfall on the Website/API summary view.

### 4. Retention default fix
- `MonitorMetricUtil.DEFAULT_RETENTION_DAYS` raised **1 → 30 days**. One day made week-over-week charts impossible out of the box, and `AlertService`/`IncidentService` already assume 180 days for the same GlobalConfig setting.

## Deliberately not in this PR
- **30-second check intervals**: intervals are cron-expression based (min 1 minute) and the probe work-fetch loop runs on a per-minute cron with a random 0–45 s sleep — sub-minute checks need that scheduling model reworked, which deserves its own PR.
- Traceroute as a first-class monitor type (auto-on-failure is the high-leverage part; a dedicated type ripples through the whole monitor-creation UI).
- Criteria on individual HTTP phases (metrics are stored, so this is a small follow-up).

## Verification
- `tsc --noEmit` clean on Common, Probe, and App.
- ESLint clean on all changed files.
- `Common/Tests/Types/Monitor/CriteriaFilter.test.ts`: 84/84 pass.
- Live smoke test: multi-packet ping against 127.0.0.1 returned `packetsSent: 5, packetLossPercent: 0, min/avg/max/jitter` populated; instrumented HTTPS request to example.com returned all five phases (DNS 19 ms, TCP 7.7 ms, TLS 17.3 ms, TTFB 14.7 ms, download 21.4 ms); traceroute failure path degrades gracefully when the binary is missing.

## Compatibility
All new response fields are optional — older probes simply omit them, and the ingest/UI treat absence as "not captured". No schema migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)