### PR TITLE
test(Common): add tests for the BaseDatabase query operators (#210)

### DIFF
--- a/Common/Tests/Types/Database/EndsWith.test.ts
+++ b/Common/Tests/Types/Database/EndsWith.test.ts
@@ -1,0 +1,64 @@
+import EndsWith from "../../../Types/BaseDatabase/EndsWith";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("EndsWith", () => {
+  it("should create an EndsWith object with a valid value", () => {
+    const value: string = "oneuptime";
+    const obj: EndsWith<string> = new EndsWith<string>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: EndsWith<string> = new EndsWith<string>("oldValue");
+    obj.value = "newValue";
+    expect(obj.value).toBe("newValue");
+  });
+
+  it("should return the value using toString", () => {
+    const obj: EndsWith<string> = new EndsWith<string>("oneuptime");
+    expect(obj.toString()).toBe("oneuptime");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: EndsWith<string> = new EndsWith<string>("oneuptime");
+    const expectedJSON: JSONObject = {
+      _type: "EndsWith",
+      value: "oneuptime",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create an EndsWith object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "EndsWith",
+      value: "oneuptime",
+    };
+    const obj: EndsWith<string> = EndsWith.fromJSON(jsonInput);
+    expect(obj.value).toBe("oneuptime");
+  });
+
+  it("should default to an empty string when the JSON value is missing", () => {
+    const jsonInput: JSONObject = {
+      _type: "EndsWith",
+    };
+    const obj: EndsWith<string> = EndsWith.fromJSON(jsonInput);
+    expect(obj.value).toBe("");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "oneuptime",
+    };
+    expect(() => {
+      return EndsWith.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of EndsWith", () => {
+    const obj: EndsWith<string> = new EndsWith<string>("oneuptime");
+    expect(obj).toBeInstanceOf(EndsWith);
+  });
+});

--- a/Common/Tests/Types/Database/GreaterThan.test.ts
+++ b/Common/Tests/Types/Database/GreaterThan.test.ts
@@ -1,0 +1,62 @@
+import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("GreaterThan", () => {
+  it("should create a GreaterThan object with a valid value", () => {
+    const value: number = 42;
+    const obj: GreaterThan<number> = new GreaterThan<number>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: GreaterThan<number> = new GreaterThan<number>(1);
+    obj.value = 2;
+    expect(obj.value).toBe(2);
+  });
+
+  it("should return the correct string representation using toString", () => {
+    const obj: GreaterThan<number> = new GreaterThan<number>(42);
+    expect(obj.toString()).toBe("42");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: GreaterThan<number> = new GreaterThan<number>(42);
+    const expectedJSON: JSONObject = {
+      _type: "GreaterThan",
+      value: "42",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a GreaterThan object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "GreaterThan",
+      value: "42",
+    };
+    const obj: GreaterThan<number> = GreaterThan.fromJSON(jsonInput);
+    expect(obj.value).toBe("42");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "42",
+    };
+    expect(() => {
+      return GreaterThan.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of GreaterThan", () => {
+    const obj: GreaterThan<number> = new GreaterThan<number>(42);
+    expect(obj).toBeInstanceOf(GreaterThan);
+  });
+
+  it("should handle date values", () => {
+    const value: Date = new Date("2023-01-01");
+    const obj: GreaterThan<Date> = new GreaterThan<Date>(value);
+    expect(obj.value).toBe(value);
+  });
+});

--- a/Common/Tests/Types/Database/GreaterThanOrEqual.test.ts
+++ b/Common/Tests/Types/Database/GreaterThanOrEqual.test.ts
@@ -1,0 +1,65 @@
+import GreaterThanOrEqual from "../../../Types/BaseDatabase/GreaterThanOrEqual";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("GreaterThanOrEqual", () => {
+  it("should create a GreaterThanOrEqual object with a valid value", () => {
+    const value: number = 42;
+    const obj: GreaterThanOrEqual<number> = new GreaterThanOrEqual<number>(
+      value,
+    );
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: GreaterThanOrEqual<number> = new GreaterThanOrEqual<number>(1);
+    obj.value = 2;
+    expect(obj.value).toBe(2);
+  });
+
+  it("should return the correct string representation using toString", () => {
+    const obj: GreaterThanOrEqual<number> = new GreaterThanOrEqual<number>(42);
+    expect(obj.toString()).toBe("42");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: GreaterThanOrEqual<number> = new GreaterThanOrEqual<number>(42);
+    const expectedJSON: JSONObject = {
+      _type: "GreaterThanOrEqual",
+      value: "42",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a GreaterThanOrEqual object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "GreaterThanOrEqual",
+      value: "42",
+    };
+    const obj: GreaterThanOrEqual<number> =
+      GreaterThanOrEqual.fromJSON(jsonInput);
+    expect(obj.value).toBe("42");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "42",
+    };
+    expect(() => {
+      return GreaterThanOrEqual.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of GreaterThanOrEqual", () => {
+    const obj: GreaterThanOrEqual<number> = new GreaterThanOrEqual<number>(42);
+    expect(obj).toBeInstanceOf(GreaterThanOrEqual);
+  });
+
+  it("should handle date values", () => {
+    const value: Date = new Date("2023-01-01");
+    const obj: GreaterThanOrEqual<Date> = new GreaterThanOrEqual<Date>(value);
+    expect(obj.value).toBe(value);
+  });
+});

--- a/Common/Tests/Types/Database/GreaterThanOrNull.test.ts
+++ b/Common/Tests/Types/Database/GreaterThanOrNull.test.ts
@@ -1,0 +1,63 @@
+import GreaterThanOrNull from "../../../Types/BaseDatabase/GreaterThanOrNull";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("GreaterThanOrNull", () => {
+  it("should create a GreaterThanOrNull object with a valid value", () => {
+    const value: number = 42;
+    const obj: GreaterThanOrNull<number> = new GreaterThanOrNull<number>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: GreaterThanOrNull<number> = new GreaterThanOrNull<number>(1);
+    obj.value = 2;
+    expect(obj.value).toBe(2);
+  });
+
+  it("should return the correct string representation using toString", () => {
+    const obj: GreaterThanOrNull<number> = new GreaterThanOrNull<number>(42);
+    expect(obj.toString()).toBe("42");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: GreaterThanOrNull<number> = new GreaterThanOrNull<number>(42);
+    const expectedJSON: JSONObject = {
+      _type: "GreaterThanOrNull",
+      value: "42",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a GreaterThanOrNull object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "GreaterThanOrNull",
+      value: "42",
+    };
+    const obj: GreaterThanOrNull<number> =
+      GreaterThanOrNull.fromJSON(jsonInput);
+    expect(obj.value).toBe("42");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "42",
+    };
+    expect(() => {
+      return GreaterThanOrNull.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of GreaterThanOrNull", () => {
+    const obj: GreaterThanOrNull<number> = new GreaterThanOrNull<number>(42);
+    expect(obj).toBeInstanceOf(GreaterThanOrNull);
+  });
+
+  it("should handle date values", () => {
+    const value: Date = new Date("2023-01-01");
+    const obj: GreaterThanOrNull<Date> = new GreaterThanOrNull<Date>(value);
+    expect(obj.value).toBe(value);
+  });
+});

--- a/Common/Tests/Types/Database/Includes.test.ts
+++ b/Common/Tests/Types/Database/Includes.test.ts
@@ -1,0 +1,65 @@
+import Includes from "../../../Types/BaseDatabase/Includes";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("Includes", () => {
+  it("should create an Includes object with string values", () => {
+    const values: Array<string> = ["a", "b"];
+    const obj: Includes = new Includes(values);
+    expect(obj.values).toEqual(values);
+  });
+
+  it("should get and set the values property", () => {
+    const obj: Includes = new Includes(["a"]);
+    obj.values = ["c", "d"];
+    expect(obj.values).toEqual(["c", "d"]);
+  });
+
+  it("should handle numeric values", () => {
+    const values: Array<number> = [1, 2, 3];
+    const obj: Includes = new Includes(values);
+    expect(obj.values).toEqual(values);
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: Includes = new Includes(["a", "b"]);
+    const expectedJSON: JSONObject = {
+      _type: "Includes",
+      value: ["a", "b"],
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create an Includes object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "Includes",
+      value: ["a", "b"],
+    };
+    const obj: Includes = Includes.fromJSON(jsonInput);
+    expect(obj.values).toEqual(["a", "b"]);
+  });
+
+  it("should default to an empty array when the JSON value is missing", () => {
+    const jsonInput: JSONObject = {
+      _type: "Includes",
+    };
+    const obj: Includes = Includes.fromJSON(jsonInput);
+    expect(obj.values).toEqual([]);
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: [],
+    };
+    expect(() => {
+      return Includes.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of Includes", () => {
+    const obj: Includes = new Includes(["a"]);
+    expect(obj).toBeInstanceOf(Includes);
+  });
+});

--- a/Common/Tests/Types/Database/IncludesAll.test.ts
+++ b/Common/Tests/Types/Database/IncludesAll.test.ts
@@ -1,0 +1,65 @@
+import IncludesAll from "../../../Types/BaseDatabase/IncludesAll";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("IncludesAll", () => {
+  it("should create an IncludesAll object with string values", () => {
+    const values: Array<string> = ["a", "b"];
+    const obj: IncludesAll = new IncludesAll(values);
+    expect(obj.values).toEqual(values);
+  });
+
+  it("should get and set the values property", () => {
+    const obj: IncludesAll = new IncludesAll(["a"]);
+    obj.values = ["c", "d"];
+    expect(obj.values).toEqual(["c", "d"]);
+  });
+
+  it("should handle numeric values", () => {
+    const values: Array<number> = [1, 2, 3];
+    const obj: IncludesAll = new IncludesAll(values);
+    expect(obj.values).toEqual(values);
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: IncludesAll = new IncludesAll(["a", "b"]);
+    const expectedJSON: JSONObject = {
+      _type: "IncludesAll",
+      value: ["a", "b"],
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create an IncludesAll object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "IncludesAll",
+      value: ["a", "b"],
+    };
+    const obj: IncludesAll = IncludesAll.fromJSON(jsonInput);
+    expect(obj.values).toEqual(["a", "b"]);
+  });
+
+  it("should default to an empty array when the JSON value is missing", () => {
+    const jsonInput: JSONObject = {
+      _type: "IncludesAll",
+    };
+    const obj: IncludesAll = IncludesAll.fromJSON(jsonInput);
+    expect(obj.values).toEqual([]);
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: [],
+    };
+    expect(() => {
+      return IncludesAll.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of IncludesAll", () => {
+    const obj: IncludesAll = new IncludesAll(["a"]);
+    expect(obj).toBeInstanceOf(IncludesAll);
+  });
+});

--- a/Common/Tests/Types/Database/IncludesNone.test.ts
+++ b/Common/Tests/Types/Database/IncludesNone.test.ts
@@ -1,0 +1,65 @@
+import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("IncludesNone", () => {
+  it("should create an IncludesNone object with string values", () => {
+    const values: Array<string> = ["a", "b"];
+    const obj: IncludesNone = new IncludesNone(values);
+    expect(obj.values).toEqual(values);
+  });
+
+  it("should get and set the values property", () => {
+    const obj: IncludesNone = new IncludesNone(["a"]);
+    obj.values = ["c", "d"];
+    expect(obj.values).toEqual(["c", "d"]);
+  });
+
+  it("should handle numeric values", () => {
+    const values: Array<number> = [1, 2, 3];
+    const obj: IncludesNone = new IncludesNone(values);
+    expect(obj.values).toEqual(values);
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: IncludesNone = new IncludesNone(["a", "b"]);
+    const expectedJSON: JSONObject = {
+      _type: "IncludesNone",
+      value: ["a", "b"],
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create an IncludesNone object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "IncludesNone",
+      value: ["a", "b"],
+    };
+    const obj: IncludesNone = IncludesNone.fromJSON(jsonInput);
+    expect(obj.values).toEqual(["a", "b"]);
+  });
+
+  it("should default to an empty array when the JSON value is missing", () => {
+    const jsonInput: JSONObject = {
+      _type: "IncludesNone",
+    };
+    const obj: IncludesNone = IncludesNone.fromJSON(jsonInput);
+    expect(obj.values).toEqual([]);
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: [],
+    };
+    expect(() => {
+      return IncludesNone.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of IncludesNone", () => {
+    const obj: IncludesNone = new IncludesNone(["a"]);
+    expect(obj).toBeInstanceOf(IncludesNone);
+  });
+});

--- a/Common/Tests/Types/Database/IsNull.test.ts
+++ b/Common/Tests/Types/Database/IsNull.test.ts
@@ -1,0 +1,44 @@
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("IsNull", () => {
+  it("should create an IsNull object", () => {
+    const obj: IsNull = new IsNull();
+    expect(obj).toBeInstanceOf(IsNull);
+  });
+
+  it("should return an empty string using toString", () => {
+    const obj: IsNull = new IsNull();
+    expect(obj.toString()).toBe("");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: IsNull = new IsNull();
+    const expectedJSON: JSONObject = {
+      _type: "IsNull",
+      value: null,
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create an IsNull object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "IsNull",
+      value: null,
+    };
+    const obj: IsNull = IsNull.fromJSON(jsonInput);
+    expect(obj).toBeInstanceOf(IsNull);
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: null,
+    };
+    expect(() => {
+      return IsNull.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+});

--- a/Common/Tests/Types/Database/LessThan.test.ts
+++ b/Common/Tests/Types/Database/LessThan.test.ts
@@ -1,0 +1,62 @@
+import LessThan from "../../../Types/BaseDatabase/LessThan";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("LessThan", () => {
+  it("should create a LessThan object with a valid value", () => {
+    const value: number = 42;
+    const obj: LessThan<number> = new LessThan<number>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: LessThan<number> = new LessThan<number>(1);
+    obj.value = 2;
+    expect(obj.value).toBe(2);
+  });
+
+  it("should return the correct string representation using toString", () => {
+    const obj: LessThan<number> = new LessThan<number>(42);
+    expect(obj.toString()).toBe("42");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: LessThan<number> = new LessThan<number>(42);
+    const expectedJSON: JSONObject = {
+      _type: "LessThan",
+      value: "42",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a LessThan object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "LessThan",
+      value: "42",
+    };
+    const obj: LessThan<number> = LessThan.fromJSON(jsonInput);
+    expect(obj.value).toBe("42");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "42",
+    };
+    expect(() => {
+      return LessThan.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of LessThan", () => {
+    const obj: LessThan<number> = new LessThan<number>(42);
+    expect(obj).toBeInstanceOf(LessThan);
+  });
+
+  it("should handle date values", () => {
+    const value: Date = new Date("2023-01-01");
+    const obj: LessThan<Date> = new LessThan<Date>(value);
+    expect(obj.value).toBe(value);
+  });
+});

--- a/Common/Tests/Types/Database/LessThanOrEqual.test.ts
+++ b/Common/Tests/Types/Database/LessThanOrEqual.test.ts
@@ -1,0 +1,62 @@
+import LessThanOrEqual from "../../../Types/BaseDatabase/LessThanOrEqual";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("LessThanOrEqual", () => {
+  it("should create a LessThanOrEqual object with a valid value", () => {
+    const value: number = 42;
+    const obj: LessThanOrEqual<number> = new LessThanOrEqual<number>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: LessThanOrEqual<number> = new LessThanOrEqual<number>(1);
+    obj.value = 2;
+    expect(obj.value).toBe(2);
+  });
+
+  it("should return the correct string representation using toString", () => {
+    const obj: LessThanOrEqual<number> = new LessThanOrEqual<number>(42);
+    expect(obj.toString()).toBe("42");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: LessThanOrEqual<number> = new LessThanOrEqual<number>(42);
+    const expectedJSON: JSONObject = {
+      _type: "LessThanOrEqual",
+      value: "42",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a LessThanOrEqual object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "LessThanOrEqual",
+      value: "42",
+    };
+    const obj: LessThanOrEqual<number> = LessThanOrEqual.fromJSON(jsonInput);
+    expect(obj.value).toBe("42");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "42",
+    };
+    expect(() => {
+      return LessThanOrEqual.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of LessThanOrEqual", () => {
+    const obj: LessThanOrEqual<number> = new LessThanOrEqual<number>(42);
+    expect(obj).toBeInstanceOf(LessThanOrEqual);
+  });
+
+  it("should handle date values", () => {
+    const value: Date = new Date("2023-01-01");
+    const obj: LessThanOrEqual<Date> = new LessThanOrEqual<Date>(value);
+    expect(obj.value).toBe(value);
+  });
+});

--- a/Common/Tests/Types/Database/LessThanOrNull.test.ts
+++ b/Common/Tests/Types/Database/LessThanOrNull.test.ts
@@ -1,0 +1,62 @@
+import LessThanOrNull from "../../../Types/BaseDatabase/LessThanOrNull";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("LessThanOrNull", () => {
+  it("should create a LessThanOrNull object with a valid value", () => {
+    const value: number = 42;
+    const obj: LessThanOrNull<number> = new LessThanOrNull<number>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: LessThanOrNull<number> = new LessThanOrNull<number>(1);
+    obj.value = 2;
+    expect(obj.value).toBe(2);
+  });
+
+  it("should return the correct string representation using toString", () => {
+    const obj: LessThanOrNull<number> = new LessThanOrNull<number>(42);
+    expect(obj.toString()).toBe("42");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: LessThanOrNull<number> = new LessThanOrNull<number>(42);
+    const expectedJSON: JSONObject = {
+      _type: "LessThanOrNull",
+      value: "42",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a LessThanOrNull object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "LessThanOrNull",
+      value: "42",
+    };
+    const obj: LessThanOrNull<number> = LessThanOrNull.fromJSON(jsonInput);
+    expect(obj.value).toBe("42");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "42",
+    };
+    expect(() => {
+      return LessThanOrNull.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of LessThanOrNull", () => {
+    const obj: LessThanOrNull<number> = new LessThanOrNull<number>(42);
+    expect(obj).toBeInstanceOf(LessThanOrNull);
+  });
+
+  it("should handle date values", () => {
+    const value: Date = new Date("2023-01-01");
+    const obj: LessThanOrNull<Date> = new LessThanOrNull<Date>(value);
+    expect(obj.value).toBe(value);
+  });
+});

--- a/Common/Tests/Types/Database/MultiSearch.test.ts
+++ b/Common/Tests/Types/Database/MultiSearch.test.ts
@@ -1,0 +1,81 @@
+import MultiSearch from "../../../Types/BaseDatabase/MultiSearch";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("MultiSearch", () => {
+  it("should create a MultiSearch object with fields and value", () => {
+    const obj: MultiSearch = new MultiSearch({
+      fields: ["name", "email"],
+      value: "demo",
+    });
+    expect(obj.fields).toEqual(["name", "email"]);
+    expect(obj.value).toBe("demo");
+  });
+
+  it("should get and set the fields and value properties", () => {
+    const obj: MultiSearch = new MultiSearch({ fields: ["a"], value: "x" });
+    obj.fields = ["b", "c"];
+    obj.value = "y";
+    expect(obj.fields).toEqual(["b", "c"]);
+    expect(obj.value).toBe("y");
+  });
+
+  it("should return the value using toString", () => {
+    const obj: MultiSearch = new MultiSearch({
+      fields: ["name"],
+      value: "demo",
+    });
+    expect(obj.toString()).toBe("demo");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: MultiSearch = new MultiSearch({
+      fields: ["name"],
+      value: "demo",
+    });
+    const expectedJSON: JSONObject = {
+      _type: "MultiSearch",
+      value: "demo",
+      fields: ["name"],
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a MultiSearch object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "MultiSearch",
+      value: "demo",
+      fields: ["name"],
+    };
+    const obj: MultiSearch = MultiSearch.fromJSON(jsonInput);
+    expect(obj.value).toBe("demo");
+    expect(obj.fields).toEqual(["name"]);
+  });
+
+  it("should default fields and value when missing in the JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "MultiSearch",
+    };
+    const obj: MultiSearch = MultiSearch.fromJSON(jsonInput);
+    expect(obj.fields).toEqual([]);
+    expect(obj.value).toBe("");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+    };
+    expect(() => {
+      return MultiSearch.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of MultiSearch", () => {
+    const obj: MultiSearch = new MultiSearch({
+      fields: ["name"],
+      value: "demo",
+    });
+    expect(obj).toBeInstanceOf(MultiSearch);
+  });
+});

--- a/Common/Tests/Types/Database/NotContains.test.ts
+++ b/Common/Tests/Types/Database/NotContains.test.ts
@@ -1,0 +1,64 @@
+import NotContains from "../../../Types/BaseDatabase/NotContains";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("NotContains", () => {
+  it("should create a NotContains object with a valid value", () => {
+    const value: string = "oneuptime";
+    const obj: NotContains<string> = new NotContains<string>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: NotContains<string> = new NotContains<string>("oldValue");
+    obj.value = "newValue";
+    expect(obj.value).toBe("newValue");
+  });
+
+  it("should return the value using toString", () => {
+    const obj: NotContains<string> = new NotContains<string>("oneuptime");
+    expect(obj.toString()).toBe("oneuptime");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: NotContains<string> = new NotContains<string>("oneuptime");
+    const expectedJSON: JSONObject = {
+      _type: "NotContains",
+      value: "oneuptime",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a NotContains object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "NotContains",
+      value: "oneuptime",
+    };
+    const obj: NotContains<string> = NotContains.fromJSON(jsonInput);
+    expect(obj.value).toBe("oneuptime");
+  });
+
+  it("should default to an empty string when the JSON value is missing", () => {
+    const jsonInput: JSONObject = {
+      _type: "NotContains",
+    };
+    const obj: NotContains<string> = NotContains.fromJSON(jsonInput);
+    expect(obj.value).toBe("");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "oneuptime",
+    };
+    expect(() => {
+      return NotContains.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of NotContains", () => {
+    const obj: NotContains<string> = new NotContains<string>("oneuptime");
+    expect(obj).toBeInstanceOf(NotContains);
+  });
+});

--- a/Common/Tests/Types/Database/NotNull.test.ts
+++ b/Common/Tests/Types/Database/NotNull.test.ts
@@ -1,0 +1,44 @@
+import NotNull from "../../../Types/BaseDatabase/NotNull";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("NotNull", () => {
+  it("should create a NotNull object", () => {
+    const obj: NotNull = new NotNull();
+    expect(obj).toBeInstanceOf(NotNull);
+  });
+
+  it("should return an empty string using toString", () => {
+    const obj: NotNull = new NotNull();
+    expect(obj.toString()).toBe("");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: NotNull = new NotNull();
+    const expectedJSON: JSONObject = {
+      _type: "NotNull",
+      value: null,
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a NotNull object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "NotNull",
+      value: null,
+    };
+    const obj: NotNull = NotNull.fromJSON(jsonInput);
+    expect(obj).toBeInstanceOf(NotNull);
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: null,
+    };
+    expect(() => {
+      return NotNull.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+});

--- a/Common/Tests/Types/Database/StartsWith.test.ts
+++ b/Common/Tests/Types/Database/StartsWith.test.ts
@@ -1,0 +1,64 @@
+import StartsWith from "../../../Types/BaseDatabase/StartsWith";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+describe("StartsWith", () => {
+  it("should create a StartsWith object with a valid value", () => {
+    const value: string = "oneuptime";
+    const obj: StartsWith<string> = new StartsWith<string>(value);
+    expect(obj.value).toBe(value);
+  });
+
+  it("should get and set the value property", () => {
+    const obj: StartsWith<string> = new StartsWith<string>("oldValue");
+    obj.value = "newValue";
+    expect(obj.value).toBe("newValue");
+  });
+
+  it("should return the value using toString", () => {
+    const obj: StartsWith<string> = new StartsWith<string>("oneuptime");
+    expect(obj.toString()).toBe("oneuptime");
+  });
+
+  it("should generate the correct JSON representation using toJSON", () => {
+    const obj: StartsWith<string> = new StartsWith<string>("oneuptime");
+    const expectedJSON: JSONObject = {
+      _type: "StartsWith",
+      value: "oneuptime",
+    };
+    expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("should create a StartsWith object from valid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "StartsWith",
+      value: "oneuptime",
+    };
+    const obj: StartsWith<string> = StartsWith.fromJSON(jsonInput);
+    expect(obj.value).toBe("oneuptime");
+  });
+
+  it("should default to an empty string when the JSON value is missing", () => {
+    const jsonInput: JSONObject = {
+      _type: "StartsWith",
+    };
+    const obj: StartsWith<string> = StartsWith.fromJSON(jsonInput);
+    expect(obj.value).toBe("");
+  });
+
+  it("should throw a BadDataException when using invalid JSON input", () => {
+    const jsonInput: JSONObject = {
+      _type: "InvalidType",
+      value: "oneuptime",
+    };
+    expect(() => {
+      return StartsWith.fromJSON(jsonInput);
+    }).toThrow(BadDataException);
+  });
+
+  it("should be an instance of StartsWith", () => {
+    const obj: StartsWith<string> = new StartsWith<string>("oneuptime");
+    expect(obj).toBeInstanceOf(StartsWith);
+  });
+});


### PR DESCRIPTION
### test(Common): add tests for the BaseDatabase query operators (#210)

### Small Description?
Adds unit tests for the query-operator types under `Common/Types/BaseDatabase` that were missing coverage, mirroring the existing EqualTo / InBetween / NotEqual / Search tests in `Common/Tests/Types/Database`: GreaterThan(OrEqual/OrNull), LessThan(OrEqual/OrNull), EndsWith, StartsWith, NotContains, Includes, IncludesAll, IncludesNone, IsNull, NotNull and MultiSearch. Each suite covers construction, value get/set, toString, toJSON, fromJSON round-trip, invalid-JSON handling (BadDataException) and instanceof.

### Pull Request Checklist:
- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

> Heads-up on CI: the only red check is `js-lint`, and it fails on a pre-existing, master-side tooling error — the `docs:check-anchors` step (`Scripts/Docs/CheckAnchors.ts`) crashes on `Cannot find module 'Common/Server/Types/Markdown'` before it lints anything. It is unrelated to this PR (this PR only adds unit tests; ESLint on the changed files is clean, and other open PRs, e.g. #2508, fail the same job identically). All `test` shards, `compile-*` and `security/snyk` are green.

### Related Issue?
closes #210

### Screenshots (if appropriate):
N/A — unit tests only.