### PR TITLE
fix(navbar): let the mobile products menu scroll

### DIFF
--- a/Common/UI/Components/Navbar/NavBar.tsx
+++ b/Common/UI/Components/Navbar/NavBar.tsx
@@ -69,6 +69,13 @@ export interface ComponentProps {
   children?: ReactElement | Array<ReactElement>;
 }
 
+/*
+ * Breathing room kept between the bottom of the open mobile menu and the bottom
+ * of the viewport, and the smallest height we will ever shrink the menu to.
+ */
+const MOBILE_MENU_BOTTOM_GAP_IN_PX: number = 16;
+const MOBILE_MENU_MIN_HEIGHT_IN_PX: number = 160;
+
 const Navbar: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
@@ -76,6 +83,9 @@ const Navbar: FunctionComponent<ComponentProps> = (
   const [isMobileMenuVisible, setIsMobileMenuVisible] =
     useState<boolean>(false);
   const [isMoreMenuVisible, setIsMoreMenuVisible] = useState<boolean>(false);
+  const [mobileMenuMaxHeight, setMobileMenuMaxHeight] = useState<
+    number | undefined
+  >(undefined);
 
   // Use the existing outside click hook for mobile menu
   const {
@@ -102,6 +112,54 @@ const Navbar: FunctionComponent<ComponentProps> = (
       return window.removeEventListener("resize", checkMobile);
     };
   }, []);
+
+  /*
+   * The mobile menu is absolutely positioned inside a `sticky top-0` header, so
+   * anything that overflows past the bottom of the viewport is unreachable —
+   * scrolling the page just drags the sticky header (and the menu pinned to it)
+   * along. Cap the menu to the space left below it so it scrolls on its own.
+   */
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    const updateMobileMenuMaxHeight: () => void = (): void => {
+      const menuTop: number =
+        mobileMenuRef.current?.getBoundingClientRect().top ?? 0;
+      const viewportHeight: number =
+        window.visualViewport?.height ?? window.innerHeight;
+
+      setMobileMenuMaxHeight(
+        Math.max(
+          viewportHeight - menuTop - MOBILE_MENU_BOTTOM_GAP_IN_PX,
+          MOBILE_MENU_MIN_HEIGHT_IN_PX,
+        ),
+      );
+    };
+
+    updateMobileMenuMaxHeight();
+
+    window.addEventListener("resize", updateMobileMenuMaxHeight);
+    window.addEventListener("orientationchange", updateMobileMenuMaxHeight);
+    // The address bar collapsing on mobile only shows up on the visual viewport.
+    window.visualViewport?.addEventListener(
+      "resize",
+      updateMobileMenuMaxHeight,
+    );
+
+    return () => {
+      window.removeEventListener("resize", updateMobileMenuMaxHeight);
+      window.removeEventListener(
+        "orientationchange",
+        updateMobileMenuMaxHeight,
+      );
+      window.visualViewport?.removeEventListener(
+        "resize",
+        updateMobileMenuMaxHeight,
+      );
+    };
+  }, [isMobileMenuOpen]);
 
   // Open/close the products menu with Cmd/Ctrl + K from anywhere.
   useEffect(() => {
@@ -235,7 +293,14 @@ const Navbar: FunctionComponent<ComponentProps> = (
             ref={mobileMenuRef}
             className="absolute top-full left-0 right-0 z-50 mt-1 transition-all duration-200 ease-in-out"
           >
-            <nav className="bg-white rounded-lg shadow-lg px-3 py-3 space-y-1 border border-gray-200">
+            <nav
+              className="bg-white rounded-lg shadow-lg px-3 py-3 space-y-1 border border-gray-200 overflow-y-auto overscroll-contain"
+              style={
+                mobileMenuMaxHeight
+                  ? { maxHeight: `${mobileMenuMaxHeight}px` }
+                  : undefined
+              }
+            >
               {allNavItems.map((item: any) => {
                 return (
                   <div key={item.id} className="block w-full">


### PR DESCRIPTION
Fixes #2757

## Problem

On a phone, the products dropdown could not be scrolled. The list rendered every product (25+ items), so a large chunk of it sat below the fold and was simply unreachable.

Two things combined to cause it:

- The mobile dropdown is `absolute top-full` inside a container that lives in the `sticky top-0` header (`Common/UI/Components/MasterPage/MasterPage.tsx:65`). Scrolling the page drags the sticky header — and the dropdown pinned to it — along, so page scroll never reveals the overflow.
- The dropdown itself had no `max-height` and no `overflow-y`, so it had no scroll area of its own either.

## Fix

Cap the dropdown to the space between its top edge and the bottom of the viewport, and let it scroll internally (`overflow-y-auto overscroll-contain`). The height is measured rather than hardcoded, because the dropdown's top offset depends on the header above it; it's recomputed on `resize`, `orientationchange`, and `visualViewport` resize so it stays correct when the mobile address bar collapses or the device rotates.

`overscroll-contain` keeps the scroll from chaining into the page once the list hits its end.

## Verification

Reproduced the exact DOM nesting (sticky header → relative container → absolute dropdown, 25 items) at a 375×812 mobile viewport and measured before/after:

| | before | after |
|---|---|---|
| list bottom vs. viewport (812px) | 1152px — **340px unreachable** | 796px — fits |
| still overflows after scrolling page 500px | yes (sticky pins it) | n/a |
| internally scrollable | no | yes |
| last item ("Billing") reachable | no | yes, fully visible |

Also ran `tsc --noEmit` on `Common` and `eslint --fix` on the changed file — both clean.

Note: the marketing site's products modal (`Home/Views/nav.ejs`) already has `max-height: 82vh` plus an `overflow-y-auto` body, so it was not affected.