### PR TITLE
feat(dashboard): persist table filters, facets, search, sort and pagination in the url

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
@@ -314,6 +314,15 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
     }),
   ];
 
+  /*
+   * One namespace for everything this table mirrors into the URL, so the
+   * column filters (persisted by ModelTable) and the facet chips (persisted
+   * by useResourceOwners) always travel together. Falls back to a stable
+   * per-table id for the pages that embed this table without saved views.
+   */
+  const tableUrlStateKey: string =
+    props.saveFilterProps?.tableId || "alerts-table";
+
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -323,7 +332,7 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
     facetSaveState,
     restoreFacetState,
   } = useResourceOwners<Alert>({
-    persistKey: props.saveFilterProps?.tableId,
+    persistKey: tableUrlStateKey,
     ownerUserModelType: AlertOwnerUser,
     ownerTeamModelType: AlertOwnerTeam,
     resourceIdField: "alertId",
@@ -542,6 +551,7 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
         searchableFields={["title", "description"]}
         showViewIdButton={true}
         saveFilterProps={props.saveFilterProps}
+        urlStateKey={tableUrlStateKey}
         viewPageRoute={RouteUtil.populateRouteParams(RouteMap[PageMap.ALERTS]!)}
         filters={[
           {

--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionsViewer.tsx
@@ -49,6 +49,7 @@ import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
 import ExceptionRow from "./ExceptionRow";
+import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
 
 const DEFAULT_PAGE_SIZE: number = 50;
 
@@ -342,15 +343,7 @@ const ExceptionsViewer: FunctionComponent<ExceptionsViewerProps> = (
       params.set("status", status);
     }
 
-    const query: string = params.toString();
-    const nextSearch: string = query ? `?${query}` : "";
-    if (nextSearch !== window.location.search) {
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${nextSearch}${window.location.hash}`,
-      );
-    }
+    writeTelemetryViewerUrlState(Object.fromEntries(params.entries()));
   }, [
     submittedSearch,
     activeFilters,

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
@@ -244,6 +244,15 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
     }),
   ];
 
+  /*
+   * One namespace for everything this table mirrors into the URL, so the
+   * column filters (persisted by ModelTable) and the facet chips (persisted
+   * by useResourceOwners) always travel together. Falls back to a stable
+   * per-table id for the pages that embed this table without saved views.
+   */
+  const tableUrlStateKey: string =
+    props.saveFilterProps?.tableId || "incidents-table";
+
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -253,7 +262,7 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
     facetSaveState,
     restoreFacetState,
   } = useResourceOwners<Incident>({
-    persistKey: props.saveFilterProps?.tableId,
+    persistKey: tableUrlStateKey,
     ownerUserModelType: IncidentOwnerUser,
     ownerTeamModelType: IncidentOwnerTeam,
     resourceIdField: "incidentId",
@@ -481,6 +490,7 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
         }}
         modelType={Incident}
         saveFilterProps={props.saveFilterProps}
+        urlStateKey={tableUrlStateKey}
         id="incidents-table"
         isDeleteable={false}
         showCreateForm={false}

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -60,6 +60,7 @@ import RangeStartAndEndDateTime, {
 } from "Common/Types/Time/RangeStartAndEndDateTime";
 import TimeRange from "Common/Types/Time/TimeRange";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
+import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
 
 export interface ComponentProps {
   id: string;
@@ -477,15 +478,7 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
       params.set("pageSize", String(pageSize));
     }
 
-    const query: string = params.toString();
-    const nextSearch: string = query ? `?${query}` : "";
-    if (nextSearch !== window.location.search) {
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${nextSearch}${window.location.hash}`,
-      );
-    }
+    writeTelemetryViewerUrlState(Object.fromEntries(params.entries()));
   }, [
     props.syncUrlState,
     appliedFacetFilters,

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricsViewer.tsx
@@ -63,6 +63,7 @@ import HTTPResponse from "Common/Types/API/HTTPResponse";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import { JSONObject } from "Common/Types/JSON";
 import { APP_API_URL } from "Common/UI/Config";
+import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
 
 async function postApi(
   path: string,
@@ -444,15 +445,7 @@ const MetricsViewer: FunctionComponent<Props> = (
       params.set("pageSize", String(pageSize));
     }
 
-    const query: string = params.toString();
-    const nextSearch: string = query ? `?${query}` : "";
-    if (nextSearch !== window.location.search) {
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${nextSearch}${window.location.hash}`,
-      );
-    }
+    writeTelemetryViewerUrlState(Object.fromEntries(params.entries()));
   }, [submittedSearch, activeFilters, timeRange, page, pageSize]);
 
   // Load services and telemetry attributes once

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
@@ -182,6 +182,15 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
     },
   ];
 
+  /*
+   * One namespace for everything this table mirrors into the URL, so the
+   * column filters (persisted by ModelTable) and the facet chips (persisted
+   * by useResourceOwners) always travel together. Falls back to a stable
+   * per-table id for the pages that embed this table without saved views.
+   */
+  const tableUrlStateKey: string =
+    props.saveFilterProps?.tableId || "monitors-table";
+
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -196,7 +205,7 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
     resourceIdField: "monitorId",
     showLabelsFacet: true,
     extraFacets: monitorExtraFacets,
-    persistKey: props.saveFilterProps?.tableId,
+    persistKey: tableUrlStateKey,
   });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
@@ -482,6 +491,7 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
         userPreferencesKey="monitors-table"
         id="Monitors-table"
         saveFilterProps={props.saveFilterProps}
+        urlStateKey={tableUrlStateKey}
         bulkActions={{
           buttons: [
             {

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
@@ -1,0 +1,172 @@
+import { FilterOperator } from "./FilterChipDropdown";
+import { JSONObject } from "Common/Types/JSON";
+
+/**
+ * Everything the facet bar lets a user pick, in a form that survives a round
+ * trip through a URL query param or a saved `TableView`.
+ *
+ * Only IDs and operators are stored — never the display labels — so a restored
+ * selection produces the correct query immediately, before the (async) option
+ * lists have loaded and can supply names.
+ */
+export interface FacetSelectionState {
+  selectedOwnerKeys: Array<string>;
+  selectedLabelIds: Array<string>;
+  facetSelections: { [facetKey: string]: Array<string> };
+  ownerOperator: FilterOperator;
+  labelOperator: FilterOperator;
+  facetOperators: { [facetKey: string]: FilterOperator };
+}
+
+export type IsFilterOperatorFunction = (
+  value: unknown,
+) => value is FilterOperator;
+
+export const isFilterOperator: IsFilterOperatorFunction = (
+  value: unknown,
+): value is FilterOperator => {
+  return (
+    value === "is" ||
+    value === "is_not" ||
+    value === "is_empty" ||
+    value === "is_not_empty"
+  );
+};
+
+export type GetEmptyFacetSelectionStateFunction = () => FacetSelectionState;
+
+/**
+ * A fresh "nothing selected" state. Returned as a new object each call so
+ * callers can hand it straight to `useState` without sharing mutable arrays.
+ */
+export const getEmptyFacetSelectionState: GetEmptyFacetSelectionStateFunction =
+  (): FacetSelectionState => {
+    return {
+      selectedOwnerKeys: [],
+      selectedLabelIds: [],
+      facetSelections: {},
+      ownerOperator: "is",
+      labelOperator: "is",
+      facetOperators: {},
+    };
+  };
+
+type ToStringArrayFunction = (value: unknown) => Array<string>;
+
+const toStringArray: ToStringArrayFunction = (
+  value: unknown,
+): Array<string> => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry: unknown): entry is string => {
+    return typeof entry === "string" && entry.length > 0;
+  });
+};
+
+export type ParseFacetSelectionStateFunction = (
+  state: JSONObject | null | undefined,
+) => FacetSelectionState;
+
+/**
+ * Rebuild facet selections from an untrusted snapshot (a URL param a teammate
+ * pasted, or a saved view written by an older build).
+ *
+ * Every field is validated on its own and falls back to its default, so one
+ * malformed entry can never take the whole filter bar down — the worst case is
+ * that a single chip comes back empty.
+ */
+export const parseFacetSelectionState: ParseFacetSelectionStateFunction = (
+  state: JSONObject | null | undefined,
+): FacetSelectionState => {
+  const parsed: FacetSelectionState = getEmptyFacetSelectionState();
+
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    return parsed;
+  }
+
+  parsed.selectedOwnerKeys = toStringArray(state["selectedOwnerKeys"]);
+  parsed.selectedLabelIds = toStringArray(state["selectedLabelIds"]);
+
+  const rawSelections: unknown = state["facetSelections"];
+  if (
+    rawSelections &&
+    typeof rawSelections === "object" &&
+    !Array.isArray(rawSelections)
+  ) {
+    for (const [key, value] of Object.entries(
+      rawSelections as Record<string, unknown>,
+    )) {
+      if (Array.isArray(value)) {
+        parsed.facetSelections[key] = toStringArray(value);
+      }
+    }
+  }
+
+  if (isFilterOperator(state["ownerOperator"])) {
+    parsed.ownerOperator = state["ownerOperator"];
+  }
+
+  if (isFilterOperator(state["labelOperator"])) {
+    parsed.labelOperator = state["labelOperator"];
+  }
+
+  const rawFacetOperators: unknown = state["facetOperators"];
+  if (
+    rawFacetOperators &&
+    typeof rawFacetOperators === "object" &&
+    !Array.isArray(rawFacetOperators)
+  ) {
+    for (const [key, value] of Object.entries(
+      rawFacetOperators as Record<string, unknown>,
+    )) {
+      if (isFilterOperator(value)) {
+        parsed.facetOperators[key] = value;
+      }
+    }
+  }
+
+  return parsed;
+};
+
+export type IsFacetSelectionActiveFunction = (
+  state: FacetSelectionState,
+) => boolean;
+
+/**
+ * Does this state constrain anything? Used to decide whether the snapshot is
+ * worth putting on the URL at all.
+ */
+export const isFacetSelectionActive: IsFacetSelectionActiveFunction = (
+  state: FacetSelectionState,
+): boolean => {
+  const operatorIsActive: (operator: FilterOperator) => boolean = (
+    operator: FilterOperator,
+  ): boolean => {
+    return operator === "is_empty" || operator === "is_not_empty";
+  };
+
+  if (
+    state.selectedOwnerKeys.length > 0 ||
+    state.selectedLabelIds.length > 0 ||
+    operatorIsActive(state.ownerOperator) ||
+    operatorIsActive(state.labelOperator)
+  ) {
+    return true;
+  }
+
+  for (const key of Object.keys(state.facetSelections)) {
+    if ((state.facetSelections[key] || []).length > 0) {
+      return true;
+    }
+  }
+
+  for (const key of Object.keys(state.facetOperators)) {
+    if (operatorIsActive(state.facetOperators[key] as FilterOperator)) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners.tsx
@@ -31,6 +31,10 @@ import FilterChipDropdown, {
   FilterOperator,
 } from "./FilterChipDropdown";
 import { ResourceOwnerEntry } from "./OwnerEntry";
+import {
+  FacetSelectionState,
+  parseFacetSelectionState,
+} from "./FacetSelectionState";
 
 const PICKER_PAGE_SIZE: number = 50;
 
@@ -354,20 +358,43 @@ const useResourceOwners: <TResource extends BaseModel>(
   }>({});
   const [isLoadingOwners, setIsLoadingOwners] = useState<boolean>(false);
 
-  const [selectedOwnerKeys, setSelectedOwnerKeys] = useState<Array<string>>([]);
-  const [selectedLabelIds, setSelectedLabelIds] = useState<Array<string>>([]);
+  /*
+   * Selections that were on the URL when this page was opened — a Back
+   * navigation from a detail page, or a link a teammate shared. Read once,
+   * synchronously, so the very first merged query already carries them and
+   * the table never flashes the unfiltered list.
+   *
+   * Only IDs are restored, so this does not have to wait for the facets'
+   * option lists to load; the chips fill in their display names later.
+   */
+  const initialFacetState: FacetSelectionState = useMemo(() => {
+    return parseFacetSelectionState(
+      TableFilterUrlState.read(persistKey, "facets"),
+    );
+  }, []);
+
+  const [selectedOwnerKeys, setSelectedOwnerKeys] = useState<Array<string>>(
+    initialFacetState.selectedOwnerKeys,
+  );
+  const [selectedLabelIds, setSelectedLabelIds] = useState<Array<string>>(
+    initialFacetState.selectedLabelIds,
+  );
 
   // Per-facet operator (defaults to "is" when missing).
-  const [ownerOperator, setOwnerOperator] = useState<FilterOperator>("is");
-  const [labelOperator, setLabelOperator] = useState<FilterOperator>("is");
+  const [ownerOperator, setOwnerOperator] = useState<FilterOperator>(
+    initialFacetState.ownerOperator,
+  );
+  const [labelOperator, setLabelOperator] = useState<FilterOperator>(
+    initialFacetState.labelOperator,
+  );
   const [facetOperators, setFacetOperators] = useState<{
     [facetKey: string]: FilterOperator;
-  }>({});
+  }>(initialFacetState.facetOperators);
 
   // Per-facet selected values keyed by facet.key.
   const [facetSelections, setFacetSelections] = useState<{
     [facetKey: string]: Array<string>;
-  }>({});
+  }>(initialFacetState.facetSelections);
   // Per-facet dynamic option lists keyed by facet.key.
   const [facetDynamicOptions, setFacetDynamicOptions] = useState<{
     [facetKey: string]: Array<FilterChipDropdownOption>;
@@ -1635,131 +1662,37 @@ const useResourceOwners: <TResource extends BaseModel>(
   const restoreFacetState: (state: JSONObject | null) => void = (
     state: JSONObject | null,
   ): void => {
+    const parsed: FacetSelectionState = parseFacetSelectionState(state);
+
+    setSelectedOwnerKeys(parsed.selectedOwnerKeys);
+    setSelectedLabelIds(parsed.selectedLabelIds);
+    setFacetSelections(parsed.facetSelections);
+    setOwnerOperator(parsed.ownerOperator);
+    setLabelOperator(parsed.labelOperator);
+    setFacetOperators(parsed.facetOperators);
+
     if (!state) {
-      setSelectedOwnerKeys([]);
-      setSelectedLabelIds([]);
-      setFacetSelections({});
-      setOwnerOperator("is");
-      setLabelOperator("is");
-      setFacetOperators({});
       setFacetMatchingIds({});
-      return;
-    }
-
-    const isValidOperator: (v: unknown) => v is FilterOperator = (
-      v: unknown,
-    ): v is FilterOperator => {
-      return (
-        v === "is" || v === "is_not" || v === "is_empty" || v === "is_not_empty"
-      );
-    };
-
-    const rawOwners: unknown = state["selectedOwnerKeys"];
-    if (Array.isArray(rawOwners)) {
-      setSelectedOwnerKeys(
-        rawOwners.filter((v: unknown): v is string => {
-          return typeof v === "string";
-        }),
-      );
-    } else {
-      setSelectedOwnerKeys([]);
-    }
-
-    const rawLabels: unknown = state["selectedLabelIds"];
-    if (Array.isArray(rawLabels)) {
-      setSelectedLabelIds(
-        rawLabels.filter((v: unknown): v is string => {
-          return typeof v === "string";
-        }),
-      );
-    } else {
-      setSelectedLabelIds([]);
-    }
-
-    const rawSelections: unknown = state["facetSelections"];
-    if (
-      rawSelections &&
-      typeof rawSelections === "object" &&
-      !Array.isArray(rawSelections)
-    ) {
-      const next: { [k: string]: Array<string> } = {};
-      for (const [k, v] of Object.entries(
-        rawSelections as Record<string, unknown>,
-      )) {
-        if (Array.isArray(v)) {
-          next[k] = v.filter((x: unknown): x is string => {
-            return typeof x === "string";
-          });
-        }
-      }
-      setFacetSelections(next);
-    } else {
-      setFacetSelections({});
-    }
-
-    setOwnerOperator(
-      isValidOperator(state["ownerOperator"]) ? state["ownerOperator"] : "is",
-    );
-    setLabelOperator(
-      isValidOperator(state["labelOperator"]) ? state["labelOperator"] : "is",
-    );
-
-    const rawFacetOps: unknown = state["facetOperators"];
-    if (
-      rawFacetOps &&
-      typeof rawFacetOps === "object" &&
-      !Array.isArray(rawFacetOps)
-    ) {
-      const next: { [k: string]: FilterOperator } = {};
-      for (const [k, v] of Object.entries(
-        rawFacetOps as Record<string, unknown>,
-      )) {
-        if (isValidOperator(v)) {
-          next[k] = v;
-        }
-      }
-      setFacetOperators(next);
-    } else {
-      setFacetOperators({});
     }
   };
 
   /*
-   * URL persistence for facets.
+   * Mirror active facet selections into the URL whenever they change, so the
+   * chips survive a Back-navigation and the link can be shared.
    *
-   * `hasRestoredFacetUrlState` is intentionally state (not a ref): the persist
-   * effect below depends on it, so it only runs *after* the render in which the
-   * restore has been applied. That guarantees we never write the empty default
-   * back over a snapshot we're about to restore.
+   * The restore side happens in the `useState` initializers above — reading
+   * the URL synchronously on the first render means the merged query is
+   * already correct when the table fires its first fetch. Restoring in an
+   * effect instead (what this used to do) fetched the unfiltered list first
+   * and then threw it away.
    */
-  const [hasRestoredFacetUrlState, setHasRestoredFacetUrlState] =
-    useState<boolean>(false);
-
-  // On mount, restore facet selections from the URL (Back-button / shared link).
   useEffect(() => {
-    if (persistKey) {
-      const restored: JSONObject | null = TableFilterUrlState.read(
-        persistKey,
-        "facets",
-      );
-      if (restored) {
-        restoreFacetState(restored);
-      }
-    }
-    setHasRestoredFacetUrlState(true);
-  }, []);
-
-  // Mirror active facet selections into the URL whenever they change.
-  useEffect(() => {
-    if (!persistKey || !hasRestoredFacetUrlState) {
-      return;
-    }
     TableFilterUrlState.write(
       persistKey,
       "facets",
       hasActiveFilters ? facetSaveState : null,
     );
-  }, [persistKey, hasRestoredFacetUrlState, hasActiveFilters, facetSaveState]);
+  }, [persistKey, hasActiveFilters, facetSaveState]);
 
   const getOwnersForResource: (
     resource: TResource,

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
@@ -181,6 +181,15 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
     }),
   ];
 
+  /*
+   * One namespace for everything this table mirrors into the URL, so the
+   * column filters (persisted by ModelTable) and the facet chips (persisted
+   * by useResourceOwners) always travel together. Falls back to a stable
+   * per-table id for the pages that embed this table without saved views.
+   */
+  const tableUrlStateKey: string =
+    props.saveFilterProps?.tableId || "scheduled-maintenance-table";
+
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -190,7 +199,7 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
     facetSaveState,
     restoreFacetState,
   } = useResourceOwners<ScheduledMaintenance>({
-    persistKey: props.saveFilterProps?.tableId,
+    persistKey: tableUrlStateKey,
     ownerUserModelType: ScheduledMaintenanceOwnerUser,
     ownerTeamModelType: ScheduledMaintenanceOwnerTeam,
     resourceIdField: "scheduledMaintenanceId",
@@ -432,6 +441,7 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
         isCreateable={false}
         isViewable={true}
         saveFilterProps={props.saveFilterProps}
+        urlStateKey={tableUrlStateKey}
         showCreateForm={false}
         cardProps={{
           title: props.title || "Scheduled Maintenance Events",

--- a/App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer.tsx
@@ -71,6 +71,7 @@ import TraceAggregationType from "Common/Types/Trace/TraceAggregationType";
 import TraceRecordingRuleDefinition, {
   TraceRecordingRuleAttributeFilter,
 } from "Common/Types/Trace/TraceRecordingRuleDefinition";
+import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
 
 const DEFAULT_PAGE_SIZE: number = 50;
 const LIVE_POLL_INTERVAL_MS: number = 10000;
@@ -947,15 +948,7 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
       params.set("rootOnly", "true");
     }
 
-    const query: string = params.toString();
-    const nextSearch: string = query ? `?${query}` : "";
-    if (nextSearch !== window.location.search) {
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${nextSearch}${window.location.hash}`,
-      );
-    }
+    writeTelemetryViewerUrlState(Object.fromEntries(params.entries()));
   }, [
     submittedSearch,
     activeFilters,

--- a/App/FeatureSet/Dashboard/src/Pages/UserSettings/AlertOnCallRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/UserSettings/AlertOnCallRules.tsx
@@ -68,7 +68,18 @@ const Settings: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return (
       <ModelTable<UserNotificationRule>
         modelType={UserNotificationRule}
-        userPreferencesKey={`user-notification-rules-table-${options.ruleType}`}
+        /*
+         * One of these tables is rendered per severity, so the severity has to
+         * be part of the key: it namespaces both the stored page-size
+         * preference and this table's slice of the URL state. Without it every
+         * table on the page would share one namespace and paging one would
+         * repaginate the rest.
+         */
+        userPreferencesKey={`user-notification-rules-table-${options.ruleType}${
+          options.alertSeverity?.id
+            ? `-${options.alertSeverity.id.toString()}`
+            : ""
+        }`}
         query={{
           projectId: ProjectUtil.getCurrentProjectId()!,
           userId: User.getUserId()!,

--- a/App/FeatureSet/Dashboard/src/Pages/UserSettings/EpisodeOnCallRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/UserSettings/EpisodeOnCallRules.tsx
@@ -68,7 +68,18 @@ const Settings: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return (
       <ModelTable<UserNotificationRule>
         modelType={UserNotificationRule}
-        userPreferencesKey={`user-notification-rules-table-${options.ruleType}`}
+        /*
+         * One of these tables is rendered per severity, so the severity has to
+         * be part of the key: it namespaces both the stored page-size
+         * preference and this table's slice of the URL state. Without it every
+         * table on the page would share one namespace and paging one would
+         * repaginate the rest.
+         */
+        userPreferencesKey={`user-notification-rules-table-${options.ruleType}${
+          options.alertSeverity?.id
+            ? `-${options.alertSeverity.id.toString()}`
+            : ""
+        }`}
         query={{
           projectId: ProjectUtil.getCurrentProjectId()!,
           userId: User.getUserId()!,

--- a/App/FeatureSet/Dashboard/src/Pages/UserSettings/IncidentEpisodeOnCallRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/UserSettings/IncidentEpisodeOnCallRules.tsx
@@ -68,7 +68,18 @@ const Settings: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return (
       <ModelTable<UserNotificationRule>
         modelType={UserNotificationRule}
-        userPreferencesKey={`user-notification-rules-table-${options.ruleType}`}
+        /*
+         * One of these tables is rendered per severity, so the severity has to
+         * be part of the key: it namespaces both the stored page-size
+         * preference and this table's slice of the URL state. Without it every
+         * table on the page would share one namespace and paging one would
+         * repaginate the rest.
+         */
+        userPreferencesKey={`user-notification-rules-table-${options.ruleType}${
+          options.incidentSeverity?.id
+            ? `-${options.incidentSeverity.id.toString()}`
+            : ""
+        }`}
         query={{
           projectId: ProjectUtil.getCurrentProjectId()!,
           userId: User.getUserId()!,

--- a/App/FeatureSet/Dashboard/src/Pages/UserSettings/IncidentOnCallRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/UserSettings/IncidentOnCallRules.tsx
@@ -68,7 +68,18 @@ const Settings: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return (
       <ModelTable<UserNotificationRule>
         modelType={UserNotificationRule}
-        userPreferencesKey={`user-notification-rules-table-${options.ruleType}`}
+        /*
+         * One of these tables is rendered per severity, so the severity has to
+         * be part of the key: it namespaces both the stored page-size
+         * preference and this table's slice of the URL state. Without it every
+         * table on the page would share one namespace and paging one would
+         * repaginate the rest.
+         */
+        userPreferencesKey={`user-notification-rules-table-${options.ruleType}${
+          options.incidentSeverity?.id
+            ? `-${options.incidentSeverity.id.toString()}`
+            : ""
+        }`}
         query={{
           projectId: ProjectUtil.getCurrentProjectId()!,
           userId: User.getUserId()!,

--- a/App/FeatureSet/Dashboard/src/Utils/TelemetryViewerUrlState.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/TelemetryViewerUrlState.ts
@@ -1,0 +1,72 @@
+import Dictionary from "Common/Types/Dictionary";
+import Navigation from "Common/UI/Utils/Navigation";
+
+/**
+ * The query params the telemetry explorers (Logs / Traces / Metrics /
+ * Exceptions) own. Every write clears the ones the current view isn't using,
+ * which is what lets a filter be *removed* from the URL — while leaving every
+ * other param on the route alone.
+ *
+ * Only one explorer is mounted per route at a time, so a single shared set is
+ * enough; the names are identical across the four anyway.
+ */
+export const TelemetryViewerUrlParamNames: Array<string> = [
+  "search",
+  "filters",
+  "range",
+  "start",
+  "end",
+  "page",
+  "pageSize",
+  "view",
+  "rootOnly",
+  "status",
+];
+
+export type BuildTelemetryViewerUrlParamsFunction = (
+  values: Dictionary<string | null>,
+) => Dictionary<string | null>;
+
+/**
+ * Expand the params a view wants to set into the full owned set, with the
+ * unused ones explicitly nulled so {@link Navigation.setQueryString} deletes
+ * them.
+ */
+export const buildTelemetryViewerUrlParams: BuildTelemetryViewerUrlParamsFunction =
+  (values: Dictionary<string | null>): Dictionary<string | null> => {
+    const params: Dictionary<string | null> = {};
+
+    for (const name of TelemetryViewerUrlParamNames) {
+      params[name] = null;
+    }
+
+    for (const name of Object.keys(values)) {
+      params[name] = values[name] ?? null;
+    }
+
+    return params;
+  };
+
+export type WriteTelemetryViewerUrlStateFunction = (
+  values: Dictionary<string | null>,
+) => void;
+
+/**
+ * Mirror an explorer's view into the URL.
+ *
+ * Goes through {@link Navigation.setQueryString} rather than calling
+ * `history.replaceState` directly, which matters for two reasons:
+ *
+ *  - it *merges* instead of replacing the whole query string. The explorers
+ *    used to build a fresh `URLSearchParams` and overwrite `location.search`
+ *    wholesale, which silently deleted every param owned by anything else on
+ *    the route — a co-mounted table's saved filters, the Profiles tab's
+ *    deep-link ids, dashboard variables.
+ *  - it preserves `window.history.state`. Passing `null` (as the old code did)
+ *    wipes react-router's `{usr, key, idx}` bookkeeping on the current entry,
+ *    which corrupts its history index and drops any navigation state.
+ */
+export const writeTelemetryViewerUrlState: WriteTelemetryViewerUrlStateFunction =
+  (values: Dictionary<string | null>): void => {
+    Navigation.setQueryString(buildTelemetryViewerUrlParams(values));
+  };

--- a/App/Tests/Dashboard/FacetSelectionState.test.ts
+++ b/App/Tests/Dashboard/FacetSelectionState.test.ts
@@ -1,0 +1,266 @@
+import {
+  FacetSelectionState,
+  getEmptyFacetSelectionState,
+  isFacetSelectionActive,
+  isFilterOperator,
+  parseFacetSelectionState,
+} from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState";
+import { JSONObject } from "Common/Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The facet chips above a list (Owner, Labels, Status, ...) are mirrored into
+ * the URL so they survive "open a row, press Back" and so a filtered view can
+ * be pasted to a teammate. That snapshot is also what a saved TableView
+ * stores, which means this parser has to cope with:
+ *
+ *   - a link a user hand-edited,
+ *   - a view saved by an older build with a different shape, and
+ *   - facet keys that no longer exist.
+ *
+ * In every case one bad entry must cost at most one chip — never the whole
+ * filter bar, and never a crash on a page the user can only reach by
+ * navigating back.
+ */
+
+describe("isFilterOperator", () => {
+  test("accepts the four supported operators", () => {
+    expect(isFilterOperator("is")).toBe(true);
+    expect(isFilterOperator("is_not")).toBe(true);
+    expect(isFilterOperator("is_empty")).toBe(true);
+    expect(isFilterOperator("is_not_empty")).toBe(true);
+  });
+
+  test("rejects anything else", () => {
+    expect(isFilterOperator("contains")).toBe(false);
+    expect(isFilterOperator("")).toBe(false);
+    expect(isFilterOperator(null)).toBe(false);
+    expect(isFilterOperator(undefined)).toBe(false);
+    expect(isFilterOperator(5)).toBe(false);
+    expect(isFilterOperator({})).toBe(false);
+  });
+});
+
+describe("getEmptyFacetSelectionState", () => {
+  test("has nothing selected", () => {
+    expect(getEmptyFacetSelectionState()).toEqual({
+      selectedOwnerKeys: [],
+      selectedLabelIds: [],
+      facetSelections: {},
+      ownerOperator: "is",
+      labelOperator: "is",
+      facetOperators: {},
+    });
+  });
+
+  test("returns a fresh object each time, so callers can't share arrays", () => {
+    const first: FacetSelectionState = getEmptyFacetSelectionState();
+    const second: FacetSelectionState = getEmptyFacetSelectionState();
+
+    first.selectedLabelIds.push("a");
+
+    expect(second.selectedLabelIds).toEqual([]);
+  });
+});
+
+describe("parseFacetSelectionState", () => {
+  test("returns the empty state for null / undefined", () => {
+    expect(parseFacetSelectionState(null)).toEqual(
+      getEmptyFacetSelectionState(),
+    );
+    expect(parseFacetSelectionState(undefined)).toEqual(
+      getEmptyFacetSelectionState(),
+    );
+  });
+
+  test("returns the empty state for a non-object", () => {
+    expect(parseFacetSelectionState("nope" as unknown as JSONObject)).toEqual(
+      getEmptyFacetSelectionState(),
+    );
+    expect(parseFacetSelectionState([] as unknown as JSONObject)).toEqual(
+      getEmptyFacetSelectionState(),
+    );
+  });
+
+  test("reads a well-formed snapshot", () => {
+    expect(
+      parseFacetSelectionState({
+        selectedOwnerKeys: ["user:1", "team:2"],
+        selectedLabelIds: ["label-a"],
+        facetSelections: { monitorStatus: ["online", "offline"] },
+        ownerOperator: "is_not",
+        labelOperator: "is",
+        facetOperators: { monitorStatus: "is_not" },
+      }),
+    ).toEqual({
+      selectedOwnerKeys: ["user:1", "team:2"],
+      selectedLabelIds: ["label-a"],
+      facetSelections: { monitorStatus: ["online", "offline"] },
+      ownerOperator: "is_not",
+      labelOperator: "is",
+      facetOperators: { monitorStatus: "is_not" },
+    });
+  });
+
+  test("drops non-string owner keys but keeps the rest", () => {
+    expect(
+      parseFacetSelectionState({
+        selectedOwnerKeys: ["user:1", 5, null, "team:2"],
+      } as unknown as JSONObject).selectedOwnerKeys,
+    ).toEqual(["user:1", "team:2"]);
+  });
+
+  test("drops owner keys that aren't an array at all", () => {
+    expect(
+      parseFacetSelectionState({
+        selectedOwnerKeys: "user:1",
+      } as unknown as JSONObject).selectedOwnerKeys,
+    ).toEqual([]);
+  });
+
+  test("drops empty-string ids", () => {
+    expect(
+      parseFacetSelectionState({ selectedLabelIds: ["a", "", "b"] })
+        .selectedLabelIds,
+    ).toEqual(["a", "b"]);
+  });
+
+  test("keeps only the facet selections that are arrays", () => {
+    expect(
+      parseFacetSelectionState({
+        facetSelections: {
+          good: ["a"],
+          bad: "not-an-array",
+          alsoBad: 5,
+        },
+      } as unknown as JSONObject).facetSelections,
+    ).toEqual({ good: ["a"] });
+  });
+
+  test("falls back to 'is' for an unrecognised operator", () => {
+    const parsed: FacetSelectionState = parseFacetSelectionState({
+      ownerOperator: "sideways",
+      labelOperator: 5,
+    } as unknown as JSONObject);
+
+    expect(parsed.ownerOperator).toBe("is");
+    expect(parsed.labelOperator).toBe("is");
+  });
+
+  test("drops per-facet operators that aren't valid", () => {
+    expect(
+      parseFacetSelectionState({
+        facetOperators: { good: "is_not", bad: "like" },
+      } as unknown as JSONObject).facetOperators,
+    ).toEqual({ good: "is_not" });
+  });
+
+  test("one malformed field does not discard the others", () => {
+    const parsed: FacetSelectionState = parseFacetSelectionState({
+      selectedOwnerKeys: "broken",
+      selectedLabelIds: ["label-a"],
+      ownerOperator: "garbage",
+      labelOperator: "is_not",
+    } as unknown as JSONObject);
+
+    expect(parsed.selectedOwnerKeys).toEqual([]);
+    expect(parsed.selectedLabelIds).toEqual(["label-a"]);
+    expect(parsed.ownerOperator).toBe("is");
+    expect(parsed.labelOperator).toBe("is_not");
+  });
+
+  test("keeps an unknown facet key rather than throwing (the facet may load later)", () => {
+    expect(
+      parseFacetSelectionState({
+        facetSelections: { someFacetAddedLater: ["x"] },
+      }).facetSelections,
+    ).toEqual({ someFacetAddedLater: ["x"] });
+  });
+
+  test("round-trips through JSON unchanged", () => {
+    const state: FacetSelectionState = {
+      selectedOwnerKeys: ["user:1"],
+      selectedLabelIds: ["label-a", "label-b"],
+      facetSelections: { monitorStatus: ["online"] },
+      ownerOperator: "is_not_empty",
+      labelOperator: "is",
+      facetOperators: { monitorStatus: "is" },
+    };
+
+    expect(
+      parseFacetSelectionState(JSON.parse(JSON.stringify(state)) as JSONObject),
+    ).toEqual(state);
+  });
+});
+
+describe("isFacetSelectionActive", () => {
+  test("an untouched filter bar is not active", () => {
+    expect(isFacetSelectionActive(getEmptyFacetSelectionState())).toBe(false);
+  });
+
+  test("a selected owner makes it active", () => {
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        selectedOwnerKeys: ["user:1"],
+      }),
+    ).toBe(true);
+  });
+
+  test("a selected label makes it active", () => {
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        selectedLabelIds: ["label-a"],
+      }),
+    ).toBe(true);
+  });
+
+  test("a selected extra-facet value makes it active", () => {
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        facetSelections: { monitorStatus: ["online"] },
+      }),
+    ).toBe(true);
+  });
+
+  test("a presence operator is active even with nothing selected", () => {
+    /*
+     * "has no owner" constrains the list without naming a single owner, so it
+     * has to count as active or it would never reach the URL.
+     */
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        ownerOperator: "is_empty",
+      }),
+    ).toBe(true);
+
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        facetOperators: { monitorStatus: "is_not_empty" },
+      }),
+    ).toBe(true);
+  });
+
+  test("an 'is'/'is_not' operator with nothing selected is not active", () => {
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        ownerOperator: "is_not",
+        facetOperators: { monitorStatus: "is" },
+      }),
+    ).toBe(false);
+  });
+
+  test("an empty selection array is not active", () => {
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        facetSelections: { monitorStatus: [] },
+      }),
+    ).toBe(false);
+  });
+});

--- a/App/Tests/Dashboard/TelemetryViewerUrlState.test.ts
+++ b/App/Tests/Dashboard/TelemetryViewerUrlState.test.ts
@@ -1,0 +1,103 @@
+import {
+  TelemetryViewerUrlParamNames,
+  buildTelemetryViewerUrlParams,
+} from "../../FeatureSet/Dashboard/src/Utils/TelemetryViewerUrlState";
+import Dictionary from "Common/Types/Dictionary";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The Logs / Traces / Metrics / Exceptions explorers each mirror their view
+ * into the URL. They used to do it by building a fresh URLSearchParams and
+ * replacing `location.search` wholesale, which deleted every param they didn't
+ * own — a co-mounted table's saved filters, the Profiles tab's deep-link ids,
+ * dashboard variables — the moment an explorer rendered.
+ *
+ * They now hand this helper the params they want set, and it expands them into
+ * the full owned set with the unused ones nulled, so `Navigation.setQueryString`
+ * removes exactly those and merges the rest.
+ */
+
+describe("buildTelemetryViewerUrlParams", () => {
+  test("nulls every owned param when the view sets nothing", () => {
+    const params: Dictionary<string | null> = buildTelemetryViewerUrlParams({});
+
+    expect(Object.keys(params).sort()).toEqual(
+      [...TelemetryViewerUrlParamNames].sort(),
+    );
+
+    for (const name of TelemetryViewerUrlParamNames) {
+      expect(params[name]).toBeNull();
+    }
+  });
+
+  test("keeps the params the view set and nulls the rest", () => {
+    const params: Dictionary<string | null> = buildTelemetryViewerUrlParams({
+      search: "service:api",
+      page: "3",
+    });
+
+    expect(params["search"]).toBe("service:api");
+    expect(params["page"]).toBe("3");
+    expect(params["filters"]).toBeNull();
+    expect(params["range"]).toBeNull();
+    expect(params["pageSize"]).toBeNull();
+  });
+
+  test("never mentions a param it does not own, so foreign params survive", () => {
+    const params: Dictionary<string | null> = buildTelemetryViewerUrlParams({
+      search: "api",
+    });
+
+    /*
+     * These are owned by other things on the same route. Because they are
+     * absent from the result, setQueryString leaves them exactly as they are.
+     */
+    expect(params).not.toHaveProperty("monitors-table-filter");
+    expect(params).not.toHaveProperty("monitors-table-view");
+    expect(params).not.toHaveProperty("var-region");
+    expect(params).not.toHaveProperty("serviceId");
+    expect(params).not.toHaveProperty("tab");
+  });
+
+  test("treats an explicit null the same as omitting the param", () => {
+    const params: Dictionary<string | null> = buildTelemetryViewerUrlParams({
+      search: null,
+    });
+
+    expect(params["search"]).toBeNull();
+  });
+
+  test("carries a value that is not part of the owned set through unchanged", () => {
+    /*
+     * A viewer that grows a new param still works — it just needs adding to
+     * TelemetryViewerUrlParamNames before it can be *cleared*.
+     */
+    const params: Dictionary<string | null> = buildTelemetryViewerUrlParams({
+      brandNewParam: "value",
+    });
+
+    expect(params["brandNewParam"]).toBe("value");
+  });
+
+  test("covers every param the four explorers write", () => {
+    /*
+     * Guards against a viewer adding a param and forgetting to register it —
+     * an unregistered param can be set but never removed, so a filter the user
+     * cleared would linger in a shared link.
+     */
+    for (const name of [
+      "search",
+      "filters",
+      "range",
+      "start",
+      "end",
+      "page",
+      "pageSize",
+      "view",
+      "rootOnly",
+      "status",
+    ]) {
+      expect(TelemetryViewerUrlParamNames).toContain(name);
+    }
+  });
+});

--- a/Common/Tests/Types/Database/CompareOperatorWireSerialization.test.ts
+++ b/Common/Tests/Types/Database/CompareOperatorWireSerialization.test.ts
@@ -1,4 +1,6 @@
 import CompareBase, { CompareType } from "../../../Types/Database/CompareBase";
+import EqualTo from "../../../Types/BaseDatabase/EqualTo";
+import EqualToOrNull from "../../../Types/BaseDatabase/EqualToOrNull";
 import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "../../../Types/BaseDatabase/GreaterThanOrEqual";
 import GreaterThanOrNull from "../../../Types/BaseDatabase/GreaterThanOrNull";
@@ -6,6 +8,7 @@ import InBetween from "../../../Types/BaseDatabase/InBetween";
 import LessThan from "../../../Types/BaseDatabase/LessThan";
 import LessThanOrEqual from "../../../Types/BaseDatabase/LessThanOrEqual";
 import LessThanOrNull from "../../../Types/BaseDatabase/LessThanOrNull";
+import NotEqual from "../../../Types/BaseDatabase/NotEqual";
 import JSONFunctions from "../../../Types/JSONFunctions";
 import { JSONObject } from "../../../Types/JSON";
 import { describe, expect, it } from "@jest/globals";
@@ -85,6 +88,36 @@ const OPERATOR_CASES: Array<OperatorCase> = [
     type: GreaterThanOrNull,
     create: (value: CompareType) => {
       return new GreaterThanOrNull(value);
+    },
+  },
+  /*
+   * The equality operators were missed when the six ordering operators above
+   * were converted, and kept serializing via toString(). That made them the
+   * only type-lossy path left: `new EqualTo(42)` came back as the string
+   * "42", and a Date came back as a locale string such as
+   * "Wed Jul 01 2026 13:34:56 GMT+0100 (British Summer Time)" — timezone
+   * dependent and missing milliseconds. Both broke as soon as a filter had to
+   * survive a round trip through the URL.
+   */
+  {
+    name: "EqualTo",
+    type: EqualTo,
+    create: (value: CompareType) => {
+      return new EqualTo(value);
+    },
+  },
+  {
+    name: "EqualToOrNull",
+    type: EqualToOrNull,
+    create: (value: CompareType) => {
+      return new EqualToOrNull(value);
+    },
+  },
+  {
+    name: "NotEqual",
+    type: NotEqual,
+    create: (value: CompareType) => {
+      return new NotEqual(value);
     },
   },
 ];

--- a/Common/Tests/UI/Components/EntityFilterRoundTrip.test.tsx
+++ b/Common/Tests/UI/Components/EntityFilterRoundTrip.test.tsx
@@ -1,0 +1,103 @@
+import EntityFilter from "../../../UI/Components/Filters/EntityFilter";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import Filter from "../../../UI/Components/Filters/Types/Filter";
+import FilterData from "../../../UI/Components/Filters/Types/FilterData";
+import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import NotNull from "../../../Types/BaseDatabase/NotNull";
+import GenericObject from "../../../Types/GenericObject";
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * `EntityFilter` encodes a single-entity "is not" as a one-item IncludesNone,
+ * because there is no dedicated NotEqual-for-entities operator. Reading that
+ * encoding back is what makes the operator survive a remount — which is every
+ * Back-navigation and every shared link.
+ *
+ * The read side used to only understand IsNull, NotNull and a bare string, so
+ * "is not" silently reverted to "is" (with its value dropped) the moment the
+ * component re-mounted: the URL still carried the right filter, but the UI
+ * disagreed with it.
+ */
+
+type Resource = GenericObject & { ownerId?: string };
+
+const FILTER: Filter<Resource> = {
+  key: "ownerId",
+  title: "Owner",
+  type: FieldType.Entity,
+  filterDropdownOptions: [
+    { label: "Alex", value: "user-1" },
+    { label: "Sam", value: "user-2" },
+  ],
+} as unknown as Filter<Resource>;
+
+type RenderWithFunction = (filterData: FilterData<Resource>) => void;
+
+const renderWith: RenderWithFunction = (
+  filterData: FilterData<Resource>,
+): void => {
+  render(
+    <EntityFilter<Resource>
+      filter={FILTER}
+      filterData={filterData}
+      onFilterChanged={jest.fn()}
+    />,
+  );
+};
+
+describe("EntityFilter operator round trip", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("a bare id reads back as 'is'", () => {
+    renderWith({ ownerId: "user-1" } as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("is")).toBeTruthy();
+  });
+
+  test("a one-item IncludesNone reads back as 'is not', not 'is'", () => {
+    renderWith({
+      ownerId: new IncludesNone(["user-1"]),
+    } as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("is not")).toBeTruthy();
+  });
+
+  test("the selected entity survives alongside the 'is not' operator", () => {
+    renderWith({
+      ownerId: new IncludesNone(["user-1"]),
+    } as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("Alex")).toBeTruthy();
+  });
+
+  test("IsNull reads back as 'is empty'", () => {
+    renderWith({ ownerId: new IsNull() } as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("is empty")).toBeTruthy();
+  });
+
+  test("NotNull reads back as 'is not empty'", () => {
+    renderWith({ ownerId: new NotNull() } as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("is not empty")).toBeTruthy();
+  });
+
+  test("no value at all falls back to 'is'", () => {
+    renderWith({} as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("is")).toBeTruthy();
+  });
+
+  test("an empty IncludesNone still selects the 'is not' operator", () => {
+    renderWith({
+      ownerId: new IncludesNone([]),
+    } as unknown as FilterData<Resource>);
+
+    expect(screen.getByText("is not")).toBeTruthy();
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableUrlState.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableUrlState.test.tsx
@@ -1,0 +1,612 @@
+import "@testing-library/jest-dom/extend-expect";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import React, { ReactElement } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * BaseModelTable pulls in permissions, the current project and the i18n
+ * provider. None of those are what these tests are about, so they are stubbed
+ * to their permissive/no-op form and the tests focus on the one thing that
+ * matters here: the table's view state and the URL are kept in sync, in both
+ * directions.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return true;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined) => {
+          return value;
+        },
+        translateValue: (value: unknown) => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import Navigation from "../../../../UI/Utils/Navigation";
+import Filter from "../../../../UI/Components/ModelFilter/Filter";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Query from "../../../../Types/BaseDatabase/Query";
+import Search from "../../../../Types/BaseDatabase/Search";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+type GetListCall = {
+  query: Query<Monitor>;
+  limit: number;
+  skip: number;
+  sort: JSONObject;
+};
+
+type RenderTableOptions = {
+  urlStateKey?: string | undefined;
+  userPreferencesKey?: string | undefined;
+  disableUrlState?: boolean | undefined;
+  sortBy?: keyof Monitor | undefined;
+  sortOrder?: SortOrder | undefined;
+  query?: Query<Monitor> | undefined;
+};
+
+const FILTERS: Array<Filter<Monitor>> = [
+  { title: "Name", type: FieldType.Text, field: { name: true } },
+  {
+    title: "Description",
+    type: FieldType.Text,
+    field: { description: true },
+  },
+] as unknown as Array<Filter<Monitor>>;
+
+type SetUrlFunction = (url: string) => void;
+
+const setUrl: SetUrlFunction = (url: string): void => {
+  window.history.replaceState(window.history.state, "", url);
+};
+
+describe("BaseModelTable URL state", () => {
+  let calls: Array<GetListCall> = [];
+
+  type MakeCallbacksFunction = () => BaseTableCallbacks<Monitor>;
+
+  const makeCallbacks: MakeCallbacksFunction =
+    (): BaseTableCallbacks<Monitor> => {
+      return {
+        deleteItem: async () => {
+          return undefined;
+        },
+        getModelFromJSON: (item: JSONObject) => {
+          return item as unknown as Monitor;
+        },
+        getJSONFromModel: (item: Monitor) => {
+          return item as unknown as JSONObject;
+        },
+        addSlugToSelect: (select: unknown) => {
+          return select;
+        },
+        getList: async (data: GetListCall): Promise<ListResult<Monitor>> => {
+          calls.push({
+            query: data.query,
+            limit: data.limit,
+            skip: data.skip,
+            sort: data.sort as unknown as JSONObject,
+          });
+          return { data: [], count: 0, skip: 0, limit: data.limit };
+        },
+        toJSONArray: () => {
+          return [];
+        },
+        updateById: async () => {
+          return undefined;
+        },
+        showCreateEditModal: () => {
+          return <></>;
+        },
+      } as unknown as BaseTableCallbacks<Monitor>;
+    };
+
+  type RenderTableFunction = (
+    options?: RenderTableOptions,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    options: RenderTableOptions = {},
+  ): ReturnType<typeof render> => {
+    const props: BaseModelTableProps<Monitor> = {
+      modelType: Monitor,
+      id: "monitors-table",
+      name: "Monitors",
+      userPreferencesKey: options.userPreferencesKey || "monitors-table",
+      columns: [],
+      filters: FILTERS,
+      isDeleteable: false,
+      isCreateable: false,
+      isViewable: false,
+      isEditable: false,
+      callbacks: makeCallbacks(),
+      searchableFields: ["name"] as Array<keyof Monitor>,
+      ...(options.urlStateKey ? { urlStateKey: options.urlStateKey } : {}),
+      ...(options.disableUrlState ? { disableUrlState: true } : {}),
+      ...(options.sortBy ? { sortBy: options.sortBy } : {}),
+      ...(options.sortOrder ? { sortOrder: options.sortOrder } : {}),
+      ...(options.query ? { query: options.query } : {}),
+    } as unknown as BaseModelTableProps<Monitor>;
+
+    return render(<BaseModelTable<Monitor> {...props} />);
+  };
+
+  beforeEach(() => {
+    calls = [];
+    setUrl("/dashboard/monitors");
+    TableFilterUrlState.resetClaimedKeys();
+    /*
+     * The table stores its page size per `userPreferencesKey` in localStorage,
+     * so without this a test that changes the page size would silently set the
+     * starting page size for every test after it.
+     */
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("restoring from the URL", () => {
+    test("the FIRST fetch already carries the restored filter", async () => {
+      /*
+       * The whole point of reading the URL during render rather than in an
+       * effect. If the restore happened in an effect, this first request would
+       * go out unfiltered — the user would see a flash of every row, and the
+       * server would do the work twice.
+       */
+      TableFilterUrlState.write("monitors-table", "filter", {
+        name: new Search("api"),
+      });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBeInstanceOf(Search);
+      expect((calls[0]?.query["name"] as Search<string>).toString()).toBe(
+        "api",
+      );
+    });
+
+    test("an unfiltered table fetches without a filter", async () => {
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBeUndefined();
+    });
+
+    test("restores the page number instead of snapping back to page 1", async () => {
+      TableFilterUrlState.write("monitors-table", "view", { page: 3 });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      // page 3 at the default page size of 10
+      expect(calls[0]?.skip).toBe(20);
+    });
+
+    test("restores the sort", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        sortBy: "name",
+        sortOrder: SortOrder.Descending,
+      });
+
+      renderTable({ sortBy: "createdAt", sortOrder: SortOrder.Ascending });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.sort).toEqual({ name: SortOrder.Descending });
+    });
+
+    test("restores the page size", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        itemsOnPage: 25,
+        page: 2,
+      });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.limit).toBe(25);
+      expect(calls[0]?.skip).toBe(25);
+    });
+
+    test("restores the search term into the first fetch", async () => {
+      TableFilterUrlState.write("monitors-table", "view", { search: "api" });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(
+        (calls[0]?.query as unknown as JSONObject)["_multiFieldSearch"],
+      ).toBeDefined();
+    });
+
+    test("ignores a key the table has no filter for", async () => {
+      /*
+       * A hand-edited link must not be able to add a constraint the filter UI
+       * could never have produced.
+       */
+      TableFilterUrlState.write("monitors-table", "filter", {
+        name: "api",
+        projectId: "somebody-elses-project",
+      });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBe("api");
+      expect(calls[0]?.query["projectId"]).toBeUndefined();
+    });
+
+    test("survives a corrupt param and renders unfiltered", async () => {
+      Navigation.setQueryString({
+        "monitors-table-filter": "}{ not json",
+        "monitors-table-view": "also not json",
+      });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBeUndefined();
+      expect(calls[0]?.skip).toBe(0);
+    });
+
+    test("falls back to userPreferencesKey when no explicit key is given", async () => {
+      TableFilterUrlState.write("custom-prefs-key", "filter", { name: "api" });
+
+      renderTable({ userPreferencesKey: "custom-prefs-key" });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBe("api");
+    });
+
+    test("an explicit urlStateKey wins over userPreferencesKey", async () => {
+      TableFilterUrlState.write("explicit-key", "filter", { name: "api" });
+      TableFilterUrlState.write("prefs-key", "filter", { name: "wrong" });
+
+      renderTable({
+        urlStateKey: "explicit-key",
+        userPreferencesKey: "prefs-key",
+      });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBe("api");
+    });
+
+    test("disableUrlState ignores the URL entirely", async () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      renderTable({ disableUrlState: true });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["name"]).toBeUndefined();
+    });
+  });
+
+  describe("writing to the URL", () => {
+    test("a table nobody has touched adds no query params", async () => {
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(window.location.search).toBe("");
+    });
+
+    test("keeps params owned by anything else on the route", async () => {
+      Navigation.setQueryString({ tab: "overview" });
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(Navigation.getQueryStringByName("tab")).toBe("overview");
+    });
+
+    test("a restored view is written back unchanged, not widened", async () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      renderTable();
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toEqual({
+        name: "api",
+      });
+    });
+
+    test("disableUrlState writes nothing", async () => {
+      renderTable({ disableUrlState: true });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(window.location.search).toBe("");
+    });
+  });
+
+  describe("several tables on one page", () => {
+    type RenderTwoFunction = () => ReactElement;
+
+    const renderTwo: RenderTwoFunction = (): ReactElement => {
+      const base: JSONObject = {
+        modelType: Monitor,
+        name: "Monitors",
+        columns: [],
+        filters: FILTERS,
+        isDeleteable: false,
+        isCreateable: false,
+        isViewable: false,
+        isEditable: false,
+      } as unknown as JSONObject;
+
+      return (
+        <>
+          <BaseModelTable<Monitor>
+            {...(base as unknown as BaseModelTableProps<Monitor>)}
+            id="left-table"
+            userPreferencesKey="left-table"
+            callbacks={makeCallbacks()}
+          />
+          <BaseModelTable<Monitor>
+            {...(base as unknown as BaseModelTableProps<Monitor>)}
+            id="right-table"
+            userPreferencesKey="right-table"
+            callbacks={makeCallbacks()}
+          />
+        </>
+      );
+    };
+
+    test("each table restores only its own filter", async () => {
+      TableFilterUrlState.write("left-table", "filter", { name: "left" });
+      TableFilterUrlState.write("right-table", "filter", { name: "right" });
+
+      render(renderTwo());
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const names: Array<unknown> = calls.map((c: GetListCall) => {
+        return c.query["name"];
+      });
+
+      expect(names).toContain("left");
+      expect(names).toContain("right");
+    });
+
+    test("each table restores only its own page", async () => {
+      TableFilterUrlState.write("left-table", "view", { page: 2 });
+      TableFilterUrlState.write("right-table", "view", { page: 5 });
+
+      render(renderTwo());
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const skips: Array<number> = calls.map((c: GetListCall) => {
+        return c.skip;
+      });
+
+      expect(skips).toContain(10);
+      expect(skips).toContain(40);
+    });
+
+    test("one table's params never clobber the other's", async () => {
+      TableFilterUrlState.write("left-table", "filter", { name: "left" });
+      TableFilterUrlState.write("right-table", "filter", { name: "right" });
+
+      render(renderTwo());
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      expect(TableFilterUrlState.read("left-table", "filter")).toEqual({
+        name: "left",
+      });
+      expect(TableFilterUrlState.read("right-table", "filter")).toEqual({
+        name: "right",
+      });
+    });
+
+    test("warns when two tables are given the same key", async () => {
+      const warn: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const base: JSONObject = {
+        modelType: Monitor,
+        name: "Monitors",
+        columns: [],
+        filters: FILTERS,
+        isDeleteable: false,
+        isCreateable: false,
+        isViewable: false,
+        isEditable: false,
+        userPreferencesKey: "duplicate-key",
+        id: "duplicate-key",
+      } as unknown as JSONObject;
+
+      render(
+        <>
+          <BaseModelTable<Monitor>
+            {...(base as unknown as BaseModelTableProps<Monitor>)}
+            callbacks={makeCallbacks()}
+          />
+          <BaseModelTable<Monitor>
+            {...(base as unknown as BaseModelTableProps<Monitor>)}
+            callbacks={makeCallbacks()}
+          />
+        </>,
+      );
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const messages: Array<string> = warn.mock.calls.map(
+        (c: Array<unknown>) => {
+          return String(c[0]);
+        },
+      );
+
+      expect(
+        messages.some((m: string) => {
+          return m.includes("duplicate-key");
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("the caller's scoping query", () => {
+    test("is still applied alongside a restored filter", async () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      renderTable({
+        query: { projectId: "scoped-project" } as unknown as Query<Monitor>,
+      });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+
+      expect(calls[0]?.query["projectId"]).toBe("scoped-project");
+      expect(calls[0]?.query["name"]).toBe("api");
+    });
+
+    test("a facet-driven query change sends the user back to page 1", async () => {
+      /*
+       * Facet selections reach the table through the `query` prop. Narrowing
+       * the result set while on page 3 used to re-request page 3 of a shorter
+       * list — an empty page, which then got written into the shareable URL.
+       */
+      TableFilterUrlState.write("monitors-table", "view", { page: 3 });
+
+      const view: ReturnType<typeof render> = renderTable({
+        query: { projectId: "a" } as unknown as Query<Monitor>,
+      });
+
+      await waitFor(() => {
+        expect(calls.length).toBeGreaterThan(0);
+      });
+      expect(calls[0]?.skip).toBe(20);
+
+      const props: BaseModelTableProps<Monitor> = {
+        modelType: Monitor,
+        id: "monitors-table",
+        name: "Monitors",
+        userPreferencesKey: "monitors-table",
+        columns: [],
+        filters: FILTERS,
+        isDeleteable: false,
+        isCreateable: false,
+        isViewable: false,
+        isEditable: false,
+        callbacks: makeCallbacks(),
+        query: { projectId: "b" },
+      } as unknown as BaseModelTableProps<Monitor>;
+
+      await act(async () => {
+        view.rerender(<BaseModelTable<Monitor> {...props} />);
+      });
+
+      await waitFor(() => {
+        expect(calls[calls.length - 1]?.skip).toBe(0);
+      });
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/FilterDataToQuery.test.ts
+++ b/Common/Tests/UI/Components/ModelTable/FilterDataToQuery.test.ts
@@ -1,0 +1,275 @@
+import buildQueryFromFilterData, {
+  getFilterKeys,
+  sanitizeFilterData,
+} from "../../../../UI/Components/ModelTable/FilterDataToQuery";
+import Filter from "../../../../UI/Components/ModelFilter/Filter";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import IsNull from "../../../../Types/BaseDatabase/IsNull";
+import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
+import Search from "../../../../Types/BaseDatabase/Search";
+import Query from "../../../../Types/BaseDatabase/Query";
+import FilterData from "../../../../UI/Components/Filters/Types/FilterData";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * `buildQueryFromFilterData` is what turns the filter popup's selections into
+ * the query the table fetches with. It lives outside the component so the
+ * table can derive its query *synchronously during the first render* when
+ * filters come back from the URL — without that, the first request would go
+ * out unfiltered and be immediately superseded, flashing the wrong rows.
+ *
+ * `sanitizeFilterData` is the trust boundary for that same path: the snapshot
+ * arrives from a query string anyone can edit.
+ */
+
+const FILTERS: Array<Filter<Monitor>> = [
+  { title: "Name", type: FieldType.Text, field: { name: true } },
+  {
+    title: "Description",
+    type: FieldType.Text,
+    field: { description: true },
+  },
+  {
+    title: "Monitoring disabled",
+    type: FieldType.Boolean,
+    field: { disableActiveMonitoring: true },
+  },
+  { title: "Created", type: FieldType.Date, field: { createdAt: true } },
+  { title: "Labels", type: FieldType.EntityArray, field: { labels: true } },
+  {
+    title: "Custom fields",
+    type: FieldType.JSON,
+    field: { customFields: true },
+  },
+] as unknown as Array<Filter<Monitor>>;
+
+type BuildFunction = (filterData: FilterData<Monitor>) => Query<Monitor>;
+
+const build: BuildFunction = (
+  filterData: FilterData<Monitor>,
+): Query<Monitor> => {
+  return buildQueryFromFilterData<Monitor>({
+    filterData: filterData,
+    filters: FILTERS,
+  });
+};
+
+describe("getFilterKeys", () => {
+  test("returns the model field behind each declared filter", () => {
+    expect(getFilterKeys<Monitor>(FILTERS)).toEqual([
+      "name",
+      "description",
+      "disableActiveMonitoring",
+      "createdAt",
+      "labels",
+      "customFields",
+    ]);
+  });
+
+  test("tolerates an empty or missing filter list", () => {
+    expect(getFilterKeys<Monitor>([])).toEqual([]);
+    expect(
+      getFilterKeys<Monitor>(undefined as unknown as Array<Filter<Monitor>>),
+    ).toEqual([]);
+  });
+});
+
+describe("buildQueryFromFilterData", () => {
+  test("returns an empty query for no filters", () => {
+    expect(build({})).toEqual({});
+  });
+
+  test("passes a text value through", () => {
+    expect(build({ name: "api" } as FilterData<Monitor>)).toEqual({
+      name: "api",
+    });
+  });
+
+  test("keeps a false boolean — it is a real constraint, not an absent one", () => {
+    expect(
+      build({
+        disableActiveMonitoring: false,
+      } as unknown as FilterData<Monitor>),
+    ).toEqual({ disableActiveMonitoring: false });
+  });
+
+  test("keeps a zero number", () => {
+    const query: Query<Monitor> = build({
+      name: 0,
+    } as unknown as FilterData<Monitor>);
+
+    expect(query).toEqual({ name: 0 });
+  });
+
+  test("passes a Date through unchanged", () => {
+    const date: Date = new Date("2026-07-01T12:34:56.789Z");
+
+    expect(
+      build({ createdAt: date } as unknown as FilterData<Monitor>)["createdAt"],
+    ).toBe(date);
+  });
+
+  test("passes a Search through unchanged", () => {
+    const search: Search<string> = new Search("api");
+
+    expect(
+      build({ name: search } as unknown as FilterData<Monitor>)["name"],
+    ).toBe(search);
+  });
+
+  test("passes an InBetween through unchanged", () => {
+    const range: InBetween<Date> = new InBetween(
+      new Date("2026-01-01T00:00:00.000Z"),
+      new Date("2026-02-01T00:00:00.000Z"),
+    );
+
+    expect(
+      build({ createdAt: range } as unknown as FilterData<Monitor>)[
+        "createdAt"
+      ],
+    ).toBe(range);
+  });
+
+  test("wraps a bare array into an Includes", () => {
+    const query: Query<Monitor> = build({
+      labels: ["a", "b"],
+    } as unknown as FilterData<Monitor>);
+
+    expect(query["labels"]).toBeInstanceOf(Includes);
+    expect((query["labels"] as Includes).values).toEqual(["a", "b"]);
+  });
+
+  test("passes any QueryOperator through as-is", () => {
+    const operators: Record<string, unknown> = {
+      includesNone: new IncludesNone(["a"]),
+      isNull: new IsNull(),
+      notEqual: new NotEqual("api"),
+    };
+
+    for (const operator of Object.values(operators)) {
+      expect(
+        build({ name: operator } as unknown as FilterData<Monitor>)["name"],
+      ).toBe(operator);
+    }
+  });
+
+  test("passes a plain object through only for a JSON-typed filter", () => {
+    const value: Record<string, string> = { team: "platform" };
+
+    expect(
+      build({ customFields: value } as unknown as FilterData<Monitor>)[
+        "customFields"
+      ],
+    ).toBe(value);
+  });
+
+  test("drops a plain object on a non-JSON filter", () => {
+    expect(
+      build({ name: { nope: true } } as unknown as FilterData<Monitor>),
+    ).toEqual({});
+  });
+
+  test("drops an empty string — an empty text box is not a filter", () => {
+    expect(build({ name: "" } as unknown as FilterData<Monitor>)).toEqual({});
+  });
+
+  test("builds every kind of value in one pass", () => {
+    const query: Query<Monitor> = build({
+      name: new Search("api"),
+      disableActiveMonitoring: false,
+      labels: ["a"],
+    } as unknown as FilterData<Monitor>);
+
+    expect(query["name"]).toBeInstanceOf(Search);
+    expect(query["disableActiveMonitoring"]).toBe(false);
+    expect(query["labels"]).toBeInstanceOf(Includes);
+  });
+});
+
+describe("sanitizeFilterData", () => {
+  type SanitizeFunction = (
+    filterData: FilterData<Monitor>,
+  ) => FilterData<Monitor>;
+
+  const sanitize: SanitizeFunction = (
+    filterData: FilterData<Monitor>,
+  ): FilterData<Monitor> => {
+    return sanitizeFilterData<Monitor>({
+      filterData: filterData,
+      filters: FILTERS,
+    });
+  };
+
+  test("keeps every field the table declares a filter for", () => {
+    expect(
+      sanitize({ name: "api", description: "prod" } as FilterData<Monitor>),
+    ).toEqual({ name: "api", description: "prod" });
+  });
+
+  test("drops a field the table does not expose a filter for", () => {
+    /*
+     * The restored filter is spread into the outgoing list query, so an
+     * undeclared key in a hand-edited link would otherwise become a real
+     * constraint the filter UI could never have produced.
+     */
+    expect(
+      sanitize({
+        name: "api",
+        projectId: "somebody-elses-project",
+      } as unknown as FilterData<Monitor>),
+    ).toEqual({ name: "api" });
+  });
+
+  test("drops a key that tries to re-scope the page's own query", () => {
+    expect(
+      sanitize({
+        monitorId: "another-monitor",
+        _id: "specific-row",
+      } as unknown as FilterData<Monitor>),
+    ).toEqual({});
+  });
+
+  test("drops null and undefined values", () => {
+    expect(
+      sanitize({
+        name: "api",
+        description: undefined,
+        createdAt: null,
+      } as unknown as FilterData<Monitor>),
+    ).toEqual({ name: "api" });
+  });
+
+  test("keeps a false boolean", () => {
+    expect(
+      sanitize({
+        disableActiveMonitoring: false,
+      } as unknown as FilterData<Monitor>),
+    ).toEqual({ disableActiveMonitoring: false });
+  });
+
+  test("keeps typed operator instances intact", () => {
+    const search: Search<string> = new Search("api");
+
+    expect(
+      sanitize({ name: search } as unknown as FilterData<Monitor>)["name"],
+    ).toBe(search);
+  });
+
+  test("returns an empty object when the table declares no filters at all", () => {
+    expect(
+      sanitizeFilterData<Monitor>({
+        filterData: { name: "api" } as FilterData<Monitor>,
+        filters: [],
+      }),
+    ).toEqual({});
+  });
+
+  test("tolerates an empty snapshot", () => {
+    expect(sanitize({})).toEqual({});
+    expect(sanitize(undefined as unknown as FilterData<Monitor>)).toEqual({});
+  });
+});

--- a/Common/Tests/UI/Utils/Navigation.test.ts
+++ b/Common/Tests/UI/Utils/Navigation.test.ts
@@ -1,0 +1,183 @@
+import Navigation from "../../../UI/Utils/Navigation";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * `Navigation.setQueryString` is the single write path for every piece of URL
+ * state in the app (table filters, facets, sort/pagination, the telemetry
+ * explorers). Its exact semantics are load-bearing:
+ *
+ *  - it must MERGE, so one component writing its params never deletes another
+ *    component's params from the same route;
+ *  - it must use `replaceState`, so dragging a filter around doesn't bury the
+ *    "back to the list" entry under a hundred history entries;
+ *  - it must pass the CURRENT `history.state` through, because that object is
+ *    react-router's `{usr, key, idx}` bookkeeping — replacing it with `null`
+ *    corrupts the router's history index;
+ *  - and it must leave the pathname and hash alone.
+ */
+
+type SetUrlFunction = (url: string) => void;
+
+const setUrl: SetUrlFunction = (url: string): void => {
+  window.history.replaceState(window.history.state, "", url);
+};
+
+describe("Navigation URL query string helpers", () => {
+  beforeEach(() => {
+    setUrl("/dashboard/monitors");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("getQueryString", () => {
+    test("returns the raw search string including the leading ?", () => {
+      setUrl("/dashboard/monitors?a=1&b=2");
+
+      expect(Navigation.getQueryString()).toBe("?a=1&b=2");
+    });
+
+    test("returns an empty string when there is no query", () => {
+      expect(Navigation.getQueryString()).toBe("");
+    });
+  });
+
+  describe("getQueryStringByName", () => {
+    test("reads a param and percent-decodes it", () => {
+      setUrl(`/dashboard/monitors?q=${encodeURIComponent('{"a":"b c"}')}`);
+
+      expect(Navigation.getQueryStringByName("q")).toBe('{"a":"b c"}');
+    });
+
+    test("returns null for a missing param", () => {
+      setUrl("/dashboard/monitors?other=1");
+
+      expect(Navigation.getQueryStringByName("q")).toBeNull();
+    });
+
+    test("returns null for a present-but-empty param", () => {
+      setUrl("/dashboard/monitors?q=");
+
+      expect(Navigation.getQueryStringByName("q")).toBeNull();
+    });
+  });
+
+  describe("setQueryString", () => {
+    test("adds a param without touching the ones already there", () => {
+      setUrl("/dashboard/monitors?existing=keepme");
+
+      Navigation.setQueryString({ added: "value" });
+
+      expect(Navigation.getQueryStringByName("existing")).toBe("keepme");
+      expect(Navigation.getQueryStringByName("added")).toBe("value");
+    });
+
+    test("overwrites only the named param", () => {
+      setUrl("/dashboard/monitors?a=1&b=2");
+
+      Navigation.setQueryString({ a: "9" });
+
+      expect(Navigation.getQueryStringByName("a")).toBe("9");
+      expect(Navigation.getQueryStringByName("b")).toBe("2");
+    });
+
+    test("deletes a param when the value is null", () => {
+      setUrl("/dashboard/monitors?a=1&b=2");
+
+      Navigation.setQueryString({ a: null });
+
+      expect(Navigation.getQueryStringByName("a")).toBeNull();
+      expect(Navigation.getQueryStringByName("b")).toBe("2");
+    });
+
+    test("deletes a param when the value is an empty string", () => {
+      setUrl("/dashboard/monitors?a=1");
+
+      Navigation.setQueryString({ a: "" });
+
+      expect(Navigation.getQueryStringByName("a")).toBeNull();
+    });
+
+    test("applies several params in one call", () => {
+      setUrl("/dashboard/monitors?keep=1&drop=2");
+
+      Navigation.setQueryString({ drop: null, one: "1", two: "2" });
+
+      expect(Navigation.getQueryStringByName("keep")).toBe("1");
+      expect(Navigation.getQueryStringByName("drop")).toBeNull();
+      expect(Navigation.getQueryStringByName("one")).toBe("1");
+      expect(Navigation.getQueryStringByName("two")).toBe("2");
+    });
+
+    test("leaves the pathname and hash intact", () => {
+      setUrl("/dashboard/monitors/abc#section-two");
+
+      Navigation.setQueryString({ a: "1" });
+
+      expect(window.location.pathname).toBe("/dashboard/monitors/abc");
+      expect(window.location.hash).toBe("#section-two");
+      expect(Navigation.getQueryStringByName("a")).toBe("1");
+    });
+
+    test("drops the '?' entirely when the last param is removed", () => {
+      setUrl("/dashboard/monitors?only=1");
+
+      Navigation.setQueryString({ only: null });
+
+      expect(window.location.search).toBe("");
+    });
+
+    test("round-trips a value containing URL-significant characters", () => {
+      const value: string = '{"name":{"_type":"Search","value":"a&b=c d"}}';
+
+      Navigation.setQueryString({ q: value });
+
+      expect(Navigation.getQueryStringByName("q")).toBe(value);
+    });
+
+    test("replaces the current history entry instead of pushing a new one", () => {
+      const lengthBefore: number = window.history.length;
+
+      Navigation.setQueryString({ a: "1" });
+      Navigation.setQueryString({ a: "2" });
+      Navigation.setQueryString({ a: "3" });
+
+      expect(window.history.length).toBe(lengthBefore);
+    });
+
+    test("preserves history.state so react-router's bookkeeping survives", () => {
+      const routerState: { usr: null; key: string; idx: number } = {
+        usr: null,
+        key: "abc123",
+        idx: 4,
+      };
+      window.history.replaceState(routerState, "", "/dashboard/monitors");
+
+      Navigation.setQueryString({ a: "1" });
+
+      expect(window.history.state).toEqual(routerState);
+    });
+
+    test("swallows the SecurityError Safari throws when replaceState is called too often", () => {
+      const replaceState: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(window.history, "replaceState")
+        .mockImplementation(() => {
+          throw new Error("SecurityError: too many calls to replaceState");
+        });
+
+      expect(() => {
+        Navigation.setQueryString({ a: "1" });
+      }).not.toThrow();
+
+      expect(replaceState).toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/UI/Utils/TableFilterUrlState.test.ts
+++ b/Common/Tests/UI/Utils/TableFilterUrlState.test.ts
@@ -1,0 +1,539 @@
+import TableFilterUrlState from "../../../UI/Utils/TableFilterUrlState";
+import Navigation from "../../../UI/Utils/Navigation";
+import EqualTo from "../../../Types/BaseDatabase/EqualTo";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import NotEqual from "../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../Types/BaseDatabase/NotNull";
+import Search from "../../../Types/BaseDatabase/Search";
+import ObjectID from "../../../Types/ObjectID";
+import { JSONObject } from "../../../Types/JSON";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * TableFilterUrlState is what makes a filtered table survive "click a row,
+ * press Back" and what makes the resulting URL shareable. The behaviours
+ * pinned here are the ones a user would notice breaking:
+ *
+ *  - typed query values (Search / Includes / InBetween / the comparison
+ *    operators) have to come back as real class instances, or the restored
+ *    query silently means something different from the one the user built;
+ *  - each table's state is namespaced, so several tables on one page keep
+ *    their own filters;
+ *  - a hand-edited or truncated param degrades to "no filters", never to a
+ *    crash;
+ *  - and the URL can't grow without bound.
+ */
+
+type SetUrlFunction = (url: string) => void;
+
+const setUrl: SetUrlFunction = (url: string): void => {
+  window.history.replaceState(window.history.state, "", url);
+};
+
+type ReadParamFunction = (name: string) => string | null;
+
+const readParam: ReadParamFunction = (name: string): string | null => {
+  return Navigation.getQueryStringByName(name);
+};
+
+type BuildIdsFunction = (count: number) => Array<string>;
+
+const buildIds: BuildIdsFunction = (count: number): Array<string> => {
+  const ids: Array<string> = [];
+  for (let i: number = 0; i < count; i++) {
+    ids.push(ObjectID.generate().toString());
+  }
+  return ids;
+};
+
+describe("TableFilterUrlState", () => {
+  beforeEach(() => {
+    setUrl("/dashboard/monitors");
+    TableFilterUrlState.resetClaimedKeys();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("param naming", () => {
+    test("namespaces each slice under the table id", () => {
+      expect(TableFilterUrlState.getParamName("monitors-table", "filter")).toBe(
+        "monitors-table-filter",
+      );
+      expect(TableFilterUrlState.getParamName("monitors-table", "facets")).toBe(
+        "monitors-table-facets",
+      );
+      expect(TableFilterUrlState.getParamName("monitors-table", "view")).toBe(
+        "monitors-table-view",
+      );
+    });
+
+    test("lists every param a table can own", () => {
+      expect(TableFilterUrlState.getAllParamNames("monitors-table")).toEqual([
+        "monitors-table-filter",
+        "monitors-table-facets",
+        "monitors-table-view",
+      ]);
+    });
+  });
+
+  describe("read", () => {
+    test("returns null when the table id is missing", () => {
+      expect(TableFilterUrlState.read(undefined, "filter")).toBeNull();
+      expect(TableFilterUrlState.read("", "filter")).toBeNull();
+    });
+
+    test("returns null when the param is absent", () => {
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+    });
+
+    test("returns null for an empty snapshot", () => {
+      Navigation.setQueryString({ "monitors-table-filter": "{}" });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+    });
+
+    test("returns null for an unparseable param instead of throwing", () => {
+      Navigation.setQueryString({ "monitors-table-filter": "not json {{{" });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+    });
+
+    test("does not read another table's param", () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      expect(TableFilterUrlState.read("incidents-table", "filter")).toBeNull();
+    });
+
+    test("does not read another slice's param", () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      expect(TableFilterUrlState.read("monitors-table", "view")).toBeNull();
+      expect(TableFilterUrlState.read("monitors-table", "facets")).toBeNull();
+    });
+  });
+
+  describe("write", () => {
+    test("round-trips plain values", () => {
+      TableFilterUrlState.write("monitors-table", "filter", {
+        name: "api",
+        disableActiveMonitoring: false,
+        count: 12,
+      });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toEqual({
+        name: "api",
+        disableActiveMonitoring: false,
+        count: 12,
+      });
+    });
+
+    test("removes the param when the state is null", () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+      expect(readParam("monitors-table-filter")).not.toBeNull();
+
+      TableFilterUrlState.write("monitors-table", "filter", null);
+
+      expect(readParam("monitors-table-filter")).toBeNull();
+    });
+
+    test("removes the param when the state has no keys", () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      TableFilterUrlState.write("monitors-table", "filter", {});
+
+      expect(readParam("monitors-table-filter")).toBeNull();
+    });
+
+    test("no-ops without a table id", () => {
+      TableFilterUrlState.write(undefined, "filter", { name: "api" });
+
+      expect(window.location.search).toBe("");
+    });
+
+    test("leaves params owned by anything else on the route alone", () => {
+      Navigation.setQueryString({ tab: "overview", "var-region": "eu" });
+
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      expect(readParam("tab")).toBe("overview");
+      expect(readParam("var-region")).toBe("eu");
+    });
+  });
+
+  describe("typed query values survive the round trip", () => {
+    type RoundTripFunction = (state: JSONObject) => JSONObject | null;
+
+    const roundTrip: RoundTripFunction = (
+      state: JSONObject,
+    ): JSONObject | null => {
+      TableFilterUrlState.write("monitors-table", "filter", state);
+      return TableFilterUrlState.read("monitors-table", "filter");
+    };
+
+    test("Search comes back as a Search", () => {
+      const restored: JSONObject | null = roundTrip({
+        name: new Search("api gateway"),
+      });
+
+      expect(restored?.["name"]).toBeInstanceOf(Search);
+      expect((restored?.["name"] as Search<string>).toString()).toBe(
+        "api gateway",
+      );
+    });
+
+    test("Includes comes back as an Includes with its ids", () => {
+      const ids: Array<string> = [
+        ObjectID.generate().toString(),
+        ObjectID.generate().toString(),
+      ];
+
+      const restored: JSONObject | null = roundTrip({
+        labels: new Includes(ids),
+      });
+
+      expect(restored?.["labels"]).toBeInstanceOf(Includes);
+      expect(
+        (restored?.["labels"] as Includes).values.map((v: unknown) => {
+          return v!.toString();
+        }),
+      ).toEqual(ids);
+    });
+
+    test("IncludesNone (the entity 'is not' encoding) comes back intact", () => {
+      const restored: JSONObject | null = roundTrip({
+        projectId: new IncludesNone(["abc"]),
+      });
+
+      expect(restored?.["projectId"]).toBeInstanceOf(IncludesNone);
+    });
+
+    test("InBetween keeps both bounds at full precision", () => {
+      const start: string = "2026-04-22T00:30:00.000Z";
+      const end: string = "2026-07-21T14:35:12.345Z";
+
+      const restored: JSONObject | null = roundTrip({
+        createdAt: new InBetween(new Date(start), new Date(end)),
+      });
+
+      expect(restored?.["createdAt"]).toBeInstanceOf(InBetween);
+      expect(
+        (restored?.["createdAt"] as InBetween<Date>).toStartValueString(),
+      ).toBe(start);
+      expect(
+        (restored?.["createdAt"] as InBetween<Date>).toEndValueString(),
+      ).toBe(end);
+    });
+
+    test("EqualTo keeps a number a number", () => {
+      const restored: JSONObject | null = roundTrip({
+        priority: new EqualTo(42),
+      });
+
+      expect(restored?.["priority"]).toBeInstanceOf(EqualTo);
+      expect((restored?.["priority"] as EqualTo<number>).value).toBe(42);
+    });
+
+    test("NotEqual keeps a Date at full ISO precision, not a locale string", () => {
+      const iso: string = "2026-07-01T12:34:56.789Z";
+
+      const restored: JSONObject | null = roundTrip({
+        createdAt: new NotEqual(new Date(iso)),
+      });
+
+      expect(restored?.["createdAt"]).toBeInstanceOf(NotEqual);
+      expect((restored?.["createdAt"] as NotEqual<Date>).toString()).toBe(iso);
+    });
+
+    test("IsNull / NotNull come back as operators, not empty objects", () => {
+      const restored: JSONObject | null = roundTrip({
+        deletedAt: new IsNull(),
+        createdAt: new NotNull(),
+      });
+
+      expect(restored?.["deletedAt"]).toBeInstanceOf(IsNull);
+      expect(restored?.["createdAt"]).toBeInstanceOf(NotNull);
+    });
+
+    test("a Date value comes back as a Date", () => {
+      const iso: string = "2026-07-01T12:34:56.789Z";
+
+      const restored: JSONObject | null = roundTrip({
+        createdAt: new Date(iso),
+      });
+
+      expect(restored?.["createdAt"]).toBeInstanceOf(Date);
+      expect((restored?.["createdAt"] as Date).toISOString()).toBe(iso);
+    });
+
+    test("a mixed snapshot round-trips every value at once", () => {
+      const restored: JSONObject | null = roundTrip({
+        name: new Search("api"),
+        labels: new Includes(["a", "b"]),
+        disableActiveMonitoring: false,
+        createdAt: new InBetween(
+          new Date("2026-01-01T00:00:00.000Z"),
+          new Date("2026-02-01T00:00:00.000Z"),
+        ),
+      });
+
+      expect(restored?.["name"]).toBeInstanceOf(Search);
+      expect(restored?.["labels"]).toBeInstanceOf(Includes);
+      expect(restored?.["disableActiveMonitoring"]).toBe(false);
+      expect(restored?.["createdAt"]).toBeInstanceOf(InBetween);
+    });
+  });
+
+  describe("several tables on one page", () => {
+    test("each table keeps its own filters", () => {
+      TableFilterUrlState.write("monitors-table", "filter", {
+        name: new Search("api"),
+      });
+      TableFilterUrlState.write("incidents-table", "filter", {
+        title: new Search("outage"),
+      });
+
+      expect(
+        (
+          TableFilterUrlState.read("monitors-table", "filter")?.[
+            "name"
+          ] as Search<string>
+        ).toString(),
+      ).toBe("api");
+      expect(
+        (
+          TableFilterUrlState.read("incidents-table", "filter")?.[
+            "title"
+          ] as Search<string>
+        ).toString(),
+      ).toBe("outage");
+    });
+
+    test("clearing one table leaves the others untouched", () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+      TableFilterUrlState.write("incidents-table", "filter", {
+        title: "outage",
+      });
+
+      TableFilterUrlState.clear("monitors-table");
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+      expect(TableFilterUrlState.read("incidents-table", "filter")).toEqual({
+        title: "outage",
+      });
+    });
+
+    test("all three slices of one table can coexist with another table's", () => {
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: { name: "api" },
+        view: { page: 3 },
+        facets: { selectedLabelIds: ["a"] },
+      });
+      TableFilterUrlState.write("incidents-table", "view", { page: 7 });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toEqual({
+        name: "api",
+      });
+      expect(TableFilterUrlState.read("monitors-table", "view")).toEqual({
+        page: 3,
+      });
+      expect(TableFilterUrlState.read("monitors-table", "facets")).toEqual({
+        selectedLabelIds: ["a"],
+      });
+      expect(TableFilterUrlState.read("incidents-table", "view")).toEqual({
+        page: 7,
+      });
+    });
+  });
+
+  describe("writeMany", () => {
+    test("applies every slice in a single history write", () => {
+      const replaceState: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        window.history,
+        "replaceState",
+      );
+
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: { name: "api" },
+        view: { page: 2 },
+      });
+
+      expect(replaceState).toHaveBeenCalledTimes(1);
+    });
+
+    test("leaves a slice that wasn't passed alone", () => {
+      TableFilterUrlState.write("monitors-table", "facets", {
+        selectedLabelIds: ["a"],
+      });
+
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: { name: "api" },
+      });
+
+      expect(TableFilterUrlState.read("monitors-table", "facets")).toEqual({
+        selectedLabelIds: ["a"],
+      });
+    });
+
+    test("removes only the slices explicitly cleared", () => {
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: { name: "api" },
+        view: { page: 2 },
+      });
+
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: null,
+      });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+      expect(TableFilterUrlState.read("monitors-table", "view")).toEqual({
+        page: 2,
+      });
+    });
+  });
+
+  describe("URL size guard", () => {
+    type OversizedFilterFunction = () => JSONObject;
+
+    const oversizedFilter: OversizedFilterFunction = (): JSONObject => {
+      return { labels: new Includes(buildIds(400)) };
+    };
+
+    test("skips a slice that would blow past the length cap", () => {
+      TableFilterUrlState.write("monitors-table", "filter", oversizedFilter());
+
+      expect(readParam("monitors-table-filter")).toBeNull();
+    });
+
+    test("drops the stale param rather than leaving it describing an older view", () => {
+      TableFilterUrlState.write("monitors-table", "filter", { name: "api" });
+
+      TableFilterUrlState.write("monitors-table", "filter", oversizedFilter());
+
+      /*
+       * The table keeps working from React state; only the link stops
+       * describing it. Leaving the previous param behind would be worse than
+       * removing it — a refresh would silently restore a *different*, older
+       * filter set than the one on screen.
+       */
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+    });
+
+    test("an oversized slice does not take its siblings down with it", () => {
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: oversizedFilter(),
+        view: { page: 4 },
+      });
+
+      expect(TableFilterUrlState.read("monitors-table", "filter")).toBeNull();
+      expect(TableFilterUrlState.read("monitors-table", "view")).toEqual({
+        page: 4,
+      });
+    });
+
+    test("counts the other slices in the same batch toward the cap", () => {
+      /*
+       * Two slices that each fit on their own but not together: the second one
+       * has to be dropped, otherwise the batch commits a query string over the
+       * limit.
+       */
+      const half: JSONObject = { labels: new Includes(buildIds(60)) };
+
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: half,
+        facets: { selectedLabelIds: buildIds(60) },
+      });
+
+      const query: string = new URLSearchParams(
+        window.location.search,
+      ).toString();
+
+      expect(query.length).toBeLessThanOrEqual(
+        TableFilterUrlState.MaxQueryStringLength,
+      );
+    });
+
+    test("never writes a query string longer than the cap", () => {
+      TableFilterUrlState.writeMany("monitors-table", {
+        filter: oversizedFilter(),
+        view: { page: 2 },
+        facets: { selectedLabelIds: buildIds(300) },
+      });
+
+      expect(window.location.search.length).toBeLessThanOrEqual(
+        TableFilterUrlState.MaxQueryStringLength + 1,
+      );
+    });
+  });
+
+  describe("claimKey", () => {
+    test("stays quiet for a single table", () => {
+      const warn: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      TableFilterUrlState.claimKey("monitors-table");
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    test("warns when two mounted tables share one namespace", () => {
+      const warn: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      TableFilterUrlState.claimKey("monitors-table");
+      TableFilterUrlState.claimKey("monitors-table");
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain("monitors-table");
+    });
+
+    test("releasing frees the namespace for the next mount", () => {
+      const warn: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const release: () => void = TableFilterUrlState.claimKey(
+        "monitors-table",
+      ) as () => void;
+      release();
+      TableFilterUrlState.claimKey("monitors-table");
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    test("different keys never collide", () => {
+      const warn: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      TableFilterUrlState.claimKey("monitors-table");
+      TableFilterUrlState.claimKey("incidents-table");
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    test("an undefined key is not claimed at all", () => {
+      const warn: ReturnType<typeof jest.spyOn> = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      TableFilterUrlState.claimKey(undefined);
+      TableFilterUrlState.claimKey(undefined);
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/UI/Utils/TableViewUrlState.test.ts
+++ b/Common/Tests/UI/Utils/TableViewUrlState.test.ts
@@ -1,0 +1,272 @@
+import TableViewUrlState, {
+  MaxItemsOnPage,
+  TableViewUrlStateData,
+} from "../../../UI/Utils/TableViewUrlState";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The `view` slice carries the parts of a table's state that aren't column
+ * filters: the search box, its label chips, the active sort and where the user
+ * is in the pagination.
+ *
+ * Two properties matter and are pinned here:
+ *
+ *  1. Defaults are never written. A table nobody has touched must contribute
+ *     no query params at all, otherwise every page in the app grows a tail of
+ *     noise the first time it renders.
+ *  2. Every field is validated independently on the way back in. The param is
+ *     user-editable, so `?...-view={"page":"drop table"}` has to degrade to
+ *     "no page", not to a broken table or a hostile value in the API call.
+ */
+
+describe("TableViewUrlState.toJSON", () => {
+  test("returns null when nothing differs from the defaults", () => {
+    expect(TableViewUrlState.toJSON({})).toBeNull();
+    expect(
+      TableViewUrlState.toJSON({
+        search: "",
+        labels: [],
+        page: 1,
+      }),
+    ).toBeNull();
+  });
+
+  test("treats a whitespace-only search as empty", () => {
+    expect(TableViewUrlState.toJSON({ search: "   " })).toBeNull();
+  });
+
+  test("includes a search term", () => {
+    expect(TableViewUrlState.toJSON({ search: "api" })).toEqual({
+      search: "api",
+    });
+  });
+
+  test("includes selected labels and drops empty ids", () => {
+    expect(TableViewUrlState.toJSON({ labels: ["a", "", "b"] })).toEqual({
+      labels: ["a", "b"],
+    });
+  });
+
+  test("omits the page when it is the first one", () => {
+    expect(TableViewUrlState.toJSON({ page: 1 })).toBeNull();
+    expect(TableViewUrlState.toJSON({ page: 3 })).toEqual({ page: 3 });
+  });
+
+  test("omits a sort that matches the table's own default", () => {
+    expect(
+      TableViewUrlState.toJSON(
+        { sortBy: "createdAt", sortOrder: SortOrder.Descending },
+        { sortBy: "createdAt", sortOrder: SortOrder.Descending },
+      ),
+    ).toBeNull();
+  });
+
+  test("includes a sort that differs from the default field", () => {
+    expect(
+      TableViewUrlState.toJSON(
+        { sortBy: "name", sortOrder: SortOrder.Ascending },
+        { sortBy: "createdAt", sortOrder: SortOrder.Descending },
+      ),
+    ).toEqual({ sortBy: "name", sortOrder: SortOrder.Ascending });
+  });
+
+  test("includes a sort that only differs by direction", () => {
+    expect(
+      TableViewUrlState.toJSON(
+        { sortBy: "createdAt", sortOrder: SortOrder.Ascending },
+        { sortBy: "createdAt", sortOrder: SortOrder.Descending },
+      ),
+    ).toEqual({ sortBy: "createdAt", sortOrder: SortOrder.Ascending });
+  });
+
+  test("includes a sort when the table had no default", () => {
+    expect(
+      TableViewUrlState.toJSON({
+        sortBy: "name",
+        sortOrder: SortOrder.Ascending,
+      }),
+    ).toEqual({ sortBy: "name", sortOrder: SortOrder.Ascending });
+  });
+
+  test("includes the page size only when one was supplied", () => {
+    expect(TableViewUrlState.toJSON({ itemsOnPage: 50 })).toEqual({
+      itemsOnPage: 50,
+    });
+    expect(TableViewUrlState.toJSON({ itemsOnPage: undefined })).toBeNull();
+  });
+
+  test("carries every field at once", () => {
+    expect(
+      TableViewUrlState.toJSON({
+        search: "api",
+        labels: ["label-1"],
+        sortBy: "name",
+        sortOrder: SortOrder.Descending,
+        page: 4,
+        itemsOnPage: 25,
+      }),
+    ).toEqual({
+      search: "api",
+      labels: ["label-1"],
+      sortBy: "name",
+      sortOrder: SortOrder.Descending,
+      page: 4,
+      itemsOnPage: 25,
+    });
+  });
+});
+
+describe("TableViewUrlState.fromJSON", () => {
+  test("returns an empty state for null / undefined / a non-object", () => {
+    expect(TableViewUrlState.fromJSON(null)).toEqual({});
+    expect(TableViewUrlState.fromJSON(undefined)).toEqual({});
+    expect(TableViewUrlState.fromJSON("nope" as unknown as JSONObject)).toEqual(
+      {},
+    );
+  });
+
+  test("reads a well-formed snapshot", () => {
+    expect(
+      TableViewUrlState.fromJSON({
+        search: "api",
+        labels: ["a", "b"],
+        sortBy: "name",
+        sortOrder: SortOrder.Descending,
+        page: 3,
+        itemsOnPage: 25,
+      }),
+    ).toEqual({
+      search: "api",
+      labels: ["a", "b"],
+      sortBy: "name",
+      sortOrder: SortOrder.Descending,
+      page: 3,
+      itemsOnPage: 25,
+    });
+  });
+
+  describe("hand-edited values are rejected field by field", () => {
+    test("a non-string search is dropped", () => {
+      expect(
+        TableViewUrlState.fromJSON({ search: 5 as unknown as string }).search,
+      ).toBeUndefined();
+    });
+
+    test("an empty search is dropped", () => {
+      expect(
+        TableViewUrlState.fromJSON({ search: "  " }).search,
+      ).toBeUndefined();
+    });
+
+    test("labels that aren't an array are dropped", () => {
+      expect(
+        TableViewUrlState.fromJSON({ labels: "a" as unknown as Array<string> })
+          .labels,
+      ).toBeUndefined();
+    });
+
+    test("non-string entries inside labels are dropped", () => {
+      expect(
+        TableViewUrlState.fromJSON({
+          labels: ["a", 5, null, "b"] as unknown as Array<string>,
+        }).labels,
+      ).toEqual(["a", "b"]);
+    });
+
+    test("an unrecognised sortOrder falls back to ascending", () => {
+      expect(
+        TableViewUrlState.fromJSON({
+          sortBy: "name",
+          sortOrder: "sideways" as unknown as SortOrder,
+        }),
+      ).toEqual({ sortBy: "name", sortOrder: SortOrder.Ascending });
+    });
+
+    test("a sortOrder without a sortBy is ignored", () => {
+      expect(
+        TableViewUrlState.fromJSON({ sortOrder: SortOrder.Descending }),
+      ).toEqual({});
+    });
+
+    test("a non-numeric page is dropped", () => {
+      expect(
+        TableViewUrlState.fromJSON({ page: "2" as unknown as number }).page,
+      ).toBeUndefined();
+    });
+
+    test("a zero or negative page is dropped", () => {
+      expect(TableViewUrlState.fromJSON({ page: 0 }).page).toBeUndefined();
+      expect(TableViewUrlState.fromJSON({ page: -4 }).page).toBeUndefined();
+    });
+
+    test("a fractional page is floored", () => {
+      expect(TableViewUrlState.fromJSON({ page: 3.9 }).page).toBe(3);
+    });
+
+    test("NaN and Infinity are dropped", () => {
+      expect(TableViewUrlState.fromJSON({ page: NaN }).page).toBeUndefined();
+      expect(
+        TableViewUrlState.fromJSON({ page: Infinity }).page,
+      ).toBeUndefined();
+    });
+
+    test("a page size above the cap is dropped rather than sent to the API", () => {
+      expect(
+        TableViewUrlState.fromJSON({ itemsOnPage: MaxItemsOnPage }).itemsOnPage,
+      ).toBe(MaxItemsOnPage);
+      expect(
+        TableViewUrlState.fromJSON({ itemsOnPage: MaxItemsOnPage + 1 })
+          .itemsOnPage,
+      ).toBeUndefined();
+      expect(
+        TableViewUrlState.fromJSON({ itemsOnPage: 10_000_000 }).itemsOnPage,
+      ).toBeUndefined();
+    });
+
+    test("one bad field does not discard the good ones", () => {
+      expect(
+        TableViewUrlState.fromJSON({
+          search: "api",
+          page: "not a page" as unknown as number,
+          itemsOnPage: -1,
+          sortBy: "name",
+          sortOrder: SortOrder.Descending,
+        }),
+      ).toEqual({
+        search: "api",
+        sortBy: "name",
+        sortOrder: SortOrder.Descending,
+      });
+    });
+
+    test("unknown keys are ignored entirely", () => {
+      expect(
+        TableViewUrlState.fromJSON({
+          search: "api",
+          somethingElse: "ignored",
+        } as unknown as JSONObject),
+      ).toEqual({ search: "api" });
+    });
+  });
+});
+
+describe("TableViewUrlState round trip", () => {
+  test("survives toJSON -> JSON -> fromJSON unchanged", () => {
+    const state: TableViewUrlStateData = {
+      search: "api gateway",
+      labels: ["label-1", "label-2"],
+      sortBy: "name",
+      sortOrder: SortOrder.Descending,
+      page: 7,
+      itemsOnPage: 50,
+    };
+
+    const json: JSONObject | null = TableViewUrlState.toJSON(state);
+
+    expect(
+      TableViewUrlState.fromJSON(JSON.parse(JSON.stringify(json))),
+    ).toEqual(state);
+  });
+});

--- a/Common/Types/BaseDatabase/EqualTo.ts
+++ b/Common/Types/BaseDatabase/EqualTo.ts
@@ -15,7 +15,15 @@ export default class EqualTo<T extends CompareType> extends CompareBase<T> {
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.EqualTo,
-      value: (this as EqualTo<T>).toString(),
+      /*
+       * The RAW value is serialized (like GreaterThan / InBetween), not
+       * toString(): toString() stringifies a Date into a locale- and
+       * timezone-dependent form that loses milliseconds, and coerces a number
+       * into a string. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision — and which is
+       * what lets an equality filter survive a round trip through the URL.
+       */
+      value: (this as EqualTo<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/EqualToOrNull.ts
+++ b/Common/Types/BaseDatabase/EqualToOrNull.ts
@@ -17,7 +17,15 @@ export default class EqualToOrNull<
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.EqualToOrNull,
-      value: (this as EqualToOrNull<T>).toString(),
+      /*
+       * The RAW value is serialized (like GreaterThan / InBetween), not
+       * toString(): toString() stringifies a Date into a locale- and
+       * timezone-dependent form that loses milliseconds, and coerces a number
+       * into a string. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision — and which is
+       * what lets an equality filter survive a round trip through the URL.
+       */
+      value: (this as EqualToOrNull<T>).value,
     };
   }
 

--- a/Common/Types/BaseDatabase/NotEqual.ts
+++ b/Common/Types/BaseDatabase/NotEqual.ts
@@ -14,7 +14,15 @@ export default class NotEqual<T extends CompareType> extends CompareBase<T> {
   public override toJSON(): JSONObject {
     return {
       _type: ObjectType.NotEqual,
-      value: (this as NotEqual<T>).toString(),
+      /*
+       * The RAW value is serialized (like GreaterThan / InBetween), not
+       * toString(): toString() stringifies a Date into a locale- and
+       * timezone-dependent form that loses milliseconds, and coerces a number
+       * into a string. JSON.stringify emits a raw Date as its full ISO
+       * timestamp, which the server binds at full precision — and which is
+       * what lets an equality filter survive a round trip through the URL.
+       */
+      value: (this as NotEqual<T>).value,
     };
   }
 

--- a/Common/UI/Components/Filters/EntityFilter.tsx
+++ b/Common/UI/Components/Filters/EntityFilter.tsx
@@ -97,6 +97,22 @@ const detectSingleState: DetectStateFunction = (
   if (rawValue instanceof NotNull) {
     return { operator: FilterOperator.IsNotEmpty, values: [] };
   }
+  /*
+   * The mirror image of `buildSingleValue`'s "is not" case, which encodes the
+   * operator as a single-item IncludesNone. Without this the dropdown lost the
+   * operator (and its value) on every remount — which is every Back
+   * navigation and every shared link.
+   */
+  if (rawValue instanceof IncludesNone) {
+    const values: Array<string> = (rawValue.values || []).map((v: unknown) => {
+      return v!.toString();
+    });
+
+    return {
+      operator: FilterOperator.IsNot,
+      values: values.length > 0 ? [values[0] as string] : [],
+    };
+  }
   if (typeof rawValue === "string" && rawValue) {
     return { operator: FilterOperator.Is, values: [rawValue] };
   }

--- a/Common/UI/Components/Filters/FilterViewer.tsx
+++ b/Common/UI/Components/Filters/FilterViewer.tsx
@@ -466,10 +466,27 @@ const FilterComponent: FilterComponentFunction = <T extends GenericObject>(
         items = rawValue.values as Array<string>;
       } else if (Array.isArray(rawValue)) {
         items = rawValue as Array<string>;
-      } else if (typeof rawValue === "string") {
-        items = [rawValue];
+      } else if (
+        typeof rawValue === "string" ||
+        typeof rawValue === "number" ||
+        typeof rawValue === "boolean"
+      ) {
+        /*
+         * Not every dropdown value is a string — enum-backed and boolean
+         * dropdowns store their raw value, and those used to match none of
+         * the branches above and render no chip at all.
+         */
+        items = [rawValue.toString()];
       }
 
+      /*
+       * Resolve ids to their human label where we can. When we cannot, fall
+       * back to the raw value instead of dropping the chip: the options list
+       * is fetched lazily, so a filter restored from the URL is live on the
+       * query *before* its labels exist. Returning null there left the user
+       * looking at a filtered table with nothing to explain it and no
+       * "Clear Filters" button to escape it.
+       */
       const entityNames: string = items
         .map((item: string) => {
           const entity: DropdownOption | undefined =
@@ -481,10 +498,10 @@ const FilterComponent: FilterComponentFunction = <T extends GenericObject>(
           if (entity) {
             return entity.label.toString();
           }
-          return null;
+          return item.toString();
         })
-        .filter((name: string | null) => {
-          return name !== null;
+        .filter((name: string) => {
+          return name !== "";
         })
         .join(", ");
 

--- a/Common/UI/Components/List/List.tsx
+++ b/Common/UI/Components/List/List.tsx
@@ -45,6 +45,13 @@ export interface ComponentProps<T extends GenericObject> {
   showFilterModal?: undefined | boolean;
   filterError?: string | undefined;
   onFilterChanged?: undefined | ((filterData: FilterData<T>) => void);
+  /*
+   * The active filter selections. Without this the list's FilterViewer
+   * always fell back to `{}` and rendered no chips, so a filtered list
+   * (including one restored from the URL) gave the user nothing to see or
+   * clear.
+   */
+  filterData?: FilterData<T> | undefined;
   onFilterRefreshClick?: undefined | (() => void);
   onFilterModalClose?: (() => void) | undefined;
   onFilterModalOpen?: (() => void) | undefined;
@@ -118,6 +125,7 @@ const List: ListFunction = <T extends GenericObject>(
             filterError={props.filterError}
             onFilterRefreshClick={props.onFilterRefreshClick}
             filters={props.filters || []}
+            filterData={props.filterData}
             onFilterModalClose={() => {
               props.onFilterModalClose?.();
             }}

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -1,5 +1,4 @@
 import Includes from "../../../Types/BaseDatabase/Includes";
-import QueryOperator from "../../../Types/BaseDatabase/QueryOperator";
 import { API_DOCS_URL, BILLING_ENABLED, getAllEnvVars } from "../../Config";
 import { GetReactElementFunction } from "../../Types/FunctionTypes";
 import SelectEntityField from "../../Types/SelectEntityField";
@@ -13,6 +12,12 @@ import Select from "../../../Types/BaseDatabase/Select";
 import { Logger } from "../../Utils/Logger";
 import Navigation from "../../Utils/Navigation";
 import TableFilterUrlState from "../../Utils/TableFilterUrlState";
+import TableViewUrlState, {
+  TableViewUrlStateData,
+} from "../../Utils/TableViewUrlState";
+import buildQueryFromFilterData, {
+  sanitizeFilterData,
+} from "./FilterDataToQuery";
 import PermissionUtil from "../../Utils/Permission";
 import ProjectUtil from "../../Utils/Project";
 import User from "../../Utils/User";
@@ -67,8 +72,6 @@ import AccessControlModel from "../../../Models/DatabaseModels/DatabaseBaseModel
 import Route from "../../../Types/API/Route";
 import URL from "../../../Types/API/URL";
 import { ColumnAccessControl } from "../../../Types/BaseDatabase/AccessControl";
-import InBetween from "../../../Types/BaseDatabase/InBetween";
-import Search from "../../../Types/BaseDatabase/Search";
 import MultiSearch from "../../../Types/BaseDatabase/MultiSearch";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import SubscriptionPlan, {
@@ -91,7 +94,6 @@ import Permission, {
   PermissionHelper,
   UserPermission,
 } from "../../../Types/Permission";
-import Typeof from "../../../Types/Typeof";
 import React, {
   MutableRefObject,
   ReactElement,
@@ -287,6 +289,24 @@ export interface BaseTableProps<
    * If you do not provide this key, the table will not save the user preferences in local storage.
    */
   userPreferencesKey: string;
+
+  /**
+   * Namespace for this table's filter/facet/view state in the URL query
+   * string. Defaults to `saveFilterProps.tableId`, falling back to
+   * `userPreferencesKey` — both of which are already unique per table, which
+   * is what lets several tables share a page without clobbering each other.
+   *
+   * Only set this explicitly when the same table component is mounted more
+   * than once on one route and the two instances must keep separate state.
+   */
+  urlStateKey?: string | undefined;
+
+  /**
+   * Opt out of mirroring this table's filters into the URL. Use for tables
+   * inside modals/side-overs, or transient tables whose filters shouldn't
+   * outlive the page.
+   */
+  disableUrlState?: boolean | undefined;
 }
 
 export interface ComponentProps<
@@ -377,6 +397,61 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     return props.initialItemsOnPage || 10;
   };
 
+  /*
+   * ---------------------------------------------------------------------
+   * URL-persisted view state
+   * ---------------------------------------------------------------------
+   *
+   * The table mirrors its filters, facets, search, sort and page into the URL
+   * query string so that (a) navigating into a row and pressing Back brings
+   * the same filtered view back, and (b) the URL can be pasted to a teammate.
+   *
+   * The snapshot is read *once, synchronously, during the first render* and
+   * fed to the `useState` initializers below. Restoring in an effect instead
+   * would fire the first fetch against the unfiltered defaults and then throw
+   * that response away — a visible flash of the wrong rows plus a wasted
+   * request.
+   */
+  const urlStateKey: string | undefined = props.disableUrlState
+    ? undefined
+    : props.urlStateKey ||
+      props.saveFilterProps?.tableId ||
+      props.userPreferencesKey ||
+      undefined;
+
+  const initialUrlState: {
+    filter: FilterData<TBaseModel> | null;
+    view: TableViewUrlStateData;
+  } = useMemo(() => {
+    const restoredFilter: JSONObject | null = TableFilterUrlState.read(
+      urlStateKey,
+      "filter",
+    );
+
+    /*
+     * Anything on the URL is user-editable, so keep only the fields this table
+     * actually offers a filter for before it reaches the outgoing query.
+     */
+    const sanitized: FilterData<TBaseModel> | null = restoredFilter
+      ? sanitizeFilterData<TBaseModel>({
+          filterData: restoredFilter as unknown as FilterData<TBaseModel>,
+          filters: props.filters,
+        })
+      : null;
+
+    return {
+      filter: sanitized && Object.keys(sanitized).length > 0 ? sanitized : null,
+      view: TableViewUrlState.fromJSON(
+        TableFilterUrlState.read(urlStateKey, "view"),
+      ),
+    };
+  }, []);
+
+  // Surfaces two tables on one page accidentally sharing a URL namespace.
+  useEffect(() => {
+    return TableFilterUrlState.claimKey(urlStateKey);
+  }, [urlStateKey]);
+
   const [orderedStatesListNewItemOrder, setOrderedStatesListNewItemOrder] =
     useState<number | null>(null);
 
@@ -384,8 +459,15 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     TBaseModel | undefined
   >(undefined);
   const [data, setData] = useState<Array<TBaseModel>>([]);
-  const [query, setQuery] = useState<Query<TBaseModel>>({});
-  const [currentPageNumber, setCurrentPageNumber] = useState<number>(1);
+  const [query, setQuery] = useState<Query<TBaseModel>>(() => {
+    return buildQueryFromFilterData<TBaseModel>({
+      filterData: initialUrlState.filter || props.initialFilterData || {},
+      filters: props.filters,
+    });
+  });
+  const [currentPageNumber, setCurrentPageNumber] = useState<number>(
+    initialUrlState.view.page || 1,
+  );
   const [totalItemsCount, setTotalItemsCount] = useState<number>(0);
   /*
    * Analytics endpoints (Log/Span/Metric/...) skip COUNT(*) for
@@ -399,10 +481,18 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [error, setError] = useState<string>("");
   const [tableFilterError, setTableFilterError] = useState<string>("");
 
-  const [searchText, setSearchText] = useState<string>("");
-  const [debouncedSearchText, setDebouncedSearchText] = useState<string>("");
+  const [searchText, setSearchText] = useState<string>(
+    initialUrlState.view.search || "",
+  );
+  const [debouncedSearchText, setDebouncedSearchText] = useState<string>(
+    initialUrlState.view.search || "",
+  );
   const [isSearchFocused, setIsSearchFocused] = useState<boolean>(false);
-  const [isSearchExpanded, setIsSearchExpanded] = useState<boolean>(false);
+  const [isSearchExpanded, setIsSearchExpanded] = useState<boolean>(
+    Boolean(
+      initialUrlState.view.search || (initialUrlState.view.labels || []).length,
+    ),
+  );
   const searchInputRef: React.RefObject<HTMLInputElement> =
     React.useRef<HTMLInputElement>(null!);
 
@@ -415,12 +505,35 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [availableLabels, setAvailableLabels] = useState<
     Array<SearchLabelOption>
   >([]);
+  /*
+   * Restored label chips start as bare IDs — the id is all the query needs, so
+   * rows are correct on the very first fetch. The human-readable name/colour
+   * are filled in by the hydration effect below once the label list loads.
+   */
   const [selectedLabels, setSelectedLabels] = useState<
     Array<SearchLabelOption>
-  >([]);
+  >(() => {
+    return (initialUrlState.view.labels || []).map((id: string) => {
+      return { id: id, name: id, color: "#94a3b8" };
+    });
+  });
   const [isLabelsLoading, setIsLabelsLoading] = useState<boolean>(false);
   const [labelsFetched, setLabelsFetched] = useState<boolean>(false);
   const [labelDropdownIndex, setLabelDropdownIndex] = useState<number>(0);
+
+  /*
+   * Only the *ids* affect the query, so effects key off this instead of the
+   * array itself. Without it, merely re-labelling a chip (which happens when
+   * URL-restored chips get their display name hydrated) would look like a
+   * filter change and trigger a refetch + a jump back to page 1.
+   */
+  const selectedLabelIds: Array<string> = useMemo(() => {
+    return selectedLabels.map((l: SearchLabelOption) => {
+      return l.id;
+    });
+  }, [selectedLabels]);
+
+  const selectedLabelIdsKey: string = selectedLabelIds.join(",");
 
   useEffect(() => {
     const handle: ReturnType<typeof setTimeout> = setTimeout(() => {
@@ -477,12 +590,23 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     ) {
       setIsSearchExpanded(true);
     }
-  }, [debouncedSearchText, selectedLabels]);
+  }, [debouncedSearchText, selectedLabelIdsKey]);
+
+  /*
+   * Effects run on mount too, so without this guard the very first pass would
+   * stomp a page number restored from the URL back to 1.
+   */
+  const isFirstRenderRef: MutableRefObject<boolean> = React.useRef(true);
 
   useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+
     // reset to first page whenever the active search term or labels change
     setCurrentPageNumber(1);
-  }, [debouncedSearchText, selectedLabels]);
+  }, [debouncedSearchText, selectedLabelIdsKey]);
 
   /*
    * Auto-detect label support from the existing filters array. We look for
@@ -582,14 +706,52 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     };
   }, [isSearchExpanded, labelFilterConfig, labelsFetched]);
 
+  /*
+   * Chips restored from the URL only carry an id. Once the label list lands,
+   * swap in the real name and colour so the chip reads "Production" rather
+   * than a raw ObjectID. Labels that no longer exist (deleted, or not visible
+   * to this user) keep their id — the filter still applies, it just isn't
+   * pretty, which beats silently dropping a constraint from a shared link.
+   */
+  useEffect(() => {
+    if (availableLabels.length === 0 || selectedLabels.length === 0) {
+      return;
+    }
+
+    let didHydrate: boolean = false;
+
+    const hydrated: Array<SearchLabelOption> = selectedLabels.map(
+      (selected: SearchLabelOption) => {
+        const match: SearchLabelOption | undefined = availableLabels.find(
+          (available: SearchLabelOption) => {
+            return available.id === selected.id;
+          },
+        );
+
+        if (!match || match.name === selected.name) {
+          return selected;
+        }
+
+        didHydrate = true;
+        return match;
+      },
+    );
+
+    if (didHydrate) {
+      setSelectedLabels(hydrated);
+    }
+  }, [availableLabels]);
+
   const [showModel, setShowModal] = useState<boolean>(false);
   const [showFilterModal, setShowFilterModal] = useState<boolean>(false);
   const [modalType, setModalType] = useState<ModalType>(ModalType.Create);
   const [sortBy, setSortBy] = useState<keyof TBaseModel | null>(
-    props.sortBy || null,
+    (initialUrlState.view.sortBy as keyof TBaseModel | undefined) ||
+      props.sortBy ||
+      null,
   );
   const [sortOrder, setSortOrder] = useState<SortOrder>(
-    props.sortOrder || SortOrder.Ascending,
+    initialUrlState.view.sortOrder || props.sortOrder || SortOrder.Ascending,
   );
   const [showDeleteConfirmModal, setShowDeleteConfirmModal] =
     useState<boolean>(false);
@@ -598,7 +760,24 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [currentDeleteableItem, setCurrentDeleteableItem] =
     useState<TBaseModel | null>(null);
 
-  const [itemsOnPage, setItemsOnPage] = useState<number>(getItemsOnPage());
+  /*
+   * A page size that came in on the URL wins over the viewer's own stored
+   * preference — a shared link should render the same slice of rows for
+   * everyone who opens it.
+   */
+  const [itemsOnPage, setItemsOnPage] = useState<number>(
+    initialUrlState.view.itemsOnPage || getItemsOnPage(),
+  );
+
+  /*
+   * Page size is a personal preference (it already lives in localStorage), so
+   * it is only put on the URL once it is explicitly part of *this* view —
+   * either it arrived on the link, or the viewer changed it here. Otherwise
+   * every table would carry a redundant `itemsOnPage` param.
+   */
+  const isItemsOnPageExplicitRef: MutableRefObject<boolean> = React.useRef(
+    Boolean(initialUrlState.view.itemsOnPage),
+  );
 
   useEffect(() => {
     // update items on page in localstorage.
@@ -624,6 +803,24 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     // only update if the query has changed.
     if (JSON.stringify(currentQuery) !== JSON.stringify(newQuery)) {
       propsQueryRef.current = newQuery;
+
+      /*
+       * This is how facet-bar selections reach the API, so narrowing the
+       * result set has to send the user back to page 1 — exactly like the
+       * column-filter path does in `onFilterChanged`. Without it, changing a
+       * facet while on page 5 re-queries page 5 of a now-shorter list and
+       * lands on an empty page (and, since the page number is mirrored into
+       * the URL, shares that empty page too).
+       *
+       * When the page is already 1, `setCurrentPageNumber` is a no-op and the
+       * explicit fetch below is what refreshes the list; when it isn't, the
+       * state change re-runs the main fetch effect.
+       */
+      if (currentPageNumber !== 1) {
+        setCurrentPageNumber(1);
+        return;
+      }
+
       fetchItems().catch((err: Error) => {
         setError(API.getFriendlyMessage(err));
       });
@@ -1204,6 +1401,31 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     }
   }, [showFilterModal, props.filters]);
 
+  /*
+   * A table restored from the URL is already filtered, so its chips have to
+   * render immediately — and entity/dropdown chips can only resolve their
+   * labels from `filterDropdownOptions`, which are otherwise fetched lazily
+   * when the filter popup opens. Without this, a shared link (or a Back
+   * navigation) showed a filtered list with no visible indication of *why*,
+   * and no "Clear Filters" button to escape it.
+   */
+  useEffect(() => {
+    if (!initialUrlState.filter) {
+      return;
+    }
+
+    /*
+     * Callers use this to render their own "filters active" affordance. It is
+     * otherwise only fired by the filter form, so a restored view would show a
+     * clean banner over a filtered table.
+     */
+    props.onFilterApplied?.(true);
+
+    getFilterDropdownItems().catch((err: Error) => {
+      setTableFilterError(API.getFriendlyMessage(err));
+    });
+  }, []);
+
   type GetSelectFunction = () => Select<TBaseModel>;
 
   const getSelect: GetSelectFunction = (): Select<TBaseModel> => {
@@ -1284,6 +1506,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               // then set query, sort and items on the page
               setQuery(tableView.query || {});
               setFilterData(tableView.query || {});
+              // a saved view pins its own page size, so it belongs on the URL
+              isItemsOnPageExplicitRef.current = true;
               setItemsOnPage(tableView.itemsOnPage || 10);
               setSortBy((sortBy as keyof TBaseModel) || null);
               setSortOrder(sortOrder);
@@ -1300,6 +1524,13 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               }
             } else {
               setQuery({});
+              /*
+               * Also clear the filter chips. Leaving `filterData` behind kept
+               * the chips on screen and the `-filter` param in the URL, so the
+               * next visit re-applied the very filters the user just cleared.
+               */
+              setFilterData({});
+              props.onFilterApplied?.(false);
               setSortBy(null);
               setSortOrder(SortOrder.Descending);
               setItemsOnPage(10);
@@ -1427,7 +1658,13 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         buttonSize: ButtonSize.Small,
         className: "",
         onClick: () => {
-          setQuery({});
+          /*
+           * Just open the popup. This used to `setQuery({})` first, which
+           * dropped the active filters (and refetched everything) the moment
+           * the user opened the filter UI — while the chips and the URL still
+           * advertised them. Filters now change only when the form applies
+           * them.
+           */
           setShowFilterModal(true);
         },
         disabled: isFilterFetchLoading,
@@ -1449,7 +1686,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     itemsOnPage,
     query,
     debouncedSearchText,
-    selectedLabels,
+    selectedLabelIdsKey,
     props.refreshToggle,
   ]);
 
@@ -1766,7 +2003,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   };
 
   const [filterData, setFilterData] = useState<FilterData<TBaseModel>>(
-    props.initialFilterData || {},
+    initialUrlState.filter || props.initialFilterData || {},
   );
 
   type OnFilterChangedFunction = (filterData: FilterData<TBaseModel>) => void;
@@ -1774,100 +2011,56 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const onFilterChanged: OnFilterChangedFunction = (
     filterData: FilterData<TBaseModel>,
   ): void => {
-    const newQuery: Query<TBaseModel> = {};
-
     setFilterData(filterData);
     setCurrentPageNumber(1);
 
-    for (const key in filterData) {
-      if (filterData[key] && typeof filterData[key] === Typeof.String) {
-        newQuery[key as keyof TBaseModel] = (filterData[key] || "").toString();
-      }
-
-      if (typeof filterData[key] === Typeof.Boolean) {
-        newQuery[key as keyof TBaseModel] = Boolean(filterData[key]);
-      }
-
-      if (typeof filterData[key] === Typeof.Number) {
-        newQuery[key as keyof TBaseModel] = filterData[key];
-      }
-
-      if (filterData[key] instanceof Date) {
-        newQuery[key as keyof TBaseModel] = filterData[key];
-      }
-
-      if (filterData[key] instanceof Search) {
-        newQuery[key as keyof TBaseModel] = filterData[key];
-      }
-
-      if (filterData[key] instanceof InBetween) {
-        newQuery[key as keyof TBaseModel] = filterData[key];
-      }
-
-      if (
-        props.filters.find((f: Filter<TBaseModel>) => {
-          return f.field && f.field[key];
-        })?.type === FieldType.JSON &&
-        typeof filterData[key] === Typeof.Object
-      ) {
-        newQuery[key as keyof TBaseModel] = filterData[key];
-      }
-
-      if (Array.isArray(filterData[key])) {
-        newQuery[key as keyof TBaseModel] = new Includes(
-          filterData[key] as Array<string>,
-        );
-      }
-
-      /*
-       * Pass any QueryOperator instance (IncludesAll, IncludesNone, StartsWith,
-       * EndsWith, NotContains, EqualTo, NotEqual, GreaterThan, LessThan,
-       * InBetween, IsNull, NotNull, ...) through to the query as-is.
-       */
-      if (filterData[key] instanceof QueryOperator) {
-        newQuery[key as keyof TBaseModel] = filterData[key];
-      }
-    }
-
-    setQuery({ ...newQuery });
+    setQuery(
+      buildQueryFromFilterData<TBaseModel>({
+        filterData: filterData,
+        filters: props.filters,
+      }),
+    );
   };
 
   /*
-   * URL persistence for classic (column) filters, keyed by the table's
-   * `saveFilterProps.tableId`. Mirrors the facet persistence in
-   * `useResourceOwners` so filters survive navigating to a detail page and
-   * back, and so a filtered view is shareable. `hasRestoredUrlFilters` is
-   * state (not a ref) so the persist effect only runs after the restore has
-   * been applied — never clobbering the snapshot with the empty default.
+   * Mirror the table's view into the URL so Back restores it and the link can
+   * be handed to a teammate. Restoring happens in the `useState` initializers
+   * above (synchronously, before the first fetch), so there is nothing to gate
+   * here: the first write after mount already carries the restored values.
+   *
+   * `replaceState` is used under the hood, so dragging a filter around doesn't
+   * flood the back stack.
    */
-  const [hasRestoredUrlFilters, setHasRestoredUrlFilters] =
-    useState<boolean>(false);
-
   useEffect(() => {
-    const restored: JSONObject | null = TableFilterUrlState.read(
-      props.saveFilterProps?.tableId,
-      "filter",
-    );
-    if (restored) {
-      /*
-       * Re-run through onFilterChanged so the derived query is rebuilt and the
-       * first fetch uses the restored filters.
-       */
-      onFilterChanged(restored as unknown as FilterData<TBaseModel>);
-    }
-    setHasRestoredUrlFilters(true);
-  }, []);
-
-  useEffect(() => {
-    if (!hasRestoredUrlFilters) {
-      return;
-    }
-    TableFilterUrlState.write(
-      props.saveFilterProps?.tableId,
-      "filter",
-      filterData as unknown as JSONObject,
-    );
-  }, [hasRestoredUrlFilters, filterData]);
+    TableFilterUrlState.writeMany(urlStateKey, {
+      filter: filterData as unknown as JSONObject,
+      view: TableViewUrlState.toJSON(
+        {
+          search: debouncedSearchText,
+          labels: selectedLabelIds,
+          sortBy: sortBy as string | undefined,
+          sortOrder: sortOrder,
+          page: currentPageNumber,
+          itemsOnPage: isItemsOnPageExplicitRef.current
+            ? itemsOnPage
+            : undefined,
+        },
+        {
+          sortBy: props.sortBy as string | undefined,
+          sortOrder: props.sortOrder,
+        },
+      ),
+    });
+  }, [
+    urlStateKey,
+    filterData,
+    debouncedSearchText,
+    selectedLabelIdsKey,
+    sortBy,
+    sortOrder,
+    currentPageNumber,
+    itemsOnPage,
+  ]);
 
   type GetDeleteBulkActionFunction = () => BulkActionButtonSchema<TBaseModel>;
 
@@ -2161,6 +2354,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
           if (newItemsOnPage !== itemsOnPage) {
             setTableView(null);
+            isItemsOnPageExplicitRef.current = true;
           }
 
           setItemsOnPage(newItemsOnPage);
@@ -2252,6 +2446,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           await getFilterDropdownItems();
         }}
         filters={classicTableFilters}
+        filterData={filterData}
         filterError={tableFilterError}
         isFilterLoading={isFilterFetchLoading}
         showFilterModal={showFilterModal}
@@ -2294,9 +2489,17 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         fields={fields}
         itemsOnPage={itemsOnPage}
         disablePagination={props.disablePagination || false}
-        onNavigateToPage={async (pageNumber: number, itemsOnPage: number) => {
+        onNavigateToPage={async (
+          pageNumber: number,
+          newItemsOnPage: number,
+        ) => {
           setCurrentPageNumber(pageNumber);
-          setItemsOnPage(itemsOnPage);
+
+          if (newItemsOnPage !== itemsOnPage) {
+            isItemsOnPageExplicitRef.current = true;
+          }
+
+          setItemsOnPage(newItemsOnPage);
         }}
         noItemsMessage={props.noItemsMessage || ""}
         onRefreshClick={async () => {

--- a/Common/UI/Components/ModelTable/FilterDataToQuery.ts
+++ b/Common/UI/Components/ModelTable/FilterDataToQuery.ts
@@ -1,0 +1,172 @@
+import Filter from "../ModelFilter/Filter";
+import FilterData from "../Filters/Types/FilterData";
+import FieldType from "../Types/FieldType";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Query from "../../../Types/BaseDatabase/Query";
+import QueryOperator from "../../../Types/BaseDatabase/QueryOperator";
+import Search from "../../../Types/BaseDatabase/Search";
+import Typeof from "../../../Types/Typeof";
+
+/**
+ * Translate the filter popup's selections into the database query the table
+ * fetches with.
+ *
+ * Lives outside `BaseModelTable` on purpose: the table needs to derive the
+ * query *synchronously during its first render* when filters are restored from
+ * the URL (otherwise the first fetch would go out unfiltered and be
+ * immediately superseded), and a pure function is the only way to do that
+ * without an effect.
+ */
+export type GetFilterKeysFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  filters: Array<Filter<TBaseModel>>,
+) => Array<string>;
+
+/**
+ * The model fields this table actually exposes a filter for.
+ */
+export const getFilterKeys: GetFilterKeysFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  filters: Array<Filter<TBaseModel>>,
+): Array<string> => {
+  const keys: Array<string> = [];
+
+  for (const filter of filters || []) {
+    const key: string | undefined = filter.field
+      ? Object.keys(filter.field)[0]
+      : undefined;
+
+    if (key) {
+      keys.push(key);
+    }
+  }
+
+  return keys;
+};
+
+export type SanitizeFilterDataFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  filterData: FilterData<TBaseModel>;
+  filters: Array<Filter<TBaseModel>>;
+}) => FilterData<TBaseModel>;
+
+/**
+ * Drop any key that this table does not expose as a filter.
+ *
+ * The filter snapshot arrives from the URL, which anyone can edit, and the
+ * result is spread into the outgoing list query *after* the caller's own
+ * scoping query. Without this, a hand-crafted link could add a constraint on a
+ * field the table never offered — or overwrite the page's own scoping (say the
+ * `projectId` on a nested list) — just by naming it in the query string.
+ *
+ * Restricting to declared filter keys keeps a shared link to exactly what the
+ * filter UI could have produced.
+ */
+const sanitizeFilterData: SanitizeFilterDataFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  filterData: FilterData<TBaseModel>;
+  filters: Array<Filter<TBaseModel>>;
+}): FilterData<TBaseModel> => {
+  const allowedKeys: Array<string> = getFilterKeys<TBaseModel>(data.filters);
+  const sanitized: FilterData<TBaseModel> = {};
+
+  for (const key in data.filterData || {}) {
+    if (!allowedKeys.includes(key)) {
+      continue;
+    }
+
+    const value: unknown = (data.filterData as any)[key];
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    (sanitized as any)[key] = value;
+  }
+
+  return sanitized;
+};
+
+export { sanitizeFilterData };
+
+export type BuildQueryFromFilterDataFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  filterData: FilterData<TBaseModel>;
+  filters: Array<Filter<TBaseModel>>;
+}) => Query<TBaseModel>;
+
+const buildQueryFromFilterData: BuildQueryFromFilterDataFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  filterData: FilterData<TBaseModel>;
+  filters: Array<Filter<TBaseModel>>;
+}): Query<TBaseModel> => {
+  const filterData: FilterData<TBaseModel> = data.filterData || {};
+  const filters: Array<Filter<TBaseModel>> = data.filters || [];
+
+  const query: Query<TBaseModel> = {};
+
+  for (const key in filterData) {
+    const value: unknown = filterData[key];
+
+    if (value && typeof value === Typeof.String) {
+      query[key as keyof TBaseModel] = (value || "").toString();
+    }
+
+    if (typeof value === Typeof.Boolean) {
+      query[key as keyof TBaseModel] = Boolean(value);
+    }
+
+    if (typeof value === Typeof.Number) {
+      query[key as keyof TBaseModel] = value as any;
+    }
+
+    if (value instanceof Date) {
+      query[key as keyof TBaseModel] = value as any;
+    }
+
+    if (value instanceof Search) {
+      query[key as keyof TBaseModel] = value as any;
+    }
+
+    if (value instanceof InBetween) {
+      query[key as keyof TBaseModel] = value as any;
+    }
+
+    if (
+      filters.find((f: Filter<TBaseModel>) => {
+        return f.field && (f.field as any)[key];
+      })?.type === FieldType.JSON &&
+      typeof value === Typeof.Object
+    ) {
+      query[key as keyof TBaseModel] = value as any;
+    }
+
+    if (Array.isArray(value)) {
+      query[key as keyof TBaseModel] = new Includes(
+        value as Array<string>,
+      ) as any;
+    }
+
+    /*
+     * Pass any QueryOperator instance (IncludesAll, IncludesNone, StartsWith,
+     * EndsWith, NotContains, EqualTo, NotEqual, GreaterThan, LessThan,
+     * InBetween, IsNull, NotNull, ...) through to the query as-is.
+     */
+    if (value instanceof QueryOperator) {
+      query[key as keyof TBaseModel] = value as any;
+    }
+  }
+
+  return query;
+};
+
+export default buildQueryFromFilterData;

--- a/Common/UI/Utils/Navigation.ts
+++ b/Common/UI/Utils/Navigation.ts
@@ -52,6 +52,16 @@ abstract class Navigation {
     return pathes?.[0]?.route.path || "";
   }
 
+  /**
+   * The raw query string of the current URL, including the leading "?" when
+   * non-empty (i.e. exactly `window.location.search`). Reading it through
+   * Navigation keeps callers testable and consistent with
+   * {@link setQueryString}, which also works off `window.location`.
+   */
+  public static getQueryString(): string {
+    return window.location.search;
+  }
+
   public static getQueryStringByName(paramName: string): string | null {
     const urlSearchParams: URLSearchParams = new URLSearchParams(
       window.location.search,

--- a/Common/UI/Utils/TableFilterUrlState.ts
+++ b/Common/UI/Utils/TableFilterUrlState.ts
@@ -1,26 +1,124 @@
 import Navigation from "./Navigation";
+import Dictionary from "../../Types/Dictionary";
 import { JSONObject } from "../../Types/JSON";
 import JSONFunctions from "../../Types/JSONFunctions";
-
-export type TableFilterUrlStateKind = "facets" | "filter";
+import { Logger } from "./Logger";
+import { VoidFunction } from "../../Types/FunctionTypes";
 
 /**
- * Persists a table's filter/facet selections in the URL query string so they:
+ * The three independent slices of a table's view state. Each is stored under
+ * its own `<tableId>-<kind>` query param so a change to one never has to
+ * re-serialize the others.
+ *
+ *  - `filter` — the classic column-filter popup selections (`FilterData`).
+ *  - `facets` — the chip/facet bar selections (see `useResourceOwners`).
+ *  - `view`   — search text, label chips, sort and pagination.
+ */
+export type TableFilterUrlStateKind = "facets" | "filter" | "view";
+
+export const TableFilterUrlStateKinds: Array<TableFilterUrlStateKind> = [
+  "filter",
+  "facets",
+  "view",
+];
+
+/**
+ * Persists a table's filter / facet / view selections in the URL query string
+ * so they:
  *  - survive navigating to a detail page and clicking the browser "Back" button
  *    (the list page remounts with the params still on the URL), and
  *  - are shareable/bookmarkable (the URL fully describes the filtered view).
  *
  * The snapshot is run through {@link JSONFunctions} so OneUptime's typed query
  * values (Search, Includes, InBetween, ...) round-trip as real class instances
- * rather than plain objects. Params are namespaced by `tableId` so two tables on
- * the same route don't clobber each other.
+ * rather than plain objects. Params are namespaced by `tableId` so several
+ * tables on the same route each keep their own state.
  */
 export default class TableFilterUrlState {
-  private static getParamName(
+  /**
+   * Upper bound on the whole query string we are willing to produce.
+   *
+   * nginx's default `large_client_header_buffers` gives ~8KB for the entire
+   * request line, and that budget is shared with the path and every other
+   * table on the page. We stay well under it: past this point the table keeps
+   * working from React state, it just stops mirroring the offending slice into
+   * the URL (so the link degrades to "unshared" rather than the page failing
+   * to load on refresh).
+   */
+  public static readonly MaxQueryStringLength: number = 4000;
+
+  public static getParamName(
     tableId: string,
     kind: TableFilterUrlStateKind,
   ): string {
     return `${tableId}-${kind}`;
+  }
+
+  /**
+   * Keys currently claimed by mounted tables, so a duplicate can be reported.
+   * Not used to change behaviour — two tables sharing a key would already have
+   * shared their `userPreferencesKey` page-size preference, so the fix always
+   * belongs at the call site.
+   */
+  private static claimedKeys: Map<string, number> = new Map<string, number>();
+
+  /**
+   * Register a mounted table's URL namespace. Returns a release function to
+   * call on unmount.
+   *
+   * Two tables on one route claiming the same key would read and write the
+   * same params — paging one would repaginate the other, and a reload would
+   * restore whichever wrote last. That is always a call-site bug (give the
+   * tables distinct `userPreferencesKey`/`urlStateKey` values), so this warns
+   * loudly rather than silently renaming a key that may already be in
+   * someone's bookmarks.
+   */
+  public static claimKey(tableId: string | undefined): VoidFunction {
+    if (!tableId) {
+      return () => {
+        // nothing claimed
+      };
+    }
+
+    const claims: number = (this.claimedKeys.get(tableId) || 0) + 1;
+    this.claimedKeys.set(tableId, claims);
+
+    if (claims > 1) {
+      Logger.warn(
+        `TableFilterUrlState: ${claims} tables on this page share the URL state key "${tableId}". ` +
+          `They will overwrite each other's filters, sort and pagination in the URL. ` +
+          `Give each table a distinct "userPreferencesKey" (or pass "urlStateKey").`,
+      );
+    }
+
+    return () => {
+      const remaining: number = (this.claimedKeys.get(tableId) || 1) - 1;
+
+      if (remaining <= 0) {
+        this.claimedKeys.delete(tableId);
+        return;
+      }
+
+      this.claimedKeys.set(tableId, remaining);
+    };
+  }
+
+  /**
+   * Test seam — drops every claim so one test's mounted tables don't leak into
+   * the next.
+   */
+  public static resetClaimedKeys(): void {
+    this.claimedKeys.clear();
+  }
+
+  /**
+   * Every param name this table could own. Used to clear a table's state and
+   * by tests.
+   */
+  public static getAllParamNames(tableId: string): Array<string> {
+    return TableFilterUrlStateKinds.map((kind: TableFilterUrlStateKind) => {
+      return this.getParamName(tableId, kind);
+    });
   }
 
   /*
@@ -68,25 +166,114 @@ export default class TableFilterUrlState {
     kind: TableFilterUrlStateKind,
     state: JSONObject | null,
   ): void {
+    this.writeMany(tableId, { [kind]: state });
+  }
+
+  /**
+   * Write several slices in one `history.replaceState` call. Passing a kind
+   * with a `null`/empty value removes that param; omitting a kind leaves
+   * whatever is already on the URL untouched.
+   */
+  public static writeMany(
+    tableId: string | undefined,
+    states: Partial<Record<TableFilterUrlStateKind, JSONObject | null>>,
+  ): void {
     if (!tableId) {
       return;
     }
 
+    const params: Dictionary<string | null> = {};
+
+    /*
+     * Track the query string as it would look after each param is applied, so
+     * the size check accounts for the other params in this same batch — not
+     * just the URL as it was before the batch started.
+     */
+    const projected: URLSearchParams = this.getCurrentSearchParams();
+
+    for (const kind of Object.keys(states) as Array<TableFilterUrlStateKind>) {
+      const state: JSONObject | null | undefined = states[kind];
+      const paramName: string = this.getParamName(tableId, kind);
+
+      let value: string | null = null;
+
+      try {
+        const hasState: boolean = Boolean(
+          state && Object.keys(state).length > 0,
+        );
+
+        value = hasState
+          ? JSON.stringify(JSONFunctions.serialize(state as JSONObject))
+          : null;
+      } catch (err) {
+        /*
+         * Serialization failure (shouldn't happen for filter data) — drop the
+         * param rather than break the table, and leave a breadcrumb.
+         */
+        Logger.warn(
+          `TableFilterUrlState: could not serialize "${paramName}": ${err}`,
+        );
+        value = null;
+      }
+
+      if (value === null) {
+        projected.delete(paramName);
+      } else {
+        const previous: string | null = projected.get(paramName);
+        projected.set(paramName, value);
+
+        if (projected.toString().length > this.MaxQueryStringLength) {
+          /*
+           * Too big to share. Drop the param so a page refresh doesn't hit an
+           * over-long request line — React state remains the source of truth
+           * for this session.
+           */
+          Logger.warn(
+            `TableFilterUrlState: "${paramName}" is too large for the URL (${value.length} chars) and was not persisted.`,
+          );
+          value = null;
+
+          if (previous === null) {
+            projected.delete(paramName);
+          } else {
+            projected.set(paramName, previous);
+          }
+        }
+      }
+
+      params[paramName] = value;
+    }
+
+    Navigation.setQueryString(params);
+  }
+
+  /**
+   * Remove every param this table owns from the URL.
+   */
+  public static clear(tableId: string | undefined): void {
+    if (!tableId) {
+      return;
+    }
+
+    const params: Dictionary<string | null> = {};
+
+    for (const paramName of this.getAllParamNames(tableId)) {
+      params[paramName] = null;
+    }
+
+    Navigation.setQueryString(params);
+  }
+
+  /**
+   * The current query string as a mutable `URLSearchParams`. Size checks
+   * measure `toString()` on this — the *encoded* length, because that is what
+   * actually travels on the wire.
+   */
+  private static getCurrentSearchParams(): URLSearchParams {
     try {
-      const hasState: boolean = Boolean(state && Object.keys(state).length > 0);
-
-      const value: string | null = hasState
-        ? JSON.stringify(JSONFunctions.serialize(state as JSONObject))
-        : null;
-
-      Navigation.setQueryString({
-        [this.getParamName(tableId, kind)]: value,
-      });
+      return new URLSearchParams(Navigation.getQueryString());
     } catch {
-      /*
-       * Serialization failure (shouldn't happen for filter data) — skip the
-       * URL sync rather than break the table.
-       */
+      return new URLSearchParams();
     }
   }
 }

--- a/Common/UI/Utils/TableViewUrlState.ts
+++ b/Common/UI/Utils/TableViewUrlState.ts
@@ -1,0 +1,165 @@
+import { JSONObject } from "../../Types/JSON";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
+
+/**
+ * The "everything that isn't a column filter or a facet" slice of a table's
+ * view: the search box, the label chips next to it, the active sort and where
+ * in the pagination the user is.
+ *
+ * Kept deliberately primitive (strings / numbers / string arrays) so the URL
+ * param stays short and human-readable, and so a hand-edited link can never
+ * smuggle a typed object into the table's query.
+ */
+export interface TableViewUrlStateData {
+  search?: string | undefined;
+  labels?: Array<string> | undefined;
+  sortBy?: string | undefined;
+  sortOrder?: SortOrder | undefined;
+  page?: number | undefined;
+  itemsOnPage?: number | undefined;
+}
+
+/**
+ * The values a slice is compared against before being written. Anything equal
+ * to its default is left out of the URL, so a table the user hasn't touched
+ * contributes no query params at all.
+ */
+export interface TableViewUrlStateDefaults {
+  sortBy?: string | undefined;
+  sortOrder?: SortOrder | undefined;
+}
+
+/**
+ * Hard ceiling on a restored page size. Anything above this is a hand-edited
+ * URL trying to make the table ask the API for an unbounded page.
+ */
+export const MaxItemsOnPage: number = 1000;
+
+export default class TableViewUrlState {
+  /**
+   * Serialize to the plain object that goes in the URL, omitting every value
+   * that matches its default. Returns `null` when nothing is worth persisting
+   * so the caller can drop the param entirely.
+   */
+  public static toJSON(
+    state: TableViewUrlStateData,
+    defaults?: TableViewUrlStateDefaults | undefined,
+  ): JSONObject | null {
+    const json: JSONObject = {};
+
+    const search: string = (state.search || "").trim();
+    if (search.length > 0) {
+      json["search"] = search;
+    }
+
+    const labels: Array<string> = (state.labels || []).filter((l: string) => {
+      return Boolean(l);
+    });
+    if (labels.length > 0) {
+      json["labels"] = labels;
+    }
+
+    /*
+     * Sort is only worth persisting when it differs from the sort the table
+     * was mounted with — otherwise every table on the page would carry a
+     * redundant param.
+     */
+    const sortIsDefault: boolean =
+      (state.sortBy || null) === (defaults?.sortBy || null) &&
+      (state.sortOrder || null) === (defaults?.sortOrder || null);
+
+    if (state.sortBy && !sortIsDefault) {
+      json["sortBy"] = state.sortBy;
+      json["sortOrder"] = state.sortOrder || SortOrder.Ascending;
+    }
+
+    if (state.page && state.page > 1) {
+      json["page"] = state.page;
+    }
+
+    if (state.itemsOnPage && state.itemsOnPage > 0) {
+      json["itemsOnPage"] = state.itemsOnPage;
+    }
+
+    if (Object.keys(json).length === 0) {
+      return null;
+    }
+
+    return json;
+  }
+
+  /**
+   * Rebuild the view state from a URL param. Every field is validated
+   * independently: a bad `page` doesn't discard a good `search`, and an
+   * unrecognised value is dropped rather than passed through to the query.
+   */
+  public static fromJSON(
+    json: JSONObject | null | undefined,
+  ): TableViewUrlStateData {
+    const state: TableViewUrlStateData = {};
+
+    if (!json || typeof json !== "object") {
+      return state;
+    }
+
+    if (typeof json["search"] === "string" && json["search"].trim() !== "") {
+      state.search = json["search"];
+    }
+
+    if (Array.isArray(json["labels"])) {
+      const labels: Array<string> = (json["labels"] as Array<unknown>)
+        .filter((l: unknown) => {
+          return typeof l === "string" && l.trim() !== "";
+        })
+        .map((l: unknown) => {
+          return l as string;
+        });
+
+      if (labels.length > 0) {
+        state.labels = labels;
+      }
+    }
+
+    if (typeof json["sortBy"] === "string" && json["sortBy"].trim() !== "") {
+      state.sortBy = json["sortBy"];
+
+      state.sortOrder =
+        json["sortOrder"] === SortOrder.Descending
+          ? SortOrder.Descending
+          : SortOrder.Ascending;
+    }
+
+    const page: number | null = this.toPositiveInteger(json["page"]);
+    if (page !== null && page >= 1) {
+      state.page = page;
+    }
+
+    const itemsOnPage: number | null = this.toPositiveInteger(
+      json["itemsOnPage"],
+    );
+    if (
+      itemsOnPage !== null &&
+      itemsOnPage >= 1 &&
+      itemsOnPage <= MaxItemsOnPage
+    ) {
+      state.itemsOnPage = itemsOnPage;
+    }
+
+    return state;
+  }
+
+  private static toPositiveInteger(value: unknown): number | null {
+    if (typeof value !== "number" || !isFinite(value)) {
+      return null;
+    }
+
+    const asInteger: number = Math.floor(value);
+
+    if (asInteger < 1 || asInteger > LIMIT_MAX) {
+      return null;
+    }
+
+    return asInteger;
+  }
+}


### PR DESCRIPTION
## what changed and why

filtered table views were lost the moment you left the page. click into a
monitor from a filtered, sorted, page-3 list and hit Back, and you got the
unfiltered page 1. the view also could not be shared — the url said nothing
about what you were looking at. this mirrors a table's full view into the url
query string, namespaced per table, so Back restores it and the link describes
it.

### common / table core
- new `TableViewUrlState` serializes the "everything that isn't a column filter
  or a facet" slice — search text, label chips, sort and pagination — omitting
  any value equal to its default so an untouched table writes no params at all.
  restored `itemsOnPage` is capped (1000) so a hand-edited url can't ask the api
  for an unbounded page.
- new `FilterDataToQuery` extracts `getFilterKeys` / `sanitizeFilterData` /
  `buildQueryFromFilterData` out of `BaseModelTable` as pure functions, so the
  table can derive its query synchronously on first render when filters come
  from the url (otherwise the first fetch goes out unfiltered and is immediately
  superseded). `sanitizeFilterData` drops any key the table doesn't expose as a
  filter, so a crafted link can only reproduce what the filter ui could — it
  can't add a constraint on, or overwrite, the page's own scoping query.
- `TableFilterUrlState` gains a third `view` slice alongside `filter` and
  `facets` (each under its own `<tableId>-<kind>` param), a total query-string
  length ceiling (degrades to react-state-only past it rather than failing to
  load on refresh), and `claimKey`, which warns when two tables on one route
  share a url namespace.
- `BaseModelTable` restores filter/facet/view state into `useState` on mount
  instead of an effect, and mirrors changes back out.
- `Navigation.getQueryString()` added for testable reads.
- `EntityFilter` now decodes the `IncludesNone` "is not" encoding on remount
  (previously the operator and value were lost on every Back / shared link), and
  `FilterViewer` / `List` render a chip for enum/boolean/number dropdown values
  and fall back to the raw id when the option list hasn't loaded yet, instead of
  showing a filtered table with no chips and no "clear filters" escape.

### comparison-type serialization
- `EqualTo`, `NotEqual` and `EqualToOrNull` `toJSON` now serialize the raw value
  (like `GreaterThan` / `InBetween`) instead of `toString()`. `toString()`
  stringified a Date into a locale-/timezone-dependent form that lost
  milliseconds and coerced numbers to strings; the raw value round-trips through
  the url and binds server-side at full precision. legacy date-only strings
  still round-trip.

### telemetry explorers
- Logs / Traces / Metrics / Exceptions now write their url through
  `writeTelemetryViewerUrlState` (built on `Navigation.setQueryString`) rather
  than `history.replaceState(null, ...)`. the old path replaced the whole query
  string — deleting params owned by anything else on the route — and wiped
  react-router's `history.state` bookkeeping. the new path merges and preserves
  it. unused owned params are explicitly nulled so a removed filter leaves the
  url.

### resource-owner tables and on-call rules
- the four owner tables (Monitors, Alerts, Incidents, Scheduled Maintenance)
  pass `urlStateKey`, and `useResourceOwners` persists its facet selections via
  the new `FacetSelectionState` (ids and operators only — never display labels —
  so a restored selection produces the correct query before option lists load).
- the four on-call-rules pages fold `alertSeverity` into `userPreferencesKey`;
  one table is rendered per severity, so without it every table shared one url /
  page-size namespace and paging one repaginated the rest.

## how it works

each table owns up to three query params: `<tableId>-filter` (column filters),
`<tableId>-facets` (facet bar) and `<tableId>-view` (search / labels / sort /
page). on mount the table reads them synchronously and seeds `useState`, so the
first fetch already reflects the shared/back-restored view. on change it
re-serializes only the affected slice. everything untrusted from the url is
validated field-by-field and, for filters, restricted to the table's declared
filter keys before it reaches the query, so a hand-edited link can't smuggle in
a typed object or an out-of-scope constraint. writes go through
`Navigation.setQueryString`, which merges into the existing query string and
preserves `history.state`.

## known limitation / follow-up

**page number does not restore for owner/resolver facets.** when a shared link
(or a Back navigation) carries `page > 1` *and* the active filter is an owner
facet or a resolver-backed extra facet, the table lands on page 1 instead of the
shared page. those facets resolve their `_id` constraint asynchronously after
mount (via `ModelAPI.getList`), and when that resolved query arrives,
`BaseModelTable`'s "reset to page 1 when the query narrows" guard cannot tell it
apart from a user-initiated facet change and snaps the page to 1. column
filters, label chips, search and sort all restore correctly (they build
synchronously on first render), so this is a narrow inconsistency rather than a
broad regression — there was no page restore at all before this change. the fix
needs `BaseModelTable` to distinguish async hydration of a restored facet from a
genuine user action, which is worth doing deliberately rather than with a
heuristic; tracked as a follow-up. `Common/UI/Components/ModelTable/BaseModelTable.tsx`
around the `props.query` effect.

## testing

new test files:
- `Common/Tests/UI/Utils/TableViewUrlState.test.ts`
- `Common/Tests/UI/Utils/TableFilterUrlState.test.ts`
- `Common/Tests/UI/Utils/Navigation.test.ts`
- `Common/Tests/UI/Components/ModelTable/FilterDataToQuery.test.ts`
- `Common/Tests/UI/Components/ModelTable/BaseModelTableUrlState.test.tsx`
- `Common/Tests/UI/Components/EntityFilterRoundTrip.test.tsx`
- `App/Tests/Dashboard/TelemetryViewerUrlState.test.ts`
- `App/Tests/Dashboard/FacetSelectionState.test.ts`

extended:
- `Common/Tests/Types/Database/CompareOperatorWireSerialization.test.ts` — wire
  round-trip for the EqualTo / NotEqual / EqualToOrNull toJSON change.

verified locally: `Common` `tsc` clean; App `tsc` adds no new errors (the one
pre-existing `MqttServer.ts` error is present on master too); eslint clean on
all changed files; App jest 29/29; Common url-state + comparison suites 180/180;
full Common suite shows 7343/7343 individual tests passing (the 17 failing
*suites* are the pre-existing `toBeInTheDocument` jest-dom matcher-type issue,
none of them touched by this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CsmZMPd1tCfSKNN4wxNJg
