### PR TITLE
fix(monitor): let users pick probes when creating a monitor, and make probe edits actually save

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
@@ -63,6 +63,11 @@ import MonitoringInterval from "../../Utils/MonitorIntervalDropdownOptions";
 import Card from "Common/UI/Components/Card/Card";
 import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import NetworkDeviceAlertPackUtil from "Common/Types/Monitor/SnmpMonitor/NetworkDeviceAlertPack";
+import Probe from "Common/Models/DatabaseModels/Probe";
+import Project from "Common/Models/DatabaseModels/Project";
+import ProjectUtil from "Common/UI/Utils/Project";
+import ProbeUtil from "../../Utils/Probe";
+import MonitorProbeSelectionUtil from "Common/Utils/Monitor/MonitorProbeSelectionUtil";
 
 /*
  * Candidate rolling windows for "create monitor from this explorer view" —
@@ -174,6 +179,80 @@ const MonitorCreate: FunctionComponent<
   );
   const [error, setError] = useState<string>("");
   const [initialValues, setInitialValues] = useState<JSONObject>({});
+
+  /*
+   * Probe picker state. Probes used to be chosen for you after the monitor was
+   * created (every probe flagged "auto enable on new monitors"), with no way to
+   * say which probe should watch this particular resource. The picker starts
+   * out on exactly that default set, so leaving it alone keeps the old
+   * behaviour and changing it is now possible.
+   */
+  const [probeOptions, setProbeOptions] = useState<Array<DropdownOption>>([]);
+  const [defaultProbeIds, setDefaultProbeIds] = useState<Array<string> | null>(
+    null,
+  );
+  const [isLoadingProbes, setIsLoadingProbes] = useState<boolean>(true);
+
+  const loadProbes: () => Promise<void> = async (): Promise<void> => {
+    try {
+      const [probes, project]: [Array<Probe>, Project | null] =
+        await Promise.all([
+          ProbeUtil.getAllProbes(),
+          ModelAPI.getItem<Project>({
+            modelType: Project,
+            id: ProjectUtil.getCurrentProjectId()!,
+            select: {
+              doNotAddGlobalProbesByDefaultOnNewMonitors: true,
+            },
+          }),
+        ]);
+
+      setProbeOptions(
+        probes
+          .filter((probe: Probe) => {
+            return Boolean(probe._id);
+          })
+          .map((probe: Probe) => {
+            return {
+              label: probe.name?.toString() || "Probe",
+              value: probe._id!.toString(),
+            };
+          }),
+      );
+
+      setDefaultProbeIds(
+        MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+          probes: probes.map((probe: Probe) => {
+            return {
+              id: probe._id?.toString() || "",
+              isGlobalProbe: Boolean(probe.isGlobalProbe),
+              shouldAutoEnableProbeOnNewMonitors: Boolean(
+                probe.shouldAutoEnableProbeOnNewMonitors,
+              ),
+            };
+          }),
+          doNotAddGlobalProbesByDefaultOnNewMonitors:
+            project?.doNotAddGlobalProbesByDefaultOnNewMonitors,
+        }),
+      );
+    } catch {
+      /*
+       * Non-fatal. With no probe list the picker is hidden and no "probes"
+       * value is submitted, so the server keeps assigning the defaults exactly
+       * as it did before - creating a monitor must not be blocked by this.
+       */
+      setProbeOptions([]);
+      setDefaultProbeIds(null);
+    }
+
+    setIsLoadingProbes(false);
+  };
+
+  useEffect(() => {
+    loadProbes().catch(() => {
+      setIsLoadingProbes(false);
+    });
+  }, []);
 
   /*
    * "Create monitor from this view" deep link from the metric explorer:
@@ -521,14 +600,22 @@ const MonitorCreate: FunctionComponent<
         className="mb-10"
       >
         <div>
-          {isLoading && <PageLoader isVisible={true} />}
+          {(isLoading || isLoadingProbes) && <PageLoader isVisible={true} />}
           {error && <ErrorMessage message={error} />}
-          {!isLoading && !error && (
+          {!isLoading && !isLoadingProbes && !error && (
             <ModelForm<Monitor>
               modelType={Monitor}
               name="Create New Monitor"
               id="create-monitor-form"
-              initialValues={initialValues}
+              initialValues={
+                /*
+                 * The form reads initialValues once, on mount - which is why
+                 * the render above waits for the probe list.
+                 */
+                defaultProbeIds
+                  ? { ...initialValues, probes: defaultProbeIds }
+                  : initialValues
+              }
               fields={[
                 {
                   field: {
@@ -597,6 +684,33 @@ const MonitorCreate: FunctionComponent<
                   },
                 },
                 {
+                  /*
+                   * Not a Monitor column - the selection is carried to the
+                   * server in miscDataProps and turned into MonitorProbe rows
+                   * by MonitorService.onCreateSuccess. overrideField keeps it
+                   * out of the Monitor payload; showEvenIfPermissionDoesNotExist
+                   * is required because Monitor has no "probes" column to
+                   * derive field permissions from.
+                   */
+                  overrideField: {
+                    probes: true,
+                  },
+                  overrideFieldKey: "probes",
+                  showEvenIfPermissionDoesNotExist: true,
+                  stepId: "monitoring-interval",
+                  title: "Probes",
+                  description:
+                    "Which probes should monitor this resource? Leave this empty to use every probe that is set to monitor new monitors by default.",
+                  fieldType: FormFieldSchemaType.MultiSelectDropdown,
+                  required: false,
+                  placeholder: "Select Probes",
+                  dropdownOptions: probeOptions,
+                  showIf: () => {
+                    // Nothing to choose from - keep the step uncluttered.
+                    return probeOptions.length > 0;
+                  },
+                },
+                {
                   field: {
                     monitoringInterval: true,
                   },
@@ -645,7 +759,13 @@ const MonitorCreate: FunctionComponent<
                   },
                 },
                 {
-                  title: "Interval",
+                  /*
+                   * Probes live on this step rather than a step of their own:
+                   * doesMonitorTypeHaveInterval is isProbableMonitor, so this
+                   * step already appears for exactly the monitor types that
+                   * are watched by probes.
+                   */
+                  title: "Probes & Interval",
                   id: "monitoring-interval",
                   showIf: (values: FormValues<Monitor>) => {
                     return MonitorTypeHelper.doesMonitorTypeHaveInterval(

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorProbeView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorProbeView.tsx
@@ -53,22 +53,18 @@ const ProbeView: FunctionComponent<PageComponentProps> = (
           description: "Here are more details for this probe.",
         }}
         isEditable={true}
-        formSteps={[
-          {
-            title: "Basic Info",
-            id: "basic-info",
-          },
-          {
-            title: "More",
-            id: "more",
-          },
-        ]}
+        /*
+         * Deliberately NOT a multi-step form. With steps, the modal's primary
+         * button reads "Next" until the last step, so someone editing the name
+         * or the auto-enable toggle sees only "Cancel" and "Next" and closes
+         * the modal thinking there is nothing to save - and the edit is lost.
+         * Five fields fit on one page with a real "Save Changes" button.
+         */
         formFields={[
           {
             field: {
               name: true,
             },
-            stepId: "basic-info",
             title: "Name",
             fieldType: FormFieldSchemaType.Text,
             required: true,
@@ -83,7 +79,6 @@ const ProbeView: FunctionComponent<PageComponentProps> = (
               description: true,
             },
             title: "Description",
-            stepId: "basic-info",
             fieldType: FormFieldSchemaType.LongText,
             required: false,
             placeholder: "This probe is to monitor all the internal services.",
@@ -94,7 +89,6 @@ const ProbeView: FunctionComponent<PageComponentProps> = (
               iconFile: true,
             },
             title: "Probe Logo",
-            stepId: "basic-info",
             fieldType: FormFieldSchemaType.ImageFile,
             required: false,
             placeholder: "Upload logo",
@@ -103,8 +97,9 @@ const ProbeView: FunctionComponent<PageComponentProps> = (
             field: {
               shouldAutoEnableProbeOnNewMonitors: true,
             },
-            stepId: "more",
             title: "Enable monitoring automatically on new monitors",
+            description:
+              "When on, this probe is pre-selected for every new monitor you create.",
             fieldType: FormFieldSchemaType.Toggle,
             required: false,
           },
@@ -114,7 +109,6 @@ const ProbeView: FunctionComponent<PageComponentProps> = (
             },
 
             title: "Labels ",
-            stepId: "more",
             description:
               "Team members with access to these labels will only be able to access this resource. This is optional and an advanced feature.",
             fieldType: FormFieldSchemaType.MultiSelectDropdown,
@@ -161,6 +155,19 @@ const ProbeView: FunctionComponent<PageComponentProps> = (
               },
               title: "Probe Key",
               fieldType: FieldType.HiddenText,
+            },
+            {
+              /*
+               * The edit form sets this, so the card has to show it -
+               * otherwise saving the toggle looks like it did nothing.
+               */
+              field: {
+                shouldAutoEnableProbeOnNewMonitors: true,
+              },
+              title: "Enable Monitoring on New Monitors",
+              description:
+                "When on, this probe is pre-selected for every new monitor you create.",
+              fieldType: FieldType.Boolean,
             },
             {
               field: {

--- a/App/FeatureSet/Dashboard/src/Utils/Probe.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Probe.ts
@@ -7,6 +7,11 @@ import Probe from "Common/Models/DatabaseModels/Probe";
 import ProjectUtil from "Common/UI/Utils/Project";
 
 export default class ProbeUtil {
+  /*
+   * Every probe this project can monitor with: its own custom probes plus the
+   * global ones (which are not project rows, so they come from their own
+   * endpoint).
+   */
   public static async getAllProbes(): Promise<Array<Probe>> {
     const projectProbeList: ListResult<Probe> = await ModelAPI.getList({
       modelType: Probe,
@@ -18,9 +23,14 @@ export default class ProbeUtil {
       select: {
         name: true,
         _id: true,
+        shouldAutoEnableProbeOnNewMonitors: true,
       },
       sort: {},
     });
+
+    for (const probe of projectProbeList.data) {
+      probe.isGlobalProbe = false;
+    }
 
     const globalProbeList: ListResult<Probe> = await ModelAPI.getList({
       modelType: Probe,
@@ -30,6 +40,7 @@ export default class ProbeUtil {
       select: {
         name: true,
         _id: true,
+        shouldAutoEnableProbeOnNewMonitors: true,
       },
       sort: {},
       requestOptions: {
@@ -38,6 +49,15 @@ export default class ProbeUtil {
         ),
       },
     });
+
+    /*
+     * The global-probes endpoint does not select isGlobalProbe, but every row
+     * it returns is one by definition - and callers need the flag to know
+     * which probes a project's "disable global probes" setting applies to.
+     */
+    for (const probe of globalProbeList.data) {
+      probe.isGlobalProbe = true;
+    }
 
     return [...projectProbeList.data, ...globalProbeList.data];
   }

--- a/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
@@ -179,7 +179,7 @@ export const enqueueDueTelemetryMonitorEvaluationJobs: () => Promise<void> =
       },
     });
 
-    const updatePromises: Array<Promise<void>> = [];
+    const updatePromises: Array<Promise<number>> = [];
 
     for (const telemetryMonitor of telemetryMonitors) {
       let nextPing: Date = OneUptimeDate.addRemoveMinutes(

--- a/App/Tests/Dashboard/MonitorProbeSelectionPages.test.ts
+++ b/App/Tests/Dashboard/MonitorProbeSelectionPages.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Two probe defects, both of which live in a prop or a field list rather than
+ * in extractable logic - and the App suite runs in a plain Node environment
+ * with no renderer, so these read the sources and assert the exact
+ * expressions, the same way NetworkSitePageInvariants.test.ts does.
+ *
+ * 1. Monitor creation had no probe step. Probes were chosen for you afterwards
+ *    (every probe flagged "auto enable on new monitors"), so a project with a
+ *    global probe and a custom probe could not say which one should watch a
+ *    given resource.
+ *
+ * 2. Editing a probe looked like it did nothing. The Probe Details form was a
+ *    two-step wizard, so the modal's primary button read "Next" and a user who
+ *    edited a field on step one never saw a Save button - closing the modal
+ *    threw the edit away. And the card never displayed the auto-enable toggle
+ *    it edits, so even a successful save left the page looking unchanged.
+ *
+ * Sources are whitespace-squashed first so prettier re-wrapping a line cannot
+ * turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+  );
+}
+
+describe("Monitor create page lets the user pick probes", () => {
+  const source: string = readSource("Pages", "Monitor", "Create.tsx");
+
+  test("declares a probes field", () => {
+    expect(source).toContain(squash("overrideField: { probes: true, },"));
+    expect(source).toContain(squash('title: "Probes",'));
+  });
+
+  test("carries the selection through miscDataProps, not as a Monitor column", () => {
+    /*
+     * overrideField (not field) keeps `probes` out of ModelForm's select and
+     * out of the Monitor payload; overrideFieldKey is what puts it into
+     * miscDataProps, where MonitorService.onCreateSuccess reads it.
+     */
+    expect(source).toContain(squash('overrideFieldKey: "probes",'));
+    expect(source).not.toContain(squash("field: { probes: true, },"));
+  });
+
+  test("shows the field even though Monitor has no probes column", () => {
+    // Without this, ModelForm drops the field for lack of column permissions.
+    expect(source).toContain("showEvenIfPermissionDoesNotExist: true");
+  });
+
+  test("puts probes on the step that already gates on probeable monitor types", () => {
+    /*
+     * doesMonitorTypeHaveInterval is isProbableMonitor, so this step appears
+     * for exactly the monitor types a probe can watch. Moving probes to a step
+     * of their own would also need E2E/Tests/Dashboard/Helpers/Monitors.ts to
+     * grow another submit click.
+     */
+    expect(source).toContain(squash('stepId: "monitoring-interval",'));
+    expect(source).toContain(squash('title: "Probes & Interval",'));
+    expect(source).toContain(
+      squash("MonitorTypeHelper.doesMonitorTypeHaveInterval("),
+    );
+  });
+
+  test("pre-selects the probes the server would have attached anyway", () => {
+    /*
+     * Leaving the picker alone must keep the old behaviour, so the default
+     * selection comes from the same rule the server applies.
+     */
+    expect(source).toContain(
+      "MonitorProbeSelectionUtil.getDefaultSelectedProbeIds(",
+    );
+    expect(source).toContain("doNotAddGlobalProbesByDefaultOnNewMonitors");
+  });
+
+  test("waits for the probe list before mounting the form", () => {
+    // ModelForm reads initialValues once, on mount.
+    expect(source).toContain("isLoadingProbes");
+    expect(source).toContain(
+      squash("{!isLoading && !isLoadingProbes && !error && ("),
+    );
+  });
+
+  test("still creates the monitor when the probe list cannot be loaded", () => {
+    /*
+     * On failure defaultProbeIds stays null, so no "probes" value is submitted
+     * and the server keeps assigning the defaults exactly as before.
+     */
+    expect(source).toContain(
+      squash(
+        "defaultProbeIds ? { ...initialValues, probes: defaultProbeIds } : initialValues",
+      ),
+    );
+  });
+});
+
+describe("Probe list carries the flag the create form pre-selects on", () => {
+  const source: string = readSource("Utils", "Probe.ts");
+
+  test("selects shouldAutoEnableProbeOnNewMonitors for both probe sources", () => {
+    const matches: number = (
+      source.match(/shouldAutoEnableProbeOnNewMonitors: true/g) || []
+    ).length;
+
+    expect(matches).toBe(2);
+  });
+
+  test("marks which probes are global, since the endpoint does not return it", () => {
+    expect(source).toContain("probe.isGlobalProbe = true;");
+    expect(source).toContain("probe.isGlobalProbe = false;");
+  });
+});
+
+describe("Probe view page makes an edit saveable and visible", () => {
+  const source: string = readSource(
+    "Pages",
+    "Monitor",
+    "Settings",
+    "MonitorProbeView.tsx",
+  );
+
+  test("the Probe Details form is not a wizard, so Save is always on screen", () => {
+    /*
+     * ModelFormModal labels its primary button "Next" on every step but the
+     * last. With steps, someone editing the name or the auto-enable toggle saw
+     * only "Cancel" and "Next" and lost the edit by closing the modal.
+     */
+    expect(source).not.toContain("formSteps=");
+    expect(source).not.toContain(squash('stepId: "basic-info",'));
+    expect(source).not.toContain(squash('stepId: "more",'));
+  });
+
+  test("the card displays the auto-enable toggle the form edits", () => {
+    // Otherwise a successful save is invisible and reads as "not applied".
+    expect(source).toContain(
+      squash(
+        'field: { shouldAutoEnableProbeOnNewMonitors: true, }, title: "Enable Monitoring on New Monitors",',
+      ),
+    );
+  });
+
+  test("the form still edits the toggle", () => {
+    expect(source).toContain(
+      squash(
+        'field: { shouldAutoEnableProbeOnNewMonitors: true, }, title: "Enable monitoring automatically on new monitors",',
+      ),
+    );
+  });
+});

--- a/App/Tests/Workers/Jobs/MarketingConversions/UploadMarketingConversions.test.ts
+++ b/App/Tests/Workers/Jobs/MarketingConversions/UploadMarketingConversions.test.ts
@@ -230,12 +230,13 @@ const mockStatePersistence: () => {
     );
   const updateSpy: SpyInstance<any> = jest
     .spyOn(MarketingConversionService, "updateOneById")
-    .mockImplementation(async (args: any): Promise<void> => {
+    .mockImplementation(async (args: any): Promise<number> => {
       const existing: MarketingConversion =
         conversions.get(args.id.toString()) || new MarketingConversion();
       existing.id = args.id;
       existing.uploadState = args.data.uploadState;
       conversions.set(args.id.toString(), existing);
+      return 1;
     });
 
   return { findOneSpy, updateSpy };

--- a/Common/Models/DatabaseModels/Probe.ts
+++ b/Common/Models/DatabaseModels/Probe.ts
@@ -285,7 +285,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.CreateProjectStatusPage,
+      Permission.CreateProjectProbe,
     ],
     read: [
       Permission.ProjectOwner,
@@ -295,7 +295,7 @@ export default class Probe extends BaseModel {
       Permission.SettingsAdmin,
       Permission.SettingsMember,
       Permission.SettingsViewer,
-      Permission.ReadProjectStatusPage,
+      Permission.ReadProjectProbe,
     ],
     update: [
       Permission.ProjectOwner,
@@ -303,7 +303,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.EditProjectStatusPage,
+      Permission.EditProjectProbe,
     ],
   })
   @TableColumn({
@@ -334,7 +334,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.CreateProjectStatusPage,
+      Permission.CreateProjectProbe,
     ],
     read: [
       Permission.ProjectOwner,
@@ -344,7 +344,7 @@ export default class Probe extends BaseModel {
       Permission.SettingsAdmin,
       Permission.SettingsMember,
       Permission.SettingsViewer,
-      Permission.ReadProjectStatusPage,
+      Permission.ReadProjectProbe,
     ],
     update: [
       Permission.ProjectOwner,
@@ -352,7 +352,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.EditProjectStatusPage,
+      Permission.EditProjectProbe,
     ],
   })
   @TableColumn({
@@ -546,7 +546,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.CreateProjectStatusPage,
+      Permission.CreateProjectProbe,
     ],
     read: [
       Permission.ProjectOwner,
@@ -556,7 +556,7 @@ export default class Probe extends BaseModel {
       Permission.SettingsAdmin,
       Permission.SettingsMember,
       Permission.SettingsViewer,
-      Permission.ReadProjectStatusPage,
+      Permission.ReadProjectProbe,
     ],
     update: [
       Permission.ProjectOwner,
@@ -564,7 +564,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.EditProjectStatusPage,
+      Permission.EditProjectProbe,
     ],
   })
   @TableColumn({
@@ -592,7 +592,7 @@ export default class Probe extends BaseModel {
       Permission.SettingsAdmin,
       Permission.SettingsMember,
       Permission.SettingsViewer,
-      Permission.ReadProjectStatusPage,
+      Permission.ReadProjectProbe,
     ],
     update: [],
   })
@@ -618,7 +618,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.CreateProjectStatusPage,
+      Permission.CreateProjectProbe,
     ],
     read: [
       Permission.ProjectOwner,
@@ -628,7 +628,7 @@ export default class Probe extends BaseModel {
       Permission.SettingsAdmin,
       Permission.SettingsMember,
       Permission.SettingsViewer,
-      Permission.ReadProjectStatusPage,
+      Permission.ReadProjectProbe,
     ],
     update: [
       Permission.ProjectOwner,
@@ -636,7 +636,7 @@ export default class Probe extends BaseModel {
       Permission.ProjectMember,
       Permission.SettingsAdmin,
       Permission.SettingsMember,
-      Permission.EditProjectStatusPage,
+      Permission.EditProjectProbe,
     ],
   })
   @TableColumn({

--- a/Common/Server/API/BaseAPI.ts
+++ b/Common/Server/API/BaseAPI.ts
@@ -23,6 +23,7 @@ import {
 } from "../../Types/Database/LimitMax";
 import PartialEntity from "../../Types/Database/PartialEntity";
 import BadRequestException from "../../Types/Exception/BadRequestException";
+import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import { JSONObject } from "../../Types/JSON";
 import JSONFunctions from "../../Types/JSONFunctions";
 import ObjectID from "../../Types/ObjectID";
@@ -406,11 +407,26 @@ export default class BaseAPI<
     delete (item as any)["createdAt"];
     delete (item as any)["updatedAt"];
 
-    await this.service.updateOneById({
+    const numberOfDocsAffected: number = await this.service.updateOneById({
       id: new ObjectID(objectIdString),
       data: item,
       props: await CommonAPI.getDatabaseCommonInteractionProps(req),
     });
+
+    /*
+     * The permission layer narrows the update query after we build it (tenant
+     * scope, access-control labels, owned scope), so it is possible to match
+     * no rows at all. Reporting 200 for that told the client the edit was
+     * saved when nothing was written - the change then "disappeared" on the
+     * next page load with no error anywhere.
+     */
+    if (numberOfDocsAffected === 0) {
+      throw new NotAuthorizedException(
+        `Unable to update this ${(
+          new this.entityType().singularName || "item"
+        ).toLowerCase()}. It either does not exist, has been deleted, or you do not have permission to update it.`,
+      );
+    }
 
     return Response.sendEmptySuccessResponse(req, res);
   }

--- a/Common/Server/API/ProbeAPI.ts
+++ b/Common/Server/API/ProbeAPI.ts
@@ -32,6 +32,8 @@ export default class ProbeAPI extends BaseAPI<Probe, ProbeServiceType> {
               lastAlive: true,
               iconFileId: true,
               connectionStatus: true,
+              // The monitor create form pre-selects the auto-enabled probes.
+              shouldAutoEnableProbeOnNewMonitors: true,
             },
             props: {
               isRoot: true,

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -2015,10 +2015,17 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     return await this._updateBy(updateBy);
   }
 
+  /*
+   * Returns how many rows the update actually matched. Callers that need to
+   * tell "saved" apart from "matched nothing" must check it: the permission
+   * layer narrows the query after the caller builds it (tenant scope, access
+   * control labels, owned scope), so an update can legitimately reach here
+   * and write nothing at all.
+   */
   @CaptureSpan()
   public async updateOneById(
     updateById: UpdateByID<TBaseModel>,
-  ): Promise<void> {
+  ): Promise<number> {
     if (!updateById.id) {
       throw new BadDataException("updateById.id is required");
     }
@@ -2048,7 +2055,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       props: updateById.props,
     });
 
-    await this.updateOneBy({
+    return await this.updateOneBy({
       query: {
         _id: updateById.id.toString() as any,
       },

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -30,7 +30,7 @@ import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
-import { JSONObject } from "../../Types/JSON";
+import { JSONObject, JSONValue } from "../../Types/JSON";
 import MonitorType, {
   MonitorTypeHelper,
 } from "../../Types/Monitor/MonitorType";
@@ -705,6 +705,34 @@ ${createdItem.description?.trim() || "No description provided."}
       feedInfoInMarkdown += `\n\n`;
     }
 
+    /*
+     * Probes are attached inline rather than on the detached chain below: the
+     * create form redirects straight to the monitor, and a monitor that shows
+     * no probes for a second or two reads as "the probe was never assigned".
+     * Failures are logged, never thrown - a probe problem must not fail the
+     * monitor create.
+     */
+    if (
+      createdItem.monitorType &&
+      MonitorTypeHelper.isProbableMonitor(createdItem.monitorType)
+    ) {
+      try {
+        await this.addProbesToMonitor({
+          projectId: createdItem.projectId,
+          monitorId: createdItem.id,
+          selectedProbeIds: this.getSelectedProbeIdsFromMiscDataProps(
+            onCreate.createBy.miscDataProps,
+          ),
+        });
+      } catch (error) {
+        logger.error("Add probes failed in MonitorService.onCreateSuccess", {
+          projectId: createdItem.projectId?.toString(),
+          monitorId: createdItem.id?.toString(),
+        } as LogAttributes);
+        logger.error(error as Error);
+      }
+    }
+
     // Execute operations sequentially with error handling (workspace first)
     Promise.resolve()
       .then(async () => {
@@ -742,30 +770,6 @@ ${createdItem.description?.trim() || "No description provided."}
         } catch (error) {
           logger.error(
             "Change monitor status failed in MonitorService.onCreateSuccess",
-            {
-              projectId: createdItem.projectId?.toString(),
-              monitorId: createdItem.id?.toString(),
-            } as LogAttributes,
-          );
-          logger.error(error as Error);
-          return Promise.resolve();
-        }
-      })
-      .then(async () => {
-        try {
-          if (
-            createdItem.monitorType &&
-            MonitorTypeHelper.isProbableMonitor(createdItem.monitorType)
-          ) {
-            return await this.addDefaultProbesToMonitor(
-              createdItem.projectId!,
-              createdItem.id!,
-            );
-          }
-          return Promise.resolve();
-        } catch (error) {
-          logger.error(
-            "Add default probes failed in MonitorService.onCreateSuccess",
             {
               projectId: createdItem.projectId?.toString(),
               monitorId: createdItem.id?.toString(),
@@ -1069,6 +1073,134 @@ ${createdItem.description?.trim() || "No description provided."}
     }
   }
 
+  /*
+   * The monitor create form sends the probes the user picked through
+   * miscDataProps (the same side channel the owner fields use). They arrive as
+   * plain strings because miscDataProps is not run through the model
+   * serializer, so normalise before anything else touches them.
+   */
+  public getSelectedProbeIdsFromMiscDataProps(
+    miscDataProps: JSONObject | undefined,
+  ): Array<ObjectID> | undefined {
+    const rawProbeIds: JSONValue | undefined = miscDataProps?.["probes"];
+
+    if (!Array.isArray(rawProbeIds)) {
+      // Nothing was sent (API clients, templates) - fall back to the defaults.
+      return undefined;
+    }
+
+    const probeIds: Array<ObjectID> = [];
+    const seen: Set<string> = new Set<string>();
+
+    for (const rawProbeId of rawProbeIds) {
+      if (!rawProbeId) {
+        continue;
+      }
+
+      const probeId: string =
+        rawProbeId instanceof ObjectID
+          ? rawProbeId.toString()
+          : String(rawProbeId);
+
+      if (!probeId || seen.has(probeId)) {
+        continue;
+      }
+
+      seen.add(probeId);
+      probeIds.push(new ObjectID(probeId));
+    }
+
+    return probeIds;
+  }
+
+  /*
+   * Attaches the probes the user explicitly selected at create time, or the
+   * project's auto-enable defaults when no selection was made. An explicit but
+   * empty selection means "no probes" and is honoured as such.
+   */
+  @CaptureSpan()
+  public async addProbesToMonitor(data: {
+    projectId: ObjectID | undefined;
+    monitorId: ObjectID | undefined | null;
+    selectedProbeIds: Array<ObjectID> | undefined;
+  }): Promise<void> {
+    if (!data.projectId) {
+      throw new BadDataException("projectId is required");
+    }
+
+    if (!data.monitorId) {
+      throw new BadDataException("monitorId is required");
+    }
+
+    if (data.selectedProbeIds === undefined) {
+      return await this.addDefaultProbesToMonitor(
+        data.projectId,
+        data.monitorId,
+      );
+    }
+
+    return await this.addSelectedProbesToMonitor(
+      data.projectId,
+      data.monitorId,
+      data.selectedProbeIds,
+    );
+  }
+
+  /*
+   * Only global probes and probes belonging to this project may be attached -
+   * the id list comes from the browser, so it cannot be trusted to stay inside
+   * the tenant.
+   */
+  @CaptureSpan()
+  public async addSelectedProbesToMonitor(
+    projectId: ObjectID,
+    monitorId: ObjectID,
+    probeIds: Array<ObjectID>,
+  ): Promise<void> {
+    if (probeIds.length === 0) {
+      return;
+    }
+
+    const [globalProbes, projectProbes]: [Array<Probe>, Array<Probe>] =
+      await Promise.all([
+        ProbeService.findBy({
+          query: {
+            _id: QueryHelper.any(probeIds),
+            isGlobalProbe: true,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        }),
+        ProbeService.findBy({
+          query: {
+            _id: QueryHelper.any(probeIds),
+            isGlobalProbe: false,
+            projectId: projectId,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        }),
+      ]);
+
+    await this.createMonitorProbes({
+      projectId: projectId,
+      monitorId: monitorId,
+      probes: [...globalProbes, ...projectProbes],
+    });
+  }
+
   @CaptureSpan()
   public async addDefaultProbesToMonitor(
     projectId: ObjectID,
@@ -1124,20 +1256,31 @@ ${createdItem.description?.trim() || "No description provided."}
       },
     });
 
-    const totalProbes: Array<Probe> = [...globalProbes, ...projectProbes];
+    await this.createMonitorProbes({
+      projectId: projectId,
+      monitorId: monitorId,
+      probes: [...globalProbes, ...projectProbes],
+    });
+  }
 
-    if (totalProbes.length === 0) {
+  @CaptureSpan()
+  public async createMonitorProbes(data: {
+    projectId: ObjectID;
+    monitorId: ObjectID;
+    probes: Array<Probe>;
+  }): Promise<void> {
+    if (data.probes.length === 0) {
       return;
     }
 
     // Create all monitor probes in parallel for better performance
     const createPromises: Array<Promise<MonitorProbe>> = [];
 
-    for (const probe of totalProbes) {
+    for (const probe of data.probes) {
       const monitorProbe: MonitorProbe = new MonitorProbe();
-      monitorProbe.monitorId = monitorId;
+      monitorProbe.monitorId = data.monitorId;
       monitorProbe.probeId = probe.id!;
-      monitorProbe.projectId = projectId;
+      monitorProbe.projectId = data.projectId;
       monitorProbe.isEnabled = true;
 
       createPromises.push(

--- a/Common/Tests/Models/DatabaseModels/ProbeColumnAccessControl.test.ts
+++ b/Common/Tests/Models/DatabaseModels/ProbeColumnAccessControl.test.ts
@@ -1,0 +1,103 @@
+import Probe from "../../../Models/DatabaseModels/Probe";
+import { ColumnAccessControl } from "../../../Types/BaseDatabase/AccessControl";
+import Permission from "../../../Types/Permission";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Several Probe columns were gated on status-page permissions
+ * (Create/Read/EditProjectStatusPage) instead of the probe ones. The table
+ * itself is gated on Create/Read/Edit/DeleteProjectProbe, so a team granted
+ * only granular probe permissions could open the probe edit form and change
+ * "Enable monitoring automatically on new monitors" - and ModelForm would drop
+ * the field from both the form and the request, with no error. The toggle
+ * looked unset afterwards, and the probe never got attached to new monitors.
+ *
+ * Any Probe column gated on a status-page permission is a copy-paste bug, so
+ * this asserts the absence outright rather than listing today's offenders.
+ */
+
+const STATUS_PAGE_PERMISSIONS: Array<Permission> = [
+  Permission.CreateProjectStatusPage,
+  Permission.ReadProjectStatusPage,
+  Permission.EditProjectStatusPage,
+  Permission.DeleteProjectStatusPage,
+];
+
+describe("Probe column access control", () => {
+  const accessControl: Record<string, ColumnAccessControl> =
+    new Probe().getColumnAccessControlForAllColumns();
+
+  it("never gates a probe column on a status page permission", () => {
+    const offenders: Array<string> = [];
+
+    for (const columnName of Object.keys(accessControl)) {
+      const column: ColumnAccessControl | undefined = accessControl[columnName];
+
+      const allPermissions: Array<Permission> = [
+        ...(column?.create || []),
+        ...(column?.read || []),
+        ...(column?.update || []),
+      ];
+
+      for (const permission of allPermissions) {
+        if (STATUS_PAGE_PERMISSIONS.includes(permission)) {
+          offenders.push(`${columnName}: ${permission}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("lets a user with granular probe permissions edit the auto-enable toggle", () => {
+    const column: ColumnAccessControl | undefined =
+      accessControl["shouldAutoEnableProbeOnNewMonitors"];
+
+    expect(column).toBeDefined();
+    expect(column!.update).toContain(Permission.EditProjectProbe);
+    expect(column!.read).toContain(Permission.ReadProjectProbe);
+    expect(column!.create).toContain(Permission.CreateProjectProbe);
+  });
+
+  it("keeps every field on the probe edit form readable and writable by a project owner", () => {
+    /*
+     * Every field the "Probe Details" card edits. If any of these stops
+     * intersecting a project owner's permissions, editing a probe silently
+     * stops working for the person who created it - which is exactly how the
+     * original bug presented.
+     */
+    const editableColumns: Array<string> = [
+      "name",
+      "description",
+      "iconFile",
+      "shouldAutoEnableProbeOnNewMonitors",
+      "labels",
+    ];
+
+    // What a signed-in project owner actually carries.
+    const ownerPermissions: Array<Permission> = [
+      Permission.Public,
+      Permission.User,
+      Permission.CurrentUser,
+      Permission.ProjectOwner,
+    ];
+
+    for (const columnName of editableColumns) {
+      const column: ColumnAccessControl | undefined = accessControl[columnName];
+
+      expect(column).toBeDefined();
+
+      expect(
+        (column!.update || []).some((permission: Permission) => {
+          return ownerPermissions.includes(permission);
+        }),
+      ).toBe(true);
+
+      expect(
+        (column!.read || []).some((permission: Permission) => {
+          return ownerPermissions.includes(permission);
+        }),
+      ).toBe(true);
+    }
+  });
+});

--- a/Common/Tests/Server/API/BaseAPIUpdateNoOp.test.ts
+++ b/Common/Tests/Server/API/BaseAPIUpdateNoOp.test.ts
@@ -1,0 +1,135 @@
+import BaseAPI from "../../../Server/API/BaseAPI";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import {
+  ExpressResponse,
+  OneUptimeRequest,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import { mockRouter } from "./Helpers";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+import ObjectID from "../../../Types/ObjectID";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import { getJestSpyOn } from "../../Spy";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+/*
+ * PUT /<model>/:id answered 200 with an empty body no matter what happened.
+ *
+ * DatabaseService narrows the update query AFTER the caller builds it - tenant
+ * scope, access-control labels, owned scope - so an update can match zero rows
+ * and write nothing. updateOneById threw that count away and BaseAPI reported
+ * success regardless, so the client showed a saved edit that was never
+ * persisted and "disappeared" on the next page load, with no error anywhere.
+ */
+
+const TEST_ID: string = "550e8400-e29b-41d4-a716-446655440009";
+
+describe("BaseAPI.updateItem when the update matches nothing", () => {
+  let service: DatabaseService<Probe>;
+  let api: BaseAPI<Probe, DatabaseService<Probe>>;
+  let request: OneUptimeRequest;
+  let response: ExpressResponse;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    service = new DatabaseService<Probe>(Probe);
+    api = new BaseAPI<Probe, DatabaseService<Probe>>(Probe, service);
+
+    request = {
+      params: { id: TEST_ID },
+      body: { data: { name: "renamed-probe" } },
+      headers: {},
+    } as unknown as OneUptimeRequest;
+
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+  });
+
+  it("reports success when a row was actually updated", async () => {
+    getJestSpyOn(service, "updateOneById").mockResolvedValue(1);
+
+    await api.updateItem(request, response);
+
+    expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+      request,
+      response,
+    );
+  });
+
+  it("refuses to report success when nothing was written", async () => {
+    getJestSpyOn(service, "updateOneById").mockResolvedValue(0);
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      NotAuthorizedException,
+    );
+
+    expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+  });
+
+  it("names the resource in the error so the message is actionable", async () => {
+    getJestSpyOn(service, "updateOneById").mockResolvedValue(0);
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(/probe/i);
+  });
+});
+
+describe("DatabaseService.updateOneById", () => {
+  it("hands back the number of rows the update matched", async () => {
+    const service: DatabaseService<Probe> = new DatabaseService<Probe>(Probe);
+
+    getJestSpyOn(
+      ModelPermission,
+      "checkUpdatePermissionByModel",
+    ).mockResolvedValue(undefined);
+    getJestSpyOn(service, "updateOneBy").mockResolvedValue(3);
+
+    const numberOfDocsAffected: number = await service.updateOneById({
+      id: new ObjectID(TEST_ID),
+      data: {} as any,
+      props: { isRoot: true },
+    });
+
+    expect(numberOfDocsAffected).toBe(3);
+  });
+
+  it("hands back zero when the permission-scoped query matched no rows", async () => {
+    const service: DatabaseService<Probe> = new DatabaseService<Probe>(Probe);
+
+    getJestSpyOn(
+      ModelPermission,
+      "checkUpdatePermissionByModel",
+    ).mockResolvedValue(undefined);
+    getJestSpyOn(service, "updateOneBy").mockResolvedValue(0);
+
+    const numberOfDocsAffected: number = await service.updateOneById({
+      id: new ObjectID(TEST_ID),
+      data: {} as any,
+      props: { isRoot: true },
+    });
+
+    expect(numberOfDocsAffected).toBe(0);
+  });
+});

--- a/Common/Tests/Server/API/ProbeAPI.test.ts
+++ b/Common/Tests/Server/API/ProbeAPI.test.ts
@@ -71,6 +71,12 @@ describe("ProbeAPI", () => {
         connectionStatus: true,
         lastAlive: true,
         iconFileId: true,
+        /*
+         * The monitor create form pre-selects the probes that auto-enable on
+         * new monitors, and global probes are not project rows - this endpoint
+         * is the only place the browser can learn the flag for them.
+         */
+        shouldAutoEnableProbeOnNewMonitors: true,
       },
       props: {
         isRoot: true,

--- a/Common/Tests/Server/Services/MonitorServiceProbeSelection.test.ts
+++ b/Common/Tests/Server/Services/MonitorServiceProbeSelection.test.ts
@@ -1,0 +1,401 @@
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorProbeService from "../../../Server/Services/MonitorProbeService";
+import ProbeService from "../../../Server/Services/ProbeService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import MonitorProbe from "../../../Models/DatabaseModels/MonitorProbe";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import Project from "../../../Models/DatabaseModels/Project";
+import ObjectID from "../../../Types/ObjectID";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * Probe assignment at monitor-create time.
+ *
+ * Before this, every probe flagged "auto enable on new monitors" was attached
+ * and there was no way to say which probe should watch a given resource. The
+ * create form now sends the user's choice through miscDataProps; these tests
+ * pin the three things that matter:
+ *
+ *   - no selection sent (API clients, monitor templates) still gets the old
+ *     auto-enable defaults, unchanged,
+ *   - a selection is honoured exactly - including an explicitly empty one,
+ *   - ids from the browser cannot pull in another project's probes.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const GLOBAL_PROBE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PROJECT_PROBE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OTHER_PROJECT_PROBE_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+type MakeProbeFunction = (id: ObjectID) => Probe;
+
+const makeProbe: MakeProbeFunction = (id: ObjectID): Probe => {
+  const probe: Probe = new Probe();
+  probe.id = id;
+  return probe;
+};
+
+describe("MonitorService probe selection", () => {
+  let createdMonitorProbes: Array<MonitorProbe> = [];
+
+  beforeEach(() => {
+    createdMonitorProbes = [];
+
+    getJestSpyOn(MonitorProbeService, "create").mockImplementation(
+      async (createBy: any): Promise<MonitorProbe> => {
+        createdMonitorProbes.push(createBy.data as MonitorProbe);
+        return createBy.data as MonitorProbe;
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("getSelectedProbeIdsFromMiscDataProps", () => {
+    it("returns undefined when no probes key was sent, so defaults still apply", () => {
+      expect(
+        MonitorService.getSelectedProbeIdsFromMiscDataProps(undefined),
+      ).toBeUndefined();
+
+      expect(
+        MonitorService.getSelectedProbeIdsFromMiscDataProps({}),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when probes is not an array", () => {
+      expect(
+        MonitorService.getSelectedProbeIdsFromMiscDataProps({
+          probes: GLOBAL_PROBE_ID.toString(),
+        }),
+      ).toBeUndefined();
+    });
+
+    it("returns an empty array for an explicitly empty selection", () => {
+      /*
+       * Distinct from undefined: the user cleared the picker, so no probes are
+       * wanted - falling back to defaults here would silently re-add them.
+       */
+      expect(
+        MonitorService.getSelectedProbeIdsFromMiscDataProps({ probes: [] }),
+      ).toEqual([]);
+    });
+
+    it("coerces the plain strings that actually arrive on the wire into ObjectIDs", () => {
+      /*
+       * miscDataProps is not run through the model serializer, so ids reach
+       * the server as strings.
+       */
+      const probeIds: Array<ObjectID> | undefined =
+        MonitorService.getSelectedProbeIdsFromMiscDataProps({
+          probes: [GLOBAL_PROBE_ID.toString(), PROJECT_PROBE_ID.toString()],
+        });
+
+      expect(probeIds).toHaveLength(2);
+      expect(probeIds![0]).toBeInstanceOf(ObjectID);
+      expect(
+        probeIds!.map((id: ObjectID) => {
+          return id.toString();
+        }),
+      ).toEqual([GLOBAL_PROBE_ID.toString(), PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("deduplicates repeated ids so MonitorProbeService does not reject the second insert", () => {
+      const probeIds: Array<ObjectID> | undefined =
+        MonitorService.getSelectedProbeIdsFromMiscDataProps({
+          probes: [
+            GLOBAL_PROBE_ID.toString(),
+            GLOBAL_PROBE_ID.toString(),
+            PROJECT_PROBE_ID.toString(),
+          ],
+        });
+
+      expect(
+        probeIds!.map((id: ObjectID) => {
+          return id.toString();
+        }),
+      ).toEqual([GLOBAL_PROBE_ID.toString(), PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("skips empty entries", () => {
+      const probeIds: Array<ObjectID> | undefined =
+        MonitorService.getSelectedProbeIdsFromMiscDataProps({
+          probes: ["", null, PROJECT_PROBE_ID.toString()],
+        });
+
+      expect(
+        probeIds!.map((id: ObjectID) => {
+          return id.toString();
+        }),
+      ).toEqual([PROJECT_PROBE_ID.toString()]);
+    });
+  });
+
+  describe("addProbesToMonitor", () => {
+    it("falls back to the auto-enable defaults when nothing was selected", async () => {
+      const addDefaultSpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        MonitorService,
+        "addDefaultProbesToMonitor",
+      ).mockResolvedValue(undefined);
+
+      await MonitorService.addProbesToMonitor({
+        projectId: PROJECT_ID,
+        monitorId: MONITOR_ID,
+        selectedProbeIds: undefined,
+      });
+
+      expect(addDefaultSpy).toHaveBeenCalledWith(PROJECT_ID, MONITOR_ID);
+    });
+
+    it("uses the explicit selection instead of the defaults when one was sent", async () => {
+      const addDefaultSpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        MonitorService,
+        "addDefaultProbesToMonitor",
+      ).mockResolvedValue(undefined);
+
+      const addSelectedSpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        MonitorService,
+        "addSelectedProbesToMonitor",
+      ).mockResolvedValue(undefined);
+
+      await MonitorService.addProbesToMonitor({
+        projectId: PROJECT_ID,
+        monitorId: MONITOR_ID,
+        selectedProbeIds: [PROJECT_PROBE_ID],
+      });
+
+      expect(addSelectedSpy).toHaveBeenCalledWith(PROJECT_ID, MONITOR_ID, [
+        PROJECT_PROBE_ID,
+      ]);
+      expect(addDefaultSpy).not.toHaveBeenCalled();
+    });
+
+    it("attaches nothing - not the defaults - for an explicitly empty selection", async () => {
+      const addDefaultSpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        MonitorService,
+        "addDefaultProbesToMonitor",
+      ).mockResolvedValue(undefined);
+
+      await MonitorService.addProbesToMonitor({
+        projectId: PROJECT_ID,
+        monitorId: MONITOR_ID,
+        selectedProbeIds: [],
+      });
+
+      expect(addDefaultSpy).not.toHaveBeenCalled();
+      expect(createdMonitorProbes).toHaveLength(0);
+    });
+
+    it("rejects a missing projectId or monitorId", async () => {
+      await expect(
+        MonitorService.addProbesToMonitor({
+          projectId: undefined,
+          monitorId: MONITOR_ID,
+          selectedProbeIds: [],
+        }),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        MonitorService.addProbesToMonitor({
+          projectId: PROJECT_ID,
+          monitorId: null,
+          selectedProbeIds: [],
+        }),
+      ).rejects.toThrow(BadDataException);
+    });
+  });
+
+  describe("addSelectedProbesToMonitor", () => {
+    type MockProbeLookupFunction = (data: {
+      globalProbes: Array<Probe>;
+      projectProbes: Array<Probe>;
+    }) => void;
+
+    const mockProbeLookup: MockProbeLookupFunction = (data: {
+      globalProbes: Array<Probe>;
+      projectProbes: Array<Probe>;
+    }): void => {
+      getJestSpyOn(ProbeService, "findBy").mockImplementation(
+        async (findBy: any): Promise<Array<Probe>> => {
+          return findBy.query.isGlobalProbe === true
+            ? data.globalProbes
+            : data.projectProbes;
+        },
+      );
+    };
+
+    it("creates one enabled MonitorProbe per selected probe", async () => {
+      mockProbeLookup({
+        globalProbes: [makeProbe(GLOBAL_PROBE_ID)],
+        projectProbes: [makeProbe(PROJECT_PROBE_ID)],
+      });
+
+      await MonitorService.addSelectedProbesToMonitor(PROJECT_ID, MONITOR_ID, [
+        GLOBAL_PROBE_ID,
+        PROJECT_PROBE_ID,
+      ]);
+
+      expect(createdMonitorProbes).toHaveLength(2);
+
+      for (const monitorProbe of createdMonitorProbes) {
+        expect(monitorProbe.monitorId?.toString()).toEqual(
+          MONITOR_ID.toString(),
+        );
+        expect(monitorProbe.projectId?.toString()).toEqual(
+          PROJECT_ID.toString(),
+        );
+        expect(monitorProbe.isEnabled).toBe(true);
+      }
+
+      expect(
+        createdMonitorProbes.map((monitorProbe: MonitorProbe) => {
+          return monitorProbe.probeId?.toString();
+        }),
+      ).toEqual([GLOBAL_PROBE_ID.toString(), PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("drops ids that are neither global nor owned by this project", async () => {
+      /*
+       * The id list comes from the browser. A probe belonging to someone
+       * else's project must not become a MonitorProbe row just because its id
+       * was posted.
+       */
+      mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [makeProbe(PROJECT_PROBE_ID)],
+      });
+
+      await MonitorService.addSelectedProbesToMonitor(PROJECT_ID, MONITOR_ID, [
+        PROJECT_PROBE_ID,
+        OTHER_PROJECT_PROBE_ID,
+      ]);
+
+      expect(
+        createdMonitorProbes.map((monitorProbe: MonitorProbe) => {
+          return monitorProbe.probeId?.toString();
+        }),
+      ).toEqual([PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("scopes the two lookups to global probes and to this project only", async () => {
+      const findBySpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        ProbeService,
+        "findBy",
+      ).mockResolvedValue([]);
+
+      await MonitorService.addSelectedProbesToMonitor(PROJECT_ID, MONITOR_ID, [
+        PROJECT_PROBE_ID,
+      ]);
+
+      const queries: Array<any> = findBySpy.mock.calls.map(
+        (call: Array<any>) => {
+          return call[0].query;
+        },
+      );
+
+      expect(queries).toHaveLength(2);
+      expect(queries[0].isGlobalProbe).toBe(true);
+      expect(queries[0].projectId).toBeUndefined();
+      expect(queries[1].isGlobalProbe).toBe(false);
+      expect(queries[1].projectId).toEqual(PROJECT_ID);
+    });
+
+    it("does nothing at all for an empty id list", async () => {
+      const findBySpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        ProbeService,
+        "findBy",
+      ).mockResolvedValue([]);
+
+      await MonitorService.addSelectedProbesToMonitor(
+        PROJECT_ID,
+        MONITOR_ID,
+        [],
+      );
+
+      expect(findBySpy).not.toHaveBeenCalled();
+      expect(createdMonitorProbes).toHaveLength(0);
+    });
+  });
+
+  describe("addDefaultProbesToMonitor", () => {
+    type MockProjectFunction = (skipGlobalProbes: boolean) => void;
+
+    const mockProject: MockProjectFunction = (
+      skipGlobalProbes: boolean,
+    ): void => {
+      const project: Project = new Project();
+      project.id = PROJECT_ID;
+      project.doNotAddGlobalProbesByDefaultOnNewMonitors = skipGlobalProbes;
+
+      getJestSpyOn(ProjectService, "findOneById").mockResolvedValue(project);
+    };
+
+    it("attaches every probe that opted in to new monitors", async () => {
+      mockProject(false);
+
+      getJestSpyOn(ProbeService, "findBy").mockImplementation(
+        async (findBy: any): Promise<Array<Probe>> => {
+          return findBy.query.isGlobalProbe === true
+            ? [makeProbe(GLOBAL_PROBE_ID)]
+            : [makeProbe(PROJECT_PROBE_ID)];
+        },
+      );
+
+      await MonitorService.addDefaultProbesToMonitor(PROJECT_ID, MONITOR_ID);
+
+      expect(
+        createdMonitorProbes.map((monitorProbe: MonitorProbe) => {
+          return monitorProbe.probeId?.toString();
+        }),
+      ).toEqual([GLOBAL_PROBE_ID.toString(), PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("skips the global probe lookup entirely when the project opted out", async () => {
+      mockProject(true);
+
+      const findBySpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        ProbeService,
+        "findBy",
+      ).mockResolvedValue([makeProbe(PROJECT_PROBE_ID)]);
+
+      await MonitorService.addDefaultProbesToMonitor(PROJECT_ID, MONITOR_ID);
+
+      expect(findBySpy).toHaveBeenCalledTimes(1);
+      expect(findBySpy.mock.calls[0]![0].query.isGlobalProbe).toBe(false);
+      expect(
+        createdMonitorProbes.map((monitorProbe: MonitorProbe) => {
+          return monitorProbe.probeId?.toString();
+        }),
+      ).toEqual([PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("only asks for probes that opted in", async () => {
+      mockProject(false);
+
+      const findBySpy: jest.SpyInstance<any, any> = getJestSpyOn(
+        ProbeService,
+        "findBy",
+      ).mockResolvedValue([]);
+
+      await MonitorService.addDefaultProbesToMonitor(PROJECT_ID, MONITOR_ID);
+
+      for (const call of findBySpy.mock.calls) {
+        expect(call[0].query.shouldAutoEnableProbeOnNewMonitors).toBe(true);
+      }
+    });
+  });
+});

--- a/Common/Tests/UI/Components/CardModelDetailEdit.test.tsx
+++ b/Common/Tests/UI/Components/CardModelDetailEdit.test.tsx
@@ -1,0 +1,315 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, { UserPermission } from "../../../Types/Permission";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The "Probe Details" card - and every other CardModelDetail - used to derive
+ * the id its edit modal updates from the record the card had finished loading:
+ *
+ *   modelIdToEdit={item?.id || undefined}
+ *
+ * The Edit button is rendered by Card, outside ModelDetail, in a mount-only
+ * effect - so it is clickable while the card is still on its spinner. Opening
+ * the modal then gave ModelForm an Update form with no id, and ModelForm's
+ * fetch effect (guarded on the id, deps []) skipped the prefill with no loader
+ * and no error. The form rendered defaults, BasicForm coerced every untouched
+ * Toggle to false, and pressing Save wrote that over the real probe - which is
+ * how "Enable monitoring automatically on new monitors" silently went back to
+ * off, and why the page looked unchanged after a refresh.
+ *
+ * These tests drive the real components: they open the modal before the detail
+ * fetch resolves and assert on what actually reaches the API.
+ */
+
+const getItemMock: MockFunction = getJestMockFunction();
+const createOrUpdateMock: MockFunction = getJestMockFunction();
+const showToastMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      createOrUpdate: (...args: Array<any>) => {
+        return createOrUpdateMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/Toast/ToastInit", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return null;
+    },
+    ShowToastNotification: (...args: Array<any>) => {
+      return showToastMock(...args);
+    },
+  };
+});
+
+const OWNER_PERMISSIONS: Array<Permission> = [
+  Permission.Public,
+  Permission.User,
+  Permission.CurrentUser,
+  Permission.ProjectOwner,
+];
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return OWNER_PERMISSIONS;
+      },
+      getProjectPermissions: () => {
+        return {
+          permissions: OWNER_PERMISSIONS.map((permission: Permission) => {
+            return {
+              permission,
+              labelIds: [],
+              _type: "UserPermission",
+            } as UserPermission;
+          }),
+        };
+      },
+      getGlobalPermissions: () => {
+        return { globalPermissions: OWNER_PERMISSIONS };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return false;
+      },
+    },
+  };
+});
+
+import CardModelDetail from "../../../UI/Components/ModelDetail/CardModelDetail";
+import Probe from "../../../Models/DatabaseModels/Probe";
+
+/*
+ * These render real components that fetch, so give the waits enough room to
+ * survive a loaded CI box - the testing-library default of 1s flakes there.
+ */
+const WAIT_TIMEOUT: number = 20000;
+
+const PROBE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+
+type RenderProbeCardFunction = () => void;
+
+const renderProbeCard: RenderProbeCardFunction = (): void => {
+  render(
+    <CardModelDetail<Probe>
+      name="Probe Details"
+      cardProps={{
+        title: "Probe Details",
+        description: "Here are more details for this probe.",
+      }}
+      isEditable={true}
+      formFields={[
+        {
+          field: { name: true },
+          title: "Name",
+          fieldType: FormFieldSchemaType.Text,
+          required: true,
+        },
+        {
+          field: { shouldAutoEnableProbeOnNewMonitors: true },
+          title: "Enable monitoring automatically on new monitors",
+          fieldType: FormFieldSchemaType.Toggle,
+          required: false,
+          dataTestId: "auto-enable-toggle",
+        },
+      ]}
+      modelDetailProps={{
+        modelType: Probe,
+        id: "probe-detail",
+        modelId: PROBE_ID,
+        fields: [
+          {
+            field: { name: true },
+            title: "Name",
+          },
+          {
+            field: { shouldAutoEnableProbeOnNewMonitors: true },
+            title: "Enable Monitoring on New Monitors",
+            fieldType: FieldType.Boolean,
+          },
+        ],
+      }}
+    />,
+  );
+};
+
+type LoadedProbeFunction = () => Probe;
+
+const loadedProbe: LoadedProbeFunction = (): Probe => {
+  const probe: Probe = new Probe();
+  probe.id = PROBE_ID;
+  probe.name = "WBHQ";
+  probe.shouldAutoEnableProbeOnNewMonitors = true;
+  return probe;
+};
+
+describe("CardModelDetail edit modal", () => {
+  beforeEach(() => {
+    getItemMock.mockReset();
+    createOrUpdateMock.mockReset();
+    showToastMock.mockReset();
+    createOrUpdateMock.mockResolvedValue({ data: {} });
+  });
+
+  it("edits the record the card was told to show, even while the card is still loading", async () => {
+    /*
+     * The card's own detail fetch never settles, so the card stays on its
+     * spinner and never reports a loaded item - which is what used to leave
+     * the edit modal with no id. ModelDetail's request is the one that asks
+     * for _id; ModelForm's is built from the form fields only.
+     */
+    getItemMock.mockImplementation((data: any) => {
+      if (data?.select?.["_id"]) {
+        return new Promise(() => {});
+      }
+      return Promise.resolve(loadedProbe());
+    });
+
+    renderProbeCard();
+
+    await userEvent.click(
+      await screen.findByText("Edit Probe", {}, { timeout: WAIT_TIMEOUT }),
+    );
+
+    // Prefilled, rather than a blank form or a "still loading" error.
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue("WBHQ")).toBeDefined();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await userEvent.click(screen.getByText("Save Changes"));
+
+    await waitFor(
+      () => {
+        expect(createOrUpdateMock).toHaveBeenCalled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const submitted: any = (createOrUpdateMock.mock.calls[0] as Array<any>)[0];
+
+    expect(submitted.model._id).toEqual(PROBE_ID.toString());
+    expect(submitted.model.shouldAutoEnableProbeOnNewMonitors).toBe(true);
+  });
+
+  it("prefills the form from the record instead of blanking untouched toggles", async () => {
+    getItemMock.mockResolvedValue(loadedProbe());
+
+    renderProbeCard();
+
+    await userEvent.click(
+      await screen.findByText("Edit Probe", {}, { timeout: WAIT_TIMEOUT }),
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue("WBHQ")).toBeDefined();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await userEvent.click(screen.getByText("Save Changes"));
+
+    await waitFor(
+      () => {
+        expect(createOrUpdateMock).toHaveBeenCalled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const submitted: any = (createOrUpdateMock.mock.calls[0] as Array<any>)[0];
+
+    expect(submitted.model.name).toEqual("WBHQ");
+    // The regression: this used to be submitted as false.
+    expect(submitted.model.shouldAutoEnableProbeOnNewMonitors).toBe(true);
+    expect(submitted.model._id).toEqual(PROBE_ID.toString());
+  });
+
+  it("submits a toggle the user actually turned off", async () => {
+    getItemMock.mockResolvedValue(loadedProbe());
+
+    renderProbeCard();
+
+    await userEvent.click(
+      await screen.findByText("Edit Probe", {}, { timeout: WAIT_TIMEOUT }),
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue("WBHQ")).toBeDefined();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await userEvent.click(screen.getByTestId("auto-enable-toggle"));
+
+    await userEvent.click(screen.getByText("Save Changes"));
+
+    await waitFor(
+      () => {
+        expect(createOrUpdateMock).toHaveBeenCalled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const submitted: any = (createOrUpdateMock.mock.calls[0] as Array<any>)[0];
+
+    expect(submitted.model.shouldAutoEnableProbeOnNewMonitors).toBe(false);
+  });
+
+  it("confirms the save so a successful edit is not just a modal that vanished", async () => {
+    getItemMock.mockResolvedValue(loadedProbe());
+
+    renderProbeCard();
+
+    await userEvent.click(
+      await screen.findByText("Edit Probe", {}, { timeout: WAIT_TIMEOUT }),
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByDisplayValue("WBHQ")).toBeDefined();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await userEvent.click(screen.getByText("Save Changes"));
+
+    await waitFor(
+      () => {
+        expect(showToastMock).toHaveBeenCalled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const toast: any = (showToastMock.mock.calls[0] as Array<any>)[0];
+
+    expect(toast.title).toEqual("Changes saved");
+  });
+});

--- a/Common/Tests/UI/Components/ModelDetailSelect.test.tsx
+++ b/Common/Tests/UI/Components/ModelDetailSelect.test.tsx
@@ -1,0 +1,229 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import Select from "../../../Types/BaseDatabase/Select";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, { UserPermission } from "../../../Types/Permission";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import FieldType from "../../../UI/Components/Types/FieldType";
+
+/*
+ * ModelDetail builds the get-item `select` from the fields its card declares.
+ *
+ * Two things were wrong with that:
+ *
+ *   1. It never asked for _id, even though CardModelDetail derives the id its
+ *      edit modal updates from the loaded record. Nothing else in the client
+ *      guarantees the id comes back.
+ *   2. It did not filter by read permission, while the render path right below
+ *      it does. Server-side, SelectPermission.checkSelectPermission rejects the
+ *      WHOLE request when a single selected column is unreadable - so one
+ *      privileged column (Probe.key is readable only by owners and admins)
+ *      blanked the entire card for everyone else, instead of hiding one row.
+ */
+
+const getItemMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+    },
+  };
+});
+
+let currentPermissions: Array<Permission> = [];
+let isMasterAdmin: boolean = false;
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return currentPermissions;
+      },
+      getProjectPermissions: () => {
+        return {
+          permissions: currentPermissions.map((permission: Permission) => {
+            return {
+              permission,
+              labelIds: [],
+              _type: "UserPermission",
+            } as UserPermission;
+          }),
+        };
+      },
+      getGlobalPermissions: () => {
+        return { globalPermissions: currentPermissions };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return isMasterAdmin;
+      },
+    },
+  };
+});
+
+import ModelDetail from "../../../UI/Components/ModelDetail/ModelDetail";
+import Probe from "../../../Models/DatabaseModels/Probe";
+
+/*
+ * These render real components that fetch, so give the waits enough room to
+ * survive a loaded CI box - the testing-library default of 1s flakes there.
+ */
+const WAIT_TIMEOUT: number = 20000;
+
+const PROBE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+
+/*
+ * Signed-in users always carry Public/User/CurrentUser on top of their project
+ * role (AccessTokenService.refreshUserGlobalAccessPermission), and some Probe
+ * columns - name, description - are readable on Public alone. Tests mirror
+ * that, otherwise they would assert against a permission set no real user has.
+ */
+type PermissionsForRoleFunction = (role: Permission) => Array<Permission>;
+
+const permissionsForRole: PermissionsForRoleFunction = (
+  role: Permission,
+): Array<Permission> => {
+  return [Permission.Public, Permission.User, Permission.CurrentUser, role];
+};
+
+type RenderProbeDetailFunction = () => Promise<Select<Probe>>;
+
+/*
+ * Renders the same card shape the Probe view page uses and hands back the
+ * select ModelDetail actually put on the wire.
+ */
+const renderProbeDetail: RenderProbeDetailFunction = async (): Promise<
+  Select<Probe>
+> => {
+  render(
+    <ModelDetail<Probe>
+      modelType={Probe}
+      id="probe-detail"
+      modelId={PROBE_ID}
+      fields={[
+        {
+          field: { name: true },
+          title: "Name",
+        },
+        {
+          field: { key: true },
+          title: "Probe Key",
+          fieldType: FieldType.HiddenText,
+        },
+        {
+          field: { shouldAutoEnableProbeOnNewMonitors: true },
+          title: "Enable Monitoring on New Monitors",
+          fieldType: FieldType.Boolean,
+        },
+      ]}
+    />,
+  );
+
+  await waitFor(
+    () => {
+      expect(getItemMock).toHaveBeenCalled();
+    },
+    { timeout: WAIT_TIMEOUT },
+  );
+
+  return (getItemMock.mock.calls[0] as Array<any>)[0].select as Select<Probe>;
+};
+
+describe("ModelDetail select", () => {
+  beforeEach(() => {
+    getItemMock.mockReset();
+    getItemMock.mockResolvedValue(new Probe());
+    isMasterAdmin = false;
+    currentPermissions = [];
+  });
+
+  it("always asks for _id so the edit modal knows which record it is updating", async () => {
+    currentPermissions = permissionsForRole(Permission.ProjectOwner);
+
+    const select: Select<Probe> = await renderProbeDetail();
+
+    expect((select as any)["_id"]).toBe(true);
+  });
+
+  it("selects every declared column for a user who can read them all", async () => {
+    currentPermissions = permissionsForRole(Permission.ProjectOwner);
+
+    const select: Select<Probe> = await renderProbeDetail();
+
+    expect((select as any)["name"]).toBe(true);
+    expect((select as any)["key"]).toBe(true);
+    expect((select as any)["shouldAutoEnableProbeOnNewMonitors"]).toBe(true);
+  });
+
+  it("drops a column the user cannot read instead of failing the whole request", async () => {
+    /*
+     * A SettingsMember can view probes but cannot read Probe.key. Asking for
+     * it anyway is what used to blank the card.
+     */
+    currentPermissions = permissionsForRole(Permission.SettingsMember);
+
+    const select: Select<Probe> = await renderProbeDetail();
+
+    expect((select as any)["key"]).toBeUndefined();
+    expect((select as any)["shouldAutoEnableProbeOnNewMonitors"]).toBe(true);
+    expect((select as any)["_id"]).toBe(true);
+  });
+
+  it("selects everything for a master admin", async () => {
+    isMasterAdmin = true;
+    currentPermissions = [];
+
+    const select: Select<Probe> = await renderProbeDetail();
+
+    expect((select as any)["key"]).toBe(true);
+    expect((select as any)["name"]).toBe(true);
+  });
+
+  it("drops unreadable selectMoreFields too", async () => {
+    currentPermissions = permissionsForRole(Permission.SettingsMember);
+
+    render(
+      <ModelDetail<Probe>
+        modelType={Probe}
+        id="probe-detail-more-fields"
+        modelId={PROBE_ID}
+        fields={[
+          {
+            field: { name: true },
+            title: "Name",
+          },
+        ]}
+        selectMoreFields={{
+          key: true,
+          shouldAutoEnableProbeOnNewMonitors: true,
+        }}
+      />,
+    );
+
+    await waitFor(
+      () => {
+        expect(getItemMock).toHaveBeenCalled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const select: Select<Probe> = (getItemMock.mock.calls[0] as Array<any>)[0]
+      .select as Select<Probe>;
+
+    expect((select as any)["key"]).toBeUndefined();
+    expect((select as any)["shouldAutoEnableProbeOnNewMonitors"]).toBe(true);
+  });
+});

--- a/Common/Tests/Utils/Monitor/MonitorProbeSelectionUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorProbeSelectionUtil.test.ts
@@ -1,0 +1,145 @@
+import MonitorProbeSelectionUtil, {
+  ProbeSelectionCandidate,
+} from "../../../Utils/Monitor/MonitorProbeSelectionUtil";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The monitor create form pre-selects the probe picker with the set the server
+ * would have attached on its own (MonitorService.addDefaultProbesToMonitor).
+ * If these two ever disagree, opening the form and pressing Create silently
+ * changes which probes watch the monitor - so the rule is pinned here:
+ *
+ *   - only probes that opted in via shouldAutoEnableProbeOnNewMonitors,
+ *   - minus every global probe when the project turned global probes off,
+ *   - deduplicated, because MonitorProbe has no unique index and the second
+ *     insert is rejected with "Probe is already added to this monitor."
+ */
+
+const GLOBAL_PROBE: ProbeSelectionCandidate = {
+  id: "11111111-1111-4111-8111-111111111111",
+  isGlobalProbe: true,
+  shouldAutoEnableProbeOnNewMonitors: true,
+};
+
+const CUSTOM_PROBE: ProbeSelectionCandidate = {
+  id: "22222222-2222-4222-8222-222222222222",
+  isGlobalProbe: false,
+  shouldAutoEnableProbeOnNewMonitors: true,
+};
+
+const OPTED_OUT_CUSTOM_PROBE: ProbeSelectionCandidate = {
+  id: "33333333-3333-4333-8333-333333333333",
+  isGlobalProbe: false,
+  shouldAutoEnableProbeOnNewMonitors: false,
+};
+
+const OPTED_OUT_GLOBAL_PROBE: ProbeSelectionCandidate = {
+  id: "44444444-4444-4444-8444-444444444444",
+  isGlobalProbe: true,
+  shouldAutoEnableProbeOnNewMonitors: false,
+};
+
+describe("MonitorProbeSelectionUtil.getDefaultSelectedProbeIds", () => {
+  it("selects every probe flagged to auto-enable on new monitors", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [GLOBAL_PROBE, CUSTOM_PROBE],
+      }),
+    ).toEqual([GLOBAL_PROBE.id, CUSTOM_PROBE.id]);
+  });
+
+  it("leaves out probes that did not opt in, global or custom", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [
+          GLOBAL_PROBE,
+          OPTED_OUT_GLOBAL_PROBE,
+          CUSTOM_PROBE,
+          OPTED_OUT_CUSTOM_PROBE,
+        ],
+      }),
+    ).toEqual([GLOBAL_PROBE.id, CUSTOM_PROBE.id]);
+  });
+
+  it("drops global probes when the project disabled them for new monitors", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [GLOBAL_PROBE, CUSTOM_PROBE],
+        doNotAddGlobalProbesByDefaultOnNewMonitors: true,
+      }),
+    ).toEqual([CUSTOM_PROBE.id]);
+  });
+
+  it("keeps global probes when the project setting is false or unset", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [GLOBAL_PROBE],
+        doNotAddGlobalProbesByDefaultOnNewMonitors: false,
+      }),
+    ).toEqual([GLOBAL_PROBE.id]);
+
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [GLOBAL_PROBE],
+        doNotAddGlobalProbesByDefaultOnNewMonitors: undefined,
+      }),
+    ).toEqual([GLOBAL_PROBE.id]);
+  });
+
+  it("returns an empty list when nothing opted in", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [OPTED_OUT_GLOBAL_PROBE, OPTED_OUT_CUSTOM_PROBE],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns an empty list for an empty probe list", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("deduplicates a probe that appears in more than one source list", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [GLOBAL_PROBE, { ...GLOBAL_PROBE }, CUSTOM_PROBE],
+      }),
+    ).toEqual([GLOBAL_PROBE.id, CUSTOM_PROBE.id]);
+  });
+
+  it("ignores probes with no id rather than sending an empty id to the server", () => {
+    expect(
+      MonitorProbeSelectionUtil.getDefaultSelectedProbeIds({
+        probes: [
+          {
+            id: "",
+            isGlobalProbe: false,
+            shouldAutoEnableProbeOnNewMonitors: true,
+          },
+          CUSTOM_PROBE,
+        ],
+      }),
+    ).toEqual([CUSTOM_PROBE.id]);
+  });
+});
+
+describe("MonitorProbeSelectionUtil.dedupeProbeIds", () => {
+  it("keeps the first occurrence and preserves order", () => {
+    expect(
+      MonitorProbeSelectionUtil.dedupeProbeIds(["a", "b", "a", "c", "b"]),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops empty ids", () => {
+    expect(MonitorProbeSelectionUtil.dedupeProbeIds(["", "a", ""])).toEqual([
+      "a",
+    ]);
+  });
+
+  it("handles an empty list", () => {
+    expect(MonitorProbeSelectionUtil.dedupeProbeIds([])).toEqual([]);
+  });
+});

--- a/Common/UI/Components/Forms/ModelForm.tsx
+++ b/Common/UI/Components/Forms/ModelForm.tsx
@@ -641,27 +641,50 @@ const ModelForm: <TBaseModel extends BaseModel>(
     return fields;
   };
 
+  /*
+   * Keyed on the id (as a string - ObjectID identity changes every render)
+   * so a form that mounts before its id is known still fetches once it
+   * arrives. It used to run only on mount, which left an Update form showing
+   * blank defaults: submitting that silently wrote empty values - and false
+   * for every Toggle, since BasicForm defaults untouched toggles to false -
+   * over the real record.
+   */
   useAsyncEffect(async () => {
-    if (
-      props.modelIdToEdit &&
-      props.formType === FormType.Update &&
-      !props.doNotFetchExistingModel
-    ) {
-      // get item.
-      setLoading(true);
-      setIsFetching(true);
-      setError("");
-      try {
-        await fetchItem();
-      } catch (err) {
-        setError(API.getFriendlyMessage(err));
-        props.onError?.(API.getFriendlyMessage(err));
-      }
-
-      setLoading(false);
-      setIsFetching(false);
+    if (props.formType !== FormType.Update || props.doNotFetchExistingModel) {
+      return;
     }
-  }, []);
+
+    if (!props.modelIdToEdit) {
+      /*
+       * Without an id there is nothing to prefill and nothing to update, so
+       * say so rather than rendering an empty form that looks editable.
+       *
+       * Deliberately not props.onError: ModelFormModal unmounts the form on
+       * that, and this state is recoverable - the effect re-runs and clears
+       * the message as soon as the id arrives.
+       */
+      setError(
+        `Cannot edit this ${(
+          model.singularName || "item"
+        ).toLowerCase()} yet because it is still loading. Please try again in a moment.`,
+      );
+      return;
+    }
+
+    // get item.
+    setLoading(true);
+    setIsFetching(true);
+    setError("");
+    try {
+      await fetchItem();
+    } catch (err) {
+      setError(API.getFriendlyMessage(err));
+      props.onError?.(API.getFriendlyMessage(err));
+    }
+
+    setLoading(false);
+    setIsFetching(false);
+  }, [props.modelIdToEdit?.toString()]);
 
   type GetMiscDataPropsFunction = (
     values: FormValues<JSONObject>,

--- a/Common/UI/Components/ModelDetail/CardModelDetail.tsx
+++ b/Common/UI/Components/ModelDetail/CardModelDetail.tsx
@@ -12,6 +12,8 @@ import Fields from "../Forms/Types/Fields";
 import { FormStep } from "../Forms/Types/FormStep";
 import { ModalWidth } from "../Modal/Modal";
 import ModelFormModal from "../ModelFormModal/ModelFormModal";
+import { ToastType } from "../Toast/Toast";
+import { ShowToastNotification } from "../Toast/ToastInit";
 import ModelDetail, { ComponentProps as ModeDetailProps } from "./ModelDetail";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -165,6 +167,16 @@ const CardModelDetail: <TBaseModel extends BaseModel>(
           onSuccess={(item: TBaseModel) => {
             setShowModal(false);
             setRefresher(!refresher);
+            /*
+             * The modal just disappears otherwise, which reads as "nothing
+             * happened" - especially on cards that do not display every field
+             * the edit form exposes.
+             */
+            ShowToastNotification({
+              title: "Changes saved",
+              description: `${model.singularName || "Item"} updated successfully.`,
+              type: ToastType.SUCCESS,
+            });
             if (props.onSaveSuccess) {
               props.onSaveSuccess(item);
             }
@@ -180,7 +192,17 @@ const CardModelDetail: <TBaseModel extends BaseModel>(
             steps: props.formSteps || [],
             createOrUpdateApiUrl: props.createOrUpdateApiUrl,
           }}
-          modelIdToEdit={item?.id || undefined}
+          /*
+           * Prefer the id the caller already handed us. Deriving it purely
+           * from the loaded item meant that opening the modal before (or
+           * without) a successful detail fetch produced an Update form with
+           * no id: ModelForm silently skipped its fetch, rendered defaults,
+           * and BasicForm coerced every untouched Toggle to false - so
+           * saving quietly wrote blank values over the real record.
+           */
+          modelIdToEdit={
+            props.modelDetailProps.modelId || item?.id || undefined
+          }
         />
       ) : (
         <></>

--- a/Common/UI/Components/ModelDetail/ModelDetail.tsx
+++ b/Common/UI/Components/ModelDetail/ModelDetail.tsx
@@ -51,15 +51,55 @@ const ModelDetail: <TBaseModel extends BaseModel>(
     JSONObject | undefined
   >(undefined);
 
+  type HasPermissionToReadFieldFunction = (fieldName: string) => boolean;
+
+  /*
+   * The server rejects the WHOLE get-item request when the select names a
+   * single column the caller cannot read (SelectPermission.checkSelectPermission
+   * throws NotAuthorizedException), which blanks the entire card instead of
+   * hiding one row. setDetailFields() below already drops unreadable fields
+   * from the render, so the fetch has to drop them too - the same thing
+   * BaseModelTable does for its selectMoreFields.
+   */
+  const hasPermissionToReadField: HasPermissionToReadFieldFunction = (
+    fieldName: string,
+  ): boolean => {
+    if (User.isMasterAdmin()) {
+      return true;
+    }
+
+    const accessControl: Dictionary<ColumnAccessControl> =
+      new props.modelType().getColumnAccessControlForAllColumns() || {};
+
+    const fieldPermissions: Array<Permission> =
+      accessControl[fieldName]?.read || [];
+
+    return PermissionHelper.doesPermissionsIntersect(
+      PermissionUtil.getAllPermissions(),
+      fieldPermissions,
+    );
+  };
+
   type GetSelectFields = () => Select<TBaseModel>;
 
   const getSelectFields: GetSelectFields = (): Select<TBaseModel> => {
     const select: Select<TBaseModel> = {};
+
+    /*
+     * _id is never a declared field on most cards, but CardModelDetail needs
+     * it to know which record its edit modal is updating. It is exempt from
+     * select permission checks server-side, so it is always safe to ask for.
+     */
+    (select as Dictionary<boolean>)["_id"] = true;
+
     for (const field of props.fields) {
       if (!field.field) {
         continue;
       }
       for (const key of Object.keys(field.field)) {
+        if (!hasPermissionToReadField(key)) {
+          continue;
+        }
         select[key as keyof TBaseModel] = true;
       }
     }
@@ -70,7 +110,8 @@ const ModelDetail: <TBaseModel extends BaseModel>(
         typeof field === "string" &&
         field &&
         props.selectMoreFields &&
-        (props.selectMoreFields as Select<TBaseModel>)[keyofField]
+        (props.selectMoreFields as Select<TBaseModel>)[keyofField] &&
+        hasPermissionToReadField(field)
       ) {
         select[keyofField] = props.selectMoreFields[keyofField] as JSONObject;
       }
@@ -91,6 +132,10 @@ const ModelDetail: <TBaseModel extends BaseModel>(
           continue;
         }
         for (const key of Object.keys(field.field)) {
+          if (!hasPermissionToReadField(key)) {
+            continue;
+          }
+
           if (model.isFileColumn(key)) {
             (relationSelect as JSONObject)[key] = {
               file: true,

--- a/Common/Utils/Monitor/MonitorProbeSelectionUtil.ts
+++ b/Common/Utils/Monitor/MonitorProbeSelectionUtil.ts
@@ -1,0 +1,72 @@
+/*
+ * Which probes a brand-new monitor starts out with.
+ *
+ * The server applies this same rule in
+ * MonitorService.addDefaultProbesToMonitor (as a database query rather than a
+ * filter over a list). The create form uses it to pre-select the probe picker,
+ * so what the user sees before pressing "Create Monitor" is what they would
+ * have got anyway - and can now change.
+ */
+
+export interface ProbeSelectionCandidate {
+  id: string;
+  isGlobalProbe: boolean;
+  shouldAutoEnableProbeOnNewMonitors: boolean;
+}
+
+export default class MonitorProbeSelectionUtil {
+  /*
+   * A probe is auto-enabled on new monitors when it opts in with
+   * shouldAutoEnableProbeOnNewMonitors - except that global probes are skipped
+   * entirely for projects that turned off "add global probes by default".
+   */
+  public static getDefaultSelectedProbeIds(data: {
+    probes: Array<ProbeSelectionCandidate>;
+    doNotAddGlobalProbesByDefaultOnNewMonitors?: boolean | undefined;
+  }): Array<string> {
+    const skipGlobalProbes: boolean =
+      data.doNotAddGlobalProbesByDefaultOnNewMonitors === true;
+
+    const selected: Array<string> = [];
+
+    for (const probe of data.probes || []) {
+      if (!probe || !probe.id) {
+        continue;
+      }
+
+      if (!probe.shouldAutoEnableProbeOnNewMonitors) {
+        continue;
+      }
+
+      if (probe.isGlobalProbe && skipGlobalProbes) {
+        continue;
+      }
+
+      selected.push(probe.id);
+    }
+
+    return MonitorProbeSelectionUtil.dedupeProbeIds(selected);
+  }
+
+  /*
+   * Probe ids reach the server as plain strings and the same probe can be
+   * offered by more than one source, so duplicates have to go: MonitorProbe
+   * has no unique index and MonitorProbeService rejects the second insert with
+   * "Probe is already added to this monitor."
+   */
+  public static dedupeProbeIds(probeIds: Array<string>): Array<string> {
+    const seen: Set<string> = new Set<string>();
+    const deduped: Array<string> = [];
+
+    for (const probeId of probeIds || []) {
+      if (!probeId || seen.has(probeId)) {
+        continue;
+      }
+
+      seen.add(probeId);
+      deduped.push(probeId);
+    }
+
+    return deduped;
+  }
+}

--- a/E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts
@@ -1,0 +1,329 @@
+import { BASE_URL } from "../../Config";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import {
+  APIResponse,
+  Browser,
+  Locator,
+  Page,
+  expect,
+  test,
+} from "@playwright/test";
+import URL from "Common/Types/API/URL";
+import Faker from "Common/Utils/Faker";
+
+/*
+ * Two probe regressions, end to end.
+ *
+ * (A) Creating a monitor had no probe step. Probes were attached afterwards -
+ *     every probe flagged "auto enable on new monitors" - so a project with a
+ *     global probe and a custom probe could not say which one should watch a
+ *     given resource. Test: create a Website monitor selecting ONLY the custom
+ *     probe, then read /api/monitor-probe back and assert the global probe is
+ *     not attached.
+ *
+ * (B) Editing a probe looked like it did nothing: the Probe Details form was a
+ *     two-step wizard whose primary button read "Next", so a user who changed
+ *     a field on step one never saw a Save button. Test: toggle "enable
+ *     monitoring automatically on new monitors" from the card, save, reload,
+ *     and assert the card shows the new value.
+ *
+ * To run locally against a full stack:
+ *
+ *   cd E2E && HOST=localhost npx playwright test \
+ *     Tests/Dashboard/MonitorProbeSelection.spec.ts --project=chromium
+ */
+test.describe.configure({ mode: "serial" });
+
+const monitorCreateFormSelector: string = "#create-monitor-form";
+const submitButtonTestId: string = "Create Monitor";
+const autoEnableToggleName: RegExp =
+  /Enable monitoring automatically on new monitors/i;
+
+interface SharedContext {
+  page: Page;
+  projectId: string;
+  customProbeName: string;
+  customProbeId: string;
+}
+
+type ApiUrlFunction = (path: string) => string;
+
+const apiUrl: ApiUrlFunction = (path: string): string => {
+  return URL.fromString(BASE_URL.toString()).addRoute(path).toString();
+};
+
+/*
+ * Creates a custom probe through the CRUD API with the authenticated browser
+ * session (page.request shares the login cookies). Deliberately created with
+ * the auto-enable flag OFF so test (B) has something to turn on, and so test
+ * (A) proves the picker - not the flag - is what attached it.
+ */
+type SeedCustomProbeFunction = (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+}) => Promise<string>;
+
+const seedCustomProbe: SeedCustomProbeFunction = async (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+}): Promise<string> => {
+  const response: APIResponse = await data.page.request.post(
+    apiUrl("/api/probe"),
+    {
+      headers: {
+        "content-type": "application/json",
+        tenantid: data.projectId,
+      },
+      data: {
+        data: {
+          name: data.name,
+          description: "Seeded by the probe selection e2e spec.",
+          projectId: data.projectId,
+          shouldAutoEnableProbeOnNewMonitors: false,
+        },
+      },
+    },
+  );
+
+  expect(
+    response.ok(),
+    `Seed custom probe failed: ${response.status()} ${await response.text()}`,
+  ).toBe(true);
+
+  const body: any = await response.json();
+
+  return (body?.data?._id || body?._id || "").toString();
+};
+
+type ListMonitorProbesFunction = (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+}) => Promise<Array<any>>;
+
+const listMonitorProbes: ListMonitorProbesFunction = async (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+}): Promise<Array<any>> => {
+  const response: APIResponse = await data.page.request.post(
+    apiUrl("/api/monitor-probe/get-list"),
+    {
+      headers: {
+        "content-type": "application/json",
+        tenantid: data.projectId,
+      },
+      data: {
+        query: { monitorId: data.monitorId, projectId: data.projectId },
+        select: { probeId: true, isEnabled: true },
+        limit: 50,
+        skip: 0,
+        sort: {},
+      },
+    },
+  );
+
+  expect(
+    response.ok(),
+    `List monitor probes failed: ${response.status()} ${await response.text()}`,
+  ).toBe(true);
+
+  const body: any = await response.json();
+
+  return (body?.data || []) as Array<any>;
+};
+
+test.describe("Monitor probe selection", () => {
+  const ctx: SharedContext = {
+    page: undefined as unknown as Page,
+    projectId: "",
+    customProbeName: "",
+    customProbeId: "",
+  };
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    test.setTimeout(300000);
+    ctx.page = await browser.newPage();
+    ctx.projectId = await registerAndCreateProject({
+      page: ctx.page,
+      projectNamePrefix: "E2E Probe Selection Project",
+    });
+
+    ctx.customProbeName = `e2e-probe-${Faker.generateRandomString(6)}`;
+    ctx.customProbeId = await seedCustomProbe({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      name: ctx.customProbeName,
+    });
+
+    expect(ctx.customProbeId).not.toEqual("");
+  });
+
+  test.afterAll(async () => {
+    await ctx.page?.close();
+  });
+
+  test("the create form offers a probe picker and attaches exactly what was picked", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+    const monitorName: string = `e2e-probe-monitor-${Faker.generateRandomString(6)}`;
+
+    await page.goto(
+      apiUrl(`/dashboard/${ctx.projectId}/monitors/create`).replace(
+        "/api/",
+        "/",
+      ),
+      { waitUntil: "domcontentloaded" },
+    );
+    await page
+      .locator(monitorCreateFormSelector)
+      .waitFor({ state: "visible", timeout: 60000 });
+
+    // Step 1: name + type.
+    await page
+      .locator(`${monitorCreateFormSelector} input[placeholder='Monitor Name']`)
+      .fill(monitorName);
+    const card: Locator = page.getByTestId("card-select-option-Website");
+    await expect(card).toBeVisible({ timeout: 30000 });
+    await card.click();
+    await page.getByTestId(submitButtonTestId).click();
+
+    // Step 2: criteria. Wait for the async defaults, then fill the URL.
+    await expect(page.getByText("Monitor Criteria").first()).toBeVisible({
+      timeout: 60000,
+    });
+    const destination: Locator = page
+      .locator(monitorCreateFormSelector)
+      .getByRole("textbox")
+      .first();
+    await destination.waitFor({ state: "visible", timeout: 30000 });
+    await destination.fill("https://oneuptime.com");
+    await page.getByTestId(submitButtonTestId).click();
+
+    // Step 3: probes + interval.
+    const probesCombo: Locator = page.getByRole("combobox", {
+      name: "Probes",
+    });
+    await expect(probesCombo).toBeVisible({ timeout: 60000 });
+
+    /*
+     * The picker starts on the set the server would have attached on its own,
+     * which on a fresh project is the global probe.
+     */
+    await expect(page.getByText("Probe", { exact: true }).first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // Replace the default selection with only the custom probe.
+    await probesCombo.click();
+    await page.keyboard.press("Backspace");
+    await probesCombo.fill(ctx.customProbeName);
+    await page
+      .getByRole("option", { name: ctx.customProbeName, exact: true })
+      .click();
+
+    const intervalCombo: Locator = page.getByRole("combobox", {
+      name: "Monitoring Interval",
+    });
+    await intervalCombo.click();
+    await page
+      .getByRole("option", { name: "Every 5 Minutes", exact: true })
+      .click();
+
+    await page.getByTestId(submitButtonTestId).click();
+
+    await page.waitForURL(
+      new RegExp(
+        `/dashboard/${ctx.projectId}/monitors/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`,
+        "i",
+      ),
+      { timeout: 120000 },
+    );
+
+    const monitorId: string =
+      page
+        .url()
+        .match(
+          /\/monitors\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+        )?.[1] || "";
+
+    expect(monitorId).not.toEqual("");
+
+    const monitorProbes: Array<any> = await listMonitorProbes({
+      page,
+      projectId: ctx.projectId,
+      monitorId,
+    });
+
+    const probeIds: Array<string> = monitorProbes.map((monitorProbe: any) => {
+      return (monitorProbe.probeId || monitorProbe.probe?._id || "").toString();
+    });
+
+    /*
+     * The whole point of the picker: exactly the chosen probe, and none of the
+     * probes that would have been attached automatically.
+     */
+    expect(probeIds).toEqual([ctx.customProbeId]);
+  });
+
+  test("editing a probe shows a Save button, persists, and shows the new value", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+
+    const probeViewUrl: string = URL.fromString(BASE_URL.toString())
+      .addRoute(
+        `/dashboard/${ctx.projectId}/monitors/settings/probes/${ctx.customProbeId}`,
+      )
+      .toString();
+
+    await page.goto(probeViewUrl, { waitUntil: "domcontentloaded" });
+
+    // The card shows the flag it edits, so a save is observable.
+    await expect(
+      page.getByText("Enable Monitoring on New Monitors").first(),
+    ).toBeVisible({ timeout: 60000 });
+
+    await page.getByRole("button", { name: /Edit Probe/i }).click();
+
+    /*
+     * A one-page form: the primary button is a real Save, not a "Next" that
+     * hides the save behind another step.
+     */
+    const saveButton: Locator = page.getByRole("button", {
+      name: /Save Changes/i,
+    });
+    await expect(saveButton).toBeVisible({ timeout: 30000 });
+    await expect(page.getByRole("button", { name: /^Next$/ })).toHaveCount(0);
+
+    const toggle: Locator = page.getByRole("switch", {
+      name: autoEnableToggleName,
+    });
+    await expect(toggle).toBeVisible({ timeout: 30000 });
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+    await toggle.click();
+
+    await saveButton.click();
+
+    // An explicit confirmation, rather than a modal that just disappears.
+    await expect(page.getByText("Changes saved").first()).toBeVisible({
+      timeout: 30000,
+    });
+
+    // And it survives a reload - the actual bug report.
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    const detailRow: Locator = page
+      .locator("div")
+      .filter({ hasText: /^Enable Monitoring on New Monitors$/ })
+      .first();
+    await expect(detailRow).toBeVisible({ timeout: 60000 });
+
+    await expect(
+      page.getByText("Enable Monitoring on New Monitors").locator("xpath=.."),
+    ).toContainText("Yes", { timeout: 30000 });
+  });
+});


### PR DESCRIPTION
## What was reported

1. **No probe-selection step when creating a monitor.** Probes were assigned automatically after creation, and the monitor kept using the default probe — with no way to say which probe should watch a given resource.
2. **Editing a probe's settings showed no Save or Discard confirmation, and refreshing showed the change was not applied.**

## Why

### Probe selection (1)

`Create.tsx` had no probe field or step, and there was no server seam for one either. `MonitorService.onCreateSuccess` unconditionally called `addDefaultProbesToMonitor`, which attaches *every* probe flagged `shouldAutoEnableProbeOnNewMonitors`. The bundled global probe registers itself with that flag hard-coded on (`ProbeIngest/Register.ts:97`), while dashboard-created custom probes default to `false` — which is why the global "Probe" won. The attach also ran on a detached promise chain, so probes materialised *after* the form had already redirected to the monitor.

### Probe edits (2)

Three separate defects, all of which read as "my edit didn't save":

- **The Save button was hidden behind a wizard.** The Probe Details form declared `formSteps`, and `ModelFormModal` labels its primary button `"Next"` on every step but the last. Someone editing the name or the auto-enable toggle on step one saw only *Cancel* and *Next* — closing the modal discarded the edit silently.
- **A successful save was invisible.** The card's `modelDetailProps.fields` never included `shouldAutoEnableProbeOnNewMonitors`, so the page looked identical before and after. Nothing anywhere confirmed the write.
- **Probe column ACLs were copy-pasted from StatusPage.** `iconFile`, `iconFileId`, `shouldAutoEnableProbeOnNewMonitors`, `connectionStatus` and `labels` were gated on `Create/Read/EditProjectStatusPage` while the table is gated on `…ProjectProbe`. A user with only granular probe permissions saw the Edit button, but `ModelForm` dropped those fields from both the form and the payload with no message.

Three related latent defects in the shared edit stack came out of the same trace and are fixed here too:

- `CardModelDetail` derived the id its edit modal updates from the *loaded* record (`item?.id`), while the Edit button is rendered outside `ModelDetail` in a mount-only effect. Clicking Edit during the spinner gave `ModelForm` an Update form with no id; its fetch effect (deps `[]`) then skipped the prefill with no loader and no error, `BasicForm` coerced every untouched Toggle to `false`, and saving wrote blanks over the real record.
- `ModelDetail` built its `select` without a read-permission filter, though the render path right below it has one. The server rejects the *whole* get-item request over a single unreadable column (`Probe.key` is owner/admin only), so the entire card blanked for every other role.
- `BaseAPI.updateItem` answered `200 {}` regardless. The permission layer narrows the update query after the caller builds it (tenant scope, access-control labels, owned scope), so an update can match zero rows and write nothing — indistinguishable from success on the client.

## What changed

**Probe selection at create time**

- `Create.tsx`: a **Probes** multi-select on the step that already gates on probeable monitor types (`doesMonitorTypeHaveInterval` *is* `isProbableMonitor`), pre-selected with exactly the set the server would have attached anyway — so leaving it alone preserves today's behaviour. A failed probe fetch hides the picker and submits nothing, so creating a monitor is never blocked.
- The selection travels in `miscDataProps`, the repo's existing create-time side channel (`overrideField` / `overrideFieldKey`, same as the owner fields). `MonitorService.addProbesToMonitor` turns it into `MonitorProbe` rows; only global probes and probes owned by the project are accepted, since the ids come from the browser.
- Probes are attached before `onCreateSuccess` returns rather than on the detached chain, so the redirect target isn't probe-less.
- `MonitorProbeSelectionUtil` holds the default-selection rule the form pre-selects on, so the client and server can't drift silently.

**Probe edits**

- `Probe.ts`: probe columns use probe permissions.
- `MonitorProbeView`: the Probe Details form is one page with a real "Save Changes" button, and the card displays the auto-enable flag it edits.
- `CardModelDetail`: uses the id it was already handed, and shows a "Changes saved" toast.
- `ModelForm`: re-fetches when the id arrives instead of only on mount, and says the record is still loading rather than rendering an empty form that looks editable.
- `ModelDetail`: always selects `_id`, and skips columns the caller cannot read.
- `BaseAPI.updateItem`: throws instead of reporting success when the update matched no rows. `updateOneById` now returns the affected-row count.

## Tests

New:

| File | Covers |
| --- | --- |
| `Common/Tests/Utils/Monitor/MonitorProbeSelectionUtil.test.ts` | the default-probe rule (opt-in, global opt-out, dedupe) |
| `Common/Tests/Server/Services/MonitorServiceProbeSelection.test.ts` | wire-shape coercion, explicit vs. empty vs. absent selection, the cross-tenant guard, unchanged default behaviour |
| `Common/Tests/Models/DatabaseModels/ProbeColumnAccessControl.test.ts` | no Probe column may be gated on a status-page permission |
| `Common/Tests/UI/Components/ModelDetailSelect.test.tsx` | `_id` always selected; unreadable columns dropped from `fields` and `selectMoreFields` |
| `Common/Tests/UI/Components/CardModelDetailEdit.test.tsx` | the edit-during-load race (fails on the old code), toggle round-trip, save confirmation |
| `Common/Tests/Server/API/BaseAPIUpdateNoOp.test.ts` | 0-row updates no longer report success |
| `App/Tests/Dashboard/MonitorProbeSelectionPages.test.ts` | page invariants for both Dashboard pages |
| `E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts` | both reports end to end |

Run locally:

- `cd Common && npx jest --config jest.config.json Tests/UI/Components/CardModelDetailEdit.test.tsx Tests/UI/Components/ModelDetailSelect.test.tsx Tests/Models/DatabaseModels/ProbeColumnAccessControl.test.ts Tests/Server/API/BaseAPIUpdateNoOp.test.ts Tests/Server/Services/MonitorServiceProbeSelection.test.ts Tests/Utils/Monitor/MonitorProbeSelectionUtil.test.ts` — 47 passed
- `cd App && npx jest --config jest.config.json` — 83 suites / 1309 tests passed
- `npx tsc --noEmit` clean in `Common`, `App`, `App/FeatureSet/{Dashboard,AdminDashboard,StatusPage,Accounts}`, `Home`, `CLI`, `TestServer`, `E2E`
- `npx eslint` clean on every touched file

The Playwright spec typechecks but has **not** been executed — it needs a live stack running this branch.

## Notes for review

- `updateOneById` changes from `Promise<void>` to `Promise<number>`. Existing callers that ignore the value are unaffected; two typed call sites were updated.
- `BaseAPI.updateItem` throwing on a 0-row update is the widest-reaching change here. It only fires when the permission-scoped query matched nothing, which was previously reported as success.
- No migration: nothing new is persisted on `Monitor`.
- Monitor templates still carry no probe selection — a template-created monitor lands on the create form with the picker pre-filled with the defaults, so it is adjustable before submit. Adding `probes` to `MonitorTemplate` needs a migration and is left as a follow-up.
