### PR TITLE
fix(probe-ingest): stop healthy probes being flagged Disconnected when the DB is slow

### DIFF
--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -87,22 +87,26 @@ router.post(
         });
 
       for (const scan of scans) {
-        await NetworkDeviceDiscoveryScanService.updateOneById({
+        /*
+         * Claim via the hook-free single-statement write: the model and
+         * service have no update hooks, workflow, realtime, or audit
+         * decorators, so the full updateOneById pipeline (permission
+         * pre-fetch SELECT + row re-fetch + save() transaction) was pure
+         * overhead — three extra pool round-trips on a route the probe
+         * polls every minute and whose response it synchronously waits on.
+         *
+         * Plain object, NOT a model instance: a `new
+         * NetworkDeviceDiscoveryScan()` payload carries non-column base
+         * props (isPermissionIf) that made every update here throw, so no
+         * scan ever left Pending. Cast: the model's JSON column makes
+         * DeepPartial recursion blow up.
+         */
+        await NetworkDeviceDiscoveryScanService.updateColumnsByIdWithoutHooks({
           id: scan.id!,
-          /*
-           * Plain object, NOT a model instance: a `new
-           * NetworkDeviceDiscoveryScan()` payload carries non-column base
-           * props (isPermissionIf) that made every update here throw, so no
-           * scan ever left Pending. Cast: the model's JSON column makes
-           * DeepPartial recursion blow up.
-           */
           data: {
             status: "In Progress",
             startedAt: OneUptimeDate.getCurrentDate(),
           } as unknown as QueryDeepPartialEntity<NetworkDeviceDiscoveryScan>,
-          props: {
-            isRoot: true,
-          },
         });
       }
 

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/Probe.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/Probe.ts
@@ -44,14 +44,15 @@ router.post(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      // Update last alive in probe and return success response.
-
-      const data: JSONObject = req.body;
-
-      const probeId: ObjectID = new ObjectID(data["probeId"] as string);
-
-      await ProbeService.updateLastAlive(probeId);
-
+      /*
+       * The auth middleware has already verified this probe AND scheduled
+       * the lastAlive stamp (it does so for every authenticated probe
+       * request — a request that authenticates IS proof of liveness).
+       * Awaiting a second updateLastAlive here would re-couple the
+       * heartbeat's response time to Postgres write latency, which is the
+       * exact coupling that let a slow database mark healthy probes
+       * Disconnected while they were successfully running their checks.
+       */
       return Response.sendEmptySuccessResponse(req, res);
     } catch (err) {
       return next(err);

--- a/App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts
+++ b/App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts
@@ -4,6 +4,9 @@ import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import ProbeService from "Common/Server/Services/ProbeService";
 import { ExpressResponse, NextFunction } from "Common/Server/Utils/Express";
+import logger, {
+  getLogAttributesFromRequest,
+} from "Common/Server/Utils/Logger";
 import Response from "Common/Server/Utils/Response";
 import Probe from "Common/Models/DatabaseModels/Probe";
 
@@ -13,45 +16,82 @@ export default class ProbeAuthorization {
     res: ExpressResponse,
     next: NextFunction,
   ): Promise<void> {
-    const data: JSONObject = req.body;
+    /*
+     * The whole body is wrapped in try/catch because this is an ASYNC
+     * middleware on Express 4, which ignores the promise a middleware
+     * returns: a rejection here (pool-acquire timeout, statement timeout,
+     * Redis failure) would otherwise be swallowed by the process-level
+     * unhandledRejection logger and the HTTP request would NEVER be
+     * answered — the probe client sees a connection that accepts the
+     * request and then goes silent until its own timeout. That silent-hang
+     * mode is exactly how a briefly-starved database turned into probes
+     * being flagged Disconnected in the field.
+     */
+    try {
+      const data: JSONObject = req.body;
 
-    if (!data["probeId"] || !data["probeKey"]) {
-      return Response.sendErrorResponse(
-        req,
-        res,
-        new BadDataException("ProbeId or ProbeKey is missing"),
-      );
+      if (!data["probeId"] || !data["probeKey"]) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("ProbeId or ProbeKey is missing"),
+        );
+      }
+
+      const probeId: ObjectID = new ObjectID(data["probeId"] as string);
+
+      const probeKey: string = data["probeKey"] as string;
+
+      /*
+       * Cache-backed verification: repeat requests from a probe skip the
+       * per-request Probe SELECT, so authentication stays fast even while
+       * the Postgres pool is busy. Falls back to the database on any cache
+       * miss or cache failure.
+       */
+      const isValidProbe: boolean = await ProbeService.verifyProbeKey({
+        probeId: probeId,
+        probeKey: probeKey,
+      });
+
+      if (!isValidProbe) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("Invalid Probe ID or Probe Key"),
+        );
+      }
+
+      /*
+       * Every authenticated request proves the probe is alive, so the
+       * liveness stamp rides along here — but deliberately WITHOUT being
+       * awaited. The write is throttled (one single-statement UPDATE per
+       * probe per 30s) and self-heals (a failed write clears the throttle
+       * so the next request retries), and nothing downstream reads its
+       * result. Awaiting it would chain every probe request's latency —
+       * including the /alive heartbeat itself — to Postgres write latency,
+       * which is precisely the coupling that let a slow database mark
+       * healthy probes Disconnected.
+       */
+      ProbeService.updateLastAlive(probeId).catch((err: Error) => {
+        logger.error(
+          `Failed to update lastAlive for probe ${probeId.toString()}`,
+          getLogAttributesFromRequest(req as any),
+        );
+        logger.error(err, getLogAttributesFromRequest(req as any));
+      });
+
+      /*
+       * Handlers only ever read req.probe.id (verified: DiscoveryScan,
+       * NetworkDevicePoll, Monitor routes), so hand them exactly that
+       * instead of a fetched row.
+       */
+      const probe: Probe = new Probe();
+      probe.id = probeId;
+      req.probe = probe;
+
+      return next();
+    } catch (err) {
+      return next(err);
     }
-
-    const probeId: ObjectID = new ObjectID(data["probeId"] as string);
-
-    const probeKey: string = data["probeKey"] as string;
-
-    const probe: Probe | null = await ProbeService.findOneBy({
-      query: {
-        _id: probeId.toString(),
-        key: probeKey,
-      },
-      select: {
-        _id: true,
-      },
-      props: {
-        isRoot: true,
-      },
-    });
-
-    if (!probe) {
-      return Response.sendErrorResponse(
-        req,
-        res,
-        new BadDataException("Invalid Probe ID or Probe Key"),
-      );
-    }
-
-    await ProbeService.updateLastAlive(probeId);
-
-    req.probe = probe;
-
-    return next();
   }
 }

--- a/App/FeatureSet/Workers/Jobs/Probe/UpdateConnectionStatus.ts
+++ b/App/FeatureSet/Workers/Jobs/Probe/UpdateConnectionStatus.ts
@@ -1,11 +1,27 @@
 import OneUptimeDate from "Common/Types/Date";
 import RunCron from "../../Utils/Cron";
 import { EVERY_MINUTE } from "Common/Utils/CronTime";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import ProbeService from "Common/Server/Services/ProbeService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 import logger from "Common/Server/Utils/Logger";
 import Probe, {
   ProbeConnectionStatus,
 } from "Common/Models/DatabaseModels/Probe";
+
+/*
+ * Staleness cutoff, chosen for exact parity with the historical in-process
+ * check `OneUptimeDate.getDifferenceInMinutes(now, lastAlive) > 2`:
+ * moment's diff-in-minutes truncates, so "difference > 2 minutes" was only
+ * true once a probe was >= 3 whole minutes stale. The SQL predicate
+ * `lastAlive <= now - 3 minutes` flips at exactly the same instant.
+ */
+const STALE_CUTOFF_IN_MINUTES: number = 3;
+
+type FlipCandidate = {
+  probe: Probe;
+  newStatus: ProbeConnectionStatus;
+};
 
 RunCron(
   "Probe:UpdateConnectionStatus",
@@ -15,82 +31,126 @@ RunCron(
       service: "workers",
     });
 
-    const probes: Array<Probe> = await ProbeService.findAllBy({
-      query: {},
-      props: {
-        isRoot: true,
+    const staleCutoff: Date = OneUptimeDate.getSomeMinutesAgo(
+      STALE_CUTOFF_IN_MINUTES,
+    );
+
+    /*
+     * Fetch ONLY the probes whose stored status disagrees with what their
+     * lastAlive implies, instead of every probe row in the system every
+     * minute. On a steady-state deployment both queries return zero rows —
+     * the common case costs two indexed-predicate SELECTs and nothing else.
+     *
+     * A NULL connectionStatus (probe that never had one stamped) counts as
+     * "disagrees" for both directions, mirroring the old in-process
+     * comparison `probe.connectionStatus !== computedStatus`. The
+     * notify-owners hook (ProbeService.onBeforeUpdate) independently skips
+     * NULL→anything transitions, so no extra notifications are introduced.
+     */
+    const toDisconnect: Array<Probe> = await ProbeService.findBy({
+      query: {
+        // Stale OR never seen at all.
+        lastAlive: QueryHelper.lessThanEqualToOrNull(staleCutoff),
+        connectionStatus: QueryHelper.notInOrNull([
+          ProbeConnectionStatus.Disconnected,
+        ]),
       },
       select: {
         _id: true,
-        lastAlive: true,
-        connectionStatus: true,
         projectId: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
       },
     });
 
-    logger.debug(`Found ${probes.length} probes`, { service: "workers" });
+    const toConnect: Array<Probe> = await ProbeService.findBy({
+      query: {
+        lastAlive: QueryHelper.greaterThan(staleCutoff),
+        connectionStatus: QueryHelper.notInOrNull([
+          ProbeConnectionStatus.Connected,
+        ]),
+      },
+      select: {
+        _id: true,
+        projectId: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
 
-    logger.debug(probes, { service: "workers" });
+    /*
+     * A probe can appear in BOTH lists in one narrow case: its
+     * connectionStatus is NULL (matches neither notInOrNull filter) and a
+     * heartbeat landed between the two SELECTs, moving it from stale to
+     * fresh. The connect query ran later, so its verdict is the fresher
+     * one — drop the disconnect flip rather than writing both.
+     */
+    const toConnectIds: Set<string> = new Set(
+      toConnect.map((probe: Probe) => {
+        return probe.id?.toString() || "";
+      }),
+    );
 
-    for (const probe of probes) {
+    const flips: Array<FlipCandidate> = [
+      ...toDisconnect
+        .filter((probe: Probe) => {
+          return !toConnectIds.has(probe.id?.toString() || "");
+        })
+        .map((probe: Probe) => {
+          return {
+            probe,
+            newStatus: ProbeConnectionStatus.Disconnected,
+          };
+        }),
+      ...toConnect.map((probe: Probe) => {
+        return {
+          probe,
+          newStatus: ProbeConnectionStatus.Connected,
+        };
+      }),
+    ];
+
+    if (flips.length === 0) {
+      return;
+    }
+
+    logger.debug(
+      `Found ${toDisconnect.length} probe(s) to mark Disconnected and ${toConnect.length} to mark Connected`,
+      { service: "workers" },
+    );
+
+    for (const flip of flips) {
       try {
-        // if the lastAlive is more than 2 minutes old, then set the connection status to false
-
-        if (!probe.id) {
+        if (!flip.probe.id) {
           continue;
         }
 
-        let connectionStatus: ProbeConnectionStatus =
-          ProbeConnectionStatus.Connected;
-
-        if (!probe.lastAlive) {
-          connectionStatus = ProbeConnectionStatus.Disconnected;
-        }
-
-        if (
-          probe.lastAlive &&
-          OneUptimeDate.getDifferenceInMinutes(
-            OneUptimeDate.getCurrentDate(),
-            probe.lastAlive,
-          ) > 2
-        ) {
-          connectionStatus = ProbeConnectionStatus.Disconnected;
-        } else {
-          connectionStatus = ProbeConnectionStatus.Connected;
-        }
-
-        if (!probe.lastAlive) {
-          connectionStatus = ProbeConnectionStatus.Disconnected;
-        }
-
-        let shouldUpdateConnectionStatus: boolean = false;
-
-        if (probe.connectionStatus !== connectionStatus) {
-          shouldUpdateConnectionStatus = true;
-        }
-
-        if (!shouldUpdateConnectionStatus) {
-          continue; // no need to update the connection status.
-        }
-
-        // now update the connection status
-        probe.connectionStatus = connectionStatus;
-
-        if (shouldUpdateConnectionStatus) {
-          await ProbeService.updateOneById({
-            id: probe.id!,
-            data: {
-              connectionStatus: connectionStatus,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
-        }
+        /*
+         * Full-pipeline update on purpose: the status flip is what fires
+         * ProbeService's hooks (owner notifications, monitor status
+         * refresh). Those hooks are the expensive part, which is exactly
+         * why the queries above make sure this only ever runs for probes
+         * that actually changed state.
+         */
+        await ProbeService.updateOneById({
+          id: flip.probe.id,
+          data: {
+            connectionStatus: flip.newStatus,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
       } catch (error) {
         logger.error(error, {
           service: "workers",
-          projectId: probe.projectId?.toString(),
+          projectId: flip.probe.projectId?.toString(),
         });
       }
     }

--- a/App/Tests/Telemetry/ProbeAuthorizationMiddleware.test.ts
+++ b/App/Tests/Telemetry/ProbeAuthorizationMiddleware.test.ts
@@ -1,0 +1,332 @@
+import ProbeService from "Common/Server/Services/ProbeService";
+import Response from "Common/Server/Utils/Response";
+import logger from "Common/Server/Utils/Logger";
+import Probe from "Common/Models/DatabaseModels/Probe";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import { ExpressResponse, NextFunction } from "Common/Server/Utils/Express";
+import { ProbeExpressRequest } from "../../FeatureSet/Telemetry/Types/Request";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Regression tests for the probe-auth middleware.
+ *
+ * This middleware runs on EVERY authenticated probe request — including the
+ * /alive heartbeat — so its failure modes decide whether a briefly-starved
+ * database turns into probes being flagged Disconnected:
+ *
+ *   1. It is an ASYNC middleware on Express 4, which ignores the promise a
+ *      middleware returns. Before the try/catch wrapped the whole body, any
+ *      rejection (pool-acquire timeout, statement timeout) was swallowed and
+ *      the request was NEVER answered — the probe client saw the connection
+ *      go silent until its own 45s+ timeout fired. Errors must reach
+ *      next(err) so Express answers the request.
+ *
+ *   2. The lastAlive stamp is fire-and-forget. Awaiting it would chain every
+ *      probe request's latency — including the heartbeat itself — to
+ *      Postgres write latency, which is precisely the coupling that let a
+ *      slow database mark healthy probes Disconnected.
+ */
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    // The middleware imports this named export for log attribution.
+    getLogAttributesFromRequest: jest.fn(() => {
+      return {};
+    }),
+  };
+});
+
+jest.mock("Common/Server/Services/ProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      verifyProbeKey: jest.fn(),
+      updateLastAlive: jest.fn(),
+    },
+  };
+});
+
+import ProbeAuthorization from "../../FeatureSet/Telemetry/Middleware/ProbeAuthorization";
+
+type ProbeServiceMock = {
+  verifyProbeKey: jest.Mock;
+  updateLastAlive: jest.Mock;
+};
+
+const probeService: ProbeServiceMock =
+  ProbeService as unknown as ProbeServiceMock;
+
+const responseUtil: { sendErrorResponse: jest.Mock } = Response as unknown as {
+  sendErrorResponse: jest.Mock;
+};
+
+const loggerMock: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const mockResponse: ExpressResponse = {} as ExpressResponse;
+
+type MiddlewareInvocation = {
+  req: ProbeExpressRequest;
+  next: NextFunction;
+  middlewarePromise: Promise<void>;
+};
+
+/*
+ * Invokes the middleware WITHOUT awaiting it, so tests can observe timing:
+ * whether the returned promise settles independently of the promises the
+ * middleware kicked off internally.
+ */
+function callMiddleware(body: JSONObject): MiddlewareInvocation {
+  const req: ProbeExpressRequest = { body } as unknown as ProbeExpressRequest;
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+  const middlewarePromise: Promise<void> =
+    ProbeAuthorization.isAuthorizedServiceMiddleware(req, mockResponse, next);
+  return { req, next, middlewarePromise };
+}
+
+describe("ProbeAuthorization.isAuthorizedServiceMiddleware", () => {
+  const probeId: ObjectID = ObjectID.generate();
+  const probeKey: string = "test-probe-key";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    probeService.verifyProbeKey.mockResolvedValue(true as never);
+    probeService.updateLastAlive.mockResolvedValue(undefined as never);
+  });
+
+  test("rejects a request with no probeId before touching the service", async () => {
+    const { next, middlewarePromise } = callMiddleware({
+      probeKey: probeKey,
+    });
+    await middlewarePromise;
+
+    expect(responseUtil.sendErrorResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+      expect.any(BadDataException),
+    );
+    expect(probeService.verifyProbeKey).not.toHaveBeenCalled();
+    expect(probeService.updateLastAlive).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("rejects a request with no probeKey before touching the service", async () => {
+    const { next, middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+    });
+    await middlewarePromise;
+
+    expect(responseUtil.sendErrorResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+      expect.any(BadDataException),
+    );
+    expect(probeService.verifyProbeKey).not.toHaveBeenCalled();
+    expect(probeService.updateLastAlive).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("an invalid probeId/probeKey pair is refused and never stamps liveness", async () => {
+    probeService.verifyProbeKey.mockResolvedValue(false as never);
+
+    const { next, middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+      probeKey: "wrong-key",
+    });
+    await middlewarePromise;
+
+    expect(responseUtil.sendErrorResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+      expect.any(BadDataException),
+    );
+    // A failed authentication must not count as proof of liveness.
+    expect(probeService.updateLastAlive).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("a valid pair authenticates, attaches req.probe, and stamps liveness", async () => {
+    const { req, next, middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+      probeKey: probeKey,
+    });
+    await middlewarePromise;
+
+    expect(next).toHaveBeenCalledTimes(1);
+    // next() with NO argument — an argument would route to the error handler.
+    expect(next).toHaveBeenCalledWith();
+    expect(responseUtil.sendErrorResponse).not.toHaveBeenCalled();
+
+    // Verification goes through the cache-backed check, not a per-request findOneBy.
+    expect(probeService.verifyProbeKey).toHaveBeenCalledTimes(1);
+    const verifyArgs: { probeId: ObjectID; probeKey: string } = probeService
+      .verifyProbeKey.mock.calls[0]![0] as {
+      probeId: ObjectID;
+      probeKey: string;
+    };
+    expect(verifyArgs.probeId.toString()).toBe(probeId.toString());
+    expect(verifyArgs.probeKey).toBe(probeKey);
+
+    /*
+     * Handlers downstream only ever read req.probe.id, and the middleware
+     * hands them exactly that — a Probe instance carrying the id — instead
+     * of a row fetched from the database.
+     */
+    expect(req.probe).toBeInstanceOf(Probe);
+    expect(req.probe?.id?.toString()).toBe(probeId.toString());
+
+    expect(probeService.updateLastAlive).toHaveBeenCalledTimes(1);
+    const stampedId: ObjectID = probeService.updateLastAlive.mock
+      .calls[0]![0] as ObjectID;
+    expect(stampedId).toBeInstanceOf(ObjectID);
+    expect(stampedId.toString()).toBe(probeId.toString());
+  });
+
+  /*
+   * THE non-blocking pin: the lastAlive stamp must be fire-and-forget. If
+   * someone re-introduces an `await` on updateLastAlive, this test hangs on
+   * a never-resolving promise and the 500ms timer wins the race — awaiting
+   * the stamp re-couples every probe request (including the /alive
+   * heartbeat) to Postgres write latency, which is exactly how a slow
+   * database marked healthy probes Disconnected.
+   */
+  test("resolves and calls next() even when the lastAlive write never settles", async () => {
+    probeService.updateLastAlive.mockReturnValue(
+      new Promise<void>(() => {}) as never,
+    );
+
+    const { next, middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+      probeKey: probeKey,
+    });
+
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+    const timeout: Promise<string> = new Promise<string>(
+      (resolve: (value: string) => void) => {
+        timer = setTimeout(() => {
+          resolve("timed out");
+        }, 500);
+      },
+    );
+
+    try {
+      const winner: string = await Promise.race([
+        middlewarePromise.then(() => {
+          return "middleware resolved";
+        }),
+        timeout,
+      ]);
+      expect(winner).toBe("middleware resolved");
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  /*
+   * A failed lastAlive write must not fail the request (the write is
+   * throttled and self-healing), and the rejection must be HANDLED: the
+   * .catch on the fire-and-forget promise is what keeps an async stamp
+   * failure from surfacing as an unhandledRejection. logger.error receiving
+   * the error proves the .catch handler observed it.
+   */
+  test("a lastAlive write failure is logged, not surfaced to the request", async () => {
+    const failure: Error = new Error("postgres write failed");
+    probeService.updateLastAlive.mockImplementation(() => {
+      return new Promise<void>(
+        (_resolve: () => void, reject: (err: Error) => void) => {
+          setImmediate(() => {
+            reject(failure);
+          });
+        },
+      );
+    });
+
+    const { next, middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+      probeKey: probeKey,
+    });
+    await middlewarePromise;
+
+    // The request already proceeded — before the write failure even landed.
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+
+    // Let the rejection land and its .catch handler run.
+    await new Promise<void>((resolve: () => void) => {
+      setImmediate(resolve);
+    });
+    await new Promise<void>((resolve: () => void) => {
+      setImmediate(resolve);
+    });
+
+    expect(loggerMock.error).toHaveBeenCalled();
+    const loggedTheError: boolean = loggerMock.error.mock.calls.some(
+      (call: Array<unknown>) => {
+        return call[0] === failure;
+      },
+    );
+    expect(loggedTheError).toBe(true);
+
+    // The failure never turned into next(err) after the fact.
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * THE silent-hang regression pin. This is an async middleware on Express
+   * 4, which ignores the promise a middleware returns: without the
+   * try/catch → next(err), a verifyProbeKey rejection (pool-acquire
+   * timeout, statement timeout, Redis failure) was swallowed by the
+   * process-level unhandledRejection logger and the HTTP request was NEVER
+   * answered. The probe client saw a connection that accepted the request
+   * and then went silent until its own timeout — the customer-visible 45s+
+   * ECONNABORTED hang that got healthy probes flagged Disconnected.
+   */
+  test("a verifyProbeKey rejection reaches next(err) so the request is answered", async () => {
+    const boom: Error = new Error("pool acquire timeout");
+    probeService.verifyProbeKey.mockRejectedValue(boom as never);
+
+    const { next, middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+      probeKey: probeKey,
+    });
+    await middlewarePromise;
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(responseUtil.sendErrorResponse).not.toHaveBeenCalled();
+    expect(probeService.updateLastAlive).not.toHaveBeenCalled();
+  });
+});

--- a/App/Tests/Telemetry/ProbeIngestAlive.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestAlive.test.ts
@@ -1,0 +1,261 @@
+import { mockRouter } from "Common/Tests/Server/API/Helpers";
+import ProbeService from "Common/Server/Services/ProbeService";
+import Response from "Common/Server/Utils/Response";
+import ObjectID from "Common/Types/ObjectID";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Regression tests for POST /alive.
+ *
+ * The /alive heartbeat is what keeps a probe from being flagged
+ * Disconnected, so its latency budget is the whole point: the handler used
+ * to run a second, AWAITED ProbeService.updateLastAlive on top of the one
+ * the auth middleware already schedules. That await chained the heartbeat's
+ * response time to Postgres write latency — a briefly-starved pool made
+ * /alive hang past the probe client's timeout and healthy probes were
+ * marked Disconnected. The middleware now owns the stamp
+ * (fire-and-forget); the handler must do NO database work at all.
+ */
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: () => {
+        return mockRouter;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendEmptySuccessResponse: jest.fn(),
+      sendErrorResponse: jest.fn(),
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    // The route module imports this named export for log attribution.
+    getLogAttributesFromRequest: jest.fn(() => {
+      return {};
+    }),
+  };
+});
+
+jest.mock("Common/Server/Services/ProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      updateLastAlive: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../FeatureSet/Telemetry/Middleware/ProbeAuthorization", () => {
+  return {
+    __esModule: true,
+    default: {
+      isAuthorizedServiceMiddleware: jest.fn(),
+    },
+  };
+});
+
+/*
+ * The queue module pulls in BullMQ at import time; the /alive handler must
+ * never touch it.
+ */
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        addProbeIngestJob: jest.fn(),
+        addSnmpTrapIngestJob: jest.fn(),
+        getQueueStats: jest.fn(),
+        getQueueSize: jest.fn(),
+        getFailedJobs: jest.fn(),
+      },
+    };
+  },
+);
+
+jest.mock("Common/Server/Middleware/ClusterKeyAuthorization", () => {
+  return {
+    __esModule: true,
+    default: {
+      isAuthorizedServiceMiddleware: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+      getActiveProjectStatusQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      countBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getEnabledMonitorQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+/*
+ * Importing the router module registers its routes on the mocked router so
+ * each handler can be invoked directly. The probe-auth middleware is mocked
+ * out; on the real server it runs before the handler and owns the lastAlive
+ * stamp.
+ */
+import "../../FeatureSet/Telemetry/API/ProbeIngest/Probe";
+import ProbeAuthorization from "../../FeatureSet/Telemetry/Middleware/ProbeAuthorization";
+
+const probeService: {
+  findOneBy: jest.Mock;
+  updateLastAlive: jest.Mock;
+} = ProbeService as unknown as {
+  findOneBy: jest.Mock;
+  updateLastAlive: jest.Mock;
+};
+
+const responseUtil: {
+  sendEmptySuccessResponse: jest.Mock;
+  sendErrorResponse: jest.Mock;
+  sendJsonObjectResponse: jest.Mock;
+} = Response as unknown as {
+  sendEmptySuccessResponse: jest.Mock;
+  sendErrorResponse: jest.Mock;
+  sendJsonObjectResponse: jest.Mock;
+};
+
+const mockResponse: ExpressResponse = {} as ExpressResponse;
+
+type CallAliveEndpointFunction = (
+  req: ExpressRequest,
+) => Promise<{ next: NextFunction }>;
+
+const callAliveEndpoint: CallAliveEndpointFunction = async (
+  req: ExpressRequest,
+): Promise<{ next: NextFunction }> => {
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+  await mockRouter
+    .match("post", "/alive")
+    .handlerFunction(req, mockResponse, next);
+  return { next };
+};
+
+describe("POST /alive", () => {
+  const probeId: ObjectID = ObjectID.generate();
+
+  function makeRequest(): ExpressRequest {
+    // The wire shape the probe sends; the handler must not need any of it.
+    return {
+      body: {
+        probeId: probeId.toString(),
+        probeKey: "test-probe-key",
+      },
+    } as unknown as ExpressRequest;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /*
+   * THE regression pin: the handler responds immediately and does ZERO
+   * database work. A re-introduced (awaited) updateLastAlive here would
+   * re-couple heartbeat latency to Postgres write latency — the exact
+   * coupling that let a slow database mark healthy probes Disconnected
+   * while they were successfully running their checks.
+   */
+  test("responds with empty success and never calls updateLastAlive itself", async () => {
+    const { next } = await callAliveEndpoint(makeRequest());
+
+    expect(responseUtil.sendEmptySuccessResponse).toHaveBeenCalledTimes(1);
+    expect(responseUtil.sendEmptySuccessResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+    );
+
+    // The auth middleware owns the lastAlive stamp; the handler owns nothing.
+    expect(probeService.updateLastAlive).not.toHaveBeenCalled();
+    expect(probeService.findOneBy).not.toHaveBeenCalled();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(responseUtil.sendErrorResponse).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The stamp only rides along because the auth middleware runs on this
+   * route: /alive registered WITHOUT it would authenticate nobody and stamp
+   * nothing, silently letting every probe go stale.
+   */
+  test("is registered with the probe-auth middleware", () => {
+    expect(mockRouter.match("post", "/alive").middleware).toBe(
+      ProbeAuthorization.isAuthorizedServiceMiddleware,
+    );
+  });
+
+  test("does not call next with an error on the happy path", async () => {
+    const { next } = await callAliveEndpoint(makeRequest());
+
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -58,6 +58,7 @@ jest.mock("Common/Server/Services/NetworkDeviceDiscoveryScanService", () => {
       findBy: jest.fn(),
       findOneBy: jest.fn(),
       updateOneById: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
     },
   };
 });
@@ -92,6 +93,7 @@ type MockedService = {
   findBy: jest.Mock;
   findOneBy: jest.Mock;
   updateOneById: jest.Mock;
+  updateColumnsByIdWithoutHooks: jest.Mock;
 };
 
 const scanService: MockedService =
@@ -179,7 +181,9 @@ describe("POST /probe/discovery-scan/list", () => {
       scanId,
     );
     scanService.findBy.mockResolvedValue([scan] as never);
-    scanService.updateOneById.mockResolvedValue(undefined as never);
+    scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+      undefined as never,
+    );
 
     const { next } = await callListEndpoint(makeRequest({ probeId }));
 
@@ -199,10 +203,17 @@ describe("POST /probe/discovery-scan/list", () => {
     );
     expect((findArgs["props"] as JSONObject)["isRoot"]).toBe(true);
 
-    // The claim: status In Progress + startedAt, and nothing else.
-    expect(scanService.updateOneById).toHaveBeenCalledTimes(1);
-    const updateArgs: JSONObject = scanService.updateOneById.mock
-      .calls[0]![0] as JSONObject;
+    /*
+     * The claim: status In Progress + startedAt, and nothing else — via the
+     * hook-free single-statement write. The probe synchronously waits on
+     * this route every minute, so the claim must not pay the full
+     * updateOneById pipeline (permission pre-fetch + row re-fetch + save()
+     * transaction) for a model with no update hooks.
+     */
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+    expect(scanService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(1);
+    const updateArgs: JSONObject = scanService.updateColumnsByIdWithoutHooks
+      .mock.calls[0]![0] as JSONObject;
     expect((updateArgs["id"] as ObjectID).toString()).toBe(scanId.toString());
     const data: JSONObject = expectPlainUpdateData(updateArgs["data"]);
     expect(Object.keys(data).sort()).toEqual(["startedAt", "status"]);
@@ -224,12 +235,14 @@ describe("POST /probe/discovery-scan/list", () => {
       ObjectID.generate(),
     );
     scanService.findBy.mockResolvedValue([scan] as never);
-    scanService.updateOneById.mockResolvedValue(undefined as never);
+    scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+      undefined as never,
+    );
 
     await callListEndpoint(makeRequest({ probeId }));
 
     const updateOrder: number =
-      scanService.updateOneById.mock.invocationCallOrder[0]!;
+      scanService.updateColumnsByIdWithoutHooks.mock.invocationCallOrder[0]!;
     const respondOrder: number =
       responseUtil.sendEntityArrayResponse.mock.invocationCallOrder[0]!;
     expect(updateOrder).toBeLessThan(respondOrder);
@@ -266,11 +279,13 @@ describe("POST /probe/discovery-scan/list", () => {
       new NetworkDeviceDiscoveryScan(ObjectID.generate()),
     ];
     scanService.findBy.mockResolvedValue(scans as never);
-    scanService.updateOneById.mockResolvedValue(undefined as never);
+    scanService.updateColumnsByIdWithoutHooks.mockResolvedValue(
+      undefined as never,
+    );
 
     await callListEndpoint(makeRequest({ probeId }));
 
-    expect(scanService.updateOneById).toHaveBeenCalledTimes(2);
+    expect(scanService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(2);
   });
 
   test("no pending scans: responds with an empty list and updates nothing", async () => {
@@ -278,6 +293,7 @@ describe("POST /probe/discovery-scan/list", () => {
 
     await callListEndpoint(makeRequest({ probeId }));
 
+    expect(scanService.updateColumnsByIdWithoutHooks).not.toHaveBeenCalled();
     expect(scanService.updateOneById).not.toHaveBeenCalled();
     expect(responseUtil.sendEntityArrayResponse).toHaveBeenCalledWith(
       expect.anything(),

--- a/App/Tests/Workers/Jobs/Probe/UpdateConnectionStatus.test.ts
+++ b/App/Tests/Workers/Jobs/Probe/UpdateConnectionStatus.test.ts
@@ -1,0 +1,504 @@
+import Probe, {
+  ProbeConnectionStatus,
+} from "Common/Models/DatabaseModels/Probe";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import ObjectID from "Common/Types/ObjectID";
+import { EVERY_MINUTE } from "Common/Utils/CronTime";
+
+/*
+ * Regression tests for the Probe:UpdateConnectionStatus cron rewrite. The job
+ * runs EVERY MINUTE and used to call ProbeService.findAllBy({}) - a full-table
+ * scan that hauled EVERY probe row in the system into JS on every tick, just
+ * to compare two columns (lastAlive vs connectionStatus) per row and decide
+ * whether to flip the status. On a large deployment that scan competed with
+ * the /probe-ingest hot path for the same table and connections. The rewrite
+ * pushes the comparison into SQL: two targeted findBy queries fetch ONLY the
+ * probes whose stored status disagrees with what their lastAlive implies, so
+ * a steady-state tick costs two indexed-predicate SELECTs and nothing else.
+ * These tests pin:
+ *   1. the query fan-in: exactly two findBy calls per tick, ZERO findAllBy /
+ *      findOneBy / findOneById calls, select limited to {_id, projectId},
+ *   2. the predicate shapes (lessThanEqualToOrNull / greaterThan / notInOrNull
+ *      over ONE shared 3-minute cutoff) and their exact-parity semantics with
+ *      the old in-process check,
+ *   3. the flip writes: full-pipeline updateOneById per candidate carrying
+ *      ONLY connectionStatus, with per-probe failure isolation.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler and options (the same
+ * recorder the other App/Tests/Workers/Jobs suites use) and each test drives
+ * one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+interface CronOptions {
+  schedule: string;
+  runOnStartup: boolean;
+}
+
+interface CapturedJob {
+  options: CronOptions;
+  handler: CronHandler;
+}
+
+/*
+ * Captured cron registrations, keyed by job name. Must be declared before the
+ * job import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CapturedJob> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (
+        jobName: string,
+        options: CronOptions,
+        runFunction: CronHandler,
+      ): void => {
+        mockCapturedJobs[jobName] = { options, handler: runFunction };
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * findAllBy / findOneBy / findOneById are mocked ALONGSIDE the targeted findBy
+ * precisely so the suite can prove they are never called: if the job regressed
+ * back to the all-rows findAllBy({}) scan (or per-probe point reads), the
+ * assertions would flag it instead of the mock throwing "not a function".
+ */
+jest.mock("Common/Server/Services/ProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOneBy: jest.fn(),
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+/*
+ * QueryHelper is mocked with sentinel-returning fns so the tests can assert
+ * BOTH which predicate factory each query field came from AND the exact
+ * argument it was built with (the real helpers return opaque typeorm Raw
+ * FindOperators keyed by random parameter names, which are awkward to
+ * introspect). Each sentinel captures the factory args, so asserting the
+ * query field deep-equals the sentinel pins the whole predicate.
+ */
+jest.mock("Common/Server/Types/Database/QueryHelper", () => {
+  return {
+    __esModule: true,
+    default: {
+      lessThanEqualToOrNull: jest.fn((value: Date) => {
+        return { op: "lessThanEqualToOrNull", value };
+      }),
+      greaterThan: jest.fn((value: Date) => {
+        return { op: "greaterThan", value };
+      }),
+      notInOrNull: jest.fn((values: Array<string>) => {
+        return { op: "notInOrNull", values };
+      }),
+    },
+  };
+});
+
+import ProbeService from "Common/Server/Services/ProbeService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/Probe/UpdateConnectionStatus";
+
+interface ProbeServiceMock {
+  findBy: jest.Mock;
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOneBy: jest.Mock;
+  findOneById: jest.Mock;
+}
+
+interface QueryHelperMock {
+  lessThanEqualToOrNull: jest.Mock;
+  greaterThan: jest.Mock;
+  notInOrNull: jest.Mock;
+}
+
+const probeService: ProbeServiceMock =
+  ProbeService as unknown as ProbeServiceMock;
+const queryHelper: QueryHelperMock = QueryHelper as unknown as QueryHelperMock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const JOB_NAME: string = "Probe:UpdateConnectionStatus";
+
+const PROJECT_1_ID: ObjectID = new ObjectID("project-1");
+const PROJECT_2_ID: ObjectID = new ObjectID("project-2");
+
+// The staleness cutoff: 3 whole minutes, see the parity test below for why.
+const STALE_CUTOFF_IN_MS: number = 3 * 60 * 1000;
+
+function makeProbe(data: { id?: ObjectID; projectId?: ObjectID }): Probe {
+  const probe: Probe = new Probe(data.id);
+
+  if (data.projectId) {
+    probe.projectId = data.projectId;
+  }
+
+  return probe;
+}
+
+interface FindByArgs {
+  query: Record<string, unknown>;
+  select: Record<string, boolean>;
+  skip: number;
+  limit: number;
+  props: Record<string, unknown>;
+}
+
+// The two findBy calls are issued sequentially: disconnect first, connect second.
+function disconnectQueryArgs(): FindByArgs {
+  return probeService.findBy.mock.calls[0]![0] as FindByArgs;
+}
+
+function connectQueryArgs(): FindByArgs {
+  return probeService.findBy.mock.calls[1]![0] as FindByArgs;
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+  props: Record<string, unknown>;
+}
+
+function updateCalls(): Array<UpdateCallArgs> {
+  return probeService.updateOneById.mock.calls.map((args: Array<unknown>) => {
+    return args[0] as UpdateCallArgs;
+  });
+}
+
+async function runWorkerTick(): Promise<void> {
+  const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+  if (!captured) {
+    throw new Error(
+      "Probe:UpdateConnectionStatus did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await captured.handler();
+}
+
+describe("Probe:UpdateConnectionStatus worker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    probeService.findBy.mockResolvedValue([]);
+    probeService.updateOneById.mockResolvedValue(undefined);
+  });
+
+  test("registers on EVERY_MINUTE without running on startup", () => {
+    const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+    expect(captured).toBeDefined();
+    expect(captured!.options).toEqual({
+      schedule: EVERY_MINUTE,
+      runOnStartup: false,
+    });
+  });
+
+  test("one tick issues exactly two targeted findBy queries - never the all-rows scan", async () => {
+    await runWorkerTick();
+
+    /*
+     * THE regression this rewrite removed: findAllBy({}) fetched every Probe
+     * row in the system every minute - a full-table scan whose rows were all
+     * hauled into JS just to compare two columns per row. The status
+     * disagreement now lives in the SQL predicates, so the tick issues
+     * exactly two SELECTs (stale-but-not-Disconnected, fresh-but-not-
+     * Connected) and touches nothing else.
+     */
+    expect(probeService.findBy).toHaveBeenCalledTimes(2);
+    expect(probeService.findAllBy).not.toHaveBeenCalled();
+    expect(probeService.findOneBy).not.toHaveBeenCalled();
+    expect(probeService.findOneById).not.toHaveBeenCalled();
+  });
+
+  test("disconnect query: stale-or-never-alive AND not-already-Disconnected, id+projectId only, root, LIMIT_MAX", async () => {
+    await runWorkerTick();
+
+    const args: FindByArgs = disconnectQueryArgs();
+
+    /*
+     * lessThanEqualToOrNull (not plain lessThanEqualTo): a probe that has
+     * NEVER stamped lastAlive must also count as stale, mirroring the old
+     * in-process branch that treated a missing lastAlive as disconnected.
+     */
+    expect(args.query["lastAlive"]).toEqual({
+      op: "lessThanEqualToOrNull",
+      value: expect.any(Date),
+    });
+
+    /*
+     * notInOrNull (not notEquals): a NULL connectionStatus (probe that never
+     * had one stamped) must still be flipped, matching the old comparison
+     * `probe.connectionStatus !== computedStatus`.
+     */
+    expect(args.query["connectionStatus"]).toEqual({
+      op: "notInOrNull",
+      values: [ProbeConnectionStatus.Disconnected],
+    });
+
+    /*
+     * Only the columns the flip loop needs - selecting more (probe keys,
+     * icon blobs) would re-inflate the rows this rewrite stopped hauling.
+     */
+    expect(args.select).toEqual({
+      _id: true,
+      projectId: true,
+    });
+    expect(args.skip).toBe(0);
+    expect(args.limit).toBe(LIMIT_MAX);
+    expect(args.props).toEqual({ isRoot: true });
+  });
+
+  test("connect query: alive-within-cutoff AND not-already-Connected, same shape", async () => {
+    await runWorkerTick();
+
+    const args: FindByArgs = connectQueryArgs();
+
+    /*
+     * Strict greaterThan (no OrNull): a NULL lastAlive can never count as
+     * "recently alive", so it must not qualify a probe for the Connected
+     * flip.
+     */
+    expect(args.query["lastAlive"]).toEqual({
+      op: "greaterThan",
+      value: expect.any(Date),
+    });
+    expect(args.query["connectionStatus"]).toEqual({
+      op: "notInOrNull",
+      values: [ProbeConnectionStatus.Connected],
+    });
+
+    expect(args.select).toEqual({
+      _id: true,
+      projectId: true,
+    });
+    expect(args.skip).toBe(0);
+    expect(args.limit).toBe(LIMIT_MAX);
+    expect(args.props).toEqual({ isRoot: true });
+  });
+
+  test("both queries share ONE now-minus-3-minutes cutoff - exact parity with the old moment-truncated check", async () => {
+    const tickStart: number = Date.now();
+
+    await runWorkerTick();
+
+    expect(queryHelper.lessThanEqualToOrNull).toHaveBeenCalledTimes(1);
+    expect(queryHelper.greaterThan).toHaveBeenCalledTimes(1);
+
+    const staleCutoff: Date = queryHelper.lessThanEqualToOrNull.mock
+      .calls[0]![0] as Date;
+
+    /*
+     * 3 minutes, NOT the 2 minutes the old code appears to say: the historical
+     * in-process check was `OneUptimeDate.getDifferenceInMinutes(now,
+     * lastAlive) > 2`, and moment's diff-in-minutes TRUNCATES - "difference
+     * > 2 minutes" was only true once a probe was >= 3 whole minutes stale.
+     * The SQL predicate `lastAlive <= now - 3 minutes` flips at exactly the
+     * same instant. Shrinking this to 2 minutes would flag probes
+     * Disconnected a full minute earlier than the job ever did.
+     */
+    expect(
+      Math.abs(staleCutoff.getTime() - (tickStart - STALE_CUTOFF_IN_MS)),
+    ).toBeLessThanOrEqual(2000);
+
+    /*
+     * The SAME cutoff instant feeds both predicates: computing "now" twice
+     * would open a sliver between the two queries where a probe matches
+     * neither (or both) directions.
+     */
+    expect(queryHelper.greaterThan.mock.calls[0]![0] as Date).toBe(staleCutoff);
+  });
+
+  test("a steady-state tick with zero candidates writes nothing", async () => {
+    await runWorkerTick();
+
+    // The common case: two SELECTs, no updates, no hooks fired.
+    expect(probeService.updateOneById).not.toHaveBeenCalled();
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+
+  test("flips disconnect candidates to Disconnected and connect candidates to Connected - connectionStatus is the ONLY column written", async () => {
+    const staleProbeId: ObjectID = new ObjectID("probe-stale");
+    const freshProbeId: ObjectID = new ObjectID("probe-fresh");
+
+    probeService.findBy
+      .mockResolvedValueOnce([
+        makeProbe({ id: staleProbeId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([
+        makeProbe({ id: freshProbeId, projectId: PROJECT_2_ID }),
+      ]);
+
+    await runWorkerTick();
+
+    const updates: Array<UpdateCallArgs> = updateCalls();
+
+    expect(updates).toHaveLength(2);
+
+    expect(updates[0]!.id.toString()).toBe(staleProbeId.toString());
+    expect(updates[0]!.data["connectionStatus"]).toBe(
+      ProbeConnectionStatus.Disconnected,
+    );
+    expect(updates[0]!.props).toEqual({ isRoot: true });
+
+    expect(updates[1]!.id.toString()).toBe(freshProbeId.toString());
+    expect(updates[1]!.data["connectionStatus"]).toBe(
+      ProbeConnectionStatus.Connected,
+    );
+    expect(updates[1]!.props).toEqual({ isRoot: true });
+
+    /*
+     * The full-pipeline updateOneById is what fires ProbeService's hooks
+     * (owner notifications, monitor status refresh) - the write must carry
+     * ONLY the status flip, so no other column rides along into those hooks.
+     */
+    for (const update of updates) {
+      expect(Object.keys(update.data)).toEqual(["connectionStatus"]);
+    }
+  });
+
+  test("one probe's flip failure does not prevent the remaining flips", async () => {
+    const failingProbeId: ObjectID = new ObjectID("probe-failing");
+    const survivingProbeId: ObjectID = new ObjectID("probe-surviving");
+    const freshProbeId: ObjectID = new ObjectID("probe-fresh");
+
+    probeService.findBy
+      .mockResolvedValueOnce([
+        makeProbe({ id: failingProbeId, projectId: PROJECT_1_ID }),
+        makeProbe({ id: survivingProbeId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([
+        makeProbe({ id: freshProbeId, projectId: PROJECT_2_ID }),
+      ]);
+
+    const flipError: Error = new Error("db connection reset");
+
+    probeService.updateOneById.mockImplementation(
+      (args: UpdateCallArgs): Promise<void> => {
+        if (args.id.toString() === failingProbeId.toString()) {
+          return Promise.reject(flipError);
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    // The tick itself must not reject (per-probe try/catch).
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    // ALL flips were attempted; the failure only logged, tagged with its project.
+    const updates: Array<UpdateCallArgs> = updateCalls();
+
+    expect(updates).toHaveLength(3);
+    expect(
+      updates.map((update: UpdateCallArgs) => {
+        return update.id.toString();
+      }),
+    ).toEqual([
+      failingProbeId.toString(),
+      survivingProbeId.toString(),
+      freshProbeId.toString(),
+    ]);
+    expect(mockedLogger.error).toHaveBeenCalledWith(flipError, {
+      service: "workers",
+      projectId: PROJECT_1_ID.toString(),
+    });
+  });
+
+  test("a candidate row without an id is skipped without a write or an error", async () => {
+    const validProbeId: ObjectID = new ObjectID("probe-valid");
+
+    probeService.findBy
+      .mockResolvedValueOnce([
+        // Defensive: a row that somehow came back id-less must not crash the loop.
+        makeProbe({ projectId: PROJECT_1_ID }),
+        makeProbe({ id: validProbeId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    const updates: Array<UpdateCallArgs> = updateCalls();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.id.toString()).toBe(validProbeId.toString());
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The two SELECTs run sequentially, so one probe can appear in BOTH
+   * result sets in exactly one case: its connectionStatus is NULL (matches
+   * neither notInOrNull filter) and a heartbeat lands between the queries,
+   * moving it from stale to fresh. Writing both flips would stamp
+   * Disconnected and then Connected in one tick; the connect query ran
+   * later, so only its (fresher) verdict may be written.
+   */
+  test("a probe listed by both queries gets exactly one flip — to Connected", async () => {
+    const doubleListedProbeId: ObjectID = new ObjectID("probe-double-listed");
+    const staleOnlyProbeId: ObjectID = new ObjectID("probe-stale-only");
+
+    probeService.findBy
+      .mockResolvedValueOnce([
+        makeProbe({ id: doubleListedProbeId, projectId: PROJECT_1_ID }),
+        makeProbe({ id: staleOnlyProbeId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([
+        makeProbe({ id: doubleListedProbeId, projectId: PROJECT_1_ID }),
+      ]);
+
+    await runWorkerTick();
+
+    const updates: Array<UpdateCallArgs> = updateCalls();
+    expect(updates).toHaveLength(2);
+
+    const doubleListedUpdates: Array<UpdateCallArgs> = updates.filter(
+      (update: UpdateCallArgs) => {
+        return update.id.toString() === doubleListedProbeId.toString();
+      },
+    );
+    expect(doubleListedUpdates).toHaveLength(1);
+    expect(doubleListedUpdates[0]!.data).toEqual({
+      connectionStatus: ProbeConnectionStatus.Connected,
+    });
+
+    // The genuinely stale probe still gets its Disconnected flip.
+    const staleUpdates: Array<UpdateCallArgs> = updates.filter(
+      (update: UpdateCallArgs) => {
+        return update.id.toString() === staleOnlyProbeId.toString();
+      },
+    );
+    expect(staleUpdates).toHaveLength(1);
+    expect(staleUpdates[0]!.data).toEqual({
+      connectionStatus: ProbeConnectionStatus.Disconnected,
+    });
+  });
+});

--- a/Common/Server/Services/ProbeService.ts
+++ b/Common/Server/Services/ProbeService.ts
@@ -1,6 +1,7 @@
+import crypto from "crypto";
 import User from "../../Models/DatabaseModels/User";
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import DatabaseService from "./DatabaseService";
 import ObjectID from "../../Types/ObjectID";
 import Version from "../../Types/Version";
@@ -36,9 +37,251 @@ import GlobalCache from "../Infrastructure/GlobalCache";
 import { createWhatsAppMessageFromTemplate } from "../Utils/WhatsAppTemplateUtil";
 import { WhatsAppMessagePayload } from "../../Types/WhatsApp/WhatsAppMessage";
 
+/*
+ * Cache namespace for the probe heartbeat throttle: holds the wall-clock of
+ * the last attempted lastAlive write per probe, so at most one Postgres
+ * write happens per probe per 30 seconds no matter how many requests the
+ * probe sends.
+ */
+const PROBE_LAST_ALIVE_CACHE_NAMESPACE: string = "probe-last-alive";
+
+/*
+ * Cache namespace for probe authentication: probeId → SHA-256 of the
+ * probe's CURRENT key, written only after the key was verified against the
+ * database. Lets the probe-auth middleware skip its per-request Probe
+ * SELECT — the exact query that queues behind a starved connection pool and
+ * stalls heartbeats. Entries are deleted whenever a probe's key changes or
+ * the probe is deleted (see onUpdateSuccess / onDeleteSuccess below), and
+ * the TTL bounds the exposure if that invalidation is ever missed.
+ */
+const PROBE_AUTH_KEY_HASH_CACHE_NAMESPACE: string = "probe-auth-key-hash";
+const PROBE_AUTH_KEY_HASH_CACHE_TTL_IN_SECONDS: number = 120;
+
+/*
+ * Revocation sentinel. Invalidation WRITES this value (with the normal TTL)
+ * instead of deleting the key: a bare DELETE can be silently undone by an
+ * in-flight verification that DB-checked the OLD key just before a rotation
+ * committed and then re-cached it just after the delete ran. The sentinel —
+ * combined with verifyProbeKey's write-only-if-unchanged re-read below —
+ * makes the straggler skip its write, so invalidation wins the race. It can
+ * never equal a real SHA-256 hex digest, so on the auth path it always
+ * behaves as a cache miss.
+ */
+const PROBE_AUTH_KEY_REVOKED_SENTINEL: string = "revoked";
+
+/*
+ * Upper bound for a single Redis cache operation on the probe request path.
+ * The ioredis client has no command timeout, so a stalled-but-open Redis
+ * socket would otherwise hang the probe-auth middleware forever with no
+ * error at all. Cache is an optimization here — on timeout we fall back to
+ * the database, exactly as we do when Redis rejects.
+ */
+const PROBE_CACHE_OPERATION_TIMEOUT_IN_MS: number = 2000;
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * Bounds a cache operation in time. Promise.race subscribes to both
+   * promises, so a late settlement of the losing cache operation is
+   * observed and can never surface as an unhandled rejection.
+   */
+  private async boundedCacheOperation<T>(
+    operationName: string,
+    operation: Promise<T>,
+  ): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+
+    const timeout: Promise<never> = new Promise<never>(
+      (_resolve: (value: never) => void, reject: (err: Error) => void) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `${operationName} timed out after ${PROBE_CACHE_OPERATION_TIMEOUT_IN_MS}ms`,
+            ),
+          );
+        }, PROBE_CACHE_OPERATION_TIMEOUT_IN_MS);
+      },
+    );
+
+    try {
+      return await Promise.race([operation, timeout]);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  public hashProbeKey(probeKey: string): string {
+    return crypto.createHash("sha256").update(probeKey).digest("hex");
+  }
+
+  /*
+   * Verifies a probeId/probeKey pair, serving repeat verifications from
+   * cache. This runs on EVERY authenticated probe request (heartbeats,
+   * monitor list fetches, result ingest), so it must stay responsive even
+   * when the Postgres pool is saturated — which is exactly when the
+   * heartbeat matters most: if this check queues behind a starved pool, the
+   * probe's lastAlive goes stale and a healthy probe gets flagged
+   * Disconnected.
+   *
+   * Security invariants:
+   * - The cache stores only a SHA-256 hash of the key, never the key.
+   * - A cache entry is only ever written from a value that was JUST
+   *   verified against the database.
+   * - A cache mismatch falls through to the database, so a rotated key
+   *   works immediately.
+   * - Rotating or deleting a probe overwrites its cache entry cluster-wide
+   *   with the revocation sentinel (GlobalCache is Redis-backed), and the
+   *   write below is write-only-if-unchanged so an in-flight verification
+   *   straddling the rotation cannot resurrect the old hash. The TTL caps
+   *   the stale window if the invalidation write itself fails: a REVOKED
+   *   key can then still authenticate for at most
+   *   PROBE_AUTH_KEY_HASH_CACHE_TTL_IN_SECONDS.
+   * - Any cache failure (Redis down, slow, timeout) falls back to the
+   *   database check — never open.
+   */
+  public async verifyProbeKey(data: {
+    probeId: ObjectID;
+    probeKey: string;
+  }): Promise<boolean> {
+    if (!data.probeId) {
+      throw new BadDataException("probeId is required");
+    }
+
+    if (!data.probeKey) {
+      throw new BadDataException("probeKey is required");
+    }
+
+    const presentedKeyHash: string = this.hashProbeKey(data.probeKey);
+
+    try {
+      const cachedKeyHash: string | null = await this.boundedCacheOperation(
+        "Probe auth cache read",
+        GlobalCache.getString(
+          PROBE_AUTH_KEY_HASH_CACHE_NAMESPACE,
+          data.probeId.toString(),
+        ),
+      );
+
+      if (cachedKeyHash && cachedKeyHash === presentedKeyHash) {
+        return true;
+      }
+    } catch (err) {
+      logger.error("Error in reading probe auth cache", {
+        probeId: data.probeId?.toString(),
+      } as LogAttributes);
+      logger.error(err, {
+        probeId: data.probeId?.toString(),
+      } as LogAttributes);
+    }
+
+    // Cache miss, mismatch (e.g. key rotated), or cache failure: ask the DB.
+    const probe: Model | null = await this.findOneBy({
+      query: {
+        _id: data.probeId.toString(),
+        key: data.probeKey,
+      },
+      select: {
+        _id: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!probe) {
+      return false;
+    }
+
+    try {
+      /*
+       * Write-only-if-unchanged: re-read the entry right before writing and
+       * skip the write when someone else changed it since our first read.
+       * The DB verification above can straddle a key rotation — its SELECT
+       * resolves against the pre-rotation row, the rotation commits and
+       * invalidates, and an unconditional write here would then re-cache
+       * the just-revoked key for a fresh TTL. Seeing the revocation
+       * sentinel (or any other concurrent write) means skip: the DB check
+       * stays the source of truth and caching resumes once the entry
+       * expires. The remaining race window is the microseconds between
+       * this re-read and the write — down from the full DB round-trip.
+       */
+      const currentCacheValue: string | null = await this.boundedCacheOperation(
+        "Probe auth cache pre-write read",
+        GlobalCache.getString(
+          PROBE_AUTH_KEY_HASH_CACHE_NAMESPACE,
+          data.probeId.toString(),
+        ),
+      );
+
+      if (
+        currentCacheValue === null ||
+        currentCacheValue === presentedKeyHash
+      ) {
+        await this.boundedCacheOperation(
+          "Probe auth cache write",
+          GlobalCache.setString(
+            PROBE_AUTH_KEY_HASH_CACHE_NAMESPACE,
+            data.probeId.toString(),
+            presentedKeyHash,
+            {
+              expiresInSeconds: PROBE_AUTH_KEY_HASH_CACHE_TTL_IN_SECONDS,
+            },
+          ),
+        );
+      }
+    } catch (err) {
+      // Next request re-verifies against the DB. Nothing is broken.
+      logger.error("Error in writing probe auth cache", {
+        probeId: data.probeId?.toString(),
+      } as LogAttributes);
+      logger.error(err, {
+        probeId: data.probeId?.toString(),
+      } as LogAttributes);
+    }
+
+    return true;
+  }
+
+  /*
+   * Replaces cached auth entries with the revocation sentinel so a rotated
+   * key stops working everywhere immediately (the cache is Redis-backed and
+   * shared by all pods). A sentinel WRITE rather than a delete: a deleted
+   * key can be silently re-created by an in-flight verification that
+   * DB-checked the old key just before the rotation committed, whereas the
+   * sentinel makes that straggler's write-only-if-unchanged check fail.
+   * Errors are logged loudly but not thrown: the entries also expire via
+   * TTL, and failing the surrounding update/delete over a cache hiccup
+   * would be worse than a bounded stale window.
+   */
+  public async invalidateProbeAuthCache(
+    probeIds: Array<ObjectID>,
+  ): Promise<void> {
+    for (const probeId of probeIds) {
+      try {
+        await this.boundedCacheOperation(
+          "Probe auth cache invalidation",
+          GlobalCache.setString(
+            PROBE_AUTH_KEY_HASH_CACHE_NAMESPACE,
+            probeId.toString(),
+            PROBE_AUTH_KEY_REVOKED_SENTINEL,
+            {
+              expiresInSeconds: PROBE_AUTH_KEY_HASH_CACHE_TTL_IN_SECONDS,
+            },
+          ),
+        );
+      } catch (err) {
+        logger.error(
+          `CRITICAL: failed to invalidate probe auth cache for probe ${probeId.toString()} — a rotated/revoked probe key may keep authenticating for up to ${PROBE_AUTH_KEY_HASH_CACHE_TTL_IN_SECONDS}s`,
+          { probeId: probeId?.toString() } as LogAttributes,
+        );
+        logger.error(err, { probeId: probeId?.toString() } as LogAttributes);
+      }
+    }
   }
 
   public async saveLastAliveInCache(
@@ -50,10 +293,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     try {
-      await GlobalCache.setString(
-        "probe-last-alive",
-        probeId.toString(),
-        OneUptimeDate.toString(lastAlive),
+      await this.boundedCacheOperation(
+        "Probe last-alive cache write",
+        GlobalCache.setString(
+          PROBE_LAST_ALIVE_CACHE_NAMESPACE,
+          probeId.toString(),
+          OneUptimeDate.toString(lastAlive),
+        ),
       );
     } catch (err) {
       logger.error("Error in saving last alive in cache", {
@@ -68,10 +314,14 @@ export class Service extends DatabaseService<Model> {
 
     try {
       // before we hit the database, we need to check if the lastAlive was updated in Global Cache.
-      const previousLastAliveCheck: string | null = await GlobalCache.getString(
-        "probe-last-alive",
-        probeId.toString(),
-      );
+      const previousLastAliveCheck: string | null =
+        await this.boundedCacheOperation(
+          "Probe last-alive cache read",
+          GlobalCache.getString(
+            PROBE_LAST_ALIVE_CACHE_NAMESPACE,
+            probeId.toString(),
+          ),
+        );
 
       if (!previousLastAliveCheck) {
         await this.saveLastAliveInCache(probeId, now);
@@ -129,12 +379,44 @@ export class Service extends DatabaseService<Model> {
      * hooks (onBeforeUpdate/onUpdateSuccess) are inert here. See
      * ServiceService.updateLastSeen.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: probeId,
-      data: {
-        lastAlive: now,
-      },
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: probeId,
+        data: {
+          lastAlive: now,
+        },
+      });
+    } catch (err) {
+      /*
+       * The 30s throttle stamp was written BEFORE this write was attempted
+       * (shouldSaveLastAlive sets it — deliberately, as dogpile
+       * protection). If we leave it in place after a FAILED write, every
+       * request for the next 30 seconds silently skips the retry, lastAlive
+       * quietly crosses the connection-status worker's staleness threshold,
+       * and a healthy probe gets flagged Disconnected. Clear the stamp so
+       * the very next request retries the write.
+       */
+      await this.clearLastAliveThrottle(probeId);
+      throw err;
+    }
+  }
+
+  // Best-effort: on failure the throttle simply expires on its own.
+  private async clearLastAliveThrottle(probeId: ObjectID): Promise<void> {
+    try {
+      await this.boundedCacheOperation(
+        "Probe last-alive throttle clear",
+        GlobalCache.deleteKey(
+          PROBE_LAST_ALIVE_CACHE_NAMESPACE,
+          probeId.toString(),
+        ),
+      );
+    } catch (err) {
+      logger.error("Error in clearing last alive throttle", {
+        probeId: probeId?.toString(),
+      } as LogAttributes);
+      logger.error(err, { probeId: probeId?.toString() } as LogAttributes);
+    }
   }
 
   @CaptureSpan()
@@ -266,8 +548,18 @@ export class Service extends DatabaseService<Model> {
   @CaptureSpan()
   protected override async onUpdateSuccess(
     onUpdate: OnUpdate<Model>,
-    _updatedItemIds: Array<ObjectID>,
+    updatedItemIds: Array<ObjectID>,
   ): Promise<OnUpdate<Model>> {
+    /*
+     * Key rotation: the auth middleware trusts a cached hash of the key, so
+     * the moment the key column changes the cached entries for the updated
+     * probes must go — otherwise the OLD key keeps authenticating until the
+     * cache TTL runs out.
+     */
+    if (onUpdate.updateBy.data.key !== undefined) {
+      await this.invalidateProbeAuthCache(updatedItemIds);
+    }
+
     if (
       onUpdate.carryForward &&
       onUpdate.carryForward.probesToNotifyOwners.length > 0
@@ -282,6 +574,17 @@ export class Service extends DatabaseService<Model> {
     }
 
     return Promise.resolve(onUpdate);
+  }
+
+  @CaptureSpan()
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<Model>,
+    itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<Model>> {
+    // A deleted probe's key must stop authenticating.
+    await this.invalidateProbeAuthCache(itemIdsBeforeDelete);
+
+    return Promise.resolve(onDelete);
   }
 
   @CaptureSpan()

--- a/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+++ b/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
@@ -1,0 +1,121 @@
+import NetworkDeviceDiscoveryScanService, {
+  Service as NetworkDeviceDiscoveryScanServiceClass,
+} from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The /probe-ingest/probe/discovery-scan/list route hands the requesting
+ * probe its pending subnet scans and claims them (status "In Progress" +
+ * startedAt) via DatabaseService.updateColumnsByIdWithoutHooks — one raw
+ * parameterized UPDATE that skips ALL on-update hooks: workflow HTTP
+ * triggers, audit-log inserts, realtime events, service
+ * onBeforeUpdate/onUpdateSuccess. The probe synchronously waits on this
+ * route's response, and it sits behind the same probe-auth middleware whose
+ * hang got healthy probes flagged Disconnected — so the claim write must
+ * stay a single statement, not the full updateOneById pipeline (permission
+ * pre-fetch SELECT + row re-fetch + save() transaction).
+ *
+ *   - App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+ *       NetworkDeviceDiscoveryScan.status/startedAt when a probe claims a
+ *       Pending scan
+ *
+ * The conversion dropped NOTHING: the model declares no update workflow, no
+ * audit logging and no realtime events, and the service overrides neither
+ * update hook — so the old pipeline's hook stages were inert for this
+ * write. But the fast path skips hooks UNCONDITIONALLY: if someone later
+ * adds a decorator to NetworkDeviceDiscoveryScan or an update-hook override
+ * to its service, nothing at the call site fails — the new hook is just
+ * silently never fired for the claim write. This suite turns that silent
+ * drift into a loud test failure: if any assertion here starts failing, the
+ * hookless claim writes in DiscoveryScan.ts silently skip that new hook —
+ * revisit the call site before changing the assertion.
+ *
+ * Pure model-metadata + class-shape tests — no Postgres, no Redis.
+ */
+
+describe("discovery-scan claim hookless write safety preconditions", () => {
+  describe("NetworkDeviceDiscoveryScan model (claim write in DiscoveryScan.ts)", () => {
+    /*
+     * No @EnableWorkflow decorator AT ALL — the accessor is entirely unset,
+     * which resolves to "no update workflow". If this becomes defined,
+     * someone added @EnableWorkflow to NetworkDeviceDiscoveryScan and must
+     * decide whether the claim write should keep skipping it.
+     */
+    test("has no @EnableWorkflow metadata at all", () => {
+      const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+      expect(scan.enableWorkflowOn).toBeFalsy();
+      expect(scan.enableWorkflowOn?.update).toBeFalsy();
+    });
+
+    test("has no on-update audit log", () => {
+      const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+      expect(scan.enableAuditLogOn?.update).toBeFalsy();
+    });
+
+    test("has no realtime events", () => {
+      const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+      expect(scan.enableRealtimeEventsOn).toBeFalsy();
+    });
+  });
+
+  describe("fast-path columns exist on the entity", () => {
+    /*
+     * updateColumnsByIdWithoutHooks validates column names against entity
+     * metadata at runtime and throws BadDataException on an unknown column.
+     * Pinning column existence here means a rename breaks this suite at CI
+     * time instead of leaving every claimed scan stuck in Pending at
+     * runtime.
+     */
+    test("NetworkDeviceDiscoveryScan has every column the claim write stamps", () => {
+      const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+      const fastPathColumns: Array<string> = ["status", "startedAt"];
+      for (const column of fastPathColumns) {
+        expect(scan.isTableColumn(column)).toBe(true);
+      }
+      // Negative control: isTableColumn actually discriminates.
+      expect(scan.isTableColumn("notARealColumn")).toBe(false);
+    });
+  });
+
+  describe("service defines no update hooks of its own", () => {
+    /*
+     * DatabaseService's base onBeforeUpdate/onUpdateSuccess are no-op
+     * pass-throughs; a service only gets update behavior by OVERRIDING
+     * them. Own-property checks on the concrete service prototype pin that
+     * NetworkDeviceDiscoveryScanService does not — so the fast path skips
+     * nothing. If an override appears, these fail loudly and the claim
+     * write in DiscoveryScan.ts must be re-evaluated.
+     */
+    const updateHooks: Array<string> = ["onBeforeUpdate", "onUpdateSuccess"];
+
+    test("NetworkDeviceDiscoveryScanService does not override onBeforeUpdate/onUpdateSuccess", () => {
+      for (const hook of updateHooks) {
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            NetworkDeviceDiscoveryScanServiceClass.prototype,
+            hook,
+          ),
+        ).toBe(false);
+      }
+      // The default export is an instance of the class checked above.
+      expect(NetworkDeviceDiscoveryScanService).toBeInstanceOf(
+        NetworkDeviceDiscoveryScanServiceClass,
+      );
+    });
+
+    /*
+     * Positive control: the hooks DO exist on the DatabaseService base
+     * prototype, so the own-property checks above cannot pass vacuously
+     * (e.g. after a rename of the hook methods themselves).
+     */
+    test("the base DatabaseService prototype defines both hooks", () => {
+      for (const hook of updateHooks) {
+        expect(
+          Object.prototype.hasOwnProperty.call(DatabaseService.prototype, hook),
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/Common/Tests/Server/Services/ProbeAuthKeyCacheAndHeartbeat.test.ts
+++ b/Common/Tests/Server/Services/ProbeAuthKeyCacheAndHeartbeat.test.ts
@@ -1,0 +1,679 @@
+/*
+ * Probe liveness hardening in ProbeService: a customer's probes were flagged
+ * Disconnected because /probe-ingest/alive hung 45+ seconds — every probe
+ * request re-authenticated with a Probe SELECT that queued behind a starved
+ * Postgres pool, and the throttled lastAlive stamp could silently suppress
+ * its own retry after a failed write. This suite pins the fixes:
+ *
+ *   - verifyProbeKey: Redis-cached SHA-256 key verification (namespace
+ *     "probe-auth-key-hash", TTL 120s) with DB fallback, so repeat probe
+ *     requests skip the per-request Probe SELECT entirely.
+ *   - boundedCacheOperation: a 2s cap on every cache op — ioredis has no
+ *     command timeout, so a stalled-but-open Redis socket must not hang
+ *     probe auth.
+ *   - updateLastAlive: clears the 30s "probe-last-alive" throttle stamp when
+ *     the DB write FAILS, so the next request retries instead of silently
+ *     letting lastAlive cross the 3-minute Disconnected cutoff.
+ *   - onUpdateSuccess/onDeleteSuccess: key rotation and probe deletion
+ *     overwrite the cached auth hash cluster-wide with a revocation
+ *     sentinel, and verifyProbeKey's write-only-if-unchanged re-read keeps
+ *     an in-flight verification from resurrecting the revoked hash.
+ *
+ * GlobalCache and MonitorService are mocked at the module boundary — the
+ * real modules pull in Redis and the whole database stack. DB calls are
+ * spied on the ProbeService singleton. No Postgres, no Redis.
+ */
+
+const mockGetString: jest.Mock = jest.fn();
+const mockSetString: jest.Mock = jest.fn();
+const mockDeleteKey: jest.Mock = jest.fn();
+
+jest.mock("../../../Server/Infrastructure/GlobalCache", () => {
+  return {
+    __esModule: true,
+    default: {
+      getString: (...args: Array<unknown>) => {
+        return mockGetString(...args);
+      },
+      setString: (...args: Array<unknown>) => {
+        return mockSetString(...args);
+      },
+      deleteKey: (...args: Array<unknown>) => {
+        return mockDeleteKey(...args);
+      },
+    },
+  };
+});
+
+const mockRefreshProbeStatus: jest.Mock = jest.fn();
+
+jest.mock("../../../Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      refreshProbeStatus: (...args: Array<unknown>) => {
+        return mockRefreshProbeStatus(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    getLogAttributesFromRequest: jest.fn(() => {
+      return {};
+    }),
+  };
+});
+
+import crypto from "crypto";
+import logger from "../../../Server/Utils/Logger";
+import ProbeService from "../../../Server/Services/ProbeService";
+import Probe, {
+  ProbeConnectionStatus,
+} from "../../../Models/DatabaseModels/Probe";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import DeleteBy from "../../../Server/Types/Database/DeleteBy";
+import { OnDelete, OnUpdate } from "../../../Server/Types/Database/Hooks";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+const PROBE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const SECOND_PROBE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROBE_KEY: string = "probe-key-abc-123";
+const ROTATED_PROBE_KEY: string = "probe-key-rotated-456";
+
+const AUTH_CACHE_NAMESPACE: string = "probe-auth-key-hash";
+const AUTH_CACHE_TTL_IN_SECONDS: number = 120;
+const AUTH_CACHE_REVOKED_SENTINEL: string = "revoked";
+const LAST_ALIVE_CACHE_NAMESPACE: string = "probe-last-alive";
+const CACHE_OPERATION_TIMEOUT_IN_MS: number = 2000;
+
+type Sha256Function = (value: string) => string;
+
+/*
+ * Computed independently of ProbeService.hashProbeKey so the tests pin the
+ * EXACT on-the-wire cache format, not whatever the service happens to do.
+ */
+const sha256: Sha256Function = (value: string): string => {
+  return crypto.createHash("sha256").update(value).digest("hex");
+};
+
+type MakeProbeRowFunction = () => Probe;
+
+const makeProbeRow: MakeProbeRowFunction = (): Probe => {
+  const probe: Probe = new Probe();
+  probe.id = PROBE_ID;
+  return probe;
+};
+
+describe("ProbeService probe-auth cache and heartbeat throttle", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetString.mockResolvedValue(null);
+    mockSetString.mockResolvedValue(undefined);
+    mockDeleteKey.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe("verifyProbeKey (cache-backed auth)", () => {
+    /*
+     * The whole point of the cache: a repeat request from a known probe must
+     * authenticate WITHOUT touching Postgres. If findOneBy fires here, the
+     * per-request Probe SELECT is back and probe auth queues behind the pool
+     * again — the original 45s-hang ingredient.
+     */
+    test("cache hit with matching SHA-256 authenticates with NO Probe SELECT", async () => {
+      mockGetString.mockResolvedValue(sha256(PROBE_KEY));
+      // Would return "not found" if consulted — proving the cache decided.
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(null);
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(findOneBySpy).not.toHaveBeenCalled();
+      expect(mockSetString).not.toHaveBeenCalled();
+      expect(mockGetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+      );
+    });
+
+    /*
+     * Security invariant: the cache stores only a SHA-256 hex digest of the
+     * key with a bounded TTL — a Redis dump must never contain a usable
+     * probe credential.
+     */
+    test("caches only the SHA-256 hex of the key with the 120s TTL — never the raw key", async () => {
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+      expect(mockSetString).toHaveBeenCalledTimes(1);
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+        sha256(PROBE_KEY),
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+      // The raw key must not appear ANYWHERE in the cache-write arguments.
+      expect(JSON.stringify(mockSetString.mock.calls)).not.toContain(PROBE_KEY);
+    });
+
+    test("cache miss verifies against the DB with the presented id+key pair", async () => {
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+      expect(findOneBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { _id: PROBE_ID.toString(), key: PROBE_KEY },
+          props: { isRoot: true },
+        }),
+      );
+    });
+
+    /*
+     * A cache entry may only ever be written from a value that was JUST
+     * verified against the database — caching an UNVERIFIED hash would let a
+     * wrong key poison the cache and then authenticate itself on retry.
+     */
+    test("DB not-found returns false and writes NOTHING to the cache", async () => {
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(null);
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: "wrong-key",
+      });
+
+      expect(result).toBe(false);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+      expect(mockSetString).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Key rotation: the cached hash belongs to the OLD key, the probe
+     * presents the NEW one. The mismatch must fall through to the DB (so a
+     * freshly rotated key works immediately, no TTL wait). The cache write
+     * is SKIPPED while a conflicting entry is still present — the
+     * write-only-if-unchanged rule never overwrites a value someone else
+     * put there — so requests keep DB-verifying until the old entry
+     * expires, at which point caching resumes (pinned below).
+     */
+    test("stale cached hash (rotated key) falls through to the DB and does not clobber the existing entry", async () => {
+      mockGetString.mockResolvedValue(sha256(PROBE_KEY));
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: ROTATED_PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+      expect(mockSetString).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The revocation sentinel written by invalidation can never equal a
+     * SHA-256 digest, so it must behave as a miss on the auth path (DB
+     * decides) and must NOT be overwritten by the verification it forced —
+     * that write-back is exactly the rotation race the sentinel exists to
+     * stop.
+     */
+    test("the revocation sentinel forces a DB check and is never overwritten", async () => {
+      mockGetString.mockResolvedValue(AUTH_CACHE_REVOKED_SENTINEL);
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+      expect(mockSetString).not.toHaveBeenCalled();
+    });
+
+    /*
+     * THE rotation-TOCTOU pin. A verification can straddle a key rotation:
+     * its DB SELECT resolves against the pre-rotation row, THEN the
+     * rotation commits and invalidation lands. An unconditional cache write
+     * here would re-cache the just-revoked key for a fresh TTL —
+     * resurrecting a credential the rotation was meant to kill. The
+     * pre-write re-read must see the change and skip the write.
+     */
+    test("a rotation landing mid-verification wins: the straddling write is skipped", async () => {
+      mockGetString
+        .mockResolvedValueOnce(null) // initial read: plain miss
+        .mockResolvedValueOnce(AUTH_CACHE_REVOKED_SENTINEL); // pre-write read: rotation landed
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      // The DB verified the (pre-rotation) key, so THIS request passes...
+      expect(result).toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+      // ...but nothing may be written over the invalidation.
+      expect(mockSetString).not.toHaveBeenCalled();
+    });
+
+    test("caching resumes once the conflicting entry has expired", async () => {
+      // Both reads see an empty slot — the sentinel/old hash TTL'd out.
+      mockGetString.mockResolvedValue(null);
+      jest.spyOn(ProbeService, "findOneBy").mockResolvedValue(makeProbeRow());
+
+      await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: ROTATED_PROBE_KEY,
+      });
+
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+        sha256(ROTATED_PROBE_KEY),
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+    });
+
+    /*
+     * Redis down must degrade to "cache off", not "auth off": the DB is the
+     * source of truth and a cache failure may neither fail the request
+     * (closed) nor skip verification (open).
+     */
+    test("cache read rejection falls back to the DB and still authenticates", async () => {
+      mockGetString.mockRejectedValue(new Error("Redis connection refused"));
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * THE hang pin. ioredis has no command timeout: a stalled-but-open Redis
+     * socket returns a promise that never settles, and before the 2s
+     * boundedCacheOperation cap that promise would have hung probe auth
+     * forever — the async middleware's rejection-free stall was exactly the
+     * silent-hang mode that got healthy probes flagged Disconnected. A
+     * never-settling cache read must time out and fall back to the DB.
+     */
+    test("a never-settling cache read is capped at 2s and falls back to the DB", async () => {
+      jest.useFakeTimers();
+
+      mockGetString.mockReturnValue(
+        new Promise<string | null>(() => {
+          // Never settles — simulates a dead-but-open Redis socket.
+        }),
+      );
+      const findOneBySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "findOneBy")
+        .mockResolvedValue(makeProbeRow());
+
+      const resultPromise: Promise<boolean> = ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      /*
+       * Two caps fire on this path: the initial read (→ DB fallback) and
+       * the pre-write re-read (→ skip the cache write). The microtask
+       * flushes between the advances let the promise chain progress far
+       * enough that the second bounded op has registered its cap timer
+       * before it is advanced.
+       */
+      jest.advanceTimersByTime(CACHE_OPERATION_TIMEOUT_IN_MS);
+      for (let i: number = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+      jest.advanceTimersByTime(CACHE_OPERATION_TIMEOUT_IN_MS);
+
+      await expect(resultPromise).resolves.toBe(true);
+      expect(findOneBySpy).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The cap timer must not outlive a fast cache operation: a leaked 2s
+     * timer per probe request would accumulate thousands of live timers on
+     * a busy ingest pod.
+     */
+    test("a settled cache operation leaves no cap timer behind", async () => {
+      jest.useFakeTimers();
+      mockGetString.mockResolvedValue(sha256(PROBE_KEY));
+
+      const result: boolean = await ProbeService.verifyProbeKey({
+        probeId: PROBE_ID,
+        probeKey: PROBE_KEY,
+      });
+
+      expect(result).toBe(true);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    test("missing probeId or probeKey is rejected with BadDataException", async () => {
+      await expect(
+        ProbeService.verifyProbeKey({
+          probeId: undefined as unknown as ObjectID,
+          probeKey: PROBE_KEY,
+        }),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        ProbeService.verifyProbeKey({
+          probeId: PROBE_ID,
+          probeKey: "",
+        }),
+      ).rejects.toThrow(BadDataException);
+    });
+  });
+
+  describe("updateLastAlive (throttled heartbeat stamp)", () => {
+    /*
+     * The throttle is what makes it safe to stamp lastAlive on EVERY
+     * authenticated probe request: at most one single-statement UPDATE per
+     * probe per 30s, no matter how chatty the probe is.
+     */
+    test("skips the DB write while the 30s throttle stamp is fresh", async () => {
+      mockGetString.mockResolvedValue(
+        OneUptimeDate.toString(OneUptimeDate.getSomeSecondsAgo(10)),
+      );
+      const updateSpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await ProbeService.updateLastAlive(PROBE_ID);
+
+      expect(updateSpy).not.toHaveBeenCalled();
+      // The stamp is not refreshed either — that would extend the throttle.
+      expect(mockSetString).not.toHaveBeenCalled();
+    });
+
+    test("writes exactly one hookless lastAlive UPDATE once the stamp is stale", async () => {
+      mockGetString.mockResolvedValue(
+        OneUptimeDate.toString(OneUptimeDate.getSomeSecondsAgo(45)),
+      );
+      const updateSpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await ProbeService.updateLastAlive(PROBE_ID);
+
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy).toHaveBeenCalledWith({
+        id: PROBE_ID,
+        data: { lastAlive: expect.any(Date) },
+      });
+      // The throttle stamp is re-written for the next 30s window.
+      expect(mockSetString).toHaveBeenCalledWith(
+        LAST_ALIVE_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+        expect.any(String),
+      );
+    });
+
+    test("writes when no throttle stamp exists (first heartbeat)", async () => {
+      // Default mockGetString resolves null — nothing cached yet.
+      const updateSpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await ProbeService.updateLastAlive(PROBE_ID);
+
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * THE self-heal pin. The throttle stamp is written BEFORE the DB write
+     * is attempted (deliberately, as dogpile protection). Leaving it in
+     * place after a FAILED write means every request for the next 30s
+     * silently skips the retry; a couple of consecutive failures and
+     * lastAlive crosses the connection-status worker's 3-minute staleness
+     * cutoff — a HEALTHY probe gets flagged Disconnected, which is the
+     * customer-reported failure mode. A failed write must clear the stamp
+     * so the very next request retries, and must rethrow so the caller's
+     * error logging still fires.
+     */
+    test("a FAILED lastAlive write clears the throttle stamp and rethrows", async () => {
+      const updateSpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "updateColumnsByIdWithoutHooks")
+        .mockRejectedValue(new Error("connection pool exhausted"));
+
+      await expect(ProbeService.updateLastAlive(PROBE_ID)).rejects.toThrow(
+        "connection pool exhausted",
+      );
+
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(mockDeleteKey).toHaveBeenCalledWith(
+        LAST_ALIVE_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+      );
+    });
+
+    /*
+     * The throttle-clear is best-effort: if Redis is ALSO down, the stamp
+     * expires on its own — but the ORIGINAL database error must surface,
+     * not the secondary cache error.
+     */
+    test("throttle-clear failure does not mask the original DB error", async () => {
+      mockDeleteKey.mockRejectedValue(new Error("redis down"));
+      jest
+        .spyOn(ProbeService, "updateColumnsByIdWithoutHooks")
+        .mockRejectedValue(new Error("connection pool exhausted"));
+
+      await expect(ProbeService.updateLastAlive(PROBE_ID)).rejects.toThrow(
+        "connection pool exhausted",
+      );
+    });
+
+    test("a successful write leaves the throttle stamp in place", async () => {
+      jest
+        .spyOn(ProbeService, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await ProbeService.updateLastAlive(PROBE_ID);
+
+      expect(mockDeleteKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("auth cache invalidation hooks", () => {
+    /*
+     * The auth middleware trusts a cached hash of the key, so the moment
+     * the key column changes the cached entries for the updated probes must
+     * be revoked — otherwise the OLD key keeps authenticating until the
+     * 120s TTL runs out. Invalidation WRITES the sentinel rather than
+     * deleting: a bare delete can be silently undone by an in-flight
+     * verification re-caching the old hash (see the TOCTOU pin above),
+     * while the sentinel makes that straggler's write-only-if-unchanged
+     * check fail.
+     */
+    test("onUpdateSuccess writes the revocation sentinel for every updated probe when the key changes", async () => {
+      const onUpdate: OnUpdate<Probe> = {
+        updateBy: {
+          query: {},
+          data: { key: ROTATED_PROBE_KEY },
+          props: { isRoot: true },
+        } as UpdateBy<Probe>,
+        carryForward: { probesToNotifyOwners: [] },
+      };
+
+      await (ProbeService as any)["onUpdateSuccess"](onUpdate, [
+        PROBE_ID,
+        SECOND_PROBE_ID,
+      ]);
+
+      expect(mockSetString).toHaveBeenCalledTimes(2);
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+        AUTH_CACHE_REVOKED_SENTINEL,
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        SECOND_PROBE_ID.toString(),
+        AUTH_CACHE_REVOKED_SENTINEL,
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+    });
+
+    test("onUpdateSuccess leaves the cache alone when data does not touch the key", async () => {
+      const onUpdate: OnUpdate<Probe> = {
+        updateBy: {
+          query: {},
+          data: { name: "renamed probe" },
+          props: { isRoot: true },
+        } as UpdateBy<Probe>,
+        carryForward: { probesToNotifyOwners: [] },
+      };
+
+      await (ProbeService as any)["onUpdateSuccess"](onUpdate, [PROBE_ID]);
+
+      expect(mockSetString).not.toHaveBeenCalled();
+      expect(mockRefreshProbeStatus).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Invalidation is best-effort per probe: one Redis failure must be
+     * logged loudly (a revoked key may keep working for up to the TTL) but
+     * must neither fail the surrounding update nor stop the remaining
+     * probes from being invalidated.
+     */
+    test("an invalidation failure is logged, does not throw, and does not stop the remaining probes", async () => {
+      mockSetString
+        .mockRejectedValueOnce(new Error("redis write failed"))
+        .mockResolvedValue(undefined);
+
+      await expect(
+        ProbeService.invalidateProbeAuthCache([PROBE_ID, SECOND_PROBE_ID]),
+      ).resolves.toBeUndefined();
+
+      // Both probes were attempted despite the first failure...
+      expect(mockSetString).toHaveBeenCalledTimes(2);
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        SECOND_PROBE_ID.toString(),
+        AUTH_CACHE_REVOKED_SENTINEL,
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+      // ...and the failure was surfaced in the logs.
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("CRITICAL"),
+        expect.anything(),
+      );
+    });
+
+    /*
+     * Existing behavior preserved: the cache-invalidation addition must not
+     * displace the connection-status owner-notification path that
+     * onUpdateSuccess already ran.
+     */
+    test("connection-status change still refreshes monitors and notifies owners", async () => {
+      const probeRow: Probe = makeProbeRow();
+      const notifySpy: jest.SpyInstance = jest
+        .spyOn(ProbeService, "notifyOwnersOnStatusChange")
+        .mockResolvedValue(undefined);
+
+      const onUpdate: OnUpdate<Probe> = {
+        updateBy: {
+          query: {},
+          data: { connectionStatus: ProbeConnectionStatus.Disconnected },
+          props: { isRoot: true },
+        } as UpdateBy<Probe>,
+        carryForward: { probesToNotifyOwners: [probeRow] },
+      };
+
+      await (ProbeService as any)["onUpdateSuccess"](onUpdate, [PROBE_ID]);
+
+      expect(mockRefreshProbeStatus).toHaveBeenCalledTimes(1);
+      expect(mockRefreshProbeStatus).toHaveBeenCalledWith(PROBE_ID);
+      expect(notifySpy).toHaveBeenCalledWith({ probeId: PROBE_ID });
+      // A status flip is not a key change — cached auth stays valid.
+      expect(mockDeleteKey).not.toHaveBeenCalled();
+    });
+
+    /*
+     * A deleted probe's key must stop authenticating immediately, not after
+     * the cache TTL.
+     */
+    test("onDeleteSuccess writes the revocation sentinel for every deleted probe", async () => {
+      const onDelete: OnDelete<Probe> = {
+        deleteBy: {
+          query: {},
+          props: { isRoot: true },
+        } as DeleteBy<Probe>,
+        carryForward: null,
+      };
+
+      await (ProbeService as any)["onDeleteSuccess"](onDelete, [
+        PROBE_ID,
+        SECOND_PROBE_ID,
+      ]);
+
+      expect(mockSetString).toHaveBeenCalledTimes(2);
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        PROBE_ID.toString(),
+        AUTH_CACHE_REVOKED_SENTINEL,
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+      expect(mockSetString).toHaveBeenCalledWith(
+        AUTH_CACHE_NAMESPACE,
+        SECOND_PROBE_ID.toString(),
+        AUTH_CACHE_REVOKED_SENTINEL,
+        { expiresInSeconds: AUTH_CACHE_TTL_IN_SECONDS },
+      );
+    });
+  });
+});

--- a/Probe/API/Metrics.ts
+++ b/Probe/API/Metrics.ts
@@ -15,7 +15,6 @@ import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
 import LocalCache from "Common/Server/Infrastructure/LocalCache";
 import ProbeAPIRequest from "../Utils/ProbeAPIRequest";
-import ProxyConfig from "../Utils/ProxyConfig";
 
 const router: ExpressRouter = Express.getRouter();
 
@@ -66,7 +65,7 @@ router.get(
           url: pendingMonitorsUrl,
           data: requestBody,
           headers: {},
-          options: { ...ProxyConfig.getRequestProxyAgents(pendingMonitorsUrl) },
+          options: ProbeAPIRequest.getDefaultRequestOptions(pendingMonitorsUrl),
         });
 
       if (result instanceof HTTPErrorResponse) {

--- a/Probe/Config.ts
+++ b/Probe/Config.ts
@@ -82,6 +82,24 @@ export const PROBE_MONITOR_RETRY_LIMIT: number =
     min: 0,
   });
 
+/*
+ * Hard deadline for every control-plane request the probe sends to the
+ * OneUptime server (alive heartbeat, monitor/discovery/network-device list
+ * fetches, result ingest, registration). Axios's default timeout is 0 —
+ * infinite — so without this a server that accepts the TCP connection but
+ * never responds wedges the request forever, and because these calls run
+ * from cron ticks with no overlap guard, a new hung request piles on every
+ * minute while the probe's lastAlive quietly goes stale and the dashboard
+ * flags a perfectly healthy probe as Disconnected. A bounded failure is
+ * loud (logged, and retried on the next tick); an unbounded hang is silent.
+ */
+export const PROBE_API_REQUEST_TIMEOUT_IN_MS: number =
+  NumberUtil.parseNumberWithDefault({
+    value: process.env["PROBE_API_REQUEST_TIMEOUT_IN_MS"],
+    defaultValue: 45000,
+    min: 1000,
+  });
+
 export const PORT: Port = new Port(
   NumberUtil.parseNumberWithDefault({
     value: process.env["PORT"],

--- a/Probe/Jobs/Alive.ts
+++ b/Probe/Jobs/Alive.ts
@@ -9,7 +9,69 @@ import BasicCron from "Common/Server/Utils/BasicCron";
 import logger from "Common/Server/Utils/Logger";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import { JSONObject } from "Common/Types/JSON";
-import ProxyConfig from "../Utils/ProxyConfig";
+
+/*
+ * node-cron fires every tick regardless of whether the previous run
+ * finished, so without this guard a heartbeat that is stuck waiting on a
+ * slow server stacks a brand-new hung request every minute (each pinning a
+ * socket) until the process is restarted. One in-flight heartbeat at a time;
+ * a skipped tick just means the next one reports slightly later.
+ */
+let isAliveCheckInProgress: boolean = false;
+
+// Exported for tests: lets a wedged-state test reset between cases.
+export function resetAliveCheckInProgress(): void {
+  isAliveCheckInProgress = false;
+}
+
+// Exported for tests: one heartbeat tick, exactly as the cron runs it.
+export async function checkAliveAndReport(): Promise<void> {
+  if (isAliveCheckInProgress) {
+    logger.warn(
+      "Previous alive check is still in progress. Skipping this tick.",
+    );
+    return;
+  }
+
+  isAliveCheckInProgress = true;
+
+  try {
+    logger.debug("Checking if probe is alive...");
+
+    const probeId: string | undefined = LocalCache.getString(
+      "PROBE",
+      "PROBE_ID",
+    );
+
+    if (!probeId) {
+      logger.warn(
+        "Probe is not registered yet. Skipping alive check. Trying to register probe again...",
+      );
+      await Register.registerProbe();
+      return;
+    }
+
+    logger.debug("Probe ID: " + probeId.toString());
+
+    const aliveUrl: URL = URL.fromString(PROBE_INGEST_URL.toString()).addRoute(
+      "/alive",
+    );
+
+    const result: HTTPResponse<JSONObject> = await API.post({
+      url: aliveUrl,
+      data: ProbeAPIRequest.getDefaultRequestBody(),
+      options: ProbeAPIRequest.getDefaultRequestOptions(aliveUrl),
+    });
+
+    if (result.isSuccess()) {
+      logger.debug("Probe update sent to server successfully.");
+    } else {
+      logger.error("Failed to send probe update to server.");
+    }
+  } finally {
+    isAliveCheckInProgress = false;
+  }
+}
 
 const InitJob: VoidFunction = (): void => {
   BasicCron({
@@ -18,40 +80,7 @@ const InitJob: VoidFunction = (): void => {
       schedule: EVERY_MINUTE,
       runOnStartup: false,
     },
-    runFunction: async () => {
-      logger.debug("Checking if probe is alive...");
-
-      const probeId: string | undefined = LocalCache.getString(
-        "PROBE",
-        "PROBE_ID",
-      );
-
-      if (!probeId) {
-        logger.warn(
-          "Probe is not registered yet. Skipping alive check. Trying to register probe again...",
-        );
-        await Register.registerProbe();
-        return;
-      }
-
-      logger.debug("Probe ID: " + probeId.toString());
-
-      const aliveUrl: URL = URL.fromString(
-        PROBE_INGEST_URL.toString(),
-      ).addRoute("/alive");
-
-      const result: HTTPResponse<JSONObject> = await API.post({
-        url: aliveUrl,
-        data: ProbeAPIRequest.getDefaultRequestBody(),
-        options: { ...ProxyConfig.getRequestProxyAgents(aliveUrl) },
-      });
-
-      if (result.isSuccess()) {
-        logger.debug("Probe update sent to server successfully.");
-      } else {
-        logger.error("Failed to send probe update to server.");
-      }
-    },
+    runFunction: checkAliveAndReport,
   });
 };
 

--- a/Probe/Jobs/Discovery/FetchScans.ts
+++ b/Probe/Jobs/Discovery/FetchScans.ts
@@ -25,7 +25,6 @@ import SnmpPrivProtocol, {
 } from "Common/Types/Monitor/SnmpMonitor/SnmpPrivProtocol";
 import { EVERY_MINUTE } from "Common/Utils/CronTime";
 import BasicCron from "Common/Server/Utils/BasicCron";
-import ProxyConfig from "../../Utils/ProxyConfig";
 
 /*
  * Assembles the SnmpV3Auth the scanner needs from the scan's flattened
@@ -89,6 +88,20 @@ export function buildSnmpV3Auth(
   };
 }
 
+/*
+ * node-cron fires every tick regardless of whether the previous run
+ * finished. A subnet sweep legitimately runs for many minutes (up to 4096
+ * hosts), and a slow/unresponsive server can hang the list fetch itself —
+ * either way, without this guard every subsequent tick stacks another
+ * request/sweep on top of the stuck one. One discovery cycle at a time.
+ */
+let isDiscoveryRunInProgress: boolean = false;
+
+// Exported for tests: lets a wedged-state test reset between cases.
+export function resetDiscoveryRunInProgress(): void {
+  isDiscoveryRunInProgress = false;
+}
+
 const InitJob: VoidFunction = (): void => {
   BasicCron({
     jobName: "Probe:DiscoveryScanFetch",
@@ -97,11 +110,22 @@ const InitJob: VoidFunction = (): void => {
       runOnStartup: true,
     },
     runFunction: async () => {
+      if (isDiscoveryRunInProgress) {
+        logger.debug(
+          "Previous discovery scan run is still in progress. Skipping this tick.",
+        );
+        return;
+      }
+
+      isDiscoveryRunInProgress = true;
+
       try {
         await fetchAndRunScans();
       } catch (err) {
         logger.error("Discovery scan fetch failed");
         logger.error(err);
+      } finally {
+        isDiscoveryRunInProgress = false;
       }
     },
   });
@@ -121,7 +145,7 @@ export async function fetchAndRunScans(): Promise<void> {
         ...ProbeAPIRequest.getDefaultRequestBody(),
       },
       headers: {},
-      options: { ...ProxyConfig.getRequestProxyAgents(listUrl) },
+      options: ProbeAPIRequest.getDefaultRequestOptions(listUrl),
     });
 
   const scans: Array<NetworkDeviceDiscoveryScan> = BaseModel.fromJSONArray(
@@ -140,66 +164,24 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
     "/probe/discovery-scan/result",
   );
 
+  let scanResult: SubnetScanResult;
+
   try {
     logger.debug(
       `Running discovery scan ${scan.id?.toString()} on ${scan.cidr}`,
     );
 
-    const scanResult: SubnetScanResult = await SubnetScanner.scan({
+    scanResult = await SubnetScanner.scan({
       cidr: scan.cidr || "",
       snmpVersion: scan.snmpVersion,
       snmpCommunityString: scan.snmpCommunityString,
       snmpV3Auth: buildSnmpV3Auth(scan),
       snmpPort: scan.snmpPort,
     });
-
-    /*
-     * discoveredHosts now includes ping-only hosts (snmpReachable false),
-     * so the "answered SNMP" count must filter — the whole-array length
-     * would overstate manageable devices.
-     */
-    const snmpResponderCount: number = scanResult.discoveredHosts.filter(
-      (host: DiscoveredHost) => {
-        return host.snmpReachable;
-      },
-    ).length;
-
-    /*
-     * The scan model has no column for the ICMP pre-sweep count, so it rides
-     * along in statusMessage (which the ingest endpoint already accepts)
-     * instead of a payload field the server would silently drop.
-     */
-    const statusMessage: string =
-      scanResult.respondedToPingCount !== undefined
-        ? `Swept ${scanResult.scannedHostCount} hosts: ` +
-          `${scanResult.respondedToPingCount} answered ICMP ping, ` +
-          `${snmpResponderCount} answered SNMP.`
-        : `Swept ${scanResult.scannedHostCount} hosts via SNMP ` +
-          `(ICMP pre-sweep unavailable on this probe): ` +
-          `${snmpResponderCount} answered SNMP.`;
-
-    await API.fetch<JSONArray>({
-      method: HTTPMethod.POST,
-      url: resultUrl,
-      data: {
-        ...ProbeAPIRequest.getDefaultRequestBody(),
-        scanId: scan.id?.toString(),
-        success: true,
-        statusMessage: statusMessage,
-        discoveredDevices: scanResult.discoveredHosts as unknown as JSONArray,
-        scannedHostCount: scanResult.scannedHostCount,
-      },
-      headers: {},
-      options: { ...ProxyConfig.getRequestProxyAgents(resultUrl) },
-    });
-
-    logger.debug(
-      `Discovery scan ${scan.id?.toString()} found ${snmpResponderCount} SNMP hosts (${scanResult.discoveredHosts.length} alive in total)`,
-    );
   } catch (err) {
     logger.error(`Discovery scan ${scan.id?.toString()} failed: ${err}`);
 
-    // Report the failure so the scan doesn't sit In Progress forever.
+    // Report the SWEEP failure so the scan doesn't sit In Progress forever.
     try {
       await API.fetch<JSONArray>({
         method: HTTPMethod.POST,
@@ -212,13 +194,76 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
           discoveredDevices: [],
         },
         headers: {},
-        options: { ...ProxyConfig.getRequestProxyAgents(resultUrl) },
+        options: ProbeAPIRequest.getDefaultRequestOptions(resultUrl),
       });
     } catch (reportErr) {
       logger.error(
         `Failed to report discovery scan failure for ${scan.id?.toString()}: ${reportErr}`,
       );
     }
+
+    return;
+  }
+
+  /*
+   * discoveredHosts now includes ping-only hosts (snmpReachable false),
+   * so the "answered SNMP" count must filter — the whole-array length
+   * would overstate manageable devices.
+   */
+  const snmpResponderCount: number = scanResult.discoveredHosts.filter(
+    (host: DiscoveredHost) => {
+      return host.snmpReachable;
+    },
+  ).length;
+
+  /*
+   * The scan model has no column for the ICMP pre-sweep count, so it rides
+   * along in statusMessage (which the ingest endpoint already accepts)
+   * instead of a payload field the server would silently drop.
+   */
+  const statusMessage: string =
+    scanResult.respondedToPingCount !== undefined
+      ? `Swept ${scanResult.scannedHostCount} hosts: ` +
+        `${scanResult.respondedToPingCount} answered ICMP ping, ` +
+        `${snmpResponderCount} answered SNMP.`
+      : `Swept ${scanResult.scannedHostCount} hosts via SNMP ` +
+        `(ICMP pre-sweep unavailable on this probe): ` +
+        `${snmpResponderCount} answered SNMP.`;
+
+  /*
+   * The RESULT UPLOAD failing must NOT trigger the success:false report
+   * above: the upload's own timeout does not cancel the server-side
+   * handler, so on a slow server the sweep's Completed write can land
+   * AFTER the client gave up — a failure report sent then would race it,
+   * flip the finished scan to Failed and wipe its discovered hosts. Log
+   * and walk away instead: a genuinely lost result leaves the scan In
+   * Progress, and the server's stale-In-Progress reaper
+   * (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts) already
+   * self-heals that case.
+   */
+  try {
+    await API.fetch<JSONArray>({
+      method: HTTPMethod.POST,
+      url: resultUrl,
+      data: {
+        ...ProbeAPIRequest.getDefaultRequestBody(),
+        scanId: scan.id?.toString(),
+        success: true,
+        statusMessage: statusMessage,
+        discoveredDevices: scanResult.discoveredHosts as unknown as JSONArray,
+        scannedHostCount: scanResult.scannedHostCount,
+      },
+      headers: {},
+      options: ProbeAPIRequest.getDefaultRequestOptions(resultUrl),
+    });
+
+    logger.debug(
+      `Discovery scan ${scan.id?.toString()} found ${snmpResponderCount} SNMP hosts (${scanResult.discoveredHosts.length} alive in total)`,
+    );
+  } catch (uploadErr) {
+    logger.error(
+      `Failed to upload discovery scan result for ${scan.id?.toString()}: ${uploadErr}`,
+    );
   }
 }
 

--- a/Probe/Jobs/Monitor/FetchList.ts
+++ b/Probe/Jobs/Monitor/FetchList.ts
@@ -20,7 +20,6 @@ import { EVERY_MINUTE } from "Common/Utils/CronTime";
 import BasicCron from "Common/Server/Utils/BasicCron";
 import NumberUtil from "Common/Utils/Number";
 import Sleep from "Common/Types/Sleep";
-import ProxyConfig from "../../Utils/ProxyConfig";
 
 const InitJob: VoidFunction = (): void => {
   BasicCron({
@@ -101,7 +100,7 @@ class FetchListAndProbe {
             limit: PROBE_MONITOR_FETCH_LIMIT || 100,
           },
           headers: {},
-          options: { ...ProxyConfig.getRequestProxyAgents(monitorListUrl) },
+          options: ProbeAPIRequest.getDefaultRequestOptions(monitorListUrl),
         });
 
       logger.debug("Fetched monitor list");

--- a/Probe/Jobs/Monitor/FetchMonitorTest.ts
+++ b/Probe/Jobs/Monitor/FetchMonitorTest.ts
@@ -14,7 +14,25 @@ import API from "Common/Utils/API";
 import logger from "Common/Server/Utils/Logger";
 import BasicCron from "Common/Server/Utils/BasicCron";
 import { EVERY_TEN_SECONDS } from "Common/Utils/CronTime";
-import ProxyConfig from "../../Utils/ProxyConfig";
+
+/*
+ * Single-flight guard for the LIST FETCH only. This job fires every 10
+ * seconds and node-cron does not wait for the previous run — against an
+ * unresponsive server that is 6 new hung requests per minute, the
+ * fastest-growing pile-up of all the probe's cron jobs.
+ *
+ * The guard deliberately does NOT cover the test execution that follows:
+ * the server hands out each test exactly once (the list endpoint claims
+ * tests atomically), so overlapping ticks execute disjoint batches — and
+ * "Test monitor" is an interactive dashboard flow, so a long-running
+ * synthetic test must not delay the pickup of the next user's test.
+ */
+let isMonitorTestFetchInProgress: boolean = false;
+
+// Exported for tests: lets a wedged-state test reset between cases.
+export function resetMonitorTestRunInProgress(): void {
+  isMonitorTestFetchInProgress = false;
+}
 
 const InitJob: VoidFunction = (): void => {
   BasicCron({
@@ -24,8 +42,29 @@ const InitJob: VoidFunction = (): void => {
       runOnStartup: true,
     },
     runFunction: async () => {
+      if (isMonitorTestFetchInProgress) {
+        logger.debug(
+          "Previous monitor test fetch is still in flight. Skipping this tick.",
+        );
+        return;
+      }
+
+      isMonitorTestFetchInProgress = true;
+
+      let monitorTests: Array<MonitorTest> = [];
+
       try {
-        await FetchMonitorTestAndProbe.run();
+        monitorTests = await FetchMonitorTestAndProbe.fetchTestList();
+      } catch (err) {
+        logger.error("Error in worker");
+        logger.error(err);
+      } finally {
+        // Release as soon as the fetch settles — see the guard comment.
+        isMonitorTestFetchInProgress = false;
+      }
+
+      try {
+        await FetchMonitorTestAndProbe.probeTests(monitorTests);
       } catch (err) {
         logger.error("Error in worker");
         logger.error(err);
@@ -35,20 +74,7 @@ const InitJob: VoidFunction = (): void => {
 };
 
 class FetchMonitorTestAndProbe {
-  public static async run(): Promise<void> {
-    try {
-      logger.debug(`MONITOR TEST: Probing monitors `);
-
-      await this.fetchListAndProbe();
-
-      logger.debug(`MONITOR TEST: Probing monitors  complete`);
-    } catch (err) {
-      logger.error(`Error in worker `);
-      logger.error(err);
-    }
-  }
-
-  private static async fetchListAndProbe(): Promise<void> {
+  public static async fetchTestList(): Promise<Array<MonitorTest>> {
     try {
       logger.debug("MONITOR TEST: Fetching monitor  list");
 
@@ -65,48 +91,13 @@ class FetchMonitorTestAndProbe {
             limit: 100,
           },
           headers: {},
-          options: { ...ProxyConfig.getRequestProxyAgents(monitorListUrl) },
+          options: ProbeAPIRequest.getDefaultRequestOptions(monitorListUrl),
         });
 
       logger.debug("MONITOR TEST: Fetched monitor test list");
       logger.debug(result);
 
-      const monitorTests: Array<MonitorTest> = BaseModel.fromJSONArray(
-        result.data as JSONArray,
-        MonitorTest,
-      );
-
-      const probeMonitorPromises: Array<
-        Promise<Array<ProbeMonitorResponse | null>>
-      > = []; // Array of promises to probe monitors
-
-      for (const monitorTest of monitorTests) {
-        probeMonitorPromises.push(MonitorUtil.probeMonitorTest(monitorTest));
-      }
-
-      // all settled
-      // eslint-disable-next-line no-undef
-      const results: PromiseSettledResult<(ProbeMonitorResponse | null)[]>[] =
-        await Promise.allSettled(probeMonitorPromises);
-
-      let resultIndex: number = 0;
-
-      for (const result of results) {
-        if (monitorTests && monitorTests[resultIndex]) {
-          logger.debug("Monitor Test:");
-          logger.debug(monitorTests[resultIndex]);
-        }
-
-        if (result.status === "rejected") {
-          logger.error("Error in probing monitor:");
-          logger.error(result.reason);
-        } else {
-          logger.debug("Probed monitor: ");
-          logger.debug(result.value);
-        }
-
-        resultIndex++;
-      }
+      return BaseModel.fromJSONArray(result.data as JSONArray, MonitorTest);
     } catch (err) {
       logger.error("Error in fetching monitor list");
       logger.error(err);
@@ -115,7 +106,53 @@ class FetchMonitorTestAndProbe {
         logger.error("API Exception Error");
         logger.error(JSON.stringify(err.error, null, 2));
       }
+
+      return [];
     }
+  }
+
+  public static async probeTests(
+    monitorTests: Array<MonitorTest>,
+  ): Promise<void> {
+    if (monitorTests.length === 0) {
+      return;
+    }
+
+    logger.debug(`MONITOR TEST: Probing monitors `);
+
+    const probeMonitorPromises: Array<
+      Promise<Array<ProbeMonitorResponse | null>>
+    > = []; // Array of promises to probe monitors
+
+    for (const monitorTest of monitorTests) {
+      probeMonitorPromises.push(MonitorUtil.probeMonitorTest(monitorTest));
+    }
+
+    // all settled
+    // eslint-disable-next-line no-undef
+    const results: PromiseSettledResult<(ProbeMonitorResponse | null)[]>[] =
+      await Promise.allSettled(probeMonitorPromises);
+
+    let resultIndex: number = 0;
+
+    for (const result of results) {
+      if (monitorTests && monitorTests[resultIndex]) {
+        logger.debug("Monitor Test:");
+        logger.debug(monitorTests[resultIndex]);
+      }
+
+      if (result.status === "rejected") {
+        logger.error("Error in probing monitor:");
+        logger.error(result.reason);
+      } else {
+        logger.debug("Probed monitor: ");
+        logger.debug(result.value);
+      }
+
+      resultIndex++;
+    }
+
+    logger.debug(`MONITOR TEST: Probing monitors  complete`);
   }
 }
 

--- a/Probe/Jobs/NetworkDevice/FetchList.ts
+++ b/Probe/Jobs/NetworkDevice/FetchList.ts
@@ -1,6 +1,5 @@
 import { PROBE_INGEST_URL } from "../../Config";
 import ProbeAPIRequest from "../../Utils/ProbeAPIRequest";
-import ProxyConfig from "../../Utils/ProxyConfig";
 import SnmpMonitor from "../../Utils/Monitors/MonitorTypes/SnmpMonitor";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
@@ -39,6 +38,24 @@ export interface DevicePollConfig {
   snmpMonitor: MonitorStepSnmpMonitor;
 }
 
+/*
+ * Single-flight guard for the LIST FETCH only. node-cron fires every tick
+ * regardless of whether the previous one finished, so a fetch stuck on an
+ * unresponsive server would otherwise stack a new hung request per minute.
+ *
+ * The guard deliberately does NOT cover the SNMP walking that follows: the
+ * server claims due devices atomically when handing out the list, so
+ * overlapping ticks poll disjoint device sets — that pipelining is what
+ * keeps a fleet whose poll cycle exceeds a minute (slow or unreachable
+ * devices) polling at its configured cadence.
+ */
+let isDeviceFetchInProgress: boolean = false;
+
+// Exported for tests: lets a wedged-state test reset between cases.
+export function resetDevicePollRunInProgress(): void {
+  isDeviceFetchInProgress = false;
+}
+
 const InitJob: VoidFunction = (): void => {
   BasicCron({
     jobName: "Probe:NetworkDeviceFetchList",
@@ -47,18 +64,39 @@ const InitJob: VoidFunction = (): void => {
       runOnStartup: true,
     },
     runFunction: async () => {
+      if (isDeviceFetchInProgress) {
+        logger.debug(
+          "Previous network device list fetch is still in flight. Skipping this tick.",
+        );
+        return;
+      }
+
+      isDeviceFetchInProgress = true;
+
+      let devices: Array<DevicePollConfig> = [];
+
       try {
-        await fetchAndPollDevices();
+        devices = await fetchDeviceList();
       } catch (err) {
         logger.error("Network device poll fetch failed");
+        logger.error(err);
+      } finally {
+        // Release as soon as the fetch settles — see the guard comment.
+        isDeviceFetchInProgress = false;
+      }
+
+      try {
+        await pollDevices(devices);
+      } catch (err) {
+        logger.error("Network device poll failed");
         logger.error(err);
       }
     },
   });
 };
 
-// Exported for tests: fetches this probe's due devices and polls them.
-export async function fetchAndPollDevices(): Promise<void> {
+// Exported for tests: fetches this probe's due devices from the server.
+export async function fetchDeviceList(): Promise<Array<DevicePollConfig>> {
   const listUrl: URL = URL.fromString(PROBE_INGEST_URL.toString()).addRoute(
     "/probe/network-device/list",
   );
@@ -71,15 +109,20 @@ export async function fetchAndPollDevices(): Promise<void> {
         ...ProbeAPIRequest.getDefaultRequestBody(),
       },
       headers: {},
-      options: { ...ProxyConfig.getRequestProxyAgents(listUrl) },
+      options: ProbeAPIRequest.getDefaultRequestOptions(listUrl),
     });
 
-  const devices: Array<DevicePollConfig> = (
-    ((result.data as JSONObject)?.["devices"] as JSONArray) || []
-  ).map((device: JSONObject) => {
-    return device as unknown as DevicePollConfig;
-  });
+  return (((result.data as JSONObject)?.["devices"] as JSONArray) || []).map(
+    (device: JSONObject) => {
+      return device as unknown as DevicePollConfig;
+    },
+  );
+}
 
+// Exported for tests: walks the handed-out devices in bounded batches.
+export async function pollDevices(
+  devices: Array<DevicePollConfig>,
+): Promise<void> {
   if (devices.length === 0) {
     return;
   }
@@ -102,6 +145,11 @@ export async function fetchAndPollDevices(): Promise<void> {
       }),
     );
   }
+}
+
+// Exported for tests: fetches this probe's due devices and polls them.
+export async function fetchAndPollDevices(): Promise<void> {
+  await pollDevices(await fetchDeviceList());
 }
 
 // Exported for tests: walks one device and reports the outcome back.
@@ -154,7 +202,7 @@ export async function pollDevice(device: DevicePollConfig): Promise<void> {
         monitoredAt: new Date().toISOString(),
       },
       headers: {},
-      options: { ...ProxyConfig.getRequestProxyAgents(ingestUrl) },
+      options: ProbeAPIRequest.getDefaultRequestOptions(ingestUrl),
     });
   } catch (err) {
     logger.error(

--- a/Probe/Services/Register.ts
+++ b/Probe/Services/Register.ts
@@ -22,7 +22,6 @@ import {
 } from "Common/Server/EnvironmentConfig";
 import LocalCache from "Common/Server/Infrastructure/LocalCache";
 import logger from "Common/Server/Utils/Logger";
-import ProxyConfig from "../Utils/ProxyConfig";
 
 export default class Register {
   public static async isPingMonitoringEnabled(): Promise<boolean> {
@@ -80,16 +79,29 @@ export default class Register {
         PROBE_INGEST_URL.toString(),
       ).addRoute("/probe/status-report/offline");
 
-      await API.fetch<JSONObject>({
-        method: HTTPMethod.POST,
-        url: statusReportUrl,
-        data: {
-          ...ProbeAPIRequest.getDefaultRequestBody(),
-          statusReport: stausReport as any,
-        },
-        headers: {},
-        options: { ...ProxyConfig.getRequestProxyAgents(statusReportUrl) },
-      });
+      /*
+       * Best-effort: this report only triggers a courtesy notification
+       * email. It runs at every startup on hosts where ICMP is blocked
+       * (most cloud VMs), and it now carries a request timeout — so a
+       * throw here on a slow server would otherwise bubble into the fatal
+       * registration path and crash-loop a probe whose monitoring is
+       * perfectly able to run.
+       */
+      try {
+        await API.fetch<JSONObject>({
+          method: HTTPMethod.POST,
+          url: statusReportUrl,
+          data: {
+            ...ProbeAPIRequest.getDefaultRequestBody(),
+            statusReport: stausReport as any,
+          },
+          headers: {},
+          options: ProbeAPIRequest.getDefaultRequestOptions(statusReportUrl),
+        });
+      } catch (err) {
+        logger.error("Failed to send probe offline status report");
+        logger.error(err);
+      }
     }
   }
 
@@ -145,9 +157,8 @@ export default class Register {
             probeDescription: PROBE_DESCRIPTION,
             registerProbeKey: RegisterProbeKey.toString(),
           },
-          options: {
-            ...ProxyConfig.getRequestProxyAgents(probeRegistrationUrl),
-          },
+          options:
+            ProbeAPIRequest.getDefaultRequestOptions(probeRegistrationUrl),
         });
 
       if (result instanceof HTTPErrorResponse || !result.isSuccess()) {
@@ -187,7 +198,7 @@ export default class Register {
             probeKey: PROBE_KEY.toString(),
             probeId: PROBE_ID.toString(),
           },
-          options: { ...ProxyConfig.getRequestProxyAgents(aliveUrl) },
+          options: ProbeAPIRequest.getDefaultRequestOptions(aliveUrl),
         });
 
       if (

--- a/Probe/Tests/Jobs/Alive.test.ts
+++ b/Probe/Tests/Jobs/Alive.test.ts
@@ -1,0 +1,189 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import LocalCache from "Common/Server/Infrastructure/LocalCache";
+import logger from "Common/Server/Utils/Logger";
+import Register from "../../Services/Register";
+import {
+  checkAliveAndReport,
+  resetAliveCheckInProgress,
+} from "../../Jobs/Alive";
+
+/*
+ * The alive heartbeat is what keeps a probe out of the Disconnected state:
+ * the server stamps lastAlive on every POST /probe-ingest/alive, and a
+ * worker flips any probe silent for 3 minutes to Disconnected. In the field
+ * an unresponsive server hung this request forever (axios default timeout is
+ * 0 = infinite) while node-cron stacked a brand-new hung request every
+ * minute — the probe looked Disconnected on the dashboard while it was
+ * perfectly healthy. These tests pin the two fixes: an explicit request
+ * deadline, and a one-heartbeat-at-a-time overlap guard.
+ */
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let postSpy = jest.spyOn(API, "post");
+
+function makeSuccessResponse(): unknown {
+  return {
+    isSuccess: (): boolean => {
+      return true;
+    },
+  };
+}
+
+beforeEach(() => {
+  // A wedged in-flight heartbeat from a previous test must never leak in.
+  resetAliveCheckInProgress();
+  postSpy = jest
+    .spyOn(API, "post")
+    .mockResolvedValue(makeSuccessResponse() as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+type PostCall = {
+  url: string;
+  body: JSONObject;
+  options: JSONObject;
+};
+
+function postCalls(): Array<PostCall> {
+  return postSpy.mock.calls.map((call: Array<unknown>) => {
+    const arg: JSONObject = call[0] as JSONObject;
+    return {
+      url: String(arg["url"]),
+      body: arg["data"] as JSONObject,
+      options: arg["options"] as JSONObject,
+    };
+  });
+}
+
+/*
+ * LocalCache has no delete, so once a test stamps PROBE.PROBE_ID it stays
+ * set for the rest of this file. The unregistered case therefore MUST run
+ * first; the registered describe below sets the cache key in its beforeEach.
+ */
+describe("checkAliveAndReport — before the probe is registered", () => {
+  test("re-registers instead of posting a heartbeat", async () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {
+      // Keep test output clean.
+    });
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const registerSpy = jest
+      .spyOn(Register, "registerProbe")
+      .mockResolvedValue(undefined as never);
+
+    await checkAliveAndReport();
+
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("checkAliveAndReport — registered probe", () => {
+  beforeEach(() => {
+    LocalCache.setString(
+      "PROBE",
+      "PROBE_ID",
+      "11111111-2222-3333-4444-555555555555",
+    );
+  });
+
+  test("posts one heartbeat to the alive endpoint, authenticated as this probe, with an explicit deadline", async () => {
+    await checkAliveAndReport();
+
+    const calls: Array<PostCall> = postCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "https://oneuptime.example.com/probe-ingest/alive",
+    );
+    expect(calls[0]!.body["probeId"]).toBe(
+      "11111111-2222-3333-4444-555555555555",
+    );
+    expect(calls[0]!.body["probeKey"]).toBe("test-probe-key");
+
+    /*
+     * THE timeout pin: axios's default timeout is 0 — infinite — and this
+     * heartbeat used to be sent with no options at all. A server that
+     * accepted the TCP connection but never answered wedged the request
+     * forever, the probe's lastAlive went stale, and the dashboard flagged a
+     * healthy probe as Disconnected. Every heartbeat must carry a deadline.
+     */
+    expect(calls[0]!.options["timeout"]).toBe(45000);
+  });
+
+  test("a tick that arrives while the previous heartbeat is still in flight is skipped", async () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {
+      // Keep test output clean.
+    });
+
+    postSpy.mockReturnValue(
+      new Promise<never>(() => {
+        // Never settles — a heartbeat stuck on an unresponsive server.
+      }) as never,
+    );
+
+    /*
+     * First tick starts and hangs on the POST; the second tick must return
+     * without posting instead of stacking another hung request (the old
+     * behavior piled one on every minute until the process was restarted).
+     */
+    const firstTick: Promise<void> = checkAliveAndReport();
+    await flushMicrotasks();
+
+    await checkAliveAndReport();
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Previous alive check is still in progress. Skipping this tick.",
+    );
+
+    // Never settles by design; the beforeEach guard reset un-wedges the file.
+    void firstTick;
+  });
+
+  test("a failed heartbeat rejects but releases the guard — the next tick posts again", async () => {
+    postSpy.mockRejectedValueOnce(new Error("ingest unreachable") as never);
+
+    /*
+     * The rejection propagates (BasicCron catches and logs it in
+     * production); what matters is the finally releases the guard so one
+     * failed heartbeat cannot permanently wedge the job.
+     */
+    await expect(checkAliveAndReport()).rejects.toThrow("ingest unreachable");
+
+    await checkAliveAndReport();
+
+    expect(postSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("sequential heartbeats each post — the guard releases after success", async () => {
+    await checkAliveAndReport();
+    await checkAliveAndReport();
+
+    expect(postSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Probe/Tests/Jobs/Discovery/FetchScansGuardAndTimeout.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansGuardAndTimeout.test.ts
@@ -1,0 +1,264 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+
+type CapturedCronJob = {
+  jobName: string;
+  runFunction: PromiseVoidFunction;
+};
+
+const mockCapturedCronJobs: Array<CapturedCronJob> = [];
+
+/*
+ * BasicCron would hand the runFunction to node-cron; capturing it instead
+ * lets these tests drive the exact closure production runs — overlap guard
+ * included — without a real scheduler.
+ */
+jest.mock("Common/Server/Utils/BasicCron", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedCronJob): void => {
+      mockCapturedCronJobs.push(props);
+    },
+  };
+});
+
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import SubnetScanner, {
+  SubnetScanResult,
+} from "../../../Utils/Discovery/SubnetScanner";
+import InitJob, {
+  fetchAndRunScans,
+  runScan,
+  resetDiscoveryRunInProgress,
+} from "../../../Jobs/Discovery/FetchScans";
+
+/*
+ * The request-contract half of this job is covered by
+ * FetchScansLifecycle.test.ts. These tests pin the liveness fixes:
+ *
+ *   - every control-plane request carries an explicit deadline (axios's
+ *     default timeout is 0 = infinite, and a hung list fetch is exactly what
+ *     wedged the customer's probe), and
+ *   - one discovery cycle at a time: a subnet sweep legitimately runs many
+ *     minutes (up to 4096 hosts), and before the guard every minutely tick
+ *     stacked another fetch/sweep on top of the one still in flight.
+ */
+
+const scanId: ObjectID = ObjectID.generate();
+
+function makeScan(overrides?: JSONObject): NetworkDeviceDiscoveryScan {
+  return {
+    id: scanId,
+    cidr: "10.0.0.0/24",
+    snmpVersion: "V2c",
+    snmpCommunityString: "public",
+    snmpPort: 161,
+    ...overrides,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+function makeScanResult(): SubnetScanResult {
+  return {
+    discoveredHosts: [],
+    scannedHostCount: 254,
+    respondedToPingCount: 0,
+  } as unknown as SubnetScanResult;
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+// eslint-disable-next-line @typescript-eslint/typedef
+let scanSpy = jest.spyOn(SubnetScanner, "scan");
+
+beforeEach(() => {
+  // A wedged in-flight run from a previous test must never leak in.
+  resetDiscoveryRunInProgress();
+  mockCapturedCronJobs.length = 0;
+  fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: [] } as never);
+  scanSpy = jest
+    .spyOn(SubnetScanner, "scan")
+    .mockResolvedValue(makeScanResult() as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+type FetchCall = {
+  url: string;
+  body: JSONObject;
+  options: JSONObject;
+};
+
+function fetchCalls(): Array<FetchCall> {
+  return fetchSpy.mock.calls.map((call: Array<unknown>) => {
+    const arg: JSONObject = call[0] as JSONObject;
+    return {
+      url: String(arg["url"]),
+      body: arg["data"] as JSONObject,
+      options: arg["options"] as JSONObject,
+    };
+  });
+}
+
+describe("request deadlines — no discovery request may hang forever", () => {
+  test("the pending-scan list fetch carries the 45s deadline", async () => {
+    await fetchAndRunScans();
+
+    const calls: Array<FetchCall> = fetchCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "https://oneuptime.example.com/probe-ingest/probe/discovery-scan/list",
+    );
+    /*
+     * This exact request hanging 45+s is the customer's field failure:
+     * without a deadline the fetch never returned and (pre-guard) every
+     * subsequent tick stacked another one.
+     */
+    expect(calls[0]!.options["timeout"]).toBe(45000);
+  });
+
+  test("the result report carries the deadline", async () => {
+    await runScan(makeScan());
+
+    const calls: Array<FetchCall> = fetchCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      "https://oneuptime.example.com/probe-ingest/probe/discovery-scan/result",
+    );
+    expect(calls[0]!.body["success"]).toBe(true);
+    expect(calls[0]!.options["timeout"]).toBe(45000);
+  });
+
+  test("the failure report carries the deadline too", async () => {
+    jest.spyOn(logger, "error").mockImplementation(() => {
+      // Keep test output clean.
+    });
+    scanSpy.mockRejectedValue(new Error("CIDR too large") as never);
+
+    await runScan(makeScan());
+
+    /*
+     * The failure-report POST is the easiest call to forget: it exists so a
+     * failed sweep does not strand the scan In Progress, and a hung failure
+     * report would defeat that purpose just as thoroughly.
+     */
+    const calls: Array<FetchCall> = fetchCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body["success"]).toBe(false);
+    expect(calls[0]!.options["timeout"]).toBe(45000);
+  });
+
+  /*
+   * The deadline on the RESULT upload cuts both ways: the client can now
+   * give up on an upload the server is actually still processing. The
+   * client's abort does not cancel the server-side handler, so a
+   * success:false report fired from that failure would race the sweep's
+   * own Completed write — and, landing last, flip a finished scan to
+   * Failed and wipe its discovered hosts. An upload failure must be logged
+   * and dropped: the server's stale-In-Progress reaper self-heals a truly
+   * lost result.
+   */
+  test("a failed RESULT upload does not fire a success:false overwrite", async () => {
+    jest.spyOn(logger, "error").mockImplementation(() => {
+      // Keep test output clean.
+    });
+    scanSpy.mockResolvedValue(makeScanResult() as never);
+    fetchSpy.mockRejectedValue(
+      new Error("timeout of 45000ms exceeded") as never,
+    );
+
+    await expect(runScan(makeScan())).resolves.toBeUndefined();
+
+    // Exactly ONE fetch: the failed upload itself. No follow-up report.
+    const calls: Array<FetchCall> = fetchCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body["success"]).toBe(true);
+  });
+});
+
+describe("overlap guard — one discovery cycle at a time", () => {
+  function capturedRunFunction(): PromiseVoidFunction {
+    InitJob();
+    const captured: CapturedCronJob | undefined =
+      mockCapturedCronJobs[mockCapturedCronJobs.length - 1];
+    if (!captured) {
+      throw new Error("InitJob did not register a cron job");
+    }
+    return captured.runFunction;
+  }
+
+  test("a tick that arrives while the previous run is still in flight is skipped", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockReturnValue(
+      new Promise<never>(() => {
+        // Never settles — a list fetch stuck on an unresponsive server.
+      }) as never,
+    );
+
+    /*
+     * A subnet sweep legitimately runs for many minutes; before the guard
+     * every minutely tick stacked another fetch/sweep on top of the stuck
+     * one. The second tick must return without fetching.
+     */
+    const firstTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    await runFunction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Never settles by design; the beforeEach guard reset un-wedges the file.
+    void firstTick;
+  });
+
+  test("the guard releases after a completed run — the next tick fetches again", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    await runFunction();
+    await runFunction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("the guard releases after a failed run — one bad fetch cannot wedge discovery forever", async () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {
+      // Keep test output clean.
+    });
+
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockRejectedValue(new Error("ingest unreachable") as never);
+
+    // The runFunction catches and logs; the tick itself must resolve.
+    await expect(runFunction()).resolves.toBeUndefined();
+    await expect(runFunction()).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/Probe/Tests/Jobs/Monitor/FetchMonitorTestGuard.test.ts
+++ b/Probe/Tests/Jobs/Monitor/FetchMonitorTestGuard.test.ts
@@ -1,0 +1,186 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+
+type CapturedCronJob = {
+  jobName: string;
+  runFunction: PromiseVoidFunction;
+};
+
+const mockCapturedCronJobs: Array<CapturedCronJob> = [];
+
+/*
+ * BasicCron would hand the runFunction to node-cron; capturing it instead
+ * lets these tests drive the exact closure production runs — overlap guard
+ * included — without a real scheduler.
+ */
+jest.mock("Common/Server/Utils/BasicCron", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedCronJob): void => {
+      mockCapturedCronJobs.push(props);
+    },
+  };
+});
+
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import API from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import MonitorUtil from "../../../Utils/Monitors/Monitor";
+import InitJob, {
+  resetMonitorTestRunInProgress,
+} from "../../../Jobs/Monitor/FetchMonitorTest";
+
+/*
+ * The monitor-test job fires EVERY_TEN_SECONDS and node-cron does not wait
+ * for the previous run — against a slow server that is 6 new hung requests
+ * per minute, the fastest-growing pile-up of all the probe's cron jobs.
+ * These tests pin the two liveness fixes: an explicit deadline on the list
+ * fetch (axios's default timeout is 0 = infinite) and a skip-tick overlap
+ * guard.
+ */
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+
+beforeEach(() => {
+  mockCapturedCronJobs.length = 0;
+  // A test that wedges a run in flight must never leak into the next case.
+  resetMonitorTestRunInProgress();
+  fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: [] } as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+function capturedRunFunction(): PromiseVoidFunction {
+  InitJob();
+  const captured: CapturedCronJob | undefined =
+    mockCapturedCronJobs[mockCapturedCronJobs.length - 1];
+  if (!captured) {
+    throw new Error("InitJob did not register a cron job");
+  }
+  return captured.runFunction;
+}
+
+describe("monitor-test job — deadline and overlap guard", () => {
+  test("the list fetch is authenticated as this probe and carries the 45s deadline", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    await runFunction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const arg: JSONObject = fetchSpy.mock.calls[0]![0] as unknown as JSONObject;
+    expect(String(arg["url"])).toBe(
+      "https://oneuptime.example.com/probe-ingest/monitor-test/list",
+    );
+
+    const body: JSONObject = arg["data"] as JSONObject;
+    expect(body["probeId"]).toBe("11111111-2222-3333-4444-555555555555");
+    expect(body["probeKey"]).toBe("test-probe-key");
+    expect(body["limit"]).toBe(100);
+
+    /*
+     * THE timeout pin: this fetch used to go out with no options, so an
+     * unresponsive server hung it forever — at 6 ticks a minute, forever
+     * adds up fast.
+     */
+    expect((arg["options"] as JSONObject)["timeout"]).toBe(45000);
+  });
+
+  test("a failed list fetch releases the guard — the next tick fetches again", async () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {
+      // Keep test output clean.
+    });
+
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockRejectedValue(new Error("ingest unreachable") as never);
+
+    // The job catches and logs internally; the tick itself must resolve.
+    await expect(runFunction()).resolves.toBeUndefined();
+    await expect(runFunction()).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test("a tick that arrives while the previous run is still in flight is skipped", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockReturnValue(
+      new Promise<never>(() => {
+        // Never settles — a list fetch stuck on an unresponsive server.
+      }) as never,
+    );
+
+    const firstTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    await runFunction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Never settles by design; module state dies with this test file.
+    void firstTick;
+  });
+
+  /*
+   * The guard covers ONLY the list fetch. The server hands each test out
+   * exactly once, so overlapping ticks execute disjoint batches — and
+   * "Test monitor" is an interactive flow: a long-running synthetic test
+   * (legitimately up to minutes) must not delay the pickup of the next
+   * user's test by even one tick.
+   */
+  test("a long-running test batch does not block the next tick's fetch", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockResolvedValue({
+      data: [{ _id: ObjectID.generate().toString() }],
+    } as never);
+
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const probeSpy = jest
+      .spyOn(MonitorUtil, "probeMonitorTest")
+      .mockReturnValue(
+        new Promise<never>(() => {
+          // Never settles — a synthetic test mid-run.
+        }) as never,
+      );
+
+    const firstTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    // The batch is still probing, but the guard was already released...
+    const secondTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    // ...so the second tick fetched a fresh list.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(probeSpy).toHaveBeenCalled();
+
+    // Never settle by design; module state dies with this test file.
+    void firstTick;
+    void secondTick;
+  });
+});

--- a/Probe/Tests/Jobs/NetworkDevice/FetchListGuardAndTimeout.test.ts
+++ b/Probe/Tests/Jobs/NetworkDevice/FetchListGuardAndTimeout.test.ts
@@ -1,0 +1,194 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+
+type CapturedCronJob = {
+  jobName: string;
+  runFunction: PromiseVoidFunction;
+};
+
+const mockCapturedCronJobs: Array<CapturedCronJob> = [];
+
+/*
+ * BasicCron would hand the runFunction to node-cron; capturing it instead
+ * lets these tests drive the exact closure production runs — overlap guard
+ * included — without a real scheduler.
+ */
+jest.mock("Common/Server/Utils/BasicCron", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedCronJob): void => {
+      mockCapturedCronJobs.push(props);
+    },
+  };
+});
+
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import SnmpMonitor from "../../../Utils/Monitors/MonitorTypes/SnmpMonitor";
+import InitJob, {
+  resetDevicePollRunInProgress,
+} from "../../../Jobs/NetworkDevice/FetchList";
+
+/*
+ * The polling logic itself is covered by FetchList.test.ts. These tests pin
+ * the liveness fixes on the device-poll job:
+ *
+ *   - the list fetch carries an explicit deadline (axios's default timeout
+ *     is 0 = infinite, so a hung fetch used to pile up one new request per
+ *     minute forever), and
+ *   - the single-flight guard covers ONLY the fetch: the server claims due
+ *     devices atomically when handing out the list, so overlapping ticks
+ *     poll disjoint device sets — a fleet whose poll cycle exceeds a minute
+ *     must keep fetching at its cadence, not degrade to one fetch per
+ *     cycle.
+ */
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+
+beforeEach(() => {
+  // A wedged in-flight fetch from a previous test must never leak in.
+  resetDevicePollRunInProgress();
+  mockCapturedCronJobs.length = 0;
+  fetchSpy = jest
+    .spyOn(API, "fetch")
+    .mockResolvedValue({ data: { devices: [] } } as never);
+  jest.spyOn(logger, "error").mockImplementation(() => {
+    // Keep test output clean.
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+}
+
+function capturedRunFunction(): PromiseVoidFunction {
+  InitJob();
+  const captured: CapturedCronJob | undefined =
+    mockCapturedCronJobs[mockCapturedCronJobs.length - 1];
+  if (!captured) {
+    throw new Error("InitJob did not register a cron job");
+  }
+  return captured.runFunction;
+}
+
+describe("network-device job — deadline and fetch-only overlap guard", () => {
+  test("the device list fetch carries the 45s deadline", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    await runFunction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const arg: JSONObject = fetchSpy.mock.calls[0]![0] as unknown as JSONObject;
+    expect(String(arg["url"])).toBe(
+      "https://oneuptime.example.com/probe-ingest/probe/network-device/list",
+    );
+
+    const body: JSONObject = arg["data"] as JSONObject;
+    expect(body["probeId"]).toBe("11111111-2222-3333-4444-555555555555");
+    expect(body["probeKey"]).toBe("test-probe-key");
+
+    /*
+     * THE timeout pin: this fetch used to go out with no options object at
+     * all, so an unresponsive server hung it forever while node-cron
+     * stacked a new one every minute.
+     */
+    expect((arg["options"] as JSONObject)["timeout"]).toBe(45000);
+  });
+
+  test("a tick that arrives while the list fetch is still in flight is skipped", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockReturnValue(
+      new Promise<never>(() => {
+        // Never settles — a list fetch stuck on an unresponsive server.
+      }) as never,
+    );
+
+    const firstTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    await runFunction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Never settles by design; the beforeEach reset unwedges the next test.
+    void firstTick;
+  });
+
+  test("a failed list fetch releases the guard — the next tick fetches again", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockRejectedValue(new Error("ingest unreachable") as never);
+
+    // The job catches and logs internally; the tick itself must resolve.
+    await expect(runFunction()).resolves.toBeUndefined();
+    await expect(runFunction()).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  /*
+   * The guard covers ONLY the fetch. The server claims due devices
+   * atomically, so overlapping poll cycles walk disjoint sets — a slow
+   * device fleet (5s SNMP timeouts, retries) whose cycle exceeds the
+   * minute must not throttle the fetch cadence down to one per cycle.
+   */
+  test("an in-flight poll cycle does not block the next tick's fetch", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockResolvedValue({
+      data: {
+        devices: [
+          {
+            networkDeviceId: "device-1",
+            projectId: "project-1",
+            collectEndpoints: false,
+            snmpMonitor: { hostname: "10.0.0.5" },
+          },
+        ],
+      },
+    } as never);
+
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const querySpy = jest.spyOn(SnmpMonitor, "query").mockReturnValue(
+      new Promise<never>(() => {
+        // Never settles — an SNMP walk mid-flight.
+      }) as never,
+    );
+
+    const firstTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    // The walk is still running, but the guard was already released...
+    const secondTick: Promise<void> = runFunction();
+    await flushMicrotasks();
+
+    // ...so the second tick fetched a fresh device list.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(querySpy).toHaveBeenCalled();
+
+    // Never settle by design; module state dies with this test file.
+    void firstTick;
+    void secondTick;
+  });
+});

--- a/Probe/Tests/Utils/ProbeAPIRequest.test.ts
+++ b/Probe/Tests/Utils/ProbeAPIRequest.test.ts
@@ -1,0 +1,114 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import URL from "Common/Types/API/URL";
+import { RequestOptions } from "Common/Utils/API";
+import ProbeAPIRequest from "../../Utils/ProbeAPIRequest";
+
+/*
+ * Every control-plane request the probe sends (alive heartbeat, list
+ * fetches, result ingest, registration) is assembled here. The options are
+ * what fixed the customer's Disconnected-probe incident: axios's default
+ * timeout is 0 — infinite — so before getDefaultRequestOptions existed, a
+ * server that accepted the TCP connection but never answered wedged the
+ * request forever while cron ticks piled new ones on top. These tests pin
+ * the deadline, its env override, and the exact clamp semantics.
+ */
+
+const aliveUrl: URL = URL.fromString(
+  "https://oneuptime.example.com/probe-ingest/alive",
+);
+
+describe("getDefaultRequestBody", () => {
+  test("authenticates as this probe: probeKey and probeId from the environment", () => {
+    expect(ProbeAPIRequest.getDefaultRequestBody()).toEqual({
+      probeKey: "test-probe-key",
+      probeId: "11111111-2222-3333-4444-555555555555",
+    });
+  });
+});
+
+describe("getDefaultRequestOptions", () => {
+  test("carries the 45s default deadline", () => {
+    const options: RequestOptions =
+      ProbeAPIRequest.getDefaultRequestOptions(aliveUrl);
+
+    expect(options.timeout).toBe(45000);
+  });
+
+  test("with no proxy configured, no agent keys leak into the options", () => {
+    const options: RequestOptions =
+      ProbeAPIRequest.getDefaultRequestOptions(aliveUrl);
+
+    /*
+     * ProxyConfig.getRequestProxyAgents returns {} when no proxy is
+     * configured, so the request rides axios's default agents. Pinned as
+     * exact shape: an accidental httpAgent/httpsAgent key here would apply
+     * to every control-plane request the probe makes.
+     */
+    expect(options).toEqual({ timeout: 45000 });
+    expect("httpAgent" in options).toBe(false);
+    expect("httpsAgent" in options).toBe(false);
+  });
+});
+
+describe("PROBE_API_REQUEST_TIMEOUT_IN_MS — env override and clamp semantics", () => {
+  /*
+   * Config.ts reads the env var at import time, so each scenario re-requires
+   * a fresh Config inside jest.isolateModules. The synchronous require is
+   * deliberate: a static import would be hoisted and bound to the module
+   * this file already loaded.
+   */
+  function loadConfiguredTimeout(envValue: string | undefined): number {
+    if (envValue === undefined) {
+      delete process.env["PROBE_API_REQUEST_TIMEOUT_IN_MS"];
+    } else {
+      process.env["PROBE_API_REQUEST_TIMEOUT_IN_MS"] = envValue;
+    }
+
+    let timeout: number = 0;
+
+    jest.isolateModules(() => {
+      /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      const config: { PROBE_API_REQUEST_TIMEOUT_IN_MS: number } =
+        require("../../Config") as { PROBE_API_REQUEST_TIMEOUT_IN_MS: number };
+      /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      timeout = config.PROBE_API_REQUEST_TIMEOUT_IN_MS;
+    });
+
+    return timeout;
+  }
+
+  afterEach(() => {
+    delete process.env["PROBE_API_REQUEST_TIMEOUT_IN_MS"];
+  });
+
+  test("unset: defaults to 45000", () => {
+    expect(loadConfiguredTimeout(undefined)).toBe(45000);
+  });
+
+  test("a valid override is honored", () => {
+    expect(loadConfiguredTimeout("60000")).toBe(60000);
+  });
+
+  test("the 1000ms minimum itself is accepted", () => {
+    expect(loadConfiguredTimeout("1000")).toBe(1000);
+  });
+
+  test("a sub-minimum value falls back to the 45000 default, not the minimum", () => {
+    /*
+     * NumberUtil.parseNumberWithDefault REJECTS below-min values back to the
+     * default — it does not floor them to min. So "500" yields 45000, not
+     * 1000: a nonsense deadline is treated the same as no configuration at
+     * all rather than silently becoming the most aggressive legal one.
+     */
+    expect(loadConfiguredTimeout("500")).toBe(45000);
+  });
+
+  test("a non-numeric value falls back to the 45000 default", () => {
+    expect(loadConfiguredTimeout("not-a-number")).toBe(45000);
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -57,7 +57,6 @@ import Monitor from "Common/Models/DatabaseModels/Monitor";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import ObjectID from "Common/Types/ObjectID";
 import MonitorTest from "Common/Models/DatabaseModels/MonitorTest";
-import ProxyConfig from "../ProxyConfig";
 
 export default class MonitorUtil {
   // Replace dynamic URL placeholders like {{timestamp}} and {{random}} with actual values.
@@ -141,9 +140,8 @@ export default class MonitorUtil {
             probeMonitorResponse: result as any,
           },
           headers: {},
-          options: {
-            ...ProxyConfig.getRequestProxyAgents(monitorTestIngestUrl),
-          },
+          options:
+            ProbeAPIRequest.getDefaultRequestOptions(monitorTestIngestUrl),
         });
       }
 
@@ -212,9 +210,7 @@ export default class MonitorUtil {
             probeMonitorResponse: result as any,
           },
           headers: {},
-          options: {
-            ...ProxyConfig.getRequestProxyAgents(monitorIngestUrl),
-          },
+          options: ProbeAPIRequest.getDefaultRequestOptions(monitorIngestUrl),
         });
       }
 

--- a/Probe/Utils/ProbeAPIRequest.ts
+++ b/Probe/Utils/ProbeAPIRequest.ts
@@ -1,5 +1,8 @@
-import { PROBE_KEY } from "../Config";
+import { PROBE_API_REQUEST_TIMEOUT_IN_MS, PROBE_KEY } from "../Config";
 import ProbeUtil from "./Probe";
+import ProxyConfig from "./ProxyConfig";
+import URL from "Common/Types/API/URL";
+import { RequestOptions } from "Common/Utils/API";
 import { JSONObject } from "Common/Types/JSON";
 
 export default class ProbeAPIRequest {
@@ -7,6 +10,20 @@ export default class ProbeAPIRequest {
     return {
       probeKey: PROBE_KEY,
       probeId: ProbeUtil.getProbeId().toString(),
+    };
+  }
+
+  /*
+   * Every control-plane request to the server goes through this: proxy
+   * agents when a proxy is configured, plus an explicit timeout so a
+   * non-responding server produces a logged failure instead of an
+   * infinitely hung request (axios's default timeout is 0 = no timeout,
+   * and a hung request from a cron tick piles onto the next tick's).
+   */
+  public static getDefaultRequestOptions(url: URL): RequestOptions {
+    return {
+      ...ProxyConfig.getRequestProxyAgents(url),
+      timeout: PROBE_API_REQUEST_TIMEOUT_IN_MS,
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the field-reported failure where healthy custom probes are flagged **Disconnected** because `POST /probe-ingest/alive` and `POST /probe-ingest/probe/discovery-scan/list` stop responding (45+ s client-side timeouts), while the probes' monitor checks keep succeeding.

Reported against a self-hosted deployment with 5 custom probes: two probes showed identical `ECONNABORTED / timeout of 45000ms exceeded` on exactly those two routes, TCP/TLS/DNS all healthy, requests reaching the server but never answered.

## Root cause (verified against the code, all pieces required)

1. **Async middleware rejections were never answered.** `ProbeAuthorization.isAuthorizedServiceMiddleware` is an async middleware on Express 4 with no try/catch. Express 4 ignores the returned promise, so when the middleware's awaited DB work rejected (pool-acquire timeout after 5 s, statement timeout at 30 s), the rejection went to the process-level `unhandledRejection` logger and the HTTP request was **never answered at all** — the customer's exact "connects fine, then silence" signature.
2. **The heartbeat write lands deterministically on these two routes.** All probe cron jobs fire on the same node-cron second (`* * * * *`), Alive dispatched first. The lastAlive write is throttled to once per 30 s via a Redis stamp, so the first request(s) of each minute tick — `/alive`, and same-tick racers like `discovery-scan/list` — always take the Postgres write path, while later requests (`/monitor/list`) hit the fresh stamp and skip it. `/probe/response/ingest` responds before doing any awaited work, so it always looks healthy.
3. **The throttle stamp is written before the write it throttles.** When the write failed, the stamp still suppressed every retry for 30 s. A few consecutive failed windows crossed the connection-status worker's staleness cutoff — so `lastAlive` went stale in Postgres *even though the probe's other requests kept succeeding*.
4. **Status flips are what starve the pool — and staleness causes flips.** `Probe:UpdateConnectionStatus` (every minute) fetched **every probe row in the system**, and each status flip runs `MonitorService.refreshProbeStatus` — up to 50 concurrent per-monitor query chains, scaling with the number of monitors on the probe (the customer's own hunch) — plus per-owner notifications. Flip → pool starved at second 0 → heartbeat fails → stale → flip back → repeat. A self-sustaining flap loop, re-running the storm in both directions.
5. **The probe client made it invisible and worse.** None of the probe's control-plane HTTP calls set a timeout (axios default = infinite), and node-cron (`noOverlap` unset) starts a new run every tick regardless — so hung requests silently piled up, one per minute per job (six per minute for monitor-test), exactly as the customer observed before they patched a 45 s timeout in themselves.

## Fixes

### Server
- **`ProbeAuthorization` middleware rewritten**: full try/catch with `next(err)` — a failing dependency now yields an immediate, logged error response instead of infinite silence.
- **Cached probe authentication** (`ProbeService.verifyProbeKey`): Redis-cached SHA-256 of the probe key (never the key itself), 120 s TTL, written only after a successful DB verification. Cache mismatch falls through to the DB, so a rotated key works instantly; rotation/deletion invalidate cluster-wide via new `onUpdateSuccess`/`onDeleteSuccess` hooks, with the TTL bounding any missed invalidation. Removes the per-request Probe SELECT — probe auth stays fast while the pool is busy, which is precisely when the heartbeat matters.
- **Heartbeat stamp is fire-and-forget**: every authenticated probe request proves liveness, so the middleware schedules the throttled single-statement `lastAlive` UPDATE without awaiting it. `/alive` no longer runs a second, awaited `updateLastAlive` — its response time is now independent of Postgres write latency.
- **Failed heartbeat writes self-heal**: `updateLastAlive` clears the 30 s throttle stamp when the UPDATE fails, so the next request retries immediately instead of silently drifting toward the staleness cutoff.
- **Bounded cache operations**: all probe-path Redis calls are capped at 2 s (ioredis has no command timeout; a stalled-but-open socket must not hang probe auth), falling back to the DB.
- **Discovery-scan claim is now a single-statement hookless write**: the model/service have no update hooks, workflow, realtime, or audit decorators, so the full `updateOneById` pipeline (permission pre-fetch + row re-fetch + `save()` transaction) was pure overhead on a route the probe synchronously waits on every minute.
- **`Probe:UpdateConnectionStatus` worker**: two targeted SQL-predicate queries (stale-but-not-Disconnected, fresh-but-not-Connected) replace the full-table fetch; a steady-state tick now costs two indexed SELECTs and zero updates. The 3-minute cutoff is exact parity with the old moment-truncated `getDifferenceInMinutes > 2` check (which only ever fired at ≥3 whole minutes).

### Probe client (upstreams the customer's mitigation, properly)
- **`PROBE_API_REQUEST_TIMEOUT_IN_MS`** (default 45 s, env-overridable): every control-plane call — alive, monitor/discovery/network-device/monitor-test list fetches, all result-ingest posts, registration, KEDA metrics — now goes through `ProbeAPIRequest.getDefaultRequestOptions()`, which sets proxy agents + an explicit timeout. A non-responding server produces a clean, logged failure retried on the next tick.
- **Overlap guards** on the pile-up-prone cron jobs (Alive, DiscoveryScanFetch, MonitorTest, NetworkDeviceFetchList): a still-running tick is skipped instead of stacked.

## Review hardening (from a 23-agent adversarial review of the diff; every finding verified by two independent skeptics)

- **Rotation TOCTOU closed**: invalidation now *writes a revocation sentinel* instead of deleting, and the auth-cache write is *write-only-if-unchanged* (re-read immediately before writing) — an in-flight verification that DB-checked the old key just before a rotation committed can no longer resurrect the revoked hash for a fresh TTL.
- **Overlap guards narrowed to the fetch only** for monitor-test and network-device jobs: the server claims tests/devices atomically, so overlapping ticks execute disjoint batches. Guarding whole cycles would have delayed interactive "Test monitor" pickups behind long synthetic runs and throttled large device fleets to one fetch per cycle. (Discovery keeps its full-cycle guard deliberately — the server hands out one sweep at a time by design.)
- **Discovery result-upload failures no longer fire a `success:false` report**: the client's timeout doesn't cancel the server-side handler, so that report could race the sweep's own Completed write, flip a finished scan to Failed and wipe its hosts. Upload failures are logged; the existing 2-hour stale-In-Progress reaper self-heals a truly lost result.
- **`reportIfOffline` is now best-effort**: with a timeout attached, a slow server could otherwise turn the startup courtesy status-report into a probe crash-loop on ICMP-blocked hosts.
- **Worker double-list dedupe**: a NULL-status probe whose heartbeat lands between the two SELECTs gets one flip (the fresher verdict), not two.
- Coverage gaps closed: network-device guard/deadline suite, invalidation-failure pins, TOCTOU pin, cap-timer-cleanup pin.

## Behavior notes
- `/alive` 200 now means "authenticated and stamp scheduled" rather than "stamp committed"; write failures are logged server-side and self-heal via throttle-clearing. The client never consumed the difference (it only logs).
- A revoked/rotated probe key stops working immediately via hook invalidation; if the cache delete is ever missed, the 120 s TTL bounds the stale window. The cache stores only SHA-256 hashes.
- No schema changes; no migration.

## Tests

74 new/updated tests across nine files, all green (`Probe`: 22 suites / 520 tests total incl. pre-existing; App probe suites: 41; Common probe suites: 36):

- `App/Tests/Telemetry/ProbeAuthorizationMiddleware.test.ts` — pins the silent-hang fix (`verifyProbeKey` rejection → `next(err)`), fire-and-forget stamping (middleware resolves while the write never settles), stamp-failure logging without failing the request, no-stamp-on-failed-auth.
- `App/Tests/Telemetry/ProbeIngestAlive.test.ts` — `/alive` responds via middleware auth only and never calls `updateLastAlive` itself; middleware wiring pinned.
- `Common/Tests/Server/Services/ProbeAuthKeyCacheAndHeartbeat.test.ts` — cache hit needs no Probe SELECT; only SHA-256 + 120 s TTL ever cached; rotated-key fall-through and overwrite; DB-not-found writes nothing; Redis rejection *and* never-settling Redis read (2 s cap) both fall back to the DB; 30 s throttle; failed write clears the throttle and rethrows (and a failed clear doesn't mask the DB error); hook invalidation on key change/delete; connection-status notifications unchanged.
- `Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts` — loud-failure preconditions for the hookless claim (no workflow/audit/realtime metadata, no service update hooks).
- `App/Tests/Workers/Jobs/Probe/UpdateConnectionStatus.test.ts` — exactly two targeted queries and never the all-rows scan; exact predicate/select shapes; shared now−3 min cutoff (parity with the moment-truncated check); zero-candidate ticks write nothing; per-probe failure isolation.
- `App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts` (updated) — claim asserted against the hookless write, ordering (claim before respond) preserved.
- `Probe/Tests/Jobs/Alive.test.ts`, `.../Discovery/FetchScansGuardAndTimeout.test.ts`, `.../Monitor/FetchMonitorTestGuard.test.ts`, `.../Utils/ProbeAPIRequest.test.ts` — every control-plane call carries the 45 s deadline (incl. the sweep failure-report), overlap guards skip in-flight ticks and release on success/failure, env override + clamp semantics of `PROBE_API_REQUEST_TIMEOUT_IN_MS`.

Also verified: `Common` and `App` full compiles, `Probe` tsc, eslint clean on all changed files; pre-existing probe-related suites (`HeartbeatWriteFastPathSafety`, `ProbeAPI`, `ProbeIngestNetworkDevicePoll`, probe client discovery/network-device suites) all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gznz9FpUDyXMQqxhewxGc3
