### PR TITLE
fix(ui): load Monaco from the install instead of the CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 # Build Dist
 **/dist/*
 
+# Monaco runtime, copied from node_modules at build time
+**/public/assets/monaco/
+
 .idea
 # testing
 **/coverage

--- a/Common/Tests/UI/Components/MonacoLoader.test.ts
+++ b/Common/Tests/UI/Components/MonacoLoader.test.ts
@@ -1,0 +1,46 @@
+import getJestMockFunction, { MockFunction } from "../../../Tests/MockType";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+const config: MockFunction = getJestMockFunction();
+
+jest.mock("@monaco-editor/react", () => {
+  return {
+    loader: {
+      config,
+    },
+  };
+});
+
+describe("configureMonacoLoader", () => {
+  afterEach(() => {
+    config.mockClear();
+    delete process.env["MONACO_ASSET_PATH"];
+    jest.resetModules();
+  });
+
+  type LoadLoader = () => Promise<() => void>;
+
+  const loadLoader: LoadLoader = async (): Promise<() => void> => {
+    const { default: configureMonacoLoader } = await import(
+      "../../../UI/Components/CodeEditor/MonacoLoader"
+    );
+
+    return configureMonacoLoader;
+  };
+
+  test("points Monaco at the path the build baked in", async () => {
+    process.env["MONACO_ASSET_PATH"] = "/dashboard/assets/monaco/vs";
+
+    (await loadLoader())();
+
+    expect(config).toHaveBeenCalledWith({
+      paths: { vs: "/dashboard/assets/monaco/vs" },
+    });
+  });
+
+  test("keeps the bundled default when the build set no path", async () => {
+    (await loadLoader())();
+
+    expect(config).not.toHaveBeenCalled();
+  });
+});

--- a/Common/UI/Components/CodeEditor/CodeEditor.tsx
+++ b/Common/UI/Components/CodeEditor/CodeEditor.tsx
@@ -1,4 +1,5 @@
 import Editor from "@monaco-editor/react";
+import configureMonacoLoader from "./MonacoLoader";
 import CodeType from "../../../Types/Code/CodeType";
 import MarkdownUtil from "../../Utils/Markdown";
 import { Theme, useTheme } from "../../Utils/Theme";
@@ -9,6 +10,8 @@ import React, {
   useRef,
   useState,
 } from "react";
+
+configureMonacoLoader();
 
 export interface ComponentProps {
   initialValue?: undefined | string;

--- a/Common/UI/Components/CodeEditor/MonacoLoader.ts
+++ b/Common/UI/Components/CodeEditor/MonacoLoader.ts
@@ -1,0 +1,23 @@
+import { loader } from "@monaco-editor/react";
+
+/**
+ * Points Monaco at the copy of its runtime that ships with the app.
+ *
+ * @monaco-editor/loader otherwise fetches it from cdn.jsdelivr.net at runtime,
+ * which never resolves on an air-gapped install and leaves every code editor
+ * stuck on "Loading...". The path is baked in by the build, which is the only
+ * place that knows where this service is mounted.
+ */
+export default function configureMonacoLoader(): void {
+  const assetPath: string | undefined = process.env["MONACO_ASSET_PATH"];
+
+  if (!assetPath) {
+    return;
+  }
+
+  loader.config({
+    paths: {
+      vs: assetPath,
+    },
+  });
+}

--- a/Common/UI/esbuild-config.js
+++ b/Common/UI/esbuild-config.js
@@ -182,6 +182,37 @@ function createFileLoaderPlugin() {
   };
 }
 
+// Services that never bundle a CodeEditor should not carry the runtime, so the
+// built output decides rather than a hand-maintained list of service names.
+function usesMonaco(outdir) {
+  if (!outdir || !fs.existsSync(outdir)) {
+    return false;
+  }
+
+  return fs.readdirSync(outdir, { recursive: true }).some((entry) => {
+    return (
+      typeof entry === "string" &&
+      entry.endsWith(".js") &&
+      fs
+        .readFileSync(path.join(outdir, entry), "utf8")
+        .includes("assets/monaco/vs")
+    );
+  });
+}
+
+// Copy Monaco's runtime next to the bundle so the editor loads from this
+// install instead of cdn.jsdelivr.net, which is unreachable when self-hosted
+// offline. Only min/vs is copied - the rest of the package is sources and
+// type definitions the browser never asks for.
+function copyMonacoAssets(outdir) {
+  const source = path.join(resolvePackageRoot("monaco-editor"), "min", "vs");
+  const destination = path.resolve(path.dirname(outdir), "assets/monaco/vs");
+
+  fs.rmSync(destination, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.cpSync(source, destination, { recursive: true });
+}
+
 // Read environment variables from .env file
 function readEnvFile(pathToFile) {
   if (!fs.existsSync(pathToFile)) {
@@ -265,6 +296,11 @@ function createConfig(options) {
     splitting: true,
     publicPath,
     define: {
+      // Monaco resolves its runtime against this at load time. import.meta is
+      // empty at the es2017 target, so the path has to come from the build.
+      "process.env.MONACO_ASSET_PATH": JSON.stringify(
+        `${publicPath.replace(/dist\/$/, "")}assets/monaco/vs`,
+      ),
       "process.env.NODE_ENV": JSON.stringify(
         isDev ? "development" : "production",
       ),
@@ -319,6 +355,11 @@ async function build(config, serviceName) {
   try {
     const result = await esbuild.build(config);
 
+    if (usesMonaco(config.outdir)) {
+      copyMonacoAssets(config.outdir);
+      console.log(`📦 Copied Monaco assets for ${serviceName}`);
+    }
+
     if (isAnalyze && result.metafile) {
       const analyzeText = await esbuild.analyzeMetafile(result.metafile);
       console.log(`\n📊 Bundle analysis for ${serviceName}:`);
@@ -345,6 +386,13 @@ async function build(config, serviceName) {
 async function watch(config, serviceName) {
   try {
     const context = await esbuild.context(config);
+    await context.rebuild();
+
+    if (usesMonaco(config.outdir)) {
+      copyMonacoAssets(config.outdir);
+      console.log(`📦 Copied Monaco assets for ${serviceName}`);
+    }
+
     await context.watch();
     console.log(`👀 Watching ${serviceName} for changes...`);
   } catch (error) {

--- a/Common/package-lock.json
+++ b/Common/package-lock.json
@@ -75,6 +75,7 @@
         "mermaid": "^11.12.2",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
+        "monaco-editor": "^0.53.0",
         "multer": "^2.1.1",
         "node-cron": "^4.0.0",
         "nodemailer": "^8.0.11",
@@ -13063,7 +13064,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.53.0.tgz",
       "integrity": "sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^1.0.6"
       }

--- a/Common/package.json
+++ b/Common/package.json
@@ -118,6 +118,7 @@
     "mermaid": "^11.12.2",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",
+    "monaco-editor": "^0.53.0",
     "multer": "^2.1.1",
     "node-cron": "^4.0.0",
     "nodemailer": "^8.0.11",


### PR DESCRIPTION
### Title of this pull request?

fix(ui): load Monaco from the install instead of the CDN

### Small Description?

`@monaco-editor/loader` fetches the Monaco runtime from `cdn.jsdelivr.net` at runtime, so on a self-hosted install with no outbound internet every code editor sits on "Loading..." forever. This affects the Workflow JSON/JavaScript step editors, Runbook steps, HTTP request headers and body, and the admin query console. #2570 reports the exact URL that fails, `https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js`, and #2655 is the same problem on an air-gapped Helm install.

The build now copies `monaco-editor`'s `min/vs` alongside the bundle it already writes and bakes the resulting path in as a define, so the editor resolves against whichever service served the page. That keeps Monaco lazily loaded exactly as it is today; the only thing that changes is where it loads from. Services whose output does not reference the editor are skipped so they do not carry the runtime, and the copied assets are gitignored since they come from `node_modules` at build time.

`monaco-editor` was already being resolved as a peer dependency of `@monaco-editor/react` and is now a direct dependency at the same resolved version (0.53.0), so what npm actually installs is unchanged.

This is the piece #1736 left behind when it moved Tailwind off the CDN for the same reason.

### Pull Request Checklist: 

- [x] Please make sure all jobs pass before requesting a review. 
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

Fixes #2655. Refs #2570.

### Screenshots (if appropriate):

_Screenshot to be attached._
