### PR TITLE
feat: add Windows Integrated authentication to SQL Monitor

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/SqlMonitor/SqlMonitorStepForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/SqlMonitor/SqlMonitorStepForm.tsx
@@ -34,6 +34,11 @@ const SqlMonitorStepForm: FunctionComponent<ComponentProps> = (
       },
     );
 
+  const useWindowsIntegratedAuthentication: boolean =
+    props.monitorStepSqlMonitor.databaseType ===
+      SqlDatabaseType.MicrosoftSqlServer &&
+    Boolean(props.monitorStepSqlMonitor.useWindowsIntegratedAuthentication);
+
   return (
     <div className="space-y-5">
       <div>
@@ -53,10 +58,32 @@ const SqlMonitorStepForm: FunctionComponent<ComponentProps> = (
               ...props.monitorStepSqlMonitor,
               databaseType: databaseType,
               port: SqlDatabaseTypeUtil.getDefaultPort(databaseType),
+              useWindowsIntegratedAuthentication:
+                databaseType === SqlDatabaseType.MicrosoftSqlServer
+                  ? props.monitorStepSqlMonitor
+                      .useWindowsIntegratedAuthentication
+                  : false,
             });
           }}
         />
       </div>
+
+      {props.monitorStepSqlMonitor.databaseType ===
+        SqlDatabaseType.MicrosoftSqlServer && (
+        <div>
+          <Toggle
+            title="Use Windows Integrated Authentication"
+            description="Authenticate as the account running the probe (SSPI on Windows or Kerberos on Linux/macOS). Username and password are ignored."
+            initialValue={useWindowsIntegratedAuthentication}
+            onChange={(value: boolean) => {
+              props.onChange({
+                ...props.monitorStepSqlMonitor,
+                useWindowsIntegratedAuthentication: value,
+              });
+            }}
+          />
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-4">
         <div>
@@ -99,7 +126,11 @@ const SqlMonitorStepForm: FunctionComponent<ComponentProps> = (
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div
+        className={`grid gap-4 ${
+          useWindowsIntegratedAuthentication ? "grid-cols-1" : "grid-cols-2"
+        }`}
+      >
         <div>
           <FieldLabelElement
             title="Database Name"
@@ -118,60 +149,65 @@ const SqlMonitorStepForm: FunctionComponent<ComponentProps> = (
           />
         </div>
 
+        {!useWindowsIntegratedAuthentication && (
+          <div>
+            <FieldLabelElement
+              title="Username"
+              description="Use a read-only, least-privilege database user."
+              required={false}
+            />
+            <Input
+              initialValue={props.monitorStepSqlMonitor.username}
+              placeholder="readonly_user"
+              onChange={(value: string) => {
+                props.onChange({
+                  ...props.monitorStepSqlMonitor,
+                  username: value,
+                });
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {!useWindowsIntegratedAuthentication && (
         <div>
           <FieldLabelElement
-            title="Username"
-            description="Use a read-only, least-privilege database user."
+            title="Password"
+            description={
+              <p>
+                Database password. We recommend referencing a monitor secret
+                with{" "}
+                <code className="bg-gray-100 px-1 rounded">
+                  {"{{monitorSecrets.name}}"}
+                </code>{" "}
+                instead of typing the password here, so it stays encrypted at
+                rest.{" "}
+                <Link
+                  className="underline"
+                  openInNewTab={true}
+                  to={URL.fromString(
+                    DOCS_URL.toString() + "/monitor/monitor-secrets",
+                  )}
+                >
+                  Learn more about secrets.
+                </Link>
+              </p>
+            }
             required={false}
           />
           <Input
-            initialValue={props.monitorStepSqlMonitor.username}
-            placeholder="readonly_user"
+            initialValue={props.monitorStepSqlMonitor.password}
+            placeholder="{{monitorSecrets.dbPassword}}"
             onChange={(value: string) => {
               props.onChange({
                 ...props.monitorStepSqlMonitor,
-                username: value,
+                password: value,
               });
             }}
           />
         </div>
-      </div>
-
-      <div>
-        <FieldLabelElement
-          title="Password"
-          description={
-            <p>
-              Database password. We recommend referencing a monitor secret with{" "}
-              <code className="bg-gray-100 px-1 rounded">
-                {"{{monitorSecrets.name}}"}
-              </code>{" "}
-              instead of typing the password here, so it stays encrypted at
-              rest.{" "}
-              <Link
-                className="underline"
-                openInNewTab={true}
-                to={URL.fromString(
-                  DOCS_URL.toString() + "/monitor/monitor-secrets",
-                )}
-              >
-                Learn more about secrets.
-              </Link>
-            </p>
-          }
-          required={false}
-        />
-        <Input
-          initialValue={props.monitorStepSqlMonitor.password}
-          placeholder="{{monitorSecrets.dbPassword}}"
-          onChange={(value: string) => {
-            props.onChange({
-              ...props.monitorStepSqlMonitor,
-              password: value,
-            });
-          }}
-        />
-      </div>
+      )}
 
       <div>
         <FieldLabelElement

--- a/App/FeatureSet/Docs/Content/en/monitor/sql-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/sql-monitor.md
@@ -42,7 +42,7 @@ Running a customer-supplied query against a production database is sensitive, so
 ## Prerequisites
 
 - A **probe** with network access to your database host and port. This can be a OneUptime-hosted probe (if your database is reachable from the internet) or a self-hosted probe running inside your network. See the probe documentation for how to install a custom probe.
-- A **read-only database user** and the connection details (host, port, database name, username, password).
+- A **read-only database user** and the connection details (host, port, database name, username, password), or a read-only Windows/domain identity when using SQL Server Integrated Authentication.
 
 ## Configuration
 
@@ -52,10 +52,20 @@ Create a new monitor and choose **SQL Query** as the monitor type, then fill in 
 - **Host** — the database host reachable from the probe (for example `db.internal`).
 - **Port** — the database port.
 - **Database Name** — the database to run the query against.
+- **Use Windows Integrated Authentication** — Microsoft SQL Server only. Authenticate with the account running the probe instead of a SQL username and password. See [Windows Integrated Authentication](#windows-integrated-authentication).
 - **Username** — a read-only, least-privilege database user.
 - **Password** — the database password. We strongly recommend referencing a [Monitor Secret](/docs/monitor/monitor-secrets) with `{{monitorSecrets.name}}` instead of typing the password in plain text (see below).
 - **SQL Query** — the read-only query to run (see [Writing the query](#writing-the-query)).
 - **Use SSL/TLS** — enable to connect over TLS. When enabled, you can turn off **Verify server certificate** if the database uses a self-signed certificate.
+
+### Windows Integrated Authentication
+
+For Microsoft SQL Server, enable **Use Windows Integrated Authentication** to open a trusted connection with the identity of the probe process. The Username and Password fields are ignored in this mode and are not passed to the driver. Because the probe needs an identity trusted by your domain, use a self-hosted probe for this authentication mode.
+
+- **Windows probes:** run the probe service as a domain account that has a read-only SQL Server login.
+- **Linux or macOS probes:** configure Kerberos for the SQL Server domain and give the probe process a valid ticket (for example through a keytab). The official Linux probe image includes Microsoft ODBC Driver 18, unixODBC, and the Kerberos client. Mount the Kerberos configuration and ticket cache into the container, make them readable by the probe process, and set `KRB5_CONFIG` or `KRB5CCNAME` when their locations are non-default.
+
+SQL Server must have an appropriate `MSSQLSvc` service principal name, the probe and domain controller clocks must be synchronized, and the probe must resolve/reach the SQL Server by the hostname covered by that service principal. Grant only the database permissions needed by the monitoring query to the trusted identity.
 
 ### Advanced options
 

--- a/Common/Tests/Types/Monitor/MonitorStepSqlMonitor.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepSqlMonitor.test.ts
@@ -12,6 +12,33 @@ import MonitorStepSqlMonitor, {
 } from "../../../Types/Monitor/MonitorStepSqlMonitor";
 import SqlDatabaseType from "../../../Types/Monitor/SqlDatabaseType";
 import { JSONObject } from "../../../Types/JSON";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+
+const getSqlMonitorStep: (
+  overrides?: Partial<MonitorStepSqlMonitor>,
+) => MonitorStep = (
+  overrides: Partial<MonitorStepSqlMonitor> = {},
+): MonitorStep => {
+  const id: ObjectID = ObjectID.generate();
+  const monitorStep: MonitorStep = MonitorStep.getDefaultMonitorStep({
+    monitorName: "SQL monitor",
+    monitorType: MonitorType.SQLQuery,
+    onlineMonitorStatusId: id,
+    offlineMonitorStatusId: id,
+    defaultIncidentSeverityId: id,
+    defaultAlertSeverityId: id,
+  });
+
+  return monitorStep.setSqlMonitor({
+    ...MonitorStepSqlMonitorUtil.getDefault(),
+    host: "sql.internal",
+    databaseName: "orders",
+    query: "SELECT 1",
+    ...overrides,
+  });
+};
 
 describe("MonitorStepSqlMonitorUtil", () => {
   describe("getDefault", () => {
@@ -63,7 +90,7 @@ describe("MonitorStepSqlMonitorUtil", () => {
   describe("fromJSON/toJSON round-trip", () => {
     test("preserves values and clamps out-of-range inputs", () => {
       const json: JSONObject = {
-        databaseType: SqlDatabaseType.PostgreSQL,
+        databaseType: SqlDatabaseType.MicrosoftSqlServer,
         host: "db.internal",
         port: 5433,
         databaseName: "orders",
@@ -109,6 +136,57 @@ describe("MonitorStepSqlMonitorUtil", () => {
       expect(parsed.rejectUnauthorizedSsl).toBe(true);
       expect(parsed.useSsl).toBe(false);
       expect(parsed.useWindowsIntegratedAuthentication).toBe(false);
+    });
+
+    test("serializes an explicit false value for older SQL monitor configurations", () => {
+      const json: JSONObject = MonitorStepSqlMonitorUtil.toJSON(
+        MonitorStepSqlMonitorUtil.getDefault(),
+      );
+
+      expect(json["useWindowsIntegratedAuthentication"]).toBe(false);
+    });
+  });
+
+  describe("MonitorStep validation", () => {
+    test("accepts integrated authentication for Microsoft SQL Server", () => {
+      const monitorStep: MonitorStep = getSqlMonitorStep({
+        databaseType: SqlDatabaseType.MicrosoftSqlServer,
+        port: 1433,
+        username: "",
+        password: "",
+        useWindowsIntegratedAuthentication: true,
+      });
+
+      expect(
+        MonitorStep.getValidationError(monitorStep, MonitorType.SQLQuery),
+      ).toBeNull();
+    });
+
+    test.each([SqlDatabaseType.PostgreSQL, SqlDatabaseType.MySQL])(
+      "rejects integrated authentication for %s",
+      (databaseType: SqlDatabaseType) => {
+        const monitorStep: MonitorStep = getSqlMonitorStep({
+          databaseType,
+          useWindowsIntegratedAuthentication: true,
+        });
+
+        expect(
+          MonitorStep.getValidationError(monitorStep, MonitorType.SQLQuery),
+        ).toBe(
+          "Windows Integrated Authentication is only supported for Microsoft SQL Server",
+        );
+      },
+    );
+
+    test("preserves validation compatibility for SQL-login monitors", () => {
+      const monitorStep: MonitorStep = getSqlMonitorStep({
+        databaseType: SqlDatabaseType.PostgreSQL,
+        useWindowsIntegratedAuthentication: false,
+      });
+
+      expect(
+        MonitorStep.getValidationError(monitorStep, MonitorType.SQLQuery),
+      ).toBeNull();
     });
   });
 });

--- a/Common/Tests/Types/Monitor/MonitorStepSqlMonitor.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepSqlMonitor.test.ts
@@ -20,6 +20,7 @@ describe("MonitorStepSqlMonitorUtil", () => {
       expect(def.databaseType).toBe(SqlDatabaseType.PostgreSQL);
       expect(def.port).toBe(5432);
       expect(def.useSsl).toBe(false);
+      expect(def.useWindowsIntegratedAuthentication).toBe(false);
       expect(def.rejectUnauthorizedSsl).toBe(true);
       expect(def.statementTimeoutInMs).toBe(
         DEFAULT_SQL_STATEMENT_TIMEOUT_IN_MS,
@@ -68,6 +69,7 @@ describe("MonitorStepSqlMonitorUtil", () => {
         databaseName: "orders",
         username: "readonly",
         password: "{{monitorSecrets.dbPass}}",
+        useWindowsIntegratedAuthentication: true,
         useSsl: true,
         rejectUnauthorizedSsl: false,
         query: "SELECT COUNT(*) FROM orders",
@@ -82,6 +84,7 @@ describe("MonitorStepSqlMonitorUtil", () => {
       expect(parsed.host).toBe("db.internal");
       expect(parsed.port).toBe(5433);
       expect(parsed.password).toBe("{{monitorSecrets.dbPass}}");
+      expect(parsed.useWindowsIntegratedAuthentication).toBe(true);
       expect(parsed.useSsl).toBe(true);
       expect(parsed.rejectUnauthorizedSsl).toBe(false);
       // clamped
@@ -105,6 +108,7 @@ describe("MonitorStepSqlMonitorUtil", () => {
       });
       expect(parsed.rejectUnauthorizedSsl).toBe(true);
       expect(parsed.useSsl).toBe(false);
+      expect(parsed.useWindowsIntegratedAuthentication).toBe(false);
     });
   });
 });

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -47,6 +47,7 @@ import MonitorStepDnssecMonitor, {
 import MonitorStepSqlMonitor, {
   MonitorStepSqlMonitorUtil,
 } from "./MonitorStepSqlMonitor";
+import SqlDatabaseType from "./SqlDatabaseType";
 import MonitorStepExternalStatusPageMonitor, {
   MonitorStepExternalStatusPageMonitorUtil,
 } from "./MonitorStepExternalStatusPageMonitor";
@@ -779,6 +780,14 @@ export default class MonitorStep extends DatabaseProperty {
 
       if (!value.data.sqlMonitor.query || !value.data.sqlMonitor.query.trim()) {
         return "SQL query is required";
+      }
+
+      if (
+        value.data.sqlMonitor.useWindowsIntegratedAuthentication &&
+        value.data.sqlMonitor.databaseType !==
+          SqlDatabaseType.MicrosoftSqlServer
+      ) {
+        return "Windows Integrated Authentication is only supported for Microsoft SQL Server";
       }
     }
 

--- a/Common/Types/Monitor/MonitorStepSqlMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepSqlMonitor.ts
@@ -64,6 +64,12 @@ export default interface MonitorStepSqlMonitor {
   username: string;
   // Raw password OR a {{monitorSecrets.name}} reference resolved server-side.
   password: string;
+  /*
+   * Microsoft SQL Server only: authenticate with the identity under which the
+   * probe is running (SSPI on Windows, Kerberos on Linux/macOS). Username and
+   * password are ignored when this is enabled.
+   */
+  useWindowsIntegratedAuthentication: boolean;
   useSsl: boolean;
   /*
    * When SSL is on, whether the server certificate chain must validate. Users
@@ -87,6 +93,7 @@ export class MonitorStepSqlMonitorUtil {
       databaseName: "",
       username: "",
       password: "",
+      useWindowsIntegratedAuthentication: false,
       useSsl: false,
       rejectUnauthorizedSsl: true,
       query: "",
@@ -105,6 +112,9 @@ export class MonitorStepSqlMonitorUtil {
       databaseName: (json["databaseName"] as string) || "",
       username: (json["username"] as string) || "",
       password: (json["password"] as string) || "",
+      useWindowsIntegratedAuthentication: Boolean(
+        json["useWindowsIntegratedAuthentication"],
+      ),
       useSsl: Boolean(json["useSsl"]),
       rejectUnauthorizedSsl:
         json["rejectUnauthorizedSsl"] === undefined ||
@@ -130,6 +140,8 @@ export class MonitorStepSqlMonitorUtil {
       databaseName: monitor.databaseName,
       username: monitor.username,
       password: monitor.password,
+      useWindowsIntegratedAuthentication:
+        monitor.useWindowsIntegratedAuthentication,
       useSsl: monitor.useSsl,
       rejectUnauthorizedSsl: monitor.rejectUnauthorizedSsl,
       query: monitor.query,

--- a/Probe/Dockerfile.tpl
+++ b/Probe/Dockerfile.tpl
@@ -60,19 +60,29 @@ RUN if [ -z "$APP_VERSION" ]; then export APP_VERSION=1.0.0; fi
 #   - tini: a tiny init for containers to properly reap zombie processes
 #   - ca-certificates: required by update-ca-certificates (intermediate certs
 #     copied above)
-#   - Build toolchain: python3, make, g++ (node-gyp / native npm modules)
+#   - Build toolchain: python3, make, g++, unixODBC headers (node-gyp / native
+#     npm modules, including the SQL Server trusted-connection driver)
+#   - Kerberos client: required for SQL Server Integrated Authentication on
+#     Linux; users provide their realm configuration and ticket cache
 #   - Playwright/Chromium system libraries
 # apt lists are removed in the same RUN so package metadata doesn't persist
 # in the layer.
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bash curl iputils-ping net-tools dnsutils traceroute tini ca-certificates \
-        python3 make g++ \
+        python3 make g++ unixodbc-dev krb5-user \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
         libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
         libgbm1 libgtk-3-0 libpango-1.0-0 libcairo2 libgdk-pixbuf2.0-0 \
         libasound2 libatspi2.0-0 \
+    && curl --fail --show-error --silent --location \
+        --output /tmp/packages-microsoft-prod.deb \
+        https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+    && dpkg -i /tmp/packages-microsoft-prod.deb \
+    && rm /tmp/packages-microsoft-prod.deb \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -104,6 +114,11 @@ WORKDIR /usr/src/app
 # Install app dependencies first so local Playwright CLI is available
 COPY ./Probe/package*.json /usr/src/app/
 RUN --mount=type=cache,target=/tmp/npm npm ci --prefer-offline
+# The native dependency is optional for non-ODBC development environments,
+# but it is required in the official image. Fail the image build if either the
+# Node binding or Microsoft ODBC Driver 18 is unavailable.
+RUN node -e "require('mssql/msnodesqlv8')" \
+    && odbcinst -q -d -n "ODBC Driver 18 for SQL Server"
 
 # Install browsers to a fixed path accessible by any runtime user (root or non-root)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright-browsers

--- a/Probe/Tests/Build/ProbeDockerfile.test.ts
+++ b/Probe/Tests/Build/ProbeDockerfile.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+interface ProbePackageJson {
+  optionalDependencies: Record<string, string>;
+  allowScripts: Record<string, boolean>;
+}
+
+interface ProbePackageLock {
+  packages: Record<string, { version?: string }>;
+}
+
+const probeRoot: string = resolve(__dirname, "../..");
+const packageJson: ProbePackageJson = JSON.parse(
+  readFileSync(resolve(probeRoot, "package.json"), "utf8"),
+) as ProbePackageJson;
+const packageLock: ProbePackageLock = JSON.parse(
+  readFileSync(resolve(probeRoot, "package-lock.json"), "utf8"),
+) as ProbePackageLock;
+const dockerfile: string = readFileSync(
+  resolve(probeRoot, "Dockerfile.tpl"),
+  "utf8",
+);
+
+describe("Probe SQL Server integrated-authentication image", () => {
+  test("keeps the native driver optional for non-ODBC development environments", () => {
+    expect(packageJson.optionalDependencies["msnodesqlv8"]).toBeDefined();
+  });
+
+  test("approves only the exact locked native-driver install script", () => {
+    const lockedVersion: string | undefined =
+      packageLock.packages["node_modules/msnodesqlv8"]?.version;
+
+    expect(lockedVersion).toBeDefined();
+    expect(packageJson.allowScripts).toEqual({
+      [`msnodesqlv8@${lockedVersion}`]: true,
+    });
+  });
+
+  test("installs and verifies the complete ODBC/Kerberos runtime", () => {
+    for (const requiredPackage of [
+      "unixodbc-dev",
+      "krb5-user",
+      "msodbcsql18",
+    ]) {
+      expect(dockerfile).toContain(requiredPackage);
+    }
+
+    expect(dockerfile).toContain("require('mssql/msnodesqlv8')");
+    expect(dockerfile).toContain(
+      'odbcinst -q -d -n "ODBC Driver 18 for SQL Server"',
+    );
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
@@ -3,6 +3,8 @@ process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
 process.env["PROBE_KEY"] = "test-probe-key";
 
 import SqlMonitor, {
+  buildSqlServerIntegratedConnectionString,
+  SQL_SERVER_ODBC_DRIVER,
   SqlQueryValidator,
 } from "../../../../Utils/Monitors/MonitorTypes/SqlMonitor";
 import SqlMonitorResponse from "Common/Types/Monitor/SqlMonitor/SqlMonitorResponse";
@@ -275,6 +277,7 @@ describe("SqlMonitor.execute (guard rejections, no DB needed)", () => {
         databaseName: "orders",
         username: "readonly",
         password: "",
+        useWindowsIntegratedAuthentication: false,
         useSsl: false,
         rejectUnauthorizedSsl: true,
         query: "DELETE FROM orders",
@@ -300,6 +303,7 @@ describe("SqlMonitor.execute (guard rejections, no DB needed)", () => {
         databaseName: "orders",
         username: "readonly",
         password: "",
+        useWindowsIntegratedAuthentication: false,
         useSsl: false,
         rejectUnauthorizedSsl: true,
         query: "SELECT 1",
@@ -329,6 +333,7 @@ describe("SqlMonitor.execute (guard rejections, no DB needed)", () => {
           databaseName: "orders",
           username: "readonly",
           password: "",
+          useWindowsIntegratedAuthentication: false,
           useSsl: false,
           rejectUnauthorizedSsl: true,
           query: "DELETE FROM orders",
@@ -343,5 +348,64 @@ describe("SqlMonitor.execute (guard rejections, no DB needed)", () => {
       expect(response!.isOnline).toBe(false);
       expect(response!.queryError).toBeTruthy();
     }
+  });
+
+  it("rejects integrated authentication for non-SQL Server engines", async () => {
+    const response: SqlMonitorResponse | null = await SqlMonitor.execute(
+      {
+        databaseType: "PostgreSQL" as any,
+        host: "db.internal",
+        port: 5432,
+        databaseName: "orders",
+        username: "",
+        password: "",
+        useWindowsIntegratedAuthentication: true,
+        useSsl: false,
+        rejectUnauthorizedSsl: true,
+        query: "SELECT 1",
+        connectionTimeoutInMs: 10000,
+        statementTimeoutInMs: 15000,
+        maxRows: 100,
+      },
+      { isOnlineCheckRequest: true },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response!.isOnline).toBe(false);
+    expect(response!.failureCause).toContain("only supported");
+  });
+});
+
+describe("buildSqlServerIntegratedConnectionString", () => {
+  it("uses a trusted connection without SQL login credentials", () => {
+    const connectionString: string = buildSqlServerIntegratedConnectionString({
+      host: "sql.internal",
+      port: 1433,
+      databaseName: "orders",
+      useSsl: true,
+      rejectUnauthorizedSsl: true,
+    });
+
+    expect(connectionString).toContain(`Driver={${SQL_SERVER_ODBC_DRIVER}}`);
+    expect(connectionString).toContain("Server={sql.internal,1433}");
+    expect(connectionString).toContain("Database={orders}");
+    expect(connectionString).toContain("Trusted_Connection=yes");
+    expect(connectionString).toContain("Encrypt=yes");
+    expect(connectionString).toContain("TrustServerCertificate=no");
+    expect(connectionString).not.toMatch(/(?:Uid|Pwd|Password)=/i);
+  });
+
+  it("escapes ODBC values and supports trusted self-signed certificates", () => {
+    const connectionString: string = buildSqlServerIntegratedConnectionString({
+      host: "sql;primary}",
+      port: 1433,
+      databaseName: "orders;archive}",
+      useSsl: true,
+      rejectUnauthorizedSsl: false,
+    });
+
+    expect(connectionString).toContain("Server={sql;primary}},1433}");
+    expect(connectionString).toContain("Database={orders;archive}}}");
+    expect(connectionString).toContain("TrustServerCertificate=yes");
   });
 });

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
@@ -493,9 +493,7 @@ describe("buildMicrosoftSqlServerPoolConfig", () => {
     );
     expect(poolConfig.connectionString).toContain("Trusted_Connection=yes");
     expect(poolConfig.connectionString).not.toContain("must-not-leak-user");
-    expect(poolConfig.connectionString).not.toContain(
-      "must-not-leak-password",
-    );
+    expect(poolConfig.connectionString).not.toContain("must-not-leak-password");
   });
 
   it("keeps pool sizing, timeout, and application metadata identical for both authentication modes", () => {
@@ -516,9 +514,7 @@ describe("buildMicrosoftSqlServerPoolConfig", () => {
         min: 0,
         idleTimeoutMillis: 30000,
       });
-      expect(poolConfig.options?.appName).toBe(
-        "OneUptimeProbe-SQLMonitor",
-      );
+      expect(poolConfig.options?.appName).toBe("OneUptimeProbe-SQLMonitor");
     }
   });
 });

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
@@ -3,12 +3,41 @@ process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
 process.env["PROBE_KEY"] = "test-probe-key";
 
 import SqlMonitor, {
+  buildMicrosoftSqlServerPoolConfig,
   buildSqlServerIntegratedConnectionString,
+  loadMicrosoftSqlServerDriver,
+  MicrosoftSqlServerPoolConfig,
   SQL_SERVER_ODBC_DRIVER,
   SqlQueryValidator,
 } from "../../../../Utils/Monitors/MonitorTypes/SqlMonitor";
 import SqlMonitorResponse from "Common/Types/Monitor/SqlMonitor/SqlMonitorResponse";
+import MonitorStepSqlMonitor from "Common/Types/Monitor/MonitorStepSqlMonitor";
+import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
+import * as mssql from "mssql";
 import { describe, expect, it } from "@jest/globals";
+
+const getMicrosoftSqlServerConfig: (
+  overrides?: Partial<MonitorStepSqlMonitor>,
+) => MonitorStepSqlMonitor = (
+  overrides: Partial<MonitorStepSqlMonitor> = {},
+): MonitorStepSqlMonitor => {
+  return {
+    databaseType: SqlDatabaseType.MicrosoftSqlServer,
+    host: "sql.internal",
+    port: 1433,
+    databaseName: "orders",
+    username: "readonly",
+    password: "sql-password",
+    useWindowsIntegratedAuthentication: false,
+    useSsl: true,
+    rejectUnauthorizedSsl: true,
+    query: "SELECT 1",
+    connectionTimeoutInMs: 10000,
+    statementTimeoutInMs: 15000,
+    maxRows: 100,
+    ...overrides,
+  };
+};
 
 describe("SqlQueryValidator.getRejectionReason", () => {
   it("allows a plain SELECT", () => {
@@ -407,5 +436,135 @@ describe("buildSqlServerIntegratedConnectionString", () => {
     expect(connectionString).toContain("Server={sql;primary}},1433}");
     expect(connectionString).toContain("Database={orders;archive}}}");
     expect(connectionString).toContain("TrustServerCertificate=yes");
+  });
+
+  it("turns encryption and certificate trust off together when TLS is disabled", () => {
+    const connectionString: string = buildSqlServerIntegratedConnectionString({
+      host: "sql.internal",
+      port: 1433,
+      databaseName: "orders",
+      useSsl: false,
+      rejectUnauthorizedSsl: false,
+    });
+
+    expect(connectionString).toContain("Encrypt=no");
+    expect(connectionString).toContain("TrustServerCertificate=no");
+  });
+});
+
+describe("buildMicrosoftSqlServerPoolConfig", () => {
+  it("preserves SQL login credentials for the default Tedious driver", () => {
+    const poolConfig: MicrosoftSqlServerPoolConfig =
+      buildMicrosoftSqlServerPoolConfig({
+        config: getMicrosoftSqlServerConfig(),
+        connectionTimeoutInMs: 7000,
+        statementTimeoutInMs: 9000,
+      });
+
+    expect(poolConfig.server).toBe("sql.internal");
+    expect(poolConfig.port).toBe(1433);
+    expect(poolConfig.database).toBe("orders");
+    expect(poolConfig.user).toBe("readonly");
+    expect(poolConfig.password).toBe("sql-password");
+    expect(poolConfig.connectionString).toBeUndefined();
+    expect(poolConfig.connectionTimeout).toBe(7000);
+    expect(poolConfig.requestTimeout).toBe(9000);
+    expect(poolConfig.options?.encrypt).toBe(true);
+    expect(poolConfig.options?.trustServerCertificate).toBe(false);
+  });
+
+  it("omits every SQL credential property for integrated authentication", () => {
+    const poolConfig: MicrosoftSqlServerPoolConfig =
+      buildMicrosoftSqlServerPoolConfig({
+        config: getMicrosoftSqlServerConfig({
+          username: "must-not-leak-user",
+          password: "must-not-leak-password",
+          useWindowsIntegratedAuthentication: true,
+        }),
+        connectionTimeoutInMs: 7000,
+        statementTimeoutInMs: 9000,
+      });
+
+    expect(Object.prototype.hasOwnProperty.call(poolConfig, "user")).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(poolConfig, "password")).toBe(
+      false,
+    );
+    expect(poolConfig.connectionString).toContain("Trusted_Connection=yes");
+    expect(poolConfig.connectionString).not.toContain("must-not-leak-user");
+    expect(poolConfig.connectionString).not.toContain(
+      "must-not-leak-password",
+    );
+  });
+
+  it("keeps pool sizing, timeout, and application metadata identical for both authentication modes", () => {
+    for (const useWindowsIntegratedAuthentication of [false, true]) {
+      const poolConfig: MicrosoftSqlServerPoolConfig =
+        buildMicrosoftSqlServerPoolConfig({
+          config: getMicrosoftSqlServerConfig({
+            useWindowsIntegratedAuthentication,
+          }),
+          connectionTimeoutInMs: 1234,
+          statementTimeoutInMs: 5678,
+        });
+
+      expect(poolConfig.connectionTimeout).toBe(1234);
+      expect(poolConfig.requestTimeout).toBe(5678);
+      expect(poolConfig.pool).toEqual({
+        max: 1,
+        min: 0,
+        idleTimeoutMillis: 30000,
+      });
+      expect(poolConfig.options?.appName).toBe(
+        "OneUptimeProbe-SQLMonitor",
+      );
+    }
+  });
+});
+
+describe("loadMicrosoftSqlServerDriver", () => {
+  it("does not load the native module for SQL login authentication", () => {
+    let loaderWasCalled: boolean = false;
+
+    const driver: typeof mssql = loadMicrosoftSqlServerDriver(false, () => {
+      loaderWasCalled = true;
+      throw new Error("The native driver must remain lazy");
+    });
+
+    expect(loaderWasCalled).toBe(false);
+    expect(driver.ConnectionPool).toBe(mssql.ConnectionPool);
+  });
+
+  it("loads the msnodesqlv8 mssql adapter for integrated authentication", () => {
+    const fakeDriver: typeof mssql = {
+      marker: "native-driver",
+    } as unknown as typeof mssql;
+    let requestedModule: string | undefined;
+
+    const driver: typeof mssql = loadMicrosoftSqlServerDriver(
+      true,
+      (moduleId: string): unknown => {
+        requestedModule = moduleId;
+        return fakeDriver;
+      },
+    );
+
+    expect(requestedModule).toBe("mssql/msnodesqlv8");
+    expect(driver).toBe(fakeDriver);
+  });
+
+  it("returns an actionable error when the native driver cannot load", () => {
+    expect(() => {
+      loadMicrosoftSqlServerDriver(true, () => {
+        throw new Error("missing native binding");
+      });
+    }).toThrow("Windows Integrated Authentication requires");
+
+    expect(() => {
+      loadMicrosoftSqlServerDriver(true, () => {
+        throw new Error("missing native binding");
+      });
+    }).toThrow(SQL_SERVER_ODBC_DRIVER);
   });
 });

--- a/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
@@ -20,6 +20,55 @@ import {
   createConnection as createMySqlConnection,
 } from "mysql2/promise";
 import * as mssql from "mssql";
+import { createRequire } from "module";
+
+const loadProbeModule: ReturnType<typeof createRequire> =
+  createRequire(__filename);
+
+export const SQL_SERVER_ODBC_DRIVER: string = "ODBC Driver 18 for SQL Server";
+
+/*
+ * Escape a value for an ODBC connection string. Braced values can safely
+ * contain semicolons; a literal closing brace is represented by two braces.
+ */
+const escapeOdbcConnectionStringValue: (value: string) => string = (
+  value: string,
+): string => {
+  return `{${value.replace(/}/g, "}}")}}`;
+};
+
+/*
+ * Build the trusted connection string used by msnodesqlv8. Keeping this
+ * separate from the normal Tedious config ensures SQL credentials are never
+ * passed when integrated authentication is selected.
+ */
+export const buildSqlServerIntegratedConnectionString: (
+  config: Pick<
+    MonitorStepSqlMonitor,
+    "host" | "port" | "databaseName" | "useSsl" | "rejectUnauthorizedSsl"
+  >,
+) => string = (
+  config: Pick<
+    MonitorStepSqlMonitor,
+    "host" | "port" | "databaseName" | "useSsl" | "rejectUnauthorizedSsl"
+  >,
+): string => {
+  return [
+    `Driver=${escapeOdbcConnectionStringValue(SQL_SERVER_ODBC_DRIVER)}`,
+    `Server=${escapeOdbcConnectionStringValue(`${config.host},${config.port}`)}`,
+    `Database=${escapeOdbcConnectionStringValue(config.databaseName)}`,
+    "Trusted_Connection=yes",
+    `Encrypt=${config.useSsl ? "yes" : "no"}`,
+    `TrustServerCertificate=${
+      config.useSsl && !config.rejectUnauthorizedSsl ? "yes" : "no"
+    }`,
+    `APP=${escapeOdbcConnectionStringValue("OneUptimeProbe-SQLMonitor")}`,
+  ].join(";");
+};
+
+interface MicrosoftSqlServerPoolConfig extends mssql.config {
+  connectionString?: string | undefined;
+}
 
 export interface SqlQueryOptions {
   timeout?: number | undefined;
@@ -336,6 +385,23 @@ export default class SqlMonitor {
       const message: string = `Database type "${config.databaseType}" is not supported yet. Supported: ${SqlDatabaseTypeUtil.getSupportedDatabaseTypes().join(
         ", ",
       )}.`;
+      return {
+        isOnline: false,
+        responseTimeInMs: 0,
+        failureCause: message,
+        rowCount: null,
+        scalarValue: null,
+        firstRow: null,
+        queryError: message,
+      };
+    }
+
+    if (
+      config.useWindowsIntegratedAuthentication &&
+      config.databaseType !== SqlDatabaseType.MicrosoftSqlServer
+    ) {
+      const message: string =
+        "Windows Integrated Authentication is only supported for Microsoft SQL Server.";
       return {
         isOnline: false,
         responseTimeInMs: 0,
@@ -848,12 +914,16 @@ export default class SqlMonitor {
      */
     const teardownTimeoutInMs: number = 5000;
 
-    const poolConfig: mssql.config = {
+    const poolConfig: MicrosoftSqlServerPoolConfig = {
       server: config.host,
       port: config.port,
       database: config.databaseName,
-      user: config.username,
-      password: config.password,
+      user: config.useWindowsIntegratedAuthentication
+        ? undefined
+        : config.username,
+      password: config.useWindowsIntegratedAuthentication
+        ? undefined
+        : config.password,
       connectionTimeout: connectionTimeoutInMs,
       requestTimeout: statementTimeoutInMs,
       pool: { max: 1, min: 0, idleTimeoutMillis: 30000 },
@@ -870,7 +940,29 @@ export default class SqlMonitor {
       },
     };
 
-    const pool: mssql.ConnectionPool = new mssql.ConnectionPool(poolConfig);
+    let sqlServerDriver: typeof mssql = mssql;
+
+    if (config.useWindowsIntegratedAuthentication) {
+      poolConfig.connectionString =
+        buildSqlServerIntegratedConnectionString(config);
+
+      try {
+        /*
+         * This native driver is intentionally loaded only for trusted
+         * connections. It is an optional dependency because local developers
+         * without unixODBC should still be able to use every other monitor.
+         */
+        sqlServerDriver = loadProbeModule("mssql/msnodesqlv8") as typeof mssql;
+      } catch {
+        throw new Error(
+          `Windows Integrated Authentication requires ${SQL_SERVER_ODBC_DRIVER} and the msnodesqlv8 driver on the probe. Use the official probe image or install both dependencies, then run the probe under the trusted Windows account or with a valid Kerberos ticket.`,
+        );
+      }
+    }
+
+    const pool: mssql.ConnectionPool = new sqlServerDriver.ConnectionPool(
+      poolConfig,
+    );
     let transaction: mssql.Transaction | undefined;
     let transactionBegun: boolean = false;
 
@@ -881,7 +973,7 @@ export default class SqlMonitor {
        */
       await pool.connect();
 
-      transaction = new mssql.Transaction(pool);
+      transaction = new sqlServerDriver.Transaction(pool);
       await transaction.begin();
       transactionBegun = true;
 
@@ -891,10 +983,12 @@ export default class SqlMonitor {
        * wins over a larger user-supplied TOP. It is connection-scoped, so it
        * applies to the query request that runs next on this transaction.
        */
-      const setRequest: mssql.Request = new mssql.Request(transaction);
+      const setRequest: mssql.Request = new sqlServerDriver.Request(
+        transaction,
+      );
       await setRequest.batch(`SET ROWCOUNT ${maxRows + 1}`);
 
-      const request: mssql.Request = new mssql.Request(transaction);
+      const request: mssql.Request = new sqlServerDriver.Request(transaction);
 
       const result: mssql.IResult<Record<string, unknown>> =
         await SqlMonitor.withHardTimeout({

--- a/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
@@ -66,9 +66,88 @@ export const buildSqlServerIntegratedConnectionString: (
   ].join(";");
 };
 
-interface MicrosoftSqlServerPoolConfig extends mssql.config {
+export interface MicrosoftSqlServerPoolConfig extends mssql.config {
   connectionString?: string | undefined;
 }
+
+export type SqlServerDriverLoader = (moduleId: string) => unknown;
+
+/*
+ * Build the pool configuration independently from opening a connection. This
+ * makes the authentication boundary explicit: SQL credentials are present for
+ * the normal Tedious driver, while a trusted connection has only an ODBC
+ * connection string and cannot accidentally forward a saved username/password.
+ */
+export const buildMicrosoftSqlServerPoolConfig: (input: {
+  config: MonitorStepSqlMonitor;
+  statementTimeoutInMs: number;
+  connectionTimeoutInMs: number;
+}) => MicrosoftSqlServerPoolConfig = (input: {
+  config: MonitorStepSqlMonitor;
+  statementTimeoutInMs: number;
+  connectionTimeoutInMs: number;
+}): MicrosoftSqlServerPoolConfig => {
+  const { config, statementTimeoutInMs, connectionTimeoutInMs } = input;
+
+  const baseConfig: MicrosoftSqlServerPoolConfig = {
+    server: config.host,
+    port: config.port,
+    database: config.databaseName,
+    connectionTimeout: connectionTimeoutInMs,
+    requestTimeout: statementTimeoutInMs,
+    pool: { max: 1, min: 0, idleTimeoutMillis: 30000 },
+    options: {
+      encrypt: config.useSsl,
+      /*
+       * When SSL is on, validate the chain unless the user opted out (a
+       * self-signed cert). When SSL is off this value is irrelevant.
+       */
+      trustServerCertificate: config.useSsl
+        ? !config.rejectUnauthorizedSsl
+        : true,
+      appName: "OneUptimeProbe-SQLMonitor",
+    },
+  };
+
+  if (config.useWindowsIntegratedAuthentication) {
+    return {
+      ...baseConfig,
+      connectionString: buildSqlServerIntegratedConnectionString(config),
+    };
+  }
+
+  return {
+    ...baseConfig,
+    user: config.username,
+    password: config.password,
+  };
+};
+
+/*
+ * Keep the native driver lazy so PostgreSQL, MySQL, and SQL-authenticated SQL
+ * Server monitors continue to work on developer probes without unixODBC. The
+ * loader parameter makes the selection and failure behavior unit-testable
+ * without requiring a native binary in the test environment.
+ */
+export const loadMicrosoftSqlServerDriver: (
+  useWindowsIntegratedAuthentication: boolean,
+  moduleLoader?: SqlServerDriverLoader,
+) => typeof mssql = (
+  useWindowsIntegratedAuthentication: boolean,
+  moduleLoader: SqlServerDriverLoader = loadProbeModule,
+): typeof mssql => {
+  if (!useWindowsIntegratedAuthentication) {
+    return mssql;
+  }
+
+  try {
+    return moduleLoader("mssql/msnodesqlv8") as typeof mssql;
+  } catch {
+    throw new Error(
+      `Windows Integrated Authentication requires ${SQL_SERVER_ODBC_DRIVER} and the msnodesqlv8 driver on the probe. Use the official probe image or install both dependencies, then run the probe under the trusted Windows account or with a valid Kerberos ticket.`,
+    );
+  }
+};
 
 export interface SqlQueryOptions {
   timeout?: number | undefined;
@@ -914,51 +993,16 @@ export default class SqlMonitor {
      */
     const teardownTimeoutInMs: number = 5000;
 
-    const poolConfig: MicrosoftSqlServerPoolConfig = {
-      server: config.host,
-      port: config.port,
-      database: config.databaseName,
-      user: config.useWindowsIntegratedAuthentication
-        ? undefined
-        : config.username,
-      password: config.useWindowsIntegratedAuthentication
-        ? undefined
-        : config.password,
-      connectionTimeout: connectionTimeoutInMs,
-      requestTimeout: statementTimeoutInMs,
-      pool: { max: 1, min: 0, idleTimeoutMillis: 30000 },
-      options: {
-        encrypt: config.useSsl,
-        /*
-         * When SSL is on, validate the chain unless the user opted out (a
-         * self-signed cert). When SSL is off this value is irrelevant.
-         */
-        trustServerCertificate: config.useSsl
-          ? !config.rejectUnauthorizedSsl
-          : true,
-        appName: "OneUptimeProbe-SQLMonitor",
-      },
-    };
+    const poolConfig: MicrosoftSqlServerPoolConfig =
+      buildMicrosoftSqlServerPoolConfig({
+        config,
+        statementTimeoutInMs,
+        connectionTimeoutInMs,
+      });
 
-    let sqlServerDriver: typeof mssql = mssql;
-
-    if (config.useWindowsIntegratedAuthentication) {
-      poolConfig.connectionString =
-        buildSqlServerIntegratedConnectionString(config);
-
-      try {
-        /*
-         * This native driver is intentionally loaded only for trusted
-         * connections. It is an optional dependency because local developers
-         * without unixODBC should still be able to use every other monitor.
-         */
-        sqlServerDriver = loadProbeModule("mssql/msnodesqlv8") as typeof mssql;
-      } catch {
-        throw new Error(
-          `Windows Integrated Authentication requires ${SQL_SERVER_ODBC_DRIVER} and the msnodesqlv8 driver on the probe. Use the official probe image or install both dependencies, then run the probe under the trusted Windows account or with a valid Kerberos ticket.`,
-        );
-      }
-    }
+    const sqlServerDriver: typeof mssql = loadMicrosoftSqlServerDriver(
+      config.useWindowsIntegratedAuthentication,
+    );
 
     const pool: mssql.ConnectionPool = new sqlServerDriver.ConnectionPool(
       poolConfig,

--- a/Probe/package-lock.json
+++ b/Probe/package-lock.json
@@ -16,6 +16,7 @@
         "fast-xml-parser": "^5.3.7",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
+        "msnodesqlv8": "^5.2.2",
         "mssql": "^12.7.0",
         "mysql2": "^3.22.6",
         "net-snmp": "^3.26.1",
@@ -35,6 +36,9 @@
         "jest": "^28.1.0",
         "nodemon": "^3.1.14",
         "ts-jest": "^28.0.2"
+      },
+      "optionalDependencies": {
+        "msnodesqlv8": "^5.2.2"
       }
     },
     "../Common": {
@@ -2083,6 +2087,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2242,6 +2253,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -2253,6 +2280,16 @@
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
       "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
       "license": "MIT"
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -2319,6 +2356,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -2417,6 +2464,16 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2552,6 +2609,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect": {
@@ -2803,6 +2870,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2914,6 +2988,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -3154,6 +3235,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -4693,6 +4781,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4706,10 +4807,48 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/msnodesqlv8": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/msnodesqlv8/-/msnodesqlv8-5.2.2.tgz",
+      "integrity": "sha512-7iIslJ/d/Rs0ZfwQcMAFr3uQARxsR//NHp9QLFOZocWZoTo/SkILJ1XhCnA+zXdCy5VvYUNQbGTuWsuOaJwD3Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32",
+        "linux",
+        "darwin"
+      ],
+      "dependencies": {
+        "node-abi": "^4.28.0",
+        "node-addon-api": "^8.7.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/mssql": {
       "version": "12.7.0",
@@ -4764,6 +4903,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
@@ -4793,6 +4939,42 @@
       "license": "MIT",
       "dependencies": {
         "lower-case": "^1.1.1"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-int64": {
@@ -4953,7 +5135,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5352,6 +5534,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -5414,6 +5650,43 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -5614,6 +5887,53 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -5885,6 +6205,88 @@
         "upper-case": "^1.1.1"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tarn": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.1.2.tgz",
@@ -6131,6 +6533,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6230,6 +6645,13 @@
       "dependencies": {
         "upper-case": "^1.1.1"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -6399,7 +6821,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/Probe/package.json
+++ b/Probe/package.json
@@ -50,5 +50,8 @@
   },
   "optionalDependencies": {
     "msnodesqlv8": "^5.2.2"
+  },
+  "allowScripts": {
+    "msnodesqlv8@5.2.2": true
   }
 }

--- a/Probe/package.json
+++ b/Probe/package.json
@@ -47,5 +47,8 @@
     "jest": "^28.1.0",
     "nodemon": "^3.1.14",
     "ts-jest": "^28.0.2"
+  },
+  "optionalDependencies": {
+    "msnodesqlv8": "^5.2.2"
   }
 }


### PR DESCRIPTION
## What changed

- add a Microsoft SQL Server-only **Windows Integrated Authentication** option to SQL Query monitors
- persist and validate the authentication setting while keeping existing SQL login monitors backward-compatible
- use a trusted ODBC connection backed by the probe process identity (SSPI on Windows or Kerberos on Linux/macOS), without passing SQL username/password fields to the driver
- add Microsoft ODBC Driver 18, unixODBC build headers, Kerberos tooling, and a native-driver assertion to the official Probe image
- explicitly approve the version-pinned `msnodesqlv8@5.2.2` native install script required by npm 12
- document self-hosted probe identity/Kerberos prerequisites

## Why

The SQL Monitor previously supported only SQL username/password authentication for Microsoft SQL Server. Environments that disable SQL logins and require domain-backed trusted connections could not use the monitor.

## Backward compatibility

Existing PostgreSQL, MySQL, and SQL Server monitors continue to use their current credential path. Configurations created before this change deserialize the new flag as `false`. The option is shown only for Microsoft SQL Server; when selected, the Dashboard hides username/password inputs and the Probe authenticates as its runtime identity.

## Tests and validation

- 51 targeted tests pass across Common and Probe, covering legacy defaults, serialization, server/probe validation, credential isolation, ODBC escaping, TLS modes, lazy driver selection, actionable native-driver failures, exact npm script approval, and image prerequisites
- full Common and Probe test jobs pass
- Common, Probe, Dashboard, and all repository compile jobs pass
- `npm run fix`, docs anchor validation, CodeQL, Snyk, OpenAPI generation, and Terraform provider generation pass
- the official Probe image builds successfully on Node 26 and verifies both `mssql/msnodesqlv8` and Microsoft ODBC Driver 18
- Terraform E2E passes
- all 39 PR checks pass
