### PR TITLE
fix(analytics): stop the Total aggregate alias from shadowing its own WHERE filter

### DIFF
--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -57,6 +57,7 @@ import AnalyticsTableColumn from "../../Types/AnalyticsDatabase/TableColumn";
 import TableColumnType from "../../Types/AnalyticsDatabase/TableColumnType";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../Types/Date";
+import Dictionary from "../../Types/Dictionary";
 import BadDataException from "../../Types/Exception/BadDataException";
 import Exception from "../../Types/Exception/Exception";
 import ExceptionCode from "../../Types/Exception/ExceptionCode";
@@ -854,12 +855,18 @@ export default class AnalyticsDatabaseService<
         groupByColumnNames.push("attributes");
       }
 
+      /*
+       * The bucket timestamp does not always come back under the
+       * timestamp column's own name — a `Total` (whole-window)
+       * aggregation aliases it away from the column so the aggregate
+       * cannot shadow the window filter in WHERE. Reading rows by the
+       * column name in that case would drop every one of them.
+       */
+      const bucketTimestampColumn: string =
+        AggregateUtil.getBucketTimestampAliasForAggregate(aggregateBy);
+
       for (const item of items) {
-        if (
-          !(item as JSONObject)[
-            aggregateBy.aggregationTimestampColumnName as string
-          ]
-        ) {
+        if (!(item as JSONObject)[bucketTimestampColumn]) {
           continue;
         }
 
@@ -888,9 +895,7 @@ export default class AnalyticsDatabaseService<
          */
         const aggregatedModel: AggregatedModel = {
           timestamp: OneUptimeDate.fromString(
-            (item as JSONObject)[
-              aggregateBy.aggregationTimestampColumnName as string
-            ] as string,
+            (item as JSONObject)[bucketTimestampColumn] as string,
           ),
           value: (item as JSONObject)[
             aggregateBy.aggregateColumnName as string
@@ -1277,6 +1282,36 @@ export default class AnalyticsDatabaseService<
     return aggregateBy.timeoutOverflowMode === "throw" ? "throw" : "break";
   }
 
+  /**
+   * Sort-key → SELECT-alias remapping for an aggregate statement's ORDER
+   * BY. Only the aggregation timestamp column ever needs remapping, and
+   * only for a `Total` (whole-window) aggregation, where the bucket is
+   * `min(col) as <alias>`: ordering by `col` there would reference the
+   * raw column, which is neither grouped nor aggregated. Every bucketed
+   * interval aliases the bucket back onto the column name, so this is an
+   * empty map and ORDER BY is unchanged.
+   *
+   * Shared with the MetricService statement builders so every aggregate
+   * path orders by the same identifier its SELECT actually emits.
+   */
+  protected getAggregateSortColumnAliases(
+    aggregateBy: AggregateBy<TBaseModel>,
+    resolvedInterval: AggregationInterval,
+  ): Dictionary<string> {
+    const timestampColumn: string =
+      aggregateBy.aggregationTimestampColumnName.toString();
+    const bucketAlias: string = AggregateUtil.getBucketTimestampAlias(
+      resolvedInterval,
+      timestampColumn,
+    );
+
+    if (bucketAlias === timestampColumn) {
+      return {};
+    }
+
+    return { [timestampColumn]: bucketAlias };
+  }
+
   public toAggregateStatement(aggregateBy: AggregateBy<TBaseModel>): {
     statement: Statement;
     columns: Array<string>;
@@ -1308,19 +1343,6 @@ export default class AnalyticsDatabaseService<
       aggregateBy.query,
     );
 
-    const sortStatement: Statement = this.statementGenerator.toSortStatement(
-      aggregateBy.sort!,
-    );
-
-    const statement: Statement = SQL``;
-
-    statement.append(SQL`SELECT `.append(select.statement));
-    statement.append(SQL` FROM ${databaseName}.${this.model.tableName}`);
-    statement
-      .append(SQL` WHERE TRUE `)
-      .append(whereStatement)
-      .append(this.getRetentionReadFilter());
-
     /*
      * The time bucket is a grouping key only when we ARE bucketing by
      * time. For a `Total` (whole-window) aggregation the timestamp is
@@ -1339,6 +1361,20 @@ export default class AnalyticsDatabaseService<
     const hasGroupBy: boolean = Boolean(
       aggregateBy.groupBy && Object.keys(aggregateBy.groupBy).length > 0,
     );
+
+    const sortStatement: Statement = this.statementGenerator.toSortStatement(
+      aggregateBy.sort!,
+      this.getAggregateSortColumnAliases(aggregateBy, resolvedInterval),
+    );
+
+    const statement: Statement = SQL``;
+
+    statement.append(SQL`SELECT `.append(select.statement));
+    statement.append(SQL` FROM ${databaseName}.${this.model.tableName}`);
+    statement
+      .append(SQL` WHERE TRUE `)
+      .append(whereStatement)
+      .append(this.getRetentionReadFilter());
 
     if (bucketByTime) {
       statement

--- a/Common/Server/Services/MetricService.ts
+++ b/Common/Server/Services/MetricService.ts
@@ -1096,6 +1096,7 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
     );
     const sortStatement: Statement = this.statementGenerator.toSortStatement(
       aggregateBy.sort!,
+      this.getAggregateSortColumnAliases(aggregateBy, resolvedInterval),
     );
 
     /*
@@ -1434,6 +1435,7 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
     );
     const sortStatement: Statement = this.statementGenerator.toSortStatement(
       aggregateBy.sort!,
+      this.getAggregateSortColumnAliases(aggregateBy, resolvedInterval),
     );
 
     const aggregationExpression: string =
@@ -1638,8 +1640,27 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
       );
     const outerWhereStatement: Statement =
       this.statementGenerator.toWhereStatement(aggregateBy.query);
+
+    /*
+     * Mirror the base builder's Total handling: the SELECT above (shared
+     * toAggregateSelectStatement) emits `min(time)` for a `Total`
+     * interval, so the time column must NOT appear in GROUP BY (grouping
+     * by an aggregate is a ClickHouse error) and ORDER BY has to name the
+     * alias the aggregate was given rather than the raw column.
+     */
+    const mutableResolvedInterval: AggregationInterval =
+      AggregateUtil.getAggregationInterval({
+        startDate: aggregateBy.startTimestamp!,
+        endDate: aggregateBy.endTimestamp!,
+        aggregationInterval: aggregateBy.aggregationInterval,
+      });
+    const mutableBucketByTime: boolean = !AggregateUtil.isTotalAggregation(
+      mutableResolvedInterval,
+    );
+
     const sortStatement: Statement = this.statementGenerator.toSortStatement(
       aggregateBy.sort!,
+      this.getAggregateSortColumnAliases(aggregateBy, mutableResolvedInterval),
     );
 
     /*
@@ -1740,21 +1761,9 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
     }
 
     /*
-     * Mirror the base builder's Total handling: the SELECT above (shared
-     * toAggregateSelectStatement) already emits `min(time)` for a `Total`
-     * interval, so the time column must NOT appear in GROUP BY — grouping
-     * by an aggregate alias is a ClickHouse error. Omit the clause
-     * entirely when nothing else is grouped.
+     * Omit the GROUP BY clause entirely for a group-less Total (see the
+     * interval resolution above the WHERE statements).
      */
-    const mutableResolvedInterval: AggregationInterval =
-      AggregateUtil.getAggregationInterval({
-        startDate: aggregateBy.startTimestamp!,
-        endDate: aggregateBy.endTimestamp!,
-        aggregationInterval: aggregateBy.aggregationInterval,
-      });
-    const mutableBucketByTime: boolean = !AggregateUtil.isTotalAggregation(
-      mutableResolvedInterval,
-    );
     const mutableHasGroupBy: boolean = Boolean(
       aggregateBy.groupBy && Object.keys(aggregateBy.groupBy).length > 0,
     );

--- a/Common/Server/Types/AnalyticsDatabase/AggregateBy.ts
+++ b/Common/Server/Types/AnalyticsDatabase/AggregateBy.ts
@@ -39,6 +39,61 @@ export class AggregateUtil {
   }
 
   /**
+   * Output-column name the whole-window (`Total`) bucket timestamp is
+   * returned under.
+   *
+   * It deliberately does NOT reuse the timestamp column's own name.
+   * `Total` compiles the bucket to `min(col)`, and ClickHouse resolves
+   * SELECT aliases inside WHERE — so `min(col) as col` sitting next to
+   * the window filter `col >= ... AND col <= ...` makes that filter
+   * reference the aggregate, and the entire statement fails with
+   * `ILLEGAL_AGGREGATION` (error 184: "Aggregate function min(col) AS
+   * col is found in WHERE in query"). Every bucketed interval keeps the
+   * column-name alias: its expression is not an aggregate, so it is
+   * legal in WHERE, and GROUP BY resolving to it is load-bearing.
+   */
+  public static readonly TOTAL_BUCKET_TIMESTAMP_ALIAS: string =
+    "__oneuptime_total_bucket_timestamp";
+
+  /**
+   * The name the bucket timestamp is actually SELECTed as for a given
+   * interval. Both the ORDER BY clause and the read-side row parsing
+   * must go through this rather than using the timestamp column name
+   * directly: in a `Total` statement the raw column is neither grouped
+   * nor aggregated (ordering by it fails), and rows come back keyed by
+   * the alias (reading them by column name silently drops every row).
+   */
+  public static getBucketTimestampAlias(
+    resolvedInterval: AggregationInterval,
+    timestampColumn: string,
+  ): string {
+    if (AggregateUtil.isTotalAggregation(resolvedInterval)) {
+      return AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS;
+    }
+
+    return timestampColumn;
+  }
+
+  /**
+   * getBucketTimestampAlias for a whole AggregateBy — resolves the
+   * interval the same way the statement builders do, so the statement
+   * side and the row-parsing side can never disagree about which
+   * column the bucket timestamp arrives in.
+   */
+  public static getBucketTimestampAliasForAggregate<
+    TBaseModel extends AnalyticsBaseModel,
+  >(aggregateBy: CommonAggregateBy<TBaseModel>): string {
+    return AggregateUtil.getBucketTimestampAlias(
+      AggregateUtil.getAggregationInterval({
+        startDate: aggregateBy.startTimestamp!,
+        endDate: aggregateBy.endTimestamp!,
+        aggregationInterval: aggregateBy.aggregationInterval,
+      }),
+      aggregateBy.aggregationTimestampColumnName.toString(),
+    );
+  }
+
+  /**
    * The single source of truth for "which ClickHouse expression buckets
    * a timestamp at this interval". Every aggregate SQL builder (raw
    * table, minute MV, per-host MV, span projections) must go through
@@ -80,17 +135,24 @@ export class AggregateUtil {
    * paths:
    *
    *   - normal interval → buildBucketTimestampExpression(...) `as col`
-   *   - Total           → `min(col) as col` (one row per group; the
-   *     earliest sample timestamp in the window is the bucket label)
+   *   - Total           → `min(col) as TOTAL_BUCKET_TIMESTAMP_ALIAS`
+   *     (one row per group; the earliest sample timestamp in the window
+   *     is the bucket label. The alias must not be `col` — see
+   *     TOTAL_BUCKET_TIMESTAMP_ALIAS.)
    */
   public static buildBucketTimestampSelect(
     resolvedInterval: AggregationInterval,
     timestampColumn: string,
   ): string {
+    const alias: string = AggregateUtil.getBucketTimestampAlias(
+      resolvedInterval,
+      timestampColumn,
+    );
+
     if (AggregateUtil.isTotalAggregation(resolvedInterval)) {
-      return `min(${timestampColumn}) as ${timestampColumn}`;
+      return `min(${timestampColumn}) as ${alias}`;
     }
 
-    return `${AggregateUtil.buildBucketTimestampExpression(resolvedInterval, timestampColumn)} as ${timestampColumn}`;
+    return `${AggregateUtil.buildBucketTimestampExpression(resolvedInterval, timestampColumn)} as ${alias}`;
   }
 }

--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -46,6 +46,7 @@ import EndsWith from "../../../Types/BaseDatabase/EndsWith";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../../Types/Date";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import Dictionary from "../../../Types/Dictionary";
 import { JSONObject } from "../../../Types/JSON";
 import JSONFunctions from "../../../Types/JSONFunctions";
 import AggregateBy, {
@@ -1127,7 +1128,18 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
     return groupByStatement;
   }
 
-  public toSortStatement(sort: Sort<TBaseModel>): Statement {
+  /**
+   * `columnAliases` remaps a sort key onto the name the statement
+   * actually SELECTs it as. Aggregate statements need this for the
+   * whole-window (`Total`) bucket timestamp: the SELECT emits
+   * `min(col) as <alias>`, so `ORDER BY col` would reference the raw
+   * column — neither grouped nor aggregated, which ClickHouse rejects.
+   * The key is still validated as a real model column either way.
+   */
+  public toSortStatement(
+    sort: Sort<TBaseModel>,
+    columnAliases?: Dictionary<string> | undefined,
+  ): Statement {
     const sortStatement: Statement = new Statement();
 
     for (const key in sort) {
@@ -1135,8 +1147,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
         throw new BadDataException(`Unknown column: ${key}`);
       }
 
+      const sortColumn: string = columnAliases?.[key] || key;
+
       const value: SortOrder = sort[key]!;
-      sortStatement.append(SQL`${key} `).append(
+      sortStatement.append(SQL`${sortColumn} `).append(
         {
           [SortOrder.Ascending]: SQL`ASC`,
           [SortOrder.Descending]: SQL`DESC`,
@@ -1220,9 +1234,17 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
       `${aggregationExpression} as ${aggregationColumn}, ${AggregateUtil.buildBucketTimestampSelect(aggregationInterval, aggregationTimestampColumn)}`,
     );
 
+    /*
+     * The bucket timestamp is not always returned under the timestamp
+     * column's own name — a `Total` aggregation aliases it away from the
+     * column so the WHERE clause is not shadowed by the aggregate.
+     */
     const columns: Array<string> = [
       aggregateBy.aggregateColumnName.toString(),
-      aggregateBy.aggregationTimestampColumnName.toString(),
+      AggregateUtil.getBucketTimestampAlias(
+        aggregationInterval,
+        aggregationTimestampColumn,
+      ),
     ];
 
     if (aggregateBy.groupBy && Object.keys(aggregateBy.groupBy).length > 0) {

--- a/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
@@ -11,7 +11,9 @@ import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTabl
 import AnalyticsTableColumn from "../../../Types/AnalyticsDatabase/TableColumn";
 import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
 import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { AggregateUtil } from "../../../Server/Types/AnalyticsDatabase/AggregateBy";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import GenericObject from "../../../Types/GenericObject";
 import ObjectID from "../../../Types/ObjectID";
@@ -362,6 +364,23 @@ describe("AnalyticsDatabaseService", () => {
       };
     };
 
+    /*
+     * Sort keys are parameter-bound identifiers, so the column ORDER BY
+     * actually names lives in query_params rather than in the SQL text.
+     */
+    const orderByIdentifierParameter: RegExp = /ORDER BY \{p(\d+):Identifier\}/;
+
+    const getOrderByColumn: (statement: Statement) => unknown = (
+      statement: Statement,
+    ): unknown => {
+      const match: RegExpExecArray | null = orderByIdentifierParameter.exec(
+        statement.query,
+      );
+      return (statement.query_params as Record<string, unknown>)[
+        `p${match![1]}`
+      ];
+    };
+
     test("derives the window bucket and groups by time when interval is omitted", () => {
       const query: string = service.toAggregateStatement(makeBaseAggregateBy())
         .statement.query;
@@ -398,7 +417,9 @@ describe("AnalyticsDatabaseService", () => {
         makeBaseAggregateBy({ aggregationInterval: "Total" }),
       ).statement.query;
 
-      expect(query).toContain("min(column_ObjectID) as column_ObjectID");
+      expect(query).toContain(
+        `min(column_ObjectID) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).not.toContain("date_trunc");
       expect(query).not.toContain("GROUP BY");
       expect(query).toContain("HAVING count() > 0");
@@ -412,12 +433,95 @@ describe("AnalyticsDatabaseService", () => {
         }),
       ).statement.query;
 
-      expect(query).toContain("min(column_ObjectID) as column_ObjectID");
+      expect(query).toContain(
+        `min(column_ObjectID) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).toContain("GROUP BY");
       // The time column must not be a grouping key under Total.
       expect(query).not.toContain("GROUP BY column_ObjectID");
       // A grouped query never needs the empty-window guard.
       expect(query).not.toContain("HAVING count() > 0");
+    });
+
+    /*
+     * Regression: ClickHouse resolves SELECT aliases inside WHERE, so a
+     * Total aggregation that aliased `min(col)` back onto `col` made the
+     * window filter reference the aggregate and the server rejected the
+     * whole statement with ILLEGAL_AGGREGATION (error 184) — every
+     * grouped whole-window query (the Kubernetes cost pages) 500'd.
+     */
+    test("Total keeps the window filter on the raw timestamp column, not on the aggregate", () => {
+      const statement: Statement = service.toAggregateStatement(
+        makeBaseAggregateBy({
+          aggregationInterval: "Total",
+          groupBy: { column_1: true },
+          query: {
+            column_ObjectID: new InBetween<Date>(
+              new Date("2024-01-01"),
+              new Date("2024-01-02"),
+            ),
+          },
+        }),
+      ).statement;
+
+      const bucketAlias: string = AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS;
+
+      // The aggregate is aliased away from the column it aggregates...
+      expect(statement.query).toContain(
+        `min(column_ObjectID) as ${bucketAlias}`,
+      );
+
+      /*
+       * ...so the alias can never be substituted into the WHERE clause.
+       * Identifiers are parameter-bound, so the filter's reference to the
+       * raw column shows up as a bound `column_ObjectID` parameter, and
+       * the alias appears nowhere among the identifier parameters except
+       * in ORDER BY (asserted below).
+       */
+      const parameters: Array<unknown> = Object.values(
+        statement.query_params as Record<string, unknown>,
+      );
+      expect(parameters).toContain("column_ObjectID");
+      expect(statement.query).toContain(`WHERE TRUE`);
+      expect(statement.query).not.toContain(`WHERE TRUE AND ${bucketAlias}`);
+    });
+
+    test("Total orders by the bucket alias, never by the raw timestamp column", () => {
+      const statement: Statement = service.toAggregateStatement(
+        makeBaseAggregateBy({
+          aggregationInterval: "Total",
+          groupBy: { column_1: true },
+        }),
+      ).statement;
+
+      /*
+       * `ORDER BY column_ObjectID` under Total would be a reference to a
+       * column that is neither grouped nor aggregated — ClickHouse
+       * rejects it. The sort key has to name the alias the SELECT emits.
+       */
+      expect(getOrderByColumn(statement)).toBe(
+        AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS,
+      );
+    });
+
+    test("bucketed intervals still alias the bucket onto the timestamp column and order by it", () => {
+      const statement: Statement = service.toAggregateStatement(
+        makeBaseAggregateBy({ aggregationInterval: "Hour" }),
+      ).statement;
+
+      /*
+       * The bucketed shape is deliberately unchanged: its expression is
+       * not an aggregate, and GROUP BY resolving to the alias is what
+       * makes the bucketing work.
+       */
+      expect(statement.query).toContain(
+        "toStartOfInterval(column_ObjectID, INTERVAL 1 hour)) as column_ObjectID",
+      );
+      expect(statement.query).not.toContain(
+        AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS,
+      );
+
+      expect(getOrderByColumn(statement)).toBe("column_ObjectID");
     });
   });
 

--- a/Common/Tests/Server/Services/MetricServiceAggregate.test.ts
+++ b/Common/Tests/Server/Services/MetricServiceAggregate.test.ts
@@ -3,7 +3,9 @@ import fs from "fs";
 import path from "path";
 import { MetricService } from "../../../Server/Services/MetricService";
 import Metric from "../../../Models/AnalyticsModels/Metric";
-import AggregateBy from "../../../Server/Types/AnalyticsDatabase/AggregateBy";
+import AggregateBy, {
+  AggregateUtil,
+} from "../../../Server/Types/AnalyticsDatabase/AggregateBy";
 import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
 import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
 import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
@@ -273,7 +275,9 @@ describe("MetricService aggregate statement generation", () => {
         "date_trunc('minute', toStartOfInterval(time, INTERVAL 1 minute))",
       );
       expect(query).toContain("GROUP BY time");
-      expect(query).not.toContain("min(time) as time");
+      expect(query).not.toContain(
+        `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).not.toContain("HAVING count() > 0");
     });
   });
@@ -293,7 +297,9 @@ describe("MetricService aggregate statement generation", () => {
 
       const query: string = getQuery(aggregateBy);
 
-      expect(query).toContain("min(time) as time");
+      expect(query).toContain(
+        `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).not.toContain("date_trunc");
       expect(query).toContain("GROUP BY __attr_grp_0");
       expect(query).not.toContain("GROUP BY time");
@@ -317,7 +323,9 @@ describe("MetricService aggregate statement generation", () => {
       const query: string = getQuery(aggregateBy);
 
       expect(query).not.toContain("MetricItemAggMV1m");
-      expect(query).toContain("min(time) as time");
+      expect(query).toContain(
+        `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).not.toContain("GROUP BY");
       // The phantom row an empty window would return is suppressed.
       expect(query).toContain("HAVING count() > 0");
@@ -332,7 +340,9 @@ describe("MetricService aggregate statement generation", () => {
 
       // The time-bucketed MV cannot serve a whole-window aggregation.
       expect(query).not.toContain("MetricItemAggMV1m");
-      expect(query).toContain("min(time) as time");
+      expect(query).toContain(
+        `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).not.toContain("GROUP BY");
       expect(query).toContain("HAVING count() > 0");
     });
@@ -345,7 +355,9 @@ describe("MetricService aggregate statement generation", () => {
 
       const query: string = getQuery(aggregateBy);
 
-      expect(query).toContain("min(time) as time");
+      expect(query).toContain(
+        `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       // The model column survives as the sole grouping key...
       expect(query).toContain("GROUP BY metricPointType");
       // ...and the time bucket is gone (it is now an aggregate).
@@ -365,7 +377,9 @@ describe("MetricService aggregate statement generation", () => {
       const query: string = getQuery(aggregateBy);
 
       expect(query).toContain("quantileExactWeighted(0.9)");
-      expect(query).toContain("min(time) as time");
+      expect(query).toContain(
+        `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+      );
       expect(query).toContain("GROUP BY __attr_grp_0");
       expect(query).not.toContain("date_trunc");
     });
@@ -1499,7 +1513,9 @@ describe("MetricService aggregate statement generation", () => {
         );
 
         expect(query).not.toContain("MetricItemAggMV1mByK8sCluster");
-        expect(query).toContain("min(time) as time");
+        expect(query).toContain(
+          `min(time) as ${AggregateUtil.TOTAL_BUCKET_TIMESTAMP_ALIAS}`,
+        );
       });
 
       it("bails without a projectId (entity keys are tenant-scoped)", () => {


### PR DESCRIPTION
### Title of this pull request?

fix(analytics): stop the Total aggregate alias from shadowing its own WHERE filter

### Small Description?

**Both Kubernetes Costs pages returned a server error on every load.** ClickHouse rejected each of their aggregate queries:

```
Code: 184. DB::Exception: Aggregate function min(windowStart) AS windowStart
is found in WHERE in query. (ILLEGAL_AGGREGATION)
```

**Root cause.** A whole-window (`Total`) aggregation compiled its bucket timestamp as `min(windowStart) as windowStart`. ClickHouse resolves SELECT aliases *inside WHERE*, so the window filter `windowStart >= … AND windowStart <= …` in the same statement bound to the aggregate rather than to the column, and the whole statement was rejected.

The cost pages are the only production caller that pins `AggregationInterval.Total` (`KubernetesCostUtils.ts` — 7 call sites), which is why no other page ever surfaced this. Because *every* grouped cost query failed, the pages' single `catch` replaced the entire page with the error rather than degrading one widget.

**The fix.** Alias the `Total` bucket away from the column it aggregates, and route the two other places that name that column through the same alias:

| File | Change |
|---|---|
| `Common/Server/Types/AnalyticsDatabase/AggregateBy.ts` | `AggregateUtil` gains `TOTAL_BUCKET_TIMESTAMP_ALIAS`, `getBucketTimestampAlias()` and `getBucketTimestampAliasForAggregate()`. One pure function is now the single source of truth for the bucket column's name, so the statement side and the row-parsing side cannot drift. |
| `Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts` | `toSortStatement` takes an optional column→alias map. `ORDER BY windowStart` under `Total` references a column that is neither grouped nor aggregated, which ClickHouse also rejects. |
| `Common/Server/Services/AnalyticsDatabaseService.ts` | Shared `getAggregateSortColumnAliases()`; `_aggregateBy` reads the bucket timestamp out of the row under the alias. Without this last part the rows would be dropped by the falsy-timestamp guard and the pages would silently render **empty** instead of erroring. |
| `Common/Server/Services/MetricService.ts` | The three builders that can reach `Total` (percentile, scalar, mutable-metric) pass the same alias map. |

**Bucketed intervals are unaffected, by design.** For any non-`Total` interval the alias map is empty and the generated SQL is byte-identical: the bucket expression is not an aggregate (so it is legal in WHERE) and GROUP BY resolving to the column-name alias is load-bearing. The two materialized-view builders return `null` on `Total`, so their own `as time` alias is untouched.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). — no tracking issue
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None. Reported directly: the `/dashboard/:projectId/kubernetes/costs` page showed "server error". Regression from #2828 / #2831 (`feat(kubernetes): add Kubernetes cost observability`, 35e28e07b3), which introduced the first caller of `AggregationInterval.Total`.

### Screenshots (if appropriate):

Not applicable — server-side SQL generation. Verified against a live ClickHouse instead (below).

---

## How this was verified

Ran the **real** `KubernetesCostAllocationService` — statement generation, execution and row parsing — against a live ClickHouse 26.7 with seeded rows, covering all eight query shapes the two cost pages issue:

- grouped `Total` (cluster totals), grouped `Total` + namespace filter (idle spend), grouped `Total` with `Avg` (efficiency)
- multi-measure grouped `Total` (namespace breakdown), three-column grouped `Total` (workload breakdown)
- group-less `Total` over a populated window, and over an empty window (the `HAVING count() > 0` phantom-row guard)
- the bucketed (non-`Total`) trend query, asserting it is unchanged
- a window-bound assertion proving rows past `endTimestamp` no longer leak in

All 8 passed. Seeded rows and the scratch table were removed afterwards.

Also: 126 existing tests in the two aggregate suites pass, plus 3 new regression tests pinning that (a) the `Total` window filter stays on the raw column, (b) `Total` orders by the alias, and (c) bucketed intervals still alias onto the column and order by it. Sibling aggregation suites (`SpanService`, `LogAggregation`, `TraceAggregation`, `MetricAggregation`) pass. `Common` and `App` both `tsc --noEmit` clean. ESLint clean.

## For the reviewer — four pre-existing bugs found while investigating, deliberately **not** in this PR

Each was confirmed against ClickHouse. None is caused by this change; all are filed separately.

1. **(High) Bucketed aggregates have the same shadowing bug**, so their time filter is applied to the *truncated bucket*. The leading edge drops the entire first bucket when the window start is off-boundary; the trailing edge admits rows past the window end. Measured on a real `MetricItemV3`: hour tier `07:15→08:35` aggregates **4339 of 7648** rows; minute tier `08:30:02→08:31:20` gets **84 of 226**. That minute-tier shape is what the 9 metric criteria evaluators in `MonitorTelemetryMonitor.ts` use on an unaligned `now-N…now` window — so a `Past1Minute` metric monitor is evaluating only the current wall-clock minute. Fixing it shifts the numbers on every existing chart and alert, so it wants its own reviewed change.
2. **(Low) The measure is aliased onto its own column too** (`sum(totalCost) as totalCost`), so an aggregate whose query filters the measure 500s. API-reachable only; no UI caller does it. Note the alias is *load-bearing* — sorting by the measure works precisely because ORDER BY resolves to it — so a naive rename would regress measure-sorting.
3. **(Low) `toSortStatement` omits the comma between sort keys**, so any 2-key analytics sort is a syntax error. No in-repo caller passes two keys; the REST and MCP endpoints accept them unvalidated.
4. **(High) The cost pages report wrong idle/efficiency numbers** — the project page counts only `__idle__` and not `__unallocated__` (so its Idle % disagrees with the per-cluster page and Workload Spend is inflated), and efficiency is an unweighted `avg()` that includes zero-filled sentinel rows. Separately, cost rows carry no `@OwnedThrough`, so they are not narrowed by `KubernetesCluster`'s label access control.
