### PR TITLE
fix: let projects with cross-project monitor status references be deleted

### DIFF
--- a/Common/Models/DatabaseModels/MonitorStatusTimeline.ts
+++ b/Common/Models/DatabaseModels/MonitorStatusTimeline.ts
@@ -418,6 +418,7 @@ export default class MonitorStatusTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Models/DatabaseModels/NetworkSiteStatusTimeline.ts
+++ b/Common/Models/DatabaseModels/NetworkSiteStatusTimeline.ts
@@ -276,6 +276,7 @@ export default class NetworkSiteStatusTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785240000000-RepairCrossProjectMonitorStatusReferences.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785240000000-RepairCrossProjectMonitorStatusReferences.ts
@@ -31,6 +31,14 @@ export class RepairCrossProjectMonitorStatusReferences1785240000000
     "RepairCrossProjectMonitorStatusReferences1785240000000";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    /*
+     * The repair below scans MonitorStatusTimeline, which is in the millions of
+     * rows. Measured at ~4.5s on a production-sized table, but the connection
+     * carries the app's 30s statement_timeout (DATABASE_STATEMENT_TIMEOUT_MS)
+     * and a loaded database should not turn this into a failed deploy.
+     */
+    await queryRunner.query(`SET LOCAL statement_timeout = '600s'`);
+
     // 1. MonitorStatusTimeline rows pointing at another project's status.
     await queryRunner.query(`
       WITH bad AS (
@@ -225,7 +233,17 @@ export class RepairCrossProjectMonitorStatusReferences1785240000000
      * blocking. Without this, a leftover cross-project row (one we could not
      * resolve above, e.g. a project with no statuses of its own) would still
      * make the referenced project undeletable.
+     *
+     * Swapping a foreign key needs ACCESS EXCLUSIVE on MonitorStatusTimeline —
+     * the busiest write table there is — and the lock is held until this
+     * migration commits. The DDL itself measures ~1.3s, but the server has no
+     * lock_timeout, so without the line below a single slow transaction holding
+     * the table would make this statement queue *and* park every reader and
+     * writer behind it until the 30s statement_timeout fired. Failing fast and
+     * retrying the deploy is much cheaper than stalling the table.
      */
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+
     await queryRunner.query(
       `ALTER TABLE "MonitorStatusTimeline" DROP CONSTRAINT "FK_574feb4161c5216c2c7ee0faaf8"`,
     );

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785240000000-RepairCrossProjectMonitorStatusReferences.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785240000000-RepairCrossProjectMonitorStatusReferences.ts
@@ -1,0 +1,262 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Monitors can end up holding references to another project's MonitorStatus,
+ * IncidentSeverity or AlertSeverity — nothing validated that the ids embedded
+ * in `monitorSteps` belong to the monitor's own project, so a status id picked
+ * up from a second project got persisted and then copied onto every
+ * MonitorStatusTimeline row the monitor wrote.
+ *
+ * That makes the *referenced* project undeletable: deleting a Project cascades
+ * into its MonitorStatus rows, but MonitorStatusTimeline rows owned by a
+ * different project still point at them and the FK is ON DELETE NO ACTION, so
+ * Postgres raises 23503 and the API answers "Server Error".
+ *
+ * This migration:
+ *   1. repoints every cross-project reference at the equivalent record in the
+ *      row's own project (matched by name, then by operational/offline role,
+ *      then by nearest priority), and
+ *   2. switches the two status-timeline FKs to ON DELETE CASCADE, which is
+ *      what they should always have been — a status timeline row is
+ *      meaningless once its status is gone.
+ *
+ * Step 1 runs before step 2 on purpose: repairing first means the timeline
+ * history stays attached to the surviving project instead of being swept up by
+ * the new cascade.
+ */
+export class RepairCrossProjectMonitorStatusReferences1785240000000
+  implements MigrationInterface
+{
+  public name: string =
+    "RepairCrossProjectMonitorStatusReferences1785240000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. MonitorStatusTimeline rows pointing at another project's status.
+    await queryRunner.query(`
+      WITH bad AS (
+        SELECT t."_id" AS row_id,
+               t."projectId" AS project_id,
+               ms."name" AS status_name,
+               ms."isOperationalState" AS is_operational,
+               ms."isOfflineState" AS is_offline,
+               ms."priority" AS priority
+        FROM "MonitorStatusTimeline" t
+        JOIN "MonitorStatus" ms ON ms."_id" = t."monitorStatusId"
+        WHERE t."projectId" IS DISTINCT FROM ms."projectId"
+      ), resolved AS (
+        SELECT b.row_id, COALESCE(
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id AND lower(s."name") = lower(b.status_name)
+            ORDER BY s."priority" LIMIT 1),
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id
+              AND s."isOperationalState" = b.is_operational
+              AND s."isOfflineState" = b.is_offline
+            ORDER BY s."priority" LIMIT 1),
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id
+            ORDER BY abs(s."priority" - b.priority), s."priority" LIMIT 1)
+        ) AS good_status_id
+        FROM bad b
+      )
+      UPDATE "MonitorStatusTimeline" t
+      SET "monitorStatusId" = r.good_status_id
+      FROM resolved r
+      WHERE t."_id" = r.row_id AND r.good_status_id IS NOT NULL
+    `);
+
+    // 2. NetworkSiteStatusTimeline rows pointing at another project's status.
+    await queryRunner.query(`
+      WITH bad AS (
+        SELECT t."_id" AS row_id,
+               t."projectId" AS project_id,
+               ms."name" AS status_name,
+               ms."isOperationalState" AS is_operational,
+               ms."isOfflineState" AS is_offline,
+               ms."priority" AS priority
+        FROM "NetworkSiteStatusTimeline" t
+        JOIN "MonitorStatus" ms ON ms."_id" = t."monitorStatusId"
+        WHERE t."projectId" IS DISTINCT FROM ms."projectId"
+      ), resolved AS (
+        SELECT b.row_id, COALESCE(
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id AND lower(s."name") = lower(b.status_name)
+            ORDER BY s."priority" LIMIT 1),
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id
+              AND s."isOperationalState" = b.is_operational
+              AND s."isOfflineState" = b.is_offline
+            ORDER BY s."priority" LIMIT 1),
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id
+            ORDER BY abs(s."priority" - b.priority), s."priority" LIMIT 1)
+        ) AS good_status_id
+        FROM bad b
+      )
+      UPDATE "NetworkSiteStatusTimeline" t
+      SET "monitorStatusId" = r.good_status_id
+      FROM resolved r
+      WHERE t."_id" = r.row_id AND r.good_status_id IS NOT NULL
+    `);
+
+    /*
+     * 3. Monitor.currentMonitorStatusId pointing at another project's status.
+     * This FK stays NO ACTION — deleting a status that monitors are currently
+     * in should be blocked — so a cross-project value here blocks deletion the
+     * same way. The column is NOT NULL, hence a repoint rather than a null.
+     */
+    await queryRunner.query(`
+      WITH bad AS (
+        SELECT m."_id" AS row_id,
+               m."projectId" AS project_id,
+               ms."name" AS status_name,
+               ms."isOperationalState" AS is_operational,
+               ms."isOfflineState" AS is_offline,
+               ms."priority" AS priority
+        FROM "Monitor" m
+        JOIN "MonitorStatus" ms ON ms."_id" = m."currentMonitorStatusId"
+        WHERE m."projectId" IS DISTINCT FROM ms."projectId"
+      ), resolved AS (
+        SELECT b.row_id, COALESCE(
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id AND lower(s."name") = lower(b.status_name)
+            ORDER BY s."priority" LIMIT 1),
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id
+              AND s."isOperationalState" = b.is_operational
+              AND s."isOfflineState" = b.is_offline
+            ORDER BY s."priority" LIMIT 1),
+          (SELECT s."_id" FROM "MonitorStatus" s
+            WHERE s."projectId" = b.project_id
+            ORDER BY abs(s."priority" - b.priority), s."priority" LIMIT 1)
+        ) AS good_status_id
+        FROM bad b
+      )
+      UPDATE "Monitor" m
+      SET "currentMonitorStatusId" = r.good_status_id
+      FROM resolved r
+      WHERE m."_id" = r.row_id AND r.good_status_id IS NOT NULL
+    `);
+
+    /*
+     * 4. Cross-project ids embedded in Monitor.monitorSteps. These carry no FK,
+     * so they would silently dangle once the other project is deleted (the
+     * monitor's default status, and the severity used to open incidents/alerts,
+     * would both point at nothing). Rewrite them onto the monitor's own
+     * project's equivalents.
+     */
+    await queryRunner.query(`
+      DO $$
+      DECLARE
+        monitor_row record;
+        remap_row record;
+        steps_text text;
+      BEGIN
+        CREATE TEMP TABLE _cross_project_step_refs ON COMMIT DROP AS
+        SELECT m."_id" AS monitor_id,
+               m."projectId" AS project_id,
+               matched.arr[1]::uuid AS ref_id
+        FROM "Monitor" m
+        CROSS JOIN LATERAL regexp_matches(
+          m."monitorSteps"::text,
+          '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+          'g'
+        ) AS matched(arr)
+        WHERE m."monitorSteps" IS NOT NULL;
+
+        CREATE TEMP TABLE _cross_project_step_remap ON COMMIT DROP AS
+        SELECT DISTINCT sr.monitor_id, sr.ref_id AS bad_id, COALESCE(
+          (SELECT x."_id" FROM "MonitorStatus" x
+            WHERE x."projectId" = sr.project_id AND lower(x."name") = lower(ms."name")
+            ORDER BY x."priority" LIMIT 1),
+          (SELECT x."_id" FROM "MonitorStatus" x
+            WHERE x."projectId" = sr.project_id
+              AND x."isOperationalState" = ms."isOperationalState"
+              AND x."isOfflineState" = ms."isOfflineState"
+            ORDER BY x."priority" LIMIT 1)
+        ) AS good_id
+        FROM _cross_project_step_refs sr
+        JOIN "MonitorStatus" ms ON ms."_id" = sr.ref_id
+        WHERE ms."projectId" IS DISTINCT FROM sr.project_id
+
+        UNION ALL
+
+        SELECT DISTINCT sr.monitor_id, sr.ref_id, (
+          SELECT x."_id" FROM "IncidentSeverity" x
+          WHERE x."projectId" = sr.project_id AND lower(x."name") = lower(sev."name")
+          ORDER BY x."order" LIMIT 1
+        )
+        FROM _cross_project_step_refs sr
+        JOIN "IncidentSeverity" sev ON sev."_id" = sr.ref_id
+        WHERE sev."projectId" IS DISTINCT FROM sr.project_id
+
+        UNION ALL
+
+        SELECT DISTINCT sr.monitor_id, sr.ref_id, (
+          SELECT x."_id" FROM "AlertSeverity" x
+          WHERE x."projectId" = sr.project_id AND lower(x."name") = lower(sev."name")
+          ORDER BY x."order" LIMIT 1
+        )
+        FROM _cross_project_step_refs sr
+        JOIN "AlertSeverity" sev ON sev."_id" = sr.ref_id
+        WHERE sev."projectId" IS DISTINCT FROM sr.project_id;
+
+        FOR monitor_row IN
+          SELECT DISTINCT monitor_id FROM _cross_project_step_remap WHERE good_id IS NOT NULL
+        LOOP
+          SELECT "monitorSteps"::text INTO steps_text
+          FROM "Monitor" WHERE "_id" = monitor_row.monitor_id;
+
+          FOR remap_row IN
+            SELECT bad_id, good_id FROM _cross_project_step_remap
+            WHERE monitor_id = monitor_row.monitor_id AND good_id IS NOT NULL
+          LOOP
+            steps_text := replace(steps_text, remap_row.bad_id::text, remap_row.good_id::text);
+          END LOOP;
+
+          UPDATE "Monitor" SET "monitorSteps" = steps_text::jsonb
+          WHERE "_id" = monitor_row.monitor_id;
+        END LOOP;
+      END $$;
+    `);
+
+    /*
+     * 5. A status timeline row cannot outlive its status, so cascade instead of
+     * blocking. Without this, a leftover cross-project row (one we could not
+     * resolve above, e.g. a project with no statuses of its own) would still
+     * make the referenced project undeletable.
+     */
+    await queryRunner.query(
+      `ALTER TABLE "MonitorStatusTimeline" DROP CONSTRAINT "FK_574feb4161c5216c2c7ee0faaf8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "MonitorStatusTimeline" ADD CONSTRAINT "FK_574feb4161c5216c2c7ee0faaf8" FOREIGN KEY ("monitorStatusId") REFERENCES "MonitorStatus"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkSiteStatusTimeline" DROP CONSTRAINT "FK_8886e21e28e5287abb5b26475a1"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkSiteStatusTimeline" ADD CONSTRAINT "FK_8886e21e28e5287abb5b26475a1" FOREIGN KEY ("monitorStatusId") REFERENCES "MonitorStatus"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  /*
+   * Only the constraints are reversible. The repaired references are not:
+   * the previous values pointed at another project's records and there is
+   * nothing worth restoring them to.
+   */
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkSiteStatusTimeline" DROP CONSTRAINT "FK_8886e21e28e5287abb5b26475a1"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkSiteStatusTimeline" ADD CONSTRAINT "FK_8886e21e28e5287abb5b26475a1" FOREIGN KEY ("monitorStatusId") REFERENCES "MonitorStatus"("_id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "MonitorStatusTimeline" DROP CONSTRAINT "FK_574feb4161c5216c2c7ee0faaf8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "MonitorStatusTimeline" ADD CONSTRAINT "FK_574feb4161c5216c2c7ee0faaf8" FOREIGN KEY ("monitorStatusId") REFERENCES "MonitorStatus"("_id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -472,6 +472,7 @@ import { AddServiceLevelObjective1784987015619 } from "./1784987015619-AddServic
 import { MigrationName1785066759532 } from "./1785066759532-MigrationName";
 import { AddHotQueryIndexes1785140242697 } from "./1785140242697-AddHotQueryIndexes";
 import { AddHotQueryIndexesSecondPass1785148065137 } from "./1785148065137-AddHotQueryIndexesSecondPass";
+import { RepairCrossProjectMonitorStatusReferences1785240000000 } from "./1785240000000-RepairCrossProjectMonitorStatusReferences";
 
 export default [
   InitialMigration,
@@ -948,4 +949,5 @@ export default [
   MigrationName1785066759532,
   AddHotQueryIndexes1785140242697,
   AddHotQueryIndexesSecondPass1785148065137,
+  RepairCrossProjectMonitorStatusReferences1785240000000,
 ];

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -30,6 +30,7 @@ import UpdateByID from "../Types/Database/UpdateByID";
 import UpdateByIDAndFetch from "../Types/Database/UpdateByIDAndFetch";
 import UpdateOneBy from "../Types/Database/UpdateOneBy";
 import Encryption from "../Utils/Encryption";
+import PostgresErrorTranslator from "../Utils/Database/PostgresErrorTranslator";
 import logger, { LogAttributes } from "../Utils/Logger";
 import BaseService from "./BaseService";
 import BaseModel from "../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
@@ -453,7 +454,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * propagates the original exception on the synchronous throw path.
    */
   protected getException(error: Exception): never {
-    throw error;
+    throw PostgresErrorTranslator.translateException(error);
   }
 
   private generateSlug(createBy: CreateBy<TBaseModel>): CreateBy<TBaseModel> {

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -60,6 +60,7 @@ import UserNotificationSettingService from "./UserNotificationSettingService";
 import NotificationSettingEventType from "../../Types/NotificationSetting/NotificationSettingEventType";
 import Query from "../Types/Database/Query";
 import DeleteBy from "../Types/Database/DeleteBy";
+import UpdateBy from "../Types/Database/UpdateBy";
 import StatusPageResourceService from "./StatusPageResourceService";
 import Label from "../../Models/DatabaseModels/Label";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -68,6 +69,7 @@ import NotificationRuleWorkspaceChannel from "../../Types/Workspace/Notification
 import WorkspaceNotificationRuleService, {
   MessageBlocksByWorkspaceType,
 } from "./WorkspaceNotificationRuleService";
+import MonitorStepsProjectValidator from "../Utils/Monitor/MonitorStepsProjectValidator";
 import MonitorWorkspaceMessages from "../Utils/Workspace/WorkspaceMessages/Monitor";
 import MonitorFeedService from "./MonitorFeedService";
 import { MonitorFeedEventType } from "../../Models/DatabaseModels/MonitorFeed";
@@ -383,6 +385,57 @@ export class Service extends DatabaseService<Model> {
   }
 
   @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    if (updateBy.data.monitorSteps) {
+      /*
+       * Root/API updates do not always carry a tenantId, so fall back to the
+       * project of each monitor the query actually matches.
+       */
+      const projectIds: Array<ObjectID> = updateBy.props.tenantId
+        ? [updateBy.props.tenantId]
+        : await this.getProjectIdsForUpdateQuery(updateBy);
+
+      for (const projectId of projectIds) {
+        await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+          monitorSteps: updateBy.data.monitorSteps as MonitorSteps | JSONObject,
+          projectId: projectId,
+        });
+      }
+    }
+
+    return { updateBy, carryForward: null };
+  }
+
+  private async getProjectIdsForUpdateQuery(
+    updateBy: UpdateBy<Model>,
+  ): Promise<Array<ObjectID>> {
+    const monitors: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      select: {
+        projectId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+
+    const projectIds: Dictionary<ObjectID> = {};
+
+    for (const monitor of monitors) {
+      if (monitor.projectId) {
+        projectIds[monitor.projectId.toString()] = monitor.projectId;
+      }
+    }
+
+    return Object.values(projectIds);
+  }
+
+  @CaptureSpan()
   protected override async onUpdateSuccess(
     onUpdate: OnUpdate<Model>,
     updatedItemIds: ObjectID[],
@@ -601,6 +654,11 @@ export class Service extends DatabaseService<Model> {
     if (!createBy.props.tenantId) {
       throw new BadDataException("ProjectId required to create monitor.");
     }
+
+    await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+      monitorSteps: createBy.data.monitorSteps,
+      projectId: createBy.props.tenantId,
+    });
 
     const monitorStatus: MonitorStatus | null =
       await MonitorStatusService.findOneBy({

--- a/Common/Server/Utils/Database/PostgresErrorTranslator.ts
+++ b/Common/Server/Utils/Database/PostgresErrorTranslator.ts
@@ -1,0 +1,131 @@
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Exception from "../../../Types/Exception/Exception";
+
+/*
+ * Postgres error codes we can turn into something the caller can act on.
+ * https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+const FOREIGN_KEY_VIOLATION: string = "23503";
+
+/*
+ * TypeORM reports driver failures as QueryFailedError, which does not extend
+ * Exception. Those fall all the way through to the generic handler in
+ * StartServer and reach the client as a bare 500 `{"error": "Server Error"}`
+ * with nothing to act on — the user just sees "Server Error" in the UI.
+ *
+ * Translate the failures a user can actually do something about into a
+ * BadDataException so the API answers with a 400 and a readable message.
+ * Anything we do not recognise is returned untouched, so behaviour for the
+ * rest of the error surface is unchanged.
+ */
+
+interface PostgresDriverError {
+  code?: string | undefined;
+  table?: string | undefined;
+  detail?: string | undefined;
+}
+
+export default class PostgresErrorTranslator {
+  public static translate(error: unknown): unknown {
+    const driverError: PostgresDriverError | null =
+      this.getPostgresDriverError(error);
+
+    if (!driverError || driverError.code !== FOREIGN_KEY_VIOLATION) {
+      return error;
+    }
+
+    const detail: string = driverError.detail || "";
+
+    /*
+     * DELETE blocked by a child row:
+     *   Key (_id)=(...) is still referenced from table "MonitorStatusTimeline".
+     */
+    if (detail.includes("is still referenced from table")) {
+      const referencingTable: string =
+        this.getTableNameFromDetail(detail) || driverError.table || "";
+
+      return new BadDataException(
+        referencingTable
+          ? `This item cannot be deleted because ${this.humanizeTableName(
+              referencingTable,
+            )} records still reference it. Please delete those records first, and then try again.`
+          : "This item cannot be deleted because other records still reference it. Please delete those records first, and then try again.",
+      );
+    }
+
+    /*
+     * INSERT/UPDATE pointing at a row that does not exist:
+     *   Key (monitorStatusId)=(...) is not present in table "MonitorStatus".
+     */
+    if (detail.includes("is not present in table")) {
+      const referencedTable: string = this.getTableNameFromDetail(detail) || "";
+
+      return new BadDataException(
+        referencedTable
+          ? `This request references ${this.humanizeTableName(
+              referencedTable,
+            )} that does not exist. Please check the request and try again.`
+          : "This request references an item that does not exist. Please check the request and try again.",
+      );
+    }
+
+    return error;
+  }
+
+  /*
+   * `throw`-friendly wrapper. Kept synchronous so callers can keep using
+   * `throw translator(...)` on the synchronous throw path.
+   */
+  public static translateException(error: Exception): Exception {
+    return this.translate(error) as Exception;
+  }
+
+  private static getPostgresDriverError(
+    error: unknown,
+  ): PostgresDriverError | null {
+    if (!error || typeof error !== "object") {
+      return null;
+    }
+
+    /*
+     * QueryFailedError hoists the pg fields onto itself and also keeps the
+     * original under `driverError`. Prefer whichever one carries the code.
+     */
+    const candidate: PostgresDriverError = error as PostgresDriverError;
+
+    if (typeof candidate.code === "string") {
+      return candidate;
+    }
+
+    const driverError: unknown = (error as { driverError?: unknown })
+      .driverError;
+
+    if (
+      driverError &&
+      typeof driverError === "object" &&
+      typeof (driverError as PostgresDriverError).code === "string"
+    ) {
+      return driverError as PostgresDriverError;
+    }
+
+    return null;
+  }
+
+  private static getTableNameFromDetail(detail: string): string | null {
+    const match: RegExpMatchArray | null = detail.match(/table "([^"]+)"/);
+
+    return match && match[1] ? match[1] : null;
+  }
+
+  /*
+   * "MonitorStatusTimeline" -> "Monitor Status Timeline". Table names are the
+   * PascalCase model names, so this reads well enough to put in front of a
+   * user without maintaining a lookup table of display names.
+   */
+  private static humanizeTableName(tableName: string): string {
+    return tableName
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+      .trim();
+  }
+}

--- a/Common/Server/Utils/Monitor/MonitorStepsProjectValidator.ts
+++ b/Common/Server/Utils/Monitor/MonitorStepsProjectValidator.ts
@@ -1,0 +1,158 @@
+import AlertSeverityService from "../../Services/AlertSeverityService";
+import IncidentSeverityService from "../../Services/IncidentSeverityService";
+import MonitorStatusService from "../../Services/MonitorStatusService";
+import QueryHelper from "../../Types/Database/QueryHelper";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import MonitorSteps from "../../../Types/Monitor/MonitorSteps";
+import ObjectID from "../../../Types/ObjectID";
+import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
+import IncidentSeverity from "../../../Models/DatabaseModels/IncidentSeverity";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+
+const UUID_REGEX: RegExp =
+  /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+
+interface ForeignReference {
+  modelName: string;
+  name: string;
+}
+
+/*
+ * `monitorSteps` is a JSON blob that embeds ids of other project-scoped
+ * records — the default monitor status, the status each criteria switches to,
+ * and the severities used to open incidents and alerts. Nothing used to check
+ * that those ids belonged to the monitor's own project, so a status id from a
+ * second project could be saved and then stamped onto every
+ * MonitorStatusTimeline row the monitor wrote. That silently ties two projects
+ * together and leaves the referenced project undeletable.
+ *
+ * The check below is deliberately narrow: it only rejects an id that really is
+ * another project's record. monitorSteps is full of unrelated uuids (step ids,
+ * criteria ids, incident/alert template ids) and those never match a row here,
+ * so they pass through untouched. Ids that match nothing at all are also left
+ * alone — refusing them would block users from saving their way out of a
+ * monitor that already references a deleted record.
+ */
+export default class MonitorStepsProjectValidator {
+  public static async validateMonitorStepsBelongToProject(data: {
+    monitorSteps: MonitorSteps | JSONObject | undefined;
+    projectId: ObjectID | undefined;
+  }): Promise<void> {
+    if (!data.monitorSteps || !data.projectId) {
+      return;
+    }
+
+    const referencedIds: Array<string> = this.extractUuids(data.monitorSteps);
+
+    if (referencedIds.length === 0) {
+      return;
+    }
+
+    const foreignReferences: Array<ForeignReference> = [];
+
+    const monitorStatuses: Array<MonitorStatus> =
+      await MonitorStatusService.findBy({
+        query: {
+          _id: QueryHelper.any(referencedIds),
+        },
+        select: { _id: true, name: true, projectId: true },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+    for (const monitorStatus of monitorStatuses) {
+      if (monitorStatus.projectId?.toString() !== data.projectId.toString()) {
+        foreignReferences.push({
+          modelName: "Monitor Status",
+          name: monitorStatus.name || monitorStatus.id?.toString() || "",
+        });
+      }
+    }
+
+    const incidentSeverities: Array<IncidentSeverity> =
+      await IncidentSeverityService.findBy({
+        query: {
+          _id: QueryHelper.any(referencedIds),
+        },
+        select: { _id: true, name: true, projectId: true },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+    for (const incidentSeverity of incidentSeverities) {
+      if (
+        incidentSeverity.projectId?.toString() !== data.projectId.toString()
+      ) {
+        foreignReferences.push({
+          modelName: "Incident Severity",
+          name: incidentSeverity.name || incidentSeverity.id?.toString() || "",
+        });
+      }
+    }
+
+    const alertSeverities: Array<AlertSeverity> =
+      await AlertSeverityService.findBy({
+        query: {
+          _id: QueryHelper.any(referencedIds),
+        },
+        select: { _id: true, name: true, projectId: true },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+    for (const alertSeverity of alertSeverities) {
+      if (alertSeverity.projectId?.toString() !== data.projectId.toString()) {
+        foreignReferences.push({
+          modelName: "Alert Severity",
+          name: alertSeverity.name || alertSeverity.id?.toString() || "",
+        });
+      }
+    }
+
+    if (foreignReferences.length > 0) {
+      const described: string = foreignReferences
+        .map((reference: ForeignReference) => {
+          return `${reference.modelName} "${reference.name}"`;
+        })
+        .join(", ");
+
+      throw new BadDataException(
+        `Monitor criteria reference records that belong to a different project: ${described}. Please pick values from this project and try again.`,
+      );
+    }
+  }
+
+  private static extractUuids(
+    monitorSteps: MonitorSteps | JSONObject,
+  ): Array<string> {
+    let serialized: string = "";
+
+    try {
+      serialized =
+        monitorSteps instanceof MonitorSteps
+          ? JSON.stringify(monitorSteps.toJSON())
+          : JSON.stringify(monitorSteps);
+    } catch {
+      /*
+       * Unserializable monitorSteps is a different problem and is reported by
+       * MonitorSteps' own validation. Nothing to check here.
+       */
+      return [];
+    }
+
+    const matches: Array<string> = serialized.match(UUID_REGEX) || [];
+
+    return Array.from(
+      new Set(
+        matches.map((match: string) => {
+          return match.toLowerCase();
+        }),
+      ),
+    );
+  }
+}

--- a/Common/Tests/Server/Utils/Database/PostgresErrorTranslator.test.ts
+++ b/Common/Tests/Server/Utils/Database/PostgresErrorTranslator.test.ts
@@ -1,0 +1,125 @@
+import PostgresErrorTranslator from "../../../../Server/Utils/Database/PostgresErrorTranslator";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import Exception from "../../../../Types/Exception/Exception";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test: TypeORM's QueryFailedError is not an Exception, so it
+ * used to fall through StartServer's generic handler and reach the client as a
+ * bare 500 "Server Error" — which is exactly what deleting a project hit when
+ * another project's MonitorStatusTimeline rows still referenced its statuses.
+ *
+ * The translator turns the actionable Postgres failures into a
+ * BadDataException (400) and leaves everything else untouched.
+ */
+
+type FakeQueryFailedError = {
+  message: string;
+  code?: string | undefined;
+  table?: string | undefined;
+  detail?: string | undefined;
+  driverError?: unknown;
+};
+
+const foreignKeyDeleteError: () => FakeQueryFailedError =
+  (): FakeQueryFailedError => {
+    return {
+      message:
+        'update or delete on table "MonitorStatus" violates foreign key constraint "FK_574feb4161c5216c2c7ee0faaf8" on table "MonitorStatusTimeline"',
+      code: "23503",
+      table: "MonitorStatusTimeline",
+      detail:
+        'Key (_id)=(cfc2f04f-79cb-4344-8c54-dafe5e3a290c) is still referenced from table "MonitorStatusTimeline".',
+    };
+  };
+
+describe("PostgresErrorTranslator", () => {
+  describe("foreign key violation on delete", () => {
+    it("translates to a BadDataException naming the blocking table", () => {
+      const translated: unknown = PostgresErrorTranslator.translate(
+        foreignKeyDeleteError(),
+      );
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect((translated as Exception).message).toBe(
+        "This item cannot be deleted because Monitor Status Timeline records still reference it. Please delete those records first, and then try again.",
+      );
+    });
+
+    it("reads the pg fields off driverError when the wrapper has no code", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "wrapped",
+        driverError: foreignKeyDeleteError(),
+      });
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect((translated as Exception).message).toContain(
+        "Monitor Status Timeline",
+      );
+    });
+
+    it("does not leak the offending row id into the message", () => {
+      const translated: unknown = PostgresErrorTranslator.translate(
+        foreignKeyDeleteError(),
+      );
+
+      expect((translated as Exception).message).not.toContain(
+        "cfc2f04f-79cb-4344-8c54-dafe5e3a290c",
+      );
+    });
+  });
+
+  describe("foreign key violation on insert or update", () => {
+    it("translates to a BadDataException naming the missing record", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "insert violates foreign key constraint",
+        code: "23503",
+        table: "MonitorStatusTimeline",
+        detail:
+          'Key (monitorStatusId)=(cfc2f04f-79cb-4344-8c54-dafe5e3a290c) is not present in table "MonitorStatus".',
+      });
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect((translated as Exception).message).toBe(
+        "This request references Monitor Status that does not exist. Please check the request and try again.",
+      );
+    });
+  });
+
+  describe("errors it should not touch", () => {
+    it("passes through a non-foreign-key Postgres error unchanged", () => {
+      const uniqueViolation: FakeQueryFailedError = {
+        message: "duplicate key value violates unique constraint",
+        code: "23505",
+        table: "Project",
+        detail: "Key (slug)=(acme) already exists.",
+      };
+
+      expect(PostgresErrorTranslator.translate(uniqueViolation)).toBe(
+        uniqueViolation,
+      );
+    });
+
+    it("passes through an ordinary Exception unchanged", () => {
+      const exception: BadDataException = new BadDataException("Nope");
+
+      expect(PostgresErrorTranslator.translate(exception)).toBe(exception);
+    });
+
+    it("passes through null and non-objects unchanged", () => {
+      expect(PostgresErrorTranslator.translate(null)).toBeNull();
+      expect(PostgresErrorTranslator.translate("boom")).toBe("boom");
+    });
+
+    it("passes through a 23503 with an unrecognised detail unchanged", () => {
+      const odd: FakeQueryFailedError = {
+        message: "foreign key",
+        code: "23503",
+        table: "MonitorStatusTimeline",
+        detail: "something we have not seen before",
+      };
+
+      expect(PostgresErrorTranslator.translate(odd)).toBe(odd);
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorStepsProjectValidator.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorStepsProjectValidator.test.ts
@@ -1,0 +1,176 @@
+import MonitorStepsProjectValidator from "../../../../Server/Utils/Monitor/MonitorStepsProjectValidator";
+import AlertSeverityService from "../../../../Server/Services/AlertSeverityService";
+import IncidentSeverityService from "../../../../Server/Services/IncidentSeverityService";
+import MonitorStatusService from "../../../../Server/Services/MonitorStatusService";
+import AlertSeverity from "../../../../Models/DatabaseModels/AlertSeverity";
+import IncidentSeverity from "../../../../Models/DatabaseModels/IncidentSeverity";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../Types/ObjectID";
+import { JSONObject } from "../../../../Types/JSON";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Contract under test: monitorSteps embeds ids of project-scoped records (the
+ * default monitor status, the status each criteria switches to, and the
+ * severities used to open incidents and alerts). Saving one that belongs to a
+ * *different* project is what tied two projects together in production and
+ * left the referenced project undeletable, so it must be rejected on write.
+ *
+ * The check has to stay narrow: monitorSteps is full of unrelated uuids (step
+ * ids, criteria ids, incident/alert template ids) that match no record at all,
+ * and those must keep saving fine.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "4af3a31b-58b0-4746-8025-f9cd4db1945e",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "3376855b-361c-427c-8982-bad7ada30414",
+);
+
+const OWN_STATUS_ID: string = "59b5ab80-63f6-4ffd-b3df-31c6ad127695";
+const FOREIGN_STATUS_ID: string = "cfc2f04f-79cb-4344-8c54-dafe5e3a290c";
+const FOREIGN_ALERT_SEVERITY_ID: string =
+  "a2eb67d4-bd2e-4186-9187-dad799c9316c";
+
+type FoundRecords = {
+  monitorStatuses?: Array<MonitorStatus>;
+  incidentSeverities?: Array<IncidentSeverity>;
+  alertSeverities?: Array<AlertSeverity>;
+};
+
+const monitorStatus: (id: string, projectId: ObjectID) => MonitorStatus = (
+  id: string,
+  projectId: ObjectID,
+): MonitorStatus => {
+  const status: MonitorStatus = new MonitorStatus();
+  status._id = id;
+  status.name = "Operational";
+  status.projectId = projectId;
+  return status;
+};
+
+const alertSeverity: (id: string, projectId: ObjectID) => AlertSeverity = (
+  id: string,
+  projectId: ObjectID,
+): AlertSeverity => {
+  const severity: AlertSeverity = new AlertSeverity();
+  severity._id = id;
+  severity.name = "High";
+  severity.projectId = projectId;
+  return severity;
+};
+
+const stubLookups: (found: FoundRecords) => void = (
+  found: FoundRecords,
+): void => {
+  jest
+    .spyOn(MonitorStatusService, "findBy")
+    .mockResolvedValue(found.monitorStatuses || []);
+  jest
+    .spyOn(IncidentSeverityService, "findBy")
+    .mockResolvedValue(found.incidentSeverities || []);
+  jest
+    .spyOn(AlertSeverityService, "findBy")
+    .mockResolvedValue(found.alertSeverities || []);
+};
+
+const stepsReferencing: (ids: Array<string>) => JSONObject = (
+  ids: Array<string>,
+): JSONObject => {
+  return {
+    _type: "MonitorSteps",
+    value: {
+      defaultMonitorStatusId: ids[0],
+      monitorStepsInstanceArray: ids.slice(1).map((id: string) => {
+        return { _type: "MonitorStep", value: { id: id } };
+      }),
+    },
+  };
+};
+
+describe("MonitorStepsProjectValidator", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("rejects a monitor status that belongs to another project", async () => {
+    stubLookups({
+      monitorStatuses: [monitorStatus(FOREIGN_STATUS_ID, OTHER_PROJECT_ID)],
+    });
+
+    await expect(
+      MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+        monitorSteps: stepsReferencing([FOREIGN_STATUS_ID]),
+        projectId: PROJECT_ID,
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("names every offending record in the message", async () => {
+    stubLookups({
+      monitorStatuses: [monitorStatus(FOREIGN_STATUS_ID, OTHER_PROJECT_ID)],
+      alertSeverities: [
+        alertSeverity(FOREIGN_ALERT_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    await expect(
+      MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+        monitorSteps: stepsReferencing([
+          FOREIGN_STATUS_ID,
+          FOREIGN_ALERT_SEVERITY_ID,
+        ]),
+        projectId: PROJECT_ID,
+      }),
+    ).rejects.toThrow(
+      /Monitor Status "Operational".*Alert Severity "High"|Alert Severity "High".*Monitor Status "Operational"/,
+    );
+  });
+
+  it("accepts records that belong to the monitor's own project", async () => {
+    stubLookups({
+      monitorStatuses: [monitorStatus(OWN_STATUS_ID, PROJECT_ID)],
+    });
+
+    await expect(
+      MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+        monitorSteps: stepsReferencing([OWN_STATUS_ID]),
+        projectId: PROJECT_ID,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores uuids that are not project-scoped records", async () => {
+    // Step ids and criteria ids are uuids too, and match nothing.
+    stubLookups({});
+
+    await expect(
+      MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+        monitorSteps: stepsReferencing([
+          OWN_STATUS_ID,
+          "679a113f-669e-4b0f-b3db-31eb2a794ed5",
+          "ff11aa22-bb33-cc44-dd55-000000000ee1",
+        ]),
+        projectId: PROJECT_ID,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does no lookups when there are no monitorSteps or no project", async () => {
+    const findBy: jest.SpiedFunction<typeof MonitorStatusService.findBy> =
+      jest.spyOn(MonitorStatusService, "findBy");
+
+    await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+      monitorSteps: undefined,
+      projectId: PROJECT_ID,
+    });
+    await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
+      monitorSteps: stepsReferencing([OWN_STATUS_ID]),
+      projectId: undefined,
+    });
+
+    expect(findBy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Deleting a project from the dashboard returns `Server Error`. In the app logs:

```
QueryFailedError: update or delete on table "MonitorStatus" violates foreign key
constraint "FK_574feb4161c5216c2c7ee0faaf8" on table "MonitorStatusTimeline"
  query: 'DELETE FROM "Project" WHERE ("_id" IN ($1))'
  detail: Key (_id)=(cfc2f04f-…) is still referenced from table "MonitorStatusTimeline".
```

Two separate bugs stack up here.

**1. Cross-project references are allowed to be created.** `Monitor.monitorSteps` embeds ids of project-scoped records — the default monitor status, the status each criteria switches to, and the severities used to open incidents and alerts. `MonitorSteps.getValidationError` only checks that `defaultMonitorStatusId` is *present*, never that it belongs to the monitor's project. A status id picked up from a second project gets persisted, and is then stamped onto every `MonitorStatusTimeline` row that monitor writes.

**2. That makes the referenced project undeletable.** Deleting a `Project` cascades into its `MonitorStatus` rows, but timeline rows owned by a *different* project still point at them and the FK is `ON DELETE NO ACTION`. `MonitorStatusTimeline.monitorStatus` was the only `@ManyToOne` in that model with no `onDelete` — every sibling relation has `CASCADE` or `SET NULL`. `NetworkSiteStatusTimeline` has the same gap.

The error surfaces as a bare `Server Error` because `QueryFailedError` does not extend `Exception`, so it falls through to the generic `else` in `StartServer.ts` → `500 {error: "Server Error"}`.

This is not a one-off — **seven projects** are currently undeletable for this reason.

## Changes

- **`PostgresErrorTranslator`** (new) — turns actionable Postgres failures into `BadDataException`, so a blocked delete answers `400` with *"This item cannot be deleted because Monitor Status Timeline records still reference it"* instead of `Server Error`. Wired in at `DatabaseService.getException`, the single choke point every service error already routes through. Unrecognised errors pass through untouched, so the rest of the error surface is unchanged.
- **`MonitorStepsProjectValidator`** (new) — rejects `monitorSteps` referencing another project's `MonitorStatus`, `IncidentSeverity` or `AlertSeverity`, on create and update. Deliberately narrow: it only fires on ids that genuinely *are* another project's record, so the many unrelated uuids in `monitorSteps` (step ids, criteria ids, incident/alert template ids) keep saving fine, and ids matching nothing are left alone rather than blocking users from saving their way out of a broken monitor.
- **`onDelete: "CASCADE"`** on `MonitorStatusTimeline.monitorStatus` and `NetworkSiteStatusTimeline.monitorStatus` — a status timeline row cannot outlive its status.
- **Migration** — repoints existing cross-project references at the equivalent record in the row's own project (matched by name, then by operational/offline role, then by nearest priority), *then* switches the two FKs to cascade. Order matters: repairing first keeps timeline history attached to the surviving project instead of letting the new cascade sweep it up.

## Verification

The migration was run against a copy of production state inside a transaction and rolled back — production was not modified.

```
BEGIN
UPDATE 477   -- MonitorStatusTimeline repaired
UPDATE 0     -- NetworkSiteStatusTimeline (table empty)
UPDATE 11    -- Monitor.currentMonitorStatusId repaired
DO           -- monitorSteps JSON repaired
ALTER TABLE ×4
DELETE 1     -- the previously-blocked project delete now succeeds
ROLLBACK
```

Cross-project references before → after the migration:

| check | before | after |
|---|---|---|
| timeline rows pointing at another project's status | 477 | 0 |
| `Monitor.currentMonitorStatusId` cross-project | 11 | 0 |
| `monitorSteps` default status cross-project | 23 | 0 |

`tsc --noEmit` and `eslint` are clean on all changed files.

⚠️ **Unit tests could not be run locally** — `babel.config.ts` references `@babel/plugin-proposal-private-methods` and `@babel/plugin-proposal-class-properties`, neither of which is declared in `package.json`, so every jest suite fails to transform on this checkout (pre-existing, not caused by this branch). Tests for both new units are included and rely on CI to execute.

## Deploy note

The migration rewrites rows in `MonitorStatusTimeline` (477), `Monitor` (11 + the `monitorSteps` blobs) before altering the constraints. `down()` restores the constraints only — the repaired references are not reverted, since the previous values pointed at another project's records.
