### PR TITLE
fix(ui): stop the side menu sliding under the app header

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Components/MasterPage/MasterPage.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Components/MasterPage/MasterPage.tsx
@@ -26,7 +26,12 @@ const DashboardMasterPage: FunctionComponent<ComponentProps> = (
         navBar={<NavBar />}
         isLoading={false}
         error={""}
-        className="flex flex-col h-screen"
+        /*
+         * min-h-screen, not h-screen — see the dashboard master page: a fixed
+         * 100vh caps the sticky top section's containing block at one viewport
+         * and the header scrolls away on longer pages.
+         */
+        className="flex flex-col min-h-screen"
       >
         {props.children}
       </MasterPage>

--- a/App/FeatureSet/Dashboard/src/Components/MasterPage/MasterPage.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MasterPage/MasterPage.tsx
@@ -116,7 +116,14 @@ const DashboardMasterPage: FunctionComponent<ComponentProps> = (
         }
         isLoading={props.isLoading}
         error={error}
-        className="flex flex-col h-screen"
+        /*
+         * min-h-screen, not h-screen: the top section sticks inside this box,
+         * so a fixed 100vh height caps its containing block at one viewport and
+         * the header scrolls away for good once the page is longer than that.
+         * The min-height still keeps the footer pushed to the bottom on short
+         * pages, because <main> grows.
+         */
+        className="flex flex-col min-h-screen"
       >
         {props.children}
       </MasterPage>

--- a/Common/UI/Components/MasterPage/MasterPage.tsx
+++ b/Common/UI/Components/MasterPage/MasterPage.tsx
@@ -27,6 +27,70 @@ const MasterPage: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const [isOnline, setIsOnline] = React.useState(true);
+  const topSectionRef: React.RefObject<HTMLDivElement> =
+    React.useRef<HTMLDivElement>(null);
+
+  /*
+   * Publish the sticky top section's height as --app-header-height so anything
+   * that sticks underneath it (the side menu, for example) can offset itself by
+   * the real header instead of guessing and ending up tucked behind it. The
+   * height is not a constant — it changes when the navbar is hidden, when the
+   * header wraps on narrow viewports and when top alerts appear — so keep it in
+   * sync rather than measuring once.
+   */
+  React.useLayoutEffect(() => {
+    const setHeaderHeight: (height: number) => void = (
+      height: number,
+    ): void => {
+      document.documentElement.style.setProperty(
+        "--app-header-height",
+        `${height}px`,
+      );
+    };
+
+    const element: HTMLDivElement | null = topSectionRef.current;
+
+    if (!element || props.makeTopSectionUnstick) {
+      // Nothing is overlaying the content, so no offset is needed.
+      setHeaderHeight(0);
+      return undefined;
+    }
+
+    const measure: () => void = (): void => {
+      setHeaderHeight(element.offsetHeight);
+    };
+
+    measure();
+
+    /*
+     * ResizeObserver is missing in jsdom and in older browsers, so fall back to
+     * resize events there — less precise, but the header only really changes
+     * height when the viewport does.
+     */
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+
+      return () => {
+        window.removeEventListener("resize", measure);
+        document.documentElement.style.removeProperty("--app-header-height");
+      };
+    }
+
+    const observer: ResizeObserver = new ResizeObserver(measure);
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+      document.documentElement.style.removeProperty("--app-header-height");
+    };
+  }, [
+    props.makeTopSectionUnstick,
+    props.hideHeader,
+    props.isLoading,
+    props.error,
+    props.disableMainContentWrapper,
+    isOnline,
+  ]);
 
   if (props.isLoading) {
     return (
@@ -62,6 +126,7 @@ const MasterPage: FunctionComponent<ComponentProps> = (
             </a>
           )}
           <div
+            ref={topSectionRef}
             className={props.makeTopSectionUnstick ? "" : "sticky top-0 z-10"}
           >
             <TopSection

--- a/Common/UI/Components/SideMenu/SideMenu.tsx
+++ b/Common/UI/Components/SideMenu/SideMenu.tsx
@@ -415,30 +415,50 @@ const SideMenu: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
       role="navigation"
       aria-label="Main navigation"
     >
-      <div className="sticky top-6">
+      {/*
+       * Stick below the app header, not at the top of the viewport. The header
+       * is sticky too, so a plain `top-6` slides the first menu items behind it
+       * as soon as the page scrolls. --app-header-height is measured and
+       * published by MasterPage; the 0px fallback keeps this correct on pages
+       * that render without a sticky header.
+       */}
+      <div
+        className="sticky"
+        style={{ top: "calc(var(--app-header-height, 0px) + 1.5rem)" }}
+      >
         <div
           className={`
+            flex flex-col
             bg-white rounded-2xl
             border border-gray-200/80
             shadow-sm
             overflow-hidden
           `}
+          /*
+           * Menus longer than the viewport (the Kubernetes cluster menu, for
+           * one) would otherwise get pushed back up behind the header near the
+           * bottom of a long page. Cap the card to the space left under the
+           * header and let the item list scroll inside it instead.
+           */
+          style={{
+            maxHeight: "calc(100vh - var(--app-header-height, 0px) - 3rem)",
+          }}
         >
           {/* Optional Header */}
           {props.header && (
-            <div className="px-3 py-3 border-b border-gray-100 bg-gradient-to-b from-gray-50 to-white">
+            <div className="flex-shrink-0 px-3 py-3 border-b border-gray-100 bg-gradient-to-b from-gray-50 to-white">
               {props.header}
             </div>
           )}
 
           {/* Menu Content */}
-          <nav className="p-2">
+          <nav className="p-2 min-h-0 overflow-y-auto">
             <div className="space-y-0.5">{renderMenuContent()}</div>
           </nav>
 
           {/* Optional Footer */}
           {props.footer && (
-            <div className="px-3 py-2 border-t border-gray-100 bg-gray-50/50">
+            <div className="flex-shrink-0 px-3 py-2 border-t border-gray-100 bg-gray-50/50">
               {props.footer}
             </div>
           )}


### PR DESCRIPTION
### Title of this pull request?

fix(ui): stop the side menu sliding under the app header

### Small Description?

The side menu was not aligned to the top of the page. Two separate layout defects were combining to cause it.

**1. The menu stuck to the viewport top, not below the header.** `SideMenu` used `sticky top-6` — 24px from the top of the *viewport*. The app header is itself `sticky top-0` and roughly 129px tall, so as soon as the page scrolled the menu slid underneath it and the first ~105px (the leading section heading and its first items) disappeared behind the header.

**2. The header stopped sticking after one screenful.** The dashboard and admin master pages passed `className="flex flex-col h-screen"` to `MasterPage`. A sticky element can only travel within its containing block, and `h-screen` caps that block at exactly 100vh — so past ~1 viewport of scrolling the header scrolled away for good, leaving the menu floating with a header-sized gap above it.

**The fix**

- `Common/UI/Components/MasterPage/MasterPage.tsx` — measures the sticky top section and publishes it as an `--app-header-height` CSS variable, kept in sync with a `ResizeObserver` (with a resize-event fallback, since jsdom and older browsers lack it). The height is not a constant in practice: pages that hide the navbar, narrow viewports where the header wraps, and billing top alerts all change it.
- `Common/UI/Components/SideMenu/SideMenu.tsx` — sticks at `calc(var(--app-header-height, 0px) + 1.5rem)` instead of `top-6`, and caps the card to the space left under the header so long menus (the Kubernetes cluster menu, for one) scroll internally rather than being pushed back up behind it. The `0px` fallback leaves pages that render without a sticky header unchanged.
- Dashboard + AdminDashboard master pages — `h-screen` → `min-h-screen`. The footer still sits at the bottom on short pages because `<main>` has `grow`.

Mobile rendering is untouched — the mobile branch of `SideMenu` is a static collapsible panel, not a sticky one.

**How this was verified**

The live app needs a login and the dev containers run against the main checkout rather than the worktree, so the exact DOM/class chain was rebuilt in a standalone page and measured. At a 900px viewport, scrolled:

| | menu top | header bottom |
|---|---|---|
| before | 24px (under the header) | −600px (gone) |
| after | 153px = 129 + 24px gap | 129px (holds) |

At scroll 0 the menu top now matches the content column exactly (193px for both), which is the reported symptom.

`tsc --noEmit` is clean on `Common` and `App`; eslint is clean on all four files; `MasterPage.test.tsx` (6 tests) and `SideMenuItem.test.tsx` (9 tests) pass.

Two suites fail on this branch — `MonacoRuntime.test.ts`, and a `toBeInTheDocument`/`toHaveClass` typing error that hits whichever UI suite runs against a warm ts-jest cache. Both were confirmed to fail identically on pristine `master`, so they are pre-existing and unrelated to this change.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None — reported directly.

### Screenshots (if appropriate):

Measured before/after is in the table above. The user-visible difference when scrolled: previously the menu's top items sat behind the header (and further down the page the header vanished entirely); now the menu pins cleanly below the header with a 24px gap and scrolls internally when it is taller than the viewport.
