### PR TITLE
feat(ui): let viewers choose and reorder ModelTable columns

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
@@ -18,6 +18,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import Query from "Common/Types/BaseDatabase/Query";
 import Search from "Common/Types/BaseDatabase/Search";
 import Alert from "Common/Models/DatabaseModels/Alert";
+import AlertCustomField from "Common/Models/DatabaseModels/AlertCustomField";
 import AlertOwnerTeam from "Common/Models/DatabaseModels/AlertOwnerTeam";
 import AlertOwnerUser from "Common/Models/DatabaseModels/AlertOwnerUser";
 import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
@@ -510,6 +511,7 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
       <ModelTable<Alert>
         name="Alerts"
         userPreferencesKey="alerts-table"
+        customFieldsModelType={AlertCustomField}
         bulkActions={{
           buttons: [
             getBulkChangeStateAction(),

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
@@ -28,6 +28,7 @@ import Search from "Common/Types/BaseDatabase/Search";
 import DropdownUtil from "Common/UI/Utils/Dropdown";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Incident from "Common/Models/DatabaseModels/Incident";
+import IncidentCustomField from "Common/Models/DatabaseModels/IncidentCustomField";
 import IncidentOwnerTeam from "Common/Models/DatabaseModels/IncidentOwnerTeam";
 import IncidentOwnerUser from "Common/Models/DatabaseModels/IncidentOwnerUser";
 import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
@@ -480,6 +481,7 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
       <ModelTable<Incident>
         name="Incidents"
         userPreferencesKey="incidents-table"
+        customFieldsModelType={IncidentCustomField}
         bulkActions={{
           buttons: [
             getBulkChangeStateAction(),

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
@@ -28,6 +28,7 @@ import API from "Common/UI/Utils/API/API";
 import Query from "Common/Types/BaseDatabase/Query";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorCustomField from "Common/Models/DatabaseModels/MonitorCustomField";
 import MonitorOwnerTeam from "Common/Models/DatabaseModels/MonitorOwnerTeam";
 import MonitorOwnerUser from "Common/Models/DatabaseModels/MonitorOwnerUser";
 import MonitorStatus from "Common/Models/DatabaseModels/MonitorStatus";
@@ -489,6 +490,7 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
         enableJsonImportExport={!props.disableCreate}
         name="Monitors"
         userPreferencesKey="monitors-table"
+        customFieldsModelType={MonitorCustomField}
         id="Monitors-table"
         saveFilterProps={props.saveFilterProps}
         urlStateKey={tableUrlStateKey}

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
@@ -14,6 +14,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import Query from "Common/Types/BaseDatabase/Query";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import ScheduledMaintenance from "Common/Models/DatabaseModels/ScheduledMaintenance";
+import ScheduledMaintenanceCustomField from "Common/Models/DatabaseModels/ScheduledMaintenanceCustomField";
 import ScheduledMaintenanceOwnerTeam from "Common/Models/DatabaseModels/ScheduledMaintenanceOwnerTeam";
 import ScheduledMaintenanceOwnerUser from "Common/Models/DatabaseModels/ScheduledMaintenanceOwnerUser";
 import ScheduledMaintenanceState from "Common/Models/DatabaseModels/ScheduledMaintenanceState";
@@ -421,6 +422,7 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
         id="scheduledMaintenances-table"
         name="Scheduled Maintenance Events"
         userPreferencesKey={"scheduled-maintenance-table"}
+        customFieldsModelType={ScheduledMaintenanceCustomField}
         bulkActions={{
           buttons: [
             getBulkChangeStateAction(),

--- a/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutyPolicies.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutyPolicies.tsx
@@ -9,6 +9,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import Label from "Common/Models/DatabaseModels/Label";
 import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
+import OnCallDutyPolicyCustomField from "Common/Models/DatabaseModels/OnCallDutyPolicyCustomField";
 import OnCallDutyPolicyOwnerTeam from "Common/Models/DatabaseModels/OnCallDutyPolicyOwnerTeam";
 import OnCallDutyPolicyOwnerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyOwnerUser";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
@@ -51,6 +52,7 @@ const OnCallDutyPage: FunctionComponent<
         enableJsonImportExport={true}
         id="on-call-duty-table"
         userPreferencesKey="on-call-duty-table"
+        customFieldsModelType={OnCallDutyPolicyCustomField}
         topContent={filterBar}
         currentFacetState={facetSaveState}
         onFacetStateRestored={restoreFacetState}

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/StatusPages.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/StatusPages.tsx
@@ -8,6 +8,7 @@ import useBulkOwnerActions from "Common/UI/Components/BulkUpdate/BulkOwnerAction
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPage from "Common/Models/DatabaseModels/StatusPage";
+import StatusPageCustomField from "Common/Models/DatabaseModels/StatusPageCustomField";
 import StatusPageOwnerTeam from "Common/Models/DatabaseModels/StatusPageOwnerTeam";
 import StatusPageOwnerUser from "Common/Models/DatabaseModels/StatusPageOwnerUser";
 import React, { FunctionComponent, ReactElement } from "react";
@@ -56,6 +57,7 @@ const StatusPages: FunctionComponent<PageComponentProps> = (): ReactElement => {
         enableJsonImportExport={true}
         id="status-page-table"
         userPreferencesKey="status-page-table"
+        customFieldsModelType={StatusPageCustomField}
         isDeleteable={false}
         isEditable={false}
         isCreateable={true}

--- a/App/FeatureSet/Dashboard/src/Pages/Teams/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Teams/Index.tsx
@@ -5,6 +5,7 @@ import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchem
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Team from "Common/Models/DatabaseModels/Team";
+import TeamCustomField from "Common/Models/DatabaseModels/TeamCustomField";
 import IconProp from "Common/Types/Icon/IconProp";
 import Query from "Common/Types/BaseDatabase/Query";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
@@ -83,6 +84,7 @@ const Teams: FunctionComponent<PageComponentProps> = (
         isCreateable={true}
         isViewable={true}
         userPreferencesKey="teams-table"
+        customFieldsModelType={TeamCustomField}
         topContent={filterBar}
         currentFacetState={facetSaveState}
         onFacetStateRestored={restoreFacetState}

--- a/Common/Models/DatabaseModels/TableView.ts
+++ b/Common/Models/DatabaseModels/TableView.ts
@@ -555,4 +555,44 @@ export default class TableView extends BaseModel {
     nullable: true,
   })
   public facets?: JSONObject = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateTableView,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.SettingsViewer,
+      Permission.ReadTableView,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditTableView,
+    ],
+  })
+  @TableColumn({
+    title: "Columns",
+    required: false,
+    unique: false,
+    type: TableColumnType.JSON,
+    canReadOnRelationQuery: true,
+    description:
+      "Which columns are shown, and in what order, for this table view",
+    example:
+      '{"order": ["name", "currentMonitorStatus"], "hidden": ["labels"]}',
+  })
+  @Column({
+    type: ColumnType.JSON,
+    unique: false,
+    nullable: true,
+  })
+  public columns?: JSONObject = undefined;
 }

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785241000000-AddColumnsToTableView.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785241000000-AddColumnsToTableView.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddColumnsToTableView1785241000000 implements MigrationInterface {
+  public name: string = "AddColumnsToTableView1785241000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "TableView" ADD "columns" jsonb`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "TableView" DROP COLUMN "columns"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -473,6 +473,7 @@ import { MigrationName1785066759532 } from "./1785066759532-MigrationName";
 import { AddHotQueryIndexes1785140242697 } from "./1785140242697-AddHotQueryIndexes";
 import { AddHotQueryIndexesSecondPass1785148065137 } from "./1785148065137-AddHotQueryIndexesSecondPass";
 import { RepairCrossProjectMonitorStatusReferences1785240000000 } from "./1785240000000-RepairCrossProjectMonitorStatusReferences";
+import { AddColumnsToTableView1785241000000 } from "./1785241000000-AddColumnsToTableView";
 
 export default [
   InitialMigration,
@@ -950,4 +951,5 @@ export default [
   AddHotQueryIndexes1785140242697,
   AddHotQueryIndexesSecondPass1785148065137,
   RepairCrossProjectMonitorStatusReferences1785240000000,
+  AddColumnsToTableView1785241000000,
 ];

--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableColumnCustomization.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableColumnCustomization.test.tsx
@@ -1,0 +1,679 @@
+import "@testing-library/jest-dom/extend-expect";
+import {
+  act,
+  cleanup,
+  configure,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+/*
+ * A real BaseModelTable mounts a card, a header, a full table and (in the
+ * picker tests) a modal on top of that. That comfortably outruns the 1s
+ * default when the whole Common suite is competing for the same box. A
+ * regression still fails, just later.
+ */
+configure({ asyncUtilTimeout: 15000 });
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * BaseModelTable pulls in permissions, the current project and the i18n
+ * provider. None of those are what these tests are about, so they are stubbed
+ * to their permissive/no-op form and the tests focus on one thing: the column
+ * layout a viewer chose, and how it survives the round trip through
+ * localStorage into the rendered <th> cells.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return true;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined) => {
+          return value;
+        },
+        translateValue: (value: unknown) => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import Filter from "../../../../UI/Components/ModelFilter/Filter";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Query from "../../../../Types/BaseDatabase/Query";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import UserPreferences, {
+  UserPreferenceType,
+} from "../../../../Utils/UserPreferences";
+import { JSONObject } from "../../../../Types/JSON";
+
+const PREFS_KEY: string = "monitors-columns-table";
+
+type GetListCall = {
+  query: Query<Monitor>;
+  select: JSONObject;
+};
+
+const FILTERS: Array<Filter<Monitor>> = [
+  { title: "Name", type: FieldType.Text, field: { name: true } },
+] as unknown as Array<Filter<Monitor>>;
+
+type MakeColumnsOptions = {
+  // Adds a `isHiddenByDefault` column ("Monitor Type") at the end.
+  withHiddenByDefault?: boolean | undefined;
+  // Marks "Name" `isNotCustomizable`, i.e. pinned and kept out of the picker.
+  pinName?: boolean | undefined;
+};
+
+type MakeColumnsFunction = (options?: MakeColumnsOptions) => Columns<Monitor>;
+
+/*
+ * Real Monitor columns, not placeholders: the ids the layout is keyed on are
+ * derived from the declared `field`, so a table of fake columns would not
+ * exercise the same id derivation the app does.
+ */
+const makeColumns: MakeColumnsFunction = (
+  options: MakeColumnsOptions = {},
+): Columns<Monitor> => {
+  const columns: Array<unknown> = [
+    {
+      field: { name: true },
+      title: "Name",
+      type: FieldType.Text,
+      ...(options.pinName ? { isNotCustomizable: true } : {}),
+    },
+    {
+      field: { description: true },
+      title: "Description",
+      type: FieldType.LongText,
+    },
+    {
+      field: { currentMonitorStatus: { name: true } },
+      title: "Monitor Status",
+      type: FieldType.Entity,
+    },
+    {
+      field: { labels: { name: true } },
+      title: "Labels",
+      type: FieldType.EntityArray,
+    },
+  ];
+
+  if (options.withHiddenByDefault) {
+    columns.push({
+      field: { monitorType: true },
+      title: "Monitor Type",
+      type: FieldType.Text,
+      isHiddenByDefault: true,
+    });
+  }
+
+  return columns as unknown as Columns<Monitor>;
+};
+
+const ALL_TITLES: Array<string> = [
+  "Name",
+  "Description",
+  "Monitor Status",
+  "Labels",
+];
+
+type SeedPreferenceFunction = (data: {
+  key: string;
+  order: Array<string>;
+  hidden: Array<string>;
+}) => void;
+
+/*
+ * Written through UserPreferences rather than localStorage directly, so the
+ * key derivation the table reads with is the same one the test writes with.
+ */
+const seedPreference: SeedPreferenceFunction = (data: {
+  key: string;
+  order: Array<string>;
+  hidden: Array<string>;
+}): void => {
+  UserPreferences.saveUserPreferenceByTypeAsJSON({
+    key: data.key,
+    userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+    value: { order: data.order, hidden: data.hidden },
+  });
+};
+
+type ReadPreferenceFunction = (key: string) => JSONObject | null;
+
+const readPreference: ReadPreferenceFunction = (
+  key: string,
+): JSONObject | null => {
+  return UserPreferences.getUserPreferenceByTypeAsJSON({
+    key: key,
+    userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+  });
+};
+
+type GetHeadersFunction = () => Array<string>;
+
+const getHeaders: GetHeadersFunction = (): Array<string> => {
+  return screen.getAllByRole("columnheader").map((header: HTMLElement) => {
+    return (header.textContent || "").trim();
+  });
+};
+
+type GetPickerRowIdsFunction = () => Array<string>;
+
+/*
+ * One checkbox per row in the picker, each tagged with the column id the
+ * layout is stored under.
+ */
+const getPickerRowIds: GetPickerRowIdsFunction = (): Array<string> => {
+  const modal: HTMLElement = screen.getByTestId("column-customization-modal");
+
+  return Array.from(
+    modal.querySelectorAll('[data-testid^="column-toggle-"]'),
+  ).map((element: Element) => {
+    return (element.getAttribute("data-testid") || "").replace(
+      "column-toggle-",
+      "",
+    );
+  });
+};
+
+describe("BaseModelTable column customization", () => {
+  let calls: Array<GetListCall> = [];
+
+  type MakeCallbacksFunction = () => BaseTableCallbacks<Monitor>;
+
+  const makeCallbacks: MakeCallbacksFunction =
+    (): BaseTableCallbacks<Monitor> => {
+      return {
+        deleteItem: async () => {
+          return undefined;
+        },
+        getModelFromJSON: (item: JSONObject) => {
+          return item as unknown as Monitor;
+        },
+        getJSONFromModel: (item: Monitor) => {
+          return item as unknown as JSONObject;
+        },
+        addSlugToSelect: (select: unknown) => {
+          return select;
+        },
+        getList: async (data: {
+          query: Query<Monitor>;
+          limit: number;
+          select: JSONObject;
+        }): Promise<ListResult<Monitor>> => {
+          calls.push({
+            query: data.query,
+            select: (data.select || {}) as unknown as JSONObject,
+          });
+          return { data: [], count: 0, skip: 0, limit: data.limit };
+        },
+        toJSONArray: () => {
+          return [];
+        },
+        updateById: async () => {
+          return undefined;
+        },
+        showCreateEditModal: () => {
+          return <></>;
+        },
+      } as unknown as BaseTableCallbacks<Monitor>;
+    };
+
+  type RenderTableOptions = {
+    userPreferencesKey?: string | undefined;
+    columns?: Columns<Monitor> | undefined;
+    isDeleteable?: boolean | undefined;
+    disableColumnCustomization?: boolean | undefined;
+  };
+
+  type RenderTableFunction = (
+    options?: RenderTableOptions,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    options: RenderTableOptions = {},
+  ): ReturnType<typeof render> => {
+    const props: BaseModelTableProps<Monitor> = {
+      modelType: Monitor,
+      id: "monitors-table",
+      name: "Monitors",
+      userPreferencesKey: options.userPreferencesKey || PREFS_KEY,
+      /*
+       * The Columns control lives in the card header, and BaseModelTable only
+       * renders a header at all when cardProps is set.
+       */
+      cardProps: { title: "Monitors" },
+      columns: options.columns || makeColumns(),
+      filters: FILTERS,
+      isDeleteable: Boolean(options.isDeleteable),
+      isCreateable: false,
+      isViewable: false,
+      isEditable: false,
+      // This suite is about columns; keep the URL out of it entirely.
+      disableUrlState: true,
+      callbacks: makeCallbacks(),
+      ...(options.disableColumnCustomization
+        ? { disableColumnCustomization: true }
+        : {}),
+    } as unknown as BaseModelTableProps<Monitor>;
+
+    return render(<BaseModelTable<Monitor> {...props} />);
+  };
+
+  type WaitForTableFunction = () => Promise<void>;
+
+  const waitForTable: WaitForTableFunction = async (): Promise<void> => {
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("columnheader").length).toBeGreaterThan(0);
+    });
+  };
+
+  type OpenPickerFunction = () => Promise<void>;
+
+  /*
+   * The real click path. The Columns control is an icon-only card button, and
+   * every non-primary card button is folded into the "⋯" overflow menu, where
+   * it is labelled from its icon — so the viewer reaches it in two clicks.
+   */
+  const openPicker: OpenPickerFunction = async (): Promise<void> => {
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "More options" }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Columns"));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("column-customization-modal")).not.toBeNull();
+    });
+  };
+
+  type ClickFunction = (element: HTMLElement) => Promise<void>;
+
+  const click: ClickFunction = async (element: HTMLElement): Promise<void> => {
+    await act(async () => {
+      fireEvent.click(element);
+    });
+  };
+
+  type SavePickerFunction = () => Promise<void>;
+
+  const savePicker: SavePickerFunction = async (): Promise<void> => {
+    await click(screen.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("column-customization-modal")).toBeNull();
+    });
+  };
+
+  beforeEach(() => {
+    calls = [];
+    window.history.replaceState(
+      window.history.state,
+      "",
+      "/dashboard/monitors",
+    );
+    TableFilterUrlState.resetClaimedKeys();
+    /*
+     * The whole point of this suite is what the table reads out of
+     * localStorage on mount, and the runner shares one jsdom across files.
+     */
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("rendering the declared layout", () => {
+    test("renders every declared column, in declared order", async () => {
+      renderTable({ columns: makeColumns({ withHiddenByDefault: true }) });
+
+      await waitForTable();
+
+      /*
+       * `isHiddenByDefault` is the table author saying "useful, but not worth
+       * the horizontal space" — it must not show up until someone asks for it
+       * in the picker.
+       */
+      expect(getHeaders()).toEqual(ALL_TITLES);
+    });
+
+    test("a stored layout is applied on the very first paint", async () => {
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["labels", "currentMonitorStatus", "description", "name"],
+        hidden: ["description"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      /*
+       * Both halves of the layout at once: Description is gone, and what is
+       * left follows the stored order rather than the declared one. Read
+       * during render, not in an effect, so there is no flash of the default
+       * layout first.
+       */
+      expect(getHeaders()).toEqual(["Labels", "Monitor Status", "Name"]);
+    });
+
+    test("a layout stored for another table does not leak into this one", async () => {
+      seedPreference({
+        key: "some-other-table",
+        order: ["name"],
+        hidden: ["description", "labels"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toEqual(ALL_TITLES);
+    });
+
+    test("a stale layout naming columns that no longer exist is ignored", async () => {
+      /*
+       * A stored layout outlives the release that wrote it. If a dropped
+       * column's id could still take part, a table could be left permanently
+       * mis-ordered - or, worse, with everything hidden - by a layout the
+       * viewer has no way to reason about.
+       */
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["monitorSteps", "incomingRequestReceivedAt", "ghost-column"],
+        hidden: ["monitorSteps", "ghost-column"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toEqual(ALL_TITLES);
+    });
+
+    test("disableColumnCustomization ignores a stored layout entirely", async () => {
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["labels", "name"],
+        hidden: ["description", "currentMonitorStatus"],
+      });
+
+      renderTable({ disableColumnCustomization: true });
+
+      await waitForTable();
+
+      /*
+       * Tables opt out when their layout is load-bearing. Honouring a stored
+       * layout there would break the surrounding page, and the viewer would
+       * have no control to undo it with - the Columns button is gone too.
+       */
+      expect(getHeaders()).toEqual(ALL_TITLES);
+      expect(
+        screen.queryByRole("button", { name: "More options" }),
+      ).not.toBeNull();
+      expect(screen.queryByText("Columns")).toBeNull();
+    });
+  });
+
+  describe("what hiding a column does NOT do", () => {
+    test("a hidden column's field is still selected from the API", async () => {
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["name", "description", "currentMonitorStatus", "labels"],
+        hidden: ["description"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).not.toContain("Description");
+
+      /*
+       * Deliberate: a *visible* column's getElement is arbitrary caller code
+       * that may read a hidden column's field, and nothing can detect that
+       * statically. Narrowing the select to what is on screen would therefore
+       * silently blank some other cell. The cost is a few unused fields on the
+       * wire; this test is the guard on that trade.
+       */
+      expect(calls[0]?.select["description"]).toBe(true);
+      expect(calls[0]?.select["name"]).toBe(true);
+    });
+  });
+
+  describe("the generated Actions column", () => {
+    test("stays last however the viewer reorders, and is not in the picker", async () => {
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["labels", "currentMonitorStatus", "description", "name"],
+        hidden: [],
+      });
+
+      renderTable({ isDeleteable: true });
+
+      await waitForTable();
+
+      const headers: Array<string> = getHeaders();
+
+      expect(headers).toEqual([
+        "Labels",
+        "Monitor Status",
+        "Description",
+        "Name",
+        "Actions",
+      ]);
+
+      /*
+       * Actions is generated, not declared, and the row buttons it holds are
+       * right-aligned against the edge of the table. It is not the viewer's to
+       * move or switch off, so the layout is applied to the *input* of the
+       * column build rather than to the finished array.
+       */
+      expect(headers[headers.length - 1]).toBe("Actions");
+
+      await openPicker();
+
+      expect(getPickerRowIds()).toEqual([
+        "labels",
+        "currentMonitorStatus",
+        "description",
+        "name",
+      ]);
+      expect(
+        screen
+          .getByTestId("column-customization-modal")
+          .textContent?.includes("Actions"),
+      ).toBe(false);
+    });
+  });
+
+  describe("the picker", () => {
+    test("opens from the card header with a row per customizable column", async () => {
+      renderTable({
+        columns: makeColumns({ withHiddenByDefault: true, pinName: true }),
+      });
+
+      await waitForTable();
+
+      await openPicker();
+
+      /*
+       * Name is pinned (`isNotCustomizable`), so it is not offered: a table
+       * must never be customizable into anonymity. Monitor Type is offered
+       * even though it starts hidden - that is the only way to switch it on.
+       */
+      expect(getPickerRowIds()).toEqual([
+        "description",
+        "currentMonitorStatus",
+        "labels",
+        "monitorType",
+      ]);
+
+      expect(
+        screen.getByTestId("column-customization-count").textContent,
+      ).toContain("3 of 4 columns shown");
+    });
+
+    test("saving a change updates the table and stores the layout", async () => {
+      renderTable();
+
+      await waitForTable();
+      expect(getHeaders()).toEqual(ALL_TITLES);
+
+      await openPicker();
+      await click(screen.getByTestId("column-toggle-description"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toEqual(["Name", "Monitor Status", "Labels"]);
+      });
+
+      const stored: JSONObject | null = readPreference(PREFS_KEY);
+
+      expect(stored).not.toBeNull();
+      expect(stored?.["hidden"]).toEqual(["description"]);
+      expect(stored?.["order"]).toEqual([
+        "name",
+        "description",
+        "currentMonitorStatus",
+        "labels",
+      ]);
+    });
+
+    test("saving a layout identical to the default stores nothing", async () => {
+      renderTable({ columns: makeColumns({ withHiddenByDefault: true }) });
+
+      await waitForTable();
+
+      await openPicker();
+      await savePicker();
+
+      /*
+       * Otherwise every table anyone ever opened the picker on would be pinned
+       * to the column set of the release they opened it in, and a column
+       * shipped later would arrive already stale - present in the code, absent
+       * from every viewer's stored order.
+       */
+      expect(readPreference(PREFS_KEY)).toBeNull();
+      expect(
+        window.localStorage.getItem(
+          `${UserPreferenceType.BaseModelTableColumns}.${PREFS_KEY}`,
+        ),
+      ).toBeNull();
+
+      expect(getHeaders()).toEqual(ALL_TITLES);
+    });
+
+    test("Reset drops the stored layout and restores the declared columns", async () => {
+      seedPreference({
+        key: PREFS_KEY,
+        order: ["labels", "name", "currentMonitorStatus", "description"],
+        hidden: ["description"],
+      });
+
+      renderTable();
+
+      await waitForTable();
+      expect(getHeaders()).toEqual(["Labels", "Name", "Monitor Status"]);
+
+      await openPicker();
+      await click(screen.getByTestId("column-customization-reset"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("column-customization-modal")).toBeNull();
+      });
+
+      await waitFor(() => {
+        expect(getHeaders()).toEqual(ALL_TITLES);
+      });
+
+      expect(readPreference(PREFS_KEY)).toBeNull();
+    });
+  });
+
+  describe("persistence across a remount", () => {
+    test("a layout saved from the picker is still there on the next visit", async () => {
+      const view: ReturnType<typeof render> = renderTable();
+
+      await waitForTable();
+
+      await openPicker();
+      await click(screen.getByTestId("column-toggle-labels"));
+      await savePicker();
+
+      await waitFor(() => {
+        expect(getHeaders()).toEqual(["Name", "Description", "Monitor Status"]);
+      });
+
+      view.unmount();
+      calls = [];
+
+      // Same userPreferencesKey: this is the viewer coming back to the page.
+      renderTable();
+
+      await waitForTable();
+
+      expect(getHeaders()).toEqual(["Name", "Description", "Monitor Status"]);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/ColumnCustomizationModal.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/ColumnCustomizationModal.test.tsx
@@ -1,0 +1,572 @@
+import ColumnCustomizationModal from "../../../../UI/Components/ModelTable/ColumnCustomizationModal";
+import {
+  CustomizableColumn,
+  ModelTableColumn,
+} from "../../../../UI/Components/ModelTable/ColumnPreference";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+import "@testing-library/jest-dom";
+import {
+  RenderResult,
+  cleanup,
+  fireEvent,
+  render,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * The "Customize Columns" picker. Two invariants carry real weight here and
+ * are pinned below:
+ *
+ *  1. Nothing leaves the modal until Save. Cancel has to be a genuine escape
+ *     hatch, so every checkbox and every reorder is staged in local state.
+ *
+ *  2. The viewer can never end up with zero columns. A table with no columns
+ *     renders as an empty shell with no header row, and the only control that
+ *     could undo that is the picker they just closed. Both the per-row
+ *     checkbox and "Hide all" have to respect that.
+ *
+ * Drag-and-drop is deliberately not exercised: react-beautiful-dnd renders
+ * fine in jsdom but a synthetic drag cannot be driven through it. The Up/Down
+ * buttons exist precisely so that reordering is reachable without a pointer,
+ * which also makes it the reorder path these tests use.
+ */
+
+type MakeEntryFunction = (data: {
+  id: string;
+  title: string;
+  isVisible: boolean;
+}) => CustomizableColumn<Monitor>;
+
+const makeEntry: MakeEntryFunction = (data: {
+  id: string;
+  title: string;
+  isVisible: boolean;
+}): CustomizableColumn<Monitor> => {
+  const column: ModelTableColumn<Monitor> = {
+    field: { name: true },
+    title: data.title,
+    type: FieldType.Text,
+  };
+
+  return {
+    id: data.id,
+    column: column,
+    isVisible: data.isVisible,
+    isPinned: false,
+  };
+};
+
+type GetDefaultColumnsFunction = () => Array<CustomizableColumn<Monitor>>;
+
+// Three on, one off - so the count line has something to say from the start.
+const getDefaultColumns: GetDefaultColumnsFunction = (): Array<
+  CustomizableColumn<Monitor>
+> => {
+  return [
+    makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+    makeEntry({
+      id: "currentMonitorStatus",
+      title: "Status",
+      isVisible: true,
+    }),
+    makeEntry({ id: "description", title: "Description", isVisible: true }),
+    makeEntry({ id: "createdAt", title: "Created At", isVisible: false }),
+  ];
+};
+
+interface RenderedModal {
+  view: RenderResult;
+  onSave: MockFunction;
+  onClose: MockFunction;
+  onReset: MockFunction;
+}
+
+type RenderModalFunction = (data?: {
+  columns?: Array<CustomizableColumn<Monitor>> | undefined;
+  isDefaultLayout?: boolean | undefined;
+  title?: string | undefined;
+}) => RenderedModal;
+
+const renderModal: RenderModalFunction = (data?: {
+  columns?: Array<CustomizableColumn<Monitor>> | undefined;
+  isDefaultLayout?: boolean | undefined;
+  title?: string | undefined;
+}): RenderedModal => {
+  const onSave: MockFunction = getJestMockFunction();
+  const onClose: MockFunction = getJestMockFunction();
+  const onReset: MockFunction = getJestMockFunction();
+
+  const view: RenderResult = render(
+    <ColumnCustomizationModal<Monitor>
+      columns={data?.columns || getDefaultColumns()}
+      onSave={onSave}
+      onClose={onClose}
+      onReset={onReset}
+      isDefaultLayout={data?.isDefaultLayout}
+      title={data?.title}
+    />,
+  );
+
+  return { view, onSave, onClose, onReset };
+};
+
+type GetSavedFunction = (
+  onSave: MockFunction,
+) => Array<CustomizableColumn<Monitor>>;
+
+const getSaved: GetSavedFunction = (
+  onSave: MockFunction,
+): Array<CustomizableColumn<Monitor>> => {
+  return onSave.mock.calls[0]![0] as Array<CustomizableColumn<Monitor>>;
+};
+
+type GetSavedIdsFunction = (onSave: MockFunction) => Array<string>;
+
+const getSavedIds: GetSavedIdsFunction = (
+  onSave: MockFunction,
+): Array<string> => {
+  return getSaved(onSave).map((entry: CustomizableColumn<Monitor>) => {
+    return entry.id;
+  });
+};
+
+type TypeSearchFunction = (view: RenderResult, text: string) => void;
+
+const typeSearch: TypeSearchFunction = (
+  view: RenderResult,
+  text: string,
+): void => {
+  fireEvent.change(view.getByTestId("column-customization-search"), {
+    target: { value: text },
+  });
+};
+
+describe("ColumnCustomizationModal", () => {
+  beforeEach(() => {
+    /*
+     * The whole Common suite runs --runInBand, so storage written by an
+     * earlier file is still around. Nothing here reads it, but leaving it
+     * behind is how the next test starts flaking.
+     */
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  test("renders one row per column, with the titles visible", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("column-customization-modal")).toBeInTheDocument();
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(4);
+
+    expect(view.getByText("Monitor Name")).toBeInTheDocument();
+    expect(view.getByText("Status")).toBeInTheDocument();
+    expect(view.getByText("Description")).toBeInTheDocument();
+    expect(view.getByText("Created At")).toBeInTheDocument();
+
+    expect(view.getByTestId("column-toggle-name")).toBeChecked();
+    expect(view.getByTestId("column-toggle-createdAt")).not.toBeChecked();
+  });
+
+  test("counts the visible columns and keeps the count in step with the checkboxes", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "3 of 4 columns shown",
+    );
+
+    fireEvent.click(view.getByTestId("column-toggle-createdAt"));
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "4 of 4 columns shown",
+    );
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "3 of 4 columns shown",
+    );
+  });
+
+  test("stages changes locally: nothing is handed back before Save", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test("Cancel discards the staged changes", () => {
+    const { view, onSave, onClose }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+    fireEvent.click(view.getByTestId("modal-footer-close-button"));
+
+    // The caller is told to close and is told nothing else - the edit is gone.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test("Save hands back every entry with its new isVisible flag", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+    fireEvent.click(view.getByTestId("column-toggle-createdAt"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    /*
+     * Hidden columns are still in the list. The caller needs the full set to
+     * build the stored layout - "hidden" is not the complement of "order".
+     */
+    expect(
+      getSaved(onSave).map((entry: CustomizableColumn<Monitor>) => {
+        return { id: entry.id, isVisible: entry.isVisible };
+      }),
+    ).toEqual([
+      { id: "name", isVisible: true },
+      { id: "currentMonitorStatus", isVisible: true },
+      { id: "description", isVisible: false },
+      { id: "createdAt", isVisible: true },
+    ]);
+  });
+
+  test("the last visible column cannot be switched off", () => {
+    const { view, onSave }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+        makeEntry({
+          id: "description",
+          title: "Description",
+          isVisible: false,
+        }),
+        makeEntry({ id: "createdAt", title: "Created At", isVisible: false }),
+      ],
+    });
+
+    const onlyVisible: HTMLElement = view.getByTestId("column-toggle-name");
+
+    // First line of defence: the viewer cannot reach the control at all.
+    expect(onlyVisible).toBeDisabled();
+
+    /*
+     * Second line of defence: even if a change does arrive - a stray
+     * programmatic event, a future restyle that drops `disabled` - the state
+     * update refuses rather than leaving the table with no columns to render.
+     */
+    fireEvent.click(onlyVisible);
+    fireEvent.change(onlyVisible, { target: { checked: false } });
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "1 of 3 columns shown",
+    );
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).filter((entry: CustomizableColumn<Monitor>) => {
+        return entry.isVisible;
+      }),
+    ).toHaveLength(1);
+  });
+
+  test("switching the second-to-last column off locks the survivor", () => {
+    const { view }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+        makeEntry({ id: "description", title: "Description", isVisible: true }),
+      ],
+    });
+
+    expect(view.getByTestId("column-toggle-name")).not.toBeDisabled();
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "1 of 2 columns shown",
+    );
+    expect(view.getByTestId("column-toggle-name")).toBeDisabled();
+  });
+
+  test("Down moves a column later and Save reports the new order", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-move-down-name"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "currentMonitorStatus",
+      "name",
+      "description",
+      "createdAt",
+    ]);
+  });
+
+  test("Up moves a column earlier and Save reports the new order", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-move-up-createdAt"));
+    fireEvent.click(view.getByTestId("column-move-up-createdAt"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "name",
+      "createdAt",
+      "currentMonitorStatus",
+      "description",
+    ]);
+  });
+
+  test("reordering does not disturb the visibility flags", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-move-up-createdAt"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).map((entry: CustomizableColumn<Monitor>) => {
+        return { id: entry.id, isVisible: entry.isVisible };
+      }),
+    ).toEqual([
+      { id: "name", isVisible: true },
+      { id: "currentMonitorStatus", isVisible: true },
+      { id: "createdAt", isVisible: false },
+      { id: "description", isVisible: true },
+    ]);
+  });
+
+  test("Up is dead on the first row and Down on the last, and that follows the move", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("column-move-up-name")).toBeDisabled();
+    expect(view.getByTestId("column-move-down-name")).not.toBeDisabled();
+    expect(view.getByTestId("column-move-down-createdAt")).toBeDisabled();
+    expect(view.getByTestId("column-move-up-createdAt")).not.toBeDisabled();
+
+    fireEvent.click(view.getByTestId("column-move-down-name"));
+
+    // "name" is now second, so both of its buttons are live and Status leads.
+    expect(view.getByTestId("column-move-up-name")).not.toBeDisabled();
+    expect(
+      view.getByTestId("column-move-up-currentMonitorStatus"),
+    ).toBeDisabled();
+  });
+
+  test("Show all turns every column on", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-customization-show-all"));
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "4 of 4 columns shown",
+    );
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).every((entry: CustomizableColumn<Monitor>) => {
+        return entry.isVisible;
+      }),
+    ).toBe(true);
+  });
+
+  test("Hide all leaves exactly one column standing - the first", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-customization-hide-all"));
+
+    /*
+     * Not zero: the leftmost column is kept because it is normally the one
+     * that identifies the row, and because a table with no columns cannot be
+     * recovered from.
+     */
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "1 of 4 columns shown",
+    );
+    expect(view.getByTestId("column-toggle-name")).toBeDisabled();
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave)
+        .filter((entry: CustomizableColumn<Monitor>) => {
+          return entry.isVisible;
+        })
+        .map((entry: CustomizableColumn<Monitor>) => {
+          return entry.id;
+        }),
+    ).toEqual(["name"]);
+  });
+
+  test("Hide all keeps the first column even after the list has been reordered", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-move-up-createdAt"));
+    fireEvent.click(view.getByTestId("column-move-up-createdAt"));
+    fireEvent.click(view.getByTestId("column-move-up-createdAt"));
+    fireEvent.click(view.getByTestId("column-customization-hide-all"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    // "createdAt" is now the leftmost column, so it is the one that survives.
+    expect(
+      getSaved(onSave)
+        .filter((entry: CustomizableColumn<Monitor>) => {
+          return entry.isVisible;
+        })
+        .map((entry: CustomizableColumn<Monitor>) => {
+          return entry.id;
+        }),
+    ).toEqual(["createdAt"]);
+  });
+
+  test("search filters the list by title", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "desc");
+
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(1);
+    expect(view.getByTestId("column-toggle-description")).toBeInTheDocument();
+    expect(view.queryByTestId("column-toggle-name")).not.toBeInTheDocument();
+  });
+
+  test("search is case-insensitive and ignores surrounding whitespace", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "  STATUS  ");
+
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(1);
+    expect(
+      view.getByTestId("column-toggle-currentMonitorStatus"),
+    ).toBeInTheDocument();
+  });
+
+  test("search says so when nothing matches", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "no-such-column");
+
+    expect(view.queryAllByTestId(/^column-toggle-/)).toHaveLength(0);
+    expect(
+      view.getByTestId("column-customization-no-results"),
+    ).toHaveTextContent('No columns match "no-such-column".');
+  });
+
+  test("the move buttons are inert while a search is active", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "e");
+
+    /*
+     * A filtered list renumbers the rows, so "move down" would land the column
+     * at a position that only means something inside the filter. Rather than
+     * guess what the viewer meant, reordering is switched off until the search
+     * is cleared.
+     */
+    expect(view.getByTestId("column-move-up-description")).toBeDisabled();
+    expect(view.getByTestId("column-move-down-description")).toBeDisabled();
+    expect(view.getByTestId("column-move-up-name")).toBeDisabled();
+    expect(view.getByTestId("column-move-down-name")).toBeDisabled();
+  });
+
+  test("clearing the search restores the full list and the move buttons", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    typeSearch(view, "desc");
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(1);
+
+    typeSearch(view, "");
+
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(4);
+    expect(view.getByTestId("column-move-down-name")).not.toBeDisabled();
+    expect(view.getByTestId("column-move-up-description")).not.toBeDisabled();
+
+    // And reordering works again once the buttons come back.
+    fireEvent.click(view.getByTestId("column-move-down-name"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "currentMonitorStatus",
+      "name",
+      "description",
+      "createdAt",
+    ]);
+  });
+
+  test("a change made before searching survives the search", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+    typeSearch(view, "created");
+    fireEvent.click(view.getByTestId("column-toggle-createdAt"));
+    typeSearch(view, "");
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).map((entry: CustomizableColumn<Monitor>) => {
+        return { id: entry.id, isVisible: entry.isVisible };
+      }),
+    ).toEqual([
+      { id: "name", isVisible: true },
+      { id: "currentMonitorStatus", isVisible: true },
+      { id: "description", isVisible: false },
+      { id: "createdAt", isVisible: true },
+    ]);
+  });
+
+  test("Reset is absent while the layout is still the one the table ships", () => {
+    const { view }: RenderedModal = renderModal({ isDefaultLayout: true });
+
+    // Nothing to reset to, so offering the button would only be confusing.
+    expect(
+      view.queryByTestId("column-customization-reset"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("Reset appears once the layout has been customized and calls back", () => {
+    const { view, onReset, onSave }: RenderedModal = renderModal({
+      isDefaultLayout: false,
+    });
+
+    const reset: HTMLElement = view.getByTestId("column-customization-reset");
+
+    expect(reset).toBeInTheDocument();
+
+    fireEvent.click(reset);
+
+    // Reset is the caller's business: it drops the stored layout, not a draft.
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test("uses a custom title when one is given", () => {
+    const { view }: RenderedModal = renderModal({
+      title: "Pick your columns",
+    });
+
+    expect(view.getByTestId("modal-title")).toHaveTextContent(
+      "Pick your columns",
+    );
+  });
+
+  test("falls back to the default title", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("modal-title")).toHaveTextContent(
+      "Customize Columns",
+    );
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/ColumnPreference.test.ts
+++ b/Common/Tests/UI/Components/ModelTable/ColumnPreference.test.ts
@@ -1,0 +1,1678 @@
+import Column from "../../../../UI/Components/ModelTable/Column";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import {
+  ColumnPreference,
+  CustomizableColumn,
+  EmptyColumnPreference,
+  applyColumnPreference,
+  buildColumnPreference,
+  fromJSON,
+  getColumnBaseId,
+  getColumnIds,
+  getCustomizableColumns,
+  isEmptyColumnPreference,
+  sanitizeColumnPreference,
+  toJSON,
+} from "../../../../UI/Components/ModelTable/ColumnPreference";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import { JSONObject } from "../../../../Types/JSON";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * A ModelTable's column layout is per viewer and is persisted, which means it
+ * routinely outlives the release that produced it: the column set is edited
+ * every time someone touches the page, and for tables with custom fields the
+ * set is not even fixed within a release.
+ *
+ * So the module has one job that everything else serves — a stored layout must
+ * degrade gracefully. Two invariants carry that:
+ *
+ *  1. Identity comes from the declared field, never from array position, so
+ *     inserting a column does not silently re-point every stored id one slot
+ *     to the left.
+ *  2. Anything the layout does not recognise fails *open*: an unmentioned
+ *     column is visible, a stale id is dropped, and a layout that would leave
+ *     the table blank is refused outright.
+ *
+ * These are pinned here rather than through a rendered table because a wrong
+ * answer shows up as "my columns are gone", which nobody reports as a bug —
+ * they just re-pick them and lose the layout again next release.
+ */
+
+type ColumnOverrides = Partial<Column<Monitor>>;
+
+type MakeColumnFunction = (overrides: ColumnOverrides) => Column<Monitor>;
+
+const makeColumn: MakeColumnFunction = (
+  overrides: ColumnOverrides,
+): Column<Monitor> => {
+  return {
+    field: {},
+    title: "Untitled",
+    type: FieldType.Text,
+    ...overrides,
+  };
+};
+
+type TitlesOfFunction = (columns: Columns<Monitor>) => Array<string>;
+
+const titlesOf: TitlesOfFunction = (
+  columns: Columns<Monitor>,
+): Array<string> => {
+  return columns.map((column: Column<Monitor>): string => {
+    return column.title;
+  });
+};
+
+type EntryIdsFunction = (
+  entries: Array<CustomizableColumn<Monitor>>,
+) => Array<string>;
+
+const entryIds: EntryIdsFunction = (
+  entries: Array<CustomizableColumn<Monitor>>,
+): Array<string> => {
+  return entries.map((entry: CustomizableColumn<Monitor>): string => {
+    return entry.id;
+  });
+};
+
+type VisibilityOfFunction = (
+  entries: Array<CustomizableColumn<Monitor>>,
+) => Record<string, boolean>;
+
+const visibilityOf: VisibilityOfFunction = (
+  entries: Array<CustomizableColumn<Monitor>>,
+): Record<string, boolean> => {
+  const map: Record<string, boolean> = {};
+
+  entries.forEach((entry: CustomizableColumn<Monitor>): void => {
+    map[entry.id] = entry.isVisible;
+  });
+
+  return map;
+};
+
+type FindEntryFunction = (
+  entries: Array<CustomizableColumn<Monitor>>,
+  id: string,
+) => CustomizableColumn<Monitor>;
+
+const findEntry: FindEntryFunction = (
+  entries: Array<CustomizableColumn<Monitor>>,
+  id: string,
+): CustomizableColumn<Monitor> => {
+  const entry: CustomizableColumn<Monitor> | undefined = entries.find(
+    (candidate: CustomizableColumn<Monitor>): boolean => {
+      return candidate.id === id;
+    },
+  );
+
+  if (!entry) {
+    throw new Error(`No column entry with id "${id}"`);
+  }
+
+  return entry;
+};
+
+beforeEach(() => {
+  /*
+   * Nothing here reads storage, but the Common suite runs --runInBand and
+   * localStorage leaks between files; clearing keeps a future refactor that
+   * memoizes layouts from inheriting another suite's state.
+   */
+  window.localStorage.clear();
+});
+
+describe("getColumnBaseId", () => {
+  test("an explicit id beats the derived one", () => {
+    /*
+     * The escape hatch for cells rendered entirely through getElement off a
+     * placeholder field — their derived id would be a title slug, and titles
+     * are the part of a column authors change most freely.
+     */
+    expect(
+      getColumnBaseId<Monitor>(
+        makeColumn({
+          id: "monitor-uptime",
+          field: { name: true },
+          title: "Uptime",
+        }),
+      ),
+    ).toBe("monitor-uptime");
+  });
+
+  test("derives from the first declared field key", () => {
+    expect(
+      getColumnBaseId<Monitor>(
+        makeColumn({ field: { name: true }, title: "Name" }),
+      ),
+    ).toBe("name");
+  });
+
+  test("uses only the first key when a column selects several fields", () => {
+    /*
+     * A composite cell (say "3/5 online") selects more than one field, but its
+     * identity has to be a single stable string, so the first declared key is
+     * the one that counts.
+     */
+    expect(
+      getColumnBaseId<Monitor>(
+        makeColumn({
+          field: { monitorType: true, description: true },
+          title: "Type",
+        }),
+      ),
+    ).toBe("monitorType");
+  });
+
+  test("a selectedProperty makes each custom field its own column", () => {
+    /*
+     * This is what the whole custom-field feature rests on: every custom field
+     * hangs off the same `customFields` JSON column, so without the property
+     * suffix they would all collapse onto one id and switching one off would
+     * switch off all of them.
+     */
+    expect(
+      getColumnBaseId<Monitor>(
+        makeColumn({
+          field: { customFields: true },
+          selectedProperty: "Severity",
+          title: "Severity",
+        }),
+      ),
+    ).toBe("customFields.Severity");
+
+    expect(
+      getColumnBaseId<Monitor>(
+        makeColumn({
+          field: { customFields: true },
+          selectedProperty: "Owning Team",
+          title: "Owning Team",
+        }),
+      ),
+    ).toBe("customFields.Owning Team");
+  });
+
+  test("falls back to a slug of the title when there is no field key", () => {
+    expect(getColumnBaseId<Monitor>(makeColumn({ title: "Row Actions" }))).toBe(
+      "row-actions",
+    );
+  });
+
+  test("the title slug collapses punctuation and trims stray separators", () => {
+    expect(getColumnBaseId<Monitor>(makeColumn({ title: "CPU % (avg)" }))).toBe(
+      "cpu-avg",
+    );
+  });
+
+  test("falls back to the title when `field` is missing altogether", () => {
+    // Hand-written columns in the wild do omit `field`; the guard must hold.
+    const column: Column<Monitor> = {
+      ...makeColumn({ title: "Actions" }),
+      field: undefined,
+    } as unknown as Column<Monitor>;
+
+    expect(getColumnBaseId<Monitor>(column)).toBe("actions");
+  });
+
+  test('degrades to the literal "column" when there is nothing to derive from', () => {
+    // An id must exist even for a column with neither field nor title.
+    expect(getColumnBaseId<Monitor>(makeColumn({ title: "" }))).toBe("column");
+    expect(getColumnBaseId<Monitor>(makeColumn({ title: "!!!" }))).toBe(
+      "column",
+    );
+  });
+});
+
+describe("getColumnIds", () => {
+  test("returns one id per column, in declaration order", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    expect(getColumnIds<Monitor>(columns)).toEqual([
+      "name",
+      "description",
+      "labels",
+    ]);
+  });
+
+  test("empty column set produces no ids", () => {
+    expect(getColumnIds<Monitor>([])).toEqual([]);
+  });
+
+  test("columns sharing a base field are disambiguated by title slug", () => {
+    /*
+     * Several cells rendering from the same placeholder `field: { _id: true }`
+     * is the common shape, not an edge case. Title is used first because it is
+     * what the viewer sees in the picker and it does not move when a column is
+     * inserted next to it.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Owner" }),
+    ];
+
+    expect(getColumnIds<Monitor>(columns)).toEqual([
+      "_id:actions",
+      "_id:owner",
+    ]);
+  });
+
+  test("columns sharing a base AND a title fall back to a positional suffix", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+    ];
+
+    expect(getColumnIds<Monitor>(columns)).toEqual([
+      "_id:actions",
+      "_id:actions#2",
+      "_id:actions#3",
+    ]);
+  });
+
+  test("colliding columns with no title at all still get distinct ids", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { _id: true }, title: "" }),
+      makeColumn({ field: { _id: true }, title: "" }),
+    ];
+
+    expect(getColumnIds<Monitor>(columns)).toEqual(["_id", "_id#2"]);
+  });
+
+  test("only the colliding columns are suffixed", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Owner" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    expect(getColumnIds<Monitor>(columns)).toEqual([
+      "name",
+      "_id:actions",
+      "_id:owner",
+      "labels",
+    ]);
+  });
+
+  test("every custom field on one JSON column gets its own id", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+      }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Team",
+        title: "Team",
+      }),
+    ];
+
+    // Different base ids, so no collision handling kicks in.
+    expect(getColumnIds<Monitor>(columns)).toEqual([
+      "customFields.Severity",
+      "customFields.Team",
+    ]);
+  });
+
+  test("an id does not move when unrelated columns are added around it", () => {
+    /*
+     * The point of deriving from the field: a release that adds three columns
+     * must not invalidate the stored layout for the ones that already existed.
+     */
+    const small: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+    ];
+
+    const large: Columns<Monitor> = [
+      makeColumn({ field: { monitorType: true }, title: "Type" }),
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+    ];
+
+    const smallIds: Array<string> = getColumnIds<Monitor>(small);
+    const largeIds: Array<string> = getColumnIds<Monitor>(large);
+
+    expect(smallIds).toEqual(["name", "description"]);
+    expect(largeIds).toContain("name");
+    expect(largeIds).toContain("description");
+  });
+
+  test("an id is unaffected by the column's title when nothing collides", () => {
+    const before: Columns<Monitor> = [
+      makeColumn({ field: { description: true }, title: "Description" }),
+    ];
+    const after: Columns<Monitor> = [
+      makeColumn({ field: { description: true }, title: "Summary" }),
+    ];
+
+    expect(getColumnIds<Monitor>(before)).toEqual(getColumnIds<Monitor>(after));
+  });
+
+  test("introducing a collision does re-key the column that was alone", () => {
+    /*
+     * The documented trade-off, pinned so it is a decision rather than a
+     * surprise: adding a second `_id` column changes the first one's id, the
+     * stored entry goes stale and the column simply defaults back to visible.
+     * Authors who cannot afford that set an explicit `id`.
+     */
+    expect(
+      getColumnIds<Monitor>([
+        makeColumn({ field: { _id: true }, title: "Actions" }),
+      ]),
+    ).toEqual(["_id"]);
+
+    expect(
+      getColumnIds<Monitor>([
+        makeColumn({ field: { _id: true }, title: "Actions" }),
+        makeColumn({ field: { _id: true }, title: "Owner" }),
+      ]),
+    ).toEqual(["_id:actions", "_id:owner"]);
+  });
+
+  test("ids are unique across a pathological column set", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "" }),
+      makeColumn({ field: {}, title: "" }),
+      makeColumn({ field: {}, title: "" }),
+      makeColumn({ id: "explicit", field: { name: true }, title: "Name" }),
+    ];
+
+    const ids: Array<string> = getColumnIds<Monitor>(columns);
+
+    expect(ids).toHaveLength(columns.length);
+    expect(new Set(ids).size).toBe(columns.length);
+  });
+});
+
+describe("getCustomizableColumns without a preference", () => {
+  test("keeps declaration order and shows everything", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({ columns });
+
+    expect(entryIds(entries)).toEqual(["name", "description", "labels"]);
+    expect(visibilityOf(entries)).toEqual({
+      name: true,
+      description: true,
+      labels: true,
+    });
+  });
+
+  test("isHiddenByDefault columns start switched off but are still listed", () => {
+    // They have to be listed, otherwise there is no way to switch them on.
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({ columns });
+
+    expect(entryIds(entries)).toEqual(["name", "customFields.Severity"]);
+    expect(findEntry(entries, "customFields.Severity").isVisible).toBe(false);
+  });
+
+  test("null and undefined preferences behave the same as no preference", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    expect(entryIds(getCustomizableColumns<Monitor>({ columns }))).toEqual([
+      "name",
+      "labels",
+    ]);
+    expect(
+      entryIds(getCustomizableColumns<Monitor>({ columns, preference: null })),
+    ).toEqual(["name", "labels"]);
+    expect(
+      entryIds(
+        getCustomizableColumns<Monitor>({ columns, preference: undefined }),
+      ),
+    ).toEqual(["name", "labels"]);
+  });
+
+  test("carries the original column object through untouched", () => {
+    // The picker and the table both need the real column, not a copy of it.
+    const name: Column<Monitor> = makeColumn({
+      field: { name: true },
+      title: "Name",
+    });
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({ columns: [name] });
+
+    expect(findEntry(entries, "name").column).toBe(name);
+  });
+
+  test("an empty column set yields no entries", () => {
+    expect(getCustomizableColumns<Monitor>({ columns: [] })).toEqual([]);
+  });
+});
+
+describe("getCustomizableColumns pinning", () => {
+  test("isNotCustomizable marks the entry pinned", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({ columns });
+
+    expect(findEntry(entries, "name").isPinned).toBe(true);
+    expect(findEntry(entries, "labels").isPinned).toBe(false);
+  });
+
+  test("a pinned column is never hidden by a preference that names it", () => {
+    /*
+     * Pinned columns are absent from the picker, so a stored `hidden` entry
+     * for one would be unrecoverable: the viewer would have no control to
+     * bring the row's identifying column back.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["labels", "name"], hidden: ["name", "labels"] },
+      });
+
+    expect(findEntry(entries, "name").isVisible).toBe(true);
+    expect(findEntry(entries, "labels").isVisible).toBe(false);
+  });
+
+  test("isHiddenByDefault is ignored on a pinned column", () => {
+    // Contradictory flags: pinning wins, because it is the stronger promise.
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({ columns });
+
+    expect(findEntry(entries, "name").isVisible).toBe(true);
+  });
+
+  test("a pinned column keeps its declared position under a stale order", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { monitorType: true }, title: "Type" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    /*
+     * `name` appears in `order` — a layout written before the column was
+     * pinned, or hand-edited. It must not drag the pinned column anywhere.
+     */
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: {
+          order: ["labels", "monitorType", "name"],
+          hidden: ["name"],
+        },
+      });
+
+    expect(entryIds(entries)).toEqual(["name", "labels", "monitorType"]);
+    expect(findEntry(entries, "name").isVisible).toBe(true);
+  });
+});
+
+describe("getCustomizableColumns ordering", () => {
+  test("a preference reorders the entries", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["labels", "name", "description"], hidden: [] },
+      });
+
+    expect(entryIds(entries)).toEqual(["labels", "name", "description"]);
+  });
+
+  test("an order that lists ids the table no longer has is simply skipped", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: {
+          order: ["labels", "deletedColumn", "name"],
+          hidden: [],
+        },
+      });
+
+    expect(entryIds(entries)).toEqual(["labels", "name"]);
+  });
+
+  test("a column declared in the middle and absent from the order stays in the middle", () => {
+    /*
+     * The load-bearing case for a new release: `slug` ships between
+     * Description and Labels and the stored layout has never heard of it. It
+     * has to appear where its author put it, not be swept to the end where
+     * nobody looks.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+      makeColumn({ field: { monitorType: true }, title: "Type" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: {
+          order: ["name", "description", "labels", "monitorType"],
+          hidden: [],
+        },
+      });
+
+    expect(entryIds(entries)).toEqual([
+      "name",
+      "description",
+      "slug",
+      "labels",
+      "monitorType",
+    ]);
+  });
+
+  test("an unmentioned column follows the last arranged column declared before it", () => {
+    /*
+     * The rule is "declared neighbours", not "declared index": once the viewer
+     * has reshuffled things, `slug`'s anchor is Description — the last column
+     * that both precedes it in the declaration and appears in the layout.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: {
+          order: ["labels", "name", "description"],
+          hidden: [],
+        },
+      });
+
+    expect(entryIds(entries)).toEqual([
+      "labels",
+      "name",
+      "description",
+      "slug",
+    ]);
+  });
+
+  test("a new first column sorts ahead of everything the layout arranged", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["labels", "name"], hidden: [] },
+      });
+
+    expect(entryIds(entries)).toEqual(["slug", "labels", "name"]);
+  });
+
+  test("several consecutive new columns keep their relative declaration order", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+      makeColumn({ field: { monitorType: true }, title: "Type" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["name", "labels"], hidden: [] },
+      });
+
+    // Equal sort keys must be broken by declaration order, i.e. stably.
+    expect(entryIds(entries)).toEqual([
+      "name",
+      "slug",
+      "monitorType",
+      "labels",
+    ]);
+  });
+
+  test("a duplicated id in the order uses its first occurrence", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["labels", "name", "labels"], hidden: [] },
+      });
+
+    expect(entryIds(entries)).toEqual(["labels", "name"]);
+  });
+
+  test("an empty order leaves declaration order alone", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: [], hidden: ["labels"] },
+      });
+
+    expect(entryIds(entries)).toEqual(["name", "labels"]);
+    expect(findEntry(entries, "labels").isVisible).toBe(false);
+  });
+});
+
+describe("getCustomizableColumns visibility", () => {
+  test("an id in `hidden` switches the column off", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["name", "labels"], hidden: ["labels"] },
+      });
+
+    expect(visibilityOf(entries)).toEqual({ name: true, labels: false });
+  });
+
+  test("an id in `order` but not `hidden` switches a default-hidden column on", () => {
+    /*
+     * This is the only mechanism by which a viewer turns a custom field on:
+     * custom-field columns ship hidden, and the layout says "on" by naming the
+     * id in `order` while leaving it out of `hidden`.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: {
+          order: ["name", "customFields.Severity"],
+          hidden: [],
+        },
+      });
+
+    expect(findEntry(entries, "customFields.Severity").isVisible).toBe(true);
+  });
+
+  test("`hidden` wins over `order` when an id is in both", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: {
+          order: ["customFields.Severity"],
+          hidden: ["customFields.Severity"],
+        },
+      });
+
+    expect(findEntry(entries, "customFields.Severity").isVisible).toBe(false);
+  });
+
+  test("a default-hidden column the layout never mentions stays hidden", () => {
+    // A custom field added after the viewer last touched this table.
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Team",
+        title: "Team",
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["name"], hidden: [] },
+      });
+
+    expect(findEntry(entries, "customFields.Team").isVisible).toBe(false);
+  });
+
+  test("a normal column the layout never mentions stays visible", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+    ];
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["name"], hidden: [] },
+      });
+
+    expect(findEntry(entries, "slug").isVisible).toBe(true);
+  });
+});
+
+describe("applyColumnPreference", () => {
+  test("renders only the visible columns, in layout order", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const rendered: Columns<Monitor> = applyColumnPreference<Monitor>({
+      columns,
+      preference: {
+        order: ["labels", "name", "description"],
+        hidden: ["description"],
+      },
+    });
+
+    expect(titlesOf(rendered)).toEqual(["Labels", "Name"]);
+  });
+
+  test("returns the very same column objects, not copies", () => {
+    const name: Column<Monitor> = makeColumn({
+      field: { name: true },
+      title: "Name",
+    });
+    const labels: Column<Monitor> = makeColumn({
+      field: { labels: true },
+      title: "Labels",
+    });
+
+    const rendered: Columns<Monitor> = applyColumnPreference<Monitor>({
+      columns: [name, labels],
+      preference: { order: ["labels", "name"], hidden: [] },
+    });
+
+    expect(rendered).toEqual([labels, name]);
+    expect(rendered[0]).toBe(labels);
+    expect(rendered[1]).toBe(name);
+  });
+
+  test("shows everything when the layout would leave the table blank", () => {
+    /*
+     * The safety net. An empty table has no header, therefore no "Columns"
+     * button rendered against a column, and a viewer who hid the last column
+     * would have nothing left to click to undo it. Refuse the layout instead.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+    ];
+
+    const rendered: Columns<Monitor> = applyColumnPreference<Monitor>({
+      columns,
+      preference: {
+        order: ["description", "name"],
+        hidden: ["name", "description"],
+      },
+    });
+
+    expect(rendered).toHaveLength(2);
+    expect(titlesOf(rendered)).toEqual(["Description", "Name"]);
+  });
+
+  test("the never-empty fallback also covers a single-column table", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+    ];
+
+    expect(
+      titlesOf(
+        applyColumnPreference<Monitor>({
+          columns,
+          preference: { order: ["name"], hidden: ["name"] },
+        }),
+      ),
+    ).toEqual(["Name"]);
+  });
+
+  test("with no preference the input comes back unchanged", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({
+        field: { labels: true },
+        title: "Labels",
+      }),
+    ];
+
+    expect(titlesOf(applyColumnPreference<Monitor>({ columns }))).toEqual([
+      "Name",
+      "Description",
+      "Labels",
+    ]);
+    expect(
+      titlesOf(applyColumnPreference<Monitor>({ columns, preference: null })),
+    ).toEqual(["Name", "Description", "Labels"]);
+  });
+
+  test("a default-hidden column is dropped even without a preference", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    expect(titlesOf(applyColumnPreference<Monitor>({ columns }))).toEqual([
+      "Name",
+    ]);
+  });
+
+  test("no columns in, no columns out", () => {
+    expect(applyColumnPreference<Monitor>({ columns: [] })).toEqual([]);
+    expect(
+      applyColumnPreference<Monitor>({
+        columns: [],
+        preference: { order: ["gone"], hidden: ["gone"] },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("buildColumnPreference", () => {
+  test("round-trips through getCustomizableColumns", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+      makeColumn({ field: { monitorType: true }, title: "Type" }),
+    ];
+
+    const preference: ColumnPreference = {
+      order: ["monitorType", "description", "labels"],
+      hidden: ["labels"],
+    };
+
+    const rebuilt: ColumnPreference = buildColumnPreference<Monitor>(
+      getCustomizableColumns<Monitor>({ columns, preference }),
+    );
+
+    expect(rebuilt).toEqual(preference);
+  });
+
+  test("re-applying what it produced is a no-op", () => {
+    // Saving the picker without touching it must not perturb the table.
+    const columns: Columns<Monitor> = [
+      makeColumn({ field: { name: true }, title: "Name" }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    const first: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: { order: ["labels", "name", "description"], hidden: [] },
+      });
+
+    const second: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: buildColumnPreference<Monitor>(first),
+      });
+
+    expect(entryIds(second)).toEqual(entryIds(first));
+    expect(visibilityOf(second)).toEqual(visibilityOf(first));
+  });
+
+  test("pinned entries are left out of both lists", () => {
+    /*
+     * Recording a pinned column would create an entry that goes stale the
+     * moment a table stops pinning it — and worse, a `hidden` entry for a
+     * column the picker cannot show.
+     */
+    const columnA: Column<Monitor> = makeColumn({ title: "A" });
+    const columnB: Column<Monitor> = makeColumn({ title: "B" });
+    const columnC: Column<Monitor> = makeColumn({ title: "C" });
+
+    const entries: Array<CustomizableColumn<Monitor>> = [
+      { id: "a", column: columnA, isVisible: true, isPinned: true },
+      { id: "b", column: columnB, isVisible: false, isPinned: true },
+      { id: "c", column: columnC, isVisible: true, isPinned: false },
+    ];
+
+    expect(buildColumnPreference<Monitor>(entries)).toEqual({
+      order: ["c"],
+      hidden: [],
+    });
+  });
+
+  test("hidden holds exactly the not-visible, non-pinned ids", () => {
+    const column: Column<Monitor> = makeColumn({ title: "X" });
+
+    const entries: Array<CustomizableColumn<Monitor>> = [
+      { id: "a", column, isVisible: true, isPinned: false },
+      { id: "b", column, isVisible: false, isPinned: false },
+      { id: "c", column, isVisible: true, isPinned: false },
+      { id: "d", column, isVisible: false, isPinned: false },
+    ];
+
+    expect(buildColumnPreference<Monitor>(entries)).toEqual({
+      order: ["a", "b", "c", "d"],
+      hidden: ["b", "d"],
+    });
+  });
+
+  test("no entries produce an empty layout", () => {
+    expect(buildColumnPreference<Monitor>([])).toEqual({
+      order: [],
+      hidden: [],
+    });
+    expect(isEmptyColumnPreference(buildColumnPreference<Monitor>([]))).toBe(
+      true,
+    );
+  });
+});
+
+describe("sanitizeColumnPreference", () => {
+  test("drops ids that name no current column", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: {
+          order: ["name", "removedInThisRelease", "labels"],
+          hidden: ["removedInThisRelease"],
+        },
+        knownColumnIds: ["name", "labels"],
+      }),
+    ).toEqual({ order: ["name", "labels"], hidden: [] });
+  });
+
+  test("de-duplicates each list", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: {
+          order: ["name", "labels", "name"],
+          hidden: ["labels", "labels"],
+        },
+        knownColumnIds: ["name", "labels"],
+      }),
+    ).toEqual({ order: ["name", "labels"], hidden: ["labels"] });
+  });
+
+  test("returns null when nothing survives", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: { order: ["gone"], hidden: ["alsoGone"] },
+        knownColumnIds: ["name"],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when the table has no columns at all", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: { order: ["name"], hidden: [] },
+        knownColumnIds: [],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for a null preference", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: null,
+        knownColumnIds: ["name"],
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for an already-empty preference", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: { order: [], hidden: [] },
+        knownColumnIds: ["name"],
+      }),
+    ).toBeNull();
+  });
+
+  test("a partially stale layout keeps its valid entries", () => {
+    expect(
+      sanitizeColumnPreference({
+        preference: {
+          order: ["customFields.Deleted", "name", "customFields.Severity"],
+          hidden: ["customFields.Deleted", "customFields.Severity"],
+        },
+        knownColumnIds: ["name", "customFields.Severity"],
+      }),
+    ).toEqual({
+      order: ["name", "customFields.Severity"],
+      hidden: ["customFields.Severity"],
+    });
+  });
+
+  test("survives when only `hidden` has anything left", () => {
+    // `order` empty but `hidden` populated is still a meaningful layout.
+    expect(
+      sanitizeColumnPreference({
+        preference: { order: ["gone"], hidden: ["labels"] },
+        knownColumnIds: ["labels"],
+      }),
+    ).toEqual({ order: [], hidden: ["labels"] });
+  });
+
+  test("does not mutate the preference it was given", () => {
+    const preference: ColumnPreference = {
+      order: ["name", "gone"],
+      hidden: ["gone"],
+    };
+
+    sanitizeColumnPreference({ preference, knownColumnIds: ["name"] });
+
+    expect(preference).toEqual({ order: ["name", "gone"], hidden: ["gone"] });
+  });
+});
+
+describe("isEmptyColumnPreference", () => {
+  test("null and undefined are empty", () => {
+    expect(isEmptyColumnPreference(null)).toBe(true);
+    expect(isEmptyColumnPreference(undefined)).toBe(true);
+  });
+
+  test("two empty lists are empty", () => {
+    expect(isEmptyColumnPreference({ order: [], hidden: [] })).toBe(true);
+    expect(isEmptyColumnPreference(EmptyColumnPreference)).toBe(true);
+  });
+
+  test("either list carrying something makes it non-empty", () => {
+    expect(isEmptyColumnPreference({ order: ["name"], hidden: [] })).toBe(
+      false,
+    );
+    expect(isEmptyColumnPreference({ order: [], hidden: ["name"] })).toBe(
+      false,
+    );
+    expect(isEmptyColumnPreference({ order: ["name"], hidden: ["name"] })).toBe(
+      false,
+    );
+  });
+});
+
+describe("toJSON", () => {
+  test("a layout that changes nothing is stored as nothing", () => {
+    /*
+     * Otherwise every table anybody merely opened would write a row of default
+     * preferences, and there would be no way to tell "never customised" from
+     * "customised back to the default".
+     */
+    expect(toJSON(null)).toBeNull();
+    expect(toJSON(undefined)).toBeNull();
+    expect(toJSON({ order: [], hidden: [] })).toBeNull();
+    expect(toJSON(EmptyColumnPreference)).toBeNull();
+  });
+
+  test("writes both lists", () => {
+    expect(toJSON({ order: ["labels", "name"], hidden: ["name"] })).toEqual({
+      order: ["labels", "name"],
+      hidden: ["name"],
+    });
+  });
+
+  test("writes an order-only layout", () => {
+    expect(toJSON({ order: ["labels", "name"], hidden: [] })).toEqual({
+      order: ["labels", "name"],
+      hidden: [],
+    });
+  });
+
+  test("writes a hidden-only layout", () => {
+    expect(toJSON({ order: [], hidden: ["labels"] })).toEqual({
+      order: [],
+      hidden: ["labels"],
+    });
+  });
+
+  test("copies the arrays rather than aliasing them", () => {
+    // The stored value must not change under a later picker edit.
+    const preference: ColumnPreference = { order: ["name"], hidden: ["name"] };
+    const json: JSONObject | null = toJSON(preference);
+
+    expect(json?.["order"]).not.toBe(preference.order);
+    expect(json?.["hidden"]).not.toBe(preference.hidden);
+  });
+});
+
+describe("fromJSON", () => {
+  test("rejects anything that is not a plain object", () => {
+    /*
+     * The stored value is untrusted: it may have been hand-edited, or written
+     * by a release that shaped it differently.
+     */
+    expect(fromJSON(null)).toBeNull();
+    expect(fromJSON(undefined)).toBeNull();
+    expect(fromJSON("nope" as unknown as JSONObject)).toBeNull();
+    expect(fromJSON(7 as unknown as JSONObject)).toBeNull();
+    expect(fromJSON(true as unknown as JSONObject)).toBeNull();
+    expect(fromJSON([] as unknown as JSONObject)).toBeNull();
+    expect(fromJSON(["name", "labels"] as unknown as JSONObject)).toBeNull();
+  });
+
+  test("reads a well-formed layout", () => {
+    expect(fromJSON({ order: ["labels", "name"], hidden: ["name"] })).toEqual({
+      order: ["labels", "name"],
+      hidden: ["name"],
+    });
+  });
+
+  test("an object with neither list reads as no layout", () => {
+    expect(fromJSON({})).toBeNull();
+    expect(fromJSON({ order: [], hidden: [] })).toBeNull();
+  });
+
+  test("a list that is not an array degrades to empty", () => {
+    expect(fromJSON({ order: "labels", hidden: ["name"] })).toEqual({
+      order: [],
+      hidden: ["name"],
+    });
+  });
+
+  test("one malformed list does not discard the other", () => {
+    // Each list is validated on its own so a single bad key is survivable.
+    expect(
+      fromJSON({
+        order: ["name"],
+        hidden: { name: true } as unknown as string,
+      }),
+    ).toEqual({ order: ["name"], hidden: [] });
+  });
+
+  test("non-string entries are dropped", () => {
+    expect(
+      fromJSON({
+        order: ["name", 5, null, true, { a: 1 }, "labels"],
+        hidden: [["labels"], "labels"],
+      } as unknown as JSONObject),
+    ).toEqual({ order: ["name", "labels"], hidden: ["labels"] });
+  });
+
+  test("empty-string entries are dropped", () => {
+    expect(fromJSON({ order: ["", "name", ""], hidden: [""] })).toEqual({
+      order: ["name"],
+      hidden: [],
+    });
+  });
+
+  test("duplicates are dropped within each list independently", () => {
+    // The same id in both lists is legitimate: arranged, then switched off.
+    expect(
+      fromJSON({
+        order: ["name", "labels", "name"],
+        hidden: ["name", "name"],
+      }),
+    ).toEqual({ order: ["name", "labels"], hidden: ["name"] });
+  });
+
+  test("unknown keys are ignored", () => {
+    expect(
+      fromJSON({
+        order: ["name"],
+        hidden: [],
+        pinned: ["name"],
+        version: 3,
+      } as unknown as JSONObject),
+    ).toEqual({ order: ["name"], hidden: [] });
+  });
+
+  test("a layout that sanitizes down to nothing reads as no layout", () => {
+    expect(
+      fromJSON({ order: [1, 2], hidden: [""] } as unknown as JSONObject),
+    ).toBeNull();
+  });
+});
+
+describe("ColumnPreference round trip", () => {
+  test("survives toJSON -> JSON -> fromJSON unchanged", () => {
+    const preference: ColumnPreference = {
+      order: ["labels", "name", "customFields.Severity", "description"],
+      hidden: ["description"],
+    };
+
+    const json: JSONObject | null = toJSON(preference);
+
+    expect(fromJSON(JSON.parse(JSON.stringify(json)))).toEqual(preference);
+  });
+
+  test("survives the full picker cycle: columns -> entries -> JSON -> columns", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+        isHiddenByDefault: true,
+      }),
+    ];
+
+    // The viewer drags Severity to the front and switches Description off.
+    const edited: Array<CustomizableColumn<Monitor>> = [
+      { ...findEntry(getCustomizableColumns<Monitor>({ columns }), "name") },
+      {
+        ...findEntry(
+          getCustomizableColumns<Monitor>({ columns }),
+          "customFields.Severity",
+        ),
+        isVisible: true,
+      },
+      { ...findEntry(getCustomizableColumns<Monitor>({ columns }), "labels") },
+      {
+        ...findEntry(
+          getCustomizableColumns<Monitor>({ columns }),
+          "description",
+        ),
+        isVisible: false,
+      },
+    ];
+
+    const stored: JSONObject | null = toJSON(
+      buildColumnPreference<Monitor>(edited),
+    );
+
+    const restored: ColumnPreference | null = fromJSON(
+      JSON.parse(JSON.stringify(stored)),
+    );
+
+    expect(
+      titlesOf(
+        applyColumnPreference<Monitor>({ columns, preference: restored }),
+      ),
+    ).toEqual(["Name", "Severity", "Labels"]);
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * The property the whole feature rests on
+ * ---------------------------------------------------------------------------
+ *
+ * A layout is written against one release's column set and read back against
+ * another's. Every case below takes ONE stored layout - the one a viewer would
+ * plausibly have - and replays it against a changed table. The bar is not
+ * "the layout is honoured exactly"; it is "the table is still usable and
+ * nothing the viewer did not ask to hide has disappeared".
+ */
+describe("a stored layout replayed against a changed column set", () => {
+  type ReleaseOneColumnsFunction = () => Columns<Monitor>;
+
+  // Name (pinned) | Description | Labels | Severity(custom field)
+  const releaseOneColumns: ReleaseOneColumnsFunction = (): Columns<Monitor> => {
+    return [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { description: true }, title: "Description" }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Severity",
+        title: "Severity",
+        isHiddenByDefault: true,
+      }),
+    ];
+  };
+
+  /*
+   * What the viewer did: pulled the Severity custom field to the front and
+   * switched Labels off.
+   */
+  const storedPreference: ColumnPreference = {
+    order: ["customFields.Severity", "description", "labels"],
+    hidden: ["labels"],
+  };
+
+  type ReplayFunction = (columns: Columns<Monitor>) => Array<string>;
+
+  const replay: ReplayFunction = (columns: Columns<Monitor>): Array<string> => {
+    const sanitized: ColumnPreference | null = sanitizeColumnPreference({
+      preference: storedPreference,
+      knownColumnIds: getColumnIds<Monitor>(columns),
+    });
+
+    return titlesOf(
+      applyColumnPreference<Monitor>({ columns, preference: sanitized }),
+    );
+  };
+
+  test("the layout is honoured when nothing changed", () => {
+    expect(replay(releaseOneColumns())).toEqual([
+      "Name",
+      "Severity",
+      "Description",
+    ]);
+  });
+
+  test("a removed column just falls out; the rest keep their arrangement", () => {
+    const columns: Columns<Monitor> = releaseOneColumns().filter(
+      (column: Column<Monitor>): boolean => {
+        return column.title !== "Labels";
+      },
+    );
+
+    expect(replay(columns)).toEqual(["Name", "Severity", "Description"]);
+  });
+
+  test("a removed CUSTOM FIELD does not drag its neighbours out of order", () => {
+    /*
+     * Custom fields are deleted by project admins, so this is the most common
+     * way a stored id goes stale — much more common than a shipped column
+     * being removed.
+     */
+    const columns: Columns<Monitor> = releaseOneColumns().filter(
+      (column: Column<Monitor>): boolean => {
+        return column.selectedProperty !== "Severity";
+      },
+    );
+
+    expect(replay(columns)).toEqual(["Name", "Description"]);
+  });
+
+  test("a column added at the start appears there, and visible", () => {
+    const columns: Columns<Monitor> = releaseOneColumns();
+    columns.splice(1, 0, makeColumn({ field: { slug: true }, title: "Slug" }));
+
+    expect(replay(columns)).toEqual([
+      "Name",
+      "Slug",
+      "Severity",
+      "Description",
+    ]);
+  });
+
+  test("a column added in the middle lands next to its declared predecessor", () => {
+    const columns: Columns<Monitor> = releaseOneColumns();
+    // Declared between Description and Labels.
+    columns.splice(2, 0, makeColumn({ field: { slug: true }, title: "Slug" }));
+
+    expect(replay(columns)).toEqual([
+      "Name",
+      "Severity",
+      "Description",
+      "Slug",
+    ]);
+  });
+
+  test("a column added at the end is visible and does not disturb the layout", () => {
+    const columns: Columns<Monitor> = releaseOneColumns();
+    columns.push(makeColumn({ field: { monitorType: true }, title: "Type" }));
+
+    const rendered: Array<string> = replay(columns);
+
+    expect(rendered).toContain("Type");
+    // Labels stays hidden; the arranged columns keep their relative order.
+    expect(rendered).not.toContain("Labels");
+    expect(rendered.indexOf("Severity")).toBeLessThan(
+      rendered.indexOf("Description"),
+    );
+  });
+
+  test("a new custom field is offered in the picker but stays switched off", () => {
+    /*
+     * New custom fields ship hidden by default, and a layout written before
+     * they existed says nothing about them — so they stay off until the viewer
+     * opts in, rather than widening everyone's table overnight.
+     */
+    const columns: Columns<Monitor> = releaseOneColumns();
+    columns.push(
+      makeColumn({
+        field: { customFields: true },
+        selectedProperty: "Team",
+        title: "Team",
+        isHiddenByDefault: true,
+      }),
+    );
+
+    const entries: Array<CustomizableColumn<Monitor>> =
+      getCustomizableColumns<Monitor>({
+        columns,
+        preference: storedPreference,
+      });
+
+    // Listed in the picker, so it can be switched on...
+    expect(entryIds(entries)).toContain("customFields.Team");
+    // ...but off until then.
+    expect(findEntry(entries, "customFields.Team").isVisible).toBe(false);
+  });
+
+  test("renaming a column does not disturb a layout keyed off its field", () => {
+    const columns: Columns<Monitor> = releaseOneColumns().map(
+      (column: Column<Monitor>): Column<Monitor> => {
+        return column.title === "Description"
+          ? { ...column, title: "Summary" }
+          : column;
+      },
+    );
+
+    expect(replay(columns)).toEqual(["Name", "Severity", "Summary"]);
+  });
+
+  test("renaming a COLLIDING column loses its layout entry but never the column", () => {
+    /*
+     * Colliding columns are keyed partly by title, so a rename is a new id.
+     * The consequence is bounded on purpose: the entry goes stale, sanitize
+     * drops it, and the column comes back as if it were newly shipped —
+     * visible. Failing open is the whole point.
+     */
+    const before: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Owner" }),
+    ];
+
+    const preference: ColumnPreference = {
+      order: ["_id:actions", "_id:owner"],
+      hidden: ["_id:owner"],
+    };
+
+    expect(
+      titlesOf(applyColumnPreference<Monitor>({ columns: before, preference })),
+    ).toEqual(["Name", "Actions"]);
+
+    const after: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Owned By" }),
+    ];
+
+    const sanitized: ColumnPreference | null = sanitizeColumnPreference({
+      preference,
+      knownColumnIds: getColumnIds<Monitor>(after),
+    });
+
+    expect(sanitized).toEqual({ order: ["_id:actions"], hidden: [] });
+    expect(
+      titlesOf(
+        applyColumnPreference<Monitor>({
+          columns: after,
+          preference: sanitized,
+        }),
+      ),
+    ).toEqual(["Name", "Actions", "Owned By"]);
+  });
+
+  test("a layout whose columns are all gone sanitizes away and the table renders its own defaults", () => {
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { monitorType: true }, title: "Type" }),
+      makeColumn({ field: { slug: true }, title: "Slug" }),
+    ];
+
+    const sanitized: ColumnPreference | null = sanitizeColumnPreference({
+      preference: storedPreference,
+      knownColumnIds: getColumnIds<Monitor>(columns),
+    });
+
+    expect(sanitized).toBeNull();
+    expect(
+      titlesOf(
+        applyColumnPreference<Monitor>({
+          columns,
+          preference: sanitized,
+        }),
+      ),
+    ).toEqual(["Name", "Type", "Slug"]);
+  });
+
+  test("a column that becomes pinned stops obeying the layout that hid it", () => {
+    /*
+     * Tables do gain a pinned column over time (usually the name). A layout
+     * that hid it must not survive that change, or the row would be
+     * unidentifiable with no control to fix it.
+     */
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({
+        field: { description: true },
+        title: "Description",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { labels: true }, title: "Labels" }),
+    ];
+
+    expect(
+      titlesOf(
+        applyColumnPreference<Monitor>({
+          columns,
+          preference: {
+            order: ["labels", "description"],
+            hidden: ["description", "labels"],
+          },
+        }),
+      ),
+    ).toEqual(["Name", "Description"]);
+  });
+
+  test("the whole table changing shape at once still renders something usable", () => {
+    // Nothing in common with the layout except the pinned column.
+    const columns: Columns<Monitor> = [
+      makeColumn({
+        field: { name: true },
+        title: "Name",
+        isNotCustomizable: true,
+      }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: { _id: true }, title: "Actions" }),
+      makeColumn({ field: {}, title: "" }),
+    ];
+
+    const rendered: Columns<Monitor> = applyColumnPreference<Monitor>({
+      columns,
+      preference: storedPreference,
+    });
+
+    expect(rendered).toHaveLength(4);
+    expect(titlesOf(rendered)).toEqual(["Name", "Actions", "Actions", ""]);
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/CustomFieldColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/CustomFieldColumns.test.tsx
@@ -1,0 +1,1094 @@
+import Column from "../../../../UI/Components/ModelTable/Column";
+import Columns from "../../../../UI/Components/ModelTable/Columns";
+import {
+  CustomFieldDefinition,
+  CustomFieldsColumnKey,
+  getCustomFieldColumns,
+  getCustomFieldDefinitions,
+  getCustomFieldValue,
+  parseDropdownOptions,
+  renderCustomFieldValue,
+} from "../../../../UI/Components/ModelTable/CustomFieldColumns";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorCustomField from "../../../../Models/DatabaseModels/MonitorCustomField";
+import CustomFieldType from "../../../../Types/CustomField/CustomFieldType";
+import { JSONObject } from "../../../../Types/JSON";
+import "@testing-library/jest-dom/extend-expect";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Custom field *definitions* live in a per-resource table; the *values* live in
+ * one `customFields` jsonb column on the resource. This module turns the former
+ * into table columns that read the latter, and the exact shape it produces is
+ * load-bearing in several places that will not complain loudly when it is
+ * wrong - the table either throws on select, sends garbage to TypeORM, or
+ * silently renders every cell blank. Each shape rule below is pinned with a
+ * note about what breaks if it changes.
+ */
+
+const textDefinition: CustomFieldDefinition = {
+  name: "Owner",
+  customFieldType: CustomFieldType.Text,
+};
+
+const booleanDefinition: CustomFieldDefinition = {
+  name: "Paging",
+  customFieldType: CustomFieldType.Boolean,
+};
+
+const dropdownDefinition: CustomFieldDefinition = {
+  name: "Severity",
+  customFieldType: CustomFieldType.Dropdown,
+  dropdownOptions: "Low\nHigh",
+};
+
+const multiSelectDefinition: CustomFieldDefinition = {
+  name: "Teams",
+  customFieldType: CustomFieldType.MultiSelectDropdown,
+  dropdownOptions: "Infra\nApps",
+};
+
+type RenderValueFunction = (data: {
+  value: unknown;
+  definition: CustomFieldDefinition;
+  noValueMessage?: string | undefined;
+}) => HTMLElement;
+
+const renderValue: RenderValueFunction = (data: {
+  value: unknown;
+  definition: CustomFieldDefinition;
+  noValueMessage?: string | undefined;
+}): HTMLElement => {
+  const { container } = render(<>{renderCustomFieldValue(data)}</>);
+
+  return container;
+};
+
+/*
+ * Every badge is the same markup - an indigo pill with a dot - so counting the
+ * pills is how we tell "one badge holding a comma list" apart from "one badge
+ * per value".
+ */
+type GetBadgeLabelsFunction = (container: HTMLElement) => Array<string>;
+
+const getBadgeLabels: GetBadgeLabelsFunction = (
+  container: HTMLElement,
+): Array<string> => {
+  return Array.from(container.querySelectorAll("span.bg-indigo-50")).map(
+    (element: Element): string => {
+      return (element.textContent || "").trim();
+    },
+  );
+};
+
+type GetPlaceholderFunction = (container: HTMLElement) => Element | null;
+
+const getPlaceholder: GetPlaceholderFunction = (
+  container: HTMLElement,
+): Element | null => {
+  return container.querySelector("span.text-gray-400");
+};
+
+type ColumnAtFunction = (
+  columns: Columns<Monitor>,
+  index: number,
+) => Column<Monitor>;
+
+const columnAt: ColumnAtFunction = (
+  columns: Columns<Monitor>,
+  index: number,
+): Column<Monitor> => {
+  const column: Column<Monitor> | undefined = columns[index];
+
+  if (!column) {
+    throw new Error(`Expected a generated column at index ${index}`);
+  }
+
+  return column;
+};
+
+type ExportValueOfFunction = (column: Column<Monitor>, item: Monitor) => string;
+
+const exportValueOf: ExportValueOfFunction = (
+  column: Column<Monitor>,
+  item: Monitor,
+): string => {
+  if (!column.getExportValue) {
+    throw new Error(`Column "${column.title}" has no getExportValue`);
+  }
+
+  return column.getExportValue(item);
+};
+
+type RenderColumnFunction = (
+  column: Column<Monitor>,
+  item: Monitor,
+) => HTMLElement;
+
+const renderColumn: RenderColumnFunction = (
+  column: Column<Monitor>,
+  item: Monitor,
+): HTMLElement => {
+  if (!column.getElement) {
+    throw new Error(`Column "${column.title}" has no getElement`);
+  }
+
+  const { container } = render(<>{column.getElement(item)}</>);
+
+  return container;
+};
+
+type MonitorWithFieldsFunction = (customFields: JSONObject) => Monitor;
+
+const monitorWithFields: MonitorWithFieldsFunction = (
+  customFields: JSONObject,
+): Monitor => {
+  const monitor: Monitor = new Monitor();
+  monitor.customFields = customFields;
+
+  return monitor;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CustomFieldColumns.parseDropdownOptions", () => {
+  test("splits the stored blob into one option per line", () => {
+    /*
+     * The settings page writes dropdown options as a textarea blob, so the
+     * newline is the only separator there is - a comma is a legal character
+     * inside an option label.
+     */
+    expect(parseDropdownOptions("Low\nMedium\nHigh")).toEqual([
+      "Low",
+      "Medium",
+      "High",
+    ]);
+  });
+
+  test("trims each option", () => {
+    expect(parseDropdownOptions("  Low  \n\tHigh\t")).toEqual(["Low", "High"]);
+  });
+
+  test("drops blank and whitespace-only lines", () => {
+    // A trailing newline in the textarea must not become an empty option.
+    expect(parseDropdownOptions("Low\n\n   \nHigh\n")).toEqual(["Low", "High"]);
+  });
+
+  test("returns an empty list for a blob that is only whitespace", () => {
+    expect(parseDropdownOptions("\n \n\t\n")).toEqual([]);
+  });
+
+  test("returns the single option when the blob has no newline at all", () => {
+    expect(parseDropdownOptions("Low")).toEqual(["Low"]);
+  });
+
+  test("returns an empty list for empty, null, undefined and non-string input", () => {
+    // The column is nullable and the API is free to hand back anything.
+    expect(parseDropdownOptions("")).toEqual([]);
+    expect(parseDropdownOptions(null)).toEqual([]);
+    expect(parseDropdownOptions(undefined)).toEqual([]);
+    expect(parseDropdownOptions(42 as unknown as string)).toEqual([]);
+    expect(parseDropdownOptions({} as unknown as string)).toEqual([]);
+    expect(parseDropdownOptions([] as unknown as string)).toEqual([]);
+  });
+});
+
+describe("CustomFieldColumns.getCustomFieldDefinitions", () => {
+  test("normalises a plain JSON object off the definitions endpoint", () => {
+    expect(
+      getCustomFieldDefinitions([
+        {
+          name: "Severity",
+          description: "How bad it is",
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "Low\nHigh",
+        },
+      ]),
+    ).toEqual([
+      {
+        name: "Severity",
+        description: "How bad it is",
+        customFieldType: CustomFieldType.Dropdown,
+        dropdownOptions: "Low\nHigh",
+      },
+    ]);
+  });
+
+  test("normalises a hydrated BaseModel the same way", () => {
+    /*
+     * ModelAPI hands back model instances, not plain JSON, and the hook feeds
+     * them in unchanged.
+     */
+    const model: MonitorCustomField = new MonitorCustomField();
+    model.name = "Severity";
+    model.description = "How bad it is";
+    model.customFieldType = CustomFieldType.Dropdown;
+    model.dropdownOptions = "Low\nHigh";
+
+    expect(getCustomFieldDefinitions([model])).toEqual([
+      {
+        name: "Severity",
+        description: "How bad it is",
+        customFieldType: CustomFieldType.Dropdown,
+        dropdownOptions: "Low\nHigh",
+      },
+    ]);
+  });
+
+  test("leaves the optional properties undefined when they are absent", () => {
+    expect(getCustomFieldDefinitions([{ name: "Owner" }])).toEqual([
+      {
+        name: "Owner",
+        description: undefined,
+        customFieldType: undefined,
+        dropdownOptions: undefined,
+      },
+    ]);
+  });
+
+  test("drops non-string description, type and options rather than passing them through", () => {
+    /*
+     * A number sitting in `description` would end up as a column tooltip, and
+     * a non-string type would silently miss every renderer branch.
+     */
+    expect(
+      getCustomFieldDefinitions([
+        {
+          name: "Owner",
+          description: 42,
+          customFieldType: 7,
+          dropdownOptions: ["Low", "High"],
+        },
+      ]),
+    ).toEqual([
+      {
+        name: "Owner",
+        description: undefined,
+        customFieldType: undefined,
+        dropdownOptions: undefined,
+      },
+    ]);
+  });
+
+  test("skips an entry with no name", () => {
+    // The name is the jsonb key; without one there is nothing to read.
+    expect(getCustomFieldDefinitions([{ description: "orphan" }])).toEqual([]);
+  });
+
+  test("skips an entry whose name is not a string", () => {
+    expect(
+      getCustomFieldDefinitions([
+        { name: 42 },
+        { name: null },
+        { name: { first: "Severity" } },
+        { name: ["Severity"] },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("skips an entry whose name is empty or whitespace-only", () => {
+    expect(
+      getCustomFieldDefinitions([
+        { name: "" },
+        { name: "   " },
+        { name: "\n" },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("keeps the good entries alongside the skipped ones", () => {
+    expect(
+      getCustomFieldDefinitions([
+        { name: "Owner" },
+        { name: "  " },
+        { description: "no name here" },
+        { name: "Severity" },
+      ]).map((definition: CustomFieldDefinition): string => {
+        return definition.name;
+      }),
+    ).toEqual(["Owner", "Severity"]);
+  });
+
+  test("trims the name", () => {
+    /*
+     * The trimmed name becomes the column id and the jsonb key lookup, so a
+     * stray space would produce a column that never matches a value.
+     */
+    expect(
+      getCustomFieldDefinitions([{ name: "  Severity  " }])[0]?.name,
+    ).toEqual("Severity");
+  });
+
+  test("de-duplicates by name, keeping the first entry", () => {
+    /*
+     * Two definitions with the same name would generate two columns with the
+     * same id, and the preference layer keys on that id.
+     */
+    expect(
+      getCustomFieldDefinitions([
+        { name: "Severity", description: "first" },
+        { name: "Severity", description: "second" },
+      ]),
+    ).toEqual([
+      {
+        name: "Severity",
+        description: "first",
+        customFieldType: undefined,
+        dropdownOptions: undefined,
+      },
+    ]);
+  });
+
+  test("de-duplicates after trimming, not before", () => {
+    expect(
+      getCustomFieldDefinitions([{ name: "Severity" }, { name: " Severity " }]),
+    ).toHaveLength(1);
+  });
+
+  test("sorts by name", () => {
+    /*
+     * This is the load-bearing one. The definition models carry no ordering
+     * column and the list endpoint is queried with an empty sort, so Postgres
+     * may hand back a different order on every request. Without a
+     * deterministic order here the viewer's saved column layout would appear
+     * to shuffle itself between page loads.
+     */
+    expect(
+      getCustomFieldDefinitions([
+        { name: "Zone" },
+        { name: "Alpha" },
+        { name: "Middle" },
+      ]).map((definition: CustomFieldDefinition): string => {
+        return definition.name;
+      }),
+    ).toEqual(["Alpha", "Middle", "Zone"]);
+  });
+
+  test("sorts case-insensitively the way a human reads the picker", () => {
+    // localeCompare, not a raw code point compare: "apple" sorts before "Banana".
+    expect(
+      getCustomFieldDefinitions([
+        { name: "Banana" },
+        { name: "apple" },
+        { name: "Cherry" },
+      ]).map((definition: CustomFieldDefinition): string => {
+        return definition.name;
+      }),
+    ).toEqual(["apple", "Banana", "Cherry"]);
+  });
+
+  test("sorts on the trimmed name", () => {
+    expect(
+      getCustomFieldDefinitions([{ name: "  Zone" }, { name: "Alpha  " }]).map(
+        (definition: CustomFieldDefinition): string => {
+          return definition.name;
+        },
+      ),
+    ).toEqual(["Alpha", "Zone"]);
+  });
+
+  test("returns an empty list for an empty or missing input", () => {
+    expect(getCustomFieldDefinitions([])).toEqual([]);
+    expect(
+      getCustomFieldDefinitions(undefined as unknown as Array<JSONObject>),
+    ).toEqual([]);
+    expect(
+      getCustomFieldDefinitions(null as unknown as Array<JSONObject>),
+    ).toEqual([]);
+  });
+
+  test("survives null and undefined entries inside the list", () => {
+    expect(
+      getCustomFieldDefinitions([
+        null as unknown as JSONObject,
+        undefined as unknown as JSONObject,
+        { name: "Owner" },
+      ]),
+    ).toHaveLength(1);
+  });
+});
+
+describe("CustomFieldColumns.getCustomFieldValue", () => {
+  test("reads the named key out of the customFields object", () => {
+    expect(
+      getCustomFieldValue({ customFields: { Severity: "High" } }, "Severity"),
+    ).toEqual("High");
+  });
+
+  test("reads a value off a hydrated model", () => {
+    expect(
+      getCustomFieldValue(monitorWithFields({ Owner: "SRE" }), "Owner"),
+    ).toEqual("SRE");
+  });
+
+  test("preserves the raw value type", () => {
+    /*
+     * The renderer branches on the value's type, so this must not stringify
+     * on the way out.
+     */
+    expect(
+      getCustomFieldValue({ customFields: { Paging: false } }, "Paging"),
+    ).toBe(false);
+    expect(getCustomFieldValue({ customFields: { Count: 0 } }, "Count")).toBe(
+      0,
+    );
+    expect(
+      getCustomFieldValue({ customFields: { Teams: ["Infra"] } }, "Teams"),
+    ).toEqual(["Infra"]);
+  });
+
+  test("returns undefined when the row carries no customFields", () => {
+    /*
+     * The column is only selected when at least one definition exists, and a
+     * row that has never been edited has a null jsonb column.
+     */
+    expect(getCustomFieldValue({}, "Severity")).toBeUndefined();
+    expect(
+      getCustomFieldValue({ customFields: null }, "Severity"),
+    ).toBeUndefined();
+    expect(
+      getCustomFieldValue({ customFields: undefined }, "Severity"),
+    ).toBeUndefined();
+    expect(getCustomFieldValue(new Monitor(), "Severity")).toBeUndefined();
+  });
+
+  test("returns undefined when customFields is not an object", () => {
+    expect(
+      getCustomFieldValue({ customFields: "High" }, "Severity"),
+    ).toBeUndefined();
+    expect(
+      getCustomFieldValue({ customFields: 42 }, "Severity"),
+    ).toBeUndefined();
+    expect(
+      getCustomFieldValue({ customFields: true }, "Severity"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when the key is absent", () => {
+    // A field added after the row was last saved.
+    expect(
+      getCustomFieldValue({ customFields: { Owner: "SRE" } }, "Severity"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for a missing or non-object row", () => {
+    expect(getCustomFieldValue(undefined, "Severity")).toBeUndefined();
+    expect(getCustomFieldValue(null, "Severity")).toBeUndefined();
+  });
+});
+
+describe("CustomFieldColumns.getCustomFieldColumns", () => {
+  test("generates one column per definition, in the order given", () => {
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [textDefinition, dropdownDefinition],
+    });
+
+    expect(columns).toHaveLength(2);
+    expect(
+      columns.map((column: Column<Monitor>): string => {
+        return column.title;
+      }),
+    ).toEqual(["Owner", "Severity"]);
+  });
+
+  test("declares the real model column as its field", () => {
+    /*
+     * A synthetic `field: { "customFields.Severity": true }` would fail the
+     * model's column check inside getSelectFromColumns and throw the whole
+     * table away, so the declared field has to be exactly the jsonb column.
+     */
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [dropdownDefinition] }),
+      0,
+    );
+
+    expect(column.field).toEqual({ customFields: true });
+    expect(Object.keys(column.field as JSONObject)).toEqual([
+      CustomFieldsColumnKey,
+    ]);
+  });
+
+  test("puts the definition name in selectedProperty", () => {
+    /*
+     * BaseModelTable joins field + selectedProperty into the column key
+     * "customFields.<name>"; without selectedProperty every custom field
+     * column would collapse onto the same key.
+     */
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [dropdownDefinition] }),
+      0,
+    );
+
+    expect(column.selectedProperty).toEqual("Severity");
+  });
+
+  test("always disables sorting", () => {
+    /*
+     * Nothing downstream validates `sort` before it reaches TypeORM, so a
+     * clickable header here would send an unknown property into the query
+     * builder. Postgres can only order by a jsonb key through an explicit ->>
+     * expression, which the sort path has no concept of.
+     */
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [
+        textDefinition,
+        booleanDefinition,
+        dropdownDefinition,
+        multiSelectDefinition,
+      ],
+    });
+
+    for (const column of columns) {
+      expect(column.disableSort).toBe(true);
+    }
+  });
+
+  test("gives the column a stable id derived from the field name", () => {
+    /*
+     * The id is what the saved preference stores. Deriving it from the title
+     * (as untagged columns do) would be the same string today but would drift
+     * the moment anything about the title changes.
+     */
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [dropdownDefinition, multiSelectDefinition],
+    });
+
+    expect(
+      columns.map((column: Column<Monitor>): string | undefined => {
+        return column.id;
+      }),
+    ).toEqual(["customFields.Severity", "customFields.Teams"]);
+  });
+
+  test("produces the same id for the same definition every time", () => {
+    const first: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [dropdownDefinition],
+    });
+    const second: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [dropdownDefinition],
+      isHiddenByDefault: false,
+    });
+
+    expect(columnAt(first, 0).id).toEqual(columnAt(second, 0).id);
+  });
+
+  test("hides custom field columns by default", () => {
+    /*
+     * A project is free to define a dozen custom fields, and turning every one
+     * on by default would push the columns the table was designed around off
+     * the side of the screen the first time anyone opens it.
+     */
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [textDefinition, dropdownDefinition],
+    });
+
+    for (const column of columns) {
+      expect(column.isHiddenByDefault).toBe(true);
+    }
+  });
+
+  test("stays hidden when isHiddenByDefault is passed explicitly or as undefined", () => {
+    expect(
+      columnAt(
+        getCustomFieldColumns<Monitor>({
+          definitions: [textDefinition],
+          isHiddenByDefault: true,
+        }),
+        0,
+      ).isHiddenByDefault,
+    ).toBe(true);
+
+    expect(
+      columnAt(
+        getCustomFieldColumns<Monitor>({
+          definitions: [textDefinition],
+          isHiddenByDefault: undefined,
+        }),
+        0,
+      ).isHiddenByDefault,
+    ).toBe(true);
+  });
+
+  test("can be asked to show the columns instead", () => {
+    // Only an explicit `false` opts in - a caller that wants them visible.
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [textDefinition, dropdownDefinition],
+      isHiddenByDefault: false,
+    });
+
+    for (const column of columns) {
+      expect(column.isHiddenByDefault).toBe(false);
+    }
+  });
+
+  test("takes the title and description from the definition", () => {
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({
+        definitions: [
+          {
+            name: "Severity",
+            description: "How bad it is",
+            customFieldType: CustomFieldType.Dropdown,
+          },
+        ],
+      }),
+      0,
+    );
+
+    expect(column.title).toEqual("Severity");
+    expect(column.description).toEqual("How bad it is");
+  });
+
+  test("leaves the description undefined when the definition has none", () => {
+    expect(
+      columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+        0,
+      ).description,
+    ).toBeUndefined();
+  });
+
+  test("declares itself as an Element column", () => {
+    expect(
+      columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+        0,
+      ).type,
+    ).toEqual(FieldType.Element);
+  });
+
+  test("gives every column a getElement", () => {
+    /*
+     * The typed cell renderers index item[column.key] directly, so with a
+     * dotted key like "customFields.Severity" they would look for a literal
+     * property of that name and find nothing. Only getElement can reach into
+     * the jsonb object.
+     */
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [
+        textDefinition,
+        booleanDefinition,
+        dropdownDefinition,
+        multiSelectDefinition,
+      ],
+    });
+
+    for (const column of columns) {
+      expect(typeof column.getElement).toEqual("function");
+    }
+  });
+
+  test("exports a plain string for a text value", () => {
+    /*
+     * The CSV export walks the same dotted key and would come back empty
+     * without an explicit getExportValue.
+     */
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+      0,
+    );
+
+    expect(exportValueOf(column, monitorWithFields({ Owner: "SRE" }))).toEqual(
+      "SRE",
+    );
+  });
+
+  test("exports non-string scalars through String()", () => {
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [booleanDefinition, { name: "Count" }],
+    });
+
+    /*
+     * A zero and a false have to survive the export: the "" fallback is only
+     * for undefined and null, so these go through String() like any other
+     * scalar.
+     */
+    expect(
+      exportValueOf(columnAt(columns, 0), monitorWithFields({ Paging: false })),
+    ).toEqual("false");
+    expect(
+      exportValueOf(columnAt(columns, 1), monitorWithFields({ Count: 0 })),
+    ).toEqual("0");
+  });
+
+  test("joins an array value for the CSV cell", () => {
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [multiSelectDefinition] }),
+      0,
+    );
+
+    expect(
+      exportValueOf(column, monitorWithFields({ Teams: ["Infra", "Apps"] })),
+    ).toEqual("Infra, Apps");
+  });
+
+  test("JSON-stringifies an object value for the CSV cell", () => {
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+      0,
+    );
+
+    expect(
+      exportValueOf(column, monitorWithFields({ Owner: { team: "SRE" } })),
+    ).toEqual('{"team":"SRE"}');
+  });
+
+  test("exports an empty string when the value is missing", () => {
+    /*
+     * An empty cell, not the literal "undefined", which is what String()
+     * would have produced.
+     */
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+      0,
+    );
+
+    expect(exportValueOf(column, new Monitor())).toEqual("");
+    expect(exportValueOf(column, monitorWithFields({}))).toEqual("");
+    expect(exportValueOf(column, monitorWithFields({ Owner: null }))).toEqual(
+      "",
+    );
+  });
+
+  test("returns no columns for an empty or missing definition list", () => {
+    /*
+     * A resource with no custom fields must contribute nothing at all, or the
+     * picker grows an empty section.
+     */
+    expect(getCustomFieldColumns<Monitor>({ definitions: [] })).toEqual([]);
+    expect(
+      getCustomFieldColumns<Monitor>({
+        definitions: undefined as unknown as Array<CustomFieldDefinition>,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("CustomFieldColumns.renderCustomFieldValue", () => {
+  test("renders a text value as-is", () => {
+    expect(
+      renderValue({ value: "SRE", definition: textDefinition }).textContent,
+    ).toEqual("SRE");
+  });
+
+  test("renders a number value", () => {
+    expect(
+      renderValue({
+        value: 42,
+        definition: { name: "Count", customFieldType: CustomFieldType.Number },
+      }).textContent,
+    ).toEqual("42");
+  });
+
+  test("renders a zero rather than treating it as missing", () => {
+    // 0 is a real answer; only undefined, null and "" are missing.
+    const container: HTMLElement = renderValue({
+      value: 0,
+      definition: { name: "Count", customFieldType: CustomFieldType.Number },
+    });
+
+    expect(container.textContent).toEqual("0");
+    expect(getPlaceholder(container)).toBeNull();
+  });
+
+  test("renders a false boolean as 'No', not as the empty placeholder", () => {
+    /*
+     * The whole reason the boolean branch sits above the empty check: `false`
+     * is a real answer to a yes/no field, and rendering it as "-" would read
+     * as "nobody has filled this in".
+     */
+    const container: HTMLElement = renderValue({
+      value: false,
+      definition: booleanDefinition,
+    });
+
+    expect(container.textContent).toEqual("No");
+    expect(getPlaceholder(container)).toBeNull();
+  });
+
+  test("renders a true boolean as 'Yes'", () => {
+    expect(
+      renderValue({ value: true, definition: booleanDefinition }).textContent,
+    ).toEqual("Yes");
+  });
+
+  test("renders the string forms of a boolean", () => {
+    /*
+     * jsonb round-trips through a form that posts strings, so both shapes are
+     * in the wild.
+     */
+    expect(
+      renderValue({ value: "true", definition: booleanDefinition }).textContent,
+    ).toEqual("Yes");
+    expect(
+      renderValue({ value: "false", definition: booleanDefinition })
+        .textContent,
+    ).toEqual("No");
+  });
+
+  test("treats anything else on a boolean field as 'No'", () => {
+    expect(
+      renderValue({ value: "maybe", definition: booleanDefinition })
+        .textContent,
+    ).toEqual("No");
+    expect(
+      renderValue({ value: 1, definition: booleanDefinition }).textContent,
+    ).toEqual("No");
+  });
+
+  test("styles Yes and No differently", () => {
+    expect(
+      renderValue({
+        value: true,
+        definition: booleanDefinition,
+      }).querySelector("span.bg-green-50"),
+    ).not.toBeNull();
+    expect(
+      renderValue({
+        value: false,
+        definition: booleanDefinition,
+      }).querySelector("span.bg-gray-50"),
+    ).not.toBeNull();
+  });
+
+  test("still shows the placeholder for a boolean nobody answered", () => {
+    // Missing is missing - the boolean branch only claims real values.
+    expect(
+      getPlaceholder(
+        renderValue({ value: undefined, definition: booleanDefinition }),
+      ),
+    ).not.toBeNull();
+  });
+
+  test("renders a dropdown value as a single badge", () => {
+    const container: HTMLElement = renderValue({
+      value: "High",
+      definition: dropdownDefinition,
+    });
+
+    expect(getBadgeLabels(container)).toEqual(["High"]);
+  });
+
+  test("renders one badge per multi-select value", () => {
+    /*
+     * One badge each rather than a single comma-joined badge: the table reads
+     * as a set of tags, which is what a multi-select is.
+     */
+    const container: HTMLElement = renderValue({
+      value: ["Infra", "Apps"],
+      definition: multiSelectDefinition,
+    });
+
+    expect(getBadgeLabels(container)).toEqual(["Infra", "Apps"]);
+  });
+
+  test("renders a bare string on a multi-select field as one badge", () => {
+    /*
+     * Tolerant on the way out: a value saved while the field was a
+     * single-select is still a bare string in the jsonb after someone switches
+     * the field type, and it must not render as one badge per character.
+     */
+    const container: HTMLElement = renderValue({
+      value: "Infra",
+      definition: multiSelectDefinition,
+    });
+
+    expect(getBadgeLabels(container)).toEqual(["Infra"]);
+  });
+
+  test("drops empty entries out of a multi-select array", () => {
+    const container: HTMLElement = renderValue({
+      value: ["Infra", "", null, undefined, "Apps"],
+      definition: multiSelectDefinition,
+    });
+
+    expect(getBadgeLabels(container)).toEqual(["Infra", "Apps"]);
+  });
+
+  test("stringifies non-string multi-select entries", () => {
+    expect(
+      getBadgeLabels(
+        renderValue({ value: [1, 2], definition: multiSelectDefinition }),
+      ),
+    ).toEqual(["1", "2"]);
+  });
+
+  test("renders the placeholder for an empty multi-select array", () => {
+    /*
+     * An empty array is not caught by the `value === ""` check above, so the
+     * multi-select branch has to fall back to the placeholder itself.
+     */
+    const container: HTMLElement = renderValue({
+      value: [],
+      definition: multiSelectDefinition,
+    });
+
+    expect(getBadgeLabels(container)).toEqual([]);
+    expect(getPlaceholder(container)).not.toBeNull();
+    expect(container.textContent).toEqual("-");
+  });
+
+  test("renders the placeholder when every multi-select entry is empty", () => {
+    const container: HTMLElement = renderValue({
+      value: ["", null],
+      definition: multiSelectDefinition,
+    });
+
+    expect(getPlaceholder(container)).not.toBeNull();
+  });
+
+  test("renders the placeholder for undefined, null and an empty string", () => {
+    for (const value of [undefined, null, ""]) {
+      const container: HTMLElement = renderValue({
+        value: value,
+        definition: textDefinition,
+      });
+
+      expect(container.textContent).toEqual("-");
+      expect(getPlaceholder(container)).not.toBeNull();
+    }
+  });
+
+  test("uses the column's own noValueMessage when it has one", () => {
+    expect(
+      renderValue({
+        value: undefined,
+        definition: textDefinition,
+        noValueMessage: "Not set",
+      }).textContent,
+    ).toEqual("Not set");
+  });
+
+  test("joins an array value on a plain text field", () => {
+    /*
+     * The field type changed the other way round - an old multi-select value
+     * on a field that is now Text still has to read as something.
+     */
+    expect(
+      renderValue({ value: ["Infra", "Apps"], definition: textDefinition })
+        .textContent,
+    ).toEqual("Infra, Apps");
+  });
+
+  test("JSON-stringifies an object value", () => {
+    // Better than React's "[object Object]" or an outright render crash.
+    expect(
+      renderValue({ value: { team: "SRE" }, definition: textDefinition })
+        .textContent,
+    ).toEqual('{"team":"SRE"}');
+  });
+
+  test("falls through to the text path when the definition has no type", () => {
+    /*
+     * customFieldType is nullable on the definition models, so an untyped
+     * field has to render rather than blank out.
+     */
+    const definition: CustomFieldDefinition = { name: "Notes" };
+
+    expect(
+      renderValue({ value: "hello", definition: definition }).textContent,
+    ).toEqual("hello");
+    expect(
+      renderValue({ value: 7, definition: definition }).textContent,
+    ).toEqual("7");
+    expect(
+      renderValue({ value: true, definition: definition }).textContent,
+    ).toEqual("true");
+    expect(
+      getPlaceholder(renderValue({ value: undefined, definition: definition })),
+    ).not.toBeNull();
+  });
+
+  test("renders a boolean-looking string on an untyped field as the string", () => {
+    /*
+     * Without a Boolean type there is no yes/no to render - the value is just
+     * text, and pretending otherwise would invent a meaning the field does not
+     * have.
+     */
+    const container: HTMLElement = renderValue({
+      value: "false",
+      definition: { name: "Notes" },
+    });
+
+    expect(container.textContent).toEqual("false");
+    expect(container.querySelector("span.bg-gray-50")).toBeNull();
+  });
+});
+
+describe("CustomFieldColumns generated getElement", () => {
+  test("reads the value out of the row's customFields and renders it", () => {
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+      0,
+    );
+
+    expect(
+      renderColumn(column, monitorWithFields({ Owner: "SRE" })).textContent,
+    ).toEqual("SRE");
+  });
+
+  test("renders the placeholder for a row with no customFields at all", () => {
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [textDefinition] }),
+      0,
+    );
+
+    expect(getPlaceholder(renderColumn(column, new Monitor()))).not.toBeNull();
+  });
+
+  test("renders 'No' for a false boolean straight off the row", () => {
+    /*
+     * The end-to-end version of the boolean rule: a monitor that was
+     * explicitly marked as not paging must not read as unanswered in the
+     * table.
+     */
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [booleanDefinition] }),
+      0,
+    );
+
+    expect(
+      renderColumn(column, monitorWithFields({ Paging: false })).textContent,
+    ).toEqual("No");
+  });
+
+  test("renders one badge per multi-select value straight off the row", () => {
+    const column: Column<Monitor> = columnAt(
+      getCustomFieldColumns<Monitor>({ definitions: [multiSelectDefinition] }),
+      0,
+    );
+
+    expect(
+      getBadgeLabels(
+        renderColumn(column, monitorWithFields({ Teams: ["Infra", "Apps"] })),
+      ),
+    ).toEqual(["Infra", "Apps"]);
+  });
+
+  test("each column reads only its own key", () => {
+    /*
+     * Every generated column shares the same `field`, so the only thing
+     * keeping them apart is the name closed over by getElement.
+     */
+    const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+      definitions: [dropdownDefinition, textDefinition],
+    });
+    const monitor: Monitor = monitorWithFields({
+      Owner: "SRE",
+      Severity: "High",
+    });
+
+    // Sorted input is not required here; definitions map straight through.
+    expect(renderColumn(columnAt(columns, 0), monitor).textContent).toEqual(
+      "High",
+    );
+    expect(renderColumn(columnAt(columns, 1), monitor).textContent).toEqual(
+      "SRE",
+    );
+  });
+});

--- a/Common/Tests/Utils/UserPreferences.test.ts
+++ b/Common/Tests/Utils/UserPreferences.test.ts
@@ -1,0 +1,563 @@
+import UserPreferences, {
+  UserPreferenceType,
+} from "../../Utils/UserPreferences";
+import { JSONObject } from "../../Types/JSON";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * UserPreferences is the only thing standing between a table's saved layout and
+ * real browser storage, so the two properties worth pinning are:
+ *
+ *  1. Namespacing. Every entry lands under `${UserPreferenceType}.${key}`. Two
+ *     tables, and two kinds of preference on the same table, must never land in
+ *     the same slot - a collision there means changing a page size silently
+ *     wipes a column layout.
+ *  2. The read guard. localStorage is user-editable and can be left half
+ *     written by a closing tab, so anything that comes back as the wrong type
+ *     has to degrade to "no preference" instead of being handed to the caller,
+ *     which would spread the bad value through the column-preference code.
+ *
+ * These run against the real jsdom localStorage rather than a mock, so the raw
+ * keys asserted below are exactly what ships in a browser. Jest runs with
+ * --runInBand and storage leaks between files, hence the clear() below.
+ */
+
+const TABLE_KEY: string = "monitors-table";
+const OTHER_TABLE_KEY: string = "incidents-table";
+
+type ReadRawFn = (key: string) => string | null;
+
+const readRaw: ReadRawFn = (key: string): string | null => {
+  return window.localStorage.getItem(key);
+};
+
+describe("UserPreferences", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe("UserPreferenceType", () => {
+    /*
+     * These strings are baked into every user's localStorage. Renaming one does
+     * not migrate anything - it just makes every saved preference unreachable,
+     * so everyone's table silently resets to the default layout.
+     */
+    test("exposes the stable persisted key for column layouts", () => {
+      expect(UserPreferenceType.BaseModelTableColumns).toBe(
+        "BaseModelTableColumns",
+      );
+    });
+
+    test("keeps the pre-existing page size key unchanged", () => {
+      expect(UserPreferenceType.BaseModelTablePageSize).toBe(
+        "BaseModelTablePageSize",
+      );
+    });
+  });
+
+  describe("key namespacing", () => {
+    test("stores a number under `${UserPreferenceType}.${key}`", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 25,
+      });
+
+      expect(readRaw("BaseModelTablePageSize.monitors-table")).toBe("25");
+    });
+
+    test("stores an object under `${UserPreferenceType}.${key}`", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: [] },
+      });
+
+      const raw: string | null = readRaw(
+        "BaseModelTableColumns.monitors-table",
+      );
+
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string)).toEqual({
+        order: ["name"],
+        hidden: [],
+      });
+    });
+
+    // Two tables on the same page must not overwrite each other's layout.
+    test("two tables with different keys do not collide", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["monitor-name"], hidden: ["monitor-status"] },
+      });
+
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: OTHER_TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["incident-title"], hidden: [] },
+      });
+
+      expect(readRaw("BaseModelTableColumns.monitors-table")).not.toBe(
+        readRaw("BaseModelTableColumns.incidents-table"),
+      );
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({ order: ["monitor-name"], hidden: ["monitor-status"] });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: OTHER_TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({ order: ["incident-title"], hidden: [] });
+    });
+
+    /*
+     * One table holds both a page size and a column layout under the same
+     * userPreferencesKey. The type prefix is the only thing keeping them apart.
+     */
+    test("two preference types on the same table key do not collide", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 50,
+      });
+
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: ["description"] },
+      });
+
+      expect(readRaw("BaseModelTablePageSize.monitors-table")).toBe("50");
+      expect(readRaw("BaseModelTableColumns.monitors-table")).not.toBeNull();
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBe(50);
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({ order: ["name"], hidden: ["description"] });
+    });
+
+    test("a value saved under one type is invisible to another type", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 25,
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toBeNull();
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("number preferences", () => {
+    test("saves and reads back a page size", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 25,
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBe(25);
+    });
+
+    // A number must not come back as the string localStorage actually holds.
+    test("reads back a number, not the stored string", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 10,
+      });
+
+      expect(
+        typeof UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBe("number");
+    });
+
+    test("the newest value wins", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 10,
+      });
+
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 50,
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBe(50);
+    });
+
+    test("returns null when nothing was ever saved", () => {
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: "never-rendered-table",
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("JSON preferences", () => {
+    test("round trips a column preference", () => {
+      const preference: JSONObject = {
+        order: ["name", "currentMonitorStatus", "labels"],
+        hidden: ["description"],
+      };
+
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: preference,
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual(preference);
+    });
+
+    /*
+     * The column preference is nothing but arrays of ids, and LocalStorage runs
+     * everything through a serializer on the way in and out - so the arrays,
+     * their order, and empty arrays all have to survive intact.
+     */
+    test("arrays keep their contents and their order", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: {
+          order: ["c", "a", "b"],
+          hidden: [],
+        },
+      });
+
+      const preference: JSONObject | null =
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        });
+
+      expect(preference?.["order"]).toEqual(["c", "a", "b"]);
+      expect(preference?.["hidden"]).toEqual([]);
+    });
+
+    test("arrays nested inside a nested object survive", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: {
+          columns: {
+            order: ["name", "customField.severity"],
+            hidden: ["createdAt"],
+          },
+          version: 1,
+        },
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({
+        columns: {
+          order: ["name", "customField.severity"],
+          hidden: ["createdAt"],
+        },
+        version: 1,
+      });
+    });
+
+    /*
+     * An empty object is a real, deliberately saved preference (the caller
+     * wrote it), not the absence of one - collapsing it to null would resurrect
+     * the default layout the user just cleared.
+     */
+    test("an empty object is a preference, not an absent one", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: {},
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({});
+    });
+
+    test("returns null when nothing was ever saved", () => {
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: "never-rendered-table",
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  /*
+   * Everything below writes straight into localStorage, which is what a
+   * hand-edited entry, an older build, or a tab that died mid-write leaves
+   * behind. None of it may reach the caller as anything but null: the column
+   * code expects an object and would happily read `.order` off a string.
+   */
+  describe("JSON preferences reject anything that is not an object", () => {
+    const columnsKey: string = "BaseModelTableColumns.monitors-table";
+
+    type ReadPreferenceFn = () => JSONObject | null;
+
+    const readPreference: ReadPreferenceFn = (): JSONObject | null => {
+      return UserPreferences.getUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+    };
+
+    test("a bare string that is not JSON at all", () => {
+      window.localStorage.setItem(columnsKey, "just-a-string");
+
+      expect(readPreference()).toBeNull();
+    });
+
+    test("a quoted string that parses cleanly into a string", () => {
+      window.localStorage.setItem(columnsKey, JSON.stringify("name,status"));
+
+      expect(readPreference()).toBeNull();
+    });
+
+    test("a number", () => {
+      // e.g. a build where this key used to hold a page size.
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: 25,
+      });
+
+      expect(readPreference()).toBeNull();
+    });
+
+    // An array of ids is not a preference object, even though it parses.
+    test("an array", () => {
+      window.localStorage.setItem(
+        columnsKey,
+        JSON.stringify(["name", "status"]),
+      );
+
+      expect(readPreference()).toBeNull();
+    });
+
+    test("malformed JSON left behind by a half-finished write", () => {
+      window.localStorage.setItem(columnsKey, '{"order": ["name",');
+
+      expect(readPreference()).toBeNull();
+    });
+
+    test("a stored null", () => {
+      window.localStorage.setItem(columnsKey, "null");
+
+      expect(readPreference()).toBeNull();
+    });
+
+    test("a bad entry never throws and never returns a string", () => {
+      window.localStorage.setItem(columnsKey, '{"order": ["name",');
+
+      const preference: JSONObject | null = readPreference();
+
+      expect(typeof preference).not.toBe("string");
+      expect(preference).toBeNull();
+    });
+
+    // A rejected entry must not poison the neighbouring page size.
+    test("a bad column entry leaves the page size readable", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 50,
+      });
+
+      window.localStorage.setItem(columnsKey, "not json");
+
+      expect(readPreference()).toBeNull();
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBe(50);
+    });
+  });
+
+  describe("removeUserPreferenceByType", () => {
+    test("removes the value it owns", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: [] },
+      });
+
+      UserPreferences.removeUserPreferenceByType({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+
+      expect(readRaw("BaseModelTableColumns.monitors-table")).toBeNull();
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toBeNull();
+    });
+
+    // "Reset columns" on one table must not reset every other table.
+    test("leaves the same preference type on another table alone", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: [] },
+      });
+
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: OTHER_TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["title"], hidden: [] },
+      });
+
+      UserPreferences.removeUserPreferenceByType({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: OTHER_TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({ order: ["title"], hidden: [] });
+    });
+
+    // ...nor the page size the same table stored under the same key.
+    test("leaves the other preference type on the same table alone", () => {
+      UserPreferences.saveUserPreferenceByTypeAsNumber({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        value: 25,
+      });
+
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: [] },
+      });
+
+      UserPreferences.removeUserPreferenceByType({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+
+      expect(readRaw("BaseModelTableColumns.monitors-table")).toBeNull();
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsNumber({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTablePageSize,
+        }),
+      ).toBe(25);
+    });
+
+    test("removing something that was never saved is a no-op", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: [] },
+      });
+
+      UserPreferences.removeUserPreferenceByType({
+        key: "never-rendered-table",
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({ order: ["name"], hidden: [] });
+    });
+
+    test("a removed preference can be saved again", () => {
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["name"], hidden: [] },
+      });
+
+      UserPreferences.removeUserPreferenceByType({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+
+      UserPreferences.saveUserPreferenceByTypeAsJSON({
+        key: TABLE_KEY,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        value: { order: ["status"], hidden: ["name"] },
+      });
+
+      expect(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: TABLE_KEY,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      ).toEqual({ order: ["status"], hidden: ["name"] });
+    });
+  });
+});

--- a/Common/Types/JSONFunctions.ts
+++ b/Common/Types/JSONFunctions.ts
@@ -342,9 +342,12 @@ export default class JSONFunctions {
       ].fromJSON(val);
     } else if (val instanceof Date) {
       return val;
-    } else if (typeof val === Typeof.Object) {
-      return this.deserialize(val as JSONObject);
     } else if (Array.isArray(val)) {
+      /*
+       * This has to be checked before the plain-object branch below: arrays are
+       * typeof "object", so falling through to deserialize() would walk them by
+       * key and hand back { "0": ..., "1": ... } instead of an array.
+       */
       const arr: Array<JSONValue> = [];
 
       for (const v of val) {
@@ -352,6 +355,8 @@ export default class JSONFunctions {
       }
 
       return arr;
+    } else if (typeof val === Typeof.Object) {
+      return this.deserialize(val as JSONObject);
     }
 
     return val;

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -58,6 +58,23 @@ import TableColumn from "../Table/Types/Column";
 import FieldType from "../Types/FieldType";
 import ModelTableColumn from "./Column";
 import Columns from "./Columns";
+import ColumnCustomizationModal from "./ColumnCustomizationModal";
+import {
+  ColumnPreference,
+  CustomizableColumn,
+  applyColumnPreference,
+  buildColumnPreference,
+  fromJSON as columnPreferenceFromJSON,
+  getCustomizableColumns,
+  isEmptyColumnPreference,
+  sanitizeColumnPreference,
+  getColumnIds,
+  toJSON as columnPreferenceToJSON,
+} from "./ColumnPreference";
+import { CustomFieldsColumnKey } from "./CustomFieldColumns";
+import useCustomFieldColumns, {
+  CustomFieldColumnsResult,
+} from "./useCustomFieldColumns";
 import { getExportKeysFromColumn } from "./ExportFromColumns";
 import {
   getRelationSelectFromColumns,
@@ -323,6 +340,26 @@ export interface BaseTableProps<
    * outlive the page.
    */
   disableUrlState?: boolean | undefined;
+
+  /**
+   * Hide the "Columns" control and always render the declared column set.
+   *
+   * Column customization is on by default for every table that renders
+   * columns. Turn it off for tables whose layout is load-bearing — a
+   * two-column key/value table, or one the surrounding page reads positions
+   * out of.
+   */
+  disableColumnCustomization?: boolean | undefined;
+
+  /**
+   * The model holding this resource's custom field *definitions* — e.g.
+   * `MonitorCustomField` for a table of monitors. Set it and every custom
+   * field the project has defined becomes an optional column, off by default
+   * and listed in the column picker.
+   *
+   * Only meaningful for resources with a `customFields` column of their own.
+   */
+  customFieldsModelType?: { new (): BaseModel } | undefined;
 }
 
 export interface ComponentProps<
@@ -394,6 +431,115 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [tableColumns, setColumns] = useState<Array<TableColumn<TBaseModel>>>(
     [],
   );
+
+  /*
+   * ---------------------------------------------------------------------
+   * Viewer-customizable columns
+   * ---------------------------------------------------------------------
+   *
+   * The viewer's layout (which columns are on, and in what order) is a
+   * personal, presentational preference, so it lives in localStorage next to
+   * the page size rather than on the server: saved views are named, explicit,
+   * plan-gated and need write permission, none of which should stand between
+   * someone and hiding a column they don't care about. A saved view can still
+   * carry a layout of its own, and when one is active it wins.
+   *
+   * Custom fields are appended to the declared columns as additional,
+   * off-by-default columns; from here on they are ordinary columns.
+   */
+  const customFieldColumns: CustomFieldColumnsResult<TBaseModel> =
+    useCustomFieldColumns<TBaseModel>({
+      customFieldsModelType: props.customFieldsModelType,
+    });
+
+  const isColumnCustomizationEnabled: boolean = Boolean(
+    !props.disableColumnCustomization &&
+      props.userPreferencesKey &&
+      showAs !== ShowAs.OrderedStatesList,
+  );
+
+  const allColumns: Columns<TBaseModel> = useMemo(() => {
+    if (customFieldColumns.columns.length === 0) {
+      return props.columns || [];
+    }
+
+    return [...(props.columns || []), ...customFieldColumns.columns];
+  }, [props.columns, customFieldColumns.columns]);
+
+  type ReadStoredColumnPreferenceFunction = () => ColumnPreference | null;
+
+  const readStoredColumnPreference: ReadStoredColumnPreferenceFunction =
+    (): ColumnPreference | null => {
+      if (!props.userPreferencesKey) {
+        return null;
+      }
+
+      return columnPreferenceFromJSON(
+        UserPreferences.getUserPreferenceByTypeAsJSON({
+          key: props.userPreferencesKey,
+          userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+        }),
+      );
+    };
+
+  const [columnPreference, setColumnPreference] =
+    useState<ColumnPreference | null>(readStoredColumnPreference);
+
+  const [showColumnCustomizationModal, setShowColumnCustomizationModal] =
+    useState<boolean>(false);
+
+  /*
+   * Ids are derived over the *whole* declared set, so a column dropping out
+   * for lack of permission can never renumber the ones that remain.
+   */
+  const allColumnIds: Array<string> = useMemo(() => {
+    return getColumnIds<TBaseModel>(allColumns);
+  }, [allColumns]);
+
+  const effectiveColumnPreference: ColumnPreference | null = useMemo(() => {
+    if (!isColumnCustomizationEnabled) {
+      return null;
+    }
+
+    /*
+     * A stored layout outlives the release that wrote it, so anything naming
+     * a column this table no longer has is dropped before it is applied.
+     */
+    return sanitizeColumnPreference({
+      preference: columnPreference,
+      knownColumnIds: allColumnIds,
+    });
+  }, [columnPreference, allColumnIds, isColumnCustomizationEnabled]);
+
+  type SaveColumnPreferenceFunction = (
+    preference: ColumnPreference | null,
+  ) => void;
+
+  const saveColumnPreference: SaveColumnPreferenceFunction = (
+    preference: ColumnPreference | null,
+  ): void => {
+    setColumnPreference(preference);
+
+    if (!props.userPreferencesKey) {
+      return;
+    }
+
+    const json: JSONObject | null = columnPreferenceToJSON(preference);
+
+    if (!json) {
+      UserPreferences.removeUserPreferenceByType({
+        key: props.userPreferencesKey,
+        userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      });
+      return;
+    }
+
+    UserPreferences.saveUserPreferenceByTypeAsJSON({
+      key: props.userPreferencesKey,
+      userPreferenceType: UserPreferenceType.BaseModelTableColumns,
+      value: json,
+    });
+  };
 
   const [classicTableFilters, setClassicTableFilters] = useState<
     Array<ClassicFilterType<TBaseModel>>
@@ -903,8 +1049,11 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
   const getRelationSelect: GetRelationSelectFunction =
     (): Select<TBaseModel> => {
+      /*
+       * Deliberately the *unfiltered* column set. See getSelect() below.
+       */
       return getRelationSelectFromColumns<TBaseModel>({
-        columns: props.columns || [],
+        columns: allColumns,
         model: model,
       });
     };
@@ -950,7 +1099,30 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     const accessControl: Dictionary<ColumnAccessControl> =
       model.getColumnAccessControlForAllColumns();
 
-    for (const column of props.columns || []) {
+    /*
+     * The viewer's layout is applied to the *input* of this loop, never to
+     * the finished array: the Actions column is appended below and has to
+     * stay last, and it is generated rather than declared, so it is not the
+     * viewer's to move or switch off.
+     */
+    const columnsToRender: Columns<TBaseModel> =
+      applyColumnPreference<TBaseModel>({
+        columns: allColumns,
+        preference: effectiveColumnPreference,
+      });
+
+    const columnIdByColumn: Map<
+      ModelTableColumn<TBaseModel>,
+      string
+    > = new Map();
+
+    allColumns.forEach(
+      (column: ModelTableColumn<TBaseModel>, index: number) => {
+        columnIdByColumn.set(column, allColumnIds[index] as string);
+      },
+    );
+
+    for (const column of columnsToRender) {
       const hasPermission: boolean =
         hasPermissionToReadColumn(column) || User.isMasterAdmin();
       const key: keyof TBaseModel | null = getColumnKey(column);
@@ -983,6 +1155,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
 
         columns.push({
           ...column,
+          id: columnIdByColumn.get(column),
           disableSort: column.disableSort || shouldDisableSort(key),
           key: columnKey,
           /*
@@ -1692,13 +1865,38 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   type GetSelectFunction = () => Select<TBaseModel>;
 
   const getSelect: GetSelectFunction = (): Select<TBaseModel> => {
+    /*
+     * Every declared column, including the ones the viewer has switched off.
+     *
+     * Hiding must not narrow the request. A column's `getElement` is arbitrary
+     * caller code that can read any field on the row — a "Status" cell that
+     * also reads `currentMonitorStatus`, say — so dropping a hidden column's
+     * fields from the select would silently blank a *different*, visible cell,
+     * and there is no way to detect that statically. The sort field is
+     * likewise independent of what is on screen. The cost is a few unused
+     * fields on the wire.
+     */
     const selectFields: Select<TBaseModel> = getSelectFromColumns<TBaseModel>({
-      columns: props.columns || [],
+      columns: allColumns,
       model: model,
       hasPermissionToReadField: (field: string): boolean => {
         return hasPermissionToReadField(field as keyof TBaseModel);
       },
     });
+
+    /*
+     * Custom field columns arrive asynchronously, but the table does not
+     * refetch when its column set changes — so the JSON column that backs
+     * every one of them is selected up front, off the synchronous prop, and
+     * the values are there the moment the definitions land.
+     */
+    if (
+      props.customFieldsModelType &&
+      model.hasColumn(CustomFieldsColumnKey) &&
+      hasPermissionToReadField(CustomFieldsColumnKey as keyof TBaseModel)
+    ) {
+      (selectFields as Dictionary<boolean>)[CustomFieldsColumnKey] = true;
+    }
 
     const selectMoreFields: Array<keyof TBaseModel> = props.selectMoreFields
       ? (Object.keys(props.selectMoreFields) as Array<keyof TBaseModel>)
@@ -1751,6 +1949,9 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           currentItemsOnPage={itemsOnPage}
           currentSortOrder={sortOrder}
           currentFacetState={props.currentFacetState}
+          currentColumns={
+            columnPreferenceToJSON(effectiveColumnPreference) || undefined
+          }
           onViewChange={async (tableView: TableView | null) => {
             setTableView(tableView);
 
@@ -1785,6 +1986,20 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
                   (tableView.facets as JSONObject | undefined) || null,
                 );
               }
+
+              /*
+               * A saved view carries the columns it was saved with. Views
+               * created before this existed have none, which restores the
+               * table's default layout rather than leaving the previous
+               * view's columns in place.
+               */
+              if (isColumnCustomizationEnabled) {
+                saveColumnPreference(
+                  columnPreferenceFromJSON(
+                    (tableView.columns as JSONObject | undefined) || null,
+                  ),
+                );
+              }
             } else {
               setQuery({});
               /*
@@ -1802,6 +2017,13 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
               if (props.onFacetStateRestored) {
                 props.onFacetStateRestored(null);
               }
+
+              /*
+               * Columns are deliberately left alone here. Clearing a saved
+               * view means "stop filtering like that", not "throw away the
+               * column layout I built" - which the viewer may well have set
+               * up long before this view existed.
+               */
             }
           }}
         />
@@ -1932,6 +2154,23 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         },
         disabled: isFilterFetchLoading,
         icon: IconProp.Filter,
+      });
+    }
+
+    /*
+     * Only worth offering once there is a choice to make. A single-column
+     * table has nothing to hide and nothing to reorder.
+     */
+    if (isColumnCustomizationEnabled && allColumns.length > 1) {
+      headerbuttons.push({
+        title: "",
+        buttonStyle: ButtonStyleType.ICON,
+        buttonSize: ButtonSize.Small,
+        className: "",
+        onClick: () => {
+          setShowColumnCustomizationModal(true);
+        },
+        icon: IconProp.TableCells,
       });
     }
 
@@ -2107,6 +2346,14 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   useEffect(() => {
     serializeToTableColumns();
   }, [props.columns]);
+
+  /*
+   * The viewer changed their layout, or the project's custom field
+   * definitions finally arrived.
+   */
+  useEffect(() => {
+    serializeToTableColumns();
+  }, [effectiveColumnPreference, customFieldColumns.columns]);
 
   const setActionSchema: VoidFunction = () => {
     const permissions: Array<Permission> = PermissionUtil.getAllPermissions();
@@ -3375,6 +3622,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
         return "Watch Demo";
       case IconProp.Search:
         return "Search";
+      case IconProp.TableCells:
+        return "Columns";
       default:
         return "Action";
     }
@@ -3581,6 +3830,133 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
     return originalTitle;
   };
 
+  type IsPickableColumnFunction = (
+    column: ModelTableColumn<TBaseModel>,
+  ) => boolean;
+
+  /*
+   * A column the viewer cannot read is left out of the picker entirely.
+   * Listing it would advertise a field they have no access to, and switching
+   * it on would put that field in the select — which the API rejects for the
+   * whole request, blanking the table.
+   */
+  const isPickableColumn: IsPickableColumnFunction = (
+    column: ModelTableColumn<TBaseModel>,
+  ): boolean => {
+    if (column.isNotCustomizable) {
+      return false;
+    }
+
+    return hasPermissionToReadColumn(column) || User.isMasterAdmin();
+  };
+
+  type GetPickerEntriesFunction = (
+    preference: ColumnPreference | null,
+  ) => Array<CustomizableColumn<TBaseModel>>;
+
+  const getPickerEntries: GetPickerEntriesFunction = (
+    preference: ColumnPreference | null,
+  ): Array<CustomizableColumn<TBaseModel>> => {
+    return getCustomizableColumns<TBaseModel>({
+      columns: allColumns,
+      preference: preference,
+    }).filter((entry: CustomizableColumn<TBaseModel>) => {
+      return isPickableColumn(entry.column);
+    });
+  };
+
+  type GetColumnSortKeyFunction = (
+    column: ModelTableColumn<TBaseModel>,
+  ) => string | null;
+
+  // Mirrors how serializeToTableColumns derives the key the header sorts on.
+  const getColumnSortKey: GetColumnSortKeyFunction = (
+    column: ModelTableColumn<TBaseModel>,
+  ): string | null => {
+    const key: keyof TBaseModel | null = getColumnKey(column);
+
+    if (!key) {
+      return null;
+    }
+
+    return column.selectedProperty
+      ? `${String(key)}.${column.selectedProperty}`
+      : String(key);
+  };
+
+  type OnColumnCustomizationSaveFunction = (
+    entries: Array<CustomizableColumn<TBaseModel>>,
+  ) => void;
+
+  const onColumnCustomizationSave: OnColumnCustomizationSaveFunction = (
+    entries: Array<CustomizableColumn<TBaseModel>>,
+  ): void => {
+    const preference: ColumnPreference =
+      buildColumnPreference<TBaseModel>(entries);
+
+    /*
+     * If the layout the viewer just saved matches what the table ships with,
+     * store nothing. Otherwise every table anyone ever opened the picker on
+     * would be pinned to the column set of the release they opened it in, and
+     * columns added later would arrive already stale.
+     */
+    const defaultPreference: ColumnPreference =
+      buildColumnPreference<TBaseModel>(getPickerEntries(null));
+
+    const isBackToDefault: boolean =
+      JSON.stringify(preference) === JSON.stringify(defaultPreference);
+
+    /*
+     * Sorting by a column that is no longer on screen leaves the viewer with
+     * an ordering they can neither see nor undo — there is no header left to
+     * click. Fall back to the table's own default sort.
+     */
+    if (sortBy) {
+      const hiddenIds: Set<string> = new Set(preference.hidden);
+
+      const isSortedColumnHidden: boolean = entries.some(
+        (entry: CustomizableColumn<TBaseModel>) => {
+          return (
+            hiddenIds.has(entry.id) &&
+            getColumnSortKey(entry.column) === String(sortBy)
+          );
+        },
+      );
+
+      if (isSortedColumnHidden) {
+        setSortBy((props.sortBy as keyof TBaseModel | undefined) || null);
+        setSortOrder(props.sortOrder || SortOrder.Ascending);
+        setCurrentPageNumber(1);
+      }
+    }
+
+    saveColumnPreference(isBackToDefault ? null : preference);
+    setShowColumnCustomizationModal(false);
+  };
+
+  const getColumnCustomizationModal: () => ReactElement | null =
+    (): ReactElement | null => {
+      if (!showColumnCustomizationModal || !isColumnCustomizationEnabled) {
+        return null;
+      }
+
+      return (
+        <ColumnCustomizationModal<TBaseModel>
+          columns={getPickerEntries(effectiveColumnPreference)}
+          isDefaultLayout={isEmptyColumnPreference(effectiveColumnPreference)}
+          title={tx("Customize Columns")}
+          onSave={onColumnCustomizationSave}
+          onReset={() => {
+            saveColumnPreference(null);
+            setShowColumnCustomizationModal(false);
+          }}
+          onClose={() => {
+            setShowColumnCustomizationModal(false);
+          }}
+        />
+      );
+    };
+
   const getCardComponent: GetReactElementFunction = (): ReactElement => {
     const headerButtons: Array<CardButtonSchema | ReactElement> =
       getHeaderButtonsWithSearch();
@@ -3601,7 +3977,12 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
                 getCardTitle(props.cardProps.title || ""),
               )}
             >
-              {tableColumns.length === 0 && props.columns.length > 0 ? (
+              {/*
+               * A viewer's layout can never empty this out — applyColumnPreference
+               * refuses to return nothing — so zero columns still means exactly
+               * what it always did: every column was denied by permission.
+               */}
+              {tableColumns.length === 0 && allColumns.length > 0 ? (
                 <ErrorMessage
                   message={`You are not authorized to view this table. You need any one of these permissions: ${PermissionHelper.getPermissionTitles(
                     model.getReadPermissions(),
@@ -3799,6 +4180,8 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
           </div>
         </Modal>
       )}
+
+      {getColumnCustomizationModal()}
     </>
   );
 };

--- a/Common/UI/Components/ModelTable/Column.ts
+++ b/Common/UI/Components/ModelTable/Column.ts
@@ -19,6 +19,23 @@ export default interface Columns<
   field: SelectEntityField<TEntity>;
   selectedProperty?: string | undefined;
   title: string;
+  /*
+   * Stable identity for this column, used to persist the viewer's show/hide
+   * and ordering choices. Leave it unset and one is derived from the declared
+   * field (see ColumnPreference.getColumnIds) - set it only when the derived
+   * id would be unstable, e.g. a cell rendered entirely through `getElement`
+   * off a placeholder `field: { _id: true }` whose title is likely to change.
+   */
+  id?: string | undefined;
+  /*
+   * Keep this column out of the "Customize Columns" picker: it is always
+   * shown and can never be moved. Use it for the column that identifies the
+   * row (usually the name), so a table can never be customized into
+   * anonymity.
+   */
+  isNotCustomizable?: boolean | undefined;
+  // Start hidden. The viewer can still switch it on from the picker.
+  isHiddenByDefault?: boolean | undefined;
   contentClassName?: string | undefined;
   colSpan?: number | undefined;
   disableSort?: boolean;

--- a/Common/UI/Components/ModelTable/ColumnCustomizationModal.tsx
+++ b/Common/UI/Components/ModelTable/ColumnCustomizationModal.tsx
@@ -1,0 +1,420 @@
+import { CustomizableColumn } from "./ColumnPreference";
+import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
+import CheckboxElement from "../Checkbox/Checkbox";
+import Icon from "../Icon/Icon";
+import Input, { InputType } from "../Input/Input";
+import Modal, { ModalWidth } from "../Modal/Modal";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import IconProp from "../../../Types/Icon/IconProp";
+import React, { ReactElement, useMemo, useState } from "react";
+import {
+  DragDropContext,
+  Draggable,
+  DraggableProvided,
+  Droppable,
+  DroppableProvided,
+  DropResult,
+} from "react-beautiful-dnd";
+
+export interface ComponentProps<
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+> {
+  // Every customizable column, already in the order the table renders them.
+  columns: Array<CustomizableColumn<TBaseModel>>;
+  onSave: (columns: Array<CustomizableColumn<TBaseModel>>) => void;
+  onClose: () => void;
+  // Drop the stored layout and go back to what the table ships with.
+  onReset: () => void;
+  title?: string | undefined;
+  description?: string | undefined;
+  /*
+   * False once the viewer has customized anything, which is when Reset earns
+   * its place in the footer.
+   */
+  isDefaultLayout?: boolean | undefined;
+}
+
+type ColumnCustomizationModalFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  props: ComponentProps<TBaseModel>,
+) => ReactElement;
+
+/*
+ * The "Customize Columns" picker: a checkbox and a drag handle per column.
+ *
+ * Two constraints shape it:
+ *
+ *  - The last visible column cannot be switched off. A table with no columns
+ *    renders as an empty shell with no header row, and the only control that
+ *    could undo that is the one the viewer just closed.
+ *
+ *  - Reordering is offered through Up/Down buttons as well as drag. Drag alone
+ *    is unusable with a keyboard or a screen reader, and pointer-only
+ *    reordering is also the part that cannot be exercised in tests.
+ *
+ * Changes are staged locally and only handed back on Save, so Cancel really
+ * does cancel.
+ */
+const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  props: ComponentProps<TBaseModel>,
+): ReactElement => {
+  const [entries, setEntries] = useState<Array<CustomizableColumn<TBaseModel>>>(
+    [...props.columns],
+  );
+  const [searchText, setSearchText] = useState<string>("");
+
+  const visibleCount: number = useMemo(() => {
+    return entries.filter((entry: CustomizableColumn<TBaseModel>) => {
+      return entry.isVisible;
+    }).length;
+  }, [entries]);
+
+  const normalizedSearch: string = searchText.trim().toLowerCase();
+  const isSearching: boolean = normalizedSearch.length > 0;
+
+  const shownEntries: Array<CustomizableColumn<TBaseModel>> = useMemo(() => {
+    if (!isSearching) {
+      return entries;
+    }
+
+    return entries.filter((entry: CustomizableColumn<TBaseModel>) => {
+      return (entry.column.title || "")
+        .toLowerCase()
+        .includes(normalizedSearch);
+    });
+  }, [entries, normalizedSearch, isSearching]);
+
+  type ToggleFunction = (id: string, isVisible: boolean) => void;
+
+  const toggleColumn: ToggleFunction = (
+    id: string,
+    isVisible: boolean,
+  ): void => {
+    setEntries((current: Array<CustomizableColumn<TBaseModel>>) => {
+      const isLastVisible: boolean =
+        !isVisible &&
+        current.filter((entry: CustomizableColumn<TBaseModel>) => {
+          return entry.isVisible;
+        }).length <= 1;
+
+      if (isLastVisible) {
+        // Refuse rather than render a table with nothing in it.
+        return current;
+      }
+
+      return current.map((entry: CustomizableColumn<TBaseModel>) => {
+        return entry.id === id ? { ...entry, isVisible } : entry;
+      });
+    });
+  };
+
+  type MoveFunction = (fromIndex: number, toIndex: number) => void;
+
+  const moveColumn: MoveFunction = (
+    fromIndex: number,
+    toIndex: number,
+  ): void => {
+    setEntries((current: Array<CustomizableColumn<TBaseModel>>) => {
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= current.length ||
+        toIndex >= current.length
+      ) {
+        return current;
+      }
+
+      const next: Array<CustomizableColumn<TBaseModel>> = [...current];
+      const [moved] = next.splice(fromIndex, 1);
+
+      if (!moved) {
+        return current;
+      }
+
+      next.splice(toIndex, 0, moved);
+
+      return next;
+    });
+  };
+
+  type OnDragEndFunction = (result: DropResult) => void;
+
+  const onDragEnd: OnDragEndFunction = (result: DropResult): void => {
+    /*
+     * Guard on the object, not on the index: a drop into the first slot has
+     * `index === 0`, which a truthiness check would throw away.
+     */
+    if (!result.destination) {
+      return;
+    }
+
+    moveColumn(result.source.index, result.destination.index);
+  };
+
+  type SetAllVisibleFunction = (isVisible: boolean) => void;
+
+  const setAllVisible: SetAllVisibleFunction = (isVisible: boolean): void => {
+    setEntries((current: Array<CustomizableColumn<TBaseModel>>) => {
+      if (!isVisible) {
+        /*
+         * "Hide all" still has to leave one column standing, so it keeps the
+         * first one - the leftmost, which is normally the row's name.
+         */
+        let isFirstKept: boolean = false;
+
+        return current.map((entry: CustomizableColumn<TBaseModel>) => {
+          if (!isFirstKept) {
+            isFirstKept = true;
+            return { ...entry, isVisible: true };
+          }
+
+          return { ...entry, isVisible: false };
+        });
+      }
+
+      return current.map((entry: CustomizableColumn<TBaseModel>) => {
+        return { ...entry, isVisible: true };
+      });
+    });
+  };
+
+  type GetRowFunction = (data: {
+    entry: CustomizableColumn<TBaseModel>;
+    index: number;
+    dragHandle?: ReactElement | undefined;
+  }) => ReactElement;
+
+  const getRowContents: GetRowFunction = (data: {
+    entry: CustomizableColumn<TBaseModel>;
+    index: number;
+    dragHandle?: ReactElement | undefined;
+  }): ReactElement => {
+    const { entry, index } = data;
+
+    const isOnlyVisibleColumn: boolean = entry.isVisible && visibleCount <= 1;
+
+    return (
+      <div className="flex items-center gap-3 px-3 py-2">
+        {data.dragHandle || <div className="w-4" />}
+
+        <div className="flex-1 min-w-0">
+          <CheckboxElement
+            value={entry.isVisible}
+            disabled={isOnlyVisibleColumn}
+            dataTestId={`column-toggle-${entry.id}`}
+            title={entry.column.title}
+            onChange={(value: boolean) => {
+              toggleColumn(entry.id, value);
+            }}
+          />
+        </div>
+
+        <div className="flex flex-none items-center gap-1">
+          <Button
+            buttonSize={ButtonSize.Small}
+            buttonStyle={ButtonStyleType.ICON}
+            icon={IconProp.ChevronUp}
+            title=""
+            dataTestId={`column-move-up-${entry.id}`}
+            disabled={isSearching || index === 0}
+            onClick={() => {
+              moveColumn(index, index - 1);
+            }}
+          />
+          <Button
+            buttonSize={ButtonSize.Small}
+            buttonStyle={ButtonStyleType.ICON}
+            icon={IconProp.ChevronDown}
+            title=""
+            dataTestId={`column-move-down-${entry.id}`}
+            disabled={isSearching || index === entries.length - 1}
+            onClick={() => {
+              moveColumn(index, index + 1);
+            }}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  type GetListFunction = () => ReactElement;
+
+  const getList: GetListFunction = (): ReactElement => {
+    if (shownEntries.length === 0) {
+      return (
+        <div
+          className="px-3 py-6 text-center text-sm text-gray-400"
+          data-testid="column-customization-no-results"
+        >
+          No columns match &quot;{searchText}&quot;.
+        </div>
+      );
+    }
+
+    /*
+     * Dragging a filtered list would move a column to a position that only
+     * makes sense inside the filter, so while a search is active the list is
+     * rendered plain and the reorder controls are disabled.
+     */
+    if (isSearching) {
+      return (
+        <div className="divide-y divide-gray-100">
+          {shownEntries.map((entry: CustomizableColumn<TBaseModel>) => {
+            return (
+              <div key={entry.id}>
+                {getRowContents({
+                  entry,
+                  index: entries.indexOf(entry),
+                })}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    return (
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="model-table-columns">
+          {(droppableProvided: DroppableProvided) => {
+            return (
+              <div
+                ref={droppableProvided.innerRef}
+                {...droppableProvided.droppableProps}
+                className="divide-y divide-gray-100"
+              >
+                {shownEntries.map(
+                  (entry: CustomizableColumn<TBaseModel>, index: number) => {
+                    return (
+                      <Draggable
+                        draggableId={entry.id}
+                        index={index}
+                        key={entry.id}
+                      >
+                        {(draggableProvided: DraggableProvided) => {
+                          return (
+                            <div
+                              ref={draggableProvided.innerRef}
+                              {...draggableProvided.draggableProps}
+                              className="bg-white"
+                            >
+                              {getRowContents({
+                                entry,
+                                index,
+                                dragHandle: (
+                                  <div
+                                    {...draggableProvided.dragHandleProps}
+                                    className="flex-none cursor-grab text-gray-400 hover:text-gray-600 active:cursor-grabbing"
+                                    aria-label={`Drag to reorder ${entry.column.title}`}
+                                    title="Drag to reorder"
+                                  >
+                                    <Icon
+                                      icon={IconProp.GripVertical}
+                                      className="h-4 w-4"
+                                    />
+                                  </div>
+                                ),
+                              })}
+                            </div>
+                          );
+                        }}
+                      </Draggable>
+                    );
+                  },
+                )}
+                {droppableProvided.placeholder}
+              </div>
+            );
+          }}
+        </Droppable>
+      </DragDropContext>
+    );
+  };
+
+  return (
+    <Modal
+      title={props.title || "Customize Columns"}
+      description={
+        props.description ||
+        "Choose which columns to show and drag them into the order you want."
+      }
+      modalWidth={ModalWidth.Medium}
+      icon={IconProp.TableCells}
+      submitButtonText="Save"
+      closeButtonText="Cancel"
+      onClose={props.onClose}
+      onSubmit={() => {
+        props.onSave(entries);
+      }}
+      leftFooterElement={
+        props.isDefaultLayout ? (
+          <></>
+        ) : (
+          <Button
+            title="Reset to default"
+            buttonSize={ButtonSize.Normal}
+            buttonStyle={ButtonStyleType.OUTLINE}
+            dataTestId="column-customization-reset"
+            onClick={() => {
+              props.onReset();
+            }}
+          />
+        )
+      }
+    >
+      <div className="space-y-3" data-testid="column-customization-modal">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <Input
+              type={InputType.TEXT}
+              placeholder="Search columns..."
+              value={searchText}
+              dataTestId="column-customization-search"
+              onChange={(value: string) => {
+                setSearchText(value);
+              }}
+            />
+          </div>
+          <div className="flex flex-none gap-2">
+            <Button
+              title="Show all"
+              buttonSize={ButtonSize.Small}
+              buttonStyle={ButtonStyleType.OUTLINE}
+              dataTestId="column-customization-show-all"
+              onClick={() => {
+                setAllVisible(true);
+              }}
+            />
+            <Button
+              title="Hide all"
+              buttonSize={ButtonSize.Small}
+              buttonStyle={ButtonStyleType.OUTLINE}
+              dataTestId="column-customization-hide-all"
+              onClick={() => {
+                setAllVisible(false);
+              }}
+            />
+          </div>
+        </div>
+
+        <div
+          className="text-xs text-gray-500"
+          data-testid="column-customization-count"
+        >
+          {visibleCount} of {entries.length} columns shown
+        </div>
+
+        <div className="rounded-md border border-gray-200 overflow-hidden">
+          {getList()}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ColumnCustomizationModal;

--- a/Common/UI/Components/ModelTable/ColumnPreference.ts
+++ b/Common/UI/Components/ModelTable/ColumnPreference.ts
@@ -1,0 +1,482 @@
+import Column from "./Column";
+import Columns from "./Columns";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import { JSONObject } from "../../../Types/JSON";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Per-viewer column layout for a ModelTable
+ * ---------------------------------------------------------------------------
+ *
+ * A layout is two lists of column ids: the order the viewer arranged the
+ * columns in, and the ones they switched off. Both are stored - "hidden" is
+ * not the complement of "order" - because a column the viewer has never seen
+ * (one shipped in a later release, or a custom field added after they last
+ * touched this table) has to default to *visible* and land in a predictable
+ * spot, rather than silently vanishing because it is missing from `order`.
+ *
+ * Everything here is pure so the rules below can be pinned by unit tests
+ * rather than inferred from a rendered table:
+ *
+ *  - ids are derived from the declared field, never from array position,
+ *    because `props.columns` is edited every release;
+ *  - an id that no longer matches a column is dropped on read, the same way
+ *    restored filters are sanitized, so a stale entry cannot wedge the table;
+ *  - a layout that would leave nothing on screen is refused.
+ */
+
+export interface ColumnPreference {
+  // Column ids in the order the viewer arranged them.
+  order: Array<string>;
+  // Column ids the viewer switched off.
+  hidden: Array<string>;
+}
+
+export type ModelTableColumn<
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+> = Column<TBaseModel>;
+
+export const EmptyColumnPreference: ColumnPreference = {
+  order: [],
+  hidden: [],
+};
+
+export type SlugifyFunction = (value: string) => string;
+
+const slugify: SlugifyFunction = (value: string): string => {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+};
+
+export type GetColumnBaseIdFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  column: ModelTableColumn<TBaseModel>,
+) => string;
+
+/*
+ * The identity a column would have if no other column competed for it. An
+ * explicit `id` always wins; otherwise it is the field the column reads,
+ * which is the one thing about a column that survives re-ordering, renaming
+ * and re-styling. `selectedProperty` is part of it so that every custom field
+ * on one JSON column gets its own id ("customFields.Severity").
+ */
+export const getColumnBaseId: GetColumnBaseIdFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  column: ModelTableColumn<TBaseModel>,
+): string => {
+  if (column.id) {
+    return column.id;
+  }
+
+  const fieldKey: string | undefined = column.field
+    ? Object.keys(column.field)[0]
+    : undefined;
+
+  if (fieldKey) {
+    return column.selectedProperty
+      ? `${fieldKey}.${column.selectedProperty}`
+      : fieldKey;
+  }
+
+  return slugify(column.title || "") || "column";
+};
+
+export type GetColumnIdsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  columns: Columns<TBaseModel>,
+) => Array<string>;
+
+/*
+ * Ids for a whole column set, in declaration order and guaranteed unique.
+ *
+ * Collisions are real and common: a table often carries several cells that
+ * render from `getElement` off the same placeholder `field: { _id: true }`.
+ * Those are disambiguated by title first (stable, and what the viewer
+ * actually sees in the picker) and only then by position, which is the one
+ * part that can shift when a column is inserted. A shifted id is harmless -
+ * it simply reads as a new column, so it defaults to visible.
+ */
+export const getColumnIds: GetColumnIdsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  columns: Columns<TBaseModel>,
+): Array<string> => {
+  const baseIds: Array<string> = columns.map(
+    (column: ModelTableColumn<TBaseModel>) => {
+      return getColumnBaseId<TBaseModel>(column);
+    },
+  );
+
+  const baseIdCounts: Record<string, number> = {};
+
+  for (const baseId of baseIds) {
+    baseIdCounts[baseId] = (baseIdCounts[baseId] || 0) + 1;
+  }
+
+  const candidateIds: Array<string> = columns.map(
+    (column: ModelTableColumn<TBaseModel>, index: number) => {
+      const baseId: string = baseIds[index] as string;
+
+      if ((baseIdCounts[baseId] || 0) < 2) {
+        return baseId;
+      }
+
+      const titleSlug: string = slugify(column.title || "");
+
+      return titleSlug ? `${baseId}:${titleSlug}` : baseId;
+    },
+  );
+
+  const usedIds: Record<string, number> = {};
+  const ids: Array<string> = [];
+
+  for (const candidateId of candidateIds) {
+    const timesUsed: number = usedIds[candidateId] || 0;
+    usedIds[candidateId] = timesUsed + 1;
+    ids.push(timesUsed === 0 ? candidateId : `${candidateId}#${timesUsed + 1}`);
+  }
+
+  return ids;
+};
+
+export interface CustomizableColumn<
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+> {
+  id: string;
+  column: ModelTableColumn<TBaseModel>;
+  isVisible: boolean;
+  // Pinned columns are always shown and cannot be moved.
+  isPinned: boolean;
+}
+
+export type IsDefaultHiddenFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  column: ModelTableColumn<TBaseModel>,
+) => boolean;
+
+const isHiddenByDefault: IsDefaultHiddenFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  column: ModelTableColumn<TBaseModel>,
+): boolean => {
+  return Boolean(column.isHiddenByDefault) && !column.isNotCustomizable;
+};
+
+export type GetCustomizableColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  columns: Columns<TBaseModel>;
+  preference?: ColumnPreference | null | undefined;
+}) => Array<CustomizableColumn<TBaseModel>>;
+
+/*
+ * The picker's model: every column the viewer may act on, already in the
+ * order they arranged them, each tagged with whether it is currently on.
+ *
+ * Pinned columns keep their declared position rather than being dragged
+ * around by a stale layout - they are not in the picker, so the viewer has no
+ * way to put them back if a persisted `order` moved them.
+ */
+export const getCustomizableColumns: GetCustomizableColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  columns: Columns<TBaseModel>;
+  preference?: ColumnPreference | null | undefined;
+}): Array<CustomizableColumn<TBaseModel>> => {
+  const { columns, preference } = data;
+
+  const ids: Array<string> = getColumnIds<TBaseModel>(columns);
+
+  const entries: Array<CustomizableColumn<TBaseModel>> = columns.map(
+    (column: ModelTableColumn<TBaseModel>, index: number) => {
+      const id: string = ids[index] as string;
+      const isPinned: boolean = Boolean(column.isNotCustomizable);
+
+      let isVisible: boolean = !isHiddenByDefault<TBaseModel>(column);
+
+      if (preference && !isPinned) {
+        if (preference.hidden.includes(id)) {
+          isVisible = false;
+        } else if (preference.order.includes(id)) {
+          /*
+           * The viewer has arranged this column at least once and did not
+           * put it in `hidden`, so it is on - even if the table now ships it
+           * hidden by default.
+           */
+          isVisible = true;
+        }
+      }
+
+      return { id, column, isVisible, isPinned };
+    },
+  );
+
+  if (!preference || preference.order.length === 0) {
+    return entries;
+  }
+
+  const orderIndexById: Record<string, number> = {};
+
+  preference.order.forEach((id: string, index: number) => {
+    if (orderIndexById[id] === undefined) {
+      orderIndexById[id] = index;
+    }
+  });
+
+  /*
+   * A column the layout does not mention keeps its declared neighbours: it
+   * sorts just after the last arranged column that precedes it in the
+   * declaration, so a newly shipped column appears where its author put it
+   * rather than being swept to the end.
+   */
+  const sortKeys: Array<number> = [];
+  let lastKnownOrderIndex: number = -1;
+
+  entries.forEach((entry: CustomizableColumn<TBaseModel>) => {
+    const knownIndex: number | undefined = entry.isPinned
+      ? undefined
+      : orderIndexById[entry.id];
+
+    if (knownIndex !== undefined) {
+      lastKnownOrderIndex = knownIndex;
+      sortKeys.push(knownIndex);
+      return;
+    }
+
+    sortKeys.push(lastKnownOrderIndex + 0.5);
+  });
+
+  return entries
+    .map(
+      (
+        entry: CustomizableColumn<TBaseModel>,
+        index: number,
+      ): { entry: CustomizableColumn<TBaseModel>; key: number; at: number } => {
+        return { entry, key: sortKeys[index] as number, at: index };
+      },
+    )
+    .sort(
+      (
+        a: { key: number; at: number },
+        b: { key: number; at: number },
+      ): number => {
+        // Stable: equal keys keep declaration order.
+        return a.key === b.key ? a.at - b.at : a.key - b.key;
+      },
+    )
+    .map(
+      (item: {
+        entry: CustomizableColumn<TBaseModel>;
+      }): CustomizableColumn<TBaseModel> => {
+        return item.entry;
+      },
+    );
+};
+
+export type ApplyColumnPreferenceFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  columns: Columns<TBaseModel>;
+  preference?: ColumnPreference | null | undefined;
+}) => Columns<TBaseModel>;
+
+/*
+ * The column set the table should actually render. Refuses to return an empty
+ * set: a layout that hides everything would replace the table with an empty
+ * shell the viewer cannot get out of, so it falls back to showing everything.
+ */
+export const applyColumnPreference: ApplyColumnPreferenceFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  columns: Columns<TBaseModel>;
+  preference?: ColumnPreference | null | undefined;
+}): Columns<TBaseModel> => {
+  const entries: Array<CustomizableColumn<TBaseModel>> =
+    getCustomizableColumns<TBaseModel>(data);
+
+  const visible: Columns<TBaseModel> = entries
+    .filter((entry: CustomizableColumn<TBaseModel>) => {
+      return entry.isVisible;
+    })
+    .map((entry: CustomizableColumn<TBaseModel>) => {
+      return entry.column;
+    });
+
+  if (visible.length === 0) {
+    return entries.map((entry: CustomizableColumn<TBaseModel>) => {
+      return entry.column;
+    });
+  }
+
+  return visible;
+};
+
+export type BuildColumnPreferenceFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  entries: Array<CustomizableColumn<TBaseModel>>,
+) => ColumnPreference;
+
+/*
+ * The inverse of getCustomizableColumns: turn what the picker is showing back
+ * into something storable. Pinned columns are left out entirely - they are
+ * not the viewer's to arrange, so recording them would only create entries
+ * that go stale when a table stops pinning a column.
+ */
+export const buildColumnPreference: BuildColumnPreferenceFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(
+  entries: Array<CustomizableColumn<TBaseModel>>,
+): ColumnPreference => {
+  const order: Array<string> = [];
+  const hidden: Array<string> = [];
+
+  for (const entry of entries) {
+    if (entry.isPinned) {
+      continue;
+    }
+
+    order.push(entry.id);
+
+    if (!entry.isVisible) {
+      hidden.push(entry.id);
+    }
+  }
+
+  return { order, hidden };
+};
+
+export type SanitizeColumnPreferenceFunction = (data: {
+  preference: ColumnPreference | null;
+  knownColumnIds: Array<string>;
+}) => ColumnPreference | null;
+
+/*
+ * Drop everything that no longer names a column on this table. A stored
+ * layout outlives the release that produced it, so it routinely mentions
+ * columns that have since been renamed, removed, or - for custom fields -
+ * deleted from the project.
+ */
+export const sanitizeColumnPreference: SanitizeColumnPreferenceFunction =
+  (data: {
+    preference: ColumnPreference | null;
+    knownColumnIds: Array<string>;
+  }): ColumnPreference | null => {
+    const { preference, knownColumnIds } = data;
+
+    if (!preference) {
+      return null;
+    }
+
+    const known: Set<string> = new Set(knownColumnIds);
+
+    const keep: (ids: Array<string>) => Array<string> = (
+      ids: Array<string>,
+    ): Array<string> => {
+      const seen: Set<string> = new Set();
+
+      return ids.filter((id: string) => {
+        if (!known.has(id) || seen.has(id)) {
+          return false;
+        }
+        seen.add(id);
+        return true;
+      });
+    };
+
+    const sanitized: ColumnPreference = {
+      order: keep(preference.order),
+      hidden: keep(preference.hidden),
+    };
+
+    if (sanitized.order.length === 0 && sanitized.hidden.length === 0) {
+      return null;
+    }
+
+    return sanitized;
+  };
+
+export type IsEmptyColumnPreferenceFunction = (
+  preference: ColumnPreference | null | undefined,
+) => boolean;
+
+export const isEmptyColumnPreference: IsEmptyColumnPreferenceFunction = (
+  preference: ColumnPreference | null | undefined,
+): boolean => {
+  return Boolean(
+    !preference ||
+      (preference.order.length === 0 && preference.hidden.length === 0),
+  );
+};
+
+export type ColumnPreferenceToJSONFunction = (
+  preference: ColumnPreference | null | undefined,
+) => JSONObject | null;
+
+// A layout that changes nothing is stored as nothing.
+export const toJSON: ColumnPreferenceToJSONFunction = (
+  preference: ColumnPreference | null | undefined,
+): JSONObject | null => {
+  if (isEmptyColumnPreference(preference)) {
+    return null;
+  }
+
+  return {
+    order: [...preference!.order],
+    hidden: [...preference!.hidden],
+  };
+};
+
+export type ColumnPreferenceFromJSONFunction = (
+  json: JSONObject | null | undefined,
+) => ColumnPreference | null;
+
+/*
+ * Read a stored layout back. Anything on the way in is untrusted - it may
+ * have been hand-edited in devtools or written by an older release - so each
+ * list is validated on its own and a malformed one degrades to empty instead
+ * of taking the other down with it.
+ */
+export const fromJSON: ColumnPreferenceFromJSONFunction = (
+  json: JSONObject | null | undefined,
+): ColumnPreference | null => {
+  if (!json || typeof json !== "object" || Array.isArray(json)) {
+    return null;
+  }
+
+  const readIds: (value: unknown) => Array<string> = (
+    value: unknown,
+  ): Array<string> => {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    const seen: Set<string> = new Set();
+
+    return value.filter((entry: unknown): entry is string => {
+      if (typeof entry !== "string" || entry.length === 0 || seen.has(entry)) {
+        return false;
+      }
+      seen.add(entry);
+      return true;
+    });
+  };
+
+  const preference: ColumnPreference = {
+    order: readIds((json as JSONObject)["order"]),
+    hidden: readIds((json as JSONObject)["hidden"]),
+  };
+
+  if (isEmptyColumnPreference(preference)) {
+    return null;
+  }
+
+  return preference;
+};

--- a/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
+++ b/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
@@ -1,0 +1,326 @@
+import Column from "./Column";
+import Columns from "./Columns";
+import FieldType from "../Types/FieldType";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import CustomFieldType from "../../../Types/CustomField/CustomFieldType";
+import { JSONObject } from "../../../Types/JSON";
+import React, { ReactElement } from "react";
+
+/*
+ * ---------------------------------------------------------------------------
+ * One table column per custom field
+ * ---------------------------------------------------------------------------
+ *
+ * Custom field *definitions* live in a per-resource table (MonitorCustomField,
+ * IncidentCustomField, ...); the *values* live in a single `customFields`
+ * jsonb column on the resource itself, keyed by the definition's name. So a
+ * generated column reads the whole JSON column and picks one key out of it:
+ *
+ *     field:            { customFields: true }   <- a real model column
+ *     selectedProperty: "Severity"               <- the key inside it
+ *
+ * which BaseModelTable turns into the column key "customFields.Severity".
+ *
+ * Two things about that shape are load-bearing:
+ *
+ *  - the declared field has to be the real column. A synthetic
+ *    `field: { "customFields.Severity": true }` would fail the model's column
+ *    check in getSelectFromColumns and throw the whole table away.
+ *
+ *  - sorting has to be off. Nothing downstream validates `sort` before it
+ *    reaches TypeORM, so a clickable header here would send an unknown
+ *    property into the query builder. Postgres can only order by a jsonb
+ *    key through an explicit ->> expression, which the sort path has no
+ *    concept of.
+ *
+ * Cells render through `getElement` for the same class of reason: the typed
+ * cell renderers index `item[column.key]` directly, so they would look for a
+ * literal "customFields.Severity" property and find nothing. Only the
+ * fall-through text branch understands a dotted key.
+ */
+
+export interface CustomFieldDefinition {
+  name: string;
+  description?: string | undefined;
+  customFieldType?: CustomFieldType | undefined;
+  dropdownOptions?: string | undefined;
+}
+
+export const CustomFieldsColumnKey: string = "customFields";
+
+export type ParseDropdownOptionsFunction = (
+  value: string | undefined | null,
+) => Array<string>;
+
+/*
+ * Dropdown options are stored as one option per line, the same format the
+ * settings page writes.
+ */
+export const parseDropdownOptions: ParseDropdownOptionsFunction = (
+  value: string | undefined | null,
+): Array<string> => {
+  if (typeof value !== "string" || !value) {
+    return [];
+  }
+
+  return value
+    .split("\n")
+    .map((line: string) => {
+      return line.trim();
+    })
+    .filter((line: string) => {
+      return line.length > 0;
+    });
+};
+
+export type GetCustomFieldDefinitionsFunction = (
+  items: Array<BaseModel | JSONObject>,
+) => Array<CustomFieldDefinition>;
+
+/*
+ * Normalise whatever the definition API returned into a plain, sorted list.
+ *
+ * Sorting matters: the definition models carry no ordering column and the
+ * list endpoint is queried with an empty sort, so Postgres is free to hand
+ * back a different order on every request. Without a deterministic order
+ * here, a viewer's saved column layout would appear to shuffle itself
+ * between page loads.
+ */
+export const getCustomFieldDefinitions: GetCustomFieldDefinitionsFunction = (
+  items: Array<BaseModel | JSONObject>,
+): Array<CustomFieldDefinition> => {
+  const definitions: Array<CustomFieldDefinition> = [];
+  const seenNames: Set<string> = new Set();
+
+  for (const item of items || []) {
+    const name: unknown = (item as JSONObject)?.["name"];
+
+    if (typeof name !== "string" || name.trim().length === 0) {
+      continue;
+    }
+
+    const trimmedName: string = name.trim();
+
+    if (seenNames.has(trimmedName)) {
+      continue;
+    }
+
+    seenNames.add(trimmedName);
+
+    const description: unknown = (item as JSONObject)["description"];
+    const customFieldType: unknown = (item as JSONObject)["customFieldType"];
+    const dropdownOptions: unknown = (item as JSONObject)["dropdownOptions"];
+
+    definitions.push({
+      name: trimmedName,
+      description: typeof description === "string" ? description : undefined,
+      customFieldType:
+        typeof customFieldType === "string"
+          ? (customFieldType as CustomFieldType)
+          : undefined,
+      dropdownOptions:
+        typeof dropdownOptions === "string" ? dropdownOptions : undefined,
+    });
+  }
+
+  return definitions.sort(
+    (a: CustomFieldDefinition, b: CustomFieldDefinition) => {
+      return a.name.localeCompare(b.name);
+    },
+  );
+};
+
+export type GetCustomFieldValueFunction = (
+  item: unknown,
+  name: string,
+) => unknown;
+
+export const getCustomFieldValue: GetCustomFieldValueFunction = (
+  item: unknown,
+  name: string,
+): unknown => {
+  const customFields: unknown = (item as JSONObject | undefined)?.[
+    CustomFieldsColumnKey
+  ];
+
+  if (!customFields || typeof customFields !== "object") {
+    return undefined;
+  }
+
+  return (customFields as JSONObject)[name];
+};
+
+type BadgeFunction = (data: { label: string; key: string }) => ReactElement;
+
+const badge: BadgeFunction = (data: {
+  label: string;
+  key: string;
+}): ReactElement => {
+  return (
+    <span
+      key={data.key}
+      className="inline-flex items-center gap-x-1.5 px-2 py-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium ring-1 ring-inset ring-indigo-700/10"
+    >
+      <svg
+        className="h-1.5 w-1.5 fill-indigo-500"
+        viewBox="0 0 6 6"
+        aria-hidden="true"
+      >
+        <circle cx={3} cy={3} r={3} />
+      </svg>
+      {data.label}
+    </span>
+  );
+};
+
+export type RenderCustomFieldValueFunction = (data: {
+  value: unknown;
+  definition: CustomFieldDefinition;
+  noValueMessage?: string | undefined;
+}) => ReactElement;
+
+export const renderCustomFieldValue: RenderCustomFieldValueFunction = (data: {
+  value: unknown;
+  definition: CustomFieldDefinition;
+  noValueMessage?: string | undefined;
+}): ReactElement => {
+  const { value, definition } = data;
+  const noValueMessage: string = data.noValueMessage ?? "-";
+
+  const empty: ReactElement = (
+    <span className="text-gray-400">{noValueMessage}</span>
+  );
+
+  if (value === undefined || value === null || value === "") {
+    return empty;
+  }
+
+  if (definition.customFieldType === CustomFieldType.Boolean) {
+    /*
+     * A boolean custom field renders "No" rather than falling into the empty
+     * branch above - `false` is a real answer, not a missing one.
+     */
+    const isTrue: boolean = value === true || value === "true";
+
+    return (
+      <span
+        className={
+          isTrue
+            ? "inline-flex items-center px-2 py-1 rounded-md bg-green-50 text-green-700 text-xs font-medium ring-1 ring-inset ring-green-600/20"
+            : "inline-flex items-center px-2 py-1 rounded-md bg-gray-50 text-gray-600 text-xs font-medium ring-1 ring-inset ring-gray-500/10"
+        }
+      >
+        {isTrue ? "Yes" : "No"}
+      </span>
+    );
+  }
+
+  if (definition.customFieldType === CustomFieldType.MultiSelectDropdown) {
+    /*
+     * Tolerant on the way out: an older single-select value that was later
+     * switched to multi-select is still a bare string in the JSON.
+     */
+    const values: Array<unknown> = Array.isArray(value) ? value : [value];
+
+    const labels: Array<string> = values
+      .filter((entry: unknown) => {
+        return entry !== undefined && entry !== null && entry !== "";
+      })
+      .map((entry: unknown) => {
+        return String(entry);
+      });
+
+    if (labels.length === 0) {
+      return empty;
+    }
+
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {labels.map((label: string, index: number) => {
+          return badge({ label, key: `${label}-${index}` });
+        })}
+      </div>
+    );
+  }
+
+  if (definition.customFieldType === CustomFieldType.Dropdown) {
+    return badge({ label: String(value), key: String(value) });
+  }
+
+  if (Array.isArray(value)) {
+    return <span>{value.join(", ")}</span>;
+  }
+
+  if (typeof value === "object") {
+    return <span>{JSON.stringify(value)}</span>;
+  }
+
+  return <span>{String(value)}</span>;
+};
+
+export type GetCustomFieldColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  definitions: Array<CustomFieldDefinition>;
+  isHiddenByDefault?: boolean | undefined;
+}) => Columns<TBaseModel>;
+
+/*
+ * Custom field columns default to hidden. A project is free to define a dozen
+ * of them, and turning every one on by default would push the columns the
+ * table was designed around off the side of the screen the first time anyone
+ * opens it. They are all listed in the column picker, one click away.
+ */
+export const getCustomFieldColumns: GetCustomFieldColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  definitions: Array<CustomFieldDefinition>;
+  isHiddenByDefault?: boolean | undefined;
+}): Columns<TBaseModel> => {
+  const isHidden: boolean = data.isHiddenByDefault !== false;
+
+  return (data.definitions || []).map(
+    (definition: CustomFieldDefinition): Column<TBaseModel> => {
+      return {
+        id: `${CustomFieldsColumnKey}.${definition.name}`,
+        field: {
+          [CustomFieldsColumnKey]: true,
+        } as Column<TBaseModel>["field"],
+        selectedProperty: definition.name,
+        title: definition.name,
+        description: definition.description,
+        type: FieldType.Element,
+        /*
+         * See the file header: sorting a jsonb key is not something the
+         * query path can express.
+         */
+        disableSort: true,
+        isHiddenByDefault: isHidden,
+        getExportValue: (item: TBaseModel): string => {
+          const value: unknown = getCustomFieldValue(item, definition.name);
+
+          if (value === undefined || value === null) {
+            return "";
+          }
+
+          if (Array.isArray(value)) {
+            return value.join(", ");
+          }
+
+          if (typeof value === "object") {
+            return JSON.stringify(value);
+          }
+
+          return String(value);
+        },
+        getElement: (item: TBaseModel): ReactElement => {
+          return renderCustomFieldValue({
+            value: getCustomFieldValue(item, definition.name),
+            definition: definition,
+          });
+        },
+      };
+    },
+  );
+};

--- a/Common/UI/Components/ModelTable/TableView.tsx
+++ b/Common/UI/Components/ModelTable/TableView.tsx
@@ -40,6 +40,13 @@ export interface ComponentProps<T extends GenericObject> {
    * `TableView.facets`). Owner: the parent's filter hook.
    */
   currentFacetState?: JSONObject | undefined;
+  /**
+   * The viewer's current column layout ({ order, hidden }), persisted on
+   * `TableView.columns` so a saved view restores the columns it was saved
+   * with. `undefined` means "the table's default layout", which is stored as
+   * no value at all.
+   */
+  currentColumns?: JSONObject | undefined;
   tableView: TableView | null;
 }
 
@@ -90,6 +97,7 @@ const TableViewElement: <T extends DatabaseBaseModel | AnalyticsBaseModel>(
           query: true,
           name: true,
           facets: true,
+          columns: true,
         },
         sort: {
           name: SortOrder.Ascending,
@@ -223,6 +231,17 @@ const TableViewElement: <T extends DatabaseBaseModel | AnalyticsBaseModel>(
 
   const hasActiveFilters: boolean = hasQueryFilters || hasFacetState;
 
+  /*
+   * A customized column layout is worth saving on its own - "the columns I
+   * care about, in my order" is a view even when nothing is filtered.
+   */
+  const hasColumnLayout: boolean = Boolean(
+    props.currentColumns &&
+      Object.keys(props.currentColumns as JSONObject).length > 0,
+  );
+
+  const hasSavableState: boolean = hasActiveFilters || hasColumnLayout;
+
   const getMenuContents: GetReactElementArrayFunction =
     (): Array<ReactElement> => {
       if (isLoading) {
@@ -239,7 +258,7 @@ const TableViewElement: <T extends DatabaseBaseModel | AnalyticsBaseModel>(
         );
       }
 
-      if (hasActiveFilters) {
+      if (hasSavableState) {
         elements.push(
           <MoreMenuItem
             key={"save-new-view"}
@@ -359,6 +378,9 @@ const TableViewElement: <T extends DatabaseBaseModel | AnalyticsBaseModel>(
           if (props.currentFacetState) {
             tableView.facets = props.currentFacetState;
           }
+          if (props.currentColumns) {
+            tableView.columns = props.currentColumns;
+          }
           return Promise.resolve(tableView);
         }}
         onSuccess={async (tableView: TableView) => {
@@ -476,7 +498,7 @@ const TableViewElement: <T extends DatabaseBaseModel | AnalyticsBaseModel>(
   if (
     !isLoading &&
     allTableViews.length === 0 &&
-    !hasActiveFilters &&
+    !hasSavableState &&
     !currentlySelectedView
   ) {
     return <></>;

--- a/Common/UI/Components/ModelTable/useCustomFieldColumns.ts
+++ b/Common/UI/Components/ModelTable/useCustomFieldColumns.ts
@@ -1,0 +1,150 @@
+import Columns from "./Columns";
+import {
+  CustomFieldDefinition,
+  getCustomFieldColumns,
+  getCustomFieldDefinitions,
+} from "./CustomFieldColumns";
+import ModelAPI from "../../Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../Utils/Project";
+import { Logger } from "../../Utils/Logger";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import ListResult from "../../../Types/BaseDatabase/ListResult";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import ObjectID from "../../../Types/ObjectID";
+import { useEffect, useMemo, useState } from "react";
+
+export interface CustomFieldColumnsResult<
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+> {
+  columns: Columns<TBaseModel>;
+  definitions: Array<CustomFieldDefinition>;
+  isLoading: boolean;
+  error: string;
+}
+
+/*
+ * Loads a resource's custom field *definitions* and turns them into table
+ * columns.
+ *
+ * The definitions arrive after the table's first render, which is fine: they
+ * only add columns, and every one of them is hidden until the viewer switches
+ * it on. What must NOT wait on this request is the `customFields` entry in the
+ * API select - the table does not refetch when its column set changes, so the
+ * select has to be right from the first request. BaseModelTable handles that
+ * from the synchronous `customFieldsModelType` prop instead.
+ *
+ * Pass `undefined` for the model type to switch the whole thing off; the hook
+ * still runs (hooks cannot be conditional) but makes no request.
+ */
+export type UseCustomFieldColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  customFieldsModelType?: { new (): BaseModel } | undefined;
+  projectId?: ObjectID | null | undefined;
+}) => CustomFieldColumnsResult<TBaseModel>;
+
+const useCustomFieldColumns: UseCustomFieldColumnsFunction = <
+  TBaseModel extends BaseModel | AnalyticsBaseModel,
+>(data: {
+  customFieldsModelType?: { new (): BaseModel } | undefined;
+  projectId?: ObjectID | null | undefined;
+}): CustomFieldColumnsResult<TBaseModel> => {
+  const { customFieldsModelType } = data;
+
+  const [definitions, setDefinitions] = useState<Array<CustomFieldDefinition>>(
+    [],
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+
+  const projectId: ObjectID | null =
+    data.projectId ?? ProjectUtil.getCurrentProjectId();
+
+  const projectIdString: string = projectId?.toString() || "";
+  const modelName: string = customFieldsModelType?.name || "";
+
+  useEffect(() => {
+    if (!customFieldsModelType || !projectId) {
+      setDefinitions([]);
+      return;
+    }
+
+    let isCancelled: boolean = false;
+
+    const load: () => Promise<void> = async (): Promise<void> => {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const result: ListResult<BaseModel> = await ModelAPI.getList<BaseModel>(
+          {
+            modelType: customFieldsModelType,
+            query: {
+              projectId: projectId,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            limit: LIMIT_PER_PROJECT,
+            skip: 0,
+            select: {
+              name: true,
+              customFieldType: true,
+              description: true,
+              dropdownOptions: true,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            sort: {},
+          },
+        );
+
+        if (isCancelled) {
+          return;
+        }
+
+        setDefinitions(getCustomFieldDefinitions(result.data || []));
+      } catch (err) {
+        if (isCancelled) {
+          return;
+        }
+
+        /*
+         * Custom fields are a paid feature and the caller may not have read
+         * access to the definition table, so a failure here is expected in
+         * normal operation. It costs the viewer some optional columns; it must
+         * never take the table down with it.
+         */
+        Logger.warn(
+          `Could not load custom field definitions for ${modelName}: ${
+            (err as Error)?.message || String(err)
+          }`,
+        );
+        setDefinitions([]);
+        setError((err as Error)?.message || "");
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    load().catch(() => {
+      // load() already funnels every failure into the catch above.
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [modelName, projectIdString]);
+
+  const columns: Columns<TBaseModel> = useMemo(() => {
+    if (definitions.length === 0) {
+      return [];
+    }
+
+    return getCustomFieldColumns<TBaseModel>({ definitions });
+  }, [definitions]);
+
+  return { columns, definitions, isLoading, error };
+};
+
+export default useCustomFieldColumns;

--- a/Common/UI/Components/Table/Table.tsx
+++ b/Common/UI/Components/Table/Table.tsx
@@ -181,9 +181,22 @@ const Table: TableFunction = <T extends GenericObject>(
     }
   }, [props.bulkSelectedItems]);
 
+  /*
+   * Width of the loading / error / "no items" row, in cells. It has to match
+   * what TableHeader actually renders or those messages sit under part of the
+   * table instead of spanning it: the Actions column is already one of
+   * `props.columns`, and the drag-handle and bulk-select cells are extra
+   * leading columns that only exist when those features are on.
+   */
   let colspan: number = props.columns.length || 0;
-  if (props.actionButtons && props.actionButtons?.length > 0) {
+  if (props.enableDragAndDrop) {
     colspan++;
+  }
+  if (isBulkActionsEnabled) {
+    colspan++;
+  }
+  if (colspan === 0) {
+    colspan = 1;
   }
 
   const getTablebody: GetReactElementFunction = (): ReactElement => {

--- a/Common/UI/Components/Table/TableRow.tsx
+++ b/Common/UI/Components/Table/TableRow.tsx
@@ -77,6 +77,13 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
     };
   }, []);
 
+  // The columns this row will actually put on screen.
+  const renderedColumns: Array<Column<T>> = (props.columns || []).filter(
+    (column: Column<T>) => {
+      return !(column.hideOnMobile && isMobile);
+    },
+  );
+
   type GetRowFunction = (provided?: DraggableProvided) => ReactElement;
 
   const getRow: GetRowFunction = (
@@ -339,186 +346,184 @@ const TableRow: TableRowFunction = <T extends GenericObject>(
             </td>
           )}
           {props.columns &&
-            props.columns
-              .filter((column: Column<T>) => {
-                return !(column.hideOnMobile && isMobile);
-              })
-              .map((column: Column<T>, i: number) => {
-                let className: string =
-                  "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
-                if (i === props.columns.length - 1) {
-                  className =
-                    "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
-                }
+            renderedColumns.map((column: Column<T>, i: number) => {
+              let className: string =
+                "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+              /*
+               * Compared against the rendered count, not the declared one:
+               * with any column filtered out the two differ, and the extra
+               * right padding would land on the wrong cell - or on none.
+               */
+              if (i === renderedColumns.length - 1) {
+                className =
+                  "whitespace-nowrap py-4 pl-4 pr-6 text-sm font-medium text-gray-500 sm:pl-6 align-top";
+              }
 
-                let columnContent: React.ReactNode = null;
+              let columnContent: React.ReactNode = null;
 
-                if (column.key && !column.getElement) {
-                  columnContent =
-                    column.type === FieldType.Date ? (
-                      props.item[column.key] ? (
-                        OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
-                          props.item[column.key] as string,
-                          true,
-                        )
-                      ) : (
-                        column.noValueMessage || ""
-                      )
-                    ) : column.type === FieldType.DateTime ? (
-                      props.item[column.key] ? (
-                        OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
-                          props.item[column.key] as string,
-                          false,
-                        )
-                      ) : (
-                        column.noValueMessage || ""
-                      )
-                    ) : column.type === FieldType.USDCents ? (
-                      props.item[column.key] ? (
-                        ((props.item[column.key] as number) || 0) / 100 + " USD"
-                      ) : (
-                        column.noValueMessage || "0 USD"
-                      )
-                    ) : column.type === FieldType.Percent ? (
-                      props.item[column.key] ? (
-                        props.item[column.key] + "%"
-                      ) : (
-                        column.noValueMessage || "0%"
-                      )
-                    ) : column.type === FieldType.Color ? (
-                      props.item[column.key] ? (
-                        <ColorInput value={props.item[column.key] as Color} />
-                      ) : (
-                        column.noValueMessage || "0%"
-                      )
-                    ) : column.type === FieldType.LongText ? (
-                      props.item[column.key] ? (
-                        <LongTextViewer
-                          text={props.item[column.key] as string}
-                        />
-                      ) : (
-                        column.noValueMessage || ""
-                      )
-                    ) : column.type === FieldType.Boolean ? (
-                      props.item[column.key] ? (
-                        <Icon
-                          icon={IconProp.Check}
-                          className={"h-5 w-5 text-gray-500"}
-                          thick={ThickProp.Thick}
-                        />
-                      ) : (
-                        <Icon
-                          icon={IconProp.False}
-                          className={"h-5 w-5 text-gray-500"}
-                          thick={ThickProp.Thick}
-                        />
+              if (column.key && !column.getElement) {
+                columnContent =
+                  column.type === FieldType.Date ? (
+                    props.item[column.key] ? (
+                      OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+                        props.item[column.key] as string,
+                        true,
                       )
                     ) : (
-                      getNestedValue(
-                        props.item,
-                        String(column.key),
-                      )?.toString() ||
-                      column.noValueMessage ||
-                      ""
-                    );
-                } else if (column.key && column.getElement) {
-                  columnContent = column.getElement(props.item);
-                }
+                      column.noValueMessage || ""
+                    )
+                  ) : column.type === FieldType.DateTime ? (
+                    props.item[column.key] ? (
+                      OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+                        props.item[column.key] as string,
+                        false,
+                      )
+                    ) : (
+                      column.noValueMessage || ""
+                    )
+                  ) : column.type === FieldType.USDCents ? (
+                    props.item[column.key] ? (
+                      ((props.item[column.key] as number) || 0) / 100 + " USD"
+                    ) : (
+                      column.noValueMessage || "0 USD"
+                    )
+                  ) : column.type === FieldType.Percent ? (
+                    props.item[column.key] ? (
+                      props.item[column.key] + "%"
+                    ) : (
+                      column.noValueMessage || "0%"
+                    )
+                  ) : column.type === FieldType.Color ? (
+                    props.item[column.key] ? (
+                      <ColorInput value={props.item[column.key] as Color} />
+                    ) : (
+                      column.noValueMessage || "0%"
+                    )
+                  ) : column.type === FieldType.LongText ? (
+                    props.item[column.key] ? (
+                      <LongTextViewer text={props.item[column.key] as string} />
+                    ) : (
+                      column.noValueMessage || ""
+                    )
+                  ) : column.type === FieldType.Boolean ? (
+                    props.item[column.key] ? (
+                      <Icon
+                        icon={IconProp.Check}
+                        className={"h-5 w-5 text-gray-500"}
+                        thick={ThickProp.Thick}
+                      />
+                    ) : (
+                      <Icon
+                        icon={IconProp.False}
+                        className={"h-5 w-5 text-gray-500"}
+                        thick={ThickProp.Thick}
+                      />
+                    )
+                  ) : (
+                    getNestedValue(
+                      props.item,
+                      String(column.key),
+                    )?.toString() ||
+                    column.noValueMessage ||
+                    ""
+                  );
+              } else if (column.key && column.getElement) {
+                columnContent = column.getElement(props.item);
+              }
 
-                const contentWrapperClassName: string = column.contentClassName
-                  ? column.contentClassName
-                  : "";
+              const contentWrapperClassName: string = column.contentClassName
+                ? column.contentClassName
+                : "";
 
-                const actionsContainerClassName: string =
-                  column.contentClassName
-                    ? `flex justify-end ${column.contentClassName}`
-                    : "flex justify-end";
+              const actionsContainerClassName: string = column.contentClassName
+                ? `flex justify-end ${column.contentClassName}`
+                : "flex justify-end";
 
-                return (
-                  <td
-                    key={i}
-                    className={className}
-                    style={{
-                      textAlign:
-                        column.type === FieldType.Actions ? "right" : "left",
-                    }}
-                    onClick={() => {
-                      if (column.tooltipText) {
-                        setTooltipModalText(column.tooltipText(props.item));
-                      }
-                    }}
-                  >
-                    {columnContent !== null && columnContent !== undefined && (
-                      <div className={contentWrapperClassName}>
-                        {columnContent}
-                      </div>
-                    )}
-                    {column.type === FieldType.Actions && (
-                      <div className={actionsContainerClassName}>
-                        {error && (
-                          <div className="text-align-left">
-                            <ConfirmModal
-                              title={`Error`}
-                              description={error}
-                              submitButtonText={"Close"}
-                              onSubmit={() => {
-                                return setError("");
-                              }}
-                            />
-                          </div>
-                        )}
-                        {props.actionButtons?.map(
-                          (button: ActionButtonSchema<T>, i: number) => {
-                            if (
-                              button.isVisible &&
-                              !button.isVisible(props.item)
-                            ) {
-                              return <div key={i}></div>;
-                            }
+              return (
+                <td
+                  key={i}
+                  className={className}
+                  style={{
+                    textAlign:
+                      column.type === FieldType.Actions ? "right" : "left",
+                  }}
+                  onClick={() => {
+                    if (column.tooltipText) {
+                      setTooltipModalText(column.tooltipText(props.item));
+                    }
+                  }}
+                >
+                  {columnContent !== null && columnContent !== undefined && (
+                    <div className={contentWrapperClassName}>
+                      {columnContent}
+                    </div>
+                  )}
+                  {column.type === FieldType.Actions && (
+                    <div className={actionsContainerClassName}>
+                      {error && (
+                        <div className="text-align-left">
+                          <ConfirmModal
+                            title={`Error`}
+                            description={error}
+                            submitButtonText={"Close"}
+                            onSubmit={() => {
+                              return setError("");
+                            }}
+                          />
+                        </div>
+                      )}
+                      {props.actionButtons?.map(
+                        (button: ActionButtonSchema<T>, i: number) => {
+                          if (
+                            button.isVisible &&
+                            !button.isVisible(props.item)
+                          ) {
+                            return <div key={i}></div>;
+                          }
 
-                            // Hide button on mobile if hideOnMobile is true
-                            if (button.hideOnMobile && isMobile) {
-                              return <div key={i}></div>;
-                            }
+                          // Hide button on mobile if hideOnMobile is true
+                          if (button.hideOnMobile && isMobile) {
+                            return <div key={i}></div>;
+                          }
 
-                            return (
-                              <div key={i}>
-                                <Button
-                                  buttonSize={ButtonSize.Small}
-                                  title={button.title}
-                                  icon={button.icon}
-                                  buttonStyle={button.buttonStyleType}
-                                  isLoading={isButtonLoading[i]}
-                                  onClick={() => {
-                                    if (button.onClick) {
-                                      isButtonLoading[i] = true;
-                                      setIsButtonLoading(isButtonLoading);
+                          return (
+                            <div key={i}>
+                              <Button
+                                buttonSize={ButtonSize.Small}
+                                title={button.title}
+                                icon={button.icon}
+                                buttonStyle={button.buttonStyleType}
+                                isLoading={isButtonLoading[i]}
+                                onClick={() => {
+                                  if (button.onClick) {
+                                    isButtonLoading[i] = true;
+                                    setIsButtonLoading(isButtonLoading);
 
-                                      button.onClick(
-                                        props.item,
-                                        () => {
-                                          // on action complete
-                                          isButtonLoading[i] = false;
-                                          setIsButtonLoading(isButtonLoading);
-                                        },
-                                        (err: Error) => {
-                                          isButtonLoading[i] = false;
-                                          setIsButtonLoading(isButtonLoading);
-                                          setError((err as Error).message);
-                                        },
-                                      );
-                                    }
-                                  }}
-                                />
-                              </div>
-                            );
-                          },
-                        )}
-                      </div>
-                    )}
-                  </td>
-                );
-              })}
+                                    button.onClick(
+                                      props.item,
+                                      () => {
+                                        // on action complete
+                                        isButtonLoading[i] = false;
+                                        setIsButtonLoading(isButtonLoading);
+                                      },
+                                      (err: Error) => {
+                                        isButtonLoading[i] = false;
+                                        setIsButtonLoading(isButtonLoading);
+                                        setError((err as Error).message);
+                                      },
+                                    );
+                                  }
+                                }}
+                              />
+                            </div>
+                          );
+                        },
+                      )}
+                    </div>
+                  )}
+                </td>
+              );
+            })}
         </tr>
         {tooltipModalText && (
           <ConfirmModal

--- a/Common/UI/Components/Table/Types/Column.ts
+++ b/Common/UI/Components/Table/Types/Column.ts
@@ -5,6 +5,8 @@ import { ReactElement } from "react";
 
 export default interface Column<T extends GenericObject> {
   title: string;
+  // Stable identity carried over from the ModelTable column, if it had one.
+  id?: string | undefined;
   description?: string | undefined;
   disableSort?: boolean | undefined;
   tooltipText?: ((item: T) => string) | undefined;

--- a/Common/Utils/UserPreferences.ts
+++ b/Common/Utils/UserPreferences.ts
@@ -1,7 +1,9 @@
 import LocalStorage from "../UI/Utils/LocalStorage";
+import { JSONObject } from "../Types/JSON";
 
 export enum UserPreferenceType {
   BaseModelTablePageSize = "BaseModelTablePageSize",
+  BaseModelTableColumns = "BaseModelTableColumns",
 }
 
 export default class UserPreferences {
@@ -29,5 +31,56 @@ export default class UserPreferences {
 
     const finalKey: string = `${userPreferenceType}.${key}`;
     LocalStorage.setItem(finalKey, value);
+  }
+
+  /*
+   * Object-shaped preferences (e.g. a table's column layout). LocalStorage
+   * already JSON-serializes objects on the way in and parses them on the way
+   * out, so this only has to reject anything that came back as something other
+   * than a plain object - a half-written or hand-edited entry must degrade to
+   * "no preference" rather than reaching the caller as a string or an array.
+   */
+  public static getUserPreferenceByTypeAsJSON(data: {
+    key: string;
+    userPreferenceType: UserPreferenceType;
+  }): JSONObject | null {
+    const { key, userPreferenceType } = data;
+
+    const finalKey: string = `${userPreferenceType}.${key}`;
+
+    let value: unknown = null;
+
+    try {
+      value = LocalStorage.getItem(finalKey);
+    } catch {
+      return null;
+    }
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return null;
+    }
+
+    return value as JSONObject;
+  }
+
+  public static saveUserPreferenceByTypeAsJSON(data: {
+    key: string;
+    userPreferenceType: UserPreferenceType;
+    value: JSONObject;
+  }): void {
+    const { key, userPreferenceType, value } = data;
+
+    const finalKey: string = `${userPreferenceType}.${key}`;
+    LocalStorage.setItem(finalKey, value);
+  }
+
+  public static removeUserPreferenceByType(data: {
+    key: string;
+    userPreferenceType: UserPreferenceType;
+  }): void {
+    const { key, userPreferenceType } = data;
+
+    const finalKey: string = `${userPreferenceType}.${key}`;
+    LocalStorage.removeItem(finalKey);
   }
 }


### PR DESCRIPTION
Every ModelTable now carries a **Columns** control in its card header. From it a viewer can switch columns off, drag them into the order they want, and — on resources that have custom fields — turn any custom field into a column of its own.

## How it hangs together

`BaseModelTable.serializeToTableColumns()` is the single funnel that turns declared columns into rendered ones. The viewer's layout is applied to the **input** of that loop, *before* the Actions column is appended — so Actions stays last and is never offered as something to hide or move. Column order downstream is just array order, so no renderer needed changing.

**Where the layout lives.** localStorage, next to the page size, keyed by `userPreferencesKey`. Saved views are named, explicit, plan-gated and need write permission — none of which should stand between someone and hiding a column they don't care about. A saved view *additionally* carries its own layout on the new `TableView.columns` column, and loading one restores the columns it was saved with. Clearing a view deliberately leaves your columns alone.

**Identity, not position.** A stored layout outlives the release that wrote it, so columns are keyed by the field they read (plus `selectedProperty`, which is what gives each custom field its own id) rather than by array index. Ids that no longer name a column are dropped on read; a column the layout has never seen defaults to visible and sorts next to its declared neighbours, so a column shipped later appears where its author put it instead of vanishing.

**Two things are deliberately refused:**

1. A layout that would leave the table with no columns at all — the picker blocks unchecking the last one, and `applyColumnPreference` refuses it as a backstop. A zero-column table renders as an empty shell whose only escape hatch is the control the viewer just closed.
2. Any narrowing of the API `select`. A visible cell's `getElement` is arbitrary caller code that may read a hidden column's field, so dropping it would silently blank a *different* cell — and that is not detectable statically. Hiding costs a few unused fields on the wire; that's the right trade, and there's a test pinning it.

## Custom field columns

Definitions live in the per-resource `*CustomField` table; values live in one `customFields` jsonb column keyed by definition name. A generated column therefore reads the real column and picks one key out of it: `field: { customFields: true }` + `selectedProperty: "<name>"`.

- **Sorting is always off** — nothing validates `sort` before it reaches TypeORM, so a clickable header here would push an unknown property into the query builder.
- **Cells always render through `getElement`** — the typed cell renderers index `item[column.key]` directly and would miss a dotted key.
- **Hidden by default** — a project with a dozen custom fields would otherwise wreck every table on first load. They're all one click away in the picker.
- The `customFields` select entry is added from the synchronous prop, not from the fetched definitions, because the table doesn't refetch when its column set changes.

Wired up on monitors, incidents, alerts, scheduled maintenance, on-call policies, status pages and teams.

## Latent bugs this exposed, fixed here

- **`JSONFunctions.deserializeValue`** tested `typeof val === "object"` *before* `Array.isArray(val)`, so its own array branch was unreachable and every array came back as `{"0": …, "1": …}`. That silently broke the type contract of `LocalStorage.getItem` for anything array-shaped.
- **`Table` colspan** double-counted the Actions column (already one of `props.columns`) and ignored the drag-handle and bulk-select cells, so the loading / error / "no items" rows never actually spanned the table.
- **`TableRow`** compared the filtered cell index against the *unfiltered* column count, putting the last-cell padding on the wrong cell as soon as any column was filtered out.

## Migration

`AddColumnsToTableView1785241000000` adds a nullable `columns` jsonb to `TableView`, generated via `npm run generate-postgres-migration` and registered in `SchemaMigrations/Index.ts`.

## Tests

**234 new tests across five suites:**

| Suite | Tests | Covers |
|---|---|---|
| `ColumnPreference.test.ts` | 94 | id derivation and collision handling, ordering rules, the never-empty guarantee, sanitizing stale layouts, JSON round trip, and replaying one stored layout against a column set that has since changed (columns removed, added at start/middle/end, renamed, newly pinned) |
| `CustomFieldColumns.test.tsx` | 75 | definition normalisation and sorting, every shape rule with a note on what breaks otherwise, and each `CustomFieldType`'s rendering — including `false` rendering "No" rather than the empty placeholder |
| `UserPreferences.test.ts` | 29 | key namespacing, JSON round trip, and the guard that degrades a malformed or hand-edited entry to "no preference" |
| `ColumnCustomizationModal.test.tsx` | 24 | staged-until-Save semantics, reordering, search, and the two safety invariants (last column can't be unchecked, "Hide all" leaves one) |
| `BaseModelTableColumnCustomization.test.tsx` | 12 | integration on a real `BaseModelTable`: layout applied on first paint, survives remount, doesn't leak across tables, stale entries ignored, hidden columns still selected, Actions stays last, save/reset round trip |

Verified together with every pre-existing suite that touches table columns: **13 suites, 459 tests, all green.** `npm run fix` is clean and `npm run compile` passes in both `Common` and `App`.

The modal's two safety invariants and three of the integration assertions were mutation-checked — the source guard was removed to confirm the test actually fails without it.

> Note: `Common/Tests/UI/Components/MonacoRuntime.test.ts` fails locally, but only because this checkout's `node_modules` has `monaco-editor@0.53.0` while `Common/package.json` pins `0.52.2`. That test reads nothing but installed package versions, and this branch touches no `package.json` — unrelated to these changes.
