### PR TITLE
fix(cost): correct the engine's RAM wire names and dedup ingest per chunk

### DIFF
--- a/App/FeatureSet/Telemetry/Services/KubernetesCostIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/KubernetesCostIngestService.ts
@@ -17,8 +17,8 @@ import {
 import ServiceType from "Common/Types/Telemetry/ServiceType";
 import OneUptimeDate from "Common/Types/Date";
 import ObjectID from "Common/Types/ObjectID";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
 import { JSONObject } from "Common/Types/JSON";
-import PositiveNumber from "Common/Types/PositiveNumber";
 import logger from "Common/Server/Utils/Logger";
 import CaptureSpan from "Common/Server/Utils/Telemetry/CaptureSpan";
 
@@ -159,13 +159,21 @@ export default class KubernetesCostIngestService {
 
     /*
      * Restart idempotency: the poller's checkpoint is in-memory, so after a
-     * restart it re-ships its lookback windows. A window that already has
-     * rows for this cluster was fully shipped before (the poller ships whole
-     * windows and only advances its checkpoint on success) — re-inserting it
-     * would double-count spend, so drop those allocations here. BullMQ
-     * retries of THIS job are covered separately by the insert-dedup tokens
-     * (see ProcessTelemetry), which make re-inserts of the same batch no-ops.
+     * restart it re-ships its lookback windows. A window a PREVIOUS shipment
+     * already delivered must not be re-inserted or spend double-counts.
+     *
+     * "Previous shipment", not "already has rows": a window wider than the
+     * agent's batch size is delivered as several requests, each its own job,
+     * so the plain has-rows test dropped every chunk after the first and left
+     * large clusters permanently short of most of every hour. The agent
+     * stamps each request with a content hash of the window (identical
+     * across restarts) plus the request's index within that delivery, which
+     * separates the two cases. BullMQ retries of THIS job remain covered by
+     * the insert-dedup tokens (see ProcessTelemetry).
      */
+    const shipmentId: string = this.sanitizeString(payload.shipmentId);
+    const shipmentChunk: number = this.sanitizeNumber(payload.shipmentChunk);
+
     const alreadyIngestedWindows: Set<string> = new Set<string>();
     const distinctWindowStarts: Map<string, Date> = new Map<string, Date>();
 
@@ -184,20 +192,18 @@ export default class KubernetesCostIngestService {
     }
 
     for (const [windowKey, windowStart] of distinctWindowStarts) {
-      const existing: PositiveNumber =
-        await KubernetesCostAllocationService.countBy({
-          query: {
-            projectId: projectId,
-            kubernetesClusterId: cluster.id,
-            windowStart: windowStart,
-          } as JSONObject,
-          props: { isRoot: true },
-        });
+      const alreadyIngested: boolean = await this.isWindowAlreadyIngested({
+        projectId: projectId,
+        kubernetesClusterId: cluster.id,
+        windowStart: windowStart,
+        shipmentId: shipmentId,
+        shipmentChunk: shipmentChunk,
+      });
 
-      if (existing.toNumber() > 0) {
+      if (alreadyIngested) {
         alreadyIngestedWindows.add(windowKey);
         logger.debug(
-          `KubernetesCostIngestService: window ${windowKey} for cluster "${clusterName}" already ingested — skipping ${existing.toNumber()} pre-existing rows' window.`,
+          `KubernetesCostIngestService: window ${windowKey} for cluster "${clusterName}" was already ingested by another shipment — skipping its rows.`,
         );
       }
     }
@@ -212,6 +218,8 @@ export default class KubernetesCostIngestService {
         clusterName: clusterIdentifier,
         k8sClusterEntityKey,
         currency,
+        shipmentId,
+        shipmentChunk,
         retentionDays,
         ingestionTimestamp,
         alreadyIngestedWindows,
@@ -252,6 +260,74 @@ export default class KubernetesCostIngestService {
     await Promise.all(pendingAcks);
   }
 
+  /**
+   * Whether this window's rows have already been ingested by a DIFFERENT
+   * shipment, or this exact chunk of the current one has already landed.
+   */
+  private static async isWindowAlreadyIngested(data: {
+    projectId: ObjectID;
+    kubernetesClusterId: ObjectID;
+    windowStart: Date;
+    shipmentId: string;
+    shipmentChunk: number;
+  }): Promise<boolean> {
+    if (!data.shipmentId) {
+      /*
+       * An agent older than the shipment contract cannot say which delivery
+       * this is, so fall back to the original whole-window guard: correct
+       * against double-counting, and no worse than what that agent got
+       * before. Such an agent still loses rows past its first chunk on a
+       * window wider than its batch size — that half of the fix ships in the
+       * agent, so both sides have to be upgraded to get it.
+       */
+      return await KubernetesCostAllocationService.existsBy({
+        query: {
+          projectId: data.projectId,
+          kubernetesClusterId: data.kubernetesClusterId,
+          windowStart: data.windowStart,
+        },
+        props: { isRoot: true },
+      });
+    }
+
+    /*
+     * A row from a different shipment means an earlier delivery already
+     * covered this window — the poller only advances its checkpoint once a
+     * whole window has shipped, so anything it re-sends is a restart's
+     * lookback, not a continuation. Re-inserting would double-count spend.
+     */
+    const fromAnotherShipment: boolean =
+      await KubernetesCostAllocationService.existsBy({
+        query: {
+          projectId: data.projectId,
+          kubernetesClusterId: data.kubernetesClusterId,
+          windowStart: data.windowStart,
+          shipmentId: new NotEqual<string>(data.shipmentId),
+        },
+        props: { isRoot: true },
+      });
+
+    if (fromAnotherShipment) {
+      return true;
+    }
+
+    /*
+     * Same shipment, so this is another chunk of a delivery in progress —
+     * accept it unless this exact chunk already landed, which is what a
+     * re-ship of a window whose later chunks failed looks like.
+     */
+    return await KubernetesCostAllocationService.existsBy({
+      query: {
+        projectId: data.projectId,
+        kubernetesClusterId: data.kubernetesClusterId,
+        windowStart: data.windowStart,
+        shipmentId: data.shipmentId,
+        shipmentChunk: data.shipmentChunk,
+      },
+      props: { isRoot: true },
+    });
+  }
+
   private static buildRow(data: {
     allocation: KubernetesCostAllocationIngestRow;
     projectId: ObjectID;
@@ -259,6 +335,8 @@ export default class KubernetesCostIngestService {
     clusterName: string;
     k8sClusterEntityKey: string;
     currency: string;
+    shipmentId: string;
+    shipmentChunk: number;
     retentionDays: number;
     ingestionTimestamp: string;
     alreadyIngestedWindows: Set<string>;
@@ -338,6 +416,8 @@ export default class KubernetesCostIngestService {
       ramEfficiency: this.sanitizeNumber(allocation.ramEfficiency),
       totalEfficiency: this.sanitizeNumber(allocation.totalEfficiency),
       currency: data.currency,
+      shipmentId: data.shipmentId,
+      shipmentChunk: data.shipmentChunk,
       retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
     };
   }

--- a/App/FeatureSet/Workers/DataMigrations/AddShipmentColumnsToKubernetesCostAllocation.ts
+++ b/App/FeatureSet/Workers/DataMigrations/AddShipmentColumnsToKubernetesCostAllocation.ts
@@ -1,0 +1,59 @@
+import DataMigrationBase from "./DataMigrationBase";
+import AnalyticsTableColumn from "Common/Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "Common/Types/AnalyticsDatabase/TableColumnType";
+import KubernetesCostAllocationService from "Common/Server/Services/KubernetesCostAllocationService";
+import KubernetesCostAllocation from "Common/Models/AnalyticsModels/KubernetesCostAllocation";
+
+/*
+ * Adds shipmentId / shipmentChunk so the cost ingest can tell one agent
+ * delivery of a window from another. Without them a window wider than the
+ * agent's batch size arrives as several jobs and every job after the first
+ * saw the earlier one's rows and dropped itself, so clusters above
+ * SHIP_BATCH_SIZE containers stored only a fraction of each hour.
+ *
+ * Metadata-only and idempotent: ADD COLUMN IF NOT EXISTS, no part rewrite,
+ * sort keys untouched. Existing rows read back "" / 0, which the ingest
+ * service treats as "no shipment identity" and handles with the original
+ * whole-window guard.
+ */
+export default class AddShipmentColumnsToKubernetesCostAllocation extends DataMigrationBase {
+  public constructor() {
+    super("AddShipmentColumnsToKubernetesCostAllocation");
+  }
+
+  public override runsInClusterMode(): boolean {
+    return false;
+  }
+
+  public override async migrate(): Promise<void> {
+    await this.addColumnIfMissing("shipmentId");
+    await this.addColumnIfMissing("shipmentChunk");
+  }
+
+  public async addColumnIfMissing(columnName: string): Promise<void> {
+    const column: AnalyticsTableColumn | undefined =
+      new KubernetesCostAllocation().tableColumns.find(
+        (column: AnalyticsTableColumn) => {
+          return column.key === columnName;
+        },
+      );
+
+    if (!column) {
+      return;
+    }
+
+    const columnType: TableColumnType | null =
+      await KubernetesCostAllocationService.getColumnTypeInDatabase(column);
+
+    if (columnType) {
+      // Already present — never drop it; cost rows are immutable facts.
+      return;
+    }
+
+    await KubernetesCostAllocationService.addColumnInDatabase(column);
+  }
+
+  public override async rollback(): Promise<void> {
+    return;
+  }
+}

--- a/App/FeatureSet/Workers/DataMigrations/Index.ts
+++ b/App/FeatureSet/Workers/DataMigrations/Index.ts
@@ -95,6 +95,7 @@ import AddMetricEntityMinuteAggregateMaterializedViews from "./AddMetricEntityMi
 import CloseOrphanedMonitorStatusTimelineRows from "./CloseOrphanedMonitorStatusTimelineRows";
 import MigrateMetricAggregatesToStrictSchema from "./MigrateMetricAggregatesToStrictSchema";
 import AddInterfaceIndexColumnsToNetworkFlow from "./AddInterfaceIndexColumnsToNetworkFlow";
+import AddShipmentColumnsToKubernetesCostAllocation from "./AddShipmentColumnsToKubernetesCostAllocation";
 import MoveNetworkDeviceMonitorCollectionToDevices from "./MoveNetworkDeviceMonitorCollectionToDevices";
 import BackfillNetworkSiteTypes from "./BackfillNetworkSiteTypes";
 
@@ -295,6 +296,15 @@ const DataMigrations: Array<DataMigrationBase> = [
    * networkSiteTypeId are touched.
    */
   new BackfillNetworkSiteTypes(),
+  /*
+   * Adds shipmentId / shipmentChunk to KubernetesCostAllocation so the cost
+   * ingest can tell one agent delivery of a window from another, instead of
+   * dropping every request after the first on clusters whose hourly rows
+   * exceed the agent's batch size. Existing rows read back "" / 0 and keep
+   * the original whole-window behaviour. Idempotent: skips columns that
+   * exist.
+   */
+  new AddShipmentColumnsToKubernetesCostAllocation(),
 ];
 
 export default DataMigrations;

--- a/App/Tests/Telemetry/KubernetesCostIngestService.test.ts
+++ b/App/Tests/Telemetry/KubernetesCostIngestService.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
-import PositiveNumber from "Common/Types/PositiveNumber";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
 import ServiceType from "Common/Types/Telemetry/ServiceType";
 import { JSONObject } from "Common/Types/JSON";
 import { keyForKubernetesCluster } from "Common/Utils/Telemetry/EntityKey";
@@ -53,7 +53,7 @@ jest.mock("Common/Server/Services/KubernetesCostAllocationService", () => {
   return {
     __esModule: true,
     default: {
-      countBy: jest.fn(),
+      existsBy: jest.fn(),
     },
   };
 });
@@ -110,8 +110,8 @@ const findOrCreateMock: MockedFn =
   KubernetesClusterService.findOrCreateByClusterIdentifier as unknown as MockedFn;
 const updateLastSeenMock: MockedFn =
   KubernetesClusterService.updateLastSeen as unknown as MockedFn;
-const countByMock: MockedFn =
-  KubernetesCostAllocationService.countBy as unknown as MockedFn;
+const existsByMock: MockedFn =
+  KubernetesCostAllocationService.existsBy as unknown as MockedFn;
 const buildMetadataMock: MockedFn =
   OpenTelemetryIngestService.buildResourceMetadataForNonService as unknown as MockedFn;
 const submitMock: MockedFn = TelemetryFanInWriter.submit as unknown as MockedFn;
@@ -119,6 +119,8 @@ const submitMock: MockedFn = TelemetryFanInWriter.submit as unknown as MockedFn;
 const PROJECT_ID: ObjectID = ObjectID.generate();
 const CLUSTER_ID: ObjectID = ObjectID.generate();
 const RETENTION_DAYS: number = 15;
+/** The window makeAllocation() defaults to. */
+const WINDOW: string = "2026-07-24T10:00:00Z";
 
 function makeJobData(
   payload: Partial<KubernetesCostIngestPayload>,
@@ -159,6 +161,47 @@ function getSubmittedRows(callIndex: number = 0): Array<JSONObject> {
   return submitMock.mock.calls[callIndex]![1] as Array<JSONObject>;
 }
 
+/*
+ * The dedup path issues real ClickHouse existence queries, so the mock stands
+ * in for the table rather than for the answer: tests declare which rows are
+ * already stored and the query is evaluated against them. That keeps the
+ * NotEqual / equality query shapes under test instead of hard-coding a
+ * boolean per call and asserting on call counts.
+ */
+type StoredRow = {
+  windowStart: string;
+  shipmentId: string;
+  shipmentChunk: number;
+};
+
+let stored: Array<StoredRow> = [];
+
+function matchesStoredRow(row: StoredRow, query: JSONObject): boolean {
+  const queriedWindow: Date = query["windowStart"] as Date;
+  if (
+    OneUptimeDate.fromString(row.windowStart).getTime() !==
+    queriedWindow.getTime()
+  ) {
+    return false;
+  }
+
+  const shipmentId: unknown = query["shipmentId"];
+  if (shipmentId instanceof NotEqual) {
+    if (row.shipmentId === shipmentId.value) {
+      return false;
+    }
+  } else if (shipmentId !== undefined && row.shipmentId !== shipmentId) {
+    return false;
+  }
+
+  const shipmentChunk: unknown = query["shipmentChunk"];
+  if (shipmentChunk !== undefined && row.shipmentChunk !== shipmentChunk) {
+    return false;
+  }
+
+  return true;
+}
+
 describe("KubernetesCostIngestService.processFromQueue", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -168,7 +211,16 @@ describe("KubernetesCostIngestService.processFromQueue", () => {
       clusterIdentifier: "prod-cluster",
     } as never);
     updateLastSeenMock.mockResolvedValue(undefined as never);
-    countByMock.mockResolvedValue(new PositiveNumber(0) as never);
+    stored = [];
+    existsByMock.mockImplementation(((existsBy: {
+      query: JSONObject;
+    }): Promise<boolean> => {
+      return Promise.resolve(
+        stored.some((row: StoredRow): boolean => {
+          return matchesStoredRow(row, existsBy.query);
+        }),
+      );
+    }) as never);
     buildMetadataMock.mockResolvedValue({
       dataRententionInDays: RETENTION_DAYS,
     } as never);
@@ -391,26 +443,127 @@ describe("KubernetesCostIngestService.processFromQueue", () => {
     expect(submitMock).not.toHaveBeenCalled();
   });
 
-  test("skips windows that already have rows and keeps new windows", async () => {
-    const ingestedWindow: string = "2026-07-24T10:00:00Z";
-    const newWindow: string = "2026-07-24T11:00:00Z";
+  test("stamps the shipment identity on every row", async () => {
+    await KubernetesCostIngestService.processFromQueue(
+      makeJobData({
+        clusterName: "prod-cluster",
+        shipmentId: "abc123",
+        shipmentChunk: 2,
+        allocations: [makeAllocation()],
+      }),
+    );
 
-    countByMock.mockImplementation(((countBy: {
-      query: JSONObject;
-    }): Promise<PositiveNumber> => {
-      const queried: Date = countBy.query["windowStart"] as Date;
-      const isIngested: boolean =
-        queried.getTime() ===
-        OneUptimeDate.fromString(ingestedWindow).getTime();
-      return Promise.resolve(new PositiveNumber(isIngested ? 42 : 0));
-    }) as never);
+    const row: JSONObject = getSubmittedRows()[0]!;
+    expect(row["shipmentId"]).toBe("abc123");
+    expect(row["shipmentChunk"]).toBe(2);
+  });
+
+  test("defaults the shipment identity to empty for agents that send none", async () => {
+    await KubernetesCostIngestService.processFromQueue(
+      makeJobData({
+        clusterName: "prod-cluster",
+        allocations: [makeAllocation()],
+      }),
+    );
+
+    const row: JSONObject = getSubmittedRows()[0]!;
+    expect(row["shipmentId"]).toBe("");
+    expect(row["shipmentChunk"]).toBe(0);
+  });
+
+  /*
+   * The bug this contract exists for: a window wider than the agent's batch
+   * size arrives as several requests, each its own job. Before shipment ids,
+   * chunk 2 saw chunk 1's rows and dropped itself, so a cluster with more
+   * containers than SHIP_BATCH_SIZE stored only the first slice of each hour.
+   */
+  test("accepts a later chunk of the shipment already being ingested", async () => {
+    stored = [
+      { windowStart: WINDOW, shipmentId: "shipment-a", shipmentChunk: 0 },
+    ];
 
     await KubernetesCostIngestService.processFromQueue(
       makeJobData({
         clusterName: "prod-cluster",
+        shipmentId: "shipment-a",
+        shipmentChunk: 1,
+        allocations: [makeAllocation({ namespace: "chunk-1" })],
+      }),
+    );
+
+    const rows: Array<JSONObject> = getSubmittedRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!["namespace"]).toBe("chunk-1");
+  });
+
+  /*
+   * Restart idempotency: the poller's checkpoint is in-memory, so it re-ships
+   * its lookback windows. Those hash to a different shipment only when the
+   * window's contents changed — either way, re-inserting would double-count.
+   */
+  test("drops a window a different shipment already ingested", async () => {
+    stored = [
+      { windowStart: WINDOW, shipmentId: "shipment-a", shipmentChunk: 0 },
+    ];
+
+    await KubernetesCostIngestService.processFromQueue(
+      makeJobData({
+        clusterName: "prod-cluster",
+        shipmentId: "shipment-b",
+        shipmentChunk: 0,
+        allocations: [makeAllocation()],
+      }),
+    );
+
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  // The agent re-sending a chunk that already landed must not duplicate it.
+  test("drops a chunk of the current shipment that already landed", async () => {
+    stored = [
+      { windowStart: WINDOW, shipmentId: "shipment-a", shipmentChunk: 3 },
+    ];
+
+    await KubernetesCostIngestService.processFromQueue(
+      makeJobData({
+        clusterName: "prod-cluster",
+        shipmentId: "shipment-a",
+        shipmentChunk: 3,
+        allocations: [makeAllocation()],
+      }),
+    );
+
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the whole-window guard when the agent sends no shipment id", async () => {
+    stored = [{ windowStart: WINDOW, shipmentId: "", shipmentChunk: 0 }];
+
+    await KubernetesCostIngestService.processFromQueue(
+      makeJobData({
+        clusterName: "prod-cluster",
+        allocations: [makeAllocation()],
+      }),
+    );
+
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  test("skips only the already-ingested window and keeps the others", async () => {
+    const newWindow: string = "2026-07-24T11:00:00Z";
+
+    stored = [
+      { windowStart: WINDOW, shipmentId: "shipment-a", shipmentChunk: 0 },
+    ];
+
+    await KubernetesCostIngestService.processFromQueue(
+      makeJobData({
+        clusterName: "prod-cluster",
+        shipmentId: "shipment-b",
+        shipmentChunk: 0,
         allocations: [
-          makeAllocation({ windowStart: ingestedWindow, namespace: "old-a" }),
-          makeAllocation({ windowStart: ingestedWindow, namespace: "old-b" }),
+          makeAllocation({ windowStart: WINDOW, namespace: "old-a" }),
+          makeAllocation({ windowStart: WINDOW, namespace: "old-b" }),
           makeAllocation({
             windowStart: newWindow,
             windowEnd: "2026-07-24T12:00:00Z",
@@ -419,9 +572,6 @@ describe("KubernetesCostIngestService.processFromQueue", () => {
         ],
       }),
     );
-
-    // One existence check per DISTINCT window, not per row.
-    expect(countByMock).toHaveBeenCalledTimes(2);
 
     const rows: Array<JSONObject> = getSubmittedRows();
     expect(rows).toHaveLength(1);

--- a/Common/Models/AnalyticsModels/KubernetesCostAllocation.ts
+++ b/Common/Models/AnalyticsModels/KubernetesCostAllocation.ts
@@ -472,6 +472,49 @@ export default class KubernetesCostAllocation extends AnalyticsBaseModel {
       },
     });
 
+    /*
+     * Delivery bookkeeping, not workload data. A window wider than the
+     * agent's batch size arrives as several independent ingest jobs, so the
+     * ingest service needs to tell "another chunk of the delivery I am
+     * already ingesting" (accept) from "a window a previous delivery already
+     * ingested" (drop, or a restarted agent double-counts spend). shipmentId
+     * is the agent's content hash of the window — identical across restarts,
+     * different when the engine's answer for that window changed.
+     *
+     * Empty / 0 on rows written before these columns existed and on rows
+     * from agents older than the shipment contract; the ingest service falls
+     * back to the whole-window guard for those.
+     */
+    const shipmentIdColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "shipmentId",
+      title: "Shipment ID",
+      description:
+        "Content hash identifying the agent delivery this row arrived in. Used to deduplicate re-shipped windows; empty for rows ingested before the shipment contract.",
+      required: true,
+      defaultValue: "",
+      type: TableColumnType.Text,
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
+    const shipmentChunkColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
+      key: "shipmentChunk",
+      title: "Shipment Chunk",
+      description:
+        "Index of the request within its shipment that carried this row. 0 for single-request shipments and for rows ingested before the shipment contract.",
+      required: true,
+      defaultValue: 0,
+      type: TableColumnType.Number,
+      accessControl: {
+        read: readPermissions,
+        create: createPermissions,
+        update: [],
+      },
+    });
+
     const retentionDateColumn: AnalyticsTableColumn = new AnalyticsTableColumn({
       key: "retentionDate",
       codec: [{ codec: "DoubleDelta" }, { codec: "ZSTD", level: 1 }],
@@ -517,6 +560,8 @@ export default class KubernetesCostAllocation extends AnalyticsBaseModel {
         labelKeysColumn,
         ...measureColumns,
         currencyColumn,
+        shipmentIdColumn,
+        shipmentChunkColumn,
         retentionDateColumn,
       ],
       sortKeys: [
@@ -830,6 +875,22 @@ export default class KubernetesCostAllocation extends AnalyticsBaseModel {
 
   public set currency(v: string | undefined) {
     this.setColumnValue("currency", v);
+  }
+
+  public get shipmentId(): string | undefined {
+    return this.getColumnValue("shipmentId") as string | undefined;
+  }
+
+  public set shipmentId(v: string | undefined) {
+    this.setColumnValue("shipmentId", v);
+  }
+
+  public get shipmentChunk(): number | undefined {
+    return this.getColumnValue("shipmentChunk") as number | undefined;
+  }
+
+  public set shipmentChunk(v: number | undefined) {
+    this.setColumnValue("shipmentChunk", v);
   }
 
   public get retentionDate(): Date | undefined {

--- a/Common/Tests/Models/AnalyticsModels/KubernetesCostAllocation.test.ts
+++ b/Common/Tests/Models/AnalyticsModels/KubernetesCostAllocation.test.ts
@@ -95,6 +95,19 @@ describe("Analytics KubernetesCostAllocation model", () => {
     );
   });
 
+  test("carries the shipment identity the ingest dedup relies on", () => {
+    const shipmentId: AnalyticsTableColumn | null =
+      model.getTableColumn("shipmentId");
+    expect(shipmentId?.type).toBe(TableColumnType.Text);
+    // Rows written before the shipment contract read back as "no identity".
+    expect(shipmentId?.defaultValue).toBe("");
+
+    const shipmentChunk: AnalyticsTableColumn | null =
+      model.getTableColumn("shipmentChunk");
+    expect(shipmentChunk?.type).toBe(TableColumnType.Number);
+    expect(shipmentChunk?.defaultValue).toBe(0);
+  });
+
   test("stores labels as a map with an extracted key column", () => {
     const labels: AnalyticsTableColumn | null = model.getTableColumn("labels");
     expect(labels?.type).toBe(TableColumnType.MapStringString);

--- a/Common/Types/Kubernetes/KubernetesCostIngest.ts
+++ b/Common/Types/Kubernetes/KubernetesCostIngest.ts
@@ -69,6 +69,26 @@ export interface KubernetesCostIngestPayload {
   clusterName: string;
   /** Currency code of all cost figures (e.g. "USD"). Optional. */
   currency?: string | undefined;
+
+  /*
+   * Identity of one shipment — the agent's delivery of ONE window — and this
+   * request's position within it.
+   *
+   * A window wider than the agent's batch size arrives as several requests,
+   * each becoming its own ingest job. Without an identity the server cannot
+   * tell "another chunk of the shipment I have already started" (accept)
+   * from "a window an earlier shipment already delivered in full" (drop, or
+   * a restart double-counts spend), so it dropped both and lost every row
+   * past the first chunk on clusters above SHIP_BATCH_SIZE containers.
+   *
+   * shipmentId is a content hash over the window's row identities, so the
+   * same window re-shipped after a restart hashes the same and its chunks
+   * dedup individually. Both are absent on agents older than this contract;
+   * the server then falls back to the whole-window guard.
+   */
+  shipmentId?: string | undefined;
+  shipmentChunk?: number | undefined;
+
   allocations: Array<KubernetesCostAllocationIngestRow>;
 }
 

--- a/KubernetesCostAgent/AllocationMapper.ts
+++ b/KubernetesCostAgent/AllocationMapper.ts
@@ -65,8 +65,9 @@ export const mapAllocationToRow: (data: {
     cpuCoreUsageAverage: allocation.cpuCoreUsageAverage,
     gpuHours: allocation.gpuHours,
     ramByteHours: allocation.ramByteHours,
-    ramBytesRequestAverage: allocation.ramBytesRequestAverage,
-    ramBytesUsageAverage: allocation.ramBytesUsageAverage,
+    // Engine wire names are singular "Byte"; ours are plural. See Types.ts.
+    ramBytesRequestAverage: allocation.ramByteRequestAverage,
+    ramBytesUsageAverage: allocation.ramByteUsageAverage,
     pvByteHours: allocation.pvByteHours,
 
     /*

--- a/KubernetesCostAgent/Shipment.ts
+++ b/KubernetesCostAgent/Shipment.ts
@@ -1,0 +1,113 @@
+import { createHash } from "crypto";
+import { KubernetesCostAllocationIngestRow } from "./Types";
+
+/*
+ * Shipment identity.
+ *
+ * One window's rows are POSTed in several chunks, and each chunk becomes an
+ * independent ingest job server-side. The server has to accept every chunk of
+ * the shipment it is currently ingesting while still dropping a window that
+ * an earlier shipment already delivered — otherwise a restart, which re-ships
+ * the last LOOKBACK_WINDOWS windows, double-counts spend.
+ *
+ * The discriminator is a hash over the window's row IDENTITIES (not their
+ * costs). That makes it:
+ *
+ *   - stable across restarts, so a re-ship of an already-delivered window is
+ *     recognised as the same shipment and dedups chunk by chunk rather than
+ *     landing twice;
+ *   - stable across a partial failure, so the retry of a window whose third
+ *     chunk failed tops up only that chunk;
+ *   - different when the engine's answer for the window actually changed, in
+ *     which case the server keeps what it already stored rather than mixing
+ *     two versions of the same hour.
+ *
+ * Costs are deliberately excluded: an engine that re-prices a settled window
+ * must not make the shipment look new, and "first delivery wins" is the
+ * pricing the server already had.
+ */
+
+/*
+ * The identity of one allocation row. The engine reports at most one row per
+ * (window, namespace, controller, pod, container) — node and provider are
+ * properties of that slice, not part of what makes it unique. NUL joins the
+ * parts so a name containing the separator cannot forge a different identity.
+ */
+const rowIdentity: (row: KubernetesCostAllocationIngestRow) => string = (
+  row: KubernetesCostAllocationIngestRow,
+): string => {
+  return [
+    row.windowStart,
+    row.windowEnd,
+    row.namespace || "",
+    row.controllerKind || "",
+    row.controllerName || "",
+    row.podName || "",
+    row.containerName || "",
+  ].join("\u0000");
+};
+
+export interface Shipment {
+  /** Content hash of the window, shared by every chunk of this delivery. */
+  id: string;
+  /**
+   * The same rows in a deterministic order. Chunk boundaries are taken from
+   * this order, so chunk N of a re-shipped window holds the same rows it held
+   * the first time — which is what makes per-chunk dedup meaningful.
+   */
+  rows: Array<KubernetesCostAllocationIngestRow>;
+}
+
+export const buildShipment: (
+  rows: Array<KubernetesCostAllocationIngestRow>,
+) => Shipment = (rows: Array<KubernetesCostAllocationIngestRow>): Shipment => {
+  const identified: Array<{
+    key: string;
+    row: KubernetesCostAllocationIngestRow;
+  }> = rows.map(
+    (
+      row: KubernetesCostAllocationIngestRow,
+    ): { key: string; row: KubernetesCostAllocationIngestRow } => {
+      return { key: rowIdentity(row), row: row };
+    },
+  );
+
+  /*
+   * Plain codepoint ordering, not localeCompare: the sort has to produce the
+   * same sequence on every machine and under every locale, or the chunk
+   * boundaries move and the hash stops matching.
+   */
+  identified.sort(
+    (
+      a: { key: string; row: KubernetesCostAllocationIngestRow },
+      b: { key: string; row: KubernetesCostAllocationIngestRow },
+    ): number => {
+      if (a.key < b.key) {
+        return -1;
+      }
+      if (a.key > b.key) {
+        return 1;
+      }
+      return 0;
+    },
+  );
+
+  const hash: ReturnType<typeof createHash> = createHash("sha256");
+  for (const entry of identified) {
+    hash.update(entry.key);
+    hash.update("\n");
+  }
+
+  return {
+    // 128 bits is far more than enough to tell two deliveries apart.
+    id: hash.digest("hex").slice(0, 32),
+    rows: identified.map(
+      (entry: {
+        key: string;
+        row: KubernetesCostAllocationIngestRow;
+      }): KubernetesCostAllocationIngestRow => {
+        return entry.row;
+      },
+    ),
+  };
+};

--- a/KubernetesCostAgent/Shipper.ts
+++ b/KubernetesCostAgent/Shipper.ts
@@ -7,6 +7,7 @@ import {
   ONEUPTIME_URL,
   SHIP_BATCH_SIZE,
 } from "./Config";
+import { buildShipment, Shipment } from "./Shipment";
 import { httpPostJson, HttpResult } from "./HttpClient";
 import Logger from "./Logger";
 import {
@@ -64,14 +65,23 @@ export class Shipper {
   public async ship(
     rows: Array<KubernetesCostAllocationIngestRow>,
   ): Promise<void> {
-    for (let i: number = 0; i < rows.length; i += SHIP_BATCH_SIZE) {
-      const chunk: Array<KubernetesCostAllocationIngestRow> = rows.slice(
-        i,
-        i + SHIP_BATCH_SIZE,
-      );
+    /*
+     * Every chunk carries the same shipment id and its own index. The server
+     * needs both to accept a multi-chunk window whole while still rejecting a
+     * window an earlier shipment already delivered — see Shipment.ts. Rows are
+     * shipped in the shipment's deterministic order so chunk N of a re-shipped
+     * window holds exactly the rows it held the first time.
+     */
+    const shipment: Shipment = buildShipment(rows);
+
+    for (let i: number = 0; i < shipment.rows.length; i += SHIP_BATCH_SIZE) {
+      const chunk: Array<KubernetesCostAllocationIngestRow> =
+        shipment.rows.slice(i, i + SHIP_BATCH_SIZE);
       const payload: KubernetesCostIngestPayload = {
         clusterName: CLUSTER_NAME,
         currency: COST_CURRENCY,
+        shipmentId: shipment.id,
+        shipmentChunk: i / SHIP_BATCH_SIZE,
         allocations: chunk,
       };
       await this.post(payload, chunk.length);

--- a/KubernetesCostAgent/Tests/Poller.test.ts
+++ b/KubernetesCostAgent/Tests/Poller.test.ts
@@ -68,6 +68,39 @@ test("mapAllocationToRow maps properties and sums adjustments", (): void => {
   assert.strictEqual(row.cpuEfficiency, 0.4);
 });
 
+/*
+ * Regression: the request/usage averages arrive under the engines' JSON tag
+ * names, not their Go struct field names — `ramByteRequestAverage`, singular,
+ * against a RAMBytesRequestAverage field. Parsing real engine JSON (rather
+ * than an EngineAllocation literal) is the point: a literal would only prove
+ * our own interface is self-consistent, and reading the plural spelling
+ * yields undefined, which the server stores as a silent 0.
+ */
+test("mapAllocationToRow reads the engine's request/usage averages", (): void => {
+  const engineJson: string = `{
+    "name": "prod/deployment/api/api-abc/api",
+    "properties": { "namespace": "prod", "container": "api" },
+    "window": { "start": "2026-07-24T10:00:00Z", "end": "2026-07-24T11:00:00Z" },
+    "cpuCoreRequestAverage": 0.5,
+    "cpuCoreUsageAverage": 0.07,
+    "ramByteHours": 1073741824,
+    "ramByteRequestAverage": 1073741824,
+    "ramByteUsageAverage": 268435456
+  }`;
+
+  const row: KubernetesCostAllocationIngestRow = mapAllocationToRow({
+    allocation: JSON.parse(engineJson) as EngineAllocation,
+    windowStart: new Date("2026-07-24T10:00:00Z"),
+    windowEnd: new Date("2026-07-24T11:00:00Z"),
+  });
+
+  assert.strictEqual(row.cpuCoreRequestAverage, 0.5);
+  assert.strictEqual(row.cpuCoreUsageAverage, 0.07);
+  assert.strictEqual(row.ramByteHours, 1073741824);
+  assert.strictEqual(row.ramBytesRequestAverage, 1073741824);
+  assert.strictEqual(row.ramBytesUsageAverage, 268435456);
+});
+
 test("mapAllocationToRow marks idle allocations with the sentinel namespace", (): void => {
   const allocation: EngineAllocation = {
     name: "__idle__",

--- a/KubernetesCostAgent/Tests/Shipment.test.ts
+++ b/KubernetesCostAgent/Tests/Shipment.test.ts
@@ -1,0 +1,123 @@
+import * as assert from "assert";
+import { test } from "node:test";
+import { buildShipment, Shipment } from "../Shipment";
+import { KubernetesCostAllocationIngestRow } from "../Types";
+
+/*
+ * Shipment.ts is Config-free (like AllocationMapper), so these tests load it
+ * without the agent's required environment variables.
+ */
+
+function row(
+  overrides: Partial<KubernetesCostAllocationIngestRow> = {},
+): KubernetesCostAllocationIngestRow {
+  return {
+    windowStart: "2026-07-24T10:00:00Z",
+    windowEnd: "2026-07-24T11:00:00Z",
+    namespace: "prod",
+    controllerKind: "deployment",
+    controllerName: "api",
+    podName: "api-abc",
+    containerName: "api",
+    totalCost: 1,
+    ...overrides,
+  };
+}
+
+test("buildShipment orders rows independently of the engine's ordering", (): void => {
+  const forward: Shipment = buildShipment([
+    row({ podName: "a" }),
+    row({ podName: "b" }),
+    row({ podName: "c" }),
+  ]);
+  const reversed: Shipment = buildShipment([
+    row({ podName: "c" }),
+    row({ podName: "b" }),
+    row({ podName: "a" }),
+  ]);
+
+  const podsOf: (shipment: Shipment) => Array<string> = (
+    shipment: Shipment,
+  ): Array<string> => {
+    return shipment.rows.map(
+      (entry: KubernetesCostAllocationIngestRow): string => {
+        return entry.podName || "";
+      },
+    );
+  };
+
+  assert.deepStrictEqual(podsOf(forward), ["a", "b", "c"]);
+  assert.deepStrictEqual(podsOf(reversed), ["a", "b", "c"]);
+});
+
+/*
+ * The restart case, and the whole point of the hash: the poller re-ships its
+ * lookback windows after a restart, and the server must recognise those as
+ * the SAME delivery so it dedups them chunk by chunk instead of storing the
+ * window twice.
+ */
+test("buildShipment gives the same id to the same window shipped again", (): void => {
+  const first: Shipment = buildShipment([
+    row({ podName: "a" }),
+    row({ podName: "b" }),
+  ]);
+  const second: Shipment = buildShipment([
+    row({ podName: "b" }),
+    row({ podName: "a" }),
+  ]);
+
+  assert.strictEqual(first.id, second.id);
+});
+
+/*
+ * Costs are not hashed: an engine that re-prices a settled window must not
+ * make the shipment look new, or the re-priced rows land alongside the
+ * originals and the hour double-counts.
+ */
+test("buildShipment ignores cost changes when the row identities match", (): void => {
+  const cheap: Shipment = buildShipment([row({ totalCost: 1 })]);
+  const expensive: Shipment = buildShipment([row({ totalCost: 999 })]);
+
+  assert.strictEqual(cheap.id, expensive.id);
+});
+
+test("buildShipment gives different ids to different windows and row sets", (): void => {
+  const base: Shipment = buildShipment([row()]);
+
+  const laterWindow: Shipment = buildShipment([
+    row({
+      windowStart: "2026-07-24T11:00:00Z",
+      windowEnd: "2026-07-24T12:00:00Z",
+    }),
+  ]);
+  const extraRow: Shipment = buildShipment([row(), row({ podName: "api-2" })]);
+  const otherContainer: Shipment = buildShipment([
+    row({ containerName: "sidecar" }),
+  ]);
+
+  assert.notStrictEqual(base.id, laterWindow.id);
+  assert.notStrictEqual(base.id, extraRow.id);
+  assert.notStrictEqual(base.id, otherContainer.id);
+});
+
+/*
+ * The parts are NUL-joined so a name containing the separator cannot make two
+ * different workloads hash alike.
+ */
+test("buildShipment does not let a name forge another row's identity", (): void => {
+  const split: Shipment = buildShipment([
+    row({ controllerName: "api", podName: "abc" }),
+  ]);
+  const forged: Shipment = buildShipment([
+    row({ controllerName: "api\u0000abc", podName: "" }),
+  ]);
+
+  assert.notStrictEqual(split.id, forged.id);
+});
+
+test("buildShipment handles an empty window without throwing", (): void => {
+  const empty: Shipment = buildShipment([]);
+
+  assert.deepStrictEqual(empty.rows, []);
+  assert.strictEqual(empty.id.length, 32);
+});

--- a/KubernetesCostAgent/Tests/Shipper.test.ts
+++ b/KubernetesCostAgent/Tests/Shipper.test.ts
@@ -102,6 +102,25 @@ test("ships rows chunked at SHIP_BATCH_SIZE with cluster, currency and token", a
     assert.strictEqual(request.payload.currency, "USD");
   }
 
+  /*
+   * Every chunk of one window carries the same shipment id and its own index,
+   * which is what lets the server accept the whole window instead of dropping
+   * everything after the first chunk.
+   */
+  const shipmentIds: Array<string | undefined> = recorded.map(
+    (request: RecordedRequest): string | undefined => {
+      return request.payload.shipmentId;
+    },
+  );
+  assert.strictEqual(new Set(shipmentIds).size, 1);
+  assert.ok(shipmentIds[0]);
+  assert.deepStrictEqual(
+    recorded.map((request: RecordedRequest): number | undefined => {
+      return request.payload.shipmentChunk;
+    }),
+    [0, 1, 2],
+  );
+
   // Chunks preserve row order end-to-end.
   const shippedNamespaces: Array<string> = recorded.flatMap(
     (request: RecordedRequest): Array<string> => {

--- a/KubernetesCostAgent/Types.ts
+++ b/KubernetesCostAgent/Types.ts
@@ -50,6 +50,16 @@ export interface KubernetesCostAllocationIngestRow {
 export interface KubernetesCostIngestPayload {
   clusterName: string;
   currency?: string | undefined;
+  /*
+   * Shipment identity — see Common/Types/Kubernetes/KubernetesCostIngest.ts
+   * for the full rationale. shipmentId is a content hash over the window's
+   * row identities (stable across agent restarts); shipmentChunk is this
+   * request's index within the shipment. Together they let the server accept
+   * every chunk of one window while still dropping a window a previous
+   * shipment already delivered.
+   */
+  shipmentId?: string | undefined;
+  shipmentChunk?: number | undefined;
   allocations: Array<KubernetesCostAllocationIngestRow>;
 }
 
@@ -120,9 +130,19 @@ export interface EngineAllocation {
   gpuHours?: number;
   gpuCost?: number;
   gpuCostAdjustment?: number;
+  /*
+   * Singular "Byte", deliberately. The engines' Go struct fields are
+   * RAMBytesRequestAverage / RAMBytesUsageAverage but their json tags are
+   * `ramByteRequestAverage` / `ramByteUsageAverage` — plural field name,
+   * singular wire name. Reading the field name instead of the tag yields
+   * undefined, which the server's sanitizeNumber turns into a silent 0, so
+   * the mismatch is invisible until someone charts memory requests. Stable
+   * across every OpenCost release from v1.108 to the bundled 1.121, and
+   * Kubecost shares the lineage.
+   */
   ramByteHours?: number;
-  ramBytesRequestAverage?: number;
-  ramBytesUsageAverage?: number;
+  ramByteRequestAverage?: number;
+  ramByteUsageAverage?: number;
   ramCost?: number;
   ramCostAdjustment?: number;
   pvByteHours?: number;


### PR DESCRIPTION
Two independent bugs in the Kubernetes cost pipeline, found while assessing what it would take to build Kubecost-style request right-sizing on top of it. Both corrupt stored data silently rather than failing loudly, so neither is visible until you read the columns they damage — which right-sizing would.

## 1. Memory request/usage were always stored as `0`

The agent read `allocation.ramBytesRequestAverage` / `ramBytesUsageAverage` — the engines' Go **struct field** names. Their **JSON tags** are singular:

```go
RAMBytesRequestAverage  float64  `json:"ramByteRequestAverage"`
RAMBytesUsageAverage    float64  `json:"ramByteUsageAverage"`
```

Both deserialized as `undefined`, and `KubernetesCostIngestService.sanitizeNumber` turned that into `0`. CPU used the correct names throughout and was unaffected, which is why total spend and the Efficiency column looked fine — the damage is confined to two columns nothing currently reads.

Verified the singular spelling against OpenCost's `Allocation` `MarshalJSON` and against the v1.108 struct; it is stable through the bundled 1.121, and Kubecost shares the lineage.

`EngineAllocation` now declares **only** the wire names, so reintroducing the plural spelling is a compile error rather than another silent zero. The new test parses real engine JSON rather than a typed literal — a literal would only prove our own interface is self-consistent.

## 2. Clusters above `SHIP_BATCH_SIZE` containers lost most of every hour

`Shipper.ship()` splits one window into batches of 1000, each its own POST and its own ingest job. The server then dropped an entire window whenever it already held any row for it, so chunk 1 landed and chunks 2..N saw chunk 1's rows and dropped themselves. Fine for a spend trend; fatal for anything per-container.

That guard exists for restart idempotency — the poller's checkpoint is in-memory, so it re-ships its lookback windows — but it could not distinguish:

- *another chunk of the delivery in progress* → must accept
- *a window a previous delivery already covered* → must drop, or a restart double-counts spend

Each request now carries a `shipmentId` plus its chunk index, both persisted on the row. `shipmentId` is a content hash over the window's **row identities** (not their costs), computed in the new `KubernetesCostAgent/Shipment.ts`. That choice is what makes it work:

- **identical across restarts**, so a re-ship of an already-delivered window is recognised as the same shipment and dedups chunk by chunk;
- **identical across a partial failure**, so a window whose third chunk failed is topped up on retry instead of staying short forever — this case was previously unrecoverable;
- **different when the engine's answer actually changed**, in which case the server keeps what it stored rather than mixing two versions of one hour;
- **cost changes don't perturb it**, so an engine re-pricing a settled window can't make the shipment look new.

Rows ship in a deterministic (locale-independent) order so chunk N of a re-shipped window holds the rows it held the first time — without that, per-chunk dedup would be meaningless.

The window check also moves from `countBy` to `existsBy`, which compiles to `SELECT 1 … LIMIT 1` instead of counting every matching row.

## Compatibility

- **Old agent → new server:** no shipment id, so the server falls back to the original whole-window guard. Safe against double-counting, but *still loses chunks* — both halves must ship together for the fix to take effect. Called out in the code.
- **Existing rows** read back `""` / `0` and take that same fallback path.
- **New columns** arrive via the boot-time column reconciler (`reconcileColumns` → `ALTER TABLE … ADD COLUMN IF NOT EXISTS`), plus a paired idempotent `DataMigration` following the `AddInterfaceIndexColumnsToNetworkFlow` convention. Metadata-only: no part rewrite, sort keys untouched.

## Testing

| Suite | Result |
|---|---|
| `KubernetesCostAgent` (`node --test`) | 57/57 |
| `App/Tests/Telemetry` (20 suites) | 210/210 |
| `Common` analytics-database + services | 138/138 |
| `Common/Tests/Models/AnalyticsModels` | 15/15 |
| `tsc --noEmit` — App and Common | clean |
| `eslint` on all changed files | clean |

Both fixes were mutation-checked: reverting the mapper makes the agent fail to compile, and restoring the old dedup fails exactly one test (`accepts a later chunk of the shipment already being ingested`) and no others.

## Note for reviewers

`App/node_modules` symlinks to the main checkout, whose `Common` symlink resolves back to the main checkout's `Common/`. In a git worktree this means ts-jest type-checks App against the **wrong** `Common` while jest *runs* against the worktree's. App tests were verified here with a temporary tsconfig `paths` override (not committed). Unrelated to this change, but worth fixing — right now any App test run from a worktree silently type-checks the wrong source.

## Not included

OpenCost also emits `cpuCoreLimitAverage` / `ramByteLimitAverage`, which the agent doesn't collect. Relevant to right-sizing, out of scope here.
