### PR TITLE
Metric Explorer UI overhaul: inline query builder, unified toolbar, chart card polish

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -931,11 +931,11 @@ function renderSeriesControls(input: {
        */}
       <div className="flex flex-wrap items-center gap-2">
         {unitLabel ? (
-          <span className="text-xs text-gray-500">{unitLabel}</span>
+          <span className="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600">
+            {unitLabel}
+          </span>
         ) : null}
-        <span className="rounded-full bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600">
-          {totalSeries} series
-        </span>
+        <span className="text-xs text-gray-500">{totalSeries} series</span>
         {serverHasMoreSeries ? (
           <span className="text-xs text-gray-500">
             Showing top{" "}

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricExplorer.tsx
@@ -660,132 +660,132 @@ const MetricExplorer: FunctionComponent = (): ReactElement => {
 
   return (
     <div>
-      <div className="mb-4 space-y-3">
-        {/* Row 1 — view identity & actions */}
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          {headerError ? (
-            <HintChip variant="red" className="mr-auto">
-              {headerError}
-            </HintChip>
-          ) : null}
-          <TelemetrySavedViewsControl<MetricSavedView>
-            modelType={MetricSavedView}
-            savedViewNoun="Metric Explorer"
-            explorerLabel="metric explorer"
-            hasInitialUrlState={hasInitialUrlState}
-            captureCurrentState={captureCurrentState}
-            applyState={applySavedViewState}
-            onError={setHeaderError}
-            additionalQuery={
-              {
-                viewType: TelemetrySavedViewType.Explorer,
-              } as Query<MetricSavedView>
-            }
-            additionalSaveFields={
-              {
-                viewType: TelemetrySavedViewType.Explorer,
-              } as Partial<MetricSavedView>
-            }
-          />
-          <CopyTextButton
-            textToBeCopied={ExplorerLink.buildExplorerUrl(
-              metricViewData,
-            ).toString()}
-            label="Copy Link"
-            copiedLabel="Link Copied!"
-            size="sm"
-            variant="ghost"
-            title="Copy a shareable link to this view"
-          />
-          <MoreMenu text="Actions">
-            <MoreMenuItem
-              key="create-monitor-from-view"
-              icon={IconProp.Activity}
-              text="Create monitor from this view"
-              onClick={navigateToCreateMonitor}
-            />
-            <MoreMenuItem
-              key="add-to-dashboard"
-              icon={IconProp.ChartBarSquare}
-              text="Add to dashboard"
-              onClick={() => {
-                setShowAddToDashboardModal(true);
-              }}
-            />
-          </MoreMenu>
-        </div>
+      <div className="mb-4 space-y-2">
+        {headerError ? <HintChip variant="red">{headerError}</HintChip> : null}
 
-        {/* Row 2 — investigation toolbar: time window · signal pivots · overlays */}
-        <div className="flex flex-wrap items-center gap-y-2">
-          <AutoRefreshControl
-            autoRefreshInterval={autoRefreshInterval}
-            onAutoRefreshIntervalChange={setAutoRefreshInterval}
-            onManualRefresh={handleRefresh}
-            isRefreshing={isFetchingResults}
-            lastRefreshedAt={lastRefreshedAt}
-            timeRangePicker={
-              <TelemetryTimeRangePicker
-                value={timeRangePickerValue}
-                onChange={handleTimeRangePicked}
-              />
-            }
-          />
-          <div className="ml-3 flex items-center gap-2 border-l border-gray-200 pl-3">
-            <Tooltip text="Open the logs explorer scoped to this time window">
-              <button
-                type="button"
-                aria-label="View logs for this time window"
-                className={`${TOOLBAR_BUTTON_CLASS_NAME} ${TOOLBAR_BUTTON_IDLE_CLASS_NAME}`}
-                onClick={() => {
-                  navigateToSignalWithCurrentWindow(PageMap.LOGS);
-                }}
-              >
-                <Icon icon={IconProp.Logs} className="h-4 w-4" />
-                <span>View Logs</span>
-              </button>
-            </Tooltip>
-            <Tooltip text="Open the traces explorer scoped to this time window">
-              <button
-                type="button"
-                aria-label="View traces for this time window"
-                className={`${TOOLBAR_BUTTON_CLASS_NAME} ${TOOLBAR_BUTTON_IDLE_CLASS_NAME}`}
-                onClick={() => {
-                  navigateToSignalWithCurrentWindow(PageMap.TRACES);
-                }}
-              >
-                <Icon icon={IconProp.Layers} className="h-4 w-4" />
-                <span>View Traces</span>
-              </button>
-            </Tooltip>
-          </div>
-          <div className="ml-3 flex items-center border-l border-gray-200 pl-3">
-            <Tooltip
-              text={
-                showEvents
-                  ? "Hide incident and alert markers on the charts"
-                  : "Show incident and alert markers on the charts"
+        {/*
+         * One toolbar row: time window · refresh cadence · signal pivots ·
+         * overlays on the left; view identity & share actions on the right.
+         * Wraps into stacked clusters on narrow screens.
+         */}
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+          <div className="flex flex-wrap items-center gap-y-2">
+            <AutoRefreshControl
+              autoRefreshInterval={autoRefreshInterval}
+              onAutoRefreshIntervalChange={setAutoRefreshInterval}
+              onManualRefresh={handleRefresh}
+              isRefreshing={isFetchingResults}
+              lastRefreshedAt={lastRefreshedAt}
+              timeRangePicker={
+                <TelemetryTimeRangePicker
+                  value={timeRangePickerValue}
+                  onChange={handleTimeRangePicked}
+                />
               }
-            >
-              <button
-                type="button"
-                aria-label="Toggle incident and alert markers"
-                aria-pressed={showEvents}
-                onClick={toggleShowEvents}
-                className={`${TOOLBAR_BUTTON_CLASS_NAME} ${
+            />
+            <div className="ml-3 flex items-center gap-2 border-l border-gray-200 pl-3">
+              <Tooltip text="Open the logs explorer scoped to this time window">
+                <button
+                  type="button"
+                  aria-label="View logs for this time window"
+                  className={`${TOOLBAR_BUTTON_CLASS_NAME} ${TOOLBAR_BUTTON_IDLE_CLASS_NAME}`}
+                  onClick={() => {
+                    navigateToSignalWithCurrentWindow(PageMap.LOGS);
+                  }}
+                >
+                  <Icon icon={IconProp.Logs} className="h-3.5 w-3.5" />
+                  <span>Logs</span>
+                </button>
+              </Tooltip>
+              <Tooltip text="Open the traces explorer scoped to this time window">
+                <button
+                  type="button"
+                  aria-label="View traces for this time window"
+                  className={`${TOOLBAR_BUTTON_CLASS_NAME} ${TOOLBAR_BUTTON_IDLE_CLASS_NAME}`}
+                  onClick={() => {
+                    navigateToSignalWithCurrentWindow(PageMap.TRACES);
+                  }}
+                >
+                  <Icon icon={IconProp.Layers} className="h-3.5 w-3.5" />
+                  <span>Traces</span>
+                </button>
+              </Tooltip>
+              <Tooltip
+                text={
                   showEvents
-                    ? TOOLBAR_BUTTON_ACTIVE_CLASS_NAME
-                    : TOOLBAR_BUTTON_IDLE_CLASS_NAME
-                }`}
+                    ? "Hide incident and alert markers on the charts"
+                    : "Show incident and alert markers on the charts"
+                }
               >
-                <Icon icon={IconProp.Bolt} className="h-4 w-4" />
-                <span>Show events</span>
-                {showEvents && eventMarkers.length > 0 ? (
-                  <span className="rounded-full bg-gray-100 px-1.5 text-xs text-gray-600">
-                    {eventMarkers.length}
-                  </span>
-                ) : null}
-              </button>
-            </Tooltip>
+                <button
+                  type="button"
+                  aria-label="Toggle incident and alert markers"
+                  aria-pressed={showEvents}
+                  onClick={toggleShowEvents}
+                  className={`${TOOLBAR_BUTTON_CLASS_NAME} ${
+                    showEvents
+                      ? TOOLBAR_BUTTON_ACTIVE_CLASS_NAME
+                      : TOOLBAR_BUTTON_IDLE_CLASS_NAME
+                  }`}
+                >
+                  <Icon icon={IconProp.Bolt} className="h-3.5 w-3.5" />
+                  <span>Events</span>
+                  {showEvents && eventMarkers.length > 0 ? (
+                    <span className="rounded-full bg-indigo-100 px-1.5 text-[11px] font-semibold text-indigo-700">
+                      {eventMarkers.length}
+                    </span>
+                  ) : null}
+                </button>
+              </Tooltip>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <TelemetrySavedViewsControl<MetricSavedView>
+              modelType={MetricSavedView}
+              savedViewNoun="Metric Explorer"
+              explorerLabel="metric explorer"
+              hasInitialUrlState={hasInitialUrlState}
+              captureCurrentState={captureCurrentState}
+              applyState={applySavedViewState}
+              onError={setHeaderError}
+              additionalQuery={
+                {
+                  viewType: TelemetrySavedViewType.Explorer,
+                } as Query<MetricSavedView>
+              }
+              additionalSaveFields={
+                {
+                  viewType: TelemetrySavedViewType.Explorer,
+                } as Partial<MetricSavedView>
+              }
+            />
+            <CopyTextButton
+              textToBeCopied={ExplorerLink.buildExplorerUrl(
+                metricViewData,
+              ).toString()}
+              label="Copy Link"
+              copiedLabel="Link Copied!"
+              size="sm"
+              variant="ghost"
+              title="Copy a shareable link to this view"
+            />
+            <MoreMenu text="Actions">
+              <MoreMenuItem
+                key="create-monitor-from-view"
+                icon={IconProp.Activity}
+                text="Create monitor from this view"
+                onClick={navigateToCreateMonitor}
+              />
+              <MoreMenuItem
+                key="add-to-dashboard"
+                icon={IconProp.ChartBarSquare}
+                text="Add to dashboard"
+                onClick={() => {
+                  setShowAddToDashboardModal(true);
+                }}
+              />
+            </MoreMenu>
           </div>
         </div>
       </div>

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricFormulaConfig.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricFormulaConfig.tsx
@@ -98,7 +98,8 @@ const MetricFormulaConfigComponent: FunctionComponent<ComponentProps> = (
       <div className="border-t border-gray-200 pt-3 mt-4">
         <button
           type="button"
-          className="flex items-center gap-2 text-xs font-medium text-gray-500 uppercase tracking-wide hover:text-gray-700 transition-colors w-full"
+          aria-expanded={showDisplaySettings}
+          className="flex w-full items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-gray-400 transition-colors hover:text-gray-600"
           onClick={() => {
             setShowDisplaySettings(!showDisplaySettings);
           }}

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricQuery.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricQuery.tsx
@@ -1,9 +1,6 @@
-import FiltersForm from "Common/UI/Components/Filters/FiltersForm";
 import FieldType from "Common/UI/Components/Types/FieldType";
-import Button, {
-  ButtonSize,
-  ButtonStyleType,
-} from "Common/UI/Components/Button/Button";
+import JSONFilter from "Common/UI/Components/Filters/JSONFilter";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import IconProp from "Common/Types/Icon/IconProp";
 import Dropdown, {
   DropdownOption,
@@ -18,7 +15,6 @@ import React, {
 } from "react";
 import DropdownUtil from "Common/UI/Utils/Dropdown";
 import MetricsAggregationType from "Common/Types/Metrics/MetricsAggregationType";
-import Query from "Common/Types/BaseDatabase/Query";
 import MetricsQuery from "Common/Types/Metrics/MetricsQuery";
 import MetricQueryData from "Common/Types/Metrics/MetricQueryData";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
@@ -146,6 +142,53 @@ const MetricFilter: FunctionComponent<ComponentProps> = (
     });
   };
 
+  /*
+   * Direct write onto filterData (the shape FiltersForm used to manage):
+   * set or delete a single key, preserving everything else (attributes,
+   * groupByAttribute, ...) so query state never gets dropped on the floor.
+   */
+  const updateFilterDataKey: (
+    key: string,
+    value: string | undefined,
+  ) => void = (key: string, value: string | undefined): void => {
+    const newFilterData: Record<string, unknown> = {
+      ...(props.data.filterData as Record<string, unknown>),
+    };
+    if (value) {
+      newFilterData[key] = value;
+    } else {
+      delete newFilterData[key];
+    }
+    props.onDataChanged({
+      ...props.data,
+      filterData: newFilterData as MetricQueryData["filterData"],
+    });
+  };
+
+  const metricNameOptions: Array<DropdownOption> =
+    DropdownUtil.getDropdownOptionsFromArray(
+      props.metricTypes.map((metricType: MetricType) => {
+        return metricType.name || "";
+      }),
+    );
+
+  const selectedMetricNameOption: DropdownOption | undefined =
+    metricNameOptions.find((option: DropdownOption) => {
+      return option.value === selectedMetricName;
+    });
+
+  const aggregationOptions: Array<DropdownOption> =
+    DropdownUtil.getDropdownOptionsFromEnum(MetricsAggregationType);
+
+  const selectedAggregationType: string =
+    props.data.filterData?.aggegationType?.toString() ||
+    MetricsAggregationType.Avg;
+
+  const selectedAggregationOption: DropdownOption | undefined =
+    aggregationOptions.find((option: DropdownOption) => {
+      return option.value === selectedAggregationType;
+    });
+
   const groupByOptions: Array<DropdownOption> = (
     props.telemetryAttributes || []
   ).map((attr: string) => {
@@ -161,64 +204,61 @@ const MetricFilter: FunctionComponent<ComponentProps> = (
     },
   );
 
+  const activeFilterCount: number = Object.keys(
+    ((props.data.filterData as Record<string, unknown> | undefined)?.[
+      "attributes"
+    ] as Record<string, unknown> | undefined) || {},
+  ).length;
+
   return (
     <Fragment>
-      <div>
-        <FiltersForm<MetricsQuery>
-          showFilter={true}
-          id="metrics-filter"
-          filterData={props.data.filterData}
-          onFilterChanged={(filterData: Query<MetricsQuery>) => {
-            props.onDataChanged({
-              ...props.data,
-              filterData,
-            });
-          }}
-          showAdvancedFilters={showAdvancedFilters}
-          hideAdvancedFilterToggle={true}
-          isFilterLoading={false}
-          filterError={showAdvancedFilters ? props.attributesError : undefined}
-          onFilterRefreshClick={
-            showAdvancedFilters ? props.onAttributesRetry : undefined
-          }
-          filters={[
-            {
-              key: "metricName",
-              title: "Metric Name",
-              type: FieldType.Dropdown,
-              filterDropdownOptions: DropdownUtil.getDropdownOptionsFromArray(
-                props.metricTypes.map((metricType: MetricType) => {
-                  return metricType.name || "";
-                }),
-              ),
-            },
-            {
-              key: "aggegationType",
-              type: FieldType.Dropdown,
-              title: "Aggregation Type",
-              filterDropdownOptions: DropdownUtil.getDropdownOptionsFromEnum(
-                MetricsAggregationType,
-              ),
-            },
-            {
-              key: "attributes",
-              type: FieldType.JSON,
-              title: "Filter by Attributes",
-              jsonKeys: props.telemetryAttributes,
-              jsonValueSuggestions: props.telemetryAttributeValueSuggestions,
-              onJsonKeySelected: props.onAttributeKeySelected,
-              onJsonValueSearch: props.onAttributeValueSearch,
-              isLoadingJsonKeys: props.isAttributesLoading,
-              loadingJsonValueKeys: props.loadingAttributeValueKeys,
-              jsonEnableOperators: true,
-              isAdvancedFilter: true,
-            },
-          ]}
-        />
+      {/*
+       * Inline query builder: metric picker + aggregation on one row,
+       * replacing the old label-column FiltersForm rows.
+       */}
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="min-w-[240px] flex-1">
+          <label className="mb-1 block text-xs font-medium text-gray-500">
+            Metric
+          </label>
+          <Dropdown
+            options={metricNameOptions}
+            value={selectedMetricNameOption}
+            placeholder="Search and select a metric..."
+            ariaLabel="Metric name"
+            onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+              updateFilterDataKey(
+                "metricName",
+                value ? value.toString() : undefined,
+              );
+            }}
+          />
+        </div>
+        <div className="w-full sm:w-44">
+          <label className="mb-1 block text-xs font-medium text-gray-500">
+            Aggregate by
+          </label>
+          <Dropdown
+            options={aggregationOptions}
+            value={selectedAggregationOption}
+            placeholder="Aggregation"
+            ariaLabel="Aggregation type"
+            onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+              /*
+               * A cleared aggregation falls back to Avg — every query
+               * needs one, and Avg is the creation-site default.
+               */
+              updateFilterDataKey(
+                "aggegationType",
+                value ? value.toString() : MetricsAggregationType.Avg,
+              );
+            }}
+          />
+        </div>
       </div>
 
       {showRateHint ? (
-        <div className="mt-2">
+        <div className="mt-3">
           <HintChip variant="amber" icon={IconProp.Bolt}>
             <button
               type="button"
@@ -245,52 +285,111 @@ const MetricFilter: FunctionComponent<ComponentProps> = (
         </div>
       ) : null}
 
-      {showAdvancedFilters ? (
-        <div className="mt-4">
-          <label className="block text-sm font-medium text-gray-700">
-            Group By
-          </label>
-          <p className="mt-1 text-xs text-gray-500">
-            Split this query into one series per unique value (e.g. one line per
-            host). Leave empty to aggregate everything into a single series.
-          </p>
-          <div className="mt-2">
-            <Dropdown
-              options={groupByOptions}
-              isMultiSelect={true}
-              value={selectedGroupByOptions}
-              placeholder="Select attributes to group by"
-              onChange={(
-                value: DropdownValue | Array<DropdownValue> | null,
-              ): void => {
-                const keys: Array<string> = Array.isArray(value)
-                  ? value.map((v: DropdownValue) => {
-                      return String(v);
-                    })
-                  : value
-                    ? [String(value)]
-                    : [];
+      {/* Filters & grouping toggle */}
+      <div className="mt-3">
+        <button
+          type="button"
+          aria-expanded={showAdvancedFilters}
+          className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 -ml-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+          onClick={toggleAdvancedFilters}
+        >
+          <Icon
+            icon={
+              showAdvancedFilters ? IconProp.ChevronUp : IconProp.ChevronDown
+            }
+            className="h-3 w-3"
+          />
+          <span>Filters &amp; grouping</span>
+          {!showAdvancedFilters &&
+          (activeFilterCount > 0 || selectedGroupByKeys.length > 0) ? (
+            <span className="inline-flex h-1.5 w-1.5 rounded-full bg-indigo-400" />
+          ) : null}
+        </button>
+      </div>
 
-                props.onDataChanged({
-                  ...props.data,
-                  groupByAttributeKeys: keys.length > 0 ? keys : undefined,
-                });
-              }}
-            />
+      {showAdvancedFilters ? (
+        <div className="mt-2 space-y-4 border-l-2 border-gray-100 pl-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Filter by attributes
+            </label>
+            <p className="mt-1 text-xs text-gray-500">
+              Only chart series whose attributes match these conditions.
+            </p>
+            {props.attributesError ? (
+              <div className="py-2">
+                <ErrorMessage
+                  message={props.attributesError}
+                  onRefreshClick={props.onAttributesRetry}
+                />
+              </div>
+            ) : (
+              <div className="mt-2">
+                <JSONFilter<MetricsQuery>
+                  filter={{
+                    key: "attributes",
+                    type: FieldType.JSON,
+                    title: "Attribute Filter",
+                  }}
+                  filterData={props.data.filterData}
+                  onFilterChanged={(
+                    filterData: MetricQueryData["filterData"],
+                  ) => {
+                    props.onDataChanged({
+                      ...props.data,
+                      filterData,
+                    });
+                  }}
+                  jsonKeys={props.telemetryAttributes}
+                  jsonValueSuggestions={
+                    props.telemetryAttributeValueSuggestions
+                  }
+                  onJsonKeySelected={props.onAttributeKeySelected}
+                  onJsonValueSearch={props.onAttributeValueSearch}
+                  isLoadingJsonKeys={props.isAttributesLoading}
+                  loadingJsonValueKeys={props.loadingAttributeValueKeys}
+                  enableOperators={true}
+                />
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              Group by
+            </label>
+            <p className="mt-1 text-xs text-gray-500">
+              Split this query into one series per unique value (e.g. one line
+              per host). Leave empty to aggregate everything into a single
+              series.
+            </p>
+            <div className="mt-2">
+              <Dropdown
+                options={groupByOptions}
+                isMultiSelect={true}
+                value={selectedGroupByOptions}
+                placeholder="Select attributes to group by"
+                onChange={(
+                  value: DropdownValue | Array<DropdownValue> | null,
+                ): void => {
+                  const keys: Array<string> = Array.isArray(value)
+                    ? value.map((v: DropdownValue) => {
+                        return String(v);
+                      })
+                    : value
+                      ? [String(value)]
+                      : [];
+
+                  props.onDataChanged({
+                    ...props.data,
+                    groupByAttributeKeys: keys.length > 0 ? keys : undefined,
+                  });
+                }}
+              />
+            </div>
           </div>
         </div>
       ) : null}
-
-      <div className="mt-3">
-        <Button
-          className="-ml-3"
-          buttonSize={ButtonSize.Small}
-          buttonStyle={ButtonStyleType.SECONDARY_LINK}
-          icon={showAdvancedFilters ? IconProp.ChevronUp : IconProp.ChevronDown}
-          title="Filters & grouping"
-          onClick={toggleAdvancedFilters}
-        />
-      </div>
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricQueryConfig.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricQueryConfig.tsx
@@ -527,7 +527,8 @@ const MetricGraphConfig: FunctionComponent<ComponentProps> = (
             <div className="border-t border-gray-200 pt-3">
               <button
                 type="button"
-                className="flex items-center gap-2 text-xs font-medium text-gray-500 uppercase tracking-wide hover:text-gray-700 transition-colors w-full"
+                aria-expanded={showDisplaySettings}
+                className="flex w-full items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-gray-400 transition-colors hover:text-gray-600"
                 onClick={() => {
                   setShowDisplaySettings(!showDisplaySettings);
                 }}

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -796,7 +796,7 @@ const MetricView: FunctionComponent<ComponentProps> = (
           <Card>
             <div className="-mt-5">
               <div className="flex items-center gap-2 mb-3">
-                <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
                   Time Range
                 </span>
               </div>
@@ -819,8 +819,13 @@ const MetricView: FunctionComponent<ComponentProps> = (
         {/* Query configs */}
         {!props.hideQueryElements && (
           <div>
-            <div className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">
-              Queries
+            <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+              <span>Queries</span>
+              {props.data.queryConfigs.length > 1 && (
+                <span className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-gray-100 px-1 text-[10px] font-semibold text-gray-500">
+                  {props.data.queryConfigs.length}
+                </span>
+              )}
             </div>
             <div className="space-y-3">
               {props.data.queryConfigs.map(
@@ -1090,12 +1095,10 @@ const MetricView: FunctionComponent<ComponentProps> = (
             )}
 
             {/* Add metric / Add formula buttons */}
-            <div className="flex items-center gap-2 pt-2">
-              <Button
-                title="Add Metric"
-                buttonSize={ButtonSize.Small}
-                buttonStyle={ButtonStyleType.OUTLINE}
-                icon={IconProp.Add}
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-md border border-dashed border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm transition-colors hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
                 onClick={() => {
                   if (props.onChange) {
                     props.onChange({
@@ -1107,12 +1110,13 @@ const MetricView: FunctionComponent<ComponentProps> = (
                     });
                   }
                 }}
-              />
-              <Button
-                title="Add Formula"
-                buttonSize={ButtonSize.Small}
-                buttonStyle={ButtonStyleType.OUTLINE}
-                icon={IconProp.Calculator}
+              >
+                <Icon icon={IconProp.Add} className="h-3.5 w-3.5" />
+                <span>Add Metric</span>
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-md border border-dashed border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 shadow-sm transition-colors hover:border-violet-300 hover:bg-violet-50 hover:text-violet-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
                 onClick={() => {
                   if (props.onChange) {
                     props.onChange({
@@ -1124,7 +1128,10 @@ const MetricView: FunctionComponent<ComponentProps> = (
                     });
                   }
                 }}
-              />
+              >
+                <Icon icon={IconProp.Calculator} className="h-3.5 w-3.5" />
+                <span>Add Formula</span>
+              </button>
             </div>
           </div>
         )}
@@ -1198,8 +1205,32 @@ const MetricView: FunctionComponent<ComponentProps> = (
           (!isMetricResultsLoading || hasFetchedResultsOnce) && (
             <div>
               {!props.hideQueryElements && (
-                <div className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">
-                  Charts
+                <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+                  <span>Charts</span>
+                  {/*
+                   * Panel count, not result count: a query flagged
+                   * overlayWithPreviousQuery draws on the previous query's
+                   * chart panel, so it must not count as its own card.
+                   */}
+                  {(() => {
+                    const chartPanelCount: number =
+                      props.data.queryConfigs.filter(
+                        (
+                          queryConfig: MetricQueryConfigData,
+                          index: number,
+                        ): boolean => {
+                          return !(
+                            index > 0 &&
+                            queryConfig.overlayWithPreviousQuery === true
+                          );
+                        },
+                      ).length + props.data.formulaConfigs.length;
+                    return chartPanelCount > 1 ? (
+                      <span className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-gray-100 px-1 text-[10px] font-semibold text-gray-500">
+                        {chartPanelCount}
+                      </span>
+                    ) : null;
+                  })()}
                 </div>
               )}
               {/*

--- a/App/FeatureSet/Dashboard/src/Components/TelemetryResource/AutoRefreshControl.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TelemetryResource/AutoRefreshControl.tsx
@@ -159,7 +159,7 @@ const AutoRefreshControl: FunctionComponent<AutoRefreshControlProps> = (
         onClick={props.onManualRefresh}
         disabled={props.isRefreshing}
         title="Refresh now"
-        className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Icon
           icon={IconProp.Refresh}
@@ -187,7 +187,7 @@ const AutoRefreshControl: FunctionComponent<AutoRefreshControlProps> = (
               e.target.value as AutoRefreshInterval,
             );
           }}
-          className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          className="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
         >
           {intervals.map((interval: AutoRefreshInterval): ReactElement => {
             return (

--- a/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
+++ b/Common/UI/Components/Charts/ChartGroup/ChartGroup.tsx
@@ -133,7 +133,9 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
     }
 
     return (
-      <span className="ml-auto text-[10px] text-gray-300">Drag to zoom</span>
+      <span className="ml-auto shrink-0 whitespace-nowrap text-[10px] text-gray-400">
+        Drag to zoom
+      </span>
     );
   };
 
@@ -147,7 +149,7 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
     return (
       <button
         type="button"
-        className="ml-1.5 inline-flex items-center justify-center rounded-full w-5 h-5 text-gray-300 hover:text-gray-500 hover:bg-gray-100 transition-all duration-150"
+        className="ml-1.5 inline-flex items-center justify-center rounded-full w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-all duration-150"
         title="View metric details"
         onClick={() => {
           setMetricInfoModalChart(chart.metricInfo || null);
@@ -174,7 +176,7 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
     return (
       <button
         type="button"
-        className="ml-1.5 inline-flex items-center justify-center rounded-full w-5 h-5 text-gray-300 hover:text-gray-500 hover:bg-gray-100 transition-all duration-150"
+        className="ml-1.5 inline-flex items-center justify-center rounded-full w-5 h-5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-all duration-150"
         title="Open in Metric Explorer"
         onClick={() => {
           chart.onOpenInExplorer?.();
@@ -305,7 +307,10 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
                 <div className="px-5 pt-4 pb-4 flex flex-col flex-1">
                   <div className="mb-3 pb-3 border-b border-gray-100">
                     <div className="flex items-center">
-                      <h3 className="text-sm font-semibold text-gray-800 tracking-tight">
+                      <h3
+                        className="min-w-0 truncate text-sm font-semibold text-gray-800 tracking-tight"
+                        title={chart.title}
+                      >
                         {chart.title}
                       </h3>
                       {getInfoIcon(chart)}
@@ -320,7 +325,7 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
                   </div>
                   {getChartContent(chart, index)}
                   {chart.seriesControls ? (
-                    <div className="mb-3">{chart.seriesControls}</div>
+                    <div className="mt-3">{chart.seriesControls}</div>
                   ) : null}
                 </div>
               </div>
@@ -338,39 +343,46 @@ const ChartGroup: FunctionComponent<ComponentProps> = (
   return (
     <>
       {renderMetricInfoModal()}
-      <div
-        className={`grid grid-cols-1 ${gridCols} gap-4 space-y-4 lg:space-y-0`}
-      >
+      <div className={`grid grid-cols-1 ${gridCols} gap-4`}>
         {props.charts.map((chart: Chart, index: number) => {
           return (
             <div
               key={index}
-              className={`p-5 rounded-lg border border-gray-200 bg-white shadow-sm flex flex-col gap-3 ${props.chartCssClass || ""}`}
+              className={`flex flex-col rounded-lg border border-gray-200 bg-white shadow-sm ${props.chartCssClass || ""}`}
             >
-              <div className="flex items-center">
-                <h2
-                  data-testid="card-details-heading"
-                  id="card-details-heading"
-                  className="text-base font-semibold leading-6 text-gray-900"
-                >
-                  {chart.title}
-                </h2>
-                {getInfoIcon(chart)}
-                {getExplorerIcon(chart)}
-                {getDragToZoomHint(chart)}
+              {/* Header strip — title, meta icons, hover-revealed zoom hint */}
+              <div className="border-b border-gray-100 px-4 py-2.5">
+                <div className="flex items-center">
+                  <h2
+                    data-testid="card-details-heading"
+                    id="card-details-heading"
+                    className="min-w-0 truncate text-sm font-semibold leading-6 text-gray-900"
+                    title={chart.title}
+                  >
+                    {chart.title}
+                  </h2>
+                  {getInfoIcon(chart)}
+                  {getExplorerIcon(chart)}
+                  {getDragToZoomHint(chart)}
+                </div>
+                {chart.description && (
+                  <p
+                    data-testid="card-description"
+                    className="mt-0.5 w-full truncate text-xs text-gray-500 hidden md:block"
+                    title={chart.description}
+                  >
+                    {chart.description}
+                  </p>
+                )}
               </div>
-              {chart.description && (
-                <p
-                  data-testid="card-description"
-                  className="mt-0.5 text-sm text-gray-500 w-full hidden md:block"
-                >
-                  {chart.description}
-                </p>
-              )}
-              <div className="flex-1 flex flex-col min-h-80">
+              <div className="flex-1 flex flex-col min-h-80 px-4 pt-3 pb-2">
                 {getChartContent(chart, index)}
               </div>
-              {chart.seriesControls ? chart.seriesControls : null}
+              {chart.seriesControls ? (
+                <div className="border-t border-gray-100 px-4 py-3">
+                  {chart.seriesControls}
+                </div>
+              ) : null}
             </div>
           );
         })}

--- a/Common/Utils/ValueFormatter.ts
+++ b/Common/Utils/ValueFormatter.ts
@@ -292,7 +292,28 @@ function formatNumber(value: number): string {
     return (Math.round(value * 10) / 10).toString();
   }
 
-  return (Math.round(value * 100) / 100).toString();
+  if (absValue >= 1) {
+    return (Math.round(value * 100) / 100).toString();
+  }
+
+  /*
+   * Below 1, fixed two-decimal rounding collapses distinct values onto the
+   * same label (0.004 and 0.006 both become "0.01"), which renders chart
+   * axes with runs of duplicate ticks. Two significant digits keeps
+   * neighbouring ticks distinct at any magnitude.
+   */
+  const rounded: number = parseFloat(value.toPrecision(2));
+  const asString: string = rounded.toString();
+  if (!asString.includes("e") && !asString.includes("E")) {
+    return asString;
+  }
+
+  /*
+   * Number.prototype.toString switches to exponential notation below 1e-6
+   * ("1.2e-7"), which is unreadable on an axis label — expand it back to
+   * plain decimals and trim the trailing zeros toFixed pads with.
+   */
+  return rounded.toFixed(20).replace(/0+$/, "").replace(/\.$/, "");
 }
 
 /*


### PR DESCRIPTION
# Metric Explorer UI overhaul

The Metric Explorer page looked dated and cluttered: a form-like query builder with stacked label rows, a fragmented toolbar of disconnected boxes, floating top-right actions, plain chart cards, and duplicate y-axis tick labels on small-value metrics. This PR reworks the page's visual language to match the recently overhauled Logs/Traces explorer surfaces (single-row toolbar, white pill buttons, indigo accent, bordered card strips) without changing any behavior or data flow.

## What changed

### Query builder (`MetricQuery.tsx`)
- Replaced the generic `FiltersForm` usage (140px label column + per-row clear buttons, "Metric Name" / "Aggregation Type" stacked rows) with a purpose-built inline builder: a searchable **Metric** picker and a compact **Aggregate by** dropdown on one row.
- Attribute filters now render the `JSONFilter` (key / operator / value rows) directly under a labeled "Filter by attributes" block inside the **Filters & grouping** section, alongside **Group by** — indented behind a subtle rule.
- The Filters & grouping toggle shows an indigo activity dot when collapsed filters/group-bys exist.
- All callbacks, loading/error/retry paths, deep-link auto-expansion, and the cumulative-counter rate hint are preserved. `FiltersForm` itself is untouched (it is shared app-wide).

### Explorer toolbar (`MetricExplorer.tsx`, `AutoRefreshControl.tsx`)
- Merged the two header rows into one toolbar: time range · Refresh · auto-refresh on the left, signal pivots (**Logs**, **Traces**, **Events**) in the middle, **Saved Views · Copy Link · Actions** on the right.
- Events toggle shows an indigo count badge when markers are in range.
- `AutoRefreshControl` buttons/selects now match the canonical toolbar pill sizing (`px-2.5 py-1.5`, `shadow-sm`) — this also harmonizes the 15 other pages using it.

### Chart cards (`ChartGroup.tsx`, `MetricCharts.tsx`)
- Cards now have a bordered header strip (title + info icons + drag-to-zoom hint), a padded chart body, and a separated legend/controls footer — replacing the single padded blob.
- Removed the `space-y-4` + `grid gap-4` double-spacing hack.
- Unit label renders as a badge in the legend footer; series count reads as quiet text.

### Y-axis ticks (`ValueFormatter.ts`)
- `formatNumber` now formats absolute values below 1 with two significant digits instead of two fixed decimals, so axes no longer render runs of duplicate ticks (`0.01, 0.01, 0, 0, 0`).

### Sections (`MetricView.tsx`, `MetricQueryConfig.tsx`, `MetricFormulaConfig.tsx`)
- QUERIES / CHARTS headers use the house micro-label idiom with count badges.
- Add Metric / Add Formula are dashed ghost buttons with hover accents.
- Display Settings toggles get `aria-expanded` and the same micro-label style.

## What did not change
- All query/fetch semantics, saved views, deep links, drag-to-zoom, event overlays, Top-N, series controls, and exemplars.
- Embedded surfaces (`hideCard` paths: monitor step forms, incident/alert pages, dashboard widgets) keep their layout contract.

## Verification
- `tsc` passes in `Common`, `App`, and `App/FeatureSet/Dashboard`; eslint clean on changed files.
- Verified against the local dev stack with seeded metric data: default view, empty state, Filters & grouping (attribute filter rows + group-by), grouped multi-series legend, two queries + formula, and small-value (ms) axis ticks — all render correctly with no console errors.
- Diff reviewed by a multi-agent adversarial pass for behavior parity with the old query builder, shared-component consumers, and formatter edge cases.
