### PR TITLE
fix: histogram-aware metric aggregation and key-scoped attribute group-by

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/Utils/Metrics.ts
@@ -300,25 +300,40 @@ export default class MetricUtil {
       metricViewData.queryConfigs.map((queryConfig: MetricQueryConfigData) => {
         /*
          * Per-series viewing: when the user has selected attribute
-         * keys to group by (e.g. host.name), inject the nested
-         * `attributes` column into the aggregation's GROUP BY so
-         * ClickHouse emits one row per unique attribute map. The
-         * chart layer then splits those rows into one line per
-         * unique label combination via `getSeries` (injected in
-         * MetricView before render).
+         * keys to group by (e.g. host.name), pass them through as
+         * `groupByAttributeKeys` so the server groups on the
+         * individual map entries (`attributes['host.name']`) and
+         * returns one pooled series per unique key-value combination.
+         * The chart layer splits those rows into one line per label
+         * combination via `getSeries` (injected in MetricView before
+         * render).
+         *
+         * Grouping by the whole `attributes` Map column (the previous
+         * approach, still baked into older stored dashboard configs)
+         * fragments the result into one series per unique attribute
+         * combination — for percentiles of histogram metrics that
+         * collapses every sub-series onto a near-constant bucket
+         * midpoint and renders as flat straight lines — so any legacy
+         * `attributes` entry in groupBy is stripped when key-scoped
+         * grouping is active.
          */
-        const hasGroupByAttributes: boolean = Boolean(
-          queryConfig.metricQueryData.groupByAttributeKeys &&
-            queryConfig.metricQueryData.groupByAttributeKeys.length > 0,
-        );
+        const groupByAttributeKeys: Array<string> =
+          queryConfig.metricQueryData.groupByAttributeKeys || [];
+        const hasGroupByAttributes: boolean = groupByAttributeKeys.length > 0;
 
-        const aggregationGroupBy: typeof queryConfig.metricQueryData.groupBy =
-          hasGroupByAttributes
-            ? ({
-                ...(queryConfig.metricQueryData.groupBy || {}),
-                attributes: true,
-              } as typeof queryConfig.metricQueryData.groupBy)
-            : queryConfig.metricQueryData.groupBy;
+        let aggregationGroupBy: typeof queryConfig.metricQueryData.groupBy =
+          queryConfig.metricQueryData.groupBy;
+
+        if (hasGroupByAttributes && aggregationGroupBy) {
+          const strippedGroupBy: Record<string, unknown> = {
+            ...(aggregationGroupBy as Record<string, unknown>),
+          };
+          delete strippedGroupBy["attributes"];
+          aggregationGroupBy =
+            Object.keys(strippedGroupBy).length > 0
+              ? (strippedGroupBy as typeof queryConfig.metricQueryData.groupBy)
+              : undefined;
+        }
 
         return dedupedAggregate({
           query: {
@@ -346,6 +361,9 @@ export default class MetricUtil {
           limit: LIMIT_PER_PROJECT,
           skip: 0,
           groupBy: aggregationGroupBy,
+          groupByAttributeKeys: hasGroupByAttributes
+            ? groupByAttributeKeys
+            : undefined,
         } as AggregateBy<Metric>);
       }),
     );

--- a/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
@@ -51,6 +51,7 @@ import MetricService from "Common/Server/Services/MetricService";
 import MetricTypeService from "Common/Server/Services/MetricTypeService";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
 import MetricsAggregationType from "Common/Types/Metrics/MetricsAggregationType";
+import { getPercentileLevel } from "Common/Types/BaseDatabase/AggregationType";
 import Dictionary from "Common/Types/Dictionary";
 import MetricFormulaConfigData from "Common/Types/Metrics/MetricFormulaConfigData";
 import MetricFormulaEvaluator from "Common/Utils/Metrics/MetricFormulaEvaluator";
@@ -580,6 +581,28 @@ const aggregatePerSeriesFromRawMetrics: (input: {
       case MetricsAggregationType.Min:
         aggregated = Math.min(...vs);
         break;
+      case MetricsAggregationType.P50:
+      case MetricsAggregationType.P90:
+      case MetricsAggregationType.P95:
+      case MetricsAggregationType.P99: {
+        /*
+         * Nearest-rank percentile over the bucket's raw values. This
+         * path serves the infra monitors' gauge metrics, where every
+         * row is a single observation — histogram metrics go through
+         * the SQL bucket fanout instead. Previously these fell into
+         * the default branch and were silently computed as Avg.
+         */
+        const sorted: Array<number> = [...vs].sort((a: number, b: number) => {
+          return a - b;
+        });
+        const level: number = getPercentileLevel(input.aggregationType) || 0.5;
+        const rankIndex: number = Math.min(
+          sorted.length - 1,
+          Math.max(0, Math.ceil(level * sorted.length) - 1),
+        );
+        aggregated = sorted[rankIndex]!;
+        break;
+      }
       case MetricsAggregationType.Avg:
       default:
         aggregated =
@@ -1038,40 +1061,23 @@ const monitorMetric: MonitorMetricFunction = async (data: {
         .aggegationType as MetricsAggregationType) ||
       MetricsAggregationType.Avg;
 
-    let aggregatedResults: AggregatedResult;
-
-    if (groupByAttributeKeys.length > 0) {
-      /*
-       * Per-series path: fetch raw rows including the full
-       * attributes map, then bucket + aggregate in code. We can't
-       * push this through aggregateBy+SQL because the @clickhouse/client
-       * parameterized query returns 0 rows when GROUP BY includes the
-       * Map column. See aggregatePerSeriesFromRawMetrics for details.
-       */
-      const rawMetrics: Array<Metric> = await MetricService.findBy({
-        query: query,
-        select: {
-          attributes: true,
-          value: true,
-          time: true,
-        },
-        sort: {
-          time: SortOrder.Descending,
-        },
-        limit: LIMIT_PER_PROJECT,
-        skip: 0,
-        props: {
-          isRoot: true,
-        },
-      });
-
-      aggregatedResults = aggregatePerSeriesFromRawMetrics({
-        rawMetrics,
-        attributeKeys: groupByAttributeKeys,
-        aggregationType,
-      });
-    } else {
-      aggregatedResults = await MetricService.aggregateBy({
+    /*
+     * Grouped and ungrouped monitors share the SQL aggregation path.
+     * Per-series grouping goes through `groupByAttributeKeys`, which
+     * MetricService compiles to `GROUP BY attributes['<key>']` — the
+     * previous raw-row JS fallback aggregated the `value` column
+     * directly, which for histogram metrics holds the datapoint SUM
+     * (so an "Avg of http.client.request.duration" monitor evaluated
+     * ~110s instead of ~0.6s and false-alerted), silently computed
+     * percentile aggregations as Avg, and truncated high-cardinality
+     * metrics at the 10k raw-row limit. The SQL path is histogram-
+     * aware for both scalar and percentile aggregations, and returns
+     * one row per (bucket, selected-key values) with an `attributes`
+     * map carrying exactly the grouped keys — the shape
+     * buildSeriesBreakdown already consumes.
+     */
+    const aggregatedResults: AggregatedResult = await MetricService.aggregateBy(
+      {
         query: query,
         aggregationType,
         aggregateColumnName: "value",
@@ -1084,11 +1090,13 @@ const monitorMetric: MonitorMetricFunction = async (data: {
         limit: LIMIT_PER_PROJECT,
         skip: 0,
         groupBy: queryConfig.metricQueryData.groupBy,
+        groupByAttributeKeys:
+          groupByAttributeKeys.length > 0 ? groupByAttributeKeys : undefined,
         props: {
           isRoot: true,
         },
-      });
-    }
+      },
+    );
 
     logger.debug("Aggregated results", {
       service: "workers",

--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -813,6 +813,19 @@ export default class AnalyticsDatabaseService<
         ? Object.keys(aggregateBy.groupBy)
         : [];
 
+      /*
+       * Attribute-key grouping returns the selected keys folded into a
+       * single `attributes` map column (see MetricService); carry it
+       * onto the aggregated rows so series splitters can read labels.
+       */
+      if (
+        aggregateBy.groupByAttributeKeys &&
+        aggregateBy.groupByAttributeKeys.length > 0 &&
+        !groupByColumnNames.includes("attributes")
+      ) {
+        groupByColumnNames.push("attributes");
+      }
+
       for (const item of items) {
         if (
           !(item as JSONObject)[
@@ -1171,6 +1184,20 @@ export default class AnalyticsDatabaseService<
     statement: Statement;
     columns: Array<string>;
   } {
+    /*
+     * Attribute-key grouping needs model-specific SQL over a map column
+     * (MetricService builds it); reaching this generic path with keys
+     * set would silently return ungrouped results.
+     */
+    if (
+      aggregateBy.groupByAttributeKeys &&
+      aggregateBy.groupByAttributeKeys.length > 0
+    ) {
+      throw new BadDataException(
+        `groupByAttributeKeys is not supported for ${this.model.tableName}.`,
+      );
+    }
+
     if (!this.database) {
       this.useDefaultDatabase();
     }

--- a/Common/Server/Services/MetricService.ts
+++ b/Common/Server/Services/MetricService.ts
@@ -1,4 +1,5 @@
 import ClickhouseDatabase from "../Infrastructure/ClickhouseDatabase";
+import { ResponseJSON, ResultSet } from "@clickhouse/client";
 import AnalyticsDatabaseService from "./AnalyticsDatabaseService";
 import { MutableMetricService as MutableMetricServiceClass } from "./MutableMetricService";
 import Metric from "../../Models/AnalyticsModels/Metric";
@@ -14,15 +15,325 @@ import AggregationType, {
   isPercentileAggregation,
 } from "../../Types/BaseDatabase/AggregationType";
 import AggregationInterval from "../../Types/BaseDatabase/AggregationInterval";
+import AggregatedResult from "../../Types/BaseDatabase/AggregatedResult";
 import AnalyticsTableName from "../../Types/AnalyticsDatabase/AnalyticsTableName";
 import TableColumnType from "../../Types/AnalyticsDatabase/TableColumnType";
+import BadDataException from "../../Types/Exception/BadDataException";
+import { JSONObject } from "../../Types/JSON";
 import { keyForHost } from "../../Utils/Telemetry/EntityKey";
 import ObjectID from "../../Types/ObjectID";
 import logger, { LogAttributes } from "../Utils/Logger";
 
+/*
+ * Metric point types whose rows carry a pre-aggregated distribution
+ * (count/sum/min/max + buckets) instead of a single observation. For
+ * these rows the `value` column holds the datapoint's SUM of all
+ * observations in the export interval (see OtelMetricsIngestService's
+ * buildMetricRow: value = asInt ?? asDouble ?? sum), so aggregating
+ * `value` directly produces sum-scale numbers — e.g. "Avg of
+ * http.client.request.duration" would return ~110s for a service whose
+ * true mean latency is 0.586s at ~188 requests per export interval.
+ */
+const DISTRIBUTION_POINT_TYPES: ReadonlyArray<string> = [
+  "Histogram",
+  "ExponentialHistogram",
+  "Summary",
+];
+
+const MAX_GROUP_BY_ATTRIBUTE_KEYS: number = 10;
+const MAX_GROUP_BY_ATTRIBUTE_KEY_LENGTH: number = 256;
+
+const POINT_TYPE_CACHE_TTL_MS: number = 10 * 60 * 1000;
+const POINT_TYPE_CACHE_MAX_ENTRIES: number = 5000;
+
 export class MetricService extends AnalyticsDatabaseService<Metric> {
+  /*
+   * (projectId|metricName) -> metricPointType, resolved lazily on the
+   * aggregate path so scalar aggregations of distribution metrics can
+   * skip the MVs (whose states collapse `value` — the histogram sum)
+   * and use the count-weighted expressions instead. Bounded + TTL'd so
+   * a tenant churning metric names can't grow it without limit.
+   */
+  private metricPointTypeCache: Map<
+    string,
+    { pointType: string | null; expiresAt: number }
+  > = new Map();
+
+  /*
+   * Point-type hint per aggregateBy call. toAggregateStatement is a
+   * synchronous override, so the async lookup happens in aggregateBy
+   * and is handed over keyed on the (shared) aggregateBy object.
+   */
+  private pointTypeHintByAggregate: WeakMap<
+    AggregateBy<Metric>,
+    string | null
+  > = new WeakMap();
+
+  private inFlightPointTypeLookups: Map<string, Promise<string | null>> =
+    new Map();
+
   public constructor(clickhouseDatabase?: ClickhouseDatabase | undefined) {
     super({ modelType: Metric, database: clickhouseDatabase });
+  }
+
+  public override async aggregateBy(
+    aggregateBy: AggregateBy<Metric>,
+  ): Promise<AggregatedResult> {
+    /*
+     * Only scalar aggregations over `value` need the point type — the
+     * percentile path is already distribution-aware via the bucket
+     * fanout, and MV routing is the only decision the hint drives.
+     * Grouped queries (model-column or attribute-key) never route to
+     * the MVs, so the lookup would be dead weight there.
+     */
+    if (
+      !isPercentileAggregation(aggregateBy.aggregationType) &&
+      aggregateBy.aggregateColumnName.toString() === "value" &&
+      (!aggregateBy.groupBy || Object.keys(aggregateBy.groupBy).length === 0) &&
+      (!aggregateBy.groupByAttributeKeys ||
+        aggregateBy.groupByAttributeKeys.length === 0)
+    ) {
+      const pointType: string | null =
+        await this.resolveMetricPointType(aggregateBy);
+      this.pointTypeHintByAggregate.set(aggregateBy, pointType);
+    }
+
+    return super.aggregateBy(aggregateBy);
+  }
+
+  private async resolveMetricPointType(
+    aggregateBy: AggregateBy<Metric>,
+  ): Promise<string | null> {
+    const metricName: string | null = this.getExactMetricNameFromQuery(
+      aggregateBy.query,
+    );
+    if (!metricName) {
+      return null;
+    }
+
+    const queryRecord: Record<string, unknown> =
+      (aggregateBy.query as unknown as Record<string, unknown>) || {};
+    const projectIdValue: unknown = queryRecord["projectId"];
+    let projectId: string = "";
+    if (projectIdValue instanceof ObjectID) {
+      projectId = projectIdValue.toString();
+    } else if (typeof projectIdValue === "string") {
+      projectId = projectIdValue;
+    }
+    if (!projectId) {
+      return null;
+    }
+
+    const cacheKey: string = `${projectId}|${metricName}`;
+    const cached: { pointType: string | null; expiresAt: number } | undefined =
+      this.metricPointTypeCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.pointType;
+    }
+
+    /*
+     * Coalesce concurrent misses: a dashboard refresh fires many
+     * aggregates for the same metric at once; without this every one
+     * of them would issue the same lookup before any could populate
+     * the cache.
+     */
+    const inFlight: Promise<string | null> | undefined =
+      this.inFlightPointTypeLookups.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const lookup: Promise<string | null> = this.lookupMetricPointType(
+      aggregateBy,
+      projectId,
+      metricName,
+    )
+      .then((pointType: string | null) => {
+        this.evictExpiredPointTypeCacheEntries();
+        this.metricPointTypeCache.set(cacheKey, {
+          pointType,
+          expiresAt: Date.now() + POINT_TYPE_CACHE_TTL_MS,
+        });
+        return pointType;
+      })
+      .finally(() => {
+        this.inFlightPointTypeLookups.delete(cacheKey);
+      });
+
+    this.inFlightPointTypeLookups.set(cacheKey, lookup);
+    return lookup;
+  }
+
+  private async lookupMetricPointType(
+    aggregateBy: AggregateBy<Metric>,
+    projectId: string,
+    metricName: string,
+  ): Promise<string | null> {
+    try {
+      if (!this.database) {
+        this.useDefaultDatabase();
+      }
+      const databaseName: string =
+        this.database.getDatasourceOptions().database!;
+
+      const statement: Statement = SQL`SELECT metricPointType FROM `;
+      statement.append(`${databaseName}.${this.model.tableName}`);
+      statement.append(
+        SQL` WHERE projectId = ${{
+          value: projectId,
+          type: TableColumnType.ObjectID,
+        }} AND name = ${{
+          value: metricName,
+          type: TableColumnType.Text,
+        }} AND isNotNull(metricPointType)`,
+      );
+
+      /*
+       * Bound the lookup to the aggregation's own window so ClickHouse
+       * can prune daily partitions (the table partitions on
+       * toYYYYMMDD(time)); without this the LIMIT 1 seek could touch
+       * every partition in retention for a metric with all-null point
+       * types. The point type is stable per metric name, so any window
+       * that has data answers correctly.
+       */
+      if (aggregateBy.startTimestamp && aggregateBy.endTimestamp) {
+        statement.append(
+          ` AND time >= toDateTime('${this.formatDateTime(
+            aggregateBy.startTimestamp,
+          )}') AND time <= toDateTime('${this.formatDateTime(
+            aggregateBy.endTimestamp,
+          )}')`,
+        );
+      }
+
+      statement.append(SQL` LIMIT 1`);
+
+      const dbResult: ResultSet<"JSON"> = await this.executeQuery(statement);
+      const responseJSON: ResponseJSON<JSONObject> =
+        await dbResult.json<JSONObject>();
+      const row: JSONObject | undefined = (responseJSON.data || [])[0];
+      const rawPointType: unknown = row ? row["metricPointType"] : undefined;
+      return typeof rawPointType === "string" ? rawPointType : null;
+    } catch (err) {
+      /*
+       * Lookup failures must not fail the aggregation — fall back to
+       * the (possibly MV-served) scalar path, which is today's
+       * behavior for unknown point types.
+       */
+      logger.debug("Metric point type lookup failed");
+      logger.debug(err);
+      return null;
+    }
+  }
+
+  private evictExpiredPointTypeCacheEntries(): void {
+    if (this.metricPointTypeCache.size < POINT_TYPE_CACHE_MAX_ENTRIES) {
+      return;
+    }
+    const now: number = Date.now();
+    for (const [key, entry] of this.metricPointTypeCache) {
+      if (entry.expiresAt <= now) {
+        this.metricPointTypeCache.delete(key);
+      }
+    }
+    /*
+     * Still full after dropping expired entries: evict oldest-inserted
+     * until under the cap (Map preserves insertion order). Never
+     * clear() — that would stampede every active dashboard into
+     * re-issuing its lookup at once.
+     */
+    while (this.metricPointTypeCache.size >= POINT_TYPE_CACHE_MAX_ENTRIES) {
+      const oldestKey: string | undefined = this.metricPointTypeCache
+        .keys()
+        .next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      this.metricPointTypeCache.delete(oldestKey);
+    }
+  }
+
+  private isDistributionMetricAggregate(
+    aggregateBy: AggregateBy<Metric>,
+  ): boolean {
+    const pointType: string | null | undefined =
+      this.pointTypeHintByAggregate.get(aggregateBy);
+    return Boolean(pointType && DISTRIBUTION_POINT_TYPES.includes(pointType));
+  }
+
+  /**
+   * Validated, deduplicated attribute keys to group the aggregation by.
+   * Keys are bound as query parameters wherever they reach SQL, so this
+   * is shape validation (not injection defense): drop non-strings and
+   * empties, cap key length and count.
+   */
+  private getSanitizedGroupByAttributeKeys(
+    aggregateBy: AggregateBy<Metric>,
+  ): Array<string> {
+    const keys: Array<string> = [];
+    for (const rawKey of aggregateBy.groupByAttributeKeys || []) {
+      if (typeof rawKey !== "string") {
+        continue;
+      }
+      const key: string = rawKey.trim();
+      if (
+        !key ||
+        key.length > MAX_GROUP_BY_ATTRIBUTE_KEY_LENGTH ||
+        keys.includes(key)
+      ) {
+        continue;
+      }
+      keys.push(key);
+    }
+
+    if (keys.length > MAX_GROUP_BY_ATTRIBUTE_KEYS) {
+      throw new BadDataException(
+        `A maximum of ${MAX_GROUP_BY_ATTRIBUTE_KEYS} group-by attribute keys is supported.`,
+      );
+    }
+
+    return keys;
+  }
+
+  /**
+   * Appends `, attributes[{key}] AS __attr_grp_<i>` for every group-by
+   * attribute key. Used in the (inner) SELECT so the outer/main query
+   * can group on and re-project the extracted values.
+   */
+  private appendAttributeGroupExtractionColumns(
+    statement: Statement,
+    attributeGroupKeys: Array<string>,
+  ): void {
+    attributeGroupKeys.forEach((key: string, index: number) => {
+      statement.append(`, `);
+      statement.append(
+        SQL`attributes[${{ value: key, type: TableColumnType.Text }}]`,
+      );
+      statement.append(` AS __attr_grp_${index}`);
+    });
+  }
+
+  /**
+   * Appends `, map({key0}, __attr_grp_0, ...) AS attributes` so grouped
+   * rows return exactly the selected keys as an attributes map — the
+   * same shape series splitters already read (`row.attributes[key]`).
+   */
+  private appendAttributeGroupMapColumn(
+    statement: Statement,
+    attributeGroupKeys: Array<string>,
+  ): void {
+    if (attributeGroupKeys.length === 0) {
+      return;
+    }
+    statement.append(`, map(`);
+    attributeGroupKeys.forEach((key: string, index: number) => {
+      if (index > 0) {
+        statement.append(`, `);
+      }
+      statement.append(SQL`${{ value: key, type: TableColumnType.Text }}`);
+      statement.append(`, __attr_grp_${index}`);
+    });
+    statement.append(`) AS attributes`);
   }
 
   /*
@@ -182,6 +493,9 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
       return mutableMetricStatement;
     }
 
+    const attributeGroupKeys: Array<string> =
+      this.getSanitizedGroupByAttributeKeys(aggregateBy);
+
     if (!isPercentileAggregation(aggregateBy.aggregationType)) {
       /*
        * Try the per-host MV first — host detail pages are the
@@ -189,21 +503,43 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
        * the only one that can serve them. If it doesn't apply
        * (no host filter, or extra attrs/groupBy), fall through
        * to the project/primaryEntityId MV, then to the base table.
+       *
+       * Distribution metrics (histograms/summaries) must skip the
+       * MVs entirely: their states collapse `value`, which for
+       * distribution rows is the datapoint SUM — merging those can
+       * only ever produce sum-scale results. The base-table builder
+       * below weights by the datapoint `count` instead.
        */
-      const hostMvStatement: {
-        statement: Statement;
-        columns: Array<string>;
-      } | null = this.tryBuildHostAggregateMVStatement(aggregateBy);
-      if (hostMvStatement) {
-        return hostMvStatement;
+      if (
+        attributeGroupKeys.length === 0 &&
+        !this.isDistributionMetricAggregate(aggregateBy)
+      ) {
+        const hostMvStatement: {
+          statement: Statement;
+          columns: Array<string>;
+        } | null = this.tryBuildHostAggregateMVStatement(aggregateBy);
+        if (hostMvStatement) {
+          return hostMvStatement;
+        }
+        const mvStatement: {
+          statement: Statement;
+          columns: Array<string>;
+        } | null = this.tryBuildMinuteAggregateMVStatement(aggregateBy);
+        if (mvStatement) {
+          return mvStatement;
+        }
       }
-      const mvStatement: {
-        statement: Statement;
-        columns: Array<string>;
-      } | null = this.tryBuildMinuteAggregateMVStatement(aggregateBy);
-      if (mvStatement) {
-        return mvStatement;
+
+      if (
+        aggregateBy.aggregateColumnName.toString() === "value" &&
+        aggregateBy.aggregationTimestampColumnName.toString() === "time"
+      ) {
+        return this.buildScalarAggregateStatement(
+          aggregateBy,
+          attributeGroupKeys,
+        );
       }
+
       return super.toAggregateStatement(aggregateBy);
     }
 
@@ -233,12 +569,18 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
      * Group-by columns from the caller need to be carried through the
      * inner subquery so the outer GROUP BY can reference them. Only
      * columns that exist on the model are accepted (matches the base
-     * generator's safety net).
+     * generator's safety net). A whole-map `attributes` group-by is
+     * dropped when key-scoped grouping is requested — keeping both
+     * would fragment the series again and collide with the
+     * `map(...) AS attributes` projection.
      */
     const groupByKeys: Array<string> = [];
     if (aggregateBy.groupBy) {
       for (const key of Object.keys(aggregateBy.groupBy)) {
         if (!this.model.getTableColumn(key)) {
+          continue;
+        }
+        if (key === "attributes" && attributeGroupKeys.length > 0) {
           continue;
         }
         groupByKeys.push(key);
@@ -336,8 +678,20 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
       statement.append(`, ${key}`);
     }
 
+    /*
+     * Attribute-key grouping: the inner subquery extracts each selected
+     * key into `__attr_grp_<i>`; the outer query groups on those and
+     * folds them back into a per-row `attributes` map so the result
+     * shape matches what series splitters read. Grouping happens on the
+     * individual keys — NOT the whole attributes map, which would
+     * fragment the quantile into one near-constant series per unique
+     * attribute combination.
+     */
+    this.appendAttributeGroupMapColumn(statement, attributeGroupKeys);
+
     statement.append(SQL` FROM (`);
     statement.append(`SELECT ${innerSelectClause}`);
+    this.appendAttributeGroupExtractionColumns(statement, attributeGroupKeys);
     statement.append(
       ` FROM ${databaseName}.${this.model.tableName} WHERE TRUE `,
     );
@@ -349,6 +703,9 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
     for (const key of groupByKeys) {
       statement.append(`, ${key}`);
     }
+    attributeGroupKeys.forEach((_key: string, index: number) => {
+      statement.append(`, __attr_grp_${index}`);
+    });
 
     statement.append(SQL` ORDER BY `).append(sortStatement);
 
@@ -385,9 +742,221 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
       aggregationColumn,
       aggregationTimestampColumn,
       ...groupByKeys,
+      ...(attributeGroupKeys.length > 0 ? ["attributes"] : []),
     ];
 
     logger.debug(`${this.model.tableName} Percentile Aggregate Statement`, {
+      tableName: this.model.tableName,
+    } as LogAttributes);
+    logger.debug(statement, {
+      tableName: this.model.tableName,
+    } as LogAttributes);
+
+    return { statement, columns };
+  }
+
+  /**
+   * Distribution-aware per-bucket expression for scalar aggregations
+   * over `value`. Distribution rows (histogram/summary — identified by
+   * a non-null `count`) carry the datapoint's observation total in
+   * `sum` (mirrored into `value` at ingest) and the observation count
+   * in `count`, so:
+   *
+   *   Avg   -> sum(sum) / sum(count)   (count-weighted mean of
+   *            observations, not the mean of per-export-interval sums)
+   *   Sum   -> sum(sum)                (total of all observations)
+   *   Count -> sum(count)              (number of observations, not
+   *            the number of export intervals)
+   *   Min   -> min(min), falling back to the datapoint mean when the
+   *            optional OTLP min is absent
+   *   Max   -> max(max), same fallback
+   *
+   * Scalar rows (Sum/Gauge points — `count` is null) degrade to the
+   * plain value semantics these aggregations always had: each row is
+   * one observation of `value` with weight 1.
+   */
+  private getDistributionAwareAggregationExpression(
+    aggregationType: AggregationType,
+    column: string,
+  ): string {
+    const distRowCondition: string = `isNotNull(count) AND isNotNull(coalesce(sum, ${column}))`;
+    const observationTotalExpression: string = `sum(multiIf(${distRowCondition}, toFloat64(coalesce(sum, ${column})), isNotNull(${column}), toFloat64(${column}), 0))`;
+    const observationCountExpression: string = `sum(multiIf(${distRowCondition}, toFloat64(count), isNotNull(${column}), 1, 0))`;
+    const datapointMeanExpression: string = `toFloat64(coalesce(sum, ${column})) / toFloat64(count)`;
+
+    switch (aggregationType) {
+      case AggregationType.Sum:
+        return observationTotalExpression;
+      case AggregationType.Count:
+        return observationCountExpression;
+      case AggregationType.Avg:
+        return `if(${observationCountExpression} = 0, 0, ${observationTotalExpression} / ${observationCountExpression})`;
+      case AggregationType.Min:
+        return `min(multiIf(isNotNull(min), toFloat64(min), ${distRowCondition} AND count > 0, ${datapointMeanExpression}, isNotNull(${column}), toFloat64(${column}), NULL))`;
+      case AggregationType.Max:
+        return `max(multiIf(isNotNull(max), toFloat64(max), ${distRowCondition} AND count > 0, ${datapointMeanExpression}, isNotNull(${column}), toFloat64(${column}), NULL))`;
+      default:
+        return `${aggregationType.toLocaleLowerCase()}(${column})`;
+    }
+  }
+
+  /**
+   * Base-table statement for non-percentile aggregations over `value`,
+   * used whenever the MV fast paths don't apply (attribute filters,
+   * group-by, or a distribution metric). Compared to the generic
+   * statement in AnalyticsDatabaseService this adds:
+   *
+   *   - distribution-aware aggregation expressions (see
+   *     getDistributionAwareAggregationExpression), and
+   *   - grouping by individual attribute keys via
+   *     `attributes['<key>']` (aliased and re-projected as a compact
+   *     `attributes` map), which GroupBy<Metric> cannot express since
+   *     it only references whole model columns.
+   *
+   * Model-column group-bys (including the legacy whole-map
+   * `groupBy: { attributes: true }` used by the infra pages) are
+   * carried through unchanged, appended as raw identifiers exactly
+   * like the percentile path does.
+   */
+  private buildScalarAggregateStatement(
+    aggregateBy: AggregateBy<Metric>,
+    attributeGroupKeys: Array<string>,
+  ): { statement: Statement; columns: Array<string> } {
+    if (!this.database) {
+      this.useDefaultDatabase();
+    }
+
+    const databaseName: string = this.database.getDatasourceOptions().database!;
+
+    const aggregationColumn: string =
+      aggregateBy.aggregateColumnName.toString();
+    const aggregationTimestampColumn: string =
+      aggregateBy.aggregationTimestampColumnName.toString();
+    const aggregationInterval: string = AggregateUtil.getAggregationInterval({
+      startDate: aggregateBy.startTimestamp!,
+      endDate: aggregateBy.endTimestamp!,
+    }).toLowerCase();
+
+    const groupByKeys: Array<string> = [];
+    if (aggregateBy.groupBy) {
+      for (const key of Object.keys(aggregateBy.groupBy)) {
+        if (!this.model.getTableColumn(key)) {
+          continue;
+        }
+        /*
+         * Key-scoped grouping supersedes a whole-map `attributes`
+         * group-by: keeping both would fragment the series again AND
+         * collide with the `map(...) AS attributes` projection below.
+         */
+        if (key === "attributes" && attributeGroupKeys.length > 0) {
+          continue;
+        }
+        groupByKeys.push(key);
+      }
+    }
+
+    const whereStatement: Statement = this.statementGenerator.toWhereStatement(
+      aggregateBy.query,
+    );
+    const sortStatement: Statement = this.statementGenerator.toSortStatement(
+      aggregateBy.sort!,
+    );
+
+    const aggregationExpression: string =
+      this.getDistributionAwareAggregationExpression(
+        aggregateBy.aggregationType,
+        aggregationColumn,
+      );
+
+    const statement: Statement = SQL``;
+
+    statement.append(
+      `SELECT ${aggregationExpression} as ${aggregationColumn}, date_trunc('${aggregationInterval}', toStartOfInterval(${aggregationTimestampColumn}, INTERVAL 1 ${aggregationInterval})) as ${aggregationTimestampColumn}`,
+    );
+    for (const key of groupByKeys) {
+      statement.append(`, ${key}`);
+    }
+    this.appendAttributeGroupMapColumn(statement, attributeGroupKeys);
+
+    if (attributeGroupKeys.length > 0) {
+      /*
+       * Subquery form: extract the selected keys into `__attr_grp_<i>`
+       * one level down so the outer `map(...) AS attributes` alias can
+       * never shadow (or cycle with) the real `attributes` column the
+       * extraction and WHERE filters read. Mirrors the percentile path.
+       */
+      const innerColumns: Array<string> = [
+        aggregationTimestampColumn,
+        "value",
+        "sum",
+        "count",
+        "min",
+        "max",
+      ];
+      for (const key of groupByKeys) {
+        if (!innerColumns.includes(key)) {
+          innerColumns.push(key);
+        }
+      }
+
+      statement.append(SQL` FROM (`);
+      statement.append(`SELECT ${innerColumns.join(", ")}`);
+      this.appendAttributeGroupExtractionColumns(statement, attributeGroupKeys);
+      statement.append(
+        ` FROM ${databaseName}.${this.model.tableName} WHERE TRUE `,
+      );
+      statement.append(whereStatement);
+      statement.append(this.getRetentionReadFilter());
+      statement.append(SQL`) `);
+    } else {
+      statement.append(
+        ` FROM ${databaseName}.${this.model.tableName} WHERE TRUE `,
+      );
+      statement.append(whereStatement);
+      statement.append(this.getRetentionReadFilter());
+    }
+
+    statement.append(SQL` GROUP BY `).append(`${aggregationTimestampColumn}`);
+    for (const key of groupByKeys) {
+      statement.append(`, ${key}`);
+    }
+    attributeGroupKeys.forEach((_key: string, index: number) => {
+      statement.append(`, __attr_grp_${index}`);
+    });
+
+    statement.append(SQL` ORDER BY `).append(sortStatement);
+
+    statement.append(
+      SQL` LIMIT ${{
+        value: Number(aggregateBy.limit),
+        type: TableColumnType.Number,
+      }}`,
+    );
+    statement.append(
+      SQL` OFFSET ${{
+        value: Number(aggregateBy.skip),
+        type: TableColumnType.Number,
+      }} `,
+    );
+
+    statement.append(
+      getQuerySettings({
+        additionalSettings: {
+          optimize_aggregation_in_order: 1,
+          optimize_move_to_prewhere: 1,
+          max_threads: 4,
+        },
+      }),
+    );
+
+    const columns: Array<string> = [
+      aggregationColumn,
+      aggregationTimestampColumn,
+      ...groupByKeys,
+      ...(attributeGroupKeys.length > 0 ? ["attributes"] : []),
+    ];
+
+    logger.debug(`${this.model.tableName} Scalar Aggregate Statement`, {
       tableName: this.model.tableName,
     } as LogAttributes);
     logger.debug(statement, {
@@ -564,6 +1133,13 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
   private canRouteAggregateToMutableMetricTable(
     aggregateBy: AggregateBy<Metric>,
   ): boolean {
+    if (
+      aggregateBy.groupByAttributeKeys &&
+      aggregateBy.groupByAttributeKeys.length > 0
+    ) {
+      return false;
+    }
+
     const supportedColumns: Set<string> = new Set<string>([
       "projectId",
       "name",
@@ -684,6 +1260,13 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
     }
 
     if (aggregateBy.groupBy && Object.keys(aggregateBy.groupBy).length > 0) {
+      return null;
+    }
+
+    if (
+      aggregateBy.groupByAttributeKeys &&
+      aggregateBy.groupByAttributeKeys.length > 0
+    ) {
       return null;
     }
 
@@ -839,6 +1422,13 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
     }
 
     if (aggregateBy.groupBy && Object.keys(aggregateBy.groupBy).length > 0) {
+      return null;
+    }
+
+    if (
+      aggregateBy.groupByAttributeKeys &&
+      aggregateBy.groupByAttributeKeys.length > 0
+    ) {
       return null;
     }
 

--- a/Common/Tests/Server/Services/MetricServiceAggregate.test.ts
+++ b/Common/Tests/Server/Services/MetricServiceAggregate.test.ts
@@ -1,0 +1,194 @@
+import "../TestingUtils/Init";
+import { MetricService } from "../../../Server/Services/MetricService";
+import Metric from "../../../Models/AnalyticsModels/Metric";
+import AggregateBy from "../../../Server/Types/AnalyticsDatabase/AggregateBy";
+import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+
+describe("MetricService aggregate statement generation", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const startDate: Date = new Date("2026-07-09T19:08:00.000Z");
+  const endDate: Date = new Date("2026-07-09T19:13:00.000Z");
+
+  let service: MetricService;
+
+  beforeEach(() => {
+    service = new MetricService();
+  });
+
+  type BuildAggregateByFunction = (
+    overrides?: Partial<AggregateBy<Metric>>,
+  ) => AggregateBy<Metric>;
+
+  const buildAggregateBy: BuildAggregateByFunction = (
+    overrides?: Partial<AggregateBy<Metric>>,
+  ): AggregateBy<Metric> => {
+    return {
+      query: {
+        projectId: projectId,
+        name: "http.client.request.duration",
+        time: new InBetween(startDate, endDate),
+      } as AggregateBy<Metric>["query"],
+      aggregationType: AggregationType.Avg,
+      aggregateColumnName: "value",
+      aggregationTimestampColumnName: "time",
+      startTimestamp: startDate,
+      endTimestamp: endDate,
+      limit: 10000,
+      skip: 0,
+      sort: { time: SortOrder.Ascending } as AggregateBy<Metric>["sort"],
+      props: { isRoot: true },
+      ...overrides,
+    };
+  };
+
+  type GetQueryFunction = (aggregateBy: AggregateBy<Metric>) => string;
+
+  const getQuery: GetQueryFunction = (
+    aggregateBy: AggregateBy<Metric>,
+  ): string => {
+    const result: { statement: Statement; columns: Array<string> } =
+      service.toAggregateStatement(aggregateBy);
+    return result.statement.query;
+  };
+
+  describe("scalar aggregations", () => {
+    it("routes plain Avg (no filters, no group-by, no distribution hint) to the minute MV", () => {
+      const query: string = getQuery(buildAggregateBy());
+      expect(query).toContain("MetricItemAggMV1m");
+    });
+
+    it("skips the MVs and uses count-weighted expressions when the metric is a distribution (histogram) metric", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy();
+      (
+        service as unknown as {
+          pointTypeHintByAggregate: WeakMap<AggregateBy<Metric>, string | null>;
+        }
+      ).pointTypeHintByAggregate.set(aggregateBy, "Histogram");
+
+      const query: string = getQuery(aggregateBy);
+
+      expect(query).not.toContain("MetricItemAggMV1m");
+      /*
+       * Avg must be count-weighted (sum of observation totals divided
+       * by sum of observation counts) — NOT avg(value), which for
+       * histogram rows averages per-export-interval sums.
+       */
+      expect(query).toContain("sum(multiIf(isNotNull(count)");
+      expect(query).toContain("toFloat64(count)");
+      expect(query).not.toContain("avg(value)");
+    });
+
+    it("uses count-weighted expressions on the base table when an attribute filter blocks the MVs", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        query: {
+          projectId: projectId,
+          name: "http.client.request.duration",
+          time: new InBetween(startDate, endDate),
+          attributes: { "oneuptime.service.name": "starship-web" },
+        } as unknown as AggregateBy<Metric>["query"],
+      });
+
+      const query: string = getQuery(aggregateBy);
+
+      expect(query).not.toContain("MetricItemAggMV1m");
+      expect(query).toContain("sum(multiIf(isNotNull(count)");
+    });
+
+    it("groups by individual attribute keys, not the whole attributes map", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        groupByAttributeKeys: ["oneuptime.service.name"],
+      });
+
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(aggregateBy);
+      const query: string = result.statement.query;
+
+      // Key extraction is parameter-bound and aliased...
+      expect(query).toMatch(/attributes\[\{p\d+:String\}\] AS __attr_grp_0/);
+      // ...regrouped rows re-project the selected keys as a compact map...
+      expect(query).toMatch(
+        /map\(\{p\d+:String\}, __attr_grp_0\) AS attributes/,
+      );
+      // ...grouping happens on the extracted key, never the Map column.
+      expect(query).toContain("GROUP BY time, __attr_grp_0");
+      expect(query).not.toContain("GROUP BY time, attributes");
+
+      // The selected key reaches the query only as a bound parameter.
+      const parameterValues: Array<unknown> = Object.values(
+        result.statement.query_params,
+      );
+      expect(
+        parameterValues.filter((value: unknown) => {
+          return value === "oneuptime.service.name";
+        }),
+      ).toHaveLength(2); // extraction + map key
+
+      expect(result.columns).toContain("attributes");
+    });
+
+    it("drops a legacy whole-map attributes group-by when key-scoped grouping is requested", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        groupBy: { attributes: true } as AggregateBy<Metric>["groupBy"],
+        groupByAttributeKeys: ["oneuptime.service.name"],
+      });
+
+      const query: string = getQuery(aggregateBy);
+
+      expect(query).toContain("GROUP BY time, __attr_grp_0");
+      expect(query).not.toContain("GROUP BY time, attributes");
+    });
+
+    it("rejects more than 10 group-by attribute keys", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        groupByAttributeKeys: Array.from(
+          { length: 11 },
+          (_: unknown, i: number) => {
+            return `key.${i}`;
+          },
+        ),
+      });
+
+      expect(() => {
+        return service.toAggregateStatement(aggregateBy);
+      }).toThrow(BadDataException);
+    });
+  });
+
+  describe("percentile aggregations", () => {
+    it("keeps the histogram bucket fanout and pools by selected attribute keys", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        aggregationType: AggregationType.P90,
+        groupByAttributeKeys: ["oneuptime.service.name"],
+      });
+
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(aggregateBy);
+      const query: string = result.statement.query;
+
+      expect(query).toContain("quantileExactWeighted(0.9)");
+      expect(query).toMatch(/attributes\[\{p\d+:String\}\] AS __attr_grp_0/);
+      expect(query).toMatch(
+        /map\(\{p\d+:String\}, __attr_grp_0\) AS attributes/,
+      );
+      expect(query).toContain("GROUP BY time, __attr_grp_0");
+      expect(result.columns).toContain("attributes");
+    });
+
+    it("does not group when no attribute keys are selected (regression: whole-map fragmentation)", () => {
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        aggregationType: AggregationType.P90,
+      });
+
+      const query: string = getQuery(aggregateBy);
+
+      expect(query).toContain("quantileExactWeighted(0.9)");
+      expect(query).not.toContain("__attr_grp_0");
+      expect(query).toContain("GROUP BY time");
+    });
+  });
+});

--- a/Common/Types/BaseDatabase/AggregateBy.ts
+++ b/Common/Types/BaseDatabase/AggregateBy.ts
@@ -16,4 +16,16 @@ export default interface AggregateBy<TBaseModel extends GenericObject> {
   skip: number;
   sort?: Sort<TBaseModel> | undefined;
   groupBy?: GroupBy<TBaseModel> | undefined;
+  /**
+   * OpenTelemetry attribute keys (e.g. "service.name") to group the
+   * aggregation by. Grouping happens on the individual map entries —
+   * `attributes['service.name']` — so all rows sharing the selected
+   * key values are pooled into one series per bucket. This is distinct
+   * from `groupBy: { attributes: true }`, which groups by the ENTIRE
+   * attribute map and therefore fragments the result into one series
+   * per unique attribute combination. Only supported by models with an
+   * `attributes` map column (currently Metric); result rows carry an
+   * `attributes` object containing exactly these keys.
+   */
+  groupByAttributeKeys?: Array<string> | undefined;
 }

--- a/Common/Types/Dashboard/DashboardTemplates.ts
+++ b/Common/Types/Dashboard/DashboardTemplates.ts
@@ -192,7 +192,15 @@ function buildMetricQueryConfig(config: MetricConfig): Record<string, unknown> {
         metricName: config.metricName,
         aggegationType: config.aggregationType,
       },
-      groupBy: config.groupByAttributeKeys ? { attributes: true } : undefined,
+      /*
+       * groupByAttributeKeys alone drives per-series grouping — the
+       * fetch layer compiles it to `GROUP BY attributes['<key>']`.
+       * Baking a whole-map `groupBy: { attributes: true }` alongside
+       * it (the old approach) fragmented results into one series per
+       * unique attribute combination; older stored configs that still
+       * carry it are stripped at fetch time (MetricUtil.fetchResults).
+       */
+      groupBy: undefined,
       groupByAttributeKeys: config.groupByAttributeKeys,
     },
     transformAsRate: config.transformAsRate,


### PR DESCRIPTION
### Title of this pull request?

fix: histogram-aware metric aggregation and key-scoped attribute group-by

### Small Description?

Fixes two customer-reported bugs (Aptean) that share a root-cause family:

**1. Metric monitors on histogram metrics false-alert with sum-scale values.**
At ingest, histogram datapoints store the interval **sum** of observations in the `value` column (`value = asInt ?? asDouble ?? sum`). Every non-percentile aggregation over `value` therefore returned avg/min/max **of sums**: "Average of `http.client.request.duration` > 5 sec" evaluated ~110 s (0.586 s true mean × ~188 requests/export interval) and fired a false High alert whose own chart showed 586 ms.
Fix: non-percentile aggregations over `value` are now count-weighted per datapoint (`Avg = sum(sum)/sum(count)`, `Count = sum(count)`, `Min/Max` prefer the datapoint min/max columns, falling back to the datapoint mean). Distribution metrics (Histogram/ExponentialHistogram/Summary — resolved via a cached, time-bounded, stampede-coalesced `metricPointType` lookup) skip the 1-minute/per-host MVs, whose merge states collapse `value` and cannot produce a correct histogram mean. Scalar (Sum/Gauge) metrics keep their existing semantics and MV fast paths.

**2. "Group By \<attribute\>" charts render flat straight lines.**
The UI compiled attribute group-by as `groupBy: { attributes: true }` — the **entire** attributes Map — so SQL grouped by every unique attribute combination. A grouped P90 of a histogram collapsed each tiny per-combination series onto a fixed bucket midpoint (~586 ms) and the chart merged them into misleading flat lines.
Fix: `AggregateBy` gains `groupByAttributeKeys`; MetricService compiles it to `GROUP BY attributes['<key>']` (keys parameter-bound, capped at 10, re-projected as a compact `attributes` map) in both the percentile and scalar paths. The UI sends the selected keys and strips the legacy whole-map entry from stored configs; dashboard templates no longer bake it in. Intentional whole-map group-bys (infra pages, probe charts) are untouched.

**3. Grouped metric monitors bypassed SQL entirely** — raw rows aggregated in JS: wrong for histograms, percentiles silently computed as Avg, truncated at 10k rows sorted desc. The generic metric monitor now uses the SQL path with `groupByAttributeKeys`; the JS aggregator retained by the infra monitors (gauge metrics) gains real nearest-rank percentile support.

Notes for reviewers:
- Grouped monitors with rolling windows > 3h now bucket per the standard window→interval mapping (hour/day) instead of always per-minute, matching the ungrouped path.
- Known follow-ups (deliberately out of scope): migrate the 9 infra-monitor call sites off the JS aggregator; AI-toolbox metric aggregations build queries without `projectId` so the MV skip doesn't engage there; MV schemas could store observation-count states to regain the fast path for histograms.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate? (`Common/Tests/Server/Services/MetricServiceAggregate.test.ts` — 8 statement-generation tests; existing 92 metric/monitor/statement tests pass)

### Related Issue?

Customer report (Aptean): P90 chart of `http.client.request.duration` turns into straight lines when grouped by `oneuptime.service.name`; monitor "StarShip Blue response time" false-alerted with root cause "All values ... 110.29, 110.07, 109.83, 109.61, 109.4 sec".

### Screenshots (if appropriate):

N/A