### PR TITLE
fix(admin-dashboard): repair Postgres health connection stats and add live activity debugging

### DIFF
--- a/App/API/AdminHealth.ts
+++ b/App/API/AdminHealth.ts
@@ -1440,8 +1440,8 @@ async function getPostgresDiagnostics(): Promise<JSONObject> {
          count(*) FILTER (WHERE state = 'idle in transaction') AS idle_in_transaction,
          count(*) FILTER (WHERE wait_event_type = 'Lock') AS waiting_on_lock,
          COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - xact_start))), 0) AS longest_transaction_seconds,
-         COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - query_start)) FILTER (WHERE state = 'active')), 0) AS longest_active_query_seconds,
-         COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - state_change)) FILTER (WHERE state = 'idle in transaction')), 0) AS longest_idle_in_transaction_seconds
+         COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - query_start) FILTER (WHERE state = 'active'))), 0) AS longest_active_query_seconds,
+         COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - state_change) FILTER (WHERE state = 'idle in transaction'))), 0) AS longest_idle_in_transaction_seconds
        FROM pg_stat_activity
        WHERE datname = current_database()`,
     );
@@ -1700,8 +1700,8 @@ async function getPostgresClusterHealth(): Promise<JSONObject> {
            count(*) FILTER (WHERE wait_event_type = 'Lock') AS waiting_on_lock,
            count(*) FILTER (WHERE cardinality(pg_blocking_pids(pid)) > 0) AS blocked,
            COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - xact_start))), 0) AS longest_transaction_seconds,
-           COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - query_start)) FILTER (WHERE state = 'active')), 0) AS longest_active_query_seconds,
-           COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - state_change)) FILTER (WHERE state = 'idle in transaction')), 0) AS longest_idle_in_transaction_seconds
+           COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - query_start) FILTER (WHERE state = 'active'))), 0) AS longest_active_query_seconds,
+           COALESCE(ROUND(EXTRACT(EPOCH FROM max(now() - state_change) FILTER (WHERE state = 'idle in transaction'))), 0) AS longest_idle_in_transaction_seconds
          FROM pg_stat_activity`,
       );
 
@@ -1915,6 +1915,265 @@ async function getPostgresClusterHealth(): Promise<JSONObject> {
     }
   } catch (err) {
     logger.error("AdminHealth: failed to read Postgres cluster health");
+    logger.error(err);
+  }
+
+  return result;
+}
+
+// How much statement text the activity probe returns per query, in characters.
+const ACTIVITY_QUERY_TEXT_LENGTH: number = 500;
+
+/*
+ * Live Postgres activity for interactive debugging: the queries running right
+ * now (longest-running first), lock blocking pairs (who is stuck behind whom),
+ * cumulative statement statistics (pg_stat_statements, when installed) and
+ * autovacuum progress. Unlike getPostgresClusterHealth() above, this DOES
+ * return statement text: pg_stat_activity queries verbatim (truncated) and
+ * pg_stat_statements queries normalized by Postgres (constants become $n
+ * placeholders). Statement text is what an operator needs to debug a slow or
+ * stuck instance, and the master-admin audience already holds query-console
+ * access — but it can embed customer data in literals, which is why this probe
+ * is deliberately NOT included in the downloadable support bundle, which is
+ * meant to stay shareable.
+ */
+async function getPostgresActivity(): Promise<JSONObject> {
+  const result: JSONObject = {
+    connected: false,
+    activeQueries: [],
+    blockedSessions: [],
+    statementsAvailable: false,
+    topStatements: [],
+    vacuumProgress: [],
+  };
+
+  try {
+    const dataSource: ReturnType<typeof PostgresAppInstance.getDataSource> =
+      PostgresAppInstance.getDataSource();
+
+    if (!dataSource) {
+      return result;
+    }
+
+    result["connected"] = true;
+
+    /*
+     * 1. Running queries, longest-running first. Excludes idle sessions and
+     * this probe's own backend; includes idle-in-transaction sessions because
+     * their last statement is the one holding the transaction (and its locks)
+     * open.
+     */
+    try {
+      const activityRows: Array<{
+        pid: string;
+        username: string | null;
+        application_name: string | null;
+        client_addr: string | null;
+        state: string | null;
+        wait_event_type: string | null;
+        wait_event: string | null;
+        query_age_seconds: string | null;
+        transaction_age_seconds: string | null;
+        query: string | null;
+      }> = await dataSource.query(
+        `SELECT
+           a.pid,
+           a.usename AS username,
+           a.application_name,
+           host(a.client_addr) AS client_addr,
+           a.state,
+           a.wait_event_type,
+           a.wait_event,
+           ROUND(EXTRACT(EPOCH FROM (now() - a.query_start))) AS query_age_seconds,
+           ROUND(EXTRACT(EPOCH FROM (now() - a.xact_start))) AS transaction_age_seconds,
+           LEFT(a.query, ${ACTIVITY_QUERY_TEXT_LENGTH}) AS query
+         FROM pg_stat_activity a
+         WHERE a.backend_type = 'client backend'
+           AND a.state IS NOT NULL
+           AND a.state <> 'idle'
+           AND a.pid <> pg_backend_pid()
+         ORDER BY a.query_start ASC NULLS LAST
+         LIMIT 20`,
+      );
+
+      result["activeQueries"] = activityRows.map(
+        (row: (typeof activityRows)[number]): JSONObject => {
+          return {
+            pid: toNumberOrNull(row.pid),
+            username: row.username ? String(row.username) : null,
+            applicationName: row.application_name
+              ? String(row.application_name)
+              : null,
+            clientAddr: row.client_addr ? String(row.client_addr) : null,
+            state: row.state ? String(row.state) : null,
+            waitEventType: row.wait_event_type
+              ? String(row.wait_event_type)
+              : null,
+            waitEvent: row.wait_event ? String(row.wait_event) : null,
+            queryAgeSeconds: toNumberOrNull(row.query_age_seconds),
+            transactionAgeSeconds: toNumberOrNull(row.transaction_age_seconds),
+            query: row.query ? String(row.query) : null,
+          };
+        },
+      );
+    } catch (err) {
+      logger.debug("AdminHealth: postgres active-query probe failed");
+      logger.debug(err);
+    }
+
+    /*
+     * 2. Lock blocking pairs — each blocked session joined to every session
+     * blocking it, so a lock convoy reads as "PID a waits on PID b" with both
+     * statements visible. unnest(pg_blocking_pids()) produces no rows for
+     * unblocked sessions, so this is empty on a healthy instance.
+     */
+    try {
+      const blockedRows: Array<{
+        blocked_pid: string;
+        blocked_user: string | null;
+        blocked_for_seconds: string | null;
+        blocked_query: string | null;
+        blocking_pid: string;
+        blocking_user: string | null;
+        blocking_state: string | null;
+        blocking_query: string | null;
+      }> = await dataSource.query(
+        `SELECT
+           blocked.pid AS blocked_pid,
+           blocked.usename AS blocked_user,
+           ROUND(EXTRACT(EPOCH FROM (now() - blocked.query_start))) AS blocked_for_seconds,
+           LEFT(blocked.query, ${ACTIVITY_QUERY_TEXT_LENGTH}) AS blocked_query,
+           blocker.pid AS blocking_pid,
+           blocker.usename AS blocking_user,
+           blocker.state AS blocking_state,
+           LEFT(blocker.query, ${ACTIVITY_QUERY_TEXT_LENGTH}) AS blocking_query
+         FROM pg_stat_activity blocked
+         JOIN LATERAL unnest(pg_blocking_pids(blocked.pid)) AS b(pid) ON true
+         JOIN pg_stat_activity blocker ON blocker.pid = b.pid
+         ORDER BY blocked_for_seconds DESC NULLS LAST
+         LIMIT 10`,
+      );
+
+      result["blockedSessions"] = blockedRows.map(
+        (row: (typeof blockedRows)[number]): JSONObject => {
+          return {
+            blockedPid: toNumberOrNull(row.blocked_pid),
+            blockedUser: row.blocked_user ? String(row.blocked_user) : null,
+            blockedForSeconds: toNumberOrNull(row.blocked_for_seconds),
+            blockedQuery: row.blocked_query ? String(row.blocked_query) : null,
+            blockingPid: toNumberOrNull(row.blocking_pid),
+            blockingUser: row.blocking_user ? String(row.blocking_user) : null,
+            blockingState: row.blocking_state
+              ? String(row.blocking_state)
+              : null,
+            blockingQuery: row.blocking_query
+              ? String(row.blocking_query)
+              : null,
+          };
+        },
+      );
+    } catch (err) {
+      logger.debug("AdminHealth: postgres blocking probe failed");
+      logger.debug(err);
+    }
+
+    /*
+     * 3. Cumulative statement statistics. pg_stat_statements needs both
+     * CREATE EXTENSION and shared_preload_libraries, and querying the view is
+     * the only check that covers both — so probe by querying and treat any
+     * failure as "not installed" (the dashboard then shows setup instructions
+     * instead of an error).
+     */
+    try {
+      const statementRows: Array<{
+        query: string | null;
+        calls: string;
+        total_ms: string | null;
+        mean_ms: string | null;
+        max_ms: string | null;
+        rows: string;
+        cache_hit_ratio: string | null;
+      }> = await dataSource.query(
+        `SELECT
+           LEFT(s.query, ${ACTIVITY_QUERY_TEXT_LENGTH}) AS query,
+           s.calls,
+           ROUND(s.total_exec_time::numeric) AS total_ms,
+           ROUND(s.mean_exec_time::numeric, 2) AS mean_ms,
+           ROUND(s.max_exec_time::numeric) AS max_ms,
+           s.rows,
+           CASE WHEN (s.shared_blks_hit + s.shared_blks_read) > 0
+                THEN ROUND(s.shared_blks_hit::numeric / (s.shared_blks_hit + s.shared_blks_read) * 100, 1)
+                ELSE NULL END AS cache_hit_ratio
+         FROM pg_stat_statements s
+         JOIN pg_database d ON d.oid = s.dbid
+         WHERE d.datname = current_database()
+         ORDER BY s.total_exec_time DESC
+         LIMIT 10`,
+      );
+
+      result["statementsAvailable"] = true;
+      result["topStatements"] = statementRows.map(
+        (row: (typeof statementRows)[number]): JSONObject => {
+          return {
+            query: row.query ? String(row.query) : null,
+            calls: toNumberOrNull(row.calls),
+            totalMilliseconds: toNumberOrNull(row.total_ms),
+            meanMilliseconds: toNumberOrNull(row.mean_ms),
+            maxMilliseconds: toNumberOrNull(row.max_ms),
+            rows: toNumberOrNull(row.rows),
+            cacheHitRatio: toNumberOrNull(row.cache_hit_ratio),
+          };
+        },
+      );
+    } catch (err) {
+      logger.debug(
+        "AdminHealth: pg_stat_statements unavailable (extension not installed?)",
+      );
+      logger.debug(err);
+    }
+
+    // 4. Vacuum / autovacuum progress — pairs with the dead-tuple hotspots list.
+    try {
+      const vacuumRows: Array<{
+        pid: string;
+        table_name: string | null;
+        phase: string | null;
+        heap_blks_total: string | null;
+        heap_blks_scanned: string | null;
+        percent_scanned: string | null;
+      }> = await dataSource.query(
+        `SELECT
+           p.pid,
+           c.relname AS table_name,
+           p.phase,
+           p.heap_blks_total,
+           p.heap_blks_scanned,
+           CASE WHEN p.heap_blks_total > 0
+                THEN ROUND(p.heap_blks_scanned::numeric / p.heap_blks_total * 100, 1)
+                ELSE NULL END AS percent_scanned
+         FROM pg_stat_progress_vacuum p
+         LEFT JOIN pg_class c ON c.oid = p.relid
+         WHERE p.datname = current_database()`,
+      );
+
+      result["vacuumProgress"] = vacuumRows.map(
+        (row: (typeof vacuumRows)[number]): JSONObject => {
+          return {
+            pid: toNumberOrNull(row.pid),
+            tableName: row.table_name ? String(row.table_name) : null,
+            phase: row.phase ? String(row.phase) : null,
+            heapBlocksTotal: toNumberOrNull(row.heap_blks_total),
+            heapBlocksScanned: toNumberOrNull(row.heap_blks_scanned),
+            percentScanned: toNumberOrNull(row.percent_scanned),
+          };
+        },
+      );
+    } catch (err) {
+      logger.debug("AdminHealth: pg_stat_progress_vacuum probe failed");
+      logger.debug(err);
+    }
+  } catch (err) {
+    logger.error("AdminHealth: failed to read Postgres activity");
     logger.error(err);
   }
 
@@ -3408,6 +3667,39 @@ router.get(
       }
 
       const data: JSONObject = await getPostgresClusterHealth();
+      return Response.sendJsonObjectResponse(req, res, data);
+    } catch (err) {
+      return next(err);
+    }
+  },
+);
+
+/*
+ * Live Postgres activity for the dashboard: running queries, lock blocking
+ * pairs, pg_stat_statements and vacuum progress. This is the only health GET
+ * endpoint that returns statement text (see getPostgresActivity), so — like
+ * the query console routes below — it stays on the JWT-only middleware (no
+ * static master API key) and is intentionally excluded from both the
+ * downloadable support bundle and the master-admin API docs.
+ */
+router.get(
+  "/postgres-activity",
+  MasterAdminAuthorization.isAuthorizedMasterAdminMiddleware,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      if (!IsEnterpriseEdition) {
+        throw new PaymentRequiredException(
+          "The OneUptime Health dashboard is only available on the OneUptime Enterprise Edition. " +
+            "Please switch to the Enterprise Edition build to enable this feature. " +
+            "See https://oneuptime.com/enterprise/overview for details.",
+        );
+      }
+
+      const data: JSONObject = await getPostgresActivity();
       return Response.sendJsonObjectResponse(req, res, data);
     } catch (err) {
       return next(err);

--- a/App/FeatureSet/AdminDashboard/src/Pages/Health/PostgresCluster.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Health/PostgresCluster.tsx
@@ -102,6 +102,23 @@ const formatDuration: (value: unknown) => string = (value: unknown): string => {
   return `${Math.round(seconds / 86400)}d`;
 };
 
+// Format a millisecond count (pg_stat_statements timings) into a compact human string.
+const formatMilliseconds: (value: unknown) => string = (
+  value: unknown,
+): string => {
+  const milliseconds: number = Number(value);
+
+  if (value === null || value === undefined || isNaN(milliseconds)) {
+    return "—";
+  }
+
+  if (milliseconds < 1000) {
+    return `${Math.round(milliseconds)}ms`;
+  }
+
+  return formatDuration(milliseconds / 1000);
+};
+
 // Relative "x ago" from an ISO timestamp, for last-autovacuum hints.
 const timeAgo: (value: unknown) => string = (value: unknown): string => {
   if (!value) {
@@ -145,9 +162,11 @@ const formatShareOfDatabase: (
 
 const PostgresCluster: FunctionComponent = (): ReactElement => {
   const [data, setData] = useState<JSONObject | null>(null);
+  const [activity, setActivity] = useState<JSONObject | null>(null);
   const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
+  const [activityError, setActivityError] = useState<string>("");
 
   const loadClusterHealth: () => Promise<void> = async (): Promise<void> => {
     setError("");
@@ -167,6 +186,34 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
       setData(response.data);
     } catch (err) {
       setError(API.getFriendlyMessage(err));
+    }
+  };
+
+  const loadActivity: () => Promise<void> = async (): Promise<void> => {
+    setActivityError("");
+
+    try {
+      const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+        await API.get<JSONObject>({
+          url: URL.fromString(APP_API_URL.toString()).addRoute(
+            "/admin/health/postgres-activity",
+          ),
+        });
+
+      if (response instanceof HTTPErrorResponse) {
+        throw response;
+      }
+
+      setActivity(response.data);
+    } catch (err) {
+      setActivityError(API.getFriendlyMessage(err));
+    }
+  };
+
+  // Both cards refresh together so the topology and the live activity agree.
+  const loadAll: () => Promise<void> = async (): Promise<void> => {
+    try {
+      await Promise.all([loadClusterHealth(), loadActivity()]);
     } finally {
       setIsInitialLoading(false);
       setIsRefreshing(false);
@@ -174,15 +221,27 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
   };
 
   useEffect(() => {
-    loadClusterHealth().catch(() => {
-      // handled via setError
+    loadAll().catch(() => {
+      // handled via setError / setActivityError
     });
   }, []);
 
-  // A small labelled stat cell.
-  const renderStat: (label: string, value: string) => ReactElement = (
+  const refresh: () => void = (): void => {
+    setIsRefreshing(true);
+    loadAll().catch(() => {
+      // handled via setError / setActivityError
+    });
+  };
+
+  // A small labelled stat cell, with an optional context line under the value.
+  const renderStat: (
     label: string,
     value: string,
+    hint?: string,
+  ) => ReactElement = (
+    label: string,
+    value: string,
+    hint?: string,
   ): ReactElement => {
     return (
       <div className="rounded-lg border border-gray-200 p-3">
@@ -190,6 +249,11 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
         <div className="text-base font-semibold text-gray-900 mt-1">
           {value}
         </div>
+        {hint ? (
+          <div className="text-xs text-gray-400 mt-0.5">{hint}</div>
+        ) : (
+          <></>
+        )}
       </div>
     );
   };
@@ -395,6 +459,14 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
       ? toNum(database["cacheHitRatio"])
       : null;
 
+    /*
+     * Counters in pg_stat_database accumulate since the last stats reset, so
+     * big numbers (commits, deadlocks) only mean something next to their age.
+     */
+    const statsResetHint: string | undefined = database["statsReset"]
+      ? `since stats reset ${timeAgo(database["statsReset"])}`
+      : undefined;
+
     // Overall verdict — red for a hard problem, yellow for a soft one.
     let statusText: string = "Healthy";
     let statusColor: Color = Green;
@@ -465,6 +537,23 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
             "Database size",
             bytesToReadable(data?.["databaseSizeInBytes"]),
           )}
+          {renderStat(
+            "Commits",
+            formatNumber(database["xactCommit"]),
+            statsResetHint,
+          )}
+          {renderStat(
+            "Rollbacks",
+            formatNumber(database["xactRollback"]),
+            statsResetHint,
+          )}
+          {renderStat(
+            "Temp files",
+            formatNumber(database["tempFiles"]),
+            isNum(database["tempBytes"])
+              ? `${bytesToReadable(database["tempBytes"])} written`
+              : undefined,
+          )}
         </div>
 
         {/* Streaming replication — the primary's view of every standby. */}
@@ -532,7 +621,11 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
             "Longest transaction",
             formatDuration(connections["longestTransactionSeconds"]),
           )}
-          {renderStat("Deadlocks", formatNumber(database["deadlocks"]))}
+          {renderStat(
+            "Deadlocks",
+            formatNumber(database["deadlocks"]),
+            statsResetHint,
+          )}
           {renderStat(
             "Wraparound headroom",
             wrapHeadroom !== null ? `${wrapHeadroom.toFixed(0)}%` : "—",
@@ -670,6 +763,349 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
     );
   };
 
+  /*
+   * Live activity — blocked sessions, running queries (longest first) and
+   * vacuum progress. Mirrors renderContent()'s early returns so the card never
+   * shows a broken table while the first load is in flight or when Postgres is
+   * unreachable.
+   */
+  const renderActivity: () => ReactElement = (): ReactElement => {
+    if (isInitialLoading && !activity) {
+      return <ComponentLoader />;
+    }
+
+    /*
+     * No payload at all means the /postgres-activity request itself failed
+     * (the alert above this content carries the actual error) — distinct from
+     * a payload that reports Postgres as unreachable.
+     */
+    if (!activity) {
+      return (
+        <div className="text-sm text-gray-500">
+          Live activity could not be loaded.
+        </div>
+      );
+    }
+
+    const connected: boolean = Boolean(activity["connected"]);
+    if (!connected) {
+      return (
+        <div className="text-sm text-gray-500">
+          PostgreSQL is not reachable from this instance.
+        </div>
+      );
+    }
+
+    const activeQueries: JSONArray = asArray(activity?.["activeQueries"]);
+    const blockedSessions: JSONArray = asArray(activity?.["blockedSessions"]);
+    const vacuumProgress: JSONArray = asArray(activity?.["vacuumProgress"]);
+
+    return (
+      <div className="space-y-6">
+        {/* Blocked sessions first — when any exist, they are the story. */}
+        <div>
+          <div className="text-sm font-semibold text-gray-900 mb-2">
+            Blocked sessions
+          </div>
+          {blockedSessions.length === 0 ? (
+            <div className="text-xs text-gray-500">
+              No sessions are blocked on locks.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {blockedSessions
+                .slice(0, MAX_ROWS_TO_SHOW)
+                .map((value: unknown, index: number): ReactElement => {
+                  const pair: JSONObject = asObject(value);
+                  return (
+                    <div
+                      key={index}
+                      className="rounded-md border border-red-200 bg-red-50 px-3 py-2 space-y-1"
+                    >
+                      <div className="text-xs font-medium text-red-800">
+                        PID {formatNumber(pair["blockedPid"])}
+                        {pair["blockedUser"]
+                          ? ` (${String(pair["blockedUser"])})`
+                          : ""}{" "}
+                        · waiting {formatDuration(pair["blockedForSeconds"])}
+                      </div>
+                      <div
+                        className="text-xs font-mono text-gray-900 truncate"
+                        title={String(pair["blockedQuery"] ?? "")}
+                      >
+                        {String(pair["blockedQuery"] ?? "—")}
+                      </div>
+                      <div className="text-xs text-gray-600">
+                        blocked by PID {formatNumber(pair["blockingPid"])}
+                        {pair["blockingUser"]
+                          ? ` (${String(pair["blockingUser"])})`
+                          : ""}
+                        {pair["blockingState"]
+                          ? ` · ${String(pair["blockingState"])}`
+                          : ""}
+                      </div>
+                      <div
+                        className="text-xs font-mono text-gray-700 truncate"
+                        title={String(pair["blockingQuery"] ?? "")}
+                      >
+                        {String(pair["blockingQuery"] ?? "—")}
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+        </div>
+
+        {/* Running queries, longest first — idle-in-transaction included. */}
+        <div>
+          <div className="text-sm font-semibold text-gray-900 mb-2">
+            Running queries
+          </div>
+          {activeQueries.length === 0 ? (
+            <div className="text-xs text-gray-500">
+              Nothing is running right now. (This page&apos;s own health probe
+              is excluded.)
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    <th className="pb-2 pr-4">PID</th>
+                    <th className="pb-2 px-4">State</th>
+                    <th className="pb-2 px-4 text-right">Running</th>
+                    <th className="pb-2 px-4 text-right">In txn</th>
+                    <th className="pb-2 pl-4">Query</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {activeQueries.map(
+                    (value: unknown, index: number): ReactElement => {
+                      const session: JSONObject = asObject(value);
+                      const sessionMeta: string = [
+                        session["username"] ? String(session["username"]) : "",
+                        session["applicationName"]
+                          ? String(session["applicationName"])
+                          : "",
+                        session["clientAddr"]
+                          ? String(session["clientAddr"])
+                          : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" · ");
+
+                      return (
+                        <tr key={`postgres-active-query-${index}`}>
+                          <td className="py-2 pr-4 text-sm text-gray-900 tabular-nums">
+                            {formatNumber(session["pid"])}
+                          </td>
+                          <td className="py-2 px-4">
+                            <div className="text-sm text-gray-900 whitespace-nowrap">
+                              {String(session["state"] ?? "—")}
+                            </div>
+                            {session["waitEventType"] ? (
+                              <div className="text-xs text-gray-500 whitespace-nowrap">
+                                waits on {String(session["waitEventType"])}
+                                {session["waitEvent"]
+                                  ? `: ${String(session["waitEvent"])}`
+                                  : ""}
+                              </div>
+                            ) : (
+                              <></>
+                            )}
+                          </td>
+                          <td className="py-2 px-4 text-sm text-right text-gray-700 tabular-nums whitespace-nowrap">
+                            {formatDuration(session["queryAgeSeconds"])}
+                          </td>
+                          <td className="py-2 px-4 text-sm text-right text-gray-700 tabular-nums whitespace-nowrap">
+                            {isNum(session["transactionAgeSeconds"])
+                              ? formatDuration(session["transactionAgeSeconds"])
+                              : "—"}
+                          </td>
+                          <td className="py-2 pl-4">
+                            <div
+                              className="text-xs font-mono text-gray-900 truncate max-w-lg"
+                              title={String(session["query"] ?? "")}
+                            >
+                              {String(session["query"] ?? "—")}
+                            </div>
+                            {sessionMeta ? (
+                              <div className="text-xs text-gray-500 truncate max-w-lg">
+                                {sessionMeta}
+                              </div>
+                            ) : (
+                              <></>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    },
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* Vacuum progress — pairs with the autovacuum hotspots list above. */}
+        <div>
+          <div className="text-sm font-semibold text-gray-900 mb-2">
+            Vacuum progress
+          </div>
+          {vacuumProgress.length === 0 ? (
+            <div className="text-xs text-gray-500">
+              No vacuum is running right now.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {vacuumProgress.map(
+                (value: unknown, index: number): ReactElement => {
+                  const vacuum: JSONObject = asObject(value);
+                  const percent: number | null = isNum(vacuum["percentScanned"])
+                    ? toNum(vacuum["percentScanned"])
+                    : null;
+                  const label: string = `${
+                    vacuum["tableName"]
+                      ? String(vacuum["tableName"])
+                      : `PID ${formatNumber(vacuum["pid"])}`
+                  } · ${String(vacuum["phase"] ?? "—")}`;
+
+                  return percent !== null ? (
+                    <ResourceUsageBar
+                      key={index}
+                      label={label}
+                      value={percent}
+                      valueLabel={`${percent.toFixed(0)}%`}
+                      secondaryLabel={`${formatNumber(
+                        vacuum["heapBlocksScanned"],
+                      )} / ${formatNumber(vacuum["heapBlocksTotal"])} blocks`}
+                    />
+                  ) : (
+                    <div key={index} className="text-xs text-gray-700">
+                      {label}
+                    </div>
+                  );
+                },
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  /*
+   * Cumulative statement statistics from pg_stat_statements — or setup
+   * instructions when the extension is not available on this instance.
+   */
+  const renderTopStatements: () => ReactElement = (): ReactElement => {
+    if (isInitialLoading && !activity) {
+      return <ComponentLoader />;
+    }
+
+    // Same failed-request vs unreachable-database distinction as renderActivity().
+    if (!activity) {
+      return (
+        <div className="text-sm text-gray-500">
+          Statement statistics could not be loaded.
+        </div>
+      );
+    }
+
+    const connected: boolean = Boolean(activity["connected"]);
+    if (!connected) {
+      return (
+        <div className="text-sm text-gray-500">
+          PostgreSQL is not reachable from this instance.
+        </div>
+      );
+    }
+
+    if (!activity?.["statementsAvailable"]) {
+      return (
+        <div className="text-sm text-gray-500">
+          The <span className="font-mono">pg_stat_statements</span> extension is
+          not available on this instance. Add{" "}
+          <span className="font-mono">pg_stat_statements</span> to{" "}
+          <span className="font-mono">shared_preload_libraries</span>, restart
+          PostgreSQL, then run{" "}
+          <span className="font-mono">
+            CREATE EXTENSION pg_stat_statements;
+          </span>{" "}
+          to unlock cumulative query statistics.
+        </div>
+      );
+    }
+
+    const topStatements: JSONArray = asArray(activity?.["topStatements"]);
+
+    if (topStatements.length === 0) {
+      return (
+        <div className="text-sm text-gray-500">
+          No statements have been recorded yet.
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr className="text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="pb-2 pr-4">Query</th>
+              <th className="pb-2 px-4 text-right">Calls</th>
+              <th className="pb-2 px-4 text-right">Total</th>
+              <th className="pb-2 px-4 text-right">Mean</th>
+              <th className="pb-2 px-4 text-right">Max</th>
+              <th className="pb-2 px-4 text-right">Rows</th>
+              <th className="pb-2 pl-4 text-right">Cache hit</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {topStatements.map(
+              (value: unknown, index: number): ReactElement => {
+                const statement: JSONObject = asObject(value);
+                return (
+                  <tr key={`postgres-top-statement-${index}`}>
+                    <td className="py-2 pr-4">
+                      <div
+                        className="text-xs font-mono text-gray-900 truncate max-w-lg"
+                        title={String(statement["query"] ?? "")}
+                      >
+                        {String(statement["query"] ?? "—")}
+                      </div>
+                    </td>
+                    <td className="py-2 px-4 text-sm text-right text-gray-700 tabular-nums">
+                      {formatNumber(statement["calls"])}
+                    </td>
+                    <td className="py-2 px-4 text-sm text-right text-gray-900 tabular-nums whitespace-nowrap">
+                      {formatMilliseconds(statement["totalMilliseconds"])}
+                    </td>
+                    <td className="py-2 px-4 text-sm text-right text-gray-700 tabular-nums whitespace-nowrap">
+                      {formatMilliseconds(statement["meanMilliseconds"])}
+                    </td>
+                    <td className="py-2 px-4 text-sm text-right text-gray-700 tabular-nums whitespace-nowrap">
+                      {formatMilliseconds(statement["maxMilliseconds"])}
+                    </td>
+                    <td className="py-2 px-4 text-sm text-right text-gray-700 tabular-nums">
+                      {formatNumber(statement["rows"])}
+                    </td>
+                    <td className="py-2 pl-4 text-sm text-right text-gray-700 tabular-nums">
+                      {isNum(statement["cacheHitRatio"])
+                        ? `${toNum(statement["cacheHitRatio"]).toFixed(1)}%`
+                        : "—"}
+                    </td>
+                  </tr>
+                );
+              },
+            )}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
   return (
     <>
       <Card
@@ -681,12 +1117,7 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
             icon: IconProp.Refresh,
             buttonStyle: ButtonStyleType.NORMAL,
             isLoading: isRefreshing,
-            onClick: () => {
-              setIsRefreshing(true);
-              loadClusterHealth().catch(() => {
-                // handled via setError
-              });
-            },
+            onClick: refresh,
           },
         ]}
       >
@@ -697,6 +1128,51 @@ const PostgresCluster: FunctionComponent = (): ReactElement => {
             <></>
           )}
           {renderContent()}
+        </div>
+      </Card>
+
+      <Card
+        title="Live activity"
+        description="What Postgres is executing right now — blocked sessions, longest-running queries and vacuum progress. Statement text is shown to master admins here and is never part of the support bundle."
+        buttons={[
+          {
+            title: "Refresh",
+            icon: IconProp.Refresh,
+            buttonStyle: ButtonStyleType.NORMAL,
+            isLoading: isRefreshing,
+            onClick: refresh,
+          },
+        ]}
+      >
+        <div>
+          {activityError ? (
+            <Alert
+              type={AlertType.DANGER}
+              title={activityError}
+              className="mb-4"
+            />
+          ) : (
+            <></>
+          )}
+          {renderActivity()}
+        </div>
+      </Card>
+
+      <Card
+        title="Slow statements"
+        description="The statements that cost the most total execution time since stats were reset (pg_stat_statements). Queries are normalized — literals are replaced with $n placeholders — so no row data appears here."
+      >
+        <div>
+          {activityError ? (
+            <Alert
+              type={AlertType.DANGER}
+              title={activityError}
+              className="mb-4"
+            />
+          ) : (
+            <></>
+          )}
+          {renderTopStatements()}
         </div>
       </Card>
 


### PR DESCRIPTION
## Problem

The **Instance Health → Postgres** page showed `—` for every connection metric (Active, Idle, Idle in txn, Waiting on lock, Longest transaction) and never rendered the connection-saturation bar.

## Root cause

In both `pg_stat_activity` aggregate queries in `App/API/AdminHealth.ts`, the aggregate `FILTER` clause was attached to `EXTRACT(...)` instead of the `max()` aggregate:

```sql
-- broken: FILTER cannot attach to EXTRACT (hard syntax error)
ROUND(EXTRACT(EPOCH FROM max(now() - query_start)) FILTER (WHERE state = 'active'))
-- fixed: FILTER attaches to the max() aggregate
ROUND(EXTRACT(EPOCH FROM max(now() - query_start) FILTER (WHERE state = 'active')))
```

Postgres rejects the whole statement, the guarded probe swallowed the error at debug level, and `connections` stayed `null` — hence the em-dashes. Both the cluster-health probe and the diagnostics probe had the same bug.

## Also in this PR: live activity debugging (requested)

New **`GET /admin/health/postgres-activity`** endpoint + two new cards on the page:

- **Live activity** — running queries (longest first, with statement text, user/app/client, wait events, query & txn age), lock **blocking pairs** (who is stuck behind whom, both statements shown), and live **vacuum progress**.
- **Slow statements** — `pg_stat_statements` top statements by total execution time (calls, total/mean/max, rows, cache hit), with setup instructions when the extension isn't installed.
- New stat tiles for commits, rollbacks, temp files, and deadlocks contextualized by stats-reset age (data was already fetched, never rendered).

### Security posture

Statement text is console-tier data, so the new route deliberately:
- uses the **JWT-only** master-admin middleware (`isAuthorizedMasterAdminMiddleware`, same as the query console — a leaked static master API key cannot read query text headlessly),
- is **excluded from the support bundle** (which stays shareable / free of statement text) and from the master-admin API docs,
- truncates statement text server-side (500 chars); `pg_stat_statements` text is already normalized by Postgres (`$1` placeholders, no literals).

## Verification

- Broken query reproduced against live postgres:15 (`ERROR: syntax error at or near "FILTER"`); fixed queries return real data.
- All four new activity queries executed against a live database, including a staged lock conflict (blocking-pair query correctly reported blocked/blocking PIDs and statements) and `pg_stat_statements` in a throwaway container with the extension preloaded.
- `tsc` clean in `App` and `App/FeatureSet/AdminDashboard`; eslint clean.
- Multi-agent adversarial review (SQL semantics across pg 13–17, API/frontend contract, React state handling, security/data exposure): all findings addressed.