### PR TITLE
fix(kubernetes-cost): make cost.enabled=true work end to end

### DIFF
--- a/Common/Types/Kubernetes/KubernetesCostIngest.ts
+++ b/Common/Types/Kubernetes/KubernetesCostIngest.ts
@@ -5,6 +5,10 @@
  * `/model/allocation`). One request carries one cluster's allocation rows
  * for one or more closed time windows.
  *
+ * The route is mounted under both "/telemetry" and "/" (TELEMETRY_PREFIXES).
+ * The agent posts to the "/telemetry" prefix — see the note in
+ * KubernetesCostAgent/Shipper.ts for why.
+ *
  * The agent projects are standalone (no dependency on Common), so the
  * poller carries its own mirror of these interfaces
  * (KubernetesCostAgent/Types.ts) — keep the two in sync.

--- a/HelmChart/Public/kubernetes-agent/templates/NOTES.txt
+++ b/HelmChart/Public/kubernetes-agent/templates/NOTES.txt
@@ -52,6 +52,14 @@ The agent is now collecting:
 {{- if .Values.coreDns.enabled }}
   - CoreDNS metrics (query rate, latency, cache hits, errors)
 {{- end }}
+{{- if .Values.cost.enabled }}
+{{- if .Values.cost.agent.enabled }}
+  - Per-workload cost allocations (cpu/ram/gpu/pv/network/idle spend and efficiency) from {{ if eq (include "kubernetes-agent.costEngineBundled" .) "true" }}the bundled OpenCost engine{{ else }}the cost engine at {{ .Values.cost.engine.url }}{{ end }} — the first closed hourly window lands within the hour
+{{- end }}
+{{- if .Values.cost.metrics.enabled }}
+  - Raw cost metrics (node hourly cost, container allocation, PV and load balancer cost) for Metric Explorer and the Kubernetes Cost dashboard
+{{- end }}
+{{- end }}
 {{- if .Values.preset }}
 
 Preset: {{ .Values.preset }}

--- a/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cost-agent
-          image: "{{ .Values.cost.agent.image.repository }}:{{ .Values.cost.agent.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.cost.agent.image.repository }}:{{ .Values.cost.agent.image.tag | default "release" }}"
           imagePullPolicy: {{ .Values.cost.agent.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/HelmChart/Public/kubernetes-agent/templates/deployment-logs-api.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-logs-api.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: log-tailer
-          image: "{{ .Values.logs.api.image.repository }}:{{ .Values.logs.api.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.logs.api.image.repository }}:{{ .Values.logs.api.image.tag | default "release" }}"
           imagePullPolicy: {{ .Values.logs.api.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/HelmChart/Public/kubernetes-agent/values.yaml
+++ b/HelmChart/Public/kubernetes-agent/values.yaml
@@ -386,9 +386,11 @@ logs:
   api:
     image:
       repository: oneuptime/kubernetes-log-tailer
-      # Leave empty to track the chart's appVersion — set at release time to
-      # the OneUptime product version (the release pipeline publishes
-      # oneuptime/kubernetes-log-tailer with the same tag). Override to pin.
+      # Leave empty to track `release` — the moving tag the release pipeline
+      # republishes for every OneUptime version. Set this to a version
+      # (e.g. "11.6.1") to pin. Do NOT expect the chart's appVersion to work
+      # as a tag: nothing bumps it at release time, so it names no
+      # published image.
       tag: ""
       pullPolicy: IfNotPresent
     replicas: 1
@@ -649,6 +651,9 @@ cost:
     enabled: true
     image:
       repository: oneuptime/kubernetes-cost-agent
+      # Leave empty to track `release` — the moving tag the release pipeline
+      # republishes for every OneUptime version. Set this to a version
+      # (e.g. "11.6.1") to pin.
       tag: ""
       pullPolicy: IfNotPresent
     # Allocation window length. Hourly is the engines' native ETL

--- a/KubernetesCostAgent/CostEngineClient.ts
+++ b/KubernetesCostAgent/CostEngineClient.ts
@@ -17,6 +17,22 @@ const CANDIDATE_PATHS: Array<string> = [
   "/allocation",
 ];
 
+/*
+ * RFC3339 to the SECOND — no fractional part. Both engines parse the
+ * `window` bound with a fixed set of layouts and none of them accept
+ * milliseconds, so a raw Date.toISOString() (which always emits `.sssZ`)
+ * is rejected outright:
+ *
+ *   HTTP 400 Invalid 'window' parameter: illegal window:
+ *     2026-07-25T16:00:00.000Z,2026-07-25T17:00:00.000Z
+ *
+ * Windows are floored to the window grid by the poller, so truncating the
+ * millisecond field never loses information.
+ */
+const toEngineTimestamp: (date: Date) => string = (date: Date): string => {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+};
+
 export class CostEngineClient {
   /** Detected (or configured) allocation path; null until first success. */
   private allocationPath: string | null = COST_ALLOCATION_PATH || null;
@@ -34,7 +50,7 @@ export class CostEngineClient {
     windowStart: Date;
     windowEnd: Date;
   }): Promise<Array<EngineAllocation>> {
-    const window: string = `${data.windowStart.toISOString()},${data.windowEnd.toISOString()}`;
+    const window: string = `${toEngineTimestamp(data.windowStart)},${toEngineTimestamp(data.windowEnd)}`;
 
     const paths: Array<string> = this.allocationPath
       ? [this.allocationPath]

--- a/KubernetesCostAgent/Shipper.ts
+++ b/KubernetesCostAgent/Shipper.ts
@@ -21,8 +21,16 @@ const sleep: (ms: number) => Promise<void> = (ms: number): Promise<void> => {
 };
 
 export class Shipper {
+  /*
+   * The server mounts this route under both "/telemetry" and "/". Post to
+   * the "/telemetry" prefix: it is the one every OneUptime ingress has
+   * routed to the app since the OTLP endpoints shipped, so the agent
+   * reaches instances whose reverse proxy has no /kubernetes-cost location
+   * yet (on a billing-enabled deployment the catch-all serves the
+   * marketing site, and a root-path POST 404s there).
+   */
   private readonly endpoint: URL = new URL(
-    `${ONEUPTIME_URL}/kubernetes-cost/ingest`,
+    `${ONEUPTIME_URL}/telemetry/kubernetes-cost/ingest`,
   );
 
   private lastShipOk: number = 0;

--- a/KubernetesCostAgent/Tests/CostEngineClient.test.ts
+++ b/KubernetesCostAgent/Tests/CostEngineClient.test.ts
@@ -124,9 +124,13 @@ test("sends window, accumulate and includeIdle query params", async (): Promise<
   await client.fetchAllocations(WINDOW);
 
   const url: URL = new URL(`http://x${capturedUrl}`);
+  /*
+   * Second precision, not Date.toISOString()'s millisecond form — the
+   * engines answer HTTP 400 "illegal window" for a fractional bound.
+   */
   assert.strictEqual(
     url.searchParams.get("window"),
-    "2026-07-24T10:00:00.000Z,2026-07-24T11:00:00.000Z",
+    "2026-07-24T10:00:00Z,2026-07-24T11:00:00Z",
   );
   assert.strictEqual(url.searchParams.get("accumulate"), "true");
   assert.strictEqual(url.searchParams.get("includeIdle"), "true");

--- a/KubernetesCostAgent/Tests/Shipper.test.ts
+++ b/KubernetesCostAgent/Tests/Shipper.test.ts
@@ -9,7 +9,8 @@ import {
 } from "../Types";
 
 /*
- * Local HTTP stub playing OneUptime's /kubernetes-cost/ingest endpoint.
+ * Local HTTP stub playing OneUptime's /telemetry/kubernetes-cost/ingest
+ * endpoint.
  * TestEnv pins SHIP_BATCH_SIZE=2 and EXPORT_MAX_RETRIES=2 so chunking and
  * retry exhaustion are testable with tiny inputs and sub-second backoffs.
  */
@@ -94,7 +95,7 @@ test("ships rows chunked at SHIP_BATCH_SIZE with cluster, currency and token", a
   );
 
   for (const request of recorded) {
-    assert.strictEqual(request.path, "/kubernetes-cost/ingest");
+    assert.strictEqual(request.path, "/telemetry/kubernetes-cost/ingest");
     assert.strictEqual(request.token, "test-ingestion-key");
     assert.strictEqual(request.payload.clusterName, "test-cluster");
     assert.strictEqual(request.payload.currency, "USD");

--- a/Nginx/default.conf.template
+++ b/Nginx/default.conf.template
@@ -644,6 +644,26 @@ ${PROVISION_SSL_CERTIFICATE_KEY_DIRECTIVE}
         proxy_pass ${BACKEND_APP_TARGET};
     }
 
+    # Kubernetes cost-allocation ingestion endpoint, posted to by the
+    # kubernetes-agent chart's cost poller. Needs its own location for the
+    # same reason /otlp and /pyroscope do: with BILLING_ENABLED=true the
+    # catch-all `location /` proxies to the marketing Home service, so a
+    # root-path ingest would 404 instead of reaching the app.
+    location /kubernetes-cost {
+        resolver ${NGINX_RESOLVER} valid=30s;
+        set $backend_app http://${SERVER_APP_HOSTNAME}:${APP_PORT};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Reuse pooled upstream connections for this high-volume ingest path.
+        proxy_http_version 1.1;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_pass ${BACKEND_APP_TARGET};
+    }
+
     # Pyroscope profiling ingestion endpoint
     location /pyroscope {
         resolver ${NGINX_RESOLVER} valid=30s;


### PR DESCRIPTION
Found by deploying the `kubernetes-agent` chart with `--set cost.enabled=true` against a real 3-node DigitalOcean cluster and following the data. It produced **zero cost rows**. Three independent defects, each fatal on its own.

## 1. The poller never got a single allocation

`Date.toISOString()` always emits milliseconds, and neither OpenCost nor Kubecost accepts a fractional RFC3339 bound in the Allocation API. Every fetch, on every candidate path, failed:

```
HTTP 400 Invalid 'window' parameter: illegal window:
  2026-07-25T16:00:00.000Z,2026-07-25T17:00:00.000Z
```

Confirmed by hand against the bundled OpenCost 1.121.0:

| `window` bound | `/allocation/compute` | `/allocation` |
| --- | --- | --- |
| `2026-07-25T17:00:00.000Z,...` | **400** `illegal window` | **400** `illegal window` |
| `2026-07-25T17:00:00Z,...` | 200 | 200 |

Truncated to second precision. The poller floors windows to the window grid before this point, so the millisecond field is always zero — nothing is lost.

The existing test asserted the millisecond form, which is how this shipped; it now pins the format the engines actually parse.

## 2. The cost agent image was unpullable

`cost.agent.image.tag` fell back to `.Chart.AppVersion` (`"1.0.0"`). Nothing bumps the chart's appVersion at release time, and the pipeline publishes `<major>.<minor>` plus `release` — so the documented one-command install lands in `ImagePullBackOff`. Now defaults to `release`, the moving tag that always exists (same convention as the main `oneuptime` chart).

`logs.api.image.tag` had the identical latent bug, reachable via `preset=gke-autopilot` / `eks-fargate`.

## 3. Ingest was unroutable through the standard ingress

Every other ingest family has its own nginx location (`/otlp`, `/telemetry`, `/pyroscope`, `/probe-ingest`, `/server-monitor`, ...). `/kubernetes-cost` had none, so with `BILLING_ENABLED=true` the catch-all `location /` proxies to the marketing Home service and the POST 404s there. On a live billing-enabled instance:

```
POST /kubernetes-cost/ingest            -> 404 {"message":"Page not found - /kubernetes-cost/ingest"}
POST /telemetry/kubernetes-cost/ingest  -> 200
```

Both are the same Express route (`TELEMETRY_PREFIXES = ["/telemetry", "/"]`), which is what pins this on the proxy rather than the app.

Added the missing location (validated with `nginx -t`), and pointed the poller at the `/telemetry` prefix so a new agent also reaches instances whose reverse proxy predates this change.

## Also

Cost was the one enabled collector `NOTES.txt` never mentioned — added, distinguishing the bundled engine from an external `cost.engine.url`.

## Verification

Deployed against a 3-node DigitalOcean cluster (`s-4vcpu-8gb`, k8s 1.35.1) with the bundled engine.

- OpenCost detects DigitalOcean and prices nodes at **\$0.0714/hr** — the real list price — and volumes at \$0.000137/GiB/hr, with no credentials.
- Bundled Prometheus: both scrape targets (`kubernetes-nodes-cadvisor` via the API-server node proxy, and `opencost`) up.
- Path auto-detection resolves correctly: `/model/allocation` 404s, `/allocation/compute` wins.
- After the fix the poller ships its first closed window: `shipped cost window windowStart=18:00 windowEnd=19:00 rows=39`.
- Running the agent's own `mapAllocationToRow` over that window: 39 rows, all with valid second-precision windows, namespaces `__idle__` / `kube-system` / `oneuptime` / `wordpress`, `__idle__` sentinel mapped correctly, per-component costs and efficiency populated. Totals are internally consistent — \$0.137/hr against 3 x \$0.0714/hr of capacity scaled by the ~64% of the window Prometheus had history for.
- 11 of the 14 allowlisted cost metrics are exported by the bundled engine; the 3 absent ones (`kubecost_network_*_egress_cost`) are Kubecost-only and no dashboard panel references them.
- `KubernetesCostAgent`: 28/28 tests pass. eslint and `tsc` clean.

**Not verified here:** ClickHouse persistence and the Costs UI rendering. The test instance runs with `DISABLE_TELEMETRY_INGESTION=true`, so every ingest endpoint returns 200 and drops the payload (a malformed body with a valid key returns 200 instead of 400). The 39 rows above were accepted and dropped. That is an instance setting, not a code path in this diff.