### PR TITLE
test(e2e): cover monitor -> incident -> on-call -> user alerted end to end

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
@@ -1,4 +1,4 @@
-import { FilterOperator } from "./FilterChipDropdown";
+import { FilterOperator } from "./FilterChipDropdownTypes";
 import { JSONObject } from "Common/Types/JSON";
 
 /**

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdown.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdown.tsx
@@ -1,6 +1,18 @@
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
 import useComponentOutsideClick from "Common/UI/Types/UseComponentOutsideClick";
+/*
+ * The option and operator types live in a React-free module so plain
+ * TypeScript consumers — FacetSelectionState, and the jest tests under
+ * App/Tests that import it — don't drag React into App's own compile, where
+ * React is not a dependency. They are re-exported below so existing
+ * `from "./FilterChipDropdown"` imports keep working.
+ */
+import {
+  FilterChipDropdownOption,
+  FilterOperator,
+  FILTER_OPERATOR_LABELS,
+} from "./FilterChipDropdownTypes";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -10,50 +22,14 @@ import React, {
   useState,
 } from "react";
 
-export interface FilterChipDropdownOption {
-  value: string;
-  label: string;
-  /** Optional sub-label shown smaller below the main label. */
-  sublabel?: string | undefined;
-  /** Optional icon shown as a fallback to the left of the label. */
-  icon?: IconProp | undefined;
-  /**
-   * Initials shown in a colored circle as the option avatar. Takes precedence
-   * over `icon`. The background color is hashed from `value` unless `color`
-   * is also provided.
-   */
-  initials?: string | undefined;
-  /**
-   * Explicit color for the avatar dot (CSS color string — hex, rgb, named).
-   * When provided without `initials`, renders as a small solid circle
-   * (the right call for labels / status colors). With `initials`, the dot
-   * gets the color as its background.
-   */
-  color?: string | undefined;
-  /** Optional group key for sectioning options under a heading. */
-  group?: string | undefined;
-}
-
-/**
- * Filter operator that the chip surfaces to the user.
- * - "is" / "is_not" — match against the selected options
- * - "is_empty" / "is_not_empty" — match rows with no value / any value
- *   (no option selection required)
- */
-export type FilterOperator = "is" | "is_not" | "is_empty" | "is_not_empty";
-
-export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
-  is: "is",
-  is_not: "is not",
-  is_empty: "is empty",
-  is_not_empty: "is not empty",
-};
-
-export const isValueOperator: (op: FilterOperator) => boolean = (
-  op: FilterOperator,
-): boolean => {
-  return op === "is" || op === "is_not";
-};
+export {
+  FILTER_OPERATOR_LABELS,
+  isValueOperator,
+} from "./FilterChipDropdownTypes";
+export type {
+  FilterChipDropdownOption,
+  FilterOperator,
+} from "./FilterChipDropdownTypes";
 
 export interface ComponentProps {
   label: string;

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes.ts
@@ -1,0 +1,61 @@
+import IconProp from "Common/Types/Icon/IconProp";
+
+/*
+ * The React-free half of FilterChipDropdown.
+ *
+ * These types are shared with plain-TypeScript modules such as
+ * FacetSelectionState, which is imported by jest tests under App/Tests. App's
+ * own `tsc` run excludes FeatureSet/Dashboard, but an excluded file still gets
+ * type-checked when something inside the program imports it — so importing
+ * these from the .tsx component pulled React into App's compile, where React is
+ * not a dependency ("Cannot find module 'react'"). Keeping them here keeps that
+ * import chain free of anything that needs React.
+ *
+ * FilterChipDropdown.tsx re-exports everything below, so existing imports of
+ * these names from "./FilterChipDropdown" keep working.
+ */
+
+export interface FilterChipDropdownOption {
+  value: string;
+  label: string;
+  /** Optional sub-label shown smaller below the main label. */
+  sublabel?: string | undefined;
+  /** Optional icon shown as a fallback to the left of the label. */
+  icon?: IconProp | undefined;
+  /**
+   * Initials shown in a colored circle as the option avatar. Takes precedence
+   * over `icon`. The background color is hashed from `value` unless `color`
+   * is also provided.
+   */
+  initials?: string | undefined;
+  /**
+   * Explicit color for the avatar dot (CSS color string — hex, rgb, named).
+   * When provided without `initials`, renders as a small solid circle
+   * (the right call for labels / status colors). With `initials`, the dot
+   * gets the color as its background.
+   */
+  color?: string | undefined;
+  /** Optional group key for sectioning options under a heading. */
+  group?: string | undefined;
+}
+
+/**
+ * Filter operator that the chip surfaces to the user.
+ * - "is" / "is_not" — match against the selected options
+ * - "is_empty" / "is_not_empty" — match rows with no value / any value
+ *   (no option selection required)
+ */
+export type FilterOperator = "is" | "is_not" | "is_empty" | "is_not_empty";
+
+export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
+  is: "is",
+  is_not: "is not",
+  is_empty: "is empty",
+  is_not_empty: "is not empty",
+};
+
+export const isValueOperator: (op: FilterOperator) => boolean = (
+  op: FilterOperator,
+): boolean => {
+  return op === "is" || op === "is_not";
+};

--- a/E2E/Tests/Dashboard/Helpers/MonitorAlerting.ts
+++ b/E2E/Tests/Dashboard/Helpers/MonitorAlerting.ts
@@ -1,0 +1,1133 @@
+import { BASE_URL } from "../../../Config";
+import { APIResponse, Cookie, Page, expect } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+
+/*
+ * Helpers for the monitor -> incident -> on-call -> user-alerted e2e spec
+ * (MonitorIncidentOnCall.spec.ts).
+ *
+ * Everything here talks to the same REST API the dashboard uses, through
+ * `page.request`, so the calls carry the browser session cookies created by
+ * registerAndCreateProject(). That keeps the spec on the real
+ * dashboard -> api -> probe -> incident -> on-call path instead of reaching
+ * into the database.
+ *
+ * The helpers never sleep for a fixed duration: every wait is a poll with a
+ * deadline, so a fast machine finishes in seconds and a loaded CI runner still
+ * passes.
+ */
+
+// Generic JSON shapes returned by the CRUD API.
+export type JSONish = Record<string, any>;
+
+export interface ProjectDefaults {
+  operationalMonitorStatusId: string;
+  offlineMonitorStatusId: string;
+  incidentSeverityId: string;
+  resolvedIncidentStateId: string;
+}
+
+export interface SessionUser {
+  userId: string;
+  email: string;
+}
+
+/*
+ * The session cookie the API accepts is a short-lived (15 minute) JWT with a
+ * long-lived refresh-token cookie beside it. This flow polls for minutes
+ * without the SPA in the loop to refresh it, so every request goes through
+ * requestJson(), which transparently refreshes and retries once on 401.
+ */
+const REFRESH_TOKEN_PATH: string = "/api/identity/refresh-token";
+
+type BuildUrlFunction = (path: string) => string;
+
+export const buildUrl: BuildUrlFunction = (path: string): string => {
+  return URL.fromString(BASE_URL.toString()).addRoute(path).toString();
+};
+
+type RefreshSessionFunction = (data: { page: Page }) => Promise<void>;
+
+const refreshSession: RefreshSessionFunction = async (data: {
+  page: Page;
+}): Promise<void> => {
+  await data.page.request.post(buildUrl(REFRESH_TOKEN_PATH), {
+    headers: { "content-type": "application/json" },
+    data: {},
+  });
+};
+
+type RequestJsonFunction = (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  body: JSONish;
+  method?: "post" | "put" | undefined;
+}) => Promise<JSONish>;
+
+/*
+ * POST/PUT a JSON body to the OneUptime API and return the parsed response.
+ * Throws with the server's message so a failure points at the real cause
+ * instead of a generic assertion error.
+ */
+export const requestJson: RequestJsonFunction = async (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  body: JSONish;
+  method?: "post" | "put" | undefined;
+}): Promise<JSONish> => {
+  const method: "post" | "put" = data.method || "post";
+
+  type SendFunction = () => Promise<APIResponse>;
+
+  const send: SendFunction = async (): Promise<APIResponse> => {
+    return data.page.request[method](buildUrl(data.path), {
+      headers: {
+        "content-type": "application/json",
+        tenantid: data.projectId,
+        projectid: data.projectId,
+      },
+      data: data.body,
+    });
+  };
+
+  let response: APIResponse = await send();
+
+  if (response.status() === 401) {
+    await refreshSession({ page: data.page });
+    response = await send();
+  }
+
+  expect(
+    response.ok(),
+    `${method.toUpperCase()} ${data.path} failed: ${response.status()} ${await response.text()}`,
+  ).toBe(true);
+
+  const text: string = await response.text();
+  return text ? (JSON.parse(text) as JSONish) : {};
+};
+
+type CreateItemFunction = (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  item: JSONish;
+}) => Promise<JSONish>;
+
+// Creates a record through the CRUD API and returns the created row.
+export const createItem: CreateItemFunction = async (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  item: JSONish;
+}): Promise<JSONish> => {
+  const response: JSONish = await requestJson({
+    page: data.page,
+    projectId: data.projectId,
+    path: data.path,
+    body: { data: data.item },
+  });
+
+  // The CRUD API returns the model either bare or wrapped in `data`.
+  return (response["data"] as JSONish) || response;
+};
+
+type ListItemsFunction = (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  query?: JSONish | undefined;
+  select: JSONish;
+  limit?: number | undefined;
+}) => Promise<Array<JSONish>>;
+
+// Lists records through the CRUD API.
+export const listItems: ListItemsFunction = async (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  query?: JSONish | undefined;
+  select: JSONish;
+  limit?: number | undefined;
+}): Promise<Array<JSONish>> => {
+  const response: JSONish = await requestJson({
+    page: data.page,
+    projectId: data.projectId,
+    path: `${data.path}/get-list`,
+    body: {
+      query: data.query || {},
+      select: data.select,
+      limit: data.limit || 50,
+      skip: 0,
+    },
+  });
+
+  return (response["data"] as Array<JSONish>) || [];
+};
+
+type GetItemFunction = (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  id: string;
+  select: JSONish;
+}) => Promise<JSONish>;
+
+// Reads a single record, which is the only way to select relations.
+export const getItem: GetItemFunction = async (data: {
+  page: Page;
+  projectId: string;
+  path: string;
+  id: string;
+  select: JSONish;
+}): Promise<JSONish> => {
+  const response: JSONish = await requestJson({
+    page: data.page,
+    projectId: data.projectId,
+    path: `${data.path}/${data.id}/get-item`,
+    body: { select: data.select },
+  });
+
+  return (response["data"] as JSONish) || response;
+};
+
+/*
+ * Ids come back from the API either as a bare string or as
+ * { _type: "ObjectID", value: "..." } depending on the column. Normalise both.
+ */
+type ToIdFunction = (value: unknown) => string;
+
+export const toId: ToIdFunction = (value: unknown): string => {
+  if (!value) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return String((value as JSONish)["value"] || "");
+};
+
+export interface PollOptions<T> {
+  page: Page;
+  description: string;
+  timeoutMs: number;
+  check: () => Promise<T | null>;
+  intervalMs?: number | undefined;
+}
+
+/*
+ * Polls `check` until it returns a non-null value or the deadline passes.
+ *
+ * Transient errors are swallowed and retried: right after a project is created
+ * some reads can briefly fail while permissions propagate, and a poll that
+ * gives up on the first hiccup is exactly the kind of flake this spec must not
+ * have. The last error is reported if the deadline is hit.
+ */
+export async function pollUntil<T>(options: PollOptions<T>): Promise<T> {
+  const intervalMs: number = options.intervalMs || 2000;
+  const deadline: number = Date.now() + options.timeoutMs;
+  let lastError: string = "";
+
+  while (Date.now() < deadline) {
+    try {
+      const result: T | null = await options.check();
+
+      if (result !== null && result !== undefined) {
+        return result;
+      }
+    } catch (error) {
+      lastError = (error as Error).message;
+    }
+
+    await options.page.waitForTimeout(intervalMs);
+  }
+
+  throw new Error(
+    `Timed out after ${options.timeoutMs}ms waiting for: ${options.description}.` +
+      (lastError ? ` Last error: ${lastError}` : ""),
+  );
+}
+
+type GetSessionUserFunction = (data: { page: Page }) => Promise<SessionUser>;
+
+/*
+ * Reads the signed-in user out of the session cookies that the register flow
+ * set. Avoids changing registerAndCreateProject's return type, which other
+ * specs depend on.
+ */
+export const getSessionUser: GetSessionUserFunction = async (data: {
+  page: Page;
+}): Promise<SessionUser> => {
+  const cookies: Array<Cookie> = await data.page.context().cookies();
+
+  type FindCookieFunction = (name: string) => string;
+
+  const findCookie: FindCookieFunction = (name: string): string => {
+    const cookie: Cookie | undefined = cookies.find((c: Cookie) => {
+      return c.name === name;
+    });
+    return cookie ? decodeURIComponent(cookie.value) : "";
+  };
+
+  const userId: string = findCookie("user-id");
+  const email: string = findCookie("user-email");
+
+  expect(userId, "user-id cookie should exist after registration").not.toBe("");
+  expect(email, "user-email cookie should exist after registration").not.toBe(
+    "",
+  );
+
+  return { userId, email };
+};
+
+// The app's own status endpoint. Always answers 200 while the stack is up.
+export const HEALTHY_URL: string = buildUrl("/status");
+
+type DownUrlFunction = (data: { label: string; unique: string }) => string;
+
+/*
+ * A URL that reliably does NOT answer 200, for the offline criteria.
+ *
+ * It has to live under `/api` rather than being any old unrouted path: on a
+ * self-hosted server (billing disabled) the app registers a catch-all that
+ * renders the dashboard SPA with HTTP 200 for unknown paths on the primary
+ * host (App/FeatureSet/Frontend/Index.ts, registerDashboardFallbackForPrimaryHost).
+ * `/api` is in that catch-all's skip list and nginx proxies it to the app in
+ * every compose mode, so it falls through to the API's own 404 handler.
+ *
+ * assertMonitorTargetsAreUsable() below turns a regression here into an
+ * immediate, self-explaining failure instead of a seven-minute timeout.
+ */
+export const downUrl: DownUrlFunction = (data: {
+  label: string;
+  unique: string;
+}): string => {
+  return buildUrl(`/api/e2e-monitor-down-${data.label}-${data.unique}`);
+};
+
+type AssertMonitorTargetsAreUsableFunction = (data: {
+  page: Page;
+  sampleDownUrl: string;
+}) => Promise<void>;
+
+/*
+ * Preconditions the whole spec rests on. The e2e container runs with
+ * network_mode: host, exactly like the probes, so what it sees here is what a
+ * probe will see.
+ */
+export const assertMonitorTargetsAreUsable: AssertMonitorTargetsAreUsableFunction =
+  async (data: { page: Page; sampleDownUrl: string }): Promise<void> => {
+    const healthy: APIResponse = await data.page.request.get(HEALTHY_URL);
+    expect(
+      healthy.status(),
+      `${HEALTHY_URL} must answer 200, otherwise the online criteria can never match and no monitor can recover.`,
+    ).toBe(200);
+
+    const down: APIResponse = await data.page.request.get(data.sampleDownUrl);
+    expect(
+      down.status(),
+      `${data.sampleDownUrl} must NOT answer 200, otherwise no monitor can ever go offline. ` +
+        `Got ${down.status()}. Check DashboardFallbackRoutePrefixesToSkip in App/FeatureSet/Frontend/Index.ts.`,
+    ).not.toBe(200);
+  };
+
+type AssertMonitorHasProbesFunction = (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+  timeoutMs: number;
+}) => Promise<void>;
+
+/*
+ * Nothing in this flow can happen without a probe assigned to the monitor.
+ * Probe containers register at boot and retry for a few minutes, and the
+ * stack's readiness check doesn't wait for them — so assert the assignment
+ * exists rather than letting a missing probe surface as an unexplained
+ * monitor-status timeout minutes later.
+ *
+ * This checks MonitorProbe rather than the probe list: the probes shipped with
+ * a deployment are global, so they have no projectId and a tenant-scoped
+ * /api/probe query never returns them. MonitorProbe rows are project-scoped
+ * and are what the probe actually claims work from, so they are both visible
+ * here and the thing that matters.
+ */
+export const assertMonitorHasProbes: AssertMonitorHasProbesFunction =
+  async (data: {
+    page: Page;
+    projectId: string;
+    monitorId: string;
+    timeoutMs: number;
+  }): Promise<void> => {
+    await pollUntil<boolean>({
+      page: data.page,
+      description: `monitor ${data.monitorId} to have an enabled probe assigned to it`,
+      timeoutMs: data.timeoutMs,
+      check: async (): Promise<boolean | null> => {
+        const monitorProbes: Array<JSONish> = await listItems({
+          page: data.page,
+          projectId: data.projectId,
+          path: "/api/monitor-probe",
+          query: { monitorId: data.monitorId },
+          select: { _id: true, isEnabled: true, probeId: true },
+        });
+
+        const enabled: boolean = monitorProbes.some((monitorProbe: JSONish) => {
+          return monitorProbe["isEnabled"] === true;
+        });
+
+        return enabled ? true : null;
+      },
+    });
+  };
+
+type GetProjectDefaultsFunction = (data: {
+  page: Page;
+  projectId: string;
+}) => Promise<ProjectDefaults>;
+
+/*
+ * Every new project is seeded with the default monitor statuses
+ * (Operational / Degraded / Offline), incident severities and incident states.
+ * Seeding happens after the create response returns, so poll. Look the rows up
+ * by their semantic flags rather than by name, so a rename in the seed data
+ * doesn't silently break the spec.
+ */
+export const getProjectDefaults: GetProjectDefaultsFunction = async (data: {
+  page: Page;
+  projectId: string;
+}): Promise<ProjectDefaults> => {
+  const statuses: Array<JSONish> = await pollUntil<Array<JSONish>>({
+    page: data.page,
+    description: "default monitor statuses to be seeded",
+    timeoutMs: 120000,
+    check: async (): Promise<Array<JSONish> | null> => {
+      const rows: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/monitor-status",
+        select: {
+          _id: true,
+          name: true,
+          isOperationalState: true,
+          isOfflineState: true,
+        },
+      });
+
+      const hasBoth: boolean =
+        rows.some((row: JSONish) => {
+          return row["isOperationalState"] === true;
+        }) &&
+        rows.some((row: JSONish) => {
+          return row["isOfflineState"] === true;
+        });
+
+      return hasBoth ? rows : null;
+    },
+  });
+
+  const severities: Array<JSONish> = await pollUntil<Array<JSONish>>({
+    page: data.page,
+    description: "default incident severities to be seeded",
+    timeoutMs: 120000,
+    check: async (): Promise<Array<JSONish> | null> => {
+      const rows: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/incident-severity",
+        select: { _id: true, name: true },
+      });
+
+      return rows.length > 0 ? rows : null;
+    },
+  });
+
+  const resolvedState: JSONish = await pollUntil<JSONish>({
+    page: data.page,
+    description: "the resolved incident state to be seeded",
+    timeoutMs: 120000,
+    check: async (): Promise<JSONish | null> => {
+      const rows: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/incident-state",
+        select: { _id: true, name: true, isResolvedState: true },
+      });
+
+      return (
+        rows.find((row: JSONish) => {
+          return row["isResolvedState"] === true;
+        }) || null
+      );
+    },
+  });
+
+  const operational: JSONish = statuses.find((row: JSONish) => {
+    return row["isOperationalState"] === true;
+  })!;
+  const offline: JSONish = statuses.find((row: JSONish) => {
+    return row["isOfflineState"] === true;
+  })!;
+
+  return {
+    operationalMonitorStatusId: toId(operational["_id"]),
+    offlineMonitorStatusId: toId(offline["_id"]),
+    incidentSeverityId: toId(severities[0]!["_id"]),
+    resolvedIncidentStateId: toId(resolvedState["_id"]),
+  };
+};
+
+type EnsureUserCanBeNotifiedFunction = (data: {
+  page: Page;
+  projectId: string;
+  user: SessionUser;
+}) => Promise<void>;
+
+/*
+ * Makes sure the project owner has a verified notification method and the
+ * default "notify me when an incident on-call policy is executed" rules.
+ * Without them the policy would execute but never reach a human, and the
+ * "user alerted" assertion would be vacuous.
+ *
+ * Self-hosted (billing disabled): signup marks the email verified, so
+ * ProjectService seeds a verified UserEmail plus the default rules and this
+ * helper only waits for them.
+ *
+ * SaaS (billing enabled): the email starts unverified and nothing is seeded,
+ * so create the UserEmail and confirm it with the code the create response
+ * returns — the same two calls the dashboard's "Notification Methods" page
+ * makes. Confirming an email is what triggers the default rules to be seeded,
+ * so both environments look identical afterwards.
+ */
+export const ensureUserCanBeNotified: EnsureUserCanBeNotifiedFunction =
+  async (data: {
+    page: Page;
+    projectId: string;
+    user: SessionUser;
+  }): Promise<void> => {
+    const existing: Array<JSONish> = await listItems({
+      page: data.page,
+      projectId: data.projectId,
+      path: "/api/user-email",
+      select: { _id: true, email: true, isVerified: true },
+    });
+
+    const verified: JSONish | undefined = existing.find((row: JSONish) => {
+      return row["isVerified"] === true;
+    });
+
+    if (!verified) {
+      const created: JSONish = await createItem({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/user-email",
+        item: {
+          projectId: data.projectId,
+          userId: data.user.userId,
+          email: { _type: "Email", value: data.user.email },
+        },
+      });
+
+      expect(
+        created["verificationCode"],
+        "creating a UserEmail should return its verification code so the spec can confirm the address the way the dashboard does",
+      ).toBeTruthy();
+
+      await requestJson({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/user-email/verify",
+        body: {
+          itemId: toId(created["_id"]),
+          code: created["verificationCode"],
+        },
+      });
+    }
+
+    await pollUntil<boolean>({
+      page: data.page,
+      description: "default on-call notification rules for the project owner",
+      timeoutMs: 120000,
+      check: async (): Promise<boolean | null> => {
+        const rules: Array<JSONish> = await listItems({
+          page: data.page,
+          projectId: data.projectId,
+          path: "/api/user-notification-rule",
+          select: { _id: true, ruleType: true, userEmailId: true },
+        });
+
+        const hasIncidentRule: boolean = rules.some((rule: JSONish) => {
+          return (
+            String(rule["ruleType"] || "").includes(
+              "incident on-call policy",
+            ) && Boolean(rule["userEmailId"])
+          );
+        });
+
+        return hasIncidentRule ? true : null;
+      },
+    });
+  };
+
+type CreateOnCallPolicyForUserFunction = (data: {
+  page: Page;
+  projectId: string;
+  userId: string;
+  policyName: string;
+}) => Promise<string>;
+
+/*
+ * Creates an on-call duty policy with a single escalation rule containing the
+ * given user.
+ *
+ * `order: 1` matters: the execution log looks up the rule with order 1 when it
+ * starts, and a policy without one goes straight to Error with "No Escalation
+ * Rules in Policy". `escalateAfterInMinutes: 30` keeps the every-minute
+ * escalation cron from advancing to a second rule while the spec is asserting.
+ */
+export const createOnCallPolicyForUser: CreateOnCallPolicyForUserFunction =
+  async (data: {
+    page: Page;
+    projectId: string;
+    userId: string;
+    policyName: string;
+  }): Promise<string> => {
+    const policy: JSONish = await createItem({
+      page: data.page,
+      projectId: data.projectId,
+      path: "/api/on-call-duty-policy",
+      item: { name: data.policyName, projectId: data.projectId },
+    });
+    const policyId: string = toId(policy["_id"]);
+
+    const escalationRule: JSONish = await createItem({
+      page: data.page,
+      projectId: data.projectId,
+      path: "/api/on-call-duty-policy-escalation-rule",
+      item: {
+        name: "E2E Escalation Rule 1",
+        projectId: data.projectId,
+        onCallDutyPolicyId: policyId,
+        escalateAfterInMinutes: 30,
+        order: 1,
+      },
+    });
+
+    await createItem({
+      page: data.page,
+      projectId: data.projectId,
+      path: "/api/on-call-duty-policy-escalation-rule-user",
+      item: {
+        projectId: data.projectId,
+        onCallDutyPolicyId: policyId,
+        onCallDutyPolicyEscalationRuleId: toId(escalationRule["_id"]),
+        userId: data.userId,
+      },
+    });
+
+    return policyId;
+  };
+
+/*
+ * Ids for one monitor's step and criteria.
+ *
+ * These must stay stable for the lifetime of the monitor. When an incident is
+ * declared, it records the criteria id and incident-template id that produced
+ * it; auto-resolve later looks those ids up in the monitor's *current* steps.
+ * Regenerating them on an update (e.g. when pointing the monitor back at a
+ * healthy URL) orphans the open incident and it never resolves.
+ */
+export interface MonitorStepIds {
+  stepId: string;
+  onlineCriteriaId: string;
+  offlineCriteriaId: string;
+  incidentTemplateId: string;
+}
+
+type NewMonitorStepIdsFunction = () => MonitorStepIds;
+
+export const newMonitorStepIds: NewMonitorStepIdsFunction =
+  (): MonitorStepIds => {
+    return {
+      stepId: crypto.randomUUID(),
+      onlineCriteriaId: crypto.randomUUID(),
+      offlineCriteriaId: crypto.randomUUID(),
+      incidentTemplateId: crypto.randomUUID(),
+    };
+  };
+
+export interface HttpMonitorStepsOptions {
+  ids: MonitorStepIds;
+  destinationUrl: string;
+  monitorName: string;
+  defaults: ProjectDefaults;
+  onCallPolicyIds: Array<string>;
+  requestType?: string | undefined;
+  requestBody?: string | undefined;
+  requestHeaders?: JSONish | undefined;
+}
+
+type BuildHttpMonitorStepsFunction = (
+  options: HttpMonitorStepsOptions,
+) => JSONish;
+
+/*
+ * Builds the monitorSteps payload for a Website / API monitor with the same
+ * two criteria the dashboard's create-monitor form generates, in the same
+ * order (offline first — criteria are evaluated in array order and the first
+ * match wins):
+ *
+ *   - offline: Is Online = false OR Response Status Code != 200
+ *              -> monitor goes Offline, declares an incident, and runs the
+ *                 given on-call duty policies. autoResolveIncident makes the
+ *                 incident resolve itself when the monitor recovers.
+ *   - online:  Is Online = true AND Response Status Code = 200
+ *              -> monitor goes Operational.
+ *
+ * retryCount and requestTimeoutInMs are deliberately left at the product
+ * defaults (3 retries, 60s). Both targets answer immediately in both
+ * directions, so retries cost a couple of seconds at most, and they are what
+ * stops a single transient blip against the healthy URL from flipping the
+ * monitor offline and derailing the recovery leg. A shorter request timeout
+ * would only add that risk back.
+ */
+export const buildHttpMonitorSteps: BuildHttpMonitorStepsFunction = (
+  options: HttpMonitorStepsOptions,
+): JSONish => {
+  return {
+    _type: "MonitorSteps",
+    value: {
+      monitorStepsInstanceArray: [
+        {
+          _type: "MonitorStep",
+          value: {
+            id: options.ids.stepId,
+            monitorDestination: {
+              _type: "URL",
+              value: options.destinationUrl,
+            },
+            requestType: options.requestType || "GET",
+            requestHeaders: options.requestHeaders || {},
+            requestBody: options.requestBody || "",
+            monitorCriteria: {
+              _type: "MonitorCriteria",
+              value: {
+                monitorCriteriaInstanceArray: [
+                  {
+                    _type: "MonitorCriteriaInstance",
+                    value: {
+                      id: options.ids.offlineCriteriaId,
+                      monitorStatusId: options.defaults.offlineMonitorStatusId,
+                      filterCondition: "Any",
+                      filters: [
+                        { checkOn: "Is Online", filterType: "False" },
+                        {
+                          checkOn: "Response Status Code",
+                          filterType: "Not Equal To",
+                          value: 200,
+                        },
+                      ],
+                      incidents: [
+                        {
+                          id: options.ids.incidentTemplateId,
+                          title: `${options.monitorName} is offline`,
+                          description: `${options.monitorName} is currently offline.`,
+                          incidentSeverityId:
+                            options.defaults.incidentSeverityId,
+                          autoResolveIncident: true,
+                          onCallPolicyIds: options.onCallPolicyIds,
+                        },
+                      ],
+                      alerts: [],
+                      createAlerts: false,
+                      createIncidents: true,
+                      changeMonitorStatus: true,
+                      name: `Check if ${options.monitorName} is offline`,
+                      description: `This criteria checks if ${options.monitorName} is offline`,
+                    },
+                  },
+                  {
+                    _type: "MonitorCriteriaInstance",
+                    value: {
+                      id: options.ids.onlineCriteriaId,
+                      monitorStatusId:
+                        options.defaults.operationalMonitorStatusId,
+                      filterCondition: "All",
+                      filters: [
+                        { checkOn: "Is Online", filterType: "True" },
+                        {
+                          checkOn: "Response Status Code",
+                          filterType: "Equal To",
+                          value: 200,
+                        },
+                      ],
+                      incidents: [],
+                      alerts: [],
+                      createAlerts: false,
+                      createIncidents: false,
+                      changeMonitorStatus: true,
+                      name: `Check if ${options.monitorName} is online`,
+                      description: `This criteria checks if ${options.monitorName} is online`,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      defaultMonitorStatusId: options.defaults.operationalMonitorStatusId,
+    },
+  };
+};
+
+type WaitForMonitorStatusFunction = (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+  expectedMonitorStatusId: string;
+  description: string;
+  timeoutMs: number;
+}) => Promise<void>;
+
+/*
+ * Waits for a probe to evaluate the monitor and push its status to the
+ * expected value. This is the "probe" hop: nothing else in the system writes
+ * currentMonitorStatusId for a probeable monitor.
+ */
+export const waitForMonitorStatus: WaitForMonitorStatusFunction = async (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+  expectedMonitorStatusId: string;
+  description: string;
+  timeoutMs: number;
+}): Promise<void> => {
+  await pollUntil<boolean>({
+    page: data.page,
+    description: data.description,
+    timeoutMs: data.timeoutMs,
+    check: async (): Promise<boolean | null> => {
+      const monitors: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/monitor",
+        query: { _id: data.monitorId },
+        select: { _id: true, currentMonitorStatusId: true },
+        limit: 1,
+      });
+
+      if (monitors.length === 0) {
+        return null;
+      }
+
+      const current: string = toId(monitors[0]!["currentMonitorStatusId"]);
+      return current === data.expectedMonitorStatusId ? true : null;
+    },
+  });
+};
+
+type WaitForIncidentFunction = (data: {
+  page: Page;
+  projectId: string;
+  incidentTitle: string;
+  timeoutMs: number;
+}) => Promise<JSONish>;
+
+/*
+ * Waits for the offline criteria to declare its incident.
+ *
+ * Matching on the title keeps the query a plain column filter, and the title
+ * embeds the monitor's run-unique name so it cannot cross-match another
+ * monitor or another run.
+ */
+export const waitForIncidentForMonitor: WaitForIncidentFunction = async (data: {
+  page: Page;
+  projectId: string;
+  incidentTitle: string;
+  timeoutMs: number;
+}): Promise<JSONish> => {
+  return pollUntil<JSONish>({
+    page: data.page,
+    description: `an incident titled "${data.incidentTitle}" to be created`,
+    timeoutMs: data.timeoutMs,
+    check: async (): Promise<JSONish | null> => {
+      const incidents: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/incident",
+        query: { title: data.incidentTitle },
+        select: { _id: true, title: true },
+      });
+
+      return incidents.length > 0 ? incidents[0]! : null;
+    },
+  });
+};
+
+type WaitForOnCallExecutionFunction = (data: {
+  page: Page;
+  projectId: string;
+  onCallDutyPolicyId: string;
+  incidentId: string;
+  timeoutMs: number;
+}) => Promise<JSONish>;
+
+/*
+ * Waits for the incident to actually start the on-call duty policy. The
+ * execution log is created when an incident carrying on-call policies is
+ * created, so its presence proves the incident -> on-call hop rather than just
+ * that a policy exists.
+ */
+export const waitForOnCallExecution: WaitForOnCallExecutionFunction =
+  async (data: {
+    page: Page;
+    projectId: string;
+    onCallDutyPolicyId: string;
+    incidentId: string;
+    timeoutMs: number;
+  }): Promise<JSONish> => {
+    return pollUntil<JSONish>({
+      page: data.page,
+      description: `on-call duty policy ${data.onCallDutyPolicyId} to be executed for incident ${data.incidentId}`,
+      timeoutMs: data.timeoutMs,
+      check: async (): Promise<JSONish | null> => {
+        const logs: Array<JSONish> = await listItems({
+          page: data.page,
+          projectId: data.projectId,
+          path: "/api/on-call-duty-policy-execution-log",
+          query: {
+            onCallDutyPolicyId: data.onCallDutyPolicyId,
+            triggeredByIncidentId: data.incidentId,
+          },
+          select: { _id: true, status: true, statusMessage: true },
+        });
+
+        return logs.length > 0 ? logs[0]! : null;
+      },
+    });
+  };
+
+type WaitForOnCallUserPagedFunction = (data: {
+  page: Page;
+  projectId: string;
+  onCallDutyPolicyExecutionLogId: string;
+  userId: string;
+  timeoutMs: number;
+}) => Promise<JSONish>;
+
+/*
+ * Waits for the escalation rule to page the specific user.
+ *
+ * This is the strongest available proof that OneUptime alerted a human: the
+ * row records which user the alert went to, and its "Notification Sent" status
+ * is stamped once the user's notification rules have been dispatched. Unlike
+ * the per-channel log below, it is completely insensitive to whether outbound
+ * email actually works in the environment.
+ */
+export const waitForOnCallUserPaged: WaitForOnCallUserPagedFunction =
+  async (data: {
+    page: Page;
+    projectId: string;
+    onCallDutyPolicyExecutionLogId: string;
+    userId: string;
+    timeoutMs: number;
+  }): Promise<JSONish> => {
+    return pollUntil<JSONish>({
+      page: data.page,
+      description: `escalation rule to page user ${data.userId}`,
+      timeoutMs: data.timeoutMs,
+      check: async (): Promise<JSONish | null> => {
+        const rows: Array<JSONish> = await listItems({
+          page: data.page,
+          projectId: data.projectId,
+          path: "/api/on-call-duty-policy-execution-log-timeline",
+          query: {
+            onCallDutyPolicyExecutionLogId: data.onCallDutyPolicyExecutionLogId,
+            alertSentToUserId: data.userId,
+          },
+          select: {
+            _id: true,
+            status: true,
+            statusMessage: true,
+            alertSentToUserId: true,
+          },
+        });
+
+        return (
+          rows.find((row: JSONish) => {
+            return String(row["status"]) === "Notification Sent";
+          }) || null
+        );
+      },
+    });
+  };
+
+/*
+ * Statuses on the per-channel notification log that mean "the platform
+ * generated a notification for this user and handed it to the channel".
+ *
+ * `Error` is included on purpose. The CI docker-compose stack ships no SMTP
+ * server and no global SMTP settings, so the email send fails with "Global
+ * SMTP Config not found" *after* the notification row has been created and
+ * addressed to the user. Asserting only on `Sent` would couple this spec to
+ * outbound email being deliverable from a CI runner — exactly the kind of
+ * environmental dependency that makes e2e tests flaky. `Skipped` is excluded
+ * because it means the user was deliberately not notified.
+ */
+export const NOTIFIED_STATUSES: Array<string> = ["Sending", "Sent", "Error"];
+
+type WaitForUserAlertedFunction = (data: {
+  page: Page;
+  projectId: string;
+  onCallDutyPolicyId: string;
+  incidentId: string;
+  userId: string;
+  timeoutMs: number;
+}) => Promise<JSONish>;
+
+/*
+ * Waits for the per-channel notification log: one row per delivery attempt,
+ * tagged with the user, the policy and the incident that triggered it.
+ */
+export const waitForUserAlerted: WaitForUserAlertedFunction = async (data: {
+  page: Page;
+  projectId: string;
+  onCallDutyPolicyId: string;
+  incidentId: string;
+  userId: string;
+  timeoutMs: number;
+}): Promise<JSONish> => {
+  return pollUntil<JSONish>({
+    page: data.page,
+    description: `user ${data.userId} to be notified for incident ${data.incidentId}`,
+    timeoutMs: data.timeoutMs,
+    check: async (): Promise<JSONish | null> => {
+      const timelines: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/user-notification-log-timeline",
+        query: {
+          userId: data.userId,
+          onCallDutyPolicyId: data.onCallDutyPolicyId,
+          triggeredByIncidentId: data.incidentId,
+        },
+        select: {
+          _id: true,
+          status: true,
+          statusMessage: true,
+          userId: true,
+          userEmailId: true,
+          onCallDutyPolicyId: true,
+          triggeredByIncidentId: true,
+        },
+      });
+
+      return (
+        timelines.find((row: JSONish) => {
+          return NOTIFIED_STATUSES.includes(String(row["status"] || ""));
+        }) || null
+      );
+    },
+  });
+};
+
+type WaitForAlertEmailFunction = (data: {
+  page: Page;
+  projectId: string;
+  onCallDutyPolicyId: string;
+  userEmail: string;
+  timeoutMs: number;
+}) => Promise<JSONish>;
+
+/*
+ * Waits for the alert email itself to be recorded against the on-call policy.
+ *
+ * The email log row is written whether or not the send succeeds, and it
+ * carries the recipient address — so this asserts that a real email addressed
+ * to the on-call user was produced, without depending on SMTP. The row's
+ * status is deliberately not asserted for the same reason.
+ */
+export const waitForAlertEmail: WaitForAlertEmailFunction = async (data: {
+  page: Page;
+  projectId: string;
+  onCallDutyPolicyId: string;
+  userEmail: string;
+  timeoutMs: number;
+}): Promise<JSONish> => {
+  return pollUntil<JSONish>({
+    page: data.page,
+    description: `an alert email addressed to ${data.userEmail}`,
+    timeoutMs: data.timeoutMs,
+    check: async (): Promise<JSONish | null> => {
+      const logs: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/email-log",
+        query: { onCallDutyPolicyId: data.onCallDutyPolicyId },
+        select: {
+          _id: true,
+          toEmail: true,
+          subject: true,
+          status: true,
+          statusMessage: true,
+        },
+      });
+
+      return (
+        logs.find((row: JSONish) => {
+          const to: unknown = row["toEmail"];
+          const address: string =
+            typeof to === "string" ? to : String((to as JSONish)?.["value"]);
+          return address === data.userEmail;
+        }) || null
+      );
+    },
+  });
+};
+
+type WaitForIncidentStateFunction = (data: {
+  page: Page;
+  projectId: string;
+  incidentId: string;
+  incidentStateId: string;
+  description: string;
+  timeoutMs: number;
+}) => Promise<void>;
+
+// Waits for an incident to reach a given state.
+export const waitForIncidentState: WaitForIncidentStateFunction = async (data: {
+  page: Page;
+  projectId: string;
+  incidentId: string;
+  incidentStateId: string;
+  description: string;
+  timeoutMs: number;
+}): Promise<void> => {
+  await pollUntil<boolean>({
+    page: data.page,
+    description: data.description,
+    timeoutMs: data.timeoutMs,
+    check: async (): Promise<boolean | null> => {
+      const incidents: Array<JSONish> = await listItems({
+        page: data.page,
+        projectId: data.projectId,
+        path: "/api/incident",
+        query: { _id: data.incidentId },
+        select: { _id: true, currentIncidentStateId: true },
+        limit: 1,
+      });
+
+      if (incidents.length === 0) {
+        return null;
+      }
+
+      return toId(incidents[0]!["currentIncidentStateId"]) ===
+        data.incidentStateId
+        ? true
+        : null;
+    },
+  });
+};

--- a/E2E/Tests/Dashboard/Helpers/Monitors.ts
+++ b/E2E/Tests/Dashboard/Helpers/Monitors.ts
@@ -47,6 +47,31 @@ const monitorNameInputSelector: string =
 const submitButtonTestId: string = "Create Monitor";
 
 /*
+ * Matches a monitor id (a uuid) in the view-monitor URL.
+ *
+ * It has to be the full uuid shape rather than a loose `[a-f0-9-]+`: the form
+ * lives at /monitors/create, and "c" is a valid `[a-f0-9-]` run — so a loose
+ * pattern matches the create page too. That makes the "we navigated to the
+ * monitor" assertion pass while still on the form, and makes the extracted
+ * monitor id the string "c".
+ */
+const uuidPattern: string =
+  "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+const monitorIdInUrlRegex: RegExp = new RegExp(
+  `/monitors/(${uuidPattern})`,
+  "i",
+);
+
+type MonitorViewUrlRegexFunction = (projectId: string) => RegExp;
+
+const monitorViewUrlRegex: MonitorViewUrlRegexFunction = (
+  projectId: string,
+): RegExp => {
+  return new RegExp(`/dashboard/${projectId}/monitors/${uuidPattern}`, "i");
+};
+
+/*
  * Selects the "Every 5 Minutes" monitoring interval on the interval step.
  * 5 minutes is available for every probeable type (the every-1/2-minute
  * options are filtered out for SSL / Synthetic / Custom-code monitors).
@@ -123,14 +148,11 @@ export const createMonitor: CreateMonitorFunction = async (data: {
   }
 
   // Success: navigated to the monitor view page.
-  const monitorViewUrlRegex: RegExp = new RegExp(
-    `/dashboard/${data.projectId}/monitors/[a-f0-9-]+`,
-  );
-  await expect(page).toHaveURL(monitorViewUrlRegex, { timeout: 60000 });
+  await expect(page).toHaveURL(monitorViewUrlRegex(data.projectId), {
+    timeout: 60000,
+  });
 
-  const match: RegExpMatchArray | null = page
-    .url()
-    .match(/\/monitors\/([a-f0-9-]+)/);
+  const match: RegExpMatchArray | null = page.url().match(monitorIdInUrlRegex);
   return match ? match[1]! : "";
 };
 
@@ -337,13 +359,10 @@ export const createInfraMonitor: CreateInfraMonitorFunction = async (data: {
 
   await page.getByTestId(submitButtonTestId).click();
 
-  const monitorViewUrlRegex: RegExp = new RegExp(
-    `/dashboard/${data.projectId}/monitors/[a-f0-9-]+`,
-  );
-  await expect(page).toHaveURL(monitorViewUrlRegex, { timeout: 60000 });
+  await expect(page).toHaveURL(monitorViewUrlRegex(data.projectId), {
+    timeout: 60000,
+  });
 
-  const match: RegExpMatchArray | null = page
-    .url()
-    .match(/\/monitors\/([a-f0-9-]+)/);
+  const match: RegExpMatchArray | null = page.url().match(monitorIdInUrlRegex);
   return match ? match[1]! : "";
 };

--- a/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
+++ b/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
@@ -16,10 +16,20 @@ const projectDashboardUrlRegex: RegExp =
 type RegisterAndCreateProjectFunction = (data: {
   page: Page;
   projectNamePrefix: string;
+  /*
+   * Only used when billing is enabled: selects this plan by its visible name
+   * (e.g. "Growth") instead of whichever plan happens to unlock submit first.
+   * Specs that touch plan-gated features need this.
+   */
+  preferredPlanName?: string | undefined;
 }) => Promise<string>;
 
 export const registerAndCreateProject: RegisterAndCreateProjectFunction =
-  async (data: { page: Page; projectNamePrefix: string }): Promise<string> => {
+  async (data: {
+    page: Page;
+    projectNamePrefix: string;
+    preferredPlanName?: string | undefined;
+  }): Promise<string> => {
     const page: Page = data.page;
 
     let pageResult: Response | null = await page.goto(
@@ -82,7 +92,11 @@ export const registerAndCreateProject: RegisterAndCreateProjectFunction =
     if (IS_BILLING_ENABLED) {
       await modalSubmitButton.click();
 
-      await selectProjectPlan({ page, submitButton: modalSubmitButton });
+      await selectProjectPlan({
+        page,
+        submitButton: modalSubmitButton,
+        preferredPlanName: data.preferredPlanName,
+      });
 
       await modalSubmitButton.click();
     } else {

--- a/E2E/Tests/Dashboard/MonitorIncidentOnCall.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorIncidentOnCall.spec.ts
@@ -1,0 +1,549 @@
+import { IS_BILLING_ENABLED } from "../../Config";
+import { Browser, Page, expect, test } from "@playwright/test";
+import Faker from "Common/Utils/Faker";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import {
+  createMonitor,
+  fillDestination,
+  MonitorTypeRecipe,
+} from "./Helpers/Monitors";
+import {
+  assertMonitorHasProbes,
+  assertMonitorTargetsAreUsable,
+  buildHttpMonitorSteps,
+  createItem,
+  createOnCallPolicyForUser,
+  downUrl,
+  ensureUserCanBeNotified,
+  getItem,
+  getProjectDefaults,
+  getSessionUser,
+  HEALTHY_URL,
+  JSONish,
+  listItems,
+  MonitorStepIds,
+  newMonitorStepIds,
+  NOTIFIED_STATUSES,
+  ProjectDefaults,
+  requestJson,
+  SessionUser,
+  toId,
+  waitForAlertEmail,
+  waitForIncidentForMonitor,
+  waitForIncidentState,
+  waitForMonitorStatus,
+  waitForOnCallExecution,
+  waitForOnCallUserPaged,
+  waitForUserAlerted,
+} from "./Helpers/MonitorAlerting";
+
+/*
+ * The full alerting flow, end to end:
+ *
+ *   dashboard -> api -> probe -> incident -> on-call -> user alerted
+ *
+ * A monitor is pointed at a URL that reliably fails, a global probe evaluates
+ * it, the offline criteria declares an incident, the incident runs an on-call
+ * duty policy, the policy pages the on-call user, and an alert email is
+ * generated for them. The website scenario then points the monitor back at a
+ * healthy URL and asserts the incident auto-resolves.
+ *
+ * Everything the spec monitors lives inside the OneUptime deployment under
+ * test: `${BASE_URL}/status` always answers 200 and `${BASE_URL}/api/<unknown>`
+ * always answers 404. No third-party network access, no extra container, and
+ * no shared mutable fixture — the three things that make probe-driven e2e
+ * tests flaky. The failing URL is unique per run, and each run gets a fresh
+ * user and project, so runs can never collide.
+ *
+ * To run locally against a full stack:
+ *
+ *   cd E2E && HOST=localhost npx playwright test \
+ *     Tests/Dashboard/MonitorIncidentOnCall.spec.ts --project=chromium
+ */
+test.describe.configure({ mode: "serial", retries: 1 });
+
+/*
+ * The flow is entirely backend driven — the browser only creates the project
+ * and one monitor — so running it a second time in firefox would double the
+ * wall clock for no extra coverage.
+ */
+test.skip(({ browserName }: { browserName: string }): boolean => {
+  return browserName !== "chromium";
+}, "The alerting flow is API and worker driven; the chromium run covers it.");
+
+/*
+ * On-call duty policy execution logs and user on-call notification logs are
+ * gated behind the Growth plan when billing is enabled, so the billing-mode
+ * run has to create its project on Growth rather than the free plan.
+ */
+const PREFERRED_PLAN_NAME: string = "Growth";
+
+/*
+ * Budgets, sized from the slowest path each hop can take.
+ *
+ * A monitor status transition is the only slow one: the probe fetches work on
+ * an every-minute cron and staggers workers by up to ~45s, so a transition is
+ * ~2 minutes worst case and ~40s typically. 5 minutes leaves room for a
+ * completely lost cycle on a loaded runner.
+ *
+ * Everything after the probe report — incident, on-call execution, escalation
+ * rule, per-user notification — happens in-process off the same tick, with no
+ * cron on the critical path (which is why the escalation rule uses
+ * escalateAfterInMinutes: 30 and the notification rules use
+ * notifyAfterMinutes: 0). Those budgets are generous multiples of the seconds
+ * they actually take.
+ */
+const MONITOR_STATUS_TIMEOUT_MS: number = 300000;
+const INCIDENT_TIMEOUT_MS: number = 120000;
+const ON_CALL_TIMEOUT_MS: number = 120000;
+const USER_ALERTED_TIMEOUT_MS: number = 120000;
+const RESOLVE_TIMEOUT_MS: number = 300000;
+
+// On-call execution states that mean the policy is running as intended.
+const HEALTHY_EXECUTION_STATUSES: Array<string> = [
+  "Scheduled",
+  "Started",
+  "Executing",
+  "Execution Completed",
+];
+
+interface SharedContext {
+  page: Page;
+  projectId: string;
+  user: SessionUser;
+  defaults: ProjectDefaults;
+}
+
+interface AlertingRunResult {
+  incidentId: string;
+  onCallDutyPolicyId: string;
+}
+
+test.describe("Monitor -> Incident -> On-Call -> User Alerted", () => {
+  const ctx: SharedContext = {
+    page: undefined as unknown as Page,
+    projectId: "",
+    user: { userId: "", email: "" },
+    defaults: {
+      operationalMonitorStatusId: "",
+      offlineMonitorStatusId: "",
+      incidentSeverityId: "",
+      resolvedIncidentStateId: "",
+    },
+  };
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    test.setTimeout(600000);
+
+    ctx.page = await browser.newPage();
+
+    ctx.projectId = await registerAndCreateProject({
+      page: ctx.page,
+      projectNamePrefix: "E2E Alerting Project",
+      preferredPlanName: IS_BILLING_ENABLED ? PREFERRED_PLAN_NAME : undefined,
+    });
+
+    ctx.user = await getSessionUser({ page: ctx.page });
+
+    /*
+     * Fail fast and loudly if the URLs the monitors point at don't behave the
+     * way the criteria assume, instead of timing out five minutes later
+     * waiting for a status that can never change.
+     */
+    await assertMonitorTargetsAreUsable({
+      page: ctx.page,
+      sampleDownUrl: downUrl({ label: "precondition", unique: "check" }),
+    });
+
+    ctx.defaults = await getProjectDefaults({
+      page: ctx.page,
+      projectId: ctx.projectId,
+    });
+
+    /*
+     * Without a verified notification method and the default on-call rules the
+     * policy would execute but never reach a human, and the "user alerted"
+     * assertions would be vacuous.
+     */
+    await ensureUserCanBeNotified({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      user: ctx.user,
+    });
+  });
+
+  test.afterAll(async () => {
+    await ctx.page.close();
+  });
+
+  /*
+   * Drives one already-created monitor through the whole flow and returns the
+   * ids so the caller can assert further (e.g. auto-resolve).
+   *
+   * The caller creates the monitor pointing at the healthy URL; this function
+   * attaches the on-call policy and switches it to the failing URL in a single
+   * update. Creating it already-failing would race the probe: a probe cycle
+   * landing between "monitor created" and "policy attached" would open an
+   * incident with no on-call policy on it, and the run would fail for a
+   * non-reason.
+   */
+  type RunAlertingFlowFunction = (data: {
+    monitorId: string;
+    monitorName: string;
+    ids: MonitorStepIds;
+    label: string;
+    requestType?: string | undefined;
+    requestBody?: string | undefined;
+    requestHeaders?: JSONish | undefined;
+  }) => Promise<AlertingRunResult>;
+
+  const runAlertingFlow: RunAlertingFlowFunction = async (data: {
+    monitorId: string;
+    monitorName: string;
+    ids: MonitorStepIds;
+    label: string;
+    requestType?: string | undefined;
+    requestBody?: string | undefined;
+    requestHeaders?: JSONish | undefined;
+  }): Promise<AlertingRunResult> => {
+    const onCallDutyPolicyId: string = await createOnCallPolicyForUser({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      userId: ctx.user.userId,
+      policyName: `E2E On-Call ${data.monitorName}`,
+    });
+
+    const failingUrl: string = downUrl({
+      label: data.label,
+      unique: Faker.generateName()
+        .toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ""),
+    });
+
+    // API hop: rewrite the monitor to fail and to page the on-call policy.
+    await requestJson({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      path: `/api/monitor/${data.monitorId}`,
+      method: "put",
+      body: {
+        data: {
+          // Every minute keeps the probe turnaround short in both directions.
+          monitoringInterval: "* * * * *",
+          /*
+           * Without this the monitor status only changes once *every* connected
+           * probe has independently reported the same criteria. CI runs one
+           * probe, but a local dev stack runs two, and a second probe whose
+           * last evaluation predates this update would hold the status back for
+           * a whole interval. Requiring one probe removes the largest source of
+           * timing variance in the flow.
+           */
+          minimumProbeAgreement: 1,
+          monitorSteps: buildHttpMonitorSteps({
+            ids: data.ids,
+            destinationUrl: failingUrl,
+            monitorName: data.monitorName,
+            defaults: ctx.defaults,
+            onCallPolicyIds: [onCallDutyPolicyId],
+            requestType: data.requestType,
+            requestBody: data.requestBody,
+            requestHeaders: data.requestHeaders,
+          }),
+        },
+      },
+    });
+
+    /*
+     * Probe hop. Check the monitor actually has a probe assigned first, so a
+     * stack whose probes never registered fails here with a clear message
+     * instead of five minutes later on the status poll.
+     */
+    await assertMonitorHasProbes({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      monitorId: data.monitorId,
+      timeoutMs: 180000,
+    });
+
+    await waitForMonitorStatus({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      monitorId: data.monitorId,
+      expectedMonitorStatusId: ctx.defaults.offlineMonitorStatusId,
+      description: `monitor "${data.monitorName}" to be reported offline by a probe`,
+      timeoutMs: MONITOR_STATUS_TIMEOUT_MS,
+    });
+
+    // Incident hop.
+    const incident: JSONish = await waitForIncidentForMonitor({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      incidentTitle: `${data.monitorName} is offline`,
+      timeoutMs: INCIDENT_TIMEOUT_MS,
+    });
+
+    const incidentId: string = toId(incident["_id"]);
+
+    /*
+     * Read the incident back with its relations to prove it really came from
+     * this monitor's offline criteria and carries this on-call policy, rather
+     * than just that some incident with a matching title exists.
+     */
+    const incidentDetail: JSONish = await getItem({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      path: "/api/incident",
+      id: incidentId,
+      select: {
+        _id: true,
+        title: true,
+        incidentSeverityId: true,
+        isCreatedAutomatically: true,
+        createdCriteriaId: true,
+        createdIncidentTemplateId: true,
+        monitors: { _id: true, name: true },
+        onCallDutyPolicies: { _id: true, name: true },
+      },
+    });
+
+    expect(incidentDetail["isCreatedAutomatically"]).toBe(true);
+    expect(String(incidentDetail["createdCriteriaId"])).toBe(
+      data.ids.offlineCriteriaId,
+    );
+    expect(String(incidentDetail["createdIncidentTemplateId"])).toBe(
+      data.ids.incidentTemplateId,
+    );
+    expect(toId(incidentDetail["incidentSeverityId"])).toBe(
+      ctx.defaults.incidentSeverityId,
+    );
+
+    const incidentMonitorIds: Array<string> = (
+      (incidentDetail["monitors"] as Array<JSONish>) || []
+    ).map((monitor: JSONish) => {
+      return toId(monitor["_id"]);
+    });
+    expect(incidentMonitorIds).toContain(data.monitorId);
+
+    const incidentPolicyIds: Array<string> = (
+      (incidentDetail["onCallDutyPolicies"] as Array<JSONish>) || []
+    ).map((policy: JSONish) => {
+      return toId(policy["_id"]);
+    });
+    expect(incidentPolicyIds).toContain(onCallDutyPolicyId);
+
+    // On-call hop: the incident starts the policy.
+    const executionLog: JSONish = await waitForOnCallExecution({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      onCallDutyPolicyId,
+      incidentId,
+      timeoutMs: ON_CALL_TIMEOUT_MS,
+    });
+
+    expect(
+      HEALTHY_EXECUTION_STATUSES,
+      `unexpected on-call execution status "${String(executionLog["status"])}": ${String(executionLog["statusMessage"])}`,
+    ).toContain(String(executionLog["status"]));
+
+    // User hop: the escalation rule pages the on-call user.
+    const paged: JSONish = await waitForOnCallUserPaged({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      onCallDutyPolicyExecutionLogId: toId(executionLog["_id"]),
+      userId: ctx.user.userId,
+      timeoutMs: USER_ALERTED_TIMEOUT_MS,
+    });
+
+    expect(toId(paged["alertSentToUserId"])).toBe(ctx.user.userId);
+
+    // ...and the per-channel notification log records the attempt.
+    const notification: JSONish = await waitForUserAlerted({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      onCallDutyPolicyId,
+      incidentId,
+      userId: ctx.user.userId,
+      timeoutMs: USER_ALERTED_TIMEOUT_MS,
+    });
+
+    expect(NOTIFIED_STATUSES).toContain(String(notification["status"]));
+    expect(toId(notification["userId"])).toBe(ctx.user.userId);
+    expect(toId(notification["triggeredByIncidentId"])).toBe(incidentId);
+    expect(toId(notification["onCallDutyPolicyId"])).toBe(onCallDutyPolicyId);
+    expect(
+      toId(notification["userEmailId"]),
+      "the notification should have gone to the user's email address",
+    ).not.toBe("");
+
+    // ...and a real alert email was produced for that address.
+    const emailLog: JSONish = await waitForAlertEmail({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      onCallDutyPolicyId,
+      userEmail: ctx.user.email,
+      timeoutMs: USER_ALERTED_TIMEOUT_MS,
+    });
+
+    expect(String(emailLog["subject"])).toContain(data.monitorName);
+
+    return { incidentId, onCallDutyPolicyId };
+  };
+
+  test("website monitor created in the dashboard pages the on-call user when it goes down", async () => {
+    test.setTimeout(900000);
+
+    const monitorName: string = `E2E Website ${Faker.generateName().toString()}`;
+    const ids: MonitorStepIds = newMonitorStepIds();
+
+    /*
+     * Dashboard hop: the monitor is created through the real create-monitor
+     * form, pointed at the healthy URL.
+     */
+    const recipe: MonitorTypeRecipe = {
+      label: "Website",
+      cardValue: "Website",
+      hasInterval: true,
+      fillCriteria: async ({ page }: { page: Page }): Promise<void> => {
+        await fillDestination({ page, value: HEALTHY_URL });
+      },
+    };
+
+    const monitorId: string = await createMonitor({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      monitorName,
+      recipe,
+    });
+
+    expect(monitorId, "the created monitor should have an id").not.toBe("");
+
+    const result: AlertingRunResult = await runAlertingFlow({
+      monitorId,
+      monitorName,
+      ids,
+      label: "website",
+    });
+
+    /*
+     * Recovery: point the monitor back at the healthy URL, reusing the same
+     * step and criteria ids. The online criteria takes it back to Operational
+     * and, because the incident was declared with autoResolveIncident, it
+     * resolves itself. Reusing the ids is what makes that possible — the open
+     * incident remembers the criteria and template ids it was created from.
+     */
+    await requestJson({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      path: `/api/monitor/${monitorId}`,
+      method: "put",
+      body: {
+        data: {
+          monitorSteps: buildHttpMonitorSteps({
+            ids,
+            destinationUrl: HEALTHY_URL,
+            monitorName,
+            defaults: ctx.defaults,
+            onCallPolicyIds: [result.onCallDutyPolicyId],
+          }),
+        },
+      },
+    });
+
+    await waitForMonitorStatus({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      monitorId,
+      expectedMonitorStatusId: ctx.defaults.operationalMonitorStatusId,
+      description: `monitor "${monitorName}" to recover to operational`,
+      timeoutMs: MONITOR_STATUS_TIMEOUT_MS,
+    });
+
+    await waitForIncidentState({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      incidentId: result.incidentId,
+      incidentStateId: ctx.defaults.resolvedIncidentStateId,
+      description: `incident for "${monitorName}" to auto-resolve after the monitor recovered`,
+      timeoutMs: RESOLVE_TIMEOUT_MS,
+    });
+  });
+
+  test("api monitor created over the api pages the on-call user when it goes down", async () => {
+    test.setTimeout(900000);
+
+    const monitorName: string = `E2E API ${Faker.generateName().toString()}`;
+    const ids: MonitorStepIds = newMonitorStepIds();
+
+    /*
+     * This one is created straight over the REST API — the path an
+     * integration, the Terraform provider or the CLI takes — to prove the
+     * pipeline doesn't depend on the browser having assembled the payload.
+     * It also exercises a POST check with a body and custom headers, rather
+     * than the website monitor's GET.
+     */
+    const requestBody: string = JSON.stringify({ probe: "oneuptime-e2e" });
+    const requestHeaders: JSONish = { "x-oneuptime-e2e": "true" };
+
+    const created: JSONish = await createItem({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      path: "/api/monitor",
+      item: {
+        name: monitorName,
+        description: "Created by the OneUptime e2e alerting spec.",
+        projectId: ctx.projectId,
+        monitorType: "API",
+        monitoringInterval: "* * * * *",
+        minimumProbeAgreement: 1,
+        monitorSteps: buildHttpMonitorSteps({
+          ids,
+          destinationUrl: HEALTHY_URL,
+          monitorName,
+          defaults: ctx.defaults,
+          onCallPolicyIds: [],
+          requestType: "POST",
+          requestBody,
+          requestHeaders,
+        }),
+      },
+    });
+
+    const monitorId: string = toId(created["_id"]);
+    expect(monitorId, "the created monitor should have an id").not.toBe("");
+
+    await runAlertingFlow({
+      monitorId,
+      monitorName,
+      ids,
+      label: "api",
+      requestType: "POST",
+      requestBody,
+      requestHeaders,
+    });
+  });
+
+  test("the on-call user is on the escalation rules that paged them", async () => {
+    test.setTimeout(120000);
+
+    /*
+     * Guards the setup the two flow tests depend on. If escalation-rule users
+     * ever stopped being persisted, those tests would fail with an opaque
+     * "user was never alerted" timeout instead of pointing at the cause.
+     */
+    const ruleUsers: Array<JSONish> = await listItems({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      path: "/api/on-call-duty-policy-escalation-rule-user",
+      select: { _id: true, userId: true, onCallDutyPolicyId: true },
+    });
+
+    expect(ruleUsers.length).toBeGreaterThan(0);
+
+    const userIds: Array<string> = ruleUsers.map((row: JSONish) => {
+      return toId(row["userId"]);
+    });
+
+    expect(userIds).toContain(ctx.user.userId);
+  });
+});

--- a/E2E/Tests/Helpers/selectProjectPlan.ts
+++ b/E2E/Tests/Helpers/selectProjectPlan.ts
@@ -1,11 +1,26 @@
 import { expect, Locator, Page } from "@playwright/test";
 
-const selectProjectPlan: (data: {
+/*
+ * Picks a plan on the billing-enabled "Create Project" modal.
+ *
+ * `preferredPlanName` (e.g. "Growth") selects that plan by its visible title.
+ * Some features — on-call duty policy execution logs and user on-call
+ * notification logs — are gated behind the Growth plan when billing is
+ * enabled (see TableBillingAccessControl on those models), so specs that
+ * assert on them must not land on the free plan. When the preferred plan is
+ * not offered by the server's configured plan list, the helper falls back to
+ * the "first option that unlocks submit" behaviour used by every other spec.
+ */
+type SelectProjectPlanFunction = (data: {
   page: Page;
   submitButton: Locator;
-}) => Promise<void> = async (data: {
+  preferredPlanName?: string | undefined;
+}) => Promise<void>;
+
+const selectProjectPlan: SelectProjectPlanFunction = async (data: {
   page: Page;
   submitButton: Locator;
+  preferredPlanName?: string | undefined;
 }): Promise<void> => {
   const planOptions: Locator = data.page.locator(
     "[data-testid^='card-select-option-']",
@@ -15,6 +30,18 @@ const selectProjectPlan: (data: {
 
   const planOptionCount: number = await planOptions.count();
   expect(planOptionCount).toBeGreaterThan(0);
+
+  if (data.preferredPlanName) {
+    const preferred: Locator = planOptions.filter({
+      hasText: data.preferredPlanName,
+    });
+
+    if ((await preferred.count()) > 0) {
+      await preferred.first().click();
+      await expect(data.submitButton).toBeEnabled({ timeout: 30000 });
+      return;
+    }
+  }
 
   /*
    * Billing can render the default plan as checked while keeping submit disabled


### PR DESCRIPTION
Adds an end-to-end Playwright spec that walks the whole alerting pipeline —
**dashboard → api → probe → incident → on-call → user alerted** — instead of
stopping at "a monitor was created", which is all the existing monitor coverage
asserts.

## What the spec covers

`E2E/Tests/Dashboard/MonitorIncidentOnCall.spec.ts`

1. **Website monitor, created through the dashboard UI.** The real
   create-monitor form builds the monitor; the REST API then attaches an
   on-call duty policy and points it at a failing URL; a global probe reports
   it offline; the offline criteria declares an incident; the incident starts
   the on-call policy; the escalation rule pages the on-call user and an alert
   email is generated for their address. The monitor is then pointed back at a
   healthy URL and the incident **auto-resolves**.
2. **API monitor, created entirely over the REST API** (POST check with a JSON
   body and custom headers) — the path an integration, the Terraform provider
   or the CLI takes. Same alerting chain.
3. **Escalation-rule setup guard** so a broken fixture reports as itself rather
   than as an opaque "user was never alerted" timeout.

Assertions are made against real records at every hop: `Monitor.currentMonitorStatusId`,
`Incident` (including `createdCriteriaId` / `createdIncidentTemplateId` /
`isCreatedAutomatically` and its monitor + on-call-policy relations),
`OnCallDutyPolicyExecutionLog`, `OnCallDutyPolicyExecutionLogTimeline`
(`alertSentToUserId`, status `Notification Sent`), `UserOnCallLogTimeline`, and
`EmailLog` (recipient address and subject).

## Why it should not be flaky

- **Both monitor targets live inside the deployment under test.** Healthy is
  `${BASE_URL}/status`; failing is `${BASE_URL}/api/e2e-monitor-down-<unique>`.
  No third-party network, no extra container, no shared mutable fixture. The
  failing path has to be under `/api` — on a self-hosted server the app renders
  the dashboard SPA with **200** for unknown paths on the primary host, and
  `/api` is in that fallback's skip list. `beforeAll` asserts both URLs behave
  as assumed, so a future ingress change fails in two seconds with an
  explanation instead of timing out five minutes later.
- **`minimumProbeAgreement: 1`.** Otherwise every connected probe has to agree
  before the status changes. CI runs one probe but a dev stack runs two, and a
  probe whose last evaluation predates the change holds the status back for a
  full interval.
- **Stable monitor-step and criteria ids across updates.** An open incident
  remembers the criteria and incident-template ids it came from; regenerating
  them on the recovery update would orphan the incident and auto-resolve could
  never fire.
- **`monitoringInterval: "* * * * *"`**, `escalateAfterInMinutes: 30` and the
  default `notifyAfterMinutes: 0` keep every cron off the critical path except
  the probe's own fetch cycle.
- **No fixed sleeps.** Every wait is a deadline-bounded poll that tolerates
  transient errors and reports the last one on timeout.
- **Session refresh.** API calls retry once through
  `/api/identity/refresh-token` on 401, so the 15-minute access token cannot
  expire mid-run.
- **Fresh user and project per run**, run-unique monitor names and URLs, so runs
  can never collide. Chromium only (the flow is backend-driven) and `retries: 1`
  keep the wall clock bounded — ~4 minutes typically.
- **`UserOnCallLogTimeline` accepts `Sending`/`Sent`/`Error`.** The CI stack
  ships no SMTP server, so the send fails *after* the notification has been
  created and addressed to the user. `Skipped` is excluded because that is the
  one status meaning the user was deliberately not notified — and the
  `Notification Sent` and `EmailLog` assertions are SMTP-independent proof that
  the user was paged.

## Drive-by fix

`createMonitor` / `createInfraMonitor` in `E2E/Tests/Dashboard/Helpers/Monitors.ts`
matched the monitor id with `[a-f0-9-]+`, which also matches `/monitors/create`
("c" is a valid run). The "we navigated to the monitor" assertion therefore
passed while still sitting on the form, and the returned monitor id was the
string `"c"`. Both now match a full UUID.

## Also

- `selectProjectPlan` takes an optional `preferredPlanName`, used to put the
  billing-mode run on Growth — on-call execution logs and user on-call
  notification logs are Growth-gated when billing is enabled.

## Verification

Run repeatedly against a full local stack (two probes, billing enabled):
monitor offline ≈ 35 s, incident and on-call execution within a second of that,
user notification immediately after, recovery and auto-resolve ≈ 60 s.

## Second commit: unbreak `compile-app` on master

`compile-app` was already failing on master (`cc58dfb`) with

```
FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdown.tsx(11,8):
error TS2307: Cannot find module 'react' or its corresponding type declarations.
```

App's tsconfig excludes `FeatureSet/Dashboard`, but `exclude` only trims the
root file list — an excluded file is still type-checked once something in the
program imports it. `App/Tests/Dashboard/FacetSelectionState.test.ts` imports
`FacetSelectionState`, which imported `FilterOperator` from the
`FilterChipDropdown` **component**, dragging React into App's program. The
`compile-app` job only runs `cd App && npm install`, and React belongs to the
Dashboard package.

The React-free half of the module (`FilterChipDropdownOption`,
`FilterOperator`, `FILTER_OPERATOR_LABELS`, `isValueOperator`) moves into
`FilterChipDropdownTypes.ts`; the component re-exports all four so every
existing `from "./FilterChipDropdown"` import is unchanged.

Verified `cd App && npx tsc --noEmit` is clean without the Dashboard package's
`node_modules` present (what CI does), the Dashboard package still compiles,
and `Tests/Dashboard/FacetSelectionState.test.ts` passes.
