### PR TITLE
perf(postgres): cut hot-path query load — write fast-paths, 13 missing indexes, status-page batching

### DIFF
--- a/App/FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.ts
+++ b/App/FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.ts
@@ -114,13 +114,19 @@ const checkOnlineStatus: (monitor: Monitor) => Promise<void> = async (
       `Updating incoming email monitor heartbeat checked at: ${monitor.id?.toString()}`,
     );
 
-    await MonitorService.updateOneById({
+    /*
+     * Heartbeat bookkeeping stamp, written for EVERY incoming-email monitor
+     * every 30 seconds. The full updateOneById pipeline costs ~3 SELECTs +
+     * UPDATE and — because Monitor has @EnableWorkflow + @EnableAuditLog —
+     * fires an on-update workflow HTTP trigger and an audit-log row per
+     * monitor per tick. A scheduler timestamp should do none of that;
+     * single-statement UPDATE, same pattern as the heartbeat writes in
+     * MonitorResource.ts.
+     */
+    await MonitorService.updateColumnsByIdWithoutHooks({
       id: monitor.id!,
       data: {
         incomingEmailMonitorHeartbeatCheckedAt: OneUptimeDate.getCurrentDate(),
-      },
-      props: {
-        isRoot: true,
       },
     });
 

--- a/App/FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.ts
+++ b/App/FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.ts
@@ -114,14 +114,20 @@ const checkHeartBeat: (monitor: Monitor) => Promise<void> = async (
       `Updating incoming request monitor heartbeat checked at: ${monitor.id?.toString()}`,
     );
 
-    await MonitorService.updateOneById({
+    /*
+     * Heartbeat bookkeeping stamp, written for EVERY incoming-request
+     * monitor every 30 seconds. The full updateOneById pipeline costs ~3
+     * SELECTs + UPDATE and — because Monitor has @EnableWorkflow +
+     * @EnableAuditLog — fires an on-update workflow HTTP trigger and an
+     * audit-log row per monitor per tick. A scheduler timestamp should do
+     * none of that; single-statement UPDATE, same pattern as the heartbeat
+     * writes in MonitorResource.ts.
+     */
+    await MonitorService.updateColumnsByIdWithoutHooks({
       id: monitor.id!,
       data: {
         incomingRequestMonitorHeartbeatCheckedAt:
           OneUptimeDate.getCurrentDate(),
-      },
-      props: {
-        isRoot: true,
       },
     });
 

--- a/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
@@ -200,15 +200,21 @@ export const enqueueDueTelemetryMonitorEvaluationJobs: () => Promise<void> =
         }
       }
 
+      /*
+       * Scheduler bookkeeping stamp, written for every due telemetry/infra
+       * monitor every minute. The full updateOneById pipeline costs ~4
+       * statements and — because Monitor has @EnableWorkflow +
+       * @EnableAuditLog — fires an on-update workflow HTTP trigger and an
+       * audit entry per monitor per tick. A scheduling timestamp should do
+       * none of that; single-statement UPDATE, same pattern as the heartbeat
+       * writes in MonitorResource.ts.
+       */
       updatePromises.push(
-        MonitorService.updateOneById({
+        MonitorService.updateColumnsByIdWithoutHooks({
           id: telemetryMonitor.id!,
           data: {
             telemetryMonitorLastMonitorAt: OneUptimeDate.getCurrentDate(),
             telemetryMonitorNextMonitorAt: nextPing,
-          },
-          props: {
-            isRoot: true,
           },
         }),
       );

--- a/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
@@ -1,0 +1,441 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import OneUptimeDate from "Common/Types/Date";
+import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
+import IncomingEmailMonitorRequest from "Common/Types/Monitor/IncomingEmailMonitor/IncomingEmailMonitorRequest";
+import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * Regression tests for the IncomingEmailMonitor:CheckOnlineStatus cron's write
+ * path — the email twin of IncomingRequestMonitor:CheckHeartbeat. The
+ * heartbeat bookkeeping stamp is written for EVERY incoming-email monitor
+ * every 30 seconds; it used to go through updateOneById, whose full pipeline
+ * is ~4 statements per row plus — because Monitor is @EnableWorkflow +
+ * @EnableAuditLog — an on-update workflow HTTP trigger and an audit-log
+ * insert per monitor per tick. The perf fix rewired the stamp to the
+ * single-UPDATE updateColumnsByIdWithoutHooks fast path. These tests pin:
+ *   1. the stamp goes through the hookless fast path with EXACTLY the
+ *      incomingEmailMonitorHeartbeatCheckedAt column, and updateOneById is
+ *      never called (the regression the change removes),
+ *   2. the per-monitor control flow around the stamp is unchanged: both
+ *      findAllBy batches (never-checked isNull first, then notNull) are
+ *      concatenated; a monitor without monitorSteps is skipped with no
+ *      write; only a monitor whose criteria check CheckOn.EmailReceivedAt
+ *      (NOT the request monitor's CheckOn.IncomingRequest) is handed to
+ *      MonitorResourceUtil.monitorResource; one failing monitor does not
+ *      prevent the others.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * updateOneById is mocked ALONGSIDE the fast path precisely so the suite can
+ * prove it is never called: if the job regressed back to the hooked pipeline,
+ * the assertion would flag it instead of the mock throwing "not a function".
+ */
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      getEnabledMonitorQuery: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: { getActiveProjectStatusQuery: jest.fn() },
+  };
+});
+
+/*
+ * The real MonitorResource util transitively loads the native `isolated-vm`
+ * addon (via MonitorCriteriaEvaluator -> VMRunner); the job only needs its
+ * monitorResource entry point, so the whole module is replaced.
+ */
+jest.mock("Common/Server/Utils/Monitor/MonitorResource", () => {
+  return {
+    __esModule: true,
+    default: { monitorResource: jest.fn() },
+  };
+});
+
+import MonitorService from "Common/Server/Services/MonitorService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import logger from "Common/Server/Utils/Logger";
+import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus";
+
+interface MonitorServiceMock {
+  findAllBy: jest.Mock;
+  getEnabledMonitorQuery: jest.Mock;
+  updateColumnsByIdWithoutHooks: jest.Mock;
+  updateOneById: jest.Mock;
+}
+
+const monitorService: MonitorServiceMock =
+  MonitorService as unknown as MonitorServiceMock;
+const projectService: { getActiveProjectStatusQuery: jest.Mock } =
+  ProjectService as unknown as { getActiveProjectStatusQuery: jest.Mock };
+const monitorResourceMock: jest.Mock =
+  MonitorResourceUtil.monitorResource as unknown as jest.Mock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const NOW: Date = new Date("2026-07-27T10:00:00.000Z");
+const CREATED_AT: Date = new Date("2026-07-01T00:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const MONITOR_A_ID: ObjectID = new ObjectID("monitor-a");
+const MONITOR_B_ID: ObjectID = new ObjectID("monitor-b");
+
+// Sentinels for the enabled-monitor / active-project sub-queries the job spreads in.
+const ENABLED_MONITOR_QUERY: Record<string, unknown> = {
+  disableActiveMonitoring: false,
+};
+const ACTIVE_PROJECT_QUERY: Record<string, unknown> = {
+  markedForDeletion: false,
+};
+
+/*
+ * shouldProcessRequest only walks the plain data shape
+ * monitorSteps.data.monitorStepsInstanceArray[].data.monitorCriteria.data
+ *   .monitorCriteriaInstanceArray[].data.filters[].checkOn
+ * so a cast plain object stands in for a fully-constructed MonitorSteps.
+ */
+function stepsWithCheckOn(checkOn: CheckOn): MonitorSteps {
+  return {
+    data: {
+      monitorStepsInstanceArray: [
+        {
+          data: {
+            monitorCriteria: {
+              data: {
+                monitorCriteriaInstanceArray: [
+                  { data: { filters: [{ checkOn: checkOn }] } },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  } as unknown as MonitorSteps;
+}
+
+function makeMonitor(data: {
+  id: ObjectID;
+  monitorSteps?: MonitorSteps | undefined;
+  incomingEmailMonitorRequest?: IncomingEmailMonitorRequest | undefined;
+}): Monitor {
+  const monitor: Monitor = new Monitor(data.id);
+  monitor.projectId = PROJECT_ID;
+  monitor.createdAt = CREATED_AT;
+
+  if (data.monitorSteps) {
+    monitor.monitorSteps = data.monitorSteps;
+  }
+
+  if (data.incomingEmailMonitorRequest) {
+    monitor.incomingEmailMonitorRequest = data.incomingEmailMonitorRequest;
+  }
+
+  return monitor;
+}
+
+interface FindAllByArgs {
+  query: Record<string, unknown>;
+  sort: Record<string, unknown>;
+  select: Record<string, unknown>;
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+}
+
+function stampCalls(): Array<UpdateCallArgs> {
+  return monitorService.updateColumnsByIdWithoutHooks.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as UpdateCallArgs;
+    },
+  );
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["IncomingEmailMonitor:CheckOnlineStatus"];
+
+  if (!handler) {
+    throw new Error(
+      "IncomingEmailMonitor:CheckOnlineStatus did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+
+  /*
+   * The per-monitor work is fire-and-forget (`checkOnlineStatus(m).catch(...)`),
+   * so the handler resolves before the stamps do. A couple of macrotask turns
+   * let every mocked-promise chain settle.
+   */
+  for (let turn: number = 0; turn < 3; turn++) {
+    await new Promise<void>((resolve: () => void) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation(() => {
+      return new Date(NOW);
+    });
+
+    monitorService.findAllBy.mockResolvedValue([]);
+    monitorService.getEnabledMonitorQuery.mockReturnValue(
+      ENABLED_MONITOR_QUERY,
+    );
+    monitorService.updateColumnsByIdWithoutHooks.mockResolvedValue(undefined);
+    monitorService.updateOneById.mockResolvedValue(undefined);
+    projectService.getActiveProjectStatusQuery.mockReturnValue(
+      ACTIVE_PROJECT_QUERY,
+    );
+    monitorResourceMock.mockResolvedValue(undefined);
+  });
+
+  test("concatenates the never-checked and already-checked batches and stamps each through the hookless fast path only", async () => {
+    const neverChecked: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
+    });
+    const alreadyChecked: Monitor = makeMonitor({
+      id: MONITOR_B_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([neverChecked])
+      .mockResolvedValueOnce([alreadyChecked]);
+
+    await runWorkerTick();
+
+    // Two batches: isNull (sorted by createdAt) then notNull (sorted by last check).
+    expect(monitorService.findAllBy).toHaveBeenCalledTimes(2);
+
+    const firstBatch: FindAllByArgs = monitorService.findAllBy.mock
+      .calls[0]![0] as FindAllByArgs;
+    const secondBatch: FindAllByArgs = monitorService.findAllBy.mock
+      .calls[1]![0] as FindAllByArgs;
+
+    for (const batch of [firstBatch, secondBatch]) {
+      expect(batch.query["monitorType"]).toBe(MonitorType.IncomingEmail);
+      // the enabled-monitor and active-project gates stay in both queries.
+      expect(batch.query["disableActiveMonitoring"]).toBe(false);
+      expect(batch.query["project"]).toEqual(ACTIVE_PROJECT_QUERY);
+      expect(
+        batch.query["incomingEmailMonitorHeartbeatCheckedAt"],
+      ).toBeDefined();
+    }
+
+    expect(firstBatch.sort).toEqual({ createdAt: SortOrder.Ascending });
+    expect(secondBatch.sort).toEqual({
+      incomingEmailMonitorHeartbeatCheckedAt: SortOrder.Ascending,
+    });
+
+    // One fast-path stamp per monitor, batches concatenated in order.
+    const stamps: Array<UpdateCallArgs> = stampCalls();
+    expect(stamps).toHaveLength(2);
+    expect(
+      stamps.map((call: UpdateCallArgs) => {
+        return call.id.toString();
+      }),
+    ).toEqual([MONITOR_A_ID.toString(), MONITOR_B_ID.toString()]);
+
+    for (const stamp of stamps) {
+      // EXACTLY the bookkeeping column - nothing else rides along.
+      expect(Object.keys(stamp.data)).toEqual([
+        "incomingEmailMonitorHeartbeatCheckedAt",
+      ]);
+      expect(
+        (
+          stamp.data["incomingEmailMonitorHeartbeatCheckedAt"] as Date
+        ).getTime(),
+      ).toBe(NOW.getTime());
+    }
+
+    // THE regression this change removed: the full hooked pipeline per tick.
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("a monitor without monitorSteps is skipped with no write at all", async () => {
+    monitorService.findAllBy
+      .mockResolvedValueOnce([makeMonitor({ id: MONITOR_A_ID })])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+    expect(monitorResourceMock).not.toHaveBeenCalled();
+  });
+
+  test("criteria checking CheckOn.EmailReceivedAt hand the monitor to monitorResource with the incoming-email payload", async () => {
+    const receivedAt: Date = new Date("2026-07-27T09:55:00.000Z");
+    const monitor: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
+      incomingEmailMonitorRequest: {
+        emailReceivedAt: receivedAt,
+        emailFrom: "alerts@acme.dev",
+      } as IncomingEmailMonitorRequest,
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([monitor])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorResourceMock).toHaveBeenCalledTimes(1);
+
+    const payload: IncomingEmailMonitorRequest = monitorResourceMock.mock
+      .calls[0]![0] as IncomingEmailMonitorRequest;
+
+    expect(payload.monitorId.toString()).toBe(MONITOR_A_ID.toString());
+    expect(payload.projectId.toString()).toBe(PROJECT_ID.toString());
+    // the worker-side check only validates liveness, never re-runs criteria.
+    expect(payload.onlyCheckForIncomingEmailReceivedAt).toBe(true);
+    expect(payload.emailReceivedAt.getTime()).toBe(receivedAt.getTime());
+    expect(payload.checkedAt.getTime()).toBe(NOW.getTime());
+    expect(payload.emailFrom).toBe("alerts@acme.dev");
+    // unset email fields are defaulted to empty strings, not undefined.
+    expect(payload.emailTo).toBe("");
+    expect(payload.emailSubject).toBe("");
+    expect(payload.emailBody).toBe("");
+
+    // the heartbeat stamp is written BEFORE the resource evaluation.
+    expect(
+      monitorService.updateColumnsByIdWithoutHooks.mock.invocationCallOrder[0],
+    ).toBeLessThan(monitorResourceMock.mock.invocationCallOrder[0]!);
+  });
+
+  test("a monitor that never received an email falls back to createdAt as the received timestamp", async () => {
+    const monitor: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([monitor])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    const payload: IncomingEmailMonitorRequest = monitorResourceMock.mock
+      .calls[0]![0] as IncomingEmailMonitorRequest;
+
+    expect(payload.emailReceivedAt.getTime()).toBe(CREATED_AT.getTime());
+  });
+
+  test("criteria checking only CheckOn.IncomingRequest (the request monitor's filter) are stamped but never evaluated", async () => {
+    monitorService.findAllBy
+      .mockResolvedValueOnce([
+        makeMonitor({
+          id: MONITOR_A_ID,
+          monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(monitorResourceMock).not.toHaveBeenCalled();
+  });
+
+  test("one monitor whose stamp write fails does not prevent the other monitors from processing", async () => {
+    const failing: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
+    });
+    const healthy: Monitor = makeMonitor({
+      id: MONITOR_B_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.EmailReceivedAt),
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([failing])
+      .mockResolvedValueOnce([healthy]);
+
+    monitorService.updateColumnsByIdWithoutHooks.mockImplementation(
+      (args: UpdateCallArgs) => {
+        if (args.id.toString() === MONITOR_A_ID.toString()) {
+          return Promise.reject(new Error("db connection reset"));
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    await runWorkerTick();
+
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    // the failing monitor aborts after its stamp; the healthy one still runs.
+    expect(monitorResourceMock).toHaveBeenCalledTimes(1);
+
+    const payload: IncomingEmailMonitorRequest = monitorResourceMock.mock
+      .calls[0]![0] as IncomingEmailMonitorRequest;
+    expect(payload.monitorId.toString()).toBe(MONITOR_B_ID.toString());
+  });
+});

--- a/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
@@ -1,0 +1,437 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import OneUptimeDate from "Common/Types/Date";
+import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
+import IncomingMonitorRequest from "Common/Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
+import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * Regression tests for the IncomingRequestMonitor:CheckHeartbeat cron's write
+ * path. The heartbeat bookkeeping stamp is written for EVERY incoming-request
+ * monitor every 30 seconds; it used to go through updateOneById, whose full
+ * pipeline is ~4 statements per row plus — because Monitor is
+ * @EnableWorkflow + @EnableAuditLog — an on-update workflow HTTP trigger and
+ * an audit-log insert per monitor per tick. The perf fix rewired the stamp to
+ * the single-UPDATE updateColumnsByIdWithoutHooks fast path. These tests pin:
+ *   1. the stamp goes through the hookless fast path with EXACTLY the
+ *      incomingRequestMonitorHeartbeatCheckedAt column, and updateOneById is
+ *      never called (the regression the change removes),
+ *   2. the per-monitor control flow around the stamp is unchanged: both
+ *      findAllBy batches (never-checked isNull first, then notNull) are
+ *      concatenated; a monitor without monitorSteps is skipped with no write;
+ *      only a monitor whose criteria check CheckOn.IncomingRequest is handed
+ *      to MonitorResourceUtil.monitorResource; one failing monitor does not
+ *      prevent the others.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * updateOneById is mocked ALONGSIDE the fast path precisely so the suite can
+ * prove it is never called: if the job regressed back to the hooked pipeline,
+ * the assertion would flag it instead of the mock throwing "not a function".
+ */
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      getEnabledMonitorQuery: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: { getActiveProjectStatusQuery: jest.fn() },
+  };
+});
+
+/*
+ * The real MonitorResource util transitively loads the native `isolated-vm`
+ * addon (via MonitorCriteriaEvaluator -> VMRunner); the job only needs its
+ * monitorResource entry point, so the whole module is replaced.
+ */
+jest.mock("Common/Server/Utils/Monitor/MonitorResource", () => {
+  return {
+    __esModule: true,
+    default: { monitorResource: jest.fn() },
+  };
+});
+
+import MonitorService from "Common/Server/Services/MonitorService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import logger from "Common/Server/Utils/Logger";
+import MonitorResourceUtil from "Common/Server/Utils/Monitor/MonitorResource";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat";
+
+interface MonitorServiceMock {
+  findAllBy: jest.Mock;
+  getEnabledMonitorQuery: jest.Mock;
+  updateColumnsByIdWithoutHooks: jest.Mock;
+  updateOneById: jest.Mock;
+}
+
+const monitorService: MonitorServiceMock =
+  MonitorService as unknown as MonitorServiceMock;
+const projectService: { getActiveProjectStatusQuery: jest.Mock } =
+  ProjectService as unknown as { getActiveProjectStatusQuery: jest.Mock };
+const monitorResourceMock: jest.Mock =
+  MonitorResourceUtil.monitorResource as unknown as jest.Mock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const NOW: Date = new Date("2026-07-27T10:00:00.000Z");
+const CREATED_AT: Date = new Date("2026-07-01T00:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const MONITOR_A_ID: ObjectID = new ObjectID("monitor-a");
+const MONITOR_B_ID: ObjectID = new ObjectID("monitor-b");
+
+// Sentinels for the enabled-monitor / active-project sub-queries the job spreads in.
+const ENABLED_MONITOR_QUERY: Record<string, unknown> = {
+  disableActiveMonitoring: false,
+};
+const ACTIVE_PROJECT_QUERY: Record<string, unknown> = {
+  markedForDeletion: false,
+};
+
+/*
+ * shouldProcessRequest only walks the plain data shape
+ * monitorSteps.data.monitorStepsInstanceArray[].data.monitorCriteria.data
+ *   .monitorCriteriaInstanceArray[].data.filters[].checkOn
+ * so a cast plain object stands in for a fully-constructed MonitorSteps.
+ */
+function stepsWithCheckOn(checkOn: CheckOn): MonitorSteps {
+  return {
+    data: {
+      monitorStepsInstanceArray: [
+        {
+          data: {
+            monitorCriteria: {
+              data: {
+                monitorCriteriaInstanceArray: [
+                  { data: { filters: [{ checkOn: checkOn }] } },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  } as unknown as MonitorSteps;
+}
+
+function makeMonitor(data: {
+  id: ObjectID;
+  monitorSteps?: MonitorSteps | undefined;
+  incomingMonitorRequest?: IncomingMonitorRequest | undefined;
+}): Monitor {
+  const monitor: Monitor = new Monitor(data.id);
+  monitor.projectId = PROJECT_ID;
+  monitor.createdAt = CREATED_AT;
+
+  if (data.monitorSteps) {
+    monitor.monitorSteps = data.monitorSteps;
+  }
+
+  if (data.incomingMonitorRequest) {
+    monitor.incomingMonitorRequest = data.incomingMonitorRequest;
+  }
+
+  return monitor;
+}
+
+interface FindAllByArgs {
+  query: Record<string, unknown>;
+  sort: Record<string, unknown>;
+  select: Record<string, unknown>;
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+}
+
+function stampCalls(): Array<UpdateCallArgs> {
+  return monitorService.updateColumnsByIdWithoutHooks.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as UpdateCallArgs;
+    },
+  );
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["IncomingRequestMonitor:CheckHeartbeat"];
+
+  if (!handler) {
+    throw new Error(
+      "IncomingRequestMonitor:CheckHeartbeat did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+
+  /*
+   * The per-monitor work is fire-and-forget (`checkHeartBeat(m).catch(...)`),
+   * so the handler resolves before the stamps do. A couple of macrotask turns
+   * let every mocked-promise chain settle.
+   */
+  for (let turn: number = 0; turn < 3; turn++) {
+    await new Promise<void>((resolve: () => void) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
+describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation(() => {
+      return new Date(NOW);
+    });
+
+    monitorService.findAllBy.mockResolvedValue([]);
+    monitorService.getEnabledMonitorQuery.mockReturnValue(
+      ENABLED_MONITOR_QUERY,
+    );
+    monitorService.updateColumnsByIdWithoutHooks.mockResolvedValue(undefined);
+    monitorService.updateOneById.mockResolvedValue(undefined);
+    projectService.getActiveProjectStatusQuery.mockReturnValue(
+      ACTIVE_PROJECT_QUERY,
+    );
+    monitorResourceMock.mockResolvedValue(undefined);
+  });
+
+  test("concatenates the never-checked and already-checked batches and stamps each through the hookless fast path only", async () => {
+    const neverChecked: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
+    });
+    const alreadyChecked: Monitor = makeMonitor({
+      id: MONITOR_B_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([neverChecked])
+      .mockResolvedValueOnce([alreadyChecked]);
+
+    await runWorkerTick();
+
+    // Two batches: isNull (sorted by createdAt) then notNull (sorted by last check).
+    expect(monitorService.findAllBy).toHaveBeenCalledTimes(2);
+
+    const firstBatch: FindAllByArgs = monitorService.findAllBy.mock
+      .calls[0]![0] as FindAllByArgs;
+    const secondBatch: FindAllByArgs = monitorService.findAllBy.mock
+      .calls[1]![0] as FindAllByArgs;
+
+    for (const batch of [firstBatch, secondBatch]) {
+      expect(batch.query["monitorType"]).toBe(MonitorType.IncomingRequest);
+      // the enabled-monitor and active-project gates stay in both queries.
+      expect(batch.query["disableActiveMonitoring"]).toBe(false);
+      expect(batch.query["project"]).toEqual(ACTIVE_PROJECT_QUERY);
+      expect(
+        batch.query["incomingRequestMonitorHeartbeatCheckedAt"],
+      ).toBeDefined();
+    }
+
+    expect(firstBatch.sort).toEqual({ createdAt: SortOrder.Ascending });
+    expect(secondBatch.sort).toEqual({
+      incomingRequestMonitorHeartbeatCheckedAt: SortOrder.Ascending,
+    });
+
+    // One fast-path stamp per monitor, batches concatenated in order.
+    const stamps: Array<UpdateCallArgs> = stampCalls();
+    expect(stamps).toHaveLength(2);
+    expect(
+      stamps.map((call: UpdateCallArgs) => {
+        return call.id.toString();
+      }),
+    ).toEqual([MONITOR_A_ID.toString(), MONITOR_B_ID.toString()]);
+
+    for (const stamp of stamps) {
+      // EXACTLY the bookkeeping column - nothing else rides along.
+      expect(Object.keys(stamp.data)).toEqual([
+        "incomingRequestMonitorHeartbeatCheckedAt",
+      ]);
+      expect(
+        (
+          stamp.data["incomingRequestMonitorHeartbeatCheckedAt"] as Date
+        ).getTime(),
+      ).toBe(NOW.getTime());
+    }
+
+    // THE regression this change removed: the full hooked pipeline per tick.
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("a monitor without monitorSteps is skipped with no write at all", async () => {
+    monitorService.findAllBy
+      .mockResolvedValueOnce([makeMonitor({ id: MONITOR_A_ID })])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+    expect(monitorResourceMock).not.toHaveBeenCalled();
+  });
+
+  test("criteria checking CheckOn.IncomingRequest hand the monitor to monitorResource with the incoming-request payload", async () => {
+    const receivedAt: Date = new Date("2026-07-27T09:55:00.000Z");
+    const monitor: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+      incomingMonitorRequest: {
+        incomingRequestReceivedAt: receivedAt,
+      } as IncomingMonitorRequest,
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([monitor])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorResourceMock).toHaveBeenCalledTimes(1);
+
+    const payload: IncomingMonitorRequest = monitorResourceMock.mock
+      .calls[0]![0] as IncomingMonitorRequest;
+
+    expect(payload.monitorId.toString()).toBe(MONITOR_A_ID.toString());
+    expect(payload.projectId.toString()).toBe(PROJECT_ID.toString());
+    // the worker-side check only validates liveness, never re-runs criteria.
+    expect(payload.onlyCheckForIncomingRequestReceivedAt).toBe(true);
+    expect(payload.incomingRequestReceivedAt.getTime()).toBe(
+      receivedAt.getTime(),
+    );
+    expect(payload.checkedAt.getTime()).toBe(NOW.getTime());
+
+    // the heartbeat stamp is written BEFORE the resource evaluation.
+    expect(
+      monitorService.updateColumnsByIdWithoutHooks.mock.invocationCallOrder[0],
+    ).toBeLessThan(monitorResourceMock.mock.invocationCallOrder[0]!);
+  });
+
+  test("a monitor that never received a request falls back to createdAt as the received timestamp", async () => {
+    const monitor: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([monitor])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    const payload: IncomingMonitorRequest = monitorResourceMock.mock
+      .calls[0]![0] as IncomingMonitorRequest;
+
+    expect(payload.incomingRequestReceivedAt.getTime()).toBe(
+      CREATED_AT.getTime(),
+    );
+  });
+
+  test("a monitor with steps but no IncomingRequest criteria is stamped but never evaluated", async () => {
+    monitorService.findAllBy
+      .mockResolvedValueOnce([
+        makeMonitor({
+          id: MONITOR_A_ID,
+          monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(monitorResourceMock).not.toHaveBeenCalled();
+  });
+
+  test("one monitor whose stamp write fails does not prevent the other monitors from processing", async () => {
+    const failing: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+    });
+    const healthy: Monitor = makeMonitor({
+      id: MONITOR_B_ID,
+      monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+    });
+
+    monitorService.findAllBy
+      .mockResolvedValueOnce([failing])
+      .mockResolvedValueOnce([healthy]);
+
+    monitorService.updateColumnsByIdWithoutHooks.mockImplementation(
+      (args: UpdateCallArgs) => {
+        if (args.id.toString() === MONITOR_A_ID.toString()) {
+          return Promise.reject(new Error("db connection reset"));
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    await runWorkerTick();
+
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    // the failing monitor aborts after its stamp; the healthy one still runs.
+    expect(monitorResourceMock).toHaveBeenCalledTimes(1);
+
+    const payload: IncomingMonitorRequest = monitorResourceMock.mock
+      .calls[0]![0] as IncomingMonitorRequest;
+    expect(payload.monitorId.toString()).toBe(MONITOR_B_ID.toString());
+  });
+});

--- a/App/Tests/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitorScheduler.test.ts
+++ b/App/Tests/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitorScheduler.test.ts
@@ -1,0 +1,306 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import OneUptimeDate from "Common/Types/Date";
+import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * Regression tests for the telemetry-monitor scheduler's write path
+ * (enqueueDueTelemetryMonitorEvaluationJobs, the EVERY_MINUTE cron body
+ * registered by ScheduleTelemetryMonitorEvaluations.ts). The scheduler bumps
+ * telemetryMonitorLastMonitorAt / telemetryMonitorNextMonitorAt for every due
+ * telemetry/infra monitor every minute; those stamps used to go through
+ * updateOneById, whose full pipeline is ~4 statements per row plus — because
+ * Monitor is @EnableWorkflow + @EnableAuditLog — an on-update workflow HTTP
+ * trigger and an audit-log insert per monitor per tick. The perf fix rewired
+ * them to the single-UPDATE updateColumnsByIdWithoutHooks fast path. These
+ * tests pin:
+ *   1. exactly one hookless stamp per due monitor carrying BOTH scheduler
+ *      columns, and updateOneById is never called (the regression the change
+ *      removes),
+ *   2. the scheduling control flow is unchanged: a cron monitoringInterval
+ *      drives nextMonitorAt through CronTab, an invalid interval falls back
+ *      to now+1min (and the monitor is still stamped and enqueued), monitors
+ *      without steps are stamped but not enqueued, and one failed enqueue
+ *      neither rejects the sweep nor starves the other monitors.
+ */
+
+// Keep the heavy worker module from touching Redis at import time.
+jest.mock("Common/Server/Infrastructure/Queue", () => {
+  return {
+    __esModule: true,
+    default: { addJob: jest.fn() },
+    QueueName: { Telemetry: "Telemetry" },
+  };
+});
+
+/*
+ * The worker transitively imports MonitorResource -> MonitorCriteriaEvaluator
+ * -> VMAPI -> VMRunner, which loads the native `isolated-vm` addon. The
+ * scheduler never evaluates JavaScript expressions, so stub the VM runner out
+ * to keep the module importable in a plain jest environment.
+ */
+jest.mock("Common/Server/Utils/VM/VMRunner", () => {
+  return { __esModule: true, default: {} };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * updateOneById is mocked ALONGSIDE the fast path precisely so the suite can
+ * prove it is never called: if the scheduler regressed back to the hooked
+ * pipeline, the assertion would flag it instead of the mock throwing
+ * "not a function".
+ */
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock(
+  "../../../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService",
+  () => {
+    return {
+      __esModule: true,
+      default: { addTelemetryMonitorEvaluationJob: jest.fn() },
+    };
+  },
+);
+
+import MonitorService from "Common/Server/Services/MonitorService";
+import CronTab from "Common/Server/Utils/CronTab";
+import logger from "Common/Server/Utils/Logger";
+import TelemetryQueueService from "../../../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+import { enqueueDueTelemetryMonitorEvaluationJobs } from "../../../../FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor";
+
+interface MonitorServiceMock {
+  findAllBy: jest.Mock;
+  updateColumnsByIdWithoutHooks: jest.Mock;
+  updateOneById: jest.Mock;
+}
+
+const monitorService: MonitorServiceMock =
+  MonitorService as unknown as MonitorServiceMock;
+const enqueueJobMock: jest.Mock =
+  TelemetryQueueService.addTelemetryMonitorEvaluationJob as unknown as jest.Mock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const NOW: Date = new Date("2026-07-27T10:00:00.000Z");
+const CRON_NEXT: Date = new Date("2026-07-27T10:05:00.000Z");
+const ONE_MINUTE_MS: number = 60 * 1000;
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const MONITOR_A_ID: ObjectID = new ObjectID("monitor-a");
+const MONITOR_B_ID: ObjectID = new ObjectID("monitor-b");
+
+/*
+ * The scheduler only checks monitorSteps.data.monitorStepsInstanceArray for
+ * non-emptiness, so a cast plain object stands in for a fully-constructed
+ * MonitorSteps.
+ */
+const NON_EMPTY_STEPS: MonitorSteps = {
+  data: { monitorStepsInstanceArray: [{}] },
+} as unknown as MonitorSteps;
+
+function makeMonitor(data: {
+  id: ObjectID;
+  monitorSteps?: MonitorSteps | undefined;
+  monitoringInterval?: string | undefined;
+}): Monitor {
+  const monitor: Monitor = new Monitor(data.id);
+  monitor.projectId = PROJECT_ID;
+
+  if (data.monitorSteps) {
+    monitor.monitorSteps = data.monitorSteps;
+  }
+
+  if (data.monitoringInterval) {
+    monitor.monitoringInterval = data.monitoringInterval;
+  }
+
+  return monitor;
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+}
+
+function stampCalls(): Array<UpdateCallArgs> {
+  return monitorService.updateColumnsByIdWithoutHooks.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as UpdateCallArgs;
+    },
+  );
+}
+
+function stampFor(monitorId: ObjectID): UpdateCallArgs {
+  const matches: Array<UpdateCallArgs> = stampCalls().filter(
+    (call: UpdateCallArgs) => {
+      return call.id.toString() === monitorId.toString();
+    },
+  );
+
+  expect(matches).toHaveLength(1);
+  return matches[0]!;
+}
+
+describe("TelemetryMonitor scheduler (enqueueDueTelemetryMonitorEvaluationJobs)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation(() => {
+      return new Date(NOW);
+    });
+
+    monitorService.findAllBy.mockResolvedValue([]);
+    monitorService.updateColumnsByIdWithoutHooks.mockResolvedValue(undefined);
+    monitorService.updateOneById.mockResolvedValue(undefined);
+    enqueueJobMock.mockResolvedValue(undefined);
+  });
+
+  test("stamps every due monitor exactly once through the hookless fast path with BOTH scheduler columns", async () => {
+    jest.spyOn(CronTab, "getNextExecutionTime").mockReturnValue(CRON_NEXT);
+
+    const withInterval: Monitor = makeMonitor({
+      id: MONITOR_A_ID,
+      monitorSteps: NON_EMPTY_STEPS,
+      monitoringInterval: "*/5 * * * *",
+    });
+    // stamped even though it has no steps: the bump is scheduler bookkeeping.
+    const withoutSteps: Monitor = makeMonitor({ id: MONITOR_B_ID });
+
+    monitorService.findAllBy.mockResolvedValue([withInterval, withoutSteps]);
+
+    await enqueueDueTelemetryMonitorEvaluationJobs();
+
+    expect(monitorService.findAllBy).toHaveBeenCalledTimes(1);
+
+    const stamps: Array<UpdateCallArgs> = stampCalls();
+    expect(stamps).toHaveLength(2);
+
+    for (const stamp of stamps) {
+      // EXACTLY the two bookkeeping columns - nothing else rides along.
+      expect(Object.keys(stamp.data).sort()).toEqual([
+        "telemetryMonitorLastMonitorAt",
+        "telemetryMonitorNextMonitorAt",
+      ]);
+      expect(
+        (stamp.data["telemetryMonitorLastMonitorAt"] as Date).getTime(),
+      ).toBe(NOW.getTime());
+    }
+
+    // the cron interval drives nextMonitorAt through CronTab...
+    expect(CronTab.getNextExecutionTime).toHaveBeenCalledWith("*/5 * * * *");
+    expect(
+      (
+        stampFor(MONITOR_A_ID).data["telemetryMonitorNextMonitorAt"] as Date
+      ).getTime(),
+    ).toBe(CRON_NEXT.getTime());
+
+    // ...and no interval means the default one-minute cadence.
+    expect(
+      (
+        stampFor(MONITOR_B_ID).data["telemetryMonitorNextMonitorAt"] as Date
+      ).getTime(),
+    ).toBe(NOW.getTime() + ONE_MINUTE_MS);
+
+    // THE regression this change removed: the full hooked pipeline per tick.
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("an invalid monitoringInterval is logged, falls back to now+1min, and the monitor is still enqueued", async () => {
+    // no CronTab spy: the real parser rejects the string, the job catches.
+    monitorService.findAllBy.mockResolvedValue([
+      makeMonitor({
+        id: MONITOR_A_ID,
+        monitorSteps: NON_EMPTY_STEPS,
+        monitoringInterval: "not-a-valid-cron",
+      }),
+    ]);
+
+    await enqueueDueTelemetryMonitorEvaluationJobs();
+
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    const stamp: UpdateCallArgs = stampFor(MONITOR_A_ID);
+    expect(
+      (stamp.data["telemetryMonitorNextMonitorAt"] as Date).getTime(),
+    ).toBe(NOW.getTime() + ONE_MINUTE_MS);
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+
+    // the bad interval must not cost the monitor its evaluation.
+    expect(enqueueJobMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("monitors with steps are enqueued with monitorId + projectId; monitors without steps are stamped but not enqueued", async () => {
+    monitorService.findAllBy.mockResolvedValue([
+      makeMonitor({ id: MONITOR_A_ID, monitorSteps: NON_EMPTY_STEPS }),
+      makeMonitor({ id: MONITOR_B_ID }),
+    ]);
+
+    await enqueueDueTelemetryMonitorEvaluationJobs();
+
+    // both were stamped...
+    expect(stampCalls()).toHaveLength(2);
+
+    // ...but only the one with steps was handed to the queue.
+    expect(enqueueJobMock).toHaveBeenCalledTimes(1);
+
+    const enqueueArgs: { monitorId: ObjectID; projectId: ObjectID } =
+      enqueueJobMock.mock.calls[0]![0] as {
+        monitorId: ObjectID;
+        projectId: ObjectID;
+      };
+    expect(enqueueArgs.monitorId.toString()).toBe(MONITOR_A_ID.toString());
+    expect(enqueueArgs.projectId.toString()).toBe(PROJECT_ID.toString());
+  });
+
+  test("one rejected enqueue is logged and neither rejects the sweep nor starves the other monitors", async () => {
+    monitorService.findAllBy.mockResolvedValue([
+      makeMonitor({ id: MONITOR_A_ID, monitorSteps: NON_EMPTY_STEPS }),
+      makeMonitor({ id: MONITOR_B_ID, monitorSteps: NON_EMPTY_STEPS }),
+    ]);
+    enqueueJobMock
+      .mockRejectedValueOnce(new Error("redis connection reset"))
+      .mockResolvedValue(undefined);
+
+    await expect(
+      enqueueDueTelemetryMonitorEvaluationJobs(),
+    ).resolves.toBeUndefined();
+
+    expect(enqueueJobMock).toHaveBeenCalledTimes(2);
+    expect(mockedLogger.error).toHaveBeenCalled();
+  });
+
+  test("a tick with no due monitors writes nothing and enqueues nothing", async () => {
+    monitorService.findAllBy.mockResolvedValue([]);
+
+    await enqueueDueTelemetryMonitorEvaluationJobs();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
+    expect(monitorService.updateOneById).not.toHaveBeenCalled();
+    expect(enqueueJobMock).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Models/DatabaseModels/Incident.ts
+++ b/Common/Models/DatabaseModels/Incident.ts
@@ -1678,6 +1678,7 @@ export default class Incident extends BaseModel {
       "Status of notification sent to subscribers about this incident",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,
@@ -1764,6 +1765,7 @@ export default class Incident extends BaseModel {
       "Status of notification sent to subscribers about this incident postmortem",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/IncidentEpisode.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisode.ts
@@ -1657,6 +1657,7 @@ export default class IncidentEpisode extends BaseModel {
       "Status of notification sent to subscribers when this episode was created",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/IncidentEpisodePublicNote.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisodePublicNote.ts
@@ -504,6 +504,7 @@ export default class IncidentEpisodePublicNote extends BaseModel {
     description: "Status of notification sent to subscribers about this note",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/IncidentEpisodeStateTimeline.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisodeStateTimeline.ts
@@ -671,6 +671,7 @@ export default class IncidentEpisodeStateTimeline extends BaseModel {
       "Status of notification sent to subscribers about this state change",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/IncidentPublicNote.ts
+++ b/Common/Models/DatabaseModels/IncidentPublicNote.ts
@@ -507,6 +507,7 @@ export default class IncidentPublicNote extends BaseModel {
     description: "Status of notification sent to subscribers about this note",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/IncidentStateTimeline.ts
+++ b/Common/Models/DatabaseModels/IncidentStateTimeline.ts
@@ -506,6 +506,7 @@ export default class IncidentStateTimeline extends BaseModel {
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
     example: "Sent",
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/Monitor.ts
+++ b/Common/Models/DatabaseModels/Monitor.ts
@@ -595,6 +595,7 @@ export default class Monitor extends BaseModel {
     example: "API",
     canReadOnRelationQuery: true,
   })
+  @Index()
   @Column({
     nullable: false,
     type: ColumnType.ShortText,

--- a/Common/Models/DatabaseModels/OnCallDutyPolicyExecutionLog.ts
+++ b/Common/Models/DatabaseModels/OnCallDutyPolicyExecutionLog.ts
@@ -593,6 +593,7 @@ export default class OnCallDutyPolicyExecutionLog extends BaseModel {
     canReadOnRelationQuery: false,
     example: "Executing",
   })
+  @Index()
   @Column({
     nullable: false,
     type: ColumnType.ShortText,

--- a/Common/Models/DatabaseModels/ScheduledMaintenance.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenance.ts
@@ -1389,6 +1389,7 @@ export default class ScheduledMaintenance extends BaseModel {
       "Status of notification sent to subscribers when event was scheduled",
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/ScheduledMaintenancePublicNote.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenancePublicNote.ts
@@ -507,6 +507,7 @@ export default class ScheduledMaintenancePublicNote extends BaseModel {
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
     example: "Sent",
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline.ts
@@ -503,6 +503,7 @@ export default class ScheduledMaintenanceStateTimeline extends BaseModel {
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
     example: "Sent",
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Models/DatabaseModels/StatusPageAnnouncement.ts
+++ b/Common/Models/DatabaseModels/StatusPageAnnouncement.ts
@@ -676,6 +676,7 @@ export default class StatusPageAnnouncement extends BaseModel {
     type: TableColumnType.ShortText,
     defaultValue: StatusPageSubscriberNotificationStatus.Pending,
   })
+  @Index()
   @Column({
     type: ColumnType.ShortText,
     default: StatusPageSubscriberNotificationStatus.Pending,

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -8,7 +8,6 @@ import IncidentPublicNoteService from "../Services/IncidentPublicNoteService";
 import IncidentService from "../Services/IncidentService";
 import IncidentStateService from "../Services/IncidentStateService";
 import IncidentStateTimelineService from "../Services/IncidentStateTimelineService";
-import MonitorGroupResourceService from "../Services/MonitorGroupResourceService";
 import MonitorGroupService from "../Services/MonitorGroupService";
 import MonitorStatusService from "../Services/MonitorStatusService";
 import ScheduledMaintenancePublicNoteService from "../Services/ScheduledMaintenancePublicNoteService";
@@ -1727,10 +1726,54 @@ export default class StatusPageAPI extends BaseAPI<
         let episodePublicNotes: Array<IncidentEpisodePublicNote> = [];
         let episodeStateTimelines: Array<IncidentEpisodeStateTimeline> = [];
 
+        /*
+         * Cheap guard before the expensive part: the block below scans every
+         * incident ever attached to this page's monitors (a many-to-many
+         * join, up to LIMIT_PER_PROJECT rows) just to discover episode
+         * membership — on every overview view, even though most pages have
+         * zero active episodes most of the time. One indexed COUNT of the
+         * project's unresolved, visible episodes lets us skip all of it in
+         * the common case. Behavior-preserving: the final activeEpisodes
+         * query applies exactly these three constraints, so count == 0
+         * implies the block's outputs stay empty.
+         */
+        let unresolvedIncidentStateIds: Array<ObjectID> = [];
+        let hasActiveEpisodes: boolean = false;
+
         if (
           statusPage.showEpisodesOnStatusPage &&
           monitorsOnStatusPage.length > 0
         ) {
+          const unresolvedIncidentStates: Array<IncidentState> =
+            await IncidentStateService.getUnresolvedIncidentStates(
+              statusPage.projectId!,
+              { isRoot: true },
+            );
+
+          unresolvedIncidentStateIds = unresolvedIncidentStates.map(
+            (state: IncidentState) => {
+              return state.id!;
+            },
+          );
+
+          const activeEpisodeCount: PositiveNumber =
+            await IncidentEpisodeService.countBy({
+              query: {
+                projectId: statusPage.projectId!,
+                isVisibleOnStatusPage: true,
+                currentIncidentStateId: QueryHelper.any(
+                  unresolvedIncidentStateIds,
+                ),
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          hasActiveEpisodes = activeEpisodeCount.toNumber() > 0;
+        }
+
+        if (hasActiveEpisodes) {
           // First, get incidents that have monitors on status page
           const incidentsForEpisodes: Array<Incident> =
             await IncidentService.findBy({
@@ -1784,17 +1827,7 @@ export default class StatusPageAPI extends BaseAPI<
 
           // Fetch active (unresolved) episodes
           if (episodeIdsFromMembers.size > 0) {
-            const unresolvedIncidentStates: Array<IncidentState> =
-              await IncidentStateService.getUnresolvedIncidentStates(
-                statusPage.projectId!,
-                { isRoot: true },
-              );
-
-            const unresolvedIncidentStateIds: Array<ObjectID> =
-              unresolvedIncidentStates.map((state: IncidentState) => {
-                return state.id!;
-              });
-
+            // unresolvedIncidentStateIds was fetched by the guard above.
             let selectEpisodes: Select<IncidentEpisode> = {
               createdAt: true,
               declaredAt: true,
@@ -3009,31 +3042,15 @@ export default class StatusPageAPI extends BaseAPI<
         return Boolean(id); // remove nulls
       });
 
+    // Batched: one query for all monitor groups instead of one per group.
+    const monitorIdsByGroupId: Dictionary<Array<ObjectID>> =
+      await MonitorGroupService.getMonitorIdsInMonitorGroups(monitorGroupIds);
+
     for (const monitorGroupId of monitorGroupIds) {
       // get monitors in the group.
 
-      const groupResources: Array<MonitorGroupResource> =
-        await MonitorGroupResourceService.findBy({
-          query: {
-            monitorGroupId: monitorGroupId,
-          },
-          select: {
-            monitorId: true,
-          },
-          props: {
-            isRoot: true,
-          },
-          limit: LIMIT_PER_PROJECT,
-          skip: 0,
-        });
-
-      const monitorsInGroupIds: Array<ObjectID> = groupResources
-        .map((resource: MonitorGroupResource) => {
-          return resource.monitorId!;
-        })
-        .filter((id: ObjectID) => {
-          return Boolean(id); // remove nulls
-        });
+      const monitorsInGroupIds: Array<ObjectID> =
+        monitorIdsByGroupId[monitorGroupId.toString()] || [];
 
       for (const monitorId of monitorsInGroupIds) {
         if (
@@ -3232,31 +3249,15 @@ export default class StatusPageAPI extends BaseAPI<
         return Boolean(id); // remove nulls
       });
 
+    // Batched: one query for all monitor groups instead of one per group.
+    const monitorIdsByGroupId: Dictionary<Array<ObjectID>> =
+      await MonitorGroupService.getMonitorIdsInMonitorGroups(monitorGroupIds);
+
     for (const monitorGroupId of monitorGroupIds) {
       // get monitors in the group.
 
-      const groupResources: Array<MonitorGroupResource> =
-        await MonitorGroupResourceService.findBy({
-          query: {
-            monitorGroupId: monitorGroupId,
-          },
-          select: {
-            monitorId: true,
-          },
-          props: {
-            isRoot: true,
-          },
-          limit: LIMIT_PER_PROJECT,
-          skip: 0,
-        });
-
-      const monitorsInGroupIds: Array<ObjectID> = groupResources
-        .map((resource: MonitorGroupResource) => {
-          return resource.monitorId!;
-        })
-        .filter((id: ObjectID) => {
-          return Boolean(id); // remove nulls
-        });
+      const monitorsInGroupIds: Array<ObjectID> =
+        monitorIdsByGroupId[monitorGroupId.toString()] || [];
 
       for (const monitorId of monitorsInGroupIds) {
         if (
@@ -4177,6 +4178,8 @@ export default class StatusPageAPI extends BaseAPI<
     const { monitorsOnStatusPage, monitorsInGroup } =
       await StatusPageService.getMonitorIdsOnStatusPage({
         statusPageId: statusPageId,
+        // reuse the resources fetched above instead of re-querying them
+        statusPageResources: statusPageResources,
       });
 
     const today: Date = OneUptimeDate.getCurrentDate();
@@ -4453,6 +4456,8 @@ export default class StatusPageAPI extends BaseAPI<
     const { monitorsOnStatusPage, monitorsInGroup } =
       await StatusPageService.getMonitorIdsOnStatusPage({
         statusPageId: statusPageId,
+        // reuse the resources fetched above instead of re-querying them
+        statusPageResources: statusPageResources,
       });
 
     const today: Date = OneUptimeDate.getCurrentDate();
@@ -5049,35 +5054,42 @@ export default class StatusPageAPI extends BaseAPI<
         return Boolean(id); // remove nulls
       });
 
+    /*
+     * Batched: this loop used to issue 4 queries per monitor group per page
+     * view (3 inside MonitorGroupService.getCurrentStatus + one duplicate
+     * group-resource fetch), on the hottest public endpoint in the product.
+     * One shared fetch + the already-loaded `monitorStatuses` now serve every
+     * group.
+     */
+    const monitorGroupResourcesByGroupId: Dictionary<
+      Array<MonitorGroupResource>
+    > = await MonitorGroupService.getMonitorGroupResourcesByGroupIds(
+      monitorGroupIds,
+    );
+
+    const monitorGroupStatuses: Dictionary<MonitorStatus> =
+      await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+        monitorGroupIds: monitorGroupIds,
+        monitorStatuses: monitorStatuses,
+        monitorGroupResources: monitorGroupResourcesByGroupId,
+      });
+
     for (const monitorGroupId of monitorGroupIds) {
       // get current status of monitors in the group.
 
-      const currentStatus: MonitorStatus =
-        await MonitorGroupService.getCurrentStatus(monitorGroupId, {
-          isRoot: true,
-        });
+      const currentStatus: MonitorStatus | undefined =
+        monitorGroupStatuses[monitorGroupId.toString()];
 
-      monitorGroupCurrentStatuses[monitorGroupId.toString()] =
-        currentStatus.id!;
+      if (currentStatus) {
+        monitorGroupCurrentStatuses[monitorGroupId.toString()] =
+          currentStatus.id!;
+      }
 
       // get monitors in the group.
 
-      const groupResources: Array<MonitorGroupResource> =
-        await MonitorGroupResourceService.findBy({
-          query: {
-            monitorGroupId: monitorGroupId,
-          },
-          select: {
-            monitorId: true,
-          },
-          props: {
-            isRoot: true,
-          },
-          limit: LIMIT_PER_PROJECT,
-          skip: 0,
-        });
-
-      const monitorsInGroupIds: Array<ObjectID> = groupResources
+      const monitorsInGroupIds: Array<ObjectID> = (
+        monitorGroupResourcesByGroupId[monitorGroupId.toString()] || []
+      )
         .map((resource: MonitorGroupResource) => {
           return resource.monitorId!;
         })

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -5063,9 +5063,10 @@ export default class StatusPageAPI extends BaseAPI<
      */
     const monitorGroupResourcesByGroupId: Dictionary<
       Array<MonitorGroupResource>
-    > = await MonitorGroupService.getMonitorGroupResourcesByGroupIds(
-      monitorGroupIds,
-    );
+    > =
+      await MonitorGroupService.getMonitorGroupResourcesByGroupIds(
+        monitorGroupIds,
+      );
 
     const monitorGroupStatuses: Dictionary<MonitorStatus> =
       await MonitorGroupService.getCurrentStatusesForMonitorGroups({

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785140242697-AddHotQueryIndexes.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785140242697-AddHotQueryIndexes.ts
@@ -1,38 +1,89 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class AddHotQueryIndexes1785140242697 implements MigrationInterface {
-    name = 'AddHotQueryIndexes1785140242697'
+  name = "AddHotQueryIndexes1785140242697";
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE INDEX "IDX_ff92577021975c63c570943872" ON "Monitor" ("monitorType") `);
-        await queryRunner.query(`CREATE INDEX "IDX_de21b5271b886e528ca36388be" ON "IncidentEpisode" ("subscriberNotificationStatusOnEpisodeCreated") `);
-        await queryRunner.query(`CREATE INDEX "IDX_0a33db54e9454945d865a6461b" ON "Incident" ("subscriberNotificationStatusOnIncidentCreated") `);
-        await queryRunner.query(`CREATE INDEX "IDX_1319bc680d15900efa8f2caac6" ON "Incident" ("subscriberNotificationStatusOnPostmortemPublished") `);
-        await queryRunner.query(`CREATE INDEX "IDX_33865d2e485cb1b63cf6cb8b67" ON "ScheduledMaintenance" ("subscriberNotificationStatusOnEventScheduled") `);
-        await queryRunner.query(`CREATE INDEX "IDX_1d37348eb2a0eab9ab6b739e1b" ON "StatusPageAnnouncement" ("subscriberNotificationStatus") `);
-        await queryRunner.query(`CREATE INDEX "IDX_90c4580b2ad6fe6611f58975f7" ON "IncidentPublicNote" ("subscriberNotificationStatusOnNoteCreated") `);
-        await queryRunner.query(`CREATE INDEX "IDX_b64685d3d7303e1b62477b729e" ON "IncidentStateTimeline" ("subscriberNotificationStatus") `);
-        await queryRunner.query(`CREATE INDEX "IDX_c75caf0b6a8d66a7c64975c015" ON "OnCallDutyPolicyExecutionLog" ("status") `);
-        await queryRunner.query(`CREATE INDEX "IDX_13813da8afd9f7b4f3bdc27e68" ON "ScheduledMaintenancePublicNote" ("subscriberNotificationStatusOnNoteCreated") `);
-        await queryRunner.query(`CREATE INDEX "IDX_ae269b43b4d03e69ee3176477c" ON "ScheduledMaintenanceStateTimeline" ("subscriberNotificationStatus") `);
-        await queryRunner.query(`CREATE INDEX "IDX_203246e9d08f4673386512ca29" ON "IncidentEpisodeStateTimeline" ("subscriberNotificationStatus") `);
-        await queryRunner.query(`CREATE INDEX "IDX_e8b681595d105b37012921df1b" ON "IncidentEpisodePublicNote" ("subscriberNotificationStatusOnNoteCreated") `);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ff92577021975c63c570943872" ON "Monitor" ("monitorType") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_de21b5271b886e528ca36388be" ON "IncidentEpisode" ("subscriberNotificationStatusOnEpisodeCreated") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0a33db54e9454945d865a6461b" ON "Incident" ("subscriberNotificationStatusOnIncidentCreated") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1319bc680d15900efa8f2caac6" ON "Incident" ("subscriberNotificationStatusOnPostmortemPublished") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_33865d2e485cb1b63cf6cb8b67" ON "ScheduledMaintenance" ("subscriberNotificationStatusOnEventScheduled") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1d37348eb2a0eab9ab6b739e1b" ON "StatusPageAnnouncement" ("subscriberNotificationStatus") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_90c4580b2ad6fe6611f58975f7" ON "IncidentPublicNote" ("subscriberNotificationStatusOnNoteCreated") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b64685d3d7303e1b62477b729e" ON "IncidentStateTimeline" ("subscriberNotificationStatus") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c75caf0b6a8d66a7c64975c015" ON "OnCallDutyPolicyExecutionLog" ("status") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_13813da8afd9f7b4f3bdc27e68" ON "ScheduledMaintenancePublicNote" ("subscriberNotificationStatusOnNoteCreated") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ae269b43b4d03e69ee3176477c" ON "ScheduledMaintenanceStateTimeline" ("subscriberNotificationStatus") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_203246e9d08f4673386512ca29" ON "IncidentEpisodeStateTimeline" ("subscriberNotificationStatus") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e8b681595d105b37012921df1b" ON "IncidentEpisodePublicNote" ("subscriberNotificationStatusOnNoteCreated") `,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP INDEX "public"."IDX_e8b681595d105b37012921df1b"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_203246e9d08f4673386512ca29"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_ae269b43b4d03e69ee3176477c"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_13813da8afd9f7b4f3bdc27e68"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_c75caf0b6a8d66a7c64975c015"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_b64685d3d7303e1b62477b729e"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_90c4580b2ad6fe6611f58975f7"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_1d37348eb2a0eab9ab6b739e1b"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_33865d2e485cb1b63cf6cb8b67"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_1319bc680d15900efa8f2caac6"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_0a33db54e9454945d865a6461b"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_de21b5271b886e528ca36388be"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_ff92577021975c63c570943872"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e8b681595d105b37012921df1b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_203246e9d08f4673386512ca29"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ae269b43b4d03e69ee3176477c"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_13813da8afd9f7b4f3bdc27e68"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c75caf0b6a8d66a7c64975c015"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_b64685d3d7303e1b62477b729e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_90c4580b2ad6fe6611f58975f7"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1d37348eb2a0eab9ab6b739e1b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_33865d2e485cb1b63cf6cb8b67"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1319bc680d15900efa8f2caac6"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_0a33db54e9454945d865a6461b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_de21b5271b886e528ca36388be"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ff92577021975c63c570943872"`,
+    );
+  }
 }

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785140242697-AddHotQueryIndexes.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785140242697-AddHotQueryIndexes.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddHotQueryIndexes1785140242697 implements MigrationInterface {
+    name = 'AddHotQueryIndexes1785140242697'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE INDEX "IDX_ff92577021975c63c570943872" ON "Monitor" ("monitorType") `);
+        await queryRunner.query(`CREATE INDEX "IDX_de21b5271b886e528ca36388be" ON "IncidentEpisode" ("subscriberNotificationStatusOnEpisodeCreated") `);
+        await queryRunner.query(`CREATE INDEX "IDX_0a33db54e9454945d865a6461b" ON "Incident" ("subscriberNotificationStatusOnIncidentCreated") `);
+        await queryRunner.query(`CREATE INDEX "IDX_1319bc680d15900efa8f2caac6" ON "Incident" ("subscriberNotificationStatusOnPostmortemPublished") `);
+        await queryRunner.query(`CREATE INDEX "IDX_33865d2e485cb1b63cf6cb8b67" ON "ScheduledMaintenance" ("subscriberNotificationStatusOnEventScheduled") `);
+        await queryRunner.query(`CREATE INDEX "IDX_1d37348eb2a0eab9ab6b739e1b" ON "StatusPageAnnouncement" ("subscriberNotificationStatus") `);
+        await queryRunner.query(`CREATE INDEX "IDX_90c4580b2ad6fe6611f58975f7" ON "IncidentPublicNote" ("subscriberNotificationStatusOnNoteCreated") `);
+        await queryRunner.query(`CREATE INDEX "IDX_b64685d3d7303e1b62477b729e" ON "IncidentStateTimeline" ("subscriberNotificationStatus") `);
+        await queryRunner.query(`CREATE INDEX "IDX_c75caf0b6a8d66a7c64975c015" ON "OnCallDutyPolicyExecutionLog" ("status") `);
+        await queryRunner.query(`CREATE INDEX "IDX_13813da8afd9f7b4f3bdc27e68" ON "ScheduledMaintenancePublicNote" ("subscriberNotificationStatusOnNoteCreated") `);
+        await queryRunner.query(`CREATE INDEX "IDX_ae269b43b4d03e69ee3176477c" ON "ScheduledMaintenanceStateTimeline" ("subscriberNotificationStatus") `);
+        await queryRunner.query(`CREATE INDEX "IDX_203246e9d08f4673386512ca29" ON "IncidentEpisodeStateTimeline" ("subscriberNotificationStatus") `);
+        await queryRunner.query(`CREATE INDEX "IDX_e8b681595d105b37012921df1b" ON "IncidentEpisodePublicNote" ("subscriberNotificationStatusOnNoteCreated") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_e8b681595d105b37012921df1b"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_203246e9d08f4673386512ca29"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_ae269b43b4d03e69ee3176477c"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_13813da8afd9f7b4f3bdc27e68"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_c75caf0b6a8d66a7c64975c015"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b64685d3d7303e1b62477b729e"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_90c4580b2ad6fe6611f58975f7"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_1d37348eb2a0eab9ab6b739e1b"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_33865d2e485cb1b63cf6cb8b67"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_1319bc680d15900efa8f2caac6"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_0a33db54e9454945d865a6461b"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_de21b5271b886e528ca36388be"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_ff92577021975c63c570943872"`);
+    }
+
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -470,6 +470,7 @@ import { AddNetworkDevicePollingColumns1784970388777 } from "./1784970388777-Add
 import { AddNetworkSiteTypeTable1784986826214 } from "./1784986826214-AddNetworkSiteTypeTable";
 import { AddServiceLevelObjective1784987015619 } from "./1784987015619-AddServiceLevelObjective";
 import { MigrationName1785066759532 } from "./1785066759532-MigrationName";
+import { AddHotQueryIndexes1785140242697 } from "./1785140242697-AddHotQueryIndexes";
 
 export default [
   InitialMigration,
@@ -944,4 +945,5 @@ export default [
   AddNetworkSiteTypeTable1784986826214,
   AddServiceLevelObjective1784987015619,
   MigrationName1785066759532,
+  AddHotQueryIndexes1785140242697,
 ];

--- a/Common/Server/Services/MonitorGroupService.ts
+++ b/Common/Server/Services/MonitorGroupService.ts
@@ -4,6 +4,7 @@ import MonitorGroupResourceService from "./MonitorGroupResourceService";
 import MonitorStatusService from "./MonitorStatusService";
 import MonitorStatusTimelineService from "./MonitorStatusTimelineService";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "../../Types/Dictionary";
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
@@ -220,6 +221,153 @@ export class Service extends DatabaseService<MonitorGroup> {
     }
 
     return currentStatus;
+  }
+
+  /*
+   * Batched fetch of MonitorGroupResource rows for many groups in ONE query
+   * (paged only if the total exceeds LIMIT_MAX). The public status-page read
+   * paths used to issue one query per monitor group per page view; on a page
+   * with G groups that was an N+1 of G index lookups per request. Every
+   * requested group id gets an entry in the returned dictionary (empty array
+   * when the group has no resources).
+   */
+  @CaptureSpan()
+  public async getMonitorGroupResourcesByGroupIds(
+    monitorGroupIds: Array<ObjectID>,
+  ): Promise<Dictionary<Array<MonitorGroupResource>>> {
+    const resourcesByGroupId: Dictionary<Array<MonitorGroupResource>> = {};
+
+    const dedupedGroupIds: Array<ObjectID> = [];
+    for (const monitorGroupId of monitorGroupIds) {
+      if (
+        monitorGroupId &&
+        !resourcesByGroupId[monitorGroupId.toString()]
+      ) {
+        resourcesByGroupId[monitorGroupId.toString()] = [];
+        dedupedGroupIds.push(monitorGroupId);
+      }
+    }
+
+    if (dedupedGroupIds.length === 0) {
+      return resourcesByGroupId;
+    }
+
+    const monitorGroupResources: Array<MonitorGroupResource> =
+      await MonitorGroupResourceService.findAllBy({
+        query: {
+          monitorGroupId: QueryHelper.any(dedupedGroupIds),
+        },
+        select: {
+          monitorGroupId: true,
+          monitorId: true,
+          monitor: {
+            currentMonitorStatusId: true,
+          },
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    for (const monitorGroupResource of monitorGroupResources) {
+      if (!monitorGroupResource.monitorGroupId) {
+        continue;
+      }
+
+      resourcesByGroupId[monitorGroupResource.monitorGroupId.toString()]?.push(
+        monitorGroupResource,
+      );
+    }
+
+    return resourcesByGroupId;
+  }
+
+  // Batched twin of the per-group monitor-id lookup: ONE query for all groups.
+  @CaptureSpan()
+  public async getMonitorIdsInMonitorGroups(
+    monitorGroupIds: Array<ObjectID>,
+  ): Promise<Dictionary<Array<ObjectID>>> {
+    const resourcesByGroupId: Dictionary<Array<MonitorGroupResource>> =
+      await this.getMonitorGroupResourcesByGroupIds(monitorGroupIds);
+
+    const monitorIdsByGroupId: Dictionary<Array<ObjectID>> = {};
+
+    for (const groupId of Object.keys(resourcesByGroupId)) {
+      monitorIdsByGroupId[groupId] = (resourcesByGroupId[groupId] || [])
+        .map((resource: MonitorGroupResource) => {
+          return resource.monitorId!;
+        })
+        .filter((id: ObjectID) => {
+          return Boolean(id); // remove nulls
+        });
+    }
+
+    return monitorIdsByGroupId;
+  }
+
+  /*
+   * Batched twin of getCurrentStatus, preserving its exact semantics: each
+   * group's status starts at the project's operational state and is replaced
+   * by the highest-priority-number status among its monitors. Callers supply
+   * the project's monitor statuses (they already have them in hand on every
+   * path that renders a status page), so this issues at most ONE query — the
+   * group-resource fetch — instead of three per group.
+   */
+  @CaptureSpan()
+  public async getCurrentStatusesForMonitorGroups(data: {
+    monitorGroupIds: Array<ObjectID>;
+    monitorStatuses: Array<MonitorStatus>;
+    monitorGroupResources?: Dictionary<Array<MonitorGroupResource>> | undefined;
+  }): Promise<Dictionary<MonitorStatus>> {
+    const currentStatuses: Dictionary<MonitorStatus> = {};
+
+    if (data.monitorGroupIds.length === 0) {
+      return currentStatuses;
+    }
+
+    const operationalStatus: MonitorStatus | undefined =
+      data.monitorStatuses.find((monitorStatus: MonitorStatus) => {
+        return monitorStatus.isOperationalState;
+      });
+
+    if (!operationalStatus) {
+      throw new BadDataException("Operational state not found.");
+    }
+
+    const resourcesByGroupId: Dictionary<Array<MonitorGroupResource>> =
+      data.monitorGroupResources ||
+      (await this.getMonitorGroupResourcesByGroupIds(data.monitorGroupIds));
+
+    for (const monitorGroupId of data.monitorGroupIds) {
+      let currentStatus: MonitorStatus = operationalStatus;
+
+      for (const monitorGroupResource of resourcesByGroupId[
+        monitorGroupId.toString()
+      ] || []) {
+        if (!monitorGroupResource.monitor) {
+          continue;
+        }
+
+        const monitorStatus: MonitorStatus | undefined =
+          data.monitorStatuses.find((monitorStatus: MonitorStatus) => {
+            return (
+              monitorStatus.id?.toString() ===
+              monitorGroupResource.monitor!.currentMonitorStatusId?.toString()
+            );
+          });
+
+        if (
+          monitorStatus &&
+          currentStatus.priority! < monitorStatus.priority!
+        ) {
+          currentStatus = monitorStatus;
+        }
+      }
+
+      currentStatuses[monitorGroupId.toString()] = currentStatus;
+    }
+
+    return currentStatuses;
   }
 }
 export default new Service();

--- a/Common/Server/Services/MonitorGroupService.ts
+++ b/Common/Server/Services/MonitorGroupService.ts
@@ -239,10 +239,7 @@ export class Service extends DatabaseService<MonitorGroup> {
 
     const dedupedGroupIds: Array<ObjectID> = [];
     for (const monitorGroupId of monitorGroupIds) {
-      if (
-        monitorGroupId &&
-        !resourcesByGroupId[monitorGroupId.toString()]
-      ) {
+      if (monitorGroupId && !resourcesByGroupId[monitorGroupId.toString()]) {
         resourcesByGroupId[monitorGroupId.toString()] = [];
         dedupedGroupIds.push(monitorGroupId);
       }

--- a/Common/Server/Services/StatusPageService.ts
+++ b/Common/Server/Services/StatusPageService.ts
@@ -58,7 +58,7 @@ import StatusPageResourceService from "./StatusPageResourceService";
 import Dictionary from "../../Types/Dictionary";
 import { JSONObject } from "../../Types/JSON";
 import MonitorGroupResource from "../../Models/DatabaseModels/MonitorGroupResource";
-import MonitorGroupResourceService from "./MonitorGroupResourceService";
+import MonitorGroupService from "./MonitorGroupService";
 import QueryHelper from "../Types/Database/QueryHelper";
 import OneUptimeDate from "../../Types/Date";
 import IncidentService from "./IncidentService";
@@ -1378,12 +1378,22 @@ export class Service extends DatabaseService<StatusPage> {
   @CaptureSpan()
   public async getMonitorIdsOnStatusPage(data: {
     statusPageId: ObjectID;
+    /*
+     * Pass when the caller has already loaded the page's resources —
+     * several public endpoints fetch them right before calling this, and
+     * without this parameter the identical StatusPageResource query used to
+     * run twice per request.
+     */
+    statusPageResources?: Array<StatusPageResource> | undefined;
   }): Promise<{
     monitorsOnStatusPage: Array<ObjectID>;
     monitorsInGroup: Dictionary<Array<ObjectID>>;
   }> {
     const statusPageResources: Array<StatusPageResource> =
-      await this.getStatusPageResources(data);
+      data.statusPageResources ||
+      (await this.getStatusPageResources({
+        statusPageId: data.statusPageId,
+      }));
 
     const monitorGroupIds: Array<ObjectID> = statusPageResources
       .map((resource: StatusPageResource) => {
@@ -1404,33 +1414,15 @@ export class Service extends DatabaseService<StatusPage> {
         return Boolean(id); // remove nulls
       });
 
-    for (const monitorGroupId of monitorGroupIds) {
-      // get current status of monitors in the group.
+    // Batched: one query for all monitor groups instead of one per group.
+    const monitorIdsByGroupId: Dictionary<Array<ObjectID>> =
+      await MonitorGroupService.getMonitorIdsInMonitorGroups(monitorGroupIds);
 
+    for (const monitorGroupId of monitorGroupIds) {
       // get monitors in the group.
 
-      const groupResources: Array<MonitorGroupResource> =
-        await MonitorGroupResourceService.findBy({
-          query: {
-            monitorGroupId: monitorGroupId,
-          },
-          select: {
-            monitorId: true,
-          },
-          props: {
-            isRoot: true,
-          },
-          limit: LIMIT_PER_PROJECT,
-          skip: 0,
-        });
-
-      const monitorsInGroupIds: Array<ObjectID> = groupResources
-        .map((resource: MonitorGroupResource) => {
-          return resource.monitorId!;
-        })
-        .filter((id: ObjectID) => {
-          return Boolean(id); // remove nulls
-        });
+      const monitorsInGroupIds: Array<ObjectID> =
+        monitorIdsByGroupId[monitorGroupId.toString()] || [];
 
       for (const monitorId of monitorsInGroupIds) {
         if (
@@ -1511,25 +1503,26 @@ export class Service extends DatabaseService<StatusPage> {
   }): Promise<Dictionary<ObjectID>> {
     const monitorGroupCurrentStatuses: Dictionary<ObjectID> = {};
 
+    /*
+     * Batched: this used to issue one MonitorGroupResource query per status
+     * page resource (not even per distinct group) on every badge render and
+     * subscriber report. One query now serves all groups.
+     */
+    const resourcesByGroupId: Dictionary<Array<MonitorGroupResource>> =
+      await MonitorGroupService.getMonitorGroupResourcesByGroupIds(
+        data.statusPageResources
+          .map((resource: StatusPageResource) => {
+            return resource.monitorGroupId!;
+          })
+          .filter((id: ObjectID) => {
+            return Boolean(id); // remove nulls
+          }),
+      );
+
     for (const resource of data.statusPageResources) {
       if (resource.monitorGroupId) {
         const monitorGroupResources: Array<MonitorGroupResource> =
-          await MonitorGroupResourceService.findBy({
-            query: {
-              monitorGroupId: resource.monitorGroupId,
-            },
-            select: {
-              monitorId: true,
-              monitor: {
-                currentMonitorStatusId: true,
-              },
-            },
-            skip: 0,
-            limit: LIMIT_PER_PROJECT,
-            props: {
-              isRoot: true,
-            },
-          });
+          resourcesByGroupId[resource.monitorGroupId.toString()] || [];
 
         const statuses: Array<ObjectID> = monitorGroupResources
           .filter((item: MonitorGroupResource) => {

--- a/Common/Server/Utils/Monitor/MonitorResource.ts
+++ b/Common/Server/Utils/Monitor/MonitorResource.ts
@@ -297,11 +297,18 @@ export default class MonitorResourceUtil {
            */
 
           if (!isSnmpTrapEvent) {
-            await MonitorProbeService.updateOneBy({
-              query: {
-                monitorId: monitor.id!,
-                probeId: (dataToProcess as ProbeMonitorResponse).probeId!,
-              },
+            /*
+             * Runs once per probe check result — the hottest recurring write
+             * in the product. The full updateOneBy pipeline would re-SELECT
+             * this row (including the large lastMonitoringLog jsonb we just
+             * fetched above) and then save() it (another SELECT + UPDATE in a
+             * transaction). MonitorProbe has no workflow/audit/realtime
+             * decorators, so those hooks were inert anyway — a single
+             * UPDATE by the id we already hold is equivalent and 3x cheaper.
+             * See the Monitor heartbeat writes below for the same pattern.
+             */
+            await MonitorProbeService.updateColumnsByIdWithoutHooks({
+              id: monitorProbe.id!,
               data: {
                 lastMonitoringLog: {
                   ...(monitorProbe.lastMonitoringLog || {}),
@@ -312,9 +319,6 @@ export default class MonitorResourceUtil {
                     monitoredAt: OneUptimeDate.getCurrentDate(),
                   },
                 } as any,
-              },
-              props: {
-                isRoot: true,
               },
             });
           }

--- a/Common/Tests/Server/Services/AddHotQueryIndexesMigration.test.ts
+++ b/Common/Tests/Server/Services/AddHotQueryIndexesMigration.test.ts
@@ -1,0 +1,255 @@
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentEpisode from "../../../Models/DatabaseModels/IncidentEpisode";
+import IncidentEpisodePublicNote from "../../../Models/DatabaseModels/IncidentEpisodePublicNote";
+import IncidentEpisodeStateTimeline from "../../../Models/DatabaseModels/IncidentEpisodeStateTimeline";
+import IncidentPublicNote from "../../../Models/DatabaseModels/IncidentPublicNote";
+import IncidentStateTimeline from "../../../Models/DatabaseModels/IncidentStateTimeline";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import OnCallDutyPolicyExecutionLog from "../../../Models/DatabaseModels/OnCallDutyPolicyExecutionLog";
+import ScheduledMaintenance from "../../../Models/DatabaseModels/ScheduledMaintenance";
+import ScheduledMaintenancePublicNote from "../../../Models/DatabaseModels/ScheduledMaintenancePublicNote";
+import ScheduledMaintenanceStateTimeline from "../../../Models/DatabaseModels/ScheduledMaintenanceStateTimeline";
+import StatusPageAnnouncement from "../../../Models/DatabaseModels/StatusPageAnnouncement";
+import { AddHotQueryIndexes1785140242697 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1785140242697-AddHotQueryIndexes";
+import SchemaMigrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import { QueryRunner, getMetadataArgsStorage } from "typeorm";
+import type { IndexMetadataArgs } from "typeorm/metadata-args/IndexMetadataArgs";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The 13 columns below are the filter columns of ~13 EVERY_MINUTE worker
+ * queries (the on-call executor crons scan OnCallDutyPolicyExecutionLog.status,
+ * the every-30s heartbeat crons branch on Monitor.monitorType, and the 11
+ * subscriberNotificationStatus* columns map 1:1 to the EVERY_MINUTE
+ * SendNotificationToSubscribers jobs that poll ever-growing tables for
+ * usually-zero Pending rows). Before AddHotQueryIndexes1785140242697 every one
+ * of those queries was a full-table seq scan.
+ *
+ * These tests pin the three pieces that must all hold for the scans to stay
+ * gone — a regression in ANY one silently reintroduces them:
+ *   1. the @Index() decorator on each entity property (keeps future
+ *      schema:generate runs from emitting a DROP INDEX as "drift"),
+ *   2. the migration's SQL contract: up() creates exactly these 13 indexes
+ *      and nothing else (no ALTER TABLE drift statements from a regenerated
+ *      migration), down() drops exactly the indexes up() created,
+ *   3. the migration's registration in SchemaMigrations/Index.ts (an
+ *      unregistered migration is dead code and never runs on boot).
+ *
+ * Pure metadata/mocks — no Postgres connection anywhere.
+ */
+
+type ModelClass = { new (): unknown };
+
+// [entity class, table name (=== class name for all of these), indexed column]
+const HOT_INDEX_PAIRS: Array<[ModelClass, string, string]> = [
+  [Monitor, "Monitor", "monitorType"],
+  [OnCallDutyPolicyExecutionLog, "OnCallDutyPolicyExecutionLog", "status"],
+  [
+    IncidentStateTimeline,
+    "IncidentStateTimeline",
+    "subscriberNotificationStatus",
+  ],
+  [Incident, "Incident", "subscriberNotificationStatusOnIncidentCreated"],
+  [Incident, "Incident", "subscriberNotificationStatusOnPostmortemPublished"],
+  [
+    IncidentPublicNote,
+    "IncidentPublicNote",
+    "subscriberNotificationStatusOnNoteCreated",
+  ],
+  [
+    IncidentEpisode,
+    "IncidentEpisode",
+    "subscriberNotificationStatusOnEpisodeCreated",
+  ],
+  [
+    IncidentEpisodeStateTimeline,
+    "IncidentEpisodeStateTimeline",
+    "subscriberNotificationStatus",
+  ],
+  [
+    IncidentEpisodePublicNote,
+    "IncidentEpisodePublicNote",
+    "subscriberNotificationStatusOnNoteCreated",
+  ],
+  [
+    ScheduledMaintenance,
+    "ScheduledMaintenance",
+    "subscriberNotificationStatusOnEventScheduled",
+  ],
+  [
+    ScheduledMaintenanceStateTimeline,
+    "ScheduledMaintenanceStateTimeline",
+    "subscriberNotificationStatus",
+  ],
+  [
+    ScheduledMaintenancePublicNote,
+    "ScheduledMaintenancePublicNote",
+    "subscriberNotificationStatusOnNoteCreated",
+  ],
+  [
+    StatusPageAnnouncement,
+    "StatusPageAnnouncement",
+    "subscriberNotificationStatus",
+  ],
+];
+
+/*
+ * IndexMetadataArgs.columns is either an array of property names (property-
+ * level @Index()) or a function over the entity's properties map (class-level
+ * @Index((o) => [o.a, o.b])). Resolve both to plain property-name arrays; the
+ * function form is fed a proxy whose every property reads as its own name,
+ * which is exactly how TypeORM's propertiesMap behaves for flat columns.
+ */
+function resolveIndexColumns(
+  columns: IndexMetadataArgs["columns"],
+): Array<string> {
+  if (!columns) {
+    return [];
+  }
+  if (Array.isArray(columns)) {
+    return columns.map(String);
+  }
+  const propertiesMap: Record<string, string> = new Proxy(
+    {},
+    {
+      get: (_target: object, property: string | symbol) => {
+        return String(property);
+      },
+    },
+  );
+  const resolved: Array<unknown> | { [key: string]: number } =
+    columns(propertiesMap);
+  if (Array.isArray(resolved)) {
+    return resolved.map(String);
+  }
+  return Object.keys(resolved);
+}
+
+interface CreateIndexStatement {
+  indexName: string;
+  tableName: string;
+  columnName: string;
+}
+
+const CREATE_INDEX_REGEX: RegExp =
+  /^CREATE INDEX "([^"]+)" ON "([^"]+)" \("([^"]+)"\)\s*$/;
+const DROP_INDEX_REGEX: RegExp = /^DROP INDEX "public"\."([^"]+)"$/;
+
+function makeQueryRunner(): { runner: QueryRunner; query: jest.Mock } {
+  const query: jest.Mock = jest.fn().mockResolvedValue(undefined);
+  return { runner: { query } as unknown as QueryRunner, query };
+}
+
+function executedSql(query: jest.Mock): Array<string> {
+  return query.mock.calls.map((call: Array<unknown>) => {
+    return String(call[0]);
+  });
+}
+
+describe("AddHotQueryIndexes: entity @Index() decorators", () => {
+  test.each(
+    HOT_INDEX_PAIRS.map(
+      ([model, table, column]: [ModelClass, string, string]) => {
+        return [table, column, model] as [string, string, ModelClass];
+      },
+    ),
+  )(
+    "%s.%s has a single-column index decorator",
+    (_table: string, column: string, model: ModelClass) => {
+      const singleColumnIndexes: Array<string> = getMetadataArgsStorage()
+        .indices.filter((index: IndexMetadataArgs) => {
+          return index.target === model;
+        })
+        .map((index: IndexMetadataArgs) => {
+          return resolveIndexColumns(index.columns);
+        })
+        .filter((columns: Array<string>) => {
+          return columns.length === 1;
+        })
+        .map((columns: Array<string>) => {
+          return columns[0] as string;
+        });
+
+      expect(singleColumnIndexes).toContain(column);
+    },
+  );
+});
+
+describe("AddHotQueryIndexes1785140242697 migration SQL contract", () => {
+  const migration: AddHotQueryIndexes1785140242697 =
+    new AddHotQueryIndexes1785140242697();
+
+  test("up() issues exactly 13 CREATE INDEX statements covering exactly the 13 hot columns — and nothing else", async () => {
+    const { runner, query } = makeQueryRunner();
+    await migration.up(runner);
+
+    const statements: Array<string> = executedSql(query);
+    expect(statements).toHaveLength(13);
+
+    /*
+     * A regenerated migration on a drifted schema would interleave ALTER
+     * TABLE / DROP statements with the index creates; none may sneak in.
+     */
+    for (const sql of statements) {
+      expect(sql).not.toContain("ALTER TABLE");
+      expect(sql).not.toContain("DROP");
+      expect(sql).toMatch(CREATE_INDEX_REGEX);
+    }
+
+    const created: Array<CreateIndexStatement> = statements.map(
+      (sql: string) => {
+        const match: RegExpMatchArray = sql.match(
+          CREATE_INDEX_REGEX,
+        ) as RegExpMatchArray;
+        return {
+          indexName: match[1] as string,
+          tableName: match[2] as string,
+          columnName: match[3] as string,
+        };
+      },
+    );
+
+    const createdPairs: Array<string> = created
+      .map((statement: CreateIndexStatement) => {
+        return `"${statement.tableName}"."${statement.columnName}"`;
+      })
+      .sort();
+    const expectedPairs: Array<string> = HOT_INDEX_PAIRS.map(
+      ([, table, column]: [ModelClass, string, string]) => {
+        return `"${table}"."${column}"`;
+      },
+    ).sort();
+
+    expect(createdPairs).toEqual(expectedPairs);
+  });
+
+  test("down() drops exactly the 13 indexes up() created", async () => {
+    const upRunner: { runner: QueryRunner; query: jest.Mock } =
+      makeQueryRunner();
+    await migration.up(upRunner.runner);
+    const createdNames: Array<string> = executedSql(upRunner.query).map(
+      (sql: string) => {
+        return (sql.match(CREATE_INDEX_REGEX) as RegExpMatchArray)[1] as string;
+      },
+    );
+
+    const downRunner: { runner: QueryRunner; query: jest.Mock } =
+      makeQueryRunner();
+    await migration.down(downRunner.runner);
+    const statements: Array<string> = executedSql(downRunner.query);
+    expect(statements).toHaveLength(13);
+
+    const droppedNames: Array<string> = statements.map((sql: string) => {
+      expect(sql).toMatch(DROP_INDEX_REGEX);
+      return (sql.match(DROP_INDEX_REGEX) as RegExpMatchArray)[1] as string;
+    });
+
+    expect([...droppedNames].sort()).toEqual([...createdNames].sort());
+  });
+});
+
+describe("AddHotQueryIndexes1785140242697 registration", () => {
+  test("is registered in SchemaMigrations/Index.ts so it actually runs on boot", () => {
+    expect(SchemaMigrations).toContain(AddHotQueryIndexes1785140242697);
+  });
+});

--- a/Common/Tests/Server/Services/HeartbeatWriteFastPathSafety.test.ts
+++ b/Common/Tests/Server/Services/HeartbeatWriteFastPathSafety.test.ts
@@ -1,0 +1,200 @@
+import MonitorProbeService from "../../../Server/Services/MonitorProbeService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorProbe from "../../../Models/DatabaseModels/MonitorProbe";
+import ObjectID from "../../../Types/ObjectID";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { OnUpdate } from "../../../Server/Types/Database/Hooks";
+import { describe, expect, test, afterEach } from "@jest/globals";
+
+/*
+ * Four hot bookkeeping writes were moved off the full updateOneById/
+ * updateOneBy pipeline onto DatabaseService.updateColumnsByIdWithoutHooks
+ * (one raw parameterized UPDATE; skips ALL on-update hooks — workflow HTTP
+ * triggers, audit-log inserts, realtime events, service onUpdateSuccess):
+ *
+ *   - Common/Server/Utils/Monitor/MonitorResource.ts
+ *       MonitorProbe.lastMonitoringLog, on every probe check result
+ *   - App/FeatureSet/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.ts
+ *       Monitor.incomingRequestMonitorHeartbeatCheckedAt
+ *   - App/FeatureSet/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.ts
+ *       Monitor.incomingEmailMonitorHeartbeatCheckedAt
+ *   - App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+ *       Monitor.telemetryMonitorLastMonitorAt + telemetryMonitorNextMonitorAt
+ *
+ * Those conversions are behavior-preserving only under the model-decorator
+ * preconditions pinned below. The fast path skips hooks UNCONDITIONALLY, so
+ * if someone later adds a decorator (or a column rename breaks a fast-path
+ * write), nothing at the call sites fails — the new hook is just silently
+ * never fired for these writes. This suite turns that silent drift into a
+ * loud test failure: when one of these assertions starts failing, revisit
+ * the corresponding fast-path call site before changing the assertion.
+ *
+ * Pure model-metadata + mocked-service tests — no Postgres, no Redis.
+ */
+
+describe("heartbeat write fast-path safety preconditions", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("MonitorProbe (lastMonitoringLog write in MonitorResource.ts)", () => {
+    /*
+     * The MonitorProbe conversion dropped NOTHING: the model has no
+     * @EnableWorkflow, no @EnableAuditLog and no realtime events, so the
+     * old updateOneBy pipeline's hooks were inert for this row anyway.
+     * If any assertion here starts failing, a decorator was added to
+     * MonitorProbe and the fast-path write in MonitorResource.ts now
+     * silently skips it — revisit that call site.
+     */
+    test("has no on-update workflow trigger", () => {
+      const probe: MonitorProbe = new MonitorProbe();
+      expect(probe.enableWorkflowOn?.update).toBeFalsy();
+    });
+
+    test("has no on-update audit log", () => {
+      const probe: MonitorProbe = new MonitorProbe();
+      expect(probe.enableAuditLogOn?.update).toBeFalsy();
+    });
+
+    test("has no realtime events", () => {
+      const probe: MonitorProbe = new MonitorProbe();
+      expect(probe.enableRealtimeEventsOn).toBeFalsy();
+    });
+  });
+
+  describe("Monitor (heartbeat/scheduler timestamp writes in worker jobs)", () => {
+    /*
+     * Monitor DOES have @EnableWorkflow({ update: true }) and
+     * @EnableAuditLog(). The heartbeat/scheduler conversions DELIBERATELY
+     * skip both for these machine-stamped bookkeeping columns — firing a
+     * workflow HTTP trigger plus an audit-log insert per monitor per 30s/60s
+     * tick is exactly the load the fast path removes (documented precedent:
+     * the lastMonitoringLog write in MonitorResource.ts). These assertions
+     * pin that tradeoff so it stays a documented decision: if Monitor's
+     * decorators change shape, re-evaluate the worker-job call sites rather
+     * than assuming the skip is still the intended behavior.
+     */
+    test("still has on-update workflow enabled (the skip is deliberate)", () => {
+      const monitor: Monitor = new Monitor();
+      expect(monitor.enableWorkflowOn?.update).toBe(true);
+    });
+
+    test("still has on-update audit log enabled (the skip is deliberate)", () => {
+      const monitor: Monitor = new Monitor();
+      expect(monitor.enableAuditLogOn?.update).toBe(true);
+    });
+
+    /*
+     * Nothing ELSE was dropped: Monitor has no realtime events, so
+     * workflow + audit are the only hooks the fast path bypasses. If this
+     * starts failing, realtime updates on Monitor rows would silently never
+     * fire for the heartbeat writes — revisit the worker-job call sites.
+     */
+    test("has no realtime events (so only workflow+audit are skipped)", () => {
+      const monitor: Monitor = new Monitor();
+      expect(monitor.enableRealtimeEventsOn).toBeFalsy();
+    });
+  });
+
+  describe("fast-path columns exist on their entities", () => {
+    /*
+     * updateColumnsByIdWithoutHooks validates column names against entity
+     * metadata at runtime and throws BadDataException on an unknown column.
+     * Pinning column existence here means a rename breaks this suite at CI
+     * time instead of breaking every heartbeat write at runtime.
+     */
+    test("Monitor has every column the worker jobs stamp", () => {
+      const monitor: Monitor = new Monitor();
+      const fastPathColumns: Array<string> = [
+        "incomingRequestMonitorHeartbeatCheckedAt",
+        "incomingEmailMonitorHeartbeatCheckedAt",
+        "telemetryMonitorLastMonitorAt",
+        "telemetryMonitorNextMonitorAt",
+      ];
+      for (const column of fastPathColumns) {
+        expect(monitor.isTableColumn(column)).toBe(true);
+      }
+      // Negative control: isTableColumn actually discriminates.
+      expect(monitor.isTableColumn("notARealColumn")).toBe(false);
+    });
+
+    test("MonitorProbe has the lastMonitoringLog column", () => {
+      const probe: MonitorProbe = new MonitorProbe();
+      expect(probe.isTableColumn("lastMonitoringLog")).toBe(true);
+      expect(probe.isTableColumn("notARealColumn")).toBe(false);
+    });
+  });
+
+  describe("MonitorProbeService.onUpdateSuccess early-exit", () => {
+    /*
+     * The old updateOneBy path for lastMonitoringLog also ran
+     * MonitorProbeService.onUpdateSuccess, but that hook early-exits unless
+     * updateBy.data.isEnabled is set — so skipping it for a
+     * lastMonitoringLog-only write changes nothing. If the early-exit
+     * condition ever widens (e.g. the hook starts reacting to other
+     * columns), the no-op test below fails and the MonitorResource.ts
+     * fast-path write must be revisited.
+     */
+    test("is a no-op when data lacks isEnabled (the fast-path case)", async () => {
+      const findBySpy: jest.SpyInstance = jest
+        .spyOn(MonitorProbeService, "findBy")
+        .mockResolvedValue([]);
+      const refreshSpy: jest.SpyInstance = jest
+        .spyOn(MonitorService, "refreshMonitorProbeStatus")
+        .mockResolvedValue(undefined as never);
+
+      const onUpdate: OnUpdate<MonitorProbe> = {
+        updateBy: {
+          query: {},
+          // What the old pipeline would have passed for the converted write.
+          data: { lastMonitoringLog: {} },
+          props: { isRoot: true },
+        } as UpdateBy<MonitorProbe>,
+        carryForward: null,
+      };
+
+      const result: OnUpdate<MonitorProbe> = await (MonitorProbeService as any)[
+        "onUpdateSuccess"
+      ](onUpdate, [ObjectID.generate()]);
+
+      expect(result).toBe(onUpdate);
+      expect(findBySpy).not.toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Positive control: proves the spies above would have observed the hook
+     * doing work, so the no-op test cannot pass vacuously.
+     */
+    test("does refresh monitor status when isEnabled IS in data", async () => {
+      const monitorId: ObjectID = ObjectID.generate();
+      const probeRow: MonitorProbe = new MonitorProbe();
+      probeRow.monitorId = monitorId;
+
+      const findBySpy: jest.SpyInstance = jest
+        .spyOn(MonitorProbeService, "findBy")
+        .mockResolvedValue([probeRow]);
+      const refreshSpy: jest.SpyInstance = jest
+        .spyOn(MonitorService, "refreshMonitorProbeStatus")
+        .mockResolvedValue(undefined as never);
+
+      const onUpdate: OnUpdate<MonitorProbe> = {
+        updateBy: {
+          query: {},
+          data: { isEnabled: false },
+          props: { isRoot: true },
+        } as UpdateBy<MonitorProbe>,
+        carryForward: null,
+      };
+
+      await (MonitorProbeService as any)["onUpdateSuccess"](onUpdate, [
+        ObjectID.generate(),
+      ]);
+
+      expect(findBySpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy).toHaveBeenCalledWith(monitorId);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/MonitorGroupServiceBatchedStatuses.test.ts
+++ b/Common/Tests/Server/Services/MonitorGroupServiceBatchedStatuses.test.ts
@@ -1,0 +1,513 @@
+/*
+ * MonitorGroupService batched status helpers.
+ *
+ * The public status-page read paths used to issue one MonitorGroupResource
+ * query per monitor group per page view (plus a MonitorGroup and a
+ * MonitorStatus fetch each in getCurrentStatus) — an N+1 of 3-4 queries per
+ * group per request. getMonitorGroupResourcesByGroupIds /
+ * getMonitorIdsInMonitorGroups / getCurrentStatusesForMonitorGroups collapse
+ * that to at most ONE batched query. These tests pin:
+ *   - exactly one findAllBy regardless of group count, keyed by
+ *     QueryHelper.any over DEDUPED ids, with an entry ([] if empty) per
+ *     requested group and zero queries for empty input,
+ *   - getCurrentStatusesForMonitorGroups preserving getCurrentStatus's EXACT
+ *     semantics (operational default, HIGHER priority number wins, throws
+ *     when no operational state exists), including a direct equivalence check
+ *     against the single-group path so the two cannot silently drift, and
+ *   - no resource fetch at all when the caller already supplies the
+ *     group-resource dictionary.
+ *
+ * All service reads are spied on — no database is touched.
+ */
+
+import MonitorGroupService from "../../../Server/Services/MonitorGroupService";
+import MonitorGroupResourceService from "../../../Server/Services/MonitorGroupResourceService";
+import MonitorStatusService from "../../../Server/Services/MonitorStatusService";
+import QueryHelper from "../../../Server/Types/Database/QueryHelper";
+import MonitorGroup from "../../../Models/DatabaseModels/MonitorGroup";
+import MonitorGroupResource from "../../../Models/DatabaseModels/MonitorGroupResource";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+function makeStatus(data: {
+  priority: number;
+  isOperationalState?: boolean;
+  name?: string;
+}): MonitorStatus {
+  const status: MonitorStatus = new MonitorStatus();
+  status.id = ObjectID.generate();
+  status.priority = data.priority;
+  status.isOperationalState = data.isOperationalState || false;
+  status.name = data.name || `status-p${data.priority}`;
+  return status;
+}
+
+function makeGroupResource(data: {
+  monitorGroupId?: ObjectID | undefined;
+  monitorId?: ObjectID | undefined;
+  currentMonitorStatusId?: ObjectID | undefined;
+  omitMonitor?: boolean;
+}): MonitorGroupResource {
+  const resource: MonitorGroupResource = new MonitorGroupResource();
+  if (data.monitorGroupId) {
+    resource.monitorGroupId = data.monitorGroupId;
+  }
+  if (data.monitorId) {
+    resource.monitorId = data.monitorId;
+  }
+  if (!data.omitMonitor) {
+    const monitor: Monitor = new Monitor();
+    if (data.currentMonitorStatusId) {
+      monitor.currentMonitorStatusId = data.currentMonitorStatusId;
+    }
+    resource.monitor = monitor;
+  }
+  return resource;
+}
+
+function spyOnFindAllBy(rows: Array<MonitorGroupResource>): jest.SpyInstance {
+  return (
+    jest.spyOn(
+      MonitorGroupResourceService,
+      "findAllBy",
+    ) as unknown as jest.SpyInstance
+  ).mockResolvedValue(rows as never);
+}
+
+function toStrings(ids: Array<ObjectID>): Array<string> {
+  return ids.map((id: ObjectID) => {
+    return id.toString();
+  });
+}
+
+describe("MonitorGroupService batched status helpers", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("getMonitorGroupResourcesByGroupIds", () => {
+    test("issues exactly one findAllBy for N groups, keyed by QueryHelper.any over deduped ids", async () => {
+      const groupA: ObjectID = ObjectID.generate();
+      const groupB: ObjectID = ObjectID.generate();
+      const groupC: ObjectID = ObjectID.generate();
+
+      const rowA1: MonitorGroupResource = makeGroupResource({
+        monitorGroupId: groupA,
+        monitorId: ObjectID.generate(),
+      });
+      const rowA2: MonitorGroupResource = makeGroupResource({
+        monitorGroupId: groupA,
+        monitorId: ObjectID.generate(),
+      });
+      const rowB1: MonitorGroupResource = makeGroupResource({
+        monitorGroupId: groupB,
+        monitorId: ObjectID.generate(),
+      });
+      // Defensive-guard row: a row without monitorGroupId must be dropped, not crash.
+      const rowNoGroup: MonitorGroupResource = makeGroupResource({
+        monitorId: ObjectID.generate(),
+      });
+
+      const findAllBySpy: jest.SpyInstance = spyOnFindAllBy([
+        rowA1,
+        rowB1,
+        rowA2,
+        rowNoGroup,
+      ]);
+      const anySpy: jest.SpyInstance = jest.spyOn(
+        QueryHelper,
+        "any",
+      ) as unknown as jest.SpyInstance;
+
+      const result: Dictionary<Array<MonitorGroupResource>> =
+        await MonitorGroupService.getMonitorGroupResourcesByGroupIds([
+          groupA,
+          groupB,
+          groupA, // duplicate must collapse
+          groupC,
+          groupB, // duplicate must collapse
+        ]);
+
+      // The whole point of the batching: ONE query for all groups.
+      expect(findAllBySpy).toHaveBeenCalledTimes(1);
+
+      // The IN-list is built via QueryHelper.any over DEDUPED ids, in first-seen order.
+      expect(anySpy).toHaveBeenCalledTimes(1);
+      expect(toStrings(anySpy.mock.calls[0]![0] as Array<ObjectID>)).toEqual(
+        toStrings([groupA, groupB, groupC]),
+      );
+
+      const callArg: any = findAllBySpy.mock.calls[0]![0];
+      // The exact FindOperator QueryHelper.any built is what findAllBy receives.
+      expect(callArg.query.monitorGroupId).toBe(anySpy.mock.results[0]!.value);
+      // The select must carry the grouping key and the member's current status.
+      expect(callArg.select).toEqual({
+        monitorGroupId: true,
+        monitorId: true,
+        monitor: {
+          currentMonitorStatusId: true,
+        },
+      });
+      expect(callArg.props).toEqual({ isRoot: true });
+
+      // Every requested group gets an entry; a group with no rows gets [].
+      expect(Object.keys(result).sort()).toEqual(
+        [groupA.toString(), groupB.toString(), groupC.toString()].sort(),
+      );
+      expect(result[groupA.toString()]).toEqual([rowA1, rowA2]);
+      expect(result[groupB.toString()]).toEqual([rowB1]);
+      expect(result[groupC.toString()]).toEqual([]);
+    });
+
+    test("empty input returns {} without querying at all", async () => {
+      const findAllBySpy: jest.SpyInstance = spyOnFindAllBy([]);
+
+      const result: Dictionary<Array<MonitorGroupResource>> =
+        await MonitorGroupService.getMonitorGroupResourcesByGroupIds([]);
+
+      expect(result).toEqual({});
+      expect(findAllBySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getMonitorIdsInMonitorGroups", () => {
+    test("maps rows to monitor ids, drops null monitorIds, keeps empty-group keys", async () => {
+      const groupA: ObjectID = ObjectID.generate();
+      const groupB: ObjectID = ObjectID.generate();
+      const monitor1: ObjectID = ObjectID.generate();
+      const monitor2: ObjectID = ObjectID.generate();
+
+      spyOnFindAllBy([
+        makeGroupResource({ monitorGroupId: groupA, monitorId: monitor1 }),
+        // A resource row with no monitorId must not surface as a null id.
+        makeGroupResource({ monitorGroupId: groupA }),
+        makeGroupResource({ monitorGroupId: groupA, monitorId: monitor2 }),
+      ]);
+
+      const result: Dictionary<Array<ObjectID>> =
+        await MonitorGroupService.getMonitorIdsInMonitorGroups([
+          groupA,
+          groupB,
+        ]);
+
+      expect(Object.keys(result).sort()).toEqual(
+        [groupA.toString(), groupB.toString()].sort(),
+      );
+      expect(toStrings(result[groupA.toString()]!)).toEqual(
+        toStrings([monitor1, monitor2]),
+      );
+      // The empty group still gets an (empty) entry — callers key off it.
+      expect(result[groupB.toString()]).toEqual([]);
+    });
+  });
+
+  describe("getCurrentStatusesForMonitorGroups", () => {
+    const operational: MonitorStatus = makeStatus({
+      priority: 2,
+      isOperationalState: true,
+      name: "Operational",
+    });
+    // Lower priority NUMBER than operational: must never replace it here.
+    const lowerThanOperational: MonitorStatus = makeStatus({
+      priority: 1,
+      name: "Maintenance",
+    });
+    // Same priority number as operational: a tie must not replace either.
+    const tiedWithOperational: MonitorStatus = makeStatus({
+      priority: 2,
+      name: "Degraded-Tie",
+    });
+    const degraded: MonitorStatus = makeStatus({
+      priority: 3,
+      name: "Degraded",
+    });
+    const offline: MonitorStatus = makeStatus({ priority: 4, name: "Offline" });
+    const allStatuses: Array<MonitorStatus> = [
+      operational,
+      lowerThanOperational,
+      tiedWithOperational,
+      degraded,
+      offline,
+    ];
+
+    test("empty group defaults to the operational status", async () => {
+      const groupA: ObjectID = ObjectID.generate();
+      spyOnFindAllBy([]);
+
+      const result: Dictionary<MonitorStatus> =
+        await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [groupA],
+          monitorStatuses: allStatuses,
+        });
+
+      expect(result[groupA.toString()]).toBe(operational);
+    });
+
+    test("a member with a HIGHER priority number replaces the current status; ties and lower do not", async () => {
+      const groupHigh: ObjectID = ObjectID.generate();
+      const groupTie: ObjectID = ObjectID.generate();
+      const groupLower: ObjectID = ObjectID.generate();
+
+      spyOnFindAllBy([
+        makeGroupResource({
+          monitorGroupId: groupHigh,
+          monitorId: ObjectID.generate(),
+          currentMonitorStatusId: degraded.id!,
+        }),
+        makeGroupResource({
+          monitorGroupId: groupHigh,
+          monitorId: ObjectID.generate(),
+          currentMonitorStatusId: offline.id!,
+        }),
+        makeGroupResource({
+          monitorGroupId: groupTie,
+          monitorId: ObjectID.generate(),
+          currentMonitorStatusId: tiedWithOperational.id!,
+        }),
+        makeGroupResource({
+          monitorGroupId: groupLower,
+          monitorId: ObjectID.generate(),
+          currentMonitorStatusId: lowerThanOperational.id!,
+        }),
+      ]);
+
+      const result: Dictionary<MonitorStatus> =
+        await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [groupHigh, groupTie, groupLower],
+          monitorStatuses: allStatuses,
+        });
+
+      // In MonitorGroupService semantics the HIGHEST priority number wins.
+      expect(result[groupHigh.toString()]).toBe(offline);
+      // Strict `<` comparison: a tie keeps the operational default.
+      expect(result[groupTie.toString()]).toBe(operational);
+      // A lower priority number never demotes the operational default.
+      expect(result[groupLower.toString()]).toBe(operational);
+    });
+
+    test("members with unknown statuses or missing monitor relation are ignored", async () => {
+      const groupA: ObjectID = ObjectID.generate();
+
+      spyOnFindAllBy([
+        // Status id that resolves to nothing in monitorStatuses.
+        makeGroupResource({
+          monitorGroupId: groupA,
+          monitorId: ObjectID.generate(),
+          currentMonitorStatusId: ObjectID.generate(),
+        }),
+        // No monitor relation loaded at all.
+        makeGroupResource({
+          monitorGroupId: groupA,
+          monitorId: ObjectID.generate(),
+          omitMonitor: true,
+        }),
+      ]);
+
+      const result: Dictionary<MonitorStatus> =
+        await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [groupA],
+          monitorStatuses: allStatuses,
+        });
+
+      expect(result[groupA.toString()]).toBe(operational);
+    });
+
+    test("throws 'Operational state not found.' when groups are requested but no operational status exists", async () => {
+      const findAllBySpy: jest.SpyInstance = spyOnFindAllBy([]);
+
+      await expect(
+        MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [ObjectID.generate()],
+          monitorStatuses: [degraded, offline],
+        }),
+      ).rejects.toThrow(new BadDataException("Operational state not found."));
+
+      // The throw happens before any resource fetch is attempted.
+      expect(findAllBySpy).not.toHaveBeenCalled();
+    });
+
+    test("empty group ids return {} without fetching, even when no operational status exists", async () => {
+      const findAllBySpy: jest.SpyInstance = spyOnFindAllBy([]);
+      const resourcesSpy: jest.SpyInstance = jest.spyOn(
+        MonitorGroupService,
+        "getMonitorGroupResourcesByGroupIds",
+      ) as unknown as jest.SpyInstance;
+
+      const result: Dictionary<MonitorStatus> =
+        await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [],
+          // No operational entry: the empty-input early return wins over the throw.
+          monitorStatuses: [degraded],
+        });
+
+      expect(result).toEqual({});
+      expect(resourcesSpy).not.toHaveBeenCalled();
+      expect(findAllBySpy).not.toHaveBeenCalled();
+    });
+
+    test("uses supplied monitorGroupResources without fetching", async () => {
+      const groupA: ObjectID = ObjectID.generate();
+      const findAllBySpy: jest.SpyInstance = spyOnFindAllBy([]);
+      const resourcesSpy: jest.SpyInstance = jest.spyOn(
+        MonitorGroupService,
+        "getMonitorGroupResourcesByGroupIds",
+      ) as unknown as jest.SpyInstance;
+
+      const supplied: Dictionary<Array<MonitorGroupResource>> = {
+        [groupA.toString()]: [
+          makeGroupResource({
+            monitorGroupId: groupA,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: offline.id!,
+          }),
+        ],
+      };
+
+      const result: Dictionary<MonitorStatus> =
+        await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [groupA],
+          monitorStatuses: allStatuses,
+          monitorGroupResources: supplied,
+        });
+
+      expect(result[groupA.toString()]).toBe(offline);
+      expect(resourcesSpy).not.toHaveBeenCalled();
+      expect(findAllBySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("equivalence with the single-group getCurrentStatus path", () => {
+    /*
+     * The batched method claims to be an exact twin of getCurrentStatus. This
+     * runs BOTH implementations over the same fixture (3 groups: empty /
+     * partially degraded / offline-with-noise) and requires identical
+     * per-group answers, so a semantic change to either path fails here.
+     */
+    test("returns the same status per group as getCurrentStatus", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      const operational: MonitorStatus = makeStatus({
+        priority: 1,
+        isOperationalState: true,
+        name: "Operational",
+      });
+      const degraded: MonitorStatus = makeStatus({
+        priority: 2,
+        name: "Degraded",
+      });
+      const offline: MonitorStatus = makeStatus({
+        priority: 3,
+        name: "Offline",
+      });
+      const statuses: Array<MonitorStatus> = [operational, degraded, offline];
+
+      const groupEmpty: ObjectID = ObjectID.generate();
+      const groupDegraded: ObjectID = ObjectID.generate();
+      const groupOffline: ObjectID = ObjectID.generate();
+
+      const rowsByGroup: Dictionary<Array<MonitorGroupResource>> = {
+        [groupEmpty.toString()]: [],
+        [groupDegraded.toString()]: [
+          makeGroupResource({
+            monitorGroupId: groupDegraded,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: operational.id!,
+          }),
+          makeGroupResource({
+            monitorGroupId: groupDegraded,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: degraded.id!,
+          }),
+        ],
+        [groupOffline.toString()]: [
+          makeGroupResource({
+            monitorGroupId: groupOffline,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: offline.id!,
+          }),
+          makeGroupResource({
+            monitorGroupId: groupOffline,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: degraded.id!,
+          }),
+          // Noise both paths must ignore: unknown status + missing relation.
+          makeGroupResource({
+            monitorGroupId: groupOffline,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: ObjectID.generate(),
+          }),
+          makeGroupResource({
+            monitorGroupId: groupOffline,
+            monitorId: ObjectID.generate(),
+            omitMonitor: true,
+          }),
+        ],
+      };
+
+      // --- mocks for the single-group path (3 queries per group) ---
+      (
+        jest.spyOn(
+          MonitorGroupService,
+          "findOneById",
+        ) as unknown as jest.SpyInstance
+      ).mockImplementation((...args: Array<unknown>): Promise<MonitorGroup> => {
+        const findOneById: { id: ObjectID } = args[0] as { id: ObjectID };
+        const group: MonitorGroup = new MonitorGroup();
+        group.id = findOneById.id;
+        group.projectId = projectId;
+        return Promise.resolve(group);
+      });
+
+      (
+        jest.spyOn(
+          MonitorGroupResourceService,
+          "findBy",
+        ) as unknown as jest.SpyInstance
+      ).mockImplementation(
+        (...args: Array<unknown>): Promise<Array<MonitorGroupResource>> => {
+          const findBy: { query: { monitorGroupId: ObjectID } } = args[0] as {
+            query: { monitorGroupId: ObjectID };
+          };
+          return Promise.resolve(
+            rowsByGroup[findBy.query.monitorGroupId.toString()] || [],
+          );
+        },
+      );
+
+      (
+        jest.spyOn(
+          MonitorStatusService,
+          "findBy",
+        ) as unknown as jest.SpyInstance
+      ).mockResolvedValue(statuses as never);
+
+      // --- mock for the batched path (ONE query) ---
+      spyOnFindAllBy([
+        ...rowsByGroup[groupEmpty.toString()]!,
+        ...rowsByGroup[groupDegraded.toString()]!,
+        ...rowsByGroup[groupOffline.toString()]!,
+      ]);
+
+      const batched: Dictionary<MonitorStatus> =
+        await MonitorGroupService.getCurrentStatusesForMonitorGroups({
+          monitorGroupIds: [groupEmpty, groupDegraded, groupOffline],
+          monitorStatuses: statuses,
+        });
+
+      for (const groupId of [groupEmpty, groupDegraded, groupOffline]) {
+        const single: MonitorStatus =
+          await MonitorGroupService.getCurrentStatus(groupId, { isRoot: true });
+        expect(batched[groupId.toString()]).toBe(single);
+      }
+
+      // Anchor the shared expectation so both paths being wrong together fails too.
+      expect(batched[groupEmpty.toString()]).toBe(operational);
+      expect(batched[groupDegraded.toString()]).toBe(degraded);
+      expect(batched[groupOffline.toString()]).toBe(offline);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/StatusPageServiceMonitorGroupBatching.test.ts
+++ b/Common/Tests/Server/Services/StatusPageServiceMonitorGroupBatching.test.ts
@@ -1,0 +1,331 @@
+/*
+ * StatusPageService monitor-group batching.
+ *
+ * Public status-page reads (overview, badge, subscriber reports) used to
+ * issue one MonitorGroupResource query PER STATUS PAGE RESOURCE (not even per
+ * distinct group) and re-fetch the page's StatusPageResource rows the caller
+ * already had in hand. These tests pin the two batched entry points:
+ *   - getMonitorIdsOnStatusPage: skips the StatusPageResource query entirely
+ *     when the caller supplies the rows, resolves ALL groups through ONE
+ *     MonitorGroupService.getMonitorIdsInMonitorGroups call, and de-dupes a
+ *     monitor that is both directly on the page and inside a group,
+ *   - getMonitorGroupCurrentStatuses: one batched group-resource fetch for
+ *     any number of resources (including repeated references to the same
+ *     group), while keeping its OWN worst-status semantics (see below).
+ *
+ * SEMANTICS NOTE (deliberate, preserved as-is by the batching change):
+ * StatusPageService.getMonitorGroupCurrentStatuses picks the LOWEST
+ * priority-number status as "worst" and produces NO entry for a group whose
+ * member statuses cannot be resolved — the exact OPPOSITE of
+ * MonitorGroupService.getCurrentStatus(es), where the HIGHEST priority number
+ * wins on top of an operational default. Both behaviors predate the batching
+ * and both are pinned so neither can silently converge on the other.
+ *
+ * All service reads are spied on — no database is touched.
+ */
+
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import StatusPageResourceService from "../../../Server/Services/StatusPageResourceService";
+import MonitorGroupService from "../../../Server/Services/MonitorGroupService";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import MonitorGroupResource from "../../../Models/DatabaseModels/MonitorGroupResource";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+function makeStatusPageResource(data: {
+  monitorId?: ObjectID | undefined;
+  monitorGroupId?: ObjectID | undefined;
+}): StatusPageResource {
+  const resource: StatusPageResource = new StatusPageResource();
+  if (data.monitorId) {
+    resource.monitorId = data.monitorId;
+  }
+  if (data.monitorGroupId) {
+    resource.monitorGroupId = data.monitorGroupId;
+  }
+  return resource;
+}
+
+function makeGroupResource(data: {
+  monitorGroupId: ObjectID;
+  monitorId?: ObjectID | undefined;
+  currentMonitorStatusId?: ObjectID | undefined;
+  omitMonitor?: boolean;
+}): MonitorGroupResource {
+  const resource: MonitorGroupResource = new MonitorGroupResource();
+  resource.monitorGroupId = data.monitorGroupId;
+  if (data.monitorId) {
+    resource.monitorId = data.monitorId;
+  }
+  if (!data.omitMonitor) {
+    const monitor: Monitor = new Monitor();
+    if (data.currentMonitorStatusId) {
+      monitor.currentMonitorStatusId = data.currentMonitorStatusId;
+    }
+    resource.monitor = monitor;
+  }
+  return resource;
+}
+
+function makeStatus(data: { priority: number; name: string }): MonitorStatus {
+  const status: MonitorStatus = new MonitorStatus();
+  status.id = ObjectID.generate();
+  status.priority = data.priority;
+  status.name = data.name;
+  return status;
+}
+
+function toStrings(ids: Array<ObjectID>): Array<string> {
+  return ids.map((id: ObjectID) => {
+    return id.toString();
+  });
+}
+
+describe("StatusPageService monitor-group batching", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("getMonitorIdsOnStatusPage", () => {
+    test("supplied resources skip the StatusPageResource query; groups resolve via ONE batched call; direct+group monitor de-dupes", async () => {
+      const statusPageId: ObjectID = ObjectID.generate();
+      const groupA: ObjectID = ObjectID.generate();
+      const groupB: ObjectID = ObjectID.generate();
+      const directMonitor: ObjectID = ObjectID.generate();
+      const groupOnlyMonitorA: ObjectID = ObjectID.generate();
+      const groupOnlyMonitorB: ObjectID = ObjectID.generate();
+
+      const statusPageResources: Array<StatusPageResource> = [
+        // Direct monitor, no group: must contribute no group lookup.
+        makeStatusPageResource({ monitorId: directMonitor }),
+        makeStatusPageResource({ monitorGroupId: groupA }),
+        makeStatusPageResource({ monitorGroupId: groupB }),
+      ];
+
+      const getResourcesSpy: jest.SpyInstance = jest.spyOn(
+        StatusPageService,
+        "getStatusPageResources",
+      ) as unknown as jest.SpyInstance;
+      const findBySpy: jest.SpyInstance = jest.spyOn(
+        StatusPageResourceService,
+        "findBy",
+      ) as unknown as jest.SpyInstance;
+      const batchedSpy: jest.SpyInstance = (
+        jest.spyOn(
+          MonitorGroupService,
+          "getMonitorIdsInMonitorGroups",
+        ) as unknown as jest.SpyInstance
+      ).mockResolvedValue({
+        // groupA contains the direct monitor too — it must appear only once.
+        [groupA.toString()]: [directMonitor, groupOnlyMonitorA],
+        [groupB.toString()]: [groupOnlyMonitorB],
+      } as never);
+
+      const result: {
+        monitorsOnStatusPage: Array<ObjectID>;
+        monitorsInGroup: Dictionary<Array<ObjectID>>;
+      } = await StatusPageService.getMonitorIdsOnStatusPage({
+        statusPageId: statusPageId,
+        statusPageResources: statusPageResources,
+      });
+
+      // Supplied rows mean the (identical) StatusPageResource query never runs.
+      expect(getResourcesSpy).not.toHaveBeenCalled();
+      expect(findBySpy).not.toHaveBeenCalled();
+
+      // ONE batched group lookup for all groups; null groupIds filtered out.
+      expect(batchedSpy).toHaveBeenCalledTimes(1);
+      expect(
+        toStrings(batchedSpy.mock.calls[0]![0] as Array<ObjectID>),
+      ).toEqual(toStrings([groupA, groupB]));
+
+      // Union of direct + group monitors, without duplicating directMonitor.
+      expect(toStrings(result.monitorsOnStatusPage)).toEqual(
+        toStrings([directMonitor, groupOnlyMonitorA, groupOnlyMonitorB]),
+      );
+
+      // The per-group membership dict is passed through exactly.
+      expect(Object.keys(result.monitorsInGroup).sort()).toEqual(
+        [groupA.toString(), groupB.toString()].sort(),
+      );
+      expect(toStrings(result.monitorsInGroup[groupA.toString()]!)).toEqual(
+        toStrings([directMonitor, groupOnlyMonitorA]),
+      );
+      expect(toStrings(result.monitorsInGroup[groupB.toString()]!)).toEqual(
+        toStrings([groupOnlyMonitorB]),
+      );
+    });
+
+    test("without supplied resources it fetches them once itself", async () => {
+      const statusPageId: ObjectID = ObjectID.generate();
+      const directMonitor: ObjectID = ObjectID.generate();
+
+      const getResourcesSpy: jest.SpyInstance = (
+        jest.spyOn(
+          StatusPageService,
+          "getStatusPageResources",
+        ) as unknown as jest.SpyInstance
+      ).mockResolvedValue([
+        makeStatusPageResource({ monitorId: directMonitor }),
+      ] as never);
+      const batchedSpy: jest.SpyInstance = (
+        jest.spyOn(
+          MonitorGroupService,
+          "getMonitorIdsInMonitorGroups",
+        ) as unknown as jest.SpyInstance
+      ).mockResolvedValue({} as never);
+
+      const result: {
+        monitorsOnStatusPage: Array<ObjectID>;
+        monitorsInGroup: Dictionary<Array<ObjectID>>;
+      } = await StatusPageService.getMonitorIdsOnStatusPage({
+        statusPageId: statusPageId,
+      });
+
+      expect(getResourcesSpy).toHaveBeenCalledTimes(1);
+      expect(getResourcesSpy).toHaveBeenCalledWith({
+        statusPageId: statusPageId,
+      });
+      expect(batchedSpy).toHaveBeenCalledTimes(1);
+      expect(batchedSpy).toHaveBeenCalledWith([]);
+      expect(toStrings(result.monitorsOnStatusPage)).toEqual(
+        toStrings([directMonitor]),
+      );
+      expect(result.monitorsInGroup).toEqual({});
+    });
+  });
+
+  describe("getMonitorGroupCurrentStatuses", () => {
+    const statusOperational: MonitorStatus = makeStatus({
+      priority: 1,
+      name: "Operational",
+    });
+    const statusDegraded: MonitorStatus = makeStatus({
+      priority: 2,
+      name: "Degraded",
+    });
+    const statusOffline: MonitorStatus = makeStatus({
+      priority: 3,
+      name: "Offline",
+    });
+    const allStatuses: Array<MonitorStatus> = [
+      statusOperational,
+      statusDegraded,
+      statusOffline,
+    ];
+
+    test("one batched fetch for many resources; LOWEST priority number wins; direct/unresolvable groups get no entry", async () => {
+      const groupA: ObjectID = ObjectID.generate();
+      const groupB: ObjectID = ObjectID.generate();
+
+      const statusPageResources: Array<StatusPageResource> = [
+        makeStatusPageResource({ monitorGroupId: groupA }),
+        makeStatusPageResource({ monitorGroupId: groupB }),
+        // The same group referenced twice must not trigger a second fetch.
+        makeStatusPageResource({ monitorGroupId: groupA }),
+        // Direct monitor resource: contributes no group, gets no entry.
+        makeStatusPageResource({ monitorId: ObjectID.generate() }),
+      ];
+
+      const batchedSpy: jest.SpyInstance = (
+        jest.spyOn(
+          MonitorGroupService,
+          "getMonitorGroupResourcesByGroupIds",
+        ) as unknown as jest.SpyInstance
+      ).mockResolvedValue({
+        [groupA.toString()]: [
+          makeGroupResource({
+            monitorGroupId: groupA,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: statusDegraded.id!,
+          }),
+          makeGroupResource({
+            monitorGroupId: groupA,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: statusOffline.id!,
+          }),
+          /*
+           * Would be the "worst" under these semantics (lowest number), but
+           * the row has no monitorId, so the filter must drop it.
+           */
+          makeGroupResource({
+            monitorGroupId: groupA,
+            currentMonitorStatusId: statusOperational.id!,
+          }),
+          // No monitor relation loaded: filtered out.
+          makeGroupResource({
+            monitorGroupId: groupA,
+            monitorId: ObjectID.generate(),
+            omitMonitor: true,
+          }),
+        ],
+        // groupB's only member points at a status that no longer exists.
+        [groupB.toString()]: [
+          makeGroupResource({
+            monitorGroupId: groupB,
+            monitorId: ObjectID.generate(),
+            currentMonitorStatusId: ObjectID.generate(),
+          }),
+        ],
+      } as never);
+
+      const result: Dictionary<ObjectID> =
+        await StatusPageService.getMonitorGroupCurrentStatuses({
+          statusPageResources: statusPageResources,
+          monitorStatuses: allStatuses,
+        });
+
+      // ONE batched query serves every resource on the page.
+      expect(batchedSpy).toHaveBeenCalledTimes(1);
+      /*
+       * The raw (non-deduped, null-filtered) group id list is handed to the
+       * helper — deduping is the helper's job, pinned in its own suite.
+       */
+      expect(
+        toStrings(batchedSpy.mock.calls[0]![0] as Array<ObjectID>),
+      ).toEqual(toStrings([groupA, groupB, groupA]));
+
+      /*
+       * StatusPageService semantics: the LOWEST priority number is "worst",
+       * so Degraded (2) beats Offline (3). This is the OPPOSITE of
+       * MonitorGroupService.getCurrentStatus(es), where the HIGHEST number
+       * wins — both pre-existing behaviors are preserved as-is by the
+       * batching change, and this assertion keeps them from converging.
+       */
+      expect(result[groupA.toString()]).toBeInstanceOf(ObjectID);
+      expect(result[groupA.toString()]!.toString()).toBe(
+        statusDegraded.id!.toString(),
+      );
+
+      // No resolvable member status -> NO dict entry (no operational default).
+      expect(result[groupB.toString()]).toBeUndefined();
+      // Direct-monitor resources never produce group entries.
+      expect(Object.keys(result)).toEqual([groupA.toString()]);
+    });
+
+    test("no group resources at all yields an empty dictionary", async () => {
+      const batchedSpy: jest.SpyInstance = (
+        jest.spyOn(
+          MonitorGroupService,
+          "getMonitorGroupResourcesByGroupIds",
+        ) as unknown as jest.SpyInstance
+      ).mockResolvedValue({} as never);
+
+      const result: Dictionary<ObjectID> =
+        await StatusPageService.getMonitorGroupCurrentStatuses({
+          statusPageResources: [
+            makeStatusPageResource({ monitorId: ObjectID.generate() }),
+          ],
+          monitorStatuses: allStatuses,
+        });
+
+      expect(result).toEqual({});
+      // Still exactly one batched call (with an empty id list).
+      expect(batchedSpy).toHaveBeenCalledTimes(1);
+      expect(batchedSpy).toHaveBeenCalledWith([]);
+    });
+  });
+});


### PR DESCRIPTION
# Cut hot-path Postgres load: write fast-paths, 13 missing indexes, status-page batching

Postgres utilization at scale is dominated by a handful of recurring hot paths. This PR takes the verified low-hanging fruit — no behavior changes for API consumers, no shared-infrastructure rewrites. Every finding below was located and then adversarially verified against the actual code (call chains, cron schedules, existing indexes in `SchemaMigrations/`, and model hook decorators) before being fixed.

## 1. Write amplification: bookkeeping stamps ran the full update pipeline

`updateOneById` / `updateOneBy` cost ~4 statements per row (pre-SELECT, `save()`'s SELECT + UPDATE in a transaction, post-hook SELECT) and — on models with `@EnableWorkflow` / `@EnableAuditLog` — fire an on-update workflow HTTP trigger and an audit entry per call. Four hot machine-stamped writes now use the existing `updateColumnsByIdWithoutHooks` fast path (single parameterized UPDATE, the same precedent already used for the Monitor heartbeat writes in `MonitorResource.ts`):

| Write | Frequency | Before → after |
|---|---|---|
| `MonitorProbe.lastMonitoringLog` (`MonitorResource.ts`) | **every probe check result** — the hottest recurring write in the product | 3 statements + re-fetch of the large jsonb it just loaded → 1 UPDATE |
| `incomingRequestMonitorHeartbeatCheckedAt` (`CheckHeartbeat` cron) | every 30s × every incoming-request monitor | ~4 statements + workflow HTTP + audit row → 1 UPDATE |
| `incomingEmailMonitorHeartbeatCheckedAt` (`CheckOnlineStatus` cron) | every 30s × every incoming-email monitor | same |
| `telemetryMonitorLastMonitorAt/NextMonitorAt` (telemetry scheduler) | every minute × every telemetry/infra monitor | same |

For 500 incoming-request monitors alone the heartbeat stamp was ~7.2M statements + 1.44M audit inserts + 1.44M workflow HTTP posts per day, regardless of traffic.

Safety: `MonitorProbe` has no workflow/audit/realtime decorators, so nothing observable changes there. `Monitor` does have workflow+audit on update — skipping them for these machine-stamped columns is the same documented tradeoff already shipped for the ingest-side heartbeat columns (see the comment block in `MonitorResource.ts`); `Monitor` has no realtime events, so nothing else is dropped. These preconditions are pinned by tests.

## 2. Missing indexes: 13 hot filter columns seq-scanned every minute (migration `AddHotQueryIndexes`)

- **`OnCallDutyPolicyExecutionLog.status`** — two EVERY_MINUTE on-call executor crons issue 3 status-filtered scans/min against a table whose sibling (`UserOnCallLog.status`) already got this exact index in `AddPerformanceIndexes`.
- **`subscriberNotificationStatus*` on 10 tables** (Incident ×2, IncidentStateTimeline, IncidentPublicNote, IncidentEpisode, IncidentEpisodeStateTimeline, IncidentEpisodePublicNote, ScheduledMaintenance, ScheduledMaintenanceStateTimeline, ScheduledMaintenancePublicNote, StatusPageAnnouncement) — 11 EVERY_MINUTE `SendNotificationToSubscribers` jobs (~13 scans/min) filter `= 'Pending'`, and the jobs themselves flip rows out of Pending within a minute, so in steady state Postgres seq-scans ever-growing tables to find **zero** rows. With the index each poll is a near-empty index probe.
- **`Monitor.monitorType`** — the every-30s heartbeat crons filter `monitorType = X AND <heartbeat column> IS NULL`. Every monitor of every *other* type also has NULL there, so the existing heartbeat-column indexes are non-selective for those branches and `monitorType` did the real (unindexed) work — ~9 queries/min effectively scanning the whole Monitor table.

Migration generated with `npm run generate-postgres-migration` (pre-existing `OnCallDutyPolicyScheduleLayer` default-whitespace drift stripped), registered in `SchemaMigrations/Index.ts`, applied + re-generated locally to prove the schema now matches the entities exactly.

## 3. Public status-page N+1s (unauthenticated, no-cache endpoints)

- **Overview render** (`getStatusPageResourcesAndTimelines`, used by the overview + `/uptime` routes): issued **4 queries per monitor group per page view** — `MonitorGroupService.getCurrentStatus` re-fetched the group row (only to read a projectId already in hand) and the project's MonitorStatus list (already fetched two queries earlier), plus a duplicate group-resource fetch. Now: one batched `MonitorGroupResource` query serves all groups via new `MonitorGroupService.getMonitorGroupResourcesByGroupIds` / `getCurrentStatusesForMonitorGroups` helpers that preserve `getCurrentStatus`'s exact worst-status semantics (equivalence-tested).
- **Badge, announcements, scheduled events, incidents/episodes lists**: same per-group loop pattern, each now one batched query. The badge endpoint explicitly disables caching, so every README render paid `3 + G` queries. `getMonitorGroupCurrentStatuses` previously queried once per *status-page resource* (not even per distinct group).
- **`getIncidents`/`getEpisodes` double fetch**: both fetched the identical `StatusPageResource` list twice per request (directly + inside `getMonitorIdsOnStatusPage`); the helper now accepts pre-fetched resources.
- **Episodes block on every overview view** fetched *all incidents ever attached to the page's monitors* (up to 10,000 rows through the many-to-many join) just to discover episode membership — `showEpisodesOnStatusPage` defaults to true, so this ran for every page, even with zero episodes. An indexed `countBy` guard (project's unresolved, visible episodes — exactly the constraints the final episodes query applies, so `count == 0` provably implies identical empty output) now skips the whole block in the common case.

## Tests (57 new, all passing)

- `MonitorGroupServiceBatchedStatuses.test.ts` (10) — batched helpers: single query for N groups, dedup, empty-input short-circuits, operational-default/priority semantics, **direct equivalence check against the single-group `getCurrentStatus` path** so the two can't silently drift.
- `StatusPageServiceMonitorGroupBatching.test.ts` (4) — pre-fetched-resources dedup, one batched call regardless of group/resource count, and the (pre-existing, deliberately preserved) lowest-priority-wins semantics of the badge path.
- `AddHotQueryIndexesMigration.test.ts` (16) — every one of the 13 columns has its `@Index` decorator (TypeORM metadata), migration `up()` emits exactly 13 CREATE INDEX and nothing else (guards against regenerated-drift statements sneaking in), `down()` drops exactly those 13, and the migration is registered in `SchemaMigrations/Index.ts`.
- `HeartbeatWriteFastPathSafety.test.ts` (10) — pins the preconditions that make the fast-path conversions behavior-preserving: `MonitorProbe` has no workflow/audit/realtime hooks; `Monitor` skips exactly workflow+audit (documented tradeoff) and nothing else; every fast-path column still exists on its entity; `MonitorProbeService.onUpdateSuccess` early-exit.
- `CheckHeartbeat.test.ts` (6), `CheckOnlineStatus.test.ts` (6), `MonitorTelemetryMonitorScheduler.test.ts` (5) — drive a full cron tick each through a captured handler: fast path called with exactly the right columns per monitor, `updateOneById` **never** called, per-monitor control flow (skip-without-steps, criteria gating, error isolation, enqueue behavior) preserved. Pre-existing `MonitorTelemetryMonitor.test.ts` still passes.

## Verification

- `Common` and `App` compile (`App`'s single `MqttServer.ts` error pre-exists on master, unchanged).
- Migration applied to a dev DB and re-generated: only the known pre-existing drift remains → schema matches entities.
- Full new-test suite re-run at the end on top of the final lint-formatted tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gznz9FpUDyXMQqxhewxGc3
