### PR TITLE
fix(csv-export): export the right value for placeholder id and multi-field columns

### DIFF
--- a/Common/Tests/UI/Components/ModelTableExportFromColumns.test.ts
+++ b/Common/Tests/UI/Components/ModelTableExportFromColumns.test.ts
@@ -1,0 +1,153 @@
+import Column from "../../../UI/Components/ModelTable/Column";
+import { getExportKeysFromColumn } from "../../../UI/Components/ModelTable/ExportFromColumns";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import ProxmoxCluster from "../../../Models/DatabaseModels/ProxmoxCluster";
+import { describe, expect, test } from "@jest/globals";
+
+describe("ModelTable ExportFromColumns", () => {
+  describe("getExportKeysFromColumn", () => {
+    test("it returns every field a column declares, not just the first", () => {
+      /*
+       * The alert "Affected Resources" cell renders five relations at once.
+       * All five are selected, but the Table column's `key` only holds the
+       * first, so the CSV export used to carry the hosts and drop the rest.
+       */
+      const column: Column<Alert> = {
+        field: {
+          hosts: { name: true },
+          kubernetesClusters: { name: true },
+          dockerHosts: { name: true },
+          podmanHosts: { name: true },
+          services: { name: true },
+        },
+        title: "Affected Resources",
+        type: FieldType.EntityArray,
+      };
+
+      expect(
+        getExportKeysFromColumn<Alert>({
+          column: column,
+          columnKey: "hosts",
+        }),
+      ).toEqual([
+        "hosts",
+        "kubernetesClusters",
+        "dockerHosts",
+        "podmanHosts",
+        "services",
+      ]);
+    });
+
+    test("it returns a single key for an ordinary column", () => {
+      const column: Column<ProxmoxCluster> = {
+        field: { name: true },
+        title: "Name",
+        type: FieldType.Text,
+      };
+
+      expect(
+        getExportKeysFromColumn<ProxmoxCluster>({
+          column: column,
+          columnKey: "name",
+        }),
+      ).toEqual(["name"]);
+    });
+
+    test("it keeps the selectedProperty path the cell renders", () => {
+      /*
+       * columnKey already carries the "relation.property" path, and that is
+       * the path the export has to read - not the bare relation.
+       */
+      const column: Column<Alert> = {
+        field: { alertSeverity: { name: true } },
+        selectedProperty: "name",
+        title: "Severity",
+        type: FieldType.Text,
+      };
+
+      expect(
+        getExportKeysFromColumn<Alert>({
+          column: column,
+          columnKey: "alertSeverity.name",
+        }),
+      ).toEqual(["alertSeverity.name"]);
+    });
+
+    test("it drops secondary fields the user cannot read", () => {
+      /*
+       * Mirrors getSelectFromColumns: a field that was never selected because
+       * of permissions is not on the row, so exporting it would only ever
+       * produce an empty cell.
+       */
+      const column: Column<ProxmoxCluster> = {
+        field: { nodeCount: true, onlineNodeCount: true },
+        title: "Nodes",
+        type: FieldType.Element,
+      };
+
+      expect(
+        getExportKeysFromColumn<ProxmoxCluster>({
+          column: column,
+          columnKey: "nodeCount",
+          hasPermissionToReadField: (field: string): boolean => {
+            return field !== "onlineNodeCount";
+          },
+        }),
+      ).toEqual(["nodeCount"]);
+    });
+
+    test("it keeps the primary field even when the permission check rejects it", () => {
+      /*
+       * The primary field is what the column sorts and renders by, and
+       * BaseModelTable has already decided the column is visible by this
+       * point. Only secondary fields are gated here.
+       */
+      const column: Column<ProxmoxCluster> = {
+        field: { nodeCount: true, onlineNodeCount: true },
+        title: "Nodes",
+        type: FieldType.Element,
+      };
+
+      expect(
+        getExportKeysFromColumn<ProxmoxCluster>({
+          column: column,
+          columnKey: "nodeCount",
+          hasPermissionToReadField: (): boolean => {
+            return false;
+          },
+        }),
+      ).toEqual(["nodeCount"]);
+    });
+
+    test("it does not repeat the primary field when it is declared again", () => {
+      const column: Column<ProxmoxCluster> = {
+        field: { name: true, nodeCount: true },
+        title: "Name",
+        type: FieldType.Element,
+      };
+
+      expect(
+        getExportKeysFromColumn<ProxmoxCluster>({
+          column: column,
+          columnKey: "name",
+        }),
+      ).toEqual(["name", "nodeCount"]);
+    });
+
+    test("it returns nothing for a column with no key", () => {
+      const column: Column<ProxmoxCluster> = {
+        field: {},
+        title: "Actions",
+        type: FieldType.Actions,
+      };
+
+      expect(
+        getExportKeysFromColumn<ProxmoxCluster>({
+          column: column,
+          columnKey: null,
+        }),
+      ).toEqual([]);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/TableBulkCsvExport.test.tsx
+++ b/Common/Tests/UI/Components/TableBulkCsvExport.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 import { fireEvent, render, RenderResult } from "@testing-library/react";
 import * as React from "react";
+import { ReactElement } from "react";
 import getJestMockFunction, { MockFunction } from "../../MockType";
 import Table, { BulkActionProps } from "../../../UI/Components/Table/Table";
 import TableColumnsToCsv from "../../../UI/Utils/TableColumnsToCsv";
@@ -29,6 +30,8 @@ interface Row {
   _id?: string | undefined;
   name?: string | undefined;
   description?: string | undefined;
+  hosts?: Array<{ name: string }> | undefined;
+  services?: Array<{ name: string }> | undefined;
 }
 
 const columns: Columns<Row> = [
@@ -45,6 +48,7 @@ interface RenderTableOptions {
   bulkActions?: BulkActionProps<Row> | undefined;
   bulkSelectedItems?: Array<Row> | undefined;
   disableBulkCsvExport?: boolean | undefined;
+  columns?: Columns<Row> | undefined;
 }
 
 type RenderTableFunction = (options: RenderTableOptions) => RenderResult;
@@ -56,7 +60,7 @@ const renderTable: RenderTableFunction = (
     <Table<Row>
       id="test-table"
       data={data}
-      columns={columns}
+      columns={options.columns || columns}
       currentPageNumber={1}
       totalItemsCount={data.length}
       itemsOnPage={10}
@@ -263,6 +267,111 @@ describe("Table bulk CSV export", () => {
       "Name,Description",
       ",",
       ",",
+    ]);
+  });
+
+  test("a placeholder id column is left out instead of exporting a raw uuid", () => {
+    spyOnDownload();
+
+    /*
+     * The "Owners" column on alerts / incidents / monitors renders entirely
+     * through getElement and declares `field: { _id: true }` only so the row
+     * gets fetched. It used to put the row's UUID in the file under the
+     * header "Owners".
+     */
+    const { getByText } = renderTable({
+      bulkActions: customBulkActions,
+      bulkSelectedItems: [data[0]!],
+      columns: [
+        { title: "Name", type: FieldType.Text, key: "name" },
+        {
+          title: "Owners",
+          type: FieldType.Element,
+          key: "_id",
+          exportKeys: ["_id"],
+          getElement: (): ReactElement => {
+            return <span>Owners</span>;
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    expect(downloadedCsvFiles[0]!.csv.split("\r\n")).toEqual(["Name", "Alpha"]);
+  });
+
+  test("a placeholder id column that supplies an export value is exported", () => {
+    spyOnDownload();
+
+    const { getByText } = renderTable({
+      bulkActions: customBulkActions,
+      bulkSelectedItems: [data[0]!],
+      columns: [
+        { title: "Name", type: FieldType.Text, key: "name" },
+        {
+          title: "Owners",
+          type: FieldType.Element,
+          key: "_id",
+          exportKeys: ["_id"],
+          getElement: (): ReactElement => {
+            return <span>Owners</span>;
+          },
+          getExportValue: (item: Row): string => {
+            return `owner-of-${item.name}`;
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    expect(downloadedCsvFiles[0]!.csv.split("\r\n")).toEqual([
+      "Name,Owners",
+      "Alpha,owner-of-Alpha",
+    ]);
+  });
+
+  test("a column that renders several relations exports all of them", () => {
+    spyOnDownload();
+
+    /*
+     * The alert "Affected Resources" cell spans hosts / kubernetesClusters /
+     * dockerHosts / podmanHosts / services. All of them are fetched, but only
+     * the first reached the file.
+     */
+    const { getByText } = renderTable({
+      bulkActions: customBulkActions,
+      bulkSelectedItems: [
+        {
+          _id: "1",
+          name: "Alpha",
+          hosts: [{ name: "web-01" }],
+          services: [{ name: "checkout" }],
+        },
+      ],
+      columns: [
+        { title: "Name", type: FieldType.Text, key: "name" },
+        {
+          title: "Affected Resources",
+          type: FieldType.EntityArray,
+          key: "hosts",
+          exportKeys: ["hosts", "services"],
+          getElement: (): ReactElement => {
+            return <span>Resources</span>;
+          },
+        },
+      ],
+    });
+
+    fireEvent.click(getByText("Bulk Actions"));
+    fireEvent.click(getByText("Export CSV"));
+
+    expect(downloadedCsvFiles[0]!.csv.split("\r\n")).toEqual([
+      "Name,Affected Resources",
+      "Alpha,web-01; checkout",
     ]);
   });
 });

--- a/Common/Tests/UI/Utils/TableColumnsToCsv.test.ts
+++ b/Common/Tests/UI/Utils/TableColumnsToCsv.test.ts
@@ -6,6 +6,7 @@ import Columns from "../../../UI/Components/Table/Types/Columns";
 import FieldType from "../../../UI/Components/Types/FieldType";
 import OneUptimeDate from "../../../Types/Date";
 import ObjectID from "../../../Types/ObjectID";
+import { createElement, ReactElement } from "react";
 
 /*
  * Concrete row shape used across the tests. A real ModelTable passes model
@@ -20,7 +21,22 @@ interface Row {
   label?: { name?: string } | null | undefined;
   severityText?: string | undefined;
   _id?: string | undefined;
+  description?: string | undefined;
+  hosts?: Array<{ name: string }> | undefined;
+  services?: Array<{ name: string }> | undefined;
+  monitors?: Array<{ name: string }> | undefined;
 }
+
+/*
+ * The exporter never calls getElement - it only cares whether a column has
+ * one, because that is what makes a `_id` column a placeholder rather than an
+ * id the user asked to see.
+ */
+type RenderCellFunction = () => ReactElement;
+
+const renderCell: RenderCellFunction = (): ReactElement => {
+  return createElement("span");
+};
 
 describe("TableColumnsToCsv", () => {
   describe("escapeCsvValue", () => {
@@ -321,6 +337,192 @@ describe("TableColumnsToCsv", () => {
         ),
       ).toEqual([]);
     });
+
+    test("excludes a placeholder _id column such as Owners", () => {
+      /*
+       * The "Owners" column on alerts / incidents / monitors renders entirely
+       * through getElement and only declares `field: { _id: true }` so the row
+       * gets fetched. Exporting it wrote a raw UUID under the header "Owners".
+       */
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        { title: "Name", type: FieldType.Text, key: "name" },
+        {
+          title: "Owners",
+          type: FieldType.Element,
+          key: "_id",
+          exportKeys: ["_id"],
+          getElement: renderCell,
+        },
+      ]);
+
+      expect(
+        result.map((c: Column<Row>) => {
+          return c.title;
+        }),
+      ).toEqual(["Name"]);
+    });
+
+    test("keeps an _id column that genuinely shows the id", () => {
+      // FieldType.ObjectID is how a column says the id IS the value.
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        {
+          title: "Execution ID",
+          type: FieldType.ObjectID,
+          key: "_id",
+          exportKeys: ["_id"],
+          getElement: renderCell,
+        },
+      ]);
+
+      expect(result.length).toBe(1);
+    });
+
+    test("keeps an _id column that has no getElement", () => {
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        { title: "ID", type: FieldType.Text, key: "_id", exportKeys: ["_id"] },
+      ]);
+
+      expect(result.length).toBe(1);
+    });
+
+    test("keeps an _id column that declares other fields alongside it", () => {
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        {
+          title: "Resource",
+          type: FieldType.Element,
+          key: "_id",
+          exportKeys: ["_id", "name"],
+          getElement: renderCell,
+        },
+      ]);
+
+      expect(result.length).toBe(1);
+    });
+
+    test("excludes a column that opted out with disableCsvExport", () => {
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        { title: "Name", type: FieldType.Text, key: "name" },
+        {
+          title: "Status",
+          type: FieldType.Text,
+          key: "status",
+          disableCsvExport: true,
+        },
+      ]);
+
+      expect(
+        result.map((c: Column<Row>) => {
+          return c.title;
+        }),
+      ).toEqual(["Name"]);
+    });
+
+    test("keeps a keyless column that supplies its own export value", () => {
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        {
+          title: "Owners",
+          type: FieldType.Element,
+          getExportValue: (): string => {
+            return "someone";
+          },
+        },
+      ]);
+
+      expect(result.length).toBe(1);
+    });
+
+    test("disableCsvExport wins over an explicit export value", () => {
+      const result: Columns<Row> = TableColumnsToCsv.getExportableColumns([
+        {
+          title: "Owners",
+          type: FieldType.Element,
+          key: "_id",
+          disableCsvExport: true,
+          getExportValue: (): string => {
+            return "someone";
+          },
+        },
+      ]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getExportKeys", () => {
+    test("falls back to the single column key", () => {
+      expect(
+        TableColumnsToCsv.getExportKeys<Row>({
+          title: "Name",
+          type: FieldType.Text,
+          key: "name",
+        }),
+      ).toEqual(["name"]);
+    });
+
+    test("returns every declared key when exportKeys is set", () => {
+      expect(
+        TableColumnsToCsv.getExportKeys<Row>({
+          title: "Affected Resources",
+          type: FieldType.EntityArray,
+          key: "hosts",
+          exportKeys: ["hosts", "services", "monitors"],
+        }),
+      ).toEqual(["hosts", "services", "monitors"]);
+    });
+
+    test("returns nothing for a keyless column", () => {
+      expect(
+        TableColumnsToCsv.getExportKeys<Row>({
+          title: "Custom",
+          type: FieldType.Element,
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("isPlaceholderIdColumn", () => {
+    test("is true for an _id-only column rendered through getElement", () => {
+      expect(
+        TableColumnsToCsv.isPlaceholderIdColumn<Row>({
+          title: "Owners",
+          type: FieldType.Element,
+          key: "_id",
+          getElement: renderCell,
+        }),
+      ).toBe(true);
+    });
+
+    test("is false without a getElement", () => {
+      expect(
+        TableColumnsToCsv.isPlaceholderIdColumn<Row>({
+          title: "ID",
+          type: FieldType.Element,
+          key: "_id",
+        }),
+      ).toBe(false);
+    });
+
+    test("is false for FieldType.ObjectID", () => {
+      expect(
+        TableColumnsToCsv.isPlaceholderIdColumn<Row>({
+          title: "Run ID",
+          type: FieldType.ObjectID,
+          key: "_id",
+          getElement: renderCell,
+        }),
+      ).toBe(false);
+    });
+
+    test("is false for a column keyed on something other than _id", () => {
+      expect(
+        TableColumnsToCsv.isPlaceholderIdColumn<Row>({
+          title: "Name",
+          type: FieldType.Element,
+          key: "name",
+          getElement: renderCell,
+        }),
+      ).toBe(false);
+    });
   });
 
   describe("getCellValue", () => {
@@ -342,6 +544,100 @@ describe("TableColumnsToCsv", () => {
       expect(TableColumnsToCsv.getCellValue({ isActive: false }, column)).toBe(
         "No",
       );
+    });
+
+    test("reads every declared field, not just the first", () => {
+      /*
+       * The alert "Affected Resources" cell spans several relations at once.
+       * Only the first used to reach the file, so a row whose resources were
+       * services exported an empty cell.
+       */
+      const column: Column<Row> = {
+        title: "Affected Resources",
+        type: FieldType.EntityArray,
+        key: "hosts",
+        exportKeys: ["hosts", "services", "monitors"],
+      };
+
+      const item: Row = {
+        hosts: [{ name: "web-01" }],
+        services: [{ name: "checkout" }],
+        monitors: [{ name: "api-uptime" }],
+      };
+
+      expect(TableColumnsToCsv.getCellValue(item, column)).toBe(
+        "web-01; checkout; api-uptime",
+      );
+    });
+
+    test("skips the declared fields that are empty on this row", () => {
+      const column: Column<Row> = {
+        title: "Affected Resources",
+        type: FieldType.EntityArray,
+        key: "hosts",
+        exportKeys: ["hosts", "services", "monitors"],
+      };
+
+      expect(
+        TableColumnsToCsv.getCellValue(
+          { services: [{ name: "checkout" }] },
+          column,
+        ),
+      ).toBe("checkout");
+    });
+
+    test("does not list the same value twice across declared fields", () => {
+      const column: Column<Row> = {
+        title: "Affected Resources",
+        type: FieldType.EntityArray,
+        key: "hosts",
+        exportKeys: ["hosts", "services"],
+      };
+
+      const item: Row = {
+        hosts: [{ name: "shared" }],
+        services: [{ name: "shared" }],
+      };
+
+      expect(TableColumnsToCsv.getCellValue(item, column)).toBe("shared");
+    });
+
+    test("returns an empty cell when none of the declared fields are set", () => {
+      const column: Column<Row> = {
+        title: "Affected Resources",
+        type: FieldType.EntityArray,
+        key: "hosts",
+        exportKeys: ["hosts", "services"],
+      };
+
+      expect(TableColumnsToCsv.getCellValue({}, column)).toBe("");
+    });
+
+    test("uses getExportValue in preference to the row's own fields", () => {
+      const column: Column<Row> = {
+        title: "Owners",
+        type: FieldType.Element,
+        key: "_id",
+        getExportValue: (item: Row): string => {
+          return `owner of ${item.name}`;
+        },
+      };
+
+      expect(
+        TableColumnsToCsv.getCellValue({ _id: "abc", name: "Alpha" }, column),
+      ).toBe("owner of Alpha");
+    });
+
+    test("treats a null-ish getExportValue result as an empty cell", () => {
+      const column: Column<Row> = {
+        title: "Owners",
+        type: FieldType.Element,
+        getExportValue: (): string => {
+          return undefined as unknown as string;
+        },
+      };
+
+      expect(TableColumnsToCsv.getCellValue({}, column)).toBe("");
     });
   });
 
@@ -407,6 +703,70 @@ describe("TableColumnsToCsv", () => {
         columns: columns,
       });
       expect(csv).toBe("Name,Active");
+    });
+
+    test("drops the placeholder id column and spans every relation of a multi-field column", () => {
+      /*
+       * End to end over the two shapes that used to export the wrong value: an
+       * "Owners" column that wrote a UUID, and an "Affected Resources" column
+       * that wrote only its first relation.
+       */
+      const csv: string = TableColumnsToCsv.convertToCsv({
+        items: [
+          {
+            _id: "b6b0f3c2-0000-0000-0000-000000000000",
+            name: "Alpha",
+            hosts: [{ name: "web-01" }],
+            services: [{ name: "checkout" }],
+          },
+        ],
+        columns: [
+          { title: "Name", type: FieldType.Text, key: "name" },
+          {
+            title: "Affected Resources",
+            type: FieldType.EntityArray,
+            key: "hosts",
+            exportKeys: ["hosts", "services"],
+            getElement: renderCell,
+          },
+          {
+            title: "Owners",
+            type: FieldType.Element,
+            key: "_id",
+            exportKeys: ["_id"],
+            getElement: renderCell,
+          },
+        ],
+      });
+
+      expect(csv.split("\r\n")).toEqual([
+        "Name,Affected Resources",
+        "Alpha,web-01; checkout",
+      ]);
+    });
+
+    test("an opted-in placeholder column exports its supplied value", () => {
+      const csv: string = TableColumnsToCsv.convertToCsv({
+        items: [{ _id: "1", name: "Alpha" }],
+        columns: [
+          { title: "Name", type: FieldType.Text, key: "name" },
+          {
+            title: "Owners",
+            type: FieldType.Element,
+            key: "_id",
+            exportKeys: ["_id"],
+            getElement: renderCell,
+            getExportValue: (): string => {
+              return "jane@example.com";
+            },
+          },
+        ],
+      });
+
+      expect(csv.split("\r\n")).toEqual([
+        "Name,Owners",
+        "Alpha,jane@example.com",
+      ]);
     });
   });
 

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -58,6 +58,7 @@ import TableColumn from "../Table/Types/Column";
 import FieldType from "../Types/FieldType";
 import ModelTableColumn from "./Column";
 import Columns from "./Columns";
+import { getExportKeysFromColumn } from "./ExportFromColumns";
 import {
   getRelationSelectFromColumns,
   getSelectFromColumns,
@@ -984,6 +985,18 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           ...column,
           disableSort: column.disableSort || shouldDisableSort(key),
           key: columnKey,
+          /*
+           * `key` is only the first declared field, so a cell composed from
+           * several of them would export just that one. Hand the exporter
+           * every field the column declares (and that we actually selected).
+           */
+          exportKeys: getExportKeysFromColumn<TBaseModel>({
+            column: column,
+            columnKey: columnKey ? String(columnKey) : null,
+            hasPermissionToReadField: (field: string): boolean => {
+              return hasPermissionToReadField(field as keyof TBaseModel);
+            },
+          }),
           tooltipText,
           getElement: column.getElement,
         });

--- a/Common/UI/Components/ModelTable/Column.ts
+++ b/Common/UI/Components/ModelTable/Column.ts
@@ -29,6 +29,18 @@ export default interface Columns<
   alignItem?: AlignItem | undefined;
   noValueMessage?: string | undefined;
   hideOnMobile?: boolean | undefined; // Hide column on mobile devices
+  /*
+   * Exact text for this column's CSV cell (the text twin of getElement, and
+   * it receives the same item). Set it when the cell renders from something
+   * the row does not carry under this column's own `field` - data fetched
+   * alongside the table, or a phrase composed from several fields. Columns
+   * that render entirely through getElement off a placeholder
+   * `field: { _id: true }` are left out of the CSV unless they set this,
+   * because their only exportable value is a raw UUID.
+   */
+  getExportValue?: ((item: TEntity) => string) | undefined;
+  // Leave this column out of the CSV export entirely.
+  disableCsvExport?: boolean | undefined;
   getElement?:
     | ((item: TEntity, onBeforeFetchData?: TEntity | undefined) => ReactElement)
     | undefined;

--- a/Common/UI/Components/ModelTable/ExportFromColumns.ts
+++ b/Common/UI/Components/ModelTable/ExportFromColumns.ts
@@ -1,0 +1,57 @@
+import Column from "./Column";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+
+/*
+ * Derives the fields a ModelTable column contributes to a CSV export from its
+ * column definition, and mirrors getSelectFromColumns: a column may declare
+ * MORE THAN ONE field when its cell is composed from several of them, and all
+ * of them are fetched. The Table column's `key` only ever holds the first, so
+ * an exporter reading `key` alone drops the rest - the alert "Affected
+ * Resources" cell spans hosts / kubernetesClusters / dockerHosts /
+ * podmanHosts / services, and only the hosts made it into the file.
+ */
+
+export function getExportKeysFromColumn<
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  column: Column<TBaseModel>;
+  /*
+   * The key the Table column renders and sorts by. It is the first declared
+   * field, with `selectedProperty` appended when the column picks a single
+   * property off a relation ("label.name"), so the export reads the same path
+   * the cell does.
+   */
+  columnKey: string | null;
+  /*
+   * Secondary fields are gated on this exactly as they are in the select: a
+   * field the caller cannot read was never fetched, so exporting it would
+   * only ever produce an empty cell.
+   */
+  hasPermissionToReadField?: ((field: string) => boolean) | undefined;
+}): Array<string> {
+  const exportKeys: Array<string> = [];
+
+  if (data.columnKey) {
+    exportKeys.push(data.columnKey);
+  }
+
+  if (!data.column.field) {
+    return exportKeys;
+  }
+
+  const declaredKeys: Array<string> = Object.keys(data.column.field);
+
+  // The primary field is already covered by columnKey.
+  for (const key of declaredKeys.slice(1)) {
+    if (data.hasPermissionToReadField && !data.hasPermissionToReadField(key)) {
+      continue;
+    }
+
+    if (!exportKeys.includes(key)) {
+      exportKeys.push(key);
+    }
+  }
+
+  return exportKeys;
+}

--- a/Common/UI/Components/Table/Types/Column.ts
+++ b/Common/UI/Components/Table/Types/Column.ts
@@ -15,6 +15,24 @@ export default interface Column<T extends GenericObject> {
   alignItem?: AlignItem | undefined;
   key?: keyof T | null; //can be null because actions column does not have a key.
   hideOnMobile?: boolean | undefined; // Hide column on mobile devices
+  /*
+   * Every field that backs this cell, in declaration order. A ModelTable
+   * column may declare more than one - e.g. the alert "Affected Resources"
+   * cell spans hosts / kubernetesClusters / dockerHosts / podmanHosts /
+   * services - while `key` only ever holds the first one, because that is the
+   * one used for sorting and for the default renderer. CSV export reads all
+   * of them so it does not silently drop the rest. Defaults to [key].
+   */
+  exportKeys?: Array<string> | undefined;
+  /*
+   * Exact text for this column's CSV cell, overriding the value read off the
+   * row. Use it when the rendered cell is built from something the row does
+   * not carry under the column's own field (data fetched alongside the table,
+   * a computed summary, several fields combined into one phrase).
+   */
+  getExportValue?: ((item: T) => string) | undefined;
+  // Leave this column out of the CSV export entirely.
+  disableCsvExport?: boolean | undefined;
   getElement?:
     | ((item: T, onBeforeFetchData?: T | undefined) => ReactElement)
     | undefined;

--- a/Common/UI/Utils/TableColumnsToCsv.ts
+++ b/Common/UI/Utils/TableColumnsToCsv.ts
@@ -263,8 +263,57 @@ export default class TableColumnsToCsv {
   }
 
   /*
+   * The fields a column contributes to the export. A ModelTable column can
+   * declare several (a cell that renders hosts + clusters + services in one
+   * place), and BaseModelTable forwards all of them as exportKeys; `key`
+   * alone is only the first. Falls back to the single key for tables that
+   * build their Table columns by hand.
+   */
+  public static getExportKeys<T extends GenericObject>(
+    column: Column<T>,
+  ): Array<string> {
+    if (column.exportKeys && column.exportKeys.length > 0) {
+      return column.exportKeys;
+    }
+
+    if (column.key === null || column.key === undefined) {
+      return [];
+    }
+
+    return [String(column.key)];
+  }
+
+  /*
+   * A column that renders entirely through getElement still has to declare a
+   * field so the row gets fetched at all, and the convention for that is
+   * `field: { _id: true }` - the "Owners" column on alerts, incidents,
+   * monitors and friends. The id is plumbing, not the cell's value, so
+   * exporting it writes a raw UUID under a header like "Owners". Treat such a
+   * column as presentational and leave it out, the same way a column with no
+   * key at all is left out. A column that genuinely shows the id says so with
+   * FieldType.ObjectID, and one that wants its rendered content in the file
+   * says so with getExportValue.
+   */
+  public static isPlaceholderIdColumn<T extends GenericObject>(
+    column: Column<T>,
+  ): boolean {
+    if (!column.getElement) {
+      return false;
+    }
+
+    if (column.type === FieldType.ObjectID) {
+      return false;
+    }
+
+    const keys: Array<string> = this.getExportKeys(column);
+
+    return keys.length === 1 && keys[0] === "_id";
+  }
+
+  /*
    * Columns that can be exported: everything except the Actions column (which
-   * only holds buttons) and columns without a data key (purely presentational).
+   * only holds buttons), columns that opted out, columns without a data key
+   * (purely presentational), and placeholder id columns.
    */
   public static getExportableColumns<T extends GenericObject>(
     columns: Columns<T>,
@@ -274,7 +323,20 @@ export default class TableColumnsToCsv {
         return false;
       }
 
-      if (column.key === null || column.key === undefined) {
+      if (column.disableCsvExport) {
+        return false;
+      }
+
+      // An explicit export value makes even a keyless column exportable.
+      if (column.getExportValue) {
+        return true;
+      }
+
+      if (this.getExportKeys(column).length === 0) {
+        return false;
+      }
+
+      if (this.isPlaceholderIdColumn(column)) {
         return false;
       }
 
@@ -286,13 +348,31 @@ export default class TableColumnsToCsv {
     item: T,
     column: Column<T>,
   ): string {
-    if (column.key === null || column.key === undefined) {
-      return "";
+    if (column.getExportValue) {
+      return column.getExportValue(item) || "";
     }
 
-    const rawValue: unknown = this.getRawValueByPath(item, String(column.key));
+    /*
+     * Every declared field goes into the one cell, joined the same way a
+     * multi-value field is, so a cell that renders several relations exports
+     * all of them. Blanks are dropped (only one of the relations is usually
+     * set) and repeats are collapsed (the same entity reachable through two
+     * of them should not be listed twice).
+     */
+    const values: Array<string> = [];
 
-    return this.formatValueForCsv(rawValue, column.type);
+    for (const key of this.getExportKeys(column)) {
+      const formatted: string = this.formatValueForCsv(
+        this.getRawValueByPath(item, key),
+        column.type,
+      );
+
+      if (formatted.length > 0 && !values.includes(formatted)) {
+        values.push(formatted);
+      }
+    }
+
+    return values.join("; ");
   }
 
   /*


### PR DESCRIPTION
### Title of this pull request?

fix(csv-export): export the right value for placeholder id and multi-field columns

### Small Description?

The table "Export CSV" bulk action derived every cell from a column's **first** declared field. That is wrong for two shapes of column. Both are pre-existing, affect manual selections as well as "Select All", and were deliberately left out of #2863.

**1. Placeholder `_id` columns wrote a raw UUID.** A column that renders entirely through `getElement` still has to declare a field so the row gets fetched, and the convention for that is `field: { _id: true }`. The exporter treated that id as the cell's value, so the file carried a UUID under a header like "Owners".

I scanned all 1,113 column-level `field` declarations to size this: **27 columns declare only `_id`, and 25 are placeholders** — Owners on alerts / incidents / monitors / scheduled maintenance / hosts / on-call policies / Ceph / Docker / Docker Swarm / Kubernetes / Podman / Proxmox / IoT Fleets / dashboards / services / runbooks / status pages / workflows / AI agents / monitor groups / incoming-call policies, plus "Current Status", "MQTT Username" and two "Status" columns. The other 2 ("Execution ID", "Run ID") are real id columns and are untouched.

**2. Multi-field columns silently dropped everything but the first field.** The alert "Affected Resources" cell spans `hosts / kubernetesClusters / dockerHosts / podmanHosts / services`. `getSelectFromColumns` fetches every one, but the exporter read only `hosts` — so a row whose resources were services exported an empty cell. 18 columns declare more than one field.

#### Approach

Fixed in the framework, so **none of the ~305 table definitions had to change**:

- `BaseModelTable` now forwards every field a column declares as `exportKeys` on the Table column, via a new `getExportKeysFromColumn` that gates secondary fields on read permission exactly as `getSelectFromColumns` does (a field that was never selected would only ever export blank). `getCellValue` reads all of them into the one cell, joined the way a multi-value field already is, dropping blanks and collapsing repeats.
- `getExportableColumns` leaves out placeholder id columns: `_id` is the only export key, `getElement` is present, and the type is not `ObjectID`. A column that genuinely shows the id says so with `FieldType.ObjectID` and still exports.

Two new optional column props cover the cases the defaults do not suit — `getExportValue` for exact text (the text twin of `getElement`) and `disableCsvExport` to drop a column entirely. Both are optional and flow through the existing spread in `serializeToTableColumns`.

#### Reviewer notes

- **Omitting the Owners column rather than blanking it** is a deliberate call. A header "Owners" over empty cells reads as "this alert has no owners", which is a worse lie than a missing column; `getExportableColumns` already omits keyless presentational columns, so this is consistent. Owner names come from a fetch keyed by resource id, *outside* the row, so actually exporting them means adding `getExportValue` to those 25 tables — real work, but a separate change from fixing the framework. **This PR does not do that.**
- **Composite numeric columns get more, not less.** Docker Swarm's `{nodeCount, readyNodeCount}` cell renders "4/5 ready" and now exports `5; 4` instead of `5`. More information than before, but ambiguous; those columns should get a `getExportValue` if it matters. Same for `{alertNumber, alertNumberWithPrefix}` → `42; ALT-42`.
- **I did not render `getElement` to text.** It would pull `react-dom/server` into the export path and run arbitrary components across 305 tables — `OwnersCell` mid-fetch renders a loading state, and other cells reach for browser-only APIs.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

`cd Common && npx tsc --noEmit -p tsconfig.json` is clean, and `npx eslint <changed files> --fix` from the repo root is clean.

The Common UI jest suite passes **1041 tests, 0 failures**. 24 suites in that run fail to *compile* on a missing `@testing-library/jest-dom` matcher type (`toBeInTheDocument`); that is pre-existing and unrelated — I confirmed `Probe.test.tsx` fails the same way on a clean tree at `master`.

37 new tests:
- 27 in `Common/Tests/UI/Utils/TableColumnsToCsv.test.ts` — `getExportKeys`, `isPlaceholderIdColumn` (including the `ObjectID` and no-`getElement` exemptions), the `getExportableColumns` filters, multi-key joining / blank-skipping / dedup, `getExportValue` precedence, and two end-to-end `convertToCsv` cases over both bug shapes.
- 3 in `Common/Tests/UI/Components/TableBulkCsvExport.test.tsx` — driving the real Export CSV bulk action and asserting on the CSV text handed to the browser.
- 7 in a new `Common/Tests/UI/Components/ModelTableExportFromColumns.test.ts` — key derivation over real models (`Alert`, `ProxmoxCluster`), including the `selectedProperty` path and the permission gate.

### Related Issue?

None. Follow-up to #2863, which fixed "Select All" export and left this behind.

### Screenshots (if appropriate):

N/A — no visible UI change; only the contents of the downloaded CSV change.
