### PR TITLE
fix(analytics): parse ClickHouse count() returned as a JSON number — telemetry monitors never went Offline

### DIFF
--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -413,15 +413,23 @@ export default class AnalyticsDatabaseService<
         const resultInJSON: ResponseJSON<JSONObject> =
           await dbResult.json<JSONObject>();
 
-        if (
-          resultInJSON.data &&
-          resultInJSON.data[0] &&
-          resultInJSON.data[0]["count"] &&
-          typeof resultInJSON.data[0]["count"] === "string"
-        ) {
-          countPositive = new PositiveNumber(
-            resultInJSON.data[0]["count"] as string,
-          );
+        /*
+         * count() is a UInt64, and whether it arrives as a JSON string or a
+         * JSON number depends on the server's
+         * output_format_json_quote_64bit_integers setting: ClickHouse
+         * quoted 64-bit integers by default until 25.x flipped the default
+         * to 0 (numbers). Accept both — a string-only check silently read
+         * every count as 0 on modern servers, which (among other things)
+         * meant telemetry monitors' Log/Span/Exception counts never crossed
+         * their criteria thresholds.
+         */
+        const rawCount: unknown =
+          resultInJSON.data && resultInJSON.data[0]
+            ? resultInJSON.data[0]["count"]
+            : undefined;
+
+        if (typeof rawCount === "string" || typeof rawCount === "number") {
+          countPositive = new PositiveNumber(rawCount);
         }
       } catch {
         /*

--- a/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
@@ -16,6 +16,8 @@ import BadDataException from "../../../Types/Exception/BadDataException";
 import GenericObject from "../../../Types/GenericObject";
 import ObjectID from "../../../Types/ObjectID";
 import OneUptimeDate from "../../../Types/Date";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import ModelPermission from "../../../Server/Types/AnalyticsDatabase/ModelPermission";
 import {
   describe,
   expect,
@@ -616,6 +618,149 @@ describe("AnalyticsDatabaseService", () => {
       expect(() => {
         return check(model);
       }).toThrow("requiredText is required");
+    });
+  });
+
+  /*
+   * countBy parses the count() aggregate out of ClickHouse's JSON response.
+   * Whether that UInt64 arrives as a JSON string or a JSON number depends on
+   * the server's output_format_json_quote_64bit_integers setting — quoted
+   * (string) was the default until ClickHouse 25.x flipped it to numbers.
+   * A string-only typeof check silently read every count as 0 on modern
+   * servers, which made telemetry monitors (Logs / Traces / Exceptions)
+   * never meet their count-threshold criteria — monitors stuck "Operational"
+   * forever. These tests pin the parsing for both wire formats and every
+   * degraded-response shape.
+   */
+  describe("countBy result parsing", () => {
+    let checkReadPermissionMock: jest.Mock;
+
+    const mockCountResponse: (response: unknown) => void = (
+      response: unknown,
+    ): void => {
+      jest.spyOn(service, "executeQuery").mockResolvedValue({
+        json: () => {
+          return Promise.resolve(response);
+        },
+      } as never);
+    };
+
+    beforeEach(() => {
+      checkReadPermissionMock = jest
+        .spyOn(ModelPermission, "checkReadPermission")
+        .mockImplementation((_modelType: unknown, query: unknown) => {
+          return Promise.resolve({
+            query,
+            select: null,
+          } as never);
+        }) as unknown as jest.Mock;
+      jest.spyOn(logger, "debug").mockImplementation(() => {
+        return undefined!;
+      });
+      jest.spyOn(logger, "warn").mockImplementation(() => {
+        return undefined!;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const countBy: () => Promise<number> = async (): Promise<number> => {
+      const result: PositiveNumber = await service.countBy({
+        query: {},
+        props: { isRoot: true },
+      });
+      return result.toNumber();
+    };
+
+    test("parses count returned as a JSON number (ClickHouse >= 25.x default)", async () => {
+      mockCountResponse({ data: [{ count: 42 }] });
+      expect(await countBy()).toBe(42);
+    });
+
+    test("parses count returned as a JSON string (quoted 64-bit integers)", async () => {
+      mockCountResponse({ data: [{ count: "42" }] });
+      expect(await countBy()).toBe(42);
+    });
+
+    test("parses a numeric zero count as 0", async () => {
+      mockCountResponse({ data: [{ count: 0 }] });
+      expect(await countBy()).toBe(0);
+    });
+
+    test("parses a string zero count as 0", async () => {
+      mockCountResponse({ data: [{ count: "0" }] });
+      expect(await countBy()).toBe(0);
+    });
+
+    test("parses a count of 1 — the smallest value that can cross a monitor threshold", async () => {
+      // The default log-monitor offline criteria is "Log Count >= 1".
+      mockCountResponse({ data: [{ count: 1 }] });
+      expect(await countBy()).toBe(1);
+    });
+
+    test("parses a large count", async () => {
+      mockCountResponse({ data: [{ count: "6718284" }] });
+      expect(await countBy()).toBe(6718284);
+    });
+
+    test("defaults to 0 when the response has no data field", async () => {
+      mockCountResponse({});
+      expect(await countBy()).toBe(0);
+    });
+
+    test("defaults to 0 when the data array is empty", async () => {
+      mockCountResponse({ data: [] });
+      expect(await countBy()).toBe(0);
+    });
+
+    test("defaults to 0 when the row has no count key", async () => {
+      mockCountResponse({ data: [{ other: 5 }] });
+      expect(await countBy()).toBe(0);
+    });
+
+    test("defaults to 0 when the count value is null", async () => {
+      mockCountResponse({ data: [{ count: null }] });
+      expect(await countBy()).toBe(0);
+    });
+
+    test("defaults to 0 (with a warning) when the response body is unparseable", async () => {
+      /*
+       * timeout_overflow_mode='break' can truncate a count() response —
+       * json() then rejects. countBy must degrade to 0, not throw.
+       */
+      jest.spyOn(service, "executeQuery").mockResolvedValue({
+        json: () => {
+          return Promise.reject(new Error("truncated response"));
+        },
+      } as never);
+      expect(await countBy()).toBe(0);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    test("uses the permission-checked query for the count statement", async () => {
+      mockCountResponse({ data: [{ count: 7 }] });
+
+      // Must be a real model column: the where-statement compiler rejects unknown keys.
+      const rewrittenQuery: GenericObject = { column_1: "tenant-scoped" };
+      checkReadPermissionMock.mockImplementation(() => {
+        return Promise.resolve({
+          query: rewrittenQuery,
+          select: null,
+        } as never);
+      });
+
+      const toCountStatementSpy: jest.Mock = jest.spyOn(
+        service,
+        "toCountStatement",
+      ) as unknown as jest.Mock;
+
+      await countBy();
+
+      expect(toCountStatementSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ query: rewrittenQuery }),
+      );
     });
   });
 

--- a/Common/Tests/Server/Utils/Monitor/Criteria/LogMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/LogMonitorCriteria.test.ts
@@ -130,6 +130,36 @@ describe("LogMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
     });
   });
 
+  /*
+   * The exact production shape of a "log presence" alert: criteria
+   * "Log Count >= 1" flips the monitor Offline the moment a matching log
+   * line is ingested. Documents the comparator behavior downstream of
+   * countBy — the countBy parsing regression itself (ClickHouse >= 25.x
+   * returning count() as a JSON number) is pinned in
+   * AnalyticsDatabaseService.test.ts.
+   */
+  describe("log-presence offline criteria (Log Count >= 1)", () => {
+    const offlineCriteria: CriteriaFilter = {
+      checkOn: CheckOn.LogCount,
+      filterType: FilterType.GreaterThanOrEqualTo,
+      value: 1,
+    };
+
+    test("one matching log → met (monitor goes offline)", async () => {
+      const result: string | null = await evaluate(1, offlineCriteria);
+      expect(result).toBeTruthy();
+      expect(result).toContain("Log Count");
+    });
+
+    test("many matching logs → met", async () => {
+      expect(await evaluate(6718284, offlineCriteria)).toBeTruthy();
+    });
+
+    test("zero matching logs → not met (monitor stays operational)", async () => {
+      expect(await evaluate(0, offlineCriteria)).toBeNull();
+    });
+  });
+
   describe("edge cases", () => {
     test("a missing logCount is treated as 0", async () => {
       // undefined logCount → 0; "equal to 0" is therefore met.


### PR DESCRIPTION
# fix(analytics): parse ClickHouse count() returned as a JSON number — telemetry monitors never went Offline

## Symptom

A Logs monitor with criteria **"Log Count ≥ 1 → Offline"** never changed status, even
though the Logs Preview on the monitor page showed matching log lines well inside the
5-minute evaluation window. Every evaluation reported *"Log count was 0. (expected to be
greater than or equal to 1)"*.

Debugged live against a production deployment:

- `POST /api/logs/get-list` with the monitor's exact query (body `Search`, severity
  `Includes`, time `InBetween`) → **50 rows**
- `POST /api/logs/count` with the **identical query** → `{"count": 0}`
- Even `count` with *only* a 1-minute time filter returned 0 while `get-list` returned rows.

## Root cause

`AnalyticsDatabaseService.countBy` only accepted the `count()` aggregate when ClickHouse
returned it as a JSON **string**:

```ts
if (data[0]["count"] && typeof data[0]["count"] === "string") { ... }
```

`count()` is a UInt64, and whether it is serialized as a string or a number is controlled
by the server setting `output_format_json_quote_64bit_integers`. ClickHouse quoted 64-bit
integers by default for years; **modern ClickHouse (25.x+) defaults this to `0`**, so
`count()` now arrives as a JSON *number* and the string-only guard silently read every
count as **0**. The repo bumped ClickHouse to 26.7 ("to match production") on 2026-07-23.

Verified end-to-end against local ClickHouse 26.7 with the real `@clickhouse/client`
(inserted a log row matching the affected monitor's filter):

```
{"rawValue":1,"rawType":"number","oldGuardParsed":0,"newGuardParsed":1}
```

## Blast radius

Every analytics-table `countBy` returned 0 on modern ClickHouse:

- **Logs monitors** — logCount always 0 → count-threshold criteria never met → monitors
  stuck Operational, no incidents created (this issue).
- **Traces monitors** (spanCount) and **Exceptions monitors** (exceptionCount) — same.
- Exception spike detection (AI SRE insights) and other analytics count consumers.

The dashboards were unaffected because the list endpoint deliberately skips `countBy` and
derives a lower-bound count from the fetched rows — which is why the bug was invisible in
the UI while breaking evaluation.

## Fix

Accept the count as **string or number** (`PositiveNumber` handles both). Degraded
response shapes (missing data, truncated body from `timeout_overflow_mode='break'`)
still default to 0 with a warning, as before.

## Tests

- `Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts` — new
  **countBy result parsing** suite (12 tests): numeric count (ClickHouse ≥ 25.x default —
  the regression), string count (legacy quoted format), zero in both formats, count of 1
  (the smallest value that crosses the default monitor threshold), large counts, missing
  `data`, empty rows, missing/null count key, unparseable (truncated) response, and that
  the permission-checked query reaches the count statement.
- `Common/Tests/Server/Utils/Monitor/Criteria/LogMonitorCriteria.test.ts` — new
  **log-presence offline criteria (Log Count ≥ 1)** scenario mirroring the affected
  production monitor: 1 match → Offline, many → Offline, 0 → stays Operational.
- All 7 monitor-criteria suites (83 tests), MonitorStepLogMonitor (16), and the full
  AnalyticsDatabaseService suite (36) pass. `npm run fix` clean, `tsc` in Common clean.

## Notes

- No billing impact: telemetry usage billing sums ingested GB via raw aggregate SQL, not
  `countBy`.
- After deploy, affected monitors will start evaluating real counts on their next cycle;
  monitors whose "presence" criteria now match will flip Offline and open incidents as
  configured.
