### PR TITLE
Fix AI Insights view page indefinite loading and redesign both pages (table → cards)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/AIInsights/Insights.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/AIInsights/Insights.tsx
@@ -1,28 +1,40 @@
-import React, { FunctionComponent, ReactElement } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import PageComponentProps from "../PageComponentProps";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import Route from "Common/Types/API/Route";
-import Color from "Common/Types/Color";
-import {
-  Blue500,
-  Gray500,
-  Green500,
-  Orange500,
-  Purple500,
-  Red500,
-  Yellow500,
-} from "Common/Types/BrandColors";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import Query from "Common/Types/BaseDatabase/Query";
+import Search from "Common/Types/BaseDatabase/Search";
+import OneUptimeDate from "Common/Types/Date";
 import AIInsight from "Common/Models/DatabaseModels/AIInsight";
+import AIInsightHumanVerdict from "Common/Types/AI/AIInsightHumanVerdict";
 import AIInsightSeverity from "Common/Types/AI/AIInsightSeverity";
 import AIInsightStatus from "Common/Types/AI/AIInsightStatus";
 import AIInsightType from "Common/Types/AI/AIInsightType";
+import IconProp from "Common/Types/Icon/IconProp";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
+import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import EmptyState from "Common/UI/Components/EmptyState/EmptyState";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import FilterButtons, {
+  FilterButtonOption,
+} from "Common/UI/Components/FilterButtons/FilterButtons";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Input from "Common/UI/Components/Input/Input";
 import Link from "Common/UI/Components/Link/Link";
-import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
-import Pill from "Common/UI/Components/Pill/Pill";
-import FieldType from "Common/UI/Components/Types/FieldType";
-import DropdownUtil from "Common/UI/Utils/Dropdown";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import AIPlanGate from "../../Components/AI/AIPlanGate";
 
@@ -35,10 +47,32 @@ const INSIGHT_TYPE_LABELS: Record<AIInsightType, string> = {
   [AIInsightType.MetricDrift]: "Metric Drift",
 };
 
-const SEVERITY_COLORS: Record<AIInsightSeverity, Color> = {
-  [AIInsightSeverity.High]: Red500,
-  [AIInsightSeverity.Medium]: Yellow500,
-  [AIInsightSeverity.Low]: Blue500,
+// Human labels for the wire-contract status values (e.g. "ActionRequired").
+const STATUS_LABELS: Record<AIInsightStatus, string> = {
+  [AIInsightStatus.Detected]: "Detected",
+  [AIInsightStatus.ActionRequired]: "Needs Attention",
+  [AIInsightStatus.FixOpened]: "Fix Opened",
+  [AIInsightStatus.Resolved]: "Resolved",
+  [AIInsightStatus.Dismissed]: "Dismissed",
+};
+
+const SEVERITY_BADGE_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "bg-red-50 text-red-700 ring-red-600/20",
+  [AIInsightSeverity.Medium]: "bg-amber-50 text-amber-700 ring-amber-600/20",
+  [AIInsightSeverity.Low]: "bg-blue-50 text-blue-700 ring-blue-600/20",
+};
+
+const SEVERITY_DOT_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "bg-red-500",
+  [AIInsightSeverity.Medium]: "bg-amber-500",
+  [AIInsightSeverity.Low]: "bg-blue-500",
+};
+
+// The severity-tinted icon tile shown on each insight card.
+const SEVERITY_TILE_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "bg-red-50 text-red-600",
+  [AIInsightSeverity.Medium]: "bg-amber-50 text-amber-600",
+  [AIInsightSeverity.Low]: "bg-blue-50 text-blue-600",
 };
 
 /*
@@ -46,12 +80,31 @@ const SEVERITY_COLORS: Record<AIInsightSeverity, Color> = {
  * it, the terminal human states are calm (green/gray), and Detected — a
  * transient state the scanner routes out of in the same tick — stays gray.
  */
-const STATUS_COLORS: Record<AIInsightStatus, Color> = {
-  [AIInsightStatus.Detected]: Gray500,
-  [AIInsightStatus.ActionRequired]: Orange500,
-  [AIInsightStatus.FixOpened]: Purple500,
-  [AIInsightStatus.Resolved]: Green500,
-  [AIInsightStatus.Dismissed]: Gray500,
+const STATUS_BADGE_CLASSES: Record<AIInsightStatus, string> = {
+  [AIInsightStatus.Detected]: "bg-gray-100 text-gray-600 ring-gray-500/20",
+  [AIInsightStatus.ActionRequired]:
+    "bg-orange-50 text-orange-700 ring-orange-600/20",
+  [AIInsightStatus.FixOpened]:
+    "bg-purple-50 text-purple-700 ring-purple-600/20",
+  [AIInsightStatus.Resolved]: "bg-green-50 text-green-700 ring-green-600/20",
+  [AIInsightStatus.Dismissed]: "bg-gray-100 text-gray-600 ring-gray-500/20",
+};
+
+const STATUS_DOT_CLASSES: Record<AIInsightStatus, string> = {
+  [AIInsightStatus.Detected]: "bg-gray-400",
+  [AIInsightStatus.ActionRequired]: "bg-orange-500",
+  [AIInsightStatus.FixOpened]: "bg-purple-500",
+  [AIInsightStatus.Resolved]: "bg-green-500",
+  [AIInsightStatus.Dismissed]: "bg-gray-400",
+};
+
+// Each detector gets its own glyph so a card is recognizable at a glance.
+const INSIGHT_TYPE_ICONS: Record<AIInsightType, IconProp> = {
+  [AIInsightType.NewException]: IconProp.Bug,
+  [AIInsightType.ExceptionSpike]: IconProp.Fire,
+  [AIInsightType.ErrorLogSpike]: IconProp.Logs,
+  [AIInsightType.TraceLatencyRegression]: IconProp.Clock,
+  [AIInsightType.MetricDrift]: IconProp.ArrowTrendingUp,
 };
 
 export function getInsightTypeLabel(
@@ -63,6 +116,31 @@ export function getInsightTypeLabel(
   return INSIGHT_TYPE_LABELS[insightType] || insightType;
 }
 
+export function getStatusLabel(status: AIInsightStatus | undefined): string {
+  if (!status) {
+    return "-";
+  }
+  return STATUS_LABELS[status] || status;
+}
+
+export function getInsightTypeIcon(
+  insightType: AIInsightType | undefined,
+): IconProp {
+  if (!insightType) {
+    return IconProp.LightBulb;
+  }
+  return INSIGHT_TYPE_ICONS[insightType] || IconProp.LightBulb;
+}
+
+export function getSeverityTileClasses(
+  severity: AIInsightSeverity | undefined,
+): string {
+  if (!severity) {
+    return "bg-gray-100 text-gray-500";
+  }
+  return SEVERITY_TILE_CLASSES[severity] || "bg-gray-100 text-gray-500";
+}
+
 export function getInsightTypeElement(
   insightType: AIInsightType | undefined,
 ): ReactElement {
@@ -70,7 +148,7 @@ export function getInsightTypeElement(
     return <></>;
   }
   return (
-    <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-600/20">
+    <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-600/20">
       {getInsightTypeLabel(insightType)}
     </span>
   );
@@ -82,7 +160,21 @@ export function getSeverityElement(
   if (!severity) {
     return <></>;
   }
-  return <Pill text={severity} color={SEVERITY_COLORS[severity] || Gray500} />;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+        SEVERITY_BADGE_CLASSES[severity] ||
+        "bg-gray-100 text-gray-600 ring-gray-500/20"
+      }`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          SEVERITY_DOT_CLASSES[severity] || "bg-gray-400"
+        }`}
+      />
+      {severity}
+    </span>
+  );
 }
 
 export function getStatusElement(
@@ -91,9 +183,114 @@ export function getStatusElement(
   if (!status) {
     return <></>;
   }
-  return <Pill text={status} color={STATUS_COLORS[status] || Gray500} />;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+        STATUS_BADGE_CLASSES[status] ||
+        "bg-gray-100 text-gray-600 ring-gray-500/20"
+      }`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          STATUS_DOT_CLASSES[status] || "bg-gray-400"
+        }`}
+      />
+      {getStatusLabel(status)}
+    </span>
+  );
 }
 
+export function getHumanVerdictElement(
+  verdict: AIInsightHumanVerdict | undefined | null,
+): ReactElement {
+  if (verdict === AIInsightHumanVerdict.Confirmed) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+        <Icon icon={IconProp.Check} className="h-3 w-3" />
+        Confirmed
+      </span>
+    );
+  }
+  if (verdict === AIInsightHumanVerdict.Dismissed) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/20">
+        <Icon icon={IconProp.Close} className="h-3 w-3" />
+        Dismissed
+      </span>
+    );
+  }
+  return <></>;
+}
+
+const INSIGHTS_PER_PAGE: number = 20;
+
+const ALL_FILTER_VALUE: string = "All";
+
+const STATUS_FILTER_OPTIONS: Array<FilterButtonOption> = [
+  { label: "All", value: ALL_FILTER_VALUE },
+  {
+    label: STATUS_LABELS[AIInsightStatus.ActionRequired],
+    value: AIInsightStatus.ActionRequired,
+  },
+  {
+    label: STATUS_LABELS[AIInsightStatus.FixOpened],
+    value: AIInsightStatus.FixOpened,
+  },
+  {
+    label: STATUS_LABELS[AIInsightStatus.Resolved],
+    value: AIInsightStatus.Resolved,
+  },
+  {
+    label: STATUS_LABELS[AIInsightStatus.Dismissed],
+    value: AIInsightStatus.Dismissed,
+  },
+];
+
+const SEVERITY_FILTER_OPTIONS: Array<FilterButtonOption> = [
+  { label: "Any Severity", value: ALL_FILTER_VALUE },
+  { label: "High", value: AIInsightSeverity.High },
+  { label: "Medium", value: AIInsightSeverity.Medium },
+  { label: "Low", value: AIInsightSeverity.Low },
+];
+
+const TYPE_FILTER_OPTIONS: Array<FilterButtonOption> = [
+  { label: "All Types", value: ALL_FILTER_VALUE },
+  ...Object.values(AIInsightType).map((insightType: AIInsightType) => {
+    return {
+      label: INSIGHT_TYPE_LABELS[insightType],
+      value: insightType as string,
+    };
+  }),
+];
+
+/*
+ * Filters live in the URL query string (replaceState, no history spam) so a
+ * filtered view survives opening an insight and clicking Back, and so it can
+ * be shared/bookmarked — the same behavior the old table got from
+ * TableFilterUrlState.
+ */
+type ReadFilterParamFunction = (
+  paramName: string,
+  validValues: Array<string>,
+) => string;
+
+const readFilterParam: ReadFilterParamFunction = (
+  paramName: string,
+  validValues: Array<string>,
+): string => {
+  const value: string | null = Navigation.getQueryStringByName(paramName);
+  if (value && validValues.includes(value)) {
+    return value;
+  }
+  return ALL_FILTER_VALUE;
+};
+
+/*
+ * The AI insights inbox, rendered as cards instead of a table: each finding
+ * reads like an inbox item — severity-tinted detector icon, badges, title
+ * and the freshness/occurrence meta — with status and severity chip filters
+ * and a title search on top.
+ */
 const AIInsightsPage: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
@@ -101,142 +298,464 @@ const AIInsightsPage: FunctionComponent<
     RouteMap[PageMap.AI_INSIGHTS_SETTINGS] as Route,
   );
 
-  return (
-    <>
-      <AIPlanGate />
+  const [insights, setInsights] = useState<Array<AIInsight>>([]);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  /*
+   * Append failures get their own inline error so a transient blip on Load
+   * More never unmounts the cards that already loaded.
+   */
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
 
-      <ModelTable<AIInsight>
-        modelType={AIInsight}
-        id="ai-insights-table"
-        userPreferencesKey="ai-insights-table"
-        saveFilterProps={{
-          tableId: "ai-insights-table",
-        }}
-        isDeleteable={false}
-        isEditable={false}
-        isCreateable={false}
-        name="AI Insights"
-        isViewable={true}
-        cardProps={{
-          title: "AI Insights",
-          description:
-            "Proactive findings from OneUptime AI's deterministic telemetry sensors — new or spiking exceptions, error-log spikes, latency regressions and metric drift. Insights never page and never open incidents.",
-        }}
-        noItemsMessage={
-          <span>
-            No insights yet. When AI Insights is enabled, OneUptime AI
-            continuously watches this project&apos;s telemetry and files a quiet
-            insight whenever a deterministic sensor finds something — without
-            paging anyone or opening incidents. Turn it on in{" "}
-            <Link to={settingsRoute} className="underline">
-              Insights Settings
-            </Link>
-            .
-          </span>
+  const [statusFilter, setStatusFilter] = useState<string>(() => {
+    return readFilterParam("status", Object.values(AIInsightStatus));
+  });
+  const [severityFilter, setSeverityFilter] = useState<string>(() => {
+    return readFilterParam("severity", Object.values(AIInsightSeverity));
+  });
+  const [typeFilter, setTypeFilter] = useState<string>(() => {
+    return readFilterParam("type", Object.values(AIInsightType));
+  });
+  const [searchText, setSearchText] = useState<string>(() => {
+    return Navigation.getQueryStringByName("search") || "";
+  });
+  // Seeded from the URL too so the very first fetch already applies it.
+  const [debouncedSearchText, setDebouncedSearchText] = useState<string>(() => {
+    return (Navigation.getQueryStringByName("search") || "").trim();
+  });
+
+  // Reflect the current filters back into the URL (see readFilterParam).
+  useEffect(() => {
+    Navigation.setQueryString({
+      status: statusFilter === ALL_FILTER_VALUE ? null : statusFilter,
+      severity: severityFilter === ALL_FILTER_VALUE ? null : severityFilter,
+      type: typeFilter === ALL_FILTER_VALUE ? null : typeFilter,
+      search: debouncedSearchText || null,
+    });
+  }, [statusFilter, severityFilter, typeFilter, debouncedSearchText]);
+
+  // Debounce the title search so typing does not fire a request per key.
+  useEffect(() => {
+    const timeout: ReturnType<typeof setTimeout> = setTimeout(() => {
+      setDebouncedSearchText(searchText.trim());
+    }, 400);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [searchText]);
+
+  const hasActiveFilters: boolean = Boolean(
+    statusFilter !== ALL_FILTER_VALUE ||
+      severityFilter !== ALL_FILTER_VALUE ||
+      typeFilter !== ALL_FILTER_VALUE ||
+      debouncedSearchText,
+  );
+
+  /*
+   * Guards against out-of-order responses: a Load More issued just before a
+   * filter change could otherwise land after the filter's fresh page and
+   * append rows from the previous query onto the new list. Every fetch takes
+   * a ticket; only the latest ticket may write state.
+   */
+  const fetchGenerationRef: React.MutableRefObject<number> = useRef<number>(0);
+
+  const fetchInsights: (options: {
+    skip: number;
+    append: boolean;
+  }) => Promise<void> = useCallback(
+    async (options: { skip: number; append: boolean }): Promise<void> => {
+      const generation: number = ++fetchGenerationRef.current;
+
+      if (options.append) {
+        setIsLoadingMore(true);
+      } else {
+        setIsLoading(true);
+      }
+
+      try {
+        const query: Query<AIInsight> = {};
+
+        if (statusFilter !== ALL_FILTER_VALUE) {
+          (query as Record<string, unknown>)["status"] = statusFilter;
         }
-        showRefreshButton={true}
-        searchableFields={["title", "serviceName"]}
-        viewPageRoute={Navigation.getCurrentRoute()}
-        sortBy="lastSeenAt"
-        sortOrder={SortOrder.Descending}
-        filters={[
+
+        if (severityFilter !== ALL_FILTER_VALUE) {
+          (query as Record<string, unknown>)["severity"] = severityFilter;
+        }
+
+        if (typeFilter !== ALL_FILTER_VALUE) {
+          (query as Record<string, unknown>)["insightType"] = typeFilter;
+        }
+
+        if (debouncedSearchText) {
+          (query as Record<string, unknown>)["title"] = new Search(
+            debouncedSearchText,
+          );
+        }
+
+        const result: ListResult<AIInsight> = await ModelAPI.getList<AIInsight>(
           {
-            field: {
+            modelType: AIInsight,
+            query: query,
+            limit: INSIGHTS_PER_PAGE,
+            skip: options.skip,
+            select: {
+              _id: true,
               insightType: true,
-            },
-            title: "Type",
-            type: FieldType.Dropdown,
-            filterDropdownOptions:
-              DropdownUtil.getDropdownOptionsFromEnum(AIInsightType),
-          },
-          {
-            field: {
-              status: true,
-            },
-            title: "Status",
-            type: FieldType.Dropdown,
-            filterDropdownOptions:
-              DropdownUtil.getDropdownOptionsFromEnum(AIInsightStatus),
-          },
-          {
-            field: {
-              severity: true,
-            },
-            title: "Severity",
-            type: FieldType.Dropdown,
-            filterDropdownOptions:
-              DropdownUtil.getDropdownOptionsFromEnum(AIInsightSeverity),
-          },
-          {
-            field: {
-              serviceName: true,
-            },
-            title: "Service",
-            type: FieldType.Text,
-          },
-        ]}
-        columns={[
-          {
-            field: {
-              insightType: true,
-            },
-            title: "Type",
-            type: FieldType.Element,
-            getElement: (item: AIInsight): ReactElement => {
-              return getInsightTypeElement(item.insightType);
-            },
-          },
-          {
-            field: {
               title: true,
-            },
-            title: "Title",
-            type: FieldType.Text,
-          },
-          {
-            field: {
               serviceName: true,
-            },
-            title: "Service",
-            type: FieldType.Text,
-          },
-          {
-            field: {
               severity: true,
-            },
-            title: "Severity",
-            type: FieldType.Element,
-            getElement: (item: AIInsight): ReactElement => {
-              return getSeverityElement(item.severity);
-            },
-          },
-          {
-            field: {
               status: true,
-            },
-            title: "Status",
-            type: FieldType.Element,
-            getElement: (item: AIInsight): ReactElement => {
-              return getStatusElement(item.status);
-            },
-          },
-          {
-            field: {
+              humanVerdict: true,
+              firstSeenAt: true,
               lastSeenAt: true,
-            },
-            title: "Last Seen",
-            type: FieldType.Date,
-          },
-          {
-            field: {
               occurrenceCount: true,
             },
-            title: "Occurrences",
-            type: FieldType.Number,
+            sort: {
+              lastSeenAt: SortOrder.Descending,
+            },
           },
-        ]}
-      />
-    </>
+        );
+
+        if (generation !== fetchGenerationRef.current) {
+          // A newer fetch superseded this one — drop the stale response.
+          return;
+        }
+
+        setTotalCount(result.count);
+        setInsights((current: Array<AIInsight>) => {
+          if (!options.append) {
+            return result.data;
+          }
+          /*
+           * De-duplicate by id: the list is offset-paginated on lastSeenAt,
+           * which the scanner bumps on every re-detection, so a row already
+           * on screen can slide back into the appended window. Without this
+           * the same card renders twice (with a duplicate React key).
+           */
+          const seenIds: Set<string> = new Set(
+            current.map((item: AIInsight) => {
+              return item.id?.toString() || "";
+            }),
+          );
+          return [
+            ...current,
+            ...result.data.filter((item: AIInsight) => {
+              return !seenIds.has(item.id?.toString() || "");
+            }),
+          ];
+        });
+        setError(null);
+        setLoadMoreError(null);
+      } catch (err) {
+        if (generation === fetchGenerationRef.current) {
+          if (options.append) {
+            setLoadMoreError(API.getFriendlyMessage(err));
+          } else {
+            setError(API.getFriendlyMessage(err));
+          }
+        }
+      } finally {
+        if (generation === fetchGenerationRef.current) {
+          setIsLoading(false);
+          setIsLoadingMore(false);
+        }
+      }
+    },
+    [statusFilter, severityFilter, typeFilter, debouncedSearchText],
+  );
+
+  useEffect(() => {
+    fetchInsights({ skip: 0, append: false }).catch(() => {
+      // handled inside fetchInsights
+    });
+  }, [fetchInsights]);
+
+  type GetInsightCardFunction = (item: AIInsight) => ReactElement;
+
+  const getInsightCard: GetInsightCardFunction = (
+    item: AIInsight,
+  ): ReactElement => {
+    const viewRoute: Route = RouteUtil.populateRouteParams(
+      RouteMap[PageMap.AI_INSIGHT_VIEW] as Route,
+      { modelId: item.id! },
+    );
+
+    return (
+      <Link
+        key={item.id?.toString()}
+        to={viewRoute}
+        className="group block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      >
+        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all duration-150 group-hover:border-indigo-300 group-hover:shadow-md sm:p-5">
+          <div className="flex items-start gap-4">
+            <div
+              className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${getSeverityTileClasses(
+                item.severity,
+              )}`}
+            >
+              <Icon
+                icon={getInsightTypeIcon(item.insightType)}
+                className="h-5 w-5"
+              />
+            </div>
+
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-1.5">
+                {getInsightTypeElement(item.insightType)}
+                {getSeverityElement(item.severity)}
+                {getStatusElement(item.status)}
+                {getHumanVerdictElement(item.humanVerdict)}
+              </div>
+
+              <h3 className="mt-2 truncate text-sm font-semibold text-gray-900 group-hover:text-indigo-600">
+                {item.title}
+              </h3>
+
+              <div className="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500">
+                {item.serviceName ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Icon icon={IconProp.Cube} className="h-3.5 w-3.5" />
+                    {item.serviceName}
+                  </span>
+                ) : (
+                  <></>
+                )}
+                {item.lastSeenAt ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Icon icon={IconProp.Clock} className="h-3.5 w-3.5" />
+                    Last seen {OneUptimeDate.fromNow(item.lastSeenAt)}
+                  </span>
+                ) : (
+                  <></>
+                )}
+                {item.occurrenceCount ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Icon icon={IconProp.Refresh} className="h-3.5 w-3.5" />
+                    {item.occurrenceCount === 1
+                      ? "Detected once"
+                      : `Detected ${item.occurrenceCount} times`}
+                  </span>
+                ) : (
+                  <></>
+                )}
+              </div>
+            </div>
+
+            <Icon
+              icon={IconProp.ChevronRight}
+              className="mt-1 h-5 w-5 flex-shrink-0 text-gray-300 transition-colors group-hover:text-indigo-500"
+            />
+          </div>
+        </div>
+      </Link>
+    );
+  };
+
+  type GetContentFunction = () => ReactElement;
+
+  const getContent: GetContentFunction = (): ReactElement => {
+    // Full-page error only when there is nothing loaded to keep on screen.
+    if (error && insights.length === 0) {
+      return (
+        <ErrorMessage
+          message={error}
+          onRefreshClick={() => {
+            fetchInsights({ skip: 0, append: false }).catch(() => {
+              // handled inside fetchInsights
+            });
+          }}
+        />
+      );
+    }
+
+    if (isLoading) {
+      return <ComponentLoader />;
+    }
+
+    if (insights.length === 0 && !hasActiveFilters) {
+      return (
+        <EmptyState
+          id="ai-insights-empty-state"
+          icon={IconProp.LightBulb}
+          showSolidBackground={true}
+          title="No insights yet"
+          description={
+            <span>
+              When AI Insights is enabled, OneUptime AI continuously watches
+              this project&apos;s telemetry and files a quiet insight whenever a
+              deterministic sensor finds something — without paging anyone or
+              opening incidents.
+            </span>
+          }
+          footer={
+            <Button
+              title="Go to Insights Settings"
+              icon={IconProp.Settings}
+              buttonStyle={ButtonStyleType.OUTLINE}
+              onClick={() => {
+                Navigation.navigate(settingsRoute);
+              }}
+            />
+          }
+        />
+      );
+    }
+
+    if (insights.length === 0) {
+      return (
+        <EmptyState
+          id="ai-insights-no-match"
+          icon={IconProp.Search}
+          showSolidBackground={true}
+          title="No insights match your filters"
+          description="Try changing the status or severity filters, or clearing your search."
+          footer={
+            <Button
+              title="Clear Filters"
+              icon={IconProp.Close}
+              buttonStyle={ButtonStyleType.OUTLINE}
+              onClick={() => {
+                setStatusFilter(ALL_FILTER_VALUE);
+                setSeverityFilter(ALL_FILTER_VALUE);
+                setTypeFilter(ALL_FILTER_VALUE);
+                setSearchText("");
+                setDebouncedSearchText("");
+              }}
+            />
+          }
+        />
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        {error ? (
+          <p className="text-sm text-red-500">
+            Could not refresh insights: {error}
+          </p>
+        ) : (
+          <></>
+        )}
+
+        {insights.map((item: AIInsight) => {
+          return getInsightCard(item);
+        })}
+
+        <div className="flex flex-col items-center gap-2 pt-2">
+          {loadMoreError ? (
+            <p className="text-sm text-red-500">
+              Could not load more insights: {loadMoreError}
+            </p>
+          ) : (
+            <></>
+          )}
+          {insights.length < totalCount ? (
+            <Button
+              title="Load More"
+              icon={IconProp.ChevronDown}
+              buttonStyle={ButtonStyleType.OUTLINE}
+              buttonSize={ButtonSize.Small}
+              isLoading={isLoadingMore}
+              onClick={() => {
+                fetchInsights({ skip: insights.length, append: true }).catch(
+                  () => {
+                    // handled inside fetchInsights
+                  },
+                );
+              }}
+            />
+          ) : (
+            <></>
+          )}
+          <p className="text-xs text-gray-400">
+            Showing {insights.length} of {totalCount}{" "}
+            {totalCount === 1 ? "insight" : "insights"}
+          </p>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <AIPlanGate />
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <p className="max-w-2xl text-sm text-gray-500">
+          Proactive findings from OneUptime AI&apos;s deterministic telemetry
+          sensors — new or spiking exceptions, error-log spikes, latency
+          regressions and metric drift. Insights never page and never open
+          incidents.
+        </p>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <Button
+            title="Refresh"
+            icon={IconProp.Refresh}
+            buttonStyle={ButtonStyleType.OUTLINE}
+            buttonSize={ButtonSize.Small}
+            onClick={() => {
+              fetchInsights({ skip: 0, append: false }).catch(() => {
+                // handled inside fetchInsights
+              });
+            }}
+          />
+          <Button
+            title="Settings"
+            icon={IconProp.Settings}
+            buttonStyle={ButtonStyleType.OUTLINE}
+            buttonSize={ButtonSize.Small}
+            onClick={() => {
+              Navigation.navigate(settingsRoute);
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <FilterButtons
+            className="flex-wrap"
+            options={STATUS_FILTER_OPTIONS}
+            selectedValue={statusFilter}
+            onSelect={(value: string) => {
+              setStatusFilter(value);
+            }}
+          />
+          <div className="w-full sm:w-64">
+            <Input
+              placeholder="Search insights..."
+              value={searchText}
+              onChange={(value: string) => {
+                setSearchText(value);
+              }}
+            />
+          </div>
+        </div>
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <FilterButtons
+            className="flex-wrap"
+            options={TYPE_FILTER_OPTIONS}
+            selectedValue={typeFilter}
+            onSelect={(value: string) => {
+              setTypeFilter(value);
+            }}
+          />
+          <FilterButtons
+            className="flex-wrap"
+            options={SEVERITY_FILTER_OPTIONS}
+            selectedValue={severityFilter}
+            onSelect={(value: string) => {
+              setSeverityFilter(value);
+            }}
+          />
+        </div>
+      </div>
+
+      {getContent()}
+    </div>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Pages/AIInsights/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/AIInsights/View/Index.tsx
@@ -2,8 +2,11 @@ import PageComponentProps from "../../PageComponentProps";
 import PageMap from "../../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
 import {
+  getHumanVerdictElement,
   getInsightTypeElement,
+  getInsightTypeIcon,
   getSeverityElement,
+  getSeverityTileClasses,
   getStatusElement,
 } from "../Insights";
 import ChatActivityFeed from "../../../Components/AIChat/ChatActivityFeed";
@@ -19,6 +22,7 @@ import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import Route from "Common/Types/API/Route";
 import URL from "Common/Types/API/URL";
+import OneUptimeDate from "Common/Types/Date";
 import IconProp from "Common/Types/Icon/IconProp";
 import { JSONArray, JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
@@ -30,23 +34,22 @@ import Button, {
 import Card from "Common/UI/Components/Card/Card";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import Icon from "Common/UI/Components/Icon/Icon";
-import Link from "Common/UI/Components/Link/Link";
 import PageLoader from "Common/UI/Components/Loader/PageLoader";
 import MarkdownViewer from "Common/UI/Components/Markdown.tsx/MarkdownViewer";
-import CardModelDetail from "Common/UI/Components/ModelDetail/CardModelDetail";
-import FieldType from "Common/UI/Components/Types/FieldType";
 import { APP_API_URL } from "Common/UI/Config";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
-import Navigation from "Common/UI/Utils/Navigation";
+import Link from "Common/UI/Components/Link/Link";
 import React, {
   FunctionComponent,
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
+import { useParams } from "react-router-dom";
 
 const POLL_INTERVAL_MS: number = 5000;
 // The server caps the triage event trail at 500 — show all of it.
@@ -64,7 +67,18 @@ type InsightAction = "confirm" | "dismiss" | "resolve";
 const AIInsightViewPage: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
-  const modelId: ObjectID = Navigation.getLastParamAsObjectID();
+  /*
+   * The id must come from useParams (a stable string), NOT from
+   * Navigation.getLastParamAsObjectID(): that helper mints a fresh ObjectID
+   * object on every render, and using it as a useCallback dependency made
+   * every render rebuild the fetchers, which re-ran the fetch effect, whose
+   * setState re-rendered — an unbounded refetch loop that kept the page
+   * spinning forever.
+   */
+  const { id } = useParams();
+  const modelId: ObjectID = useMemo(() => {
+    return new ObjectID(id || "");
+  }, [id]);
 
   const [insight, setInsight] = useState<AIInsight | null>(null);
   const [insightError, setInsightError] = useState<string | null>(null);
@@ -91,8 +105,6 @@ const AIInsightViewPage: FunctionComponent<
    */
   const isSavingActionRef: React.MutableRefObject<boolean> =
     useRef<boolean>(false);
-  // Flipping this makes the CardModelDetail refetch after an action lands.
-  const [detailRefresher, setDetailRefresher] = useState<boolean>(false);
 
   const fetchInsight: () => Promise<void> =
     useCallback(async (): Promise<void> => {
@@ -101,8 +113,16 @@ const AIInsightViewPage: FunctionComponent<
           modelType: AIInsight,
           id: modelId,
           select: {
+            title: true,
+            insightType: true,
+            severity: true,
             status: true,
             humanVerdict: true,
+            serviceName: true,
+            metricName: true,
+            firstSeenAt: true,
+            lastSeenAt: true,
+            occurrenceCount: true,
             detailMarkdown: true,
             triageSummaryMarkdown: true,
             fixAiRunId: true,
@@ -268,11 +288,6 @@ const AIInsightViewPage: FunctionComponent<
         if (response instanceof HTTPErrorResponse) {
           throw response;
         }
-
-        // Make the detail card pick up the new status/verdict.
-        setDetailRefresher((value: boolean) => {
-          return !value;
-        });
       } catch (err) {
         // Roll back the optimistic update.
         setStatus(previousStatus);
@@ -339,92 +354,174 @@ const AIInsightViewPage: FunctionComponent<
     isTriageFailed = false;
   }
 
+  interface OverviewMetaItem {
+    label: string;
+    icon: IconProp;
+    value: string;
+    title?: string | undefined;
+  }
+
+  const metaItems: Array<OverviewMetaItem> = [];
+
+  if (insight.serviceName) {
+    metaItems.push({
+      label: "Service",
+      icon: IconProp.Cube,
+      value: insight.serviceName,
+    });
+  }
+
+  if (insight.metricName) {
+    metaItems.push({
+      label: "Metric",
+      icon: IconProp.ChartBar,
+      value: insight.metricName,
+    });
+  }
+
+  if (insight.firstSeenAt) {
+    metaItems.push({
+      label: "First Seen",
+      icon: IconProp.Clock,
+      value: OneUptimeDate.fromNow(insight.firstSeenAt),
+      title: OneUptimeDate.getDateAsLocalFormattedString(insight.firstSeenAt),
+    });
+  }
+
+  if (insight.lastSeenAt) {
+    metaItems.push({
+      label: "Last Seen",
+      icon: IconProp.Clock,
+      value: OneUptimeDate.fromNow(insight.lastSeenAt),
+      title: OneUptimeDate.getDateAsLocalFormattedString(insight.lastSeenAt),
+    });
+  }
+
+  metaItems.push({
+    label: "Detections",
+    icon: IconProp.Refresh,
+    value:
+      insight.occurrenceCount === 1
+        ? "Once"
+        : `${insight.occurrenceCount || 0} times`,
+  });
+
   return (
     <div className="space-y-4">
-      <CardModelDetail<AIInsight>
-        name="Insight Details"
-        cardProps={{
-          title: "Insight Details",
-          description:
-            "What OneUptime AI's deterministic sensors found, and where this insight stands.",
-        }}
-        refresher={detailRefresher}
-        modelDetailProps={{
-          showDetailsInNumberOfColumns: 2,
-          modelType: AIInsight,
-          id: "model-detail-ai-insight",
-          fields: [
-            {
-              field: {
-                insightType: true,
-              },
-              title: "Type",
-              fieldType: FieldType.Element,
-              getElement: (item: AIInsight): ReactElement => {
-                return getInsightTypeElement(item.insightType);
-              },
-            },
-            {
-              field: {
-                severity: true,
-              },
-              title: "Severity",
-              fieldType: FieldType.Element,
-              getElement: (item: AIInsight): ReactElement => {
-                return getSeverityElement(item.severity);
-              },
-            },
-            {
-              field: {
-                status: true,
-              },
-              title: "Status",
-              fieldType: FieldType.Element,
-              getElement: (item: AIInsight): ReactElement => {
-                return getStatusElement(item.status);
-              },
-            },
-            {
-              field: {
-                humanVerdict: true,
-              },
-              title: "Human Verdict",
-              fieldType: FieldType.Text,
-              placeholder: "None yet",
-            },
-            {
-              field: {
-                serviceName: true,
-              },
-              title: "Service",
-              fieldType: FieldType.Text,
-              placeholder: "-",
-            },
-            {
-              field: {
-                firstSeenAt: true,
-              },
-              title: "First Seen",
-              fieldType: FieldType.DateTime,
-            },
-            {
-              field: {
-                lastSeenAt: true,
-              },
-              title: "Last Seen",
-              fieldType: FieldType.DateTime,
-            },
-            {
-              field: {
-                occurrenceCount: true,
-              },
-              title: "Occurrences",
-              fieldType: FieldType.Number,
-            },
-          ],
-          modelId: modelId,
-        }}
-      />
+      {/* Overview: what was found, where it stands, and the one-click actions. */}
+      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="px-5 py-6 md:px-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex min-w-0 items-start gap-4">
+              <div
+                className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-lg ${getSeverityTileClasses(
+                  insight.severity,
+                )}`}
+              >
+                <Icon
+                  icon={getInsightTypeIcon(insight.insightType)}
+                  className="h-6 w-6"
+                />
+              </div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {getInsightTypeElement(insight.insightType)}
+                  {getSeverityElement(insight.severity)}
+                  {getStatusElement(status || undefined)}
+                  {getHumanVerdictElement(humanVerdict)}
+                </div>
+                <h2 className="mt-2 text-base font-semibold leading-6 text-gray-900">
+                  {insight.title}
+                </h2>
+              </div>
+            </div>
+
+            {!isTerminal ? (
+              <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+                <Button
+                  title="Confirm"
+                  icon={IconProp.Check}
+                  buttonStyle={ButtonStyleType.SUCCESS_OUTLINE}
+                  buttonSize={ButtonSize.Small}
+                  disabled={isSavingAction || isConfirmed}
+                  onClick={() => {
+                    performAction("confirm").catch(() => {
+                      // handled inside performAction
+                    });
+                  }}
+                />
+                <Button
+                  title="Dismiss"
+                  icon={IconProp.Close}
+                  buttonStyle={ButtonStyleType.HOVER_DANGER_OUTLINE}
+                  buttonSize={ButtonSize.Small}
+                  disabled={isSavingAction}
+                  onClick={() => {
+                    performAction("dismiss").catch(() => {
+                      // handled inside performAction
+                    });
+                  }}
+                />
+                <Button
+                  title="Resolve"
+                  icon={IconProp.CheckCircle}
+                  buttonStyle={ButtonStyleType.OUTLINE}
+                  buttonSize={ButtonSize.Small}
+                  disabled={isSavingAction}
+                  onClick={() => {
+                    performAction("resolve").catch(() => {
+                      // handled inside performAction
+                    });
+                  }}
+                />
+              </div>
+            ) : (
+              <></>
+            )}
+          </div>
+
+          {actionError ? (
+            <div className="mt-4">
+              <Alert
+                type={AlertType.DANGER}
+                strongTitle="Could not save your action"
+                title={actionError}
+              />
+            </div>
+          ) : (
+            <></>
+          )}
+
+          <dl className="mt-5 grid grid-cols-2 gap-4 border-t border-gray-100 pt-5 sm:grid-cols-3 lg:grid-cols-5">
+            {metaItems.map((item: OverviewMetaItem, index: number) => {
+              return (
+                <div key={index} className="min-w-0">
+                  <dt className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-gray-400">
+                    <Icon icon={item.icon} className="h-3.5 w-3.5" />
+                    {item.label}
+                  </dt>
+                  <dd
+                    className="mt-1 truncate text-sm text-gray-900"
+                    title={item.title || item.value}
+                  >
+                    {item.value}
+                  </dd>
+                </div>
+              );
+            })}
+          </dl>
+
+          {!isTerminal ? (
+            <p className="mt-4 text-xs text-gray-400">
+              Confirm or dismiss to record whether this insight was worth
+              surfacing — verdicts measure each detector&apos;s precision.
+              Resolve it once it has been handled.
+            </p>
+          ) : (
+            <></>
+          )}
+        </div>
+      </div>
 
       <Card
         title="Evidence"
@@ -513,93 +610,24 @@ const AIInsightViewPage: FunctionComponent<
           title="Fix Task"
           description="OneUptime AI queued an agent task for this insight. Fix pull requests are always drafts and always human-reviewed."
         >
+          {/*
+           * A real anchor (not a Button) so cmd/ctrl-click, middle-click
+           * and "open in new tab" work — Link always sets href.
+           */}
           <Link
-            className="text-sm underline"
             to={RouteUtil.populateRouteParams(
               RouteMap[PageMap.AI_AGENT_TASK_VIEW] as Route,
               { modelId: insight.fixAiRunId },
             )}
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-500"
           >
-            View the fix task and pull request
+            <span>View the fix task and pull request</span>
+            <Icon icon={IconProp.ArrowRight} className="h-4 w-4" />
           </Link>
         </Card>
       ) : (
         <></>
       )}
-
-      <Card
-        title="Act on This Insight"
-        description="Confirm or dismiss to record whether this insight was worth surfacing — verdicts measure each detector's precision. Resolve it once it has been handled."
-      >
-        <div className="space-y-3">
-          {actionError ? (
-            <Alert
-              type={AlertType.DANGER}
-              strongTitle="Could not save your action"
-              title={actionError}
-            />
-          ) : (
-            <></>
-          )}
-
-          {isConfirmed ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">
-              <Icon icon={IconProp.Check} className="h-3 w-3" />
-              <span>Confirmed by a human</span>
-            </span>
-          ) : (
-            <></>
-          )}
-
-          {humanVerdict === AIInsightHumanVerdict.Dismissed ? (
-            <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-              <Icon icon={IconProp.Close} className="h-3 w-3" />
-              <span>Dismissed by a human</span>
-            </span>
-          ) : (
-            <></>
-          )}
-
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              title="Confirm"
-              icon={IconProp.Check}
-              buttonStyle={ButtonStyleType.SUCCESS_OUTLINE}
-              buttonSize={ButtonSize.Small}
-              disabled={isSavingAction || isTerminal || isConfirmed}
-              onClick={() => {
-                performAction("confirm").catch(() => {
-                  // handled inside performAction
-                });
-              }}
-            />
-            <Button
-              title="Dismiss"
-              icon={IconProp.Close}
-              buttonStyle={ButtonStyleType.HOVER_DANGER_OUTLINE}
-              buttonSize={ButtonSize.Small}
-              disabled={isSavingAction || isTerminal}
-              onClick={() => {
-                performAction("dismiss").catch(() => {
-                  // handled inside performAction
-                });
-              }}
-            />
-            <Button
-              title="Resolve"
-              icon={IconProp.CheckCircle}
-              buttonStyle={ButtonStyleType.OUTLINE}
-              buttonSize={ButtonSize.Small}
-              disabled={isSavingAction || isTerminal}
-              onClick={() => {
-                performAction("resolve").catch(() => {
-                  // handled inside performAction
-                });
-              }}
-            />
-          </div>
-        </div>
-      </Card>
     </div>
   );
 };

--- a/Common/UI/Components/Page/ModelPage.tsx
+++ b/Common/UI/Components/Page/ModelPage.tsx
@@ -96,8 +96,13 @@ const ModelPage: <TBaseModel extends BaseModel>(
     } catch (err) {
       setLabels([]);
       setError(API.getFriendlyMessage(err));
+    } finally {
+      /*
+       * Must run even on the early "item not found" return above —
+       * otherwise the page shows its loader forever instead of the error.
+       */
+      setIsLoading(false);
     }
-    setIsLoading(false);
   };
 
   const [title, setTitle] = useState<string | undefined>(props.title);


### PR DESCRIPTION
## The bug: the view page never settled

`Pages/AIInsights/View/Index.tsx` derived its model id with `Navigation.getLastParamAsObjectID()`, which mints a **new `ObjectID` object on every render**. That object was a `useCallback` dependency for both fetchers, so every render rebuilt them; the fetch `useEffect` (keyed on the fetchers) re-ran; its `setInsight(newObject)` re-rendered; and the cycle repeated forever.

Measured on the live dev stack (Playwright, ~30s on the page):

| | get-item requests | triage-run requests | loaders |
|---|---|---|---|
| **Before** | 347 | 173 | flickering the whole time |
| **After** | 2 | 1 | none after initial paint |

The fix follows the sibling AI Agent Tasks page: take the stable `id` string from `useParams()` and memoize the `ObjectID`.

Also fixed a latent bug in `Common/UI/Components/Page/ModelPage.tsx`: when `getItem` returned a null item, an early `return` skipped `setIsLoading(false)`, leaving the page loader spinning forever instead of showing the error. It now runs in a `finally`.

## List page: table → cards

`Pages/AIInsights/Insights.tsx` is rewritten from a `ModelTable` into a card-based inbox:

- Each insight is a card: severity-tinted detector icon (bug / fire / logs / clock / trend per type), type + severity + status + human-verdict badges, the title, and a meta row (service, last-seen relative time, detection count). The whole card is a real anchor to the insight (cmd-click / middle-click work), with a visible keyboard focus ring.
- Filter chips for status (All / Needs Attention / Fix Opened / Resolved / Dismissed), type (all five detectors), and severity, plus a debounced title search. Filters and search persist in the URL query string (`replaceState`, no history spam) so a filtered view survives opening an insight and clicking Back, and can be shared — same behavior the old table got from `TableFilterUrlState`.
- Load-more pagination with a running "Showing X of Y" count. Out-of-order responses are dropped via a generation counter, appended pages are de-duplicated by id (the scanner bumps `lastSeenAt`, so offset pages can overlap), and a failed Load More shows an inline error instead of unmounting the loaded cards.
- Distinct empty states: "no insights yet" (pointing to Insights Settings) vs "no match for these filters" (one-click clear).
- Refresh and Settings buttons in the toolbar; the plan-gate banner is kept.

**Intentional drop:** the old table exposed bulk row selection with a Delete action for project owners/admins (a `BaseModelTable` behavior decoupled from `isDeleteable={false}`). The new inbox has no delete UI on purpose — insights are server-authored rows and Dismiss is the intended close action; the delete API remains available to admins.

## View page redesign

- The generic `CardModelDetail` (and its extra fetch + refresher hack) is replaced by a purpose-built overview card: detector icon, badges, title, Confirm / Dismiss / Resolve in the header, and a meta grid (service, metric, first/last seen as relative times with absolute tooltips, detection count).
- Action semantics unchanged (optimistic update, rollback + inline error on failure); the verdict badge updates instantly; actions hide once the insight is terminal.
- Evidence, AI Triage (live `ChatActivityFeed`) and Fix Task cards kept. Both markdown surfaces still render with `safeMode={true}` (they carry attacker-influenceable telemetry / LLM output). The fix-task link stays a real `<a>` for new-tab affordances.

## Verification

- `npm run compile` clean in `App` and `Common`; `npx eslint` clean on all three files; `npm run fix` run at root.
- Playwright against the local dev stack: cards render; status filter narrows 5 → 2; type filter narrows to the metric-drift insight; search narrows correctly; filters survive navigating into an insight and back; view page settles with no stuck loaders (request table above); Confirm immediately shows the Confirmed badge and persists.
- Mobile (390px): no horizontal overflow on either page; layout wraps cleanly.
- A 29-agent adversarial review of the diff ran; every confirmed finding (type filter loss, URL filter persistence, load-more error handling, append de-duplication, focus ring, fix-task anchor) is addressed in this PR, and the bulk-delete drop is documented above as deliberate.
