### PR TITLE
feat(monitor): native SQL Query monitor type (PostgreSQL)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorStep.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorStep.tsx
@@ -115,6 +115,10 @@ import DnsMonitorStepForm from "./DnsMonitor/DnsMonitorStepForm";
 import MonitorStepDnsMonitor, {
   MonitorStepDnsMonitorUtil,
 } from "Common/Types/Monitor/MonitorStepDnsMonitor";
+import SqlMonitorStepForm from "./SqlMonitor/SqlMonitorStepForm";
+import MonitorStepSqlMonitor, {
+  MonitorStepSqlMonitorUtil,
+} from "Common/Types/Monitor/MonitorStepSqlMonitor";
 import DomainMonitorStepForm from "./DomainMonitor/DomainMonitorStepForm";
 import MonitorStepDomainMonitor, {
   MonitorStepDomainMonitorUtil,
@@ -1522,6 +1526,24 @@ return {
             }
             onChange={(value: MonitorStepDnsMonitor) => {
               monitorStep.setDnsMonitor(value);
+              props.onChange?.(MonitorStep.clone(monitorStep));
+            }}
+          />
+        </Card>
+      )}
+
+      {props.monitorType === MonitorType.SQLQuery && (
+        <Card
+          title="SQL Query Monitor Configuration"
+          description="Configure the database connection and the read-only query to run. This monitor requires a probe with network access to your database."
+        >
+          <SqlMonitorStepForm
+            monitorStepSqlMonitor={
+              monitorStep.data?.sqlMonitor ||
+              MonitorStepSqlMonitorUtil.getDefault()
+            }
+            onChange={(value: MonitorStepSqlMonitor) => {
+              monitorStep.setSqlMonitor(value);
               props.onChange?.(MonitorStep.clone(monitorStep));
             }}
           />

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/SqlMonitor/SqlMonitorStepForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/SqlMonitor/SqlMonitorStepForm.tsx
@@ -1,0 +1,300 @@
+import React, { FunctionComponent, ReactElement, useState } from "react";
+import MonitorStepSqlMonitor from "Common/Types/Monitor/MonitorStepSqlMonitor";
+import SqlDatabaseType, {
+  SqlDatabaseTypeUtil,
+} from "Common/Types/Monitor/SqlDatabaseType";
+import Input, { InputType } from "Common/UI/Components/Input/Input";
+import TextArea from "Common/UI/Components/TextArea/TextArea";
+import Toggle from "Common/UI/Components/Toggle/Toggle";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
+import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Link from "Common/UI/Components/Link/Link";
+import URL from "Common/Types/API/URL";
+import { DOCS_URL } from "Common/UI/Config";
+
+export interface ComponentProps {
+  monitorStepSqlMonitor: MonitorStepSqlMonitor;
+  onChange: (value: MonitorStepSqlMonitor) => void;
+}
+
+const SqlMonitorStepForm: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [showAdvancedOptions, setShowAdvancedOptions] =
+    useState<boolean>(false);
+
+  const databaseTypeOptions: Array<DropdownOption> =
+    SqlDatabaseTypeUtil.getSupportedDatabaseTypes().map(
+      (type: SqlDatabaseType) => {
+        return { label: type, value: type };
+      },
+    );
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <FieldLabelElement
+          title="Database Type"
+          description="The database engine to connect to. PostgreSQL is supported today."
+          required={true}
+        />
+        <Dropdown
+          options={databaseTypeOptions}
+          initialValue={databaseTypeOptions.find((option: DropdownOption) => {
+            return option.value === props.monitorStepSqlMonitor.databaseType;
+          })}
+          onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+            const databaseType: SqlDatabaseType = value as SqlDatabaseType;
+            props.onChange({
+              ...props.monitorStepSqlMonitor,
+              databaseType: databaseType,
+              port: SqlDatabaseTypeUtil.getDefaultPort(databaseType),
+            });
+          }}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <FieldLabelElement
+            title="Host"
+            description="Database host reachable from the probe (e.g. db.internal)"
+            required={true}
+          />
+          <Input
+            initialValue={props.monitorStepSqlMonitor.host}
+            placeholder="db.internal"
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepSqlMonitor,
+                host: value,
+              });
+            }}
+          />
+        </div>
+
+        <div>
+          <FieldLabelElement
+            title="Port"
+            description="Database port"
+            required={true}
+          />
+          <Input
+            initialValue={props.monitorStepSqlMonitor.port?.toString() || "5432"}
+            placeholder="5432"
+            type={InputType.NUMBER}
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepSqlMonitor,
+                port: parseInt(value) || 5432,
+              });
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <FieldLabelElement
+            title="Database Name"
+            description="The database to run the query against"
+            required={true}
+          />
+          <Input
+            initialValue={props.monitorStepSqlMonitor.databaseName}
+            placeholder="orders"
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepSqlMonitor,
+                databaseName: value,
+              });
+            }}
+          />
+        </div>
+
+        <div>
+          <FieldLabelElement
+            title="Username"
+            description="Use a read-only, least-privilege database user."
+            required={false}
+          />
+          <Input
+            initialValue={props.monitorStepSqlMonitor.username}
+            placeholder="readonly_user"
+            onChange={(value: string) => {
+              props.onChange({
+                ...props.monitorStepSqlMonitor,
+                username: value,
+              });
+            }}
+          />
+        </div>
+      </div>
+
+      <div>
+        <FieldLabelElement
+          title="Password"
+          description={
+            <p>
+              Database password. We recommend referencing a monitor secret with{" "}
+              <code className="bg-gray-100 px-1 rounded">
+                {"{{monitorSecrets.name}}"}
+              </code>{" "}
+              instead of typing the password here, so it stays encrypted at
+              rest.{" "}
+              <Link
+                className="underline"
+                openInNewTab={true}
+                to={URL.fromString(
+                  DOCS_URL.toString() + "/monitor/monitor-secrets",
+                )}
+              >
+                Learn more about secrets.
+              </Link>
+            </p>
+          }
+          required={false}
+        />
+        <Input
+          initialValue={props.monitorStepSqlMonitor.password}
+          placeholder="{{monitorSecrets.dbPassword}}"
+          onChange={(value: string) => {
+            props.onChange({
+              ...props.monitorStepSqlMonitor,
+              password: value,
+            });
+          }}
+        />
+      </div>
+
+      <div>
+        <FieldLabelElement
+          title="SQL Query"
+          description="A single read-only query (SELECT / WITH). Writes are blocked — the probe runs it in a read-only transaction. Example: SELECT COUNT(*) FROM orders WHERE status = 'CANCELLED' AND created_at > NOW() - INTERVAL '5 minutes'"
+          required={true}
+        />
+        <TextArea
+          initialValue={props.monitorStepSqlMonitor.query}
+          disableSpellCheck={true}
+          placeholder={"SELECT COUNT(*) FROM orders WHERE status = 'CANCELLED'"}
+          onChange={(value: string) => {
+            props.onChange({
+              ...props.monitorStepSqlMonitor,
+              query: value,
+            });
+          }}
+        />
+      </div>
+
+      <div>
+        <Toggle
+          title="Use SSL/TLS"
+          initialValue={props.monitorStepSqlMonitor.useSsl}
+          onChange={(value: boolean) => {
+            props.onChange({
+              ...props.monitorStepSqlMonitor,
+              useSsl: value,
+            });
+          }}
+        />
+      </div>
+
+      {props.monitorStepSqlMonitor.useSsl && (
+        <div>
+          <Toggle
+            title="Verify server certificate"
+            description="Turn off only if the database uses a self-signed certificate."
+            initialValue={props.monitorStepSqlMonitor.rejectUnauthorizedSsl}
+            onChange={(value: boolean) => {
+              props.onChange({
+                ...props.monitorStepSqlMonitor,
+                rejectUnauthorizedSsl: value,
+              });
+            }}
+          />
+        </div>
+      )}
+
+      {!showAdvancedOptions && (
+        <div className="mt-1 -ml-3">
+          <Button
+            title="Advanced: Timeouts and Row Limit"
+            buttonStyle={ButtonStyleType.SECONDARY_LINK}
+            onClick={() => {
+              setShowAdvancedOptions(true);
+            }}
+          />
+        </div>
+      )}
+
+      {showAdvancedOptions && (
+        <div className="space-y-4 border p-4 rounded-md bg-gray-50">
+          <h4 className="font-medium">Advanced Options</h4>
+
+          <div>
+            <FieldLabelElement
+              title="Connection Timeout (ms)"
+              description="How long to wait to establish a connection (max 30000)"
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepSqlMonitor.connectionTimeoutInMs?.toString()}
+              placeholder="10000"
+              type={InputType.NUMBER}
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepSqlMonitor,
+                  connectionTimeoutInMs: parseInt(value) || 10000,
+                });
+              }}
+            />
+          </div>
+
+          <div>
+            <FieldLabelElement
+              title="Statement Timeout (ms)"
+              description="Hard cap on how long the query may run (max 60000)"
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepSqlMonitor.statementTimeoutInMs?.toString()}
+              placeholder="15000"
+              type={InputType.NUMBER}
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepSqlMonitor,
+                  statementTimeoutInMs: parseInt(value) || 15000,
+                });
+              }}
+            />
+          </div>
+
+          <div>
+            <FieldLabelElement
+              title="Max Rows"
+              description="Upper bound on rows read from the database (max 1000)"
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepSqlMonitor.maxRows?.toString()}
+              placeholder="100"
+              type={InputType.NUMBER}
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepSqlMonitor,
+                  maxRows: parseInt(value) || 100,
+                });
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SqlMonitorStepForm;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep.tsx
@@ -366,6 +366,40 @@ const MonitorStepElement: FunctionComponent<ComponentProps> = (
         },
       },
     ];
+  } else if (props.monitorType === MonitorType.SQLQuery) {
+    fields = [
+      {
+        key: "sqlMonitor",
+        title: "Database",
+        description: "The database this monitor connects to.",
+        fieldType: FieldType.Element,
+        placeholder: "No data entered",
+        getElement: (item: MonitorStepType): ReactElement => {
+          const sqlMonitor: any = item.sqlMonitor;
+          if (!sqlMonitor?.host) {
+            return <p>-</p>;
+          }
+          return (
+            <p>{`${sqlMonitor.databaseType} · ${sqlMonitor.host}:${sqlMonitor.port}/${sqlMonitor.databaseName}`}</p>
+          );
+        },
+      },
+      {
+        key: "sqlMonitor",
+        title: "Query",
+        description: "The read-only SQL query this monitor runs.",
+        fieldType: FieldType.Element,
+        placeholder: "No data entered",
+        getElement: (item: MonitorStepType): ReactElement => {
+          const sqlMonitor: any = item.sqlMonitor;
+          return (
+            <p className="font-mono text-sm break-all">
+              {sqlMonitor?.query || "-"}
+            </p>
+          );
+        },
+      },
+    ];
   } else if (props.monitorType === MonitorType.ExternalStatusPage) {
     fields = [
       {

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SqlMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SqlMonitorView.tsx
@@ -1,0 +1,159 @@
+import OneUptimeDate from "Common/Types/Date";
+import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
+import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
+import SqlMonitorResponse from "Common/Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import InfoCard from "Common/UI/Components/InfoCard/InfoCard";
+import React, { FunctionComponent, ReactElement } from "react";
+import ProbeAttemptsView from "./ProbeAttemptsView";
+
+export interface ComponentProps {
+  probeMonitorResponse: ProbeMonitorResponse;
+  probeName?: string | undefined;
+}
+
+const SqlMonitorView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const sqlResponse: SqlMonitorResponse | undefined =
+    props.probeMonitorResponse?.sqlQueryMonitorResponse;
+
+  let responseTimeInMs: number = sqlResponse?.responseTimeInMs || 0;
+
+  if (responseTimeInMs > 0) {
+    responseTimeInMs = Math.round(responseTimeInMs);
+  }
+
+  const scalarValue: string =
+    sqlResponse?.scalarValue === null ||
+    sqlResponse?.scalarValue === undefined
+      ? "-"
+      : String(sqlResponse.scalarValue);
+
+  const probeAttempts: Array<ProbeAttempt> =
+    props.probeMonitorResponse.probeAttempts || [];
+  const totalAttempts: number =
+    props.probeMonitorResponse.totalAttempts ?? probeAttempts.length;
+  const hadRetries: boolean = totalAttempts > 1;
+
+  return (
+    <div className="space-y-5">
+      <div className="flex space-x-3">
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Probe"
+          value={props.probeName || "-"}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Status"
+          value={props.probeMonitorResponse.isOnline ? "Online" : "Offline"}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Row Count"
+          value={
+            sqlResponse?.rowCount === null ||
+            sqlResponse?.rowCount === undefined
+              ? "-"
+              : sqlResponse.rowCount.toString()
+          }
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Value"
+          value={scalarValue}
+        />
+        <InfoCard
+          className="w-1/5 shadow-none border-2 border-gray-100"
+          title="Execution Time"
+          value={responseTimeInMs ? responseTimeInMs + " ms" : "-"}
+        />
+      </div>
+
+      <div className="flex space-x-3">
+        <InfoCard
+          className="w-1/2 shadow-none border-2 border-gray-100"
+          title="Rows Truncated"
+          value={sqlResponse?.isRowsCapped ? "Yes (result capped)" : "No"}
+        />
+        <InfoCard
+          className="w-1/2 shadow-none border-2 border-gray-100"
+          title="Monitored At"
+          value={
+            props.probeMonitorResponse?.monitoredAt
+              ? OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+                  props.probeMonitorResponse.monitoredAt,
+                )
+              : "-"
+          }
+        />
+      </div>
+
+      {(sqlResponse?.queryError ||
+        props.probeMonitorResponse.failureCause) && (
+        <div className="flex space-x-3">
+          <InfoCard
+            className="w-full shadow-none border-2 border-gray-100"
+            title="Error"
+            value={
+              sqlResponse?.queryError ||
+              props.probeMonitorResponse.failureCause?.toString() ||
+              "-"
+            }
+          />
+        </div>
+      )}
+
+      {hadRetries && (
+        <ProbeAttemptsView
+          attempts={probeAttempts}
+          totalAttempts={totalAttempts}
+        />
+      )}
+
+      {sqlResponse?.firstRow &&
+        Object.keys(sqlResponse.firstRow).length > 0 && (
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium text-gray-700">First Row</h3>
+            <div className="border rounded-md overflow-hidden">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Column
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Value
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {Object.keys(sqlResponse.firstRow).map(
+                    (columnName: string, index: number) => {
+                      const cellValue: unknown = (
+                        sqlResponse.firstRow as Record<string, unknown>
+                      )[columnName];
+                      return (
+                        <tr key={index}>
+                          <td className="px-4 py-2 text-sm text-gray-500 font-mono">
+                            {columnName}
+                          </td>
+                          <td className="px-4 py-2 text-sm text-gray-900 font-mono break-all">
+                            {cellValue === null || cellValue === undefined
+                              ? "-"
+                              : String(cellValue)}
+                          </td>
+                        </tr>
+                      );
+                    },
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+    </div>
+  );
+};
+
+export default SqlMonitorView;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
@@ -8,6 +8,7 @@ import SyntheticMonitorView from "./SyntheticMonitorView";
 import WebsiteMonitorSummaryView from "./WebsiteMonitorView";
 import SnmpMonitorView from "./SnmpMonitorView";
 import DnsMonitorView from "./DnsMonitorView";
+import SqlMonitorView from "./SqlMonitorView";
 import DomainMonitorView from "./DomainMonitorView";
 import DnssecMonitorView from "./DnssecMonitorView";
 import ExternalStatusPageMonitorView from "./ExternalStatusPageMonitorView";
@@ -146,6 +147,15 @@ const SummaryInfo: FunctionComponent<ComponentProps> = (
     if (props.monitorType === MonitorType.DNSSEC) {
       summaryComponent = (
         <DnssecMonitorView
+          probeMonitorResponse={probeMonitorResponse}
+          probeName={props.probeName}
+        />
+      );
+    }
+
+    if (props.monitorType === MonitorType.SQLQuery) {
+      summaryComponent = (
+        <SqlMonitorView
           probeMonitorResponse={probeMonitorResponse}
           probeName={props.probeName}
         />

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -383,6 +383,19 @@ export default class CriteriaFilterUtil {
       });
     }
 
+    if (monitorType === MonitorType.SQLQuery) {
+      options = options.filter((i: DropdownOption) => {
+        return (
+          i.value === CheckOn.SqlIsOnline ||
+          i.value === CheckOn.SqlQueryRowCount ||
+          i.value === CheckOn.SqlQueryScalarValue ||
+          i.value === CheckOn.SqlQueryExecutionTime ||
+          i.value === CheckOn.SqlQueryError ||
+          i.value === CheckOn.JavaScriptExpression
+        );
+      });
+    }
+
     if (monitorType === MonitorType.ExternalStatusPage) {
       options = options.filter((i: DropdownOption) => {
         return (
@@ -774,6 +787,58 @@ export default class CriteriaFilterUtil {
       });
     }
 
+    if (checkOn === CheckOn.SqlIsOnline) {
+      options = options.filter((i: DropdownOption) => {
+        return i.value === FilterType.True || i.value === FilterType.False;
+      });
+    }
+
+    if (
+      checkOn === CheckOn.SqlQueryRowCount ||
+      checkOn === CheckOn.SqlQueryExecutionTime
+    ) {
+      options = options.filter((i: DropdownOption) => {
+        return (
+          i.value === FilterType.GreaterThan ||
+          i.value === FilterType.LessThan ||
+          i.value === FilterType.LessThanOrEqualTo ||
+          i.value === FilterType.GreaterThanOrEqualTo ||
+          i.value === FilterType.EqualTo ||
+          i.value === FilterType.NotEqualTo
+        );
+      });
+    }
+
+    if (checkOn === CheckOn.SqlQueryScalarValue) {
+      options = options.filter((i: DropdownOption) => {
+        return (
+          i.value === FilterType.GreaterThan ||
+          i.value === FilterType.LessThan ||
+          i.value === FilterType.LessThanOrEqualTo ||
+          i.value === FilterType.GreaterThanOrEqualTo ||
+          i.value === FilterType.EqualTo ||
+          i.value === FilterType.NotEqualTo ||
+          i.value === FilterType.Contains ||
+          i.value === FilterType.NotContains ||
+          i.value === FilterType.StartsWith ||
+          i.value === FilterType.EndsWith
+        );
+      });
+    }
+
+    if (checkOn === CheckOn.SqlQueryError) {
+      options = options.filter((i: DropdownOption) => {
+        return (
+          i.value === FilterType.Contains ||
+          i.value === FilterType.NotContains ||
+          i.value === FilterType.EqualTo ||
+          i.value === FilterType.NotEqualTo ||
+          i.value === FilterType.IsEmpty ||
+          i.value === FilterType.IsNotEmpty
+        );
+      });
+    }
+
     if (checkOn === CheckOn.ExternalStatusPageIsOnline) {
       options = options.filter((i: DropdownOption) => {
         return i.value === FilterType.True || i.value === FilterType.False;
@@ -963,7 +1028,26 @@ export default class CriteriaFilterUtil {
       if (monitorType === MonitorType.IncomingRequest) {
         return "{{requestBody.result}} === true";
       }
+      if (monitorType === MonitorType.SQLQuery) {
+        return "{{scalarValue}} > 50";
+      }
       return "{{responseBody.result}} === true";
+    }
+
+    if (checkOn === CheckOn.SqlQueryRowCount) {
+      return "0";
+    }
+
+    if (checkOn === CheckOn.SqlQueryScalarValue) {
+      return "50";
+    }
+
+    if (checkOn === CheckOn.SqlQueryExecutionTime) {
+      return "5000";
+    }
+
+    if (checkOn === CheckOn.SqlQueryError) {
+      return "connection refused";
     }
 
     if (checkOn === CheckOn.ResponseStatusCode) {

--- a/App/FeatureSet/Telemetry/Utils/Monitor.ts
+++ b/App/FeatureSet/Telemetry/Utils/Monitor.ts
@@ -335,6 +335,42 @@ export default class MonitorUtil {
       }
     }
 
+    if (monitorType === MonitorType.SQLQuery) {
+      for (const monitorStep of monitorSteps?.data?.monitorStepsInstanceArray ||
+        []) {
+        if (!monitorStep.data?.sqlMonitor) {
+          continue;
+        }
+
+        /*
+         * Sensitive SQL connection fields may reference a monitor secret via
+         * {{monitorSecrets.name}}. The user opts into this — OneUptime never
+         * creates or populates a secret on their behalf; we only resolve a
+         * reference they chose to write here.
+         */
+        const sqlSecretFields: Array<"password" | "username" | "host" | "databaseName" | "query"> =
+          ["password", "username", "host", "databaseName", "query"];
+
+        for (const field of sqlSecretFields) {
+          const currentValue: string | undefined =
+            monitorStep.data.sqlMonitor[field];
+
+          if (currentValue && this.hasSecrets(currentValue)) {
+            if (!isSecretsLoaded) {
+              monitorSecrets = await MonitorUtil.loadMonitorSecrets(monitorId);
+              isSecretsLoaded = true;
+            }
+
+            monitorStep.data.sqlMonitor[field] =
+              (await MonitorUtil.fillSecretsInStringOrJSON({
+                secrets: monitorSecrets,
+                populateSecretsIn: currentValue,
+              })) as string;
+          }
+        }
+      }
+    }
+
     if (monitorType === MonitorType.ExternalStatusPage) {
       for (const monitorStep of monitorSteps?.data?.monitorStepsInstanceArray ||
         []) {

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -148,6 +148,21 @@ export class Service extends DatabaseService<Model> {
           monitorDestination =
             firstStep.data.externalStatusPageMonitor.statusPageUrl || "";
         }
+
+        // For SQL monitors, show host:port/database (never the credentials).
+        if (
+          monitorType === MonitorType.SQLQuery &&
+          firstStep?.data?.sqlMonitor
+        ) {
+          const sql: {
+            host: string;
+            port: number;
+            databaseName: string;
+          } = firstStep.data.sqlMonitor;
+          if (sql.host) {
+            monitorDestination = `${sql.host}:${sql.port}/${sql.databaseName}`;
+          }
+        }
       }
     }
 

--- a/Common/Server/Utils/Monitor/Criteria/SqlMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SqlMonitorCriteria.ts
@@ -1,0 +1,152 @@
+import DataToProcess from "../DataToProcess";
+import CompareCriteria from "./CompareCriteria";
+import {
+  CheckOn,
+  CriteriaFilter,
+} from "../../../../Types/Monitor/CriteriaFilter";
+import SqlMonitorResponse from "../../../../Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+export default class SqlMonitorCriteria {
+  @CaptureSpan()
+  public static async isMonitorInstanceCriteriaFilterMet(input: {
+    dataToProcess: DataToProcess;
+    criteriaFilter: CriteriaFilter;
+  }): Promise<string | null> {
+    let threshold: number | string | undefined | null =
+      input.criteriaFilter.value;
+
+    const dataToProcess: ProbeMonitorResponse =
+      input.dataToProcess as ProbeMonitorResponse;
+
+    const sqlResponse: SqlMonitorResponse | undefined =
+      dataToProcess.sqlQueryMonitorResponse;
+
+    // Is the database reachable / did the check succeed?
+    if (input.criteriaFilter.checkOn === CheckOn.SqlIsOnline) {
+      return CompareCriteria.compareCriteriaBoolean({
+        value: dataToProcess.isOnline as boolean,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    // Number of rows the query returned.
+    if (input.criteriaFilter.checkOn === CheckOn.SqlQueryRowCount) {
+      threshold = CompareCriteria.convertToNumber(threshold);
+
+      if (threshold === null || threshold === undefined) {
+        return null;
+      }
+
+      if (
+        sqlResponse?.rowCount === null ||
+        sqlResponse?.rowCount === undefined
+      ) {
+        return null;
+      }
+
+      return CompareCriteria.compareCriteriaNumbers({
+        value: sqlResponse.rowCount,
+        threshold: threshold as number,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    // Query execution time (in ms).
+    if (input.criteriaFilter.checkOn === CheckOn.SqlQueryExecutionTime) {
+      threshold = CompareCriteria.convertToNumber(threshold);
+
+      if (threshold === null || threshold === undefined) {
+        return null;
+      }
+
+      const executionTime: number | undefined =
+        sqlResponse?.responseTimeInMs ?? dataToProcess.responseTimeInMs;
+
+      if (executionTime === null || executionTime === undefined) {
+        return null;
+      }
+
+      return CompareCriteria.compareCriteriaNumbers({
+        value: executionTime,
+        threshold: threshold as number,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    /*
+     * The first column of the first row — the natural target for a
+     * COUNT(*)-style query. Compared numerically when both sides look
+     * numeric, otherwise as strings.
+     */
+    if (input.criteriaFilter.checkOn === CheckOn.SqlQueryScalarValue) {
+      const scalarValue: string | number | boolean | null | undefined =
+        sqlResponse?.scalarValue;
+
+      if (scalarValue === null || scalarValue === undefined) {
+        return null;
+      }
+
+      const numericThreshold: number | null =
+        CompareCriteria.convertToNumber(threshold);
+      const scalarAsNumber: number = Number(scalarValue);
+
+      if (
+        numericThreshold !== null &&
+        typeof scalarValue !== "boolean" &&
+        !isNaN(scalarAsNumber)
+      ) {
+        const numericResult: string | null =
+          CompareCriteria.compareCriteriaNumbers({
+            value: scalarAsNumber,
+            threshold: numericThreshold,
+            criteriaFilter: input.criteriaFilter,
+          });
+
+        if (numericResult) {
+          return numericResult;
+        }
+      }
+
+      if (threshold !== null && threshold !== undefined) {
+        return CompareCriteria.compareCriteriaStrings({
+          value: String(scalarValue),
+          threshold: String(threshold),
+          criteriaFilter: input.criteriaFilter,
+        });
+      }
+
+      return null;
+    }
+
+    // The query error message (present when the query failed).
+    if (input.criteriaFilter.checkOn === CheckOn.SqlQueryError) {
+      const emptyNotEmptyResult: string | null =
+        CompareCriteria.compareEmptyAndNotEmpty({
+          value: sqlResponse?.queryError,
+          criteriaFilter: input.criteriaFilter,
+        });
+
+      if (emptyNotEmptyResult) {
+        return emptyNotEmptyResult;
+      }
+
+      if (
+        threshold !== null &&
+        threshold !== undefined &&
+        typeof sqlResponse?.queryError === "string"
+      ) {
+        return CompareCriteria.compareCriteriaStrings({
+          value: sqlResponse.queryError,
+          threshold: threshold.toString(),
+          criteriaFilter: input.criteriaFilter,
+        });
+      }
+
+      return null;
+    }
+
+    return null;
+  }
+}

--- a/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
+++ b/Common/Server/Utils/Monitor/MonitorCriteriaEvaluator.ts
@@ -20,6 +20,7 @@ import SnmpMonitorCriteria from "./Criteria/SnmpMonitorCriteria";
 import DnsMonitorCriteria from "./Criteria/DnsMonitorCriteria";
 import DomainMonitorCriteria from "./Criteria/DomainMonitorCriteria";
 import DnssecMonitorCriteria from "./Criteria/DnssecMonitorCriteria";
+import SqlMonitorCriteria from "./Criteria/SqlMonitorCriteria";
 import ExternalStatusPageMonitorCriteria from "./Criteria/ExternalStatusPageMonitorCriteria";
 import MonitorCriteriaMessageBuilder from "./MonitorCriteriaMessageBuilder";
 import MonitorCriteriaDataExtractor from "./MonitorCriteriaDataExtractor";
@@ -41,6 +42,7 @@ import ProbeApiIngestResponse, {
 import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
 import RequestFailedDetails from "../../../Types/Probe/RequestFailedDetails";
 import IncomingMonitorRequest from "../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
+import SqlMonitorResponse from "../../../Types/Monitor/SqlMonitor/SqlMonitorResponse";
 import MonitorType from "../../../Types/Monitor/MonitorType";
 import { CheckOn, CriteriaFilter } from "../../../Types/Monitor/CriteriaFilter";
 import OneUptimeDate from "../../../Types/Date";
@@ -578,6 +580,21 @@ ${contextBlock}
         };
       }
 
+      if (input.monitor.monitorType === MonitorType.SQLQuery) {
+        const sqlResponse: SqlMonitorResponse | undefined = (
+          input.dataToProcess as ProbeMonitorResponse
+        ).sqlQueryMonitorResponse;
+
+        storageMap = {
+          rowCount: sqlResponse?.rowCount,
+          scalarValue: sqlResponse?.scalarValue,
+          firstRow: sqlResponse?.firstRow,
+          executionTimeInMs: sqlResponse?.responseTimeInMs,
+          queryError: sqlResponse?.queryError,
+          isOnline: (input.dataToProcess as ProbeMonitorResponse).isOnline,
+        };
+      }
+
       let expression: string = input.criteriaFilter.value as string;
       expression = VMUtil.replaceValueInPlace(storageMap, expression, false);
 
@@ -820,6 +837,18 @@ ${contextBlock}
 
       if (dnssecMonitorResult) {
         return dnssecMonitorResult;
+      }
+    }
+
+    if (input.monitor.monitorType === MonitorType.SQLQuery) {
+      const sqlMonitorResult: string | null =
+        await SqlMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: input.dataToProcess,
+          criteriaFilter: input.criteriaFilter,
+        });
+
+      if (sqlMonitorResult) {
+        return sqlMonitorResult;
       }
     }
 

--- a/Common/Tests/Server/Utils/Monitor/Criteria/SqlMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/SqlMonitorCriteria.test.ts
@@ -1,0 +1,200 @@
+import SqlMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/SqlMonitorCriteria";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import SqlMonitorResponse from "../../../../../Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import ProbeMonitorResponse from "../../../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../../../Types/ObjectID";
+import { JSONObject } from "../../../../../Types/JSON";
+
+function buildDataToProcess(input: {
+  isOnline?: boolean;
+  responseTimeInMs?: number;
+  rowCount?: number | null;
+  scalarValue?: string | number | boolean | null;
+  firstRow?: JSONObject | null;
+  queryError?: string | null;
+}): ProbeMonitorResponse {
+  const sqlResponse: SqlMonitorResponse = {
+    isOnline: input.isOnline ?? true,
+    responseTimeInMs: input.responseTimeInMs ?? 42,
+    failureCause: "",
+    rowCount: input.rowCount === undefined ? 1 : input.rowCount,
+    scalarValue: input.scalarValue === undefined ? null : input.scalarValue,
+    firstRow: input.firstRow === undefined ? null : input.firstRow,
+    queryError: input.queryError === undefined ? null : input.queryError,
+  };
+
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: "",
+    isOnline: input.isOnline ?? true,
+    responseTimeInMs: input.responseTimeInMs ?? 42,
+    sqlQueryMonitorResponse: sqlResponse,
+    monitoredAt: new Date(),
+  };
+}
+
+async function evaluate(
+  dataToProcess: ProbeMonitorResponse,
+  criteriaFilter: CriteriaFilter,
+): Promise<string | null> {
+  return SqlMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess,
+    criteriaFilter,
+  });
+}
+
+describe("SqlMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
+  describe("SqlIsOnline", () => {
+    test("online + True → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true }),
+        { checkOn: CheckOn.SqlIsOnline, filterType: FilterType.True, value: undefined },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("online + False → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true }),
+        { checkOn: CheckOn.SqlIsOnline, filterType: FilterType.False, value: undefined },
+      );
+      expect(result).toBeNull();
+    });
+
+    test("offline + False → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: false }),
+        { checkOn: CheckOn.SqlIsOnline, filterType: FilterType.False, value: undefined },
+      );
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe("SqlQueryRowCount", () => {
+    test("rowCount 120 > 50 → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ rowCount: 120 }),
+        { checkOn: CheckOn.SqlQueryRowCount, filterType: FilterType.GreaterThan, value: "50" },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("rowCount 10 > 50 → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ rowCount: 10 }),
+        { checkOn: CheckOn.SqlQueryRowCount, filterType: FilterType.GreaterThan, value: "50" },
+      );
+      expect(result).toBeNull();
+    });
+
+    test("rowCount 0 EqualTo 0 → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ rowCount: 0 }),
+        { checkOn: CheckOn.SqlQueryRowCount, filterType: FilterType.EqualTo, value: "0" },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("rowCount null → not met (no data)", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ rowCount: null }),
+        { checkOn: CheckOn.SqlQueryRowCount, filterType: FilterType.GreaterThan, value: "50" },
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("SqlQueryScalarValue", () => {
+    test("numeric string scalar '150' > 50 → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ scalarValue: "150" }),
+        { checkOn: CheckOn.SqlQueryScalarValue, filterType: FilterType.GreaterThan, value: "50" },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("numeric scalar 3 EqualTo 3 → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ scalarValue: 3 }),
+        { checkOn: CheckOn.SqlQueryScalarValue, filterType: FilterType.EqualTo, value: "3" },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("string scalar 'CANCELLED' Contains 'CANCEL' → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ scalarValue: "CANCELLED" }),
+        { checkOn: CheckOn.SqlQueryScalarValue, filterType: FilterType.Contains, value: "CANCEL" },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("null scalar → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ scalarValue: null }),
+        { checkOn: CheckOn.SqlQueryScalarValue, filterType: FilterType.GreaterThan, value: "50" },
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("SqlQueryExecutionTime", () => {
+    test("executionTime 8000 > 5000 → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ responseTimeInMs: 8000 }),
+        { checkOn: CheckOn.SqlQueryExecutionTime, filterType: FilterType.GreaterThan, value: "5000" },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("executionTime 100 > 5000 → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ responseTimeInMs: 100 }),
+        { checkOn: CheckOn.SqlQueryExecutionTime, filterType: FilterType.GreaterThan, value: "5000" },
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("SqlQueryError", () => {
+    test("error present + IsNotEmpty → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ queryError: "connection refused" }),
+        { checkOn: CheckOn.SqlQueryError, filterType: FilterType.IsNotEmpty, value: undefined },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("error null + IsEmpty → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ queryError: null }),
+        { checkOn: CheckOn.SqlQueryError, filterType: FilterType.IsEmpty, value: undefined },
+      );
+      expect(result).toBeTruthy();
+    });
+
+    test("error 'timeout' Contains 'timeout' → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ queryError: "canceling statement due to statement timeout" }),
+        { checkOn: CheckOn.SqlQueryError, filterType: FilterType.Contains, value: "timeout" },
+      );
+      expect(result).toBeTruthy();
+    });
+  });
+
+  test("unrelated checkOn → null", async () => {
+    const result: string | null = await evaluate(buildDataToProcess({}), {
+      checkOn: CheckOn.ResponseBody,
+      filterType: FilterType.Contains,
+      value: "x",
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorStepSqlMonitor.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepSqlMonitor.test.ts
@@ -1,0 +1,106 @@
+import MonitorStepSqlMonitor, {
+  MonitorStepSqlMonitorUtil,
+  clampSqlConnectionTimeoutInMs,
+  clampSqlMaxRows,
+  clampSqlStatementTimeoutInMs,
+  DEFAULT_SQL_CONNECTION_TIMEOUT_IN_MS,
+  DEFAULT_SQL_MAX_ROWS,
+  DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS,
+  MAX_SQL_CONNECTION_TIMEOUT_IN_MS,
+  MAX_SQL_MAX_ROWS,
+  MAX_SQL_STATEMENT_TIMEOUT_IN_MS,
+} from "../../../Types/Monitor/MonitorStepSqlMonitor";
+import SqlDatabaseType from "../../../Types/Monitor/SqlDatabaseType";
+import { JSONObject } from "../../../Types/JSON";
+
+describe("MonitorStepSqlMonitorUtil", () => {
+  describe("getDefault", () => {
+    test("returns a PostgreSQL default with safe caps", () => {
+      const def: MonitorStepSqlMonitor = MonitorStepSqlMonitorUtil.getDefault();
+      expect(def.databaseType).toBe(SqlDatabaseType.PostgreSQL);
+      expect(def.port).toBe(5432);
+      expect(def.useSsl).toBe(false);
+      expect(def.rejectUnauthorizedSsl).toBe(true);
+      expect(def.statementTimeoutInMs).toBe(DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS);
+      expect(def.connectionTimeoutInMs).toBe(
+        DEFAULT_SQL_CONNECTION_TIMEOUT_IN_MS,
+      );
+      expect(def.maxRows).toBe(DEFAULT_SQL_MAX_ROWS);
+    });
+  });
+
+  describe("clamps", () => {
+    test("statement timeout is clamped to the max and defaulted when invalid", () => {
+      expect(clampSqlStatementTimeoutInMs(999999)).toBe(
+        MAX_SQL_STATEMENT_TIMEOUT_IN_MS,
+      );
+      expect(clampSqlStatementTimeoutInMs(0)).toBe(
+        DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS,
+      );
+      expect(clampSqlStatementTimeoutInMs(-5)).toBe(
+        DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS,
+      );
+      expect(clampSqlStatementTimeoutInMs(8000)).toBe(8000);
+    });
+
+    test("connection timeout is clamped to the max", () => {
+      expect(clampSqlConnectionTimeoutInMs(999999)).toBe(
+        MAX_SQL_CONNECTION_TIMEOUT_IN_MS,
+      );
+      expect(clampSqlConnectionTimeoutInMs(5000)).toBe(5000);
+    });
+
+    test("maxRows is clamped, floored, and defaulted", () => {
+      expect(clampSqlMaxRows(999999)).toBe(MAX_SQL_MAX_ROWS);
+      expect(clampSqlMaxRows(0)).toBe(DEFAULT_SQL_MAX_ROWS);
+      expect(clampSqlMaxRows(12.9)).toBe(12);
+    });
+  });
+
+  describe("fromJSON/toJSON round-trip", () => {
+    test("preserves values and clamps out-of-range inputs", () => {
+      const json: JSONObject = {
+        databaseType: SqlDatabaseType.PostgreSQL,
+        host: "db.internal",
+        port: 5433,
+        databaseName: "orders",
+        username: "readonly",
+        password: "{{monitorSecrets.dbPass}}",
+        useSsl: true,
+        rejectUnauthorizedSsl: false,
+        query: "SELECT COUNT(*) FROM orders",
+        connectionTimeoutInMs: 999999,
+        statementTimeoutInMs: 20000,
+        maxRows: 999999,
+      };
+
+      const parsed: MonitorStepSqlMonitor =
+        MonitorStepSqlMonitorUtil.fromJSON(json);
+
+      expect(parsed.host).toBe("db.internal");
+      expect(parsed.port).toBe(5433);
+      expect(parsed.password).toBe("{{monitorSecrets.dbPass}}");
+      expect(parsed.useSsl).toBe(true);
+      expect(parsed.rejectUnauthorizedSsl).toBe(false);
+      // clamped
+      expect(parsed.connectionTimeoutInMs).toBe(MAX_SQL_CONNECTION_TIMEOUT_IN_MS);
+      expect(parsed.maxRows).toBe(MAX_SQL_MAX_ROWS);
+
+      const roundTripped: MonitorStepSqlMonitor =
+        MonitorStepSqlMonitorUtil.fromJSON(
+          MonitorStepSqlMonitorUtil.toJSON(parsed),
+        );
+      expect(roundTripped).toEqual(parsed);
+    });
+
+    test("defaults rejectUnauthorizedSsl to true when absent", () => {
+      const parsed: MonitorStepSqlMonitor = MonitorStepSqlMonitorUtil.fromJSON({
+        host: "h",
+        databaseName: "d",
+        query: "SELECT 1",
+      });
+      expect(parsed.rejectUnauthorizedSsl).toBe(true);
+      expect(parsed.useSsl).toBe(false);
+    });
+  });
+});

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -98,6 +98,13 @@ export enum CheckOn {
   DnssecResolverConsensus = "DNSSEC Resolver Consensus (AD Flag)",
   DnssecNameserverConsistent = "DNSSEC Nameservers Are Consistent",
 
+  // SQL Query monitors.
+  SqlIsOnline = "SQL Is Online",
+  SqlQueryRowCount = "SQL Query Row Count",
+  SqlQueryScalarValue = "SQL Query Scalar Value",
+  SqlQueryExecutionTime = "SQL Query Execution Time (in ms)",
+  SqlQueryError = "SQL Query Error",
+
   // External Status Page monitors.
   ExternalStatusPageIsOnline = "External Status Page Is Online",
   ExternalStatusPageOverallStatus = "External Status Page Overall Status",
@@ -299,6 +306,7 @@ export class CriteriaFilterUtil {
       checkOn === CheckOn.DnssecDsExists ||
       checkOn === CheckOn.DnssecResolverConsensus ||
       checkOn === CheckOn.DnssecNameserverConsistent ||
+      checkOn === CheckOn.SqlIsOnline ||
       checkOn === CheckOn.ExternalStatusPageIsOnline
     ) {
       return false;

--- a/Common/Types/Monitor/MonitorCriteriaInstance.ts
+++ b/Common/Types/Monitor/MonitorCriteriaInstance.ts
@@ -469,6 +469,33 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
       return monitorCriteriaInstance;
     }
 
+    if (arg.monitorType === MonitorType.SQLQuery) {
+      const monitorCriteriaInstance: MonitorCriteriaInstance =
+        new MonitorCriteriaInstance();
+
+      monitorCriteriaInstance.data = {
+        id: ObjectID.generate().toString(),
+        monitorStatusId: arg.monitorStatusId,
+        filterCondition: FilterCondition.All,
+        filters: [
+          {
+            checkOn: CheckOn.SqlIsOnline,
+            filterType: FilterType.True,
+            value: undefined,
+          },
+        ],
+        incidents: [],
+        alerts: [],
+        createAlerts: false,
+        changeMonitorStatus: true,
+        createIncidents: false,
+        name: `Check if ${arg.monitorName} is online`,
+        description: `This criteria checks if the ${arg.monitorName} database query ran successfully`,
+      };
+
+      return monitorCriteriaInstance;
+    }
+
     if (arg.monitorType === MonitorType.Domain) {
       const monitorCriteriaInstance: MonitorCriteriaInstance =
         new MonitorCriteriaInstance();
@@ -693,6 +720,46 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         ],
         name: `Check if ${arg.monitorName} is offline`,
         description: `This criteria checks if the ${arg.monitorName} DNS resolution is failing`,
+      };
+    }
+
+    if (arg.monitorType === MonitorType.SQLQuery) {
+      monitorCriteriaInstance.data = {
+        id: ObjectID.generate().toString(),
+        monitorStatusId: arg.monitorStatusId,
+        filterCondition: FilterCondition.Any,
+        filters: [
+          {
+            checkOn: CheckOn.SqlIsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        ],
+        incidents: [
+          {
+            title: `${arg.monitorName} is offline`,
+            description: `${arg.monitorName} database query is currently failing.`,
+            incidentSeverityId: arg.incidentSeverityId,
+            autoResolveIncident: true,
+            id: ObjectID.generate().toString(),
+            onCallPolicyIds: [],
+          },
+        ],
+        changeMonitorStatus: true,
+        createIncidents: true,
+        createAlerts: false,
+        alerts: [
+          {
+            title: `${arg.monitorName} is offline`,
+            description: `${arg.monitorName} database query is currently failing.`,
+            alertSeverityId: arg.alertSeverityId,
+            autoResolveAlert: true,
+            id: ObjectID.generate().toString(),
+            onCallPolicyIds: [],
+          },
+        ],
+        name: `Check if ${arg.monitorName} is offline`,
+        description: `This criteria checks if the ${arg.monitorName} database query is failing`,
       };
     }
 

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -44,6 +44,9 @@ import MonitorStepDomainMonitor, {
 import MonitorStepDnssecMonitor, {
   MonitorStepDnssecMonitorUtil,
 } from "./MonitorStepDnssecMonitor";
+import MonitorStepSqlMonitor, {
+  MonitorStepSqlMonitorUtil,
+} from "./MonitorStepSqlMonitor";
 import MonitorStepExternalStatusPageMonitor, {
   MonitorStepExternalStatusPageMonitorUtil,
 } from "./MonitorStepExternalStatusPageMonitor";
@@ -190,6 +193,9 @@ export interface MonitorStepType {
   // DNSSEC monitor
   dnssecMonitor?: MonitorStepDnssecMonitor | undefined;
 
+  // SQL Query monitor
+  sqlMonitor?: MonitorStepSqlMonitor | undefined;
+
   // External Status Page monitor
   externalStatusPageMonitor?: MonitorStepExternalStatusPageMonitor | undefined;
 
@@ -253,6 +259,7 @@ export default class MonitorStep extends DatabaseProperty {
       dnsMonitor: undefined,
       domainMonitor: undefined,
       dnssecMonitor: undefined,
+      sqlMonitor: undefined,
       externalStatusPageMonitor: undefined,
       kubernetesMonitor: undefined,
       dockerMonitor: undefined,
@@ -304,6 +311,7 @@ export default class MonitorStep extends DatabaseProperty {
       dnsMonitor: undefined,
       domainMonitor: undefined,
       dnssecMonitor: undefined,
+      sqlMonitor: undefined,
       externalStatusPageMonitor: undefined,
       kubernetesMonitor: undefined,
       dockerMonitor: undefined,
@@ -516,6 +524,11 @@ export default class MonitorStep extends DatabaseProperty {
     dnssecMonitor: MonitorStepDnssecMonitor,
   ): MonitorStep {
     this.data!.dnssecMonitor = dnssecMonitor;
+    return this;
+  }
+
+  public setSqlMonitor(sqlMonitor: MonitorStepSqlMonitor): MonitorStep {
+    this.data!.sqlMonitor = sqlMonitor;
     return this;
   }
 
@@ -751,6 +764,24 @@ export default class MonitorStep extends DatabaseProperty {
       }
     }
 
+    if (monitorType === MonitorType.SQLQuery) {
+      if (!value.data.sqlMonitor) {
+        return "SQL monitor configuration is required";
+      }
+
+      if (!value.data.sqlMonitor.host) {
+        return "Database host is required";
+      }
+
+      if (!value.data.sqlMonitor.databaseName) {
+        return "Database name is required";
+      }
+
+      if (!value.data.sqlMonitor.query || !value.data.sqlMonitor.query.trim()) {
+        return "SQL query is required";
+      }
+    }
+
     if (monitorType === MonitorType.ExternalStatusPage) {
       if (!value.data.externalStatusPageMonitor) {
         return "External status page configuration is required";
@@ -915,6 +946,9 @@ export default class MonitorStep extends DatabaseProperty {
             : undefined,
           dnssecMonitor: this.data.dnssecMonitor
             ? MonitorStepDnssecMonitorUtil.toJSON(this.data.dnssecMonitor)
+            : undefined,
+          sqlMonitor: this.data.sqlMonitor
+            ? MonitorStepSqlMonitorUtil.toJSON(this.data.sqlMonitor)
             : undefined,
           externalStatusPageMonitor: this.data.externalStatusPageMonitor
             ? MonitorStepExternalStatusPageMonitorUtil.toJSON(
@@ -1081,6 +1115,9 @@ export default class MonitorStep extends DatabaseProperty {
       dnssecMonitor: json["dnssecMonitor"]
         ? (json["dnssecMonitor"] as JSONObject)
         : undefined,
+      sqlMonitor: json["sqlMonitor"]
+        ? (json["sqlMonitor"] as JSONObject)
+        : undefined,
       externalStatusPageMonitor: json["externalStatusPageMonitor"]
         ? (json["externalStatusPageMonitor"] as JSONObject)
         : undefined,
@@ -1144,6 +1181,7 @@ export default class MonitorStep extends DatabaseProperty {
         dnsMonitor: Zod.any().optional(),
         domainMonitor: Zod.any().optional(),
         dnssecMonitor: Zod.any().optional(),
+        sqlMonitor: Zod.any().optional(),
         externalStatusPageMonitor: Zod.any().optional(),
         kubernetesMonitor: Zod.any().optional(),
         dockerMonitor: Zod.any().optional(),

--- a/Common/Types/Monitor/MonitorStepSqlMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepSqlMonitor.ts
@@ -1,0 +1,141 @@
+import { JSONObject } from "../JSON";
+import SqlDatabaseType from "./SqlDatabaseType";
+
+/*
+ * Caps for SQL query execution. These are enforced server/probe-side and are
+ * the safety envelope for running a customer-supplied query — a user cannot
+ * raise them past these ceilings from the UI.
+ */
+export const MAX_SQL_STATEMENT_TIMEOUT_IN_MS: number = 60000; // 60 seconds
+export const DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS: number = 15000; // 15 seconds
+export const MAX_SQL_CONNECTION_TIMEOUT_IN_MS: number = 30000; // 30 seconds
+export const DEFAULT_SQL_CONNECTION_TIMEOUT_IN_MS: number = 10000; // 10 seconds
+export const MAX_SQL_MAX_ROWS: number = 1000;
+export const DEFAULT_SQL_MAX_ROWS: number = 100;
+
+export const clampSqlStatementTimeoutInMs: (value: number) => number = (
+  value: number,
+): number => {
+  if (!value || value <= 0 || isNaN(value)) {
+    return DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS;
+  }
+  if (value > MAX_SQL_STATEMENT_TIMEOUT_IN_MS) {
+    return MAX_SQL_STATEMENT_TIMEOUT_IN_MS;
+  }
+  return value;
+};
+
+export const clampSqlConnectionTimeoutInMs: (value: number) => number = (
+  value: number,
+): number => {
+  if (!value || value <= 0 || isNaN(value)) {
+    return DEFAULT_SQL_CONNECTION_TIMEOUT_IN_MS;
+  }
+  if (value > MAX_SQL_CONNECTION_TIMEOUT_IN_MS) {
+    return MAX_SQL_CONNECTION_TIMEOUT_IN_MS;
+  }
+  return value;
+};
+
+export const clampSqlMaxRows: (value: number) => number = (
+  value: number,
+): number => {
+  if (!value || value <= 0 || isNaN(value)) {
+    return DEFAULT_SQL_MAX_ROWS;
+  }
+  if (value > MAX_SQL_MAX_ROWS) {
+    return MAX_SQL_MAX_ROWS;
+  }
+  return Math.floor(value);
+};
+
+/*
+ * Connection + query configuration for a SQL Query monitor. Sensitive fields
+ * (password, and optionally any other field) may contain a monitor-secret
+ * reference like {{monitorSecrets.name}} — the server resolves these before
+ * the config is handed to a probe. OneUptime never creates these secrets for
+ * the user; referencing one is the user's choice.
+ */
+export default interface MonitorStepSqlMonitor {
+  databaseType: SqlDatabaseType;
+  host: string;
+  port: number;
+  databaseName: string;
+  username: string;
+  // Raw password OR a {{monitorSecrets.name}} reference resolved server-side.
+  password: string;
+  useSsl: boolean;
+  /*
+   * When SSL is on, whether the server certificate chain must validate. Users
+   * connecting to a DB with a self-signed cert set this to false.
+   */
+  rejectUnauthorizedSsl: boolean;
+  // The read-only SQL query to run. A single statement is expected.
+  query: string;
+  connectionTimeoutInMs: number;
+  statementTimeoutInMs: number;
+  // Upper bound on rows read back from the DB (memory + payload guard).
+  maxRows: number;
+}
+
+export class MonitorStepSqlMonitorUtil {
+  public static getDefault(): MonitorStepSqlMonitor {
+    return {
+      databaseType: SqlDatabaseType.PostgreSQL,
+      host: "",
+      port: 5432,
+      databaseName: "",
+      username: "",
+      password: "",
+      useSsl: false,
+      rejectUnauthorizedSsl: true,
+      query: "",
+      connectionTimeoutInMs: DEFAULT_SQL_CONNECTION_TIMEOUT_IN_MS,
+      statementTimeoutInMs: DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS,
+      maxRows: DEFAULT_SQL_MAX_ROWS,
+    };
+  }
+
+  public static fromJSON(json: JSONObject): MonitorStepSqlMonitor {
+    return {
+      databaseType:
+        (json["databaseType"] as SqlDatabaseType) || SqlDatabaseType.PostgreSQL,
+      host: (json["host"] as string) || "",
+      port: (json["port"] as number) || 5432,
+      databaseName: (json["databaseName"] as string) || "",
+      username: (json["username"] as string) || "",
+      password: (json["password"] as string) || "",
+      useSsl: Boolean(json["useSsl"]),
+      rejectUnauthorizedSsl:
+        json["rejectUnauthorizedSsl"] === undefined ||
+        json["rejectUnauthorizedSsl"] === null
+          ? true
+          : Boolean(json["rejectUnauthorizedSsl"]),
+      query: (json["query"] as string) || "",
+      connectionTimeoutInMs: clampSqlConnectionTimeoutInMs(
+        json["connectionTimeoutInMs"] as number,
+      ),
+      statementTimeoutInMs: clampSqlStatementTimeoutInMs(
+        json["statementTimeoutInMs"] as number,
+      ),
+      maxRows: clampSqlMaxRows(json["maxRows"] as number),
+    };
+  }
+
+  public static toJSON(monitor: MonitorStepSqlMonitor): JSONObject {
+    return {
+      databaseType: monitor.databaseType,
+      host: monitor.host,
+      port: monitor.port,
+      databaseName: monitor.databaseName,
+      username: monitor.username,
+      password: monitor.password,
+      useSsl: monitor.useSsl,
+      rejectUnauthorizedSsl: monitor.rejectUnauthorizedSsl,
+      query: monitor.query,
+      connectionTimeoutInMs: monitor.connectionTimeoutInMs,
+      statementTimeoutInMs: monitor.statementTimeoutInMs,
+      maxRows: monitor.maxRows,
+    };
+  }
+}

--- a/Common/Types/Monitor/MonitorType.ts
+++ b/Common/Types/Monitor/MonitorType.ts
@@ -21,6 +21,9 @@ enum MonitorType {
   Server = "Server",
   SSLCertificate = "SSL Certificate",
 
+  // Database monitoring — runs a read-only SQL query on a schedule from a probe.
+  SQLQuery = "SQL Query",
+
   // These two monitor types are same but we are keeping them separate for now - this is for marketing purposes
   SyntheticMonitor = "Synthetic Monitor",
   CustomJavaScriptCode = "Custom JavaScript Code",
@@ -86,6 +89,10 @@ export class MonitorTypeHelper {
       {
         label: "DNS Monitoring",
         monitorTypes: [MonitorType.DNS, MonitorType.DNSSEC],
+      },
+      {
+        label: "Database Monitoring",
+        monitorTypes: [MonitorType.SQLQuery],
       },
       {
         label: "Synthetic Monitoring",
@@ -289,6 +296,13 @@ export class MonitorTypeHelper {
         icon: IconProp.ShieldCheck,
       },
       {
+        monitorType: MonitorType.SQLQuery,
+        title: "SQL Query",
+        description:
+          "This monitor type runs a read-only SQL query on a schedule against a database (PostgreSQL) and alerts on the result — row count, a scalar value, execution time, or query errors. Requires a probe with network access to your database.",
+        icon: IconProp.Database,
+      },
+      {
         monitorType: MonitorType.SyntheticMonitor,
         title: "Synthetic Monitor",
         description:
@@ -420,6 +434,7 @@ export class MonitorTypeHelper {
       monitorType === MonitorType.DNS ||
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
+      monitorType === MonitorType.SQLQuery ||
       monitorType === MonitorType.ExternalStatusPage;
     return isProbeableMonitor;
   }
@@ -446,6 +461,7 @@ export class MonitorTypeHelper {
       MonitorType.DNS,
       MonitorType.DNSSEC,
       MonitorType.Domain,
+      MonitorType.SQLQuery,
       MonitorType.ExternalStatusPage,
       MonitorType.Kubernetes,
       MonitorType.Docker,
@@ -491,6 +507,7 @@ export class MonitorTypeHelper {
       monitorType === MonitorType.DNS ||
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
+      monitorType === MonitorType.SQLQuery ||
       monitorType === MonitorType.ExternalStatusPage
     ) {
       return true;

--- a/Common/Types/Monitor/SqlDatabaseType.ts
+++ b/Common/Types/Monitor/SqlDatabaseType.ts
@@ -1,0 +1,43 @@
+/*
+ * Database engines a SQL Query monitor can target. Only the engines listed
+ * in SqlDatabaseTypeUtil.getSupportedDatabaseTypes() are executable today —
+ * the rest are reserved so the type system and stored config are forward
+ * compatible when their probe executors ship.
+ */
+enum SqlDatabaseType {
+  PostgreSQL = "PostgreSQL",
+  MySQL = "MySQL",
+  MicrosoftSqlServer = "Microsoft SQL Server",
+}
+
+export default SqlDatabaseType;
+
+export class SqlDatabaseTypeUtil {
+  /**
+   * Engines the probe can actually connect to and query today. PostgreSQL is
+   * the v1 engine (its driver, `pg`, is already vetted in the monorepo). The
+   * others are intentionally not returned here until their executor lands, so
+   * the dashboard never offers a database type the probe cannot run.
+   */
+  public static getSupportedDatabaseTypes(): Array<SqlDatabaseType> {
+    return [SqlDatabaseType.PostgreSQL];
+  }
+
+  public static isSupported(databaseType: SqlDatabaseType): boolean {
+    return this.getSupportedDatabaseTypes().includes(databaseType);
+  }
+
+  /** Default port for a database engine, used to seed the config form. */
+  public static getDefaultPort(databaseType: SqlDatabaseType): number {
+    switch (databaseType) {
+      case SqlDatabaseType.PostgreSQL:
+        return 5432;
+      case SqlDatabaseType.MySQL:
+        return 3306;
+      case SqlDatabaseType.MicrosoftSqlServer:
+        return 1433;
+      default:
+        return 5432;
+    }
+  }
+}

--- a/Common/Types/Monitor/SqlMonitor/SqlMonitorResponse.ts
+++ b/Common/Types/Monitor/SqlMonitor/SqlMonitorResponse.ts
@@ -1,0 +1,28 @@
+import { JSONObject } from "../../JSON";
+import ProbeAttempt from "../../Probe/ProbeAttempt";
+
+/*
+ * The compact projection of a SQL query result that a probe reports back to
+ * OneUptime. Full result sets never leave the probe / the customer network:
+ * only a row count, the first cell (scalar), and the first row are returned.
+ * This bounds payload size and avoids replicating customer data into
+ * OneUptime storage.
+ */
+export default interface SqlMonitorResponse {
+  isOnline: boolean;
+  responseTimeInMs: number;
+  failureCause: string;
+  // Number of rows the query returned (capped at maxRows). Null on error.
+  rowCount: number | null;
+  // First column of the first row — the natural value for COUNT(*)-style checks.
+  scalarValue: string | number | boolean | null;
+  // First row as a name→value map (values coerced to primitives). Null on error.
+  firstRow: JSONObject | null;
+  // True when the result was truncated because it exceeded maxRows.
+  isRowsCapped?: boolean | undefined;
+  // Sanitized DB/driver error message (never contains credentials/DSN). Null on success.
+  queryError: string | null;
+  isTimeout?: boolean | undefined;
+  probeAttempts?: Array<ProbeAttempt> | undefined;
+  totalAttempts?: number | undefined;
+}

--- a/Common/Types/Probe/ProbeMonitorResponse.ts
+++ b/Common/Types/Probe/ProbeMonitorResponse.ts
@@ -12,6 +12,7 @@ import DnsMonitorResponse from "../Monitor/DnsMonitor/DnsMonitorResponse";
 import PingMonitorResponse from "../Monitor/PingMonitor/PingMonitorResponse";
 import DomainMonitorResponse from "../Monitor/DomainMonitor/DomainMonitorResponse";
 import DnssecMonitorResponse from "../Monitor/DnssecMonitor/DnssecMonitorResponse";
+import SqlMonitorResponse from "../Monitor/SqlMonitor/SqlMonitorResponse";
 import ExternalStatusPageMonitorResponse from "../Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import HttpPhaseTimings from "../Monitor/HttpPhaseTimings";
 import MonitorEvaluationSummary from "../Monitor/MonitorEvaluationSummary";
@@ -60,6 +61,7 @@ export default interface ProbeMonitorResponse {
   dnsResponse?: DnsMonitorResponse | undefined;
   domainResponse?: DomainMonitorResponse | undefined;
   dnssecResponse?: DnssecMonitorResponse | undefined;
+  sqlQueryMonitorResponse?: SqlMonitorResponse | undefined;
   externalStatusPageResponse?: ExternalStatusPageMonitorResponse | undefined;
   monitoredAt: Date;
   isTimeout?: boolean | undefined;

--- a/Common/Utils/Monitor/MonitorMetricType.ts
+++ b/Common/Utils/Monitor/MonitorMetricType.ts
@@ -222,6 +222,7 @@ class MonitorMetricTypeUtil {
       monitorType === MonitorType.DNS ||
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
+      monitorType === MonitorType.SQLQuery ||
       monitorType === MonitorType.ExternalStatusPage
     ) {
       return [MonitorMetricType.IsOnline, MonitorMetricType.ResponseTime];

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
@@ -1,0 +1,243 @@
+// Set required env vars before importing SqlMonitor (which imports Config.ts).
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import SqlMonitor, {
+  SqlQueryValidator,
+} from "../../../../Utils/Monitors/MonitorTypes/SqlMonitor";
+import { describe, expect, it } from "@jest/globals";
+
+describe("SqlQueryValidator.getRejectionReason", () => {
+  it("allows a plain SELECT", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason(
+        "SELECT COUNT(*) FROM orders WHERE status = 'CANCELLED'",
+      ),
+    ).toBeNull();
+  });
+
+  it("allows lower-case and leading whitespace", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason("   select 1 "),
+    ).toBeNull();
+  });
+
+  it("allows the cursorable read statements WITH (CTE), VALUES, TABLE", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason(
+        "WITH t AS (SELECT 1) SELECT * FROM t",
+      ),
+    ).toBeNull();
+    expect(SqlQueryValidator.getRejectionReason("VALUES (1),(2)")).toBeNull();
+    expect(SqlQueryValidator.getRejectionReason("TABLE orders")).toBeNull();
+  });
+
+  it("rejects non-cursorable read statements (SHOW, EXPLAIN)", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason("SHOW server_version"),
+    ).toBeTruthy();
+    expect(SqlQueryValidator.getRejectionReason("EXPLAIN SELECT 1")).toBeTruthy();
+  });
+
+  it("allows a single trailing semicolon", () => {
+    expect(SqlQueryValidator.getRejectionReason("SELECT 1;")).toBeNull();
+    expect(SqlQueryValidator.getRejectionReason("SELECT 1;   ")).toBeNull();
+  });
+
+  it("rejects empty / whitespace-only queries", () => {
+    expect(SqlQueryValidator.getRejectionReason("")).toBeTruthy();
+    expect(SqlQueryValidator.getRejectionReason("   ")).toBeTruthy();
+    expect(SqlQueryValidator.getRejectionReason(";")).toBeTruthy();
+  });
+
+  it("rejects writes and DDL", () => {
+    for (const q of [
+      "UPDATE orders SET x = 1",
+      "DELETE FROM orders",
+      "INSERT INTO orders VALUES (1)",
+      "DROP TABLE orders",
+      "ALTER TABLE orders ADD COLUMN x int",
+      "TRUNCATE orders",
+      "GRANT ALL ON orders TO bob",
+      "CREATE TABLE t (id int)",
+      "MERGE INTO t USING s ON t.id = s.id",
+      "CALL do_something()",
+    ]) {
+      expect(SqlQueryValidator.getRejectionReason(q)).toBeTruthy();
+    }
+  });
+
+  it("rejects multiple statements (stacked query injection)", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason("SELECT 1; DROP TABLE orders"),
+    ).toBeTruthy();
+    expect(
+      SqlQueryValidator.getRejectionReason(
+        "SELECT 1; SELECT 2",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("does not trip on a semicolon inside a string literal", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason("SELECT ';' AS delimiter"),
+    ).toBeNull();
+  });
+
+  it("ignores keywords hidden in comments", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason("-- DROP TABLE x\nSELECT 1"),
+    ).toBeNull();
+    expect(
+      SqlQueryValidator.getRejectionReason("/* UPDATE */ SELECT 1"),
+    ).toBeNull();
+  });
+
+  it("rejects a write disguised by a leading comment", () => {
+    expect(
+      SqlQueryValidator.getRejectionReason("/* readonly */ DELETE FROM orders"),
+    ).toBeTruthy();
+  });
+});
+
+describe("SqlMonitor.sanitizeError", () => {
+  it("redacts the password substring", () => {
+    const msg: string = SqlMonitor.sanitizeError(
+      new Error("auth failed for password s3cr3tP@ss"),
+      "s3cr3tP@ss",
+    );
+    expect(msg).not.toContain("s3cr3tP@ss");
+    expect(msg).toContain("***");
+  });
+
+  it("redacts a connection URI", () => {
+    const msg: string = SqlMonitor.sanitizeError(
+      new Error("could not connect to postgres://user:pw@db.internal:5432/orders"),
+      "pw",
+    );
+    expect(msg).not.toContain("db.internal");
+    expect(msg).toContain("[redacted-dsn]");
+  });
+
+  it("handles a non-Error value and empty password", () => {
+    expect(typeof SqlMonitor.sanitizeError("boom", undefined)).toBe("string");
+    expect(SqlMonitor.sanitizeError("boom", "")).toContain("boom");
+  });
+});
+
+describe("SqlMonitor.coerceCell", () => {
+  it("passes primitives through and coerces complex types", () => {
+    expect(SqlMonitor.coerceCell(null)).toBeNull();
+    expect(SqlMonitor.coerceCell(undefined)).toBeNull();
+    expect(SqlMonitor.coerceCell(5)).toBe(5);
+    expect(SqlMonitor.coerceCell("x")).toBe("x");
+    expect(SqlMonitor.coerceCell(true)).toBe(true);
+    expect(SqlMonitor.coerceCell(BigInt(42))).toBe("42");
+    const date: Date = new Date("2026-01-01T00:00:00.000Z");
+    expect(SqlMonitor.coerceCell(date)).toBe("2026-01-01T00:00:00.000Z");
+    expect(SqlMonitor.coerceCell(Buffer.from("abc"))).toBe("[binary]");
+    expect(SqlMonitor.coerceCell({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe("SqlMonitor.shapeRows", () => {
+  it("projects rowCount, scalar (first column), and firstRow", () => {
+    const shaped: {
+      rowCount: number;
+      scalarValue: string | number | boolean | null;
+      firstRow: Record<string, unknown> | null;
+      isRowsCapped: boolean;
+    } = SqlMonitor.shapeRows({
+      rows: [{ cancelled: 7, other: "x" }],
+      fields: [{ name: "cancelled" } as any, { name: "other" } as any],
+      maxRows: 100,
+    });
+
+    expect(shaped.rowCount).toBe(1);
+    expect(shaped.scalarValue).toBe(7);
+    expect(shaped.firstRow).toEqual({ cancelled: 7, other: "x" });
+    expect(shaped.isRowsCapped).toBe(false);
+  });
+
+  it("caps rows at maxRows and flags truncation", () => {
+    const rows: Array<Record<string, unknown>> = [];
+    for (let i: number = 0; i < 6; i++) {
+      rows.push({ n: i });
+    }
+
+    const shaped: {
+      rowCount: number;
+      isRowsCapped: boolean;
+    } = SqlMonitor.shapeRows({
+      rows,
+      fields: [{ name: "n" } as any],
+      maxRows: 5,
+    });
+
+    expect(shaped.rowCount).toBe(5);
+    expect(shaped.isRowsCapped).toBe(true);
+  });
+
+  it("handles an empty result set", () => {
+    const shaped: {
+      rowCount: number;
+      scalarValue: string | number | boolean | null;
+      firstRow: Record<string, unknown> | null;
+    } = SqlMonitor.shapeRows({ rows: [], fields: [], maxRows: 100 });
+
+    expect(shaped.rowCount).toBe(0);
+    expect(shaped.scalarValue).toBeNull();
+    expect(shaped.firstRow).toBeNull();
+  });
+});
+
+describe("SqlMonitor.execute (guard rejections, no DB needed)", () => {
+  it("returns a failure for a write query without connecting", async () => {
+    const response = await SqlMonitor.execute(
+      {
+        databaseType: "PostgreSQL" as any,
+        host: "db.internal",
+        port: 5432,
+        databaseName: "orders",
+        username: "readonly",
+        password: "",
+        useSsl: false,
+        rejectUnauthorizedSsl: true,
+        query: "DELETE FROM orders",
+        connectionTimeoutInMs: 10000,
+        statementTimeoutInMs: 15000,
+        maxRows: 100,
+      },
+      { isOnlineCheckRequest: true },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.queryError).toBeTruthy();
+    expect(response!.rowCount).toBeNull();
+  });
+
+  it("returns a failure for an unsupported database type without connecting", async () => {
+    const response = await SqlMonitor.execute(
+      {
+        databaseType: "MySQL" as any,
+        host: "db.internal",
+        port: 3306,
+        databaseName: "orders",
+        username: "readonly",
+        password: "",
+        useSsl: false,
+        rejectUnauthorizedSsl: true,
+        query: "SELECT 1",
+        connectionTimeoutInMs: 10000,
+        statementTimeoutInMs: 15000,
+        maxRows: 100,
+      },
+      { isOnlineCheckRequest: true },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.failureCause).toContain("not supported");
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -23,6 +23,9 @@ import MonitorStepDomainMonitor from "Common/Types/Monitor/MonitorStepDomainMoni
 import DnssecMonitorUtil from "./MonitorTypes/DnssecMonitor";
 import DnssecMonitorResponse from "Common/Types/Monitor/DnssecMonitor/DnssecMonitorResponse";
 import MonitorStepDnssecMonitor from "Common/Types/Monitor/MonitorStepDnssecMonitor";
+import SqlMonitor from "./MonitorTypes/SqlMonitor";
+import SqlMonitorResponse from "Common/Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import MonitorStepSqlMonitor from "Common/Types/Monitor/MonitorStepSqlMonitor";
 import ExternalStatusPageMonitorUtil from "./MonitorTypes/ExternalStatusPageMonitor";
 import ExternalStatusPageMonitorResponse from "Common/Types/Monitor/ExternalStatusPageMonitor/ExternalStatusPageMonitorResponse";
 import MonitorStepExternalStatusPageMonitor from "Common/Types/Monitor/MonitorStepExternalStatusPageMonitor";
@@ -809,6 +812,46 @@ export default class MonitorUtil {
       result.responseTimeInMs = response.responseTimeInMs;
       result.failureCause = response.failureCause;
       result.dnssecResponse = response;
+      result.probeAttempts = response.probeAttempts;
+      result.totalAttempts = response.totalAttempts;
+    }
+
+    if (monitorType === MonitorType.SQLQuery) {
+      if (!monitorStep.data?.sqlMonitor) {
+        result.failureCause = "SQL monitor configuration not specified";
+        return result;
+      }
+
+      const sqlConfig: MonitorStepSqlMonitor = monitorStep.data.sqlMonitor;
+
+      if (!sqlConfig.host) {
+        result.failureCause = "Database host not specified";
+        return result;
+      }
+
+      if (!sqlConfig.query) {
+        result.failureCause = "SQL query not specified";
+        return result;
+      }
+
+      const response: SqlMonitorResponse | null = await SqlMonitor.execute(
+        sqlConfig,
+        {
+          retry: retryCount,
+          monitorId: monitorId,
+          timeout: requestTimeoutInMs,
+        },
+      );
+
+      if (!response) {
+        return null;
+      }
+
+      result.isOnline = response.isOnline;
+      result.isTimeout = response.isTimeout;
+      result.responseTimeInMs = response.responseTimeInMs;
+      result.failureCause = response.failureCause;
+      result.sqlQueryMonitorResponse = response;
       result.probeAttempts = response.probeAttempts;
       result.totalAttempts = response.totalAttempts;
     }

--- a/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
@@ -1,0 +1,440 @@
+import OnlineCheck from "../../OnlineCheck";
+import logger from "Common/Server/Utils/Logger";
+import ObjectID from "Common/Types/ObjectID";
+import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
+import Sleep from "Common/Types/Sleep";
+import { JSONObject } from "Common/Types/JSON";
+import MonitorStepSqlMonitor, {
+  clampSqlConnectionTimeoutInMs,
+  clampSqlMaxRows,
+  clampSqlStatementTimeoutInMs,
+} from "Common/Types/Monitor/MonitorStepSqlMonitor";
+import { SqlDatabaseTypeUtil } from "Common/Types/Monitor/SqlDatabaseType";
+import SqlMonitorResponse from "Common/Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import { Client, ClientConfig, FieldDef, QueryResult } from "pg";
+
+export interface SqlQueryOptions {
+  timeout?: number | undefined;
+  retry?: number | undefined;
+  currentRetryCount?: number | undefined;
+  monitorId?: ObjectID | undefined;
+  isOnlineCheckRequest?: boolean | undefined;
+  attempts?: Array<ProbeAttempt> | undefined;
+}
+
+/*
+ * First token that a read-only query is allowed to start with. Restricted to
+ * statements Postgres can run inside a DECLARE ... CURSOR (SELECT / WITH /
+ * VALUES / TABLE) so an allowed query always executes. WITH is permitted
+ * because the authoritative read-only guarantee is the read-only transaction
+ * the probe opens (which rejects writable CTEs); this allow-list is a
+ * secondary, defense-in-depth control.
+ */
+const ALLOWED_FIRST_TOKENS: Array<string> = [
+  "select",
+  "with",
+  "values",
+  "table",
+];
+
+export class SqlQueryValidator {
+  /**
+   * Remove SQL line (`-- ...`) and block (`/* ... *\/`) comments so structural
+   * checks look at real SQL, not commented-out keywords.
+   */
+  public static stripComments(query: string): string {
+    return query
+      .replace(/\/\*[\s\S]*?\*\//g, " ") // block comments
+      .replace(/--[^\n]*/g, " "); // line comments
+  }
+
+  /**
+   * Blank out string literals so a `;` or keyword inside quoted text does not
+   * trip the single-statement / keyword checks.
+   */
+  public static stripStringLiterals(query: string): string {
+    return query
+      .replace(/'(?:[^'\\]|\\.|'')*'/g, "''")
+      .replace(/"(?:[^"\\]|\\.|"")*"/g, '""');
+  }
+
+  /**
+   * Returns a human-readable reason the query is rejected, or null if it
+   * passes the (secondary) static safety checks. The primary read-only
+   * guarantee is enforced at execution time by a read-only transaction and a
+   * least-privilege database user — these checks are defense-in-depth.
+   */
+  public static getRejectionReason(query: string): string | null {
+    if (!query || !query.trim()) {
+      return "SQL query is empty.";
+    }
+
+    let normalized: string = this.stripComments(query).trim();
+
+    // Drop trailing semicolons (a single trailing terminator is fine).
+    normalized = normalized.replace(/;+\s*$/g, "").trim();
+
+    if (!normalized) {
+      return "SQL query is empty.";
+    }
+
+    const withoutStrings: string = this.stripStringLiterals(normalized);
+
+    if (withoutStrings.includes(";")) {
+      return "Multiple SQL statements are not allowed. Provide a single read-only query.";
+    }
+
+    const firstTokenMatch: RegExpMatchArray | null =
+      normalized.match(/^[a-zA-Z]+/);
+    const firstToken: string = firstTokenMatch
+      ? firstTokenMatch[0].toLowerCase()
+      : "";
+
+    if (!ALLOWED_FIRST_TOKENS.includes(firstToken)) {
+      return "Only read-only queries are allowed (must start with SELECT, WITH, VALUES, or TABLE).";
+    }
+
+    return null;
+  }
+}
+
+export default class SqlMonitor {
+  /**
+   * Strip anything that could leak the connection secret out of a driver
+   * error message before it is stored/returned. Never let the password or a
+   * connection URI escape the probe.
+   */
+  public static sanitizeError(
+    error: unknown,
+    password: string | undefined,
+  ): string {
+    let message: string =
+      (error as Error)?.message || (error as Error)?.toString() || "SQL error";
+
+    if (password && password.length > 0) {
+      message = message.split(password).join("***");
+    }
+
+    // Redact any connection URIs (postgres://user:pass@host/db).
+    message = message.replace(/[a-zA-Z]+:\/\/[^\s]*@[^\s]*/g, "[redacted-dsn]");
+
+    return message;
+  }
+
+  /**
+   * Coerce a raw DB cell into a JSON-safe primitive. Dates become ISO
+   * strings, binary becomes a placeholder, and structured values are
+   * stringified — so the compact result projection is always serializable.
+   */
+  public static coerceCell(
+    value: unknown,
+  ): string | number | boolean | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      typeof value === "string"
+    ) {
+      return value;
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    if (Buffer.isBuffer(value)) {
+      return "[binary]";
+    }
+
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  /**
+   * Turn the fetched rows into the compact projection reported to OneUptime:
+   * a bounded row count, the first cell (scalar), and the first row. Never
+   * returns the full result set.
+   */
+  public static shapeRows(input: {
+    rows: Array<Record<string, unknown>>;
+    fields: Array<FieldDef>;
+    maxRows: number;
+  }): {
+    rowCount: number;
+    scalarValue: string | number | boolean | null;
+    firstRow: JSONObject | null;
+    isRowsCapped: boolean;
+  } {
+    const maxRows: number = input.maxRows;
+    const isRowsCapped: boolean = input.rows.length > maxRows;
+    const keptRows: Array<Record<string, unknown>> = input.rows.slice(
+      0,
+      maxRows,
+    );
+    const rowCount: number = keptRows.length;
+
+    let firstRow: JSONObject | null = null;
+    let scalarValue: string | number | boolean | null = null;
+
+    if (keptRows[0]) {
+      firstRow = {};
+      for (const key of Object.keys(keptRows[0])) {
+        firstRow[key] = SqlMonitor.coerceCell(keptRows[0][key]);
+      }
+
+      const firstColumnName: string | undefined = input.fields[0]?.name;
+      if (firstColumnName !== undefined) {
+        scalarValue = SqlMonitor.coerceCell(keptRows[0][firstColumnName]);
+      }
+    }
+
+    return { rowCount, scalarValue, firstRow, isRowsCapped };
+  }
+
+  public static async execute(
+    config: MonitorStepSqlMonitor,
+    options?: SqlQueryOptions,
+  ): Promise<SqlMonitorResponse | null> {
+    if (!options) {
+      options = {};
+    }
+
+    if (options.currentRetryCount === undefined) {
+      options.currentRetryCount = 1;
+    }
+
+    if (!options.attempts) {
+      options.attempts = [];
+    }
+
+    const statementTimeoutInMs: number = clampSqlStatementTimeoutInMs(
+      config.statementTimeoutInMs,
+    );
+    const connectionTimeoutInMs: number = clampSqlConnectionTimeoutInMs(
+      config.connectionTimeoutInMs,
+    );
+    const maxRows: number = clampSqlMaxRows(config.maxRows);
+
+    // Secondary, defense-in-depth static safety check.
+    const rejectionReason: string | null = SqlQueryValidator.getRejectionReason(
+      config.query,
+    );
+    if (rejectionReason) {
+      return {
+        isOnline: false,
+        responseTimeInMs: 0,
+        failureCause: rejectionReason,
+        rowCount: null,
+        scalarValue: null,
+        firstRow: null,
+        queryError: rejectionReason,
+      };
+    }
+
+    if (!SqlDatabaseTypeUtil.isSupported(config.databaseType)) {
+      const message: string = `Database type "${config.databaseType}" is not supported yet. Supported: ${SqlDatabaseTypeUtil.getSupportedDatabaseTypes().join(
+        ", ",
+      )}.`;
+      return {
+        isOnline: false,
+        responseTimeInMs: 0,
+        failureCause: message,
+        rowCount: null,
+        scalarValue: null,
+        firstRow: null,
+        queryError: message,
+      };
+    }
+
+    logger.debug(
+      `SQL Query: ${options?.monitorId?.toString()} ${config.host}:${config.port}/${config.databaseName} - Retry: ${options?.currentRetryCount}`,
+    );
+
+    const startTime: [number, number] = process.hrtime();
+    const attemptedAt: Date = new Date();
+
+    try {
+      const { rows, fields } = await SqlMonitor.runPostgresQuery({
+        config,
+        statementTimeoutInMs,
+        connectionTimeoutInMs,
+        maxRows,
+      });
+
+      const endTime: [number, number] = process.hrtime(startTime);
+      const responseTimeInMs: number = Math.ceil(
+        (endTime[0] * 1000000000 + endTime[1]) / 1000000,
+      );
+
+      const shaped: {
+        rowCount: number;
+        scalarValue: string | number | boolean | null;
+        firstRow: JSONObject | null;
+        isRowsCapped: boolean;
+      } = SqlMonitor.shapeRows({ rows, fields, maxRows });
+
+      const responseReceivedAt: Date = new Date();
+      options.attempts.push({
+        attemptNumber: options.currentRetryCount,
+        attemptedAt,
+        responseReceivedAt,
+        responseTimeInMs,
+        isOnline: true,
+      });
+
+      return {
+        isOnline: true,
+        responseTimeInMs,
+        failureCause: "",
+        rowCount: shaped.rowCount,
+        scalarValue: shaped.scalarValue,
+        firstRow: shaped.firstRow,
+        isRowsCapped: shaped.isRowsCapped,
+        queryError: null,
+        probeAttempts: options.attempts,
+        totalAttempts: options.attempts.length,
+      };
+    } catch (err: unknown) {
+      const sanitized: string = SqlMonitor.sanitizeError(err, config.password);
+      logger.debug(
+        `SQL Query error: ${options?.monitorId?.toString()} ${config.host}:${config.port} - ${sanitized}`,
+      );
+
+      const endTime: [number, number] = process.hrtime(startTime);
+      const responseTimeInMs: number = Math.ceil(
+        (endTime[0] * 1000000000 + endTime[1]) / 1000000,
+      );
+
+      const responseReceivedAt: Date = new Date();
+      options.attempts.push({
+        attemptNumber: options.currentRetryCount || 1,
+        attemptedAt,
+        responseReceivedAt,
+        responseTimeInMs,
+        isOnline: false,
+        failureCause: sanitized,
+      });
+
+      if (options.currentRetryCount < (options.retry || 3)) {
+        options.currentRetryCount++;
+        await Sleep.sleep(1000);
+        return await SqlMonitor.execute(config, options);
+      }
+
+      // Distinguish "probe can't reach anything" from "this DB is down".
+      if (!options.isOnlineCheckRequest) {
+        if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
+          logger.error(
+            `SqlMonitor - Probe is not online. Cannot query ${options?.monitorId?.toString()} ${config.host} - ERROR: ${sanitized}`,
+          );
+          return null;
+        }
+      }
+
+      const isTimeout: boolean =
+        sanitized.toLowerCase().includes("timeout") ||
+        sanitized.toLowerCase().includes("timed out") ||
+        sanitized.toLowerCase().includes("etimedout") ||
+        sanitized.toLowerCase().includes("canceling statement");
+
+      return {
+        isOnline: false,
+        isTimeout,
+        responseTimeInMs,
+        failureCause: sanitized,
+        rowCount: null,
+        scalarValue: null,
+        firstRow: null,
+        queryError: sanitized,
+        probeAttempts: options.attempts,
+        totalAttempts: options.attempts.length,
+      };
+    }
+  }
+
+  /**
+   * Connect to PostgreSQL and run the user's query inside a READ ONLY
+   * transaction with a hard statement timeout, reading at most maxRows+1 rows
+   * via a cursor (the +1 lets the caller detect truncation). The transaction
+   * is always rolled back and the connection always closed.
+   */
+  private static async runPostgresQuery(input: {
+    config: MonitorStepSqlMonitor;
+    statementTimeoutInMs: number;
+    connectionTimeoutInMs: number;
+    maxRows: number;
+  }): Promise<{ rows: Array<Record<string, unknown>>; fields: Array<FieldDef> }> {
+    const { config, statementTimeoutInMs, connectionTimeoutInMs, maxRows } =
+      input;
+
+    const clientConfig: ClientConfig = {
+      host: config.host,
+      port: config.port,
+      database: config.databaseName,
+      user: config.username,
+      password: config.password,
+      connectionTimeoutMillis: connectionTimeoutInMs,
+      // Server-side per-statement cap (primary timeout control).
+      statement_timeout: statementTimeoutInMs,
+      // Client-side backstop in case the server ignores statement_timeout.
+      query_timeout: statementTimeoutInMs + 2000,
+      application_name: "OneUptimeProbe-SQLMonitor",
+      ssl: config.useSsl
+        ? { rejectUnauthorized: config.rejectUnauthorizedSsl }
+        : false,
+    };
+
+    const client: Client = new Client(clientConfig);
+
+    await client.connect();
+
+    const cursorName: string = "oneuptime_sql_monitor_cursor";
+
+    // Strip any trailing terminator so it can be embedded in DECLARE ... CURSOR.
+    const cursorQuery: string = config.query.replace(/;+\s*$/g, "").trim();
+
+    try {
+      // Authoritative read-only guarantee: a read-only transaction blocks all
+      // writes, including Postgres writable CTEs, regardless of the query text.
+      await client.query("START TRANSACTION READ ONLY");
+      await client.query(
+        `SET LOCAL statement_timeout = ${Math.floor(statementTimeoutInMs)}`,
+      );
+
+      await client.query(
+        `DECLARE ${cursorName} NO SCROLL CURSOR FOR ${cursorQuery}`,
+      );
+
+      const result: QueryResult = await client.query(
+        `FETCH FORWARD ${maxRows + 1} FROM ${cursorName}`,
+      );
+
+      return {
+        rows: (result.rows as Array<Record<string, unknown>>) || [],
+        fields: result.fields || [],
+      };
+    } finally {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackErr) {
+        logger.debug(`SQL monitor rollback failed: ${rollbackErr}`);
+      }
+
+      try {
+        await client.end();
+      } catch (endErr) {
+        logger.debug(`SQL monitor connection close failed: ${endErr}`);
+      }
+    }
+  }
+}

--- a/Probe/package-lock.json
+++ b/Probe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oneuptime/probe",
-  "version": "11.3.27",
+  "version": "11.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oneuptime/probe",
-      "version": "11.3.27",
+      "version": "11.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ping": "^0.4.4",
@@ -17,6 +17,7 @@
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "net-snmp": "^3.26.1",
+        "pg": "^8.22.0",
         "ping": "^0.4.4",
         "playwright": "^1.60.0",
         "ts-node": "^10.9.1",
@@ -26,6 +27,7 @@
         "@types/jest": "^27.5.2",
         "@types/net-snmp": "^3.23.0",
         "@types/node": "^17.0.31",
+        "@types/pg": "^8.20.0",
         "@types/whois-json": "^2.0.4",
         "jest": "^28.1.0",
         "nodemon": "^3.1.14",
@@ -34,7 +36,7 @@
     },
     "../Common": {
       "name": "@oneuptime/common",
-      "version": "11.3.27",
+      "version": "11.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.2",
@@ -1169,6 +1171,18 @@
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
     },
     "node_modules/@types/ping": {
       "version": "0.4.4",
@@ -4344,6 +4358,95 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4434,6 +4537,45 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-format": {
@@ -4727,6 +4869,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5358,6 +5509,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## What

Adds a first-class **SQL Query** monitor type. It runs a **read-only** SQL query on a schedule from a probe and alerts on the result — row count, a scalar value, execution time, or a query error. This covers the "run a query and open an incident" use case (e.g. monitoring order-cancellation records and paging when a threshold is crossed), with full criteria → incident/alert → on-call escalation.

Ships **PostgreSQL first** behind a `SqlDatabaseType` enum so MySQL / SQL Server can be added later without re-architecture. `pg` is already a vetted repo dependency.

## Security model (the core of the feature)

The **probe is the only component that ever holds a DB credential or opens a database socket** — the app/server never connects to customer databases. A SQL monitor therefore needs a **probe with network access to the database** (typically a private/custom probe).

- **Read-only is enforced by the DB session**, not a regex: the query runs inside a Postgres `START TRANSACTION READ ONLY`, which blocks all writes including writable CTEs. A least-privilege read-only DB user is the recommended primary control.
- **Single-statement + allow-list guard** (`SELECT` / `WITH` / `VALUES` / `TABLE`) as defense-in-depth — comment- and string-literal-aware, so a `;` or keyword inside a string/comment doesn't trip it, and stacked-query injection is rejected.
- **Hard statement timeout** (server-side `statement_timeout` + client backstop) and a **cursor-bounded row cap** (`maxRows`) — only a **compact projection** (`rowCount` / `scalarValue` / `firstRow`) ever leaves the probe, so full result sets are never replicated into OneUptime.
- **Driver errors are sanitized** (password + connection URI redacted) before they're stored or shown.
- The DB password (and other connection fields) support user-chosen **`{{monitorSecrets.name}}`** references, resolved server-side. OneUptime never creates or populates a secret on the user's behalf.

## Wiring

- **Types:** `MonitorType.SQLQuery` (+ all helpers), `SqlDatabaseType`, `MonitorStepSqlMonitor` (config + validation + JSON round-trip + schema), `SqlMonitorResponse`, `ProbeMonitorResponse` field.
- **Probe:** dispatcher branch + `SqlMonitor` handler (`pg`, read-only txn, cursor, timeouts, sanitization).
- **Criteria:** new `CheckOn`s — `SqlIsOnline`, `SqlQueryRowCount`, `SqlQueryScalarValue`, `SqlQueryExecutionTime`, `SqlQueryError` — plus `JavaScriptExpression` support (`{{scalarValue}}`, `{{rowCount}}`, `{{firstRow}}`, …), a `SqlMonitorCriteria` evaluator, and default online/offline criteria.
- **Server/App:** monitor-secret interpolation for SQL fields, monitor-list destination string (`host:port/db`, never credentials), metric grouping (IsOnline + ResponseTime graphs).
- **Dashboard:** config form (with secret hint + read-only guidance), criteria dropdown options/placeholders, read-only step view, and a per-check summary view.

## Tests

42 new tests, all green, plus existing monitor tests unaffected:
- `SqlMonitorCriteria` evaluation across every CheckOn.
- Config clamping + `fromJSON`/`toJSON` round-trip.
- Probe security guards: read-only/DDL rejection, stacked-query rejection, comment/string-literal handling, error redaction, cell coercion, row-cap/truncation, and guard-path `execute()` (no DB needed).

`Common`, `Probe`, and `Dashboard` all type-check clean.

## Follow-ups (intentionally deferred)

MySQL / SQL Server executors; connection pooling; emitting the query value as a metric for richer trend/anomaly dashboards; notification template variables for SQL results.