### PR TITLE
fix(ci): unbreak master — App compile and repo-wide lint

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards.tsx
@@ -52,51 +52,52 @@ const DeviceSummaryCards: FunctionComponent = (): ReactElement => {
         DEVICE_FRESH_WINDOW_MINUTES,
       );
 
-      const [devicesUp, devicesDown, devicesPending, devicesWithDownInterfaces]: [
-        number,
-        number,
-        number,
-        ListResult<NetworkDevice>,
-      ] = await Promise.all([
-        ModelAPI.count<NetworkDevice>({
-          modelType: NetworkDevice,
-          query: {
-            projectId: projectId,
-            isArchived: false,
-            lastSeenAt: new GreaterThanOrEqual(freshCutoff),
-          },
-        }),
-        ModelAPI.count<NetworkDevice>({
-          modelType: NetworkDevice,
-          query: {
-            projectId: projectId,
-            isArchived: false,
-            lastSeenAt: new LessThan(freshCutoff),
-          },
-        }),
-        ModelAPI.count<NetworkDevice>({
-          modelType: NetworkDevice,
-          query: {
-            projectId: projectId,
-            isArchived: false,
-            lastSeenAt: new IsNull(),
-          },
-        }),
-        ModelAPI.getList<NetworkDevice>({
-          modelType: NetworkDevice,
-          query: {
-            projectId: projectId,
-            isArchived: false,
-            interfacesDown: new GreaterThan(0),
-          },
-          limit: LIMIT_PER_PROJECT,
-          skip: 0,
-          select: {
-            interfacesDown: true,
-          },
-          sort: {},
-        }),
-      ]);
+      const [
+        devicesUp,
+        devicesDown,
+        devicesPending,
+        devicesWithDownInterfaces,
+      ]: [number, number, number, ListResult<NetworkDevice>] =
+        await Promise.all([
+          ModelAPI.count<NetworkDevice>({
+            modelType: NetworkDevice,
+            query: {
+              projectId: projectId,
+              isArchived: false,
+              lastSeenAt: new GreaterThanOrEqual(freshCutoff),
+            },
+          }),
+          ModelAPI.count<NetworkDevice>({
+            modelType: NetworkDevice,
+            query: {
+              projectId: projectId,
+              isArchived: false,
+              lastSeenAt: new LessThan(freshCutoff),
+            },
+          }),
+          ModelAPI.count<NetworkDevice>({
+            modelType: NetworkDevice,
+            query: {
+              projectId: projectId,
+              isArchived: false,
+              lastSeenAt: new IsNull(),
+            },
+          }),
+          ModelAPI.getList<NetworkDevice>({
+            modelType: NetworkDevice,
+            query: {
+              projectId: projectId,
+              isArchived: false,
+              interfacesDown: new GreaterThan(0),
+            },
+            limit: LIMIT_PER_PROJECT,
+            skip: 0,
+            select: {
+              interfacesDown: true,
+            },
+            sort: {},
+          }),
+        ]);
 
       const interfacesDown: number = devicesWithDownInterfaces.data.reduce(
         (total: number, device: NetworkDevice) => {

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceVendorTemplateBanner.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceVendorTemplateBanner.tsx
@@ -26,9 +26,7 @@ export interface ComponentProps {
 const DeviceVendorTemplateBanner: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [sysObjectId, setSysObjectId] = useState<string | undefined>(
-    undefined,
-  );
+  const [sysObjectId, setSysObjectId] = useState<string | undefined>(undefined);
   const [isDismissed, setIsDismissed] = useState<boolean>(false);
 
   useEffect(() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Documentation.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Documentation.tsx
@@ -118,8 +118,8 @@ const MonitorDocumentation: FunctionComponent<
           description={
             <span>
               Learn how to register devices, run subnet discovery, enable
-              interface monitoring and SNMP traps, and use template variables
-              in the{" "}
+              interface monitoring and SNMP traps, and use template variables in
+              the{" "}
               <Link
                 openInNewTab={true}
                 to={new URL(HTTP_PROTOCOL, HOST).addRoute(

--- a/App/FeatureSet/Workers/Jobs/NetworkDeviceOwners/SendOwnerAddedNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/NetworkDeviceOwners/SendOwnerAddedNotification.ts
@@ -57,9 +57,7 @@ RunCron(
       }
 
       for (const user of users) {
-        (deviceOwnersMap[networkDeviceId.toString()] as Array<User>).push(
-          user,
-        );
+        (deviceOwnersMap[networkDeviceId.toString()] as Array<User>).push(user);
       }
 
       // mark this as notified.

--- a/App/Tests/Dashboard/DeviceMonitorLookupUtil.test.ts
+++ b/App/Tests/Dashboard/DeviceMonitorLookupUtil.test.ts
@@ -22,10 +22,8 @@ jest.mock("Common/UI/Utils/ModelAPI/ModelAPI", () => {
   };
 });
 
-/* eslint-disable import/first -- imports must come after jest.mock above */
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import DeviceMonitorLookupUtil from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceMonitorLookupUtil";
-/* eslint-enable import/first */
 
 const getListMock: jest.Mock = ModelAPI.getList as unknown as jest.Mock;
 

--- a/App/Tests/Dashboard/DeviceStatusUtil.test.ts
+++ b/App/Tests/Dashboard/DeviceStatusUtil.test.ts
@@ -74,15 +74,13 @@ describe("DeviceStatusUtil.getStatus", () => {
     });
 
     test("null lastSeenAt (raw API payloads) is Pending", () => {
-      expect(
-        DeviceStatusUtil.getStatus(null as unknown as undefined),
-      ).toBe(NetworkDeviceStatus.Pending);
+      expect(DeviceStatusUtil.getStatus(null as unknown as undefined)).toBe(
+        NetworkDeviceStatus.Pending,
+      );
     });
 
     test("empty-string lastSeenAt is Pending", () => {
-      expect(DeviceStatusUtil.getStatus("")).toBe(
-        NetworkDeviceStatus.Pending,
-      );
+      expect(DeviceStatusUtil.getStatus("")).toBe(NetworkDeviceStatus.Pending);
     });
   });
 
@@ -101,9 +99,7 @@ describe("DeviceStatusUtil.getStatus", () => {
 
     test("seen one millisecond inside the window is Up", () => {
       expect(
-        DeviceStatusUtil.getStatus(
-          minutesAgo(DEVICE_FRESH_WINDOW_MINUTES, -1),
-        ),
+        DeviceStatusUtil.getStatus(minutesAgo(DEVICE_FRESH_WINDOW_MINUTES, -1)),
       ).toBe(NetworkDeviceStatus.Up);
     });
 
@@ -114,9 +110,9 @@ describe("DeviceStatusUtil.getStatus", () => {
     });
 
     test("accepts an ISO string the API serializes", () => {
-      expect(
-        DeviceStatusUtil.getStatus("2026-07-16T11:55:00.000Z"),
-      ).toBe(NetworkDeviceStatus.Up);
+      expect(DeviceStatusUtil.getStatus("2026-07-16T11:55:00.000Z")).toBe(
+        NetworkDeviceStatus.Up,
+      );
     });
   });
 
@@ -136,9 +132,7 @@ describe("DeviceStatusUtil.getStatus", () => {
 
     test("seen one millisecond past the window is Down", () => {
       expect(
-        DeviceStatusUtil.getStatus(
-          minutesAgo(DEVICE_FRESH_WINDOW_MINUTES, 1),
-        ),
+        DeviceStatusUtil.getStatus(minutesAgo(DEVICE_FRESH_WINDOW_MINUTES, 1)),
       ).toBe(NetworkDeviceStatus.Down);
     });
   });
@@ -151,9 +145,9 @@ describe("DeviceStatusUtil.getStatus", () => {
     });
 
     test("seen hours ago via an ISO string is Down", () => {
-      expect(
-        DeviceStatusUtil.getStatus("2026-07-16T08:00:00.000Z"),
-      ).toBe(NetworkDeviceStatus.Down);
+      expect(DeviceStatusUtil.getStatus("2026-07-16T08:00:00.000Z")).toBe(
+        NetworkDeviceStatus.Down,
+      );
     });
 
     test("seen days ago is Down", () => {

--- a/App/Tests/Dashboard/NetworkTopologyMeta.test.ts
+++ b/App/Tests/Dashboard/NetworkTopologyMeta.test.ts
@@ -97,9 +97,9 @@ describe("linkStateForEdge — classification edge cases", () => {
   });
 
   test("just below the threshold is healthy, not saturated", () => {
-    expect(
-      linkStateForEdge(edgeWith({ utilizationPercent: 79.9 })),
-    ).toBe("healthy");
+    expect(linkStateForEdge(edgeWith({ utilizationPercent: 79.9 }))).toBe(
+      "healthy",
+    );
   });
 
   test("an idle link at 0% utilization is healthy", () => {
@@ -109,9 +109,9 @@ describe("linkStateForEdge — classification edge cases", () => {
   });
 
   test("rate-only data (no utilization, no oper status) still reads healthy", () => {
-    expect(
-      linkStateForEdge(edgeWith({ inRateMbps: 0, outRateMbps: 0 })),
-    ).toBe("healthy");
+    expect(linkStateForEdge(edgeWith({ inRateMbps: 0, outRateMbps: 0 }))).toBe(
+      "healthy",
+    );
   });
 
   test("endpoint objects with every field undefined stay unknown", () => {
@@ -175,9 +175,9 @@ describe("edgeKeyForEdge", () => {
   });
 
   test("distinct pairs get distinct keys", () => {
-    expect(
-      edgeKeyForEdge({ fromNodeId: "a", toNodeId: "b" }),
-    ).not.toBe(edgeKeyForEdge({ fromNodeId: "a", toNodeId: "c" }));
+    expect(edgeKeyForEdge({ fromNodeId: "a", toNodeId: "b" })).not.toBe(
+      edgeKeyForEdge({ fromNodeId: "a", toNodeId: "c" }),
+    );
   });
 });
 
@@ -266,9 +266,9 @@ describe("describeEndpoint", () => {
   });
 
   test("prefers the real interface name over the port label", () => {
-    expect(
-      describeEndpoint({ interfaceName: "xe-0/0/7" }, "stale-label"),
-    ).toBe("xe-0/0/7");
+    expect(describeEndpoint({ interfaceName: "xe-0/0/7" }, "stale-label")).toBe(
+      "xe-0/0/7",
+    );
   });
 
   test("renders the full tooltip line for a down, busy interface", () => {
@@ -306,10 +306,7 @@ describe("describeEndpoint", () => {
 
   test("shows a dash for the missing direction when only one rate is known", () => {
     expect(
-      describeEndpoint(
-        { interfaceName: "Gi0/1", inRateMbps: 5 },
-        undefined,
-      ),
+      describeEndpoint({ interfaceName: "Gi0/1", inRateMbps: 5 }, undefined),
     ).toBe("Gi0/1 · ↓5.0 Mbps ↑—");
   });
 });

--- a/App/tsconfig.json
+++ b/App/tsconfig.json
@@ -32,7 +32,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    // "module": "es2022" /* Specify what module code is generated. */,
+    "module": "es2022" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/Common/Server/Services/NetworkDeviceOwnerTeamService.ts
+++ b/Common/Server/Services/NetworkDeviceOwnerTeamService.ts
@@ -22,8 +22,10 @@ export class Service extends DatabaseService<Model> {
     const ownerTeams: Array<Model> = await this.findBy({
       query: {
         networkDeviceId: networkDeviceId,
-        // Scope to the project when known so a monitor step referencing a
-        // device from another project can never fan out its owners.
+        /*
+         * Scope to the project when known so a monitor step referencing a
+         * device from another project can never fan out its owners.
+         */
         ...(projectId ? { projectId: projectId } : {}),
       },
       select: {

--- a/Common/Server/Services/NetworkDeviceOwnerUserService.ts
+++ b/Common/Server/Services/NetworkDeviceOwnerUserService.ts
@@ -30,8 +30,10 @@ export class Service extends DatabaseService<Model> {
     const ownerUsers: Array<Model> = await this.findBy({
       query: {
         networkDeviceId: networkDeviceId,
-        // Scope to the project when known so a monitor step referencing a
-        // device from another project can never fan out its owners.
+        /*
+         * Scope to the project when known so a monitor step referencing a
+         * device from another project can never fan out its owners.
+         */
         ...(projectId ? { projectId: projectId } : {}),
       },
       select: {

--- a/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
@@ -990,8 +990,10 @@ export default class MonitorMetricUtil {
 
     if (snmpOidResponses && snmpOidResponses.length > 0) {
       // Same unbounded-write cap rationale as the interface block above.
-      const oidResponsesToEmit: Array<SnmpOidResponse> =
-        snmpOidResponses.slice(0, 50);
+      const oidResponsesToEmit: Array<SnmpOidResponse> = snmpOidResponses.slice(
+        0,
+        50,
+      );
 
       if (oidResponsesToEmit.length < snmpOidResponses.length) {
         logger.warn(
@@ -1001,8 +1003,7 @@ export default class MonitorMetricUtil {
 
       for (const oidResponse of oidResponsesToEmit) {
         const numericValue: number | undefined =
-          typeof oidResponse.value === "number" &&
-          isFinite(oidResponse.value)
+          typeof oidResponse.value === "number" && isFinite(oidResponse.value)
             ? oidResponse.value
             : undefined;
 

--- a/Common/Tests/Server/Utils/Monitor/MonitorTemplateUtilNetworkDevice.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorTemplateUtilNetworkDevice.test.ts
@@ -155,7 +155,11 @@ describe("MonitorTemplateUtil.buildTemplateStorageMap — interface walk variabl
       buildResponse({
         snmp: {
           interfaces: [
-            iface({ interfaceIndex: 4, name: "Gi0/4", isOperationallyUp: false }),
+            iface({
+              interfaceIndex: 4,
+              name: "Gi0/4",
+              isOperationallyUp: false,
+            }),
           ],
         },
       }),
@@ -197,7 +201,10 @@ describe("MonitorTemplateUtil.buildTemplateStorageMap — interface walk variabl
     const map: JSONObject = buildMap(
       buildResponse({
         snmp: {
-          interfaces: [iface({ interfaceIndex: 1 }), iface({ interfaceIndex: 2 })],
+          interfaces: [
+            iface({ interfaceIndex: 1 }),
+            iface({ interfaceIndex: 2 }),
+          ],
         },
       }),
     );
@@ -216,7 +223,9 @@ describe("MonitorTemplateUtil.buildTemplateStorageMap — interface walk variabl
   });
 
   test("an empty interface walk exposes no interface variables either", () => {
-    const map: JSONObject = buildMap(buildResponse({ snmp: { interfaces: [] } }));
+    const map: JSONObject = buildMap(
+      buildResponse({ snmp: { interfaces: [] } }),
+    );
 
     expect(map).not.toHaveProperty("interfacesTotal");
     expect(map).not.toHaveProperty("downInterfaces");

--- a/Common/Tests/Types/Monitor/SnmpVendorTemplate.test.ts
+++ b/Common/Tests/Types/Monitor/SnmpVendorTemplate.test.ts
@@ -41,9 +41,9 @@ describe("SnmpVendorTemplateUtil.getEnterpriseNumber", () => {
   });
 
   test("parses a bare enterprise arc with no product suffix", () => {
-    expect(SnmpVendorTemplateUtil.getEnterpriseNumber("1.3.6.1.4.1.41112")).toBe(
-      41112,
-    );
+    expect(
+      SnmpVendorTemplateUtil.getEnterpriseNumber("1.3.6.1.4.1.41112"),
+    ).toBe(41112);
   });
 
   test("returns undefined for a mib-2 OID outside the enterprises arc", () => {
@@ -182,9 +182,7 @@ describe("SnmpVendorTemplateUtil.mergeOids", () => {
       "cisco-ios",
     );
 
-    expect(merged).toEqual(
-      SnmpVendorTemplateUtil.getById("cisco-ios")!.oids,
-    );
+    expect(merged).toEqual(SnmpVendorTemplateUtil.getById("cisco-ios")!.oids);
   });
 
   test("applying the same template twice never duplicates rows", () => {

--- a/Common/UI/Components/Markdown.tsx/MarkdownViewer.tsx
+++ b/Common/UI/Components/Markdown.tsx/MarkdownViewer.tsx
@@ -10,6 +10,15 @@ import React, {
 import ReactMarkdown from "react-markdown";
 // https://github.com/remarkjs/remark-gfm
 import remarkGfm from "remark-gfm";
+/*
+ * @types/react-syntax-highlighter declares every deep subpath below as ambient
+ * `declare module` blocks inside its single index.d.ts, and that file only enters the
+ * program when something resolves the bare specifier. Nothing else does, so without
+ * this line the deep imports fall back to untyped .js and every one of them errors
+ * TS7016. `import type` is erased at emit, so the deep imports below still tree-shake;
+ * importing the barrel as a value would drag in highlight.js and the full language set.
+ */
+import type {} from "react-syntax-highlighter";
 import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism-light";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";

--- a/Common/Utils/Monitor/NetworkTopologyUtil.ts
+++ b/Common/Utils/Monitor/NetworkTopologyUtil.ts
@@ -119,9 +119,7 @@ export default class NetworkTopologyUtil {
     const edgeByKey: Map<string, NetworkTopologyEdge> = new Map();
 
     for (const device of devices) {
-      for (const claim of NetworkTopologyUtil.neighborClaimsForDevice(
-        device,
-      )) {
+      for (const claim of NetworkTopologyUtil.neighborClaimsForDevice(device)) {
         if (!claim.matchKey) {
           continue;
         }

--- a/Probe/Config.ts
+++ b/Probe/Config.ts
@@ -192,8 +192,10 @@ export const PROBE_NETFLOW_RECEIVER_PORT: number =
     min: 1,
   });
 
-// Safety valve: max NetFlow DATAGRAMS accepted per minute before dropping
-// (per probe). One datagram carries up to 30 flow records.
+/*
+ * Safety valve: max NetFlow DATAGRAMS accepted per minute before dropping
+ * (per probe). One datagram carries up to 30 flow records.
+ */
 export const PROBE_NETFLOW_RATE_LIMIT_PER_MINUTE: number =
   NumberUtil.parseNumberWithDefault({
     value: process.env["PROBE_NETFLOW_RATE_LIMIT_PER_MINUTE"],

--- a/Probe/Services/SyslogReceiver.ts
+++ b/Probe/Services/SyslogReceiver.ts
@@ -188,9 +188,8 @@ export default class SyslogReceiver {
       return null;
     }
 
-    const priorityMatch: RegExpMatchArray | null = trimmed.match(
-      /^<(\d{1,3})>/,
-    );
+    const priorityMatch: RegExpMatchArray | null =
+      trimmed.match(/^<(\d{1,3})>/);
 
     if (!priorityMatch) {
       return null;

--- a/Probe/Tests/Services/SyslogReceiver.test.ts
+++ b/Probe/Tests/Services/SyslogReceiver.test.ts
@@ -87,9 +87,7 @@ describe("SyslogReceiver.parseMessage", () => {
       expect(result!.hostname).toBe("mymachine.example.com");
       expect(result!.appName).toBe("evntslog");
       expect(result!.message).toBe("An application event log entry");
-      expect(result!.timestamp.toISOString()).toBe(
-        "2026-02-05T22:14:15.003Z",
-      );
+      expect(result!.timestamp.toISOString()).toBe("2026-02-05T22:14:15.003Z");
     });
 
     it("should handle nil header values and fall back to receive time", () => {
@@ -130,7 +128,9 @@ describe("SyslogReceiver.parseMessage", () => {
     });
 
     it("should return null for an empty message", () => {
-      expect(SyslogReceiver.parseMessage("", SOURCE_IP, RECEIVED_AT)).toBeNull();
+      expect(
+        SyslogReceiver.parseMessage("", SOURCE_IP, RECEIVED_AT),
+      ).toBeNull();
       expect(
         SyslogReceiver.parseMessage("   ", SOURCE_IP, RECEIVED_AT),
       ).toBeNull();

--- a/Probe/Tests/Utils/Discovery/SubnetScanner.test.ts
+++ b/Probe/Tests/Utils/Discovery/SubnetScanner.test.ts
@@ -275,8 +275,10 @@ describe("SubnetScanner ICMP pre-sweep", () => {
     // The host whose ping errored falls through to SNMP, not into a skip.
     expect(probed).toContain("10.0.0.1");
     expect(probed).toContain("10.0.0.0");
-    // Some hosts were ping-gated and some were not: the count covers an
-    // unknown subset, so it must not be reported at all.
+    /*
+     * Some hosts were ping-gated and some were not: the count covers an
+     * unknown subset, so it must not be reported at all.
+     */
     expect(result.respondedToPingCount).toBeUndefined();
   });
 });

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SnmpMonitorHelpers.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SnmpMonitorHelpers.test.ts
@@ -382,12 +382,16 @@ describe("SnmpMonitor.toMetricNumber", () => {
   });
 
   test("a 9-byte buffer with a leading zero pad decodes to its 64-bit value", () => {
-    // 0x00 pad + eight 0xFF bytes = 2^64 - 1, the max Counter64.
+    /*
+     * 0x00 pad + eight 0xFF bytes = 2^64 - 1, the max Counter64. IEEE-754 doubles
+     * cannot represent 2^64 - 1, so the decoded value rounds up to exactly 2^64;
+     * assert that rather than a literal JavaScript cannot express.
+     */
     expect(
       Internal.toMetricNumber(
         Buffer.from([0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
       ),
-    ).toBe(18446744073709551615);
+    ).toBe(2 ** 64);
   });
 
   test("empty and beyond-64-bit buffers yield undefined", () => {

--- a/Probe/Utils/NetFlow/NetFlowV5Parser.ts
+++ b/Probe/Utils/NetFlow/NetFlowV5Parser.ts
@@ -8,13 +8,17 @@
  * partial parse — a truncated UDP datagram cannot be trusted.
  */
 
-// Header: version, count, sysUptime, unixSecs, unixNsecs, flowSequence,
-// engineType, engineId, samplingInterval.
+/*
+ * Header: version, count, sysUptime, unixSecs, unixNsecs, flowSequence,
+ * engineType, engineId, samplingInterval.
+ */
 const HEADER_LENGTH_BYTES: number = 24;
 
-// Record: srcAddr, dstAddr, nextHop, inputIf, outputIf, dPkts, dOctets,
-// first, last, srcPort, dstPort, pad, tcpFlags, prot, tos, srcAs, dstAs,
-// srcMask, dstMask, pad.
+/*
+ * Record: srcAddr, dstAddr, nextHop, inputIf, outputIf, dPkts, dOctets,
+ * first, last, srcPort, dstPort, pad, tcpFlags, prot, tos, srcAs, dstAs,
+ * srcMask, dstMask, pad.
+ */
 const RECORD_LENGTH_BYTES: number = 48;
 
 const NETFLOW_VERSION: number = 5;


### PR DESCRIPTION
Master is red on **Compile**, **Build** and **Common Jobs**. This takes it from 26 compile errors + 80 lint errors to 0/0.

## Compile + Build (same root cause)

Both run `npm run compile` (= `tsc`) in `App/`. 26 errors in 2 files, and neither file changed — a **new import edge** dragged them into App's program for the first time:

```
App/Tests/Dashboard/DeviceMonitorLookupUtil.test.ts   (added by #2707)
  -> Common/UI/Utils/ModelAPI/ModelAPI      <- the gateway; line 1 imports a *type* from a React component
    -> Forms/ModelForm -> BasicForm -> FormSummary -> Detail
      -> LazyMarkdownViewer   (1x TS1323)
        -> MarkdownViewer     (25x TS7016)
```

`tsconfig` `"exclude"` only filters *root globbing* — it does not stop files reachable via `import`. The test's `jest.mock` is a runtime seam and correctly keeps jest green, which is why **App Test passed while Compile failed**: the mock protects the runtime, not the type-check.

**The 25 TS7016 were not missing types.** `@types/react-syntax-highlighter` declares all 569 deep `dist/esm/*` subpaths as *ambient* `declare module` blocks in its `index.d.ts`. Ambient declarations only register when something resolves the bare specifier — and nothing in the repo imported the barrel, so the file never entered any program. Fixed with one **type-only** barrel import: erased at emit, so the deep imports still tree-shake (a *value* import would drag in highlight.js and the full language set). This gives real types instead of the blanket `any` the existing shims provide, and fixes App, Common and all five FeatureSets at once.

**The 1 TS1323** is `LazyMarkdownViewer`'s `React.lazy` dynamic import. `App/tsconfig.json` had `"module"` commented out → defaults to ES2015 under `target: es2017`. Uncommented `"module": "es2022"` — the value already in the file, and the exact shape `Common/tsconfig.json` uses. **Zero runtime impact:** nothing executes `App/build/dist` (App runs `ts-node` from `Index.ts`), and the `ts-node` block already pins `commonjs` unconditionally.

## Common Jobs (js-lint)

- Removed stale `eslint-disable import/first` directives — `eslint-plugin-import` isn't installed, so ESLint errored on the unknown rule *at the directives themselves*. ts-jest hoists `jest.mock` regardless of source order.
- `SnmpMonitorHelpers` Counter64 assertion used `18446744073709551615`, which isn't representable as a double and silently rounds to `2**64`. Replaced with `2 ** 64` — bit-identical at runtime (`18446744073709551615 === 2**64` → `true`) — and documented the rounding. BigInt isn't an option: Probe targets es2017.
- Remaining 77 prettier / `multiline-comment-style` errors via `eslint --fix`.

## Verification

| Check | Result |
|---|---|
| `App && tsc --noEmit` | 26 → **0** |
| `Common`, `Probe`, `FeatureSet/Dashboard` | **0** each |
| Accounts / AdminDashboard / StatusPage / PublicDashboard | **byte-identical** before/after (local installs lack `@types/node`; CI installs per-package) |
| `eslint . --no-cache` | **clean** |
| `DeviceMonitorLookupUtil.test.ts` | **13/13** |
| `SnmpMonitorHelpers.test.ts` | **59/59** |

## Deliberately not in this PR

- **Counter64 test still can't detect precision loss** in `toMetricNumber` — it asserts the rounded value. Whether it should return BigInt/string is a product decision.
- **The shorthand rsh shims** in the six `index.d.ts` files now shadow the real types back to `any` (~156 duplicated lines). Worth removing, needs its own validation pass.
- **`ModelAPI` -> `ModelForm` type import** lets any backend file pull in React. That gateway is why one test file broke two workflows.
- **js-lint isn't gating merges** — 17 of the last 20 master runs failed it, and #2707's branch was red for ~11h across 3 runs before merging. That's the process bug behind this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
