### PR TITLE
fix(dashboard): render Kubernetes cost breakdowns with the standard Table

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Costs.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Costs.tsx
@@ -7,7 +7,13 @@ import KubernetesCluster from "Common/Models/DatabaseModels/KubernetesCluster";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import EmbeddedMetricCard from "../../Components/Metrics/EmbeddedMetricCard";
-import Card from "Common/UI/Components/Card/Card";
+import GoldenMetricTile from "../../Components/Infrastructure/GoldenMetricTile";
+import Card, { CardButtonSchema } from "Common/UI/Components/Card/Card";
+import Table from "Common/UI/Components/Table/Table";
+import Column from "Common/UI/Components/Table/Types/Column";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
 import Link from "Common/UI/Components/Link/Link";
@@ -17,6 +23,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import API from "Common/UI/Utils/API/API";
@@ -40,12 +47,20 @@ import TimeRange from "Common/Types/Time/TimeRange";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import {
   ClusterCostRow,
+  COST_ROWS_PER_PAGE,
   CostTrendPoint,
   fetchClusterBreakdown,
   fetchCostTrend,
   formatCost,
-  formatEfficiency,
+  pageCostRows,
+  sortCostRows,
 } from "./Utils/KubernetesCostUtils";
+import {
+  getCostElement,
+  getEfficiencyElement,
+  getTotalCostElement,
+  noCostDataMessage,
+} from "./Utils/KubernetesCostTableCells";
 
 function getSectionTitle(icon: IconProp, title: string): ReactElement {
   return (
@@ -68,6 +83,12 @@ const KubernetesCosts: FunctionComponent<
     new Map<string, string>(),
   );
 
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [sortBy, setSortBy] = useState<keyof ClusterCostRow | null>(
+    "totalCost",
+  );
+  const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.Descending);
+
   const [timeRange, setTimeRange] = useState<RangeStartAndEndDateTime>({
     range: TimeRange.PAST_ONE_WEEK,
   });
@@ -77,6 +98,9 @@ const KubernetesCosts: FunctionComponent<
       range: TimeRange.PAST_ONE_WEEK,
     }),
   );
+
+  // Bumped by the table's Refresh button to re-run the load effect.
+  const [refreshToggle, setRefreshToggle] = useState<number>(0);
 
   const handleTimeRangeChange: (
     newTimeRange: RangeStartAndEndDateTime,
@@ -133,6 +157,7 @@ const KubernetesCosts: FunctionComponent<
         setTrend(trendPoints);
         setClusterRows(clusters);
         setClusterIdByName(idByName);
+        setCurrentPage(1);
       } catch (err) {
         if (!cancelled) {
           setError(API.getFriendlyMessage(err));
@@ -152,11 +177,7 @@ const KubernetesCosts: FunctionComponent<
     return () => {
       cancelled = true;
     };
-  }, [startMs, endMs]);
-
-  if (error) {
-    return <ErrorMessage message={error} />;
-  }
+  }, [startMs, endMs, refreshToggle]);
 
   const totalSpend: number = clusterRows.reduce(
     (sum: number, row: ClusterCostRow): number => {
@@ -170,8 +191,105 @@ const KubernetesCosts: FunctionComponent<
     },
     0,
   );
-  const idlePercent: string =
-    totalSpend > 0 ? `${Math.round((idleSpend / totalSpend) * 100)}%` : "-";
+  const idlePercent: number | null =
+    totalSpend > 0 ? (idleSpend / totalSpend) * 100 : null;
+
+  const sortedRows: Array<ClusterCostRow> = useMemo(() => {
+    return sortCostRows<ClusterCostRow>(clusterRows, sortBy, sortOrder);
+  }, [clusterRows, sortBy, sortOrder]);
+
+  const pagedRows: Array<ClusterCostRow> = useMemo(() => {
+    return pageCostRows<ClusterCostRow>(sortedRows, currentPage);
+  }, [sortedRows, currentPage]);
+
+  const tableColumns: Array<Column<ClusterCostRow>> = useMemo(() => {
+    return [
+      {
+        title: "Cluster",
+        type: FieldType.Element,
+        key: "clusterName",
+        getElement: (row: ClusterCostRow): ReactElement => {
+          const clusterId: string | undefined = clusterIdByName.get(
+            row.clusterName,
+          );
+
+          if (!row.clusterName) {
+            return <span className="text-gray-400">-</span>;
+          }
+
+          if (!clusterId) {
+            return (
+              <span className="font-medium text-gray-900">
+                {row.clusterName}
+              </span>
+            );
+          }
+
+          return (
+            <Link
+              to={RouteUtil.populateRouteParams(
+                RouteMap[PageMap.KUBERNETES_CLUSTER_VIEW_COSTS] as Route,
+                { modelId: new ObjectID(clusterId) },
+              )}
+              className="font-medium text-gray-900 hover:text-indigo-600 hover:underline"
+            >
+              {row.clusterName}
+            </Link>
+          );
+        },
+      },
+      {
+        title: "Workload",
+        type: FieldType.Element,
+        key: "workloadCost",
+        getElement: (row: ClusterCostRow): ReactElement => {
+          return getCostElement(row.workloadCost);
+        },
+      },
+      {
+        title: "Idle",
+        type: FieldType.Element,
+        key: "idleCost",
+        getElement: (row: ClusterCostRow): ReactElement => {
+          return getCostElement(row.idleCost);
+        },
+      },
+      {
+        title: "Total",
+        type: FieldType.Element,
+        key: "totalCost",
+        getElement: (row: ClusterCostRow): ReactElement => {
+          return getTotalCostElement(row.totalCost, totalSpend);
+        },
+      },
+      {
+        title: "Efficiency",
+        type: FieldType.Element,
+        key: "efficiency",
+        getElement: (row: ClusterCostRow): ReactElement => {
+          return getEfficiencyElement(row.efficiency);
+        },
+      },
+    ];
+  }, [clusterIdByName, totalSpend]);
+
+  const cardButtons: Array<CardButtonSchema> = [
+    {
+      title: "",
+      buttonStyle: ButtonStyleType.ICON,
+      className: "py-0 pr-0 pl-1 mt-1",
+      onClick: () => {
+        setRefreshToggle((toggle: number) => {
+          return toggle + 1;
+        });
+      },
+      icon: IconProp.Refresh,
+    },
+  ];
+
+  if (error) {
+    return <ErrorMessage message={error} />;
+  }
 
   const series: Array<SeriesPoint> = [
     {
@@ -203,25 +321,9 @@ const KubernetesCosts: FunctionComponent<
     },
   };
 
-  const emptyState: ReactElement = (
-    <div className="flex h-48 flex-col items-center justify-center gap-2 text-sm text-gray-400">
-      <div>No cost data reported for the selected time range.</div>
-      <div>
-        Cost data is shipped by the OneUptime Kubernetes agent — enable it with{" "}
-        <code>cost.enabled=true</code> in the kubernetes-agent Helm chart. That
-        alone is a complete install; if you already run OpenCost or Kubecost,
-        set <code>cost.engine.url</code> to it instead.
-      </div>
-    </div>
-  );
-
-  type StatTile = { title: string; value: string };
-  const tiles: Array<StatTile> = [
-    { title: "Total Spend", value: formatCost(totalSpend) },
-    { title: "Workload Spend", value: formatCost(totalSpend - idleSpend) },
-    { title: "Idle Spend", value: formatCost(idleSpend) },
-    { title: "Idle %", value: idlePercent },
-  ];
+  const clusterCountLabel: string = `${clusterRows.length} cluster${
+    clusterRows.length === 1 ? "" : "s"
+  }`;
 
   return (
     <Fragment>
@@ -233,22 +335,41 @@ const KubernetesCosts: FunctionComponent<
         startAndEndDate={startAndEndDate}
       >
         <div>
-          <div className="mb-4 grid grid-cols-2 gap-4 lg:grid-cols-4">
-            {tiles.map((tile: StatTile, index: number): ReactElement => {
-              return (
-                <div
-                  key={index}
-                  className="rounded-md border border-gray-200 p-4"
-                >
-                  <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                    {tile.title}
-                  </div>
-                  <div className="mt-1 text-2xl font-semibold text-gray-900">
-                    {isLoading ? "..." : tile.value}
-                  </div>
-                </div>
-              );
-            })}
+          <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <GoldenMetricTile
+              title="Total Spend"
+              icon={IconProp.CurrencyDollar}
+              iconColor="emerald"
+              value={isLoading ? "—" : formatCost(totalSpend)}
+              sublabel={isLoading ? "loading" : `across ${clusterCountLabel}`}
+            />
+            <GoldenMetricTile
+              title="Workload Spend"
+              icon={IconProp.Cube}
+              iconColor="blue"
+              value={isLoading ? "—" : formatCost(totalSpend - idleSpend)}
+              sublabel="attributed to workloads"
+            />
+            <GoldenMetricTile
+              title="Idle Spend"
+              icon={IconProp.Clock}
+              iconColor="amber"
+              value={isLoading ? "—" : formatCost(idleSpend)}
+              sublabel="provisioned but unused"
+            />
+            <GoldenMetricTile
+              title="Idle %"
+              icon={IconProp.ChartPie}
+              iconColor="slate"
+              value={
+                isLoading || idlePercent === null
+                  ? "—"
+                  : `${Math.round(idlePercent)}%`
+              }
+              sublabel="share of total spend"
+              percent={isLoading ? null : idlePercent}
+              thresholds={{ warn: 25, danger: 40 }}
+            />
           </div>
           {isLoading ? (
             <div className="h-48 animate-pulse rounded-md bg-gray-50" />
@@ -264,7 +385,7 @@ const KubernetesCosts: FunctionComponent<
               syncid="k8s-project-costs"
             />
           ) : (
-            emptyState
+            <ErrorMessage message={noCostDataMessage} />
           )}
         </div>
       </EmbeddedMetricCard>
@@ -272,68 +393,34 @@ const KubernetesCosts: FunctionComponent<
       <Card
         title="Spend by Cluster"
         description="Whole-window cost per cluster, highest spend first. Click a cluster to break its spend down by namespace and workload."
+        buttons={cardButtons}
       >
-        {isLoading ? (
-          <div className="h-32 animate-pulse rounded-md bg-gray-50" />
-        ) : clusterRows.length === 0 ? (
-          emptyState
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm">
-              <thead>
-                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
-                  <th className="py-2 pr-4">Cluster</th>
-                  <th className="py-2 pr-4 text-right">Workload</th>
-                  <th className="py-2 pr-4 text-right">Idle</th>
-                  <th className="py-2 pr-4 text-right">Total</th>
-                  <th className="py-2 text-right">Efficiency</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {clusterRows.map(
-                  (row: ClusterCostRow, index: number): ReactElement => {
-                    const clusterId: string | undefined = clusterIdByName.get(
-                      row.clusterName,
-                    );
-                    return (
-                      <tr key={index}>
-                        <td className="py-2 pr-4 font-medium">
-                          {clusterId ? (
-                            <Link
-                              className="text-indigo-600 hover:text-indigo-800"
-                              to={RouteUtil.populateRouteParams(
-                                RouteMap[
-                                  PageMap.KUBERNETES_CLUSTER_VIEW_COSTS
-                                ] as Route,
-                                { modelId: new ObjectID(clusterId) },
-                              )}
-                            >
-                              {row.clusterName}
-                            </Link>
-                          ) : (
-                            row.clusterName || "-"
-                          )}
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {formatCost(row.totalCost - row.idleCost)}
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {formatCost(row.idleCost)}
-                        </td>
-                        <td className="py-2 pr-4 text-right font-semibold">
-                          {formatCost(row.totalCost)}
-                        </td>
-                        <td className="py-2 text-right">
-                          {formatEfficiency(row.efficiency)}
-                        </td>
-                      </tr>
-                    );
-                  },
-                )}
-              </tbody>
-            </table>
-          </div>
-        )}
+        <Table<ClusterCostRow>
+          id="kubernetes-cluster-costs-table"
+          columns={tableColumns}
+          data={pagedRows}
+          singularLabel="Cluster"
+          pluralLabel="Clusters"
+          isLoading={isLoading}
+          error=""
+          currentPageNumber={currentPage}
+          totalItemsCount={sortedRows.length}
+          itemsOnPage={COST_ROWS_PER_PAGE}
+          onNavigateToPage={(pageNumber: number) => {
+            setCurrentPage(pageNumber);
+          }}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSortChanged={(
+            newSortBy: keyof ClusterCostRow | null,
+            newSortOrder: SortOrder,
+          ) => {
+            setSortBy(newSortBy);
+            setSortOrder(newSortOrder);
+            setCurrentPage(1);
+          }}
+          noItemsMessage={noCostDataMessage}
+        />
       </Card>
     </Fragment>
   );

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostTableCells.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostTableCells.tsx
@@ -1,0 +1,132 @@
+import React, { ReactElement } from "react";
+import { formatCost, formatEfficiency } from "./KubernetesCostUtils";
+
+/*
+ * Shared cell renderers for the Kubernetes cost breakdown tables (project
+ * Costs page and cluster Costs page), so both read as one table family:
+ * money is tabular and right-weighted, the total column carries a share-of
+ * -window bar, and efficiency is a threshold-colored pill.
+ */
+
+/** Secondary money cell — the per-component splits (cpu / memory / …). */
+export function getCostElement(value: number): ReactElement {
+  return (
+    <span className="tabular-nums text-gray-600">{formatCost(value)}</span>
+  );
+}
+
+/**
+ * Primary money cell: the amount, its share of the whole window, and a bar
+ * for that share — so the line items actually driving the bill are obvious
+ * without reading every row.
+ */
+export function getTotalCostElement(
+  value: number,
+  windowTotal: number,
+): ReactElement {
+  const share: number =
+    windowTotal > 0
+      ? Math.min(100, Math.max(0, (value / windowTotal) * 100))
+      : 0;
+
+  return (
+    <div className="w-32">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="tabular-nums font-medium text-gray-900">
+          {formatCost(value)}
+        </span>
+        <span className="tabular-nums text-xs text-gray-400">
+          {windowTotal > 0
+            ? `${share < 1 && share > 0 ? "<1" : Math.round(share)}%`
+            : "-"}
+        </span>
+      </div>
+      <div className="mt-1.5 h-1.5 w-full rounded-full bg-gray-100">
+        <div
+          className="h-1.5 rounded-full bg-indigo-500"
+          style={{ width: `${share}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/*
+ * Request-vs-usage efficiency. Higher is better: a workload at 20% is
+ * paying for five times the capacity it actually uses, so the pill goes
+ * red as efficiency falls.
+ */
+export function getEfficiencyElement(efficiency: number | null): ReactElement {
+  if (efficiency === null || !Number.isFinite(efficiency)) {
+    return <span className="text-gray-400">-</span>;
+  }
+
+  const percent: number = efficiency * 100;
+  const badgeClassName: string =
+    percent >= 70
+      ? "bg-green-50 text-green-700"
+      : percent >= 40
+        ? "bg-yellow-50 text-yellow-700"
+        : "bg-red-50 text-red-700";
+
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium tabular-nums ${badgeClassName}`}
+    >
+      {formatEfficiency(efficiency)}
+    </span>
+  );
+}
+
+/** Namespace pill — same treatment as the Kubernetes Events table. */
+export function getNamespaceElement(namespace: string): ReactElement {
+  if (!namespace) {
+    return <span className="text-gray-400">-</span>;
+  }
+
+  return (
+    <span className="inline-flex rounded bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+      {namespace}
+    </span>
+  );
+}
+
+/** Controller kind pill (Deployment, StatefulSet, DaemonSet, …). */
+export function getControllerKindElement(kind: string): ReactElement {
+  if (!kind) {
+    return <span className="text-gray-400">-</span>;
+  }
+
+  return (
+    <span className="inline-flex rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+      {kind}
+    </span>
+  );
+}
+
+function getInlineCodeElement(text: string): ReactElement {
+  return (
+    <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-gray-700">
+      {text}
+    </code>
+  );
+}
+
+/*
+ * Shown in place of an empty table. Cost is opt-in, so "no rows" almost
+ * always means the agent was never told to ship it — say how to turn it
+ * on rather than leaving an empty grid.
+ */
+export const noCostDataMessage: ReactElement = (
+  <div className="mx-auto max-w-xl space-y-2">
+    <div className="font-medium text-gray-700">
+      No cost data reported for the selected time range.
+    </div>
+    <div>
+      Cost data is shipped by the OneUptime Kubernetes agent — enable it with{" "}
+      {getInlineCodeElement("cost.enabled=true")} in the kubernetes-agent Helm
+      chart. That alone is a complete install; if you already run OpenCost or
+      Kubecost, set {getInlineCodeElement("cost.engine.url")} to it instead.
+    </div>
+  </div>
+);

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostUtils.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostUtils.ts
@@ -9,6 +9,7 @@ import AggregationInterval from "Common/Types/BaseDatabase/AggregationInterval";
 import AggregateBy from "Common/Types/BaseDatabase/AggregateBy";
 import GroupBy from "Common/Server/Types/Database/GroupBy";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import GenericObject from "Common/Types/GenericObject";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import ObjectID from "Common/Types/ObjectID";
 
@@ -58,6 +59,8 @@ export interface WorkloadCostRow {
 export interface ClusterCostRow {
   clusterName: string;
   totalCost: number;
+  /** Total minus idle — spend that actually landed on a workload. */
+  workloadCost: number;
   idleCost: number;
   efficiency: number | null;
 }
@@ -91,6 +94,61 @@ export const formatEfficiency: (value: number | null) => string = (
   }
   return `${Math.round(value * 100)}%`;
 };
+
+/** Rows per page in the cost breakdown tables. */
+export const COST_ROWS_PER_PAGE: number = 25;
+
+/*
+ * Client-side sort for the cost breakdown tables. Every breakdown is
+ * fetched whole-window in a single aggregate, so sorting and paging both
+ * happen in the browser. Numbers compare numerically, everything else as
+ * text, and unknown values (null efficiency) sink to the bottom whichever
+ * way the column is sorted.
+ */
+export function sortCostRows<T extends GenericObject>(
+  rows: Array<T>,
+  sortBy: keyof T | null,
+  sortOrder: SortOrder,
+): Array<T> {
+  if (!sortBy) {
+    return rows;
+  }
+
+  const sorted: Array<T> = [...rows];
+
+  sorted.sort((a: T, b: T): number => {
+    const aValue: unknown = a[sortBy];
+    const bValue: unknown = b[sortBy];
+
+    const isAUnknown: boolean = aValue === null || aValue === undefined;
+    const isBUnknown: boolean = bValue === null || bValue === undefined;
+
+    if (isAUnknown || isBUnknown) {
+      if (isAUnknown && isBUnknown) {
+        return 0;
+      }
+      return isAUnknown ? 1 : -1;
+    }
+
+    const comparison: number =
+      typeof aValue === "number" && typeof bValue === "number"
+        ? aValue - bValue
+        : String(aValue).localeCompare(String(bValue));
+
+    return sortOrder === SortOrder.Descending ? -comparison : comparison;
+  });
+
+  return sorted;
+}
+
+/** Page slice for a client-side paginated cost table (1-indexed page). */
+export function pageCostRows<T extends GenericObject>(
+  rows: Array<T>,
+  pageNumber: number,
+): Array<T> {
+  const start: number = (pageNumber - 1) * COST_ROWS_PER_PAGE;
+  return rows.slice(start, start + COST_ROWS_PER_PAGE);
+}
 
 type BuildAggregateBy = (data: {
   params: FetchCostParams;
@@ -415,10 +473,12 @@ export const fetchClusterBreakdown: (params: {
 
   const rows: Array<ClusterCostRow> = [];
   for (const [clusterName, totalCost] of totals) {
+    const idleCost: number = idle.get(clusterName) || 0;
     rows.push({
       clusterName,
       totalCost,
-      idleCost: idle.get(clusterName) || 0,
+      workloadCost: Math.max(0, totalCost - idleCost),
+      idleCost,
       efficiency: efficiencies.has(clusterName)
         ? efficiencies.get(clusterName)!
         : null,

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/Costs.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/Costs.tsx
@@ -2,7 +2,13 @@ import PageComponentProps from "../../PageComponentProps";
 import ObjectID from "Common/Types/ObjectID";
 import Navigation from "Common/UI/Utils/Navigation";
 import EmbeddedMetricCard from "../../../Components/Metrics/EmbeddedMetricCard";
-import Card from "Common/UI/Components/Card/Card";
+import GoldenMetricTile from "../../../Components/Infrastructure/GoldenMetricTile";
+import Card, { CardButtonSchema } from "Common/UI/Components/Card/Card";
+import Table from "Common/UI/Components/Table/Table";
+import Column from "Common/UI/Components/Table/Types/Column";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
 import React, {
@@ -11,6 +17,7 @@ import React, {
   ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import API from "Common/UI/Utils/API/API";
@@ -33,6 +40,7 @@ import RangeStartAndEndDateTime, {
 import TimeRange from "Common/Types/Time/TimeRange";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import {
+  COST_ROWS_PER_PAGE,
   CostTrendPoint,
   NamespaceCostRow,
   WorkloadCostRow,
@@ -42,17 +50,18 @@ import {
   fetchNamespaceBreakdown,
   fetchWorkloadBreakdown,
   formatCost,
-  formatEfficiency,
   isSentinelNamespace,
+  pageCostRows,
+  sortCostRows,
 } from "../Utils/KubernetesCostUtils";
-
-const TOP_ROWS_LIMIT: number = 25;
-
-interface StatTile {
-  title: string;
-  value: string;
-  description: string;
-}
+import {
+  getControllerKindElement,
+  getCostElement,
+  getEfficiencyElement,
+  getNamespaceElement,
+  getTotalCostElement,
+  noCostDataMessage,
+} from "../Utils/KubernetesCostTableCells";
 
 function getSectionTitle(icon: IconProp, title: string): ReactElement {
   return (
@@ -65,12 +74,33 @@ function getSectionTitle(icon: IconProp, title: string): ReactElement {
 
 function sentinelDisplayName(namespace: string): string {
   if (namespace === IDLE_NAMESPACE) {
-    return "Idle (unused capacity)";
+    return "Idle capacity";
   }
   if (namespace === UNALLOCATED_NAMESPACE) {
     return "Unallocated";
   }
   return namespace;
+}
+
+/*
+ * The namespace column carries two kinds of row: real namespaces, which get
+ * the same blue pill as everywhere else in the Kubernetes section, and the
+ * engine's non-workload sentinels (idle / unallocated capacity), which are
+ * labelled as such so nobody goes hunting for a namespace called `__idle__`.
+ */
+function getNamespaceCellElement(namespace: string): ReactElement {
+  if (!isSentinelNamespace(namespace)) {
+    return getNamespaceElement(namespace);
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-gray-500">
+      <span className="inline-flex rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+        {sentinelDisplayName(namespace)}
+      </span>
+      <span className="text-xs text-gray-400">not a workload</span>
+    </span>
+  );
 }
 
 const KubernetesClusterCosts: FunctionComponent<
@@ -87,6 +117,22 @@ const KubernetesClusterCosts: FunctionComponent<
   );
   const [workloadRows, setWorkloadRows] = useState<Array<WorkloadCostRow>>([]);
 
+  const [namespacePage, setNamespacePage] = useState<number>(1);
+  const [namespaceSortBy, setNamespaceSortBy] = useState<
+    keyof NamespaceCostRow | null
+  >("totalCost");
+  const [namespaceSortOrder, setNamespaceSortOrder] = useState<SortOrder>(
+    SortOrder.Descending,
+  );
+
+  const [workloadPage, setWorkloadPage] = useState<number>(1);
+  const [workloadSortBy, setWorkloadSortBy] = useState<
+    keyof WorkloadCostRow | null
+  >("totalCost");
+  const [workloadSortOrder, setWorkloadSortOrder] = useState<SortOrder>(
+    SortOrder.Descending,
+  );
+
   const [timeRange, setTimeRange] = useState<RangeStartAndEndDateTime>({
     range: TimeRange.PAST_ONE_WEEK,
   });
@@ -96,6 +142,9 @@ const KubernetesClusterCosts: FunctionComponent<
       range: TimeRange.PAST_ONE_WEEK,
     }),
   );
+
+  // Bumped by the tables' Refresh buttons to re-run the load effect.
+  const [refreshToggle, setRefreshToggle] = useState<number>(0);
 
   const handleTimeRangeChange: (
     newTimeRange: RangeStartAndEndDateTime,
@@ -139,6 +188,8 @@ const KubernetesClusterCosts: FunctionComponent<
         setTrend(trendPoints);
         setNamespaceRows(namespaces);
         setWorkloadRows(workloads);
+        setNamespacePage(1);
+        setWorkloadPage(1);
       } catch (err) {
         if (!cancelled) {
           setError(API.getFriendlyMessage(err));
@@ -158,11 +209,7 @@ const KubernetesClusterCosts: FunctionComponent<
     return () => {
       cancelled = true;
     };
-  }, [modelId.toString(), startMs, endMs]);
-
-  if (error) {
-    return <ErrorMessage message={error} />;
-  }
+  }, [modelId.toString(), startMs, endMs, refreshToggle]);
 
   const totalSpend: number = namespaceRows.reduce(
     (sum: number, row: NamespaceCostRow): number => {
@@ -178,31 +225,166 @@ const KubernetesClusterCosts: FunctionComponent<
       return sum + row.totalCost;
     }, 0);
   const workloadSpend: number = totalSpend - idleSpend;
-  const idlePercent: string =
-    totalSpend > 0 ? `${Math.round((idleSpend / totalSpend) * 100)}%` : "-";
+  const idlePercent: number | null =
+    totalSpend > 0 ? (idleSpend / totalSpend) * 100 : null;
 
-  const tiles: Array<StatTile> = [
-    {
-      title: "Total Spend",
-      value: formatCost(totalSpend),
-      description: "All cost allocated to this cluster in the window.",
+  const sortedNamespaceRows: Array<NamespaceCostRow> = useMemo(() => {
+    return sortCostRows<NamespaceCostRow>(
+      namespaceRows,
+      namespaceSortBy,
+      namespaceSortOrder,
+    );
+  }, [namespaceRows, namespaceSortBy, namespaceSortOrder]);
+
+  const pagedNamespaceRows: Array<NamespaceCostRow> = useMemo(() => {
+    return pageCostRows<NamespaceCostRow>(sortedNamespaceRows, namespacePage);
+  }, [sortedNamespaceRows, namespacePage]);
+
+  const sortedWorkloadRows: Array<WorkloadCostRow> = useMemo(() => {
+    return sortCostRows<WorkloadCostRow>(
+      workloadRows,
+      workloadSortBy,
+      workloadSortOrder,
+    );
+  }, [workloadRows, workloadSortBy, workloadSortOrder]);
+
+  const pagedWorkloadRows: Array<WorkloadCostRow> = useMemo(() => {
+    return pageCostRows<WorkloadCostRow>(sortedWorkloadRows, workloadPage);
+  }, [sortedWorkloadRows, workloadPage]);
+
+  const namespaceColumns: Array<Column<NamespaceCostRow>> = useMemo(() => {
+    return [
+      {
+        title: "Namespace",
+        type: FieldType.Element,
+        key: "namespace",
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          return getNamespaceCellElement(row.namespace);
+        },
+      },
+      {
+        title: "CPU",
+        type: FieldType.Element,
+        key: "cpuCost",
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          return getCostElement(row.cpuCost);
+        },
+      },
+      {
+        title: "Memory",
+        type: FieldType.Element,
+        key: "ramCost",
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          return getCostElement(row.ramCost);
+        },
+      },
+      {
+        title: "Storage",
+        type: FieldType.Element,
+        key: "pvCost",
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          return getCostElement(row.pvCost);
+        },
+      },
+      {
+        title: "Other",
+        type: FieldType.Element,
+        key: "otherCost",
+        hideOnMobile: true,
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          return getCostElement(row.otherCost);
+        },
+      },
+      {
+        title: "Total",
+        type: FieldType.Element,
+        key: "totalCost",
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          return getTotalCostElement(row.totalCost, totalSpend);
+        },
+      },
+      {
+        title: "Efficiency",
+        type: FieldType.Element,
+        key: "efficiency",
+        getElement: (row: NamespaceCostRow): ReactElement => {
+          // Idle / unallocated capacity has no requests to compare against.
+          if (isSentinelNamespace(row.namespace)) {
+            return <span className="text-gray-400">-</span>;
+          }
+          return getEfficiencyElement(row.efficiency);
+        },
+      },
+    ];
+  }, [totalSpend]);
+
+  const workloadColumns: Array<Column<WorkloadCostRow>> = useMemo(() => {
+    return [
+      {
+        title: "Workload",
+        type: FieldType.Element,
+        key: "controllerName",
+        getElement: (row: WorkloadCostRow): ReactElement => {
+          if (!row.controllerName) {
+            return <span className="text-gray-400">-</span>;
+          }
+          return (
+            <span className="font-medium text-gray-900">
+              {row.controllerName}
+            </span>
+          );
+        },
+      },
+      {
+        title: "Kind",
+        type: FieldType.Element,
+        key: "controllerKind",
+        getElement: (row: WorkloadCostRow): ReactElement => {
+          return getControllerKindElement(row.controllerKind);
+        },
+      },
+      {
+        title: "Namespace",
+        type: FieldType.Element,
+        key: "namespace",
+        getElement: (row: WorkloadCostRow): ReactElement => {
+          return getNamespaceElement(row.namespace);
+        },
+      },
+      {
+        title: "Total",
+        type: FieldType.Element,
+        key: "totalCost",
+        getElement: (row: WorkloadCostRow): ReactElement => {
+          return getTotalCostElement(row.totalCost, workloadSpend);
+        },
+      },
+      {
+        title: "Efficiency",
+        type: FieldType.Element,
+        key: "efficiency",
+        getElement: (row: WorkloadCostRow): ReactElement => {
+          return getEfficiencyElement(row.efficiency);
+        },
+      },
+    ];
+  }, [workloadSpend]);
+
+  const refreshButton: CardButtonSchema = {
+    title: "",
+    buttonStyle: ButtonStyleType.ICON,
+    className: "py-0 pr-0 pl-1 mt-1",
+    onClick: () => {
+      setRefreshToggle((toggle: number) => {
+        return toggle + 1;
+      });
     },
-    {
-      title: "Workload Spend",
-      value: formatCost(workloadSpend),
-      description: "Spend attributed to namespaces and workloads.",
-    },
-    {
-      title: "Idle Spend",
-      value: formatCost(idleSpend),
-      description: "Provisioned but unused capacity.",
-    },
-    {
-      title: "Idle %",
-      value: idlePercent,
-      description: "Idle spend as a share of total spend.",
-    },
-  ];
+    icon: IconProp.Refresh,
+  };
+
+  if (error) {
+    return <ErrorMessage message={error} />;
+  }
 
   const series: Array<SeriesPoint> = [
     {
@@ -234,18 +416,6 @@ const KubernetesClusterCosts: FunctionComponent<
     },
   };
 
-  const emptyState: ReactElement = (
-    <div className="flex h-48 flex-col items-center justify-center gap-2 text-sm text-gray-400">
-      <div>No cost data reported for the selected time range.</div>
-      <div>
-        Cost data is shipped by the OneUptime Kubernetes agent — enable it with{" "}
-        <code>cost.enabled=true</code> in the kubernetes-agent Helm chart. That
-        alone is a complete install; if you already run OpenCost or Kubecost,
-        set <code>cost.engine.url</code> to it instead.
-      </div>
-    </div>
-  );
-
   return (
     <Fragment>
       <EmbeddedMetricCard
@@ -256,23 +426,41 @@ const KubernetesClusterCosts: FunctionComponent<
         startAndEndDate={startAndEndDate}
       >
         <div>
-          <div className="mb-4 grid grid-cols-2 gap-4 lg:grid-cols-4">
-            {tiles.map((tile: StatTile, index: number): ReactElement => {
-              return (
-                <div
-                  key={index}
-                  className="rounded-md border border-gray-200 p-4"
-                  title={tile.description}
-                >
-                  <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                    {tile.title}
-                  </div>
-                  <div className="mt-1 text-2xl font-semibold text-gray-900">
-                    {isLoading ? "..." : tile.value}
-                  </div>
-                </div>
-              );
-            })}
+          <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <GoldenMetricTile
+              title="Total Spend"
+              icon={IconProp.CurrencyDollar}
+              iconColor="emerald"
+              value={isLoading ? "—" : formatCost(totalSpend)}
+              sublabel="allocated in this window"
+            />
+            <GoldenMetricTile
+              title="Workload Spend"
+              icon={IconProp.Cube}
+              iconColor="blue"
+              value={isLoading ? "—" : formatCost(workloadSpend)}
+              sublabel="namespaces and workloads"
+            />
+            <GoldenMetricTile
+              title="Idle Spend"
+              icon={IconProp.Clock}
+              iconColor="amber"
+              value={isLoading ? "—" : formatCost(idleSpend)}
+              sublabel="provisioned but unused"
+            />
+            <GoldenMetricTile
+              title="Idle %"
+              icon={IconProp.ChartPie}
+              iconColor="slate"
+              value={
+                isLoading || idlePercent === null
+                  ? "—"
+                  : `${Math.round(idlePercent)}%`
+              }
+              sublabel="share of total spend"
+              percent={isLoading ? null : idlePercent}
+              thresholds={{ warn: 25, danger: 40 }}
+            />
           </div>
           {isLoading ? (
             <div className="h-48 animate-pulse rounded-md bg-gray-50" />
@@ -288,7 +476,7 @@ const KubernetesClusterCosts: FunctionComponent<
               syncid={`k8s-costs-${modelId.toString()}`}
             />
           ) : (
-            emptyState
+            <ErrorMessage message={noCostDataMessage} />
           )}
         </div>
       </EmbeddedMetricCard>
@@ -296,129 +484,67 @@ const KubernetesClusterCosts: FunctionComponent<
       <Card
         title="Spend by Namespace"
         description="Whole-window cost per namespace with cpu / memory / storage split and request-vs-usage efficiency."
+        buttons={[refreshButton]}
       >
-        {isLoading ? (
-          <div className="h-32 animate-pulse rounded-md bg-gray-50" />
-        ) : namespaceRows.length === 0 ? (
-          emptyState
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm">
-              <thead>
-                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
-                  <th className="py-2 pr-4">Namespace</th>
-                  <th className="py-2 pr-4 text-right">CPU</th>
-                  <th className="py-2 pr-4 text-right">Memory</th>
-                  <th className="py-2 pr-4 text-right">Storage</th>
-                  <th className="py-2 pr-4 text-right">Other</th>
-                  <th className="py-2 pr-4 text-right">Total</th>
-                  <th className="py-2 text-right">Efficiency</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {namespaceRows
-                  .slice(0, TOP_ROWS_LIMIT)
-                  .map((row: NamespaceCostRow, index: number): ReactElement => {
-                    const isSentinel: boolean = isSentinelNamespace(
-                      row.namespace,
-                    );
-                    return (
-                      <tr
-                        key={index}
-                        className={isSentinel ? "text-gray-500" : ""}
-                      >
-                        <td className="py-2 pr-4 font-medium">
-                          {sentinelDisplayName(row.namespace) || "-"}
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {formatCost(row.cpuCost)}
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {formatCost(row.ramCost)}
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {formatCost(row.pvCost)}
-                        </td>
-                        <td className="py-2 pr-4 text-right">
-                          {formatCost(row.otherCost)}
-                        </td>
-                        <td className="py-2 pr-4 text-right font-semibold">
-                          {formatCost(row.totalCost)}
-                        </td>
-                        <td className="py-2 text-right">
-                          {isSentinel ? "-" : formatEfficiency(row.efficiency)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-              </tbody>
-            </table>
-            {namespaceRows.length > TOP_ROWS_LIMIT ? (
-              <div className="mt-2 text-xs text-gray-400">
-                Showing top {TOP_ROWS_LIMIT} of {namespaceRows.length}{" "}
-                namespaces by spend.
-              </div>
-            ) : (
-              <></>
-            )}
-          </div>
-        )}
+        <Table<NamespaceCostRow>
+          id="kubernetes-namespace-costs-table"
+          columns={namespaceColumns}
+          data={pagedNamespaceRows}
+          singularLabel="Namespace"
+          pluralLabel="Namespaces"
+          isLoading={isLoading}
+          error=""
+          currentPageNumber={namespacePage}
+          totalItemsCount={sortedNamespaceRows.length}
+          itemsOnPage={COST_ROWS_PER_PAGE}
+          onNavigateToPage={(pageNumber: number) => {
+            setNamespacePage(pageNumber);
+          }}
+          sortBy={namespaceSortBy}
+          sortOrder={namespaceSortOrder}
+          onSortChanged={(
+            newSortBy: keyof NamespaceCostRow | null,
+            newSortOrder: SortOrder,
+          ) => {
+            setNamespaceSortBy(newSortBy);
+            setNamespaceSortOrder(newSortOrder);
+            setNamespacePage(1);
+          }}
+          noItemsMessage={noCostDataMessage}
+        />
       </Card>
 
       <Card
         title="Spend by Workload"
         description="Whole-window cost per workload (controller), highest spend first. Idle capacity is excluded."
+        buttons={[refreshButton]}
       >
-        {isLoading ? (
-          <div className="h-32 animate-pulse rounded-md bg-gray-50" />
-        ) : workloadRows.length === 0 ? (
-          emptyState
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 text-sm">
-              <thead>
-                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
-                  <th className="py-2 pr-4">Workload</th>
-                  <th className="py-2 pr-4">Kind</th>
-                  <th className="py-2 pr-4">Namespace</th>
-                  <th className="py-2 pr-4 text-right">Total</th>
-                  <th className="py-2 text-right">Efficiency</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {workloadRows
-                  .slice(0, TOP_ROWS_LIMIT)
-                  .map((row: WorkloadCostRow, index: number): ReactElement => {
-                    return (
-                      <tr key={index}>
-                        <td className="py-2 pr-4 font-medium">
-                          {row.controllerName || "-"}
-                        </td>
-                        <td className="py-2 pr-4">
-                          {row.controllerKind || "-"}
-                        </td>
-                        <td className="py-2 pr-4">{row.namespace || "-"}</td>
-                        <td className="py-2 pr-4 text-right font-semibold">
-                          {formatCost(row.totalCost)}
-                        </td>
-                        <td className="py-2 text-right">
-                          {formatEfficiency(row.efficiency)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-              </tbody>
-            </table>
-            {workloadRows.length > TOP_ROWS_LIMIT ? (
-              <div className="mt-2 text-xs text-gray-400">
-                Showing top {TOP_ROWS_LIMIT} of {workloadRows.length} workloads
-                by spend.
-              </div>
-            ) : (
-              <></>
-            )}
-          </div>
-        )}
+        <Table<WorkloadCostRow>
+          id="kubernetes-workload-costs-table"
+          columns={workloadColumns}
+          data={pagedWorkloadRows}
+          singularLabel="Workload"
+          pluralLabel="Workloads"
+          isLoading={isLoading}
+          error=""
+          currentPageNumber={workloadPage}
+          totalItemsCount={sortedWorkloadRows.length}
+          itemsOnPage={COST_ROWS_PER_PAGE}
+          onNavigateToPage={(pageNumber: number) => {
+            setWorkloadPage(pageNumber);
+          }}
+          sortBy={workloadSortBy}
+          sortOrder={workloadSortOrder}
+          onSortChanged={(
+            newSortBy: keyof WorkloadCostRow | null,
+            newSortOrder: SortOrder,
+          ) => {
+            setWorkloadSortBy(newSortBy);
+            setWorkloadSortOrder(newSortOrder);
+            setWorkloadPage(1);
+          }}
+          noItemsMessage={noCostDataMessage}
+        />
       </Card>
     </Fragment>
   );


### PR DESCRIPTION
## Why

The three Kubernetes cost breakdowns — **Spend by Cluster**, **Spend by Namespace**, **Spend by Workload** — were hand-rolled `<table>` markup. They were the only tables in the product that didn't look or behave like a OneUptime table: no gray header bar, no sortable columns, no pagination, no shared loading or empty state. Rows past the first 25 were silently dropped with a "Showing top 25 of N" footnote.

## What changed

**Tables now use `Common/UI/Components/Table`** inside the existing Cards, matching Kubernetes Events, Ceph Daemons, and every other table in the dashboard:

- Standard header, row, and pagination chrome
- Sortable columns (client-side over the whole-window aggregate that's already fetched in one shot), defaulting to Total descending as before
- Real pagination replaces the top-25 truncation — every namespace and workload is reachable
- Table's own loader and empty state replace the bespoke pulse block
- Refresh button on each card

**UI improvements while in there:**

- Stat tiles use the shared `GoldenMetricTile` (icon badge, sublabel, threshold-colored bar on Idle %) instead of bespoke boxes
- The Total column carries its share of the window as a percentage plus a bar, so the line items actually driving the bill stand out
- Efficiency renders as a threshold-colored pill (green ≥ 70%, amber ≥ 40%, red below); namespace and controller kind render as pills matching the Events table
- `__idle__` / `__unallocated__` sentinels are labelled "Idle capacity" / "Unallocated" with a "not a workload" hint, instead of surfacing a namespace nobody can find
- The "enable `cost.enabled=true`" guidance is now the tables' empty state rather than a one-off block

`ClusterCostRow` gains a precomputed `workloadCost` so the Workload column sorts on a real field. Shared cell renderers live in a new `KubernetesCostTableCells.tsx` so both cost pages read as one table family.

## Testing

- `tsc --noEmit` clean for the Dashboard project; `eslint` clean on all four files
- `npm run build-frontend:dashboard` bundles successfully
- Rendered the real `Table` / `Card` / `GoldenMetricTile` components and the new cell renderers against mock cost rows in a throwaway esbuild harness (deleted before commit) to confirm the layout, sort affordances, pagination footer, sentinel rows, and empty state

No behavior change to the cost pipeline, queries, or aggregation — this is presentation only.