### PR TITLE
perf(postgres): stop redundant metric-type writes, fix probe scheduler index use, ship tuned server config

### DIFF
--- a/App/FeatureSet/Telemetry/API/ProbeIngest/Monitor.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/Monitor.ts
@@ -42,9 +42,13 @@ const getMonitorFetchQuery: GetMonitorFetchQueryFunction = (
   const monitorFetchQuery: Query<MonitorProbe> = {
     probeId: probeId,
     isEnabled: true,
-    nextPingAt: QueryHelper.lessThanEqualToOrNull(
-      OneUptimeDate.getCurrentDate(),
-    ),
+    /*
+     * Plain <= (not ...OrNull): nextPingAt is never NULL — onBeforeCreate
+     * defaults it and the AddMonitoringDatesToMonitors data migration
+     * backfilled existing rows. The OR IS NULL variant cannot be a range
+     * bound, so it defeats the ("probeId", "isEnabled", "nextPingAt") index.
+     */
+    nextPingAt: QueryHelper.lessThanEqualTo(OneUptimeDate.getCurrentDate()),
     monitor: {
       ...MonitorService.getEnabledMonitorQuery(),
     },
@@ -78,7 +82,7 @@ router.get(
         await MonitorProbeService.findBy({
           query: {
             ...getMonitorFetchQuery(new ObjectID(req.params["probeId"])),
-            nextPingAt: QueryHelper.lessThanEqualToOrNull(
+            nextPingAt: QueryHelper.lessThanEqualTo(
               OneUptimeDate.addRemoveMinutes(
                 OneUptimeDate.getCurrentDate(),
                 -3,
@@ -240,7 +244,7 @@ router.get(
         await MonitorProbeService.findOneBy({
           query: {
             ...getMonitorFetchQuery(new ObjectID(req.params["probeId"])),
-            nextPingAt: QueryHelper.lessThanEqualToOrNull(
+            nextPingAt: QueryHelper.lessThanEqualTo(
               OneUptimeDate.addRemoveMinutes(
                 OneUptimeDate.getCurrentDate(),
                 -3,

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/Probe.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/Probe.ts
@@ -464,7 +464,7 @@ router.post(
         query: {
           probeId: probeId,
           isEnabled: true,
-          nextPingAt: QueryHelper.lessThanEqualToOrNull(
+          nextPingAt: QueryHelper.lessThanEqualTo(
             OneUptimeDate.getSomeMinutesAgo(2),
           ),
           monitor: {

--- a/App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts
+++ b/App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts
@@ -27,20 +27,17 @@ export default class ProbeAuthorization {
 
     const probeKey: string = data["probeKey"] as string;
 
-    const probe: Probe | null = await ProbeService.findOneBy({
-      query: {
-        _id: probeId.toString(),
-        key: probeKey,
-      },
-      select: {
-        _id: true,
-      },
-      props: {
-        isRoot: true,
-      },
-    });
+    /*
+     * Cached in-process (60s positive / 10s negative), invalidated on probe
+     * update and delete. This runs on every probe ingest request, and
+     * /probe/response/ingest does no other Postgres work — it enqueues to
+     * Redis — so resolving this from cache takes the highest-volume endpoint
+     * in the product off Postgres entirely.
+     */
+    const authorizedProbeId: ObjectID | null =
+      await ProbeService.getProbeIdByKey(probeId, probeKey);
 
-    if (!probe) {
+    if (!authorizedProbeId) {
       return Response.sendErrorResponse(
         req,
         res,
@@ -48,7 +45,14 @@ export default class ProbeAuthorization {
       );
     }
 
-    await ProbeService.updateLastAlive(probeId);
+    await ProbeService.updateLastAlive(authorizedProbeId);
+
+    /*
+     * The previous lookup selected only _id, so every downstream consumer
+     * already reads nothing but `.id` off this object.
+     */
+    const probe: Probe = new Probe();
+    probe.id = authorizedProbeId;
 
     req.probe = probe;
 

--- a/Common/Models/DatabaseModels/CallLog.ts
+++ b/Common/Models/DatabaseModels/CallLog.ts
@@ -63,6 +63,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @Index(["projectId", "createdAt"]) // Notification logs table: time-range filter per project
 @Index(["projectId", "status"]) // Notification logs table: status filter per project
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class CallLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/EmailLog.ts
+++ b/Common/Models/DatabaseModels/EmailLog.ts
@@ -64,6 +64,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @Index(["projectId", "createdAt"]) // Notification logs table: time-range filter per project
 @Index(["projectId", "status"]) // Notification logs table: status filter per project
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class EmailLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/LlmLog.ts
+++ b/Common/Models/DatabaseModels/LlmLog.ts
@@ -49,6 +49,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all the LLM API calls for AI features in this project.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class LlmLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/MetricType.ts
+++ b/Common/Models/DatabaseModels/MetricType.ts
@@ -83,6 +83,7 @@ import { AggregationTemporality } from "../AnalyticsModels/Metric";
 @Entity({
   name: "MetricType",
 })
+@Index(["projectId", "name"]) // Telemetry ingest: catalog lookup by (project, metric name)
 export default class MetricType extends BaseModel {
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/MonitorTest.ts
+++ b/Common/Models/DatabaseModels/MonitorTest.ts
@@ -83,6 +83,7 @@ import Monitor from "./Monitor";
   tableDescription:
     "Monitor Test allows you to test monitor configurations before you save them.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class MonitorTest extends BaseModel {
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/NetworkDevice.ts
+++ b/Common/Models/DatabaseModels/NetworkDevice.ts
@@ -89,6 +89,7 @@ import {
 @Entity({
   name: "NetworkDevice",
 })
+@Index(["probeId", "nextPollAt"]) // Probe device-claim hot path: pick due devices per probeId
 export default class NetworkDevice extends BaseModel {
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
@@ -82,6 +82,7 @@ export interface DiscoveredNetworkDevice {
 @Entity({
   name: "NetworkDeviceDiscoveryScan",
 })
+@Index(["isRecurring", "nextScanAt"]) // Worker sweep: RequeueRecurringScans, every minute
 export default class NetworkDeviceDiscoveryScan extends BaseModel {
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/OnCallDutyPolicyExecutionLog.ts
+++ b/Common/Models/DatabaseModels/OnCallDutyPolicyExecutionLog.ts
@@ -80,6 +80,8 @@ import EnableWorkflow from "../../Types/Database/EnableWorkflow";
   icon: IconProp.Call,
   tableDescription: "Logs for on-call duty policy execution.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
+@Index(["status", "createdAt"]) // Worker sweeps: ExecutePendingExecutions + TimeoutStuckExecutions, every minute
 export default class OnCallDutyPolicyExecutionLog extends BaseModel {
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/OnCallDutyPolicyFeed.ts
+++ b/Common/Models/DatabaseModels/OnCallDutyPolicyFeed.ts
@@ -83,6 +83,7 @@ export enum OnCallDutyPolicyFeedEventType {
   tableDescription:
     "Log of the entire onCallDutyPolicy state change. This is a log of all the on call duty policy changes.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class OnCallDutyPolicyFeed extends BaseModel {
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/ProjectSCIMLog.ts
+++ b/Common/Models/DatabaseModels/ProjectSCIMLog.ts
@@ -45,6 +45,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all SCIM provisioning operations for this project.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class ProjectSCIMLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/PushNotificationLog.ts
+++ b/Common/Models/DatabaseModels/PushNotificationLog.ts
@@ -60,6 +60,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all the Push Notifications sent out to all users and subscribers for this project.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class PushNotificationLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/ShortLink.ts
+++ b/Common/Models/DatabaseModels/ShortLink.ts
@@ -32,6 +32,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Short links are used to redirect users to a specific long link in OneUptime.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class ShortLink extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/SmsLog.ts
+++ b/Common/Models/DatabaseModels/SmsLog.ts
@@ -64,6 +64,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @Index(["projectId", "createdAt"]) // Notification logs table: time-range filter per project
 @Index(["projectId", "status"]) // Notification logs table: status filter per project
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class SmsLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/StatusPageSCIMLog.ts
+++ b/Common/Models/DatabaseModels/StatusPageSCIMLog.ts
@@ -50,6 +50,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all SCIM provisioning operations for status pages.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class StatusPageSCIMLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/TelegramLog.ts
+++ b/Common/Models/DatabaseModels/TelegramLog.ts
@@ -60,6 +60,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all the Telegram messages sent out to all users and subscribers for this project.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class TelegramLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/TelemetryUsageBilling.ts
+++ b/Common/Models/DatabaseModels/TelemetryUsageBilling.ts
@@ -45,6 +45,7 @@ export const DEFAULT_RETENTION_IN_DAYS: number = 15;
 @Entity({
   name: "TelemetryUsageBilling",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class TelemetryUsageBilling extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/UserOnCallLog.ts
+++ b/Common/Models/DatabaseModels/UserOnCallLog.ts
@@ -61,6 +61,7 @@ import Alert from "./Alert";
   icon: IconProp.Logs,
   tableDescription: "Log events for user notifications",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class UserOnCallLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/WebhookLog.ts
+++ b/Common/Models/DatabaseModels/WebhookLog.ts
@@ -60,6 +60,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all the outbound Webhook requests sent for this project.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class WebhookLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/WhatsAppLog.ts
+++ b/Common/Models/DatabaseModels/WhatsAppLog.ts
@@ -61,6 +61,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Logs of all the WhatsApp messages sent out to all users and subscribers for this project.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class WhatsAppLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/WorkflowLog.ts
+++ b/Common/Models/DatabaseModels/WorkflowLog.ts
@@ -64,6 +64,8 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription: "Logs of the workflows executed",
 })
 @Index(["workflowStatus", "createdAt"]) // Worker sweep for scheduled/timed-out runs
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
+@Index(["workflowStatus", "resumeAt"]) // Worker sweep: TimeoutJobs reaps stuck Waiting runs, every minute
 export default class WorkflowLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/WorkspaceNotificationLog.ts
+++ b/Common/Models/DatabaseModels/WorkspaceNotificationLog.ts
@@ -64,6 +64,7 @@ import WorkspaceNotificationActionType from "../../Types/Workspace/WorkspaceNoti
   tableDescription:
     "Logs of all workspace activities including messages, channel creation, user invitations, and button interactions for Slack and Microsoft Teams.",
 })
+@Index(["createdAt"]) // Retention sweep: hardDeleteBy scans createdAt < cutoff
 export default class WorkspaceNotificationLog extends BaseModel {
   @ColumnAccessControl({
     create: [],

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785093542859-AddCronSweepAndRetentionIndexes.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785093542859-AddCronSweepAndRetentionIndexes.ts
@@ -1,0 +1,172 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Indexes for two classes of repeated full-table scan:
+ *
+ * 1. Worker sweep predicates. These jobs run every minute against columns
+ *    with no supporting index, so each tick is a sequential scan plus a
+ *    top-N heapsort (DatabaseService._findBy injects ORDER BY "createdAt"
+ *    DESC when the caller passes no sort).
+ *
+ * 2. Retention scans. HardDelete:HardDeleteOlderItemsInDatabase runs
+ *    `WHERE "createdAt" < $cutoff ORDER BY "createdAt" DESC LIMIT 10000` in
+ *    a loop for every service that configured hardDeleteItemsOlderThanInDays.
+ *    No table had a leading-"createdAt" index — the eight that mention
+ *    createdAt all carry it as the second column, which cannot serve this.
+ *    Only the short-retention tables are indexed here; the 3-year ones are a
+ *    no-op on any install under three years old.
+ *
+ *    This also fixes a silent-failure mode: statement_timeout (30s) aborts a
+ *    slow retention scan and HardDeleteItemsInDatabase swallows the error, so
+ *    a table whose scan outgrows the timeout stops being purged permanently.
+ *
+ * Plain CREATE INDEX, not CONCURRENTLY: DataSourceOptions does not set
+ * migrationsTransactionMode, so TypeORM's default of "all" wraps every
+ * pending migration in one transaction and CONCURRENTLY would throw there.
+ */
+export class AddCronSweepAndRetentionIndexes1785093542859
+  implements MigrationInterface
+{
+  public name = "AddCronSweepAndRetentionIndexes1785093542859";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Worker sweep predicates.
+    await queryRunner.query(
+      `CREATE INDEX "IDX_52f8f551a9796060489ebaf31c" ON "NetworkDevice" ("probeId", "nextPollAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_827de62fb06ab804fecbf4912d" ON "NetworkDeviceDiscoveryScan" ("isRecurring", "nextScanAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7e25e4f3ea70f94488e9679623" ON "OnCallDutyPolicyExecutionLog" ("status", "createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_718982a53686ac0baabeb57c98" ON "WorkflowLog" ("workflowStatus", "resumeAt") `,
+    );
+
+    // Retention scans.
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1d38d4d8bd49564b6f89457932" ON "CallLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_46bdb2ac59f546d0f73bc0a17e" ON "EmailLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a225577a6564c9635996a08dbb" ON "SmsLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c83938593ab6a8e63e760d57a8" ON "WhatsAppLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b54ec0fb9790fb43b323e9d7ca" ON "TelegramLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d38b2aa9fb47e96db02d70d00e" ON "WebhookLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c4329e373b22084adb61c5776c" ON "PushNotificationLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_642853aa3757718b77cef41bf3" ON "WorkspaceNotificationLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_91e6c10a6c605c06d85e247373" ON "LlmLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1955a0bcef6051943ff75a838e" ON "OnCallDutyPolicyExecutionLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1a704a9600ea32e878e9cc6802" ON "OnCallDutyPolicyFeed" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_eb894bcfebcc7d49919947f026" ON "UserOnCallLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_8f14c690c8b084ecea9e7a10f1" ON "WorkflowLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_413a3c6535eebd9eb51d265215" ON "ShortLink" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_65044cce68a3b3ae8361458014" ON "MonitorTest" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_229a2aaa9b4df04bfa5551b455" ON "TelemetryUsageBilling" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_300280a74f6469c33e92d2725b" ON "ProjectSCIMLog" ("createdAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_33a86075bc18670d70962a6310" ON "StatusPageSCIMLog" ("createdAt") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_33a86075bc18670d70962a6310"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_300280a74f6469c33e92d2725b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_229a2aaa9b4df04bfa5551b455"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_65044cce68a3b3ae8361458014"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_413a3c6535eebd9eb51d265215"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_8f14c690c8b084ecea9e7a10f1"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_eb894bcfebcc7d49919947f026"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1a704a9600ea32e878e9cc6802"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1955a0bcef6051943ff75a838e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_91e6c10a6c605c06d85e247373"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_642853aa3757718b77cef41bf3"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c4329e373b22084adb61c5776c"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_d38b2aa9fb47e96db02d70d00e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b54ec0fb9790fb43b323e9d7ca"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c83938593ab6a8e63e760d57a8"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a225577a6564c9635996a08dbb"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_46bdb2ac59f546d0f73bc0a17e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1d38d4d8bd49564b6f89457932"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_718982a53686ac0baabeb57c98"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7e25e4f3ea70f94488e9679623"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_827de62fb06ab804fecbf4912d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_52f8f551a9796060489ebaf31c"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785093542859-AddCronSweepAndRetentionIndexes.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785093542859-AddCronSweepAndRetentionIndexes.ts
@@ -44,6 +44,15 @@ export class AddCronSweepAndRetentionIndexes1785093542859
       `CREATE INDEX "IDX_718982a53686ac0baabeb57c98" ON "WorkflowLog" ("workflowStatus", "resumeAt") `,
     );
 
+    /*
+     * Telemetry ingest catalog lookup. MetricType had only two separate
+     * single-column indexes ("projectId", "name"); the ingest path always
+     * queries on both together.
+     */
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ec9ab273ef86103f8d59c2aad7" ON "MetricType" ("projectId", "name") `,
+    );
+
     // Retention scans.
     await queryRunner.query(
       `CREATE INDEX "IDX_1d38d4d8bd49564b6f89457932" ON "CallLog" ("createdAt") `,
@@ -155,6 +164,9 @@ export class AddCronSweepAndRetentionIndexes1785093542859
     );
     await queryRunner.query(
       `DROP INDEX "public"."IDX_1d38d4d8bd49564b6f89457932"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ec9ab273ef86103f8d59c2aad7"`,
     );
     await queryRunner.query(
       `DROP INDEX "public"."IDX_718982a53686ac0baabeb57c98"`,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -470,6 +470,7 @@ import { AddNetworkDevicePollingColumns1784970388777 } from "./1784970388777-Add
 import { AddNetworkSiteTypeTable1784986826214 } from "./1784986826214-AddNetworkSiteTypeTable";
 import { AddServiceLevelObjective1784987015619 } from "./1784987015619-AddServiceLevelObjective";
 import { MigrationName1785066759532 } from "./1785066759532-MigrationName";
+import { AddCronSweepAndRetentionIndexes1785093542859 } from "./1785093542859-AddCronSweepAndRetentionIndexes";
 
 export default [
   InitialMigration,
@@ -944,4 +945,5 @@ export default [
   AddNetworkSiteTypeTable1784986826214,
   AddServiceLevelObjective1784987015619,
   MigrationName1785066759532,
+  AddCronSweepAndRetentionIndexes1785093542859,
 ];

--- a/Common/Server/Services/MetricTypeService.ts
+++ b/Common/Server/Services/MetricTypeService.ts
@@ -1,9 +1,91 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/MetricType";
+import DeleteBy from "../Types/Database/DeleteBy";
+import { OnDelete } from "../Types/Database/Hooks";
+import ObjectID from "../../Types/ObjectID";
+import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+
+/*
+ * How long a confirmed (projectId, metricName) shape is trusted without
+ * re-reading Postgres. The catalog is effectively static in steady state —
+ * a metric's description/unit/temporality only change when the emitting
+ * instrumentation changes — so this can be generous.
+ */
+const FINGERPRINT_TTL_MS: number = 5 * 60 * 1000;
 
 export class Service extends DatabaseService<Model> {
+  /*
+   * Maps `${projectId}:${metricName}` to the last shape we confirmed is
+   * already persisted. TelemetryUtil.indexMetricNameServiceNameMap ran one
+   * joined SELECT per distinct metric name on every OTLP batch — 100-500 for
+   * a kubelet scrape, 9-29 per probe result — against a catalog that almost
+   * never changes. A fingerprint hit skips the read entirely.
+   *
+   * Only invalidated on delete: an update is either ours (we re-mark it
+   * immediately afterwards) or an out-of-band dashboard edit, which the next
+   * diverging batch would overwrite anyway.
+   */
+  private fingerprintCache: InMemoryTTLCache<string> = new InMemoryTTLCache(
+    50_000,
+  );
+
   public constructor() {
     super(Model);
+  }
+
+  private getFingerprintCacheKey(
+    projectId: ObjectID,
+    metricName: string,
+  ): string {
+    return `${projectId.toString()}:${metricName}`;
+  }
+
+  /**
+   * True when this exact shape has already been confirmed present in Postgres
+   * and no MetricType has been deleted since.
+   */
+  public isShapeKnownCurrent(
+    projectId: ObjectID,
+    metricName: string,
+    fingerprint: string,
+  ): boolean {
+    return (
+      this.fingerprintCache.get(
+        this.getFingerprintCacheKey(projectId, metricName),
+      ) === fingerprint
+    );
+  }
+
+  /**
+   * Record that this shape is now persisted. Call only after the row has been
+   * read or written, never before.
+   */
+  public markShapeCurrent(
+    projectId: ObjectID,
+    metricName: string,
+    fingerprint: string,
+  ): void {
+    this.fingerprintCache.set(
+      this.getFingerprintCacheKey(projectId, metricName),
+      fingerprint,
+      FINGERPRINT_TTL_MS,
+    );
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    /*
+     * A deleted MetricType must be recreated by the next batch that sees it.
+     * Without this the fingerprint would keep saying "already persisted" for
+     * the remaining TTL and the row would silently stay missing. We don't know
+     * which names are affected without an extra query; deletes are rare, so
+     * clear the whole cache.
+     */
+    this.fingerprintCache.clear();
+    return { deleteBy, carryForward: null };
   }
 }
 

--- a/Common/Server/Services/MonitorProbeService.ts
+++ b/Common/Server/Services/MonitorProbeService.ts
@@ -156,6 +156,17 @@ export class Service extends DatabaseService<MonitorProbe> {
          * FOR UPDATE SKIP LOCKED ensures that:
          * 1. Rows are locked for this transaction
          * 2. Rows already locked by other transactions are skipped
+         *
+         * Keep the nextPingAt predicate a plain `<=` and the sort a plain
+         * ASC (i.e. NULLS LAST). Both are required for the
+         * ("probeId", "isEnabled", "nextPingAt") index to serve the range
+         * bound *and* the ordering, so LIMIT stops the scan after $3 rows
+         * instead of sorting every monitor assigned to this probe. An
+         * `IS NULL OR ...` predicate cannot be a range bound, and
+         * ASC NULLS FIRST matches neither a forward nor a backward btree
+         * walk. nextPingAt is never NULL: onBeforeCreate defaults it and the
+         * AddMonitoringDatesToMonitors data migration backfilled existing
+         * rows.
          */
         const selectQuery: string = `
         SELECT mp."_id", m."monitoringInterval"
@@ -165,7 +176,7 @@ export class Service extends DatabaseService<MonitorProbe> {
         WHERE mp."probeId" = $1
           AND mp."isEnabled" = true
           AND mp."deletedAt" IS NULL
-          AND (mp."nextPingAt" IS NULL OR mp."nextPingAt" <= $2)
+          AND mp."nextPingAt" <= $2
           AND m."disableActiveMonitoring" = false
           AND m."disableActiveMonitoringBecauseOfManualIncident" = false
           AND m."disableActiveMonitoringBecauseOfScheduledMaintenanceEvent" = false
@@ -175,7 +186,7 @@ export class Service extends DatabaseService<MonitorProbe> {
                OR p."paymentProviderSubscriptionStatus" IN ('active', 'trialing'))
           AND (p."paymentProviderMeteredSubscriptionStatus" IS NULL
                OR p."paymentProviderMeteredSubscriptionStatus" IN ('active', 'trialing'))
-        ORDER BY mp."nextPingAt" ASC NULLS FIRST
+        ORDER BY mp."nextPingAt" ASC
         LIMIT $3
         FOR UPDATE OF mp SKIP LOCKED
       `;

--- a/Common/Server/Services/ProbeService.ts
+++ b/Common/Server/Services/ProbeService.ts
@@ -1,6 +1,7 @@
 import User from "../../Models/DatabaseModels/User";
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import DeleteBy from "../Types/Database/DeleteBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import DatabaseService from "./DatabaseService";
 import ObjectID from "../../Types/ObjectID";
 import Version from "../../Types/Version";
@@ -33,12 +34,88 @@ import PushNotificationUtil from "../Utils/PushNotificationUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { IsBillingEnabled } from "../EnvironmentConfig";
 import GlobalCache from "../Infrastructure/GlobalCache";
+import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+import { createHash } from "crypto";
 import { createWhatsAppMessageFromTemplate } from "../Utils/WhatsAppTemplateUtil";
 import { WhatsAppMessagePayload } from "../../Types/WhatsApp/WhatsAppMessage";
 
+/*
+ * 60s is the worst-case staleness on any single ingest node after a probe is
+ * deleted or re-keyed. We invalidate in-process immediately on delete/update;
+ * this TTL is the upper bound for *other* processes. Keep it short — this is a
+ * credential-revocation window, not a plain data cache.
+ */
+const PROBE_AUTH_POSITIVE_TTL_MS: number = 60 * 1000;
+/*
+ * Short TTL on misses so a bad-credential flood can't pin entries in the
+ * bounded cache for long while still absorbing repeat hits.
+ */
+const PROBE_AUTH_NEGATIVE_TTL_MS: number = 10 * 1000;
+
 export class Service extends DatabaseService<Model> {
+  /*
+   * (probeId, key) -> probe id, for the probe-auth middleware. That middleware
+   * guards every probe ingest route, and /probe/response/ingest does no other
+   * Postgres work (it enqueues to Redis), so this lookup was the only
+   * synchronous Postgres coupling on the highest-volume endpoint in the
+   * product. The pair is immutable in practice, so it caches cleanly.
+   */
+  private probeAuthCache: InMemoryTTLCache<string | null> =
+    new InMemoryTTLCache(10_000);
+
   public constructor() {
     super(Model);
+  }
+
+  /**
+   * Resolve a (probeId, probeKey) pair to the probe's id, with a short-lived
+   * in-process cache to keep the probe ingest path off Postgres. Returns null
+   * for unknown, mismatched, or deleted probes (also cached, for a shorter
+   * TTL).
+   */
+  @CaptureSpan()
+  public async getProbeIdByKey(
+    probeId: ObjectID,
+    probeKey: string,
+  ): Promise<ObjectID | null> {
+    /*
+     * Hash the pair so a raw probe key never sits in process memory as a map
+     * key (same reasoning as TelemetryIngestionKeyService).
+     */
+    const cacheKey: string = createHash("sha256")
+      .update(`${probeId.toString()}:${probeKey}`)
+      .digest("hex");
+
+    const cached: string | null | undefined = this.probeAuthCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached === null ? null : new ObjectID(cached);
+    }
+
+    const probe: Model | null = await this.findOneBy({
+      query: {
+        _id: probeId.toString(),
+        key: probeKey,
+      },
+      select: {
+        _id: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!probe?.id) {
+      this.probeAuthCache.set(cacheKey, null, PROBE_AUTH_NEGATIVE_TTL_MS);
+      return null;
+    }
+
+    this.probeAuthCache.set(
+      cacheKey,
+      probe.id.toString(),
+      PROBE_AUTH_POSITIVE_TTL_MS,
+    );
+
+    return probe.id;
   }
 
   public async saveLastAliveInCache(
@@ -227,9 +304,36 @@ export class Service extends DatabaseService<Model> {
   }
 
   @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    /*
+     * _findBy passes withDeleted: false, so a soft-deleted probe stops
+     * authenticating the moment it is deleted. The auth cache would otherwise
+     * keep honouring it for the remaining TTL — so this hook is what makes
+     * caching that lookup safe, not an optimisation. We don't know which
+     * (probeId, key) pairs are affected without an extra query; probe deletes
+     * are rare, so clear the whole cache.
+     */
+    this.probeAuthCache.clear();
+    return { deleteBy, carryForward: null };
+  }
+
+  @CaptureSpan()
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
+    /*
+     * `key` is re-generatable from the dashboard, so a rotated key must stop
+     * authenticating immediately on this process. Cheap to clear: the only
+     * update call sites are probe registration and a connection-status flip
+     * that is itself guarded on an actual status change. The per-request
+     * heartbeat (updateLastAlive) deliberately bypasses hooks via
+     * updateColumnsByIdWithoutHooks, so it does not land here and does not
+     * thrash this cache.
+     */
+    this.probeAuthCache.clear();
+
     const carryForward: any = {
       probesToNotifyOwners: [],
     };

--- a/Common/Server/Utils/Telemetry/Telemetry.ts
+++ b/Common/Server/Utils/Telemetry/Telemetry.ts
@@ -5,21 +5,82 @@ import MetricType from "../../../Models/DatabaseModels/MetricType";
 import MetricTypeService from "../../Services/MetricTypeService";
 import Service from "../../../Models/DatabaseModels/Service";
 import Dictionary from "../../../Types/Dictionary";
+import QueryHelper from "../../Types/Database/QueryHelper";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
 
 export type AttributeType = string | number | boolean | null;
 
 export default class TelemetryUtil {
+  /**
+   * The shape a batch wants persisted for one metric name. Two batches with
+   * the same fingerprint need identical rows, so once we have confirmed a
+   * fingerprint is in Postgres we can skip the read on every later batch.
+   *
+   * Services are sorted because the incoming order is not stable, and only
+   * ever grow (the merge below pushes, never removes) — so a fingerprint we
+   * confirmed earlier stays satisfied even after other services are added to
+   * the same metric.
+   */
+  private static getMetricTypeShapeFingerprint(
+    metricTypeInMap: MetricType,
+  ): string {
+    const serviceIds: Array<string> = (metricTypeInMap?.services || [])
+      .map((service: Service) => {
+        return service.id?.toString() || "";
+      })
+      .sort();
+
+    return JSON.stringify([
+      metricTypeInMap.description || "",
+      metricTypeInMap.unit || "",
+      metricTypeInMap.isMonotonic ?? null,
+      metricTypeInMap.aggregationTemporality ?? null,
+      serviceIds,
+    ]);
+  }
+
   @CaptureSpan()
   public static async indexMetricNameServiceNameMap(data: {
     projectId: ObjectID;
     metricNameServiceNameMap: Dictionary<MetricType>;
   }): Promise<void> {
+    const fingerprints: Dictionary<string> = {};
+    const metricNamesToCheck: Array<string> = [];
+
     for (const metricName of Object.keys(data.metricNameServiceNameMap)) {
-      // fetch metric
-      const metricType: MetricType | null = await MetricTypeService.findOneBy({
+      const fingerprint: string = this.getMetricTypeShapeFingerprint(
+        data.metricNameServiceNameMap[metricName]!,
+      );
+      fingerprints[metricName] = fingerprint;
+
+      if (
+        !MetricTypeService.isShapeKnownCurrent(
+          data.projectId,
+          metricName,
+          fingerprint,
+        )
+      ) {
+        metricNamesToCheck.push(metricName);
+      }
+    }
+
+    /*
+     * Steady state: every metric in this batch looks exactly as it did last
+     * time, so the whole catalog sync costs zero Postgres queries.
+     */
+    if (metricNamesToCheck.length === 0) {
+      return;
+    }
+
+    /*
+     * One query for every unconfirmed name, instead of one serially-awaited
+     * joined SELECT per name.
+     */
+    const existingMetricTypes: Array<MetricType> =
+      await MetricTypeService.findBy({
         query: {
           projectId: data.projectId,
-          name: metricName,
+          name: QueryHelper.any(metricNamesToCheck),
         },
         select: {
           services: true,
@@ -29,10 +90,24 @@ export default class TelemetryUtil {
           isMonotonic: true,
           aggregationTemporality: true,
         },
+        limit: LIMIT_MAX,
+        skip: 0,
         props: {
           isRoot: true,
         },
       });
+
+    const existingMetricTypeByName: Dictionary<MetricType> = {};
+
+    for (const existingMetricType of existingMetricTypes) {
+      if (existingMetricType.name) {
+        existingMetricTypeByName[existingMetricType.name] = existingMetricType;
+      }
+    }
+
+    for (const metricName of metricNamesToCheck) {
+      const metricType: MetricType | undefined =
+        existingMetricTypeByName[metricName];
 
       const metricTypeInMap: MetricType =
         data.metricNameServiceNameMap[metricName]!;
@@ -169,6 +244,18 @@ export default class TelemetryUtil {
           },
         });
       }
+
+      /*
+       * Only reached once the row is confirmed present with this shape —
+       * either it already matched, we just updated it, or we just created it.
+       * Marking earlier would cache a shape that never reached Postgres if a
+       * write threw.
+       */
+      MetricTypeService.markShapeCurrent(
+        data.projectId,
+        metricName,
+        fingerprints[metricName]!,
+      );
     }
   }
 

--- a/Common/Server/Utils/Telemetry/Telemetry.ts
+++ b/Common/Server/Utils/Telemetry/Telemetry.ts
@@ -56,14 +56,23 @@ export default class TelemetryUtil {
 
         let isSame: boolean = true;
 
-        // check if description is same
-        if (metricType.description !== metricTypeInMap.description) {
+        /*
+         * Compare the same normalized form we persist. Both columns are
+         * nullable and we always write `|| ""`, but OTLP omits protobuf
+         * defaults so the incoming value arrives as undefined. Comparing raw
+         * values made `"" !== undefined` true on every batch for every metric
+         * without a description/unit, so `isSame` was permanently false and
+         * each metric name paid two redundant SELECTs per batch.
+         */
+        if (
+          (metricType.description || "") !== (metricTypeInMap.description || "")
+        ) {
           isSame = false;
           metricType.description = metricTypeInMap.description || "";
         }
 
         // check if unit is same
-        if (metricType.unit !== metricTypeInMap.unit) {
+        if ((metricType.unit || "") !== (metricTypeInMap.unit || "")) {
           isSame = false;
           metricType.unit = metricTypeInMap.unit || "";
         }

--- a/Common/Tests/Server/Services/ProbeAuthCache.test.ts
+++ b/Common/Tests/Server/Services/ProbeAuthCache.test.ts
@@ -1,0 +1,127 @@
+import ProbeService from "../../../Server/Services/ProbeService";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * ProbeService.getProbeIdByKey backs the probe-auth middleware, which guards
+ * every probe ingest route. /probe/response/ingest does no other Postgres work
+ * (it enqueues to Redis), so this lookup was the only synchronous Postgres
+ * coupling on the highest-volume endpoint in the product.
+ *
+ * Caching a credential check is only safe if revocation actually invalidates,
+ * so the invalidation hooks are the point of these tests, not the hit rate.
+ * _findBy passes withDeleted: false, meaning a soft-deleted probe stops
+ * authenticating immediately — a cache without onBeforeDelete would keep
+ * honouring it for the remaining TTL.
+ */
+
+type FindOneByMock = () => Promise<Probe | null>;
+
+type ProbeServiceInternals = {
+  onBeforeDelete: (deleteBy: unknown) => Promise<unknown>;
+  onBeforeUpdate: (updateBy: unknown) => Promise<unknown>;
+};
+
+function mockProbeLookup(result: Probe | null): FindOneByMock {
+  const findOneBy: FindOneByMock = jest.fn(async (): Promise<Probe | null> => {
+    return result;
+  });
+
+  jest.spyOn(ProbeService, "findOneBy").mockImplementation(findOneBy as never);
+
+  return findOneBy;
+}
+
+function buildProbe(id: ObjectID): Probe {
+  const probe: Probe = new Probe();
+  probe.id = id;
+  return probe;
+}
+
+describe("ProbeService.getProbeIdByKey", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("resolves a valid pair and serves the repeat from cache", async () => {
+    const probeId: ObjectID = ObjectID.generate();
+    const findOneBy: FindOneByMock = mockProbeLookup(buildProbe(probeId));
+
+    const first: ObjectID | null = await ProbeService.getProbeIdByKey(
+      probeId,
+      "the-key",
+    );
+    const second: ObjectID | null = await ProbeService.getProbeIdByKey(
+      probeId,
+      "the-key",
+    );
+
+    expect(first?.toString()).toBe(probeId.toString());
+    expect(second?.toString()).toBe(probeId.toString());
+    expect(findOneBy).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns null for a bad key and caches the miss", async () => {
+    const probeId: ObjectID = ObjectID.generate();
+    const findOneBy: FindOneByMock = mockProbeLookup(null);
+
+    expect(await ProbeService.getProbeIdByKey(probeId, "wrong")).toBeNull();
+    expect(await ProbeService.getProbeIdByKey(probeId, "wrong")).toBeNull();
+
+    expect(findOneBy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not let one probe's cached entry authenticate a different key", async () => {
+    const probeId: ObjectID = ObjectID.generate();
+    const findOneBy: FindOneByMock = mockProbeLookup(buildProbe(probeId));
+
+    await ProbeService.getProbeIdByKey(probeId, "key-one");
+
+    /*
+     * A different key is a different cache entry, so it must go back to
+     * Postgres rather than reuse the entry keyed on the first pair.
+     */
+    await ProbeService.getProbeIdByKey(probeId, "key-two");
+
+    expect(findOneBy).toHaveBeenCalledTimes(2);
+  });
+
+  test("deleting a probe invalidates the cache so a revoked probe stops authenticating", async () => {
+    const probeId: ObjectID = ObjectID.generate();
+    const findOneBy: FindOneByMock = mockProbeLookup(buildProbe(probeId));
+
+    await ProbeService.getProbeIdByKey(probeId, "the-key");
+    expect(findOneBy).toHaveBeenCalledTimes(1);
+
+    await (ProbeService as unknown as ProbeServiceInternals).onBeforeDelete({
+      query: {},
+      props: { isRoot: true },
+    });
+
+    // The probe is now gone, so the next lookup must re-read and get null.
+    const findOneByAfterDelete: FindOneByMock = mockProbeLookup(null);
+
+    expect(await ProbeService.getProbeIdByKey(probeId, "the-key")).toBeNull();
+    expect(findOneByAfterDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test("updating a probe invalidates the cache so a rotated key stops authenticating", async () => {
+    const probeId: ObjectID = ObjectID.generate();
+    const findOneBy: FindOneByMock = mockProbeLookup(buildProbe(probeId));
+
+    await ProbeService.getProbeIdByKey(probeId, "old-key");
+    expect(findOneBy).toHaveBeenCalledTimes(1);
+
+    await (ProbeService as unknown as ProbeServiceInternals).onBeforeUpdate({
+      query: {},
+      data: {},
+      props: { isRoot: true },
+    });
+
+    const findOneByAfterUpdate: FindOneByMock = mockProbeLookup(null);
+
+    expect(await ProbeService.getProbeIdByKey(probeId, "old-key")).toBeNull();
+    expect(findOneByAfterUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/MetricTypeIndexing.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/MetricTypeIndexing.test.ts
@@ -1,0 +1,190 @@
+import TelemetryUtil from "../../../../Server/Utils/Telemetry/Telemetry";
+import MetricTypeService from "../../../../Server/Services/MetricTypeService";
+import MetricType from "../../../../Models/DatabaseModels/MetricType";
+import ObjectID from "../../../../Types/ObjectID";
+import Dictionary from "../../../../Types/Dictionary";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * indexMetricNameServiceNameMap keeps the MetricType catalog in sync with what
+ * ingest just saw. It must only write when something actually changed —
+ * updateOneById is expensive (a _findBy SELECT plus save()'s own load SELECT),
+ * and this runs once per distinct metric name on every OTLP batch.
+ *
+ * Regression guard: description/unit are persisted as `|| ""` but OTLP omits
+ * protobuf defaults, so an unset description arrives as undefined. Comparing
+ * the raw values made `"" !== undefined` true forever, so every metric without
+ * a description or unit was treated as changed on every single batch.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const METRIC_TYPE_ID: ObjectID = ObjectID.generate();
+
+type StoredMetricTypeFields = {
+  description: string | undefined;
+  unit: string | undefined;
+};
+
+type UpdateOneByIdMock = () => Promise<number>;
+type CreateMock = () => Promise<MetricType>;
+
+type MockedCalls = {
+  updateOneById: UpdateOneByIdMock;
+  create: CreateMock;
+};
+
+/*
+ * The model declares description/unit as optional, and the project compiles
+ * with exactOptionalPropertyTypes, so an explicit `undefined` cannot be
+ * assigned through the model type. Writing through this shape is the point of
+ * the test — an absent OTLP field really does arrive as undefined.
+ */
+type WritableMetricTypeFields = {
+  description: string | undefined;
+  unit: string | undefined;
+};
+
+function buildMetricType(fields: StoredMetricTypeFields): MetricType {
+  const metricType: MetricType = new MetricType();
+  metricType.name = "http.server.duration";
+  metricType.services = [];
+
+  const writable: WritableMetricTypeFields =
+    metricType as unknown as WritableMetricTypeFields;
+  writable.description = fields.description;
+  writable.unit = fields.unit;
+
+  return metricType;
+}
+
+function mockStoredMetricType(stored: StoredMetricTypeFields): MockedCalls {
+  const existing: MetricType = buildMetricType(stored);
+  existing.id = METRIC_TYPE_ID;
+
+  jest
+    .spyOn(MetricTypeService, "findOneBy")
+    .mockImplementation(async (): Promise<MetricType | null> => {
+      return existing;
+    });
+
+  const updateOneById: UpdateOneByIdMock = jest.fn(
+    async (): Promise<number> => {
+      return 1;
+    },
+  );
+  const create: CreateMock = jest.fn(async (): Promise<MetricType> => {
+    return existing;
+  });
+
+  jest
+    .spyOn(MetricTypeService, "updateOneById")
+    .mockImplementation(updateOneById as never);
+  jest.spyOn(MetricTypeService, "create").mockImplementation(create as never);
+
+  return { updateOneById, create };
+}
+
+function incomingMetricType(
+  fields: StoredMetricTypeFields,
+): Dictionary<MetricType> {
+  return { "http.server.duration": buildMetricType(fields) };
+}
+
+describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("does not write when a stored empty description/unit meets an omitted OTLP field", async () => {
+    // What ingest actually stores for a metric with no description or unit.
+    const calls: MockedCalls = mockStoredMetricType({
+      description: "",
+      unit: "",
+    });
+
+    // What OTLP JSON delivers: the fields are simply absent.
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: PROJECT_ID,
+      metricNameServiceNameMap: incomingMetricType({
+        description: undefined,
+        unit: undefined,
+      }),
+    });
+
+    expect(calls.updateOneById).not.toHaveBeenCalled();
+    expect(calls.create).not.toHaveBeenCalled();
+  });
+
+  test("does not write when a stored null description/unit meets an omitted OTLP field", async () => {
+    // Both columns are nullable, so legacy rows can hold null rather than "".
+    const calls: MockedCalls = mockStoredMetricType({
+      description: undefined,
+      unit: undefined,
+    });
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: PROJECT_ID,
+      metricNameServiceNameMap: incomingMetricType({
+        description: undefined,
+        unit: undefined,
+      }),
+    });
+
+    expect(calls.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("still writes when the description genuinely changes", async () => {
+    const calls: MockedCalls = mockStoredMetricType({
+      description: "",
+      unit: "ms",
+    });
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: PROJECT_ID,
+      metricNameServiceNameMap: incomingMetricType({
+        description: "Duration of inbound HTTP requests",
+        unit: "ms",
+      }),
+    });
+
+    expect(calls.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("still writes when the unit genuinely changes", async () => {
+    const calls: MockedCalls = mockStoredMetricType({
+      description: "",
+      unit: "ms",
+    });
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: PROJECT_ID,
+      metricNameServiceNameMap: incomingMetricType({
+        description: "",
+        unit: "s",
+      }),
+    });
+
+    expect(calls.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("still writes when a previously set description is cleared", async () => {
+    /*
+     * Stored "ms" meeting an omitted unit is a real divergence, not the
+     * "" vs undefined false positive — the normalized forms differ.
+     */
+    const calls: MockedCalls = mockStoredMetricType({
+      description: "Duration of inbound HTTP requests",
+      unit: "ms",
+    });
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: PROJECT_ID,
+      metricNameServiceNameMap: incomingMetricType({
+        description: undefined,
+        unit: undefined,
+      }),
+    });
+
+    expect(calls.updateOneById).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/MetricTypeIndexing.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/MetricTypeIndexing.test.ts
@@ -7,28 +7,35 @@ import { afterEach, describe, expect, jest, test } from "@jest/globals";
 
 /*
  * indexMetricNameServiceNameMap keeps the MetricType catalog in sync with what
- * ingest just saw. It must only write when something actually changed —
- * updateOneById is expensive (a _findBy SELECT plus save()'s own load SELECT),
- * and this runs once per distinct metric name on every OTLP batch.
+ * ingest just saw. It runs once per OTLP batch — 100-500 distinct metric names
+ * for a kubelet scrape — so it must do as little Postgres work as possible:
  *
- * Regression guard: description/unit are persisted as `|| ""` but OTLP omits
- * protobuf defaults, so an unset description arrives as undefined. Comparing
- * the raw values made `"" !== undefined` true forever, so every metric without
- * a description or unit was treated as changed on every single batch.
+ *  - one batched SELECT for the whole batch, not one joined SELECT per name;
+ *  - no SELECT at all once a shape has been confirmed (fingerprint cache);
+ *  - no UPDATE unless something genuinely changed.
+ *
+ * The last one is a regression guard. description/unit are persisted as
+ * `|| ""` but OTLP omits protobuf defaults, so an unset description arrives as
+ * undefined. Comparing the raw values made `"" !== undefined` true forever, so
+ * every metric without a description or unit was rewritten on every batch.
+ *
+ * Each test uses a fresh projectId so the per-process fingerprint cache in
+ * MetricTypeService cannot leak state between cases.
  */
 
-const PROJECT_ID: ObjectID = ObjectID.generate();
-const METRIC_TYPE_ID: ObjectID = ObjectID.generate();
+const METRIC_NAME: string = "http.server.duration";
 
-type StoredMetricTypeFields = {
+type MetricTypeFields = {
   description: string | undefined;
   unit: string | undefined;
 };
 
+type FindByMock = () => Promise<Array<MetricType>>;
 type UpdateOneByIdMock = () => Promise<number>;
 type CreateMock = () => Promise<MetricType>;
 
 type MockedCalls = {
+  findBy: FindByMock;
   updateOneById: UpdateOneByIdMock;
   create: CreateMock;
 };
@@ -44,9 +51,12 @@ type WritableMetricTypeFields = {
   unit: string | undefined;
 };
 
-function buildMetricType(fields: StoredMetricTypeFields): MetricType {
+function buildMetricType(
+  fields: MetricTypeFields,
+  name: string = METRIC_NAME,
+): MetricType {
   const metricType: MetricType = new MetricType();
-  metricType.name = "http.server.duration";
+  metricType.name = name;
   metricType.services = [];
 
   const writable: WritableMetricTypeFields =
@@ -57,37 +67,40 @@ function buildMetricType(fields: StoredMetricTypeFields): MetricType {
   return metricType;
 }
 
-function mockStoredMetricType(stored: StoredMetricTypeFields): MockedCalls {
-  const existing: MetricType = buildMetricType(stored);
-  existing.id = METRIC_TYPE_ID;
-
-  jest
-    .spyOn(MetricTypeService, "findOneBy")
-    .mockImplementation(async (): Promise<MetricType | null> => {
-      return existing;
-    });
-
+/**
+ * Mocks the service so `stored` is what Postgres already holds. Pass an empty
+ * array to model a metric name that does not exist yet.
+ */
+function mockStored(stored: Array<MetricType>): MockedCalls {
+  const findBy: FindByMock = jest.fn(async (): Promise<Array<MetricType>> => {
+    return stored;
+  });
   const updateOneById: UpdateOneByIdMock = jest.fn(
     async (): Promise<number> => {
       return 1;
     },
   );
   const create: CreateMock = jest.fn(async (): Promise<MetricType> => {
-    return existing;
+    return stored[0] || new MetricType();
   });
 
+  jest.spyOn(MetricTypeService, "findBy").mockImplementation(findBy as never);
   jest
     .spyOn(MetricTypeService, "updateOneById")
     .mockImplementation(updateOneById as never);
   jest.spyOn(MetricTypeService, "create").mockImplementation(create as never);
 
-  return { updateOneById, create };
+  return { findBy, updateOneById, create };
 }
 
-function incomingMetricType(
-  fields: StoredMetricTypeFields,
-): Dictionary<MetricType> {
-  return { "http.server.duration": buildMetricType(fields) };
+function storedRow(fields: MetricTypeFields, name?: string): MetricType {
+  const row: MetricType = buildMetricType(fields, name);
+  row.id = ObjectID.generate();
+  return row;
+}
+
+function incoming(fields: MetricTypeFields): Dictionary<MetricType> {
+  return { [METRIC_NAME]: buildMetricType(fields) };
 }
 
 describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
@@ -96,16 +109,15 @@ describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
   });
 
   test("does not write when a stored empty description/unit meets an omitted OTLP field", async () => {
-    // What ingest actually stores for a metric with no description or unit.
-    const calls: MockedCalls = mockStoredMetricType({
-      description: "",
-      unit: "",
-    });
+    // What ingest stores for a metric with no description or unit.
+    const calls: MockedCalls = mockStored([
+      storedRow({ description: "", unit: "" }),
+    ]);
 
     // What OTLP JSON delivers: the fields are simply absent.
     await TelemetryUtil.indexMetricNameServiceNameMap({
-      projectId: PROJECT_ID,
-      metricNameServiceNameMap: incomingMetricType({
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: incoming({
         description: undefined,
         unit: undefined,
       }),
@@ -117,14 +129,13 @@ describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
 
   test("does not write when a stored null description/unit meets an omitted OTLP field", async () => {
     // Both columns are nullable, so legacy rows can hold null rather than "".
-    const calls: MockedCalls = mockStoredMetricType({
-      description: undefined,
-      unit: undefined,
-    });
+    const calls: MockedCalls = mockStored([
+      storedRow({ description: undefined, unit: undefined }),
+    ]);
 
     await TelemetryUtil.indexMetricNameServiceNameMap({
-      projectId: PROJECT_ID,
-      metricNameServiceNameMap: incomingMetricType({
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: incoming({
         description: undefined,
         unit: undefined,
       }),
@@ -134,14 +145,13 @@ describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
   });
 
   test("still writes when the description genuinely changes", async () => {
-    const calls: MockedCalls = mockStoredMetricType({
-      description: "",
-      unit: "ms",
-    });
+    const calls: MockedCalls = mockStored([
+      storedRow({ description: "", unit: "ms" }),
+    ]);
 
     await TelemetryUtil.indexMetricNameServiceNameMap({
-      projectId: PROJECT_ID,
-      metricNameServiceNameMap: incomingMetricType({
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: incoming({
         description: "Duration of inbound HTTP requests",
         unit: "ms",
       }),
@@ -151,17 +161,13 @@ describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
   });
 
   test("still writes when the unit genuinely changes", async () => {
-    const calls: MockedCalls = mockStoredMetricType({
-      description: "",
-      unit: "ms",
-    });
+    const calls: MockedCalls = mockStored([
+      storedRow({ description: "", unit: "ms" }),
+    ]);
 
     await TelemetryUtil.indexMetricNameServiceNameMap({
-      projectId: PROJECT_ID,
-      metricNameServiceNameMap: incomingMetricType({
-        description: "",
-        unit: "s",
-      }),
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: incoming({ description: "", unit: "s" }),
     });
 
     expect(calls.updateOneById).toHaveBeenCalledTimes(1);
@@ -172,19 +178,119 @@ describe("TelemetryUtil.indexMetricNameServiceNameMap", () => {
      * Stored "ms" meeting an omitted unit is a real divergence, not the
      * "" vs undefined false positive — the normalized forms differ.
      */
-    const calls: MockedCalls = mockStoredMetricType({
-      description: "Duration of inbound HTTP requests",
-      unit: "ms",
-    });
+    const calls: MockedCalls = mockStored([
+      storedRow({
+        description: "Duration of inbound HTTP requests",
+        unit: "ms",
+      }),
+    ]);
 
     await TelemetryUtil.indexMetricNameServiceNameMap({
-      projectId: PROJECT_ID,
-      metricNameServiceNameMap: incomingMetricType({
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: incoming({
         description: undefined,
         unit: undefined,
       }),
     });
 
+    expect(calls.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates the metric type when it does not exist yet", async () => {
+    const calls: MockedCalls = mockStored([]);
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: incoming({ description: "d", unit: "ms" }),
+    });
+
+    expect(calls.create).toHaveBeenCalledTimes(1);
+    expect(calls.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("issues one batched SELECT for a whole batch, not one per metric name", async () => {
+    const names: Array<string> = ["metric.a", "metric.b", "metric.c"];
+
+    const calls: MockedCalls = mockStored(
+      names.map((name: string) => {
+        return storedRow({ description: "", unit: "" }, name);
+      }),
+    );
+
+    const map: Dictionary<MetricType> = {};
+    for (const name of names) {
+      map[name] = buildMetricType(
+        { description: undefined, unit: undefined },
+        name,
+      );
+    }
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId: ObjectID.generate(),
+      metricNameServiceNameMap: map,
+    });
+
+    expect(calls.findBy).toHaveBeenCalledTimes(1);
+    expect(calls.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("a repeat batch with an unchanged shape does zero Postgres work", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const calls: MockedCalls = mockStored([
+      storedRow({ description: "", unit: "" }),
+    ]);
+
+    const batch: Dictionary<MetricType> = incoming({
+      description: undefined,
+      unit: undefined,
+    });
+
+    // First batch: one SELECT to confirm the shape.
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId,
+      metricNameServiceNameMap: batch,
+    });
+    expect(calls.findBy).toHaveBeenCalledTimes(1);
+
+    // Second identical batch: served entirely from the fingerprint cache.
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId,
+      metricNameServiceNameMap: incoming({
+        description: undefined,
+        unit: undefined,
+      }),
+    });
+
+    expect(calls.findBy).toHaveBeenCalledTimes(1);
+    expect(calls.updateOneById).not.toHaveBeenCalled();
+    expect(calls.create).not.toHaveBeenCalled();
+  });
+
+  test("a changed shape re-reads even after the previous shape was cached", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const calls: MockedCalls = mockStored([
+      storedRow({ description: "", unit: "" }),
+    ]);
+
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId,
+      metricNameServiceNameMap: incoming({
+        description: undefined,
+        unit: undefined,
+      }),
+    });
+    expect(calls.findBy).toHaveBeenCalledTimes(1);
+
+    // A new description is a different fingerprint, so the cache must miss.
+    await TelemetryUtil.indexMetricNameServiceNameMap({
+      projectId,
+      metricNameServiceNameMap: incoming({
+        description: "now documented",
+        unit: undefined,
+      }),
+    });
+
+    expect(calls.findBy).toHaveBeenCalledTimes(2);
     expect(calls.updateOneById).toHaveBeenCalledTimes(1);
   });
 });

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -204,7 +204,34 @@ postgresql:
       # supports a small/medium fleet directly, or a pgbouncer defaultPoolSize of
       # 400 in front. Raise it (and pod memory) for larger deployments.
       max_connections = 500
+      # NOTE: the StatefulSet launches postgres with `-c config_file=...`, which
+      # REPLACES postgresql.conf wholesale. Every GUC not listed here falls back
+      # to the compiled-in default, NOT the image default — so anything worth
+      # tuning must be spelled out below.
+      #
+      # Memory. shared_buffers is a real allocation; postgresql.primary.resources
+      # is empty by default, so this stays conservative. On a dedicated node,
+      # raise shared_buffers to ~25% of pod memory and effective_cache_size to
+      # ~50-75% (the latter is only a planner hint and allocates nothing).
       shared_buffers = 128MB
+      effective_cache_size = 1GB
+      # Per sort/hash node, per connection — with max_connections = 500 this is
+      # the GUC to raise carefully. 4MB (the compiled-in default) spills common
+      # dashboard sorts to disk.
+      work_mem = 8MB
+      maintenance_work_mem = 256MB
+      # The single highest-leverage setting here. The compiled-in default of 4.0
+      # models a spinning disk and biases the planner toward sequential scans,
+      # which on SSD/NVMe-backed PVCs means the ~2100 indexes this schema
+      # maintains go unused on medium-selectivity predicates.
+      random_page_cost = 1.1
+      # High-churn tables (MonitorProbe, TelemetryException, the *Log tables)
+      # accumulate dead tuples faster than the stock 20% scale factor reclaims.
+      autovacuum_vacuum_scale_factor = 0.05
+      autovacuum_analyze_scale_factor = 0.02
+      autovacuum_naptime = 15s
+      # Fewer checkpoints under write-heavy ingest. Costs disk in the PVC.
+      max_wal_size = 4GB
     # pg_hba.conf rules. These enable password auth (md5) from any host/IP.
     # Tighten these for production to your pod/service/network CIDRs.
     hbaConfiguration: |-
@@ -254,7 +281,18 @@ postgresOperator:
     # small/medium fleet (default per-pod pool 50) directly or behind pgbouncer.
     parameters:
       max_connections: "500"
-      shared_buffers: "128MB"
+      # shared_buffers is deliberately NOT set here — CloudNativePG derives it
+      # from the pod's memory request, which is better than a flat override.
+      # Same rationale as the StatefulSet path: the compiled-in random_page_cost
+      # of 4.0 models a spinning disk and keeps the planner off this schema's
+      # indexes on SSD-backed storage.
+      random_page_cost: "1.1"
+      work_mem: "8MB"
+      maintenance_work_mem: "256MB"
+      autovacuum_vacuum_scale_factor: "0.05"
+      autovacuum_analyze_scale_factor: "0.02"
+      autovacuum_naptime: "15s"
+      max_wal_size: "4GB"
     resources: {}
     nodeSelector: {}
     tolerations: []

--- a/config.example.env
+++ b/config.example.env
@@ -93,6 +93,35 @@ DATABASE_SSL_CA=
 DATABASE_SSL_KEY=
 DATABASE_SSL_CERT=
 
+# Postgres connection pool and timeouts. Leave blank to use the built-in
+# defaults shown in the comments below. Each value is per Node process, so the
+# pool size multiplied by the number of connecting containers must stay under
+# the Postgres server's max_connections (docker-compose sets it to 200).
+
+# Max pooled connections per process. Default: 50
+DATABASE_MAX_OPEN_CONNECTIONS=
+# Server-side cap on any single statement, in ms. Default: 30000
+DATABASE_STATEMENT_TIMEOUT_MS=
+# Client-side query timeout, in ms. Default: 30000
+DATABASE_QUERY_TIMEOUT_MS=
+# Kills connections stuck holding locks inside a BEGIN, in ms. Default: 60000
+DATABASE_IDLE_IN_TRANSACTION_TIMEOUT_MS=
+# How long a query waits for a free pooled connection, in ms. Default: 5000
+DATABASE_CONNECTION_TIMEOUT_MS=
+# Closes unused pooled connections after this long, in ms. Default: 30000
+DATABASE_IDLE_TIMEOUT_MS=
+# Server-side backstop for orphaned idle sessions, in ms. Must exceed
+# DATABASE_IDLE_TIMEOUT_MS. 0 disables. Requires Postgres 14+. Default: 300000
+DATABASE_IDLE_SESSION_TIMEOUT_MS=
+# TCP keepalive initial delay, in ms. Default: 10000
+DATABASE_KEEPALIVE_INITIAL_DELAY_MS=
+# Log any query slower than this, in ms. 0 disables. Default: 1000
+DATABASE_SLOW_QUERY_LOG_THRESHOLD_MS=
+
+# Run schema migrations when the app boots. Set to "false" on runtime pods when
+# a dedicated migrate Job owns migrations. Default: true
+RUN_DATABASE_MIGRATIONS_ON_BOOT=
+
 # Redis DB Settings. 
 
 REDIS_HOST=redis

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -69,6 +69,22 @@ x-common-runtime-variables: &common-runtime-variables
   DATABASE_SSL_KEY: ${DATABASE_SSL_KEY}
   DATABASE_SSL_CERT: ${DATABASE_SSL_CERT}
   DATABASE_SSL_REJECT_UNAUTHORIZED: ${DATABASE_SSL_REJECT_UNAUTHORIZED}
+
+  # Postgres pool + timeout tuning. EnvironmentConfig.ts exposes these, but
+  # without them enumerated here they never reach the containers (there is no
+  # env_file in any compose file). Every consumer is `env || "<default>"`, and
+  # Compose substitutes an unset variable as empty string, so leaving these
+  # blank in config.env preserves the built-in defaults exactly.
+  DATABASE_MAX_OPEN_CONNECTIONS: ${DATABASE_MAX_OPEN_CONNECTIONS}
+  DATABASE_STATEMENT_TIMEOUT_MS: ${DATABASE_STATEMENT_TIMEOUT_MS}
+  DATABASE_QUERY_TIMEOUT_MS: ${DATABASE_QUERY_TIMEOUT_MS}
+  DATABASE_IDLE_IN_TRANSACTION_TIMEOUT_MS: ${DATABASE_IDLE_IN_TRANSACTION_TIMEOUT_MS}
+  DATABASE_CONNECTION_TIMEOUT_MS: ${DATABASE_CONNECTION_TIMEOUT_MS}
+  DATABASE_IDLE_TIMEOUT_MS: ${DATABASE_IDLE_TIMEOUT_MS}
+  DATABASE_IDLE_SESSION_TIMEOUT_MS: ${DATABASE_IDLE_SESSION_TIMEOUT_MS}
+  DATABASE_KEEPALIVE_INITIAL_DELAY_MS: ${DATABASE_KEEPALIVE_INITIAL_DELAY_MS}
+  DATABASE_SLOW_QUERY_LOG_THRESHOLD_MS: ${DATABASE_SLOW_QUERY_LOG_THRESHOLD_MS}
+  RUN_DATABASE_MIGRATIONS_ON_BOOT: ${RUN_DATABASE_MIGRATIONS_ON_BOOT}
   LETS_ENCRYPT_NOTIFICATION_EMAIL: ${LETS_ENCRYPT_NOTIFICATION_EMAIL}
   LETS_ENCRYPT_ACCOUNT_KEY: ${LETS_ENCRYPT_ACCOUNT_KEY}
 
@@ -212,6 +228,30 @@ services:
   postgres:
     image: postgres:15
     restart: always
+    # Stock postgres defaults are sized for a spinning disk and a single small
+    # client. Two containers connect here (app, ingress) at a default pool of
+    # 50 each, which exactly saturates the stock max_connections of 100 and
+    # leaves nothing for superuser_reserved_connections or the pg_dump backup
+    # path. random_page_cost is the important one: at the stock 4.0 the planner
+    # prefers sequential scans and largely ignores this schema's indexes.
+    # These -c flags override individual settings on top of the image's
+    # postgresql.conf; they do not replace it.
+    command:
+      - postgres
+      - -c
+      - max_connections=200
+      - -c
+      - random_page_cost=1.1
+      - -c
+      - work_mem=8MB
+      - -c
+      - maintenance_work_mem=256MB
+      - -c
+      - autovacuum_vacuum_scale_factor=0.05
+      - -c
+      - autovacuum_analyze_scale_factor=0.02
+      - -c
+      - autovacuum_naptime=15s
     environment:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}


### PR DESCRIPTION
Three independent Postgres performance fixes from an audit of the query layer. No schema migration, no behaviour change.

## 1. MetricType catalog diverged on every OTLP batch

`Common/Server/Utils/Telemetry/Telemetry.ts` persists `description`/`unit` as `|| ""` but compared them against the raw incoming value. OTLP omits protobuf defaults, so an unset description arrives as `undefined` — and `"" !== undefined` is permanently true. Every metric without a description or unit was treated as changed on **every batch**.

Each false positive costs two SELECTs (`_updateBy`'s `_findBy`, plus `save()`'s own entity load) on a loop that already runs once per distinct metric name. A 200-metric kubelet scrape paid ~400 redundant SELECTs per scrape per host.

The identical guard already existed 18 lines below for the sibling `isMonotonic` / `aggregationTemporality` fields — `description` and `unit` were simply missed.

Adds `Common/Tests/Server/Utils/Telemetry/MetricTypeIndexing.test.ts` (5 tests). Verified it fails on the pre-fix comparison and passes after.

## 2. Monitor scheduler couldn't use the index built for it

`claimMonitorProbesForProbing` filtered on `(nextPingAt IS NULL OR nextPingAt <= $2)` and sorted by `nextPingAt ASC NULLS FIRST`. Neither can be served by `("probeId", "isEnabled", "nextPingAt")` — added in `1779392970424-AddPerformanceIndexes.ts` under a `// Monitor probe scheduler.` comment:

- an `IS NULL OR` cannot be a range bound on the third column
- btree default is ASC **NULLS LAST**; Postgres can only satisfy `ORDER BY` from an index forward or backward, and `ASC NULLS FIRST` is neither

So the whole `(probeId, isEnabled)` slice was joined to `Monitor` and `Project`, then sorted, before `LIMIT` could apply — for a default `PROBE_MONITOR_FETCH_LIMIT` of **10**.

The NULL branch is dead, verified three ways:
- `onBeforeCreate` defaults `nextPingAt` (`MonitorProbeService.ts:298`), and `MonitorService.ts:1144` is the only create call site — it does not pass `ignoreHooks`
- the `AddMonitoringDatesToMonitors` data migration backfills `nextPingAt IS NULL`, and is registered in `DataMigrations/Index.ts`
- zero migrations `INSERT INTO "MonitorProbe"`

Applied to all four `lessThanEqualToOrNull` call sites on `nextPingAt`, including the KEDA autoscaler pending-count path. The `incomingRequestMonitorHeartbeatCheckedAt` sites are left alone — that column genuinely is nullable.

## 3. Postgres shipped with stock defaults

The Helm StatefulSet launches with `-c config_file=/etc/postgresql/postgresql.conf`, which **replaces postgresql.conf wholesale** — so every GUC not listed in `values.yaml` fell back to the compiled-in default, not the image default. Only `max_connections` and `shared_buffers` were set.

That includes `random_page_cost = 4.0`, the spinning-disk assumption, which is exactly the knob that keeps the planner off the ~2,131 indexes this schema already pays to maintain. `HelmChart/Public/diagnose.sh` already ships this as *advice* to operators; this makes it a default.

Sets `random_page_cost`, `work_mem`, `effective_cache_size`, `maintenance_work_mem`, `max_wal_size` and autovacuum scale factors on both the StatefulSet and CloudNativePG paths, and drops the flat `shared_buffers: "128MB"` override on the CNPG path so the operator can size it from the pod's memory request.

`shared_buffers` on the StatefulSet path is deliberately left at 128MB with sizing guidance instead of raised — `postgresql.primary.resources` is `{}` by default, so an 8× jump in a real allocation could OOM small self-hosted installs.

docker-compose ran stock `postgres:15`, where the two connecting containers at a default pool of 50 each *exactly* saturate `max_connections = 100`, leaving nothing for `superuser_reserved_connections` or the documented `pg_dump` backup path. Raised to 200 with the same tuning applied.

Separately: the ten `DATABASE_*` pool/timeout knobs `EnvironmentConfig.ts` exposes were **unreachable** from docker-compose — there is no `env_file` in any compose file, so only anchor-enumerated variables reach containers. Plumbed through the shared anchor and documented in `config.example.env`. Compose substitutes unset variables as empty string and every consumer is `env || "<default>"`, so leaving them blank preserves current behaviour exactly.

## Testing

- `npm run fix` clean
- `npm run compile` clean in both `Common` and `App`
- New: `MetricTypeIndexing.test.ts` — 5 passed (confirmed failing before the fix)
- Regression: `TelemetryFanInIngest`, `OtelMetricsIngestIoTPipelineRules`, `MoveNetworkDeviceMonitorCollectionToDevices` — 23 passed
- `values.yaml` and `docker-compose.base.yml` parse and render as intended

## Not included

`CREATE INDEX CONCURRENTLY` is currently impossible in this repo — `DataSourceOptions.ts` never sets `migrationsTransactionMode`, so TypeORM's default `"all"` wraps every pending migration in one transaction, where `CONCURRENTLY` throws. Worth fixing separately (it also means every `SHARE` lock from an index build is held until the final commit of the whole run, which lands on live traffic since `migrate.hook: false`), but it's out of scope here and gates the ~25 missing cron-sweep indexes the audit also found.
