### PR TITLE
fix(probe): auto-detect SQL Server ODBC driver instead of hard-coding Driver 18

### DIFF
--- a/App/FeatureSet/Docs/Content/en/monitor/sql-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/sql-monitor.md
@@ -65,6 +65,8 @@ For Microsoft SQL Server, enable **Use Windows Integrated Authentication** to op
 - **Windows probes:** run the probe service as a domain account that has a read-only SQL Server login.
 - **Linux or macOS probes:** configure Kerberos for the SQL Server domain and give the probe process a valid ticket (for example through a keytab). The official Linux probe image includes Microsoft ODBC Driver 18, unixODBC, and the Kerberos client. Mount the Kerberos configuration and ticket cache into the container, make them readable by the probe process, and set `KRB5_CONFIG` or `KRB5CCNAME` when their locations are non-default.
 
+The probe needs a Microsoft ODBC Driver for SQL Server installed on the host running it. The official probe image bundles **ODBC Driver 18**. When you run a self-hosted or custom probe, the probe automatically detects and uses the newest `ODBC Driver N for SQL Server` registered on the host (for example Driver 17 if that is what is installed) — you do not need to have exactly Driver 18. To pin a specific driver, set the `SQL_SERVER_ODBC_DRIVER` environment variable on the probe to the exact driver name (for example `ODBC Driver 17 for SQL Server`).
+
 SQL Server must have an appropriate `MSSQLSvc` service principal name, the probe and domain controller clocks must be synchronized, and the probe must resolve/reach the SQL Server by the hostname covered by that service principal. Grant only the database permissions needed by the monitoring query to the trusted identity.
 
 ### Advanced options

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SqlMonitor.test.ts
@@ -7,6 +7,11 @@ import SqlMonitor, {
   buildSqlServerIntegratedConnectionString,
   loadMicrosoftSqlServerDriver,
   MicrosoftSqlServerPoolConfig,
+  parseUnixOdbcInstDrivers,
+  parseWindowsRegistryOdbcDrivers,
+  pickBestSqlServerOdbcDriver,
+  resetSqlServerOdbcDriverCache,
+  resolveSqlServerOdbcDriver,
   SQL_SERVER_ODBC_DRIVER,
   SqlQueryValidator,
 } from "../../../../Utils/Monitors/MonitorTypes/SqlMonitor";
@@ -15,6 +20,8 @@ import MonitorStepSqlMonitor from "Common/Types/Monitor/MonitorStepSqlMonitor";
 import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
 import * as mssql from "mssql";
 import { describe, expect, it } from "@jest/globals";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 const getMicrosoftSqlServerConfig: (
   overrides?: Partial<MonitorStepSqlMonitor>,
@@ -450,6 +457,300 @@ describe("buildSqlServerIntegratedConnectionString", () => {
     expect(connectionString).toContain("Encrypt=no");
     expect(connectionString).toContain("TrustServerCertificate=no");
   });
+
+  it("defaults to the bundled driver but honors an explicit driver name", () => {
+    const baseConfig: {
+      host: string;
+      port: number;
+      databaseName: string;
+      useSsl: boolean;
+      rejectUnauthorizedSsl: boolean;
+    } = {
+      host: "sql.internal",
+      port: 1433,
+      databaseName: "orders",
+      useSsl: true,
+      rejectUnauthorizedSsl: true,
+    };
+
+    expect(buildSqlServerIntegratedConnectionString(baseConfig)).toContain(
+      `Driver={${SQL_SERVER_ODBC_DRIVER}}`,
+    );
+
+    // A host that only has Driver 17 installed (the customer's environment).
+    expect(
+      buildSqlServerIntegratedConnectionString(
+        baseConfig,
+        "ODBC Driver 17 for SQL Server",
+      ),
+    ).toContain("Driver={ODBC Driver 17 for SQL Server}");
+  });
+});
+
+describe("parseUnixOdbcInstDrivers", () => {
+  it("extracts the bracketed driver section names from odbcinst output", () => {
+    const output: string = [
+      "[ODBC Driver 18 for SQL Server]",
+      "[ODBC Driver 17 for SQL Server]",
+      "[PostgreSQL Unicode]",
+      "",
+    ].join("\n");
+
+    expect(parseUnixOdbcInstDrivers(output)).toEqual([
+      "ODBC Driver 18 for SQL Server",
+      "ODBC Driver 17 for SQL Server",
+      "PostgreSQL Unicode",
+    ]);
+  });
+
+  it("tolerates leading/trailing whitespace and CRLF line endings", () => {
+    expect(
+      parseUnixOdbcInstDrivers(
+        "  [ODBC Driver 17 for SQL Server]  \r\n[MySQL]\r\n",
+      ),
+    ).toEqual(["ODBC Driver 17 for SQL Server", "MySQL"]);
+  });
+
+  it("returns an empty list for empty or non-matching output", () => {
+    expect(parseUnixOdbcInstDrivers("")).toEqual([]);
+    expect(parseUnixOdbcInstDrivers("no drivers here")).toEqual([]);
+  });
+});
+
+describe("parseWindowsRegistryOdbcDrivers", () => {
+  it("extracts value names from `reg query` output for the ODBC Drivers key", () => {
+    const output: string = [
+      "",
+      "HKEY_LOCAL_MACHINE\\SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Drivers",
+      "    ODBC Driver 17 for SQL Server    REG_SZ    Installed",
+      "    ODBC Driver 18 for SQL Server    REG_SZ    Installed",
+      "    PostgreSQL Unicode(x64)    REG_SZ    Installed",
+      "",
+    ].join("\r\n");
+
+    expect(parseWindowsRegistryOdbcDrivers(output)).toEqual([
+      "ODBC Driver 17 for SQL Server",
+      "ODBC Driver 18 for SQL Server",
+      "PostgreSQL Unicode(x64)",
+    ]);
+  });
+
+  it("does not treat the key path header line as a driver", () => {
+    const output: string =
+      "HKEY_LOCAL_MACHINE\\SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Drivers\r\n";
+    expect(parseWindowsRegistryOdbcDrivers(output)).toEqual([]);
+  });
+});
+
+describe("pickBestSqlServerOdbcDriver", () => {
+  it("selects the highest SQL Server driver version and ignores other drivers", () => {
+    expect(
+      pickBestSqlServerOdbcDriver([
+        "PostgreSQL Unicode",
+        "ODBC Driver 17 for SQL Server",
+        "ODBC Driver 18 for SQL Server",
+        "MySQL ODBC 8.0 Driver",
+      ]),
+    ).toBe("ODBC Driver 18 for SQL Server");
+  });
+
+  it("selects the only installed SQL Server driver when it is older than the default", () => {
+    expect(
+      pickBestSqlServerOdbcDriver([
+        "ODBC Driver 13 for SQL Server",
+        "ODBC Driver 17 for SQL Server",
+      ]),
+    ).toBe("ODBC Driver 17 for SQL Server");
+  });
+
+  it("is case-insensitive on the driver name", () => {
+    expect(pickBestSqlServerOdbcDriver(["odbc driver 18 for sql server"])).toBe(
+      "odbc driver 18 for sql server",
+    );
+  });
+
+  it("returns null when no SQL Server driver is registered", () => {
+    expect(pickBestSqlServerOdbcDriver([])).toBeNull();
+    expect(
+      pickBestSqlServerOdbcDriver(["PostgreSQL Unicode", "SQLite3"]),
+    ).toBeNull();
+  });
+});
+
+describe("resolveSqlServerOdbcDriver", () => {
+  it("prefers an explicit environment override over detection", async () => {
+    resetSqlServerOdbcDriverCache();
+    const driver: string = await resolveSqlServerOdbcDriver({
+      envValue: "ODBC Driver 99 for SQL Server",
+      lister: () => {
+        return ["ODBC Driver 17 for SQL Server"];
+      },
+      useCache: false,
+    });
+    expect(driver).toBe("ODBC Driver 99 for SQL Server");
+  });
+
+  it("reads the override from process.env when no options are passed", async () => {
+    resetSqlServerOdbcDriverCache();
+    const previous: string | undefined = process.env["SQL_SERVER_ODBC_DRIVER"];
+    process.env["SQL_SERVER_ODBC_DRIVER"] = "ODBC Driver 42 for SQL Server";
+    try {
+      /*
+       * No envValue key and no lister: exercises the real process.env branch
+       * and the "envValue" in options seam — the production code path.
+       */
+      const driver: string = await resolveSqlServerOdbcDriver({
+        useCache: false,
+      });
+      expect(driver).toBe("ODBC Driver 42 for SQL Server");
+    } finally {
+      if (previous === undefined) {
+        delete process.env["SQL_SERVER_ODBC_DRIVER"];
+      } else {
+        process.env["SQL_SERVER_ODBC_DRIVER"] = previous;
+      }
+    }
+  });
+
+  it("falls through to detection when the process.env override is absent", async () => {
+    resetSqlServerOdbcDriverCache();
+    const previous: string | undefined = process.env["SQL_SERVER_ODBC_DRIVER"];
+    delete process.env["SQL_SERVER_ODBC_DRIVER"];
+    try {
+      const driver: string = await resolveSqlServerOdbcDriver({
+        lister: () => {
+          return ["ODBC Driver 17 for SQL Server"];
+        },
+        useCache: false,
+      });
+      expect(driver).toBe("ODBC Driver 17 for SQL Server");
+    } finally {
+      if (previous !== undefined) {
+        process.env["SQL_SERVER_ODBC_DRIVER"] = previous;
+      }
+    }
+  });
+
+  it("auto-detects the newest installed driver when no override is set", async () => {
+    resetSqlServerOdbcDriverCache();
+    const driver: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister: () => {
+        return [
+          "ODBC Driver 17 for SQL Server",
+          "ODBC Driver 18 for SQL Server",
+        ];
+      },
+      useCache: false,
+    });
+    expect(driver).toBe("ODBC Driver 18 for SQL Server");
+  });
+
+  it("awaits an async lister (real detection is asynchronous)", async () => {
+    resetSqlServerOdbcDriverCache();
+    const driver: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister: async () => {
+        return Promise.resolve(["ODBC Driver 17 for SQL Server"]);
+      },
+      useCache: false,
+    });
+    expect(driver).toBe("ODBC Driver 17 for SQL Server");
+  });
+
+  it("detects an older-than-default driver on a host that only has it (the reported bug)", async () => {
+    resetSqlServerOdbcDriverCache();
+    const driver: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister: () => {
+        return ["ODBC Driver 17 for SQL Server"];
+      },
+      useCache: false,
+    });
+    expect(driver).toBe("ODBC Driver 17 for SQL Server");
+  });
+
+  it("falls back to the bundled default when nothing is detected", async () => {
+    resetSqlServerOdbcDriverCache();
+    const driver: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister: () => {
+        return [];
+      },
+      useCache: false,
+    });
+    expect(driver).toBe(SQL_SERVER_ODBC_DRIVER);
+  });
+
+  it("ignores a blank/whitespace override and falls through to detection", async () => {
+    resetSqlServerOdbcDriverCache();
+    const driver: string = await resolveSqlServerOdbcDriver({
+      envValue: "   ",
+      lister: () => {
+        return ["ODBC Driver 17 for SQL Server"];
+      },
+      useCache: false,
+    });
+    expect(driver).toBe("ODBC Driver 17 for SQL Server");
+  });
+
+  it("memoizes a positive detection and can be reset", async () => {
+    resetSqlServerOdbcDriverCache();
+    let listerCalls: number = 0;
+
+    const first: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister: () => {
+        listerCalls++;
+        return ["ODBC Driver 18 for SQL Server"];
+      },
+    });
+
+    // Second call hits the cache; the (different) lister is never consulted.
+    const second: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister: () => {
+        listerCalls++;
+        return ["ODBC Driver 17 for SQL Server"];
+      },
+    });
+
+    expect(first).toBe("ODBC Driver 18 for SQL Server");
+    expect(second).toBe("ODBC Driver 18 for SQL Server");
+    expect(listerCalls).toBe(1);
+
+    resetSqlServerOdbcDriverCache();
+  });
+
+  it("does NOT cache the fallback, so a transient detection failure is retried", async () => {
+    resetSqlServerOdbcDriverCache();
+    let listerCalls: number = 0;
+
+    /*
+     * First call: detection transiently fails (empty) -> falls back to default.
+     * Second call: detection recovers and reports the host's real driver.
+     */
+    const lister: () => Array<string> = () => {
+      listerCalls++;
+      return listerCalls === 1 ? [] : ["ODBC Driver 17 for SQL Server"];
+    };
+
+    const first: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister,
+    });
+    const second: string = await resolveSqlServerOdbcDriver({
+      envValue: undefined,
+      lister,
+    });
+
+    // The fallback was not cached, so detection ran again and won.
+    expect(first).toBe(SQL_SERVER_ODBC_DRIVER);
+    expect(second).toBe("ODBC Driver 17 for SQL Server");
+    expect(listerCalls).toBe(2);
+
+    resetSqlServerOdbcDriverCache();
+  });
 });
 
 describe("buildMicrosoftSqlServerPoolConfig", () => {
@@ -517,6 +818,37 @@ describe("buildMicrosoftSqlServerPoolConfig", () => {
       expect(poolConfig.options?.appName).toBe("OneUptimeProbe-SQLMonitor");
     }
   });
+
+  it("threads a resolved ODBC driver into the integrated connection string", () => {
+    const poolConfig: MicrosoftSqlServerPoolConfig =
+      buildMicrosoftSqlServerPoolConfig({
+        config: getMicrosoftSqlServerConfig({
+          useWindowsIntegratedAuthentication: true,
+        }),
+        connectionTimeoutInMs: 7000,
+        statementTimeoutInMs: 9000,
+        odbcDriver: "ODBC Driver 17 for SQL Server",
+      });
+
+    expect(poolConfig.connectionString).toContain(
+      "Driver={ODBC Driver 17 for SQL Server}",
+    );
+  });
+
+  it("uses the bundled default driver when none is provided", () => {
+    const poolConfig: MicrosoftSqlServerPoolConfig =
+      buildMicrosoftSqlServerPoolConfig({
+        config: getMicrosoftSqlServerConfig({
+          useWindowsIntegratedAuthentication: true,
+        }),
+        connectionTimeoutInMs: 7000,
+        statementTimeoutInMs: 9000,
+      });
+
+    expect(poolConfig.connectionString).toContain(
+      `Driver={${SQL_SERVER_ODBC_DRIVER}}`,
+    );
+  });
 });
 
 describe("loadMicrosoftSqlServerDriver", () => {
@@ -562,5 +894,41 @@ describe("loadMicrosoftSqlServerDriver", () => {
         throw new Error("missing native binding");
       });
     }).toThrow(SQL_SERVER_ODBC_DRIVER);
+
+    /*
+     * The message must not overstate the requirement: after auto-detection, a
+     * different installed version (e.g. Driver 17) also works, so the error
+     * explicitly says other versions are detected automatically. Pin that so a
+     * revert to a version-specific message is caught.
+     */
+    expect(() => {
+      loadMicrosoftSqlServerDriver(true, () => {
+        throw new Error("missing native binding");
+      });
+    }).toThrow(/detected automatically/);
+  });
+});
+
+describe("ODBC driver detection stays off the synchronous path", () => {
+  /*
+   * The probe multiplexes many monitors on a single event loop, so host ODBC
+   * driver detection must use asynchronous child_process execution. Guard the
+   * source against a regression back to a blocking synchronous spawn — the
+   * behavioral tests inject a lister and cannot catch that. (Same source-text
+   * assertion idiom as Tests/Build/ProbeDockerfile.test.ts.)
+   */
+  const source: string = readFileSync(
+    resolve(__dirname, "../../../../Utils/Monitors/MonitorTypes/SqlMonitor.ts"),
+    "utf8",
+  );
+
+  it("uses promisified async execFile for driver detection", () => {
+    expect(source).toContain("promisify(execFile)");
+  });
+
+  it("does not use synchronous, event-loop-blocking child_process APIs", () => {
+    expect(source).not.toContain("execFileSync");
+    expect(source).not.toContain("execSync");
+    expect(source).not.toContain("spawnSync");
   });
 });

--- a/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SqlMonitor.ts
@@ -21,11 +21,215 @@ import {
 } from "mysql2/promise";
 import * as mssql from "mssql";
 import { createRequire } from "module";
+import { execFile } from "child_process";
+import { promisify } from "util";
 
 const loadProbeModule: ReturnType<typeof createRequire> =
   createRequire(__filename);
 
+/*
+ * Async (non-blocking) child-process runner. Detection must never run on the
+ * synchronous path: the probe multiplexes many monitors on one event loop, so
+ * a slow/wedged `odbcinst`/`reg` must not freeze unrelated checks.
+ */
+const execFileAsync: (
+  file: string,
+  args: Array<string>,
+  options: { encoding: "utf8"; timeout: number; windowsHide?: boolean },
+) => Promise<{ stdout: string; stderr: string }> = promisify(execFile);
+
+/*
+ * The Microsoft ODBC driver bundled in the official probe image and used as the
+ * fallback when the installed driver cannot be detected. Do not read this
+ * directly to build a connection string — call resolveSqlServerOdbcDriver(),
+ * which prefers an operator override or the newest driver actually registered
+ * on the host so self-hosted probes with a different version (e.g. Driver 17)
+ * work without editing source.
+ */
 export const SQL_SERVER_ODBC_DRIVER: string = "ODBC Driver 18 for SQL Server";
+
+/*
+ * Matches a Microsoft SQL Server ODBC driver registration and captures its
+ * major version, e.g. "ODBC Driver 18 for SQL Server" -> 18. Filters unrelated
+ * ODBC drivers (PostgreSQL, MySQL, ...) out of the host's list and compares
+ * versions.
+ */
+const SQL_SERVER_ODBC_DRIVER_PATTERN: RegExp =
+  /^ODBC Driver (\d+) for SQL Server$/i;
+
+/*
+ * Lists the ODBC driver names registered on the host. Injectable so the
+ * resolver can be unit-tested without a real ODBC installation. May be sync or
+ * async — the resolver awaits the result either way.
+ */
+export type OdbcDriverLister = () => Array<string> | Promise<Array<string>>;
+
+/*
+ * Parse the driver section names printed by `odbcinst -q -d` (unixODBC, used on
+ * the Linux/macOS probe). Each installed driver is a line like
+ * "[ODBC Driver 18 for SQL Server]".
+ */
+export const parseUnixOdbcInstDrivers: (output: string) => Array<string> = (
+  output: string,
+): Array<string> => {
+  const names: Array<string> = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match: RegExpMatchArray | null = line.match(/^\s*\[(.+?)\]\s*$/);
+    if (match && match[1]) {
+      names.push(match[1].trim());
+    }
+  }
+  return names;
+};
+
+/*
+ * Parse the value names printed by `reg query` for the ODBC Drivers key
+ * (Windows probes). Each installed driver is a line like
+ * "    ODBC Driver 18 for SQL Server    REG_SZ    Installed".
+ */
+export const parseWindowsRegistryOdbcDrivers: (
+  output: string,
+) => Array<string> = (output: string): Array<string> => {
+  const names: Array<string> = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match: RegExpMatchArray | null = line.match(/^\s+(.+?)\s+REG_\w+\s+/);
+    if (match && match[1]) {
+      names.push(match[1].trim());
+    }
+  }
+  return names;
+};
+
+/*
+ * Choose the newest "ODBC Driver N for SQL Server" from a list of registered
+ * ODBC driver names, ignoring unrelated drivers. Returns null when none match.
+ */
+export const pickBestSqlServerOdbcDriver: (
+  driverNames: Array<string>,
+) => string | null = (driverNames: Array<string>): string | null => {
+  let best: { name: string; version: number } | null = null;
+  for (const rawName of driverNames) {
+    const name: string = rawName.trim();
+    const match: RegExpMatchArray | null = name.match(
+      SQL_SERVER_ODBC_DRIVER_PATTERN,
+    );
+    const versionString: string | undefined = match?.[1];
+    if (!versionString) {
+      continue;
+    }
+    const version: number = parseInt(versionString, 10);
+    if (Number.isNaN(version)) {
+      continue;
+    }
+    if (!best || version > best.version) {
+      best = { name, version };
+    }
+  }
+  return best ? best.name : null;
+};
+
+/*
+ * List the ODBC drivers registered on this host using the platform-native
+ * mechanism (the Windows registry, or unixODBC's `odbcinst` elsewhere). Never
+ * throws — a missing tool or unreadable registry yields an empty list so
+ * resolution falls back to the default driver. Runs the child process
+ * asynchronously (never blocking the probe's event loop) and is bounded with a
+ * short timeout so a wedged tool cannot stall detection.
+ */
+const listHostOdbcDrivers: OdbcDriverLister = async (): Promise<
+  Array<string>
+> => {
+  try {
+    if (process.platform === "win32") {
+      const { stdout } = await execFileAsync(
+        "reg",
+        ["query", "HKLM\\SOFTWARE\\ODBC\\ODBCINST.INI\\ODBC Drivers"],
+        { encoding: "utf8", timeout: 3000, windowsHide: true },
+      );
+      return parseWindowsRegistryOdbcDrivers(stdout.toString());
+    }
+
+    const { stdout } = await execFileAsync("odbcinst", ["-q", "-d"], {
+      encoding: "utf8",
+      timeout: 3000,
+    });
+    return parseUnixOdbcInstDrivers(stdout.toString());
+  } catch (err) {
+    logger.debug(`Unable to list installed ODBC drivers: ${err}`);
+    return [];
+  }
+};
+
+let cachedSqlServerOdbcDriver: string | undefined;
+
+/*
+ * Resolve the ODBC driver name the probe should use for SQL Server trusted
+ * (Windows integrated) connections. Hard-coding a single version breaks on any
+ * host that ships a different Microsoft ODBC Driver, so resolution order is:
+ *   1. The SQL_SERVER_ODBC_DRIVER environment variable (explicit operator
+ *      override — an exact driver name).
+ *   2. The newest "ODBC Driver N for SQL Server" registered on the host.
+ *   3. SQL_SERVER_ODBC_DRIVER (the version bundled in the official image).
+ * A positive detection or an explicit override is memoized (the installed
+ * drivers do not change while the probe runs). The default fallback is
+ * deliberately NOT cached: an empty driver list can mean a genuinely
+ * driver-less host OR a transient failure (odbcinst/reg momentarily
+ * unavailable), and caching the default there would defeat the fix for the
+ * lifetime of the process — so the next integrated-auth query retries
+ * detection. Tests inject the lister/env and can disable the cache.
+ */
+export const resolveSqlServerOdbcDriver: (options?: {
+  envValue?: string | undefined;
+  lister?: OdbcDriverLister | undefined;
+  useCache?: boolean | undefined;
+}) => Promise<string> = async (options?: {
+  envValue?: string | undefined;
+  lister?: OdbcDriverLister | undefined;
+  useCache?: boolean | undefined;
+}): Promise<string> => {
+  const useCache: boolean = options?.useCache !== false;
+  if (useCache && cachedSqlServerOdbcDriver !== undefined) {
+    return cachedSqlServerOdbcDriver;
+  }
+
+  const envValue: string | undefined =
+    options && "envValue" in options
+      ? options.envValue
+      : process.env["SQL_SERVER_ODBC_DRIVER"];
+  const override: string = (envValue || "").trim();
+
+  let resolved: string;
+  // Only a real answer (override or detection) is safe to memoize.
+  let cacheable: boolean;
+  if (override) {
+    resolved = override;
+    cacheable = true;
+  } else {
+    const lister: OdbcDriverLister = options?.lister || listHostOdbcDrivers;
+    const detected: string | null = pickBestSqlServerOdbcDriver(await lister());
+    if (detected) {
+      logger.debug(`Using detected SQL Server ODBC driver: ${detected}`);
+      resolved = detected;
+      cacheable = true;
+    } else {
+      resolved = SQL_SERVER_ODBC_DRIVER;
+      cacheable = false;
+    }
+  }
+
+  if (useCache && cacheable) {
+    cachedSqlServerOdbcDriver = resolved;
+  }
+  return resolved;
+};
+
+/*
+ * Reset the memoized driver. Test-only seam so a test that injects a lister is
+ * not shadowed by a value cached from an earlier test.
+ */
+export const resetSqlServerOdbcDriverCache: () => void = (): void => {
+  cachedSqlServerOdbcDriver = undefined;
+};
 
 /*
  * Escape a value for an ODBC connection string. Braced values can safely
@@ -47,14 +251,16 @@ export const buildSqlServerIntegratedConnectionString: (
     MonitorStepSqlMonitor,
     "host" | "port" | "databaseName" | "useSsl" | "rejectUnauthorizedSsl"
   >,
+  odbcDriver?: string,
 ) => string = (
   config: Pick<
     MonitorStepSqlMonitor,
     "host" | "port" | "databaseName" | "useSsl" | "rejectUnauthorizedSsl"
   >,
+  odbcDriver: string = SQL_SERVER_ODBC_DRIVER,
 ): string => {
   return [
-    `Driver=${escapeOdbcConnectionStringValue(SQL_SERVER_ODBC_DRIVER)}`,
+    `Driver=${escapeOdbcConnectionStringValue(odbcDriver)}`,
     `Server=${escapeOdbcConnectionStringValue(`${config.host},${config.port}`)}`,
     `Database=${escapeOdbcConnectionStringValue(config.databaseName)}`,
     "Trusted_Connection=yes",
@@ -82,10 +288,12 @@ export const buildMicrosoftSqlServerPoolConfig: (input: {
   config: MonitorStepSqlMonitor;
   statementTimeoutInMs: number;
   connectionTimeoutInMs: number;
+  odbcDriver?: string | undefined;
 }) => MicrosoftSqlServerPoolConfig = (input: {
   config: MonitorStepSqlMonitor;
   statementTimeoutInMs: number;
   connectionTimeoutInMs: number;
+  odbcDriver?: string | undefined;
 }): MicrosoftSqlServerPoolConfig => {
   const { config, statementTimeoutInMs, connectionTimeoutInMs } = input;
 
@@ -112,7 +320,10 @@ export const buildMicrosoftSqlServerPoolConfig: (input: {
   if (config.useWindowsIntegratedAuthentication) {
     return {
       ...baseConfig,
-      connectionString: buildSqlServerIntegratedConnectionString(config),
+      connectionString: buildSqlServerIntegratedConnectionString(
+        config,
+        input.odbcDriver,
+      ),
     };
   }
 
@@ -144,7 +355,7 @@ export const loadMicrosoftSqlServerDriver: (
     return moduleLoader("mssql/msnodesqlv8") as typeof mssql;
   } catch {
     throw new Error(
-      `Windows Integrated Authentication requires ${SQL_SERVER_ODBC_DRIVER} and the msnodesqlv8 driver on the probe. Use the official probe image or install both dependencies, then run the probe under the trusted Windows account or with a valid Kerberos ticket.`,
+      `Windows Integrated Authentication requires a Microsoft ODBC Driver for SQL Server (the official probe image ships ${SQL_SERVER_ODBC_DRIVER}; other versions such as ODBC Driver 17 for SQL Server are detected automatically) and the msnodesqlv8 native driver on the probe. Use the official probe image or install both dependencies, then run the probe under the trusted Windows account or with a valid Kerberos ticket.`,
     );
   }
 };
@@ -993,11 +1204,21 @@ export default class SqlMonitor {
      */
     const teardownTimeoutInMs: number = 5000;
 
+    /*
+     * Only trusted connections use the ODBC connection string, so only resolve
+     * (and pay for host driver detection) in that mode.
+     */
+    const odbcDriver: string | undefined =
+      config.useWindowsIntegratedAuthentication
+        ? await resolveSqlServerOdbcDriver()
+        : undefined;
+
     const poolConfig: MicrosoftSqlServerPoolConfig =
       buildMicrosoftSqlServerPoolConfig({
         config,
         statementTimeoutInMs,
         connectionTimeoutInMs,
+        odbcDriver,
       });
 
     const sqlServerDriver: typeof mssql = loadMicrosoftSqlServerDriver(


### PR DESCRIPTION
## Problem

Windows Integrated Authentication (trusted connection) for Microsoft SQL Server built the ODBC connection string with a **hard-coded** driver name:

```ts
export const SQL_SERVER_ODBC_DRIVER = "ODBC Driver 18 for SQL Server";
```

The official probe image ships Driver 18, but **self-hosted / custom probes may have a different version installed** (e.g. Driver 17). On those hosts the trusted connection failed with a driver-not-found error until the user manually edited source and rebuilt.

Reported by a customer running a custom probe that only had *ODBC Driver 17 for SQL Server* installed; they had to change `18` → `17` in the code to make it work, and asked us to detect the installed driver automatically.

## Fix

Resolve the driver at runtime (`resolveSqlServerOdbcDriver`) instead of hard-coding it:

1. **`SQL_SERVER_ODBC_DRIVER` env var** — explicit operator override (exact driver name).
2. **Auto-detect** the newest `ODBC Driver N for SQL Server` actually registered on the host — unixODBC `odbcinst -q -d` on Linux/macOS, `reg query` on Windows.
3. **Fall back** to the bundled Driver 18.

Design notes:
- Detection runs **asynchronously** (`execFile` promisified) so it never blocks the probe's single event loop, and is bounded by a short timeout.
- A positive detection or explicit override is **memoized**; the fallback is **deliberately not cached**, so a transient detection failure (e.g. `odbcinst` momentarily unavailable) is retried on the next check rather than pinned for the process lifetime.
- Only trusted (integrated-auth) connections trigger detection.

## Not changed

The official image and its Dockerfile check are untouched — they still install and verify Driver 18. This only adds graceful support for other versions on custom probes.

## Tests

61 unit tests pass (`tsc --noEmit` clean, eslint clean), covering:
- unixODBC / Windows-registry output parsers
- newest-version selection (ignoring unrelated ODBC drivers)
- env override (including the real `process.env` read path)
- async detection, and the **no-cache-on-fallback / retry** behavior
- a source-text guard that detection stays off the synchronous (blocking) path

## Docs

Updated `App/FeatureSet/Docs/Content/en/monitor/sql-monitor.md` to document auto-detection and the `SQL_SERVER_ODBC_DRIVER` override.

---

🤖 This change was implemented and reviewed with Claude Code (multi-agent adversarial review; all confirmed findings addressed).