### PR TITLE
fix(migration): backfill LlmLog.completionTokens before SET NOT NULL

### DIFF
--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1784033837629-MigrationName.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1784033837629-MigrationName.ts
@@ -40,10 +40,13 @@ export class MigrationName1784033837629 implements MigrationInterface {
       `ALTER TABLE "OnCallDutyPolicyScheduleLayer" ALTER COLUMN "restrictionTimes" SET DEFAULT '{"_type":"RestrictionTimes","value":{"restictionType":"None","dayRestrictionTimes":null,"weeklyRestrictionTimes":[]}}'`,
     );
     await queryRunner.query(
-      `ALTER TABLE "LlmLog" ALTER COLUMN "completionTokens" SET NOT NULL`,
+      `ALTER TABLE "LlmLog" ALTER COLUMN "completionTokens" SET DEFAULT '0'`,
     );
     await queryRunner.query(
-      `ALTER TABLE "LlmLog" ALTER COLUMN "completionTokens" SET DEFAULT '0'`,
+      `UPDATE "LlmLog" SET "completionTokens" = '0' WHERE "completionTokens" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "LlmLog" ALTER COLUMN "completionTokens" SET NOT NULL`,
     );
     await queryRunner.query(
       `CREATE INDEX "IDX_4bbaf6e55d46424a79fa33a153" ON "AIRun" ("triggeredByAiInsightId") `,


### PR DESCRIPTION
Migration 1784033837629 made LlmLog.completionTokens NOT NULL before setting its default and without backfilling existing rows, so on any database with pre-existing LlmLog data it fails with:

  column "completionTokens" of relation "LlmLog" contains null values

Migrations run in a transaction during app init, so the failure rolls back and crash-loops the app on every populated environment (the "Cannot connect to Postgres" retry loop).

Fix: SET DEFAULT '0', backfill existing NULLs to 0, then SET NOT NULL, so the migration applies cleanly on populated databases.

### Title of this pull request?

### Small Description?

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

### Screenshots (if appropriate):
