### PR TITLE
fix(metrics): keep the metric explorer time range popup inside the viewport

### DIFF
--- a/Common/Tests/UI/Components/LogTimeRangePicker.test.tsx
+++ b/Common/Tests/UI/Components/LogTimeRangePicker.test.tsx
@@ -1,0 +1,138 @@
+import LogTimeRangePicker, {
+  LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX,
+} from "../../../UI/Components/LogsViewer/components/LogTimeRangePicker";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import "@testing-library/jest-dom/extend-expect";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const BUTTON_TEST_ID: string = "log-time-range-picker-button";
+const DROPDOWN_TEST_ID: string = "log-time-range-picker-dropdown";
+
+const ORIGINAL_INNER_WIDTH: number = window.innerWidth;
+const originalGetBoundingClientRect: () => DOMRect =
+  Element.prototype.getBoundingClientRect;
+
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+function stubTriggerRect(left: number, right: number): void {
+  Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    if (
+      this instanceof HTMLElement &&
+      this.getAttribute("data-testid") === BUTTON_TEST_ID
+    ) {
+      return {
+        left: left,
+        right: right,
+        top: 40,
+        bottom: 68,
+        width: right - left,
+        height: 28,
+        x: left,
+        y: 40,
+        toJSON: (): Record<string, unknown> => {
+          return {};
+        },
+      } as DOMRect;
+    }
+
+    return originalGetBoundingClientRect.call(this);
+  };
+}
+
+function openDropdown(value: RangeStartAndEndDateTime): HTMLElement {
+  render(<LogTimeRangePicker value={value} onChange={jest.fn()} />);
+  fireEvent.click(screen.getByTestId(BUTTON_TEST_ID));
+  return screen.getByTestId(DROPDOWN_TEST_ID);
+}
+
+function hasClass(element: HTMLElement, className: string): boolean {
+  return element.classList.contains(className);
+}
+
+describe("LogTimeRangePicker", () => {
+  beforeEach(() => {
+    setViewportWidth(1440);
+    stubTriggerRect(64, 180);
+  });
+
+  afterEach(() => {
+    cleanup();
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    setViewportWidth(ORIGINAL_INNER_WIDTH);
+  });
+
+  test("opens rightwards when the trigger sits at the left of the toolbar", () => {
+    const dropdown: HTMLElement = openDropdown({
+      range: TimeRange.PAST_ONE_HOUR,
+    });
+
+    expect(hasClass(dropdown, "left-0")).toBe(true);
+    expect(hasClass(dropdown, "right-0")).toBe(false);
+    expect(dropdown.getAttribute("data-align")).toBe("left");
+  });
+
+  test("flips to right alignment when the trigger is near the right edge", () => {
+    stubTriggerRect(1310, 1430);
+
+    const dropdown: HTMLElement = openDropdown({
+      range: TimeRange.PAST_ONE_HOUR,
+    });
+
+    expect(hasClass(dropdown, "right-0")).toBe(true);
+    expect(hasClass(dropdown, "left-0")).toBe(false);
+    expect(dropdown.getAttribute("data-align")).toBe("right");
+  });
+
+  test("stays left aligned on a narrow mobile viewport", () => {
+    setViewportWidth(375);
+    stubTriggerRect(12, 128);
+
+    expect(
+      hasClass(openDropdown({ range: TimeRange.PAST_ONE_HOUR }), "left-0"),
+    ).toBe(true);
+  });
+
+  test("caps the panel width so it cannot exceed the viewport", () => {
+    expect(
+      hasClass(
+        openDropdown({ range: TimeRange.PAST_ONE_HOUR }),
+        "max-w-[calc(100vw-1rem)]",
+      ),
+    ).toBe(true);
+  });
+
+  test("exports a width constant that matches the rendered w-72 panel", () => {
+    expect(LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX).toBe(288);
+    expect(
+      hasClass(openDropdown({ range: TimeRange.PAST_ONE_HOUR }), "w-72"),
+    ).toBe(true);
+  });
+
+  test("keeps the panel anchored below the trigger", () => {
+    const dropdown: HTMLElement = openDropdown({
+      range: TimeRange.PAST_ONE_HOUR,
+    });
+
+    expect(hasClass(dropdown, "absolute")).toBe(true);
+    expect(hasClass(dropdown, "top-full")).toBe(true);
+    expect(
+      dropdown.parentElement?.classList.contains("relative") ?? false,
+    ).toBe(true);
+  });
+});

--- a/Common/Tests/UI/Components/TelemetryTimeRangePicker.test.tsx
+++ b/Common/Tests/UI/Components/TelemetryTimeRangePicker.test.tsx
@@ -1,0 +1,404 @@
+import TelemetryTimeRangePicker, {
+  TIME_RANGE_DROPDOWN_WIDTH_IN_PX,
+} from "../../../UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import "@testing-library/jest-dom/extend-expect";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const BUTTON_TEST_ID: string = "telemetry-time-range-picker-button";
+const DROPDOWN_TEST_ID: string = "telemetry-time-range-picker-dropdown";
+
+const ORIGINAL_INNER_WIDTH: number = window.innerWidth;
+const originalGetBoundingClientRect: () => DOMRect =
+  Element.prototype.getBoundingClientRect;
+
+/*
+ * jsdom performs no layout, so every rect comes back zero-sized. These helpers
+ * let a test describe where the trigger button sits inside a viewport of a
+ * given width, which is the only input the alignment logic reads.
+ */
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+function stubTriggerRect(left: number, right: number): void {
+  Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    if (
+      this instanceof HTMLElement &&
+      this.getAttribute("data-testid") === BUTTON_TEST_ID
+    ) {
+      return {
+        left: left,
+        right: right,
+        top: 40,
+        bottom: 68,
+        width: right - left,
+        height: 28,
+        x: left,
+        y: 40,
+        toJSON: (): Record<string, unknown> => {
+          return {};
+        },
+      } as DOMRect;
+    }
+
+    return originalGetBoundingClientRect.call(this);
+  };
+}
+
+function renderPicker(
+  value: RangeStartAndEndDateTime,
+  onChange: (value: RangeStartAndEndDateTime) => void = jest.fn(),
+): void {
+  render(<TelemetryTimeRangePicker value={value} onChange={onChange} />);
+}
+
+function getTrigger(): HTMLElement {
+  return screen.getByTestId(BUTTON_TEST_ID);
+}
+
+function getDropdown(): HTMLElement {
+  return screen.getByTestId(DROPDOWN_TEST_ID);
+}
+
+function openDropdown(): HTMLElement {
+  fireEvent.click(getTrigger());
+  return getDropdown();
+}
+
+function hasClass(element: HTMLElement, className: string): boolean {
+  return element.classList.contains(className);
+}
+
+describe("TelemetryTimeRangePicker", () => {
+  beforeEach(() => {
+    setViewportWidth(1440);
+    stubTriggerRect(64, 180);
+  });
+
+  afterEach(() => {
+    cleanup();
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    setViewportWidth(ORIGINAL_INNER_WIDTH);
+  });
+
+  describe("dropdown alignment", () => {
+    test("opens rightwards when the trigger sits at the left of the metrics toolbar", () => {
+      /*
+       * Regression: the panel was hard-coded to `right-0`, so on the metric
+       * explorer — where the time range button is the first control in the
+       * toolbar — the 288px panel rendered off the left edge of the content
+       * area and on top of the app sidebar.
+       */
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      const dropdown: HTMLElement = openDropdown();
+
+      expect(hasClass(dropdown, "left-0")).toBe(true);
+      expect(hasClass(dropdown, "right-0")).toBe(false);
+      expect(dropdown.getAttribute("data-align")).toBe("left");
+    });
+
+    test("stays left aligned for a trigger flush against x=0", () => {
+      stubTriggerRect(0, 116);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "left-0")).toBe(true);
+    });
+
+    test("stays left aligned for a trigger in the middle of a wide toolbar", () => {
+      stubTriggerRect(500, 616);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "left-0")).toBe(true);
+    });
+
+    test("flips to right alignment when the trigger is near the right edge", () => {
+      stubTriggerRect(1310, 1430);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      const dropdown: HTMLElement = openDropdown();
+
+      expect(hasClass(dropdown, "right-0")).toBe(true);
+      expect(hasClass(dropdown, "left-0")).toBe(false);
+      expect(dropdown.getAttribute("data-align")).toBe("right");
+    });
+
+    test("never emits both positioning classes at once", () => {
+      stubTriggerRect(1310, 1430);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      const dropdown: HTMLElement = openDropdown();
+
+      expect(
+        hasClass(dropdown, "left-0") && hasClass(dropdown, "right-0"),
+      ).toBe(false);
+    });
+
+    test("stays left aligned on a narrow mobile viewport", () => {
+      setViewportWidth(375);
+      stubTriggerRect(12, 128);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "left-0")).toBe(true);
+    });
+
+    test("re-measures alignment when the window is resized", () => {
+      stubTriggerRect(1000, 1116);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "left-0")).toBe(true);
+
+      // Shrink the window so the same trigger no longer has room to its right.
+      act(() => {
+        setViewportWidth(1200);
+        window.dispatchEvent(new Event("resize"));
+      });
+
+      expect(hasClass(getDropdown(), "right-0")).toBe(true);
+    });
+
+    test("keeps the panel on screen when neither edge fits the viewport", () => {
+      /*
+       * Viewport narrower than the 288px panel: left alignment clips by 60px,
+       * right alignment would clip by 116px, so left is the lesser evil.
+       */
+      setViewportWidth(300);
+      stubTriggerRect(64, 180);
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      const dropdown: HTMLElement = openDropdown();
+
+      expect(hasClass(dropdown, "left-0")).toBe(true);
+      expect(hasClass(dropdown, "max-w-[calc(100vw-1rem)]")).toBe(true);
+    });
+
+    test("re-measures alignment when scrolling moves the trigger sideways", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "left-0")).toBe(true);
+
+      act(() => {
+        stubTriggerRect(1310, 1430);
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(hasClass(getDropdown(), "right-0")).toBe(true);
+    });
+
+    test("re-evaluates alignment each time the dropdown is reopened", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "left-0")).toBe(true);
+
+      fireEvent.click(getTrigger());
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+
+      stubTriggerRect(1310, 1430);
+      expect(hasClass(openDropdown(), "right-0")).toBe(true);
+    });
+
+    test("stops listening for layout changes once closed", () => {
+      const removedEvents: Array<string> = [];
+      const originalRemoveEventListener: typeof window.removeEventListener =
+        window.removeEventListener.bind(window);
+
+      window.removeEventListener = ((
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+      ): void => {
+        removedEvents.push(type);
+        originalRemoveEventListener(type, listener, options);
+      }) as typeof window.removeEventListener;
+
+      try {
+        renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+        openDropdown();
+        fireEvent.click(getTrigger());
+
+        expect(removedEvents).toContain("resize");
+        expect(removedEvents).toContain("scroll");
+      } finally {
+        window.removeEventListener = originalRemoveEventListener;
+      }
+    });
+
+    test("ignores layout events once the dropdown is closed", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+      fireEvent.click(getTrigger());
+
+      /*
+       * Firing a resize after close must not resurrect the panel or throw
+       * because a listener outlived the element it measured.
+       */
+      act(() => {
+        setViewportWidth(300);
+        window.dispatchEvent(new Event("resize"));
+      });
+
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+    });
+
+    test("keeps the panel anchored below the trigger inside a relative container", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      const dropdown: HTMLElement = openDropdown();
+
+      expect(hasClass(dropdown, "absolute")).toBe(true);
+      expect(hasClass(dropdown, "top-full")).toBe(true);
+      expect(
+        dropdown.parentElement?.classList.contains("relative") ?? false,
+      ).toBe(true);
+    });
+
+    test("caps the panel width so it cannot exceed the viewport", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(hasClass(openDropdown(), "max-w-[calc(100vw-1rem)]")).toBe(true);
+    });
+
+    test("exports a width constant that matches the rendered w-72 panel", () => {
+      expect(TIME_RANGE_DROPDOWN_WIDTH_IN_PX).toBe(288);
+
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      expect(hasClass(openDropdown(), "w-72")).toBe(true);
+    });
+  });
+
+  describe("open and close behaviour", () => {
+    test("is closed until the trigger is clicked", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+      expect(getTrigger().getAttribute("aria-expanded")).toBe("false");
+    });
+
+    test("marks the trigger as expanded while open", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      expect(getTrigger().getAttribute("aria-expanded")).toBe("true");
+    });
+
+    test("closes when clicking outside the picker", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+    });
+
+    test("stays open when clicking inside the dropdown", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      const dropdown: HTMLElement = openDropdown();
+
+      fireEvent.mouseDown(dropdown);
+
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).not.toBeNull();
+    });
+  });
+
+  describe("range selection", () => {
+    test("shows the label of the currently selected preset", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(getTrigger().textContent).toContain("Past 1 Hour");
+    });
+
+    test("emits the picked preset and closes the dropdown", () => {
+      const onChange: (value: RangeStartAndEndDateTime) => void = jest.fn();
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR }, onChange);
+      openDropdown();
+
+      fireEvent.click(screen.getByText("Past 30 Minutes"));
+
+      expect(onChange).toHaveBeenCalledWith({
+        range: TimeRange.PAST_THIRTY_MINS,
+      });
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+    });
+
+    test("lists every preset option plus the custom entry", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      const dropdown: HTMLElement = openDropdown();
+
+      const optionLabels: Array<string> = Array.from(
+        dropdown.querySelectorAll("button"),
+      ).map((button: HTMLButtonElement): string => {
+        return (button.textContent || "").trim();
+      });
+
+      const expectedLabels: Array<string> = [
+        "Past 5 Minutes",
+        "Past 15 Minutes",
+        "Past 30 Minutes",
+        "Past 1 Hour",
+        "Past 2 Hours",
+        "Past 3 Hours",
+        "Past 1 Day",
+        "Past 2 Days",
+        "Past 1 Week",
+        "Past 2 Weeks",
+        "Past 1 Month",
+        "Past 3 Months",
+        "Custom Range...",
+      ];
+
+      expect(optionLabels).toEqual(expectedLabels);
+    });
+
+    test("renders the custom range editor when a custom range is active", () => {
+      renderPicker({
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date("2024-01-01T00:00:00.000Z"),
+          new Date("2024-01-02T00:00:00.000Z"),
+        ),
+      });
+
+      const dropdown: HTMLElement = openDropdown();
+
+      // The custom editor lives in the same panel, so alignment still applies.
+      expect(hasClass(dropdown, "left-0")).toBe(true);
+      expect(dropdown.querySelectorAll("input").length).toBeGreaterThan(0);
+    });
+
+    test("keeps the taller custom panel inside the viewport near the right edge", () => {
+      stubTriggerRect(1310, 1430);
+
+      renderPicker({
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date("2024-01-01T00:00:00.000Z"),
+          new Date("2024-01-02T00:00:00.000Z"),
+        ),
+      });
+
+      expect(hasClass(openDropdown(), "right-0")).toBe(true);
+    });
+  });
+});

--- a/Common/Tests/UI/Utils/DropdownAlignment.test.ts
+++ b/Common/Tests/UI/Utils/DropdownAlignment.test.ts
@@ -1,0 +1,306 @@
+import {
+  DEFAULT_DROPDOWN_VIEWPORT_MARGIN_IN_PX,
+  DropdownHorizontalAlignment,
+  getDropdownAlignmentClassName,
+  getDropdownHorizontalAlignment,
+} from "../../../UI/Utils/DropdownAlignment";
+import { describe, expect, test } from "@jest/globals";
+
+// Tailwind `w-72`, the width every telemetry time range dropdown is styled to.
+const DROPDOWN_WIDTH: number = 288;
+
+describe("getDropdownHorizontalAlignment", () => {
+  describe("triggers with room to the right", () => {
+    test("left aligns a trigger at the far left of a desktop viewport", () => {
+      /*
+       * This is the metric explorer toolbar case: the time range button is the
+       * first control in the toolbar, so the popup must open rightwards.
+       */
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 64,
+          anchorRight: 180,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 1440,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+
+    test("left aligns when the trigger starts at x=0", () => {
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 0,
+          anchorRight: 116,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 1024,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+
+    test("left aligns a mid-page trigger that still fits", () => {
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 500,
+          anchorRight: 616,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 1440,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+
+    test("left aligns when the popup lands exactly on the right gutter", () => {
+      const viewportWidth: number = 1000;
+      const anchorLeft: number =
+        viewportWidth - DEFAULT_DROPDOWN_VIEWPORT_MARGIN_IN_PX - DROPDOWN_WIDTH;
+
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: anchorLeft + 116,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: viewportWidth,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+  });
+
+  describe("triggers near the right edge", () => {
+    test("flips to right alignment one pixel past the right gutter", () => {
+      const viewportWidth: number = 1000;
+      const anchorLeft: number =
+        viewportWidth -
+        DEFAULT_DROPDOWN_VIEWPORT_MARGIN_IN_PX -
+        DROPDOWN_WIDTH +
+        1;
+
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: viewportWidth - 20,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: viewportWidth,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Right);
+    });
+
+    test("right aligns a trigger flush against the right edge", () => {
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 1300,
+          anchorRight: 1436,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 1440,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Right);
+    });
+  });
+
+  describe("viewports smaller than the popup", () => {
+    test("prefers the edge that clips least when neither side fits", () => {
+      /*
+       * A 200px viewport cannot contain a 288px popup. Left alignment clips by
+       * 288 + 10 - 192 = 106; right alignment clips by 8 - (150 - 288) = 146.
+       * Left wins.
+       */
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 10,
+          anchorRight: 150,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 200,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+
+    test("picks right alignment when that is the smaller overflow", () => {
+      /*
+       * Left alignment clips by 180 + 288 - 292 = 176; right alignment clips by
+       * 8 - (290 - 288) = 6. Right wins.
+       */
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 180,
+          anchorRight: 290,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 300,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Right);
+    });
+
+    test("prefers left alignment when both edges clip by the same amount", () => {
+      /*
+       * Anchor built so both edges clip by exactly `overflow` pixels:
+       * left overflow  = 14 + 288 - (300 - 8)  = 10
+       * right overflow = 8 - (286 - 288)       = 10
+       */
+      const viewportWidth: number = 300;
+      const margin: number = 8;
+      const width: number = 288;
+      const overflow: number = 10;
+      const anchorLeft: number = viewportWidth - margin - width + overflow;
+      const anchorRight: number = width + margin - overflow;
+
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: anchorRight,
+          dropdownWidth: width,
+          viewportWidth: viewportWidth,
+          viewportMargin: margin,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+  });
+
+  describe("viewport margin", () => {
+    test("honours a custom margin when deciding to flip", () => {
+      const viewportWidth: number = 1000;
+      const anchorLeft: number = 700;
+
+      // With no gutter the popup fits: 700 + 288 = 988 <= 1000.
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: 820,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: viewportWidth,
+          viewportMargin: 0,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+
+      // With a 40px gutter it no longer fits: 988 > 960.
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: 820,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: viewportWidth,
+          viewportMargin: 40,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Right);
+    });
+
+    test("treats an explicit zero margin as zero, not as the default", () => {
+      const viewportWidth: number = 1000;
+      const anchorLeft: number = viewportWidth - DROPDOWN_WIDTH;
+
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: viewportWidth,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: viewportWidth,
+          viewportMargin: 0,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorLeft,
+          anchorRight: viewportWidth,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: viewportWidth,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Right);
+    });
+  });
+
+  describe("unmeasurable layouts", () => {
+    test("defaults to left when the popup has no width yet", () => {
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 1400,
+          anchorRight: 1440,
+          dropdownWidth: 0,
+          viewportWidth: 1440,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+
+    test("defaults to left when the viewport has no width", () => {
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 0,
+          anchorRight: 0,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: 0,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+
+    test("defaults to left for non-finite measurements", () => {
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 0,
+          anchorRight: 100,
+          dropdownWidth: Number.NaN,
+          viewportWidth: 1440,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+
+      expect(
+        getDropdownHorizontalAlignment({
+          anchorLeft: 0,
+          anchorRight: 100,
+          dropdownWidth: DROPDOWN_WIDTH,
+          viewportWidth: Number.POSITIVE_INFINITY,
+        }),
+      ).toBe(DropdownHorizontalAlignment.Left);
+    });
+  });
+
+  describe("common breakpoints", () => {
+    /*
+     * The picker is the first control in the toolbar on every telemetry page,
+     * so it must stay left aligned no matter how narrow the screen gets.
+     */
+    const leftmostAnchorCases: Array<{ name: string; viewportWidth: number }> =
+      [
+        { name: "mobile", viewportWidth: 375 },
+        { name: "tablet", viewportWidth: 768 },
+        { name: "laptop", viewportWidth: 1280 },
+        { name: "desktop", viewportWidth: 1920 },
+      ];
+
+    test.each(leftmostAnchorCases)(
+      "left aligns a leftmost toolbar trigger on $name",
+      (testCase: { name: string; viewportWidth: number }) => {
+        expect(
+          getDropdownHorizontalAlignment({
+            anchorLeft: 16,
+            anchorRight: 132,
+            dropdownWidth: DROPDOWN_WIDTH,
+            viewportWidth: testCase.viewportWidth,
+          }),
+        ).toBe(DropdownHorizontalAlignment.Left);
+      },
+    );
+  });
+});
+
+describe("getDropdownAlignmentClassName", () => {
+  test("maps left alignment to the Tailwind left-0 class", () => {
+    expect(
+      getDropdownAlignmentClassName(DropdownHorizontalAlignment.Left),
+    ).toBe("left-0");
+  });
+
+  test("maps right alignment to the Tailwind right-0 class", () => {
+    expect(
+      getDropdownAlignmentClassName(DropdownHorizontalAlignment.Right),
+    ).toBe("right-0");
+  });
+
+  test("never returns both positioning classes at once", () => {
+    const classNames: Array<string> = [
+      getDropdownAlignmentClassName(DropdownHorizontalAlignment.Left),
+      getDropdownAlignmentClassName(DropdownHorizontalAlignment.Right),
+    ];
+
+    for (const className of classNames) {
+      expect(
+        className.includes("left-0") && className.includes("right-0"),
+      ).toBe(false);
+    }
+  });
+});

--- a/Common/UI/Components/LogsViewer/components/LogTimeRangePicker.tsx
+++ b/Common/UI/Components/LogsViewer/components/LogTimeRangePicker.tsx
@@ -14,11 +14,19 @@ import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import StartAndEndDate, {
   StartAndEndDateType,
 } from "../../Date/StartAndEndDate";
+import {
+  DropdownHorizontalAlignment,
+  getDropdownAlignmentClassName,
+  useDropdownHorizontalAlignment,
+} from "../../../Utils/DropdownAlignment";
 
 export interface LogTimeRangePickerProps {
   value: RangeStartAndEndDateTime;
   onChange: (value: RangeStartAndEndDateTime) => void;
 }
+
+// Matches the Tailwind `w-72` on the dropdown below (18rem).
+export const LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX: number = 288;
 
 // Preset options to show in the dropdown (ordered for log investigation use)
 const PRESET_OPTIONS: Array<{ range: TimeRange; label: string }> = [
@@ -67,6 +75,20 @@ const LogTimeRangePicker: FunctionComponent<LogTimeRangePickerProps> = (
   );
   const containerRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
     null!,
+  );
+  const buttonRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null!);
+  const dropdownRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
+    null!,
+  );
+
+  const alignment: DropdownHorizontalAlignment = useDropdownHorizontalAlignment(
+    {
+      isOpen: isOpen,
+      anchorRef: buttonRef,
+      dropdownRef: dropdownRef,
+      dropdownWidthInPx: LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX,
+    },
   );
 
   // Close on click outside
@@ -120,7 +142,11 @@ const LogTimeRangePicker: FunctionComponent<LogTimeRangePickerProps> = (
   return (
     <div ref={containerRef} className="relative">
       <button
+        ref={buttonRef}
         type="button"
+        data-testid="log-time-range-picker-button"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
         className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors ${
           isOpen
             ? "border-indigo-300 bg-indigo-50 text-indigo-700"
@@ -139,7 +165,14 @@ const LogTimeRangePicker: FunctionComponent<LogTimeRangePickerProps> = (
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-gray-200 bg-white shadow-lg">
+        <div
+          ref={dropdownRef}
+          data-testid="log-time-range-picker-dropdown"
+          data-align={alignment}
+          className={`absolute ${getDropdownAlignmentClassName(
+            alignment,
+          )} top-full z-50 mt-1 w-72 max-w-[calc(100vw-1rem)] rounded-lg border border-gray-200 bg-white shadow-lg`}
+        >
           {/* Preset options */}
           <div className="max-h-64 overflow-y-auto py-1">
             {PRESET_OPTIONS.map(

--- a/Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker.tsx
+++ b/Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker.tsx
@@ -14,11 +14,19 @@ import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import StartAndEndDate, {
   StartAndEndDateType,
 } from "../../Date/StartAndEndDate";
+import {
+  DropdownHorizontalAlignment,
+  getDropdownAlignmentClassName,
+  useDropdownHorizontalAlignment,
+} from "../../../Utils/DropdownAlignment";
 
 export interface TelemetryTimeRangePickerProps {
   value: RangeStartAndEndDateTime;
   onChange: (value: RangeStartAndEndDateTime) => void;
 }
+
+// Matches the Tailwind `w-72` on the dropdown below (18rem).
+export const TIME_RANGE_DROPDOWN_WIDTH_IN_PX: number = 288;
 
 const PRESET_OPTIONS: Array<{ range: TimeRange; label: string }> = [
   { range: TimeRange.PAST_FIVE_MINS, label: "Past 5 Minutes" },
@@ -66,6 +74,20 @@ const TelemetryTimeRangePicker: FunctionComponent<
   );
   const containerRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
     null!,
+  );
+  const buttonRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null!);
+  const dropdownRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
+    null!,
+  );
+
+  const alignment: DropdownHorizontalAlignment = useDropdownHorizontalAlignment(
+    {
+      isOpen: isOpen,
+      anchorRef: buttonRef,
+      dropdownRef: dropdownRef,
+      dropdownWidthInPx: TIME_RANGE_DROPDOWN_WIDTH_IN_PX,
+    },
   );
 
   useEffect(() => {
@@ -117,7 +139,11 @@ const TelemetryTimeRangePicker: FunctionComponent<
   return (
     <div ref={containerRef} className="relative">
       <button
+        ref={buttonRef}
         type="button"
+        data-testid="telemetry-time-range-picker-button"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
         className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors ${
           isOpen
             ? "border-indigo-300 bg-indigo-50 text-indigo-700"
@@ -136,7 +162,14 @@ const TelemetryTimeRangePicker: FunctionComponent<
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-gray-200 bg-white shadow-lg">
+        <div
+          ref={dropdownRef}
+          data-testid="telemetry-time-range-picker-dropdown"
+          data-align={alignment}
+          className={`absolute ${getDropdownAlignmentClassName(
+            alignment,
+          )} top-full z-50 mt-1 w-72 max-w-[calc(100vw-1rem)] rounded-lg border border-gray-200 bg-white shadow-lg`}
+        >
           <div className="max-h-64 overflow-y-auto py-1">
             {PRESET_OPTIONS.map(
               (option: { range: TimeRange; label: string }) => {

--- a/Common/UI/Utils/DropdownAlignment.ts
+++ b/Common/UI/Utils/DropdownAlignment.ts
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from "react";
+
+/*
+ * Horizontal edge of the trigger that a popup pins itself to.
+ * "Left" means the popup grows rightwards from the trigger's left edge
+ * (Tailwind `left-0`), "Right" means it grows leftwards from the trigger's
+ * right edge (Tailwind `right-0`).
+ */
+export enum DropdownHorizontalAlignment {
+  Left = "left",
+  Right = "right",
+}
+
+// Breathing room we keep between a popup and the edge of the viewport.
+export const DEFAULT_DROPDOWN_VIEWPORT_MARGIN_IN_PX: number = 8;
+
+export interface DropdownAlignmentInput {
+  // Viewport-relative left edge of the trigger, as reported by getBoundingClientRect().
+  anchorLeft: number;
+  // Viewport-relative right edge of the trigger.
+  anchorRight: number;
+  // Rendered width of the popup in pixels.
+  dropdownWidth: number;
+  // Width of the viewport in pixels.
+  viewportWidth: number;
+  // Optional override for the viewport gutter.
+  viewportMargin?: number | undefined;
+}
+
+/*
+ * Picks the edge a popup should align to so that it stays inside the viewport.
+ *
+ * Left alignment is preferred because it reads naturally next to the trigger.
+ * We only flip to the right edge when left alignment would spill past the right
+ * side of the viewport, and we never flip if doing so would spill past the left
+ * side by even more (which is what produced the off-screen popup on the metric
+ * explorer toolbar, where the trigger sits at the far left of the page).
+ */
+export function getDropdownHorizontalAlignment(
+  input: DropdownAlignmentInput,
+): DropdownHorizontalAlignment {
+  const margin: number =
+    input.viewportMargin === undefined
+      ? DEFAULT_DROPDOWN_VIEWPORT_MARGIN_IN_PX
+      : input.viewportMargin;
+
+  /*
+   * Before the popup is laid out (or in a non-visual environment) measurements
+   * come back as zero. There is nothing to solve for, so keep the default.
+   */
+  if (
+    !Number.isFinite(input.dropdownWidth) ||
+    !Number.isFinite(input.viewportWidth) ||
+    input.dropdownWidth <= 0 ||
+    input.viewportWidth <= 0
+  ) {
+    return DropdownHorizontalAlignment.Left;
+  }
+
+  // How far a left-aligned popup would poke past the right gutter.
+  const leftAlignedOverflow: number =
+    input.anchorLeft + input.dropdownWidth - (input.viewportWidth - margin);
+
+  // How far a right-aligned popup would poke past the left gutter.
+  const rightAlignedOverflow: number =
+    margin - (input.anchorRight - input.dropdownWidth);
+
+  if (leftAlignedOverflow <= 0) {
+    return DropdownHorizontalAlignment.Left;
+  }
+
+  if (rightAlignedOverflow <= 0) {
+    return DropdownHorizontalAlignment.Right;
+  }
+
+  // Neither edge fits. Pick whichever clips the least, preferring left on a tie.
+  return leftAlignedOverflow <= rightAlignedOverflow
+    ? DropdownHorizontalAlignment.Left
+    : DropdownHorizontalAlignment.Right;
+}
+
+/*
+ * Tailwind positioning class for an alignment. Kept next to the resolver so
+ * callers cannot drift out of sync with the enum.
+ */
+export function getDropdownAlignmentClassName(
+  alignment: DropdownHorizontalAlignment,
+): string {
+  return alignment === DropdownHorizontalAlignment.Right ? "right-0" : "left-0";
+}
+
+export interface UseDropdownHorizontalAlignmentOptions {
+  // Only measure while the popup is actually on screen.
+  isOpen: boolean;
+  // The trigger the popup hangs off.
+  anchorRef: React.RefObject<HTMLElement>;
+  // The popup itself. When it has not been laid out we fall back to the declared width.
+  dropdownRef?: React.RefObject<HTMLElement> | undefined;
+  // Width the popup is styled to (e.g. 288 for Tailwind `w-72`).
+  dropdownWidthInPx: number;
+  viewportMargin?: number | undefined;
+}
+
+/*
+ * Keeps a popup's horizontal alignment in sync with the space available around
+ * its trigger. Re-measures when the popup opens and whenever the viewport
+ * changes size or scrolls the trigger somewhere new.
+ */
+export function useDropdownHorizontalAlignment(
+  options: UseDropdownHorizontalAlignmentOptions,
+): DropdownHorizontalAlignment {
+  const [alignment, setAlignment] = useState<DropdownHorizontalAlignment>(
+    DropdownHorizontalAlignment.Left,
+  );
+
+  const {
+    isOpen,
+    anchorRef,
+    dropdownRef,
+    dropdownWidthInPx,
+    viewportMargin,
+  }: UseDropdownHorizontalAlignmentOptions = options;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const measure: () => void = (): void => {
+      const anchor: HTMLElement | null = anchorRef.current;
+
+      if (!anchor || typeof anchor.getBoundingClientRect !== "function") {
+        return;
+      }
+
+      const anchorRect: DOMRect = anchor.getBoundingClientRect();
+      const measuredWidth: number = dropdownRef?.current?.offsetWidth || 0;
+
+      setAlignment(
+        getDropdownHorizontalAlignment({
+          anchorLeft: anchorRect.left,
+          anchorRight: anchorRect.right,
+          dropdownWidth: measuredWidth > 0 ? measuredWidth : dropdownWidthInPx,
+          viewportWidth: window.innerWidth,
+          viewportMargin: viewportMargin,
+        }),
+      );
+    };
+
+    measure();
+
+    window.addEventListener("resize", measure);
+    window.addEventListener("scroll", measure, true);
+
+    return () => {
+      window.removeEventListener("resize", measure);
+      window.removeEventListener("scroll", measure, true);
+    };
+  }, [isOpen, anchorRef, dropdownRef, dropdownWidthInPx, viewportMargin]);
+
+  return alignment;
+}


### PR DESCRIPTION
## Problem

Opening the time range picker on **Metrics → Metric Explorer** rendered the popup off to the left, outside the content area and on top of the app sidebar.

The dropdown panel was hard-coded to `right-0`:

```tsx
<div className="absolute right-0 top-full z-50 mt-1 w-72 ...">
```

`right-0` pins the panel's **right** edge to the trigger's right edge, so a 288px (`w-72`) panel extends 288px to the *left*. That is fine for a trigger sitting on the right of a toolbar, but on the metric explorer the time range button is the **first** control in the toolbar — so the panel landed almost entirely off-screen.

## Fix

Alignment is now measured against the viewport instead of assumed:

- Prefer opening rightwards from the trigger's left edge (`left-0`).
- Flip to `right-0` only when left alignment would spill past the right gutter.
- If neither edge fits (viewport narrower than the panel), pick whichever clips least.
- Re-measure on `resize` and on `scroll`, and on every reopen.
- `max-w-[calc(100vw-1rem)]` caps the panel so it can't exceed the viewport on small screens.

The logic lives in a new shared module, `Common/UI/Utils/DropdownAlignment.ts`:

- `getDropdownHorizontalAlignment(...)` — pure resolver, no DOM.
- `useDropdownHorizontalAlignment(...)` — hook that measures the trigger and keeps alignment in sync.
- `getDropdownAlignmentClassName(...)` — maps the enum to the Tailwind class.

`LogsViewer/components/LogTimeRangePicker.tsx` carried a byte-identical copy of the same bug, so it now uses the same helpers.

The pickers also pick up `aria-haspopup` / `aria-expanded` on the trigger, plus `data-testid` / `data-align` hooks for the tests.

> Note: the Dashboard loads Tailwind's browser runtime (`views/index.ejs` → `tailwind-3.4.5.js`), which generates classes from the live DOM — so the runtime-selected `left-0` / `right-0` need no safelist.

## Tests

**51 new tests across 3 files, all passing.**

`Common/Tests/UI/Utils/DropdownAlignment.test.ts` (21) — the pure resolver: leftmost/mid/right triggers, exact-gutter boundaries, the one-pixel-past-the-gutter flip, viewports narrower than the panel (both tie-break directions), custom and explicit-zero margins, unmeasurable/non-finite layouts, and a `test.each` sweep over mobile/tablet/laptop/desktop widths.

`Common/Tests/UI/Components/TelemetryTimeRangePicker.test.tsx` (24) — the rendered component with `getBoundingClientRect` and `window.innerWidth` stubbed, since jsdom does no layout. Covers the regression itself, the right-edge flip, mutual exclusivity of the two classes, re-measurement on resize / scroll / reopen, listener cleanup on close, and the existing open-close and preset-selection behaviour so the fix doesn't regress it.

`Common/Tests/UI/Components/LogTimeRangePicker.test.tsx` (6) — the same alignment contract for the logs picker.

```
Test Suites: 3 passed, 3 total
Tests:       51 passed, 51 total
```

`npx tsc --noEmit` clean in both `Common` and `App`; `npx eslint` clean on all six files.

## Not verified

No live browser check — the local Docker dev stack wasn't running in this environment, so the visual confirmation rests on the jsdom tests above rather than on the rendered app.