### PR TITLE
Network Devices: vendor health templates and recommended alert packs

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorCriteria.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorCriteria.tsx
@@ -5,6 +5,7 @@ import MonitorCriteria from "Common/Types/Monitor/MonitorCriteria";
 import MonitorCriteriaInstance from "Common/Types/Monitor/MonitorCriteriaInstance";
 import MonitorStep from "Common/Types/Monitor/MonitorStep";
 import MonitorType from "Common/Types/Monitor/MonitorType";
+import NetworkDeviceAlertPackUtil from "Common/Types/Monitor/SnmpMonitor/NetworkDeviceAlertPack";
 import FilterCondition from "Common/Types/Filter/FilterCondition";
 import Button, {
   ButtonSize,
@@ -381,7 +382,7 @@ const MonitorCriteriaElement: FunctionComponent<ComponentProps> = (
           }}
         </Droppable>
       </DragDropContext>
-      <div className="mt-4 -ml-3">
+      <div className="mt-4 -ml-3 flex">
         <Button
           title="Add Criteria"
           buttonSize={ButtonSize.Small}
@@ -401,6 +402,29 @@ const MonitorCriteriaElement: FunctionComponent<ComponentProps> = (
             );
           }}
         />
+        {props.monitorType === MonitorType.NetworkDevice ? (
+          <Button
+            title="Add Recommended Alerts"
+            buttonSize={ButtonSize.Small}
+            icon={IconProp.Star}
+            onClick={() => {
+              const newMonitorCriterias: Array<MonitorCriteriaInstance> = [
+                ...(monitorCriteria.data?.monitorCriteriaInstanceArray || []),
+                ...NetworkDeviceAlertPackUtil.buildCriteriaInstances(),
+              ];
+              props.onChange?.(
+                MonitorCriteria.fromJSON({
+                  _type: "MonitorCriteria",
+                  value: {
+                    monitorCriteriaInstanceArray: newMonitorCriterias,
+                  },
+                }),
+              );
+            }}
+          />
+        ) : (
+          <></>
+        )}
       </div>
       {showCantDeleteModal ? (
         <ConfirmModal

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/NetworkDeviceMonitor/NetworkDeviceMonitorStepForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/NetworkDeviceMonitor/NetworkDeviceMonitorStepForm.tsx
@@ -2,11 +2,25 @@ import React, { FunctionComponent, ReactElement } from "react";
 import MonitorStepNetworkDeviceMonitor from "Common/Types/Monitor/MonitorStepNetworkDeviceMonitor";
 import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import SnmpOid from "Common/Types/Monitor/SnmpMonitor/SnmpOid";
+import SnmpVendorTemplateUtil, {
+  SnmpVendorTemplate,
+} from "Common/Types/Monitor/SnmpMonitor/SnmpVendorTemplate";
 import EntityDropdown from "Common/UI/Components/EntityDropdown/EntityDropdown";
-import { DropdownValue } from "Common/UI/Components/Dropdown/Dropdown";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import Toggle from "Common/UI/Components/Toggle/Toggle";
 import SnmpOidEditor from "../SnmpMonitor/SnmpOidEditor";
+
+const vendorTemplateOptions: Array<DropdownOption> =
+  SnmpVendorTemplateUtil.getAll().map((template: SnmpVendorTemplate) => {
+    return {
+      label: template.label,
+      value: template.id,
+    };
+  });
 
 export interface ComponentProps {
   monitorStepNetworkDeviceMonitor: MonitorStepNetworkDeviceMonitor;
@@ -56,6 +70,31 @@ const NetworkDeviceMonitorStepForm: FunctionComponent<ComponentProps> = (
             props.onChange({
               ...props.monitorStepNetworkDeviceMonitor,
               monitorInterfaces: value,
+            });
+          }}
+        />
+      </div>
+
+      <div>
+        <FieldLabelElement
+          title="Vendor Health Template"
+          description="Apply a prebuilt set of CPU, memory, and temperature OIDs for your device's vendor. The OIDs are added below, where you can prune or extend them."
+          required={false}
+        />
+        <Dropdown
+          options={vendorTemplateOptions}
+          value={undefined}
+          placeholder="Apply a vendor template…"
+          onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+            if (!value) {
+              return;
+            }
+            props.onChange({
+              ...props.monitorStepNetworkDeviceMonitor,
+              oids: SnmpVendorTemplateUtil.mergeOids(
+                props.monitorStepNetworkDeviceMonitor.oids || [],
+                value.toString(),
+              ),
             });
           }}
         />

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -1,13 +1,15 @@
 import ProbeAuthorization from "../../Middleware/ProbeAuthorization";
 import { ProbeExpressRequest } from "../../Types/Request";
 import BadDataException from "Common/Types/Exception/BadDataException";
-import { JSONArray, JSONObject } from "Common/Types/JSON";
+import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
 import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
-import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import NetworkDeviceDiscoveryScan, {
+  DiscoveredNetworkDevice,
+} from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
 import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import QueryDeepPartialEntity from "Common/Types/Database/PartialEntity";
@@ -185,7 +187,8 @@ router.post(
         completed.statusMessage = req.body["statusMessage"] as string;
       }
       // Column is a JSON array of host suggestions, stored as-is.
-      completed.discoveredDevices = discoveredDevices as JSONArray;
+      completed.discoveredDevices =
+        discoveredDevices as unknown as Array<DiscoveredNetworkDevice>;
       if (typeof req.body["scannedHostCount"] === "number") {
         completed.scannedHostCount = req.body["scannedHostCount"] as number;
       }

--- a/Common/Types/Monitor/SnmpMonitor/NetworkDeviceAlertPack.ts
+++ b/Common/Types/Monitor/SnmpMonitor/NetworkDeviceAlertPack.ts
@@ -1,0 +1,116 @@
+import ObjectID from "../../ObjectID";
+import FilterCondition from "../../Filter/FilterCondition";
+import { CheckOn, CriteriaFilter, FilterType } from "../CriteriaFilter";
+import MonitorCriteriaInstance from "../MonitorCriteriaInstance";
+
+/*
+ * Prebuilt criteria for Network Device monitors — the alerts most operators
+ * want and would otherwise hand-build every time. Applying a pack appends
+ * these criteria instances to the monitor; the user still picks severities
+ * and on-call policies afterwards.
+ */
+export interface NetworkDeviceAlertPackItem {
+  name: string;
+  description: string;
+  filters: Array<CriteriaFilter>;
+  createIncidents: boolean;
+  createAlerts: boolean;
+}
+
+export interface NetworkDeviceAlertPackContext {
+  // Status to move the monitor to when a pack criteria matches (offline/degraded).
+  downMonitorStatusId?: ObjectID | undefined;
+}
+
+const PACK: Array<NetworkDeviceAlertPackItem> = [
+  {
+    name: "Device unreachable",
+    description:
+      "The device stopped answering SNMP — likely down or unreachable.",
+    filters: [
+      {
+        checkOn: CheckOn.SnmpIsOnline,
+        filterType: FilterType.False,
+        value: undefined,
+      },
+    ],
+    createIncidents: true,
+    createAlerts: false,
+  },
+  {
+    name: "Interface down",
+    description:
+      "An administratively-enabled interface went operationally down.",
+    filters: [
+      {
+        checkOn: CheckOn.SnmpInterfaceIsDown,
+        filterType: FilterType.True,
+        value: undefined,
+      },
+    ],
+    createIncidents: true,
+    createAlerts: false,
+  },
+  {
+    name: "Interface saturated",
+    description:
+      "An interface is running above 80% utilization — the link may need an upgrade.",
+    filters: [
+      {
+        checkOn: CheckOn.SnmpInterfaceUtilizationPercent,
+        filterType: FilterType.GreaterThan,
+        value: 80,
+      },
+    ],
+    createIncidents: false,
+    createAlerts: true,
+  },
+  {
+    name: "Interface errors",
+    description:
+      "An interface is logging errors — usually cabling, optics, or duplex problems.",
+    filters: [
+      {
+        checkOn: CheckOn.SnmpInterfaceErrorsPerSecond,
+        filterType: FilterType.GreaterThan,
+        value: 1,
+      },
+    ],
+    createIncidents: false,
+    createAlerts: true,
+  },
+];
+
+export default class NetworkDeviceAlertPackUtil {
+  public static getPackItems(): Array<NetworkDeviceAlertPackItem> {
+    return PACK;
+  }
+
+  /*
+   * Builds ready-to-append MonitorCriteriaInstances from the pack. Each is
+   * enabled and set to change monitor status; severities and on-call
+   * policies are left for the user to fill in.
+   */
+  public static buildCriteriaInstances(
+    context?: NetworkDeviceAlertPackContext,
+  ): Array<MonitorCriteriaInstance> {
+    return PACK.map((item: NetworkDeviceAlertPackItem) => {
+      const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+      instance.data = {
+        id: ObjectID.generate().toString(),
+        monitorStatusId: context?.downMonitorStatusId,
+        filterCondition: FilterCondition.All,
+        filters: item.filters,
+        incidents: [],
+        alerts: [],
+        createAlerts: item.createAlerts,
+        createIncidents: item.createIncidents,
+        changeMonitorStatus: item.createIncidents,
+        isEnabled: true,
+        name: item.name,
+        description: item.description,
+      };
+      return instance;
+    });
+  }
+}

--- a/Common/Types/Monitor/SnmpMonitor/SnmpVendorTemplate.ts
+++ b/Common/Types/Monitor/SnmpMonitor/SnmpVendorTemplate.ts
@@ -1,0 +1,173 @@
+import SnmpOid from "./SnmpOid";
+
+/*
+ * Prebuilt SNMP health-OID profiles for common network vendors. Applying a
+ * template appends its OIDs (CPU, memory, temperature) to a Network Device
+ * monitor so those values are collected and alertable without the user
+ * having to look up MIBs. OIDs are the ".0" / indexed scalar instances that
+ * these platforms actually expose; users can prune or extend the list after
+ * applying.
+ */
+export interface SnmpVendorTemplate {
+  id: string;
+  label: string;
+  description: string;
+  oids: Array<SnmpOid>;
+}
+
+const CISCO: SnmpVendorTemplate = {
+  id: "cisco-ios",
+  label: "Cisco IOS / IOS-XE",
+  description:
+    "CPU (5-min average), memory pool used/free, and chassis temperature for Cisco IOS and IOS-XE devices.",
+  oids: [
+    {
+      oid: "1.3.6.1.4.1.9.9.109.1.1.1.1.8.1",
+      name: "CPU 5-min %",
+      description: "cpmCPUTotal5minRev — 5-minute CPU utilization.",
+    },
+    {
+      oid: "1.3.6.1.4.1.9.9.48.1.1.1.5.1",
+      name: "Memory Used (bytes)",
+      description: "ciscoMemoryPoolUsed — processor pool bytes in use.",
+    },
+    {
+      oid: "1.3.6.1.4.1.9.9.48.1.1.1.6.1",
+      name: "Memory Free (bytes)",
+      description: "ciscoMemoryPoolFree — processor pool bytes free.",
+    },
+    {
+      oid: "1.3.6.1.4.1.9.9.13.1.3.1.3.1",
+      name: "Temperature (C)",
+      description: "ciscoEnvMonTemperatureValue — first temperature sensor.",
+    },
+  ],
+};
+
+const MIKROTIK: SnmpVendorTemplate = {
+  id: "mikrotik-routeros",
+  label: "MikroTik RouterOS",
+  description:
+    "CPU load, CPU temperature, and voltage from the MikroTik health MIB, plus standard Host Resources CPU.",
+  oids: [
+    {
+      oid: "1.3.6.1.2.1.25.3.3.1.2.1",
+      name: "CPU Load %",
+      description: "hrProcessorLoad — first processor.",
+    },
+    {
+      oid: "1.3.6.1.4.1.14988.1.1.3.10.0",
+      name: "CPU Temperature (C)",
+      description: "mtxrHlProcessorTemperature.",
+    },
+    {
+      oid: "1.3.6.1.4.1.14988.1.1.3.8.0",
+      name: "Voltage (dV)",
+      description: "mtxrHlVoltage — decivolts.",
+    },
+  ],
+};
+
+const UBIQUITI: SnmpVendorTemplate = {
+  id: "ubiquiti-edgeos",
+  label: "Ubiquiti EdgeOS / UniFi",
+  description:
+    "CPU load and memory usage via the standard Host Resources MIB, which Ubiquiti EdgeOS and UniFi expose.",
+  oids: [
+    {
+      oid: "1.3.6.1.2.1.25.3.3.1.2.1",
+      name: "CPU Load %",
+      description: "hrProcessorLoad — first processor.",
+    },
+    {
+      oid: "1.3.6.1.4.1.2021.4.5.0",
+      name: "Total RAM (KB)",
+      description: "memTotalReal — UCD-SNMP-MIB.",
+    },
+    {
+      oid: "1.3.6.1.4.1.2021.4.6.0",
+      name: "Available RAM (KB)",
+      description: "memAvailReal — UCD-SNMP-MIB.",
+    },
+  ],
+};
+
+const HOST_RESOURCES: SnmpVendorTemplate = {
+  id: "host-resources-mib",
+  label: "Generic (Host Resources MIB)",
+  description:
+    "Vendor-neutral CPU load and memory from HOST-RESOURCES-MIB — works on most Linux/BSD-based network appliances (pfSense, OPNsense, and many others).",
+  oids: [
+    {
+      oid: "1.3.6.1.2.1.25.3.3.1.2.1",
+      name: "CPU Load %",
+      description: "hrProcessorLoad — first processor.",
+    },
+    {
+      oid: "1.3.6.1.4.1.2021.4.5.0",
+      name: "Total RAM (KB)",
+      description: "memTotalReal — UCD-SNMP-MIB.",
+    },
+    {
+      oid: "1.3.6.1.4.1.2021.4.6.0",
+      name: "Available RAM (KB)",
+      description: "memAvailReal — UCD-SNMP-MIB.",
+    },
+    {
+      oid: "1.3.6.1.4.1.2021.10.1.3.1",
+      name: "Load Average (1 min)",
+      description: "laLoad.1 — UCD-SNMP-MIB.",
+    },
+  ],
+};
+
+export const SnmpVendorTemplates: Array<SnmpVendorTemplate> = [
+  HOST_RESOURCES,
+  CISCO,
+  MIKROTIK,
+  UBIQUITI,
+];
+
+export default class SnmpVendorTemplateUtil {
+  public static getAll(): Array<SnmpVendorTemplate> {
+    return SnmpVendorTemplates;
+  }
+
+  public static getById(id: string): SnmpVendorTemplate | undefined {
+    return SnmpVendorTemplates.find((template: SnmpVendorTemplate) => {
+      return template.id === id;
+    });
+  }
+
+  /*
+   * Merges a template's OIDs into an existing list, skipping any OID already
+   * present so applying a template twice (or applying two overlapping ones)
+   * never duplicates rows.
+   */
+  public static mergeOids(
+    existing: Array<SnmpOid>,
+    templateId: string,
+  ): Array<SnmpOid> {
+    const template: SnmpVendorTemplate | undefined =
+      SnmpVendorTemplateUtil.getById(templateId);
+
+    if (!template) {
+      return existing;
+    }
+
+    const seen: Set<string> = new Set(
+      existing.map((oid: SnmpOid) => {
+        return oid.oid;
+      }),
+    );
+
+    const merged: Array<SnmpOid> = [...existing];
+    for (const oid of template.oids) {
+      if (!seen.has(oid.oid)) {
+        merged.push(oid);
+        seen.add(oid.oid);
+      }
+    }
+    return merged;
+  }
+}


### PR DESCRIPTION
## What this does

Final follow-up to the Network Devices work. Two clicks-not-MIBs conveniences.

### Vendor health templates
A catalog (`SnmpVendorTemplate`) of prebuilt CPU / memory / temperature OID sets for **Cisco IOS/IOS-XE, MikroTik RouterOS, Ubiquiti EdgeOS/UniFi, and a generic Host Resources MIB** profile (pfSense/OPNsense/most Linux appliances). A **Vendor Health Template** dropdown on the Network Device monitor form appends the chosen vendor's OIDs — deduped by OID, so applying twice or overlapping templates never duplicates rows. Users prune/extend from the existing OID editor.

### Recommended alert packs
An **Add Recommended Alerts** button on Network Device criteria appends the four alerts operators build by hand every time:
- **Device unreachable** → incident
- **Interface down** (admin-up, oper-down) → incident
- **Interface utilization > 80%** → alert
- **Interface errors > 1/s** → alert

Each lands as a normal, editable criteria instance; severities and on-call policies are left for the user.

### Also
Fixes a `discoveredDevices` type mismatch in the discovery-scan ingest endpoint (`JSONArray` vs the model's `DiscoveredNetworkDevice[]`) that a background-agent race let slip into the PR #2649 merge — App now typechecks clean again.

## Verification
- `tsc --noEmit` clean on Common and App; ESLint clean.
- Catalog smoke test: 4 vendor templates; OID merge is idempotent (Cisco's 4 OIDs onto 1 existing → 5, re-apply → 5); alert pack builds 4 criteria with correct filters.

## Scope note
Templates append the vendor OIDs as generic SNMP OID reads — their values are collected and criteria-testable (SNMP OID value). Mapping specific template OIDs onto typed CPU%/memory%/temperature metric series (for pre-labeled charts) is a natural follow-up but not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)