### PR TITLE
fix(ui): make bulk "Select All" fetch the columns it selects

### DIFF
--- a/Common/Tests/UI/Components/BulkUpdateForm.test.tsx
+++ b/Common/Tests/UI/Components/BulkUpdateForm.test.tsx
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "@jest/globals";
+import { fireEvent, render, RenderResult } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import BulkUpdateForm, {
+  BulkActionButtonSchema,
+  ComponentProps,
+} from "../../../UI/Components/BulkUpdate/BulkUpdateForm";
+import { ButtonStyleType } from "../../../UI/Components/Button/Button";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+
+/*
+ * react-i18next is not initialized in the test environment. Mock the hook so
+ * translate helpers echo their input and the component renders synchronously.
+ */
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, opts?: { defaultValue?: string }): string => {
+          return opts?.defaultValue ?? key;
+        },
+      };
+    },
+  };
+});
+
+interface Row {
+  _id?: string | undefined;
+  name?: string | undefined;
+}
+
+type MakeRowsFunction = (count: number) => Array<Row>;
+
+const makeRows: MakeRowsFunction = (count: number): Array<Row> => {
+  const rows: Array<Row> = [];
+
+  for (let i: number = 0; i < count; i++) {
+    rows.push({ _id: `id-${i}`, name: `Row ${i}` });
+  }
+
+  return rows;
+};
+
+const BUTTONS: Array<BulkActionButtonSchema<Row>> = [
+  {
+    title: "Archive",
+    buttonStyleType: ButtonStyleType.NORMAL,
+    onClick: (): Promise<void> => {
+      return Promise.resolve();
+    },
+  },
+];
+
+type RenderFormFunction = (
+  overrides: Partial<ComponentProps<Row>>,
+) => RenderResult;
+
+const renderForm: RenderFormFunction = (
+  overrides: Partial<ComponentProps<Row>>,
+): RenderResult => {
+  const props: ComponentProps<Row> = {
+    selectedItems: makeRows(3),
+    isAllItemsSelected: false,
+    onSelectAllClick: () => {},
+    onClearSelectionClick: () => {},
+    singularLabel: "Label",
+    pluralLabel: "Labels",
+    buttons: BUTTONS,
+    ...overrides,
+  };
+
+  return render(<BulkUpdateForm<Row> {...props} />);
+};
+
+describe("BulkUpdateForm", () => {
+  test("renders nothing when nothing is selected", () => {
+    const { container } = renderForm({ selectedItems: [] });
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("offers Select All while only part of the table is selected", () => {
+    const { getByText } = renderForm({ isAllItemsSelected: false });
+
+    expect(getByText("3 Labels Selected")).toBeTruthy();
+    expect(getByText("Select All Labels")).toBeTruthy();
+  });
+
+  test("hides Select All once everything really is selected", () => {
+    const { queryByText } = renderForm({ isAllItemsSelected: true });
+
+    expect(queryByText("Select All Labels")).toBeNull();
+  });
+
+  test("blocks a second Select All while the first is still loading", () => {
+    const onSelectAllClick: MockFunction = getJestMockFunction();
+
+    const { getByText } = renderForm({
+      isSelectingAllItems: true,
+      onSelectAllClick: onSelectAllClick as unknown as () => void,
+    });
+
+    const button: HTMLElement = getByText("Selecting All Labels...");
+
+    fireEvent.click(button);
+
+    /*
+     * Selecting everything is a paged, multi-request fetch. Letting it be
+     * re-entrant would interleave two runs over the same selection.
+     */
+    expect(onSelectAllClick).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a failed select-all next to the button that triggered it", () => {
+    const { getByText } = renderForm({
+      errorMessage: "Network request failed",
+    });
+
+    expect(getByText("Network request failed")).toBeTruthy();
+    // The selection the user already had is still reported.
+    expect(getByText("3 Labels Selected")).toBeTruthy();
+  });
+
+  test("shows no error when the select-all succeeded", () => {
+    const { queryByText } = renderForm({ errorMessage: undefined });
+
+    expect(queryByText(/failed/)).toBeNull();
+  });
+
+  test("names real numbers when the selection was truncated", () => {
+    const { getByText } = renderForm({
+      selectedItems: makeRows(5),
+      isAllItemsSelected: true,
+      isSelectionTruncated: true,
+      totalMatchingItemsCount: 24318,
+    });
+
+    expect(
+      getByText(
+        new RegExp(`Selected 5 of ${(24318).toLocaleString()} matching Labels`),
+      ),
+    ).toBeTruthy();
+  });
+
+  test("stays quiet when a full selection happens to sit on the ceiling", () => {
+    /*
+     * The warning used to be inferred from
+     * `selectedItems.length === LIMIT_PER_PROJECT`, so a project holding
+     * exactly the ceiling was told its selection had been cut short when
+     * nothing had been dropped at all.
+     */
+    const { queryByText } = renderForm({
+      selectedItems: makeRows(LIMIT_PER_PROJECT),
+      isAllItemsSelected: true,
+      isSelectionTruncated: false,
+      totalMatchingItemsCount: LIMIT_PER_PROJECT,
+    });
+
+    expect(queryByText(/matching Labels/)).toBeNull();
+  });
+
+  test("clearing the selection calls back", () => {
+    const onClearSelectionClick: MockFunction = getJestMockFunction();
+
+    const { getByText } = renderForm({
+      onClearSelectionClick: onClearSelectionClick as unknown as () => void,
+    });
+
+    fireEvent.click(getByText("Clear Selection"));
+
+    expect(onClearSelectionClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableBulkSelectAll.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableBulkSelectAll.test.tsx
@@ -1,0 +1,930 @@
+import "@testing-library/jest-dom/extend-expect";
+import {
+  act,
+  cleanup,
+  configure,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+/*
+ * Selecting thousands of rows renders and re-renders a real table several
+ * times over, which comfortably outruns the 1s default when the whole suite
+ * is competing for the same box. A regression still fails, just later.
+ */
+configure({ asyncUtilTimeout: 15000 });
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * BaseModelTable pulls in permissions, the current project and the i18n
+ * provider. None of those are what these tests are about, so they are stubbed
+ * to their permissive/no-op form and the tests focus on one thing: what
+ * "Select All" actually asks the API for, and what ends up selected.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return true;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined) => {
+          return value;
+        },
+        translateValue: (value: unknown) => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  BULK_SELECT_ALL_PAGE_SIZE,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import TableColumnsToCsv from "../../../../UI/Utils/TableColumnsToCsv";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import { ButtonStyleType } from "../../../../UI/Components/Button/Button";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
+import Query from "../../../../Types/BaseDatabase/Query";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+type GetListCall = {
+  query: Query<Monitor>;
+  limit: number;
+  skip: number;
+  sort: JSONObject;
+  select: JSONObject;
+};
+
+type Row = {
+  _id: string;
+  name: string;
+  description: string;
+  createdAt: string;
+};
+
+type MakeRowsFunction = (count: number) => Array<Row>;
+
+const makeRows: MakeRowsFunction = (count: number): Array<Row> => {
+  const rows: Array<Row> = [];
+
+  for (let i: number = 0; i < count; i++) {
+    rows.push({
+      _id: `id-${String(i).padStart(6, "0")}`,
+      name: `Monitor ${i}`,
+      description: `Description ${i}`,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+  }
+
+  return rows;
+};
+
+const COLUMNS: Array<unknown> = [
+  { field: { name: true }, title: "Name", type: FieldType.Text },
+  {
+    field: { description: true },
+    title: "Description",
+    type: FieldType.LongText,
+  },
+];
+
+type CallPredicate = (call: GetListCall) => boolean;
+
+type RenderOptions = {
+  rows: Array<Row>;
+  /*
+   * Matched against each recorded getList call. Predicates rather than call
+   * indexes, so that a future extra fetch on mount cannot silently retarget
+   * the injected failure at the table's own page request.
+   */
+  failWhen?: CallPredicate | undefined;
+  deferWhen?: CallPredicate | undefined;
+  /*
+   * Simulates rows being inserted while the selection is being paged: every
+   * page after the first is served from `overlapPages` rows earlier than
+   * asked, so the boundary rows come back twice.
+   */
+  overlapPages?: number | undefined;
+  /*
+   * Serve the analytics shape, where the endpoint skips COUNT(*) and reports
+   * `hasMore` with a `count` that is only a lower bound.
+   */
+  useHasMore?: boolean | undefined;
+  selectMoreFields?: JSONObject | undefined;
+  query?: Query<Monitor> | undefined;
+};
+
+/*
+ * The bulk selection pages at BULK_SELECT_ALL_PAGE_SIZE; the table's own page
+ * fetches use its (much smaller) page size, so the limit tells them apart.
+ */
+type IsBulkCallFunction = (call: GetListCall) => boolean;
+
+const isBulkCall: IsBulkCallFunction = (call: GetListCall): boolean => {
+  return call.limit === BULK_SELECT_ALL_PAGE_SIZE;
+};
+
+describe("BaseModelTable bulk Select All", () => {
+  let calls: Array<GetListCall> = [];
+  let deferredResolve: (() => void) | null = null;
+  let downloadedCsvFiles: Array<{ csv: string; filename: string }> = [];
+
+  type RenderTableFunction = (
+    options: RenderOptions,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    options: RenderOptions,
+  ): ReturnType<typeof render> => {
+    const callbacks: BaseTableCallbacks<Monitor> = {
+      deleteItem: async () => {
+        return undefined;
+      },
+      getModelFromJSON: (item: JSONObject) => {
+        return item as unknown as Monitor;
+      },
+      getJSONFromModel: (item: Monitor) => {
+        return item as unknown as JSONObject;
+      },
+      addSlugToSelect: (select: unknown) => {
+        return select;
+      },
+      getList: async (data: GetListCall): Promise<ListResult<Monitor>> => {
+        const call: GetListCall = {
+          query: data.query,
+          limit: data.limit,
+          skip: data.skip,
+          sort: data.sort as unknown as JSONObject,
+          select: data.select as unknown as JSONObject,
+        };
+
+        calls.push(call);
+
+        if (options.failWhen?.(call)) {
+          throw new Error("Select all blew up");
+        }
+
+        if (options.deferWhen?.(call)) {
+          await new Promise<void>((resolve: () => void) => {
+            deferredResolve = resolve;
+          });
+        }
+
+        const skip: number =
+          options.overlapPages && data.skip > 0
+            ? Math.max(0, data.skip - options.overlapPages)
+            : data.skip;
+
+        const page: Array<Row> = options.rows.slice(skip, skip + data.limit);
+
+        /*
+         * The API only returns the fields the caller selected. Honouring that
+         * here is what makes these tests able to see the bug at all: a row
+         * fetched with `select: { _id: true }` comes back as a bare id with
+         * every other field missing.
+         */
+        const projected: Array<JSONObject> = page.map((row: Row) => {
+          const projectedRow: JSONObject = {};
+
+          for (const field of Object.keys(data.select || {})) {
+            if (field in row) {
+              projectedRow[field] = (row as unknown as JSONObject)[field];
+            }
+          }
+
+          return projectedRow;
+        });
+
+        if (options.useHasMore) {
+          const hasMore: boolean = skip + page.length < options.rows.length;
+
+          return {
+            data: projected as unknown as Array<Monitor>,
+            count: skip + page.length + (hasMore ? 1 : 0),
+            hasMore: hasMore,
+            skip: data.skip,
+            limit: data.limit,
+          };
+        }
+
+        return {
+          data: projected as unknown as Array<Monitor>,
+          count: options.rows.length,
+          skip: data.skip,
+          limit: data.limit,
+        };
+      },
+      toJSONArray: () => {
+        return [];
+      },
+      updateById: async () => {
+        return undefined;
+      },
+      showCreateEditModal: () => {
+        return <></>;
+      },
+    } as unknown as BaseTableCallbacks<Monitor>;
+
+    const props: BaseModelTableProps<Monitor> = {
+      modelType: Monitor,
+      id: "monitors-table",
+      name: "Monitors",
+      singularName: "Monitor",
+      pluralName: "Monitors",
+      userPreferencesKey: "monitors-bulk-table",
+      urlStateKey: "monitors-bulk-table",
+      columns: COLUMNS,
+      filters: [],
+      isDeleteable: false,
+      isCreateable: false,
+      isViewable: false,
+      isEditable: false,
+      callbacks: callbacks,
+      bulkActions: {
+        buttons: [
+          {
+            title: "Archive",
+            buttonStyleType: ButtonStyleType.NORMAL,
+            onClick: async (): Promise<void> => {
+              return Promise.resolve();
+            },
+          },
+        ],
+      },
+      ...(options.selectMoreFields
+        ? { selectMoreFields: options.selectMoreFields }
+        : {}),
+      ...(options.query ? { query: options.query } : {}),
+    } as unknown as BaseModelTableProps<Monitor>;
+
+    return render(<BaseModelTable<Monitor> {...props} />);
+  };
+
+  type SelectCurrentPageFunction = (container: HTMLElement) => Promise<void>;
+
+  /*
+   * Ticks the header checkbox, which selects the rows on screen and is what
+   * makes the bulk bar (and its "Select All" button) appear in the first
+   * place.
+   */
+  const selectCurrentPage: SelectCurrentPageFunction = async (
+    container: HTMLElement,
+  ): Promise<void> => {
+    // The header checkbox is disabled until the first page has rendered.
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('input[type="checkbox"]:not([disabled])')
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    const checkboxes: NodeListOf<HTMLInputElement> =
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+
+    fireEvent.click(checkboxes[0]!);
+  };
+
+  type BulkCallsFunction = () => Array<GetListCall>;
+
+  const bulkCalls: BulkCallsFunction = (): Array<GetListCall> => {
+    return calls.filter(isBulkCall);
+  };
+
+  const isSelectAllCall: CallPredicate = (call: GetListCall): boolean => {
+    return isBulkCall(call);
+  };
+
+  // Only the opening page, so later pages resolve on their own.
+  const isFirstSelectAllCall: CallPredicate = (call: GetListCall): boolean => {
+    return isBulkCall(call) && call.skip === 0;
+  };
+
+  beforeEach(() => {
+    calls = [];
+    deferredResolve = null;
+    downloadedCsvFiles = [];
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/dashboard/monitors",
+    );
+    TableFilterUrlState.resetClaimedKeys();
+    window.localStorage.clear();
+
+    /*
+     * Intercepting the download rather than the Blob keeps the assertion on
+     * the exact bytes the user would have opened in a spreadsheet.
+     */
+    jest
+      .spyOn(TableColumnsToCsv, "downloadCsv")
+      .mockImplementation((data: { csv: string; filename: string }): void => {
+        downloadedCsvFiles.push(data);
+      });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("it fetches the same columns as the page fetch, not just _id", async () => {
+    /*
+     * Regression for the reported bug: "Select All" then "Export CSV"
+     * produced a file with a header row and nothing else. Select All asked
+     * for `select: { _id: true }`, so every selected row was an id with no
+     * fields on it and every exported cell came out empty.
+     */
+    const { container, getByText } = renderTable({ rows: makeRows(25) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    const pageSelect: JSONObject = calls[0]!.select;
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(bulkCalls().length).toBe(1);
+    });
+
+    const bulkSelect: JSONObject = bulkCalls()[0]!.select;
+
+    // Every column the table renders is fetched for the selection too.
+    for (const field of Object.keys(pageSelect)) {
+      expect(bulkSelect[field]).toEqual(pageSelect[field]);
+    }
+
+    expect(bulkSelect["name"]).toBe(true);
+    expect(bulkSelect["description"]).toBe(true);
+    expect(bulkSelect["_id"]).toBe(true);
+  });
+
+  test("it selects the column it orders by, which the database requires", async () => {
+    const { container, getByText } = renderTable({ rows: makeRows(25) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(bulkCalls().length).toBe(1);
+    });
+
+    for (const sortColumn of Object.keys(bulkCalls()[0]!.sort)) {
+      expect(bulkCalls()[0]!.select[sortColumn]).toBe(true);
+    }
+  });
+
+  test("the exported CSV of a select-all carries real values on every row", async () => {
+    // More rows than fit on a page, so this cannot pass on the page selection.
+    const { container, getByText } = renderTable({ rows: makeRows(25) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("25 Monitors Selected")).toBeTruthy();
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    await waitFor(() => {
+      expect(downloadedCsvFiles.length).toBe(1);
+    });
+
+    const lines: Array<string> = downloadedCsvFiles[0]!.csv.split("\r\n");
+
+    expect(lines.length).toBe(26);
+    expect(lines[0]).toBe("Name,Description");
+    expect(lines[1]).toBe("Monitor 0,Description 0");
+    expect(lines[25]).toBe("Monitor 24,Description 24");
+  });
+
+  test("it selects every matching row, not just the current page", async () => {
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(1262),
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    // The page holds 10 rows at the default page size.
+    expect(getByText("10 Monitors Selected")).toBeTruthy();
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("1262 Monitors Selected")).toBeTruthy();
+    });
+
+    // Everything is selected, so there is nothing left for the button to do.
+    expect(queryByText("Select All Monitors")).toBeNull();
+  });
+
+  test("it pages the fetch instead of asking for everything at once", async () => {
+    const { container, getByText } = renderTable({ rows: makeRows(1262) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("1262 Monitors Selected")).toBeTruthy();
+    });
+
+    expect(
+      bulkCalls().map((call: GetListCall) => {
+        return call.skip;
+      }),
+    ).toEqual([0, BULK_SELECT_ALL_PAGE_SIZE]);
+  });
+
+  test("it stops at the first short page", async () => {
+    const { container, getByText } = renderTable({ rows: makeRows(300) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("300 Monitors Selected")).toBeTruthy();
+    });
+
+    expect(bulkCalls().length).toBe(1);
+  });
+
+  test("it does not spend a round trip proving an exact multiple is finished", async () => {
+    /*
+     * Every list request also runs an unbounded count over the filtered set,
+     * so the empty page at the end is not free.
+     */
+    const { container, getByText } = renderTable({
+      rows: makeRows(BULK_SELECT_ALL_PAGE_SIZE * 2),
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(
+        getByText(`${BULK_SELECT_ALL_PAGE_SIZE * 2} Monitors Selected`),
+      ).toBeTruthy();
+    });
+
+    expect(bulkCalls().length).toBe(2);
+  });
+
+  test("it stops on hasMore for endpoints that report no exact count", async () => {
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(BULK_SELECT_ALL_PAGE_SIZE),
+      useHasMore: true,
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(
+        getByText(`${BULK_SELECT_ALL_PAGE_SIZE} Monitors Selected`),
+      ).toBeTruthy();
+    });
+
+    expect(bulkCalls().length).toBe(1);
+    // Nothing was left behind, so there is nothing to warn about.
+    expect(queryByText(/matching Monitors/)).toBeNull();
+  });
+
+  test("a row served twice across pages is only selected once", async () => {
+    /*
+     * Offset paging over a table that is still taking writes can hand back a
+     * row an earlier page already returned. Selecting it twice would
+     * duplicate it in the export and inflate the count.
+     */
+    const { container, getByText } = renderTable({
+      rows: makeRows(1262),
+      overlapPages: 5,
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("1262 Monitors Selected")).toBeTruthy();
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    await waitFor(() => {
+      expect(downloadedCsvFiles.length).toBe(1);
+    });
+
+    const lines: Array<string> = downloadedCsvFiles[0]!.csv.split("\r\n");
+
+    expect(lines.length).toBe(1263);
+    expect(new Set(lines.slice(1)).size).toBe(1262);
+  });
+
+  test("an unsorted table keeps the order it is displayed in", async () => {
+    /*
+     * The API only applies its default ordering when no sort is sent, so the
+     * selection has to name that ordering itself - otherwise a select-all
+     * exports in an order unrelated to the table, and a selection capped at
+     * the ceiling keeps an arbitrary slice instead of the newest rows.
+     */
+    const { container, getByText } = renderTable({ rows: makeRows(25) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(bulkCalls().length).toBe(1);
+    });
+
+    expect(bulkCalls()[0]!.sort).toEqual({
+      createdAt: SortOrder.Descending,
+      _id: SortOrder.Ascending,
+    });
+  });
+
+  test("an active column sort is kept, with the id appended as a tiebreaker", async () => {
+    const { container, getByText } = renderTable({ rows: makeRows(25) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    // Sorting by the "Name" header puts a sort on the table.
+    fireEvent.click(getByText("Name"));
+
+    await waitFor(() => {
+      expect(calls[calls.length - 1]!.sort).toEqual({
+        name: SortOrder.Descending,
+      });
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(bulkCalls().length).toBe(1);
+    });
+
+    expect(bulkCalls()[0]!.sort).toEqual({
+      name: SortOrder.Descending,
+      _id: SortOrder.Ascending,
+    });
+  });
+
+  test("it carries the table's query so it never selects outside the filters", async () => {
+    const query: Query<Monitor> = {
+      projectId: "project-1",
+    } as unknown as Query<Monitor>;
+
+    const { container, getByText } = renderTable({
+      rows: makeRows(25),
+      query: query,
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(bulkCalls().length).toBe(1);
+    });
+
+    expect(bulkCalls()[0]!.query).toEqual(calls[0]!.query);
+    expect(bulkCalls()[0]!.query["projectId"]).toBe("project-1");
+  });
+
+  test("it honours selectMoreFields, which a hand-rolled column list would drop", async () => {
+    const { container, getByText } = renderTable({
+      rows: makeRows(25),
+      selectMoreFields: { monitorType: true },
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(bulkCalls().length).toBe(1);
+    });
+
+    expect(bulkCalls()[0]!.select["monitorType"]).toBe(true);
+  });
+
+  test("it stops at the selection ceiling and says so", async () => {
+    const { container, getByText } = renderTable({
+      rows: makeRows(LIMIT_PER_PROJECT + 250),
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText(`${LIMIT_PER_PROJECT} Monitors Selected`)).toBeTruthy();
+    });
+
+    expect(bulkCalls().length).toBe(
+      LIMIT_PER_PROJECT / BULK_SELECT_ALL_PAGE_SIZE,
+    );
+
+    // The warning names the real numbers rather than inferring truncation.
+    expect(
+      getByText(
+        new RegExp(
+          `Selected ${LIMIT_PER_PROJECT.toLocaleString()} of ${(
+            LIMIT_PER_PROJECT + 250
+          ).toLocaleString()} matching Monitors`,
+        ),
+      ),
+    ).toBeTruthy();
+  });
+
+  test("it does not warn about truncation when everything was selected", async () => {
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(25),
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("25 Monitors Selected")).toBeTruthy();
+    });
+
+    expect(queryByText(/matching Monitors/)).toBeNull();
+  });
+
+  test("a failed select-all keeps the previous selection and stays retryable", async () => {
+    /*
+     * The failure mode behind "even though I selected Select All, only the
+     * records on the current page are selected": the request failed, the
+     * error was swallowed, and the bulk bar hid the Select All button while
+     * still holding just the page rows.
+     */
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(1262),
+      failWhen: isSelectAllCall,
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("Select all blew up")).toBeTruthy();
+    });
+
+    // The page selection survived untouched...
+    expect(getByText("10 Monitors Selected")).toBeTruthy();
+    // ...and the button is still there to try again.
+    expect(queryByText("Select All Monitors")).not.toBeNull();
+  });
+
+  test("a failed select-all can be retried, and the error goes away", async () => {
+    let shouldFail: boolean = true;
+
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(1262),
+      failWhen: (call: GetListCall): boolean => {
+        return isSelectAllCall(call) && shouldFail;
+      },
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("Select all blew up")).toBeTruthy();
+    });
+
+    shouldFail = false;
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("1262 Monitors Selected")).toBeTruthy();
+    });
+
+    // A stale failure banner under a complete selection would be a lie.
+    expect(queryByText("Select all blew up")).toBeNull();
+  });
+
+  test("it reports progress and blocks a second run while it is loading", async () => {
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(1262),
+      deferWhen: isFirstSelectAllCall,
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(getByText("Selecting All Monitors...")).toBeTruthy();
+    });
+
+    // A second click while it runs must not start an overlapping fetch.
+    fireEvent.click(getByText("Selecting All Monitors..."));
+
+    await act(async () => {
+      deferredResolve!();
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 50);
+      });
+    });
+
+    await waitFor(() => {
+      expect(getByText("1262 Monitors Selected")).toBeTruthy();
+    });
+
+    expect(queryByText("Selecting All Monitors...")).toBeNull();
+    expect(bulkCalls().length).toBe(2);
+  });
+
+  test("clearing the selection wins over a select-all still in flight", async () => {
+    const { container, getByText, queryByText } = renderTable({
+      rows: makeRows(1262),
+      deferWhen: isFirstSelectAllCall,
+    });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Select All Monitors"));
+
+    await waitFor(() => {
+      expect(deferredResolve).not.toBeNull();
+    });
+
+    fireEvent.click(getByText("Clear Selection"));
+
+    // The bulk bar is gone once nothing is selected.
+    await waitFor(() => {
+      expect(queryByText("Clear Selection")).toBeNull();
+    });
+
+    await act(async () => {
+      deferredResolve!();
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 50);
+      });
+    });
+
+    // The superseded run must not resurrect a selection the user cleared...
+    expect(queryByText(/Monitors Selected/)).toBeNull();
+    // ...nor keep paging for it.
+    expect(bulkCalls().length).toBe(1);
+  });
+
+  test("selecting only the current page still exports just those rows", async () => {
+    const { container, getByText } = renderTable({ rows: makeRows(25) });
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await selectCurrentPage(container);
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    await waitFor(() => {
+      expect(downloadedCsvFiles.length).toBe(1);
+    });
+
+    const lines: Array<string> = downloadedCsvFiles[0]!.csv.split("\r\n");
+
+    // Header plus the ten rows on screen.
+    expect(lines.length).toBe(11);
+    expect(lines[1]).toBe("Monitor 0,Description 0");
+  });
+});

--- a/Common/Tests/UI/Components/TableBulkCsvExport.test.tsx
+++ b/Common/Tests/UI/Components/TableBulkCsvExport.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, RenderResult } from "@testing-library/react";
 import * as React from "react";
 import getJestMockFunction, { MockFunction } from "../../MockType";
 import Table, { BulkActionProps } from "../../../UI/Components/Table/Table";
+import TableColumnsToCsv from "../../../UI/Utils/TableColumnsToCsv";
 import Columns from "../../../UI/Components/Table/Types/Columns";
 import FieldType from "../../../UI/Components/Types/FieldType";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
@@ -27,15 +28,17 @@ jest.mock("react-i18next", () => {
 interface Row {
   _id?: string | undefined;
   name?: string | undefined;
+  description?: string | undefined;
 }
 
 const columns: Columns<Row> = [
   { title: "Name", type: FieldType.Text, key: "name" },
+  { title: "Description", type: FieldType.Text, key: "description" },
 ];
 
 const data: Array<Row> = [
-  { _id: "1", name: "Alpha" },
-  { _id: "2", name: "Beta" },
+  { _id: "1", name: "Alpha", description: "First" },
+  { _id: "2", name: "Beta", description: "Second" },
 ];
 
 interface RenderTableOptions {
@@ -89,6 +92,8 @@ describe("Table bulk CSV export", () => {
   let createObjectURLMock: MockFunction;
   let revokeObjectURLMock: MockFunction;
   let clickSpy: jest.SpyInstance;
+  let downloadedCsvFiles: Array<{ csv: string; filename: string }> = [];
+  let downloadCsvSpy: jest.SpyInstance;
 
   beforeEach(() => {
     createObjectURLMock = getJestMockFunction();
@@ -103,10 +108,28 @@ describe("Table bulk CSV export", () => {
     clickSpy = jest
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(() => {});
+
+    downloadedCsvFiles = [];
   });
+
+  type SpyOnDownloadFunction = () => void;
+
+  /*
+   * Asserting on the CSV text the exporter hands to the browser, rather than
+   * on the opaque Blob, is what lets these tests see an export whose rows are
+   * all blank - the shape the bug produced.
+   */
+  const spyOnDownload: SpyOnDownloadFunction = (): void => {
+    downloadCsvSpy = jest
+      .spyOn(TableColumnsToCsv, "downloadCsv")
+      .mockImplementation((...args: Array<unknown>): void => {
+        downloadedCsvFiles.push(args[0] as { csv: string; filename: string });
+      });
+  };
 
   afterEach(() => {
     clickSpy.mockRestore();
+    downloadCsvSpy?.mockRestore();
   });
 
   test("shows an Export CSV action when the table has bulk actions and rows are selected", () => {
@@ -164,5 +187,82 @@ describe("Table bulk CSV export", () => {
 
     expect(queryByText("Bulk Actions")).toBeNull();
     expect(queryByText("Export CSV")).toBeNull();
+  });
+
+  test("the exported CSV carries the values of every selected row", () => {
+    spyOnDownload();
+
+    const { getByText } = renderTable({
+      bulkActions: customBulkActions,
+      bulkSelectedItems: data,
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    expect(downloadedCsvFiles.length).toBe(1);
+    expect(downloadedCsvFiles[0]!.csv.split("\r\n")).toEqual([
+      "Name,Description",
+      "Alpha,First",
+      "Beta,Second",
+    ]);
+  });
+
+  test("it exports the selection, not the rows on screen", () => {
+    spyOnDownload();
+
+    /*
+     * The selection outgrows the page as soon as the user selects across
+     * pages or picks "Select All", so the export has to follow
+     * bulkSelectedItems rather than the rendered data.
+     */
+    const selection: Array<Row> = [];
+
+    for (let i: number = 0; i < 30; i++) {
+      selection.push({
+        _id: `${i}`,
+        name: `Row ${i}`,
+        description: `Desc ${i}`,
+      });
+    }
+
+    const { getByText } = renderTable({
+      bulkActions: customBulkActions,
+      bulkSelectedItems: selection,
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    const lines: Array<string> = downloadedCsvFiles[0]!.csv.split("\r\n");
+
+    // Header plus every selected row, even though the table renders two.
+    expect(lines.length).toBe(31);
+    expect(lines[30]).toBe("Row 29,Desc 29");
+  });
+
+  test("rows stripped down to an id export as blank cells", () => {
+    spyOnDownload();
+
+    /*
+     * Characterisation test. TableColumnsToCsv writes what it is handed, so
+     * a selection of id-only models produces a header and nothing else -
+     * which is exactly what the "Select All then Export CSV" bug looked
+     * like. The fix belongs where the selection is fetched
+     * (BaseModelTable.fetchAllBulkItems), not here.
+     */
+    const { getByText } = renderTable({
+      bulkActions: customBulkActions,
+      bulkSelectedItems: [{ _id: "1" }, { _id: "2" }],
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    expect(downloadedCsvFiles[0]!.csv.split("\r\n")).toEqual([
+      "Name,Description",
+      ",",
+      ",",
+    ]);
   });
 });

--- a/Common/UI/Components/BulkUpdate/BulkUpdateForm.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkUpdateForm.tsx
@@ -67,6 +67,21 @@ export interface ComponentProps<T extends GenericObject> {
   onActionStart?: (() => void) | undefined;
   onActionEnd?: (() => void) | undefined;
   itemToString?: ((item: T) => string) | undefined;
+  /*
+   * Selecting everything is a multi-request fetch that can fail. Surfacing it
+   * here - next to the button the user pressed - keeps the message alive; the
+   * table body's own error is wiped by the next refresh.
+   */
+  errorMessage?: string | undefined;
+  isSelectingAllItems?: boolean | undefined;
+  /*
+   * Set when the selection hit the per-selection ceiling and there are more
+   * matching rows than were selected. `totalMatchingItemsCount` is how many
+   * rows actually matched, so the warning can name real numbers instead of
+   * inferring truncation from the selected count.
+   */
+  isSelectionTruncated?: boolean | undefined;
+  totalMatchingItemsCount?: number | undefined;
 }
 
 const isDangerStyle: (style: ButtonStyleType) => boolean = (
@@ -317,9 +332,16 @@ const BulkUpdateForm: <T extends GenericObject>(
     menuChildren.push(renderMenuItem(button, safeButtons.length + index));
   });
 
-  const showLimitWarning: boolean =
-    props.isAllItemsSelected &&
-    props.selectedItems.length === LIMIT_PER_PROJECT;
+  /*
+   * Driven by what the fetch actually reported rather than by
+   * `selectedItems.length === LIMIT_PER_PROJECT`, which both cried wolf on a
+   * project holding exactly the ceiling and stayed silent whenever a partial
+   * selection came back one row short of it.
+   */
+  const showLimitWarning: boolean = Boolean(props.isSelectionTruncated);
+
+  const totalMatchingItemsCount: number =
+    props.totalMatchingItemsCount || props.selectedItems.length;
 
   return (
     <div>
@@ -345,13 +367,33 @@ const BulkUpdateForm: <T extends GenericObject>(
               {!props.isAllItemsSelected && (
                 <button
                   type="button"
+                  disabled={props.isSelectingAllItems}
                   onClick={() => {
+                    if (props.isSelectingAllItems) {
+                      // the fetch is paged, so it must not be re-entrant.
+                      return;
+                    }
                     props.onSelectAllClick();
                   }}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-indigo-50 hover:border-indigo-300 hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-150 cursor-pointer select-none"
+                  className={`inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-all duration-150 select-none ${
+                    props.isSelectingAllItems
+                      ? "opacity-50 cursor-not-allowed"
+                      : "cursor-pointer hover:bg-indigo-50 hover:border-indigo-300 hover:text-indigo-700"
+                  }`}
                 >
-                  <Icon icon={IconProp.CheckCircle} className="h-3.5 w-3.5" />
-                  <span>Select All {props.pluralLabel}</span>
+                  <Icon
+                    icon={
+                      props.isSelectingAllItems
+                        ? IconProp.Spinner
+                        : IconProp.CheckCircle
+                    }
+                    className="h-3.5 w-3.5"
+                  />
+                  <span>
+                    {props.isSelectingAllItems
+                      ? `Selecting All ${props.pluralLabel}...`
+                      : `Select All ${props.pluralLabel}`}
+                  </span>
                 </button>
               )}
 
@@ -393,8 +435,21 @@ const BulkUpdateForm: <T extends GenericObject>(
 
           {showLimitWarning && (
             <div className="mt-2 text-xs text-gray-500">
-              You can only select {LIMIT_PER_PROJECT} {props.pluralLabel} at a
-              time. This is for performance reasons.
+              Selected {props.selectedItems.length.toLocaleString()} of{" "}
+              {totalMatchingItemsCount.toLocaleString()} matching{" "}
+              {props.pluralLabel}. You can only select{" "}
+              {LIMIT_PER_PROJECT.toLocaleString()} {props.pluralLabel} at a
+              time, for performance reasons, so bulk actions will apply to the
+              selected {props.selectedItems.length.toLocaleString()} only.
+            </div>
+          )}
+
+          {props.errorMessage && (
+            <div
+              role="alert"
+              className="mt-2 rounded-lg bg-red-50 p-3 text-sm text-red-800"
+            >
+              {props.errorMessage}
             </div>
           )}
         </div>

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -115,6 +115,21 @@ export enum ShowAs {
   OrderedStatesList,
 }
 
+/*
+ * "Select All" loads the whole filtered result set - up to LIMIT_PER_PROJECT
+ * rows - with the same columns the table itself fetches. Asking for all of
+ * them in one request would mean a single wide, relation-joined query for up
+ * to 10,000 rows, which is exactly the kind of query the database statement
+ * timeout kills. It is paged instead: each request is comparable in cost to a
+ * large page load, so a big selection degrades in latency rather than failing.
+ *
+ * The page size trades those two costs off. Every list request also runs an
+ * unbounded count over the filtered set and pays a growing OFFSET, so smaller
+ * pages multiply that overhead; 1,000 keeps each query well inside the
+ * statement timeout while capping a maxed-out selection at ten round trips.
+ */
+export const BULK_SELECT_ALL_PAGE_SIZE: number = 1000;
+
 export interface SaveFilterProps {
   tableId: string;
 }
@@ -339,6 +354,28 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [bulkSelectedItems, setBulkSelectedItems] = useState<Array<TBaseModel>>(
     [],
   );
+
+  /*
+   * "Select All" gets its own loading / error state instead of sharing
+   * `isLoading` and `error` with fetchItems. They ran concurrently before, so
+   * a page refresh landing mid-selection flipped the spinner off and cleared
+   * the other's error - which is how a failed select-all could leave the user
+   * with only the current page selected and nothing on screen to say so.
+   */
+  const [isBulkSelectAllLoading, setIsBulkSelectAllLoading] =
+    useState<boolean>(false);
+  const [bulkSelectionError, setBulkSelectionError] = useState<string>("");
+  const [bulkSelectionTotalCount, setBulkSelectionTotalCount] =
+    useState<number>(0);
+  const [isBulkSelectionTruncated, setIsBulkSelectionTruncated] =
+    useState<boolean>(false);
+
+  /*
+   * The paged select-all spans several round trips, so the user can clear the
+   * selection or start another one while it is still running. Every run takes
+   * a token and drops its results if a newer one has since started.
+   */
+  const bulkSelectAllToken: MutableRefObject<number> = React.useRef<number>(0);
 
   let showAs: ShowAs | undefined = props.showAs;
 
@@ -1304,35 +1341,205 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
       return fragment;
     };
 
-  const fetchAllBulkItems: PromiseVoidFunction = async (): Promise<void> => {
-    setError("");
-    setIsLoading(true);
+  type FetchAllBulkItemsFunction = () => Promise<boolean>;
 
-    try {
-      const listResult: ListResult<TBaseModel> = await props.callbacks.getList({
-        modelType: props.modelType as
-          | DatabaseBaseModelType
-          | AnalyticsBaseModelType,
-        query: {
-          ...props.query,
-          ...query,
-          ...buildSearchQueryFragment(),
-        },
-        limit: LIMIT_PER_PROJECT,
-        skip: 0,
-        select: {
-          _id: true,
-        },
-        sort: {},
-        requestOptions: props.fetchRequestOptions,
-      });
+  /*
+   * Selects every row matching the table's current query, filters and search -
+   * not just the rows on screen - and returns whether it succeeded.
+   *
+   * It fetches the SAME columns as fetchItems. It used to ask for
+   * `select: { _id: true }`, which picked the right rows but stripped every
+   * field off them, so "Export CSV" over a select-all wrote one blank line per
+   * row and any bulk action that reads a field (or renders an item's name) saw
+   * undefined. Routing the projection through getSelect() also keeps
+   * `selectMoreFields` and per-field read permissions in play, which a
+   * hand-rolled column list would silently drop.
+   */
+  const fetchAllBulkItems: FetchAllBulkItemsFunction =
+    async (): Promise<boolean> => {
+      const token: number = ++bulkSelectAllToken.current;
 
-      setBulkSelectedItems(listResult.data);
-    } catch (err) {
-      setError(API.getFriendlyMessage(err));
-    }
+      setBulkSelectionError("");
+      setIsBulkSelectionTruncated(false);
+      setIsBulkSelectAllLoading(true);
 
-    setIsLoading(false);
+      const itemsSelected: Array<TBaseModel> = [];
+
+      try {
+        /*
+         * An unsorted table is served in the API's default order, so the
+         * selection has to ask for that order explicitly - once any sort is
+         * sent, the server stops applying its default. Without this the rows
+         * came back in random UUID order, which both scrambled the exported
+         * CSV and, on a table past the selection ceiling, kept an arbitrary
+         * slice of history instead of the newest rows the user was looking at.
+         */
+        const defaultSortColumn: string =
+          (model as AnalyticsBaseModel).defaultSortColumn || "createdAt";
+
+        const bulkSort: Sort<TBaseModel> = (
+          sortBy
+            ? { [sortBy as string]: sortOrder }
+            : { [defaultSortColumn]: SortOrder.Descending }
+        ) as Sort<TBaseModel>;
+
+        /*
+         * skip/limit paging is only stable over a total order. The field that
+         * identifies a selected row (`_id` unless a table overrides it) is
+         * appended as a tiebreaker so rows sharing a sort value - 1,200 labels
+         * imported in one transaction all share a createdAt - cannot land on
+         * two pages while another row is never returned at all.
+         */
+        if (
+          (bulkSort as Dictionary<unknown>)[
+            matchBulkSelectedItemByField as string
+          ] === undefined
+        ) {
+          (bulkSort as Dictionary<SortOrder>)[
+            matchBulkSelectedItemByField as string
+          ] = SortOrder.Ascending;
+        }
+
+        /*
+         * getSelect() throws on a misconfigured column, so it is built inside
+         * the try: otherwise the button would be left spinning forever with an
+         * unhandled rejection instead of a message.
+         */
+        const bulkSelect: Select<TBaseModel> = {
+          ...getSelect(),
+          ...getRelationSelect(),
+        };
+
+        /*
+         * Every ordered column has to be selected for the database to order by
+         * it. `_id` always is; the default sort column usually is not, and a
+         * table matching its selection on some field other than `_id` would
+         * otherwise tick no row checkboxes at all.
+         */
+        for (const sortColumn of Object.keys(bulkSort)) {
+          if (
+            (bulkSelect as Dictionary<unknown>)[sortColumn] === undefined &&
+            model.hasColumn(sortColumn)
+          ) {
+            (bulkSelect as Dictionary<boolean>)[sortColumn] = true;
+          }
+        }
+
+        let totalCount: number = 0;
+        let hasMore: boolean = false;
+        let rowsFetched: number = 0;
+
+        /*
+         * Offset paging over a table that is still receiving writes can hand
+         * back a row that an earlier page already returned. Selecting it twice
+         * would duplicate it in the export and inflate the selected count.
+         */
+        const seenItemIds: Set<string> = new Set<string>();
+
+        while (itemsSelected.length < LIMIT_PER_PROJECT) {
+          const limit: number = Math.min(
+            BULK_SELECT_ALL_PAGE_SIZE,
+            LIMIT_PER_PROJECT - itemsSelected.length,
+          );
+
+          const listResult: ListResult<TBaseModel> =
+            await props.callbacks.getList({
+              modelType: props.modelType as
+                | DatabaseBaseModelType
+                | AnalyticsBaseModelType,
+              query: {
+                ...props.query,
+                ...query,
+                ...buildSearchQueryFragment(),
+              },
+              groupBy: {
+                ...props.groupBy,
+              },
+              limit: limit,
+              skip: rowsFetched,
+              select: bulkSelect,
+              sort: bulkSort,
+              requestOptions: props.fetchRequestOptions,
+            });
+
+          if (token !== bulkSelectAllToken.current) {
+            // A newer select-all, or a cleared selection, superseded this run.
+            return false;
+          }
+
+          totalCount = listResult.count || totalCount;
+          hasMore = Boolean(listResult.hasMore);
+          rowsFetched += listResult.data.length;
+
+          for (const item of listResult.data) {
+            const itemId: string =
+              item[matchBulkSelectedItemByField]?.toString() || "";
+
+            if (itemId) {
+              if (seenItemIds.has(itemId)) {
+                continue;
+              }
+
+              seenItemIds.add(itemId);
+            }
+
+            itemsSelected.push(item);
+          }
+
+          if (listResult.data.length < limit) {
+            // A short page is the last page.
+            hasMore = false;
+            break;
+          }
+
+          if (listResult.hasMore === false) {
+            break;
+          }
+
+          if (totalCount > 0 && rowsFetched >= totalCount) {
+            /*
+             * Everything matching has been read. Stopping here saves the
+             * empty round trip a result set that is an exact multiple of the
+             * page size would otherwise cost - and each of those requests
+             * runs a full count over the filtered set.
+             */
+            break;
+          }
+        }
+
+        setBulkSelectionTotalCount(Math.max(totalCount, itemsSelected.length));
+        setIsBulkSelectionTruncated(totalCount > rowsFetched || hasMore);
+        setBulkSelectedItems(itemsSelected);
+
+        return true;
+      } catch (err) {
+        if (token === bulkSelectAllToken.current) {
+          /*
+           * Leave the existing selection alone. A half-loaded selection that
+           * claims to be everything is worse than a failed one, and the user
+           * can retry because the Select All button stays on screen.
+           */
+          setBulkSelectionError(API.getFriendlyMessage(err));
+        }
+
+        return false;
+      } finally {
+        if (token === bulkSelectAllToken.current) {
+          setIsBulkSelectAllLoading(false);
+        }
+      }
+    };
+
+  type ClearBulkSelectionStateFunction = () => void;
+
+  const clearBulkSelectionState: ClearBulkSelectionStateFunction = (): void => {
+    // Supersede any select-all still in flight so it cannot repopulate this.
+    bulkSelectAllToken.current++;
+    setIsBulkSelectAllLoading(false);
+    setBulkSelectionError("");
+    setIsBulkSelectionTruncated(false);
+    setBulkSelectionTotalCount(0);
+    setBulkSelectedItems([]);
   };
 
   const fetchItems: PromiseVoidFunction = async (): Promise<void> => {
@@ -2236,15 +2443,18 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           };
         })()}
         onBulkActionEnd={async () => {
-          setBulkSelectedItems([]);
+          clearBulkSelectionState();
           await fetchItems();
         }}
         onBulkActionStart={() => {}}
         bulkSelectedItems={bulkSelectedItems}
         onBulkSelectedItemAdded={(item: TBaseModel) => {
+          // The user has moved on from the failed select-all.
+          setBulkSelectionError("");
           setBulkSelectedItems([...bulkSelectedItems, item]);
         }}
         onBulkSelectedItemRemoved={(item: TBaseModel) => {
+          setBulkSelectionError("");
           setBulkSelectedItems(
             bulkSelectedItems.filter((i: TBaseModel) => {
               return (
@@ -2278,11 +2488,15 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           setBulkSelectedItems(uniqueItems);
         }}
         onBulkClearAllItems={() => {
-          setBulkSelectedItems([]);
+          clearBulkSelectionState();
         }}
-        onBulkSelectAllItems={async () => {
-          await fetchAllBulkItems();
+        onBulkSelectAllItems={async (): Promise<boolean> => {
+          return await fetchAllBulkItems();
         }}
+        bulkSelectionError={bulkSelectionError}
+        isBulkSelectAllLoading={isBulkSelectAllLoading}
+        isBulkSelectionTruncated={isBulkSelectionTruncated}
+        bulkSelectionTotalCount={bulkSelectionTotalCount}
         matchBulkSelectedItemByField={matchBulkSelectedItemByField || "_id"}
         bulkItemToString={(item: TBaseModel) => {
           const label: string = props.singularName || item.singularName || "";

--- a/Common/UI/Components/Table/Table.tsx
+++ b/Common/UI/Components/Table/Table.tsx
@@ -78,9 +78,19 @@ export interface ComponentProps<T extends GenericObject> {
   bulkSelectedItems?: Array<T> | undefined;
   onBulkSelectedItemAdded?: ((item: T) => void) | undefined;
   onBulkSelectedItemRemoved?: ((item: T) => void) | undefined;
-  onBulkSelectAllItems?: (() => void) | undefined;
+  /*
+   * Resolves to whether every matching row really got selected. The table
+   * only claims "all items selected" when it did - otherwise a failed
+   * select-all would hide the Select All button while leaving just the
+   * current page selected, with no way to retry.
+   */
+  onBulkSelectAllItems?: (() => Promise<boolean>) | undefined;
   onBulkSelectItemsOnCurrentPage?: (() => void) | undefined;
   onBulkClearAllItems?: (() => void) | undefined;
+  bulkSelectionError?: string | undefined;
+  isBulkSelectAllLoading?: boolean | undefined;
+  isBulkSelectionTruncated?: boolean | undefined;
+  bulkSelectionTotalCount?: number | undefined;
   matchBulkSelectedItemByField?: keyof T | undefined; // which field to use to match selected items. For exmaple this could be '_id'
   onBulkActionEnd?: (() => void) | undefined;
   onBulkActionStart?: (() => void) | undefined;
@@ -238,16 +248,20 @@ const Table: TableFunction = <T extends GenericObject>(
           if (props.matchBulkSelectedItemByField === undefined) {
             return;
           }
-          const index: number = bulkSelectedItems.findIndex((x: T) => {
-            return (
-              x[props.matchBulkSelectedItemByField!]?.toString() ===
-              item[props.matchBulkSelectedItemByField!]?.toString()
-            );
-          });
 
-          if (index > -1) {
-            bulkSelectedItems.splice(index, 1);
-          }
+          /*
+           * Rebuild rather than splice: this array is the parent's state
+           * array by reference (see the sync effect above), so mutating it
+           * in place edits React state behind React's back.
+           */
+          setBulkSelectedItems(
+            bulkSelectedItems.filter((x: T) => {
+              return (
+                x[props.matchBulkSelectedItemByField!]?.toString() !==
+                item[props.matchBulkSelectedItemByField!]?.toString()
+              );
+            }),
+          );
 
           props.onBulkSelectedItemRemoved?.(item);
         }}
@@ -301,14 +315,27 @@ const Table: TableFunction = <T extends GenericObject>(
             props.onBulkClearAllItems?.();
             setIsAllItemsSelected(false);
           }}
-          onSelectAllClick={() => {
-            props.onBulkSelectAllItems?.();
-            setIsAllItemsSelected(true);
+          onSelectAllClick={async () => {
+            const didSelectAllItems: boolean =
+              (await props.onBulkSelectAllItems?.()) ?? false;
+
+            /*
+             * Only on success. Otherwise the bulk bar would hide the Select
+             * All button and claim everything was selected while the
+             * selection is still just the current page.
+             */
+            if (didSelectAllItems) {
+              setIsAllItemsSelected(true);
+            }
           }}
           selectedItems={bulkSelectedItems}
           singularLabel={translatedSingularLabel}
           pluralLabel={translatedPluralLabel}
           isAllItemsSelected={isAllItemsSelected}
+          errorMessage={props.bulkSelectionError}
+          isSelectingAllItems={props.isBulkSelectAllLoading}
+          isSelectionTruncated={props.isBulkSelectionTruncated}
+          totalMatchingItemsCount={props.bulkSelectionTotalCount}
           onActionStart={props.onBulkActionStart}
           onActionEnd={() => {
             setIsAllItemsSelected(false);


### PR DESCRIPTION
## The bug

Selecting **Select All** in a table's bulk bar and then **Bulk Actions → Export CSV** downloaded a file with a header row and one blank line per record. Selecting ~50 rows by hand and exporting worked fine. Reported on Labels, Alerts and Incidents; it actually affected every table in the app.

## Root cause

`BaseModelTable.fetchAllBulkItems` asked the API for `select: { _id: true }`.

That picked the right **rows** — the bar honestly read "1262 Labels Selected", and the server returned all 1262 — but stripped every **column** off them. `TableColumnsToCsv` reads each column off the item, found `undefined` everywhere, and wrote empty cells. A manual selection works because those objects come from the table's own page fetch, which is fully populated: `fetchAllBulkItems` was the only place that built a selection from anything other than `data`.

So the reported "only the records on the current page are being selected" is not what was happening — the selection was complete, only its fields were missing. There is a *separate* defect that produces exactly that symptom, fixed here too (see below).

## The fix

**`BaseModelTable.fetchAllBulkItems`**
- Fetches the same projection as the page fetch (`getSelect()` + `getRelationSelect()`), which also keeps `selectMoreFields` and per-field read permissions in play — a hand-rolled column list would silently drop both.
- Pages the request at 1,000 rows instead of asking for up to 10,000 wide, relation-joined rows in a single query the statement timeout would kill. Each list request also runs an unbounded count and pays a growing offset, so the page size is a deliberate trade-off; 1,000 caps a maxed-out selection at ten round trips.
- Sends a deterministic total order — the API's default ordering (or the active column sort) with the match field appended as a tiebreaker. Offset paging without it lets rows sharing a `createdAt` (1,200 labels imported in one transaction) land on two pages while others are never returned. It also keeps the export in the order the table shows, and keeps a capped selection to the *newest* rows rather than an arbitrary slice.
- De-duplicates rows that a concurrent insert can serve on two pages.
- Stops as soon as the result set is exhausted, rather than spending an extra round trip on a count that is an exact multiple of the page size.
- Uses its own loading/error state instead of sharing `isLoading`/`error` with `fetchItems`, which used to flip each other's flags mid-flight.
- Guards against superseded runs with a token, so clearing the selection or starting again cannot be undone by an in-flight fetch.

**`Table`**
- Awaits `onBulkSelectAllItems` and only claims "all items selected" when it succeeded. Previously the call was fire-and-forget and the flag was set unconditionally, so a failed select-all left just the current page selected *and hid the button to retry* — this is the second defect, and it is the one that reads as "even though I selected Select All, only the records on the current page are being selected".
- Stops mutating the parent's state array in place with `splice` on row deselect.

**`BulkUpdateForm`**
- Shows the select-all failure in the bulk bar (with `role="alert"`), where the user clicked, rather than in a table-body error the next refresh wipes.
- Disables Select All and shows a spinner while the paged fetch runs, so it cannot be re-entered.
- The truncation warning is driven by what the fetch reported and names real numbers ("Selected 10,000 of 24,318 matching Alerts"). It used to be inferred from `selectedItems.length === LIMIT_PER_PROJECT`, so it cried wolf on a project holding exactly the ceiling and stayed silent one row short of it.

There is one implementation of `onBulkSelectAllItems` and one of `fetchAllBulkItems`, so this covers all ~305 `ModelTable` / `AnalyticsModelTable` instances at once. Every existing bulk action (delete, archive, add/remove label, add/remove owner, change state, Export JSON) keeps working and now receives populated models — which also fixes the failure list showing raw UUIDs instead of names.

## Tests

- **`Common/Tests/UI/Components/ModelTable/BaseModelTableBulkSelectAll.test.tsx`** (new, 20 cases) — an end-to-end harness whose stub API honours the requested `select`, which is what lets a test see this bug at all. Covers: the select payload matches the page fetch; ordered columns are selected; the exported CSV of a select-all carries real values; every matching row is selected; paging offsets; short-page and exact-multiple stopping; `hasMore` endpoints; cross-page dedupe; default and active sort with tiebreaker; query/filter propagation; `selectMoreFields`; the ceiling and its warning; failure leaving the previous selection intact and retryable; the error clearing on retry; loading state and re-entrancy; and cancellation beating an in-flight run.
- **`Common/Tests/UI/Components/BulkUpdateForm.test.tsx`** (new, 9 cases) — Select All visibility, the loading block, the error surface, and both sides of the truncation warning.
- **`Common/Tests/UI/Components/TableBulkCsvExport.test.tsx`** — now asserts the CSV *text* rather than only that a Blob was produced, plus a characterisation test pinning that id-only rows export as blank cells, documenting that `TableColumnsToCsv` was never at fault.

Every new guard was mutation-checked: reverting the `_id`-only select, the token guard, the dedupe, the early break, or the success-only `isAllItemsSelected` each fails exactly the intended test.

## Verification

- `Common` and `App` both `tsc --noEmit` clean.
- Full `Common` UI suite: 63 suites, 1238 tests, all passing.
- `eslint --fix` clean on every touched file.

## Follow-ups (deliberately not bundled)

- Columns that render via `getElement` over a placeholder `field: { _id: true }` (the "Owners" column on Alerts/Incidents, and the same pattern on Monitors, Scheduled Maintenance, Hosts, On-Call Policies) export raw UUIDs under a misleading header. Pre-existing, affects manual selections too.
- Multi-relation columns export only their first relation, because the CSV keys off `column.key`.
- `isAllItemsSelected` is never reset when the filter, page or query changes, so a selection can outlive the filter that produced it.
- The new bulk-bar copy is untranslated, as the surrounding `BulkUpdateForm` strings already are.