### PR TITLE
fix(analytics): table-qualify aggregate WHERE clauses so SELECT aliases cannot capture them

### DIFF
--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -1304,8 +1304,16 @@ export default class AnalyticsDatabaseService<
     const select: { statement: Statement; columns: Array<string> } =
       this.statementGenerator.toAggregateSelectStatement(aggregateBy);
 
+    /*
+     * The aggregate SELECT aliases expressions to real column names
+     * (`sum(col) as col`, and `min(ts) as ts` under Total), so the WHERE
+     * must table-qualify its column references — unqualified ones would
+     * resolve to those aliases (ILLEGAL_AGGREGATION under Total; bucket-
+     * snapped time filters otherwise). See toWhereStatement.
+     */
     const whereStatement: Statement = this.statementGenerator.toWhereStatement(
       aggregateBy.query,
+      { tableAlias: this.model.tableName },
     );
 
     const sortStatement: Statement = this.statementGenerator.toSortStatement(

--- a/Common/Server/Services/MetricService.ts
+++ b/Common/Server/Services/MetricService.ts
@@ -1429,8 +1429,18 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
       }
     }
 
+    /*
+     * The SELECT below aliases aggregates to real column names
+     * (`<agg> as value`, `min(time) as time` under Total). In the
+     * non-subquery form the WHERE sits at the same level, so its column
+     * references must be table-qualified or ClickHouse resolves them to
+     * those aliases (ILLEGAL_AGGREGATION under Total). Both forms read
+     * FROM this model's table, so the table name is a valid qualifier
+     * in either.
+     */
     const whereStatement: Statement = this.statementGenerator.toWhereStatement(
       aggregateBy.query,
+      { tableAlias: this.model.tableName },
     );
     const sortStatement: Statement = this.statementGenerator.toSortStatement(
       aggregateBy.sort!,
@@ -1636,8 +1646,17 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
       this.statementGenerator.toWhereStatement(
         this.getMutableMetricInnerQuery(aggregateBy.query),
       );
+    /*
+     * The outer SELECT aliases aggregates to real column names
+     * (`<agg> as value`, `min(time) as time` under Total) at the same
+     * level as this WHERE, so its column references must be qualified
+     * with the dedup subquery's alias — unqualified ones would resolve
+     * to those aliases (ILLEGAL_AGGREGATION under Total).
+     */
     const outerWhereStatement: Statement =
-      this.statementGenerator.toWhereStatement(aggregateBy.query);
+      this.statementGenerator.toWhereStatement(aggregateBy.query, {
+        tableAlias: "mutable_metric_latest",
+      });
     const sortStatement: Statement = this.statementGenerator.toSortStatement(
       aggregateBy.sort!,
     );
@@ -1703,7 +1722,7 @@ export class MetricService extends AnalyticsDatabaseService<Metric> {
               primaryEntityId,
               primaryEntityType,
               metricPointId
-          )
+          ) AS mutable_metric_latest
           WHERE isDeleted = false
         `,
       )

--- a/Common/Server/Types/AnalyticsDatabase/AggregateBy.ts
+++ b/Common/Server/Types/AnalyticsDatabase/AggregateBy.ts
@@ -82,6 +82,15 @@ export class AggregateUtil {
    *   - normal interval → buildBucketTimestampExpression(...) `as col`
    *   - Total           → `min(col) as col` (one row per group; the
    *     earliest sample timestamp in the window is the bucket label)
+   *
+   * IMPORTANT: because the alias shadows the real column, ClickHouse
+   * substitutes it into any same-level unqualified `WHERE col ...`
+   * reference — for Total that injects an aggregate into WHERE
+   * (ILLEGAL_AGGREGATION), and for bucketed intervals it silently
+   * filters on the truncated bucket. Every builder that embeds this
+   * fragment at the same level as its WHERE clause must table-qualify
+   * the WHERE column references (see
+   * StatementGenerator.toWhereStatement's tableAlias option).
    */
   public static buildBucketTimestampSelect(
     resolvedInterval: AggregationInterval,

--- a/Common/Server/Utils/AnalyticsDatabase/Statement.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/Statement.ts
@@ -26,16 +26,45 @@ export type StatementParameter = {
   value: RecordValue;
 };
 
+/**
+ * A table-qualified column reference (`table.column`) bound as TWO
+ * Identifier parameters. ClickHouse treats a dotted string bound as a
+ * single Identifier parameter as one quoted identifier (`` `t.col` ``),
+ * so the qualifier and the column must be bound separately.
+ *
+ * Qualification exists so a WHERE built by
+ * StatementGenerator.toWhereStatement can reference the real table
+ * column even when the surrounding SELECT aliases an expression to the
+ * same name — ClickHouse substitutes SELECT aliases into same-level
+ * unqualified WHERE references (an aggregate alias there is an
+ * ILLEGAL_AGGREGATION error; any other alias silently changes the
+ * filter), while qualified references always resolve to the table
+ * column.
+ */
+export class QualifiedColumn {
+  public constructor(
+    public readonly tableAlias: string,
+    public readonly column: string,
+  ) {}
+}
+
 export class Statement implements BaseQueryParams {
   public constructor(
     private strings: string[] = [""],
-    private values: Array<StatementParameter | string> = [],
+    private values: Array<StatementParameter | string | QualifiedColumn> = [],
   ) {}
 
   public get query(): string {
     let query: string = this.strings.reduce(
       (prev: string, curr: string, i: integer) => {
-        const param: StatementParameter | string = this.values[i - 1]!;
+        const param: StatementParameter | string | QualifiedColumn =
+          this.values[i - 1]!;
+
+        if (param instanceof QualifiedColumn) {
+          return (
+            prev + `{p${i - 1}_t:Identifier}.{p${i - 1}_c:Identifier}` + curr
+          );
+        }
 
         const dataType: string =
           typeof param === "string"
@@ -64,6 +93,12 @@ export class Statement implements BaseQueryParams {
     const returnObject: Record<string, unknown> = {};
 
     for (const v of this.values) {
+      if (v instanceof QualifiedColumn) {
+        returnObject[`p${index}_t`] = v.tableAlias;
+        returnObject[`p${index}_c`] = v.column;
+        index++;
+        continue;
+      }
       const finalValue: RecordValue | Array<RecordValue> =
         this.serializseValue(v);
       returnObject[`p${index}`] = finalValue;
@@ -228,11 +263,12 @@ export class Statement implements BaseQueryParams {
  * ClickHouse SQL template literal tag.
  *
  * String substitution values are interpereted as Identifiers (e.g. table or column names),
+ * QualifiedColumn values compile to `table.column` identifier pairs,
  * other substitution values must be StatementParameters.
  */
 export function SQL(
   strings: TemplateStringsArray,
-  ...values: Array<StatementParameter | string>
+  ...values: Array<StatementParameter | string | QualifiedColumn>
 ): Statement {
   return new Statement(strings.slice(0), values.slice(0));
 }

--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -5,7 +5,7 @@ import Select from "../../Types/AnalyticsDatabase/Select";
 import Sort from "../../Types/AnalyticsDatabase/Sort";
 import UpdateBy from "../../Types/AnalyticsDatabase/UpdateBy";
 import logger from "../Logger";
-import { SQL, Statement } from "./Statement";
+import { QualifiedColumn, SQL, Statement } from "./Statement";
 import {
   adaptTableSettingsForStorage,
   getDistributedEngine,
@@ -90,6 +90,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
     mapColumn: AnalyticsTableColumn;
     mapKey: string;
     skip?: boolean;
+    tableAlias?: string | undefined;
   }): void {
     const mapKeysColumnName: string | undefined = input.mapColumn.mapKeysColumn;
 
@@ -104,13 +105,17 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
       return;
     }
 
+    const keysColumnRef: string | QualifiedColumn = input.tableAlias
+      ? new QualifiedColumn(input.tableAlias, mapKeysColumn.key)
+      : mapKeysColumn.key;
+
     /*
      * Keep empty key-array rows eligible so data written before the
      * denormalized column existed, or by a lagging ingest path, is still
      * checked by the canonical map['key'] predicate that follows.
      */
     input.whereStatement.append(
-      SQL`AND (empty(${mapKeysColumn.key}) OR hasAny(${mapKeysColumn.key}, ${{
+      SQL`AND (empty(${keysColumnRef}) OR hasAny(${keysColumnRef}, ${{
         value: [input.mapKey],
         type: TableColumnType.ArrayText,
       }})) `,
@@ -428,10 +433,34 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
   }
 
   /**
-   * Conditions to append to "WHERE TRUE"
+   * Conditions to append to "WHERE TRUE".
+   *
+   * Compiles a Query into an `AND col <op> ...` chain. When
+   * `options.tableAlias` is set, every column reference is emitted
+   * table-qualified (`alias.col`). Builders whose SELECT aliases an
+   * expression to a real column name (aggregate statements — see
+   * AggregateUtil.buildBucketTimestampSelect) MUST pass the alias of the
+   * table the WHERE executes against: ClickHouse substitutes SELECT
+   * aliases into same-level unqualified WHERE references, which turns a
+   * `Total` aggregation's `min(col) as col` into an ILLEGAL_AGGREGATION
+   * error and silently snaps bucketed time filters to bucket boundaries.
+   * Statements that embed this WHERE against a different table (MV
+   * paths, cascade deletes) must stay unqualified.
    */
-  public toWhereStatement(query: Query<TBaseModel>): Statement {
+  public toWhereStatement(
+    query: Query<TBaseModel>,
+    options?: { tableAlias?: string | undefined },
+  ): Statement {
     const whereStatement: Statement = new Statement();
+
+    type ColumnRefFunction = (columnName: string) => string | QualifiedColumn;
+    const columnRef: ColumnRefFunction = (
+      columnName: string,
+    ): string | QualifiedColumn => {
+      return options?.tableAlias
+        ? new QualifiedColumn(options.tableAlias, columnName)
+        : columnName;
+    };
 
     let first: boolean = true;
     for (const key in query) {
@@ -476,7 +505,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
             whereStatement.append(SQL` OR `);
           }
           whereStatement.append(
-            SQL`${col.key} ILIKE ${{
+            SQL`${columnRef(col.key)} ILIKE ${{
               value: new Search<string>(ms.value),
               type: col.type,
             }}`,
@@ -536,10 +565,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
 
         if (scopeEntityKeys.length > 0 && hasAttributeFallback) {
           whereStatement.append(
-            SQL`AND (hasAny(${entityKeysColumn.key}, ${{
+            SQL`AND (hasAny(${columnRef(entityKeysColumn.key)}, ${{
               value: scopeEntityKeys,
               type: TableColumnType.ArrayText,
-            }}) OR ${attributesColumn!.key}[${{
+            }}) OR ${columnRef(attributesColumn!.key)}[${{
               value: scope.attributeKey,
               type: TableColumnType.Text,
             }}] = ${{
@@ -549,14 +578,14 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           );
         } else if (scopeEntityKeys.length > 0) {
           whereStatement.append(
-            SQL`AND hasAny(${entityKeysColumn.key}, ${{
+            SQL`AND hasAny(${columnRef(entityKeysColumn.key)}, ${{
               value: scopeEntityKeys,
               type: TableColumnType.ArrayText,
             }})`,
           );
         } else {
           whereStatement.append(
-            SQL`AND ${attributesColumn!.key}[${{
+            SQL`AND ${columnRef(attributesColumn!.key)}[${{
               value: scope.attributeKey,
               type: TableColumnType.Text,
             }}] = ${{
@@ -584,66 +613,66 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
 
       if (value instanceof Search) {
         whereStatement.append(
-          SQL`AND ${key} ILIKE ${{
+          SQL`AND ${columnRef(key)} ILIKE ${{
             value: value,
             type: tableColumn.type,
           }}`,
         );
       } else if (value instanceof NotEqual) {
         whereStatement.append(
-          SQL`AND ${key} != ${{
+          SQL`AND ${columnRef(key)} != ${{
             value: value,
             type: tableColumn.type,
           }}`,
         );
       } else if (value instanceof GreaterThan) {
         whereStatement.append(
-          SQL`AND ${key} > ${{
+          SQL`AND ${columnRef(key)} > ${{
             value: value,
             type: tableColumn.type,
           }}`,
         );
       } else if (value instanceof LessThan) {
         whereStatement.append(
-          SQL`AND ${key} < ${{
+          SQL`AND ${columnRef(key)} < ${{
             value: value,
             type: tableColumn.type,
           }}`,
         );
       } else if (value instanceof LessThanOrEqual) {
         whereStatement.append(
-          SQL`AND ${key} <= ${{
+          SQL`AND ${columnRef(key)} <= ${{
             value: value,
             type: tableColumn.type,
           }}`,
         );
       } else if (value instanceof LessThanOrNull) {
         whereStatement.append(
-          SQL`AND (${key} <= ${{
+          SQL`AND (${columnRef(key)} <= ${{
             value: value,
             type: tableColumn.type,
-          }} OR ${key} IS NULL)`,
+          }} OR ${columnRef(key)} IS NULL)`,
         );
       } else if (value instanceof GreaterThanOrNull) {
         whereStatement.append(
-          SQL`AND (${key} >= ${{
+          SQL`AND (${columnRef(key)} >= ${{
             value: value,
             type: tableColumn.type,
-          }} OR ${key} IS NULL)`,
+          }} OR ${columnRef(key)} IS NULL)`,
         );
       } else if (value instanceof GreaterThanOrEqual) {
         whereStatement.append(
-          SQL`AND ${key} >= ${{
+          SQL`AND ${columnRef(key)} >= ${{
             value: value,
             type: tableColumn.type,
           }}`,
         );
       } else if (value instanceof InBetween) {
         whereStatement.append(
-          SQL`AND ${key} >= ${{
+          SQL`AND ${columnRef(key)} >= ${{
             value: value.startValue,
             type: tableColumn.type,
-          }} AND ${key} <= ${{
+          }} AND ${columnRef(key)} <= ${{
             value: value.endValue,
             type: tableColumn.type,
           }}`,
@@ -665,7 +694,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           ((value as Includes).values as Array<string>) || [];
         if (arrayIncludeValues.length > 0) {
           whereStatement.append(
-            SQL`AND hasAny(${key}, ${{
+            SQL`AND hasAny(${columnRef(key)}, ${{
               value: arrayIncludeValues,
               type: TableColumnType.ArrayText,
             }})`,
@@ -673,7 +702,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
         }
       } else if (value instanceof Includes) {
         whereStatement.append(
-          SQL`AND ${key} IN ${{
+          SQL`AND ${columnRef(key)} IN ${{
             value: value,
             type: tableColumn.type,
           }}`,
@@ -691,7 +720,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           ((value as IncludesNone).values as Array<string>) || [];
         if (arrayExcludeValues.length > 0) {
           whereStatement.append(
-            SQL`AND NOT hasAny(${key}, ${{
+            SQL`AND NOT hasAny(${columnRef(key)}, ${{
               value: arrayExcludeValues,
               type: TableColumnType.ArrayText,
             }})`,
@@ -707,7 +736,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
           ((value as IncludesNone).values as Array<string | ObjectID>) || [];
         if (excludeValues.length > 0) {
           whereStatement.append(
-            SQL`AND ${key} NOT IN ${{
+            SQL`AND ${columnRef(key)} NOT IN ${{
               value: value,
               type: tableColumn.type,
             }}`,
@@ -715,9 +744,11 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
         }
       } else if (value instanceof IsNull) {
         if (tableColumn.type === TableColumnType.Text) {
-          whereStatement.append(SQL`AND (${key} IS NULL OR ${key} = '')`);
+          whereStatement.append(
+            SQL`AND (${columnRef(key)} IS NULL OR ${columnRef(key)} = '')`,
+          );
         } else {
-          whereStatement.append(SQL`AND ${key} IS NULL`);
+          whereStatement.append(SQL`AND ${columnRef(key)} IS NULL`);
         }
       } else if (
         tableColumn.type === TableColumnType.MapStringString &&
@@ -766,10 +797,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
            */
           if (mapEntry instanceof IsNull) {
             whereStatement.append(
-              SQL`AND ((NOT mapContains(${key}, ${{
+              SQL`AND ((NOT mapContains(${columnRef(key)}, ${{
                 value: mapKey,
                 type: TableColumnType.Text,
-              }})) OR ${key}[${{
+              }})) OR ${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}] = '')`,
@@ -782,12 +813,13 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               whereStatement,
               mapColumn: tableColumn,
               mapKey,
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND mapContains(${key}, ${{
+              SQL`AND mapContains(${columnRef(key)}, ${{
                 value: mapKey,
                 type: TableColumnType.Text,
-              }}) AND ${key}[${{
+              }}) AND ${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}] != ''`,
@@ -803,7 +835,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               }}) AND v ILIKE ${{
                 value: mapEntry as Search<string>,
                 type: TableColumnType.Text,
-              }}, mapKeys(${key}), mapValues(${key}))`,
+              }}, mapKeys(${columnRef(key)}), mapValues(${columnRef(key)}))`,
             );
             continue;
           }
@@ -817,7 +849,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               }}) AND v ILIKE ${{
                 value: literalValue,
                 type: TableColumnType.Text,
-              }}, mapKeys(${key}), mapValues(${key}))`,
+              }}, mapKeys(${columnRef(key)}), mapValues(${columnRef(key)}))`,
             );
             continue;
           }
@@ -831,7 +863,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               }}) AND v ILIKE ${{
                 value: literalValue,
                 type: TableColumnType.Text,
-              }}, mapKeys(${key}), mapValues(${key}))`,
+              }}, mapKeys(${columnRef(key)}), mapValues(${columnRef(key)}))`,
             );
             continue;
           }
@@ -845,14 +877,14 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               }}) AND v ILIKE ${{
                 value: literalValue,
                 type: TableColumnType.Text,
-              }}, mapKeys(${key}), mapValues(${key}))`,
+              }}, mapKeys(${columnRef(key)}), mapValues(${columnRef(key)}))`,
             );
             continue;
           }
 
           if (mapEntry instanceof NotEqual) {
             whereStatement.append(
-              SQL`AND ${key}[${{
+              SQL`AND ${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}] != ${{
@@ -872,9 +904,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               mapColumn: tableColumn,
               mapKey,
               skip: equalityValue === "",
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND ${key}[${{
+              SQL`AND ${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}] = ${{
@@ -897,9 +930,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               whereStatement,
               mapColumn: tableColumn,
               mapKey,
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND toFloat64OrNull(${key}[${{
+              SQL`AND toFloat64OrNull(${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}]) > ${{
@@ -915,9 +949,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               whereStatement,
               mapColumn: tableColumn,
               mapKey,
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND toFloat64OrNull(${key}[${{
+              SQL`AND toFloat64OrNull(${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}]) >= ${{
@@ -933,9 +968,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               whereStatement,
               mapColumn: tableColumn,
               mapKey,
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND toFloat64OrNull(${key}[${{
+              SQL`AND toFloat64OrNull(${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}]) < ${{
@@ -951,9 +987,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               whereStatement,
               mapColumn: tableColumn,
               mapKey,
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND toFloat64OrNull(${key}[${{
+              SQL`AND toFloat64OrNull(${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}]) <= ${{
@@ -985,9 +1022,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               mapColumn: tableColumn,
               mapKey,
               skip: includesValues.includes(""),
+              tableAlias: options?.tableAlias,
             });
             whereStatement.append(
-              SQL`AND ${key}[${{
+              SQL`AND ${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}] IN ${{
@@ -1017,7 +1055,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
               continue;
             }
             whereStatement.append(
-              SQL`AND ${key}[${{
+              SQL`AND ${columnRef(key)}[${{
                 value: mapKey,
                 type: TableColumnType.Text,
               }}] NOT IN ${{
@@ -1035,9 +1073,10 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
             mapColumn: tableColumn,
             mapKey,
             skip: equalityValue === "",
+            tableAlias: options?.tableAlias,
           });
           whereStatement.append(
-            SQL`AND ${key}[${{
+            SQL`AND ${columnRef(key)}[${{
               value: mapKey,
               type: TableColumnType.Text,
             }}] = ${{
@@ -1060,7 +1099,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
 
           if (flatValue[objKey] && typeof flatValue[objKey] === "string") {
             whereStatement.append(
-              SQL`AND JSONExtractString(${key}, ${{
+              SQL`AND JSONExtractString(${columnRef(key)}, ${{
                 value: objKey,
                 type: TableColumnType.Text,
               }}) = ${{
@@ -1073,7 +1112,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
 
           if (flatValue[objKey] && typeof flatValue[objKey] === "number") {
             whereStatement.append(
-              SQL`AND JSONExtractInt(${key}, ${{
+              SQL`AND JSONExtractInt(${columnRef(key)}, ${{
                 value: objKey,
                 type: TableColumnType.Text,
               }}) = ${{
@@ -1086,7 +1125,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
 
           if (flatValue[objKey] && typeof flatValue[objKey] === "boolean") {
             whereStatement.append(
-              SQL`AND JSONExtractBool(${key}, ${{
+              SQL`AND JSONExtractBool(${columnRef(key)}, ${{
                 value: objKey,
                 type: TableColumnType.Text,
               }}) = ${{
@@ -1099,7 +1138,7 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
         }
       } else {
         whereStatement.append(
-          SQL`AND ${key} = ${{ value, type: tableColumn.type }}`,
+          SQL`AND ${columnRef(key)} = ${{ value, type: tableColumn.type }}`,
         );
       }
     }

--- a/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
@@ -11,6 +11,8 @@ import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTabl
 import AnalyticsTableColumn from "../../../Types/AnalyticsDatabase/TableColumn";
 import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
 import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import GenericObject from "../../../Types/GenericObject";
@@ -418,6 +420,98 @@ describe("AnalyticsDatabaseService", () => {
       expect(query).not.toContain("GROUP BY column_ObjectID");
       // A grouped query never needs the empty-window guard.
       expect(query).not.toContain("HAVING count() > 0");
+    });
+
+    test("table-qualifies WHERE references so SELECT aliases cannot capture them", () => {
+      /*
+       * Regression for the Kubernetes Costs page 500: under Total the
+       * timestamp is selected as `min(col) as col`, and ClickHouse
+       * substitutes that alias into same-level unqualified WHERE
+       * references — `WHERE col >= ...` became
+       * `WHERE min(col) >= ...` (ILLEGAL_AGGREGATION). Qualified
+       * references (`table.col`) always resolve to the real column.
+       */
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(
+          makeBaseAggregateBy({
+            aggregationInterval: "Total",
+            groupBy: { column_1: true },
+            query: { column_1: "<cluster>" },
+          }),
+        );
+      const query: string = result.statement.query;
+
+      expect(query).toContain("min(column_ObjectID) as column_ObjectID");
+      expect(query).toMatch(
+        /AND \{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} = \{p\d+:String\}/,
+      );
+
+      const params: Record<string, unknown> = result.statement.query_params;
+      const qualifierEntries: Array<[string, unknown]> = Object.entries(
+        params,
+      ).filter(([key]: [string, unknown]) => {
+        return key.endsWith("_t");
+      });
+      expect(qualifierEntries).toHaveLength(1);
+      expect(qualifierEntries[0]![1]).toBe("<table-name>");
+    });
+
+    test("bucketed queries qualify the window filter so it reads raw timestamps", () => {
+      /*
+       * Before qualification the bucket alias (`date_trunc(...) as col`)
+       * was substituted into WHERE, silently snapping the window edges
+       * to bucket boundaries. The filter must read the real column.
+       */
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(
+          makeBaseAggregateBy({
+            query: {
+              column_ObjectID: new InBetween(
+                new Date("2024-01-01"),
+                new Date("2024-01-02"),
+              ),
+            },
+          }),
+        );
+      const query: string = result.statement.query;
+
+      expect(query).toContain("toStartOfInterval(column_ObjectID");
+      // Both InBetween bounds reference the qualified real column.
+      expect(query).toMatch(
+        /AND \{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} >= \{p\d+:String\} AND \{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} <= \{p\d+:String\}/,
+      );
+      // The GROUP BY / ORDER BY keep targeting the bare bucket alias.
+      expect(query).toContain("GROUP BY column_ObjectID");
+
+      const qualifiers: Array<unknown> = Object.entries(
+        result.statement.query_params,
+      )
+        .filter(([key]: [string, unknown]) => {
+          return key.endsWith("_t");
+        })
+        .map(([, value]: [string, unknown]) => {
+          return value;
+        });
+      expect(qualifiers).toStrictEqual(["<table-name>", "<table-name>"]);
+    });
+
+    test("filters on the aggregated measure column stay on the real column", () => {
+      /*
+       * `sum(column_2) as column_2` shadows the measure column too — a
+       * WHERE on it would otherwise also become an aggregate reference.
+       */
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(
+          makeBaseAggregateBy({
+            query: { column_2: new GreaterThan(5) },
+          }),
+        );
+      const query: string = result.statement.query;
+
+      expect(query).toContain("sum(column_2) as column_2");
+      expect(query).toMatch(
+        /AND \{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} > \{p\d+:Int32\}/,
+      );
     });
   });
 

--- a/Common/Tests/Server/Services/KubernetesCostAllocationAggregate.test.ts
+++ b/Common/Tests/Server/Services/KubernetesCostAllocationAggregate.test.ts
@@ -1,0 +1,338 @@
+import AnalyticsDatabaseService from "../../../Server/Services/AnalyticsDatabaseService";
+import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import logger from "../../../Server/Utils/Logger";
+import "../TestingUtils/Init";
+import KubernetesCostAllocation from "../../../Models/AnalyticsModels/KubernetesCostAllocation";
+import AggregateBy from "../../../Server/Types/AnalyticsDatabase/AggregateBy";
+import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import {
+  describe,
+  expect,
+  beforeEach,
+  test,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+/*
+ * Statement-generation regressions for the Kubernetes Costs pages.
+ *
+ * The project- and cluster-level Costs pages issue grouped `Total`
+ * (whole-window) aggregations over KubernetesCostAllocation. Under Total
+ * the timestamp is selected as `min(windowStart) as windowStart`, and
+ * ClickHouse substitutes SELECT aliases into same-level unqualified
+ * WHERE references — so the window filter `WHERE windowStart >= ...`
+ * compiled to `WHERE min(windowStart) >= ...` and every one of these
+ * queries failed with ILLEGAL_AGGREGATION ("Server Error" on the page).
+ * The WHERE must therefore be table-qualified; these tests pin the
+ * statement shapes the pages depend on.
+ */
+describe("KubernetesCostAllocation aggregate statements (Costs pages)", () => {
+  const TABLE_NAME: string = "KubernetesCostAllocationV1";
+
+  const projectId: string = "7b4157fc-c25d-41ea-aabc-972e0ee2c492";
+  const startDate: Date = new Date("2026-07-18T10:00:00.000Z");
+  const endDate: Date = new Date("2026-07-25T10:00:00.000Z");
+
+  let service: AnalyticsDatabaseService<KubernetesCostAllocation>;
+
+  beforeEach(() => {
+    service = new AnalyticsDatabaseService({
+      modelType: KubernetesCostAllocation,
+    });
+    jest.spyOn(logger, "debug").mockImplementation(() => {
+      return undefined!;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  type BuildAggregateByFunction = (
+    overrides?: Partial<AggregateBy<KubernetesCostAllocation>>,
+  ) => AggregateBy<KubernetesCostAllocation>;
+
+  /**
+   * Mirrors what the Costs pages send (see
+   * App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostUtils.ts
+   * buildAggregateBy): a project-scoped windowStart range, sorted
+   * ascending, LIMIT_PER_PROJECT.
+   */
+  const buildAggregateBy: BuildAggregateByFunction = (
+    overrides?: Partial<AggregateBy<KubernetesCostAllocation>>,
+  ): AggregateBy<KubernetesCostAllocation> => {
+    return {
+      query: {
+        projectId: projectId,
+        windowStart: new InBetween(startDate, endDate),
+      } as AggregateBy<KubernetesCostAllocation>["query"],
+      aggregationType: AggregationType.Sum,
+      aggregateColumnName: "totalCost",
+      aggregationTimestampColumnName: "windowStart",
+      startTimestamp: startDate,
+      endTimestamp: endDate,
+      limit: 10000,
+      skip: 0,
+      sort: {
+        windowStart: SortOrder.Ascending,
+      } as AggregateBy<KubernetesCostAllocation>["sort"],
+      props: { isRoot: true },
+      ...overrides,
+    };
+  };
+
+  type BuildResultFunction = (
+    aggregateBy: AggregateBy<KubernetesCostAllocation>,
+  ) => { query: string; params: Record<string, unknown> };
+
+  const build: BuildResultFunction = (
+    aggregateBy: AggregateBy<KubernetesCostAllocation>,
+  ): { query: string; params: Record<string, unknown> } => {
+    const result: { statement: Statement; columns: Array<string> } =
+      service.toAggregateStatement(aggregateBy);
+    return {
+      query: result.statement.query,
+      params: result.statement.query_params,
+    };
+  };
+
+  /**
+   * Every WHERE column reference must be qualified with the model table
+   * name — an unqualified reference would resolve to the SELECT alias.
+   */
+  type ExpectQualifiedWhereFunction = (
+    query: string,
+    params: Record<string, unknown>,
+    expectedColumns: Array<string>,
+  ) => void;
+
+  const expectQualifiedWhere: ExpectQualifiedWhereFunction = (
+    query: string,
+    params: Record<string, unknown>,
+    expectedColumns: Array<string>,
+  ): void => {
+    const qualifierTables: Array<unknown> = Object.entries(params)
+      .filter(([key]: [string, unknown]) => {
+        return key.endsWith("_t");
+      })
+      .map(([, value]: [string, unknown]) => {
+        return value;
+      });
+    const qualifierColumns: Array<unknown> = Object.entries(params)
+      .filter(([key]: [string, unknown]) => {
+        return key.endsWith("_c");
+      })
+      .map(([, value]: [string, unknown]) => {
+        return value;
+      });
+
+    expect(qualifierTables).toHaveLength(expectedColumns.length);
+    for (const table of qualifierTables) {
+      expect(table).toBe(TABLE_NAME);
+    }
+    expect([...qualifierColumns].sort()).toStrictEqual(
+      [...expectedColumns].sort(),
+    );
+    // The WHERE must not contain a single bare identifier reference.
+    expect(query).not.toMatch(/AND \{p\d+:Identifier\}/);
+  };
+
+  test("spend-by-cluster (grouped Total) keeps min(windowStart) and a qualified window filter", () => {
+    // fetchClusterBreakdown: sum(totalCost) grouped by clusterName, Total.
+    const { query, params } = build(
+      buildAggregateBy({
+        groupBy: {
+          clusterName: true,
+        } as AggregateBy<KubernetesCostAllocation>["groupBy"],
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+
+    expect(query).toContain("sum(totalCost) as totalCost");
+    expect(query).toContain("min(windowStart) as windowStart");
+    expect(query).not.toContain("date_trunc");
+
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+    ]);
+
+    // Grouped by the cluster column only — never by the Total timestamp.
+    expect(query).toContain("GROUP BY {p9:Identifier}");
+    expect(params["p9"]).toBe("clusterName");
+    // Grouped queries never carry the empty-window phantom-row guard.
+    expect(query).not.toContain("HAVING count() > 0");
+
+    /*
+     * ORDER BY / GROUP BY must stay UNqualified: they are meant to
+     * resolve to the SELECT aliases (a qualified ORDER BY would hit
+     * NOT_AN_AGGREGATE under GROUP BY).
+     */
+    expect(query).toMatch(/ORDER BY \{p\d+:Identifier\} ASC/);
+
+    expect(Object.values(params)).toContain(TABLE_NAME);
+    expect(Object.values(params)).toContain(projectId);
+  });
+
+  test("idle-spend variant adds a qualified namespace filter", () => {
+    // fetchClusterBreakdown's idle query: extraQuery namespace="__idle__".
+    const { query, params } = build(
+      buildAggregateBy({
+        query: {
+          projectId: projectId,
+          windowStart: new InBetween(startDate, endDate),
+          namespace: "__idle__",
+        } as AggregateBy<KubernetesCostAllocation>["query"],
+        groupBy: {
+          clusterName: true,
+        } as AggregateBy<KubernetesCostAllocation>["groupBy"],
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+
+    expect(query).toContain("min(windowStart) as windowStart");
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+      "namespace",
+    ]);
+    expect(Object.values(params)).toContain("__idle__");
+  });
+
+  test("efficiency variant (Avg over totalEfficiency) is qualified the same way", () => {
+    const { query, params } = build(
+      buildAggregateBy({
+        aggregateColumnName: "totalEfficiency",
+        aggregationType: AggregationType.Avg,
+        groupBy: {
+          clusterName: true,
+        } as AggregateBy<KubernetesCostAllocation>["groupBy"],
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+
+    expect(query).toContain("avg(totalEfficiency) as totalEfficiency");
+    expect(query).toContain("min(windowStart) as windowStart");
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+    ]);
+  });
+
+  test("namespace/workload breakdowns group by multiple columns under Total", () => {
+    // fetchWorkloadBreakdown groups by namespace + controllerKind + controllerName.
+    const { query, params } = build(
+      buildAggregateBy({
+        groupBy: {
+          namespace: true,
+          controllerKind: true,
+          controllerName: true,
+        } as AggregateBy<KubernetesCostAllocation>["groupBy"],
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+
+    expect(query).toContain("min(windowStart) as windowStart");
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+    ]);
+    const paramValues: Array<unknown> = Object.values(params);
+    expect(paramValues).toContain("namespace");
+    expect(paramValues).toContain("controllerKind");
+    expect(paramValues).toContain("controllerName");
+  });
+
+  test("cost-trend (bucketed) query is qualified and groups by the bucket alias", () => {
+    // fetchCostTrend: no groupBy, interval derived from the 7-day window.
+    const { query, params } = build(buildAggregateBy());
+
+    // A 7-day window derives an Hour bucket.
+    expect(query).toContain(
+      "date_trunc('hour', toStartOfInterval(windowStart, INTERVAL 1 hour)) as windowStart",
+    );
+    expect(query).not.toContain("min(windowStart)");
+
+    /*
+     * The window filter must read the RAW windowStart column. Before
+     * qualification the bucket alias was substituted into WHERE, which
+     * silently snapped the window edges to bucket boundaries.
+     */
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+    ]);
+
+    // The GROUP BY targets the bucket alias — bare, never qualified.
+    expect(query).toContain("GROUP BY windowStart");
+    expect(query).toMatch(/ORDER BY \{p\d+:Identifier\} ASC/);
+  });
+
+  test("cluster-scoped queries (cluster view page) qualify the kubernetesClusterId filter", () => {
+    const clusterId: string = "0a1b2c3d-0000-0000-0000-000000000000";
+    const { query, params } = build(
+      buildAggregateBy({
+        query: {
+          projectId: projectId,
+          windowStart: new InBetween(startDate, endDate),
+          kubernetesClusterId: clusterId,
+        } as AggregateBy<KubernetesCostAllocation>["query"],
+        groupBy: {
+          namespace: true,
+        } as AggregateBy<KubernetesCostAllocation>["groupBy"],
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+      "kubernetesClusterId",
+    ]);
+    expect(Object.values(params)).toContain(clusterId);
+  });
+
+  test("group-less Total keeps the qualified filter and the empty-window guard", () => {
+    const { query, params } = build(
+      buildAggregateBy({
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+
+    expect(query).toContain("min(windowStart) as windowStart");
+    expect(query).not.toContain("GROUP BY");
+    expect(query).toContain("HAVING count() > 0");
+    expectQualifiedWhere(query, params, [
+      "projectId",
+      "windowStart",
+      "windowStart",
+    ]);
+  });
+
+  test("the retention read filter stays a raw unaliased predicate", () => {
+    /*
+     * `retentionDate >= now()` is appended as raw SQL. No SELECT alias
+     * named retentionDate exists, so it needs no qualification — but it
+     * must be present on every aggregate read.
+     */
+    const { query } = build(
+      buildAggregateBy({
+        groupBy: {
+          clusterName: true,
+        } as AggregateBy<KubernetesCostAllocation>["groupBy"],
+        aggregationInterval: AggregationInterval.Total,
+      }),
+    );
+    expect(query).toContain("retentionDate >= now()");
+  });
+});

--- a/Common/Tests/Server/Services/MetricServiceAggregate.test.ts
+++ b/Common/Tests/Server/Services/MetricServiceAggregate.test.ts
@@ -372,6 +372,148 @@ describe("MetricService aggregate statement generation", () => {
   });
 
   /*
+   * WHERE table qualification. The scalar and mutable builders alias
+   * aggregates to real column names (`<agg> as value`, `min(time) as
+   * time` under Total) at the same level as their WHERE clause, and
+   * ClickHouse substitutes SELECT aliases into same-level unqualified
+   * WHERE references — a Total metric aggregation therefore compiled to
+   * `WHERE min(time) >= ...` (ILLEGAL_AGGREGATION). The WHERE must
+   * reference `MetricItemV3.time` / the dedup-subquery alias instead.
+   */
+  describe("WHERE table qualification", () => {
+    type QualifierValues = (result: {
+      statement: Statement;
+      columns: Array<string>;
+    }) => Array<unknown>;
+    const qualifierValues: QualifierValues = (result: {
+      statement: Statement;
+      columns: Array<string>;
+    }): Array<unknown> => {
+      return Object.entries(result.statement.query_params)
+        .filter(([key]: [string, unknown]) => {
+          return key.endsWith("_t");
+        })
+        .map(([, value]: [string, unknown]) => {
+          return value;
+        });
+    };
+
+    it("qualifies the base scalar path with the Metric table name", () => {
+      // An attribute filter blocks the MVs and routes to the base table.
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(
+          buildAggregateBy({
+            query: {
+              projectId: projectId,
+              name: "http.client.request.duration",
+              time: new InBetween(startDate, endDate),
+              attributes: { "oneuptime.service.name": "starship-web" },
+            } as unknown as AggregateBy<Metric>["query"],
+          }),
+        );
+      const query: string = result.statement.query;
+
+      expect(query).toMatch(
+        /\{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} >= \{p\d+:DateTime64\(9\)\}/,
+      );
+      const qualifiers: Array<unknown> = qualifierValues(result);
+      expect(qualifiers.length).toBeGreaterThan(0);
+      for (const qualifier of qualifiers) {
+        expect(qualifier).toBe("MetricItemV3");
+      }
+    });
+
+    it("keeps min(time) valid on the direct (non-subquery) scalar form under Total", () => {
+      /*
+       * Distribution hint + no attribute grouping = the SELECT aliases
+       * and the WHERE share one query level — the exact shape that
+       * failed with ILLEGAL_AGGREGATION before qualification.
+       */
+      const aggregateBy: AggregateBy<Metric> = buildAggregateBy({
+        aggregationInterval: AggregationInterval.Total,
+        query: {
+          projectId: projectId,
+          name: "http.client.request.duration",
+          time: new InBetween(startDate, endDate),
+          attributes: { "oneuptime.service.name": "starship-web" },
+        } as unknown as AggregateBy<Metric>["query"],
+      });
+
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(aggregateBy);
+      const query: string = result.statement.query;
+
+      expect(query).toContain("min(time) as time");
+      expect(query).toMatch(
+        /\{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} >= \{p\d+:DateTime64\(9\)\}/,
+      );
+      for (const qualifier of qualifierValues(result)) {
+        expect(qualifier).toBe("MetricItemV3");
+      }
+    });
+
+    it("leaves the minute-MV fast path unqualified (different table, no alias capture)", () => {
+      /*
+       * The MV statement filters on bucketTime/projectId/name against
+       * MetricItemAggMV1m — qualifying with the base table name would
+       * be invalid there, and its SELECT aliases shadow no MV column.
+       */
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(buildAggregateBy());
+
+      expect(result.statement.query).toContain("MetricItemAggMV1m");
+      expect(qualifierValues(result)).toHaveLength(0);
+    });
+
+    it("qualifies the mutable-metric outer WHERE with the dedup subquery alias", () => {
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(
+          buildAggregateBy({
+            query: {
+              projectId: projectId,
+              name: "oneuptime.incident.count",
+              time: new InBetween(startDate, endDate),
+            } as AggregateBy<Metric>["query"],
+          }),
+        );
+      const query: string = result.statement.query;
+
+      // The argMax dedup subquery must carry the alias the WHERE uses.
+      expect(query).toContain(") AS mutable_metric_latest");
+      expect(query).toMatch(
+        /\{p\d+_t:Identifier\}\.\{p\d+_c:Identifier\} >= \{p\d+:DateTime64\(9\)\}/,
+      );
+      for (const qualifier of qualifierValues(result)) {
+        expect(qualifier).toBe("mutable_metric_latest");
+      }
+    });
+
+    it("keeps min(time) valid on the mutable path under Total", () => {
+      const result: { statement: Statement; columns: Array<string> } =
+        service.toAggregateStatement(
+          buildAggregateBy({
+            aggregationInterval: AggregationInterval.Total,
+            query: {
+              projectId: projectId,
+              name: "oneuptime.incident.count",
+              time: new InBetween(startDate, endDate),
+            } as AggregateBy<Metric>["query"],
+          }),
+        );
+      const query: string = result.statement.query;
+
+      expect(query).toContain("min(time) as time");
+      expect(query).toContain(") AS mutable_metric_latest");
+      // Group-less Total: no time grouping, phantom row suppressed.
+      expect(query).not.toContain("GROUP BY time");
+      expect(query).toContain("HAVING count() > 0");
+      for (const qualifier of qualifierValues(result)) {
+        expect(qualifier).toBe("mutable_metric_latest");
+      }
+    });
+  });
+
+  /*
    * The sub-hour tiers (FiveMinutes/FifteenMinutes/ThirtyMinutes) are NOT
    * valid ClickHouse date_trunc units — they must compile through the
    * shared AggregateUtil expression map to `toStartOfInterval(col,

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/Statement.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/Statement.test.ts
@@ -1,4 +1,5 @@
 import {
+  QualifiedColumn,
   SQL,
   Statement,
 } from "../../../../Server/Utils/AnalyticsDatabase/Statement";
@@ -50,6 +51,27 @@ describe("Statement", () => {
         p0: "table",
         p1: 123,
         p2: "<text>",
+      });
+    });
+
+    test("should bind a QualifiedColumn as a table.column identifier pair", () => {
+      /*
+       * The qualifier and the column must be two separate Identifier
+       * params — a dotted string bound as one Identifier is treated by
+       * ClickHouse as a single quoted identifier, not a qualified
+       * reference.
+       */
+      const statement: Statement = SQL`SELECT col FROM tbl WHERE ${new QualifiedColumn(
+        "tbl",
+        "col",
+      )} = ${{ value: "<text>", type: TableColumnType.Text }}`;
+      expect(statement.query).toBe(
+        "SELECT col FROM tbl WHERE {p0_t:Identifier}.{p0_c:Identifier} = {p1:String}",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0_t: "tbl",
+        p0_c: "col",
+        p1: "<text>",
       });
     });
 

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
@@ -18,10 +18,13 @@ import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
 import IsNull from "../../../../Types/BaseDatabase/IsNull";
 import NotNull from "../../../../Types/BaseDatabase/NotNull";
 import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../../Types/BaseDatabase/Includes";
 import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
+import MultiSearch from "../../../../Types/BaseDatabase/MultiSearch";
 import Search from "../../../../Types/BaseDatabase/Search";
 import StartsWith from "../../../../Types/BaseDatabase/StartsWith";
+import BadDataException from "../../../../Types/Exception/BadDataException";
 
 function expectStatement(actual: Statement, expected: Statement): void {
   expect(actual.query).toBe(expected.query);
@@ -190,6 +193,33 @@ describe("StatementGenerator", () => {
         p1: "<value>",
         p2: "createdAt",
         p3: OneUptimeDate.toClickhouseDateTime(date),
+      });
+    });
+
+    test("table-qualifies every column reference when tableAlias is set", () => {
+      /*
+       * Aggregate statements alias expressions to real column names
+       * (`sum(col) as col`), and ClickHouse substitutes those aliases
+       * into same-level unqualified WHERE references. Qualified
+       * references always resolve to the table column.
+       */
+      const statement: Statement = generator.toWhereStatement(
+        {
+          _id: "<value>",
+          column_1: "<text>",
+        } as any,
+        { tableAlias: "<table-name>" },
+      );
+      expect(statement.query).toBe(
+        "AND {p0_t:Identifier}.{p0_c:Identifier} = {p1:String} AND {p2_t:Identifier}.{p2_c:Identifier} = {p3:String}",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0_t: "<table-name>",
+        p0_c: "_id",
+        p1: "<value>",
+        p2_t: "<table-name>",
+        p2_c: "column_1",
+        p3: "<text>",
       });
     });
 
@@ -922,6 +952,380 @@ describe("StatementGenerator", () => {
           p0: "entityKeys",
           p1: ["210dac24142f1baa"],
         });
+      });
+    });
+
+    /*
+     * Table qualification (tableAlias option). Aggregate statements
+     * alias expressions to real column names (`sum(col) as col`, and
+     * `min(ts) as ts` under Total), and ClickHouse substitutes those
+     * SELECT aliases into same-level unqualified WHERE references —
+     * which injects an aggregate into WHERE (ILLEGAL_AGGREGATION; this
+     * 500'd the Kubernetes Costs page) or silently changes the filter.
+     * Table-qualified references always resolve to the real column, so
+     * every operator branch must qualify when the option is set.
+     */
+    describe("table qualification (tableAlias)", () => {
+      class QualModel extends AnalyticsBaseModel {
+        public constructor() {
+          super({
+            tableName: "<qual-table>",
+            singularName: "<singular>",
+            pluralName: "<plural>",
+            tableColumns: [
+              new AnalyticsTableColumn({
+                key: "_id",
+                title: "<title>",
+                description: "<description>",
+                required: true,
+                type: TableColumnType.ObjectID,
+              }),
+              new AnalyticsTableColumn({
+                key: "text_col",
+                title: "<title>",
+                description: "<description>",
+                required: false,
+                type: TableColumnType.Text,
+              }),
+              new AnalyticsTableColumn({
+                key: "num_col",
+                title: "<title>",
+                description: "<description>",
+                required: false,
+                type: TableColumnType.Number,
+              }),
+              new AnalyticsTableColumn({
+                key: "time_col",
+                title: "<title>",
+                description: "<description>",
+                required: false,
+                type: TableColumnType.DateTime64,
+              }),
+              new AnalyticsTableColumn({
+                key: "arr_col",
+                title: "<title>",
+                description: "<description>",
+                required: false,
+                defaultValue: [],
+                type: TableColumnType.ArrayText,
+              }),
+              new AnalyticsTableColumn({
+                key: "json_col",
+                title: "<title>",
+                description: "<description>",
+                required: false,
+                type: TableColumnType.JSON,
+              }),
+              new AnalyticsTableColumn({
+                key: "attrKeys",
+                title: "<title>",
+                description: "<description>",
+                required: true,
+                defaultValue: [],
+                type: TableColumnType.ArrayText,
+              }),
+              new AnalyticsTableColumn({
+                key: "attributes",
+                title: "<title>",
+                description: "<description>",
+                required: true,
+                defaultValue: {},
+                type: TableColumnType.MapStringString,
+                mapKeysColumn: "attrKeys",
+              }),
+              new AnalyticsTableColumn({
+                key: "entityKeys",
+                title: "<title>",
+                description: "<description>",
+                required: true,
+                defaultValue: [],
+                type: TableColumnType.ArrayText,
+              }),
+            ],
+            crudApiPath: new Route("route"),
+            primaryKeys: ["_id"],
+            sortKeys: ["_id"],
+            partitionKey: "_id",
+            tableEngine: AnalyticsTableEngine.MergeTree,
+          });
+        }
+      }
+
+      const ALIAS: string = "<qual-table>";
+
+      let qualGenerator: StatementGenerator<QualModel>;
+      beforeEach(() => {
+        qualGenerator = new StatementGenerator<QualModel>({
+          modelType: QualModel,
+          database: ClickhouseAppInstance,
+        });
+      });
+
+      type QualifiedWhere = (query: Record<string, unknown>) => Statement;
+      const qualifiedWhere: QualifiedWhere = (
+        query: Record<string, unknown>,
+      ): Statement => {
+        return qualGenerator.toWhereStatement(query as any, {
+          tableAlias: ALIAS,
+        });
+      };
+
+      /**
+       * Every `pN_t` qualifier param must carry the table alias, and the
+       * set of qualified column names must be exactly `expectedColumns`
+       * (order-insensitive, duplicates preserved).
+       */
+      type ExpectQualifiers = (
+        statement: Statement,
+        expectedColumns: Array<string>,
+      ) => void;
+      const expectQualifiers: ExpectQualifiers = (
+        statement: Statement,
+        expectedColumns: Array<string>,
+      ): void => {
+        const params: Record<string, unknown> = statement.query_params;
+        const tableEntries: Array<unknown> = Object.entries(params)
+          .filter(([key]: [string, unknown]) => {
+            return key.endsWith("_t");
+          })
+          .map(([, value]: [string, unknown]) => {
+            return value;
+          });
+        const columnEntries: Array<unknown> = Object.entries(params)
+          .filter(([key]: [string, unknown]) => {
+            return key.endsWith("_c");
+          })
+          .map(([, value]: [string, unknown]) => {
+            return value;
+          });
+
+        expect(tableEntries).toHaveLength(expectedColumns.length);
+        for (const table of tableEntries) {
+          expect(table).toBe(ALIAS);
+        }
+        expect([...columnEntries].sort()).toStrictEqual(
+          [...expectedColumns].sort(),
+        );
+        // No unqualified bare-identifier column references may remain.
+        expect(statement.query).not.toMatch(/AND \{p\d+:Identifier\}/);
+      };
+
+      test("qualifies bare equality", () => {
+        const statement: Statement = qualifiedWhere({ _id: "<value>" });
+        expect(statement.query).toBe(
+          "AND {p0_t:Identifier}.{p0_c:Identifier} = {p1:String}",
+        );
+        expect(statement.query_params).toStrictEqual({
+          p0_t: ALIAS,
+          p0_c: "_id",
+          p1: "<value>",
+        });
+      });
+
+      test("qualifies scalar comparison operators", () => {
+        const statement: Statement = qualifiedWhere({
+          text_col: new NotEqual("<x>"),
+          num_col: new GreaterThan(5),
+        });
+        expect(statement.query).toBe(
+          "AND {p0_t:Identifier}.{p0_c:Identifier} != {p1:String} " +
+            "AND {p2_t:Identifier}.{p2_c:Identifier} > {p3:Int32}",
+        );
+        expectQualifiers(statement, ["text_col", "num_col"]);
+      });
+
+      test("qualifies both bounds of an InBetween (the costs-page window filter)", () => {
+        const start: Date = new Date("2026-07-18T10:00:00.000Z");
+        const end: Date = new Date("2026-07-25T10:00:00.000Z");
+        const statement: Statement = qualifiedWhere({
+          time_col: new InBetween(start, end),
+        });
+        expect(statement.query).toBe(
+          "AND {p0_t:Identifier}.{p0_c:Identifier} >= {p1:DateTime64(9)} " +
+            "AND {p2_t:Identifier}.{p2_c:Identifier} <= {p3:DateTime64(9)}",
+        );
+        expectQualifiers(statement, ["time_col", "time_col"]);
+      });
+
+      test("qualifies ILIKE search", () => {
+        const statement: Statement = qualifiedWhere({
+          text_col: new Search("needle"),
+        });
+        expect(statement.query).toBe(
+          "AND {p0_t:Identifier}.{p0_c:Identifier} ILIKE {p1:String}",
+        );
+        expectQualifiers(statement, ["text_col"]);
+      });
+
+      test("qualifies scalar IN / NOT IN", () => {
+        const statement: Statement = qualifiedWhere({
+          text_col: new Includes(["a", "b"]),
+        });
+        expect(statement.query).toBe(
+          "AND {p0_t:Identifier}.{p0_c:Identifier} IN {p1:Array(String)}",
+        );
+        expectQualifiers(statement, ["text_col"]);
+
+        const exclusion: Statement = qualifiedWhere({
+          text_col: new IncludesNone(["a", "b"]),
+        });
+        expect(exclusion.query).toBe(
+          "AND {p0_t:Identifier}.{p0_c:Identifier} NOT IN {p1:Array(String)}",
+        );
+        expectQualifiers(exclusion, ["text_col"]);
+      });
+
+      test("qualifies hasAny membership on ArrayText columns", () => {
+        const statement: Statement = qualifiedWhere({
+          arr_col: new Includes(["k1"]),
+        });
+        expect(statement.query).toBe(
+          "AND hasAny({p0_t:Identifier}.{p0_c:Identifier}, {p1:Array(String)})",
+        );
+        expectQualifiers(statement, ["arr_col"]);
+
+        const exclusion: Statement = qualifiedWhere({
+          arr_col: new IncludesNone(["k1"]),
+        });
+        expect(exclusion.query).toBe(
+          "AND NOT hasAny({p0_t:Identifier}.{p0_c:Identifier}, {p1:Array(String)})",
+        );
+        expectQualifiers(exclusion, ["arr_col"]);
+      });
+
+      test("qualifies both references of a Text IS NULL check", () => {
+        const statement: Statement = qualifiedWhere({
+          text_col: new IsNull(),
+        });
+        expect(statement.query).toBe(
+          "AND ({p0_t:Identifier}.{p0_c:Identifier} IS NULL OR {p1_t:Identifier}.{p1_c:Identifier} = '')",
+        );
+        expectQualifiers(statement, ["text_col", "text_col"]);
+      });
+
+      test("qualifies map subscripts and the key-presence prefilter", () => {
+        const statement: Statement = qualifiedWhere({
+          attributes: { "service.name": "web" },
+        });
+        /*
+         * The presence prefilter reads the denormalized `attrKeys`
+         * column and must be qualified too — it is part of the same
+         * WHERE level as the aggregate aliases.
+         */
+        expect(statement.query).toBe(
+          "AND (empty({p0_t:Identifier}.{p0_c:Identifier}) OR hasAny({p1_t:Identifier}.{p1_c:Identifier}, {p2:Array(String)})) " +
+            "AND {p3_t:Identifier}.{p3_c:Identifier}[{p4:String}] = {p5:String}",
+        );
+        expectQualifiers(statement, ["attrKeys", "attrKeys", "attributes"]);
+      });
+
+      test("qualifies map numeric comparisons", () => {
+        const statement: Statement = qualifiedWhere({
+          attributes: { latency: new GreaterThan(100) },
+        });
+        expect(statement.query).toBe(
+          "AND (empty({p0_t:Identifier}.{p0_c:Identifier}) OR hasAny({p1_t:Identifier}.{p1_c:Identifier}, {p2:Array(String)})) " +
+            "AND toFloat64OrNull({p3_t:Identifier}.{p3_c:Identifier}[{p4:String}]) > {p5:Int32}",
+        );
+        expectQualifiers(statement, ["attrKeys", "attrKeys", "attributes"]);
+      });
+
+      test("qualifies map null checks", () => {
+        const isNull: Statement = qualifiedWhere({
+          attributes: { k: new IsNull() },
+        });
+        expect(isNull.query).toBe(
+          "AND ((NOT mapContains({p0_t:Identifier}.{p0_c:Identifier}, {p1:String})) OR {p2_t:Identifier}.{p2_c:Identifier}[{p3:String}] = '')",
+        );
+        expectQualifiers(isNull, ["attributes", "attributes"]);
+
+        const notNull: Statement = qualifiedWhere({
+          attributes: { k: new NotNull() },
+        });
+        expect(notNull.query).toBe(
+          "AND (empty({p0_t:Identifier}.{p0_c:Identifier}) OR hasAny({p1_t:Identifier}.{p1_c:Identifier}, {p2:Array(String)})) " +
+            "AND mapContains({p3_t:Identifier}.{p3_c:Identifier}, {p4:String}) AND {p5_t:Identifier}.{p5_c:Identifier}[{p6:String}] != ''",
+        );
+        expectQualifiers(notNull, [
+          "attrKeys",
+          "attrKeys",
+          "attributes",
+          "attributes",
+        ]);
+      });
+
+      test("qualifies the case-insensitive arrayExists search over map keys/values", () => {
+        const statement: Statement = qualifiedWhere({
+          attributes: { k: new Search("needle") },
+        });
+        expect(statement.query).toBe(
+          "AND arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8({p0:String}) AND v ILIKE {p1:String}, " +
+            "mapKeys({p2_t:Identifier}.{p2_c:Identifier}), mapValues({p3_t:Identifier}.{p3_c:Identifier}))",
+        );
+        expectQualifiers(statement, ["attributes", "attributes"]);
+      });
+
+      test("qualifies JSON extraction filters", () => {
+        const statement: Statement = qualifiedWhere({
+          json_col: { field: "<v>", flag: true, count: 3 },
+        });
+        // JSON-extract fragments append back-to-back with no separator.
+        expect(statement.query).toBe(
+          "AND JSONExtractString({p0_t:Identifier}.{p0_c:Identifier}, {p1:String}) = {p2:String}" +
+            "AND JSONExtractBool({p3_t:Identifier}.{p3_c:Identifier}, {p4:String}) = {p5:Bool}" +
+            "AND JSONExtractInt({p6_t:Identifier}.{p6_c:Identifier}, {p7:String}) = {p8:Int32}",
+        );
+        expectQualifiers(statement, ["json_col", "json_col", "json_col"]);
+      });
+
+      test("qualifies every column of a MultiSearch fan-out", () => {
+        const statement: Statement = qualifiedWhere({
+          multiSearch: new MultiSearch({
+            fields: ["text_col", "num_col"],
+            value: "needle",
+          }),
+        });
+        // The search value binds with each column's own type (num_col → Int32).
+        expect(statement.query).toBe(
+          "AND ({p0_t:Identifier}.{p0_c:Identifier} ILIKE {p1:String} OR {p2_t:Identifier}.{p2_c:Identifier} ILIKE {p3:Int32})",
+        );
+        expectQualifiers(statement, ["text_col", "num_col"]);
+      });
+
+      test("qualifies both sides of the entityScope OR-fallback", () => {
+        const statement: Statement = qualifiedWhere({
+          entityScope: {
+            entityKeys: ["210dac24142f1baa"],
+            attributeKey: "resource.host.name",
+            attributeValue: "web-1",
+          },
+        });
+        expect(statement.query).toBe(
+          "AND (hasAny({p0_t:Identifier}.{p0_c:Identifier}, {p1:Array(String)}) OR {p2_t:Identifier}.{p2_c:Identifier}[{p3:String}] = {p4:String})",
+        );
+        expectQualifiers(statement, ["entityKeys", "attributes"]);
+      });
+
+      test("omitting the option produces the exact unqualified statement", () => {
+        const query: Record<string, unknown> = {
+          _id: "<value>",
+          attributes: { "service.name": "web" },
+        };
+        const unqualified: Statement = qualGenerator.toWhereStatement(
+          query as any,
+        );
+        expect(unqualified.query).not.toContain("_t:Identifier");
+        expect(unqualified.query).toBe(
+          "AND {p0:Identifier} = {p1:String} " +
+            "AND (empty({p2:Identifier}) OR hasAny({p3:Identifier}, {p4:Array(String)})) " +
+            "AND {p5:Identifier}[{p6:String}] = {p7:String}",
+        );
+      });
+
+      test("still rejects unknown columns when qualifying", () => {
+        expect(() => {
+          return qualifiedWhere({ nonexistent: "<value>" });
+        }).toThrow(BadDataException);
       });
     });
   });


### PR DESCRIPTION
## Problem

The Kubernetes **Costs** pages (`/kubernetes/costs` and the per-cluster Costs tab) showed **Server Error**. Every one of their cluster/namespace/workload breakdown queries — grouped `Total` (whole-window) aggregations over `KubernetesCostAllocation` — returned a 500.

Root cause (reproduced byte-exact against the dev deployment and ClickHouse 26.7): under `Total` the timestamp is selected as `min(windowStart) as windowStart`, and **ClickHouse substitutes SELECT aliases into same-level unqualified WHERE references**. The window filter compiled to `WHERE min(windowStart) >= ...` → `ILLEGAL_AGGREGATION`.

The same alias capture also:
- silently snapped bucketed time filters to bucket boundaries (`date_trunc` alias captured the window-edge comparison — verified with a discriminating row on a real MergeTree table), and
- broke any `Total` **metric** aggregation the same way (scalar and mutable-metric builders share the shape).

## Fix

- `QualifiedColumn` statement parameter: binds `table.column` as **two** Identifier params (a dotted string bound as one Identifier param is treated as a single quoted identifier).
- `StatementGenerator.toWhereStatement(query, { tableAlias })`: qualifies **every** column reference — scalar operators, `InBetween`, `IN`/`NOT IN`, `hasAny`, `IS NULL`, map subscripts + key-presence prefilters, `arrayExists` searches, `MultiSearch`, `entityScope`, JSON extraction.
- Opt-ins from builders whose SELECT aliases share a query level with their WHERE: the generic `toAggregateStatement`, the Metric scalar builder, and the mutable-metric builder (its argMax-dedup subquery is now aliased `mutable_metric_latest`).
- MV fast paths and cascade deletes stay unqualified — they embed the WHERE against different tables and have no alias collisions.

Default behavior (no option) is byte-identical to before.

## Verification

- Replayed the page's exact four aggregate calls against the dev API to isolate the failing shape (grouped `Total`), then executed the **exact generated statements** (named params and all) against ClickHouse 26.7 with seeded data: correct per-group sums, idle-namespace variant, out-of-window/other-project rows excluded, `min()` earliest-in-window labels, empty-window phantom row suppressed, and bucketed edges now filtering raw timestamps.
- New regression suites: statement-level `QualifiedColumn`, an operator-matrix qualification suite for `toWhereStatement`, service-level aggregate assertions, Metric scalar/MV/mutable qualification tests, and a dedicated `KubernetesCostAllocationAggregate` suite pinning the exact Costs-page statement shapes.
- `Common`: 8311 tests passing (the only failing suites load `isolated-vm`, a pre-existing local ABI issue unrelated to this change); `tsc` clean; `npm run fix` clean.