### PR TITLE
fix(concurrency): own the per-entity mutex in create() for 5 state-timeline services

### DIFF
--- a/Common/Server/Services/AlertEpisodeStateTimelineService.ts
+++ b/Common/Server/Services/AlertEpisodeStateTimelineService.ts
@@ -8,6 +8,7 @@ import UserService from "./UserService";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ServerException from "../../Types/Exception/ServerException";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import AlertState from "../../Models/DatabaseModels/AlertState";
@@ -21,11 +22,92 @@ import { AlertEpisodeFeedEventType } from "../../Models/DatabaseModels/AlertEpis
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import AlertEpisodeService from "./AlertEpisodeService";
 
+/*
+ * Thrown by create() when the per-entity mutex cannot be acquired. The write is
+ * refused rather than performed unlocked. Ingest/caller sites that already swallow
+ * the same-as-previous BadDataException match on this to log and skip.
+ */
+export const ALERT_EPISODE_STATE_TIMELINE_LOCK_ERROR_MESSAGE: string =
+  "Could not acquire the alert episode state timeline lock for this episode.";
+
 export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
   public constructor() {
     super(AlertEpisodeStateTimeline);
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("createdAt", 3 * 365); // 3 years
+    }
+  }
+
+  @CaptureSpan()
+  public override async create(
+    createBy: CreateBy<AlertEpisodeStateTimeline>,
+  ): Promise<AlertEpisodeStateTimeline> {
+    /*
+     * The per-entity mutex is owned here, around the whole create, rather than
+     * inside onBeforeCreate. DatabaseService.create() invokes onBeforeCreate and
+     * then runs validation, permission checks and the INSERT before it ever
+     * reaches onCreateSuccess, all OUTSIDE any try/catch this service can hook
+     * (onCreateError never fires for a throw raised before the INSERT). So a
+     * mutex acquired in onBeforeCreate and released in onCreateSuccess leaks on
+     * any throw in between, and a leaked redis-semaphore mutex never expires - it
+     * keeps refreshing its own Redis key for the life of the process. Holding it
+     * in a try/finally here releases it on every path.
+     */
+    if (createBy.props.ignoreHooks || !createBy.data.alertEpisodeId) {
+      // No predecessor bookkeeping runs on these paths, so no serialization is needed.
+      return await super.create(createBy);
+    }
+
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
+    } as LogAttributes;
+
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: createBy.data.alertEpisodeId.toString(),
+        namespace: "AlertEpisodeStateTimeline.create",
+      });
+    } catch (e) {
+      /*
+       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
+       * concurrent writers resolve the same predecessor and both INSERT a state
+       * row milliseconds apart; only the later one is ever closed, so the earlier
+       * is orphaned with endsAt = NULL forever and read back as unbounded
+       * downtime. Refusing the write is strictly safer: the next write for this
+       * entity re-evaluates and recreates the state change.
+       */
+      logger.error(e, logAttributes);
+      throw new ServerException(
+        ALERT_EPISODE_STATE_TIMELINE_LOCK_ERROR_MESSAGE,
+      );
+    }
+
+    try {
+      return await super.create(createBy);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  /*
+   * Releases the per-entity mutex. Never throws: a failed release must not mask an
+   * error we are already unwinding, nor fail an otherwise successful create.
+   */
+  private async releaseMutex(
+    mutex: SemaphoreMutex | null | undefined,
+    logAttributes: LogAttributes,
+  ): Promise<void> {
+    if (!mutex) {
+      return;
+    }
+
+    try {
+      await Semaphore.release(mutex);
+    } catch (err) {
+      logger.error(err, logAttributes);
     }
   }
 
@@ -37,174 +119,139 @@ export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
       throw new BadDataException("alertEpisodeId is null");
     }
 
-    let mutex: SemaphoreMutex | null = null;
-
-    try {
-      if (!createBy.data.startsAt) {
-        createBy.data.startsAt = OneUptimeDate.getCurrentDate();
-      }
-
-      try {
-        mutex = await Semaphore.lock({
-          key: createBy.data.alertEpisodeId.toString(),
-          namespace: "AlertEpisodeStateTimeline.create",
-        });
-      } catch (err) {
-        logger.error(err, {
-          projectId: createBy.data.projectId?.toString(),
-          alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
-        } as LogAttributes);
-      }
-
-      if (
-        (createBy.data.createdByUserId ||
-          createBy.data.createdByUser ||
-          createBy.props.userId) &&
-        !createBy.data.rootCause
-      ) {
-        let userId: ObjectID | undefined = createBy.data.createdByUserId;
-
-        if (createBy.props.userId) {
-          userId = createBy.props.userId;
-        }
-
-        if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
-          userId = createBy.data.createdByUser.id;
-        }
-
-        if (userId) {
-          createBy.data.rootCause = `Episode state created by ${await UserService.getUserMarkdownString(
-            {
-              userId: userId!,
-              projectId: createBy.data.projectId || createBy.props.tenantId!,
-            },
-          )}`;
-        }
-      }
-
-      const alertStateId: ObjectID | undefined | null =
-        createBy.data.alertStateId || createBy.data.alertState?.id;
-
-      if (!alertStateId) {
-        throw new BadDataException("alertStateId is null");
-      }
-
-      const stateBeforeThis: AlertEpisodeStateTimeline | null =
-        await this.findOneBy({
-          query: {
-            alertEpisodeId: createBy.data.alertEpisodeId,
-            startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Descending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            alertStateId: true,
-            alertState: {
-              order: true,
-              name: true,
-            },
-            startsAt: true,
-            endsAt: true,
-          },
-        });
-
-      logger.debug("State Before this", {
-        projectId: createBy.data.projectId?.toString(),
-        alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
-      } as LogAttributes);
-      logger.debug(stateBeforeThis, {
-        projectId: createBy.data.projectId?.toString(),
-        alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
-      } as LogAttributes);
-
-      // If this is the first state, then do not notify the owner.
-      if (!stateBeforeThis) {
-        // since this is the first status, do not notify the owner.
-        createBy.data.isOwnerNotified = true;
-      }
-
-      // Check if this new state and the previous state are same.
-      if (stateBeforeThis && stateBeforeThis.alertStateId && alertStateId) {
-        if (
-          stateBeforeThis.alertStateId.toString() === alertStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Episode state cannot be same as previous state.",
-          );
-        }
-      }
-
-      const stateAfterThis: AlertEpisodeStateTimeline | null =
-        await this.findOneBy({
-          query: {
-            alertEpisodeId: createBy.data.alertEpisodeId,
-            startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Ascending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            alertStateId: true,
-            startsAt: true,
-            endsAt: true,
-          },
-        });
-
-      // compute ends at. It's the start of the next status.
-      if (stateAfterThis && stateAfterThis.startsAt) {
-        createBy.data.endsAt = stateAfterThis.startsAt;
-      }
-
-      // Check if this new state and the next state are same.
-      if (stateAfterThis && stateAfterThis.alertStateId && alertStateId) {
-        if (
-          stateAfterThis.alertStateId.toString() === alertStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Episode state cannot be same as next state.",
-          );
-        }
-      }
-
-      logger.debug("State After this", {
-        projectId: createBy.data.projectId?.toString(),
-        alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
-      } as LogAttributes);
-      logger.debug(stateAfterThis, {
-        projectId: createBy.data.projectId?.toString(),
-        alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
-      } as LogAttributes);
-
-      return {
-        createBy,
-        carryForward: {
-          statusTimelineBeforeThisStatus: stateBeforeThis || null,
-          statusTimelineAfterThisStatus: stateAfterThis || null,
-          mutex: mutex,
-        },
-      };
-    } catch (error) {
-      // release the mutex if it was acquired.
-      if (mutex) {
-        try {
-          await Semaphore.release(mutex);
-        } catch (err) {
-          logger.error(err, {
-            projectId: createBy.data.projectId?.toString(),
-            alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
-          } as LogAttributes);
-        }
-      }
-
-      throw error;
+    if (!createBy.data.startsAt) {
+      createBy.data.startsAt = OneUptimeDate.getCurrentDate();
     }
+
+    if (
+      (createBy.data.createdByUserId ||
+        createBy.data.createdByUser ||
+        createBy.props.userId) &&
+      !createBy.data.rootCause
+    ) {
+      let userId: ObjectID | undefined = createBy.data.createdByUserId;
+
+      if (createBy.props.userId) {
+        userId = createBy.props.userId;
+      }
+
+      if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
+        userId = createBy.data.createdByUser.id;
+      }
+
+      if (userId) {
+        createBy.data.rootCause = `Episode state created by ${await UserService.getUserMarkdownString(
+          {
+            userId: userId!,
+            projectId: createBy.data.projectId || createBy.props.tenantId!,
+          },
+        )}`;
+      }
+    }
+
+    const alertStateId: ObjectID | undefined | null =
+      createBy.data.alertStateId || createBy.data.alertState?.id;
+
+    if (!alertStateId) {
+      throw new BadDataException("alertStateId is null");
+    }
+
+    const stateBeforeThis: AlertEpisodeStateTimeline | null =
+      await this.findOneBy({
+        query: {
+          alertEpisodeId: createBy.data.alertEpisodeId,
+          startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Descending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          alertStateId: true,
+          alertState: {
+            order: true,
+            name: true,
+          },
+          startsAt: true,
+          endsAt: true,
+        },
+      });
+
+    logger.debug("State Before this", {
+      projectId: createBy.data.projectId?.toString(),
+      alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
+    } as LogAttributes);
+    logger.debug(stateBeforeThis, {
+      projectId: createBy.data.projectId?.toString(),
+      alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
+    } as LogAttributes);
+
+    // If this is the first state, then do not notify the owner.
+    if (!stateBeforeThis) {
+      // since this is the first status, do not notify the owner.
+      createBy.data.isOwnerNotified = true;
+    }
+
+    // Check if this new state and the previous state are same.
+    if (stateBeforeThis && stateBeforeThis.alertStateId && alertStateId) {
+      if (stateBeforeThis.alertStateId.toString() === alertStateId.toString()) {
+        throw new BadDataException(
+          "Episode state cannot be same as previous state.",
+        );
+      }
+    }
+
+    const stateAfterThis: AlertEpisodeStateTimeline | null =
+      await this.findOneBy({
+        query: {
+          alertEpisodeId: createBy.data.alertEpisodeId,
+          startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Ascending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          alertStateId: true,
+          startsAt: true,
+          endsAt: true,
+        },
+      });
+
+    // compute ends at. It's the start of the next status.
+    if (stateAfterThis && stateAfterThis.startsAt) {
+      createBy.data.endsAt = stateAfterThis.startsAt;
+    }
+
+    // Check if this new state and the next state are same.
+    if (stateAfterThis && stateAfterThis.alertStateId && alertStateId) {
+      if (stateAfterThis.alertStateId.toString() === alertStateId.toString()) {
+        throw new BadDataException(
+          "Episode state cannot be same as next state.",
+        );
+      }
+    }
+
+    logger.debug("State After this", {
+      projectId: createBy.data.projectId?.toString(),
+      alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
+    } as LogAttributes);
+    logger.debug(stateAfterThis, {
+      projectId: createBy.data.projectId?.toString(),
+      alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
+    } as LogAttributes);
+
+    return {
+      createBy,
+      carryForward: {
+        statusTimelineBeforeThisStatus: stateBeforeThis || null,
+        statusTimelineAfterThisStatus: stateAfterThis || null,
+      },
+    };
   }
 
   @CaptureSpan()
@@ -215,8 +262,6 @@ export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
     if (!createdItem.alertEpisodeId) {
       throw new BadDataException("alertEpisodeId is null");
     }
-
-    const mutex: SemaphoreMutex | null = onCreate.carryForward.mutex;
 
     if (!createdItem.alertStateId) {
       throw new BadDataException("alertStateId is null");
@@ -356,17 +401,6 @@ export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
             } as LogAttributes,
           );
         }
-      }
-    }
-
-    if (mutex) {
-      try {
-        await Semaphore.release(mutex);
-      } catch (err) {
-        logger.error(err, {
-          projectId: createdItem.projectId?.toString(),
-          alertEpisodeId: createdItem.alertEpisodeId?.toString(),
-        } as LogAttributes);
       }
     }
 

--- a/Common/Server/Services/AlertStateTimelineService.ts
+++ b/Common/Server/Services/AlertStateTimelineService.ts
@@ -25,12 +25,92 @@ import { AlertFeedEventType } from "../../Models/DatabaseModels/AlertFeed";
 import WorkspaceNotificationRuleService from "./WorkspaceNotificationRuleService";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
+import ServerException from "../../Types/Exception/ServerException";
+
+/*
+ * Thrown by create() when the per-entity mutex cannot be acquired. The write is
+ * refused rather than performed unlocked. Ingest/caller sites that already swallow
+ * the same-as-previous BadDataException match on this to log and skip.
+ */
+export const ALERT_STATE_TIMELINE_LOCK_ERROR_MESSAGE: string =
+  "Could not acquire the alert state timeline lock for this alert.";
 
 export class Service extends DatabaseService<AlertStateTimeline> {
   public constructor() {
     super(AlertStateTimeline);
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("createdAt", 3 * 365); // 3 years
+    }
+  }
+
+  @CaptureSpan()
+  public override async create(
+    createBy: CreateBy<AlertStateTimeline>,
+  ): Promise<AlertStateTimeline> {
+    /*
+     * The per-entity mutex is owned here, around the whole create, rather than
+     * inside onBeforeCreate. DatabaseService.create() invokes onBeforeCreate and
+     * then runs validation, permission checks and the INSERT before it ever
+     * reaches onCreateSuccess, all OUTSIDE any try/catch this service can hook
+     * (onCreateError never fires for a throw raised before the INSERT). So a
+     * mutex acquired in onBeforeCreate and released in onCreateSuccess leaks on
+     * any throw in between, and a leaked redis-semaphore mutex never expires - it
+     * keeps refreshing its own Redis key for the life of the process. Holding it
+     * in a try/finally here releases it on every path.
+     */
+    if (createBy.props.ignoreHooks || !createBy.data.alertId) {
+      // No predecessor bookkeeping runs on these paths, so no serialization is needed.
+      return await super.create(createBy);
+    }
+
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      alertId: createBy.data.alertId?.toString(),
+    } as LogAttributes;
+
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: createBy.data.alertId.toString(),
+        namespace: "AlertStateTimeline.create",
+      });
+    } catch (e) {
+      /*
+       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
+       * concurrent writers resolve the same predecessor and both INSERT a state
+       * row milliseconds apart; only the later one is ever closed, so the earlier
+       * is orphaned with endsAt = NULL forever and read back as unbounded
+       * downtime. Refusing the write is strictly safer: the next write for this
+       * entity re-evaluates and recreates the state change.
+       */
+      logger.error(e, logAttributes);
+      throw new ServerException(ALERT_STATE_TIMELINE_LOCK_ERROR_MESSAGE);
+    }
+
+    try {
+      return await super.create(createBy);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  /*
+   * Releases the per-entity mutex. Never throws: a failed release must not mask an
+   * error we are already unwinding, nor fail an otherwise successful create.
+   */
+  private async releaseMutex(
+    mutex: SemaphoreMutex | null | undefined,
+    logAttributes: LogAttributes,
+  ): Promise<void> {
+    if (!mutex) {
+      return;
+    }
+
+    try {
+      await Semaphore.release(mutex);
+    } catch (err) {
+      logger.error(err, logAttributes);
     }
   }
 
@@ -66,220 +146,183 @@ export class Service extends DatabaseService<AlertStateTimeline> {
       throw new BadDataException("alertId is null");
     }
 
-    let mutex: SemaphoreMutex | null = null;
+    if (!createBy.data.startsAt) {
+      createBy.data.startsAt = OneUptimeDate.getCurrentDate();
+    }
 
-    try {
-      if (!createBy.data.startsAt) {
-        createBy.data.startsAt = OneUptimeDate.getCurrentDate();
+    if (
+      (createBy.data.createdByUserId ||
+        createBy.data.createdByUser ||
+        createBy.props.userId) &&
+      !createBy.data.rootCause
+    ) {
+      let userId: ObjectID | undefined = createBy.data.createdByUserId;
+
+      if (createBy.props.userId) {
+        userId = createBy.props.userId;
       }
 
-      try {
-        mutex = await Semaphore.lock({
-          key: createBy.data.alertId.toString(),
-          namespace: "AlertStateTimeline.create",
-        });
-      } catch (err) {
-        logger.error(err, {
-          projectId: createBy.data.projectId?.toString(),
-          alertId: createBy.data.alertId?.toString(),
-        } as LogAttributes);
+      if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
+        userId = createBy.data.createdByUser.id;
       }
 
-      if (
-        (createBy.data.createdByUserId ||
-          createBy.data.createdByUser ||
-          createBy.props.userId) &&
-        !createBy.data.rootCause
-      ) {
-        let userId: ObjectID | undefined = createBy.data.createdByUserId;
-
-        if (createBy.props.userId) {
-          userId = createBy.props.userId;
-        }
-
-        if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
-          userId = createBy.data.createdByUser.id;
-        }
-
-        if (userId) {
-          createBy.data.rootCause = `Alert state created by ${await UserService.getUserMarkdownString(
-            {
-              userId: userId!,
-              projectId: createBy.data.projectId || createBy.props.tenantId!,
-            },
-          )}`;
-        }
+      if (userId) {
+        createBy.data.rootCause = `Alert state created by ${await UserService.getUserMarkdownString(
+          {
+            userId: userId!,
+            projectId: createBy.data.projectId || createBy.props.tenantId!,
+          },
+        )}`;
       }
+    }
 
-      const alertStateId: ObjectID | undefined | null =
-        createBy.data.alertStateId || createBy.data.alertState?.id;
+    const alertStateId: ObjectID | undefined | null =
+      createBy.data.alertStateId || createBy.data.alertState?.id;
 
-      if (!alertStateId) {
-        throw new BadDataException("alertStateId is null");
-      }
+    if (!alertStateId) {
+      throw new BadDataException("alertStateId is null");
+    }
 
-      const stateBeforeThis: AlertStateTimeline | null = await this.findOneBy({
-        query: {
-          alertId: createBy.data.alertId,
-          startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
+    const stateBeforeThis: AlertStateTimeline | null = await this.findOneBy({
+      query: {
+        alertId: createBy.data.alertId,
+        startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
+      },
+      sort: {
+        startsAt: SortOrder.Descending,
+      },
+      props: {
+        isRoot: true,
+      },
+      select: {
+        alertStateId: true,
+        alertState: {
+          order: true,
+          name: true,
         },
-        sort: {
-          startsAt: SortOrder.Descending,
-        },
-        props: {
-          isRoot: true,
-        },
-        select: {
-          alertStateId: true,
-          alertState: {
+        startsAt: true,
+        endsAt: true,
+      },
+    });
+
+    logger.debug("State Before this");
+    logger.debug(stateBeforeThis);
+
+    // If this is the first state, then do not notify the owner.
+    if (!stateBeforeThis) {
+      // since this is the first status, do not notify the owner.
+      createBy.data.isOwnerNotified = true;
+    }
+
+    /*
+     * check if this new state and the previous state are same.
+     * if yes, then throw bad data exception.
+     */
+
+    if (stateBeforeThis && stateBeforeThis.alertStateId && alertStateId) {
+      if (stateBeforeThis.alertStateId.toString() === alertStateId.toString()) {
+        throw new BadDataException(
+          "Alert state cannot be same as previous state.",
+        );
+      }
+    }
+
+    if (stateBeforeThis && stateBeforeThis.alertState?.order) {
+      const newAlertState: AlertState | null =
+        await AlertStateService.findOneBy({
+          query: {
+            _id: alertStateId,
+          },
+          select: {
             order: true,
             name: true,
           },
-          startsAt: true,
-          endsAt: true,
-        },
-      });
-
-      logger.debug("State Before this");
-      logger.debug(stateBeforeThis);
-
-      // If this is the first state, then do not notify the owner.
-      if (!stateBeforeThis) {
-        // since this is the first status, do not notify the owner.
-        createBy.data.isOwnerNotified = true;
-      }
-
-      /*
-       * check if this new state and the previous state are same.
-       * if yes, then throw bad data exception.
-       */
-
-      if (stateBeforeThis && stateBeforeThis.alertStateId && alertStateId) {
-        if (
-          stateBeforeThis.alertStateId.toString() === alertStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Alert state cannot be same as previous state.",
-          );
-        }
-      }
-
-      if (stateBeforeThis && stateBeforeThis.alertState?.order) {
-        const newAlertState: AlertState | null =
-          await AlertStateService.findOneBy({
-            query: {
-              _id: alertStateId,
-            },
-            select: {
-              order: true,
-              name: true,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
-
-        if (newAlertState && newAlertState.order) {
-          // check if the new alert state is in order is greater than the previous state order
-          if (
-            stateBeforeThis &&
-            stateBeforeThis.alertState &&
-            stateBeforeThis.alertState.order &&
-            newAlertState.order <= stateBeforeThis.alertState.order
-          ) {
-            throw new BadDataException(
-              `Alert cannot transition to ${newAlertState.name} state from ${stateBeforeThis.alertState.name} state because ${newAlertState.name} is before ${stateBeforeThis.alertState.name} in the order of alert states.`,
-            );
-          }
-        }
-      }
-
-      const stateAfterThis: AlertStateTimeline | null = await this.findOneBy({
-        query: {
-          alertId: createBy.data.alertId,
-          startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
-        },
-        sort: {
-          startsAt: SortOrder.Ascending,
-        },
-        props: {
-          isRoot: true,
-        },
-        select: {
-          alertStateId: true,
-          startsAt: true,
-          endsAt: true,
-        },
-      });
-
-      // compute ends at. It's the start of the next status.
-      if (stateAfterThis && stateAfterThis.startsAt) {
-        createBy.data.endsAt = stateAfterThis.startsAt;
-      }
-
-      /*
-       * check if this new state and the previous state are same.
-       * if yes, then throw bad data exception.
-       */
-
-      if (stateAfterThis && stateAfterThis.alertStateId && alertStateId) {
-        if (
-          stateAfterThis.alertStateId.toString() === alertStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Alert state cannot be same as next state.",
-          );
-        }
-      }
-
-      logger.debug("State After this");
-      logger.debug(stateAfterThis);
-
-      const internalNote: string | undefined = (
-        createBy.miscDataProps as JSONObject | undefined
-      )?.["internalNote"] as string | undefined;
-
-      if (internalNote) {
-        const alertNote: AlertInternalNote = new AlertInternalNote();
-        alertNote.alertId = createBy.data.alertId;
-        alertNote.note = internalNote;
-        alertNote.createdAt = createBy.data.startsAt;
-        alertNote.projectId = createBy.data.projectId!;
-
-        await AlertInternalNoteService.create({
-          data: alertNote,
-          props: createBy.props,
+          props: {
+            isRoot: true,
+          },
         });
-      }
 
-      const privateNote: string | undefined = (
-        createBy.miscDataProps as JSONObject | undefined
-      )?.["privateNote"] as string | undefined;
-
-      return {
-        createBy,
-        carryForward: {
-          statusTimelineBeforeThisStatus: stateBeforeThis || null,
-          statusTimelineAfterThisStatus: stateAfterThis || null,
-          privateNote: privateNote,
-          mutex: mutex,
-        },
-      };
-    } catch (error) {
-      // release the mutex if it was acquired.
-      if (mutex) {
-        try {
-          await Semaphore.release(mutex);
-        } catch (err) {
-          logger.error(err, {
-            projectId: createBy.data.projectId?.toString(),
-            alertId: createBy.data.alertId?.toString(),
-          } as LogAttributes);
+      if (newAlertState && newAlertState.order) {
+        // check if the new alert state is in order is greater than the previous state order
+        if (
+          stateBeforeThis &&
+          stateBeforeThis.alertState &&
+          stateBeforeThis.alertState.order &&
+          newAlertState.order <= stateBeforeThis.alertState.order
+        ) {
+          throw new BadDataException(
+            `Alert cannot transition to ${newAlertState.name} state from ${stateBeforeThis.alertState.name} state because ${newAlertState.name} is before ${stateBeforeThis.alertState.name} in the order of alert states.`,
+          );
         }
       }
-
-      throw error;
     }
+
+    const stateAfterThis: AlertStateTimeline | null = await this.findOneBy({
+      query: {
+        alertId: createBy.data.alertId,
+        startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
+      },
+      sort: {
+        startsAt: SortOrder.Ascending,
+      },
+      props: {
+        isRoot: true,
+      },
+      select: {
+        alertStateId: true,
+        startsAt: true,
+        endsAt: true,
+      },
+    });
+
+    // compute ends at. It's the start of the next status.
+    if (stateAfterThis && stateAfterThis.startsAt) {
+      createBy.data.endsAt = stateAfterThis.startsAt;
+    }
+
+    /*
+     * check if this new state and the previous state are same.
+     * if yes, then throw bad data exception.
+     */
+
+    if (stateAfterThis && stateAfterThis.alertStateId && alertStateId) {
+      if (stateAfterThis.alertStateId.toString() === alertStateId.toString()) {
+        throw new BadDataException("Alert state cannot be same as next state.");
+      }
+    }
+
+    logger.debug("State After this");
+    logger.debug(stateAfterThis);
+
+    const internalNote: string | undefined = (
+      createBy.miscDataProps as JSONObject | undefined
+    )?.["internalNote"] as string | undefined;
+
+    if (internalNote) {
+      const alertNote: AlertInternalNote = new AlertInternalNote();
+      alertNote.alertId = createBy.data.alertId;
+      alertNote.note = internalNote;
+      alertNote.createdAt = createBy.data.startsAt;
+      alertNote.projectId = createBy.data.projectId!;
+
+      await AlertInternalNoteService.create({
+        data: alertNote,
+        props: createBy.props,
+      });
+    }
+
+    const privateNote: string | undefined = (
+      createBy.miscDataProps as JSONObject | undefined
+    )?.["privateNote"] as string | undefined;
+
+    return {
+      createBy,
+      carryForward: {
+        statusTimelineBeforeThisStatus: stateBeforeThis || null,
+        statusTimelineAfterThisStatus: stateAfterThis || null,
+        privateNote: privateNote,
+      },
+    };
   }
 
   @CaptureSpan()
@@ -290,8 +333,6 @@ export class Service extends DatabaseService<AlertStateTimeline> {
     if (!createdItem.alertId) {
       throw new BadDataException("alertId is null");
     }
-
-    const mutex: SemaphoreMutex | null = onCreate.carryForward.mutex;
 
     if (!createdItem.alertStateId) {
       throw new BadDataException("alertStateId is null");
@@ -366,17 +407,6 @@ export class Service extends DatabaseService<AlertStateTimeline> {
         },
         props: onCreate.createBy.props,
       });
-    }
-
-    if (mutex) {
-      try {
-        await Semaphore.release(mutex);
-      } catch (err) {
-        logger.error(err, {
-          projectId: createdItem.projectId?.toString(),
-          alertId: createdItem.alertId?.toString(),
-        } as LogAttributes);
-      }
     }
 
     const alertState: AlertState | null = await AlertStateService.findOneBy({

--- a/Common/Server/Services/IncidentEpisodeStateTimelineService.ts
+++ b/Common/Server/Services/IncidentEpisodeStateTimelineService.ts
@@ -8,6 +8,7 @@ import UserService from "./UserService";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ServerException from "../../Types/Exception/ServerException";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import IncidentState from "../../Models/DatabaseModels/IncidentState";
@@ -21,11 +22,92 @@ import { IncidentEpisodeFeedEventType } from "../../Models/DatabaseModels/Incide
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import IncidentEpisodeService from "./IncidentEpisodeService";
 
+/*
+ * Thrown by create() when the per-entity mutex cannot be acquired. The write is
+ * refused rather than performed unlocked. Ingest/caller sites that already swallow
+ * the same-as-previous BadDataException match on this to log and skip.
+ */
+export const INCIDENT_EPISODE_STATE_TIMELINE_LOCK_ERROR_MESSAGE: string =
+  "Could not acquire the incident episode state timeline lock for this episode.";
+
 export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
   public constructor() {
     super(IncidentEpisodeStateTimeline);
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("createdAt", 3 * 365); // 3 years
+    }
+  }
+
+  @CaptureSpan()
+  public override async create(
+    createBy: CreateBy<IncidentEpisodeStateTimeline>,
+  ): Promise<IncidentEpisodeStateTimeline> {
+    /*
+     * The per-entity mutex is owned here, around the whole create, rather than
+     * inside onBeforeCreate. DatabaseService.create() invokes onBeforeCreate and
+     * then runs validation, permission checks and the INSERT before it ever
+     * reaches onCreateSuccess, all OUTSIDE any try/catch this service can hook
+     * (onCreateError never fires for a throw raised before the INSERT). So a
+     * mutex acquired in onBeforeCreate and released in onCreateSuccess leaks on
+     * any throw in between, and a leaked redis-semaphore mutex never expires - it
+     * keeps refreshing its own Redis key for the life of the process. Holding it
+     * in a try/finally here releases it on every path.
+     */
+    if (createBy.props.ignoreHooks || !createBy.data.incidentEpisodeId) {
+      // No predecessor bookkeeping runs on these paths, so no serialization is needed.
+      return await super.create(createBy);
+    }
+
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
+    } as LogAttributes;
+
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: createBy.data.incidentEpisodeId.toString(),
+        namespace: "IncidentEpisodeStateTimeline.create",
+      });
+    } catch (e) {
+      /*
+       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
+       * concurrent writers resolve the same predecessor and both INSERT a state
+       * row milliseconds apart; only the later one is ever closed, so the earlier
+       * is orphaned with endsAt = NULL forever and read back as unbounded
+       * downtime. Refusing the write is strictly safer: the next write for this
+       * entity re-evaluates and recreates the state change.
+       */
+      logger.error(e, logAttributes);
+      throw new ServerException(
+        INCIDENT_EPISODE_STATE_TIMELINE_LOCK_ERROR_MESSAGE,
+      );
+    }
+
+    try {
+      return await super.create(createBy);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  /*
+   * Releases the per-entity mutex. Never throws: a failed release must not mask an
+   * error we are already unwinding, nor fail an otherwise successful create.
+   */
+  private async releaseMutex(
+    mutex: SemaphoreMutex | null | undefined,
+    logAttributes: LogAttributes,
+  ): Promise<void> {
+    if (!mutex) {
+      return;
+    }
+
+    try {
+      await Semaphore.release(mutex);
+    } catch (err) {
+      logger.error(err, logAttributes);
     }
   }
 
@@ -37,180 +119,144 @@ export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
       throw new BadDataException("incidentEpisodeId is null");
     }
 
-    let mutex: SemaphoreMutex | null = null;
-
-    try {
-      if (!createBy.data.startsAt) {
-        createBy.data.startsAt = OneUptimeDate.getCurrentDate();
-      }
-
-      try {
-        mutex = await Semaphore.lock({
-          key: createBy.data.incidentEpisodeId.toString(),
-          namespace: "IncidentEpisodeStateTimeline.create",
-        });
-      } catch (err) {
-        logger.error(err, {
-          projectId: createBy.data.projectId?.toString(),
-          incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
-        } as LogAttributes);
-      }
-
-      if (
-        (createBy.data.createdByUserId ||
-          createBy.data.createdByUser ||
-          createBy.props.userId) &&
-        !createBy.data.rootCause
-      ) {
-        let userId: ObjectID | undefined = createBy.data.createdByUserId;
-
-        if (createBy.props.userId) {
-          userId = createBy.props.userId;
-        }
-
-        if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
-          userId = createBy.data.createdByUser.id;
-        }
-
-        if (userId) {
-          createBy.data.rootCause = `Episode state created by ${await UserService.getUserMarkdownString(
-            {
-              userId: userId!,
-              projectId: createBy.data.projectId || createBy.props.tenantId!,
-            },
-          )}`;
-        }
-      }
-
-      const incidentStateId: ObjectID | undefined | null =
-        createBy.data.incidentStateId || createBy.data.incidentState?.id;
-
-      if (!incidentStateId) {
-        throw new BadDataException("incidentStateId is null");
-      }
-
-      const stateBeforeThis: IncidentEpisodeStateTimeline | null =
-        await this.findOneBy({
-          query: {
-            incidentEpisodeId: createBy.data.incidentEpisodeId,
-            startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Descending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            incidentStateId: true,
-            incidentState: {
-              order: true,
-              name: true,
-            },
-            startsAt: true,
-            endsAt: true,
-          },
-        });
-
-      logger.debug("State Before this", {
-        projectId: createBy.data.projectId?.toString(),
-        incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
-      } as LogAttributes);
-      logger.debug(stateBeforeThis, {
-        projectId: createBy.data.projectId?.toString(),
-        incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
-      } as LogAttributes);
-
-      // If this is the first state, then do not notify the owner.
-      if (!stateBeforeThis) {
-        // since this is the first status, do not notify the owner.
-        createBy.data.isOwnerNotified = true;
-      }
-
-      // Check if this new state and the previous state are same.
-      if (
-        stateBeforeThis &&
-        stateBeforeThis.incidentStateId &&
-        incidentStateId
-      ) {
-        if (
-          stateBeforeThis.incidentStateId.toString() ===
-          incidentStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Episode state cannot be same as previous state.",
-          );
-        }
-      }
-
-      const stateAfterThis: IncidentEpisodeStateTimeline | null =
-        await this.findOneBy({
-          query: {
-            incidentEpisodeId: createBy.data.incidentEpisodeId,
-            startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Ascending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            incidentStateId: true,
-            startsAt: true,
-            endsAt: true,
-          },
-        });
-
-      // compute ends at. It's the start of the next status.
-      if (stateAfterThis && stateAfterThis.startsAt) {
-        createBy.data.endsAt = stateAfterThis.startsAt;
-      }
-
-      // Check if this new state and the next state are same.
-      if (stateAfterThis && stateAfterThis.incidentStateId && incidentStateId) {
-        if (
-          stateAfterThis.incidentStateId.toString() ===
-          incidentStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Episode state cannot be same as next state.",
-          );
-        }
-      }
-
-      logger.debug("State After this", {
-        projectId: createBy.data.projectId?.toString(),
-        incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
-      } as LogAttributes);
-      logger.debug(stateAfterThis, {
-        projectId: createBy.data.projectId?.toString(),
-        incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
-      } as LogAttributes);
-
-      return {
-        createBy,
-        carryForward: {
-          statusTimelineBeforeThisStatus: stateBeforeThis || null,
-          statusTimelineAfterThisStatus: stateAfterThis || null,
-          mutex: mutex,
-        },
-      };
-    } catch (error) {
-      // release the mutex if it was acquired.
-      if (mutex) {
-        try {
-          await Semaphore.release(mutex);
-        } catch (err) {
-          logger.error(err, {
-            projectId: createBy.data.projectId?.toString(),
-            incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
-          } as LogAttributes);
-        }
-      }
-
-      throw error;
+    if (!createBy.data.startsAt) {
+      createBy.data.startsAt = OneUptimeDate.getCurrentDate();
     }
+
+    if (
+      (createBy.data.createdByUserId ||
+        createBy.data.createdByUser ||
+        createBy.props.userId) &&
+      !createBy.data.rootCause
+    ) {
+      let userId: ObjectID | undefined = createBy.data.createdByUserId;
+
+      if (createBy.props.userId) {
+        userId = createBy.props.userId;
+      }
+
+      if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
+        userId = createBy.data.createdByUser.id;
+      }
+
+      if (userId) {
+        createBy.data.rootCause = `Episode state created by ${await UserService.getUserMarkdownString(
+          {
+            userId: userId!,
+            projectId: createBy.data.projectId || createBy.props.tenantId!,
+          },
+        )}`;
+      }
+    }
+
+    const incidentStateId: ObjectID | undefined | null =
+      createBy.data.incidentStateId || createBy.data.incidentState?.id;
+
+    if (!incidentStateId) {
+      throw new BadDataException("incidentStateId is null");
+    }
+
+    const stateBeforeThis: IncidentEpisodeStateTimeline | null =
+      await this.findOneBy({
+        query: {
+          incidentEpisodeId: createBy.data.incidentEpisodeId,
+          startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Descending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          incidentStateId: true,
+          incidentState: {
+            order: true,
+            name: true,
+          },
+          startsAt: true,
+          endsAt: true,
+        },
+      });
+
+    logger.debug("State Before this", {
+      projectId: createBy.data.projectId?.toString(),
+      incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
+    } as LogAttributes);
+    logger.debug(stateBeforeThis, {
+      projectId: createBy.data.projectId?.toString(),
+      incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
+    } as LogAttributes);
+
+    // If this is the first state, then do not notify the owner.
+    if (!stateBeforeThis) {
+      // since this is the first status, do not notify the owner.
+      createBy.data.isOwnerNotified = true;
+    }
+
+    // Check if this new state and the previous state are same.
+    if (stateBeforeThis && stateBeforeThis.incidentStateId && incidentStateId) {
+      if (
+        stateBeforeThis.incidentStateId.toString() ===
+        incidentStateId.toString()
+      ) {
+        throw new BadDataException(
+          "Episode state cannot be same as previous state.",
+        );
+      }
+    }
+
+    const stateAfterThis: IncidentEpisodeStateTimeline | null =
+      await this.findOneBy({
+        query: {
+          incidentEpisodeId: createBy.data.incidentEpisodeId,
+          startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Ascending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          incidentStateId: true,
+          startsAt: true,
+          endsAt: true,
+        },
+      });
+
+    // compute ends at. It's the start of the next status.
+    if (stateAfterThis && stateAfterThis.startsAt) {
+      createBy.data.endsAt = stateAfterThis.startsAt;
+    }
+
+    // Check if this new state and the next state are same.
+    if (stateAfterThis && stateAfterThis.incidentStateId && incidentStateId) {
+      if (
+        stateAfterThis.incidentStateId.toString() === incidentStateId.toString()
+      ) {
+        throw new BadDataException(
+          "Episode state cannot be same as next state.",
+        );
+      }
+    }
+
+    logger.debug("State After this", {
+      projectId: createBy.data.projectId?.toString(),
+      incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
+    } as LogAttributes);
+    logger.debug(stateAfterThis, {
+      projectId: createBy.data.projectId?.toString(),
+      incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
+    } as LogAttributes);
+
+    return {
+      createBy,
+      carryForward: {
+        statusTimelineBeforeThisStatus: stateBeforeThis || null,
+        statusTimelineAfterThisStatus: stateAfterThis || null,
+      },
+    };
   }
 
   @CaptureSpan()
@@ -221,8 +267,6 @@ export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
     if (!createdItem.incidentEpisodeId) {
       throw new BadDataException("incidentEpisodeId is null");
     }
-
-    const mutex: SemaphoreMutex | null = onCreate.carryForward.mutex;
 
     if (!createdItem.incidentStateId) {
       throw new BadDataException("incidentStateId is null");
@@ -362,17 +406,6 @@ export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
             } as LogAttributes,
           );
         }
-      }
-    }
-
-    if (mutex) {
-      try {
-        await Semaphore.release(mutex);
-      } catch (err) {
-        logger.error(err, {
-          projectId: createdItem.projectId?.toString(),
-          incidentEpisodeId: createdItem.incidentEpisodeId?.toString(),
-        } as LogAttributes);
       }
     }
 

--- a/Common/Server/Services/IncidentStateTimelineService.ts
+++ b/Common/Server/Services/IncidentStateTimelineService.ts
@@ -14,6 +14,7 @@ import IncidentRoleService from "./IncidentRoleService";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ServerException from "../../Types/Exception/ServerException";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
@@ -35,11 +36,71 @@ import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import WorkspaceNotificationRuleService from "./WorkspaceNotificationRuleService";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 
+/*
+ * Thrown by create() when the per-entity mutex cannot be acquired. The write is
+ * refused rather than performed unlocked. Ingest/caller sites that already swallow
+ * the same-as-previous BadDataException match on this to log and skip.
+ */
+export const INCIDENT_STATE_TIMELINE_LOCK_ERROR_MESSAGE: string =
+  "Could not acquire the incident state timeline lock for this incident.";
+
 export class Service extends DatabaseService<IncidentStateTimeline> {
   public constructor() {
     super(IncidentStateTimeline);
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("startsAt", 3 * 365); // 3 years
+    }
+  }
+
+  @CaptureSpan()
+  public override async create(
+    createBy: CreateBy<IncidentStateTimeline>,
+  ): Promise<IncidentStateTimeline> {
+    /*
+     * The per-entity mutex is owned here, around the whole create, rather than
+     * inside onBeforeCreate. DatabaseService.create() invokes onBeforeCreate and
+     * then runs validation, permission checks and the INSERT before it ever
+     * reaches onCreateSuccess, all OUTSIDE any try/catch this service can hook
+     * (onCreateError never fires for a throw raised before the INSERT). So a
+     * mutex acquired in onBeforeCreate and released in onCreateSuccess leaks on
+     * any throw in between, and a leaked redis-semaphore mutex never expires - it
+     * keeps refreshing its own Redis key for the life of the process. Holding it
+     * in a try/finally here releases it on every path.
+     */
+    if (createBy.props.ignoreHooks || !createBy.data.incidentId) {
+      // No predecessor bookkeeping runs on these paths, so no serialization is needed.
+      return await super.create(createBy);
+    }
+
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      incidentId: createBy.data.incidentId?.toString(),
+    } as LogAttributes;
+
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: createBy.data.incidentId.toString(),
+        namespace: "IncidentStateTimeline.create",
+      });
+    } catch (e) {
+      /*
+       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
+       * concurrent writers resolve the same predecessor and both INSERT a state
+       * row milliseconds apart; only the later one is ever closed, so the earlier
+       * is orphaned with endsAt = NULL forever and read back as unbounded
+       * downtime. Refusing the write is strictly safer: the next write for this
+       * entity re-evaluates and recreates the state change.
+       */
+      logger.error(e, logAttributes);
+      throw new ServerException(INCIDENT_STATE_TIMELINE_LOCK_ERROR_MESSAGE);
+    }
+
+    try {
+      return await super.create(createBy);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
     }
   }
 
@@ -72,252 +133,216 @@ export class Service extends DatabaseService<IncidentStateTimeline> {
   protected override async onBeforeCreate(
     createBy: CreateBy<IncidentStateTimeline>,
   ): Promise<OnCreate<IncidentStateTimeline>> {
-    let mutex: SemaphoreMutex | null = null;
-
-    try {
-      if (!createBy.data.incidentId) {
-        throw new BadDataException("incidentId is null");
-      }
-
-      try {
-        mutex = await Semaphore.lock({
-          key: createBy.data.incidentId.toString(),
-          namespace: "IncidentStateTimeline.create",
-        });
-      } catch (err) {
-        logger.error(err, {
-          projectId: createBy.data.projectId?.toString(),
-          incidentId: createBy.data.incidentId?.toString(),
-        } as LogAttributes);
-      }
-
-      if (!createBy.data.startsAt) {
-        createBy.data.startsAt = OneUptimeDate.getCurrentDate();
-      }
-
-      if (
-        (createBy.data.createdByUserId ||
-          createBy.data.createdByUser ||
-          createBy.props.userId) &&
-        !createBy.data.rootCause
-      ) {
-        let userId: ObjectID | undefined = createBy.data.createdByUserId;
-
-        if (createBy.props.userId) {
-          userId = createBy.props.userId;
-        }
-
-        if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
-          userId = createBy.data.createdByUser.id;
-        }
-
-        if (userId) {
-          createBy.data.rootCause = `Incident state created by ${await UserService.getUserMarkdownString(
-            {
-              userId: userId!,
-              projectId: createBy.data.projectId || createBy.props.tenantId!,
-            },
-          )}`;
-        }
-      }
-
-      const incidentStateId: ObjectID | undefined | null =
-        createBy.data.incidentStateId || createBy.data.incidentState?.id;
-
-      if (!incidentStateId) {
-        throw new BadDataException("incidentStateId is null");
-      }
-
-      // Execute queries for before and after states in parallel for better performance
-      const [stateBeforeThis, stateAfterThis] = await Promise.all([
-        this.findOneBy({
-          query: {
-            incidentId: createBy.data.incidentId,
-            startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Descending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            incidentStateId: true,
-            incidentState: {
-              _id: true,
-              order: true,
-              name: true,
-              isResolvedState: true,
-            },
-            startsAt: true,
-            endsAt: true,
-          },
-        }),
-        this.findOneBy({
-          query: {
-            incidentId: createBy.data.incidentId,
-            startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Ascending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            incidentStateId: true,
-            startsAt: true,
-            endsAt: true,
-          },
-        }),
-      ]);
-
-      logger.debug("State Before this", {
-        projectId: createBy.data.projectId?.toString(),
-        incidentId: createBy.data.incidentId?.toString(),
-      } as LogAttributes);
-      logger.debug(stateBeforeThis, {
-        projectId: createBy.data.projectId?.toString(),
-        incidentId: createBy.data.incidentId?.toString(),
-      } as LogAttributes);
-
-      // If this is the first state, then do not notify the owner.
-      if (!stateBeforeThis) {
-        // since this is the first status, do not notify the owner.
-        createBy.data.isOwnerNotified = true;
-      }
-
-      /*
-       * check if this new state and the previous state are same.
-       * if yes, then throw bad data exception.
-       */
-
-      if (
-        stateBeforeThis &&
-        stateBeforeThis.incidentStateId &&
-        incidentStateId
-      ) {
-        if (
-          stateBeforeThis.incidentStateId.toString() ===
-          incidentStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Incident state cannot be same as previous state.",
-          );
-        }
-      }
-
-      if (stateBeforeThis && stateBeforeThis.incidentState?.order) {
-        const newIncidentState: IncidentState | null =
-          await IncidentStateService.findOneBy({
-            query: {
-              _id: incidentStateId,
-            },
-            select: {
-              order: true,
-              name: true,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
-
-        if (newIncidentState && newIncidentState.order) {
-          // check if the new incident state is in order is greater than the previous state order
-          if (
-            stateBeforeThis &&
-            stateBeforeThis.incidentState &&
-            stateBeforeThis.incidentState.order &&
-            newIncidentState.order <= stateBeforeThis.incidentState.order
-          ) {
-            throw new BadDataException(
-              `Incident cannot transition to ${newIncidentState.name} state from ${stateBeforeThis.incidentState.name} state because ${newIncidentState.name} is before ${stateBeforeThis.incidentState.name} in the order of incident states.`,
-            );
-          }
-        }
-      }
-
-      // compute ends at. It's the start of the next status.
-      if (stateAfterThis && stateAfterThis.startsAt) {
-        createBy.data.endsAt = stateAfterThis.startsAt;
-      }
-
-      /*
-       * check if this new state and the previous state are same.
-       * if yes, then throw bad data exception.
-       */
-
-      if (stateAfterThis && stateAfterThis.incidentStateId && incidentStateId) {
-        if (
-          stateAfterThis.incidentStateId.toString() ===
-          incidentStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Incident state cannot be same as next state.",
-          );
-        }
-      }
-
-      logger.debug("State After this", {
-        projectId: createBy.data.projectId?.toString(),
-        incidentId: createBy.data.incidentId?.toString(),
-      } as LogAttributes);
-      logger.debug(stateAfterThis, {
-        projectId: createBy.data.projectId?.toString(),
-        incidentId: createBy.data.incidentId?.toString(),
-      } as LogAttributes);
-
-      const publicNote: string | undefined = (
-        createBy.miscDataProps as JSONObject | undefined
-      )?.["publicNote"] as string | undefined;
-
-      if (publicNote) {
-        // mark status page subscribers as notified for this state change because we dont want to send duplicate (two) emails one for public note and one for state change.
-        if (createBy.data.shouldStatusPageSubscribersBeNotified) {
-          createBy.data.subscriberNotificationStatus =
-            StatusPageSubscriberNotificationStatus.Success;
-        }
-      }
-
-      // Set notification status based on shouldStatusPageSubscribersBeNotified
-      if (createBy.data.shouldStatusPageSubscribersBeNotified === false) {
-        createBy.data.subscriberNotificationStatus =
-          StatusPageSubscriberNotificationStatus.Skipped;
-        createBy.data.subscriberNotificationStatusMessage =
-          "Notifications skipped as subscribers are not to be notified for this incident state change.";
-      } else if (
-        createBy.data.shouldStatusPageSubscribersBeNotified === true &&
-        !publicNote
-      ) {
-        // Only set to Pending if there's no public note (public note handling sets it to Success)
-        createBy.data.subscriberNotificationStatus =
-          StatusPageSubscriberNotificationStatus.Pending;
-      }
-
-      return {
-        createBy,
-        carryForward: {
-          statusTimelineBeforeThisStatus: stateBeforeThis || null,
-          statusTimelineAfterThisStatus: stateAfterThis || null,
-          publicNote: publicNote,
-          mutex: mutex,
-        },
-      };
-    } catch (err) {
-      // release the mutex if it was acquired.
-      if (mutex) {
-        try {
-          await Semaphore.release(mutex);
-        } catch (err) {
-          logger.error(err, {
-            projectId: createBy.data.projectId?.toString(),
-            incidentId: createBy.data.incidentId?.toString(),
-          } as LogAttributes);
-        }
-      }
-
-      throw err;
+    if (!createBy.data.incidentId) {
+      throw new BadDataException("incidentId is null");
     }
+
+    if (!createBy.data.startsAt) {
+      createBy.data.startsAt = OneUptimeDate.getCurrentDate();
+    }
+
+    if (
+      (createBy.data.createdByUserId ||
+        createBy.data.createdByUser ||
+        createBy.props.userId) &&
+      !createBy.data.rootCause
+    ) {
+      let userId: ObjectID | undefined = createBy.data.createdByUserId;
+
+      if (createBy.props.userId) {
+        userId = createBy.props.userId;
+      }
+
+      if (createBy.data.createdByUser && createBy.data.createdByUser.id) {
+        userId = createBy.data.createdByUser.id;
+      }
+
+      if (userId) {
+        createBy.data.rootCause = `Incident state created by ${await UserService.getUserMarkdownString(
+          {
+            userId: userId!,
+            projectId: createBy.data.projectId || createBy.props.tenantId!,
+          },
+        )}`;
+      }
+    }
+
+    const incidentStateId: ObjectID | undefined | null =
+      createBy.data.incidentStateId || createBy.data.incidentState?.id;
+
+    if (!incidentStateId) {
+      throw new BadDataException("incidentStateId is null");
+    }
+
+    // Execute queries for before and after states in parallel for better performance
+    const [stateBeforeThis, stateAfterThis] = await Promise.all([
+      this.findOneBy({
+        query: {
+          incidentId: createBy.data.incidentId,
+          startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Descending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          incidentStateId: true,
+          incidentState: {
+            _id: true,
+            order: true,
+            name: true,
+            isResolvedState: true,
+          },
+          startsAt: true,
+          endsAt: true,
+        },
+      }),
+      this.findOneBy({
+        query: {
+          incidentId: createBy.data.incidentId,
+          startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Ascending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          incidentStateId: true,
+          startsAt: true,
+          endsAt: true,
+        },
+      }),
+    ]);
+
+    logger.debug("State Before this", {
+      projectId: createBy.data.projectId?.toString(),
+      incidentId: createBy.data.incidentId?.toString(),
+    } as LogAttributes);
+    logger.debug(stateBeforeThis, {
+      projectId: createBy.data.projectId?.toString(),
+      incidentId: createBy.data.incidentId?.toString(),
+    } as LogAttributes);
+
+    // If this is the first state, then do not notify the owner.
+    if (!stateBeforeThis) {
+      // since this is the first status, do not notify the owner.
+      createBy.data.isOwnerNotified = true;
+    }
+
+    /*
+     * check if this new state and the previous state are same.
+     * if yes, then throw bad data exception.
+     */
+
+    if (stateBeforeThis && stateBeforeThis.incidentStateId && incidentStateId) {
+      if (
+        stateBeforeThis.incidentStateId.toString() ===
+        incidentStateId.toString()
+      ) {
+        throw new BadDataException(
+          "Incident state cannot be same as previous state.",
+        );
+      }
+    }
+
+    if (stateBeforeThis && stateBeforeThis.incidentState?.order) {
+      const newIncidentState: IncidentState | null =
+        await IncidentStateService.findOneBy({
+          query: {
+            _id: incidentStateId,
+          },
+          select: {
+            order: true,
+            name: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      if (newIncidentState && newIncidentState.order) {
+        // check if the new incident state is in order is greater than the previous state order
+        if (
+          stateBeforeThis &&
+          stateBeforeThis.incidentState &&
+          stateBeforeThis.incidentState.order &&
+          newIncidentState.order <= stateBeforeThis.incidentState.order
+        ) {
+          throw new BadDataException(
+            `Incident cannot transition to ${newIncidentState.name} state from ${stateBeforeThis.incidentState.name} state because ${newIncidentState.name} is before ${stateBeforeThis.incidentState.name} in the order of incident states.`,
+          );
+        }
+      }
+    }
+
+    // compute ends at. It's the start of the next status.
+    if (stateAfterThis && stateAfterThis.startsAt) {
+      createBy.data.endsAt = stateAfterThis.startsAt;
+    }
+
+    /*
+     * check if this new state and the previous state are same.
+     * if yes, then throw bad data exception.
+     */
+
+    if (stateAfterThis && stateAfterThis.incidentStateId && incidentStateId) {
+      if (
+        stateAfterThis.incidentStateId.toString() === incidentStateId.toString()
+      ) {
+        throw new BadDataException(
+          "Incident state cannot be same as next state.",
+        );
+      }
+    }
+
+    logger.debug("State After this", {
+      projectId: createBy.data.projectId?.toString(),
+      incidentId: createBy.data.incidentId?.toString(),
+    } as LogAttributes);
+    logger.debug(stateAfterThis, {
+      projectId: createBy.data.projectId?.toString(),
+      incidentId: createBy.data.incidentId?.toString(),
+    } as LogAttributes);
+
+    const publicNote: string | undefined = (
+      createBy.miscDataProps as JSONObject | undefined
+    )?.["publicNote"] as string | undefined;
+
+    if (publicNote) {
+      // mark status page subscribers as notified for this state change because we dont want to send duplicate (two) emails one for public note and one for state change.
+      if (createBy.data.shouldStatusPageSubscribersBeNotified) {
+        createBy.data.subscriberNotificationStatus =
+          StatusPageSubscriberNotificationStatus.Success;
+      }
+    }
+
+    // Set notification status based on shouldStatusPageSubscribersBeNotified
+    if (createBy.data.shouldStatusPageSubscribersBeNotified === false) {
+      createBy.data.subscriberNotificationStatus =
+        StatusPageSubscriberNotificationStatus.Skipped;
+      createBy.data.subscriberNotificationStatusMessage =
+        "Notifications skipped as subscribers are not to be notified for this incident state change.";
+    } else if (
+      createBy.data.shouldStatusPageSubscribersBeNotified === true &&
+      !publicNote
+    ) {
+      // Only set to Pending if there's no public note (public note handling sets it to Success)
+      createBy.data.subscriberNotificationStatus =
+        StatusPageSubscriberNotificationStatus.Pending;
+    }
+
+    return {
+      createBy,
+      carryForward: {
+        statusTimelineBeforeThisStatus: stateBeforeThis || null,
+        statusTimelineAfterThisStatus: stateAfterThis || null,
+        publicNote: publicNote,
+      },
+    };
   }
 
   @CaptureSpan()
@@ -325,8 +350,6 @@ export class Service extends DatabaseService<IncidentStateTimeline> {
     onCreate: OnCreate<IncidentStateTimeline>,
     createdItem: IncidentStateTimeline,
   ): Promise<IncidentStateTimeline> {
-    const mutex: SemaphoreMutex | null = onCreate.carryForward.mutex;
-
     if (!createdItem.incidentId) {
       throw new BadDataException("incidentId is null");
     }
@@ -451,17 +474,6 @@ export class Service extends DatabaseService<IncidentStateTimeline> {
           name: true,
         },
       });
-
-    if (mutex) {
-      try {
-        await Semaphore.release(mutex);
-      } catch (err) {
-        logger.error(err, {
-          projectId: createdItem.projectId?.toString(),
-          incidentId: createdItem.incidentId?.toString(),
-        } as LogAttributes);
-      }
-    }
 
     const stateName: string = incidentState?.name || "";
     let stateEmoji: string = "➡️";
@@ -729,6 +741,25 @@ ${createdItem.rootCause}`,
     this.refreshIncidentMetricsForIncidentIds(incidentIds);
 
     return onUpdate;
+  }
+
+  /*
+   * Releases the per-entity mutex. Never throws: a failed release must not mask an
+   * error we are already unwinding, nor fail an otherwise successful create.
+   */
+  private async releaseMutex(
+    mutex: SemaphoreMutex | null | undefined,
+    logAttributes: LogAttributes,
+  ): Promise<void> {
+    if (!mutex) {
+      return;
+    }
+
+    try {
+      await Semaphore.release(mutex);
+    } catch (err) {
+      logger.error(err, logAttributes);
+    }
   }
 
   private async getIncidentIdsForTimelineQuery(

--- a/Common/Server/Services/ScheduledMaintenanceStateTimelineService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceStateTimelineService.ts
@@ -12,6 +12,7 @@ import ScheduledMaintenanceStateService from "./ScheduledMaintenanceStateService
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ServerException from "../../Types/Exception/ServerException";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
@@ -32,11 +33,92 @@ import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import WorkspaceNotificationRuleService from "./WorkspaceNotificationRuleService";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 
+/*
+ * Thrown by create() when the per-entity mutex cannot be acquired. The write is
+ * refused rather than performed unlocked. Ingest/caller sites that already swallow
+ * the same-as-previous BadDataException match on this to log and skip.
+ */
+export const SCHEDULED_MAINTENANCE_STATE_TIMELINE_LOCK_ERROR_MESSAGE: string =
+  "Could not acquire the scheduled maintenance state timeline lock for this scheduled maintenance.";
+
 export class Service extends DatabaseService<ScheduledMaintenanceStateTimeline> {
   public constructor() {
     super(ScheduledMaintenanceStateTimeline);
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("createdAt", 3 * 365); // 3 years
+    }
+  }
+
+  @CaptureSpan()
+  public override async create(
+    createBy: CreateBy<ScheduledMaintenanceStateTimeline>,
+  ): Promise<ScheduledMaintenanceStateTimeline> {
+    /*
+     * The per-entity mutex is owned here, around the whole create, rather than
+     * inside onBeforeCreate. DatabaseService.create() invokes onBeforeCreate and
+     * then runs validation, permission checks and the INSERT before it ever
+     * reaches onCreateSuccess, all OUTSIDE any try/catch this service can hook
+     * (onCreateError never fires for a throw raised before the INSERT). So a
+     * mutex acquired in onBeforeCreate and released in onCreateSuccess leaks on
+     * any throw in between, and a leaked redis-semaphore mutex never expires - it
+     * keeps refreshing its own Redis key for the life of the process. Holding it
+     * in a try/finally here releases it on every path.
+     */
+    if (createBy.props.ignoreHooks || !createBy.data.scheduledMaintenanceId) {
+      // No predecessor bookkeeping runs on these paths, so no serialization is needed.
+      return await super.create(createBy);
+    }
+
+    const logAttributes: LogAttributes = {
+      projectId: createBy.data.projectId?.toString(),
+      scheduledMaintenanceId: createBy.data.scheduledMaintenanceId?.toString(),
+    } as LogAttributes;
+
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: createBy.data.scheduledMaintenanceId.toString(),
+        namespace: "ScheduledMaintenanceStateTimeline.create",
+      });
+    } catch (e) {
+      /*
+       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
+       * concurrent writers resolve the same predecessor and both INSERT a state
+       * row milliseconds apart; only the later one is ever closed, so the earlier
+       * is orphaned with endsAt = NULL forever and read back as unbounded
+       * downtime. Refusing the write is strictly safer: the next write for this
+       * entity re-evaluates and recreates the state change.
+       */
+      logger.error(e, logAttributes);
+      throw new ServerException(
+        SCHEDULED_MAINTENANCE_STATE_TIMELINE_LOCK_ERROR_MESSAGE,
+      );
+    }
+
+    try {
+      return await super.create(createBy);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  /*
+   * Releases the per-entity mutex. Never throws: a failed release must not mask an
+   * error we are already unwinding, nor fail an otherwise successful create.
+   */
+  private async releaseMutex(
+    mutex: SemaphoreMutex | null | undefined,
+    logAttributes: LogAttributes,
+  ): Promise<void> {
+    if (!mutex) {
+      return;
+    }
+
+    try {
+      await Semaphore.release(mutex);
+    } catch (err) {
+      logger.error(err, logAttributes);
     }
   }
 
@@ -95,216 +177,181 @@ export class Service extends DatabaseService<ScheduledMaintenanceStateTimeline> 
       throw new BadDataException("scheduledMaintenanceId is null");
     }
 
-    let mutex: SemaphoreMutex | null = null;
-
-    try {
-      try {
-        mutex = await Semaphore.lock({
-          key: createBy.data.scheduledMaintenanceId.toString(),
-          namespace: "ScheduledMaintenanceStateTimeline.create",
-        });
-      } catch (err) {
-        logger.error(err, {
-          scheduledMaintenanceId:
-            createBy.data.scheduledMaintenanceId?.toString(),
-        } as LogAttributes);
-      }
-
-      if (!createBy.data.startsAt) {
-        createBy.data.startsAt = OneUptimeDate.getCurrentDate();
-      }
-
-      const scheduledMaintenanceStateId: ObjectID | undefined | null =
-        createBy.data.scheduledMaintenanceStateId ||
-        createBy.data.scheduledMaintenanceState?.id;
-
-      if (!scheduledMaintenanceStateId) {
-        throw new BadDataException("scheduledMaintenanceStateId is null");
-      }
-
-      const stateBeforeThis: ScheduledMaintenanceStateTimeline | null =
-        await this.findOneBy({
-          query: {
-            scheduledMaintenanceId: createBy.data.scheduledMaintenanceId,
-            startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Descending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            scheduledMaintenanceStateId: true,
-            scheduledMaintenanceState: {
-              order: true,
-              name: true,
-            },
-            startsAt: true,
-            endsAt: true,
-          },
-        });
-
-      // If this is the first state, then do not notify the owner.
-      if (!stateBeforeThis) {
-        // since this is the first status, do not notify the owner.
-        createBy.data.isOwnerNotified = true;
-      }
-
-      if (
-        stateBeforeThis &&
-        stateBeforeThis.scheduledMaintenanceStateId &&
-        scheduledMaintenanceStateId
-      ) {
-        if (
-          stateBeforeThis.scheduledMaintenanceStateId.toString() ===
-          scheduledMaintenanceStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Scheduled Maintenance state cannot be same as previous state.",
-          );
-        }
-      }
-
-      if (stateBeforeThis && stateBeforeThis.scheduledMaintenanceState?.order) {
-        const newScheduledMaintenanceState: ScheduledMaintenanceState | null =
-          await ScheduledMaintenanceStateService.findOneBy({
-            query: {
-              _id: scheduledMaintenanceStateId,
-            },
-            select: {
-              order: true,
-              name: true,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
-
-        if (
-          newScheduledMaintenanceState &&
-          newScheduledMaintenanceState.order
-        ) {
-          // check if the new scheduledMaintenance state is in order is greater than the previous state order
-          if (
-            stateBeforeThis &&
-            stateBeforeThis.scheduledMaintenanceState &&
-            stateBeforeThis.scheduledMaintenanceState.order &&
-            newScheduledMaintenanceState.order <=
-              stateBeforeThis.scheduledMaintenanceState.order
-          ) {
-            throw new BadDataException(
-              `ScheduledMaintenance cannot transition to ${newScheduledMaintenanceState.name} state from ${stateBeforeThis.scheduledMaintenanceState.name} state because ${newScheduledMaintenanceState.name} is before ${stateBeforeThis.scheduledMaintenanceState.name} in the order of scheduledMaintenance states.`,
-            );
-          }
-        }
-      }
-
-      const stateAfterThis: ScheduledMaintenanceStateTimeline | null =
-        await this.findOneBy({
-          query: {
-            scheduledMaintenanceId: createBy.data.scheduledMaintenanceId,
-            startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
-          },
-          sort: {
-            startsAt: SortOrder.Ascending,
-          },
-          props: {
-            isRoot: true,
-          },
-          select: {
-            scheduledMaintenanceStateId: true,
-            startsAt: true,
-            endsAt: true,
-          },
-        });
-
-      // compute ends at. It's the start of the next status.
-      if (stateAfterThis && stateAfterThis.startsAt) {
-        createBy.data.endsAt = stateAfterThis.startsAt;
-      }
-
-      if (
-        stateAfterThis &&
-        stateAfterThis.scheduledMaintenanceStateId &&
-        scheduledMaintenanceStateId
-      ) {
-        if (
-          stateAfterThis.scheduledMaintenanceStateId.toString() ===
-          scheduledMaintenanceStateId.toString()
-        ) {
-          throw new BadDataException(
-            "Scheduled Maintenance state cannot be same as next state.",
-          );
-        }
-      }
-
-      const publicNote: string | undefined = (
-        createBy.miscDataProps as JSONObject | undefined
-      )?.["publicNote"] as string | undefined;
-
-      if (publicNote) {
-        const scheduledMaintenancePublicNote: ScheduledMaintenancePublicNote =
-          new ScheduledMaintenancePublicNote();
-        scheduledMaintenancePublicNote.scheduledMaintenanceId =
-          createBy.data.scheduledMaintenanceId;
-        scheduledMaintenancePublicNote.note = publicNote;
-        scheduledMaintenancePublicNote.postedAt = createBy.data.startsAt;
-        scheduledMaintenancePublicNote.createdAt = createBy.data.startsAt;
-        scheduledMaintenancePublicNote.projectId = createBy.data.projectId!;
-        scheduledMaintenancePublicNote.shouldStatusPageSubscribersBeNotifiedOnNoteCreated =
-          Boolean(createBy.data.shouldStatusPageSubscribersBeNotified);
-
-        // mark status page subscribers as notified for this state change because we dont want to send duplicate (two) emails one for public note and one for state change.
-        if (
-          scheduledMaintenancePublicNote.shouldStatusPageSubscribersBeNotifiedOnNoteCreated
-        ) {
-          createBy.data.subscriberNotificationStatus =
-            StatusPageSubscriberNotificationStatus.Success;
-        }
-
-        await ScheduledMaintenancePublicNoteService.create({
-          data: scheduledMaintenancePublicNote,
-          props: createBy.props,
-        });
-      }
-
-      // Set notification status based on shouldStatusPageSubscribersBeNotified
-      if (createBy.data.shouldStatusPageSubscribersBeNotified === false) {
-        createBy.data.subscriberNotificationStatus =
-          StatusPageSubscriberNotificationStatus.Skipped;
-        createBy.data.subscriberNotificationStatusMessage =
-          "Notifications skipped as subscribers are not to be notified for this scheduled maintenance state change.";
-      } else if (createBy.data.shouldStatusPageSubscribersBeNotified === true) {
-        createBy.data.subscriberNotificationStatus =
-          StatusPageSubscriberNotificationStatus.Pending;
-      }
-
-      return {
-        createBy,
-        carryForward: {
-          statusTimelineBeforeThisStatus: stateBeforeThis || null,
-          statusTimelineAfterThisStatus: stateAfterThis || null,
-          publicNote: publicNote,
-          mutex: mutex,
-        },
-      };
-    } catch (error) {
-      // release the mutex if it was acquired.
-      if (mutex) {
-        try {
-          await Semaphore.release(mutex);
-        } catch (err) {
-          logger.error(err, {
-            projectId: createBy.data.projectId?.toString(),
-            scheduledMaintenanceId:
-              createBy.data.scheduledMaintenanceId?.toString(),
-          } as LogAttributes);
-        }
-      }
-
-      throw error;
+    if (!createBy.data.startsAt) {
+      createBy.data.startsAt = OneUptimeDate.getCurrentDate();
     }
+
+    const scheduledMaintenanceStateId: ObjectID | undefined | null =
+      createBy.data.scheduledMaintenanceStateId ||
+      createBy.data.scheduledMaintenanceState?.id;
+
+    if (!scheduledMaintenanceStateId) {
+      throw new BadDataException("scheduledMaintenanceStateId is null");
+    }
+
+    const stateBeforeThis: ScheduledMaintenanceStateTimeline | null =
+      await this.findOneBy({
+        query: {
+          scheduledMaintenanceId: createBy.data.scheduledMaintenanceId,
+          startsAt: QueryHelper.lessThanEqualTo(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Descending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          scheduledMaintenanceStateId: true,
+          scheduledMaintenanceState: {
+            order: true,
+            name: true,
+          },
+          startsAt: true,
+          endsAt: true,
+        },
+      });
+
+    // If this is the first state, then do not notify the owner.
+    if (!stateBeforeThis) {
+      // since this is the first status, do not notify the owner.
+      createBy.data.isOwnerNotified = true;
+    }
+
+    if (
+      stateBeforeThis &&
+      stateBeforeThis.scheduledMaintenanceStateId &&
+      scheduledMaintenanceStateId
+    ) {
+      if (
+        stateBeforeThis.scheduledMaintenanceStateId.toString() ===
+        scheduledMaintenanceStateId.toString()
+      ) {
+        throw new BadDataException(
+          "Scheduled Maintenance state cannot be same as previous state.",
+        );
+      }
+    }
+
+    if (stateBeforeThis && stateBeforeThis.scheduledMaintenanceState?.order) {
+      const newScheduledMaintenanceState: ScheduledMaintenanceState | null =
+        await ScheduledMaintenanceStateService.findOneBy({
+          query: {
+            _id: scheduledMaintenanceStateId,
+          },
+          select: {
+            order: true,
+            name: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      if (newScheduledMaintenanceState && newScheduledMaintenanceState.order) {
+        // check if the new scheduledMaintenance state is in order is greater than the previous state order
+        if (
+          stateBeforeThis &&
+          stateBeforeThis.scheduledMaintenanceState &&
+          stateBeforeThis.scheduledMaintenanceState.order &&
+          newScheduledMaintenanceState.order <=
+            stateBeforeThis.scheduledMaintenanceState.order
+        ) {
+          throw new BadDataException(
+            `ScheduledMaintenance cannot transition to ${newScheduledMaintenanceState.name} state from ${stateBeforeThis.scheduledMaintenanceState.name} state because ${newScheduledMaintenanceState.name} is before ${stateBeforeThis.scheduledMaintenanceState.name} in the order of scheduledMaintenance states.`,
+          );
+        }
+      }
+    }
+
+    const stateAfterThis: ScheduledMaintenanceStateTimeline | null =
+      await this.findOneBy({
+        query: {
+          scheduledMaintenanceId: createBy.data.scheduledMaintenanceId,
+          startsAt: QueryHelper.greaterThan(createBy.data.startsAt),
+        },
+        sort: {
+          startsAt: SortOrder.Ascending,
+        },
+        props: {
+          isRoot: true,
+        },
+        select: {
+          scheduledMaintenanceStateId: true,
+          startsAt: true,
+          endsAt: true,
+        },
+      });
+
+    // compute ends at. It's the start of the next status.
+    if (stateAfterThis && stateAfterThis.startsAt) {
+      createBy.data.endsAt = stateAfterThis.startsAt;
+    }
+
+    if (
+      stateAfterThis &&
+      stateAfterThis.scheduledMaintenanceStateId &&
+      scheduledMaintenanceStateId
+    ) {
+      if (
+        stateAfterThis.scheduledMaintenanceStateId.toString() ===
+        scheduledMaintenanceStateId.toString()
+      ) {
+        throw new BadDataException(
+          "Scheduled Maintenance state cannot be same as next state.",
+        );
+      }
+    }
+
+    const publicNote: string | undefined = (
+      createBy.miscDataProps as JSONObject | undefined
+    )?.["publicNote"] as string | undefined;
+
+    if (publicNote) {
+      const scheduledMaintenancePublicNote: ScheduledMaintenancePublicNote =
+        new ScheduledMaintenancePublicNote();
+      scheduledMaintenancePublicNote.scheduledMaintenanceId =
+        createBy.data.scheduledMaintenanceId;
+      scheduledMaintenancePublicNote.note = publicNote;
+      scheduledMaintenancePublicNote.postedAt = createBy.data.startsAt;
+      scheduledMaintenancePublicNote.createdAt = createBy.data.startsAt;
+      scheduledMaintenancePublicNote.projectId = createBy.data.projectId!;
+      scheduledMaintenancePublicNote.shouldStatusPageSubscribersBeNotifiedOnNoteCreated =
+        Boolean(createBy.data.shouldStatusPageSubscribersBeNotified);
+
+      // mark status page subscribers as notified for this state change because we dont want to send duplicate (two) emails one for public note and one for state change.
+      if (
+        scheduledMaintenancePublicNote.shouldStatusPageSubscribersBeNotifiedOnNoteCreated
+      ) {
+        createBy.data.subscriberNotificationStatus =
+          StatusPageSubscriberNotificationStatus.Success;
+      }
+
+      await ScheduledMaintenancePublicNoteService.create({
+        data: scheduledMaintenancePublicNote,
+        props: createBy.props,
+      });
+    }
+
+    // Set notification status based on shouldStatusPageSubscribersBeNotified
+    if (createBy.data.shouldStatusPageSubscribersBeNotified === false) {
+      createBy.data.subscriberNotificationStatus =
+        StatusPageSubscriberNotificationStatus.Skipped;
+      createBy.data.subscriberNotificationStatusMessage =
+        "Notifications skipped as subscribers are not to be notified for this scheduled maintenance state change.";
+    } else if (createBy.data.shouldStatusPageSubscribersBeNotified === true) {
+      createBy.data.subscriberNotificationStatus =
+        StatusPageSubscriberNotificationStatus.Pending;
+    }
+
+    return {
+      createBy,
+      carryForward: {
+        statusTimelineBeforeThisStatus: stateBeforeThis || null,
+        statusTimelineAfterThisStatus: stateAfterThis || null,
+        publicNote: publicNote,
+      },
+    };
   }
 
   @CaptureSpan()
@@ -312,8 +359,6 @@ export class Service extends DatabaseService<ScheduledMaintenanceStateTimeline> 
     onCreate: OnCreate<ScheduledMaintenanceStateTimeline>,
     createdItem: ScheduledMaintenanceStateTimeline,
   ): Promise<ScheduledMaintenanceStateTimeline> {
-    const mutex: SemaphoreMutex | null = onCreate.carryForward.mutex;
-
     if (!createdItem.scheduledMaintenanceId) {
       throw new BadDataException("scheduledMaintenanceId is null");
     }
@@ -421,18 +466,6 @@ export class Service extends DatabaseService<ScheduledMaintenanceStateTimeline> 
         },
         props: onCreate.createBy.props,
       });
-    }
-
-    if (mutex) {
-      try {
-        await Semaphore.release(mutex);
-      } catch (err) {
-        logger.error(err, {
-          projectId: createdItem.projectId?.toString(),
-          scheduledMaintenanceId:
-            createdItem.scheduledMaintenanceId?.toString(),
-        } as LogAttributes);
-      }
     }
 
     const scheduledMaintenanceState: ScheduledMaintenanceState | null =

--- a/Common/Server/Utils/Monitor/MonitorAlert.ts
+++ b/Common/Server/Utils/Monitor/MonitorAlert.ts
@@ -14,6 +14,7 @@ import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
 import Dictionary from "../../../Types/Dictionary";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import ServerException from "../../../Types/Exception/ServerException";
 import IncomingMonitorRequest from "../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
 import ObjectID from "../../../Types/ObjectID";
@@ -22,7 +23,9 @@ import { TelemetryQuery } from "../../../Types/Telemetry/TelemetryQuery";
 import { DisableAutomaticAlertCreation } from "../../EnvironmentConfig";
 import AlertService from "../../Services/AlertService";
 import AlertSeverityService from "../../Services/AlertSeverityService";
-import AlertStateTimelineService from "../../Services/AlertStateTimelineService";
+import AlertStateTimelineService, {
+  ALERT_STATE_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "../../Services/AlertStateTimelineService";
 import HostService from "../../Services/HostService";
 import NetworkDeviceOwnerUserService, {
   NetworkDeviceOwners,
@@ -774,6 +777,19 @@ export default class MonitorAlert {
       ) {
         logger.debug(
           `${input.openAlert.id?.toString()} - Alert already in resolved state; skipping duplicate state timeline (concurrent race).`,
+        );
+      } else if (
+        err instanceof ServerException &&
+        err.message === ALERT_STATE_TIMELINE_LOCK_ERROR_MESSAGE
+      ) {
+        /*
+         * The per-entity mutex could not be acquired, so create() fails closed
+         * rather than inserting an unlocked (and potentially orphaned) state row.
+         * Skip this state change instead of failing the queue job; the next
+         * evaluation for this alert re-evaluates and recreates the state change.
+         */
+        logger.error(
+          `${input.openAlert.id?.toString()} - Could not acquire the alert state timeline lock; skipping resolve state change (will be retried on the next evaluation).`,
         );
       } else {
         throw err;

--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -19,6 +19,7 @@ import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
 import Dictionary from "../../../Types/Dictionary";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import ServerException from "../../../Types/Exception/ServerException";
 import IncomingMonitorRequest from "../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
 import ObjectID from "../../../Types/ObjectID";
@@ -34,7 +35,9 @@ import PodmanHostService from "../../Services/PodmanHostService";
 import ProxmoxClusterService from "../../Services/ProxmoxClusterService";
 import ServiceService from "../../Services/ServiceService";
 import IncidentSeverityService from "../../Services/IncidentSeverityService";
-import IncidentStateTimelineService from "../../Services/IncidentStateTimelineService";
+import IncidentStateTimelineService, {
+  INCIDENT_STATE_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "../../Services/IncidentStateTimelineService";
 import IncidentMemberService from "../../Services/IncidentMemberService";
 import NetworkDeviceOwnerUserService, {
   NetworkDeviceOwners,
@@ -1160,6 +1163,19 @@ export default class MonitorIncident {
       ) {
         logger.debug(
           `${input.openIncident.id?.toString()} - Incident already in resolved state; skipping duplicate state timeline (concurrent race).`,
+        );
+      } else if (
+        err instanceof ServerException &&
+        err.message === INCIDENT_STATE_TIMELINE_LOCK_ERROR_MESSAGE
+      ) {
+        /*
+         * The per-incident create() mutex could not be acquired, so the write was
+         * refused (fail-closed) rather than performed unlocked. This state change
+         * is skipped; the next monitor evaluation for this incident re-evaluates
+         * and recreates it.
+         */
+        logger.error(
+          `${input.openIncident.id?.toString()} - Could not acquire the incident state timeline lock; skipping this resolve state change (will be retried on the next evaluation).`,
         );
       } else {
         throw err;


### PR DESCRIPTION
## Context

Follow-up to #2753 (the Quesada uptime bug). That PR fixed a per-monitor mutex in `MonitorStatusTimelineService`. An adversarial review of it found the **same bug copy-pasted into five sibling state-timeline services**. This PR applies the identical fix to each.

## The bug (two parts, in each of the five services)

1. **Permanent mutex leak.** Each service acquires a per-entity Redis mutex inside `onBeforeCreate`, carries it via `carryForward.mutex`, and releases it only inside `onCreateSuccess`. But `DatabaseService.create()` calls `_onBeforeCreate` **outside** the try block that reaches `onCreateSuccess`/`onCreateError`. So any throw in between — validation, unique-constraint check, permission check, or the INSERT itself — never runs the release. A leaked `redis-semaphore` mutex **never expires** (it self-refreshes for the life of the process), so it permanently freezes every future state-timeline write for that entity until the pod restarts.
2. **Unlocked fallthrough.** The `Semaphore.lock` catch logged and continued **unlocked**, which allows the same duplicate-concurrent-insert race that produces permanently-orphaned `endsAt = NULL` rows (the root cause behind #2753).

Affected services:
- `AlertStateTimelineService`
- `AlertEpisodeStateTimelineService`
- `IncidentStateTimelineService`
- `IncidentEpisodeStateTimelineService`
- `ScheduledMaintenanceStateTimelineService`

## The fix (mirrors #2753 exactly)

- The mutex is now owned by a **`create()` override** with `try/finally` around `super.create()`, so it is released on **every** path.
- Acquisition is **fail-closed**: on acquire failure it `logger.error`s and throws a `ServerException` (a per-service `*_LOCK_ERROR_MESSAGE` constant) instead of writing unlocked.
- All mutex plumbing is removed from `onBeforeCreate` and `onCreateSuccess`. **No other behaviour changes** — the large per-file line counts are almost entirely reindentation from removing the outer `try` wrapper. `git diff -w` shows only the mutex additions/removals (~130 real lines/file vs ~400 raw).
- The two ingest paths that already swallow the same-as-previous `BadDataException` (`MonitorAlert.ts`, `MonitorIncident.ts`) now also **log-and-skip** the lock `ServerException`, so a Redis blip retries on the next evaluation instead of failing the queue job. The episode/maintenance services have no such ingest caller; there the fail-closed error propagates to the (user-initiated) caller, which is the intended safer behaviour.

## Why fail-closed is correct

The old behaviour (fail-open) wrote an unlocked row on lock failure — the exact path that orphaned rows and produced unbounded phantom downtime. Refusing the write is strictly safer: the next evaluation for that entity re-derives and recreates the state change. A lock-acquire failure only happens when Redis is down or contended beyond the acquire timeout — a rare, transient condition where erroring and retrying beats silent corruption.

## Verification
- `Common` and `App` both compile clean (`tsc --noEmit`).
- ESLint clean on all changed files.
- Each of the five service diffs was independently adversarially reviewed (lock released on every path incl. the acquire-failure path; no re-entrancy/self-deadlock across the now-wider lock scope; byte-for-byte logic preservation; correct caller skip semantics) — no defects found.
- No new unit tests: these services have no existing test harness, and the change is a mechanical mirror of the already-reviewed #2753 pattern. (Two adjacent `MonitorAlert` tests can't run in this environment due to a pre-existing `isolated-vm` native-ABI issue, unrelated to this change — confirmed identical failure on clean master.)

## Relationship to #2753
Independent branch off `master`; can merge before or after #2753. No file overlap between the two PRs.
