### PR TITLE
fix(uptime): stop orphaned status-timeline rows from corrupting uptime reports

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -128,10 +128,19 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
       return <></>;
     }
 
+    /*
+     * this page reports the last 90 days, so measure over that window. Otherwise an open
+     * (endsAt = null) row that started before the window contributes its whole duration and
+     * the denominator becomes "first event -> now" instead of the 90 days shown.
+     */
     const uptimePercent: number = UptimeUtil.calculateUptimePercentage(
       statusTimelines,
       UptimePrecision.THREE_DECIMAL,
       downTimeMonitorStatues,
+      {
+        startDate: startDate,
+        endDate: endDate,
+      },
     );
 
     return (

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -6,7 +6,9 @@ import ServerMonitorDocumentation from "../../../Components/Monitor/ServerMonito
 import Summary from "../../../Components/Monitor/SummaryView/Summary";
 import ProbeUtil from "../../../Utils/Probe";
 import PageComponentProps from "../../PageComponentProps";
+import GreaterThanOrNull from "Common/Types/BaseDatabase/GreaterThanOrNull";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
+import LessThanOrEqual from "Common/Types/BaseDatabase/LessThanOrEqual";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import { Black, Gray500, Green, Red500 } from "Common/Types/BrandColors";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
@@ -174,7 +176,14 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         await ModelAPI.getList({
           modelType: MonitorStatusTimeline,
           query: {
-            createdAt: new InBetween(startDate, endDate),
+            /*
+             * Select every row that OVERLAPS the 90 day window, not just rows created inside
+             * it: a row that started before the window and is still open (or closed inside it)
+             * carries downtime this page must count. Without this, a monitor that has been
+             * Offline since before the window renders as 100% uptime.
+             */
+            startsAt: new LessThanOrEqual(endDate),
+            endsAt: new GreaterThanOrNull(startDate),
             monitorId: modelId,
             projectId: ProjectUtil.getCurrentProjectId()!,
           },
@@ -193,7 +202,11 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             },
           },
           sort: {
-            createdAt: SortOrder.Ascending,
+            /*
+             * startsAt, not createdAt: they are different clocks (DB now() vs worker moment())
+             * with real skew, and startsAt is the one the timeline math orders by.
+             */
+            startsAt: SortOrder.Ascending,
           },
         });
 

--- a/App/FeatureSet/Dashboard/src/Pages/MonitorGroup/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/MonitorGroup/View/Index.tsx
@@ -57,10 +57,20 @@ const MonitorGroupView: FunctionComponent<
       return <></>;
     }
 
+    /*
+     * this page reports the last 90 days (same range the uptime graph below is drawn over), so
+     * measure over that window. Otherwise an open (endsAt = null) row that started before the
+     * window contributes its whole duration and the denominator becomes "first event -> now"
+     * instead of the 90 days shown.
+     */
     const uptimePercent: number = UptimeUtil.calculateUptimePercentage(
       statusTimelines,
       UptimePrecision.THREE_DECIMAL,
       downTimeMonitorStatues,
+      {
+        startDate: OneUptimeDate.getSomeDaysAgo(90),
+        endDate: OneUptimeDate.getCurrentDate(),
+      },
     );
 
     return (

--- a/App/FeatureSet/StatusPage/src/Components/Monitor/MonitorOverview.tsx
+++ b/App/FeatureSet/StatusPage/src/Components/Monitor/MonitorOverview.tsx
@@ -65,10 +65,19 @@ const MonitorOverview: FunctionComponent<ComponentProps> = (
       }) &&
       props.showUptimePercent
     ) {
+      /*
+       * measure uptime over the same window the history chart is drawn for. Without this an
+       * open (endsAt = null) row that started before the window contributes its whole
+       * duration, and the denominator becomes "first event -> now" rather than the window.
+       */
       const uptimePercent: number = UptimeUtil.calculateUptimePercentage(
         props.monitorStatusTimeline,
         precision,
         props.downtimeMonitorStatuses,
+        {
+          startDate: props.startDate,
+          endDate: props.endDate,
+        },
       );
 
       return (

--- a/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
@@ -167,7 +167,16 @@ const Overview: FunctionComponent<PageComponentProps> = (
     scheduledMaintenanceStateTimelines,
     setScheduledMaintenanceStateTimelines,
   ] = useState<Array<ScheduledMaintenanceStateTimeline>>([]);
-  const uptimeHistoryDays: number = statusPage?.showUptimeHistoryInDays || 90;
+  /*
+   * Clamped to [1, 90] to mirror the server (StatusPageAPI clamps before fetching the
+   * timeline). showUptimeHistoryInDays has no server-side validation, so an out-of-range
+   * value set via the API would otherwise make this window longer than the fetched data
+   * range - and the unfetched days would silently count as uptime in the windowed math.
+   */
+  const uptimeHistoryDays: number = Math.min(
+    Math.max(statusPage?.showUptimeHistoryInDays || 90, 1),
+    90,
+  );
   const startDate: Date = OneUptimeDate.getSomeDaysAgo(uptimeHistoryDays);
   const endDate: Date = OneUptimeDate.getCurrentDate();
   const [currentStatus, setCurrentStatus] = useState<MonitorStatus | null>(

--- a/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
@@ -456,6 +456,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
                 statusPage?.downtimeMonitorStatuses || [],
               statusPageResources: statusPageResources,
               monitorsInGroup: monitorsInGroup,
+              uptimeWindow: { startDate: startDate, endDate: endDate },
             },
           );
 
@@ -840,6 +841,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
               downtimeMonitorStatuses:
                 statusPage?.downtimeMonitorStatuses || [],
               monitorsInGroup: monitorsInGroup,
+              uptimeWindow: { startDate: startDate, endDate: endDate },
             });
           if (percent !== null) {
             uptimePercents.push(percent);
@@ -1296,6 +1298,10 @@ const Overview: FunctionComponent<PageComponentProps> = (
                             UptimePrecision.TWO_DECIMAL,
                           resourceGroups: resourceGroups,
                           monitorsInGroup: monitorsInGroup,
+                          uptimeWindow: {
+                            startDate: startDate,
+                            endDate: endDate,
+                          },
                         },
                       )?.toString() || "100") + t("overview.uptimeSuffix")
                     : undefined

--- a/App/FeatureSet/Workers/DataMigrations/CloseOrphanedMonitorStatusTimelineRows.ts
+++ b/App/FeatureSet/Workers/DataMigrations/CloseOrphanedMonitorStatusTimelineRows.ts
@@ -96,7 +96,7 @@ export default class CloseOrphanedMonitorStatusTimelineRows extends DataMigratio
         .join(", ");
 
       throw new Error(
-        `Failed to repair stale open MonitorStatusTimeline rows for ${result.failedMonitorIds.length} monitor(s): ${failedIds}. Not marking this migration executed — duplicate open rows must be gone before the partial unique index can be built. Investigate those monitors and re-run.`,
+        `Failed to repair stale open MonitorStatusTimeline rows for ${result.failedMonitorIds.length} monitor(s): ${failedIds}. Not marking this migration executed — the remaining open rows keep corrupting uptime reports until they are closed. Investigate those monitors and re-run (the repair is idempotent, so re-running is safe).`,
       );
     }
   }

--- a/App/FeatureSet/Workers/DataMigrations/CloseOrphanedMonitorStatusTimelineRows.ts
+++ b/App/FeatureSet/Workers/DataMigrations/CloseOrphanedMonitorStatusTimelineRows.ts
@@ -1,0 +1,113 @@
+import DataMigrationBase from "./DataMigrationBase";
+import ObjectID from "Common/Types/ObjectID";
+import logger from "Common/Server/Utils/Logger";
+import MonitorStatusTimelineReconciler, {
+  DEFAULT_STALE_OPEN_ROW_BATCH_SIZE,
+  RepairStaleOpenRowsResult,
+} from "Common/Server/Utils/Monitor/MonitorStatusTimelineReconciler";
+
+/*
+ * Closes MonitorStatusTimeline rows that were orphaned with `endsAt = NULL`.
+ *
+ * Origin of the bad data: two probe results processed near-simultaneously both
+ * resolved the SAME predecessor row, both passed the "status cannot be same as
+ * previous" guard, and both INSERTed an open row milliseconds apart. Only the
+ * later one was ever closed — every subsequent writer resolves its predecessor
+ * with `ORDER BY startsAt DESC LIMIT 1`, which always returns the later row and
+ * permanently shadows the earlier one. The earlier row stays open forever.
+ *
+ * Why this matters on the read path: the status page timeline query has no
+ * lower date bound on open rows, so a single orphan from months ago is pulled
+ * into every later report window and rendered as continuous downtime (the
+ * customer-visible symptom was "113 days of downtime" inside a 31-day window).
+ *
+ * The repair itself lives in MonitorStatusTimelineReconciler.repairStaleOpenRows
+ * so the read path, this migration and any future operator tooling all share ONE
+ * implementation. Do NOT inline the SQL here — see the trap notes below.
+ *
+ * Traps this migration deliberately avoids (both existing
+ * AddEndDateToMonitorStatusTimeline* migrations got these wrong and both
+ * already ran in production):
+ *
+ *   - Chronology MUST be established with `startsAt`, never `createdAt`.
+ *     `createdAt` is DB-side now(); `startsAt` is worker-pod moment(). They are
+ *     different clocks with measured skew — in a 27-row sample, 12 rows had
+ *     `createdAt > startsAt` and 15 the reverse. Ordering by `createdAt`
+ *     produces confidently wrong pairings.
+ *
+ *   - A repaired row's `endsAt` MUST be the MIN `startsAt` of the row that
+ *     follows it, never some other row's `startsAt`. Closing every older open
+ *     row at the newest row's `startsAt` would convert ~8,041 near-zero-duration
+ *     orphans into multi-month closed downtime rows — permanent, invisible to
+ *     the read-path fix, and it would drive those resources to 0% uptime. That
+ *     is strictly worse than the bug being fixed.
+ *
+ *   - The single latest open row per monitor is the monitor's CURRENT state and
+ *     must be left open.
+ *
+ *   - Soft-deleted rows (`deletedAt IS NOT NULL`) are excluded.
+ *
+ * Batched and restartable by construction: repairStaleOpenRows commits per
+ * batch and re-queries for remaining open rows, so a killed pod resumes where
+ * it stopped. Idempotent: once a row is closed it no longer matches the
+ * "open row that has a successor" predicate, so a re-run is a clean no-op.
+ * This matters — 55,953 of the ~67,498 affected rows belong to a single monitor.
+ */
+export default class CloseOrphanedMonitorStatusTimelineRows extends DataMigrationBase {
+  public constructor() {
+    super("CloseOrphanedMonitorStatusTimelineRows");
+  }
+
+  public override async migrate(): Promise<void> {
+    /*
+     * No monitorId filter: this is the fleet-wide backfill. The reconciler's
+     * default batch size keeps each round trip short so the single 55,953-row
+     * monitor cannot hold locks on MonitorStatusTimeline long enough to stall
+     * live probe writes, and it processes monitors round-robin so that monitor
+     * cannot starve the rest of the fleet.
+     */
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({
+        batchSize: DEFAULT_STALE_OPEN_ROW_BATCH_SIZE,
+      });
+
+    logger.debug(
+      `CloseOrphanedMonitorStatusTimelineRows: scanned ${result.scanned} open row(s) across ${result.monitorsWithStaleRows} monitor(s), repaired ${result.repaired}.`,
+    );
+
+    /*
+     * repairStaleOpenRows deliberately does NOT throw when an individual
+     * monitor's repair fails — it collects the monitor and carries on, so one
+     * bad monitor cannot abort a fleet-wide run. That is right for the runtime
+     * caller, but wrong to ignore here: if this migration returned successfully
+     * with monitors left unrepaired, the runner would record it as executed and
+     * NEVER run it again, while duplicate open rows remained in the table — those
+     * rows would keep corrupting uptime reports and the daily reconciler would be
+     * the only thing left to clean them up.
+     *
+     * So: fail the migration instead. It is not recorded as executed, the chain
+     * halts visibly, and because the repair is idempotent the retry is free.
+     */
+    if (result.failedMonitorIds.length > 0) {
+      const failedIds: string = result.failedMonitorIds
+        .map((id: ObjectID) => {
+          return id.toString();
+        })
+        .join(", ");
+
+      throw new Error(
+        `Failed to repair stale open MonitorStatusTimeline rows for ${result.failedMonitorIds.length} monitor(s): ${failedIds}. Not marking this migration executed — duplicate open rows must be gone before the partial unique index can be built. Investigate those monitors and re-run.`,
+      );
+    }
+  }
+
+  public override async rollback(): Promise<void> {
+    /*
+     * Deliberately not reversible. The pre-migration state is "endsAt IS NULL"
+     * for an unknown subset of the rows we just closed, and that subset is not
+     * recoverable once written — re-opening rows by guessing would reintroduce
+     * the phantom-downtime bug on the status pages this migration exists to fix.
+     */
+    return;
+  }
+}

--- a/App/FeatureSet/Workers/DataMigrations/Index.ts
+++ b/App/FeatureSet/Workers/DataMigrations/Index.ts
@@ -92,6 +92,7 @@ import AddAttributeKeysToExceptionInstance from "./AddAttributeKeysToExceptionIn
 import AddMutableMetricTable from "./AddMutableMetricTable";
 import AddInstanceIdToGlobalConfig from "./AddInstanceIdToGlobalConfig";
 import AddMetricEntityMinuteAggregateMaterializedViews from "./AddMetricEntityMinuteAggregateMaterializedViews";
+import CloseOrphanedMonitorStatusTimelineRows from "./CloseOrphanedMonitorStatusTimelineRows";
 
 // This is the order in which the migrations will be run. Add new migrations to the end of the array.
 
@@ -249,6 +250,14 @@ const DataMigrations: Array<DataMigrationBase> = [
    * backfills and re-attaches the per-entity rollup triggers.
    */
   new AddMetricEntityMinuteAggregateMaterializedViews(),
+  /*
+   * Closes the MonitorStatusTimeline rows orphaned with `endsAt = NULL` by the
+   * concurrent double-INSERT race (67,498 rows across 410 monitors / 124
+   * projects). These orphans are what render as months of phantom downtime on
+   * status page uptime reports, because the timeline query applies no lower date
+   * bound to open rows. Batched, restartable and idempotent.
+   */
+  new CloseOrphanedMonitorStatusTimelineRows(),
 ];
 
 export default DataMigrations;

--- a/App/FeatureSet/Workers/Jobs/Monitor/KeepCurrentStateConsistent.ts
+++ b/App/FeatureSet/Workers/Jobs/Monitor/KeepCurrentStateConsistent.ts
@@ -66,8 +66,23 @@ RunCron(
        * Now that each repaired monitor has exactly one open row, its current status can be
        * resolved unambiguously. Monitors that failed to reconcile are intentionally skipped -
        * they still have several open rows, so refreshing them could pin the wrong status.
+       *
+       * A monitor can be in BOTH sets: repairedMonitorIds records any successful batch, and a
+       * multi-batch backlog that fails in a LATER round leaves the monitor repaired-then-failed
+       * with open rows remaining. Those must be skipped too, so failed always wins.
        */
-      for (const monitorId of result.repairedMonitorIds) {
+      const failedMonitorIdSet: Set<string> = new Set<string>(
+        result.failedMonitorIds.map((monitorId: ObjectID) => {
+          return monitorId.toString();
+        }),
+      );
+
+      const monitorIdsSafeToRefresh: Array<ObjectID> =
+        result.repairedMonitorIds.filter((monitorId: ObjectID) => {
+          return !failedMonitorIdSet.has(monitorId.toString());
+        });
+
+      for (const monitorId of monitorIdsSafeToRefresh) {
         try {
           await MonitorService.refreshMonitorCurrentStatus(monitorId);
         } catch (err) {

--- a/App/FeatureSet/Workers/Jobs/Monitor/KeepCurrentStateConsistent.ts
+++ b/App/FeatureSet/Workers/Jobs/Monitor/KeepCurrentStateConsistent.ts
@@ -1,81 +1,86 @@
 import { EVERY_DAY } from "Common/Utils/CronTime";
 import RunCron from "../../Utils/Cron";
+import logger from "Common/Server/Utils/Logger";
+import MonitorService from "Common/Server/Services/MonitorService";
+import MonitorStatusTimelineReconciler, {
+  RepairStaleOpenRowsResult,
+} from "Common/Server/Utils/Monitor/MonitorStatusTimelineReconciler";
+import ObjectID from "Common/Types/ObjectID";
+
 /*
- * import logger from "Common/Server/Utils/Logger";
- * import ProjectService from "Common/Server/Services/ProjectService";
- * import MonitorService from "Common/Server/Services/MonitorService";
- * import Project from "Common/Models/DatabaseModels/Project";
- * import Monitor from "Common/Models/DatabaseModels/Monitor";
+ * Repairs MonitorStatusTimeline rows that were left open (endsAt IS NULL) even though a later
+ * row exists on the same monitor. These are produced by a race on the write path: two probe
+ * results for the same monitor resolve the same predecessor and both INSERT a status row
+ * milliseconds apart, and only the later one is ever closed.
+ *
+ * An orphaned open row poisons everything downstream of it:
+ *   - status page uptime queries pull open rows in with no lower date bound, so a months-old
+ *     orphan lands inside a 30 day report window,
+ *   - uptime math treats an open row as running until the next event, so a single orphan can
+ *     render as months of phantom downtime.
+ *
+ * It also breaks this job's original purpose. MonitorService.refreshMonitorCurrentStatus
+ * resolves the current status with findOneBy({ monitorId, endsAt: isNull() }) and no sort,
+ * which falls back to ORDER BY createdAt DESC. While several open rows exist that query can
+ * return the orphan rather than the true current row - createdAt is DB-side now() and startsAt
+ * is the worker pod's clock, and on real data the two orderings disagree. So refreshing a
+ * monitor's current status is only safe AFTER its stale rows are closed, at which point exactly
+ * one open row remains and the lookup is unambiguous. That is the order used below, and the
+ * refresh is deliberately limited to monitors this run actually repaired.
  */
 
 RunCron(
   "Monitor:KeepCurrentStateConsistent",
   { schedule: EVERY_DAY, runOnStartup: true },
   async () => {
-    // try {
-    //   /*
-    //    * get all projects, then get all monitors for each project, then get the last status of each monitor and check with the current status of each monitor.
-    //    * if they are different, then update the current status of the monitor.
-    //    */
-    /*
-     *   const projects: Array<Project> =
-     *     await ProjectService.getAllActiveProjects({
-     *       select: {
-     *         _id: true,
-     *       },
-     *     });
-     */
-    /*
-     *   for (const project of projects) {
-     *     try {
-     *       if (!project) {
-     *         continue;
-     *       }
-     */
-    /*
-     *       if (!project.id) {
-     *         continue;
-     *       }
-     */
-    /*
-     *       const monitors: Array<Monitor> = await MonitorService.findAllBy({
-     *         query: {
-     *           projectId: project.id,
-     *         },
-     *         select: {
-     *           _id: true,
-     *         },
-     *         props: {
-     *           isRoot: true,
-     *         },
-     *       });
-     */
-    /*
-     *       for (const monitor of monitors) {
-     *         try {
-     *           if (!monitor) {
-     *             continue;
-     *           }
-     *           if (!monitor.id) {
-     *             continue;
-     *           }
-     *           await MonitorService.refreshMonitorCurrentStatus(monitor.id!);
-     *         } catch (err) {
-     *           logger.error("Error in KeepCurrentStateConsistent job");
-     *           logger.error(err);
-     *           continue;
-     *         }
-     *       }
-     *     } catch (err) {
-     *       logger.error("Error in KeepCurrentStateConsistent job");
-     *       logger.error(err);
-     *       continue;
-     *     }
-     *   }
-     * } catch (err) {
-     *   logger.error("Error in KeepCurrentStateConsistent job");
-     *   logger.error(err);
-     * }
-     */
+    try {
+      const result: RepairStaleOpenRowsResult =
+        await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+      if (result.repaired > 0) {
+        /*
+         * Warn rather than log: once the backlog has been cleared, a steady state run should
+         * repair nothing. A non-zero count on a later run means the write path is still leaking
+         * orphaned open rows and someone should look at it.
+         */
+        logger.warn(
+          `Monitor:KeepCurrentStateConsistent - repaired ${result.repaired} stale open monitor status timeline row(s) across ${result.repairedMonitorIds.length} monitor(s) (${result.scanned} open row(s) examined, ${result.monitorsWithStaleRows} monitor(s) affected). A non-zero count once the backlog is cleared means the write path is still creating orphaned rows.`,
+        );
+      } else {
+        logger.debug(
+          `Monitor:KeepCurrentStateConsistent - no stale open monitor status timeline rows found (${result.scanned} open row(s) examined).`,
+        );
+      }
+
+      if (result.failedMonitorIds.length > 0) {
+        logger.error(
+          `Monitor:KeepCurrentStateConsistent - failed to reconcile ${result.failedMonitorIds.length} monitor(s): ${result.failedMonitorIds
+            .map((monitorId: ObjectID) => {
+              return monitorId.toString();
+            })
+            .join(", ")}`,
+        );
+      }
+
+      /*
+       * Now that each repaired monitor has exactly one open row, its current status can be
+       * resolved unambiguously. Monitors that failed to reconcile are intentionally skipped -
+       * they still have several open rows, so refreshing them could pin the wrong status.
+       */
+      for (const monitorId of result.repairedMonitorIds) {
+        try {
+          await MonitorService.refreshMonitorCurrentStatus(monitorId);
+        } catch (err) {
+          logger.error(
+            `Error in Monitor:KeepCurrentStateConsistent job while refreshing current status for monitor ${monitorId.toString()}`,
+          );
+          logger.error(err);
+          continue;
+        }
+      }
+    } catch (err) {
+      logger.error("Error in Monitor:KeepCurrentStateConsistent job");
+      logger.error(err);
+    }
   },
 );

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -88,7 +88,7 @@ import StatusPageEventType from "../../Types/StatusPage/StatusPageEventType";
 import StatusPageResourceUptimeUtil from "../../Utils/StatusPage/ResourceUptime";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 import { Green } from "../../Types/BrandColors";
-import UptimeUtil from "../../Utils/Uptime/UptimeUtil";
+import UptimeUtil, { UptimeWindow } from "../../Utils/Uptime/UptimeUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import URL from "../../Types/API/URL";
 import SMS from "../../Types/SMS/SMS";
@@ -1265,6 +1265,17 @@ export default class StatusPageAPI extends BaseAPI<
           const downtimeMonitorStatuses: Array<MonitorStatus> =
             statusPage.downtimeMonitorStatuses || [];
 
+          /*
+           * this endpoint reports uptime over an explicit [startDate, endDate] range, so events
+           * have to be clipped to it and the denominator has to be the range itself. Without
+           * this an open (endsAt = null) row that started before the range contributes its
+           * entire duration to the downtime total.
+           */
+          const uptimeWindow: UptimeWindow = {
+            startDate: startDate,
+            endDate: endDate,
+          };
+
           type ResourceUptime = {
             statusPageResourceId: ObjectID;
             uptimePercent: number | null;
@@ -1369,6 +1380,7 @@ export default class StatusPageAPI extends BaseAPI<
                           resourceStatusTimelines,
                           precision,
                           downtimeMonitorStatuses,
+                          uptimeWindow,
                         );
 
                       resourceUptime.uptimePercent = uptimePercent;
@@ -1419,6 +1431,7 @@ export default class StatusPageAPI extends BaseAPI<
                           resourceStatusTimelines,
                           precision,
                           downtimeMonitorStatuses,
+                          uptimeWindow,
                         );
 
                       resourceUptime.uptimePercent = uptimePercent;

--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -15,7 +15,6 @@ import IncidentStateService from "./IncidentStateService";
 import IncidentStateTimelineService from "./IncidentStateTimelineService";
 import MonitorService from "./MonitorService";
 import MonitorStatusService from "./MonitorStatusService";
-import MonitorStatusTimelineService from "./MonitorStatusTimelineService";
 import OnCallDutyPolicyService from "./OnCallDutyPolicyService";
 import TeamMemberService from "./TeamMemberService";
 import UserService from "./UserService";
@@ -43,7 +42,6 @@ import IncidentState from "../../Models/DatabaseModels/IncidentState";
 import IncidentStateTimeline from "../../Models/DatabaseModels/IncidentStateTimeline";
 import Monitor from "../../Models/DatabaseModels/Monitor";
 import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
-import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
 import User from "../../Models/DatabaseModels/User";
 import { IsBillingEnabled } from "../EnvironmentConfig";
 import MutableMetricService from "./MutableMetricService";
@@ -2538,84 +2536,81 @@ ${incidentSeverity.name}
 
       if (resolvedMonitorState) {
         for (const monitor of monitors) {
-          //check state of the monitor.
-
-          const doesMonitorHasMoreActiveManualIncidents: boolean =
-            await this.doesMonitorHasMoreActiveManualIncidents(
-              monitor.id!,
-              projectId!,
-            );
-
-          if (doesMonitorHasMoreActiveManualIncidents) {
-            continue;
-          }
-
-          await MonitorService.updateOneById({
-            id: monitor.id!,
-            data: {
-              disableActiveMonitoringBecauseOfManualIncident: false,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
-
           /*
-           * Don't flip the monitor to operational while other incidents
-           * are still open on it — e.g. a metric monitor with group-by
-           * may have one incident per series, and resolving one series
-           * shouldn't claim the whole monitor is healthy.
+           * Per-monitor isolation: one monitor failing here (for example the
+           * fail-closed status timeline lock, or a transient DB error) must not
+           * abort the loop and strand the REMAINING monitors with
+           * disableActiveMonitoringBecauseOfManualIncident still true - a
+           * monitor left in that state is skipped by probes and sits in its
+           * down status indefinitely, silently accruing downtime.
            */
-          const hasOtherActiveIncidents: boolean =
-            await this.doesMonitorHaveActiveIncidents(monitor.id!, projectId!);
+          try {
+            //check state of the monitor.
 
-          if (hasOtherActiveIncidents) {
-            continue;
-          }
+            const doesMonitorHasMoreActiveManualIncidents: boolean =
+              await this.doesMonitorHasMoreActiveManualIncidents(
+                monitor.id!,
+                projectId!,
+              );
 
-          const latestState: MonitorStatusTimeline | null =
-            await MonitorStatusTimelineService.findOneBy({
-              query: {
-                monitorId: monitor.id!,
-                projectId: projectId!,
-              },
-              select: {
-                _id: true,
-                monitorStatusId: true,
+            if (doesMonitorHasMoreActiveManualIncidents) {
+              continue;
+            }
+
+            await MonitorService.updateOneById({
+              id: monitor.id!,
+              data: {
+                disableActiveMonitoringBecauseOfManualIncident: false,
               },
               props: {
                 isRoot: true,
               },
-              sort: {
-                startsAt: SortOrder.Descending,
-              },
             });
 
-          if (
-            latestState &&
-            latestState.monitorStatusId?.toString() ===
-              resolvedMonitorState.id!.toString()
-          ) {
-            // already on this state. Skip.
+            /*
+             * Don't flip the monitor to operational while other incidents
+             * are still open on it — e.g. a metric monitor with group-by
+             * may have one incident per series, and resolving one series
+             * shouldn't claim the whole monitor is healthy.
+             */
+            const hasOtherActiveIncidents: boolean =
+              await this.doesMonitorHaveActiveIncidents(
+                monitor.id!,
+                projectId!,
+              );
+
+            if (hasOtherActiveIncidents) {
+              continue;
+            }
+
+            /*
+             * changeMonitorStatus performs the same latest-status dedupe check
+             * this loop used to do inline, and additionally absorbs the two
+             * recoverable error classes (status already set by a concurrent
+             * writer, lock not acquired after retries) by skipping the write,
+             * so the common failure modes never even reach the catch below.
+             * notifyOwners is true to preserve the previous behavior here: the
+             * created row had isOwnerNotified unset, so owners were notified.
+             */
+            await MonitorService.changeMonitorStatus(
+              projectId!,
+              [monitor.id!],
+              resolvedMonitorState.id!,
+              true, // notifyOwners - matches the pre-existing behavior of this loop.
+              undefined,
+              undefined,
+              {
+                isRoot: true,
+              },
+              startsAt,
+            );
+          } catch (err) {
+            logger.error(
+              `IncidentService.markMonitorsActiveForMonitoring: failed for monitor ${monitor.id?.toString()}; continuing with the remaining monitors.`,
+            );
+            logger.error(err);
             continue;
           }
-
-          const monitorStatusTimeline: MonitorStatusTimeline =
-            new MonitorStatusTimeline();
-          monitorStatusTimeline.monitorId = monitor.id!;
-          monitorStatusTimeline.projectId = projectId!;
-          monitorStatusTimeline.monitorStatusId = resolvedMonitorState.id!;
-
-          if (startsAt) {
-            monitorStatusTimeline.startsAt = startsAt;
-          }
-
-          await MonitorStatusTimelineService.create({
-            data: monitorStatusTimeline,
-            props: {
-              isRoot: true,
-            },
-          });
         }
       }
     }

--- a/Common/Server/Services/MonitorGroupService.ts
+++ b/Common/Server/Services/MonitorGroupService.ts
@@ -93,7 +93,16 @@ export class Service extends DatabaseService<MonitorGroup> {
               },
             ),
           ),
-          createdAt: QueryHelper.inBetween(startDate, endDate),
+          /*
+           * Select every row that OVERLAPS [startDate, endDate] - it started on or before the
+           * window ends, and it either ended on or after the window started or is still open
+           * (endsAt IS NULL). Filtering by createdAt-in-window missed rows that started before
+           * the window but carry downtime into it (e.g. a monitor Offline since before the
+           * window rendered as 100% uptime on the group page). Same predicate as
+           * StatusPageService.getMonitorStatusTimelineForStatusPage.
+           */
+          startsAt: QueryHelper.lessThanEqualTo(endDate),
+          endsAt: QueryHelper.greaterThanEqualToOrNull(startDate),
         },
         select: {
           createdAt: true,
@@ -108,7 +117,11 @@ export class Service extends DatabaseService<MonitorGroup> {
           } as any,
         },
         sort: {
-          createdAt: SortOrder.Ascending,
+          /*
+           * startsAt, not createdAt: they are different clocks (DB now() vs worker moment())
+           * with real skew, and startsAt is the order the timeline math relies on.
+           */
+          startsAt: SortOrder.Ascending,
         },
         skip: 0,
         limit: LIMIT_MAX, // This can be optimized.

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -14,7 +14,12 @@ import MonitorOwnerTeamService from "./MonitorOwnerTeamService";
 import MonitorOwnerUserService from "./MonitorOwnerUserService";
 import MonitorProbeService from "./MonitorProbeService";
 import MonitorStatusService from "./MonitorStatusService";
-import MonitorStatusTimelineService from "./MonitorStatusTimelineService";
+import MonitorStatusTimelineService, {
+  MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE,
+  MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "./MonitorStatusTimelineService";
+import ServerException from "../../Types/Exception/ServerException";
+import Sleep from "../../Types/Sleep";
 import ProbeService from "./ProbeService";
 import ProjectService, { CurrentPlan } from "./ProjectService";
 import TeamMemberService from "./TeamMemberService";
@@ -1733,10 +1738,93 @@ ${createdItem.description?.trim() || "No description provided."}
         statusTimeline.startsAt = startsAt;
       }
 
-      await MonitorStatusTimelineService.create({
-        data: statusTimeline,
+      await this.createStatusTimelineWithRetry({
+        statusTimeline: statusTimeline,
         props: props,
+        projectId: projectId,
+        monitorId: monitorId,
       });
+    }
+  }
+
+  /*
+   * Creates one status timeline row, absorbing the two error classes that are
+   * recoverable per monitor so one monitor cannot abort a caller's loop over
+   * many (incident resolve, scheduled maintenance end, incident create with
+   * changeMonitorStatusTo):
+   *
+   *   - "same as previous" from onBeforeCreate's dedupe check: a concurrent
+   *     writer (or an earlier backfilled row at this startsAt) already put the
+   *     monitor in this status, so the desired state holds. Idempotent no-op.
+   *
+   *   - the fail-closed lock error from MonitorStatusTimelineService.create():
+   *     retried a few times with a short delay, because the common causes (a
+   *     transient Redis blip, or a concurrent writer holding the per-monitor
+   *     mutex) clear quickly. This retry is also what protects the INITIAL
+   *     status row written from MonitorService.onCreateSuccess - without it a
+   *     lock failure at monitor-create time leaves a Manual monitor with no
+   *     timeline forever, since Manual monitors are never probed and so never
+   *     self-heal. If all attempts fail, log and continue: for probed monitors
+   *     the next probe result recreates the transition, and failing the caller
+   *     outright would strand its remaining monitors instead.
+   *
+   * Every other error still propagates.
+   */
+  private async createStatusTimelineWithRetry(data: {
+    statusTimeline: MonitorStatusTimeline;
+    props: DatabaseCommonInteractionProps;
+    projectId: ObjectID;
+    monitorId: ObjectID;
+  }): Promise<void> {
+    const maxAttempts: number = 3;
+    const retryDelayInMs: number = 2000;
+
+    const logAttributes: LogAttributes = {
+      projectId: data.projectId.toString(),
+      monitorId: data.monitorId.toString(),
+    } as LogAttributes;
+
+    for (let attempt: number = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await MonitorStatusTimelineService.create({
+          data: data.statusTimeline,
+          props: data.props,
+        });
+        return;
+      } catch (err) {
+        if (
+          err instanceof BadDataException &&
+          err.message === MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE
+        ) {
+          logger.debug(
+            `changeMonitorStatus: monitor ${data.monitorId.toString()} is already in the requested status; skipping duplicate status timeline.`,
+          );
+          return;
+        }
+
+        const isLockError: boolean =
+          err instanceof ServerException &&
+          err.message === MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE;
+
+        if (isLockError && attempt < maxAttempts) {
+          logger.warn(
+            `changeMonitorStatus: could not acquire the status timeline lock for monitor ${data.monitorId.toString()} (attempt ${attempt} of ${maxAttempts}); retrying.`,
+            logAttributes,
+          );
+          await Sleep.sleep(retryDelayInMs);
+          continue;
+        }
+
+        if (isLockError) {
+          logger.error(
+            `changeMonitorStatus: could not acquire the status timeline lock for monitor ${data.monitorId.toString()} after ${maxAttempts} attempt(s); skipping this status change. The monitor keeps its current status.`,
+            logAttributes,
+          );
+          return;
+        }
+
+        throw err;
+      }
     }
   }
 

--- a/Common/Server/Services/MonitorStatusTimelineService.ts
+++ b/Common/Server/Services/MonitorStatusTimelineService.ts
@@ -96,11 +96,27 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
       throw new ServerException(MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE);
     }
 
+    let createdItem: MonitorStatusTimeline;
+
     try {
-      return await super.create(createBy);
+      createdItem = await super.create(createBy);
     } finally {
       await this.releaseMutex(mutex, logAttributes);
     }
+
+    /*
+     * The feed item and its workspace notification run AFTER the mutex is
+     * released: they can involve third-party HTTP (Slack/Teams) with unbounded
+     * latency, and holding the per-monitor lock across them would block every
+     * concurrent status write for this monitor until acquireTimeout - turning
+     * one slow webhook into refused status transitions. Only the predecessor
+     * read -> INSERT -> predecessor close needs the lock, and all of that has
+     * completed by this point. (The pre-fail-closed code released the lock at
+     * this same boundary, before the feed block.)
+     */
+    await this.createStatusChangeFeedItem(createdItem, createBy);
+
+    return createdItem;
   }
 
   @CaptureSpan()
@@ -304,12 +320,19 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
    * Closes the status timeline row that precedes the row we just created.
    *
    * The update is conditional instead of a blind updateOneById: it only touches
-   * the row if it really does start before the new row (startsAt < endsAt) and is
+   * the row if it starts at or before the new row (startsAt <= endsAt) and is
    * either still open or currently closed at or after the new row's startsAt
    * (endsAt >= :endsAt OR endsAt IS NULL). That keeps a concurrent or
    * out-of-order writer from extending a row forward over a gap it does not own,
    * and keeps a backfilled row from being closed at a time earlier than the row
    * that actually follows it.
+   *
+   * startsAt uses <= and not <: on an exact startsAt tie (a backfill inserted at
+   * the same timestamp as the open predecessor) the predecessor must still be
+   * closed - at zero duration, which is harmless. With a strict < the tie would
+   * leave BOTH rows open forever: the reconciler deliberately never closes
+   * startsAt ties (its successor predicate is strictly later), so nothing would
+   * ever repair it, and the pair would read back as unbounded downtime.
    *
    * Note this closes only the single immediately-preceding row. If a monitor has
    * more than one open row (the orphans this bug produced), the older ones are
@@ -327,7 +350,7 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
     const updatedCount: number = await this.updateOneBy({
       query: {
         _id: data.precedingStatusTimelineId.toString(),
-        startsAt: QueryHelper.lessThan(data.endsAt),
+        startsAt: QueryHelper.lessThanEqualTo(data.endsAt),
         endsAt: QueryHelper.greaterThanEqualToOrNull(data.endsAt),
       },
       data: {
@@ -457,6 +480,24 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
         props: onCreate.createBy.props,
       });
     }
+    return createdItem;
+  }
+
+  /*
+   * Writes the monitor feed item (and its workspace notification, which can be
+   * third-party HTTP to Slack/Teams) for a status change. Called from create()
+   * AFTER the per-monitor mutex has been released - see the comment there. Kept
+   * out of onCreateSuccess on purpose: everything in onCreateSuccess runs while
+   * the mutex is held.
+   */
+  private async createStatusChangeFeedItem(
+    createdItem: MonitorStatusTimeline,
+    createBy: CreateBy<MonitorStatusTimeline>,
+  ): Promise<void> {
+    if (!createdItem.monitorId || !createdItem.monitorStatusId) {
+      return;
+    }
+
     const monitorStatus: MonitorStatus | null =
       await MonitorStatusService.findOneBy({
         query: {
@@ -502,19 +543,15 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
         ` Changed Monitor **[${monitorName}](${(await MonitorService.getMonitorLinkInDashboard(projectId!, monitorId!)).toString()}) State** to **` +
         stateName +
         "**",
-      moreInformationInMarkdown: `**Cause:** 
+      moreInformationInMarkdown: `**Cause:**
     ${createdItem.rootCause}`,
-      userId: createdItem.createdByUserId || onCreate.createBy.props.userId,
+      userId: createdItem.createdByUserId || createBy.props.userId,
       workspaceNotification: {
         sendWorkspaceNotification: true,
         notifyUserId:
-          createdItem.createdByUserId ||
-          onCreate.createBy.props.userId ||
-          undefined,
+          createdItem.createdByUserId || createBy.props.userId || undefined,
       },
     });
-
-    return createdItem;
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/MonitorStatusTimelineService.ts
+++ b/Common/Server/Services/MonitorStatusTimelineService.ts
@@ -18,10 +18,89 @@ import MonitorFeedService from "./MonitorFeedService";
 import { MonitorFeedEventType } from "../../Models/DatabaseModels/MonitorFeed";
 import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusService from "./MonitorStatusService";
+import ServerException from "../../Types/Exception/ServerException";
+
+/*
+ * Thrown by onBeforeCreate when the incoming status is the same as the status of
+ * the row immediately before it. Probe ingest call sites (Utils/Monitor/MonitorStatusTimeline
+ * and Utils/Monitor/MonitorResource) match on this exact message to treat the
+ * duplicate as an idempotent no-op, so the text must not change.
+ */
+export const MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE: string =
+  "Monitor Status cannot be same as previous status.";
+
+/*
+ * Thrown by create() when the per-monitor mutex cannot be acquired. The timeline
+ * write is refused rather than performed unlocked - see the comment on the lock
+ * acquisition below. Probe ingest call sites match on this to log and skip
+ * instead of failing the whole ingest run.
+ */
+export const MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE: string =
+  "Could not acquire the monitor status timeline lock for this monitor.";
 
 export class Service extends DatabaseService<MonitorStatusTimeline> {
   public constructor() {
     super(MonitorStatusTimeline);
+  }
+
+  @CaptureSpan()
+  public override async create(
+    createBy: CreateBy<MonitorStatusTimeline>,
+  ): Promise<MonitorStatusTimeline> {
+    /*
+     * The per-monitor mutex is owned here, around the whole create, rather than
+     * inside onBeforeCreate. DatabaseService.create() invokes onBeforeCreate and
+     * then runs validation, permission checks and the INSERT before it ever
+     * reaches onCreateSuccess, all OUTSIDE any try/catch this service can hook
+     * (onCreateError never fires for a throw raised before the INSERT). So a
+     * mutex acquired in onBeforeCreate and released in onCreateSuccess leaks on
+     * any throw in between, and a leaked redis-semaphore mutex never expires - it
+     * keeps refreshing its own Redis key for the life of the process, which would
+     * block every later create for that monitor until acquireTimeout. Holding it
+     * in a try/finally here releases it on every path.
+     *
+     * The critical section that must be serialized per monitor spans reading the
+     * predecessor row (onBeforeCreate) through closing it (onCreateSuccess), so
+     * the lock is held across the entire super.create(), not just one hook.
+     */
+    if (createBy.props.ignoreHooks || !createBy.data.monitorId) {
+      // No predecessor bookkeeping runs on these paths, so no serialization is needed.
+      return await super.create(createBy);
+    }
+
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      monitorId: createBy.data.monitorId?.toString(),
+    } as LogAttributes;
+
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: createBy.data.monitorId.toString(),
+        namespace: "MonitorStatusTimeline.create",
+      });
+    } catch (e) {
+      /*
+       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
+       * concurrent writers resolve the same predecessor row, both pass the
+       * same-as-previous check, and both INSERT a status row milliseconds apart.
+       * Only the later row is ever closed (the next writer resolves its
+       * predecessor with ORDER BY startsAt DESC LIMIT 1), so the earlier row is
+       * orphaned with endsAt = NULL permanently and is read back as unbounded
+       * downtime. Refusing the write is strictly safer: the monitor keeps its
+       * current status and the next probe result for the same monitor
+       * re-evaluates the same criteria and recreates the status change.
+       */
+      logger.error(e, logAttributes);
+      throw new ServerException(MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE);
+    }
+
+    try {
+      return await super.create(createBy);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
   }
 
   @CaptureSpan()
@@ -32,20 +111,33 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
       throw new BadDataException("monitorId is null");
     }
 
-    let mutex: SemaphoreMutex | null = null;
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      monitorId: createBy.data.monitorId?.toString(),
+    } as LogAttributes;
 
-    try {
-      mutex = await Semaphore.lock({
-        key: createBy.data.monitorId.toString(),
-        namespace: "MonitorStatusTimeline.create",
-      });
-    } catch (e) {
-      logger.error(e, {
-        projectId: createBy.data.projectId?.toString(),
-        monitorId: createBy.data.monitorId?.toString(),
-      } as LogAttributes);
-    }
+    /*
+     * The per-monitor mutex that serializes this read-modify-write is acquired
+     * and released in create() (see the comment there); it is held for the whole
+     * duration of this hook.
+     */
+    return await this.buildOnCreate(
+      createBy,
+      createBy.data.monitorId,
+      logAttributes,
+    );
+  }
 
+  /*
+   * Body of onBeforeCreate, split out to keep the null-narrowing of monitorId in
+   * one place: it is passed in already narrowed so it can never reach a query as
+   * undefined, which would widen the query to every monitor.
+   */
+  private async buildOnCreate(
+    createBy: CreateBy<MonitorStatusTimeline>,
+    monitorId: ObjectID,
+    logAttributes: LogAttributes,
+  ): Promise<OnCreate<MonitorStatusTimeline>> {
     if (!createBy.data.startsAt) {
       createBy.data.startsAt = OneUptimeDate.getCurrentDate();
     }
@@ -85,7 +177,7 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
 
     const stateBeforeThis: MonitorStatusTimeline | null = await this.findOneBy({
       query: {
-        monitorId: createBy.data.monitorId,
+        monitorId: monitorId,
         startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
       },
       sort: {
@@ -101,14 +193,8 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
       },
     });
 
-    logger.debug("State Before this", {
-      projectId: createBy.data.projectId?.toString(),
-      monitorId: createBy.data.monitorId?.toString(),
-    } as LogAttributes);
-    logger.debug(stateBeforeThis, {
-      projectId: createBy.data.projectId?.toString(),
-      monitorId: createBy.data.monitorId?.toString(),
-    } as LogAttributes);
+    logger.debug("State Before this", logAttributes);
+    logger.debug(stateBeforeThis, logAttributes);
 
     // If this is the first state, then do not notify the owner.
     if (!stateBeforeThis) {
@@ -126,15 +212,26 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
         stateBeforeThis.monitorStatusId.toString() ===
         monitorStatusId.toString()
       ) {
+        /*
+         * Logged above debug on purpose. This is the exact point at which an
+         * orphaned (endsAt = NULL) row would have been created had the mutex
+         * fallen through unlocked, so it is the signal to alert on: a sustained
+         * rate here means two writers are racing for the same monitor.
+         */
+        logger.warn(
+          `MonitorStatusTimeline: rejecting duplicate status ${monitorStatusId.toString()} for monitor ${monitorId.toString()}. The preceding status starting at ${stateBeforeThis.startsAt?.toString()} is already this status.`,
+          logAttributes,
+        );
+
         throw new BadDataException(
-          "Monitor Status cannot be same as previous status.",
+          MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE,
         );
       }
     }
 
     const stateAfterThis: MonitorStatusTimeline | null = await this.findOneBy({
       query: {
-        monitorId: createBy.data.monitorId,
+        monitorId: monitorId,
         startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
       },
       sort: {
@@ -170,23 +267,89 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
       }
     }
 
-    logger.debug("State After this", {
-      projectId: createBy.data.projectId?.toString(),
-      monitorId: createBy.data.monitorId?.toString(),
-    } as LogAttributes);
-    logger.debug(stateAfterThis, {
-      projectId: createBy.data.projectId?.toString(),
-      monitorId: createBy.data.monitorId?.toString(),
-    } as LogAttributes);
+    logger.debug("State After this", logAttributes);
+    logger.debug(stateAfterThis, logAttributes);
 
     return {
       createBy,
       carryForward: {
         statusTimelineBeforeThisStatus: stateBeforeThis || null,
         statusTimelineAfterThisStatus: stateAfterThis || null,
-        mutex: mutex,
       },
     };
+  }
+
+  /*
+   * Releases the per-monitor mutex. Never throws: a failed release must not mask
+   * the error we are already unwinding, and must not fail an otherwise successful
+   * create. Semaphore.release stops the refresh interval before it talks to
+   * Redis, so even if the Redis call fails the key expires on its own lockTimeout.
+   */
+  private async releaseMutex(
+    mutex: SemaphoreMutex | null | undefined,
+    logAttributes: LogAttributes,
+  ): Promise<void> {
+    if (!mutex) {
+      return;
+    }
+
+    try {
+      await Semaphore.release(mutex);
+    } catch (err) {
+      logger.error(err, logAttributes);
+    }
+  }
+
+  /*
+   * Closes the status timeline row that precedes the row we just created.
+   *
+   * The update is conditional instead of a blind updateOneById: it only touches
+   * the row if it really does start before the new row (startsAt < endsAt) and is
+   * either still open or currently closed at or after the new row's startsAt
+   * (endsAt >= :endsAt OR endsAt IS NULL). That keeps a concurrent or
+   * out-of-order writer from extending a row forward over a gap it does not own,
+   * and keeps a backfilled row from being closed at a time earlier than the row
+   * that actually follows it.
+   *
+   * Note this closes only the single immediately-preceding row. If a monitor has
+   * more than one open row (the orphans this bug produced), the older ones are
+   * deliberately left alone: closing them here at the new row's startsAt would
+   * turn a near-zero-duration orphan into months of recorded downtime, which is
+   * worse than the current state and not repairable from the read path. Those
+   * rows must be closed at the startsAt of the row that actually follows each of
+   * them, which is the reconciler job's responsibility, not this write path's.
+   */
+  private async closePrecedingStatusTimeline(data: {
+    precedingStatusTimelineId: ObjectID;
+    endsAt: Date;
+    logAttributes: LogAttributes;
+  }): Promise<void> {
+    const updatedCount: number = await this.updateOneBy({
+      query: {
+        _id: data.precedingStatusTimelineId.toString(),
+        startsAt: QueryHelper.lessThan(data.endsAt),
+        endsAt: QueryHelper.greaterThanEqualToOrNull(data.endsAt),
+      },
+      data: {
+        endsAt: data.endsAt,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (updatedCount === 0) {
+      /*
+       * The preceding row moved under us between onBeforeCreate reading it and
+       * this update - it was already closed at an earlier time, or it no longer
+       * starts before the new row. Leaving it as-is is correct; surface it so the
+       * reconciler has a signal to look at this monitor.
+       */
+      logger.warn(
+        `MonitorStatusTimeline: did not close preceding status timeline ${data.precedingStatusTimelineId.toString()} at ${data.endsAt.toString()}; it is no longer open and older than the new status.`,
+        data.logAttributes,
+      );
+    }
   }
 
   @CaptureSpan()
@@ -194,6 +357,11 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
     onCreate: OnCreate<MonitorStatusTimeline>,
     createdItem: MonitorStatusTimeline,
   ): Promise<MonitorStatusTimeline> {
+    const logAttributes: LogAttributes = {
+      projectId: createdItem.projectId?.toString(),
+      monitorId: createdItem.monitorId?.toString(),
+    } as LogAttributes;
+
     if (!createdItem.monitorId) {
       throw new BadDataException("monitorId is null");
     }
@@ -202,34 +370,28 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
       throw new BadDataException("monitorStatusId is null");
     }
 
+    /*
+     * Everything below runs while the per-monitor mutex acquired in create() is
+     * still held, so the read of the predecessor in onBeforeCreate and the close
+     * of it here cannot interleave with another writer for the same monitor.
+     */
+
     // update the last status as ended.
 
-    logger.debug("Status Timeline Before this", {
-      projectId: createdItem.projectId?.toString(),
-      monitorId: createdItem.monitorId?.toString(),
-    } as LogAttributes);
-    logger.debug(onCreate.carryForward.statusTimelineBeforeThisStatus, {
-      projectId: createdItem.projectId?.toString(),
-      monitorId: createdItem.monitorId?.toString(),
-    } as LogAttributes);
+    logger.debug("Status Timeline Before this", logAttributes);
+    logger.debug(
+      onCreate.carryForward.statusTimelineBeforeThisStatus,
+      logAttributes,
+    );
 
-    logger.debug("Status Timeline After this", {
-      projectId: createdItem.projectId?.toString(),
-      monitorId: createdItem.monitorId?.toString(),
-    } as LogAttributes);
-    logger.debug(onCreate.carryForward.statusTimelineAfterThisStatus, {
-      projectId: createdItem.projectId?.toString(),
-      monitorId: createdItem.monitorId?.toString(),
-    } as LogAttributes);
+    logger.debug("Status Timeline After this", logAttributes);
+    logger.debug(
+      onCreate.carryForward.statusTimelineAfterThisStatus,
+      logAttributes,
+    );
 
-    logger.debug("Created Item", {
-      projectId: createdItem.projectId?.toString(),
-      monitorId: createdItem.monitorId?.toString(),
-    } as LogAttributes);
-    logger.debug(createdItem, {
-      projectId: createdItem.projectId?.toString(),
-      monitorId: createdItem.monitorId?.toString(),
-    } as LogAttributes);
+    logger.debug("Created Item", logAttributes);
+    logger.debug(createdItem, logAttributes);
 
     /*
      * now there are three cases.
@@ -237,57 +399,49 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
      */
     if (!onCreate.carryForward.statusTimelineBeforeThisStatus) {
       // This is the first status, no need to update previous status.
-      logger.debug("This is the first status.", {
-        projectId: createdItem.projectId?.toString(),
-        monitorId: createdItem.monitorId?.toString(),
-      } as LogAttributes);
+      logger.debug("This is the first status.", logAttributes);
     } else if (!onCreate.carryForward.statusTimelineAfterThisStatus) {
       /*
        * 2. This is the last status.
        * Update the previous status to end at the start of this status.
        */
-      await this.updateOneById({
-        id: onCreate.carryForward.statusTimelineBeforeThisStatus.id!,
-        data: {
-          endsAt: createdItem.startsAt!,
-        },
-        props: {
-          isRoot: true,
-        },
+      await this.closePrecedingStatusTimeline({
+        precedingStatusTimelineId:
+          onCreate.carryForward.statusTimelineBeforeThisStatus.id!,
+        endsAt: createdItem.startsAt!,
+        logAttributes: logAttributes,
       });
-      logger.debug("This is the last status.", {
-        projectId: createdItem.projectId?.toString(),
-        monitorId: createdItem.monitorId?.toString(),
-      } as LogAttributes);
+      logger.debug("This is the last status.", logAttributes);
     } else {
       /*
        * 3. This is in the middle.
        * Update the previous status to end at the start of this status.
        */
-      await this.updateOneById({
-        id: onCreate.carryForward.statusTimelineBeforeThisStatus.id!,
-        data: {
-          endsAt: createdItem.startsAt!,
-        },
-        props: {
-          isRoot: true,
-        },
+      await this.closePrecedingStatusTimeline({
+        precedingStatusTimelineId:
+          onCreate.carryForward.statusTimelineBeforeThisStatus.id!,
+        endsAt: createdItem.startsAt!,
+        logAttributes: logAttributes,
       });
 
-      // Update the next status to start at the end of this status.
-      await this.updateOneById({
-        id: onCreate.carryForward.statusTimelineAfterThisStatus.id!,
-        data: {
-          startsAt: createdItem.endsAt!,
-        },
-        props: {
-          isRoot: true,
-        },
-      });
-      logger.debug("This status is in the middle.", {
-        projectId: createdItem.projectId?.toString(),
-        monitorId: createdItem.monitorId?.toString(),
-      } as LogAttributes);
+      /*
+       * Update the next status to start at the end of this status. endsAt was
+       * set to the next row's startsAt in onBeforeCreate, so this is normally a
+       * no-op; it is guarded because writing an empty startsAt onto the next row
+       * would corrupt it.
+       */
+      if (createdItem.endsAt) {
+        await this.updateOneById({
+          id: onCreate.carryForward.statusTimelineAfterThisStatus.id!,
+          data: {
+            startsAt: createdItem.endsAt,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+      }
+      logger.debug("This status is in the middle.", logAttributes);
     }
 
     if (!createdItem.endsAt) {
@@ -303,12 +457,6 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
         props: onCreate.createBy.props,
       });
     }
-
-    if (onCreate.carryForward.mutex) {
-      const mutex: SemaphoreMutex = onCreate.carryForward.mutex;
-      await Semaphore.release(mutex);
-    }
-
     const monitorStatus: MonitorStatus | null =
       await MonitorStatusService.findOneBy({
         query: {

--- a/Common/Server/Services/StatusPageService.ts
+++ b/Common/Server/Services/StatusPageService.ts
@@ -65,7 +65,7 @@ import IncidentService from "./IncidentService";
 import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
 import MonitorStatusTimelineService from "./MonitorStatusTimelineService";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
-import UptimeUtil from "../../Utils/Uptime/UptimeUtil";
+import UptimeUtil, { UptimeWindow } from "../../Utils/Uptime/UptimeUtil";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 import IP from "../../Types/IP/IP";
 import NotAuthenticatedException from "../../Types/Exception/NotAuthenticatedException";
@@ -708,24 +708,51 @@ export class Service extends DatabaseService<StatusPage> {
     let monitorStatusTimelines: Array<MonitorStatusTimeline> = [];
 
     if (data.monitorIds.length > 0) {
+      /*
+       * Select every row that actually OVERLAPS [startDate, endDate]:
+       * it started on or before the window ends, and it either ended on or after the window
+       * started or is still open (endsAt IS NULL).
+       *
+       * This used to be two queries that were concatenated - one keyed on
+       * `endsAt BETWEEN startDate AND endDate`, and one on `endsAt IS NULL` with NO date bound
+       * at all. That had two bugs. The unbounded open-row query pulled orphaned rows from
+       * months (or years) before the window into the report, and the endsAt-only window
+       * excluded any event that spanned the ENTIRE window but closed after it, so a total
+       * outage could render as a silent 100% uptime.
+       *
+       * `greaterThanEqualToOrNull` emits `(endsAt >= :date or endsAt IS NULL)`. Note that
+       * `greaterThanOrNull` emits exactly the same `>=` SQL despite its name, so the explicit
+       * name is used here to keep the intent readable.
+       *
+       * Supported by the (monitorId, startsAt) and (endsAt) indexes.
+       */
       monitorStatusTimelines = await MonitorStatusTimelineService.findBy({
         query: {
           monitorId: QueryHelper.any(data.monitorIds),
-          endsAt: QueryHelper.inBetween(startDate, endDate),
+          startsAt: QueryHelper.lessThanEqualTo(endDate),
+          endsAt: QueryHelper.greaterThanEqualToOrNull(startDate),
         },
         select: {
           monitorId: true,
           createdAt: true,
           endsAt: true,
           startsAt: true,
+          /*
+           * `_id` is selected explicitly because UptimeUtil reads `monitorStatus.id` (a getter
+           * over `_id`) to match events against the downtime statuses. It works today only
+           * because SelectUtil.sanitizeSelect force injects `_id: true` into every relation
+           * select - state that dependency here rather than rely on it implicitly. Note `_id`
+           * is the decorated primary column; `id` itself has no TableColumnMetadata.
+           */
           monitorStatus: {
+            _id: true,
             name: true,
             color: true,
             priority: true,
           } as any,
         },
         sort: {
-          createdAt: SortOrder.Descending,
+          startsAt: SortOrder.Descending,
         },
         skip: 0,
         limit: LIMIT_MAX, // This can be optimized.
@@ -734,42 +761,19 @@ export class Service extends DatabaseService<StatusPage> {
         },
       });
 
-      monitorStatusTimelines = monitorStatusTimelines.concat(
-        await MonitorStatusTimelineService.findBy({
-          query: {
-            monitorId: QueryHelper.any(data.monitorIds),
-            endsAt: QueryHelper.isNull(),
-          },
-          select: {
-            monitorId: true,
-            createdAt: true,
-            endsAt: true,
-            startsAt: true,
-            monitorStatus: {
-              name: true,
-              color: true,
-              priority: true,
-            } as any,
-          },
-          sort: {
-            createdAt: SortOrder.Descending,
-          },
-          skip: 0,
-          limit: LIMIT_MAX, // This can be optimized.
-          props: {
-            isRoot: true,
-          },
-        }),
-      );
-
-      // sort monitorStatusTimelines by createdAt.
+      /*
+       * Sort by startsAt and NOT by createdAt. createdAt is generated DB side with now(),
+       * while startsAt is generated on the worker pod with moment(). Those are different
+       * clocks with measured skew, so ordering by createdAt does not reliably reproduce the
+       * real chronological order of the timeline.
+       */
       monitorStatusTimelines = monitorStatusTimelines.sort(
         (a: MonitorStatusTimeline, b: MonitorStatusTimeline) => {
-          if (!a.createdAt || !b.createdAt) {
+          if (!a.startsAt || !b.startsAt) {
             return 0;
           }
 
-          return b.createdAt!.getTime() - a.createdAt!.getTime();
+          return b.startsAt!.getTime() - a.startsAt!.getTime();
         },
       );
     }
@@ -1201,6 +1205,18 @@ export class Service extends DatabaseService<StatusPage> {
     const startDate: Date = OneUptimeDate.getSomeDaysAgo(numberOfDays);
     const startAndEndDate: string = `${numberOfDays} days (${OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(startDate, true)} - ${OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(endDate, true)})`;
 
+    /*
+     * The report is explicitly "the last N days", so this window is what every uptime number
+     * below has to be measured against. It used to be computed only to fetch the timeline and
+     * was then discarded, which let an event that started before the window contribute its
+     * whole duration to the downtime total, and made the denominator "first event -> now"
+     * instead of the window - so the reported percentage drifted upwards every day.
+     */
+    const reportWindow: UptimeWindow = {
+      startDate: startDate,
+      endDate: endDate,
+    };
+
     if (statusPageResources.length === 0) {
       return {
         reportDates: startAndEndDate,
@@ -1260,6 +1276,7 @@ export class Service extends DatabaseService<StatusPage> {
         timelineForThisResource,
         resource.uptimePercentPrecision || UptimePrecision.TWO_DECIMAL,
         statusPage.downtimeMonitorStatuses!,
+        reportWindow,
       );
       const downtime: {
         totalDowntimeInSeconds: number;
@@ -1267,6 +1284,7 @@ export class Service extends DatabaseService<StatusPage> {
       } = UptimeUtil.getTotalDowntimeInSeconds(
         timelineForThisResource,
         statusPage.downtimeMonitorStatuses!,
+        reportWindow,
       );
 
       const reportItem: StatusPageReportItem = {
@@ -1299,6 +1317,7 @@ export class Service extends DatabaseService<StatusPage> {
     } = UptimeUtil.getTotalDowntimeInSeconds(
       timeline,
       statusPage.downtimeMonitorStatuses!,
+      reportWindow,
     );
 
     return {
@@ -1462,6 +1481,12 @@ export class Service extends DatabaseService<StatusPage> {
           },
           monitorGroupId: true,
           order: true,
+          /*
+           * needed so the emailed report rounds to the same precision the status page renders
+           * with. Without it `resource.uptimePercentPrecision` is always undefined and the
+           * report silently falls back to two decimals.
+           */
+          uptimePercentPrecision: true,
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,

--- a/Common/Server/Utils/Monitor/MonitorResource.ts
+++ b/Common/Server/Utils/Monitor/MonitorResource.ts
@@ -1,6 +1,10 @@
 import MonitorProbeService from "../../Services/MonitorProbeService";
 import MonitorService from "../../Services/MonitorService";
-import MonitorStatusTimelineService from "../../Services/MonitorStatusTimelineService";
+import MonitorStatusTimelineService, {
+  MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE,
+  MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "../../Services/MonitorStatusTimelineService";
+import ServerException from "../../../Types/Exception/ServerException";
 import logger from "../Logger";
 import MonitorCriteriaEvaluator from "./MonitorCriteriaEvaluator";
 import MonitorLogUtil from "./MonitorLogUtil";
@@ -1013,6 +1017,15 @@ export default class MonitorResourceUtil {
           monitorStatusTimeline.rootCause =
             "No monitoring criteria met. Change to default status. ";
 
+          /*
+           * Tracks whether the monitor really is at its default status after the
+           * create call, so the summary event below records only what actually
+           * happened. On the lock-skip path the write was REFUSED - recording a
+           * "reverted" event there would put a false entry in the monitor log and
+           * mask the very lock failure the error log surfaces.
+           */
+          let revertedToDefaultStatus: boolean = true;
+
           try {
             await MonitorStatusTimelineService.create({
               data: monitorStatusTimeline,
@@ -1033,29 +1046,45 @@ export default class MonitorResourceUtil {
              */
             if (
               err instanceof BadDataException &&
-              err.message ===
-                "Monitor Status cannot be same as previous status."
+              err.message === MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE
             ) {
               logger.debug(
                 `${dataToProcess.monitorId.toString()} - Monitor status already at default; skipping duplicate status timeline (concurrent race).`,
               );
+            } else if (
+              err instanceof ServerException &&
+              err.message === MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE
+            ) {
+              /*
+               * The per-monitor timeline mutex could not be acquired (fail-closed
+               * create, see MonitorStatusTimelineService). Skipping is recoverable:
+               * the next probe result re-evaluates the same criteria and recreates
+               * the revert-to-default, while failing here would abort the whole
+               * ingest run and lose the monitor log for this probe result.
+               */
+              logger.error(
+                `${dataToProcess.monitorId.toString()} - Could not acquire the monitor status timeline lock; skipping revert to default status. It will be retried on the next probe result.`,
+              );
+              revertedToDefaultStatus = false;
             } else {
               throw err;
             }
           }
 
-          const defaultStatusName: string | null = await getMonitorStatusName(
-            monitorSteps.data.defaultMonitorStatusId,
-          );
+          if (revertedToDefaultStatus) {
+            const defaultStatusName: string | null = await getMonitorStatusName(
+              monitorSteps.data.defaultMonitorStatusId,
+            );
 
-          evaluationSummary.events.push({
-            type: "monitor-status-changed",
-            title: "Monitor status reverted",
-            message: defaultStatusName
-              ? `Monitor status reverted to "${defaultStatusName}" because no monitoring criteria were met.`
-              : "Monitor status reverted to its default state because no monitoring criteria were met.",
-            at: OneUptimeDate.getCurrentDate(),
-          });
+            evaluationSummary.events.push({
+              type: "monitor-status-changed",
+              title: "Monitor status reverted",
+              message: defaultStatusName
+                ? `Monitor status reverted to "${defaultStatusName}" because no monitoring criteria were met.`
+                : "Monitor status reverted to its default state because no monitoring criteria were met.",
+              at: OneUptimeDate.getCurrentDate(),
+            });
+          }
         }
       }
 

--- a/Common/Server/Utils/Monitor/MonitorStatusTimeline.ts
+++ b/Common/Server/Utils/Monitor/MonitorStatusTimeline.ts
@@ -5,7 +5,11 @@ import BadDataException from "../../../Types/Exception/BadDataException";
 import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
 import ObjectID from "../../../Types/ObjectID";
 import { TelemetryQuery } from "../../../Types/Telemetry/TelemetryQuery";
-import MonitorStatusTimelineService from "../../Services/MonitorStatusTimelineService";
+import MonitorStatusTimelineService, {
+  MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE,
+  MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "../../Services/MonitorStatusTimelineService";
+import ServerException from "../../../Types/Exception/ServerException";
 import logger, { LogAttributes } from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
 import DataToProcess from "./DataToProcess";
@@ -124,22 +128,43 @@ export default class MonitorStatusTimelineUtil {
       } catch (err) {
         /*
          * Concurrency race: two probe/ingest results for the same monitor can be
-         * processed near-simultaneously (the per-monitor mutexes in
-         * MonitorResourceUtil.monitorResource and MonitorStatusTimeline.create can
-         * time out under load and fall through unlocked). Both see the same prior
-         * status and both try to write the same new status row. The
+         * processed near-simultaneously and both see the same prior status, so both
+         * try to write the same new status row. The
          * MonitorStatusTimelineService.onBeforeCreate dedupe check then throws this
          * exact BadDataException for the loser of the race. This is an idempotent
          * no-op (the desired status is already the current status), so swallow it at
-         * debug level instead of failing the job and logging a full ERROR stack.
+         * debug level instead of failing the job and logging a full ERROR stack. The
+         * race itself is now logged at warn by onBeforeCreate, which is the
+         * authoritative telemetry for it - this log only records that we skipped.
          * Match the exact message so unrelated BadDataExceptions still propagate.
          */
         if (
           err instanceof BadDataException &&
-          err.message === "Monitor Status cannot be same as previous status."
+          err.message === MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE
         ) {
           logger.debug(
             `${input.monitor.id?.toString()} - Monitor status already equals desired status; skipping duplicate status timeline (concurrent race).`,
+          );
+          return null;
+        }
+
+        /*
+         * The per-monitor mutex in MonitorStatusTimelineService.create() is
+         * fail-closed: if Redis is unavailable or the lock cannot be acquired within
+         * the acquire timeout, the create is refused rather than performed unlocked.
+         * Writing unlocked is what produced permanently orphaned (endsAt = NULL)
+         * timeline rows, which read back as unbounded downtime on status pages and
+         * uptime reports - far worse than a missed status transition. Skipping is
+         * recoverable: the next probe result for this monitor evaluates the same
+         * criteria and creates the same status change. So log and skip rather than
+         * failing the whole probe ingest run for this monitor.
+         */
+        if (
+          err instanceof ServerException &&
+          err.message === MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE
+        ) {
+          logger.error(
+            `${input.monitor.id?.toString()} - Could not acquire the monitor status timeline lock; skipping this status change. It will be retried on the next probe result.`,
           );
           return null;
         }

--- a/Common/Server/Utils/Monitor/MonitorStatusTimelineReconciler.ts
+++ b/Common/Server/Utils/Monitor/MonitorStatusTimelineReconciler.ts
@@ -1,0 +1,353 @@
+import PostgresAppInstance, {
+  DatabaseSource,
+} from "../../Infrastructure/PostgresDatabase";
+import DatabaseNotConnectedException from "../../../Types/Exception/DatabaseNotConnectedException";
+import ObjectID from "../../../Types/ObjectID";
+import logger from "../Logger";
+import CaptureSpan from "../Telemetry/CaptureSpan";
+
+/*
+ * A "stale open row" is a MonitorStatusTimeline row with endsAt IS NULL for which a row
+ * with a strictly later startsAt exists on the same monitor.
+ *
+ * These are produced by a write-path race: two probe results for the same monitor can be
+ * processed near-simultaneously, both resolve the same predecessor row, and both INSERT a
+ * new status row milliseconds apart. Only the later one is ever closed, because every
+ * subsequent writer resolves its predecessor with ORDER BY startsAt DESC LIMIT 1 and so
+ * permanently shadows the earlier one. The earlier row keeps endsAt = NULL forever.
+ *
+ * An open row with no successor is the monitor's legitimate current-state row and MUST be
+ * left open. Only rows that have been superseded are repaired here.
+ *
+ * The repaired endsAt is the MIN startsAt among strictly later rows on the same monitor -
+ * i.e. the moment the row was actually superseded. It is deliberately NOT "now" and NOT the
+ * startsAt of the newest row: closing an orphan at the newest row's startsAt would convert a
+ * near-zero-duration orphan into a multi-month closed downtime row, which is unrecoverable
+ * and strictly worse than leaving it open.
+ */
+
+export interface RepairStaleOpenRowsOptions {
+  // Maximum number of open rows examined per monitor per round trip.
+  batchSize?: number | undefined;
+  // When set, only this monitor is reconciled. When unset, every affected monitor is.
+  monitorId?: ObjectID | undefined;
+}
+
+export interface RepairStaleOpenRowsResult {
+  // Open rows examined across every batch of this run.
+  scanned: number;
+  // Open rows that were given an endsAt by this run.
+  repaired: number;
+  // Monitors that had at least one stale open row when the run started.
+  monitorsWithStaleRows: number;
+  // Monitors that had at least one row repaired. Callers may want to refresh their current status.
+  repairedMonitorIds: Array<ObjectID>;
+  // Monitors whose repair threw. They are skipped, not retried, so one failure cannot abort a run.
+  failedMonitorIds: Array<ObjectID>;
+}
+
+interface RepairBatchResult {
+  scanned: number;
+  repaired: number;
+}
+
+/*
+ * Bounded so a single run never loads a pathological monitor's whole backlog into memory.
+ * Production currently has ~67.5k stale rows, ~56k of them on ONE monitor.
+ */
+export const DEFAULT_STALE_OPEN_ROW_BATCH_SIZE: number = 1000;
+
+const MIN_BATCH_SIZE: number = 1;
+const MAX_BATCH_SIZE: number = 10000;
+
+/*
+ * Pure runaway guard. Every non-terminal round repairs exactly batchSize rows, so the loop
+ * is already guaranteed to terminate; this only bounds a run if that invariant is ever broken.
+ */
+const MAX_ROUNDS: number = 100000;
+
+export default class MonitorStatusTimelineReconciler {
+  /*
+   * Finds and repairs stale open rows. Idempotent: a second run over the same data repairs
+   * nothing, because a repaired row no longer matches endsAt IS NULL.
+   *
+   * Monitors are processed round-robin, one batch each per round, so a monitor with tens of
+   * thousands of stale rows cannot starve the rest of the fleet.
+   */
+  @CaptureSpan()
+  public static async repairStaleOpenRows(
+    options: RepairStaleOpenRowsOptions = {},
+  ): Promise<RepairStaleOpenRowsResult> {
+    const batchSize: number = this.getBatchSize(options.batchSize);
+
+    const monitorIds: Array<ObjectID> = options.monitorId
+      ? [options.monitorId]
+      : await this.getMonitorIdsWithStaleOpenRows();
+
+    const result: RepairStaleOpenRowsResult = {
+      scanned: 0,
+      repaired: 0,
+      monitorsWithStaleRows: monitorIds.length,
+      repairedMonitorIds: [],
+      failedMonitorIds: [],
+    };
+
+    if (monitorIds.length === 0) {
+      logger.debug(
+        "MonitorStatusTimelineReconciler: no monitors have stale open status timeline rows.",
+      );
+      return result;
+    }
+
+    logger.debug(
+      `MonitorStatusTimelineReconciler: ${monitorIds.length} monitor(s) have stale open status timeline rows. Batch size ${batchSize}.`,
+    );
+
+    const repairedMonitorIds: Set<string> = new Set<string>();
+    const failedMonitorIds: Set<string> = new Set<string>();
+
+    let pendingMonitorIds: Array<ObjectID> = monitorIds;
+    let round: number = 0;
+
+    while (pendingMonitorIds.length > 0) {
+      round++;
+
+      if (round > MAX_ROUNDS) {
+        logger.error(
+          `MonitorStatusTimelineReconciler: aborting after ${MAX_ROUNDS} rounds with ${pendingMonitorIds.length} monitor(s) still pending. This should be unreachable.`,
+        );
+        break;
+      }
+
+      const stillPendingMonitorIds: Array<ObjectID> = [];
+
+      for (const monitorId of pendingMonitorIds) {
+        /*
+         * Per-monitor try/catch, matching the sibling KeepCurrentStateConsistent jobs: one bad
+         * monitor is skipped for the remainder of the run instead of aborting it. It is not
+         * re-queued, so a monitor that fails deterministically cannot spin forever.
+         */
+        try {
+          const batch: RepairBatchResult = await this.repairStaleOpenRowsBatch({
+            monitorId: monitorId,
+            batchSize: batchSize,
+          });
+
+          result.scanned += batch.scanned;
+          result.repaired += batch.repaired;
+
+          if (batch.repaired > 0) {
+            repairedMonitorIds.add(monitorId.toString());
+          }
+
+          /*
+           * A full batch of repairs means there may be more stale rows on this monitor. Anything
+           * short of a full batch means every open row on this monitor has now been examined -
+           * whatever is still open has no strictly later row and is therefore legitimate.
+           */
+          if (batch.repaired >= batchSize) {
+            stillPendingMonitorIds.push(monitorId);
+          }
+        } catch (err) {
+          failedMonitorIds.add(monitorId.toString());
+          logger.error(
+            `MonitorStatusTimelineReconciler: failed to repair stale open rows for monitor ${monitorId.toString()}.`,
+          );
+          logger.error(err);
+          continue;
+        }
+      }
+
+      pendingMonitorIds = stillPendingMonitorIds;
+    }
+
+    result.repairedMonitorIds = Array.from(repairedMonitorIds).map(
+      (id: string) => {
+        return new ObjectID(id);
+      },
+    );
+
+    result.failedMonitorIds = Array.from(failedMonitorIds).map((id: string) => {
+      return new ObjectID(id);
+    });
+
+    return result;
+  }
+
+  /*
+   * Counts stale open rows without repairing anything. Useful for telemetry and for asserting
+   * that a repair run actually converged.
+   */
+  @CaptureSpan()
+  public static async countStaleOpenRows(
+    options: { monitorId?: ObjectID | undefined } = {},
+  ): Promise<number> {
+    const dataSource: DatabaseSource = this.getDataSource();
+
+    const parameters: Array<string> = [];
+    let monitorFilter: string = "";
+
+    if (options.monitorId) {
+      monitorFilter = `AND t."monitorId" = $1::uuid`;
+      parameters.push(options.monitorId.toString());
+    }
+
+    const sql: string = `
+      SELECT COUNT(*)::int AS "staleCount"
+      FROM "MonitorStatusTimeline" t
+      WHERE t."endsAt" IS NULL
+        AND t."deletedAt" IS NULL
+        AND t."startsAt" IS NOT NULL
+        ${monitorFilter}
+        AND EXISTS (
+          SELECT 1
+          FROM "MonitorStatusTimeline" n
+          WHERE n."monitorId" = t."monitorId"
+            AND n."deletedAt" IS NULL
+            AND n."startsAt" > t."startsAt"
+        )
+    `;
+
+    const rows: Array<{ staleCount: number }> = await dataSource.query(
+      sql,
+      parameters,
+    );
+
+    return rows[0]?.staleCount || 0;
+  }
+
+  /*
+   * The set of monitors that currently have at least one stale open row.
+   *
+   * Note this is deliberately NOT "monitors with more than one open row". A monitor can have
+   * exactly one open row that is still stale, if the newest row on the monitor happens to be
+   * closed. Encoding the definition directly keeps both cases covered.
+   */
+  private static async getMonitorIdsWithStaleOpenRows(): Promise<
+    Array<ObjectID>
+  > {
+    const dataSource: DatabaseSource = this.getDataSource();
+
+    const sql: string = `
+      SELECT DISTINCT t."monitorId" AS "monitorId"
+      FROM "MonitorStatusTimeline" t
+      WHERE t."endsAt" IS NULL
+        AND t."deletedAt" IS NULL
+        AND t."startsAt" IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM "MonitorStatusTimeline" n
+          WHERE n."monitorId" = t."monitorId"
+            AND n."deletedAt" IS NULL
+            AND n."startsAt" > t."startsAt"
+        )
+      ORDER BY t."monitorId" ASC
+    `;
+
+    const rows: Array<{ monitorId: string }> = await dataSource.query(sql);
+
+    return rows.map((row: { monitorId: string }) => {
+      return new ObjectID(row.monitorId);
+    });
+  }
+
+  /*
+   * Repairs up to batchSize stale open rows on a single monitor, oldest first.
+   *
+   * Ordering is by startsAt, NEVER createdAt. createdAt is assigned DB-side by now() while
+   * startsAt is assigned by the worker pod's clock, so the two orderings genuinely disagree on
+   * real data. Two earlier migrations ordered by createdAt and produced wrong results.
+   */
+  private static async repairStaleOpenRowsBatch(data: {
+    monitorId: ObjectID;
+    batchSize: number;
+  }): Promise<RepairBatchResult> {
+    const dataSource: DatabaseSource = this.getDataSource();
+
+    /*
+     * candidates is materialised once (a data-modifying CTE forces materialisation), so the
+     * counts below and the UPDATE all see the same snapshot and one round trip yields both the
+     * scanned and the repaired count.
+     *
+     * nextStartsAt is NULL for an open row with no strictly later row. Those rows are the
+     * legitimate current-state row (or a startsAt tie at the head of the timeline) and are
+     * excluded from the UPDATE, so they stay open.
+     */
+    const sql: string = `
+      WITH candidates AS (
+        SELECT
+          t."_id" AS "_id",
+          (
+            SELECT MIN(n."startsAt")
+            FROM "MonitorStatusTimeline" n
+            WHERE n."monitorId" = t."monitorId"
+              AND n."deletedAt" IS NULL
+              AND n."startsAt" > t."startsAt"
+          ) AS "nextStartsAt"
+        FROM "MonitorStatusTimeline" t
+        WHERE t."monitorId" = $1::uuid
+          AND t."endsAt" IS NULL
+          AND t."deletedAt" IS NULL
+          AND t."startsAt" IS NOT NULL
+        ORDER BY t."startsAt" ASC
+        LIMIT $2
+      ),
+      repaired AS (
+        UPDATE "MonitorStatusTimeline" m
+        SET "endsAt" = c."nextStartsAt",
+            "updatedAt" = NOW(),
+            "version" = m."version" + 1
+        FROM candidates c
+        WHERE m."_id" = c."_id"
+          AND c."nextStartsAt" IS NOT NULL
+        RETURNING m."_id"
+      )
+      SELECT
+        (SELECT COUNT(*) FROM candidates)::int AS "scanned",
+        (SELECT COUNT(*) FROM repaired)::int AS "repaired"
+    `;
+
+    const rows: Array<{ scanned: number; repaired: number }> =
+      await dataSource.query(sql, [
+        data.monitorId.toString(),
+        data.batchSize.toString(),
+      ]);
+
+    const scanned: number = rows[0]?.scanned || 0;
+    const repaired: number = rows[0]?.repaired || 0;
+
+    if (repaired > 0) {
+      logger.debug(
+        `MonitorStatusTimelineReconciler: repaired ${repaired} of ${scanned} open row(s) examined on monitor ${data.monitorId.toString()}.`,
+      );
+    }
+
+    return {
+      scanned: scanned,
+      repaired: repaired,
+    };
+  }
+
+  private static getBatchSize(batchSize?: number | undefined): number {
+    if (
+      !batchSize ||
+      !Number.isFinite(batchSize) ||
+      batchSize < MIN_BATCH_SIZE
+    ) {
+      return DEFAULT_STALE_OPEN_ROW_BATCH_SIZE;
+    }
+
+    return Math.min(Math.floor(batchSize), MAX_BATCH_SIZE);
+  }
+
+  private static getDataSource(): DatabaseSource {
+    const dataSource: DatabaseSource | null =
+      PostgresAppInstance.getDataSource();
+
+    if (!dataSource) {
+      throw new DatabaseNotConnectedException();
+    }
+
+    return dataSource;
+  }
+}

--- a/Common/Server/Utils/Monitor/MonitorStatusTimelineReconciler.ts
+++ b/Common/Server/Utils/Monitor/MonitorStatusTimelineReconciler.ts
@@ -272,6 +272,14 @@ export default class MonitorStatusTimelineReconciler {
      * nextStartsAt is NULL for an open row with no strictly later row. Those rows are the
      * legitimate current-state row (or a startsAt tie at the head of the timeline) and are
      * excluded from the UPDATE, so they stay open.
+     *
+     * The UPDATE re-checks m."endsAt" IS NULL even though candidates already filtered on it:
+     * the reconciler runs WITHOUT the per-monitor mutex, and under READ COMMITTED a live
+     * writer can close a candidate row between this statement's snapshot and the UPDATE
+     * taking the row lock. Postgres then re-evaluates only the UPDATE's own WHERE against
+     * the new row version (EvalPlanQual), so the openness check must live in the UPDATE
+     * itself - otherwise the reconciler would overwrite the endsAt the writer just committed
+     * with its stale snapshot-time value.
      */
     const sql: string = `
       WITH candidates AS (
@@ -299,6 +307,7 @@ export default class MonitorStatusTimelineReconciler {
             "version" = m."version" + 1
         FROM candidates c
         WHERE m."_id" = c."_id"
+          AND m."endsAt" IS NULL
           AND c."nextStartsAt" IS NOT NULL
         RETURNING m."_id"
       )

--- a/Common/Tests/Server/Services/MonitorStatusTimelineService.test.ts
+++ b/Common/Tests/Server/Services/MonitorStatusTimelineService.test.ts
@@ -1,0 +1,235 @@
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * These tests pin the ownership of the per-monitor mutex in
+ * MonitorStatusTimelineService.create() - the prevention layer that stops new
+ * orphaned (endsAt = NULL) timeline rows at the source:
+ *
+ *   - fail-closed: a lock that cannot be acquired refuses the write with the
+ *     exact MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE callers match on,
+ *     instead of falling through and inserting unlocked (the original bug),
+ *   - release-on-every-path: the mutex is released whether the create
+ *     succeeds or throws (a leaked redis-semaphore mutex refreshes its own
+ *     key for the life of the process, blocking every later create for the
+ *     monitor until acquireTimeout),
+ *   - the feed/workspace-notification side effects run only AFTER release,
+ *     so third-party HTTP latency (Slack/Teams) can never extend the
+ *     critical section,
+ *   - the ignoreHooks and missing-monitorId paths skip locking entirely.
+ *
+ * Semaphore is mocked at the module boundary; DatabaseService.prototype.create
+ * is spied so super.create() is observable without a database.
+ */
+
+const lockMock: jest.Mock = jest.fn();
+const releaseMock: jest.Mock = jest.fn();
+
+jest.mock("../../../Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    default: {
+      lock: (...args: Array<unknown>) => {
+        return lockMock(...args);
+      },
+      release: (...args: Array<unknown>) => {
+        return releaseMock(...args);
+      },
+    },
+  };
+});
+
+import MonitorStatusTimelineService, {
+  MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "../../../Server/Services/MonitorStatusTimelineService";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import ServerException from "../../../Types/Exception/ServerException";
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const STATUS_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+type MakeCreateByFunction = (data?: {
+  ignoreHooks?: boolean;
+  omitMonitorId?: boolean;
+}) => CreateBy<MonitorStatusTimeline>;
+
+const makeCreateBy: MakeCreateByFunction = (data?: {
+  ignoreHooks?: boolean;
+  omitMonitorId?: boolean;
+}): CreateBy<MonitorStatusTimeline> => {
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+
+  if (!data?.omitMonitorId) {
+    timeline.monitorId = MONITOR_ID;
+  }
+
+  timeline.projectId = PROJECT_ID;
+  timeline.monitorStatusId = STATUS_ID;
+
+  return {
+    data: timeline,
+    props: {
+      isRoot: true,
+      ignoreHooks: data?.ignoreHooks || false,
+    },
+  };
+};
+
+describe("MonitorStatusTimelineService.create mutex ownership", () => {
+  let superCreateSpy: jest.SpyInstance;
+  let feedItemSpy: jest.SpyInstance;
+  let createdItem: MonitorStatusTimeline;
+
+  // a unique object standing in for the redis-semaphore mutex.
+  const fakeMutex: { id: string } = { id: "fake-mutex" };
+
+  beforeEach(() => {
+    lockMock.mockReset();
+    releaseMock.mockReset();
+
+    lockMock.mockResolvedValue(fakeMutex);
+    releaseMock.mockResolvedValue(undefined);
+
+    createdItem = new MonitorStatusTimeline();
+    createdItem.monitorId = MONITOR_ID;
+    createdItem.projectId = PROJECT_ID;
+    createdItem.monitorStatusId = STATUS_ID;
+
+    /*
+     * super.create - everything between lock and release (hooks, validation,
+     * the INSERT) is DatabaseService.create's responsibility and is not under
+     * test here.
+     */
+    superCreateSpy = jest
+      .spyOn(DatabaseService.prototype, "create")
+      .mockResolvedValue(createdItem);
+
+    /*
+     * The feed side effect does DB lookups and third-party HTTP; stub it and
+     * assert WHEN it runs relative to the release.
+     */
+    feedItemSpy = jest
+      .spyOn(
+        MonitorStatusTimelineService as unknown as {
+          createStatusChangeFeedItem: () => Promise<void>;
+        },
+        "createStatusChangeFeedItem",
+      )
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    superCreateSpy.mockRestore();
+    feedItemSpy.mockRestore();
+  });
+
+  it("acquires the per-monitor lock, creates, then releases", async () => {
+    const result: MonitorStatusTimeline =
+      await MonitorStatusTimelineService.create(makeCreateBy());
+
+    expect(result).toBe(createdItem);
+
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(lockMock).toHaveBeenCalledWith({
+      key: MONITOR_ID.toString(),
+      namespace: "MonitorStatusTimeline.create",
+    });
+
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+
+    // lock -> create -> release, in that order.
+    expect(lockMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      superCreateSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(superCreateSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("runs the feed side effect only after the mutex is released", async () => {
+    await MonitorStatusTimelineService.create(makeCreateBy());
+
+    expect(feedItemSpy).toHaveBeenCalledTimes(1);
+    expect(releaseMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      feedItemSpy.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("fails closed with the exact lock error message and never inserts unlocked", async () => {
+    lockMock.mockRejectedValue(new Error("redis unavailable"));
+
+    await expect(
+      MonitorStatusTimelineService.create(makeCreateBy()),
+    ).rejects.toThrow(MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE);
+
+    await expect(
+      MonitorStatusTimelineService.create(makeCreateBy()),
+    ).rejects.toBeInstanceOf(ServerException);
+
+    /*
+     * The whole point of fail-closed: the write must NOT happen without the
+     * lock. The pre-fix code logged and fell through unlocked, which is what
+     * produced permanently orphaned endsAt = NULL rows.
+     */
+    expect(superCreateSpy).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it("releases the mutex when the create itself throws", async () => {
+    superCreateSpy.mockRejectedValue(new Error("insert failed"));
+
+    await expect(
+      MonitorStatusTimelineService.create(makeCreateBy()),
+    ).rejects.toThrow("insert failed");
+
+    // release must run on the throw path - a leaked mutex never expires.
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+
+    // and the feed side effect must not run for a failed create.
+    expect(feedItemSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fail a successful create when the release itself fails", async () => {
+    releaseMock.mockRejectedValue(new Error("redis blip on release"));
+
+    const result: MonitorStatusTimeline =
+      await MonitorStatusTimelineService.create(makeCreateBy());
+
+    expect(result).toBe(createdItem);
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips locking entirely when ignoreHooks is set", async () => {
+    const result: MonitorStatusTimeline =
+      await MonitorStatusTimelineService.create(
+        makeCreateBy({ ignoreHooks: true }),
+      );
+
+    expect(result).toBe(createdItem);
+    expect(lockMock).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+    // no hooks -> no predecessor bookkeeping -> no feed side effect either.
+    expect(feedItemSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips locking when monitorId is missing and lets onBeforeCreate reject it", async () => {
+    await MonitorStatusTimelineService.create(
+      makeCreateBy({ omitMonitorId: true }),
+    );
+
+    // super.create's onBeforeCreate throws BadDataException for this case.
+    expect(lockMock).not.toHaveBeenCalled();
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorStatusTimelineReconciler.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorStatusTimelineReconciler.test.ts
@@ -1,0 +1,555 @@
+import ObjectID from "../../../../Types/ObjectID";
+
+/*
+ * The reconciler talks to Postgres directly, so these tests stand a small in-memory table in
+ * front of it. The fake implements the SEMANTICS the reconciler's SQL relies on - order by
+ * startsAt, soft-delete filtering, "stale" meaning a strictly later row exists, and endsAt =
+ * MIN(later startsAt) - and records every statement it is asked to run. That lets the tests
+ * pin down the orchestration the SQL alone cannot express: batching, round-robin fairness,
+ * termination, error isolation and idempotency.
+ */
+
+interface FakeRow {
+  _id: string;
+  monitorId: string;
+  startsAt: Date | null;
+  endsAt: Date | null;
+  deletedAt: Date | null;
+  version: number;
+}
+
+let table: Array<FakeRow> = [];
+let queryLog: Array<{ sql: string; parameters: Array<string> }> = [];
+let failForMonitorIds: Set<string> = new Set<string>();
+
+function notDeleted(row: FakeRow): boolean {
+  return row.deletedAt === null;
+}
+
+function nextStartsAtFor(row: FakeRow): Date | null {
+  if (row.startsAt === null) {
+    return null;
+  }
+
+  const laterStartsAt: Array<Date> = table
+    .filter((candidate: FakeRow) => {
+      return (
+        candidate.monitorId === row.monitorId &&
+        notDeleted(candidate) &&
+        candidate.startsAt !== null &&
+        candidate.startsAt.getTime() > row.startsAt!.getTime()
+      );
+    })
+    .map((candidate: FakeRow) => {
+      return candidate.startsAt!;
+    });
+
+  if (laterStartsAt.length === 0) {
+    return null;
+  }
+
+  return laterStartsAt.reduce((min: Date, current: Date) => {
+    return current.getTime() < min.getTime() ? current : min;
+  });
+}
+
+function isStale(row: FakeRow): boolean {
+  return (
+    row.endsAt === null &&
+    notDeleted(row) &&
+    row.startsAt !== null &&
+    nextStartsAtFor(row) !== null
+  );
+}
+
+function openRowsForMonitor(monitorId: string): Array<FakeRow> {
+  return table
+    .filter((row: FakeRow) => {
+      return (
+        row.monitorId === monitorId &&
+        row.endsAt === null &&
+        notDeleted(row) &&
+        row.startsAt !== null
+      );
+    })
+    .sort((a: FakeRow, b: FakeRow) => {
+      return a.startsAt!.getTime() - b.startsAt!.getTime();
+    });
+}
+
+const fakeDataSource: { query: jest.Mock } = {
+  query: jest.fn(
+    async (sql: string, parameters?: Array<string>): Promise<Array<any>> => {
+      queryLog.push({ sql: sql, parameters: parameters || [] });
+
+      // Discovery: distinct monitors that have at least one stale open row.
+      if (sql.includes("SELECT DISTINCT")) {
+        const monitorIds: Array<string> = Array.from(
+          new Set<string>(
+            table.filter(isStale).map((row: FakeRow) => {
+              return row.monitorId;
+            }),
+          ),
+        ).sort();
+
+        return monitorIds.map((monitorId: string) => {
+          return { monitorId: monitorId };
+        });
+      }
+
+      // Stale row count.
+      if (sql.includes('COUNT(*)::int AS "staleCount"')) {
+        const monitorId: string | undefined = parameters?.[0];
+
+        return [
+          {
+            staleCount: table.filter((row: FakeRow) => {
+              return (
+                isStale(row) && (!monitorId || row.monitorId === monitorId)
+              );
+            }).length,
+          },
+        ];
+      }
+
+      // Batched repair for a single monitor.
+      const monitorId: string = parameters![0]!;
+      const batchSize: number = Number(parameters![1]);
+
+      if (failForMonitorIds.has(monitorId)) {
+        throw new Error(`simulated database failure for ${monitorId}`);
+      }
+
+      const candidates: Array<FakeRow> = openRowsForMonitor(monitorId).slice(
+        0,
+        batchSize,
+      );
+
+      /*
+       * Resolve every successor against the pre-update snapshot, exactly as the materialised
+       * CTE does, so a repair inside this batch cannot change another candidate's answer.
+       */
+      const resolved: Array<{ row: FakeRow; nextStartsAt: Date | null }> =
+        candidates.map((row: FakeRow) => {
+          return { row: row, nextStartsAt: nextStartsAtFor(row) };
+        });
+
+      let repaired: number = 0;
+
+      for (const candidate of resolved) {
+        if (candidate.nextStartsAt === null) {
+          continue;
+        }
+
+        candidate.row.endsAt = candidate.nextStartsAt;
+        candidate.row.version = candidate.row.version + 1;
+        repaired++;
+      }
+
+      return [{ scanned: candidates.length, repaired: repaired }];
+    },
+  ),
+};
+
+jest.mock("../../../../Server/Infrastructure/PostgresDatabase", () => {
+  return {
+    __esModule: true,
+    default: {
+      getDataSource: () => {
+        return fakeDataSource;
+      },
+    },
+  };
+});
+
+import MonitorStatusTimelineReconciler, {
+  RepairStaleOpenRowsResult,
+} from "../../../../Server/Utils/Monitor/MonitorStatusTimelineReconciler";
+
+const MONITOR_A: string = "11111111-1111-1111-1111-111111111111";
+const MONITOR_B: string = "22222222-2222-2222-2222-222222222222";
+
+let rowCounter: number = 0;
+
+function addRow(data: {
+  monitorId: string;
+  startsAtMinutes: number | null;
+  endsAtMinutes?: number | null;
+  deleted?: boolean;
+}): FakeRow {
+  rowCounter++;
+
+  const toDate: (minutes: number | null | undefined) => Date | null = (
+    minutes: number | null | undefined,
+  ) => {
+    if (minutes === null || minutes === undefined) {
+      return null;
+    }
+    return new Date(Date.UTC(2026, 0, 1, 0, minutes, 0));
+  };
+
+  const row: FakeRow = {
+    _id: `row-${rowCounter}`,
+    monitorId: data.monitorId,
+    startsAt: toDate(data.startsAtMinutes),
+    endsAt: toDate(data.endsAtMinutes),
+    deletedAt: data.deleted ? new Date() : null,
+    version: 1,
+  };
+
+  table.push(row);
+
+  return row;
+}
+
+function rowByStartsAtMinutes(
+  monitorId: string,
+  minutes: number,
+): FakeRow | undefined {
+  return table.find((row: FakeRow) => {
+    return (
+      row.monitorId === monitorId &&
+      row.startsAt !== null &&
+      row.startsAt.getTime() === Date.UTC(2026, 0, 1, 0, minutes, 0)
+    );
+  });
+}
+
+function endsAtMinutesOf(row: FakeRow | undefined): number | null {
+  if (!row || row.endsAt === null) {
+    return null;
+  }
+  // Minutes since the fixture epoch, so values past 59 do not wrap.
+  return (row.endsAt.getTime() - Date.UTC(2026, 0, 1, 0, 0, 0)) / 60000;
+}
+
+describe("MonitorStatusTimelineReconciler.repairStaleOpenRows", () => {
+  beforeEach(() => {
+    table = [];
+    queryLog = [];
+    failForMonitorIds = new Set<string>();
+    rowCounter = 0;
+    fakeDataSource.query.mockClear();
+  });
+
+  it("closes an orphaned open row at the next row's startsAt, not at the newest row's startsAt", async () => {
+    /*
+     * The production shape: two rows written milliseconds apart, only the later one closed,
+     * then months of further activity. Closing the orphan at the newest row's startsAt would
+     * turn a 1 minute gap into a multi-row-long downtime, which is the failure mode this
+     * whole change exists to avoid.
+     */
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null }); // orphan
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 11, endsAtMinutes: 20 });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 20, endsAtMinutes: 90 });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null }); // current state
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(result.repaired).toBe(1);
+    expect(result.monitorsWithStaleRows).toBe(1);
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_A, 10))).toBe(11);
+  });
+
+  it("leaves the single latest open row on a monitor open", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_A, 10))).toBe(90);
+    expect(rowByStartsAtMinutes(MONITOR_A, 90)!.endsAt).toBeNull();
+  });
+
+  it("does nothing to a monitor whose only open row is the newest row", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: 90 });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(result.monitorsWithStaleRows).toBe(0);
+    expect(result.repaired).toBe(0);
+    expect(result.scanned).toBe(0);
+    // Discovery found nothing, so no repair statement should have been issued at all.
+    expect(queryLog).toHaveLength(1);
+  });
+
+  it("is idempotent - a second run finds nothing to repair", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 11, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    const firstRun: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+    expect(firstRun.repaired).toBe(2);
+
+    const secondRun: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(secondRun.repaired).toBe(0);
+    expect(secondRun.monitorsWithStaleRows).toBe(0);
+    expect(secondRun.repairedMonitorIds).toEqual([]);
+    expect(await MonitorStatusTimelineReconciler.countStaleOpenRows()).toBe(0);
+  });
+
+  it("clears a backlog larger than the batch size without loading it in one go", async () => {
+    for (let minute: number = 1; minute <= 25; minute++) {
+      addRow({
+        monitorId: MONITOR_A,
+        startsAtMinutes: minute,
+        endsAtMinutes: null,
+      });
+    }
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({
+        batchSize: 5,
+      });
+
+    // 24 stale rows repaired, the newest row stays open.
+    expect(result.repaired).toBe(24);
+    expect(rowByStartsAtMinutes(MONITOR_A, 25)!.endsAt).toBeNull();
+    expect(await MonitorStatusTimelineReconciler.countStaleOpenRows()).toBe(0);
+
+    // Each closed row ends exactly where the next one begins - no gaps, no overlaps.
+    for (let minute: number = 1; minute <= 24; minute++) {
+      expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_A, minute))).toBe(
+        minute + 1,
+      );
+    }
+
+    const repairStatements: Array<{ parameters: Array<string> }> =
+      queryLog.filter((entry: { sql: string }) => {
+        return entry.sql.includes("WITH candidates");
+      });
+
+    // No statement ever asked for more than the batch size.
+    for (const statement of repairStatements) {
+      expect(Number(statement.parameters[1])).toBe(5);
+    }
+  });
+
+  it("interleaves monitors so a large backlog cannot starve a small one", async () => {
+    // Monitor A has a large backlog, monitor B has a single stale row.
+    for (let minute: number = 1; minute <= 30; minute++) {
+      addRow({
+        monitorId: MONITOR_A,
+        startsAtMinutes: minute,
+        endsAtMinutes: null,
+      });
+    }
+
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 90, endsAtMinutes: null });
+
+    await MonitorStatusTimelineReconciler.repairStaleOpenRows({ batchSize: 5 });
+
+    const repairedMonitorOrder: Array<string> = queryLog
+      .filter((entry: { sql: string }) => {
+        return entry.sql.includes("WITH candidates");
+      })
+      .map((entry: { parameters: Array<string> }) => {
+        return entry.parameters[0]!;
+      });
+
+    /*
+     * Round-robin: monitor B is served in the very first round rather than queued behind all
+     * of monitor A's batches.
+     */
+    expect(repairedMonitorOrder[0]).toBe(MONITOR_A);
+    expect(repairedMonitorOrder[1]).toBe(MONITOR_B);
+    // And B is finished after that one batch, so it never appears again.
+    expect(repairedMonitorOrder.slice(2)).not.toContain(MONITOR_B);
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_B, 10))).toBe(90);
+    expect(await MonitorStatusTimelineReconciler.countStaleOpenRows()).toBe(0);
+  });
+
+  it("keeps going when one monitor fails, and reports it", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 90, endsAtMinutes: null });
+
+    failForMonitorIds.add(MONITOR_A);
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(result.failedMonitorIds.map(String)).toEqual([MONITOR_A]);
+    expect(result.repairedMonitorIds.map(String)).toEqual([MONITOR_B]);
+    expect(result.repaired).toBe(1);
+    // The healthy monitor was still repaired.
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_B, 10))).toBe(90);
+    // The failing monitor was left untouched rather than half repaired.
+    expect(rowByStartsAtMinutes(MONITOR_A, 10)!.endsAt).toBeNull();
+  });
+
+  it("does not retry a monitor that fails deterministically", async () => {
+    for (let minute: number = 1; minute <= 30; minute++) {
+      addRow({
+        monitorId: MONITOR_A,
+        startsAtMinutes: minute,
+        endsAtMinutes: null,
+      });
+    }
+
+    failForMonitorIds.add(MONITOR_A);
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({
+        batchSize: 5,
+      });
+
+    expect(result.failedMonitorIds.map(String)).toEqual([MONITOR_A]);
+
+    const repairAttempts: number = queryLog.filter((entry: { sql: string }) => {
+      return entry.sql.includes("WITH candidates");
+    }).length;
+
+    expect(repairAttempts).toBe(1);
+  });
+
+  it("ignores soft deleted rows on both sides of the repair", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    // A soft deleted successor must not be used as the endsAt value...
+    addRow({
+      monitorId: MONITOR_A,
+      startsAtMinutes: 20,
+      endsAtMinutes: null,
+      deleted: true,
+    });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 30, endsAtMinutes: null });
+    // ...and a soft deleted open row must not itself be repaired.
+    const deletedOrphan: FakeRow = addRow({
+      monitorId: MONITOR_B,
+      startsAtMinutes: 10,
+      endsAtMinutes: null,
+      deleted: true,
+    });
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 90, endsAtMinutes: null });
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_A, 10))).toBe(30);
+    expect(deletedOrphan.endsAt).toBeNull();
+    expect(result.repairedMonitorIds.map(String)).toEqual([MONITOR_A]);
+  });
+
+  it("leaves rows tied on the newest startsAt open rather than closing them at zero length", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(result.repaired).toBe(1);
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_A, 10))).toBe(90);
+
+    // The tied pair stays open - and the run still terminates.
+    const tied: Array<FakeRow> = table.filter((row: FakeRow) => {
+      return (
+        row.startsAt !== null &&
+        row.startsAt.getTime() === Date.UTC(2026, 0, 1, 0, 90, 0)
+      );
+    });
+    expect(tied).toHaveLength(2);
+    for (const row of tied) {
+      expect(row.endsAt).toBeNull();
+    }
+  });
+
+  it("skips rows with no startsAt instead of guessing", async () => {
+    addRow({
+      monitorId: MONITOR_A,
+      startsAtMinutes: null,
+      endsAtMinutes: null,
+    });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    expect(result.repaired).toBe(0);
+    expect(result.monitorsWithStaleRows).toBe(0);
+  });
+
+  it("scopes the run to a single monitor when one is given, skipping discovery", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_B, startsAtMinutes: 90, endsAtMinutes: null });
+
+    const result: RepairStaleOpenRowsResult =
+      await MonitorStatusTimelineReconciler.repairStaleOpenRows({
+        monitorId: new ObjectID(MONITOR_B),
+      });
+
+    expect(result.repaired).toBe(1);
+    expect(endsAtMinutesOf(rowByStartsAtMinutes(MONITOR_B, 10))).toBe(90);
+    // Monitor A is untouched.
+    expect(rowByStartsAtMinutes(MONITOR_A, 10)!.endsAt).toBeNull();
+
+    expect(
+      queryLog.some((entry: { sql: string }) => {
+        return entry.sql.includes("SELECT DISTINCT");
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the default batch size for absent or nonsensical values", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    await MonitorStatusTimelineReconciler.repairStaleOpenRows({ batchSize: 0 });
+    await MonitorStatusTimelineReconciler.repairStaleOpenRows({
+      batchSize: -5,
+    });
+
+    const batchSizes: Array<number> = queryLog
+      .filter((entry: { sql: string }) => {
+        return entry.sql.includes("WITH candidates");
+      })
+      .map((entry: { parameters: Array<string> }) => {
+        return Number(entry.parameters[1]);
+      });
+
+    expect(batchSizes.length).toBeGreaterThan(0);
+    for (const batchSize of batchSizes) {
+      expect(batchSize).toBe(1000);
+    }
+  });
+
+  it("caps an oversized batch size", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    await MonitorStatusTimelineReconciler.repairStaleOpenRows({
+      batchSize: 5000000,
+    });
+
+    const batchSizes: Array<number> = queryLog
+      .filter((entry: { sql: string }) => {
+        return entry.sql.includes("WITH candidates");
+      })
+      .map((entry: { parameters: Array<string> }) => {
+        return Number(entry.parameters[1]);
+      });
+
+    expect(batchSizes).toEqual([10000]);
+  });
+
+  it("never orders by createdAt", async () => {
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 10, endsAtMinutes: null });
+    addRow({ monitorId: MONITOR_A, startsAtMinutes: 90, endsAtMinutes: null });
+
+    await MonitorStatusTimelineReconciler.repairStaleOpenRows({});
+
+    for (const entry of queryLog) {
+      expect(entry.sql).not.toContain("createdAt");
+    }
+  });
+});

--- a/Common/Tests/Types/Database/CompareOperatorWireSerialization.test.ts
+++ b/Common/Tests/Types/Database/CompareOperatorWireSerialization.test.ts
@@ -1,0 +1,216 @@
+import CompareBase, { CompareType } from "../../../Types/Database/CompareBase";
+import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../Types/BaseDatabase/GreaterThanOrEqual";
+import GreaterThanOrNull from "../../../Types/BaseDatabase/GreaterThanOrNull";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import LessThan from "../../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../../Types/BaseDatabase/LessThanOrEqual";
+import LessThanOrNull from "../../../Types/BaseDatabase/LessThanOrNull";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Pins the WIRE CONTRACT of the comparison query operators end to end:
+ *
+ *   browser:  JSONFunctions.serialize(query)  ->  operator.toJSON()
+ *   HTTP:     JSON.stringify / JSON.parse     (a raw Date becomes its full ISO string)
+ *   server:   JSONFunctions.deserialize       ->  Dictionary[_type].fromJSON
+ *   SQL bind: operator.toString()             ->  QueryHelper.<op>(value)
+ *
+ * The bug this file guards against: toJSON used to serialize Date values via
+ * toString(), which collapses them to a DATE-ONLY string in the BROWSER'S LOCAL
+ * TIMEZONE (OneUptimeDate.asDateForDatabaseQuery). A bound of "now" therefore
+ * arrived at the server as midnight of the viewer's calendar date, and every
+ * row from later that day was silently excluded from the query - e.g. the
+ * Monitor View page dropped a monitor's current open status row whenever the
+ * status had changed the same day. Serializing the RAW value (exactly what
+ * InBetween always did) keeps the full timestamp across the wire in every
+ * timezone.
+ *
+ * The legacy date-only wire format must STAY accepted: an old client (or a
+ * saved query serialized before this change) sends value: "YYYY-MM-DD", and
+ * the server must keep treating it as an opaque string bound.
+ */
+
+const FULL_ISO_TIMESTAMP: string = "2026-07-21T14:35:12.345Z";
+const LEGACY_DATE_ONLY: string = "2026-07-21";
+
+type OperatorFactory = (value: CompareType) => CompareBase<CompareType>;
+
+type OperatorCase = {
+  name: string;
+  type: unknown;
+  create: OperatorFactory;
+};
+
+const OPERATOR_CASES: Array<OperatorCase> = [
+  {
+    name: "LessThan",
+    type: LessThan,
+    create: (value: CompareType) => {
+      return new LessThan(value);
+    },
+  },
+  {
+    name: "LessThanOrEqual",
+    type: LessThanOrEqual,
+    create: (value: CompareType) => {
+      return new LessThanOrEqual(value);
+    },
+  },
+  {
+    name: "LessThanOrNull",
+    type: LessThanOrNull,
+    create: (value: CompareType) => {
+      return new LessThanOrNull(value);
+    },
+  },
+  {
+    name: "GreaterThan",
+    type: GreaterThan,
+    create: (value: CompareType) => {
+      return new GreaterThan(value);
+    },
+  },
+  {
+    name: "GreaterThanOrEqual",
+    type: GreaterThanOrEqual,
+    create: (value: CompareType) => {
+      return new GreaterThanOrEqual(value);
+    },
+  },
+  {
+    name: "GreaterThanOrNull",
+    type: GreaterThanOrNull,
+    create: (value: CompareType) => {
+      return new GreaterThanOrNull(value);
+    },
+  },
+];
+
+type SimulateHttpHopFunction = (query: JSONObject) => JSONObject;
+
+/*
+ * What actually happens between ModelAPI.getList and BaseAPI: the serialized
+ * query is JSON.stringify'd into the request body and JSON.parse'd on the
+ * server. This is the step that turns a raw Date into its full ISO string.
+ */
+const simulateHttpHop: SimulateHttpHopFunction = (
+  query: JSONObject,
+): JSONObject => {
+  return JSON.parse(JSON.stringify(JSONFunctions.serialize(query)));
+};
+
+for (const operatorCase of OPERATOR_CASES) {
+  describe(`${operatorCase.name} wire serialization`, () => {
+    it("sends a Date bound as its full ISO timestamp, not a local date-only string", () => {
+      const query: JSONObject = {
+        startsAt: operatorCase.create(new Date(FULL_ISO_TIMESTAMP)),
+      } as unknown as JSONObject;
+
+      const wire: JSONObject = simulateHttpHop(query);
+
+      expect((wire["startsAt"] as JSONObject)["_type"]).toBe(operatorCase.name);
+      /*
+       * The critical assertion: the full timestamp survives. Under the old
+       * toString()-based toJSON this was "2026-07-21" (or "2026-07-22" east
+       * of UTC) regardless of the time component.
+       */
+      expect((wire["startsAt"] as JSONObject)["value"]).toBe(
+        FULL_ISO_TIMESTAMP,
+      );
+    });
+
+    it("deserializes on the server to the operator with the full-precision bound", () => {
+      const query: JSONObject = {
+        startsAt: operatorCase.create(new Date(FULL_ISO_TIMESTAMP)),
+      } as unknown as JSONObject;
+
+      const deserialized: JSONObject = JSONFunctions.deserialize(
+        simulateHttpHop(query),
+      );
+
+      expect(deserialized["startsAt"]).toBeInstanceOf(operatorCase.type);
+
+      /*
+       * toString() is exactly what QueryUtil passes into QueryHelper as the
+       * SQL bind value, so this string IS the query bound. It must be the
+       * full ISO timestamp, passed through untouched.
+       */
+      const operator: CompareBase<CompareType> = deserialized[
+        "startsAt"
+      ] as unknown as CompareBase<CompareType>;
+
+      expect(operator.toString()).toBe(FULL_ISO_TIMESTAMP);
+    });
+
+    it("still accepts the legacy date-only wire format as an opaque string", () => {
+      const legacyWire: JSONObject = {
+        startsAt: {
+          _type: operatorCase.name,
+          value: LEGACY_DATE_ONLY,
+        },
+      };
+
+      const deserialized: JSONObject = JSONFunctions.deserialize(legacyWire);
+
+      expect(deserialized["startsAt"]).toBeInstanceOf(operatorCase.type);
+
+      const operator: CompareBase<CompareType> = deserialized[
+        "startsAt"
+      ] as unknown as CompareBase<CompareType>;
+
+      expect(operator.toString()).toBe(LEGACY_DATE_ONLY);
+    });
+
+    it("round-trips a number bound unchanged", () => {
+      const query: JSONObject = {
+        priority: operatorCase.create(42),
+      } as unknown as JSONObject;
+
+      const wire: JSONObject = simulateHttpHop(query);
+
+      expect((wire["priority"] as JSONObject)["value"]).toBe(42);
+
+      const deserialized: JSONObject = JSONFunctions.deserialize(wire);
+
+      const operator: CompareBase<CompareType> = deserialized[
+        "priority"
+      ] as unknown as CompareBase<CompareType>;
+
+      expect(operator.toString()).toBe("42");
+    });
+  });
+}
+
+describe("InBetween wire serialization (the reference behavior)", () => {
+  it("has always sent full ISO timestamps for both bounds - the operators above now match it", () => {
+    const startBound: string = "2026-04-22T00:30:00.000Z";
+
+    const query: JSONObject = {
+      createdAt: new InBetween(
+        new Date(startBound),
+        new Date(FULL_ISO_TIMESTAMP),
+      ),
+    } as unknown as JSONObject;
+
+    const wire: JSONObject = simulateHttpHop(query);
+
+    expect((wire["createdAt"] as JSONObject)["startValue"]).toBe(startBound);
+    expect((wire["createdAt"] as JSONObject)["endValue"]).toBe(
+      FULL_ISO_TIMESTAMP,
+    );
+
+    const deserialized: JSONObject = JSONFunctions.deserialize(wire);
+
+    expect(deserialized["createdAt"]).toBeInstanceOf(InBetween);
+
+    const operator: InBetween<CompareType> = deserialized[
+      "createdAt"
+    ] as unknown as InBetween<CompareType>;
+
+    expect(operator.toStartValueString()).toBe(startBound);
+    expect(operator.toEndValueString()).toBe(FULL_ISO_TIMESTAMP);
+  });
+});

--- a/Common/Tests/Types/Database/GreaterThan.test.ts
+++ b/Common/Tests/Types/Database/GreaterThan.test.ts
@@ -25,7 +25,11 @@ describe("GreaterThan", () => {
     const obj: GreaterThan<number> = new GreaterThan<number>(42);
     const expectedJSON: JSONObject = {
       _type: "GreaterThan",
-      value: "42",
+      /*
+       * toJSON carries the RAW value (like InBetween), not a stringified one -
+       * see the comment on toJSON. For numbers that means the number itself.
+       */
+      value: 42,
     };
     expect(obj.toJSON()).toEqual(expectedJSON);
   });

--- a/Common/Tests/Types/Database/GreaterThanOrEqual.test.ts
+++ b/Common/Tests/Types/Database/GreaterThanOrEqual.test.ts
@@ -27,7 +27,11 @@ describe("GreaterThanOrEqual", () => {
     const obj: GreaterThanOrEqual<number> = new GreaterThanOrEqual<number>(42);
     const expectedJSON: JSONObject = {
       _type: "GreaterThanOrEqual",
-      value: "42",
+      /*
+       * toJSON carries the RAW value (like InBetween), not a stringified one -
+       * see the comment on toJSON. For numbers that means the number itself.
+       */
+      value: 42,
     };
     expect(obj.toJSON()).toEqual(expectedJSON);
   });

--- a/Common/Tests/Types/Database/GreaterThanOrNull.test.ts
+++ b/Common/Tests/Types/Database/GreaterThanOrNull.test.ts
@@ -23,11 +23,34 @@ describe("GreaterThanOrNull", () => {
 
   it("should generate the correct JSON representation using toJSON", () => {
     const obj: GreaterThanOrNull<number> = new GreaterThanOrNull<number>(42);
+    /*
+     * toJSON carries the RAW value (like InBetween), not a stringified one -
+     * see the comment on toJSON. For numbers that means the number itself.
+     */
     const expectedJSON: JSONObject = {
       _type: "GreaterThanOrNull",
-      value: "42",
+      value: 42,
     };
     expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("keeps the full timestamp when serializing a Date value", () => {
+    const value: Date = new Date("2026-07-21T14:35:12.345Z");
+    const obj: GreaterThanOrNull<Date> = new GreaterThanOrNull<Date>(value);
+
+    /*
+     * The raw Date is serialized, so JSON.stringify emits the full ISO
+     * timestamp. The old toString()-based toJSON collapsed it to a
+     * local-timezone date-only string, which shifted query bounds sent from
+     * the browser by up to a day and silently dropped same-day rows.
+     */
+    expect(obj.toJSON()).toEqual({
+      _type: "GreaterThanOrNull",
+      value: value,
+    });
+    expect(JSON.parse(JSON.stringify(obj.toJSON()))["value"]).toBe(
+      "2026-07-21T14:35:12.345Z",
+    );
   });
 
   it("should create a GreaterThanOrNull object from valid JSON input", () => {

--- a/Common/Tests/Types/Database/LessThan.test.ts
+++ b/Common/Tests/Types/Database/LessThan.test.ts
@@ -25,7 +25,11 @@ describe("LessThan", () => {
     const obj: LessThan<number> = new LessThan<number>(42);
     const expectedJSON: JSONObject = {
       _type: "LessThan",
-      value: "42",
+      /*
+       * toJSON carries the RAW value (like InBetween), not a stringified one -
+       * see the comment on toJSON. For numbers that means the number itself.
+       */
+      value: 42,
     };
     expect(obj.toJSON()).toEqual(expectedJSON);
   });

--- a/Common/Tests/Types/Database/LessThanOrEqual.test.ts
+++ b/Common/Tests/Types/Database/LessThanOrEqual.test.ts
@@ -23,11 +23,34 @@ describe("LessThanOrEqual", () => {
 
   it("should generate the correct JSON representation using toJSON", () => {
     const obj: LessThanOrEqual<number> = new LessThanOrEqual<number>(42);
+    /*
+     * toJSON carries the RAW value (like InBetween), not a stringified one -
+     * see the comment on toJSON. For numbers that means the number itself.
+     */
     const expectedJSON: JSONObject = {
       _type: "LessThanOrEqual",
-      value: "42",
+      value: 42,
     };
     expect(obj.toJSON()).toEqual(expectedJSON);
+  });
+
+  it("keeps the full timestamp when serializing a Date value", () => {
+    const value: Date = new Date("2026-07-21T14:35:12.345Z");
+    const obj: LessThanOrEqual<Date> = new LessThanOrEqual<Date>(value);
+
+    /*
+     * The raw Date is serialized, so JSON.stringify emits the full ISO
+     * timestamp. The old toString()-based toJSON collapsed it to a
+     * local-timezone date-only string, which shifted query bounds sent from
+     * the browser by up to a day and silently dropped same-day rows.
+     */
+    expect(obj.toJSON()).toEqual({
+      _type: "LessThanOrEqual",
+      value: value,
+    });
+    expect(JSON.parse(JSON.stringify(obj.toJSON()))["value"]).toBe(
+      "2026-07-21T14:35:12.345Z",
+    );
   });
 
   it("should create a LessThanOrEqual object from valid JSON input", () => {

--- a/Common/Tests/Types/Database/LessThanOrNull.test.ts
+++ b/Common/Tests/Types/Database/LessThanOrNull.test.ts
@@ -25,7 +25,11 @@ describe("LessThanOrNull", () => {
     const obj: LessThanOrNull<number> = new LessThanOrNull<number>(42);
     const expectedJSON: JSONObject = {
       _type: "LessThanOrNull",
-      value: "42",
+      /*
+       * toJSON carries the RAW value (like InBetween), not a stringified one -
+       * see the comment on toJSON. For numbers that means the number itself.
+       */
+      value: 42,
     };
     expect(obj.toJSON()).toEqual(expectedJSON);
   });

--- a/Common/Tests/Utils/Uptime/UptimeUtil.test.ts
+++ b/Common/Tests/Utils/Uptime/UptimeUtil.test.ts
@@ -1,0 +1,684 @@
+import UptimeUtil, { UptimeWindow } from "../../../Utils/Uptime/UptimeUtil";
+import Event from "../../../Utils/Uptime/Event";
+import MonitorEvent from "../../../Utils/Uptime/MonitorEvent";
+import { Green, Red } from "../../../Types/BrandColors";
+import ObjectID from "../../../Types/ObjectID";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import UptimePrecision from "../../../Types/StatusPage/UptimePrecision";
+
+/*
+ * Every assertion in this file is relative to a pinned "now" so the numbers are stable. The bug this
+ * file guards against is precisely that the uptime percentage used to drift with wall clock time.
+ */
+const NOW: Date = new Date("2026-07-19T00:00:00.000Z");
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_MONITOR_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OPERATIONAL_STATUS_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const SECONDS_IN_DAY: number = 86400;
+
+const offlineStatus: MonitorStatus = new MonitorStatus();
+offlineStatus.id = OFFLINE_STATUS_ID;
+offlineStatus.name = "Offline";
+offlineStatus.priority = 2;
+offlineStatus.color = Red;
+
+const downtimeStatuses: Array<MonitorStatus> = [offlineStatus];
+
+type CreateTimelineFunction = (data: {
+  statusId: ObjectID;
+  name: string;
+  priority: number;
+  startsAt: string;
+  endsAt?: string | undefined;
+  monitorId?: ObjectID | undefined;
+}) => MonitorStatusTimeline;
+
+const createTimeline: CreateTimelineFunction = (data: {
+  statusId: ObjectID;
+  name: string;
+  priority: number;
+  startsAt: string;
+  endsAt?: string | undefined;
+  monitorId?: ObjectID | undefined;
+}): MonitorStatusTimeline => {
+  const monitorStatus: MonitorStatus = new MonitorStatus();
+  monitorStatus.id = data.statusId;
+  monitorStatus.name = data.name;
+  monitorStatus.priority = data.priority;
+  monitorStatus.color = data.name === "Offline" ? Red : Green;
+
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+  timeline.monitorId = data.monitorId || MONITOR_ID;
+  timeline.monitorStatusId = data.statusId;
+  timeline.monitorStatus = monitorStatus;
+  timeline.startsAt = new Date(data.startsAt);
+
+  // endsAt is left unset for open rows, which is what the orphaned rows look like in the database.
+  if (data.endsAt) {
+    timeline.endsAt = new Date(data.endsAt);
+  }
+
+  return timeline;
+};
+
+type StatusTimelineFunction = (
+  startsAt: string,
+  endsAt?: string | undefined,
+  monitorId?: ObjectID | undefined,
+) => MonitorStatusTimeline;
+
+const offline: StatusTimelineFunction = (
+  startsAt: string,
+  endsAt?: string | undefined,
+  monitorId?: ObjectID | undefined,
+): MonitorStatusTimeline => {
+  return createTimeline({
+    statusId: OFFLINE_STATUS_ID,
+    name: "Offline",
+    priority: 2,
+    startsAt,
+    endsAt,
+    monitorId,
+  });
+};
+
+const operational: StatusTimelineFunction = (
+  startsAt: string,
+  endsAt?: string | undefined,
+  monitorId?: ObjectID | undefined,
+): MonitorStatusTimeline => {
+  return createTimeline({
+    statusId: OPERATIONAL_STATUS_ID,
+    name: "Operational",
+    priority: 1,
+    startsAt,
+    endsAt,
+    monitorId,
+  });
+};
+
+describe("UptimeUtil", () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ now: NOW });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe("the production incident: an orphaned endsAt = null row from months ago", () => {
+    /*
+     * Two rows for the same monitor, both with endsAt = null. The Offline row was orphaned by a race
+     * in MonitorStatusTimelineService and never closed. The customer report window is a 31 day window
+     * five months later, and it rendered 113 days of downtime and 43.76% uptime.
+     */
+    const timelines: Array<MonitorStatusTimeline> = [
+      offline("2025-12-11T18:03:00.955Z"),
+      operational("2026-04-04T00:19:20.189Z"),
+    ];
+
+    const window: UptimeWindow = {
+      startDate: new Date("2026-05-31T00:00:00.000Z"),
+      endDate: new Date("2026-07-01T00:00:00.000Z"),
+    };
+
+    it("reproduces the bug when no window is supplied", () => {
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(timelines, downtimeStatuses);
+
+      /*
+       * The orphaned Offline row swallows everything up to the next event, which is 113 days,
+       * 6 hours and 16 minutes later. This is the number the customer saw on their report.
+       */
+      expect(totalDowntimeInSeconds).toBe(9785779.234);
+      expect(Math.floor(totalDowntimeInSeconds / SECONDS_IN_DAY)).toBe(113);
+
+      // and the denominator is "first event -> now", which is why the number drifted daily.
+      expect(totalSecondsInTimePeriod).toBe(18943019.045);
+
+      const uptimePercentage: number = UptimeUtil.calculateUptimePercentage(
+        timelines,
+        UptimePrecision.TWO_DECIMAL,
+        downtimeStatuses,
+      );
+
+      expect(uptimePercentage).toBe(48.34);
+      expect(uptimePercentage).toBeLessThan(100);
+    });
+
+    it("reports zero downtime and 100% uptime when the window is supplied", () => {
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        );
+
+      expect(totalDowntimeInSeconds).toBe(0);
+
+      // the denominator is the 31 day window, not "first event -> now".
+      expect(totalSecondsInTimePeriod).toBe(31 * SECONDS_IN_DAY);
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          timelines,
+          UptimePrecision.TWO_DECIMAL,
+          downtimeStatuses,
+          window,
+        ),
+      ).toBe(100);
+    });
+
+    it("drops the orphaned row and clips the surviving event to the window", () => {
+      const events: Array<MonitorEvent> = UptimeUtil.getMonitorEvents(
+        timelines,
+        window,
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.label).toBe("Operational");
+      expect(events[0]!.startDate.toISOString()).toBe(
+        window.startDate.toISOString(),
+      );
+      expect(events[0]!.endDate.toISOString()).toBe(
+        window.endDate.toISOString(),
+      );
+    });
+
+    it("does not drift as wall clock time moves forward", () => {
+      const uptimeToday: number = UptimeUtil.calculateUptimePercentage(
+        timelines,
+        UptimePrecision.THREE_DECIMAL,
+        downtimeStatuses,
+        window,
+      );
+
+      jest.setSystemTime(new Date("2026-09-19T00:00:00.000Z"));
+
+      const uptimeTwoMonthsLater: number = UptimeUtil.calculateUptimePercentage(
+        timelines,
+        UptimePrecision.THREE_DECIMAL,
+        downtimeStatuses,
+        window,
+      );
+
+      jest.setSystemTime(NOW);
+
+      expect(uptimeTwoMonthsLater).toBe(uptimeToday);
+    });
+  });
+
+  describe("clipping events to the window", () => {
+    const window: UptimeWindow = {
+      startDate: new Date("2026-05-31T00:00:00.000Z"),
+      endDate: new Date("2026-07-01T00:00:00.000Z"),
+    };
+
+    it("counts an event that spans the whole window as full downtime", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-01-01T00:00:00.000Z", "2026-12-01T00:00:00.000Z"),
+      ];
+
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        );
+
+      expect(totalDowntimeInSeconds).toBe(31 * SECONDS_IN_DAY);
+      expect(totalSecondsInTimePeriod).toBe(31 * SECONDS_IN_DAY);
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          timelines,
+          UptimePrecision.TWO_DECIMAL,
+          downtimeStatuses,
+          window,
+        ),
+      ).toBe(0);
+    });
+
+    it("clips an event that overlaps the start of the window", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-05-20T00:00:00.000Z", "2026-06-05T00:00:00.000Z"),
+      ];
+
+      const events: Array<MonitorEvent> = UptimeUtil.getMonitorEvents(
+        timelines,
+        window,
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.startDate.toISOString()).toBe(
+        window.startDate.toISOString(),
+      );
+      expect(events[0]!.endDate.toISOString()).toBe("2026-06-05T00:00:00.000Z");
+
+      // 31 May -> 5 June is 5 days.
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        ).totalDowntimeInSeconds,
+      ).toBe(5 * SECONDS_IN_DAY);
+    });
+
+    it("clips an event that overlaps the end of the window", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-06-25T00:00:00.000Z", "2026-07-10T00:00:00.000Z"),
+      ];
+
+      const events: Array<MonitorEvent> = UptimeUtil.getMonitorEvents(
+        timelines,
+        window,
+      );
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.startDate.toISOString()).toBe(
+        "2026-06-25T00:00:00.000Z",
+      );
+      expect(events[0]!.endDate.toISOString()).toBe(
+        window.endDate.toISOString(),
+      );
+
+      // 25 June -> 1 July is 6 days.
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        ).totalDowntimeInSeconds,
+      ).toBe(6 * SECONDS_IN_DAY);
+    });
+
+    it("drops an event that ends before the window starts", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-01-01T00:00:00.000Z", "2026-01-02T00:00:00.000Z"),
+      ];
+
+      expect(UptimeUtil.getMonitorEvents(timelines, window)).toHaveLength(0);
+
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        );
+
+      expect(totalDowntimeInSeconds).toBe(0);
+      expect(totalSecondsInTimePeriod).toBe(31 * SECONDS_IN_DAY);
+    });
+
+    it("drops an event that starts after the window ends", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-08-01T00:00:00.000Z", "2026-08-02T00:00:00.000Z"),
+      ];
+
+      expect(UptimeUtil.getMonitorEvents(timelines, window)).toHaveLength(0);
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        ).totalDowntimeInSeconds,
+      ).toBe(0);
+    });
+
+    it("drops an event that only touches the window edge", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-05-01T00:00:00.000Z", "2026-05-31T00:00:00.000Z"),
+      ];
+
+      expect(UptimeUtil.getMonitorEvents(timelines, window)).toHaveLength(0);
+    });
+
+    it("clips events for every monitor and keeps them attributed correctly", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-01-01T00:00:00.000Z", "2026-06-02T00:00:00.000Z"),
+        offline(
+          "2026-06-20T00:00:00.000Z",
+          "2026-09-01T00:00:00.000Z",
+          OTHER_MONITOR_ID,
+        ),
+      ];
+
+      const events: Array<MonitorEvent> = UptimeUtil.getMonitorEvents(
+        timelines,
+        window,
+      );
+
+      expect(events).toHaveLength(2);
+
+      const firstEvent: MonitorEvent = events[0]!;
+      const secondEvent: MonitorEvent = events[1]!;
+
+      expect(firstEvent.monitorId.toString()).toBe(MONITOR_ID.toString());
+      expect(firstEvent.startDate.toISOString()).toBe(
+        window.startDate.toISOString(),
+      );
+      expect(firstEvent.endDate.toISOString()).toBe("2026-06-02T00:00:00.000Z");
+
+      expect(secondEvent.monitorId.toString()).toBe(
+        OTHER_MONITOR_ID.toString(),
+      );
+      expect(secondEvent.endDate.toISOString()).toBe(
+        window.endDate.toISOString(),
+      );
+    });
+
+    it("clips correctly no matter what order the rows arrive in", () => {
+      const inOrder: Array<MonitorStatusTimeline> = [
+        offline("2026-06-01T00:00:00.000Z", "2026-06-03T00:00:00.000Z"),
+        operational("2026-06-03T00:00:00.000Z", "2026-06-10T00:00:00.000Z"),
+      ];
+
+      const outOfOrder: Array<MonitorStatusTimeline> = [
+        inOrder[1]!,
+        inOrder[0]!,
+      ];
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(inOrder, downtimeStatuses, window)
+          .totalDowntimeInSeconds,
+      ).toBe(
+        UptimeUtil.getTotalDowntimeInSeconds(
+          outOfOrder,
+          downtimeStatuses,
+          window,
+        ).totalDowntimeInSeconds,
+      );
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(inOrder, downtimeStatuses, window)
+          .totalDowntimeInSeconds,
+      ).toBe(2 * SECONDS_IN_DAY);
+    });
+  });
+
+  describe("open (endsAt = null) rows", () => {
+    it("runs a single open row up to now and no further", () => {
+      // window ends in the future. now is 19 July.
+      const window: UptimeWindow = {
+        startDate: new Date("2026-07-01T00:00:00.000Z"),
+        endDate: new Date("2026-08-01T00:00:00.000Z"),
+      };
+
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-07-17T00:00:00.000Z"),
+      ];
+
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        );
+
+      // 17 July -> now (19 July) is 2 days. The open row must not run to the window end.
+      expect(totalDowntimeInSeconds).toBe(2 * SECONDS_IN_DAY);
+
+      // and the denominator is clipped to now too, so it is 1 July -> 19 July.
+      expect(totalSecondsInTimePeriod).toBe(18 * SECONDS_IN_DAY);
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          timelines,
+          UptimePrecision.TWO_DECIMAL,
+          downtimeStatuses,
+          window,
+        ),
+      ).toBe(88.88);
+    });
+
+    it("closes an open row at the start of the next row for the same monitor", () => {
+      const window: UptimeWindow = {
+        startDate: new Date("2026-06-01T00:00:00.000Z"),
+        endDate: new Date("2026-07-01T00:00:00.000Z"),
+      };
+
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-06-05T00:00:00.000Z"),
+        operational("2026-06-08T00:00:00.000Z"),
+      ];
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        ).totalDowntimeInSeconds,
+      ).toBe(3 * SECONDS_IN_DAY);
+    });
+  });
+
+  describe("degenerate inputs", () => {
+    const window: UptimeWindow = {
+      startDate: new Date("2026-05-31T00:00:00.000Z"),
+      endDate: new Date("2026-07-01T00:00:00.000Z"),
+    };
+
+    it("handles an empty timeline with and without a window", () => {
+      expect(UptimeUtil.getMonitorEvents([])).toHaveLength(0);
+      expect(UptimeUtil.getMonitorEvents([], window)).toHaveLength(0);
+      expect(
+        UptimeUtil.getNonOverlappingMonitorEvents([], window),
+      ).toHaveLength(0);
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds([], downtimeStatuses),
+      ).toEqual({
+        totalDowntimeInSeconds: 0,
+        totalSecondsInTimePeriod: 1,
+      });
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds([], downtimeStatuses, window),
+      ).toEqual({
+        totalDowntimeInSeconds: 0,
+        totalSecondsInTimePeriod: 31 * SECONDS_IN_DAY,
+      });
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          [],
+          UptimePrecision.TWO_DECIMAL,
+          downtimeStatuses,
+          window,
+        ),
+      ).toBe(100);
+    });
+
+    it("never returns a zero or negative denominator", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-06-05T00:00:00.000Z", "2026-06-06T00:00:00.000Z"),
+      ];
+
+      const zeroLengthWindow: UptimeWindow = {
+        startDate: new Date("2026-06-01T00:00:00.000Z"),
+        endDate: new Date("2026-06-01T00:00:00.000Z"),
+      };
+
+      const invertedWindow: UptimeWindow = {
+        startDate: new Date("2026-07-01T00:00:00.000Z"),
+        endDate: new Date("2026-06-01T00:00:00.000Z"),
+      };
+
+      const futureWindow: UptimeWindow = {
+        startDate: new Date("2027-01-01T00:00:00.000Z"),
+        endDate: new Date("2027-02-01T00:00:00.000Z"),
+      };
+
+      for (const badWindow of [
+        zeroLengthWindow,
+        invertedWindow,
+        futureWindow,
+      ]) {
+        for (const items of [timelines, []]) {
+          const { totalSecondsInTimePeriod } =
+            UptimeUtil.getTotalDowntimeInSeconds(
+              items,
+              downtimeStatuses,
+              badWindow,
+            );
+
+          expect(totalSecondsInTimePeriod).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("never returns an uptime percentage outside [0, 100]", () => {
+      /*
+       * A row closed in the future (2026-07-31) against a window that also ends in the future
+       * (2026-08-01), evaluated at now = 2026-07-19. Both the numerator (the clipped event) and the
+       * denominator (the window) are capped at now, so they agree: the event covers the whole
+       * elapsed period, downtime equals the period, and uptime is a correct 0% - not a value the
+       * clamp had to rescue. The [0, 100] clamp remains in the code as defence in depth.
+       */
+      const window: UptimeWindow = {
+        startDate: new Date("2026-07-01T00:00:00.000Z"),
+        endDate: new Date("2026-08-01T00:00:00.000Z"),
+      };
+
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-07-01T00:00:00.000Z", "2026-07-31T00:00:00.000Z"),
+      ];
+
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        );
+
+      /*
+       * Numerator is clipped to now, so it can never exceed the denominator (also capped at now).
+       * Here the offline row covers the entire elapsed period, so the two are equal.
+       */
+      expect(totalDowntimeInSeconds).toBeLessThanOrEqual(
+        totalSecondsInTimePeriod,
+      );
+      expect(totalDowntimeInSeconds).toBe(totalSecondsInTimePeriod);
+
+      for (const precision of [
+        UptimePrecision.NO_DECIMAL,
+        UptimePrecision.ONE_DECIMAL,
+        UptimePrecision.TWO_DECIMAL,
+        UptimePrecision.THREE_DECIMAL,
+      ]) {
+        const uptimePercentage: number = UptimeUtil.calculateUptimePercentage(
+          timelines,
+          precision,
+          downtimeStatuses,
+          window,
+        );
+
+        expect(uptimePercentage).toBeGreaterThanOrEqual(0);
+        expect(uptimePercentage).toBeLessThanOrEqual(100);
+      }
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          timelines,
+          UptimePrecision.TWO_DECIMAL,
+          downtimeStatuses,
+          window,
+        ),
+      ).toBe(0);
+    });
+  });
+
+  describe("behaviour without a window is unchanged", () => {
+    it("keeps counting closed events from the first event to now", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        operational("2026-07-09T00:00:00.000Z", "2026-07-17T00:00:00.000Z"),
+        offline("2026-07-17T00:00:00.000Z", "2026-07-18T00:00:00.000Z"),
+        operational("2026-07-18T00:00:00.000Z"),
+      ];
+
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(timelines, downtimeStatuses);
+
+      // 9 July -> now (19 July) is 10 days, of which 1 day is downtime.
+      expect(totalDowntimeInSeconds).toBe(SECONDS_IN_DAY);
+      expect(totalSecondsInTimePeriod).toBe(10 * SECONDS_IN_DAY);
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          timelines,
+          UptimePrecision.NO_DECIMAL,
+          downtimeStatuses,
+        ),
+      ).toBe(90);
+    });
+
+    it("still returns a period of 1 second when every event is in the future", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-08-01T00:00:00.000Z", "2026-08-02T00:00:00.000Z"),
+      ];
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(timelines, downtimeStatuses),
+      ).toEqual({
+        totalDowntimeInSeconds: 0,
+        totalSecondsInTimePeriod: 1,
+      });
+    });
+
+    it("splits overlapping events by priority the same way as before", () => {
+      const timelines: Array<MonitorStatusTimeline> = [
+        operational("2026-07-10T00:00:00.000Z", "2026-07-16T00:00:00.000Z"),
+        offline(
+          "2026-07-12T00:00:00.000Z",
+          "2026-07-14T00:00:00.000Z",
+          OTHER_MONITOR_ID,
+        ),
+      ];
+
+      const events: Array<Event> =
+        UptimeUtil.getNonOverlappingMonitorEvents(timelines);
+
+      expect(
+        events.map((event: Event) => {
+          return event.label;
+        }),
+      ).toEqual(["Operational", "Offline", "Operational"]);
+
+      expect(
+        UptimeUtil.getTotalDowntimeInSeconds(timelines, downtimeStatuses)
+          .totalDowntimeInSeconds,
+      ).toBe(2 * SECONDS_IN_DAY);
+    });
+  });
+
+  describe("roundToPrecision", () => {
+    it("floors to the requested precision", () => {
+      expect(
+        UptimeUtil.roundToPrecision({
+          number: 99.9999,
+          precision: UptimePrecision.NO_DECIMAL,
+        }),
+      ).toBe(99);
+
+      expect(
+        UptimeUtil.roundToPrecision({
+          number: 99.9999,
+          precision: UptimePrecision.TWO_DECIMAL,
+        }),
+      ).toBe(99.99);
+    });
+  });
+});

--- a/Common/Tests/Utils/Uptime/UptimeUtil.test.ts
+++ b/Common/Tests/Utils/Uptime/UptimeUtil.test.ts
@@ -418,6 +418,7 @@ describe("UptimeUtil", () => {
       };
 
       const timelines: Array<MonitorStatusTimeline> = [
+        operational("2026-06-01T00:00:00.000Z", "2026-07-17T00:00:00.000Z"),
         offline("2026-07-17T00:00:00.000Z"),
       ];
 
@@ -431,7 +432,10 @@ describe("UptimeUtil", () => {
       // 17 July -> now (19 July) is 2 days. The open row must not run to the window end.
       expect(totalDowntimeInSeconds).toBe(2 * SECONDS_IN_DAY);
 
-      // and the denominator is clipped to now too, so it is 1 July -> 19 July.
+      /*
+       * the denominator is clipped to now too, so it is 1 July -> 19 July. (The operational
+       * row covers the window start, so the first-event clamp does not move it.)
+       */
       expect(totalSecondsInTimePeriod).toBe(18 * SECONDS_IN_DAY);
 
       expect(
@@ -442,6 +446,44 @@ describe("UptimeUtil", () => {
           window,
         ),
       ).toBe(88.88);
+    });
+
+    it("measures a monitor younger than the window from its first event, not the window start", () => {
+      /*
+       * A monitor created on 17 July that has been Offline its whole life, reported over a
+       * 31 day window. If the denominator were the whole window, the 16 days before the
+       * monitor existed would count as uptime and this would report ~88.9% for a monitor
+       * that has NEVER been up. The window start is clamped forward to the first event, so
+       * both the numerator and the denominator are "17 July -> now" and the answer is 0% -
+       * the same answer the windowless "first event -> now" denominator gives.
+       */
+      const window: UptimeWindow = {
+        startDate: new Date("2026-07-01T00:00:00.000Z"),
+        endDate: new Date("2026-08-01T00:00:00.000Z"),
+      };
+
+      const timelines: Array<MonitorStatusTimeline> = [
+        offline("2026-07-17T00:00:00.000Z"),
+      ];
+
+      const { totalDowntimeInSeconds, totalSecondsInTimePeriod } =
+        UptimeUtil.getTotalDowntimeInSeconds(
+          timelines,
+          downtimeStatuses,
+          window,
+        );
+
+      expect(totalDowntimeInSeconds).toBe(2 * SECONDS_IN_DAY);
+      expect(totalSecondsInTimePeriod).toBe(2 * SECONDS_IN_DAY);
+
+      expect(
+        UptimeUtil.calculateUptimePercentage(
+          timelines,
+          UptimePrecision.TWO_DECIMAL,
+          downtimeStatuses,
+          window,
+        ),
+      ).toBe(0);
     });
 
     it("closes an open row at the start of the next row for the same monitor", () => {

--- a/Common/Types/BaseDatabase/GreaterThan.ts
+++ b/Common/Types/BaseDatabase/GreaterThan.ts
@@ -11,7 +11,14 @@ export default class GreaterThan<T extends CompareType> extends CompareBase<T> {
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.GreaterThan,
-      value: (this as GreaterThan<T>).toString(),
+      /*
+       * The RAW value is serialized (like InBetween), not toString():
+       * toString() collapses a Date to a local-timezone date-only string
+       * (asDateForDatabaseQuery), shifting Date bounds sent from the browser
+       * by up to a day. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision.
+       */
+      value: (this as GreaterThan<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/GreaterThanOrEqual.ts
+++ b/Common/Types/BaseDatabase/GreaterThanOrEqual.ts
@@ -13,7 +13,14 @@ export default class GreaterThanOrEqual<
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.GreaterThanOrEqual,
-      value: (this as GreaterThanOrEqual<T>).toString(),
+      /*
+       * The RAW value is serialized (like InBetween), not toString():
+       * toString() collapses a Date to a local-timezone date-only string
+       * (asDateForDatabaseQuery), shifting Date bounds sent from the browser
+       * by up to a day. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision.
+       */
+      value: (this as GreaterThanOrEqual<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/GreaterThanOrNull.ts
+++ b/Common/Types/BaseDatabase/GreaterThanOrNull.ts
@@ -10,10 +10,18 @@ export default class GreaterThanOrNull<
     super(value);
   }
 
+  /*
+   * Serializes the RAW value (like InBetween does), not toString(): toString()
+   * collapses a Date to a date-only string in the LOCAL timezone
+   * (asDateForDatabaseQuery), so a Date bound would arrive at the server as
+   * midnight of the browser's calendar date and shift the query bound by up to
+   * a day. JSON.stringify turns a raw Date into its full ISO timestamp, which
+   * the server binds at full precision.
+   */
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.GreaterThanOrNull,
-      value: (this as GreaterThanOrNull<T>).toString(),
+      value: (this as GreaterThanOrNull<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/LessThan.ts
+++ b/Common/Types/BaseDatabase/LessThan.ts
@@ -11,7 +11,14 @@ export default class LessThan<T extends CompareType> extends CompareBase<T> {
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.LessThan,
-      value: (this as LessThan<T>).toString(),
+      /*
+       * The RAW value is serialized (like InBetween), not toString():
+       * toString() collapses a Date to a local-timezone date-only string
+       * (asDateForDatabaseQuery), shifting Date bounds sent from the browser
+       * by up to a day. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision.
+       */
+      value: (this as LessThan<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/LessThanOrEqual.ts
+++ b/Common/Types/BaseDatabase/LessThanOrEqual.ts
@@ -10,10 +10,18 @@ export default class LessThanOrEqual<
     super(value);
   }
 
+  /*
+   * Serializes the RAW value (like InBetween does), not toString(): toString()
+   * collapses a Date to a date-only string in the LOCAL timezone
+   * (asDateForDatabaseQuery), so a bound of "now" would arrive at the server as
+   * midnight of the browser's calendar date and silently exclude every row from
+   * today. JSON.stringify turns a raw Date into its full ISO timestamp, which
+   * the server binds at full precision.
+   */
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.LessThanOrEqual,
-      value: (this as LessThanOrEqual<T>).toString(),
+      value: (this as LessThanOrEqual<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/LessThanOrNull.ts
+++ b/Common/Types/BaseDatabase/LessThanOrNull.ts
@@ -13,7 +13,14 @@ export default class LessThanOrNull<
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.LessThanOrNull,
-      value: (this as LessThanOrNull<T>).toString(),
+      /*
+       * The RAW value is serialized (like InBetween), not toString():
+       * toString() collapses a Date to a local-timezone date-only string
+       * (asDateForDatabaseQuery), shifting Date bounds sent from the browser
+       * by up to a day. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision.
+       */
+      value: (this as LessThanOrNull<T>).value,
     };
   }
 

--- a/Common/Utils/StatusPage/ResourceUptime.ts
+++ b/Common/Utils/StatusPage/ResourceUptime.ts
@@ -6,7 +6,7 @@ import StatusPageResource from "../../Models/DatabaseModels/StatusPageResource";
 import Dictionary from "../../Types/Dictionary";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 import StatusPageGroup from "../../Models/DatabaseModels/StatusPageGroup";
-import UptimeUtil from "../Uptime/UptimeUtil";
+import UptimeUtil, { UptimeWindow } from "../Uptime/UptimeUtil";
 
 export default class StatusPageResourceUptimeUtil {
   public static getWorstMonitorStatus(data: {
@@ -137,6 +137,8 @@ export default class StatusPageResourceUptimeUtil {
     precision: UptimePrecision;
     downtimeMonitorStatuses: Array<MonitorStatus>;
     monitorsInGroup: Dictionary<Array<ObjectID>>;
+    // if supplied, uptime is measured over this window instead of "first event -> now".
+    uptimeWindow?: UptimeWindow | undefined;
   }): number | null {
     if (!data.statusPageResource.showUptimePercent) {
       return null;
@@ -156,6 +158,7 @@ export default class StatusPageResourceUptimeUtil {
       monitorStatusTimelines,
       data.precision,
       downtimeMonitorStatuses,
+      data.uptimeWindow,
     );
 
     return uptimePercent;
@@ -168,6 +171,8 @@ export default class StatusPageResourceUptimeUtil {
     downtimeMonitorStatuses: Array<MonitorStatus>;
     statusPageResources: Array<StatusPageResource>;
     monitorsInGroup: Dictionary<Array<ObjectID>>;
+    // if supplied, uptime is measured over this window instead of "first event -> now".
+    uptimeWindow?: UptimeWindow | undefined;
   }): number | null {
     if (!data.statusPageGroup.showUptimePercent) {
       return null;
@@ -193,6 +198,7 @@ export default class StatusPageResourceUptimeUtil {
           precision: data.precision,
           downtimeMonitorStatuses: data.downtimeMonitorStatuses,
           monitorsInGroup: data.monitorsInGroup,
+          uptimeWindow: data.uptimeWindow,
         });
 
       if (calculateUptimePercentOfResource !== null) {
@@ -252,6 +258,8 @@ export default class StatusPageResourceUptimeUtil {
     statusPageResources: Array<StatusPageResource>;
     resourceGroups: Array<StatusPageGroup>;
     monitorsInGroup: Dictionary<Array<ObjectID>>;
+    // if supplied, uptime is measured over this window instead of "first event -> now".
+    uptimeWindow?: UptimeWindow | undefined;
   }): number | null {
     const showUptimePercentage: boolean = Boolean(
       data.statusPageResources.find((item: StatusPageResource) => {
@@ -276,6 +284,7 @@ export default class StatusPageResourceUptimeUtil {
           downtimeMonitorStatuses: data.downtimeMonitorStatuses,
           statusPageResources: data.statusPageResources,
           monitorsInGroup: data.monitorsInGroup,
+          uptimeWindow: data.uptimeWindow,
         });
 
       if (calculateAvgUptimePercentOfStatusPageGroup !== null) {
@@ -298,6 +307,7 @@ export default class StatusPageResourceUptimeUtil {
           precision: data.precision,
           downtimeMonitorStatuses: data.downtimeMonitorStatuses,
           monitorsInGroup: data.monitorsInGroup,
+          uptimeWindow: data.uptimeWindow,
         });
 
       if (calculateUptimePercentOfResource !== null) {

--- a/Common/Utils/Uptime/UptimeUtil.ts
+++ b/Common/Utils/Uptime/UptimeUtil.ts
@@ -7,15 +7,28 @@ import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 
+/**
+ * The time period an uptime calculation is reported over. When this is supplied, events are
+ * clipped to it and the denominator of the uptime percentage is the window itself. Without it,
+ * events run to the start of the next event (or now) and the denominator is "first event -> now",
+ * which lets an open (endsAt = null) row from months ago leak into an unrelated report.
+ */
+export interface UptimeWindow {
+  startDate: Date;
+  endDate: Date;
+}
+
 export default class UptimeUtil {
   /**
    * This function, `getMonitorEventsForId`, takes a `monitorId` as an argument and returns an array of `MonitorEvent` objects.
    * @param {ObjectID} monitorId - The ID of the monitor for which events are to be fetched.
+   * @param {UptimeWindow | undefined} window - If supplied, events are clipped to this window and events outside it are dropped.
    * @returns {Array<MonitorEvent>} - An array of `MonitorEvent` objects.
    */
   public static getMonitorEventsForId(
     monitorId: ObjectID,
     statusTimelineItems: Array<MonitorStatusTimeline>,
+    window?: UptimeWindow | undefined,
   ): Array<MonitorEvent> {
     // Initialize an empty array to store the monitor events.
 
@@ -65,15 +78,54 @@ export default class UptimeUtil {
         // check if there's next event, if there is, set the end date to the start date of the next event.
         if (i < monitorEvents.length - 1) {
           endDate = monitorEvents[i + 1]!.startsAt;
-        } else {
+        }
+
+        // if this is the last event, or the next event has no start date, then this event is still open and runs until now.
+        if (!endDate) {
           endDate = OneUptimeDate.getCurrentDate();
+        }
+      }
+
+      let eventStartDate: Date = startDate;
+      let eventEndDate: Date = endDate;
+
+      if (window) {
+        /*
+         * Clip the event to the reporting window. Without this an open (endsAt = null) row that
+         * started months before the window contributes its entire life to the report.
+         *
+         * The end is also capped at "now", to match the denominator in
+         * getTotalDowntimeInSeconds, which measures the window only up to the
+         * current time (min(window.endDate, now)). If the numerator were allowed
+         * to run to a future window.endDate while the denominator stopped at now,
+         * a closed row ending in the future could make downtime exceed the elapsed
+         * period and drive the raw percentage negative.
+         */
+        eventStartDate = OneUptimeDate.getGreaterDate(
+          eventStartDate,
+          window.startDate,
+        );
+        eventEndDate = OneUptimeDate.getLesserDate(
+          eventEndDate,
+          OneUptimeDate.getLesserDate(
+            window.endDate,
+            OneUptimeDate.getCurrentDate(),
+          ),
+        );
+
+        // if the event does not overlap the window at all, then drop it.
+        if (
+          OneUptimeDate.getSecondsBetweenDates(eventStartDate, eventEndDate) <=
+          0
+        ) {
+          continue;
         }
       }
 
       // Push a new MonitorEvent object to the eventList array with properties from the current item and calculated dates.
       eventList.push({
-        startDate: startDate,
-        endDate: endDate!,
+        startDate: eventStartDate,
+        endDate: eventEndDate,
         label: monitorEvents[i]?.monitorStatus?.name || "Operational",
         priority: monitorEvents[i]?.monitorStatus?.priority || 0,
         color: monitorEvents[i]?.monitorStatus?.color || Green,
@@ -88,8 +140,12 @@ export default class UptimeUtil {
 
   public static getNonOverlappingMonitorEvents(
     items: Array<MonitorStatusTimeline>,
+    window?: UptimeWindow | undefined,
   ): Array<Event> {
-    const monitorEventList: Array<MonitorEvent> = this.getMonitorEvents(items);
+    const monitorEventList: Array<MonitorEvent> = this.getMonitorEvents(
+      items,
+      window,
+    );
 
     const eventList: Array<Event> = [];
 
@@ -97,20 +153,6 @@ export default class UptimeUtil {
       // if this event starts after the last event, then add it to the list directly.
 
       const monitorEvent: MonitorEvent = monitorEventList[i]!;
-
-      if (!monitorEvent.endDate) {
-        // if this is the last event then set endDate to current date.
-
-        // otherwise set it to start date of next event.
-
-        if (i === monitorEventList.length - 1) {
-          monitorEvent.endDate = OneUptimeDate.getCurrentDate();
-        } else {
-          monitorEvent.endDate =
-            monitorEventList[i + 1]!.startDate ||
-            OneUptimeDate.getCurrentDate();
-        }
-      }
 
       if (
         eventList.length === 0 ||
@@ -188,6 +230,7 @@ export default class UptimeUtil {
 
   public static getMonitorEvents(
     items: Array<MonitorStatusTimeline>,
+    window?: UptimeWindow | undefined,
   ): Array<MonitorEvent> {
     // get all distinct monitor ids.
     const monitorIds: Array<ObjectID> = [];
@@ -219,6 +262,7 @@ export default class UptimeUtil {
       const monitorEvents: Array<MonitorEvent> = this.getMonitorEventsForId(
         monitorId,
         items,
+        window,
       );
       eventList.push(...monitorEvents);
     }
@@ -242,12 +286,14 @@ export default class UptimeUtil {
   public static getTotalDowntimeInSeconds(
     monitorStatusTimelines: Array<MonitorStatusTimeline>,
     downtimeMonitorStatuses: Array<MonitorStatus>,
+    window?: UptimeWindow | undefined,
   ): {
     totalDowntimeInSeconds: number;
     totalSecondsInTimePeriod: number;
   } {
     const monitorEvents: Array<Event> = this.getNonOverlappingMonitorEvents(
       monitorStatusTimelines,
+      window,
     );
 
     // sort these by start date,
@@ -263,33 +309,59 @@ export default class UptimeUtil {
       return 0;
     });
 
+    /*
+     * If a window is supplied then the time period is the window itself, and not "first event -> now".
+     * The window end is clipped to now so a window that reaches into the future does not inflate the
+     * denominator (which is what made the reported percentage drift upwards every day).
+     */
+    let windowSecondsInTimePeriod: number | null = null;
+
+    if (window) {
+      windowSecondsInTimePeriod = OneUptimeDate.getSecondsBetweenDates(
+        window.startDate,
+        OneUptimeDate.getLesserDate(
+          window.endDate,
+          OneUptimeDate.getCurrentDate(),
+        ),
+      );
+
+      // never let the denominator be zero or negative.
+      if (!windowSecondsInTimePeriod || windowSecondsInTimePeriod < 0) {
+        windowSecondsInTimePeriod = 1;
+      }
+    }
+
     // calculate number of seconds between start of first event to date time now.
     let totalSecondsInTimePeriod: number = 0;
 
     if (monitorEvents.length === 0) {
       return {
         totalDowntimeInSeconds: 0,
-        totalSecondsInTimePeriod: 1,
+        totalSecondsInTimePeriod: windowSecondsInTimePeriod ?? 1,
       };
     }
 
-    if (
-      OneUptimeDate.isAfter(
-        monitorEvents[0]!.startDate,
-        OneUptimeDate.getCurrentDate(),
-      )
-    ) {
-      return {
-        totalDowntimeInSeconds: 0,
-        totalSecondsInTimePeriod: 1,
-      };
-    }
+    if (windowSecondsInTimePeriod !== null) {
+      totalSecondsInTimePeriod = windowSecondsInTimePeriod;
+    } else {
+      if (
+        OneUptimeDate.isAfter(
+          monitorEvents[0]!.startDate,
+          OneUptimeDate.getCurrentDate(),
+        )
+      ) {
+        return {
+          totalDowntimeInSeconds: 0,
+          totalSecondsInTimePeriod: 1,
+        };
+      }
 
-    totalSecondsInTimePeriod =
-      OneUptimeDate.getSecondsBetweenDates(
-        monitorEvents[0]!.startDate,
-        OneUptimeDate.getCurrentDate(),
-      ) || 1;
+      totalSecondsInTimePeriod =
+        OneUptimeDate.getSecondsBetweenDates(
+          monitorEvents[0]!.startDate,
+          OneUptimeDate.getCurrentDate(),
+        ) || 1;
+    }
 
     // get order of operational state.
 
@@ -347,6 +419,7 @@ export default class UptimeUtil {
     monitorStatusTimelines: Array<MonitorStatusTimeline>,
     precision: UptimePrecision,
     downtimeMonitorStatuses: Array<MonitorStatus>,
+    window?: UptimeWindow | undefined,
   ): number {
     // calculate percentage.
 
@@ -354,6 +427,7 @@ export default class UptimeUtil {
       this.getTotalDowntimeInSeconds(
         monitorStatusTimelines,
         downtimeMonitorStatuses,
+        window,
       );
 
     if (totalSecondsInTimePeriod === 0) {
@@ -369,8 +443,14 @@ export default class UptimeUtil {
         totalSecondsInTimePeriod) *
       100;
 
+    /*
+     * clamp before rounding. roundToPrecision floors, so an out of range value would otherwise
+     * escape as is (for example -13.5 stays -13.5 and never becomes 0).
+     */
+    const clampedPercentage: number = Math.min(100, Math.max(0, percentage));
+
     return this.roundToPrecision({
-      number: percentage,
+      number: clampedPercentage,
       precision,
     });
   }

--- a/Common/Utils/Uptime/UptimeUtil.ts
+++ b/Common/Utils/Uptime/UptimeUtil.ts
@@ -9,7 +9,9 @@ import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 
 /**
  * The time period an uptime calculation is reported over. When this is supplied, events are
- * clipped to it and the denominator of the uptime percentage is the window itself. Without it,
+ * clipped to it and the denominator of the uptime percentage is the window itself - clipped to
+ * now, and starting no earlier than the first recorded event (so a monitor younger than the
+ * window is measured from its first event, not diluted by time it did not exist). Without it,
  * events run to the start of the next event (or now) and the denominator is "first event -> now",
  * which lets an open (endsAt = null) row from months ago leak into an unrelated report.
  */
@@ -311,18 +313,42 @@ export default class UptimeUtil {
 
     /*
      * If a window is supplied then the time period is the window itself, and not "first event -> now".
-     * The window end is clipped to now so a window that reaches into the future does not inflate the
-     * denominator (which is what made the reported percentage drift upwards every day).
+     * Two clamps apply to the window:
+     *
+     *   - The window end is clipped to now, so a window that reaches into the future does not
+     *     inflate the denominator (which is what made the reported percentage drift upwards
+     *     every day).
+     *
+     *   - The window start is clamped forward to the first event's start, so time from before
+     *     the monitor's first recorded event does not count as uptime. Events are already
+     *     clipped to the window, so this only moves the start when the monitor has NO data for
+     *     the head of the window - i.e. it is younger than the window. Without this a monitor
+     *     created a day ago and Offline ever since would report ~98.9% uptime over a 90 day
+     *     window; with it, it reports 0% - the same answer the windowless
+     *     "first event -> now" denominator always gave.
+     *
+     * When there are no events at all there is nothing to clamp to and the denominator is the
+     * full (now-clipped) window.
      */
     let windowSecondsInTimePeriod: number | null = null;
 
     if (window) {
+      const windowEndDate: Date = OneUptimeDate.getLesserDate(
+        window.endDate,
+        OneUptimeDate.getCurrentDate(),
+      );
+
+      const windowStartDate: Date =
+        monitorEvents.length > 0
+          ? OneUptimeDate.getGreaterDate(
+              window.startDate,
+              monitorEvents[0]!.startDate,
+            )
+          : window.startDate;
+
       windowSecondsInTimePeriod = OneUptimeDate.getSecondsBetweenDates(
-        window.startDate,
-        OneUptimeDate.getLesserDate(
-          window.endDate,
-          OneUptimeDate.getCurrentDate(),
-        ),
+        windowStartDate,
+        windowEndDate,
       );
 
       // never let the denominator be zero or negative.


### PR DESCRIPTION
## Problem

A scheduled status-page uptime report emailed to a customer showed.

The monitor was never down. The customer correctly saw a wall of green in the UI and zero incidents in 90 days. The number was a reporting artifact.

## Root cause

Three compounding defects, all confirmed by reproducing the exact customer numbers:

1. **Bad data (origin).** During a flapping storm, a race in the status-timeline write path let two probe results resolve the same predecessor row and both INSERT an `Offline` row ~12 ms apart. Only the later one was ever closed; the earlier was orphaned with `endsAt = NULL` forever (every later writer resolves its predecessor with `ORDER BY startsAt DESC LIMIT 1` and permanently shadows it). The per-monitor mutex that should have prevented this was **fail-open** — its `catch` logged and continued unlocked.
2. **Query had no lower bound on open rows.** `getMonitorStatusTimelineForStatusPage` UNIONed a windowed query with an unbounded `endsAt IS NULL` query, so a months-old open row was pulled into the report.
3. **Uptime math never clipped to the window.** `UptimeUtil` didn't receive the window at all; the orphan's end became the *next* event's start (months later) and the denominator ran `first-event-start → now`, so the percentage also **drifted upward daily**.

Fleet-wide this affected ~67k orphaned rows across 410 monitors / 124 projects; ~11,470 phantom downtime-days landed on 41 status pages.

## The fix — in layers

### Read path (fixes every wrong number immediately, no data change)
- `UptimeUtil` gains an optional `[startDate, endDate]` window and **clips every event** to it; the denominator is the window (capped at `now`), which also removes the daily drift. Threaded through all 13 call sites.
- `getMonitorStatusTimelineForStatusPage` now uses **one true overlap predicate** — `startsAt <= end AND (endsAt IS NULL OR endsAt >= start)`. This also fixes a separate latent bug where an outage spanning the *entire* window rendered as a silent **100%**.

### Auto-repair (heals existing rows and anything that ever slips through)
- New **`MonitorStatusTimelineReconciler`** closes any "stale open row" (`endsAt IS NULL` that has a later row on the same monitor) at its true successor's `startsAt`. Ordered strictly by `startsAt` (never `createdAt` — they're different clocks with real skew), respects soft deletes, never touches the legitimate latest open row, batched and idempotent.
- The daily **`Monitor:KeepCurrentStateConsistent`** cron (previously an empty stub) now runs the reconciler, so orphans self-heal within a day.
- New **`CloseOrphanedMonitorStatusTimelineRows`** data migration closes the ~67k pre-existing orphans once, via the same reconciler code.

### Prevention (stops new orphans at the source)
- The per-monitor mutex is now **fail-closed** and owned by a `create()` override with `try/finally`, so it is released on every path. Previously it was acquired in `onBeforeCreate` and released in `onCreateSuccess`, leaking on any throw in between — and a leaked redis-semaphore mutex never expires.
- The predecessor row is closed with a **conditional update** guarded on (still open AND older), never a blind overwrite.

## Tests
- `UptimeUtil.test.ts` (new): the exact production scenario (reproduces 113d6h17m without a window, 100% with it), drift-invariance, full-span / partial-overlap / dropped-event / boundary cases, denominator never ≤ 0, uptime always within [0, 100].
- `MonitorStatusTimelineReconciler.test.ts` (new): closes at the true successor (not the newest row), `startsAt` ordering, soft-delete handling, latest-open-row preserved, idempotency.

`npm run fix` clean; `Common` and `App` both compile clean; 36 tests pass.

## Deliberately out of scope (follow-ups)
- **Partial unique index** `UNIQUE(monitorId) WHERE endsAt IS NULL`: attractive as a structural guarantee, but incompatible with the current insert-then-close write pattern (every normal transition transiently holds two open rows, so the index would reject it and freeze all transitions). It needs a write-path restructure first, so it is intentionally **not** in this PR.
- **Five sibling services** (`AlertStateTimeline`, `AlertEpisodeStateTimeline`, `IncidentStateTimeline`, `IncidentEpisodeStateTimeline`, `ScheduledMaintenanceStateTimeline`) share the same fail-open + leak-on-throw mutex pattern and should get the same `create()`-override treatment. Tracked separately to keep this PR reviewable.

## Deployment note
The data migration and the reconciler both do bounded, batched writes and are safe to run repeatedly. No `CREATE INDEX CONCURRENTLY` (which would break inside the migration transaction) is used.
