### PR TITLE
AIAgent: sync pull-request outcomes from GitHub — G11 baseline (stacked on #2659)

### DIFF
--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -131,6 +131,7 @@ import "./Jobs/Probe/UpdateConnectionStatus";
 import "./Jobs/AIAgent/SendOwnerAddedNotification";
 import "./Jobs/AIAgent/UpdateConnectionStatus";
 import "./Jobs/AIAgent/TimeoutStuckTasks";
+import "./Jobs/AIAgent/SyncPullRequestStates";
 import "./Jobs/AIChat/TimeoutStuckRuns";
 import "./Jobs/AIChat/ProcessQueuedInvestigations";
 

--- a/App/FeatureSet/Workers/Jobs/AIAgent/SyncPullRequestStates.ts
+++ b/App/FeatureSet/Workers/Jobs/AIAgent/SyncPullRequestStates.ts
@@ -1,0 +1,151 @@
+import RunCron from "../../Utils/Cron";
+import { EVERY_THIRTY_MINUTES } from "Common/Utils/CronTime";
+import PullRequestState from "Common/Types/CodeRepository/PullRequestState";
+import AIAgentTaskPullRequest from "Common/Models/DatabaseModels/AIAgentTaskPullRequest";
+import AIAgentTaskPullRequestService from "Common/Server/Services/AIAgentTaskPullRequestService";
+import GitHubUtil, {
+  GitHubInstallationNotFoundError,
+  GitHubInstallationToken,
+} from "Common/Server/Utils/CodeRepository/GitHub/GitHub";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import logger from "Common/Server/Utils/Logger";
+
+/**
+ * Syncs the state of AI-agent-created pull requests from GitHub
+ * (Open -> Merged / Closed).
+ *
+ * This is the outcome instrumentation for the AI fix path: the merged /
+ * closed-unmerged ratio of agent PRs is the precision baseline that gates
+ * any future fix automation (roadmap gate G11). Without this job the
+ * pullRequestState column stays "Open" forever and per-project fix
+ * accuracy is unknowable.
+ */
+
+RunCron(
+  "AIAgent:SyncPullRequestStates",
+  {
+    schedule: EVERY_THIRTY_MINUTES,
+    runOnStartup: false,
+  },
+  async () => {
+    const openPullRequests: Array<AIAgentTaskPullRequest> =
+      await AIAgentTaskPullRequestService.findBy({
+        query: {
+          pullRequestState: PullRequestState.Open,
+        },
+        select: {
+          _id: true,
+          pullRequestNumber: true,
+          repoOrganizationName: true,
+          repoName: true,
+          codeRepository: {
+            _id: true,
+            organizationName: true,
+            repositoryName: true,
+            gitHubAppInstallationId: true,
+          },
+        },
+        skip: 0,
+        limit: LIMIT_MAX,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    if (openPullRequests.length === 0) {
+      return;
+    }
+
+    logger.debug(
+      `Syncing state for ${openPullRequests.length} open AI agent pull request(s)`,
+      { service: "workers" },
+    );
+
+    // One installation token per installation id, reused across its PRs.
+    const tokenByInstallationId: Map<string, GitHubInstallationToken> =
+      new Map();
+    // Installations that 404ed (app uninstalled) — skip their PRs this run.
+    const deadInstallationIds: Set<string> = new Set();
+
+    for (const pullRequest of openPullRequests) {
+      const installationId: string | undefined =
+        pullRequest.codeRepository?.gitHubAppInstallationId;
+      const organizationName: string | undefined =
+        pullRequest.repoOrganizationName ||
+        pullRequest.codeRepository?.organizationName;
+      const repositoryName: string | undefined =
+        pullRequest.repoName || pullRequest.codeRepository?.repositoryName;
+
+      if (
+        !installationId ||
+        !organizationName ||
+        !repositoryName ||
+        !pullRequest.pullRequestNumber
+      ) {
+        continue;
+      }
+
+      if (deadInstallationIds.has(installationId)) {
+        continue;
+      }
+
+      try {
+        let token: GitHubInstallationToken | undefined =
+          tokenByInstallationId.get(installationId);
+
+        if (!token) {
+          token = await GitHubUtil.getInstallationAccessToken(installationId, {
+            permissions: {
+              pull_requests: "read",
+              metadata: "read",
+            },
+          });
+          tokenByInstallationId.set(installationId, token);
+        }
+
+        const currentState: PullRequestState =
+          await GitHubUtil.getPullRequestStateWithToken({
+            token: token.token,
+            organizationName,
+            repositoryName,
+            pullRequestNumber: pullRequest.pullRequestNumber,
+          });
+
+        if (currentState === PullRequestState.Open) {
+          continue;
+        }
+
+        await AIAgentTaskPullRequestService.updateOneById({
+          id: pullRequest.id!,
+          data: {
+            pullRequestState: currentState,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+        logger.info(
+          `AI agent PR ${organizationName}/${repositoryName}#${pullRequest.pullRequestNumber} is now ${currentState}`,
+          { service: "workers" },
+        );
+      } catch (error) {
+        if (error instanceof GitHubInstallationNotFoundError) {
+          deadInstallationIds.add(installationId);
+          logger.warn(
+            `GitHub App installation ${installationId} not found while syncing AI agent PRs — skipping its pull requests`,
+            { service: "workers" },
+          );
+          continue;
+        }
+
+        // One unreachable PR must not stop the sweep.
+        logger.error(
+          `Failed to sync state for AI agent pull request ${pullRequest.id?.toString()}:`,
+          { service: "workers" },
+        );
+        logger.error(error, { service: "workers" });
+      }
+    }
+  },
+);

--- a/Common/Server/Utils/CodeRepository/GitHub/GitHub.ts
+++ b/Common/Server/Utils/CodeRepository/GitHub/GitHub.ts
@@ -421,6 +421,80 @@ export default class GitHubUtil extends HostedCodeRepository {
     };
   }
 
+  /*
+   * Maps GitHub's pull-request JSON to our PullRequestState. GitHub reports
+   * merged PRs as state "closed" with merged_at set — merged must be checked
+   * first or every merge counts as a plain close.
+   */
+  public static mapGitHubPullRequestToState(
+    pullRequest: JSONObject,
+  ): PullRequestState {
+    if (pullRequest["merged_at"] || pullRequest["merged"] === true) {
+      return PullRequestState.Merged;
+    }
+
+    if (pullRequest["state"] === "closed") {
+      return PullRequestState.Closed;
+    }
+
+    return PullRequestState.Open;
+  }
+
+  // Fetches the current state of one pull request via the GitHub App installation.
+  @CaptureSpan()
+  public static async getPullRequestState(data: {
+    installationId: string;
+    organizationName: string;
+    repositoryName: string;
+    pullRequestNumber: number;
+  }): Promise<PullRequestState> {
+    const tokenData: GitHubInstallationToken =
+      await GitHubUtil.getInstallationAccessToken(data.installationId, {
+        permissions: {
+          pull_requests: "read",
+          metadata: "read",
+        },
+      });
+
+    return GitHubUtil.getPullRequestStateWithToken({
+      token: tokenData.token,
+      organizationName: data.organizationName,
+      repositoryName: data.repositoryName,
+      pullRequestNumber: data.pullRequestNumber,
+    });
+  }
+
+  /*
+   * Same as getPullRequestState but with a pre-minted installation token, so
+   * callers syncing many PRs in one repository can reuse a single token.
+   */
+  @CaptureSpan()
+  public static async getPullRequestStateWithToken(data: {
+    token: string;
+    organizationName: string;
+    repositoryName: string;
+    pullRequestNumber: number;
+  }): Promise<PullRequestState> {
+    const url: URL = URL.fromString(
+      `https://api.github.com/repos/${data.organizationName}/${data.repositoryName}/pulls/${data.pullRequestNumber}`,
+    );
+
+    const result: HTTPErrorResponse | HTTPResponse<JSONObject> = await API.get({
+      url: url,
+      headers: {
+        Authorization: `Bearer ${data.token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (result instanceof HTTPErrorResponse) {
+      throw result;
+    }
+
+    return GitHubUtil.mapGitHubPullRequestToState(result.data);
+  }
+
   /**
    * Lists repositories accessible to a GitHub App installation
    * @param installationId - The GitHub App installation ID

--- a/Common/Tests/Server/Utils/GitHubPullRequestStateMapping.test.ts
+++ b/Common/Tests/Server/Utils/GitHubPullRequestStateMapping.test.ts
@@ -1,0 +1,50 @@
+import GitHubUtil from "../../../Server/Utils/CodeRepository/GitHub/GitHub";
+import PullRequestState from "../../../Types/CodeRepository/PullRequestState";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * State mapping for the AI-agent PR outcome sync (gate G11 instrumentation).
+ * GitHub reports merged PRs as state "closed" with merged_at set — the
+ * mapping must check merged first, or every merge counts as a plain close
+ * and the fix-acceptance baseline undercounts forever.
+ */
+
+describe("GitHubUtil.mapGitHubPullRequestToState", () => {
+  test("merged_at set means Merged even though state is closed", () => {
+    expect(
+      GitHubUtil.mapGitHubPullRequestToState({
+        state: "closed",
+        merged_at: "2026-07-13T10:00:00Z",
+      }),
+    ).toBe(PullRequestState.Merged);
+  });
+
+  test("merged boolean true means Merged", () => {
+    expect(
+      GitHubUtil.mapGitHubPullRequestToState({
+        state: "closed",
+        merged: true,
+        merged_at: null,
+      }),
+    ).toBe(PullRequestState.Merged);
+  });
+
+  test("closed without merged_at means Closed (rejected fix)", () => {
+    expect(
+      GitHubUtil.mapGitHubPullRequestToState({
+        state: "closed",
+        merged_at: null,
+        merged: false,
+      }),
+    ).toBe(PullRequestState.Closed);
+  });
+
+  test("open PR stays Open", () => {
+    expect(
+      GitHubUtil.mapGitHubPullRequestToState({
+        state: "open",
+        merged_at: null,
+      }),
+    ).toBe(PullRequestState.Open);
+  });
+});

--- a/Internal/Roadmap/AISentinelExecution.md
+++ b/Internal/Roadmap/AISentinelExecution.md
@@ -169,7 +169,7 @@ Ordering changed from the original roadmap — rationale in the Deviations log. 
 
 **X — fix-before-incident:**
 
-- [ ] Outcome instrumentation on the EXISTING manual fix path first (PR merged / closed-unmerged / merged-with-edits, from `AIAgentTaskPullRequest` state) — zero-risk, starts the G11 precision baseline immediately
+- [ ] Outcome instrumentation on the EXISTING manual fix path first (PR merged / closed-unmerged / merged-with-edits, from `AIAgentTaskPullRequest` state) — zero-risk, starts the G11 precision baseline immediately *(state-sync half shipped 2026-07-13: `AIAgent:SyncPullRequestStates` polls open agent PRs every 30 min via the GitHub App and records Merged/Closed — the raw baseline now accumulates; merged-with-edits detection + per-project rate reporting still open)*
 - [ ] Flip `enableAutomaticImprovements` default to **false** + explicit project-level preventive opt-in flag (the column shipped default-true with no engine; when an engine lands it must not become silent default-on — same opt-in posture as the investigation flags)
 - [ ] Auto-created fix tasks for graduated finding types only (new-fingerprint exceptions first — highest precision, handler exists), honoring `restrictedImprovementActions` + `maxOpenPullRequests` + a per-project daily fix-task budget + a retry cap (the 30-min stuck-task reset currently retries forever); **draft PRs, human review always**; requires the code-fix track's sandbox + verify loop (today's path commits the agent diff and opens a non-draft PR with zero build/test/lint)
 - [ ] Widen the fix context beyond the stack trace: fix tasks read the finding's cited evidence (logs/traces/spans/occurrence history) — the "grounded in full telemetry" differentiator, currently absent even from the manual path
@@ -249,6 +249,8 @@ Opsgenie EOL is **April 5, 2027**; migrating teams choose destinations 6–18 mo
 | 2026-07 | **D5:** Roadmap restructured: original `AISentinelReliabilityBrain.md` split into Vision + this tracker | The single doc's execution claims were stale at merge time ("zero implementation" shipped in the same commit); vision content had not drifted at all |
 
 ## 8. Changelog
+
+- **2026-07-13** — **Shipped Preventive-lane X-1 (first half): AI-agent PR outcome sync.** New `AIAgent:SyncPullRequestStates` worker (every 30 min) resolves open `AIAgentTaskPullRequest` rows against GitHub via the App installation (token reused per installation, uninstalled apps skipped) and records Merged / Closed — merged-first mapping so merges never count as plain closes. `pullRequestState` previously stayed "Open" forever, making fix-acceptance rates unknowable; the G11 precision baseline now accumulates from real usage. Merged-with-edits detection and rate reporting remain open.
 
 - **2026-07-13** — **Shipped UX-overhaul C3+D3: AI agent fleet demoted to Settings.** Fleet management (the Probe-pattern AIAgent credential object) moved from AI > Agents to **Settings > AI > AI Agents** at `settings/ai-agents/…` — which makes `AIAgentService.getLinkInDashboard`'s owner-notification links (emails/push/WhatsApp) point at a real page for the first time since they shipped (the server already emitted this path; it was dead in the dashboard). Probe-style "Show ID and Key" added to the list; old `/ai/agents/agents` pages/routes removed; readiness deep-link + guidance strings updated. D3: the AI Logs side-menu items on incident/alert/maintenance views (commented out 2025-12-16, pages orphaned-but-working since) are restored.
 


### PR DESCRIPTION
**Stacked on #2659 ← #2658 ← #2656** — merge those first; this diff is only the outcome sync.

First half of Preventive-lane item X-1 ("outcome instrumentation on the existing manual fix path") — the zero-risk step that starts the **G11 precision baseline** accumulating from real usage.

## Why

`AIAgentTaskPullRequest.pullRequestState` is written once as `Open` when the agent opens a PR and never touched again. That means the single most important number for ever automating fixes — how often humans actually **merge** what the agent writes versus close it unmerged — is unknowable today, even in principle.

## What's here

- **`AIAgent:SyncPullRequestStates`** worker (every 30 min): finds open agent PRs, resolves their current state via the GitHub App installation, and records `Merged` / `Closed`. One installation token minted per installation and reused across its PRs; installations that 404 (app uninstalled) are skipped for the run; a single unreachable PR logs and continues.
- **`GitHubUtil.getPullRequestState` / `getPullRequestStateWithToken`** plus a pure `mapGitHubPullRequestToState`. The mapping checks `merged_at`/`merged` **before** `state === "closed"`, because GitHub reports merged PRs as closed-with-merged_at — closed-first mapping would undercount acceptance forever.

## Verification

- `GitHubPullRequestStateMapping.test.ts` — 4 cases locking the merged-before-closed rule.
- `npm run compile` clean in Common + App; `npm run fix` clean.
- Roadmap tracker updated: X-1 annotated as half-shipped (merged-with-edits detection and per-project rate reporting remain open, as does surfacing the ratio in the dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)