### PR TITLE
fix(cost-agent): make /healthz report a stalled pipeline instead of ok

### DIFF
--- a/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
@@ -81,13 +81,20 @@ spec:
             - name: health
               containerPort: 13134
               protocol: TCP
+          # Liveness asks only "is the process up?" (/livez), because the
+          # things /healthz reports — an engine that will not answer, a
+          # window that never lands — are not fixed by a restart, and a
+          # restart loop would hide the diagnostic /healthz is carrying.
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: health
             initialDelaySeconds: 15
             periodSeconds: 30
             timeoutSeconds: 5
+          # Readiness carries the real verdict: /healthz answers 503 once the
+          # cost pipeline has demonstrably stalled, so the pod goes 0/1 Ready
+          # instead of staying green while nothing ships.
           readinessProbe:
             httpGet:
               path: /healthz

--- a/HelmChart/Public/kubernetes-agent/troubleshoot.sh
+++ b/HelmChart/Public/kubernetes-agent/troubleshoot.sh
@@ -582,8 +582,10 @@ section "9. Cost pipeline"
 #     dozen healthy ones sat in ImagePullBackOff, and
 #   * the poller sent a millisecond-precision `window` bound, which both engines
 #     reject with `400 ... illegal window`. It retries the next window forever
-#     and reports that ONLY on its own /healthz — which still answers 200,
-#     because the shipper, never handed a row, has nothing to complain about.
+#     and reports that ONLY on its own /healthz — which, on agent images before
+#     the honest-health fix, still answered 200, because the shipper, never
+#     handed a row, had nothing to complain about. Current agents fail
+#     readiness for this; the error fields are the signal on either image.
 COST_ENABLED=0        # 1 once a cost-agent Deployment is found
 COST_OK=1             # flips to 0 on the first cost-specific failure
 COST_BUNDLED=0        # 1 = chart's own OpenCost, 0 = external cost.engine.url
@@ -767,7 +769,7 @@ else
       COST_SHIP_ERR=$(printf '%s' "$RESP_BODY" | sed -n 's/.*"lastShipError":"\([^"]*\)".*/\1/p' | head -1)
       info "cost-agent /healthz → HTTP $RESP_CODE (status=${COST_STATUS:-?})"
       [ "$RESP_CODE" = "200" ] && \
-        detail "A 200 here does NOT mean cost data is flowing: the status code tracks the SHIPPER, which reports healthy until it has actually failed — and a poller that never gets a window past the engine hands it nothing to fail on. The two error fields below are the real signal."
+        detail "Current agents answer 503 here once the pipeline has demonstrably stalled, so a 200 carries real information — but it is NOT proof on older agent images, whose 200 tracked only the SHIPPER and stayed green when the poller never got a window past the engine. The two error fields below are the real signal on either image."
       if [ -n "$COST_POLL_ERR" ]; then
         fail "Poller's last error: $COST_POLL_ERR"
         COST_OK=0

--- a/KubernetesCostAgent/Config.ts
+++ b/KubernetesCostAgent/Config.ts
@@ -93,4 +93,38 @@ export const HEALTH_PORT: number = parseInt(
   10,
 );
 
+/*
+ * Health thresholds.
+ *
+ * /healthz has to separate "quiet because there is nothing to do yet" from
+ * "quiet because the pipeline is broken". A cost agent is quiet for long
+ * stretches by design — it ships once an hour — and on a fresh install the
+ * LOOKBACK_WINDOWS windows it re-ships predate the engine, so they
+ * legitimately come back empty. Both thresholds below therefore run off
+ * "time since the process started" and are generous by default; the fast
+ * signal is HEALTH_MAX_POLL_FAILURES, which needs real errors, not silence.
+ */
+
+/*
+ * Consecutive failing ticks before the agent reports degraded. At the
+ * default POLL_INTERVAL_SECONDS that is ~15 minutes of an unreachable or
+ * erroring cost engine — well past any engine's own startup. If you shorten
+ * POLL_INTERVAL_SECONDS substantially, raise this to keep the same
+ * wall-clock patience.
+ */
+export const HEALTH_MAX_POLL_FAILURES: number = parseInt(
+  optional("HEALTH_MAX_POLL_FAILURES", "3"),
+  10,
+);
+
+/*
+ * Windows of silence tolerated before the agent reports degraded. A window
+ * completes roughly every WINDOW_SECONDS, so the default leaves two whole
+ * windows of slack; anything below 2 will flap.
+ */
+export const HEALTH_STALE_WINDOWS: number = parseInt(
+  optional("HEALTH_STALE_WINDOWS", "3"),
+  10,
+);
+
 export const LOG_LEVEL: string = optional("LOG_LEVEL", "info");

--- a/KubernetesCostAgent/Health.ts
+++ b/KubernetesCostAgent/Health.ts
@@ -1,9 +1,146 @@
 import * as http from "http";
-import { HEALTH_PORT } from "./Config";
+import {
+  HEALTH_MAX_POLL_FAILURES,
+  HEALTH_PORT,
+  HEALTH_STALE_WINDOWS,
+  LOOKBACK_WINDOWS,
+  WINDOW_SECONDS,
+} from "./Config";
 import Logger from "./Logger";
 import { Poller } from "./Poller";
 import { Shipper } from "./Shipper";
+import { HealthReport, PollerStatus, ShipperStatus } from "./Types";
 
+/*
+ * Is the cost pipeline actually working?
+ *
+ * The honest answer needs the poller and the shipper together. Asking the
+ * shipper alone is how a real outage stayed invisible: the bundled OpenCost
+ * could not write /var/configs, its Allocation API never answered, the
+ * poller retried the same window forever (by design — see Poller.tick), and
+ * because a failed fetch never reaches the shipper, the shipper had nothing
+ * to complain about. /healthz answered 200 the whole time and the pod
+ * stayed Ready.
+ *
+ * The three signals below are ordered fast-to-slow. Only the first is a
+ * quick trigger, and it needs real consecutive errors — silence alone is
+ * never enough to fail an agent, because a healthy cost agent is silent
+ * most of the time:
+ *
+ *   1. The poll has thrown HEALTH_MAX_POLL_FAILURES ticks in a row. This is
+ *      the reported outage, caught in ~15 minutes at the defaults.
+ *   2. No window has completed in HEALTH_STALE_WINDOWS windows. Catches a
+ *      stall that is not throwing — a wedged timer, a starved event loop,
+ *      settle/clock math that never lets a window come due.
+ *   3. Nothing has ever shipped, well past the point where something should
+ *      have. Catches the engine that answers 200 with an empty allocation
+ *      set forever: windows drain, signal 2 stays happy, no data lands.
+ *
+ * Signals 2 and 3 are measured from process start, which IS the grace
+ * period: a freshly started agent waiting for its first closed hourly
+ * window trips neither. Signal 3's grace additionally clears LOOKBACK_WINDOWS,
+ * because on a fresh install those windows predate the cost engine and
+ * legitimately come back empty — "no rows yet" is the expected state for
+ * the first few windows of every install, so it must never be the thing
+ * that trips first.
+ */
+
+const minutesSince: (fromMs: number, nowMs: number) => number = (
+  fromMs: number,
+  nowMs: number,
+): number => {
+  return Math.max(0, Math.round((nowMs - fromMs) / 60000));
+};
+
+export const assessHealth: (args: {
+  poller: PollerStatus;
+  shipper: ShipperStatus;
+  nowMs: number;
+}) => HealthReport = (args: {
+  poller: PollerStatus;
+  shipper: ShipperStatus;
+  nowMs: number;
+}): HealthReport => {
+  const windowMs: number = WINDOW_SECONDS * 1000;
+  const staleMs: number = HEALTH_STALE_WINDOWS * windowMs;
+  const firstShipGraceMs: number =
+    (LOOKBACK_WINDOWS + HEALTH_STALE_WINDOWS) * windowMs;
+
+  const upForMs: number = Math.max(0, args.nowMs - args.poller.startedAtMs);
+  const reasons: Array<string> = [];
+
+  // 1. The poll loop is erroring every tick.
+  if (args.poller.consecutivePollFailures >= HEALTH_MAX_POLL_FAILURES) {
+    reasons.push(
+      `the cost engine poll has failed ${args.poller.consecutivePollFailures} consecutive ticks (last error: ${args.poller.lastPollError || "unknown"})`,
+    );
+  }
+
+  /*
+   * 2. Progress has stalled. A ship counts as progress on its own so a
+   * mid-window success is not overlooked, though in practice the window
+   * that contained it completes moments later.
+   */
+  const lastProgressMs: number = Math.max(
+    args.poller.lastWindowCompletedAtMs,
+    args.shipper.lastShipOkAtMs,
+  );
+  if (lastProgressMs === 0) {
+    if (upForMs > staleMs) {
+      reasons.push(
+        `no cost window has completed in the ${minutesSince(args.poller.startedAtMs, args.nowMs)} minutes since startup`,
+      );
+    }
+  } else if (args.nowMs - lastProgressMs > staleMs) {
+    reasons.push(
+      `the last cost window completed ${minutesSince(lastProgressMs, args.nowMs)} minutes ago`,
+    );
+  }
+
+  // 3. Windows are draining but no data has ever reached OneUptime.
+  if (args.shipper.lastShipOkAtMs === 0 && upForMs > firstShipGraceMs) {
+    /*
+     * Name the likely culprit, but only one the facts support: an engine
+     * answering with nothing is a different fault from a poll that never
+     * got that far, and when the poll is the broken part the reasons above
+     * already say so.
+     */
+    let detail: string = "";
+    if (args.shipper.lastShipError) {
+      detail = ` (last ship error: ${args.shipper.lastShipError})`;
+    } else if (args.poller.windowsCompleted > 0) {
+      detail = ` (the engine answered ${args.poller.windowsCompleted} windows, all with no allocations)`;
+    }
+
+    reasons.push(
+      `no cost allocations have ever shipped in the ${minutesSince(args.poller.startedAtMs, args.nowMs)} minutes since startup${detail}`,
+    );
+  }
+
+  return {
+    healthy: reasons.length === 0,
+    status: reasons.length === 0 ? "ok" : "degraded",
+    reasons,
+    lastPollError: args.poller.lastPollError,
+    lastShipError: args.shipper.lastShipError,
+    windowsCompleted: args.poller.windowsCompleted,
+    uptimeSeconds: Math.round(upForMs / 1000),
+  };
+};
+
+/*
+ * Two routes, deliberately:
+ *
+ *   /healthz (and /) — readiness. Degraded answers 503, so a pod whose cost
+ *     pipeline is dead reads 0/1 Ready instead of silently green.
+ *   /livez — liveness. 200 for as long as the process is up, because
+ *     restarting the agent cannot fix an engine that is down, and a restart
+ *     loop would both hide the diagnostic in /healthz and lose the poller's
+ *     in-memory checkpoint every time.
+ *
+ * The JSON keys status / lastPollError / lastShipError are parsed by the
+ * chart's troubleshoot.sh — keep them.
+ */
 export const startHealthServer: (args: {
   poller: Poller;
   shipper: Shipper;
@@ -13,19 +150,25 @@ export const startHealthServer: (args: {
 }): http.Server => {
   const server: http.Server = http.createServer(
     (req: http.IncomingMessage, res: http.ServerResponse): void => {
-      if (req.url === "/" || req.url === "/healthz") {
-        const healthy: boolean = args.shipper.healthy();
-        const body: Record<string, unknown> = {
-          status: healthy ? "ok" : "degraded",
-          lastPollError: args.poller.lastError(),
-          lastShipError: args.shipper.lastError(),
-        };
-        res.writeHead(healthy ? 200 : 503, {
-          "Content-Type": "application/json",
-        });
-        res.end(JSON.stringify(body));
+      if (req.url === "/livez") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "alive" }));
         return;
       }
+
+      if (req.url === "/" || req.url === "/healthz") {
+        const report: HealthReport = assessHealth({
+          poller: args.poller.status(),
+          shipper: args.shipper.status(),
+          nowMs: Date.now(),
+        });
+        res.writeHead(report.healthy ? 200 : 503, {
+          "Content-Type": "application/json",
+        });
+        res.end(JSON.stringify(report));
+        return;
+      }
+
       res.writeHead(404);
       res.end();
     },

--- a/KubernetesCostAgent/Poller.ts
+++ b/KubernetesCostAgent/Poller.ts
@@ -8,7 +8,11 @@ import { floorToWindow, mapAllocationToRow } from "./AllocationMapper";
 import { CostEngineClient } from "./CostEngineClient";
 import Logger from "./Logger";
 import { Shipper } from "./Shipper";
-import { EngineAllocation, KubernetesCostAllocationIngestRow } from "./Types";
+import {
+  EngineAllocation,
+  KubernetesCostAllocationIngestRow,
+  PollerStatus,
+} from "./Types";
 
 export class Poller {
   private readonly engine: CostEngineClient;
@@ -28,6 +32,19 @@ export class Poller {
   private stopped: boolean = false;
   private lastPollErr: string | null = null;
 
+  /*
+   * Progress bookkeeping for /healthz. A window that drained counts even
+   * when the engine reported no allocations: an empty window is a round
+   * trip the engine answered, which is exactly what a stalled agent cannot
+   * do. Shipping is tracked separately by the Shipper, because an engine
+   * that answers 200 with nothing, forever, drains windows happily and
+   * still never delivers a row.
+   */
+  private readonly startedAtMs: number = Date.now();
+  private lastWindowCompletedAtMs: number = 0;
+  private windowsCompleted: number = 0;
+  private consecutivePollFailures: number = 0;
+
   public constructor(engine: CostEngineClient, shipper: Shipper) {
     this.engine = engine;
     this.shipper = shipper;
@@ -41,6 +58,16 @@ export class Poller {
 
   public lastError(): string | null {
     return this.lastPollErr;
+  }
+
+  public status(): PollerStatus {
+    return {
+      startedAtMs: this.startedAtMs,
+      lastWindowCompletedAtMs: this.lastWindowCompletedAtMs,
+      windowsCompleted: this.windowsCompleted,
+      consecutivePollFailures: this.consecutivePollFailures,
+      lastPollError: this.lastPollErr,
+    };
   }
 
   public start(): void {
@@ -124,12 +151,24 @@ export class Poller {
 
         this.checkpointMs = windowEndMs;
         this.lastPollErr = null;
+        this.lastWindowCompletedAtMs = Date.now();
+        this.windowsCompleted++;
       }
+
+      /*
+       * The tick ran end to end. That includes the do-nothing tick where no
+       * window is closed yet — which is only reachable once the backlog is
+       * drained, so it is genuine progress, not silence: a broken engine
+       * pins the checkpoint in the past and every tick has work that throws.
+       */
+      this.consecutivePollFailures = 0;
     } catch (err: unknown) {
       const message: string = err instanceof Error ? err.message : String(err);
       this.lastPollErr = message;
+      this.consecutivePollFailures++;
       Logger.error("cost poll failed; will retry next tick", {
         error: message,
+        consecutiveFailures: this.consecutivePollFailures,
       });
     } finally {
       this.running = false;

--- a/KubernetesCostAgent/README.md
+++ b/KubernetesCostAgent/README.md
@@ -11,6 +11,15 @@ OneUptime stores the allocations in ClickHouse (`KubernetesCostAllocation`) and 
 3. The allocations are mapped to OneUptime's ingest rows (cost components include the engine's reconciliation adjustments) and POSTed to `{ONEUPTIME_URL}/kubernetes-cost/ingest`, chunked at `SHIP_BATCH_SIZE` rows, authenticated with the `x-oneuptime-token` header.
 4. Windows ship strictly in order; the checkpoint only advances when a window fully lands, so a failed ship is retried on the next tick. On restart the agent re-ships the last `LOOKBACK_WINDOWS` closed windows — the server skips windows that already have rows, so this cannot double-count.
 
+## Health
+
+Two endpoints on `HEALTH_PORT`, and the split matters:
+
+- **`/healthz`** (also `/`) — readiness. `200 {"status":"ok"}` while the pipeline is working, `503 {"status":"degraded", "reasons": [...]}` once it demonstrably is not, so the pod reads `0/1 Ready` instead of staying green while nothing ships. Degraded means any of: the poll has thrown `HEALTH_MAX_POLL_FAILURES` ticks in a row; no window has completed in `HEALTH_STALE_WINDOWS` windows; or nothing has ever shipped well past the point something should have.
+- **`/livez`** — liveness. `200` for as long as the process is up. Restarting cannot fix a cost engine that is down, and a restart loop would throw away both the poller's in-memory checkpoint and the diagnostic `/healthz` is carrying.
+
+Silence alone never fails the agent. A healthy cost agent is idle most of the time, and on a fresh install the `LOOKBACK_WINDOWS` windows it re-ships predate the engine and legitimately come back empty — so the "nothing shipped yet" signal only counts once that grace has passed, and the fast signal needs real, repeated errors.
+
 ## Configuration
 
 | Env var | Required | Default | Description |
@@ -28,7 +37,9 @@ OneUptime stores the allocations in ClickHouse (`KubernetesCostAllocation`) and 
 | `SHIP_BATCH_SIZE` | no | `1000` | Rows per ingest POST (server cap: 5000) |
 | `EXPORT_MAX_RETRIES` | no | `5` | Retries per POST before the window is retried next tick |
 | `COST_CURRENCY` | no | `USD` | Currency code forwarded with every payload |
-| `HEALTH_PORT` | no | `13134` | `/healthz` liveness port |
+| `HEALTH_PORT` | no | `13134` | Port serving `/healthz` and `/livez` |
+| `HEALTH_MAX_POLL_FAILURES` | no | `3` | Consecutive failing ticks before `/healthz` reports degraded |
+| `HEALTH_STALE_WINDOWS` | no | `3` | Windows without a completed window before `/healthz` reports degraded |
 | `LOG_LEVEL` | no | `info` | `debug` / `info` / `warn` / `error` |
 
 ## Deployment

--- a/KubernetesCostAgent/Shipper.ts
+++ b/KubernetesCostAgent/Shipper.ts
@@ -12,6 +12,7 @@ import Logger from "./Logger";
 import {
   KubernetesCostAllocationIngestRow,
   KubernetesCostIngestPayload,
+  ShipperStatus,
 } from "./Types";
 
 const sleep: (ms: number) => Promise<void> = (ms: number): Promise<void> => {
@@ -36,12 +37,19 @@ export class Shipper {
   private lastShipOk: number = 0;
   private lastShipErr: string | null = null;
 
-  public healthy(): boolean {
-    if (this.lastShipOk === 0 && this.lastShipErr === null) {
-      return true;
-    }
-    // Healthy if the last successful ship was within 3 poll windows (~3h).
-    return Date.now() - this.lastShipOk < 3 * 60 * 60 * 1000;
+  /*
+   * Facts only — no verdict. The shipper cannot tell healthy from broken on
+   * its own: it is only ever handed rows the poller managed to fetch, so an
+   * agent whose engine never answers leaves it untouched and, until this
+   * became Health.ts's call, spotless. Health.ts reads this alongside the
+   * poller's status, where "never shipped" and "never polled" are visible
+   * together.
+   */
+  public status(): ShipperStatus {
+    return {
+      lastShipOkAtMs: this.lastShipOk,
+      lastShipError: this.lastShipErr,
+    };
   }
 
   public lastError(): string | null {

--- a/KubernetesCostAgent/Tests/Health.test.ts
+++ b/KubernetesCostAgent/Tests/Health.test.ts
@@ -1,0 +1,357 @@
+import { HEALTH_PORT } from "./TestEnv";
+import * as assert from "assert";
+import * as http from "http";
+import { after, before, test } from "node:test";
+import { assessHealth, startHealthServer } from "../Health";
+import { Poller } from "../Poller";
+import { Shipper } from "../Shipper";
+import { HealthReport, PollerStatus, ShipperStatus } from "../Types";
+
+/*
+ * The health verdict. assessHealth is pure — statuses in, verdict out — so
+ * every case here is exact arithmetic rather than a slept-through clock.
+ *
+ * TestEnv pins WINDOW_SECONDS=60 and LOOKBACK_WINDOWS=2, and the health
+ * thresholds are left at their defaults (HEALTH_STALE_WINDOWS=3,
+ * HEALTH_MAX_POLL_FAILURES=3), so:
+ *
+ *   stale     = 3 windows = 3 minutes of no completed window
+ *   ship grace= (2 + 3) windows = 5 minutes before "never shipped" counts
+ */
+
+const NOW: number = Date.parse("2026-07-24T12:00:00.000Z");
+const WINDOW_MS: number = 60 * 1000;
+const STALE_MS: number = 3 * WINDOW_MS;
+const FIRST_SHIP_GRACE_MS: number = 5 * WINDOW_MS;
+
+function pollerStatus(overrides: Partial<PollerStatus> = {}): PollerStatus {
+  return {
+    startedAtMs: NOW,
+    lastWindowCompletedAtMs: 0,
+    windowsCompleted: 0,
+    consecutivePollFailures: 0,
+    lastPollError: null,
+    ...overrides,
+  };
+}
+
+function shipperStatus(overrides: Partial<ShipperStatus> = {}): ShipperStatus {
+  return { lastShipOkAtMs: 0, lastShipError: null, ...overrides };
+}
+
+function assess(
+  poller: Partial<PollerStatus>,
+  shipper: Partial<ShipperStatus> = {},
+): HealthReport {
+  return assessHealth({
+    poller: pollerStatus(poller),
+    shipper: shipperStatus(shipper),
+    nowMs: NOW,
+  });
+}
+
+// -- The grace period: silence right after boot is not a fault --------------
+
+test("a just-started agent waiting for its first closed window is ok", (): void => {
+  // Nothing polled, nothing shipped, no errors — the normal first seconds.
+  const report: HealthReport = assess({ startedAtMs: NOW - 5 * 1000 });
+
+  assert.strictEqual(report.healthy, true);
+  assert.strictEqual(report.status, "ok");
+  assert.deepStrictEqual(report.reasons, []);
+});
+
+test("empty lookback windows on a fresh install do not trip the never-shipped check", (): void => {
+  /*
+   * The boot-time shape this must tolerate: on a fresh install the
+   * LOOKBACK_WINDOWS windows predate the cost engine, so they drain with
+   * zero allocations and nothing ships. That is healthy until well past
+   * the point a real window should have landed.
+   */
+  const report: HealthReport = assess(
+    {
+      startedAtMs: NOW - (FIRST_SHIP_GRACE_MS - 1000),
+      lastWindowCompletedAtMs: NOW - 1000,
+      windowsCompleted: 2,
+    },
+    { lastShipOkAtMs: 0 },
+  );
+
+  assert.strictEqual(report.healthy, true);
+  assert.deepStrictEqual(report.reasons, []);
+});
+
+test("one failing tick is not yet a fault", (): void => {
+  const report: HealthReport = assess({
+    startedAtMs: NOW - 30 * 1000,
+    consecutivePollFailures: 1,
+    lastPollError: "connect ECONNREFUSED 10.0.0.1:9003",
+  });
+
+  assert.strictEqual(report.healthy, true);
+  // The error is still reported, it just is not a verdict yet.
+  assert.match(report.lastPollError || "", /ECONNREFUSED/);
+});
+
+// -- The outage this fix exists for ----------------------------------------
+
+test("an engine that never answers is degraded, not ok", (): void => {
+  /*
+   * The customer outage: OpenCost could not write /var/configs, its
+   * Allocation API never answered, the poller retried its oldest window
+   * forever, and — because a failed fetch never reaches the shipper — the
+   * shipper stayed spotless and /healthz answered 200 indefinitely.
+   */
+  const report: HealthReport = assess({
+    startedAtMs: NOW - 6 * 60 * 60 * 1000,
+    lastWindowCompletedAtMs: 0,
+    consecutivePollFailures: 72,
+    lastPollError:
+      "Cost engine answered HTTP 500 for /allocation/compute: no cost model",
+  });
+
+  assert.strictEqual(report.healthy, false);
+  assert.strictEqual(report.status, "degraded");
+  assert.strictEqual(report.windowsCompleted, 0);
+
+  const reasons: string = report.reasons.join(" | ");
+  assert.match(reasons, /72 consecutive ticks/);
+  assert.match(reasons, /no cost window has completed/);
+  assert.match(reasons, /no cost allocations have ever shipped/);
+  /*
+   * Nothing completed a window here, so the never-shipped reason must not
+   * blame the engine's allocations — the poll never got that far, and the
+   * reasons above already name the real fault.
+   */
+  assert.doesNotMatch(reasons, /the engine answered/);
+});
+
+test("a poll erroring on consecutive ticks is degraded before any window is due", (): void => {
+  // Fast signal: real errors, so it needs no time grace to be believed.
+  const report: HealthReport = assess({
+    startedAtMs: NOW - 60 * 1000,
+    consecutivePollFailures: 3,
+    lastPollError: "connect ECONNREFUSED 10.0.0.1:9003",
+  });
+
+  assert.strictEqual(report.healthy, false);
+  assert.strictEqual(report.reasons.length, 1);
+  assert.match(report.reasons[0]!, /3 consecutive ticks/);
+  assert.match(report.reasons[0]!, /ECONNREFUSED/);
+});
+
+// -- Stalls that are not throwing ------------------------------------------
+
+test("no window completed within the stale span is degraded even with no error", (): void => {
+  const report: HealthReport = assess({
+    startedAtMs: NOW - (STALE_MS + 1000),
+    lastWindowCompletedAtMs: 0,
+    consecutivePollFailures: 0,
+    lastPollError: null,
+  });
+
+  assert.strictEqual(report.healthy, false);
+  assert.strictEqual(report.reasons.length, 1);
+  assert.match(report.reasons[0]!, /no cost window has completed/);
+});
+
+test("a pipeline that made progress and then went quiet is degraded", (): void => {
+  const report: HealthReport = assess(
+    {
+      startedAtMs: NOW - 24 * 60 * 60 * 1000,
+      lastWindowCompletedAtMs: NOW - (STALE_MS + 60 * 1000),
+      windowsCompleted: 20,
+    },
+    { lastShipOkAtMs: NOW - (STALE_MS + 60 * 1000) },
+  );
+
+  assert.strictEqual(report.healthy, false);
+  assert.strictEqual(report.reasons.length, 1);
+  assert.match(report.reasons[0]!, /last cost window completed 4 minutes ago/);
+});
+
+test("windows draining but nothing ever shipped is degraded past the grace", (): void => {
+  /*
+   * The engine answers 200 with an empty allocation set forever, so windows
+   * complete happily and only the never-shipped signal catches it.
+   */
+  const report: HealthReport = assess(
+    {
+      startedAtMs: NOW - (FIRST_SHIP_GRACE_MS + 1000),
+      lastWindowCompletedAtMs: NOW - 1000,
+      windowsCompleted: 6,
+    },
+    { lastShipOkAtMs: 0 },
+  );
+
+  assert.strictEqual(report.healthy, false);
+  assert.strictEqual(report.reasons.length, 1);
+  assert.match(report.reasons[0]!, /no cost allocations have ever shipped/);
+  // Windows drained, so the reason points at the engine's empty answers.
+  assert.match(report.reasons[0]!, /the engine answered 6 windows/);
+});
+
+test("a never-shipped agent names the ship error when there is one", (): void => {
+  const report: HealthReport = assess(
+    {
+      startedAtMs: NOW - (FIRST_SHIP_GRACE_MS + 1000),
+      lastWindowCompletedAtMs: NOW - 1000,
+      windowsCompleted: 6,
+    },
+    { lastShipOkAtMs: 0, lastShipError: "OneUptime answered HTTP 401" },
+  );
+
+  assert.strictEqual(report.healthy, false);
+  assert.match(report.reasons.join(" | "), /HTTP 401/);
+});
+
+// -- Healthy steady state ---------------------------------------------------
+
+test("an agent shipping on schedule is ok", (): void => {
+  const report: HealthReport = assess(
+    {
+      startedAtMs: NOW - 24 * 60 * 60 * 1000,
+      lastWindowCompletedAtMs: NOW - 30 * 1000,
+      windowsCompleted: 24,
+    },
+    { lastShipOkAtMs: NOW - 30 * 1000 },
+  );
+
+  assert.strictEqual(report.healthy, true);
+  assert.strictEqual(report.status, "ok");
+  assert.deepStrictEqual(report.reasons, []);
+  assert.strictEqual(report.windowsCompleted, 24);
+  assert.strictEqual(report.uptimeSeconds, 24 * 60 * 60);
+});
+
+test("a transient ship failure that has since recovered is ok", (): void => {
+  // lastShipError lingers after a recovery; it must not be a verdict by itself.
+  const report: HealthReport = assess(
+    {
+      startedAtMs: NOW - 24 * 60 * 60 * 1000,
+      lastWindowCompletedAtMs: NOW - 30 * 1000,
+      windowsCompleted: 24,
+    },
+    {
+      lastShipOkAtMs: NOW - 30 * 1000,
+      lastShipError: "OneUptime answered HTTP 500",
+    },
+  );
+
+  assert.strictEqual(report.healthy, true);
+  assert.match(report.lastShipError || "", /HTTP 500/);
+});
+
+// -- What the kubelet actually sees ----------------------------------------
+
+interface Stubs {
+  poller: PollerStatus;
+  shipper: ShipperStatus;
+}
+
+const stubs: Stubs = {
+  poller: pollerStatus(),
+  shipper: shipperStatus(),
+};
+
+let server: http.Server;
+
+before(async (): Promise<void> => {
+  const pollerStub: Poller = {
+    status: (): PollerStatus => {
+      return stubs.poller;
+    },
+  } as unknown as Poller;
+  const shipperStub: Shipper = {
+    status: (): ShipperStatus => {
+      return stubs.shipper;
+    },
+  } as unknown as Shipper;
+
+  server = startHealthServer({ poller: pollerStub, shipper: shipperStub });
+  await new Promise<void>((resolve: () => void): void => {
+    server.once("listening", resolve);
+    if (server.listening) {
+      resolve();
+    }
+  });
+});
+
+after(async (): Promise<void> => {
+  await new Promise<void>((resolve: () => void): void => {
+    server.close((): void => {
+      resolve();
+    });
+  });
+});
+
+async function get(
+  path: string,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise(
+    (
+      resolve: (value: { statusCode: number; body: string }) => void,
+      reject: (reason: Error) => void,
+    ): void => {
+      const req: http.ClientRequest = http.get(
+        { host: "127.0.0.1", port: HEALTH_PORT, path },
+        (res: http.IncomingMessage): void => {
+          const chunks: Array<Buffer> = [];
+          res.on("data", (chunk: Buffer): void => {
+            chunks.push(chunk);
+          });
+          res.on("end", (): void => {
+            resolve({
+              statusCode: res.statusCode || 0,
+              body: Buffer.concat(chunks).toString("utf8"),
+            });
+          });
+        },
+      );
+      req.on("error", reject);
+    },
+  );
+}
+
+test("/healthz answers 200 while the agent is within its grace period", async (): Promise<void> => {
+  stubs.poller = pollerStatus({ startedAtMs: Date.now() });
+  stubs.shipper = shipperStatus();
+
+  const res: { statusCode: number; body: string } = await get("/healthz");
+
+  assert.strictEqual(res.statusCode, 200);
+  assert.match(res.body, /"status":"ok"/);
+});
+
+test("/healthz answers 503 once the pipeline is demonstrably stalled", async (): Promise<void> => {
+  stubs.poller = pollerStatus({
+    startedAtMs: Date.now() - 6 * 60 * 60 * 1000,
+    consecutivePollFailures: 40,
+    lastPollError: "Cost engine answered HTTP 500 for /allocation/compute",
+  });
+  stubs.shipper = shipperStatus();
+
+  const res: { statusCode: number; body: string } = await get("/healthz");
+
+  assert.strictEqual(res.statusCode, 503);
+  assert.match(res.body, /"status":"degraded"/);
+  // troubleshoot.sh greps these two keys out of the body — keep them.
+  assert.match(res.body, /"lastPollError":"Cost engine answered HTTP 500/);
+  assert.match(res.body, /"lastShipError":null/);
+});
+
+test("/livez stays 200 while degraded so a dead engine cannot crash-loop the pod", async (): Promise<void> => {
+  stubs.poller = pollerStatus({
+    startedAtMs: Date.now() - 6 * 60 * 60 * 1000,
+    consecutivePollFailures: 40,
+    lastPollError: "Cost engine answered HTTP 500 for /allocation/compute",
+  });
+  stubs.shipper = shipperStatus();
+
+  const live: { statusCode: number; body: string } = await get("/livez");
+  const ready: { statusCode: number; body: string } = await get("/healthz");
+
+  assert.strictEqual(live.statusCode, 200);
+  assert.match(live.body, /"status":"alive"/);
+  assert.strictEqual(ready.statusCode, 503);
+});

--- a/KubernetesCostAgent/Tests/PollerLoop.test.ts
+++ b/KubernetesCostAgent/Tests/PollerLoop.test.ts
@@ -5,7 +5,11 @@ import { floorToWindow } from "../AllocationMapper";
 import { CostEngineClient } from "../CostEngineClient";
 import { Poller } from "../Poller";
 import { Shipper } from "../Shipper";
-import { EngineAllocation, KubernetesCostAllocationIngestRow } from "../Types";
+import {
+  EngineAllocation,
+  KubernetesCostAllocationIngestRow,
+  PollerStatus,
+} from "../Types";
 
 /*
  * Checkpoint / ordering semantics of the poll loop, with the engine and
@@ -220,4 +224,99 @@ test("stop() prevents further ticks from doing work", async (): Promise<void> =>
 
   assert.strictEqual(engine.calls.length, 0);
   assert.strictEqual(shipper.calls.length, 0);
+});
+
+/*
+ * Progress bookkeeping. These are the facts Health.ts renders its verdict
+ * from, so what matters is that a stalled poller cannot look like a quiet
+ * one: failures accumulate, and lastWindowCompletedAtMs stays at 0 for as
+ * long as no window drains.
+ */
+
+test("a completed window records progress even when it shipped nothing", async (): Promise<void> => {
+  const engine: EngineStub = new EngineStub();
+  engine.allocationsPerWindow = []; // Fresh install: the lookback is empty.
+  const shipper: ShipperStub = new ShipperStub();
+  const { poller, tick } = makePoller(engine, shipper);
+
+  const before: PollerStatus = poller.status();
+  assert.strictEqual(before.lastWindowCompletedAtMs, 0);
+  assert.strictEqual(before.windowsCompleted, 0);
+  assert.ok(before.startedAtMs > 0);
+
+  await tick();
+
+  const after: PollerStatus = poller.status();
+  assert.ok(after.windowsCompleted >= 2);
+  assert.ok(after.lastWindowCompletedAtMs >= before.startedAtMs);
+  assert.strictEqual(after.consecutivePollFailures, 0);
+  assert.strictEqual(shipper.calls.length, 0);
+});
+
+test("consecutive engine failures accumulate and record no progress", async (): Promise<void> => {
+  const engine: EngineStub = new EngineStub();
+  engine.failuresRemaining = 3;
+  const shipper: ShipperStub = new ShipperStub();
+  const { poller, tick } = makePoller(engine, shipper);
+
+  await tick();
+  assert.strictEqual(poller.status().consecutivePollFailures, 1);
+  await tick();
+  assert.strictEqual(poller.status().consecutivePollFailures, 2);
+  await tick();
+
+  const stalled: PollerStatus = poller.status();
+  assert.strictEqual(stalled.consecutivePollFailures, 3);
+  // The stalled poller has nothing to show for three ticks.
+  assert.strictEqual(stalled.lastWindowCompletedAtMs, 0);
+  assert.strictEqual(stalled.windowsCompleted, 0);
+  assert.match(stalled.lastPollError || "", /engine unavailable/);
+});
+
+test("a clean tick clears the failure streak", async (): Promise<void> => {
+  const engine: EngineStub = new EngineStub();
+  engine.failuresRemaining = 2;
+  const shipper: ShipperStub = new ShipperStub();
+  const { poller, tick } = makePoller(engine, shipper);
+
+  await tick();
+  await tick();
+  assert.strictEqual(poller.status().consecutivePollFailures, 2);
+
+  await tick(); // Engine recovers and the backlog drains.
+
+  const recovered: PollerStatus = poller.status();
+  assert.strictEqual(recovered.consecutivePollFailures, 0);
+  assert.strictEqual(recovered.lastPollError, null);
+  assert.ok(recovered.windowsCompleted >= 2);
+});
+
+test("a ship failure counts as a failed tick, not as progress", async (): Promise<void> => {
+  const engine: EngineStub = new EngineStub();
+  const shipper: ShipperStub = new ShipperStub();
+  shipper.failuresRemaining = 1;
+  const { poller, tick } = makePoller(engine, shipper);
+
+  await tick();
+
+  const status: PollerStatus = poller.status();
+  assert.strictEqual(status.consecutivePollFailures, 1);
+  // The window it failed on never completed, so nothing is recorded.
+  assert.strictEqual(status.windowsCompleted, 0);
+  assert.strictEqual(status.lastWindowCompletedAtMs, 0);
+});
+
+test("an idle tick with no closed window keeps the streak at zero", async (): Promise<void> => {
+  const engine: EngineStub = new EngineStub();
+  const shipper: ShipperStub = new ShipperStub();
+  const { poller, tick } = makePoller(engine, shipper);
+
+  await tick(); // Drains the backlog.
+  const drained: number = poller.status().windowsCompleted;
+
+  await tick(); // Nothing due (or at most one newly closed window).
+
+  const idle: PollerStatus = poller.status();
+  assert.strictEqual(idle.consecutivePollFailures, 0);
+  assert.ok(idle.windowsCompleted - drained <= 1);
 });

--- a/KubernetesCostAgent/Tests/Shipper.test.ts
+++ b/KubernetesCostAgent/Tests/Shipper.test.ts
@@ -6,6 +6,7 @@ import { Shipper } from "../Shipper";
 import {
   KubernetesCostAllocationIngestRow,
   KubernetesCostIngestPayload,
+  ShipperStatus,
 } from "../Types";
 
 /*
@@ -119,7 +120,9 @@ test("ships rows chunked at SHIP_BATCH_SIZE with cluster, currency and token", a
     "ns-4",
   ]);
 
-  assert.strictEqual(shipper.healthy(), true);
+  const status: ShipperStatus = shipper.status();
+  assert.ok(status.lastShipOkAtMs > 0);
+  assert.strictEqual(status.lastShipError, null);
   assert.strictEqual(shipper.lastError(), null);
 });
 
@@ -158,4 +161,42 @@ test("a failing later chunk aborts the ship so the window is retried whole", asy
   await assert.rejects(shipper.ship(makeRows(6)), /HTTP 500/);
   // 1 success + 3 failed attempts; the third chunk is never sent.
   assert.strictEqual(recorded.length, 4);
+});
+
+/*
+ * status() reports what the shipper did, and nothing more. It used to also
+ * render a verdict — healthy() — which read "never shipped, never failed"
+ * as healthy, i.e. as healthy forever on an agent whose poller could not
+ * get it a single row. Health.ts owns that judgement now, because it is the
+ * only place that can see the poller too.
+ */
+
+test("a brand new shipper reports never-shipped rather than a verdict", (): void => {
+  const status: ShipperStatus = new Shipper().status();
+
+  assert.strictEqual(status.lastShipOkAtMs, 0);
+  assert.strictEqual(status.lastShipError, null);
+});
+
+test("status records the failure after retries are exhausted", async (): Promise<void> => {
+  statusScript = [500, 500, 500];
+  const shipper: Shipper = new Shipper();
+
+  await assert.rejects(shipper.ship(makeRows(1)), /HTTP 500/);
+
+  const status: ShipperStatus = shipper.status();
+  assert.strictEqual(status.lastShipOkAtMs, 0);
+  assert.match(status.lastShipError || "", /HTTP 500/);
+});
+
+test("a recovered ship clears the error and stamps the success", async (): Promise<void> => {
+  statusScript = [500]; // First attempt fails, the retry lands.
+  const shipper: Shipper = new Shipper();
+  const before: number = Date.now();
+
+  await shipper.ship(makeRows(1));
+
+  const status: ShipperStatus = shipper.status();
+  assert.ok(status.lastShipOkAtMs >= before);
+  assert.strictEqual(status.lastShipError, null);
 });

--- a/KubernetesCostAgent/Tests/TestEnv.ts
+++ b/KubernetesCostAgent/Tests/TestEnv.ts
@@ -5,7 +5,8 @@
  * test file in its own process, so files cannot leak env into each other.
  *
  * Ports are fixed per target so the local stub servers in the tests bind
- * predictably: 34571 plays the cost engine, 34572 plays OneUptime.
+ * predictably: 34571 plays the cost engine, 34572 plays OneUptime, and
+ * 34573 is where the agent's own health server listens.
  */
 
 process.env["TZ"] = "UTC";
@@ -28,6 +29,14 @@ process.env["ENGINE_SETTLE_SECONDS"] =
   process.env["ENGINE_SETTLE_SECONDS"] || "0";
 process.env["LOOKBACK_WINDOWS"] = process.env["LOOKBACK_WINDOWS"] || "2";
 process.env["LOG_LEVEL"] = process.env["LOG_LEVEL"] || "error";
+process.env["HEALTH_PORT"] = process.env["HEALTH_PORT"] || "34573";
+
+/*
+ * The health thresholds are deliberately NOT pinned: they read off
+ * WINDOW_SECONDS above, and Health.test.ts asserts against the shipped
+ * defaults so a change to them has to be a deliberate one.
+ */
 
 export const COST_ENGINE_PORT: number = 34571;
 export const ONEUPTIME_PORT: number = 34572;
+export const HEALTH_PORT: number = 34573;

--- a/KubernetesCostAgent/Types.ts
+++ b/KubernetesCostAgent/Types.ts
@@ -53,6 +53,44 @@ export interface KubernetesCostIngestPayload {
   allocations: Array<KubernetesCostAllocationIngestRow>;
 }
 
+/*
+ * Health snapshots. Poller and Shipper each report plain facts about what
+ * they have done; Health.ts is the single place that turns those facts into
+ * an ok/degraded verdict, so the judgement is testable without a clock, a
+ * socket or either collaborator.
+ */
+
+export interface PollerStatus {
+  /** When the poller was constructed (ms epoch). */
+  startedAtMs: number;
+  /**
+   * When a window last drained — shipped or legitimately empty (ms epoch).
+   * 0 means no window has ever completed.
+   */
+  lastWindowCompletedAtMs: number;
+  windowsCompleted: number;
+  /** Ticks that have thrown back-to-back; reset by any clean tick. */
+  consecutivePollFailures: number;
+  lastPollError: string | null;
+}
+
+export interface ShipperStatus {
+  /** Last successful POST to OneUptime (ms epoch); 0 means never. */
+  lastShipOkAtMs: number;
+  lastShipError: string | null;
+}
+
+export interface HealthReport {
+  healthy: boolean;
+  status: "ok" | "degraded";
+  /** Why it is degraded, in operator-readable prose. Empty when healthy. */
+  reasons: Array<string>;
+  lastPollError: string | null;
+  lastShipError: string | null;
+  windowsCompleted: number;
+  uptimeSeconds: number;
+}
+
 /** properties block of one engine allocation. */
 export interface EngineAllocationProperties {
   cluster?: string;


### PR DESCRIPTION
### Title of this pull request?

fix(cost-agent): make /healthz report a stalled pipeline instead of ok

### Small Description?

`Shipper.healthy()` returned `true` whenever `lastShipOk === 0 && lastShipErr === null` — i.e. forever, on an agent that had never shipped anything. It could not have been right in the shipper: the shipper only ever sees rows the poller successfully fetched, so an agent whose cost engine never answers leaves it untouched and therefore spotless.

That masked a real customer outage. The bundled OpenCost could not write `/var/configs`, its Allocation API never answered, the poller retried its oldest window forever (intended — `Poller.tick()` deliberately does not advance the checkpoint past a failing window, and that is covered by an existing test), and yet `/healthz` kept answering `200 {"status":"ok"}` and the pod stayed Ready indefinitely. The chart-side cause was fixed in `opencost.yaml`; the invisibility is what this PR fixes.

**The fix.** `Shipper` now reports facts only (`status()` → `lastShipOkAtMs`, `lastShipError`). `Health.ts` owns the verdict, since it is the one place that can see both halves. `assessHealth()` is pure — statuses and a timestamp in, verdict out — with three signals ordered fast-to-slow:

1. **`HEALTH_MAX_POLL_FAILURES` consecutive failing ticks** (default 3, ≈15 min at the default poll interval). This is the outage above, and the only fast trigger — it needs real repeated errors, never silence.
2. **No window completed in `HEALTH_STALE_WINDOWS` windows** (default 3). Catches a stall that isn't throwing: a wedged timer, a starved event loop, settle/clock math that never lets a window come due.
3. **Nothing ever shipped**, past a grace of `LOOKBACK_WINDOWS + HEALTH_STALE_WINDOWS` windows. Catches an engine that answers 200 with an empty allocation set forever — windows drain, signal 2 stays happy, no data lands.

**Boot-time correctness.** Silence alone never fails the agent. The key distinction: a window that drained **empty still counts as progress** — it is a round trip the engine answered, which is exactly what a stalled agent cannot do. So the legitimately-empty lookback windows on a fresh install keep signal 2 satisfied, and signal 3's grace covers them until a real window should have landed. Signals 2 and 3 measure from process start, which *is* the grace period, so a freshly-started agent waiting for its first closed hourly window trips neither.

### Anything a reviewer should know

**One change beyond the literal ask — please sanity-check this call.** Both probes pointed at `/healthz`, so making it 503 would have put a **liveness** failure on every broken-engine install: CrashLoopBackOff instead of visibility, restarting on a fault a restart cannot fix, discarding the poller's in-memory checkpoint each time, and hiding the diagnostic the response body now carries. So this adds `/livez` (200 for as long as the process is up) and points the chart's `livenessProbe` there. Readiness keeps `/healthz`, so a dead cost pipeline reads `0/1 Ready` — the visibility that was missing — without the restart loop.

**`Chart.yaml` left at 0.6.0**, assuming version bumps are handled by release tooling rather than per-PR. Happy to bump it if that's manual.

**`HEALTH_MAX_POLL_FAILURES` is a count, not a duration.** At the default 300s poll interval that is ~15 minutes of patience; anyone lowering `POLL_INTERVAL_SECONDS` substantially should raise it to keep the same wall-clock tolerance. Noted in `Config.ts` and the README.

**Wire-format compatibility:** the `status` / `lastPollError` / `lastShipError` JSON keys that `troubleshoot.sh` greps are preserved, and a test asserts them. `troubleshoot.sh` already accepted 503 from this endpoint.

**Unrelated pre-existing breakage worth knowing about:** `HttpClient.ts:57` does not compile against the monorepo root's `@types/node` (generic `Buffer`), which it resolves when the package has no `node_modules` of its own. This package builds standalone — its Dockerfile does `npm ci` in-directory — so that is how it was verified. No source was changed to work around it, but building this from the repo root without a local install will hit it.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review. <!-- CI has not run yet at time of opening -->
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). <!-- no tracking issue -->
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verification run locally: `npm test` in `KubernetesCostAgent` → **50/50 passing** (25 new). Prettier and ESLint clean on every changed file (ESLint needs `--no-ignore` here because the config skips `.claude/worktrees/`). `helm template` renders the probe change correctly.

### Related Issue?

None linked — this came from the field report on the OpenCost `/var/configs` outage.

### Screenshots (if appropriate):

n/a — no UI surface. The observable change is `/healthz` answering `503 {"status":"degraded","reasons":[...]}` on a stalled agent, and the pod reporting `0/1 Ready`.

