### PR TITLE
fix(llm): keep max_tokens default; opt into max_completion_tokens via additionalParams

### DIFF
--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -220,15 +220,29 @@ export default class LLMService {
     };
 
     if (request.maxTokens) {
-      data["max_completion_tokens"] = request.maxTokens;
+      data["max_tokens"] = request.maxTokens;
     }
 
     if (request.tools && request.tools.length > 0) {
       data["tools"] = this.toOpenAITools(request.tools);
     }
 
+    // Provider-configured overrides are applied last so they win over defaults.
     if (request.additionalParams) {
       Object.assign(data, request.additionalParams);
+    }
+
+    // OpenAI's newer model families (gpt-5, o1, o3, ...) reject the legacy
+    // `max_tokens` parameter and require `max_completion_tokens` instead; the
+    // two are mutually exclusive. When a provider opts into
+    // `max_completion_tokens` via additionalParams, drop the default
+    // `max_tokens` so the request is accepted. Legacy OpenAI-compatible
+    // backends (Ollama, vLLM, LocalAI, ...) keep receiving `max_tokens`.
+    if (
+      data["max_completion_tokens"] !== undefined &&
+      data["max_tokens"] !== undefined
+    ) {
+      delete data["max_tokens"];
     }
 
     return data;

--- a/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
@@ -384,3 +384,47 @@ describe("LLMService — prompt caching", () => {
     expect(response.usage!.totalTokens).toBe(55);
   });
 });
+
+describe("LLMService — additionalParams (per-provider overrides)", () => {
+  test("merges provider additionalParams into the request body", async () => {
+    const spy: PostSpy = mockPostResponse({
+      choices: [{ message: { content: "OK" } }],
+    });
+
+    await LLMService.getCompletion({
+      llmProviderConfig: { llmType: LlmType.OpenAI, apiKey: "test-key" },
+      messages: [{ role: "user", content: "hi" }],
+      maxTokens: 1024,
+      additionalParams: { temperature: 0.2, top_p: 0.9 },
+    });
+
+    const requestBody: JSONObject = (
+      spy.mock.calls[0]![0] as { data: JSONObject }
+    ).data;
+    // additionalParams override defaults and are added to the body...
+    expect(requestBody["temperature"]).toBe(0.2);
+    expect(requestBody["top_p"]).toBe(0.9);
+    // ...while leaving the default max_tokens intact for legacy providers.
+    expect(requestBody["max_tokens"]).toBe(1024);
+  });
+
+  test("max_completion_tokens in additionalParams drops the legacy max_tokens", async () => {
+    const spy: PostSpy = mockPostResponse({
+      choices: [{ message: { content: "OK" } }],
+    });
+
+    await LLMService.getCompletion({
+      llmProviderConfig: { llmType: LlmType.OpenAI, apiKey: "test-key" },
+      messages: [{ role: "user", content: "hi" }],
+      maxTokens: 1024,
+      // gpt-5 / o1 / o3 reject max_tokens and require max_completion_tokens.
+      additionalParams: { max_completion_tokens: 2048 },
+    });
+
+    const requestBody: JSONObject = (
+      spy.mock.calls[0]![0] as { data: JSONObject }
+    ).data;
+    expect(requestBody["max_completion_tokens"]).toBe(2048);
+    expect(requestBody["max_tokens"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #2645, which added the `additionalParams` field (good feature) but also **unconditionally** renamed `max_tokens` → `max_completion_tokens` in the shared OpenAI request builder. That change:

1. **Broke the `Common` test suite** — `LLMServiceToolCalling.test.ts` asserts the request body contains `max_tokens`, and CI on #2645 was red because of it.
2. **Regressed every OpenAI-compatible backend** that only understands `max_tokens` — Ollama, vLLM, LocalAI, older OpenAI/Azure API versions — which OneUptime explicitly supports. `max_completion_tokens` is the newer OpenAI parameter and is not universally recognized; those backends would silently drop the token cap or reject the request.

## Fix

- Restore `max_tokens` as the default (legacy providers keep working, unchanged from before #2645).
- Rely on the `additionalParams` field that #2645 introduced to carry `max_completion_tokens` for gpt-5/o1/o3 — exactly what the UI presets already document (`{"max_completion_tokens": 2048}`).
- When a provider opts into `max_completion_tokens`, drop the mutually-exclusive `max_tokens` so gpt-5/o1/o3 requests are accepted.

No UI change needed — the existing presets are already correct under this behavior.

## Tests

- Unbreaks the existing `serializes tools and parses tool_calls` test.
- Adds two tests: `additionalParams` are merged into the request body, and `max_completion_tokens` in `additionalParams` drops the legacy `max_tokens`.
- `npx jest LLMServiceToolCalling.test.ts` → 13 passed. Prettier clean.