### PR TITLE
fix(dashboard): reopen the last accessed project instead of the first one

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker.tsx
@@ -3,7 +3,6 @@ import SubscriptionPlan from "Common/Types/Billing/SubscriptionPlan";
 import { VoidFunction } from "Common/Types/FunctionTypes";
 import IconProp from "Common/Types/Icon/IconProp";
 import { JSONValue } from "Common/Types/JSON";
-import ObjectID from "Common/Types/ObjectID";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import Field from "Common/UI/Components/Forms/Types/Field";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
@@ -99,41 +98,19 @@ const DashboardProjectPicker: FunctionComponent<ComponentProps> = (
     }
   }, [props.showProjectModal]);
 
-  type GetCurrentProjectFunction = () => Project | null;
-
-  const getCurrentProject: GetCurrentProjectFunction = (): Project | null => {
-    // see nav params first, then local storage, then default to first project.
-    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
-
-    if (projectId) {
-      // check if this project is in the list.
-
-      const project: Project | undefined = props.projects.find(
-        (project: Project) => {
-          return project._id?.toString() === projectId.toString();
-        },
-      );
-
-      if (project) {
-        return project;
-      }
+  useEffect(() => {
+    /*
+     * The project list is still loading at this point. Fall back to the cached
+     * copy of the project the user was last on so the dashboard can start
+     * rendering it right away instead of waiting for the list. The effect below
+     * corrects this once the list arrives (e.g. if the user no longer has
+     * access to that project).
+     */
+    if (props.selectedProject) {
+      return;
     }
 
     const currentProject: Project | null = ProjectUtil.getCurrentProject();
-
-    if (currentProject) {
-      return currentProject;
-    }
-
-    if (props.projects.length > 0) {
-      return props.projects[0] || null;
-    }
-
-    return null;
-  };
-
-  useEffect(() => {
-    const currentProject: Project | null = getCurrentProject();
 
     if (currentProject && props.onProjectSelected) {
       props.onProjectSelected(currentProject);
@@ -141,29 +118,19 @@ const DashboardProjectPicker: FunctionComponent<ComponentProps> = (
   }, []);
 
   useEffect(() => {
-    if (
-      props.projects &&
-      props.projects.length > 0 &&
-      !props.selectedProject &&
-      props.projects[0]
-    ) {
-      const currentProject: Project | null = getCurrentProject();
+    /*
+     * The project list has loaded (or reloaded). Open the project in the URL,
+     * else the last project this user opened on this browser, else their first
+     * project - and always one they still have access to.
+     */
+    const projectToSelect: Project | null =
+      ProjectUtil.getProjectToSelectOnProjectsLoaded({
+        projects: props.projects,
+        selectedProject: props.selectedProject,
+      });
 
-      if (!currentProject) {
-        props.onProjectSelected(props.projects[0]);
-      } else if (
-        props.projects.filter((project: Project) => {
-          return project._id === currentProject._id;
-        }).length > 0
-      ) {
-        props.onProjectSelected(
-          props.projects.filter((project: Project) => {
-            return project._id === currentProject._id;
-          })[0] as Project,
-        );
-      } else {
-        props.onProjectSelected(props.projects[0]);
-      }
+    if (projectToSelect) {
+      props.onProjectSelected(projectToSelect);
     }
   }, [props.projects]);
 

--- a/Common/Tests/UI/Utils/Project.test.ts
+++ b/Common/Tests/UI/Utils/Project.test.ts
@@ -1,0 +1,809 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import ProjectUtil, {
+  CURRENT_PROJECT_ID_STORAGE_KEY,
+  LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+} from "../../../UI/Utils/Project";
+import Project from "../../../Models/DatabaseModels/Project";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * A user who belongs to more than one project expects the dashboard to reopen
+ * on the project they were last working in. Before this was fixed, the only
+ * record of "the project I'm on" lived in SESSION storage, which the browser
+ * throws away when the tab closes - so every fresh visit to /dashboard silently
+ * dropped the user into whichever project happened to sort first in the list.
+ *
+ * These tests pin down the resolution order that fixes that:
+ *
+ *   URL  >  this tab's session  >  last project opened on this browser  >  first
+ *
+ * and the invariant that makes it safe: a remembered project is only honoured
+ * while the user still has access to it.
+ */
+
+const PROJECT_X_ID: string = "11111111-1111-4111-8111-111111111111";
+const PROJECT_Y_ID: string = "22222222-2222-4222-8222-222222222222";
+const PROJECT_Z_ID: string = "33333333-3333-4333-8333-333333333333";
+
+type BuildProjectFunction = (id: string, name: string) => Project;
+
+const buildProject: BuildProjectFunction = (
+  id: string,
+  name: string,
+): Project => {
+  const project: Project = new Project();
+  project._id = id;
+  project.name = name;
+  return project;
+};
+
+type SetUrlFunction = (url: string) => void;
+
+const setUrl: SetUrlFunction = (url: string): void => {
+  window.history.replaceState(window.history.state, "", url);
+};
+
+/**
+ * What the browser does when the user closes the tab (or opens the dashboard in
+ * a brand new one): session storage is gone, local storage survives.
+ */
+type CloseTheTabFunction = () => void;
+
+const closeTheTab: CloseTheTabFunction = (): void => {
+  window.sessionStorage.clear();
+  setUrl("/dashboard");
+};
+
+describe("ProjectUtil", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    setUrl("/dashboard");
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  describe("the reported bug: reopening the dashboard", () => {
+    test("reopens the project the user was last in, not the first project", () => {
+      const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+      const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+      const projectZ: Project = buildProject(PROJECT_Z_ID, "Project Z");
+
+      // The user is working in Project Y.
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(projectY);
+
+      // ... and closes the dashboard, then comes back to /dashboard.
+      closeTheTab();
+
+      const projectToLoad: Project | null = ProjectUtil.getProjectToLoad([
+        projectX,
+        projectY,
+        projectZ,
+      ]);
+
+      expect(projectToLoad?._id).toBe(PROJECT_Y_ID);
+      expect(projectToLoad?.name).toBe("Project Y");
+    });
+
+    test("keeps reopening the same project across repeated visits", () => {
+      const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+      const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+      const projects: Array<Project> = [projectX, projectY];
+
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(projectY);
+
+      for (let visit: number = 0; visit < 3; visit++) {
+        closeTheTab();
+        expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_Y_ID);
+      }
+    });
+
+    test("switching projects updates what gets reopened", () => {
+      const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+      const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+      const projects: Array<Project> = [projectX, projectY];
+
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(projectY);
+
+      // The user now switches to Project X.
+      setUrl(`/dashboard/${PROJECT_X_ID}/home`);
+      ProjectUtil.setCurrentProject(projectX);
+
+      closeTheTab();
+
+      expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_X_ID);
+    });
+
+    test("falls back to the first project when the remembered one is gone", () => {
+      const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+      const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(projectY);
+
+      closeTheTab();
+
+      // The user has since been removed from Project Y.
+      expect(ProjectUtil.getProjectToLoad([projectX])?._id).toBe(PROJECT_X_ID);
+    });
+
+    test("a user with a single project is unaffected", () => {
+      const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+
+      closeTheTab();
+
+      expect(ProjectUtil.getProjectToLoad([projectX])?._id).toBe(PROJECT_X_ID);
+    });
+  });
+
+  describe("getProjectIdFromUrl", () => {
+    test("reads the project id off a project scoped route", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+
+      expect(ProjectUtil.getProjectIdFromUrl()?.toString()).toBe(PROJECT_Y_ID);
+    });
+
+    test("reads the project id off a deeply nested route", () => {
+      setUrl(
+        `/dashboard/${PROJECT_Y_ID}/monitors/44444444-4444-4444-4444-444444444444/criteria`,
+      );
+
+      expect(ProjectUtil.getProjectIdFromUrl()?.toString()).toBe(PROJECT_Y_ID);
+    });
+
+    test("survives a query string and a hash", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/logs?query=error#tail`);
+
+      expect(ProjectUtil.getProjectIdFromUrl()?.toString()).toBe(PROJECT_Y_ID);
+    });
+
+    test("returns null on routes that carry no project id", () => {
+      setUrl("/dashboard");
+      expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
+
+      setUrl("/dashboard/");
+      expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
+
+      setUrl("/dashboard/welcome");
+      expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
+    });
+
+    test("returns null for an unpopulated route template", () => {
+      setUrl("/dashboard/:projectId/home");
+
+      expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
+    });
+
+    test("returns null when the segment is not a uuid", () => {
+      setUrl("/dashboard/not-a-uuid/home");
+
+      expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
+    });
+  });
+
+  describe("getCurrentProjectId precedence", () => {
+    test("the URL wins over everything else", () => {
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        PROJECT_X_ID,
+      );
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Z_ID,
+      );
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_Y_ID);
+    });
+
+    test("this tab's session wins when the route has no project id", () => {
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        PROJECT_X_ID,
+      );
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Z_ID,
+      );
+      setUrl("/dashboard");
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_X_ID);
+    });
+
+    test("the last accessed project is used once the session is gone", () => {
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Z_ID,
+      );
+      setUrl("/dashboard");
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_Z_ID);
+    });
+
+    test("returns null when nothing is known", () => {
+      expect(ProjectUtil.getCurrentProjectId()).toBeNull();
+    });
+
+    test("ignores a corrupt session value and falls through", () => {
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        "not-a-uuid",
+      );
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Z_ID,
+      );
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_Z_ID);
+    });
+
+    test("ignores a corrupt last accessed value", () => {
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        "not-a-uuid",
+      );
+
+      expect(ProjectUtil.getCurrentProjectId()).toBeNull();
+    });
+
+    test("a second tab on another project does not disturb the first", () => {
+      /*
+       * Session storage is per tab, so tab 1 stays on X even though the last
+       * project opened on this browser is Z.
+       */
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Z_ID,
+      );
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        PROJECT_X_ID,
+      );
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_X_ID);
+    });
+
+    test("a deep link into another project is not hijacked by a stale session", () => {
+      // The classic case: an alert email opened in a tab already on Project X.
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        PROJECT_X_ID,
+      );
+      setUrl(`/dashboard/${PROJECT_Y_ID}/alerts`);
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_Y_ID);
+    });
+  });
+
+  describe("last accessed project id", () => {
+    test("round trips an ObjectID", () => {
+      ProjectUtil.setLastAccessedProjectId(new ObjectID(PROJECT_Y_ID));
+
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_Y_ID,
+      );
+    });
+
+    test("round trips a string", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_Y_ID,
+      );
+    });
+
+    test("is persisted in local storage so it outlives the tab", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(
+        window.localStorage.getItem(LAST_ACCESSED_PROJECT_ID_STORAGE_KEY),
+      ).toBe(PROJECT_Y_ID);
+
+      window.sessionStorage.clear();
+
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_Y_ID,
+      );
+    });
+
+    test("returns null when nothing was ever stored", () => {
+      expect(ProjectUtil.getLastAccessedProjectId()).toBeNull();
+    });
+
+    test.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["an empty string", ""],
+      ["a non-uuid", "not-a-uuid"],
+      ["an unpopulated route param", ":projectId"],
+    ])("clears rather than persisting %s", (_label: string, value: unknown) => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      ProjectUtil.setLastAccessedProjectId(
+        value as ObjectID | string | null | undefined,
+      );
+
+      expect(ProjectUtil.getLastAccessedProjectId()).toBeNull();
+      expect(
+        window.localStorage.getItem(LAST_ACCESSED_PROJECT_ID_STORAGE_KEY),
+      ).toBeNull();
+    });
+
+    test("clearLastAccessedProjectId removes the key", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      ProjectUtil.clearLastAccessedProjectId();
+
+      expect(ProjectUtil.getLastAccessedProjectId()).toBeNull();
+      expect(
+        window.localStorage.getItem(LAST_ACCESSED_PROJECT_ID_STORAGE_KEY),
+      ).toBeNull();
+    });
+
+    test("clearing it is safe when nothing was stored", () => {
+      expect(() => {
+        return ProjectUtil.clearLastAccessedProjectId();
+      }).not.toThrow();
+      expect(ProjectUtil.getLastAccessedProjectId()).toBeNull();
+    });
+  });
+
+  describe("setCurrentProject", () => {
+    test("records the project as both current and last accessed", () => {
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_Y_ID, "Project Y"));
+
+      expect(
+        window.sessionStorage.getItem(CURRENT_PROJECT_ID_STORAGE_KEY),
+      ).toBe(PROJECT_Y_ID);
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_Y_ID,
+      );
+    });
+
+    test("accepts a plain JSON project", () => {
+      ProjectUtil.setCurrentProject({
+        _id: PROJECT_Y_ID,
+        name: "Project Y",
+      });
+
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_Y_ID,
+      );
+      expect(ProjectUtil.getCurrentProject()?._id).toBe(PROJECT_Y_ID);
+    });
+
+    test("caches the project so it can be read back", () => {
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_Y_ID, "Project Y"));
+
+      const currentProject: Project | null = ProjectUtil.getCurrentProject();
+
+      expect(currentProject).toBeInstanceOf(Project);
+      expect(currentProject?._id).toBe(PROJECT_Y_ID);
+      expect(currentProject?.name).toBe("Project Y");
+    });
+
+    test("the cached project is still readable after the tab is closed", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_Y_ID, "Project Y"));
+
+      closeTheTab();
+
+      expect(ProjectUtil.getCurrentProject()?._id).toBe(PROJECT_Y_ID);
+    });
+
+    test("does not clobber the remembered project when the payload has no id", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+
+      ProjectUtil.setCurrentProject({ name: "Project Y" });
+
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_Y_ID,
+      );
+    });
+
+    test("switching projects overwrites the previous one", () => {
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_Y_ID, "Project Y"));
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_X_ID, "Project X"));
+
+      expect(ProjectUtil.getLastAccessedProjectId()?.toString()).toBe(
+        PROJECT_X_ID,
+      );
+    });
+  });
+
+  describe("clearCurrentProject", () => {
+    test("forgets the project everywhere", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_Y_ID, "Project Y"));
+
+      setUrl("/dashboard");
+      ProjectUtil.clearCurrentProject();
+
+      expect(ProjectUtil.getLastAccessedProjectId()).toBeNull();
+      expect(ProjectUtil.getCurrentProjectId()).toBeNull();
+      expect(ProjectUtil.getCurrentProject()).toBeNull();
+    });
+
+    test("a deleted project is not reopened on the next visit", () => {
+      const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+      const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+
+      setUrl(`/dashboard/${PROJECT_Y_ID}/settings/danger-zone`);
+      ProjectUtil.setCurrentProject(projectY);
+
+      // The user deletes Project Y from the danger zone.
+      ProjectUtil.clearCurrentProject();
+      closeTheTab();
+
+      expect(ProjectUtil.getProjectToLoad([projectX])?._id).toBe(PROJECT_X_ID);
+    });
+
+    test("is safe to call when nothing is stored", () => {
+      expect(() => {
+        return ProjectUtil.clearCurrentProject();
+      }).not.toThrow();
+    });
+  });
+
+  describe("getCurrentProject", () => {
+    test("returns null when no project is known", () => {
+      expect(ProjectUtil.getCurrentProject()).toBeNull();
+    });
+
+    test("returns null when the id is known but nothing was cached", () => {
+      window.localStorage.setItem(
+        LAST_ACCESSED_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Y_ID,
+      );
+
+      expect(ProjectUtil.getCurrentProject()).toBeNull();
+    });
+
+    test("resolves the cached project through the last accessed id", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(buildProject(PROJECT_Y_ID, "Project Y"));
+
+      closeTheTab();
+
+      const currentProject: Project | null = ProjectUtil.getCurrentProject();
+
+      expect(currentProject?._id).toBe(PROJECT_Y_ID);
+      expect(currentProject?.name).toBe("Project Y");
+    });
+  });
+
+  describe("getProjectToSelect", () => {
+    const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+    const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+    const projectZ: Project = buildProject(PROJECT_Z_ID, "Project Z");
+    const projects: Array<Project> = [projectX, projectY, projectZ];
+
+    test("prefers the current project", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: projects,
+          currentProjectId: new ObjectID(PROJECT_Z_ID),
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        })?._id,
+      ).toBe(PROJECT_Z_ID);
+    });
+
+    test("falls back to the last accessed project", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: projects,
+          currentProjectId: null,
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("skips a current project the user no longer has access to", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [projectX, projectY],
+          currentProjectId: new ObjectID(PROJECT_Z_ID),
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("falls back to the first project when no candidate is accessible", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [projectX],
+          currentProjectId: new ObjectID(PROJECT_Z_ID),
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        })?._id,
+      ).toBe(PROJECT_X_ID);
+    });
+
+    test("falls back to the first project when there are no candidates", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: projects,
+        })?._id,
+      ).toBe(PROJECT_X_ID);
+    });
+
+    test("returns null when the user has no projects", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [],
+          currentProjectId: new ObjectID(PROJECT_Y_ID),
+          lastAccessedProjectId: new ObjectID(PROJECT_Z_ID),
+        }),
+      ).toBeNull();
+    });
+
+    test("returns the project object from the list, not a stale copy", () => {
+      const freshProjectY: Project = buildProject(
+        PROJECT_Y_ID,
+        "Project Y (renamed)",
+      );
+
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [projectX, freshProjectY],
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        })?.name,
+      ).toBe("Project Y (renamed)");
+    });
+
+    test("tolerates holes in the project list", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [
+            null as unknown as Project,
+            undefined as unknown as Project,
+            projectY,
+          ],
+          currentProjectId: null,
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("tolerates a project list that is entirely holes", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [null as unknown as Project],
+        }),
+      ).toBeNull();
+    });
+
+    test("tolerates a missing project list", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: undefined as unknown as Array<Project>,
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        }),
+      ).toBeNull();
+    });
+
+    test("ignores projects without an id", () => {
+      const projectWithoutId: Project = new Project();
+      projectWithoutId.name = "Broken";
+
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [projectWithoutId, projectY],
+          lastAccessedProjectId: new ObjectID(PROJECT_Y_ID),
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("never falls back to a project without an id", () => {
+      /*
+       * The dashboard routes by project id, so an id-less project would send
+       * the user to /dashboard/undefined.
+       */
+      const projectWithoutId: Project = new Project();
+      projectWithoutId.name = "Broken";
+
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [projectWithoutId, projectY],
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("returns null when no project has an id", () => {
+      expect(
+        ProjectUtil.getProjectToSelect({
+          projects: [new Project(), new Project()],
+        }),
+      ).toBeNull();
+    });
+  });
+
+  /*
+   * This is the decision the dashboard's project picker makes every time the
+   * list of projects the user has access to lands.
+   */
+  describe("getProjectToSelectOnProjectsLoaded", () => {
+    const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+    const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+    const projects: Array<Project> = [projectX, projectY];
+
+    test("opens the last accessed project when nothing is selected yet", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: null,
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("opens the first project when nothing is selected and nothing is remembered", () => {
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: null,
+        })?._id,
+      ).toBe(PROJECT_X_ID);
+    });
+
+    test("leaves an already selected project alone", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: projectX,
+        }),
+      ).toBeNull();
+    });
+
+    test("does not overrule a project the user just created", () => {
+      /*
+       * Creating a project selects it and appends it to the list, which
+       * re-triggers this decision. The remembered project must not win.
+       */
+      const newProject: Project = buildProject(PROJECT_Z_ID, "Brand New");
+      ProjectUtil.setLastAccessedProjectId(PROJECT_X_ID);
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: [...projects, newProject],
+          selectedProject: newProject,
+        }),
+      ).toBeNull();
+    });
+
+    test("corrects a selection the user no longer has access to", () => {
+      const removedProject: Project = buildProject(PROJECT_Z_ID, "Project Z");
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: removedProject,
+        })?._id,
+      ).toBe(PROJECT_X_ID);
+    });
+
+    test("matches the selection by id, not by object identity", () => {
+      const sameProjectDifferentInstance: Project = buildProject(
+        PROJECT_Y_ID,
+        "Project Y",
+      );
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: sameProjectDifferentInstance,
+        }),
+      ).toBeNull();
+    });
+
+    test("waits while the project list is still loading", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: [],
+          selectedProject: null,
+        }),
+      ).toBeNull();
+    });
+
+    test("does nothing for a user with no projects", () => {
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: [],
+          selectedProject: null,
+        }),
+      ).toBeNull();
+    });
+
+    test("does not treat an id-less selection as a match", () => {
+      const projectWithoutId: Project = new Project();
+      projectWithoutId.name = "Half loaded";
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: [new Project(), projectY],
+          selectedProject: projectWithoutId,
+        })?._id,
+      ).toBe(PROJECT_Y_ID);
+    });
+
+    test("settles after one pass - the picked project is then left alone", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      const firstPass: Project | null =
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: null,
+        });
+
+      expect(firstPass?._id).toBe(PROJECT_Y_ID);
+
+      expect(
+        ProjectUtil.getProjectToSelectOnProjectsLoaded({
+          projects: projects,
+          selectedProject: firstPass,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("getProjectToLoad", () => {
+    const projectX: Project = buildProject(PROJECT_X_ID, "Project X");
+    const projectY: Project = buildProject(PROJECT_Y_ID, "Project Y");
+    const projects: Array<Project> = [projectX, projectY];
+
+    test("loads the project in the URL", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_X_ID);
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+
+      expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_Y_ID);
+    });
+
+    test("loads this tab's project when the route has no project id", () => {
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        PROJECT_Y_ID,
+      );
+      ProjectUtil.setLastAccessedProjectId(PROJECT_X_ID);
+
+      expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_Y_ID);
+    });
+
+    test("loads the last accessed project on a fresh session", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_Y_ID);
+    });
+
+    test("loads the first project for a brand new user", () => {
+      expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_X_ID);
+    });
+
+    test("returns null while the project list is still loading", () => {
+      ProjectUtil.setLastAccessedProjectId(PROJECT_Y_ID);
+
+      expect(ProjectUtil.getProjectToLoad([])).toBeNull();
+    });
+
+    test("does not resurrect another user's project after a logout", () => {
+      setUrl(`/dashboard/${PROJECT_Y_ID}/home`);
+      ProjectUtil.setCurrentProject(projectY);
+
+      // Logout clears all of local and session storage.
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+      setUrl("/dashboard");
+
+      expect(ProjectUtil.getLastAccessedProjectId()).toBeNull();
+      expect(ProjectUtil.getProjectToLoad(projects)?._id).toBe(PROJECT_X_ID);
+    });
+  });
+});

--- a/Common/UI/Utils/Project.ts
+++ b/Common/UI/Utils/Project.ts
@@ -4,7 +4,7 @@ import BaseModel from "../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBas
 import SubscriptionPlan, {
   PlanType,
 } from "../../Types/Billing/SubscriptionPlan";
-import { JSONObject } from "../../Types/JSON";
+import { JSONObject, JSONValue } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
 import Project from "../../Models/DatabaseModels/Project";
 import SubscriptionStatus, {
@@ -14,29 +14,193 @@ import Navigation from "./Navigation";
 import SessionStorage from "./SessionStorage";
 import Telemetry from "./Telemetry/Telemetry";
 
+/**
+ * Session storage key that pins a browser tab to the project it is showing.
+ * Session storage (and not local storage) so two tabs can show two different
+ * projects at the same time.
+ */
+export const CURRENT_PROJECT_ID_STORAGE_KEY: string = "current_project_id";
+
+/**
+ * Local storage key that remembers the last project the user opened on this
+ * browser. Unlike {@link CURRENT_PROJECT_ID_STORAGE_KEY} this survives closing
+ * the tab, which is what makes the dashboard reopen on the project the user
+ * left off on instead of always falling back to the first project.
+ */
+export const LAST_ACCESSED_PROJECT_ID_STORAGE_KEY: string =
+  "last_accessed_project_id";
+
 export default class ProjectUtil {
+  /**
+   * The project the user is currently looking at, resolved in priority order:
+   *
+   * 1. `/dashboard/:projectId/...` in the URL - the page the user actually
+   *    opened, so a deep link always wins over anything we have cached.
+   * 2. `current_project_id` in session storage - keeps this tab on the project
+   *    it was already showing while the user moves around routes that do not
+   *    carry a project id (e.g. `/dashboard`).
+   * 3. `last_accessed_project_id` in local storage - the project this user last
+   *    opened on this browser, so closing the tab and coming back to
+   *    `/dashboard` reopens that project rather than the first one.
+   */
   public static getCurrentProjectId(): ObjectID | null {
-    // if this is not available in the url, check the session storage
-    const currentProjectId: string | undefined = SessionStorage.getItem(
-      `current_project_id`,
-    ) as string;
+    const projectIdInUrl: ObjectID | null = this.getProjectIdFromUrl();
 
-    if (currentProjectId && ObjectID.isValidUUID(currentProjectId)) {
-      return new ObjectID(currentProjectId);
+    if (projectIdInUrl) {
+      return projectIdInUrl;
     }
 
-    let projectId: string | undefined = Navigation.getFirstParam(2);
+    const projectIdInSession: ObjectID | null = this.toProjectId(
+      SessionStorage.getItem(CURRENT_PROJECT_ID_STORAGE_KEY),
+    );
 
-    if (projectId && projectId.includes(":projectId")) {
-      projectId = undefined;
+    if (projectIdInSession) {
+      return projectIdInSession;
     }
 
-    // Only return the projectId if it's a valid UUID
-    if (projectId && ObjectID.isValidUUID(projectId)) {
-      return new ObjectID(projectId);
+    return this.getLastAccessedProjectId();
+  }
+
+  /**
+   * The project id in the current URL, if the user is on a project scoped route
+   * like `/dashboard/:projectId/...`. Returns null on routes that carry no
+   * project id (`/dashboard`, `/dashboard/welcome`, ...).
+   */
+  public static getProjectIdFromUrl(): ObjectID | null {
+    const projectId: string | undefined = Navigation.getFirstParam(2);
+
+    if (!projectId || projectId.includes(":projectId")) {
+      return null;
     }
 
-    return null;
+    return this.toProjectId(projectId);
+  }
+
+  /**
+   * The last project this user opened on this browser. Persisted in local
+   * storage so it outlives the tab. It is cleared on logout (which clears all
+   * of local storage) and when the project is deleted.
+   */
+  public static getLastAccessedProjectId(): ObjectID | null {
+    return this.toProjectId(
+      LocalStorage.getItem(LAST_ACCESSED_PROJECT_ID_STORAGE_KEY),
+    );
+  }
+
+  public static setLastAccessedProjectId(
+    projectId: ObjectID | string | null | undefined,
+  ): void {
+    const id: ObjectID | null = this.toProjectId(projectId);
+
+    if (!id) {
+      // Never persist junk - an unusable value would only shadow the fallbacks.
+      this.clearLastAccessedProjectId();
+      return;
+    }
+
+    LocalStorage.setItem(LAST_ACCESSED_PROJECT_ID_STORAGE_KEY, id.toString());
+  }
+
+  public static clearLastAccessedProjectId(): void {
+    LocalStorage.removeItem(LAST_ACCESSED_PROJECT_ID_STORAGE_KEY);
+  }
+
+  /**
+   * Picks the project the dashboard should load out of the projects the user
+   * has access to.
+   *
+   * Candidates are tried in order - current project (URL / this tab), then the
+   * last project opened on this browser, then the first project the user has
+   * access to. A candidate that is not in `projects` is skipped, because the
+   * user may have left, lost access to, or deleted it since.
+   */
+  public static getProjectToSelect(data: {
+    projects: Array<Project>;
+    currentProjectId?: ObjectID | null | undefined;
+    lastAccessedProjectId?: ObjectID | null | undefined;
+  }): Project | null {
+    const projects: Array<Project> = this.getSelectableProjects(data.projects);
+
+    const candidateIds: Array<ObjectID | null | undefined> = [
+      data.currentProjectId,
+      data.lastAccessedProjectId,
+    ];
+
+    for (const candidateId of candidateIds) {
+      if (!candidateId) {
+        continue;
+      }
+
+      const project: Project | undefined = projects.find((project: Project) => {
+        return project._id?.toString() === candidateId.toString();
+      });
+
+      if (project) {
+        return project;
+      }
+    }
+
+    return projects[0] || null;
+  }
+
+  /**
+   * {@link getProjectToSelect} with the candidates read off storage / the URL.
+   */
+  public static getProjectToLoad(projects: Array<Project>): Project | null {
+    return this.getProjectToSelect({
+      projects: projects,
+      currentProjectId: this.getCurrentProjectId(),
+      lastAccessedProjectId: this.getLastAccessedProjectId(),
+    });
+  }
+
+  /**
+   * The project the dashboard should switch to now that the list of projects
+   * the user has access to has (re)loaded, or null when whatever is already
+   * selected should stand.
+   *
+   * A selection is left alone as long as the user still has access to it -
+   * otherwise a project the user just picked (or just created) would be
+   * overruled by whatever we happened to have remembered.
+   */
+  public static getProjectToSelectOnProjectsLoaded(data: {
+    projects: Array<Project>;
+    selectedProject?: Project | null | undefined;
+  }): Project | null {
+    const projects: Array<Project> = this.getSelectableProjects(data.projects);
+
+    if (projects.length === 0) {
+      // Nothing to select yet - the list is still loading, or the user has no projects.
+      return null;
+    }
+
+    const selectedProjectId: string | undefined =
+      data.selectedProject?._id?.toString();
+
+    const isSelectionStillAccessible: boolean = Boolean(
+      selectedProjectId &&
+        projects.some((project: Project) => {
+          return project._id?.toString() === selectedProjectId;
+        }),
+    );
+
+    if (isSelectionStillAccessible) {
+      return null;
+    }
+
+    return this.getProjectToLoad(projects);
+  }
+
+  /**
+   * The projects that can actually be opened - a project without an id cannot
+   * be navigated to (`/dashboard/undefined`), so it is never a candidate.
+   */
+  private static getSelectableProjects(
+    projects: Array<Project> | null | undefined,
+  ): Array<Project> {
+    return (projects || []).filter((project: Project) => {
+      return Boolean(project?._id);
+    });
   }
 
   public static setIsSubscriptionInactiveOrOverdue(data: {
@@ -91,12 +255,19 @@ export default class ProjectUtil {
   public static getCurrentProject(): Project | null {
     const currentProjectId: string | undefined =
       this.getCurrentProjectId()?.toString();
-    if (!LocalStorage.getItem(`project_${currentProjectId}`)) {
+
+    if (!currentProjectId) {
       return null;
     }
+
     const projectJson: JSONObject = LocalStorage.getItem(
       `project_${currentProjectId}`,
     ) as JSONObject;
+
+    if (!projectJson) {
+      return null;
+    }
+
     return BaseModel.fromJSON(projectJson, Project) as Project;
   }
 
@@ -107,7 +278,10 @@ export default class ProjectUtil {
       project = BaseModel.toJSON(project, Project);
     }
     LocalStorage.setItem(`project_${currentProjectId}`, project);
-    SessionStorage.setItem(`current_project_id`, currentProjectId);
+    SessionStorage.setItem(CURRENT_PROJECT_ID_STORAGE_KEY, currentProjectId);
+
+    // Remember this project for the next time the user opens the dashboard.
+    this.setLastAccessedProjectId(currentProjectId);
 
     // Keep RUM span context in sync with the project being viewed.
     if (currentProjectId) {
@@ -118,8 +292,18 @@ export default class ProjectUtil {
   public static clearCurrentProject(): void {
     const currentProjectId: string | undefined =
       this.getCurrentProjectId()?.toString();
-    LocalStorage.setItem(`project_${currentProjectId}`, null);
-    SessionStorage.setItem(`current_project_id`, null);
+
+    if (currentProjectId) {
+      LocalStorage.removeItem(`project_${currentProjectId}`);
+    }
+
+    SessionStorage.removeItem(CURRENT_PROJECT_ID_STORAGE_KEY);
+
+    /*
+     * The project is gone (or the user is leaving it), so it must not be
+     * reopened the next time the dashboard loads.
+     */
+    this.clearLastAccessedProjectId();
   }
 
   public static getCurrentPlan(): PlanType | null {
@@ -136,5 +320,17 @@ export default class ProjectUtil {
       project.paymentProviderPlanId,
       getAllEnvVars(),
     );
+  }
+
+  private static toProjectId(
+    value: JSONValue | ObjectID | string | null | undefined,
+  ): ObjectID | null {
+    const id: string | undefined = value?.toString();
+
+    if (id && ObjectID.isValidUUID(id)) {
+      return new ObjectID(id);
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
## The bug

A user who belongs to several projects works in **Project Y**, closes the dashboard, and comes back to `/dashboard` — and lands in whichever project happens to sort first in their list, not Y.

The cause: the only record of "the project I'm on" was `current_project_id` in **session storage**, which the browser throws away when the tab closes. On a fresh session `ProjectUtil.getCurrentProjectId()` returned `null`, `getCurrentProject()` returned `null` (it is keyed off that same id), and the picker fell through to `props.projects[0]`.

## The fix

`ProjectUtil.setCurrentProject()` now also writes `last_accessed_project_id` to **local storage**, which survives closing the tab. Resolution of "which project do we open" moves into one documented place with this priority:

```
URL  >  this tab's session  >  last project opened on this browser  >  first project
```

Session storage still comes *before* the remembered project, so two tabs can stay on two different projects — the per-tab behaviour is unchanged.

The remembered project is only honoured while the user still has access to it. It is cleared on logout (which wipes local storage) and by `clearCurrentProject()` when a project is deleted, so a deleted project is never reopened.

## Two related fixes that fall out of this

- **The URL now wins over session storage** — which is what `getCurrentProjectId`'s own comment always claimed (`// if this is not available in the url, check the session storage`) while the code did the opposite. Previously, opening a deep link into another project (an alert email, say) in a tab that already had a project selected would redirect the user back to that other project.
- **The picker re-checks its selection when the project list (re)loads.** The old code was gated on `!props.selectedProject`, so a cached project the user had since been removed from stuck permanently. It now corrects itself, while still leaving alone any project the user explicitly picked or just created.

## Changes

| File | What |
| --- | --- |
| `Common/UI/Utils/Project.ts` | Persist + read `last_accessed_project_id`; URL-first precedence; new `getProjectToSelect` / `getProjectToLoad` / `getProjectToSelectOnProjectsLoaded`; clear the remembered project on delete |
| `App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker.tsx` | Delegate the selection decision to `ProjectUtil` (net −46 lines) |
| `Common/Tests/UI/Utils/Project.test.ts` | New — 71 tests |

## Tests

71 new tests in `Common/Tests/UI/Utils/Project.test.ts`, covering the reported scenario end to end (work in Y → clear session storage → reopen `/dashboard` → Y), the full precedence table, URL parsing (nested routes, query strings, `/dashboard/welcome`, unpopulated `:projectId` templates, non-UUIDs), storage round-tripping and rejection of junk values, `setCurrentProject` / `clearCurrentProject`, and the selection rules (project the user lost access to, project just created, id-less projects, empty and partially-loaded lists, logout).

```
Tests:       71 passed, 71 total
```

I sanity-checked the tests by mutation: reverting each part of the fix in turn (the local-storage write, the local-storage fallback, the URL-first ordering, the re-selection guard) turns 8 / 4 / 2 / 4 of them red respectively.

Also run: `Common/Tests/UI/Utils` (825 passed), `npx tsc --noEmit` on `Common`, `App/FeatureSet/Dashboard` and `App/FeatureSet/AdminDashboard`, plus `npm run fix`.

**Not verified in a running browser** — the change needs a live stack and a user in two or more projects, and the local docker-compose stack was not up in this environment.