### PR TITLE
test(Common): add tests for Types/AI/AIChatPermissionModeHelper

### DIFF
--- a/Common/Tests/Types/AI/AIChatPermissionMode.test.ts
+++ b/Common/Tests/Types/AI/AIChatPermissionMode.test.ts
@@ -1,0 +1,112 @@
+import AIChatPermissionMode, {
+  AIChatPermissionModeHelper,
+  AIChatPermissionModeOption,
+} from "../../../Types/AI/AIChatPermissionMode";
+
+describe("AIChatPermissionModeHelper", () => {
+  describe("getDefault", () => {
+    test("defaults to AskForApproval", () => {
+      expect(AIChatPermissionModeHelper.getDefault()).toBe(
+        AIChatPermissionMode.AskForApproval,
+      );
+    });
+
+    test("never defaults to the permissive AutoRun mode", () => {
+      // This mode gates every MUTATING tool, so the default must be the safe one.
+      expect(AIChatPermissionModeHelper.getDefault()).not.toBe(
+        AIChatPermissionMode.AutoRun,
+      );
+    });
+  });
+
+  describe("isValid", () => {
+    test("accepts every permission mode", () => {
+      for (const mode of Object.values(AIChatPermissionMode)) {
+        expect(AIChatPermissionModeHelper.isValid(mode)).toBe(true);
+      }
+    });
+
+    test.each([
+      undefined,
+      "",
+      "autorun", // wrong case
+      "AutoRun ", // trailing whitespace
+      "NotAMode",
+    ])("rejects %p", (value: string | undefined) => {
+      expect(AIChatPermissionModeHelper.isValid(value)).toBe(false);
+    });
+  });
+
+  describe("parse", () => {
+    test("round-trips every valid permission mode", () => {
+      for (const mode of Object.values(AIChatPermissionMode)) {
+        expect(AIChatPermissionModeHelper.parse(mode)).toBe(mode);
+      }
+    });
+
+    test.each([undefined, "", "NotAMode", "autorun"])(
+      "falls back to the default for the unrecognized value %p",
+      (value: string | undefined) => {
+        expect(AIChatPermissionModeHelper.parse(value)).toBe(
+          AIChatPermissionModeHelper.getDefault(),
+        );
+      },
+    );
+
+    test("never fails open to AutoRun for unrecognized input", () => {
+      /*
+       * A malformed or missing persisted value must not silently grant the
+       * agent permission to run mutating tools without approval.
+       */
+      const unrecognized: Array<string | undefined> = [
+        undefined,
+        "",
+        "autorun",
+        "AUTO_RUN",
+        "NotAMode",
+      ];
+
+      for (const value of unrecognized) {
+        expect(AIChatPermissionModeHelper.parse(value)).not.toBe(
+          AIChatPermissionMode.AutoRun,
+        );
+      }
+    });
+  });
+
+  describe("getOptions", () => {
+    test("exposes one option per permission mode, exactly once", () => {
+      const options: Array<AIChatPermissionModeOption> =
+        AIChatPermissionModeHelper.getOptions();
+
+      const values: Array<AIChatPermissionMode> = options.map(
+        (o: AIChatPermissionModeOption): AIChatPermissionMode => {
+          return o.value;
+        },
+      );
+
+      expect(values.length).toBe(Object.values(AIChatPermissionMode).length);
+      expect(new Set(values).size).toBe(values.length); // no duplicates
+
+      for (const mode of Object.values(AIChatPermissionMode)) {
+        expect(values).toContain(mode);
+      }
+    });
+
+    test("every option has a title and a description", () => {
+      for (const option of AIChatPermissionModeHelper.getOptions()) {
+        expect(option.title.length).toBeGreaterThan(0);
+        expect(option.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("every offered option is a parseable mode", () => {
+      for (const option of AIChatPermissionModeHelper.getOptions()) {
+        expect(AIChatPermissionModeHelper.isValid(option.value)).toBe(true);
+        expect(AIChatPermissionModeHelper.parse(option.value)).toBe(
+          option.value,
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for `AIChatPermissionModeHelper` in `Common/Types/AI/AIChatPermissionMode.ts`, which previously had no test coverage.

This enum gates whether the AI chat agent may run **mutating** tools (create/acknowledge/resolve incidents and alerts). It's persisted per-conversation on `AIConversation.permissionMode` and enforced in `ChatAgentRunner`, so its parsing behaviour is security-relevant.

Covered:

- **`getDefault`** — returns `AskForApproval`, and explicitly asserts it is **not** the permissive `AutoRun`.
- **`isValid`** — accepts every mode; rejects `undefined`, empty string, wrong casing, trailing whitespace, and unknown values.
- **`parse`** — round-trips every valid mode and falls back to the default for unrecognized input. Includes a **fail-safe invariant**: a malformed or missing persisted value must **never** resolve to `AutoRun`, so a bad column value can't silently let the agent mutate project data without approval.
- **`getOptions`** — exposes exactly one option per mode (no duplicates, none missing), each with a non-empty title and description, and every offered option is itself parseable.

## Why

Improves test coverage for the `Common/Types` utilities (part of the broader test-coverage effort). The fail-safe and option-completeness invariants guard the permission gate as new modes get added.

## Testing

```
node node_modules/.bin/jest --runInBand ./Tests/Types/AI/AIChatPermissionMode.test.ts
```

All 17 tests pass. Prettier- and eslint-clean.