### PR TITLE
fix(monitor): don't let an unreliable ClickHouse count() silently disable log/trace monitors

### DIFF
--- a/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
@@ -1090,6 +1090,57 @@ const monitorTelemetryMonitor: MonitorTelemetryMonitorFunction = async (data: {
   throw new BadDataException("Monitor type is not supported");
 };
 
+/*
+ * Guard against an unreliable ClickHouse `count()` silently disabling a
+ * telemetry monitor.
+ *
+ * count() over the large telemetry tables (Log / Span) can come back 0 even
+ * while rows plainly exist — e.g. when count() is answered from an aggregate
+ * projection that was ADDed but never MATERIALIZEd on existing parts, or when
+ * a partial 'break' result is returned under load. A raw 0 makes the criteria
+ * "<metric> Count >= 1" evaluate false, so the monitor silently never fires
+ * with nothing logged anywhere — the worst failure mode for an alerting path.
+ *
+ * Before trusting a 0, confirm with existsBy() — a cheap `SELECT 1 ... LIMIT 1`
+ * base-table scan that does NOT go through the count/projection path (see the
+ * existsBy docs, which already recommend it over `countBy(...) === 0` for
+ * existence checks). If rows actually exist, the count is unreliable: log it
+ * (so the failure is observable) and treat the match count as >=1 so
+ * existence-based criteria still fire. Threshold criteria (`> N`) can still
+ * under-evaluate until the underlying count is repaired — that is inherent and
+ * now at least surfaced in the logs. The extra scan only runs on the
+ * zero-count path, so the healthy (count > 0) path is unchanged.
+ */
+const resolveReliableTelemetryMatchCount: (data: {
+  rawCount: number;
+  existsBy: () => Promise<boolean>;
+  telemetryType: string;
+  monitorId: ObjectID;
+  projectId: ObjectID;
+}) => Promise<number> = async (data: {
+  rawCount: number;
+  existsBy: () => Promise<boolean>;
+  telemetryType: string;
+  monitorId: ObjectID;
+  projectId: ObjectID;
+}): Promise<number> => {
+  if (data.rawCount > 0) {
+    return data.rawCount;
+  }
+
+  const hasMatches: boolean = await data.existsBy();
+
+  if (!hasMatches) {
+    return 0;
+  }
+
+  logger.warn(
+    `Telemetry ${data.telemetryType} monitor ${data.monitorId.toString()} (project ${data.projectId.toString()}): count() returned 0 but matching ${data.telemetryType}s exist — the count is unreliable (e.g. an unmaterialized ClickHouse aggregate projection or a partial 'break' result). Treating the match count as >=1 so existence criteria still fire; threshold criteria may under-evaluate until the underlying count is fixed.`,
+  );
+
+  return 1;
+};
+
 type MonitorTraceFunction = (data: {
   monitorStep: MonitorStep;
   monitorId: ObjectID;
@@ -1123,9 +1174,24 @@ export const monitorTrace: MonitorTraceFunction = async (data: {
     },
   });
 
+  const spanCount: number = await resolveReliableTelemetryMatchCount({
+    rawCount: countTraces.toNumber(),
+    existsBy: () => {
+      return SpanService.existsBy({
+        query: query,
+        props: {
+          isRoot: true,
+        },
+      });
+    },
+    telemetryType: "span",
+    monitorId: data.monitorId,
+    projectId: data.projectId,
+  });
+
   return {
     projectId: data.projectId,
-    spanCount: countTraces.toNumber(),
+    spanCount: spanCount,
     spanQuery: query,
     monitorId: data.monitorId,
   };
@@ -3450,9 +3516,24 @@ export const monitorLogs: MonitorLogsFunction = async (data: {
     },
   });
 
+  const logCount: number = await resolveReliableTelemetryMatchCount({
+    rawCount: countLogs.toNumber(),
+    existsBy: () => {
+      return LogService.existsBy({
+        query: query,
+        props: {
+          isRoot: true,
+        },
+      });
+    },
+    telemetryType: "log",
+    monitorId: data.monitorId,
+    projectId: data.projectId,
+  });
+
   return {
     projectId: data.projectId,
-    logCount: countLogs.toNumber(),
+    logCount: logCount,
     logQuery: JSONFunctions.anyObjectToJSONObject(query),
     monitorId: data.monitorId,
   };

--- a/App/Tests/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.test.ts
+++ b/App/Tests/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.test.ts
@@ -37,10 +37,16 @@ jest.mock("Common/Server/Utils/VM/VMRunner", () => {
 });
 
 jest.mock("Common/Server/Services/LogService", () => {
-  return { __esModule: true, default: { countBy: jest.fn() } };
+  return {
+    __esModule: true,
+    default: { countBy: jest.fn(), existsBy: jest.fn() },
+  };
 });
 jest.mock("Common/Server/Services/SpanService", () => {
-  return { __esModule: true, default: { countBy: jest.fn() } };
+  return {
+    __esModule: true,
+    default: { countBy: jest.fn(), existsBy: jest.fn() },
+  };
 });
 jest.mock("Common/Server/Services/ExceptionInstanceService", () => {
   return { __esModule: true, default: { countBy: jest.fn() } };
@@ -64,7 +70,9 @@ import {
 } from "../../../../FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor";
 
 const logCountBy: jest.Mock = LogService.countBy as unknown as jest.Mock;
+const logExistsBy: jest.Mock = LogService.existsBy as unknown as jest.Mock;
 const spanCountBy: jest.Mock = SpanService.countBy as unknown as jest.Mock;
+const spanExistsBy: jest.Mock = SpanService.existsBy as unknown as jest.Mock;
 const exceptionCountBy: jest.Mock =
   ExceptionInstanceService.countBy as unknown as jest.Mock;
 const resolvedFingerprints: jest.Mock =
@@ -75,7 +83,9 @@ const projectId: ObjectID = ObjectID.generate();
 
 beforeEach(() => {
   logCountBy.mockReset().mockResolvedValue(new PositiveNumber(0));
+  logExistsBy.mockReset().mockResolvedValue(false);
   spanCountBy.mockReset().mockResolvedValue(new PositiveNumber(0));
+  spanExistsBy.mockReset().mockResolvedValue(false);
   exceptionCountBy.mockReset().mockResolvedValue(new PositiveNumber(0));
   resolvedFingerprints.mockReset().mockResolvedValue([]);
 });
@@ -140,6 +150,70 @@ describe("monitorTrace", () => {
     const passedQuery: Record<string, unknown> = spanCountBy.mock.calls[0]![0]
       .query as Record<string, unknown>;
     expect(passedQuery["startTime"]).toBeInstanceOf(InBetween);
+  });
+});
+
+/*
+ * Guards the "unreliable count()" fix: a telemetry count() over a large
+ * ClickHouse table can return 0 while rows exist (e.g. an unmaterialized
+ * aggregate projection). A raw 0 would silently disable the monitor, so the
+ * worker confirms a 0 with a cheap existsBy() scan and treats a present-but-
+ * uncounted result as >=1 so existence criteria still fire.
+ */
+describe("unreliable count() guard", () => {
+  test("monitorLogs: count()==0 but logs exist -> treats as 1", async () => {
+    logCountBy.mockResolvedValue(new PositiveNumber(0));
+    logExistsBy.mockResolvedValue(true);
+
+    const response: LogMonitorResponse = await monitorLogs({
+      monitorStep: new MonitorStep(),
+      monitorId,
+      projectId,
+    });
+
+    expect(response.logCount).toBe(1);
+    expect(logExistsBy).toHaveBeenCalledTimes(1);
+  });
+
+  test("monitorLogs: count()==0 and no logs exist -> stays 0", async () => {
+    logCountBy.mockResolvedValue(new PositiveNumber(0));
+    logExistsBy.mockResolvedValue(false);
+
+    const response: LogMonitorResponse = await monitorLogs({
+      monitorStep: new MonitorStep(),
+      monitorId,
+      projectId,
+    });
+
+    expect(response.logCount).toBe(0);
+    expect(logExistsBy).toHaveBeenCalledTimes(1);
+  });
+
+  test("monitorLogs: count()>0 -> trusts count, no existsBy fallback", async () => {
+    logCountBy.mockResolvedValue(new PositiveNumber(7));
+
+    const response: LogMonitorResponse = await monitorLogs({
+      monitorStep: new MonitorStep(),
+      monitorId,
+      projectId,
+    });
+
+    expect(response.logCount).toBe(7);
+    expect(logExistsBy).not.toHaveBeenCalled();
+  });
+
+  test("monitorTrace: count()==0 but spans exist -> treats as 1", async () => {
+    spanCountBy.mockResolvedValue(new PositiveNumber(0));
+    spanExistsBy.mockResolvedValue(true);
+
+    const response: TraceMonitorResponse = await monitorTrace({
+      monitorStep: new MonitorStep(),
+      monitorId,
+      projectId,
+    });
+
+    expect(response.spanCount).toBe(1);
+    expect(spanExistsBy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Problem

Telemetry **Log** and **Trace** monitors evaluate their criteria against `LogService.countBy()` / `SpanService.countBy()` (`App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts`). On large ClickHouse tables, `count()` can return **0 while rows plainly exist** — e.g. when `count()` is answered from an aggregate projection that was `ADD`ed but never `MATERIALIZE`d on existing parts, or when a partial result is returned under `timeout_overflow_mode='break'`.

A raw `0` makes the default `Count >= 1` criteria evaluate false, so the monitor **silently never fires** — no status change, no alert, and nothing logged anywhere. That is the worst failure mode for an alerting path: it looks healthy.

Observed on an 11.6.1 instance: every Logs/Traces monitor sat permanently "Operational" while matching error logs were ingested continuously, whereas Metrics/Kubernetes monitors (which don't use `countBy`) fired normally. Reproduction via the REST API:

```
POST /api/logs/get-list {"query":{...},"limit":10}   -> returns matching rows   (data exists)
POST /api/logs/count    {"query":{}}                  -> {"count":0}             (wrong)
POST /api/span/count    {"query":{}}                  -> {"count":0}             (wrong)
POST /api/telemetry-exception/count {"query":{}}      -> {"count":417}           (small table, correct)
```

## Fix

Before trusting a `0`, confirm with `existsBy()` — a cheap `SELECT 1 ... LIMIT 1` scan that short-circuits at the first matching row and does **not** go through the count/projection path. This is already the codebase's recommended existence check (see the `existsBy` docstring in `AnalyticsDatabaseService`, which explicitly says to prefer it over `countBy(...) === 0`).

If rows actually exist, the count is unreliable: log a warning (so the failure becomes observable instead of silent) and treat the match count as `>= 1` so existence-based criteria still fire. The extra scan runs **only on the zero-count path**, so the healthy (`count > 0`) path is unchanged.

Applied to both `monitorLogs` (Log) and `monitorTrace` (Span) via a small shared helper, `resolveReliableTelemetryMatchCount`.

## Scope / what this does NOT fix

- **Threshold criteria** (`Count > N` for N ≥ 1) can still under-evaluate on an instance whose `count()` is genuinely broken — that requires repairing the DB-side count (e.g. `ALTER TABLE … MATERIALIZE PROJECTION` on existing parts, or investigating the projection/async-insert interaction). This PR makes that case **observable** via the warning rather than silent, and fully fixes the common existence case (`> 0` / `>= 1`).
- Exceptions/Profiles monitors also use `countBy`; the same guard could be extended to them if desired (left out here to keep the change focused on the two confirmed-affected large tables).

## Tests

`App/Tests/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.test.ts`:
- `monitorLogs`: `count()==0` & logs exist → treated as `1` (existsBy called once)
- `monitorLogs`: `count()==0` & no logs → stays `0` (existsBy called once)
- `monitorLogs`: `count()>0` → trusts the count, no existsBy fallback
- `monitorTrace`: `count()==0` & spans exist → treated as `1`


🤖 Generated with [Claude Code](https://claude.com/claude-code)
