### PR TITLE
fix(ui): drop Monaco's vendored deps and give its workers a resolvable path

### DIFF
--- a/Common/Tests/UI/Components/MonacoLoader.test.ts
+++ b/Common/Tests/UI/Components/MonacoLoader.test.ts
@@ -33,9 +33,30 @@ describe("configureMonacoLoader", () => {
 
     (await loadLoader())();
 
+    /*
+     * Absolute, not the root-relative value the build baked in: Monaco resolves
+     * its language-service workers from this inside a blob: worker, which has no
+     * base to resolve a root-relative path against.
+     */
     expect(config).toHaveBeenCalledWith({
-      paths: { vs: "/dashboard/assets/monaco/vs" },
+      paths: {
+        vs: `${window.location.origin}/dashboard/assets/monaco/vs`,
+      },
     });
+  });
+
+  test("gives Monaco an absolute path its blob workers can resolve", async () => {
+    process.env["MONACO_ASSET_PATH"] = "/dashboard/assets/monaco/vs";
+
+    (await loadLoader())();
+
+    const configuredPath: string = (
+      config.mock.calls[0] as unknown as Array<{ paths: { vs: string } }>
+    )[0]!.paths.vs;
+
+    expect(() => {
+      return new URL(configuredPath);
+    }).not.toThrow();
   });
 
   test("keeps the bundled default when the build set no path", async () => {

--- a/Common/Tests/UI/Components/MonacoRuntime.test.ts
+++ b/Common/Tests/UI/Components/MonacoRuntime.test.ts
@@ -5,67 +5,75 @@ import path from "path";
 /*
  * The build copies monaco-editor's min/vs next to each frontend bundle and
  * MonacoLoader points @monaco-editor/loader at it, so the version we install is
- * the version that actually runs in the browser. The loader resolves init()
- * with whatever the AMD module `vs/editor/editor.main` exports, and that shape
- * is not stable across Monaco releases: 0.53 and 0.54 nest the API under
- * `exports.m`, which leaves `monaco.editor` undefined and makes every editor
- * throw "Cannot read properties of undefined (reading 'getModel')" instead of
- * mounting.
+ * the version that actually runs in the browser.
  *
- * Pinning to the version the loader itself would have fetched keeps the local
- * copy behaving exactly like the CDN load it replaced. These tests fail if the
- * two ever drift - notably if @monaco-editor/react is upgraded without moving
- * monaco-editor to match.
+ * The loader resolves init() with whatever the AMD module `vs/editor/editor.main`
+ * exports, and that shape is not stable across Monaco releases. 0.53 and 0.54
+ * nest the API under `exports.m`; against a loader that does not unwrap that,
+ * `monaco.editor` comes back undefined and every editor throws
+ * "Cannot read properties of undefined (reading 'getModel')" instead of
+ * mounting - with the assets all serving 200, so nothing else looks wrong.
+ *
+ * @monaco-editor/loader learned to unwrap it in 1.7.0. These tests fail if the
+ * two are ever moved into a combination that cannot work.
  */
 
-type ReadInstalledVersion = (packageName: string) => string;
-
-const readInstalledVersion: ReadInstalledVersion = (
-  packageName: string,
-): string => {
-  const packageJsonPath: string = require.resolve(
-    `${packageName}/package.json`,
-  );
-
-  return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")).version;
+// [from, to) - the Monaco releases whose AMD module nests the API under `exports.m`.
+const NESTED_API_RANGE: { from: string; to: string } = {
+  from: "0.53.0",
+  to: "0.55.0",
 };
 
-type ReadLoaderDefaultVersion = () => string;
+// The first @monaco-editor/loader that unwraps `exports.m`.
+const LOADER_UNWRAPS_FROM: string = "1.7.0";
 
-/*
- * @monaco-editor/loader ships its default CDN path as a plain string literal in
- * its config module. Reading the version out of it is how we learn which Monaco
- * build the loader was written against.
- */
-const readLoaderDefaultVersion: ReadLoaderDefaultVersion = (): string => {
-  const loaderRoot: string = path.dirname(
-    require.resolve("@monaco-editor/loader/package.json"),
-  );
-  const configPath: string = path.join(
-    loaderRoot,
-    "lib",
-    "cjs",
-    "config",
-    "index.js",
-  );
+type ReadVersion = (packageName: string) => string;
 
-  expect(fs.existsSync(configPath)).toBe(true);
+const readVersion: ReadVersion = (packageName: string): string => {
+  return JSON.parse(
+    fs.readFileSync(require.resolve(`${packageName}/package.json`), "utf8"),
+  ).version;
+};
 
-  const source: string = fs.readFileSync(configPath, "utf8");
-  const match: RegExpMatchArray | null = source.match(
-    /monaco-editor@([\d.]+)\/min\/vs/,
-  );
+type Compare = (a: string, b: string) => number;
 
-  expect(match).not.toBeNull();
+const compare: Compare = (a: string, b: string): number => {
+  const left: Array<number> = a.split(".").map(Number);
+  const right: Array<number> = b.split(".").map(Number);
 
-  return match![1] as string;
+  for (let i: number = 0; i < 3; i++) {
+    const difference: number = (left[i] || 0) - (right[i] || 0);
+
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
 };
 
 describe("Monaco runtime", () => {
-  test("installs the monaco-editor build @monaco-editor/loader expects", () => {
-    expect(readInstalledVersion("monaco-editor")).toBe(
-      readLoaderDefaultVersion(),
-    );
+  test("does not pair a nested-API Monaco with a loader that cannot unwrap it", () => {
+    const monacoVersion: string = readVersion("monaco-editor");
+    const loaderVersion: string = readVersion("@monaco-editor/loader");
+
+    const nestsApi: boolean =
+      compare(monacoVersion, NESTED_API_RANGE.from) >= 0 &&
+      compare(monacoVersion, NESTED_API_RANGE.to) < 0;
+
+    if (!nestsApi) {
+      return;
+    }
+
+    expect({
+      monacoVersion,
+      loaderVersion,
+      unwrapsNestedApi: compare(loaderVersion, LOADER_UNWRAPS_FROM) >= 0,
+    }).toEqual({
+      monacoVersion,
+      loaderVersion,
+      unwrapsNestedApi: true,
+    });
   });
 
   test("ships the files the loader asks for by path", () => {
@@ -84,5 +92,30 @@ describe("Monaco runtime", () => {
         true,
       );
     }
+  });
+
+  test("does not bring a second copy of anything Common already depends on", () => {
+    /*
+     * Monaco releases from 0.55 on depend on marked and dompurify, both of which
+     * Common already pins at the top level. npm nests Monaco's own copies
+     * because it pins them exactly, so the top-level pin does not reach them and
+     * the tree ends up carrying two versions - the older one being whatever
+     * Monaco vendored at release time.
+     */
+    const monacoDependencies: Array<string> = Object.keys(
+      JSON.parse(
+        fs.readFileSync(require.resolve("monaco-editor/package.json"), "utf8"),
+      ).dependencies || {},
+    );
+
+    const commonDependencies: Record<string, string> = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../../package.json"), "utf8"),
+    ).dependencies;
+
+    expect(
+      monacoDependencies.filter((name: string) => {
+        return Boolean(commonDependencies[name]);
+      }),
+    ).toEqual([]);
   });
 });

--- a/Common/UI/Components/CodeEditor/MonacoLoader.ts
+++ b/Common/UI/Components/CodeEditor/MonacoLoader.ts
@@ -8,14 +8,18 @@ import { loader } from "@monaco-editor/react";
  * stuck on "Loading...". The path is baked in by the build, which is the only
  * place that knows where this service is mounted.
  *
- * The monaco-editor version in Common/package.json stays pinned to the exact
- * one @monaco-editor/loader would have fetched. The loader resolves init() with
- * whatever the AMD module `vs/editor/editor.main` exports, and that shape is
- * not stable across Monaco releases - 0.53 and 0.54 nest the API under
- * `exports.m`, so serving one of those against a loader that does not unwrap it
- * leaves `monaco.editor` undefined and every editor throws instead of mounting.
- * Serving the build the loader was written against sidesteps the question, and
- * MonacoRuntime.test.ts fails if the two ever drift apart.
+ * The path has to be absolute. Monaco loads its language services in a worker
+ * spun up from a blob: URL, and a blob worker has no base to resolve a
+ * root-relative path against - it fetches "/dashboard/assets/monaco/vs/..." and
+ * throws "Failed to parse URL". The editor still renders, so the only visible
+ * symptom is that JSON/TypeScript validation and IntelliSense quietly stop
+ * working. The CDN default never hit this because it was already absolute.
+ *
+ * The monaco-editor version in Common/package.json is pinned exactly, because
+ * the loader resolves init() with whatever the AMD module `vs/editor/editor.main`
+ * exports and that shape is not stable across releases - 0.53 and 0.54 nest the
+ * API under `exports.m`, which leaves `monaco.editor` undefined and makes every
+ * editor throw instead of mount. MonacoRuntime.test.ts guards the pin.
  */
 export default function configureMonacoLoader(): void {
   const assetPath: string | undefined = process.env["MONACO_ASSET_PATH"];
@@ -26,7 +30,7 @@ export default function configureMonacoLoader(): void {
 
   loader.config({
     paths: {
-      vs: assetPath,
+      vs: new URL(assetPath, window.location.origin).href,
     },
   });
 }

--- a/Common/package-lock.json
+++ b/Common/package-lock.json
@@ -75,7 +75,7 @@
         "mermaid": "^11.12.2",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
-        "monaco-editor": "0.55.1",
+        "monaco-editor": "0.52.2",
         "multer": "^2.1.1",
         "node-cron": "^4.0.0",
         "nodemailer": "^8.0.11",
@@ -13050,35 +13050,10 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/Common/package.json
+++ b/Common/package.json
@@ -118,7 +118,7 @@
     "mermaid": "^11.12.2",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",
-    "monaco-editor": "0.55.1",
+    "monaco-editor": "0.52.2",
     "multer": "^2.1.1",
     "node-cron": "^4.0.0",
     "nodemailer": "^8.0.11",


### PR DESCRIPTION
### Small Description?

Two things #2872 left behind, now that it has landed on master. Both were found while verifying that PR in a browser against the actual build output.

### 1. Monaco's language workers were silently dead

Monaco runs its language services in a worker spun up from a `blob:` URL, and a blob worker has no base to resolve a **root-relative** path against. It fetched `/dashboard/assets/monaco/vs/language/json/jsonWorker.js` and threw `Failed to parse URL`.

The editor still renders, so the only symptom is that JSON/TypeScript validation and IntelliSense quietly stop working — nothing surfaces to the user. The CDN default never hit this because `paths.vs` was already an absolute URL.

`MonacoLoader` now resolves the baked-in path against `window.location.origin` before handing it to the loader.

### 2. Monaco 0.55.1 vendors its own `marked` and `dompurify`

npm nests those beside the copies Common already pins, and the older nested `dompurify` (3.2.7) is what Snyk flags. A top-level `dompurify` override would only satisfy the scanner — `min/vs` inlines its own copy either way, so the shipped bytes would not change.

Pinned to **0.52.2** instead: the last release with **no dependencies of its own**, and the last before 0.53/0.54 moved the editor API under `exports.m`. `@monaco-editor/react` 4.7.0 (loader 1.7.0) stays from #2872, so the loader also unwraps `exports.m` on its own and that trap cannot come back through a lockfile.

Worth noting the interaction: 0.53+ resolve worker URLs absolutely via `new URL(…, document.baseURI)`, which masked bug 1. Moving to 0.52.2 for bug 2 is exactly what exposed it — the classic AMD worker path needs the absolute `paths.vs`.

### Tests

`MonacoRuntime.test.ts` now checks both traps instead of pinning to the loader's own default version:

- the Monaco/loader pairing — confirmed to fail against 0.53.0 + loader 1.4.0
- Monaco not bringing a second copy of anything Common already depends on — confirmed to fail against 0.55.1

`MonacoLoader.test.ts` now asserts the configured path is absolute.

### Verification

Built the Dashboard frontend and loaded the real `MonacoLoader.ts` and `@monaco-editor/react` against the actual build output: editor mounts, JSON language worker reports "Trailing comma" on invalid input, clean console, zero requests to `cdn.jsdelivr.net`. `tsc --noEmit` clean on Common.

### Related Issue?

Follows up #2871 and #2872. Refs #2655, #2570.