### PR TITLE
fix(probe): keep a failing Ping/Port check inside its monitoring interval

### DIFF
--- a/Common/Server/Utils/Monitor/MonitorLogTimeUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorLogTimeUtil.ts
@@ -1,0 +1,87 @@
+import OneUptimeDate from "../../../Types/Date";
+import { JSONObject } from "../../../Types/JSON";
+import DataToProcess from "./DataToProcess";
+
+/**
+ * MonitorLogTimeUtil
+ *
+ * The "Monitored At" column of a monitor log should say when the check was
+ * taken, not when the server got round to writing the row. Those two are the
+ * same thing for a healthy monitor, but a failing check spends its whole retry
+ * budget before reporting, so ingest time can be tens of seconds — historically
+ * minutes — after the check actually ran. Reading the check's own timestamp
+ * off the payload keeps the column honest.
+ *
+ * Probe clocks are not trusted blindly: a probe with a skewed clock could
+ * otherwise write rows into the future or into a long-past ClickHouse
+ * partition, so anything outside a sane window falls back to server time.
+ */
+
+// A check timestamp may not be ahead of server time by more than this.
+export const MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS: number = 60 * 1000;
+
+/*
+ * Nor further behind it than this. Generous enough to cover the slowest
+ * legitimate check plus queue time, tight enough that a badly skewed probe
+ * cannot scatter rows across old partitions.
+ */
+export const MAX_MONITOR_LOG_LAG_IN_MS: number = 30 * 60 * 1000;
+
+export default class MonitorLogTimeUtil {
+  /**
+   * The moment to stamp a monitor log row with: the check's own `monitoredAt`
+   * when the payload carries a usable one, and server time otherwise.
+   */
+  public static getMonitorLogTime(
+    dataToProcess: DataToProcess | undefined,
+    now: Date = OneUptimeDate.getCurrentDate(),
+  ): Date {
+    const monitoredAt: Date | null = this.parseMonitoredAt(dataToProcess);
+
+    if (!monitoredAt) {
+      return now;
+    }
+
+    const skewInMs: number = monitoredAt.getTime() - now.getTime();
+
+    if (skewInMs > MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS) {
+      // Ahead of the server — the probe's clock is wrong, not the server's.
+      return now;
+    }
+
+    if (-skewInMs > MAX_MONITOR_LOG_LAG_IN_MS) {
+      // Too stale to be a real check timestamp.
+      return now;
+    }
+
+    return monitoredAt;
+  }
+
+  /**
+   * `monitoredAt` reaches the server as JSON, so it can be a Date, an ISO
+   * string or an epoch number depending on the path it took. Returns null for
+   * payloads that carry no usable timestamp.
+   */
+  private static parseMonitoredAt(
+    dataToProcess: DataToProcess | undefined,
+  ): Date | null {
+    const rawValue: unknown = (dataToProcess as JSONObject | undefined)?.[
+      "monitoredAt"
+    ];
+
+    if (rawValue === undefined || rawValue === null) {
+      return null;
+    }
+
+    if (rawValue instanceof Date) {
+      return isNaN(rawValue.getTime()) ? null : rawValue;
+    }
+
+    if (typeof rawValue === "string" || typeof rawValue === "number") {
+      const parsed: Date = new Date(rawValue);
+      return isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    return null;
+  }
+}

--- a/Common/Server/Utils/Monitor/MonitorLogUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorLogUtil.ts
@@ -7,6 +7,7 @@ import OneUptimeDate from "../../../Types/Date";
 import ObjectID from "../../../Types/ObjectID";
 import { JSONObject } from "../../../Types/JSON";
 import DataToProcess from "./DataToProcess";
+import MonitorLogTimeUtil from "./MonitorLogTimeUtil";
 
 /*
  * Maximum rows held in memory before we force a flush, and the
@@ -127,6 +128,17 @@ export default class MonitorLogUtil {
         const logTimestamp: string =
           OneUptimeDate.toClickhouseDateTime(logIngestionDate);
 
+        /*
+         * "Monitored At" is when the check ran, which is not when we write the
+         * row: a failing check spends its retry budget before reporting.
+         */
+        const monitoredAtTimestamp: string = OneUptimeDate.toClickhouseDateTime(
+          MonitorLogTimeUtil.getMonitorLogTime(
+            data.dataToProcess,
+            logIngestionDate,
+          ),
+        );
+
         const retentionDate: Date = OneUptimeDate.addRemoveDays(
           logIngestionDate,
           retentionDays,
@@ -137,7 +149,7 @@ export default class MonitorLogUtil {
           createdAt: logTimestamp,
           projectId: data.projectId.toString(),
           monitorId: data.monitorId.toString(),
-          time: logTimestamp,
+          time: monitoredAtTimestamp,
           logBody: JSON.parse(JSON.stringify(data.dataToProcess)),
           retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
         };

--- a/Common/Tests/Server/Utils/Monitor/MonitorLogTimeUtil.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorLogTimeUtil.test.ts
@@ -1,0 +1,176 @@
+import MonitorLogTimeUtil, {
+  MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS,
+  MAX_MONITOR_LOG_LAG_IN_MS,
+} from "../../../../Server/Utils/Monitor/MonitorLogTimeUtil";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The "Monitored At" column of a monitor log used to be the server's ingest
+ * time. That is fine while a monitor is healthy, but a failing check spends
+ * its retry budget before reporting, so the row landed noticeably after the
+ * check actually ran — a 1-minute Ping monitor looked like it had skipped
+ * three intervals. These tests cover reading the check's own timestamp off
+ * the payload, and the clock-skew guards that keep a misconfigured probe from
+ * writing rows into the future or into a long-past ClickHouse partition.
+ */
+
+const NOW: Date = new Date(Date.UTC(2026, 6, 24, 13, 14, 0));
+
+function probeResponse(monitoredAt: unknown): DataToProcess {
+  return {
+    projectId: new ObjectID("100000000000000000000001"),
+    monitorId: new ObjectID("100000000000000000000002"),
+    monitorStepId: new ObjectID("100000000000000000000003"),
+    probeId: new ObjectID("100000000000000000000004"),
+    failureCause: "",
+    monitoredAt: monitoredAt,
+  } as unknown as ProbeMonitorResponse;
+}
+
+describe("MonitorLogTimeUtil.getMonitorLogTime", () => {
+  it("uses the check's own monitoredAt when it is a Date", () => {
+    const monitoredAt: Date = new Date(NOW.getTime() - 45000);
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(monitoredAt), NOW),
+    ).toEqual(monitoredAt);
+  });
+
+  it("parses monitoredAt when it arrived as an ISO string", () => {
+    const monitoredAt: Date = new Date(NOW.getTime() - 45000);
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(
+        probeResponse(monitoredAt.toISOString()),
+        NOW,
+      ),
+    ).toEqual(monitoredAt);
+  });
+
+  it("parses monitoredAt when it arrived as an epoch number", () => {
+    const monitoredAt: Date = new Date(NOW.getTime() - 45000);
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(
+        probeResponse(monitoredAt.getTime()),
+        NOW,
+      ),
+    ).toEqual(monitoredAt);
+  });
+
+  it("keeps a slow failing check's timestamp rather than the ingest time", () => {
+    /*
+     * The regression this fixes: the check ran at 13:12 and only reported at
+     * 13:14, and the log claimed 13:14.
+     */
+    const monitoredAt: Date = new Date(NOW.getTime() - 2 * 60 * 1000);
+
+    const logTime: Date = MonitorLogTimeUtil.getMonitorLogTime(
+      probeResponse(monitoredAt),
+      NOW,
+    );
+
+    expect(logTime).toEqual(monitoredAt);
+    expect(logTime).not.toEqual(NOW);
+  });
+
+  it("falls back to server time when the payload has no monitoredAt", () => {
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(undefined), NOW),
+    ).toEqual(NOW);
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(null), NOW),
+    ).toEqual(NOW);
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime({} as DataToProcess, NOW),
+    ).toEqual(NOW);
+  });
+
+  it("falls back to server time when the payload itself is missing", () => {
+    expect(MonitorLogTimeUtil.getMonitorLogTime(undefined, NOW)).toEqual(NOW);
+  });
+
+  it("falls back to server time for an unparseable monitoredAt", () => {
+    for (const badValue of [
+      "not-a-date",
+      "",
+      NaN,
+      new Date("nonsense"),
+      {},
+      [],
+      true,
+    ]) {
+      expect(
+        MonitorLogTimeUtil.getMonitorLogTime(probeResponse(badValue), NOW),
+      ).toEqual(NOW);
+    }
+  });
+
+  it("accepts a check timestamp within the allowed forward skew", () => {
+    const monitoredAt: Date = new Date(
+      NOW.getTime() + MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS - 1000,
+    );
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(monitoredAt), NOW),
+    ).toEqual(monitoredAt);
+  });
+
+  it("rejects a check timestamp from a probe whose clock runs ahead", () => {
+    const monitoredAt: Date = new Date(
+      NOW.getTime() + MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS + 1000,
+    );
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(monitoredAt), NOW),
+    ).toEqual(NOW);
+  });
+
+  it("accepts a check timestamp within the allowed lag", () => {
+    const monitoredAt: Date = new Date(
+      NOW.getTime() - MAX_MONITOR_LOG_LAG_IN_MS + 1000,
+    );
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(monitoredAt), NOW),
+    ).toEqual(monitoredAt);
+  });
+
+  it("rejects a check timestamp that is implausibly stale", () => {
+    const monitoredAt: Date = new Date(
+      NOW.getTime() - MAX_MONITOR_LOG_LAG_IN_MS - 1000,
+    );
+
+    expect(
+      MonitorLogTimeUtil.getMonitorLogTime(probeResponse(monitoredAt), NOW),
+    ).toEqual(NOW);
+  });
+
+  it("never returns a time outside the accepted window", () => {
+    const offsetsInMs: Array<number> = [
+      -10 * 24 * 60 * 60 * 1000,
+      -MAX_MONITOR_LOG_LAG_IN_MS - 1,
+      -60000,
+      0,
+      MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS + 1,
+      10 * 24 * 60 * 60 * 1000,
+    ];
+
+    for (const offsetInMs of offsetsInMs) {
+      const logTime: Date = MonitorLogTimeUtil.getMonitorLogTime(
+        probeResponse(new Date(NOW.getTime() + offsetInMs)),
+        NOW,
+      );
+
+      const skewInMs: number = logTime.getTime() - NOW.getTime();
+
+      expect(skewInMs).toBeLessThanOrEqual(MAX_MONITOR_LOG_CLOCK_SKEW_IN_MS);
+      expect(-skewInMs).toBeLessThanOrEqual(MAX_MONITOR_LOG_LAG_IN_MS);
+    }
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorCheckBudget.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorCheckBudget.test.ts
@@ -1,0 +1,459 @@
+import MonitorCheckBudget, {
+  MAX_MONITOR_DIAGNOSTICS_BUDGET_IN_MS,
+  MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+  MIN_MONITOR_CHECK_BUDGET_IN_MS,
+  MONITOR_CHECK_BUDGET_INTERVAL_FRACTION,
+  MONITOR_CHECK_RETRY_DELAY_IN_MS,
+  MONITOR_DIAGNOSTICS_BUDGET_FRACTION,
+} from "../../../Types/Monitor/MonitorCheckBudget";
+import { DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS } from "../../../Types/Monitor/MonitorStep";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * These tests pin down the arithmetic that keeps a monitor check inside its
+ * own monitoring interval. The bug they guard against: a Ping monitor on a
+ * 1-minute interval whose target stopped responding spent 60s per attempt ×
+ * 3 attempts, so every result arrived ~3 minutes late and the monitor looked
+ * like it had skipped intervals before catching up.
+ */
+
+const FIXED_FROM: Date = new Date(Date.UTC(2026, 6, 24, 13, 8, 30));
+
+const EVERY_MINUTE: string = "* * * * *";
+const EVERY_FIVE_MINUTES: string = "*/5 * * * *";
+const EVERY_HOUR: string = "0 * * * *";
+
+describe("MonitorCheckBudget.getMonitoringIntervalInMs", () => {
+  it("derives 1 minute from an every-minute cron", () => {
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs(EVERY_MINUTE, FIXED_FROM),
+    ).toBe(60 * 1000);
+  });
+
+  it("derives 5 minutes from an every-5-minutes cron", () => {
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs(
+        EVERY_FIVE_MINUTES,
+        FIXED_FROM,
+      ),
+    ).toBe(5 * 60 * 1000);
+  });
+
+  it("derives 1 hour from an hourly cron", () => {
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs(EVERY_HOUR, FIXED_FROM),
+    ).toBe(60 * 60 * 1000);
+  });
+
+  it("derives the interval regardless of where in the minute sampling starts", () => {
+    const midMinute: Date = new Date(Date.UTC(2026, 6, 24, 13, 8, 59, 750));
+
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs(EVERY_MINUTE, midMinute),
+    ).toBe(60 * 1000);
+  });
+
+  it("takes the SMALLEST gap when the cron fires at uneven spacing", () => {
+    /*
+     * "0 0,1 * * *" alternates between a 1-hour and a 23-hour gap. Budgeting
+     * for the tighter of the two is the safe direction to be wrong in.
+     */
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs("0 0,1 * * *", FIXED_FROM),
+    ).toBe(60 * 60 * 1000);
+  });
+
+  it("returns null for an unparseable cron expression", () => {
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs("not-a-cron", FIXED_FROM),
+    ).toBeNull();
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs("* * *", FIXED_FROM),
+    ).toBeNull();
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs("99 * * * *", FIXED_FROM),
+    ).toBeNull();
+  });
+
+  it("returns null for missing, empty or whitespace-only input", () => {
+    expect(MonitorCheckBudget.getMonitoringIntervalInMs(undefined)).toBeNull();
+    expect(MonitorCheckBudget.getMonitoringIntervalInMs(null)).toBeNull();
+    expect(MonitorCheckBudget.getMonitoringIntervalInMs("")).toBeNull();
+    expect(MonitorCheckBudget.getMonitoringIntervalInMs("   ")).toBeNull();
+  });
+
+  it("returns null for a non-string value", () => {
+    expect(
+      MonitorCheckBudget.getMonitoringIntervalInMs(42 as unknown as string),
+    ).toBeNull();
+  });
+});
+
+describe("MonitorCheckBudget.getCheckBudgetInMs", () => {
+  it("caps the default 60s timeout to 80% of a 1-minute interval", () => {
+    expect(
+      MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
+        monitoringInterval: EVERY_MINUTE,
+        from: FIXED_FROM,
+      }),
+    ).toBe(60 * 1000 * MONITOR_CHECK_BUDGET_INTERVAL_FRACTION);
+  });
+
+  it("leaves the timeout alone when the interval is roomy", () => {
+    // 80% of 5 minutes is 4 minutes, so the 60s timeout is the binding limit.
+    expect(
+      MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
+        monitoringInterval: EVERY_FIVE_MINUTES,
+        from: FIXED_FROM,
+      }),
+    ).toBe(DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS);
+  });
+
+  it("never stretches a check beyond the configured timeout", () => {
+    // A user asking for 2s does not get 48s just because the interval allows it.
+    expect(
+      MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: 2000,
+        monitoringInterval: EVERY_MINUTE,
+        from: FIXED_FROM,
+      }),
+    ).toBe(2000);
+  });
+
+  it("falls back to the configured timeout when the interval is unknown", () => {
+    expect(
+      MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: 30000,
+        monitoringInterval: undefined,
+        from: FIXED_FROM,
+      }),
+    ).toBe(30000);
+
+    expect(
+      MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: 30000,
+        monitoringInterval: "garbage",
+        from: FIXED_FROM,
+      }),
+    ).toBe(30000);
+  });
+
+  it("keeps the interval-derived budget at or above the floor", () => {
+    /*
+     * A hypothetical very tight interval must not squeeze checks down to
+     * nothing — the floor wins over the 80% fraction.
+     */
+    const budget: number = MonitorCheckBudget.getCheckBudgetInMs({
+      requestTimeoutInMs: DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
+      monitoringInterval: "*/2 * * * * *", // every 2 seconds
+      from: FIXED_FROM,
+    });
+
+    expect(budget).toBe(MIN_MONITOR_CHECK_BUDGET_IN_MS);
+  });
+
+  it("handles a zero, negative or non-finite timeout without going negative", () => {
+    for (const requestTimeoutInMs of [0, -5000, NaN, Infinity]) {
+      expect(
+        MonitorCheckBudget.getCheckBudgetInMs({
+          requestTimeoutInMs,
+          monitoringInterval: EVERY_MINUTE,
+          from: FIXED_FROM,
+        }),
+      ).toBe(MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS);
+    }
+  });
+});
+
+describe("MonitorCheckBudget diagnostics / reachability split", () => {
+  it("reserves a quarter of the budget for post-failure diagnostics", () => {
+    expect(MonitorCheckBudget.getDiagnosticsBudgetInMs(48000)).toBe(
+      48000 * MONITOR_DIAGNOSTICS_BUDGET_FRACTION,
+    );
+    expect(MonitorCheckBudget.getReachabilityBudgetInMs(48000)).toBe(36000);
+  });
+
+  it("caps the diagnostics reserve so a long check does not over-reserve", () => {
+    expect(MonitorCheckBudget.getDiagnosticsBudgetInMs(600000)).toBe(
+      MAX_MONITOR_DIAGNOSTICS_BUDGET_IN_MS,
+    );
+  });
+
+  it("always leaves the two slices adding up to the whole budget", () => {
+    for (const budget of [5000, 12000, 48000, 60000, 240000]) {
+      expect(
+        MonitorCheckBudget.getDiagnosticsBudgetInMs(budget) +
+          MonitorCheckBudget.getReachabilityBudgetInMs(budget),
+      ).toBe(budget);
+    }
+  });
+
+  it("degrades safely for a zero or negative budget", () => {
+    expect(MonitorCheckBudget.getDiagnosticsBudgetInMs(0)).toBe(0);
+    expect(MonitorCheckBudget.getDiagnosticsBudgetInMs(-1)).toBe(0);
+    expect(MonitorCheckBudget.getReachabilityBudgetInMs(0)).toBe(
+      MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+    );
+  });
+});
+
+describe("MonitorCheckBudget.getAttemptTimeoutInMs", () => {
+  it("splits the budget across attempts and their backoffs", () => {
+    // 36000 - 2 backoffs of 1000 = 34000, over 3 attempts.
+    expect(
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: 36000,
+        retryCount: 3,
+      }),
+    ).toBe(Math.floor(34000 / 3));
+  });
+
+  it("gives a single attempt the whole budget", () => {
+    expect(
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: 36000,
+        retryCount: 1,
+      }),
+    ).toBe(36000);
+  });
+
+  it("keeps attempts × timeout + backoffs inside the budget", () => {
+    for (const budgetInMs of [2000, 5000, 12000, 36000, 45000, 60000]) {
+      for (const retryCount of [1, 2, 3, 5, 10]) {
+        const attempts: number = MonitorCheckBudget.getAffordableAttemptCount({
+          budgetInMs,
+          retryCount,
+        });
+
+        const attemptTimeoutInMs: number =
+          MonitorCheckBudget.getAttemptTimeoutInMs({
+            budgetInMs,
+            retryCount,
+          });
+
+        const worstCaseInMs: number =
+          attemptTimeoutInMs * attempts +
+          (attempts - 1) * MONITOR_CHECK_RETRY_DELAY_IN_MS;
+
+        expect(worstCaseInMs).toBeLessThanOrEqual(budgetInMs);
+      }
+    }
+  });
+
+  it("never returns less than the minimum attempt timeout", () => {
+    expect(
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: 100,
+        retryCount: 10,
+      }),
+    ).toBe(MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS);
+  });
+
+  it("honours a caller-supplied minimum", () => {
+    expect(
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: 100,
+        retryCount: 10,
+        minAttemptTimeoutInMs: 7500,
+      }),
+    ).toBe(7500);
+  });
+
+  it("honours a caller-supplied retry delay", () => {
+    // 36000 - 2 backoffs of 5000 = 26000, over 3 attempts.
+    expect(
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: 36000,
+        retryCount: 3,
+        retryDelayInMs: 5000,
+      }),
+    ).toBe(Math.floor(26000 / 3));
+  });
+
+  it("treats a zero retry count as one attempt", () => {
+    expect(
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: 20000,
+        retryCount: 0,
+      }),
+    ).toBe(20000);
+  });
+});
+
+describe("MonitorCheckBudget.getAffordableAttemptCount", () => {
+  it("affords every configured attempt when the budget is roomy", () => {
+    expect(
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: 36000,
+        retryCount: 3,
+      }),
+    ).toBe(3);
+  });
+
+  it("drops the attempts a tight budget cannot pay for", () => {
+    /*
+     * 5s at a 1s minimum with 1s backoffs pays for 3 attempts
+     * (3 × 1000 + 2 × 1000), not the 5 configured.
+     */
+    expect(
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: 5000,
+        retryCount: 5,
+      }),
+    ).toBe(3);
+  });
+
+  it("always keeps at least one attempt", () => {
+    expect(
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: 0,
+        retryCount: 3,
+      }),
+    ).toBe(1);
+
+    expect(
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: -5000,
+        retryCount: 3,
+      }),
+    ).toBe(1);
+  });
+
+  it("never invents attempts beyond the configured retry count", () => {
+    expect(
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: 600000,
+        retryCount: 2,
+      }),
+    ).toBe(2);
+  });
+
+  it("accounts for a caller-supplied minimum and backoff", () => {
+    // 30s at a 9s minimum with 1s backoffs pays for 3 attempts.
+    expect(
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: 30000,
+        retryCount: 5,
+        minAttemptTimeoutInMs: 9000,
+        retryDelayInMs: 1000,
+      }),
+    ).toBe(3);
+  });
+});
+
+describe("MonitorCheckBudget deadlines", () => {
+  it("puts the deadline one budget after the start", () => {
+    expect(MonitorCheckBudget.getDeadlineAt(FIXED_FROM, 36000).getTime()).toBe(
+      FIXED_FROM.getTime() + 36000,
+    );
+  });
+
+  it("never moves the deadline backwards for a negative budget", () => {
+    expect(MonitorCheckBudget.getDeadlineAt(FIXED_FROM, -1000).getTime()).toBe(
+      FIXED_FROM.getTime(),
+    );
+  });
+
+  it("reports the time left before the deadline", () => {
+    const deadlineAt: Date = new Date(FIXED_FROM.getTime() + 30000);
+
+    expect(
+      MonitorCheckBudget.getRemainingBudgetInMs(deadlineAt, FIXED_FROM),
+    ).toBe(30000);
+
+    expect(
+      MonitorCheckBudget.getRemainingBudgetInMs(
+        deadlineAt,
+        new Date(FIXED_FROM.getTime() + 25000),
+      ),
+    ).toBe(5000);
+  });
+
+  it("clamps a passed deadline to zero rather than going negative", () => {
+    expect(
+      MonitorCheckBudget.getRemainingBudgetInMs(
+        FIXED_FROM,
+        new Date(FIXED_FROM.getTime() + 90000),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("MonitorCheckBudget end-to-end: the reported regression", () => {
+  interface Scenario {
+    label: string;
+    monitoringInterval: string;
+    retryCount: number;
+  }
+
+  const SCENARIOS: Array<Scenario> = [
+    {
+      label: "1-minute interval",
+      monitoringInterval: EVERY_MINUTE,
+      retryCount: 3,
+    },
+    {
+      label: "5-minute interval",
+      monitoringInterval: EVERY_FIVE_MINUTES,
+      retryCount: 3,
+    },
+  ];
+
+  it.each(SCENARIOS)(
+    "keeps a fully-failing check inside the $label",
+    ({ monitoringInterval, retryCount }: Scenario) => {
+      const intervalInMs: number = MonitorCheckBudget.getMonitoringIntervalInMs(
+        monitoringInterval,
+        FIXED_FROM,
+      )!;
+
+      const checkBudgetInMs: number = MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
+        monitoringInterval,
+        from: FIXED_FROM,
+      });
+
+      const reachabilityBudgetInMs: number =
+        MonitorCheckBudget.getReachabilityBudgetInMs(checkBudgetInMs);
+
+      const attemptTimeoutInMs: number =
+        MonitorCheckBudget.getAttemptTimeoutInMs({
+          budgetInMs: reachabilityBudgetInMs,
+          retryCount,
+        });
+
+      // Every attempt times out, every backoff is paid, then diagnostics run.
+      const worstCaseCheckInMs: number =
+        attemptTimeoutInMs * retryCount +
+        (retryCount - 1) * MONITOR_CHECK_RETRY_DELAY_IN_MS +
+        MonitorCheckBudget.getDiagnosticsBudgetInMs(checkBudgetInMs);
+
+      expect(worstCaseCheckInMs).toBeLessThanOrEqual(checkBudgetInMs);
+      expect(worstCaseCheckInMs).toBeLessThan(intervalInMs);
+    },
+  );
+
+  it("is a real improvement on the old unbudgeted behaviour", () => {
+    const retryCount: number = 3;
+
+    /*
+     * Before the fix: the full request timeout was spent per attempt, so a
+     * dead host cost timeout × retries — over three minutes on the defaults.
+     */
+    const oldWorstCaseInMs: number =
+      DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS * retryCount +
+      (retryCount - 1) * MONITOR_CHECK_RETRY_DELAY_IN_MS;
+
+    expect(oldWorstCaseInMs).toBeGreaterThan(3 * 60 * 1000);
+
+    const checkBudgetInMs: number = MonitorCheckBudget.getCheckBudgetInMs({
+      requestTimeoutInMs: DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
+      monitoringInterval: EVERY_MINUTE,
+      from: FIXED_FROM,
+    });
+
+    expect(checkBudgetInMs).toBeLessThan(60 * 1000);
+  });
+});

--- a/Common/Types/Monitor/MonitorCheckBudget.ts
+++ b/Common/Types/Monitor/MonitorCheckBudget.ts
@@ -1,0 +1,264 @@
+import CronTab from "../../Utils/CronTab";
+
+/**
+ * MonitorCheckBudget
+ *
+ * A single monitor check has to finish inside its own monitoring interval.
+ * If it does not, checks overlap: the scheduler hands the monitor out again
+ * (nextPingAt is claimed up-front) while the previous check is still running,
+ * every result lands late, and the monitor looks like it silently skipped
+ * several intervals before "catching up".
+ *
+ * That is exactly what an unreachable Ping target used to cause. The monitor's
+ * request timeout (60s by default) was handed to `ping` as the per-reply wait
+ * and then multiplied by the retry count, so one check against a black-holed
+ * IP cost ~3 minutes — three times the interval of a 1-minute monitor.
+ *
+ * These helpers turn "request timeout" + "monitoring interval" into a concrete
+ * wall-clock budget for one check, and then split that budget across the
+ * retry attempts. Everything here is pure and isomorphic so both the probe and
+ * the tests can reason about the arithmetic without a clock.
+ */
+
+/*
+ * A check may consume at most this fraction of its monitoring interval. The
+ * remainder is headroom for fetching the monitor list, reporting the result
+ * back to the ingest API, and ordinary scheduler jitter.
+ */
+export const MONITOR_CHECK_BUDGET_INTERVAL_FRACTION: number = 0.8;
+
+/*
+ * Floor for the interval-derived budget. Guards against a pathological cron
+ * (or a future sub-minute interval) squeezing checks down to nothing.
+ */
+export const MIN_MONITOR_CHECK_BUDGET_IN_MS: number = 5000;
+
+/*
+ * Share of a check's budget reserved for post-failure diagnostics (the
+ * traceroute + DNS lookup captured when a network check fails). Diagnostics
+ * run after the verdict is known, so they must not be able to push the check
+ * past its interval.
+ */
+export const MONITOR_DIAGNOSTICS_BUDGET_FRACTION: number = 0.25;
+
+export const MAX_MONITOR_DIAGNOSTICS_BUDGET_IN_MS: number = 20000;
+
+// Backoff between two attempts of the same check.
+export const MONITOR_CHECK_RETRY_DELAY_IN_MS: number = 1000;
+
+// No attempt is ever given less than this, however tight the budget is.
+export const MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS: number = 1000;
+
+/*
+ * How many upcoming fire times are sampled to derive the interval. Cron
+ * expressions are not required to be evenly spaced ("0 0,1 * * *" alternates
+ * between 1 hour and 23 hours), so the smallest gap in the sample is used —
+ * budgeting for the tightest interval is the safe direction to be wrong in.
+ */
+const INTERVAL_SAMPLE_COUNT: number = 5;
+
+export interface MonitorCheckBudgetOptions {
+  // The user-configured per-check timeout, in milliseconds.
+  requestTimeoutInMs: number;
+  // The monitor's monitoring interval, as a cron expression.
+  monitoringInterval?: string | null | undefined;
+  // Overridable for deterministic tests.
+  from?: Date | undefined;
+}
+
+export interface MonitorCheckAttemptTimeoutOptions {
+  // Wall-clock budget the attempts have to share.
+  budgetInMs: number;
+  // Total number of attempts the check is allowed to make (not extra tries).
+  retryCount: number;
+  retryDelayInMs?: number | undefined;
+  minAttemptTimeoutInMs?: number | undefined;
+}
+
+export default class MonitorCheckBudget {
+  /**
+   * The monitor's interval in milliseconds, or null when the expression is
+   * missing / unparseable (in which case the caller keeps the configured
+   * timeout as-is rather than guessing).
+   */
+  public static getMonitoringIntervalInMs(
+    monitoringInterval?: string | null | undefined,
+    from: Date = new Date(),
+  ): number | null {
+    if (
+      !monitoringInterval ||
+      typeof monitoringInterval !== "string" ||
+      monitoringInterval.trim() === ""
+    ) {
+      return null;
+    }
+
+    let fireTimes: Array<Date> = [];
+
+    try {
+      fireTimes = CronTab.getNextExecutionTimes(
+        monitoringInterval,
+        INTERVAL_SAMPLE_COUNT,
+        from,
+      );
+    } catch {
+      return null;
+    }
+
+    if (fireTimes.length < 2) {
+      return null;
+    }
+
+    let smallestGapInMs: number = Number.POSITIVE_INFINITY;
+
+    for (let i: number = 1; i < fireTimes.length; i++) {
+      const gapInMs: number =
+        fireTimes[i]!.getTime() - fireTimes[i - 1]!.getTime();
+
+      if (gapInMs > 0 && gapInMs < smallestGapInMs) {
+        smallestGapInMs = gapInMs;
+      }
+    }
+
+    if (!isFinite(smallestGapInMs)) {
+      return null;
+    }
+
+    return smallestGapInMs;
+  }
+
+  /**
+   * Wall-clock budget for one whole check — every attempt, every backoff and
+   * any post-failure diagnostics included. It is the configured request
+   * timeout, capped so the check still fits inside its own interval.
+   */
+  public static getCheckBudgetInMs(data: MonitorCheckBudgetOptions): number {
+    const requestTimeoutInMs: number = Math.floor(data.requestTimeoutInMs);
+
+    if (!isFinite(requestTimeoutInMs) || requestTimeoutInMs <= 0) {
+      return MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS;
+    }
+
+    const intervalInMs: number | null = this.getMonitoringIntervalInMs(
+      data.monitoringInterval,
+      data.from,
+    );
+
+    if (intervalInMs === null) {
+      return requestTimeoutInMs;
+    }
+
+    const intervalBudgetInMs: number = Math.max(
+      MIN_MONITOR_CHECK_BUDGET_IN_MS,
+      Math.floor(intervalInMs * MONITOR_CHECK_BUDGET_INTERVAL_FRACTION),
+    );
+
+    /*
+     * Never stretch beyond what the user asked for — the interval only ever
+     * tightens the budget.
+     */
+    return Math.min(requestTimeoutInMs, intervalBudgetInMs);
+  }
+
+  /**
+   * Slice of the check budget held back for post-failure diagnostics.
+   */
+  public static getDiagnosticsBudgetInMs(checkBudgetInMs: number): number {
+    if (!isFinite(checkBudgetInMs) || checkBudgetInMs <= 0) {
+      return 0;
+    }
+
+    return Math.min(
+      MAX_MONITOR_DIAGNOSTICS_BUDGET_IN_MS,
+      Math.floor(checkBudgetInMs * MONITOR_DIAGNOSTICS_BUDGET_FRACTION),
+    );
+  }
+
+  /**
+   * Slice of the check budget the reachability attempts get to share.
+   */
+  public static getReachabilityBudgetInMs(checkBudgetInMs: number): number {
+    if (!isFinite(checkBudgetInMs) || checkBudgetInMs <= 0) {
+      return MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS;
+    }
+
+    return Math.max(
+      MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+      checkBudgetInMs - this.getDiagnosticsBudgetInMs(checkBudgetInMs),
+    );
+  }
+
+  /**
+   * How many of the configured attempts the budget can actually pay for, once
+   * each attempt is given at least the minimum timeout and each gap between
+   * them the backoff. Always at least one: a check that cannot afford a single
+   * attempt still has to try once and report something.
+   */
+  public static getAffordableAttemptCount(
+    data: MonitorCheckAttemptTimeoutOptions,
+  ): number {
+    const configuredAttempts: number = Math.max(
+      1,
+      Math.floor(data.retryCount || 1),
+    );
+
+    const minAttemptTimeoutInMs: number =
+      data.minAttemptTimeoutInMs ?? MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS;
+
+    const retryDelayInMs: number =
+      data.retryDelayInMs ?? MONITOR_CHECK_RETRY_DELAY_IN_MS;
+
+    /*
+     * n attempts cost n × minTimeout + (n - 1) × delay, so the largest n the
+     * budget covers is (budget + delay) / (minTimeout + delay).
+     */
+    const affordableAttempts: number = Math.floor(
+      (data.budgetInMs + retryDelayInMs) /
+        (minAttemptTimeoutInMs + retryDelayInMs),
+    );
+
+    return Math.max(1, Math.min(configuredAttempts, affordableAttempts));
+  }
+
+  /**
+   * Timeout for a single attempt, so that every attempt the budget can afford
+   * plus the backoffs between them fit inside `budgetInMs`.
+   */
+  public static getAttemptTimeoutInMs(
+    data: MonitorCheckAttemptTimeoutOptions,
+  ): number {
+    const minAttemptTimeoutInMs: number =
+      data.minAttemptTimeoutInMs ?? MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS;
+
+    const attempts: number = this.getAffordableAttemptCount(data);
+
+    const retryDelayInMs: number =
+      data.retryDelayInMs ?? MONITOR_CHECK_RETRY_DELAY_IN_MS;
+
+    const budgetForAttemptsInMs: number =
+      data.budgetInMs - (attempts - 1) * retryDelayInMs;
+
+    return Math.max(
+      minAttemptTimeoutInMs,
+      Math.floor(budgetForAttemptsInMs / attempts),
+    );
+  }
+
+  /**
+   * Absolute moment a check must be finished by.
+   */
+  public static getDeadlineAt(startedAt: Date, budgetInMs: number): Date {
+    return new Date(startedAt.getTime() + Math.max(0, budgetInMs));
+  }
+
+  /**
+   * Milliseconds left before `deadlineAt`. Never negative, so callers can
+   * safely treat it as "how much time may I still spend".
+   */
+  public static getRemainingBudgetInMs(
+    deadlineAt: Date,
+    now: Date = new Date(),
+  ): number {
+    return Math.max(0, deadlineAt.getTime() - now.getTime());
+  }
+}

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/PingMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/PingMonitor.test.ts
@@ -1,0 +1,529 @@
+// Set required env vars before importing anything that pulls Config.ts
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import type { Mock } from "jest-mock";
+import ping from "ping";
+import PingMonitor, {
+  DEFAULT_PING_ATTEMPT_TIMEOUT_IN_MS,
+  PING_PACKET_COUNT,
+  PingResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/PingMonitor";
+import MonitorCheckBudget, {
+  MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+  MONITOR_CHECK_RETRY_DELAY_IN_MS,
+} from "Common/Types/Monitor/MonitorCheckBudget";
+import Hostname from "Common/Types/API/Hostname";
+import IPv4 from "Common/Types/IP/IPv4";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * A Ping check against an unresponsive IP used to cost `timeout × retries`.
+ * With the shipped defaults (60s timeout, 3 retries) that is over three
+ * minutes, so a 1-minute monitor could never report on schedule: results
+ * landed ~3 intervals late and the monitor looked like it had stalled and then
+ * caught up. These tests pin the two things that stop that happening — the
+ * per-invocation deadline handed to `ping`, and the check-level deadline that
+ * truncates retries.
+ */
+
+jest.mock("ping", () => {
+  return {
+    promise: {
+      probe: jest.fn(),
+    },
+  };
+});
+
+type PingProbeFunction = (
+  host: string,
+  config: ping.PingConfig,
+) => Promise<ping.PingResponse>;
+
+const mockPingProbe: Mock<PingProbeFunction> = ping.promise
+  .probe as unknown as Mock<PingProbeFunction>;
+
+const HOST: IPv4 = new IPv4("10.0.0.1");
+const MONITOR_ID: ObjectID = new ObjectID("100000000000000000000001");
+
+type ProbeCall = [string, ping.PingConfig];
+
+function getProbeCalls(): Array<ProbeCall> {
+  return mockPingProbe.mock.calls as unknown as Array<ProbeCall>;
+}
+
+function getProbeConfigs(): Array<ping.PingConfig> {
+  return getProbeCalls().map((call: ProbeCall) => {
+    return call[1];
+  });
+}
+
+function getLastProbeConfig(): ping.PingConfig {
+  const configs: Array<ping.PingConfig> = getProbeConfigs();
+  return configs[configs.length - 1]!;
+}
+
+function aliveResponse(timeInMs: number = 12): ping.PingResponse {
+  return {
+    inputHost: "10.0.0.1",
+    host: "10.0.0.1",
+    alive: true,
+    output: "",
+    time: timeInMs,
+    times: [timeInMs, timeInMs, timeInMs, timeInMs, timeInMs],
+    min: `${timeInMs}`,
+    max: `${timeInMs}`,
+    avg: `${timeInMs}`,
+    stddev: "0",
+    packetLoss: "0",
+    numeric_host: "10.0.0.1",
+  } as unknown as ping.PingResponse;
+}
+
+function deadResponse(): ping.PingResponse {
+  return {
+    inputHost: "10.0.0.1",
+    host: "10.0.0.1",
+    alive: false,
+    output: "",
+    time: "unknown",
+    times: [],
+    min: "unknown",
+    max: "unknown",
+    avg: "unknown",
+    stddev: "unknown",
+    packetLoss: "100.000",
+    numeric_host: "10.0.0.1",
+  } as unknown as ping.PingResponse;
+}
+
+/*
+ * Stands in for a real ping: consumes the wall-clock the OS binary would have
+ * consumed. Paired with jest's fake clock so the suite stays fast while the
+ * budget arithmetic is exercised against realistic durations.
+ */
+function respondAfter(
+  durationInMsProvider: (config: ping.PingConfig) => number,
+  responseProvider: () => ping.PingResponse,
+): void {
+  mockPingProbe.mockImplementation(
+    (_host: string, config: ping.PingConfig): Promise<ping.PingResponse> => {
+      const durationInMs: number = durationInMsProvider(config);
+
+      return new Promise<ping.PingResponse>(
+        (resolve: (value: ping.PingResponse) => void) => {
+          setTimeout(() => {
+            resolve(responseProvider());
+          }, durationInMs);
+        },
+      );
+    },
+  );
+}
+
+// A dead host consumes exactly the deadline the caller allowed it.
+function respondDeadAtDeadline(): void {
+  respondAfter((config: ping.PingConfig) => {
+    return (config.deadline ?? config.timeout ?? 1) * 1000;
+  }, deadResponse);
+}
+
+/*
+ * Jest 28 has no runAllTimersAsync, so pump the fake clock by hand: fire the
+ * pending timers, then yield so the promise chain they unblocked can schedule
+ * the next one (another ping attempt, or the backoff between two attempts).
+ */
+async function flushTimers(): Promise<void> {
+  for (let i: number = 0; i < 200; i++) {
+    if (jest.getTimerCount() === 0) {
+      // Give any in-flight microtasks a chance to schedule more work.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      if (jest.getTimerCount() === 0) {
+        return;
+      }
+    }
+
+    jest.runOnlyPendingTimers();
+
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+describe("PingMonitor.getAttemptTimeoutInMs", () => {
+  it("uses the configured timeout when there is no check deadline", () => {
+    expect(
+      PingMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(15000),
+      }),
+    ).toBe(15000);
+  });
+
+  it("falls back to the default when no timeout is configured", () => {
+    expect(PingMonitor.getAttemptTimeoutInMs({})).toBe(
+      DEFAULT_PING_ATTEMPT_TIMEOUT_IN_MS,
+    );
+  });
+
+  it("shortens the attempt to what is left of the check budget", () => {
+    expect(
+      PingMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(15000),
+        deadlineAt: new Date(Date.now() + 4000),
+      }),
+    ).toBeLessThanOrEqual(4000);
+  });
+
+  it("never stretches an attempt past the configured timeout", () => {
+    expect(
+      PingMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(3000),
+        deadlineAt: new Date(Date.now() + 600000),
+      }),
+    ).toBe(3000);
+  });
+
+  it("keeps a floor once the budget is spent, so the attempt still happens", () => {
+    expect(
+      PingMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(15000),
+        deadlineAt: new Date(Date.now() - 30000),
+      }),
+    ).toBe(MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS);
+  });
+});
+
+describe("PingMonitor.canRetry", () => {
+  it("retries while attempts remain and no deadline is set", () => {
+    expect(PingMonitor.canRetry({ retry: 3, currentRetryCount: 1 })).toBe(true);
+  });
+
+  it("stops once the retry count is exhausted", () => {
+    expect(PingMonitor.canRetry({ retry: 3, currentRetryCount: 3 })).toBe(
+      false,
+    );
+  });
+
+  it("stops when the check deadline has passed, even with retries left", () => {
+    expect(
+      PingMonitor.canRetry({
+        retry: 3,
+        currentRetryCount: 1,
+        deadlineAt: new Date(Date.now() - 1000),
+      }),
+    ).toBe(false);
+  });
+
+  it("stops when what is left cannot fit a backoff plus a real attempt", () => {
+    const tooLittleInMs: number =
+      MONITOR_CHECK_RETRY_DELAY_IN_MS + MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS;
+
+    expect(
+      PingMonitor.canRetry({
+        retry: 3,
+        currentRetryCount: 1,
+        deadlineAt: new Date(Date.now() + tooLittleInMs - 100),
+      }),
+    ).toBe(false);
+
+    expect(
+      PingMonitor.canRetry({
+        retry: 3,
+        currentRetryCount: 1,
+        deadlineAt: new Date(Date.now() + tooLittleInMs + 5000),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("PingMonitor.ping - options handed to the ping binary", () => {
+  beforeEach(() => {
+    mockPingProbe.mockReset();
+    respondAfter(() => {
+      return 0;
+    }, aliveResponse);
+  });
+
+  it("sets a deadline so one invocation cannot outlive its attempt timeout", async () => {
+    await PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(9000),
+      retry: 1,
+      monitorId: MONITOR_ID,
+    });
+
+    const config: ping.PingConfig = getLastProbeConfig();
+
+    /*
+     * Without `deadline`, `ping -c 5 -W 9` sends its packets a second apart
+     * and then waits the full per-reply timeout for the last one, so the
+     * invocation outlives the timeout it was given.
+     */
+    expect(config.deadline).toBe(9);
+    expect(config.timeout).toBe(9);
+  });
+
+  it("still sends the full packet count for loss and jitter stats", async () => {
+    await PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(9000),
+      retry: 1,
+    });
+
+    expect(getLastProbeConfig().min_reply).toBe(PING_PACKET_COUNT);
+  });
+
+  it("rounds a sub-second timeout up to a whole second", async () => {
+    await PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(400),
+      retry: 1,
+    });
+
+    const config: ping.PingConfig = getLastProbeConfig();
+
+    expect(config.timeout).toBe(1);
+    expect(config.deadline).toBe(1);
+  });
+
+  it("pings a Hostname by name", async () => {
+    await PingMonitor.ping(new Hostname("example.com"), {
+      timeout: new PositiveNumber(5000),
+      retry: 1,
+    });
+
+    expect(getProbeCalls()[0]![0]).toBe("example.com");
+  });
+
+  it("reports packet statistics from a successful check", async () => {
+    respondAfter(
+      () => {
+        return 0;
+      },
+      () => {
+        return aliveResponse(20);
+      },
+    );
+
+    const response: PingResponse | null = await PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(5000),
+      retry: 1,
+    });
+
+    expect(response?.pingResponse?.packetsSent).toBe(PING_PACKET_COUNT);
+    expect(response?.pingResponse?.packetsReceived).toBe(PING_PACKET_COUNT);
+    expect(response?.pingResponse?.packetLossPercent).toBe(0);
+    expect(response?.pingResponse?.avgRoundTripTimeInMs).toBe(20);
+  });
+});
+
+describe("PingMonitor.ping - the check stays inside its budget", () => {
+  beforeEach(() => {
+    mockPingProbe.mockReset();
+    jest.useFakeTimers({ doNotFake: ["performance"] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("shrinks each attempt's deadline as the check budget is consumed", async () => {
+    // Each attempt burns 10s of a 25s check budget.
+    respondAfter(() => {
+      return 10000;
+    }, deadResponse);
+
+    const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(15000),
+      retry: 3,
+      deadlineAt: new Date(Date.now() + 25000),
+      isOnlineCheckRequest: true,
+    });
+
+    await flushTimers();
+    await pingPromise;
+
+    const deadlines: Array<number | undefined> = getProbeConfigs().map(
+      (config: ping.PingConfig) => {
+        return config.deadline;
+      },
+    );
+
+    expect(deadlines.length).toBeGreaterThan(1);
+
+    // The first attempt gets the configured 15s; later ones only what is left.
+    expect(deadlines[0]).toBe(15);
+    expect(deadlines[1]!).toBeLessThan(deadlines[0]!);
+  });
+
+  interface Scenario {
+    label: string;
+    monitoringInterval: string;
+  }
+
+  const SCENARIOS: Array<Scenario> = [
+    { label: "1-minute monitor", monitoringInterval: "* * * * *" },
+    { label: "5-minute monitor", monitoringInterval: "*/5 * * * *" },
+  ];
+
+  it.each(SCENARIOS)(
+    "a fully-failing check on a $label finishes inside its budget",
+    async ({ monitoringInterval }: Scenario) => {
+      respondDeadAtDeadline();
+
+      const retryCount: number = 3;
+
+      const checkBudgetInMs: number = MonitorCheckBudget.getCheckBudgetInMs({
+        requestTimeoutInMs: 60000,
+        monitoringInterval: monitoringInterval,
+      });
+
+      const reachabilityBudgetInMs: number =
+        MonitorCheckBudget.getReachabilityBudgetInMs(checkBudgetInMs);
+
+      const startedAtInMs: number = Date.now();
+
+      const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+        timeout: new PositiveNumber(
+          MonitorCheckBudget.getAttemptTimeoutInMs({
+            budgetInMs: reachabilityBudgetInMs,
+            retryCount: retryCount,
+          }),
+        ),
+        retry: retryCount,
+        deadlineAt: new Date(startedAtInMs + reachabilityBudgetInMs),
+        monitorId: MONITOR_ID,
+        isOnlineCheckRequest: true,
+      });
+
+      await flushTimers();
+
+      const response: PingResponse | null = await pingPromise;
+      const elapsedInMs: number = Date.now() - startedAtInMs;
+
+      expect(response?.isOnline).toBe(false);
+      expect(elapsedInMs).toBeLessThanOrEqual(reachabilityBudgetInMs);
+
+      /*
+       * The whole point: the old code spent 60s per attempt × 3 attempts,
+       * blowing past a 1-minute interval by minutes.
+       */
+      expect(elapsedInMs).toBeLessThan(60000);
+    },
+  );
+
+  it("does not start a retry it cannot finish before the deadline", async () => {
+    // A single attempt eats almost the entire budget.
+    respondAfter(() => {
+      return 19000;
+    }, deadResponse);
+
+    const startedAtInMs: number = Date.now();
+
+    const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(19000),
+      retry: 3,
+      deadlineAt: new Date(startedAtInMs + 20000),
+      isOnlineCheckRequest: true,
+    });
+
+    await flushTimers();
+    const response: PingResponse | null = await pingPromise;
+
+    expect(getProbeCalls()).toHaveLength(1);
+    expect(response?.totalAttempts).toBe(1);
+    expect(Date.now() - startedAtInMs).toBeLessThanOrEqual(20000);
+  });
+
+  it("uses every attempt it can afford when they are cheap", async () => {
+    respondAfter(() => {
+      return 1000;
+    }, deadResponse);
+
+    const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(11000),
+      retry: 3,
+      deadlineAt: new Date(Date.now() + 36000),
+      isOnlineCheckRequest: true,
+    });
+
+    await flushTimers();
+    const response: PingResponse | null = await pingPromise;
+
+    expect(getProbeCalls()).toHaveLength(3);
+    expect(response?.totalAttempts).toBe(3);
+    expect(response?.probeAttempts).toHaveLength(3);
+  });
+
+  it("retries the configured number of times when no deadline is set", async () => {
+    respondAfter(() => {
+      return 1000;
+    }, deadResponse);
+
+    const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(5000),
+      retry: 3,
+      isOnlineCheckRequest: true,
+    });
+
+    await flushTimers();
+    const response: PingResponse | null = await pingPromise;
+
+    expect(getProbeCalls()).toHaveLength(3);
+    expect(response?.totalAttempts).toBe(3);
+  });
+
+  it("returns as soon as the host answers, without spending the budget", async () => {
+    respondAfter(() => {
+      return 40;
+    }, aliveResponse);
+
+    const startedAtInMs: number = Date.now();
+
+    const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(11000),
+      retry: 3,
+      deadlineAt: new Date(startedAtInMs + 36000),
+    });
+
+    await flushTimers();
+    const response: PingResponse | null = await pingPromise;
+
+    expect(response?.isOnline).toBe(true);
+    expect(getProbeCalls()).toHaveLength(1);
+    expect(Date.now() - startedAtInMs).toBeLessThan(1000);
+  });
+
+  it("records every attempt it made with its own timing", async () => {
+    respondAfter(() => {
+      return 2000;
+    }, deadResponse);
+
+    const pingPromise: Promise<PingResponse | null> = PingMonitor.ping(HOST, {
+      timeout: new PositiveNumber(11000),
+      retry: 2,
+      deadlineAt: new Date(Date.now() + 36000),
+      isOnlineCheckRequest: true,
+    });
+
+    await flushTimers();
+    const response: PingResponse | null = await pingPromise;
+
+    expect(response?.probeAttempts).toHaveLength(2);
+
+    for (const attempt of response!.probeAttempts!) {
+      expect(attempt.isOnline).toBe(false);
+      expect(attempt.attemptedAt).toBeInstanceOf(Date);
+      expect(attempt.responseReceivedAt).toBeInstanceOf(Date);
+      expect(attempt.failureCause).toBeTruthy();
+    }
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/PortMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/PortMonitor.test.ts
@@ -1,0 +1,185 @@
+// Set required env vars before importing anything that pulls Config.ts
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import PortMonitor, {
+  DEFAULT_PORT_ATTEMPT_TIMEOUT_IN_MS,
+  PortMonitorResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/PortMonitor";
+import {
+  MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+  MONITOR_CHECK_RETRY_DELAY_IN_MS,
+} from "Common/Types/Monitor/MonitorCheckBudget";
+import Hostname from "Common/Types/API/Hostname";
+import Port from "Common/Types/Port";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import net, { AddressInfo } from "net";
+
+/*
+ * A Ping monitor falls back to PortMonitor when the cloud provider blocks
+ * ICMP, so it carries the same failure mode: without a check-level deadline a
+ * dead target costs `timeout × retries` and the check overruns its monitoring
+ * interval.
+ */
+
+describe("PortMonitor.getAttemptTimeoutInMs", () => {
+  it("uses the configured timeout when there is no check deadline", () => {
+    expect(
+      PortMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(15000),
+      }),
+    ).toBe(15000);
+  });
+
+  it("falls back to the default when no timeout is configured", () => {
+    expect(PortMonitor.getAttemptTimeoutInMs({})).toBe(
+      DEFAULT_PORT_ATTEMPT_TIMEOUT_IN_MS,
+    );
+  });
+
+  it("shortens the attempt to what is left of the check budget", () => {
+    expect(
+      PortMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(15000),
+        deadlineAt: new Date(Date.now() + 4000),
+      }),
+    ).toBeLessThanOrEqual(4000);
+  });
+
+  it("never stretches an attempt past the configured timeout", () => {
+    expect(
+      PortMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(3000),
+        deadlineAt: new Date(Date.now() + 600000),
+      }),
+    ).toBe(3000);
+  });
+
+  it("keeps a floor once the budget is spent, so the attempt still happens", () => {
+    expect(
+      PortMonitor.getAttemptTimeoutInMs({
+        timeout: new PositiveNumber(15000),
+        deadlineAt: new Date(Date.now() - 30000),
+      }),
+    ).toBe(MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS);
+  });
+});
+
+describe("PortMonitor.canRetry", () => {
+  it("retries while attempts remain and no deadline is set", () => {
+    expect(PortMonitor.canRetry({ retry: 3, currentRetryCount: 1 })).toBe(true);
+  });
+
+  it("stops once the retry count is exhausted", () => {
+    expect(PortMonitor.canRetry({ retry: 3, currentRetryCount: 3 })).toBe(
+      false,
+    );
+  });
+
+  it("stops when the check deadline has passed, even with retries left", () => {
+    expect(
+      PortMonitor.canRetry({
+        retry: 3,
+        currentRetryCount: 1,
+        deadlineAt: new Date(Date.now() - 1000),
+      }),
+    ).toBe(false);
+  });
+
+  it("stops when what is left cannot fit a backoff plus a real attempt", () => {
+    const tooLittleInMs: number =
+      MONITOR_CHECK_RETRY_DELAY_IN_MS + MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS;
+
+    expect(
+      PortMonitor.canRetry({
+        retry: 3,
+        currentRetryCount: 1,
+        deadlineAt: new Date(Date.now() + tooLittleInMs - 100),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("PortMonitor.ping against a real socket", () => {
+  let server: net.Server;
+  let openPort: Port;
+
+  beforeAll(async () => {
+    server = net.createServer();
+
+    await new Promise<void>((resolve: () => void) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    openPort = new Port((server.address() as AddressInfo).port);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve: () => void) => {
+      server.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  it("reports an open port as online in a single attempt", async () => {
+    const response: PortMonitorResponse | null = await PortMonitor.ping(
+      new Hostname("127.0.0.1"),
+      openPort,
+      {
+        retry: 3,
+        timeout: new PositiveNumber(5000),
+        deadlineAt: new Date(Date.now() + 20000),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response?.isOnline).toBe(true);
+    expect(response?.totalAttempts).toBe(1);
+  });
+
+  it("retries a refused connection up to the configured count", async () => {
+    // Port 1 on loopback is not listening, so connect fails immediately.
+    const response: PortMonitorResponse | null = await PortMonitor.ping(
+      new Hostname("127.0.0.1"),
+      new Port(1),
+      {
+        retry: 3,
+        timeout: new PositiveNumber(2000),
+        deadlineAt: new Date(Date.now() + 30000),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response?.isOnline).toBe(false);
+    expect(response?.totalAttempts).toBe(3);
+  });
+
+  it("stops retrying a refused connection once the deadline has passed", async () => {
+    const startedAtInMs: number = Date.now();
+
+    const response: PortMonitorResponse | null = await PortMonitor.ping(
+      new Hostname("127.0.0.1"),
+      new Port(1),
+      {
+        retry: 3,
+        timeout: new PositiveNumber(2000),
+        // Already spent: not enough left for a backoff plus a real attempt.
+        deadlineAt: new Date(startedAtInMs),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response?.isOnline).toBe(false);
+    expect(response?.totalAttempts).toBe(1);
+
+    /*
+     * With the old unbudgeted loop this would have paid two 1s backoffs on
+     * top of the failed attempts.
+     */
+    expect(Date.now() - startedAtInMs).toBeLessThan(
+      2 * MONITOR_CHECK_RETRY_DELAY_IN_MS,
+    );
+  });
+});

--- a/Probe/Tests/Utils/Monitors/PingMonitorCheckBudget.test.ts
+++ b/Probe/Tests/Utils/Monitors/PingMonitorCheckBudget.test.ts
@@ -1,0 +1,403 @@
+// Set required env vars before importing anything that pulls Config.ts
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "100000000000000000000009";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import type { Mock } from "jest-mock";
+import ping from "ping";
+import MonitorUtil from "../../../Utils/Monitors/Monitor";
+import NetworkPathMonitor from "../../../Utils/Monitors/MonitorTypes/NetworkPathMonitor";
+import MonitorCheckBudget from "Common/Types/Monitor/MonitorCheckBudget";
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import IPv4 from "Common/Types/IP/IPv4";
+import ObjectID from "Common/Types/ObjectID";
+import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
+
+/*
+ * The user-visible bug, end to end.
+ *
+ * A Ping monitor on a 1-minute interval whose target stops answering used to
+ * log at 08:08, then 08:12, then 08:13, 08:14 — a four-minute hole followed by
+ * an on-time run. Two things caused it: a check spent `timeout × retries`
+ * (over three minutes on the defaults) because the request timeout was handed
+ * to `ping` as the per-reply wait with no deadline, and the result was stamped
+ * when the check FINISHED rather than when it started.
+ *
+ * These tests drive the real probeMonitorStep with the ping binary mocked, and
+ * assert both: the check now fits inside its interval, and it reports the
+ * moment it was taken.
+ */
+
+jest.mock("ping", () => {
+  return {
+    promise: {
+      probe: jest.fn(),
+    },
+  };
+});
+
+type PingProbeFunction = (
+  host: string,
+  config: ping.PingConfig,
+) => Promise<ping.PingResponse>;
+
+const mockPingProbe: Mock<PingProbeFunction> = ping.promise
+  .probe as unknown as Mock<PingProbeFunction>;
+
+const PROJECT_ID: ObjectID = new ObjectID("100000000000000000000001");
+const MONITOR_ID: ObjectID = new ObjectID("100000000000000000000002");
+
+const EVERY_MINUTE: string = "* * * * *";
+const EVERY_FIVE_MINUTES: string = "*/5 * * * *";
+
+function buildPingMonitorStep(overrides?: {
+  requestTimeoutInMs?: number;
+  retryCount?: number;
+}): MonitorStep {
+  const monitorStep: MonitorStep = MonitorStep.getDefaultMonitorStep({
+    monitorName: "MP56",
+    monitorType: MonitorType.Ping,
+    onlineMonitorStatusId: new ObjectID("100000000000000000000011"),
+    offlineMonitorStatusId: new ObjectID("100000000000000000000012"),
+    defaultIncidentSeverityId: new ObjectID("100000000000000000000013"),
+    defaultAlertSeverityId: new ObjectID("100000000000000000000014"),
+  });
+
+  monitorStep.data!.monitorDestination = new IPv4("10.255.255.1");
+  monitorStep.data!.requestTimeoutInMs = overrides?.requestTimeoutInMs ?? 60000;
+  monitorStep.data!.retryCount = overrides?.retryCount ?? 3;
+
+  return monitorStep;
+}
+
+// A dead host burns exactly the deadline the probe allowed the attempt.
+function respondDeadAtDeadline(): void {
+  mockPingProbe.mockImplementation(
+    (_host: string, config: ping.PingConfig): Promise<ping.PingResponse> => {
+      return new Promise<ping.PingResponse>(
+        (resolve: (value: ping.PingResponse) => void) => {
+          setTimeout(
+            () => {
+              resolve({
+                inputHost: "10.255.255.1",
+                host: "10.255.255.1",
+                alive: false,
+                output: "",
+                time: "unknown",
+                times: [],
+                min: "unknown",
+                max: "unknown",
+                avg: "unknown",
+                stddev: "unknown",
+                packetLoss: "100.000",
+                numeric_host: "10.255.255.1",
+              } as unknown as ping.PingResponse);
+            },
+            (config.deadline ?? config.timeout ?? 1) * 1000,
+          );
+        },
+      );
+    },
+  );
+}
+
+function respondAliveImmediately(): void {
+  mockPingProbe.mockImplementation((): Promise<ping.PingResponse> => {
+    return Promise.resolve({
+      inputHost: "10.255.255.1",
+      host: "10.255.255.1",
+      alive: true,
+      output: "",
+      time: 8,
+      times: [8, 8, 8, 8, 8],
+      min: "8",
+      max: "8",
+      avg: "8",
+      stddev: "0",
+      packetLoss: "0",
+      numeric_host: "10.255.255.1",
+    } as unknown as ping.PingResponse);
+  });
+}
+
+/*
+ * Jest 28 has no runAllTimersAsync, so pump the fake clock by hand: fire the
+ * pending timers, then yield so the promise chain they unblocked can schedule
+ * the next one.
+ */
+async function flushTimers(): Promise<void> {
+  for (let i: number = 0; i < 200; i++) {
+    if (jest.getTimerCount() === 0) {
+      await Promise.resolve();
+      await Promise.resolve();
+
+      if (jest.getTimerCount() === 0) {
+        return;
+      }
+    }
+
+    jest.runOnlyPendingTimers();
+
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+describe("probeMonitorStep - a failing Ping check fits inside its interval", () => {
+  let traceSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    mockPingProbe.mockReset();
+
+    /*
+     * Failure diagnostics shell out to traceroute. Stub it out so the test
+     * measures the probe's own budgeting, and assert on the timeout it was
+     * handed instead.
+     */
+    traceSpy = jest
+      .spyOn(NetworkPathMonitor, "trace")
+      .mockImplementation(((): Promise<unknown> => {
+        return Promise.resolve({ hops: [] });
+      }) as never);
+
+    jest.useFakeTimers({ doNotFake: ["performance"] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    traceSpy.mockRestore();
+  });
+
+  interface Scenario {
+    label: string;
+    monitoringInterval: string;
+    intervalInMs: number;
+  }
+
+  const SCENARIOS: Array<Scenario> = [
+    {
+      label: "1-minute",
+      monitoringInterval: EVERY_MINUTE,
+      intervalInMs: 60 * 1000,
+    },
+    {
+      label: "5-minute",
+      monitoringInterval: EVERY_FIVE_MINUTES,
+      intervalInMs: 5 * 60 * 1000,
+    },
+  ];
+
+  it.each(SCENARIOS)(
+    "an unreachable target on a $label monitor reports within the interval",
+    async ({ monitoringInterval, intervalInMs }: Scenario) => {
+      respondDeadAtDeadline();
+
+      const startedAtInMs: number = Date.now();
+
+      const resultPromise: Promise<ProbeMonitorResponse | null> =
+        MonitorUtil.probeMonitorStep({
+          monitorStep: buildPingMonitorStep(),
+          monitorType: MonitorType.Ping,
+          monitorId: MONITOR_ID,
+          projectId: PROJECT_ID,
+          monitoringInterval: monitoringInterval,
+        });
+
+      await flushTimers();
+
+      const result: ProbeMonitorResponse | null = await resultPromise;
+      const elapsedInMs: number = Date.now() - startedAtInMs;
+
+      expect(result?.isOnline).toBe(false);
+
+      /*
+       * Before the fix this was ~194,000ms (3 × 60s attempts plus backoffs):
+       * over three times a 1-minute interval, and three minutes of lateness
+       * on a 5-minute one.
+       */
+      expect(elapsedInMs).toBeLessThan(intervalInMs);
+
+      expect(elapsedInMs).toBeLessThanOrEqual(
+        MonitorCheckBudget.getCheckBudgetInMs({
+          requestTimeoutInMs: 60000,
+          monitoringInterval: monitoringInterval,
+        }),
+      );
+    },
+  );
+
+  it("stamps monitoredAt when the check STARTED, not when it finished", async () => {
+    respondDeadAtDeadline();
+
+    const startedAtInMs: number = Date.now();
+
+    const resultPromise: Promise<ProbeMonitorResponse | null> =
+      MonitorUtil.probeMonitorStep({
+        monitorStep: buildPingMonitorStep(),
+        monitorType: MonitorType.Ping,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitoringInterval: EVERY_MINUTE,
+      });
+
+    await flushTimers();
+
+    const result: ProbeMonitorResponse | null = await resultPromise;
+
+    // The check consumed real (virtual) time...
+    expect(Date.now()).toBeGreaterThan(startedAtInMs);
+
+    // ...but reports the moment it began, so the log lands on schedule.
+    expect(result!.monitoredAt.getTime()).toBe(startedAtInMs);
+  });
+
+  it("makes several bounded attempts rather than one long one", async () => {
+    respondDeadAtDeadline();
+
+    const resultPromise: Promise<ProbeMonitorResponse | null> =
+      MonitorUtil.probeMonitorStep({
+        monitorStep: buildPingMonitorStep({ retryCount: 3 }),
+        monitorType: MonitorType.Ping,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitoringInterval: EVERY_MINUTE,
+      });
+
+    await flushTimers();
+    const result: ProbeMonitorResponse | null = await resultPromise;
+
+    expect(result?.totalAttempts).toBe(3);
+
+    for (const call of mockPingProbe.mock.calls) {
+      const config: ping.PingConfig = call[1] as ping.PingConfig;
+
+      // Each attempt is hard-bounded, and well short of the old 60s.
+      expect(config.deadline).toBeDefined();
+      expect(config.deadline!).toBeLessThan(60);
+      expect(config.deadline!).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives a 5-minute monitor a longer per-attempt budget than a 1-minute one", async () => {
+    respondDeadAtDeadline();
+
+    const deadlinesFor: (
+      monitoringInterval: string,
+    ) => Promise<number> = async (
+      monitoringInterval: string,
+    ): Promise<number> => {
+      mockPingProbe.mockClear();
+
+      const resultPromise: Promise<ProbeMonitorResponse | null> =
+        MonitorUtil.probeMonitorStep({
+          monitorStep: buildPingMonitorStep(),
+          monitorType: MonitorType.Ping,
+          monitorId: MONITOR_ID,
+          projectId: PROJECT_ID,
+          monitoringInterval: monitoringInterval,
+        });
+
+      await flushTimers();
+      await resultPromise;
+
+      return (mockPingProbe.mock.calls[0]![1] as ping.PingConfig).deadline!;
+    };
+
+    const oneMinuteDeadline: number = await deadlinesFor(EVERY_MINUTE);
+    const fiveMinuteDeadline: number = await deadlinesFor(EVERY_FIVE_MINUTES);
+
+    expect(fiveMinuteDeadline).toBeGreaterThan(oneMinuteDeadline);
+  });
+
+  it("bounds the failure traceroute by what is left of the check budget", async () => {
+    respondDeadAtDeadline();
+
+    const resultPromise: Promise<ProbeMonitorResponse | null> =
+      MonitorUtil.probeMonitorStep({
+        monitorStep: buildPingMonitorStep(),
+        monitorType: MonitorType.Ping,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitoringInterval: EVERY_MINUTE,
+      });
+
+    await flushTimers();
+    await resultPromise;
+
+    expect(traceSpy).toHaveBeenCalled();
+
+    const traceOptions: { timeout?: number } = traceSpy.mock.calls[0]![1] as {
+      timeout?: number;
+    };
+
+    const checkBudgetInMs: number = MonitorCheckBudget.getCheckBudgetInMs({
+      requestTimeoutInMs: 60000,
+      monitoringInterval: EVERY_MINUTE,
+    });
+
+    expect(traceOptions.timeout).toBeGreaterThan(0);
+    expect(traceOptions.timeout!).toBeLessThanOrEqual(
+      MonitorCheckBudget.getDiagnosticsBudgetInMs(checkBudgetInMs),
+    );
+  });
+
+  it("does not trace a healthy target, and returns promptly", async () => {
+    respondAliveImmediately();
+
+    const startedAtInMs: number = Date.now();
+
+    const resultPromise: Promise<ProbeMonitorResponse | null> =
+      MonitorUtil.probeMonitorStep({
+        monitorStep: buildPingMonitorStep(),
+        monitorType: MonitorType.Ping,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitoringInterval: EVERY_MINUTE,
+      });
+
+    await flushTimers();
+    const result: ProbeMonitorResponse | null = await resultPromise;
+
+    expect(result?.isOnline).toBe(true);
+    expect(result!.monitoredAt.getTime()).toBe(startedAtInMs);
+    expect(mockPingProbe.mock.calls).toHaveLength(1);
+    expect(traceSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the configured timeout when the monitor has no interval (a monitor test)", async () => {
+    respondDeadAtDeadline();
+
+    const resultPromise: Promise<ProbeMonitorResponse | null> =
+      MonitorUtil.probeMonitorStep({
+        monitorStep: buildPingMonitorStep({
+          requestTimeoutInMs: 9000,
+          retryCount: 1,
+        }),
+        monitorType: MonitorType.Ping,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+    await flushTimers();
+    await resultPromise;
+
+    /*
+     * No interval to fit inside, so the only limit is the user's 9s timeout
+     * minus the diagnostics reserve.
+     */
+    const config: ping.PingConfig = mockPingProbe.mock
+      .calls[0]![1] as ping.PingConfig;
+
+    expect(config.deadline!).toBeLessThanOrEqual(9);
+    expect(config.deadline!).toBeGreaterThan(0);
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -42,6 +42,7 @@ import MonitorStep, {
   clampMonitorRetryCount,
   DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
 } from "Common/Types/Monitor/MonitorStep";
+import MonitorCheckBudget from "Common/Types/Monitor/MonitorCheckBudget";
 import MonitorType from "Common/Types/Monitor/MonitorType";
 import BrowserType from "Common/Types/Monitor/SyntheticMonitors/BrowserType";
 import SyntheticMonitorResponse from "Common/Types/Monitor/SyntheticMonitors/SyntheticMonitorResponse";
@@ -196,6 +197,11 @@ export default class MonitorUtil {
         monitorId: monitor.id!,
         monitorStep: monitorStep,
         projectId: monitor.projectId!,
+        /*
+         * The check has to finish inside its own interval, otherwise the next
+         * one is claimed before this one reports and every result lands late.
+         */
+        monitoringInterval: monitor.monitoringInterval,
       });
 
       if (result) {
@@ -267,6 +273,8 @@ export default class MonitorUtil {
     monitorType: MonitorType;
     monitorId: ObjectID;
     projectId: ObjectID;
+    // Cron expression. Absent for one-off monitor tests, which are unscheduled.
+    monitoringInterval?: string | undefined;
   }): Promise<ProbeMonitorResponse | null> {
     const startNs: bigint = process.hrtime.bigint();
     const monitorTypeAttr: string = data.monitorType?.toString() || "unknown";
@@ -320,10 +328,18 @@ export default class MonitorUtil {
     monitorType: MonitorType;
     monitorId: ObjectID;
     projectId: ObjectID;
+    monitoringInterval?: string | undefined;
   }): Promise<ProbeMonitorResponse | null> {
     const monitorStep: MonitorStep = data.monitorStep;
     const monitorType: MonitorType = data.monitorType;
     const monitorId: ObjectID = data.monitorId;
+
+    /*
+     * When the check started. This is what the result is stamped with and what
+     * every deadline below is measured from, so a check that spends its retry
+     * budget still reports the moment it was actually taken.
+     */
+    const checkStartedAt: Date = OneUptimeDate.getCurrentDate();
 
     const result: ProbeMonitorResponse = {
       monitorStepId: monitorStep.id,
@@ -331,7 +347,7 @@ export default class MonitorUtil {
       monitorId: monitorId!,
       probeId: ProbeUtil.getProbeId(),
       failureCause: "",
-      monitoredAt: OneUptimeDate.getCurrentDate(),
+      monitoredAt: checkStartedAt,
     };
 
     if (!monitorStep.data) {
@@ -358,6 +374,64 @@ export default class MonitorUtil {
         ? clampMonitorRetryCount(monitorStep.data.retryCount)
         : PROBE_MONITOR_RETRY_LIMIT;
 
+    /*
+     * Wall-clock budget for this whole check — every attempt, every backoff
+     * and the post-failure traceroute included — capped so the check still
+     * fits inside its own monitoring interval. Reachability checks used to
+     * spend `requestTimeout × retryCount` (three minutes on the defaults)
+     * against an unreachable target, which overran the interval and made
+     * every result land minutes late.
+     *
+     * Only the reachability checks below are budgeted this way. The other
+     * monitor types keep `requestTimeoutInMs` as a plain per-request timeout.
+     */
+    const isReachabilityCheck: boolean =
+      monitorType === MonitorType.Ping ||
+      monitorType === MonitorType.IP ||
+      monitorType === MonitorType.Port;
+
+    const checkBudgetInMs: number = MonitorCheckBudget.getCheckBudgetInMs({
+      requestTimeoutInMs: requestTimeoutInMs,
+      monitoringInterval: data.monitoringInterval,
+      from: checkStartedAt,
+    });
+
+    // Held back so failure diagnostics cannot push the check past its budget.
+    const reachabilityBudgetInMs: number =
+      MonitorCheckBudget.getReachabilityBudgetInMs(checkBudgetInMs);
+
+    const reachabilityDeadlineAt: Date = MonitorCheckBudget.getDeadlineAt(
+      checkStartedAt,
+      reachabilityBudgetInMs,
+    );
+
+    const checkDeadlineAt: Date = MonitorCheckBudget.getDeadlineAt(
+      checkStartedAt,
+      checkBudgetInMs,
+    );
+
+    // Attempts the budget can actually pay for; usually all of them.
+    const reachabilityRetryCount: number =
+      MonitorCheckBudget.getAffordableAttemptCount({
+        budgetInMs: reachabilityBudgetInMs,
+        retryCount: retryCount,
+      });
+
+    const reachabilityAttemptTimeoutInMs: number =
+      MonitorCheckBudget.getAttemptTimeoutInMs({
+        budgetInMs: reachabilityBudgetInMs,
+        retryCount: retryCount,
+      });
+
+    if (
+      isReachabilityCheck &&
+      reachabilityAttemptTimeoutInMs < requestTimeoutInMs
+    ) {
+      logger.debug(
+        `Monitor ${monitorId.toString()} - attempt timeout shortened to ${reachabilityAttemptTimeoutInMs}ms (from ${requestTimeoutInMs}ms) so ${reachabilityRetryCount} attempts fit in the ${checkBudgetInMs}ms check budget.`,
+      );
+    }
+
     if (monitorType === MonitorType.Ping || monitorType === MonitorType.IP) {
       if (!monitorStep.data?.monitorDestination) {
         return result;
@@ -372,9 +446,10 @@ export default class MonitorUtil {
           monitorStep.data?.monitorDestination,
           new Port(80), // use port 80 by default.
           {
-            retry: retryCount,
+            retry: reachabilityRetryCount,
             monitorId: monitorId,
-            timeout: new PositiveNumber(requestTimeoutInMs),
+            timeout: new PositiveNumber(reachabilityAttemptTimeoutInMs),
+            deadlineAt: reachabilityDeadlineAt,
           },
         );
 
@@ -392,9 +467,10 @@ export default class MonitorUtil {
         const response: PingResponse | null = await PingMonitor.ping(
           monitorStep.data?.monitorDestination,
           {
-            retry: retryCount,
+            retry: reachabilityRetryCount,
             monitorId: monitorId,
-            timeout: new PositiveNumber(requestTimeoutInMs),
+            timeout: new PositiveNumber(reachabilityAttemptTimeoutInMs),
+            deadlineAt: reachabilityDeadlineAt,
           },
         );
 
@@ -433,9 +509,10 @@ export default class MonitorUtil {
         monitorStep.data?.monitorDestination,
         monitorStep.data.monitorDestinationPort,
         {
-          retry: retryCount,
+          retry: reachabilityRetryCount,
           monitorId: monitorId,
-          timeout: new PositiveNumber(requestTimeoutInMs),
+          timeout: new PositiveNumber(reachabilityAttemptTimeoutInMs),
+          deadlineAt: reachabilityDeadlineAt,
         },
       );
 
@@ -464,14 +541,28 @@ export default class MonitorUtil {
       result.isOnline === false &&
       monitorStep.data?.monitorDestination
     ) {
+      const diagnosticsBudgetInMs: number =
+        MonitorCheckBudget.getRemainingBudgetInMs(checkDeadlineAt);
+
       try {
-        result.networkPathTrace = await NetworkPathMonitor.trace(
-          monitorStep.data.monitorDestination,
-          {
-            timeout: 20000,
-            maxHops: 20,
-          },
-        );
+        if (diagnosticsBudgetInMs <= 0) {
+          /*
+           * The reachability attempts already used the whole budget. Skipping
+           * the trace keeps the check inside its interval — a late result is
+           * worse than a missing traceroute.
+           */
+          logger.debug(
+            `Monitor ${monitorId.toString()} - skipping network path trace, no time left in the check budget.`,
+          );
+        } else {
+          result.networkPathTrace = await NetworkPathMonitor.trace(
+            monitorStep.data.monitorDestination,
+            {
+              timeout: Math.min(20000, diagnosticsBudgetInMs),
+              maxHops: 20,
+            },
+          );
+        }
       } catch (err) {
         // Diagnostics must never turn a completed check into a failed one.
         logger.error(
@@ -900,9 +991,12 @@ export default class MonitorUtil {
       result.totalAttempts = response.totalAttempts;
     }
 
-    // update the monitoredAt time to the current time.
-    result.monitoredAt = OneUptimeDate.getCurrentDate();
-
+    /*
+     * monitoredAt stays at the moment the check STARTED (set above). Stamping
+     * it on completion instead made every result look as though it had been
+     * taken minutes after it was scheduled, because a failing check spends its
+     * whole retry budget before returning.
+     */
     return result;
   }
 }

--- a/Probe/Utils/Monitors/MonitorTypes/PingMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/PingMonitor.ts
@@ -11,6 +11,10 @@ import PositiveNumber from "Common/Types/PositiveNumber";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import Sleep from "Common/Types/Sleep";
 import logger from "Common/Server/Utils/Logger";
+import MonitorCheckBudget, {
+  MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+  MONITOR_CHECK_RETRY_DELAY_IN_MS,
+} from "Common/Types/Monitor/MonitorCheckBudget";
 import ping from "ping";
 
 /*
@@ -18,6 +22,12 @@ import ping from "ping";
  * into a measurement: packet loss %, jitter, and min/avg/max RTT.
  */
 export const PING_PACKET_COUNT: number = 5;
+
+// Used when the caller does not configure one.
+export const DEFAULT_PING_ATTEMPT_TIMEOUT_IN_MS: number = 5000;
+
+// Attempts left after this many retries, when the caller does not say.
+export const DEFAULT_PING_RETRY_COUNT: number = 5;
 
 // TODO - make sure it works for the IPV6
 export interface PingResponse {
@@ -31,15 +41,80 @@ export interface PingResponse {
 }
 
 export interface PingOptions {
+  // Timeout for a single attempt.
   timeout?: PositiveNumber;
   retry?: number | undefined;
   currentRetryCount?: number | undefined;
   monitorId?: ObjectID | undefined;
   isOnlineCheckRequest?: boolean | undefined;
   attempts?: Array<ProbeAttempt> | undefined;
+  /*
+   * Wall-clock moment the whole check (every attempt and every backoff
+   * between them) must be finished by. Without it a check against an
+   * unreachable host costs `timeout × retry`, which for the default 60s
+   * timeout and 3 retries is over three minutes — longer than the interval
+   * of most monitors, so every result lands late.
+   */
+  deadlineAt?: Date | undefined;
 }
 
 export default class PingMonitor {
+  /**
+   * How long this attempt may take: the configured per-attempt timeout,
+   * shortened when less than that is left of the check's budget.
+   */
+  public static getAttemptTimeoutInMs(pingOptions: PingOptions): number {
+    const configuredTimeoutInMs: number =
+      pingOptions.timeout?.toNumber() || DEFAULT_PING_ATTEMPT_TIMEOUT_IN_MS;
+
+    if (!pingOptions.deadlineAt) {
+      return configuredTimeoutInMs;
+    }
+
+    const remainingInMs: number = MonitorCheckBudget.getRemainingBudgetInMs(
+      pingOptions.deadlineAt,
+    );
+
+    /*
+     * The floor only ever applies to the remaining-budget clamp: an attempt
+     * is never stretched past the timeout the user configured.
+     */
+    return Math.min(
+      configuredTimeoutInMs,
+      Math.max(MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS, remainingInMs),
+    );
+  }
+
+  /**
+   * True when another attempt is both allowed by the retry count and
+   * affordable within what is left of the check's budget.
+   */
+  public static canRetry(pingOptions: PingOptions): boolean {
+    const retryLimit: number = pingOptions.retry ?? DEFAULT_PING_RETRY_COUNT;
+
+    if ((pingOptions.currentRetryCount || 0) >= retryLimit) {
+      return false;
+    }
+
+    if (!pingOptions.deadlineAt) {
+      return true;
+    }
+
+    const remainingInMs: number = MonitorCheckBudget.getRemainingBudgetInMs(
+      pingOptions.deadlineAt,
+    );
+
+    /*
+     * Only retry when the backoff plus a meaningful attempt still fit.
+     * Otherwise the retry would run past the deadline and delay the result
+     * without any chance of changing it.
+     */
+    return (
+      remainingInMs >
+      MONITOR_CHECK_RETRY_DELAY_IN_MS + MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS
+    );
+  }
+
   /*
    * Builds packet-level statistics from the ping library result. The library
    * parses the OS ping summary into strings (min/max/avg/stddev/packetLoss,
@@ -134,10 +209,23 @@ export default class PingMonitor {
       }`,
     );
 
+    const attemptTimeoutInMs: number = this.getAttemptTimeoutInMs(pingOptions);
+    const attemptTimeoutInSeconds: number = Math.max(
+      1,
+      Math.ceil(attemptTimeoutInMs / 1000),
+    );
+
     const attemptedAt: Date = new Date();
     try {
       const res: ping.PingResponse = await ping.promise.probe(hostAddress, {
-        timeout: Math.ceil((pingOptions?.timeout?.toNumber() || 5000) / 1000),
+        timeout: attemptTimeoutInSeconds, // maps to -W: how long to wait for a single reply
+        /*
+         * Hard cap on the whole invocation (-w on Linux, -t on macOS).
+         * Without it, `ping -c 5 -W 60` against a black-holed host sends its
+         * packets a second apart and then sits waiting the full 60s for the
+         * last reply, so a single attempt outlives the monitor's interval.
+         */
+        deadline: attemptTimeoutInSeconds,
         min_reply: PING_PACKET_COUNT, // maps to -c on Linux/macOS and -n on Windows
       });
 
@@ -184,10 +272,10 @@ export default class PingMonitor {
       if (
         responseTime?.toNumber() &&
         responseTime.toNumber() > 10000 &&
-        pingOptions.currentRetryCount < (pingOptions.retry || 5)
+        this.canRetry(pingOptions)
       ) {
         pingOptions.currentRetryCount++;
-        await Sleep.sleep(1000);
+        await Sleep.sleep(MONITOR_CHECK_RETRY_DELAY_IN_MS);
         return await this.ping(host, pingOptions);
       }
 
@@ -227,9 +315,9 @@ export default class PingMonitor {
         failureCause: (err as any).toString(),
       });
 
-      if (pingOptions.currentRetryCount < (pingOptions.retry || 5)) {
+      if (this.canRetry(pingOptions)) {
         pingOptions.currentRetryCount++;
-        await Sleep.sleep(1000);
+        await Sleep.sleep(MONITOR_CHECK_RETRY_DELAY_IN_MS);
         return await this.ping(host, pingOptions);
       }
 

--- a/Probe/Utils/Monitors/MonitorTypes/PortMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/PortMonitor.ts
@@ -12,8 +12,18 @@ import PositiveNumber from "Common/Types/PositiveNumber";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import Sleep from "Common/Types/Sleep";
 import logger from "Common/Server/Utils/Logger";
+import MonitorCheckBudget, {
+  MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS,
+  MONITOR_CHECK_RETRY_DELAY_IN_MS,
+} from "Common/Types/Monitor/MonitorCheckBudget";
 import net from "net";
 import Register from "../../../Services/Register";
+
+// Used when the caller does not configure one.
+export const DEFAULT_PORT_ATTEMPT_TIMEOUT_IN_MS: number = 5000;
+
+// Attempts left after this many retries, when the caller does not say.
+export const DEFAULT_PORT_RETRY_COUNT: number = 5;
 
 // TODO - make sure it works for the IPV6
 export interface PortMonitorResponse {
@@ -26,15 +36,66 @@ export interface PortMonitorResponse {
 }
 
 export interface PingOptions {
+  // Timeout for a single connect attempt.
   timeout?: PositiveNumber;
   retry?: number | undefined;
   currentRetryCount?: number | undefined;
   monitorId?: ObjectID | undefined;
   isOnlineCheckRequest?: boolean | undefined;
   attempts?: Array<ProbeAttempt> | undefined;
+  /*
+   * Wall-clock moment the whole check (every attempt and every backoff
+   * between them) must be finished by, so a dead target cannot cost
+   * `timeout × retry` and push the check past its monitoring interval.
+   */
+  deadlineAt?: Date | undefined;
 }
 
 export default class PortMonitor {
+  /**
+   * How long this attempt may take: the configured per-attempt timeout,
+   * shortened when less than that is left of the check's budget.
+   */
+  public static getAttemptTimeoutInMs(pingOptions: PingOptions): number {
+    const configuredTimeoutInMs: number =
+      pingOptions.timeout?.toNumber() || DEFAULT_PORT_ATTEMPT_TIMEOUT_IN_MS;
+
+    if (!pingOptions.deadlineAt) {
+      return configuredTimeoutInMs;
+    }
+
+    const remainingInMs: number = MonitorCheckBudget.getRemainingBudgetInMs(
+      pingOptions.deadlineAt,
+    );
+
+    // The floor only ever applies to the remaining-budget clamp.
+    return Math.min(
+      configuredTimeoutInMs,
+      Math.max(MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS, remainingInMs),
+    );
+  }
+
+  /**
+   * True when another attempt is both allowed by the retry count and
+   * affordable within what is left of the check's budget.
+   */
+  public static canRetry(pingOptions: PingOptions): boolean {
+    const retryLimit: number = pingOptions.retry ?? DEFAULT_PORT_RETRY_COUNT;
+
+    if ((pingOptions.currentRetryCount || 0) >= retryLimit) {
+      return false;
+    }
+
+    if (!pingOptions.deadlineAt) {
+      return true;
+    }
+
+    return (
+      MonitorCheckBudget.getRemainingBudgetInMs(pingOptions.deadlineAt) >
+      MONITOR_CHECK_RETRY_DELAY_IN_MS + MIN_MONITOR_CHECK_ATTEMPT_TIMEOUT_IN_MS
+    );
+  }
+
   public static async ping(
     host: Hostname | IPv4 | IPv6 | URL,
     port: Port,
@@ -92,7 +153,9 @@ export default class PortMonitor {
 
           const socket: net.Socket = new net.Socket();
 
-          const timeout: number = pingOptions?.timeout?.toNumber() || 5000;
+          const timeout: number = PortMonitor.getAttemptTimeoutInMs(
+            pingOptions || {},
+          );
 
           socket.setTimeout(timeout);
 
@@ -175,12 +238,9 @@ export default class PortMonitor {
 
       // if response time is greater than 10 seconds then give it one more try
 
-      if (
-        responseTimeInMS.toNumber() > 10000 &&
-        pingOptions.currentRetryCount < (pingOptions.retry || 5)
-      ) {
+      if (responseTimeInMS.toNumber() > 10000 && this.canRetry(pingOptions)) {
         pingOptions.currentRetryCount++;
-        await Sleep.sleep(1000);
+        await Sleep.sleep(MONITOR_CHECK_RETRY_DELAY_IN_MS);
         return await this.ping(host, port, pingOptions);
       }
 
@@ -220,9 +280,9 @@ export default class PortMonitor {
         failureCause: (err as any).toString(),
       });
 
-      if (pingOptions.currentRetryCount < (pingOptions.retry || 5)) {
+      if (this.canRetry(pingOptions)) {
         pingOptions.currentRetryCount++;
-        await Sleep.sleep(1000);
+        await Sleep.sleep(MONITOR_CHECK_RETRY_DELAY_IN_MS);
         return await this.ping(host, port, pingOptions);
       }
 


### PR DESCRIPTION
## The bug

A Ping monitor whose target stops answering logs its first offline result minutes late, then appears to resume on schedule:

| Interval | Last online | First offline | Then |
|---|---|---|---|
| 1 minute | 08:08 | **08:12** | 08:13, 08:14 |
| 5 minutes | 08:30 | **08:38** | 08:43 |

Both cases are the same ~3 minutes of lateness.

## Root cause

Three things combined:

1. **`ping` got the request timeout as its per-reply wait, with no deadline.** `Monitor.ts` passed `requestTimeoutInMs` (60 000 ms by default) straight into `PingMonitor.ping`, which handed it to the `ping` library as `timeout` — `-W` on Linux/macOS — alongside `min_reply: 5` and no `deadline`. Against a black-holed IP, `ping -c 5 -W 60` sends its five packets a second apart and then sits waiting the full 60 s for the last reply, so one *attempt* outlived the interval of most monitors.

2. **No budget across retries.** That was multiplied by `retryCount` (3) with a 1 s backoff, so one *check* cost ≈ 3 min 14 s, then a 20 s traceroute was appended on failure. The later logs only looked on time because `nextPingAt` is claimed up-front in `claimMonitorProbesForProbing` — three overlapping 3-minute checks, started a minute apart, finish a minute apart.

3. **Nothing recorded when the check actually ran.** `monitoredAt` was overwritten at the *end* of the check, and `MonitorLog.time` — the "Monitored At" column — was the server's ingest time, not the check's.

## The fix

**New `MonitorCheckBudget` helper** (`Common/Types/Monitor/MonitorCheckBudget.ts`) derives the interval from the monitor's cron expression and turns "request timeout" into a wall-clock budget for one whole check:

- capped at 80% of the monitoring interval (never stretched beyond the configured timeout);
- split across the retry attempts and their backoffs, dropping attempts a tight budget can't pay for;
- with a slice reserved for post-failure diagnostics.

**`PingMonitor` / `PortMonitor`** now take a `deadlineAt`. Ping passes `deadline` to the binary (`-w` on Linux, `-t` on macOS) so a single invocation is hard-bounded, each attempt shrinks to what's left of the budget, and retries stop once there's no room for a backoff plus a real attempt. Port gets the same treatment since Ping falls back to it when the cloud provider blocks ICMP.

**The post-failure traceroute** is bounded by the leftover diagnostics budget and skipped when none is left.

**Timestamps**: `monitoredAt` now records when the check *started*, and `MonitorLog.time` is taken from it — with clock-skew guards, so a probe with a bad clock still can't write rows into the future or into a long-past ClickHouse partition.

On the shipped defaults, a 1-minute monitor now spends at most 48 s on a fully failing check (down from ~194 s) and reports the moment it was taken. Only Ping / IP / Port are budgeted this way; every other monitor type keeps `requestTimeoutInMs` as a plain per-request timeout.

## Tests

299 assertions across four new suites, all verified to fail against the pre-fix code:

- `Common/Tests/Types/Monitor/MonitorCheckBudget.test.ts` — interval derivation (including uneven crons, where the smallest gap wins), budget clamping, the diagnostics/reachability split, per-attempt arithmetic, deadlines, degenerate inputs, plus an end-to-end check that a fully-failing check fits inside 1- and 5-minute intervals.
- `Common/Tests/Server/Utils/Monitor/MonitorLogTimeUtil.test.ts` — reading `monitoredAt` as a Date / ISO string / epoch, the fallbacks, and both clock-skew guards.
- `Probe/Tests/Utils/Monitors/MonitorTypes/PingMonitor.test.ts` — the options handed to the ping binary, deadlines shrinking as the budget is consumed, retries truncated by the deadline, and packet statistics. Uses a mocked `ping` plus a fake clock, so it exercises realistic 60-second durations in milliseconds.
- `Probe/Tests/Utils/Monitors/MonitorTypes/PortMonitor.test.ts` — the same budget helpers, plus real sockets against an open and a closed port.
- `Probe/Tests/Utils/Monitors/PingMonitorCheckBudget.test.ts` — drives the real `probeMonitorStep`: an unreachable target reports within its interval, `monitoredAt` is the check start, and a healthy target still returns in one attempt with no traceroute.

`npm run fix` is clean; Common, Probe and App all type-check. The 237 Probe and 1 291 Common monitor tests pass. (Seven Common suites fail to *load* locally on an `isolated-vm` native-binding error — reproduced on untouched `master`, unrelated to this change.)
