### PR TITLE
fix(dashboard): stop a single render error from blanking the whole screen

### DIFF
--- a/App/FeatureSet/Accounts/src/Index.tsx
+++ b/App/FeatureSet/Accounts/src/Index.tsx
@@ -1,6 +1,7 @@
 import App from "./App";
 import "./Utils/i18n";
 import Telemetry from "Common/UI/Utils/Telemetry/Telemetry";
+import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -13,8 +14,15 @@ const root: any = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
+/*
+ * Last-resort boundary. Anything that throws above the route-level boundary
+ * (or before routing is even mounted) would otherwise unmount the entire tree
+ * and paint a blank white page with no way back.
+ */
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <ErrorBoundary>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ErrorBoundary>,
 );

--- a/App/FeatureSet/AdminDashboard/src/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Index.tsx
@@ -2,6 +2,7 @@ import App from "./App";
 import "./Utils/i18n";
 import "Common/UI/Styles/Theme.css";
 import Telemetry from "Common/UI/Utils/Telemetry/Telemetry";
+import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import ThemeUtil from "Common/UI/Utils/Theme";
 import UserUtil from "Common/UI/Utils/User";
 import React from "react";
@@ -21,8 +22,15 @@ const root: any = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
+/*
+ * Last-resort boundary. Anything that throws above the route-level boundary
+ * (or before routing is even mounted) would otherwise unmount the entire tree
+ * and paint a blank white page with no way back.
+ */
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <ErrorBoundary>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ErrorBoundary>,
 );

--- a/App/FeatureSet/Dashboard/src/App.tsx
+++ b/App/FeatureSet/Dashboard/src/App.tsx
@@ -27,6 +27,7 @@ import {
 import useAsyncEffect from "use-async-effect";
 import PageComponentProps from "./Pages/PageComponentProps";
 import PageLoader from "Common/UI/Components/Loader/PageLoader";
+import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import { RoutesProps } from "./Types/RoutesProps";
 
 // Static page imports
@@ -416,8 +417,10 @@ const TeamsRoutes: React.LazyExoticComponent<AllRoutesModule["TeamsRoutes"]> =
   });
 
 const App: () => JSX.Element = () => {
+  const location: ReturnType<typeof useLocation> = useLocation();
+
   Navigation.setNavigateHook(useNavigate());
-  Navigation.setLocation(useLocation());
+  Navigation.setLocation(location);
   Navigation.setParams(useParams());
 
   const [isLoading, setLoading] = useState<boolean>(true);
@@ -562,539 +565,557 @@ const App: () => JSX.Element = () => {
       <UseTimezoneInitElement />
       <ToastLayout />
       <AIChatPanel />
-      <Suspense fallback={<PageLoader isVisible={true} />}>
-        <Routes>
-          <PageRoute
-            path="/*"
-            element={
-              <InitRoutes
-                {...commonPageProps}
-                projects={projects}
-                isLoading={isLoading}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.WELCOME]?.toString() || ""}
-            element={
-              <Welcome
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.WELCOME] as Route}
-                onClickShowProjectModal={() => {
-                  setShowProjectModal(true);
-                }}
-              />
-            }
-          />
-
-          {/* Home */}
-
-          <PageRoute
-            path={RouteMap[PageMap.HOME]?.toString() || ""}
-            element={
-              <Home
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.HOME] as Route}
-                projects={projects}
-                isLoadingProjects={isLoading}
-              />
-            }
-          />
-          <PageRoute
-            path={RouteMap[PageMap.PROJECT_SSO]?.toString() || ""}
-            element={
-              <Sso
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.PROJECT_SSO] as Route}
-              />
-            }
-          />
-
-          {/* AI Copilot */}
-
-          <PageRoute
-            path={RouteMap[PageMap.AI_COPILOT]?.toString() || ""}
-            element={
-              <AICopilot
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.AI_COPILOT] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={
-              RouteMap[PageMap.HOME_NOT_OPERATIONAL_MONITORS]?.toString() || ""
-            }
-            element={
-              <NotOperationalMonitors
-                {...commonPageProps}
-                pageRoute={
-                  RouteMap[PageMap.HOME_NOT_OPERATIONAL_MONITORS] as Route
-                }
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.HOME_ACTIVE_ALERTS]?.toString() || ""}
-            element={
-              <HomeActiveAlerts
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.HOME_ACTIVE_ALERTS] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={
-              RouteMap[
-                PageMap.HOME_ONGOING_SCHEDULED_MAINTENANCE_EVENTS
-              ]?.toString() ||
-              "" ||
-              ""
-            }
-            element={
-              <OngoingScheduledEvents
-                {...commonPageProps}
-                pageRoute={
-                  RouteMap[
-                    PageMap.HOME_ONGOING_SCHEDULED_MAINTENANCE_EVENTS
-                  ] as Route
-                }
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.HOME_ACTIVE_EPISODES]?.toString() || ""}
-            element={
-              <HomeActiveEpisodes
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.HOME_ACTIVE_EPISODES] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={
-              RouteMap[PageMap.HOME_ACTIVE_INCIDENT_EPISODES]?.toString() || ""
-            }
-            element={
-              <HomeActiveIncidentEpisodes
-                {...commonPageProps}
-                pageRoute={
-                  RouteMap[PageMap.HOME_ACTIVE_INCIDENT_EPISODES] as Route
-                }
-              />
-            }
-          />
-          {/* Logs */}
-          <PageRoute
-            path={RouteMap[PageMap.LOGS_ROOT]?.toString() || ""}
-            element={<LogsRoutes {...commonPageProps} />}
-          />
-
-          {/* Metrics */}
-          <PageRoute
-            path={RouteMap[PageMap.METRICS_ROOT]?.toString() || ""}
-            element={<MetricsRoutes {...commonPageProps} />}
-          />
-
-          {/* Traces */}
-          <PageRoute
-            path={RouteMap[PageMap.TRACES_ROOT]?.toString() || ""}
-            element={<TracesRoutes {...commonPageProps} />}
-          />
-
-          {/* Profiles */}
-          <PageRoute
-            path={RouteMap[PageMap.PROFILES_ROOT]?.toString() || ""}
-            element={<ProfilesRoutes {...commonPageProps} />}
-          />
-
-          {/* Monitors */}
-          <PageRoute
-            path={RouteMap[PageMap.MONITORS_ROOT]?.toString() || ""}
-            element={<MonitorsRoutes {...commonPageProps} />}
-          />
-
-          {/* Workflows  */}
-          <PageRoute
-            path={RouteMap[PageMap.WORKFLOWS_ROOT]?.toString() || ""}
-            element={<WorkflowRoutes {...commonPageProps} />}
-          />
-
-          {/* Runbooks */}
-          <PageRoute
-            path={RouteMap[PageMap.RUNBOOKS_ROOT]?.toString() || ""}
-            element={<RunbookRoutes {...commonPageProps} />}
-          />
-
-          {/* Status Pages */}
-          <PageRoute
-            path={RouteMap[PageMap.STATUS_PAGES_ROOT]?.toString() || ""}
-            element={<StatusPagesRoutes {...commonPageProps} />}
-          />
-
-          {/* Dashboards */}
-          <PageRoute
-            path={RouteMap[PageMap.DASHBOARDS_ROOT]?.toString() || ""}
-            element={<DashboardRoutes {...commonPageProps} />}
-          />
-
-          {/* Service */}
-          <PageRoute
-            path={RouteMap[PageMap.SERVICE_ROOT]?.toString() || ""}
-            element={<ServiceRoutes {...commonPageProps} />}
-          />
-
-          {/* Kubernetes */}
-          <PageRoute
-            path={RouteMap[PageMap.KUBERNETES_ROOT]?.toString() || ""}
-            element={<KubernetesRoutes {...commonPageProps} />}
-          />
-
-          {/* Docker */}
-          <PageRoute
-            path={RouteMap[PageMap.DOCKER_ROOT]?.toString() || ""}
-            element={<DockerRoutes {...commonPageProps} />}
-          />
-
-          {/* Network Devices */}
-          <PageRoute
-            path={RouteMap[PageMap.NETWORK_DEVICE_ROOT]?.toString() || ""}
-            element={<NetworkDeviceRoutes {...commonPageProps} />}
-          />
-
-          {/* Network Sites */}
-          <PageRoute
-            path={RouteMap[PageMap.NETWORK_SITE_ROOT]?.toString() || ""}
-            element={<NetworkSiteRoutes {...commonPageProps} />}
-          />
-
-          {/* SLOs */}
-          <PageRoute
-            path={RouteMap[PageMap.SLOS_ROOT]?.toString() || ""}
-            element={<SloRoutes {...commonPageProps} />}
-          />
-
-          {/* Podman */}
-          <PageRoute
-            path={RouteMap[PageMap.PODMAN_ROOT]?.toString() || ""}
-            element={<PodmanRoutes {...commonPageProps} />}
-          />
-
-          {/* Proxmox */}
-          <PageRoute
-            path={RouteMap[PageMap.PROXMOX_ROOT]?.toString() || ""}
-            element={<ProxmoxRoutes {...commonPageProps} />}
-          />
-
-          {/* IoT */}
-          <PageRoute
-            path={RouteMap[PageMap.IOT_ROOT]?.toString() || ""}
-            element={<IoTRoutes {...commonPageProps} />}
-          />
-
-          {/* Docker Swarm */}
-          <PageRoute
-            path={RouteMap[PageMap.DOCKER_SWARM_ROOT]?.toString() || ""}
-            element={<DockerSwarmRoutes {...commonPageProps} />}
-          />
-
-          {/* Ceph */}
-          <PageRoute
-            path={RouteMap[PageMap.CEPH_ROOT]?.toString() || ""}
-            element={<CephRoutes {...commonPageProps} />}
-          />
-
-          {/* Hosts */}
-          <PageRoute
-            path={RouteMap[PageMap.HOST_ROOT]?.toString() || ""}
-            element={<HostRoutes {...commonPageProps} />}
-          />
-
-          {/* Serverless Functions */}
-          <PageRoute
-            path={RouteMap[PageMap.SERVERLESS_ROOT]?.toString() || ""}
-            element={<ServerlessRoutes {...commonPageProps} />}
-          />
-
-          {/* Cloud Resources */}
-          <PageRoute
-            path={RouteMap[PageMap.CLOUD_ROOT]?.toString() || ""}
-            element={<CloudResourceRoutes {...commonPageProps} />}
-          />
-
-          {/* Real User Monitoring */}
-          <PageRoute
-            path={RouteMap[PageMap.RUM_ROOT]?.toString() || ""}
-            element={<RumApplicationRoutes {...commonPageProps} />}
-          />
-
-          {/* Code Repository */}
-          <PageRoute
-            path={RouteMap[PageMap.CODE_REPOSITORY_ROOT]?.toString() || ""}
-            element={<CodeRepositoryRoutes {...commonPageProps} />}
-          />
-
-          {/* Incidents */}
-          <PageRoute
-            path={RouteMap[PageMap.INCIDENTS_ROOT]?.toString() || ""}
-            element={<IncidentsRoutes {...commonPageProps} />}
-          />
-
-          {/* Incidents */}
-          <PageRoute
-            path={RouteMap[PageMap.ALERTS_ROOT]?.toString() || ""}
-            element={<AlertsRoutes {...commonPageProps} />}
-          />
-
-          {/* Scheduled Events */}
-
-          <PageRoute
-            path={
-              RouteMap[PageMap.SCHEDULED_MAINTENANCE_EVENTS_ROOT]?.toString() ||
-              ""
-            }
-            element={<ScheduledMaintenanceEventsRoutes {...commonPageProps} />}
-          />
-
-          {/* Users Routes (top-level) */}
-          <PageRoute
-            path={RouteMap[PageMap.USERS_ROOT]?.toString() || ""}
-            element={<UsersRoutes {...commonPageProps} />}
-          />
-
-          {/* Teams Routes (top-level) */}
-          <PageRoute
-            path={RouteMap[PageMap.TEAMS_ROOT]?.toString() || ""}
-            element={<TeamsRoutes {...commonPageProps} />}
-          />
-
-          {/* Settings Routes */}
-
-          <PageRoute
-            path={RouteMap[PageMap.SETTINGS_ROOT]?.toString() || ""}
-            element={<SettingsRoutes {...commonPageProps} />}
-          />
-
-          {/* As this one has dependencies with the selected project and etc, we need to put it here for now. */}
-          <PageRoute
-            path={RouteMap[PageMap.SETTINGS_DANGERZONE]?.toString() || ""}
-            element={
-              <SettingsDangerZone
-                onProjectDeleted={async () => {
-                  setSelectedProject(null);
-                  setProjects([]);
-                  await fetchProjects();
-                  Navigation.navigate(RouteMap[PageMap.INIT]!);
-                }}
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.SETTINGS_DANGERZONE] as Route}
-              />
-            }
-          />
-
-          {/* On-Call Duty */}
-
-          <PageRoute
-            path={RouteMap[PageMap.ON_CALL_DUTY_ROOT]?.toString() || ""}
-            element={<OnCallDutyRoutes {...commonPageProps} />}
-          />
-
-          {/* Misc Routes */}
-          <PageRoute
-            path={RouteMap[PageMap.LOGOUT]?.toString() || ""}
-            element={
-              <Logout
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.LOGOUT] as Route}
-              />
-            }
-          />
-
-          {/* Global Routes */}
-          <PageRoute
-            path={RouteMap[PageMap.USER_PROFILE_PICTURE]?.toString() || ""}
-            element={
-              <UserProfilePicture
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.USER_PROFILE_PICTURE] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.USER_PROFILE_OVERVIEW]?.toString() || ""}
-            element={
-              <UserProfileOverview
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.USER_PROFILE_OVERVIEW] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.USER_PROFILE_PASSWORD]?.toString() || ""}
-            element={
-              <UserProfilePassword
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.USER_PROFILE_PASSWORD] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.USER_TWO_FACTOR_AUTH]?.toString() || ""}
-            element={
-              <UseTwoFactorAuth
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.USER_TWO_FACTOR_AUTH] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.USER_PROFILE_DELETE]?.toString() || ""}
-            element={
-              <UserProfileDelete
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.USER_PROFILE_DELETE] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.PROJECT_INVITATIONS]?.toString() || ""}
-            element={
-              <ProjectInvitations
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.PROJECT_INVITATIONS] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.ACTIVE_INCIDENTS]?.toString() || ""}
-            element={
-              <ActiveIncidents
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.ACTIVE_INCIDENTS] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.ACTIVE_ALERTS]?.toString() || ""}
-            element={
-              <ActiveAlerts
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.ACTIVE_ALERTS] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.ACTIVE_ALERT_EPISODES]?.toString() || ""}
-            element={
-              <ActiveAlertEpisodes
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.ACTIVE_ALERT_EPISODES] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.ACTIVE_INCIDENT_EPISODES]?.toString() || ""}
-            element={
-              <ActiveIncidentEpisodes
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.ACTIVE_INCIDENT_EPISODES] as Route}
-              />
-            }
-          />
-
-          <PageRoute
-            path={RouteMap[PageMap.MY_ON_CALL_POLICIES]?.toString() || ""}
-            element={
-              <MyOnCallPolicies
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.MY_ON_CALL_POLICIES] as Route}
-              />
-            }
-          />
-
-          {/* User Settings */}
-
-          <PageRoute
-            path={RouteMap[PageMap.USER_SETTINGS_ROOT]?.toString() || ""}
-            element={<UserSettingsRoutes {...commonPageProps} />}
-          />
-
-          {/** Monitor Groups */}
-
-          <PageRoute
-            path={RouteMap[PageMap.MONITOR_GROUPS_ROOT]?.toString() || ""}
-            element={<MonitorGroupRoutes {...commonPageProps} />}
-          />
-
-          {/** AI Agent Tasks */}
-
-          <PageRoute
-            path={RouteMap[PageMap.AI_AGENT_TASKS_ROOT]?.toString() || ""}
-            element={<AIAgentTasksRoutes {...commonPageProps} />}
-          />
-
-          {/** AI Insights */}
-
-          <PageRoute
-            path={RouteMap[PageMap.AI_INSIGHTS_ROOT]?.toString() || ""}
-            element={<AIInsightsRoutes {...commonPageProps} />}
-          />
-
-          {/** Exceptions */}
-
-          <PageRoute
-            path={RouteMap[PageMap.EXCEPTIONS_ROOT]?.toString() || ""}
-            element={<ExceptionsRoutes {...commonPageProps} />}
-          />
-
-          {/** AI / LLM Observability */}
-
-          <PageRoute
-            path={RouteMap[PageMap.LLM_ROOT]?.toString() || ""}
-            element={<LlmRoutes {...commonPageProps} />}
-          />
-
-          {/** Entities (entity explorer) */}
-
-          <PageRoute
-            path={RouteMap[PageMap.ENTITIES_ROOT]?.toString() || ""}
-            element={<EntitiesRoutes {...commonPageProps} />}
-          />
-
-          {/** Topology (service map) */}
-
-          <PageRoute
-            path={RouteMap[PageMap.TOPOLOGY_ROOT]?.toString() || ""}
-            element={<TopologyRoutes {...commonPageProps} />}
-          />
-
-          {/* 👇️ only match this when no other routes match */}
-          <PageRoute
-            path="*"
-            element={
-              <PageNotFound
-                {...commonPageProps}
-                pageRoute={RouteMap[PageMap.LOGOUT] as Route}
-              />
-            }
-          />
-        </Routes>
-      </Suspense>
+      {/*
+       * Contain page-level render errors here. Without a boundary a single
+       * throwing component (or a lazy chunk that 404s after a deploy) unmounts
+       * the whole tree and the user is left on a blank white page. Keying the
+       * reset on the pathname means navigating elsewhere clears the error, so
+       * one broken page never traps the session.
+       */}
+      <ErrorBoundary resetKey={location.pathname}>
+        <Suspense fallback={<PageLoader isVisible={true} />}>
+          <Routes>
+            <PageRoute
+              path="/*"
+              element={
+                <InitRoutes
+                  {...commonPageProps}
+                  projects={projects}
+                  isLoading={isLoading}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.WELCOME]?.toString() || ""}
+              element={
+                <Welcome
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.WELCOME] as Route}
+                  onClickShowProjectModal={() => {
+                    setShowProjectModal(true);
+                  }}
+                />
+              }
+            />
+
+            {/* Home */}
+
+            <PageRoute
+              path={RouteMap[PageMap.HOME]?.toString() || ""}
+              element={
+                <Home
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.HOME] as Route}
+                  projects={projects}
+                  isLoadingProjects={isLoading}
+                />
+              }
+            />
+            <PageRoute
+              path={RouteMap[PageMap.PROJECT_SSO]?.toString() || ""}
+              element={
+                <Sso
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.PROJECT_SSO] as Route}
+                />
+              }
+            />
+
+            {/* AI Copilot */}
+
+            <PageRoute
+              path={RouteMap[PageMap.AI_COPILOT]?.toString() || ""}
+              element={
+                <AICopilot
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.AI_COPILOT] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={
+                RouteMap[PageMap.HOME_NOT_OPERATIONAL_MONITORS]?.toString() ||
+                ""
+              }
+              element={
+                <NotOperationalMonitors
+                  {...commonPageProps}
+                  pageRoute={
+                    RouteMap[PageMap.HOME_NOT_OPERATIONAL_MONITORS] as Route
+                  }
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.HOME_ACTIVE_ALERTS]?.toString() || ""}
+              element={
+                <HomeActiveAlerts
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.HOME_ACTIVE_ALERTS] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={
+                RouteMap[
+                  PageMap.HOME_ONGOING_SCHEDULED_MAINTENANCE_EVENTS
+                ]?.toString() ||
+                "" ||
+                ""
+              }
+              element={
+                <OngoingScheduledEvents
+                  {...commonPageProps}
+                  pageRoute={
+                    RouteMap[
+                      PageMap.HOME_ONGOING_SCHEDULED_MAINTENANCE_EVENTS
+                    ] as Route
+                  }
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.HOME_ACTIVE_EPISODES]?.toString() || ""}
+              element={
+                <HomeActiveEpisodes
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.HOME_ACTIVE_EPISODES] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={
+                RouteMap[PageMap.HOME_ACTIVE_INCIDENT_EPISODES]?.toString() ||
+                ""
+              }
+              element={
+                <HomeActiveIncidentEpisodes
+                  {...commonPageProps}
+                  pageRoute={
+                    RouteMap[PageMap.HOME_ACTIVE_INCIDENT_EPISODES] as Route
+                  }
+                />
+              }
+            />
+            {/* Logs */}
+            <PageRoute
+              path={RouteMap[PageMap.LOGS_ROOT]?.toString() || ""}
+              element={<LogsRoutes {...commonPageProps} />}
+            />
+
+            {/* Metrics */}
+            <PageRoute
+              path={RouteMap[PageMap.METRICS_ROOT]?.toString() || ""}
+              element={<MetricsRoutes {...commonPageProps} />}
+            />
+
+            {/* Traces */}
+            <PageRoute
+              path={RouteMap[PageMap.TRACES_ROOT]?.toString() || ""}
+              element={<TracesRoutes {...commonPageProps} />}
+            />
+
+            {/* Profiles */}
+            <PageRoute
+              path={RouteMap[PageMap.PROFILES_ROOT]?.toString() || ""}
+              element={<ProfilesRoutes {...commonPageProps} />}
+            />
+
+            {/* Monitors */}
+            <PageRoute
+              path={RouteMap[PageMap.MONITORS_ROOT]?.toString() || ""}
+              element={<MonitorsRoutes {...commonPageProps} />}
+            />
+
+            {/* Workflows  */}
+            <PageRoute
+              path={RouteMap[PageMap.WORKFLOWS_ROOT]?.toString() || ""}
+              element={<WorkflowRoutes {...commonPageProps} />}
+            />
+
+            {/* Runbooks */}
+            <PageRoute
+              path={RouteMap[PageMap.RUNBOOKS_ROOT]?.toString() || ""}
+              element={<RunbookRoutes {...commonPageProps} />}
+            />
+
+            {/* Status Pages */}
+            <PageRoute
+              path={RouteMap[PageMap.STATUS_PAGES_ROOT]?.toString() || ""}
+              element={<StatusPagesRoutes {...commonPageProps} />}
+            />
+
+            {/* Dashboards */}
+            <PageRoute
+              path={RouteMap[PageMap.DASHBOARDS_ROOT]?.toString() || ""}
+              element={<DashboardRoutes {...commonPageProps} />}
+            />
+
+            {/* Service */}
+            <PageRoute
+              path={RouteMap[PageMap.SERVICE_ROOT]?.toString() || ""}
+              element={<ServiceRoutes {...commonPageProps} />}
+            />
+
+            {/* Kubernetes */}
+            <PageRoute
+              path={RouteMap[PageMap.KUBERNETES_ROOT]?.toString() || ""}
+              element={<KubernetesRoutes {...commonPageProps} />}
+            />
+
+            {/* Docker */}
+            <PageRoute
+              path={RouteMap[PageMap.DOCKER_ROOT]?.toString() || ""}
+              element={<DockerRoutes {...commonPageProps} />}
+            />
+
+            {/* Network Devices */}
+            <PageRoute
+              path={RouteMap[PageMap.NETWORK_DEVICE_ROOT]?.toString() || ""}
+              element={<NetworkDeviceRoutes {...commonPageProps} />}
+            />
+
+            {/* Network Sites */}
+            <PageRoute
+              path={RouteMap[PageMap.NETWORK_SITE_ROOT]?.toString() || ""}
+              element={<NetworkSiteRoutes {...commonPageProps} />}
+            />
+
+            {/* SLOs */}
+            <PageRoute
+              path={RouteMap[PageMap.SLOS_ROOT]?.toString() || ""}
+              element={<SloRoutes {...commonPageProps} />}
+            />
+
+            {/* Podman */}
+            <PageRoute
+              path={RouteMap[PageMap.PODMAN_ROOT]?.toString() || ""}
+              element={<PodmanRoutes {...commonPageProps} />}
+            />
+
+            {/* Proxmox */}
+            <PageRoute
+              path={RouteMap[PageMap.PROXMOX_ROOT]?.toString() || ""}
+              element={<ProxmoxRoutes {...commonPageProps} />}
+            />
+
+            {/* IoT */}
+            <PageRoute
+              path={RouteMap[PageMap.IOT_ROOT]?.toString() || ""}
+              element={<IoTRoutes {...commonPageProps} />}
+            />
+
+            {/* Docker Swarm */}
+            <PageRoute
+              path={RouteMap[PageMap.DOCKER_SWARM_ROOT]?.toString() || ""}
+              element={<DockerSwarmRoutes {...commonPageProps} />}
+            />
+
+            {/* Ceph */}
+            <PageRoute
+              path={RouteMap[PageMap.CEPH_ROOT]?.toString() || ""}
+              element={<CephRoutes {...commonPageProps} />}
+            />
+
+            {/* Hosts */}
+            <PageRoute
+              path={RouteMap[PageMap.HOST_ROOT]?.toString() || ""}
+              element={<HostRoutes {...commonPageProps} />}
+            />
+
+            {/* Serverless Functions */}
+            <PageRoute
+              path={RouteMap[PageMap.SERVERLESS_ROOT]?.toString() || ""}
+              element={<ServerlessRoutes {...commonPageProps} />}
+            />
+
+            {/* Cloud Resources */}
+            <PageRoute
+              path={RouteMap[PageMap.CLOUD_ROOT]?.toString() || ""}
+              element={<CloudResourceRoutes {...commonPageProps} />}
+            />
+
+            {/* Real User Monitoring */}
+            <PageRoute
+              path={RouteMap[PageMap.RUM_ROOT]?.toString() || ""}
+              element={<RumApplicationRoutes {...commonPageProps} />}
+            />
+
+            {/* Code Repository */}
+            <PageRoute
+              path={RouteMap[PageMap.CODE_REPOSITORY_ROOT]?.toString() || ""}
+              element={<CodeRepositoryRoutes {...commonPageProps} />}
+            />
+
+            {/* Incidents */}
+            <PageRoute
+              path={RouteMap[PageMap.INCIDENTS_ROOT]?.toString() || ""}
+              element={<IncidentsRoutes {...commonPageProps} />}
+            />
+
+            {/* Incidents */}
+            <PageRoute
+              path={RouteMap[PageMap.ALERTS_ROOT]?.toString() || ""}
+              element={<AlertsRoutes {...commonPageProps} />}
+            />
+
+            {/* Scheduled Events */}
+
+            <PageRoute
+              path={
+                RouteMap[
+                  PageMap.SCHEDULED_MAINTENANCE_EVENTS_ROOT
+                ]?.toString() || ""
+              }
+              element={
+                <ScheduledMaintenanceEventsRoutes {...commonPageProps} />
+              }
+            />
+
+            {/* Users Routes (top-level) */}
+            <PageRoute
+              path={RouteMap[PageMap.USERS_ROOT]?.toString() || ""}
+              element={<UsersRoutes {...commonPageProps} />}
+            />
+
+            {/* Teams Routes (top-level) */}
+            <PageRoute
+              path={RouteMap[PageMap.TEAMS_ROOT]?.toString() || ""}
+              element={<TeamsRoutes {...commonPageProps} />}
+            />
+
+            {/* Settings Routes */}
+
+            <PageRoute
+              path={RouteMap[PageMap.SETTINGS_ROOT]?.toString() || ""}
+              element={<SettingsRoutes {...commonPageProps} />}
+            />
+
+            {/* As this one has dependencies with the selected project and etc, we need to put it here for now. */}
+            <PageRoute
+              path={RouteMap[PageMap.SETTINGS_DANGERZONE]?.toString() || ""}
+              element={
+                <SettingsDangerZone
+                  onProjectDeleted={async () => {
+                    setSelectedProject(null);
+                    setProjects([]);
+                    await fetchProjects();
+                    Navigation.navigate(RouteMap[PageMap.INIT]!);
+                  }}
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.SETTINGS_DANGERZONE] as Route}
+                />
+              }
+            />
+
+            {/* On-Call Duty */}
+
+            <PageRoute
+              path={RouteMap[PageMap.ON_CALL_DUTY_ROOT]?.toString() || ""}
+              element={<OnCallDutyRoutes {...commonPageProps} />}
+            />
+
+            {/* Misc Routes */}
+            <PageRoute
+              path={RouteMap[PageMap.LOGOUT]?.toString() || ""}
+              element={
+                <Logout
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.LOGOUT] as Route}
+                />
+              }
+            />
+
+            {/* Global Routes */}
+            <PageRoute
+              path={RouteMap[PageMap.USER_PROFILE_PICTURE]?.toString() || ""}
+              element={
+                <UserProfilePicture
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.USER_PROFILE_PICTURE] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.USER_PROFILE_OVERVIEW]?.toString() || ""}
+              element={
+                <UserProfileOverview
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.USER_PROFILE_OVERVIEW] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.USER_PROFILE_PASSWORD]?.toString() || ""}
+              element={
+                <UserProfilePassword
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.USER_PROFILE_PASSWORD] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.USER_TWO_FACTOR_AUTH]?.toString() || ""}
+              element={
+                <UseTwoFactorAuth
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.USER_TWO_FACTOR_AUTH] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.USER_PROFILE_DELETE]?.toString() || ""}
+              element={
+                <UserProfileDelete
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.USER_PROFILE_DELETE] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.PROJECT_INVITATIONS]?.toString() || ""}
+              element={
+                <ProjectInvitations
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.PROJECT_INVITATIONS] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.ACTIVE_INCIDENTS]?.toString() || ""}
+              element={
+                <ActiveIncidents
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.ACTIVE_INCIDENTS] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.ACTIVE_ALERTS]?.toString() || ""}
+              element={
+                <ActiveAlerts
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.ACTIVE_ALERTS] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.ACTIVE_ALERT_EPISODES]?.toString() || ""}
+              element={
+                <ActiveAlertEpisodes
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.ACTIVE_ALERT_EPISODES] as Route}
+                />
+              }
+            />
+
+            <PageRoute
+              path={
+                RouteMap[PageMap.ACTIVE_INCIDENT_EPISODES]?.toString() || ""
+              }
+              element={
+                <ActiveIncidentEpisodes
+                  {...commonPageProps}
+                  pageRoute={
+                    RouteMap[PageMap.ACTIVE_INCIDENT_EPISODES] as Route
+                  }
+                />
+              }
+            />
+
+            <PageRoute
+              path={RouteMap[PageMap.MY_ON_CALL_POLICIES]?.toString() || ""}
+              element={
+                <MyOnCallPolicies
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.MY_ON_CALL_POLICIES] as Route}
+                />
+              }
+            />
+
+            {/* User Settings */}
+
+            <PageRoute
+              path={RouteMap[PageMap.USER_SETTINGS_ROOT]?.toString() || ""}
+              element={<UserSettingsRoutes {...commonPageProps} />}
+            />
+
+            {/** Monitor Groups */}
+
+            <PageRoute
+              path={RouteMap[PageMap.MONITOR_GROUPS_ROOT]?.toString() || ""}
+              element={<MonitorGroupRoutes {...commonPageProps} />}
+            />
+
+            {/** AI Agent Tasks */}
+
+            <PageRoute
+              path={RouteMap[PageMap.AI_AGENT_TASKS_ROOT]?.toString() || ""}
+              element={<AIAgentTasksRoutes {...commonPageProps} />}
+            />
+
+            {/** AI Insights */}
+
+            <PageRoute
+              path={RouteMap[PageMap.AI_INSIGHTS_ROOT]?.toString() || ""}
+              element={<AIInsightsRoutes {...commonPageProps} />}
+            />
+
+            {/** Exceptions */}
+
+            <PageRoute
+              path={RouteMap[PageMap.EXCEPTIONS_ROOT]?.toString() || ""}
+              element={<ExceptionsRoutes {...commonPageProps} />}
+            />
+
+            {/** AI / LLM Observability */}
+
+            <PageRoute
+              path={RouteMap[PageMap.LLM_ROOT]?.toString() || ""}
+              element={<LlmRoutes {...commonPageProps} />}
+            />
+
+            {/** Entities (entity explorer) */}
+
+            <PageRoute
+              path={RouteMap[PageMap.ENTITIES_ROOT]?.toString() || ""}
+              element={<EntitiesRoutes {...commonPageProps} />}
+            />
+
+            {/** Topology (service map) */}
+
+            <PageRoute
+              path={RouteMap[PageMap.TOPOLOGY_ROOT]?.toString() || ""}
+              element={<TopologyRoutes {...commonPageProps} />}
+            />
+
+            {/* 👇️ only match this when no other routes match */}
+            <PageRoute
+              path="*"
+              element={
+                <PageNotFound
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.LOGOUT] as Route}
+                />
+              }
+            />
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
     </MasterPage>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MetricMonitor/MetricMonitorPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MetricMonitor/MetricMonitorPreview.tsx
@@ -1,5 +1,8 @@
 import React, { FunctionComponent, ReactElement, useEffect } from "react";
-import MonitorStepMetricMonitor from "Common/Types/Monitor/MonitorStepMetricMonitor";
+import MonitorStepMetricMonitor, {
+  MonitorStepMetricMonitorUtil,
+} from "Common/Types/Monitor/MonitorStepMetricMonitor";
+import MetricsViewConfig from "Common/Types/Metrics/MetricsViewConfig";
 import MetricView from "../../Metrics/MetricView";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import RollingTimeUtil from "Common/Types/RollingTime/RollingTimeUtil";
@@ -53,21 +56,29 @@ const MetricMonitorPreview: FunctionComponent<ComponentProps> = (
     setStartAndEndDate(RollingTimeUtil.convertToStartAndEndDate(rollingTime));
   }, [rollingTime]);
 
+  /*
+   * Monitor steps are persisted as unvalidated JSON, so metricViewConfig can be
+   * missing entirely on steps written by older builds. Resolve it through the
+   * util, which always hands back array-shaped query/formula configs — reading
+   * `metricViewConfig.queryConfigs` directly used to throw during render and
+   * blank the entire dashboard.
+   */
+  const metricViewConfig: MetricsViewConfig =
+    MonitorStepMetricMonitorUtil.getMetricViewConfig(
+      props.monitorStepMetricMonitor,
+    );
+
   const [metricViewData, setMetricViewData] = React.useState<MetricViewData>({
     startAndEndDate: startAndEndDate,
-    queryConfigs:
-      props.monitorStepMetricMonitor?.metricViewConfig.queryConfigs || [],
-    formulaConfigs:
-      props.monitorStepMetricMonitor?.metricViewConfig.formulaConfigs || [],
+    queryConfigs: metricViewConfig.queryConfigs,
+    formulaConfigs: metricViewConfig.formulaConfigs,
   });
 
   useEffect(() => {
     setMetricViewData({
       startAndEndDate: startAndEndDate,
-      queryConfigs:
-        props.monitorStepMetricMonitor?.metricViewConfig.queryConfigs || [],
-      formulaConfigs:
-        props.monitorStepMetricMonitor?.metricViewConfig.formulaConfigs || [],
+      queryConfigs: metricViewConfig.queryConfigs,
+      formulaConfigs: metricViewConfig.formulaConfigs,
     });
   }, [startAndEndDate]);
 

--- a/App/FeatureSet/Dashboard/src/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Index.tsx
@@ -2,6 +2,7 @@ import App from "./App";
 import "./Utils/i18n";
 import "Common/UI/Styles/Theme.css";
 import Telemetry from "Common/UI/Utils/Telemetry/Telemetry";
+import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import ProjectUtil from "Common/UI/Utils/Project";
 import ThemeUtil from "Common/UI/Utils/Theme";
 import UserUtil from "Common/UI/Utils/User";
@@ -38,8 +39,15 @@ const root: any = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
+/*
+ * Last-resort boundary. Anything that throws above the route-level boundary
+ * (or before routing is even mounted) would otherwise unmount the entire tree
+ * and paint a blank white page with no way back.
+ */
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <ErrorBoundary>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ErrorBoundary>,
 );

--- a/App/FeatureSet/PublicDashboard/src/Index.tsx
+++ b/App/FeatureSet/PublicDashboard/src/Index.tsx
@@ -1,5 +1,6 @@
 import App from "./App";
 import Telemetry from "Common/UI/Utils/Telemetry/Telemetry";
+import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -12,8 +13,15 @@ const root: any = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
+/*
+ * Last-resort boundary. Anything that throws above the route-level boundary
+ * (or before routing is even mounted) would otherwise unmount the entire tree
+ * and paint a blank white page with no way back.
+ */
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <ErrorBoundary>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ErrorBoundary>,
 );

--- a/App/FeatureSet/StatusPage/src/Index.tsx
+++ b/App/FeatureSet/StatusPage/src/Index.tsx
@@ -1,6 +1,7 @@
 import App from "./App";
 import "./Utils/i18n";
 import Telemetry from "Common/UI/Utils/Telemetry/Telemetry";
+import ErrorBoundary from "Common/UI/Components/ErrorBoundary";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -13,8 +14,15 @@ const root: any = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
+/*
+ * Last-resort boundary. Anything that throws above the route-level boundary
+ * (or before routing is even mounted) would otherwise unmount the entire tree
+ * and paint a blank white page with no way back.
+ */
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <ErrorBoundary>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ErrorBoundary>,
 );

--- a/Common/Tests/Types/Monitor/MonitorStepMetricMonitor.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepMetricMonitor.test.ts
@@ -1,0 +1,386 @@
+import { JSONObject } from "../../../Types/JSON";
+import MetricFormulaConfigData from "../../../Types/Metrics/MetricFormulaConfigData";
+import MetricQueryConfigData from "../../../Types/Metrics/MetricQueryConfigData";
+import MetricsViewConfig from "../../../Types/Metrics/MetricsViewConfig";
+import MonitorStep from "../../../Types/Monitor/MonitorStep";
+import MonitorStepMetricMonitor, {
+  MonitorStepMetricMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepMetricMonitor";
+import RollingTime from "../../../Types/RollingTime/RollingTime";
+
+/*
+ * Regression coverage for the blank-screen crash on the monitor view page.
+ *
+ * MetricMonitorPreview read `monitorStepMetricMonitor?.metricViewConfig.queryConfigs`.
+ * The optional chain stops at `monitorStepMetricMonitor`, so a step that HAS a
+ * metricMonitor but no metricViewConfig threw
+ *
+ *     TypeError: Cannot read properties of undefined (reading 'queryConfigs')
+ *
+ * during render. Nothing above it caught the throw, so React unmounted the whole
+ * tree and the dashboard went blank white — nav, sidebar and all.
+ *
+ * That shape is reachable because monitor steps are persisted as free-form JSON
+ * and rehydrated with a cast: nothing at runtime enforces that metricViewConfig
+ * is present. These tests lock in that resolving the config NEVER throws and
+ * always yields array-shaped queryConfigs / formulaConfigs, whatever garbage the
+ * database hands back.
+ */
+
+function queryConfig(metricVariable: string): MetricQueryConfigData {
+  return {
+    metricAliasData: {
+      metricVariable,
+      title: metricVariable,
+      description: metricVariable,
+      legend: metricVariable,
+      legendUnit: undefined,
+    },
+    metricQueryData: {
+      filterData: {},
+    },
+  } as unknown as MetricQueryConfigData;
+}
+
+function formulaConfig(metricVariable: string): MetricFormulaConfigData {
+  return {
+    metricAliasData: {
+      metricVariable,
+      title: metricVariable,
+      description: metricVariable,
+      legend: metricVariable,
+      legendUnit: undefined,
+    },
+    metricFormulaData: {
+      formula: "a + b",
+    },
+  } as unknown as MetricFormulaConfigData;
+}
+
+describe("MonitorStepMetricMonitorUtil.getMetricViewConfig", () => {
+  test("returns the config untouched when the step is well formed", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [queryConfig("a")];
+    const formulaConfigs: Array<MetricFormulaConfigData> = [formulaConfig("b")];
+
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig({
+        metricViewConfig: {
+          queryConfigs,
+          formulaConfigs,
+        },
+        rollingTime: RollingTime.Past1Hour,
+      });
+
+    expect(config.queryConfigs).toEqual(queryConfigs);
+    expect(config.formulaConfigs).toEqual(formulaConfigs);
+  });
+
+  test("returns empty arrays when the whole monitor is undefined", () => {
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig(undefined);
+
+    expect(config).toEqual({ queryConfigs: [], formulaConfigs: [] });
+  });
+
+  test("returns empty arrays when the whole monitor is null", () => {
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig(null);
+
+    expect(config).toEqual({ queryConfigs: [], formulaConfigs: [] });
+  });
+
+  test("THE CRASH: monitor present but metricViewConfig missing entirely", () => {
+    /*
+     * The exact shape from the bug report: a persisted metricMonitor that only
+     * carries rollingTime. Reading .metricViewConfig.queryConfigs off this is
+     * what threw and blanked the page.
+     */
+    const malformed: MonitorStepMetricMonitor = {
+      rollingTime: RollingTime.Past1Minute,
+    } as unknown as MonitorStepMetricMonitor;
+
+    expect(() => {
+      return MonitorStepMetricMonitorUtil.getMetricViewConfig(malformed);
+    }).not.toThrow();
+
+    expect(MonitorStepMetricMonitorUtil.getMetricViewConfig(malformed)).toEqual(
+      {
+        queryConfigs: [],
+        formulaConfigs: [],
+      },
+    );
+  });
+
+  test("returns empty arrays when metricViewConfig is explicitly null", () => {
+    const malformed: MonitorStepMetricMonitor = {
+      metricViewConfig: null,
+      rollingTime: RollingTime.Past1Minute,
+    } as unknown as MonitorStepMetricMonitor;
+
+    expect(MonitorStepMetricMonitorUtil.getMetricViewConfig(malformed)).toEqual(
+      { queryConfigs: [], formulaConfigs: [] },
+    );
+  });
+
+  test("fills in queryConfigs when only formulaConfigs was persisted", () => {
+    const formulaConfigs: Array<MetricFormulaConfigData> = [formulaConfig("b")];
+
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig({
+        metricViewConfig: { formulaConfigs },
+        rollingTime: RollingTime.Past1Minute,
+      } as unknown as MonitorStepMetricMonitor);
+
+    expect(config.queryConfigs).toEqual([]);
+    expect(config.formulaConfigs).toEqual(formulaConfigs);
+  });
+
+  test("fills in formulaConfigs when only queryConfigs was persisted", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [queryConfig("a")];
+
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig({
+        metricViewConfig: { queryConfigs },
+        rollingTime: RollingTime.Past1Minute,
+      } as unknown as MonitorStepMetricMonitor);
+
+    expect(config.queryConfigs).toEqual(queryConfigs);
+    expect(config.formulaConfigs).toEqual([]);
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "not-an-array"],
+    ["a number", 42],
+    ["an object", { length: 2 }],
+    ["a boolean", true],
+  ])(
+    "coerces non-array queryConfigs (%s) to an empty array",
+    (_label: string, value: unknown) => {
+      const config: MetricsViewConfig =
+        MonitorStepMetricMonitorUtil.getMetricViewConfig({
+          metricViewConfig: {
+            queryConfigs: value,
+            formulaConfigs: value,
+          },
+          rollingTime: RollingTime.Past1Minute,
+        } as unknown as MonitorStepMetricMonitor);
+
+      expect(config.queryConfigs).toEqual([]);
+      expect(config.formulaConfigs).toEqual([]);
+      // Callers immediately call .length / .map / .some on these.
+      expect(Array.isArray(config.queryConfigs)).toBe(true);
+      expect(Array.isArray(config.formulaConfigs)).toBe(true);
+    },
+  );
+
+  test("the result is always safe for the array reads MetricView performs", () => {
+    const malformed: MonitorStepMetricMonitor =
+      {} as unknown as MonitorStepMetricMonitor;
+
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig(malformed);
+
+    // These are the exact operations MetricView runs on the data it is given.
+    expect(() => {
+      return [
+        config.queryConfigs.length,
+        config.queryConfigs.map((q: MetricQueryConfigData) => {
+          return q;
+        }),
+        config.queryConfigs.some(() => {
+          return true;
+        }),
+        config.formulaConfigs.length,
+        config.formulaConfigs.map((f: MetricFormulaConfigData) => {
+          return f;
+        }),
+      ];
+    }).not.toThrow();
+  });
+
+  test("does not mutate the monitor it was given", () => {
+    const malformed: MonitorStepMetricMonitor = {
+      rollingTime: RollingTime.Past1Minute,
+    } as unknown as MonitorStepMetricMonitor;
+
+    MonitorStepMetricMonitorUtil.getMetricViewConfig(malformed);
+
+    expect(
+      (malformed as unknown as JSONObject)["metricViewConfig"],
+    ).toBeUndefined();
+  });
+
+  test("hands back the same array references when they are already valid", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [queryConfig("a")];
+    const formulaConfigs: Array<MetricFormulaConfigData> = [formulaConfig("b")];
+
+    const config: MetricsViewConfig =
+      MonitorStepMetricMonitorUtil.getMetricViewConfig({
+        metricViewConfig: { queryConfigs, formulaConfigs },
+        rollingTime: RollingTime.Past1Minute,
+      });
+
+    // No defensive copy: the preview passes these straight into MetricView.
+    expect(config.queryConfigs).toBe(queryConfigs);
+    expect(config.formulaConfigs).toBe(formulaConfigs);
+  });
+});
+
+describe("MonitorStepMetricMonitorUtil.getDefault", () => {
+  test("produces a config that resolves to itself", () => {
+    const defaultMonitor: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.getDefault();
+
+    expect(
+      MonitorStepMetricMonitorUtil.getMetricViewConfig(defaultMonitor),
+    ).toEqual({
+      queryConfigs: [],
+      formulaConfigs: [],
+    });
+    expect(defaultMonitor.rollingTime).toBe(RollingTime.Past1Minute);
+  });
+});
+
+describe("MonitorStepMetricMonitorUtil.fromJSON", () => {
+  test("normalizes JSON that is missing metricViewConfig", () => {
+    const monitor: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.fromJSON({
+        rollingTime: RollingTime.Past1Hour,
+      });
+
+    expect(monitor.metricViewConfig).toEqual({
+      queryConfigs: [],
+      formulaConfigs: [],
+    });
+    expect(monitor.rollingTime).toBe(RollingTime.Past1Hour);
+  });
+
+  test("normalizes JSON that is missing everything", () => {
+    const monitor: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.fromJSON({});
+
+    expect(monitor.metricViewConfig).toEqual({
+      queryConfigs: [],
+      formulaConfigs: [],
+    });
+    // rollingTime backs off to the same default a fresh step gets.
+    expect(monitor.rollingTime).toBe(RollingTime.Past1Minute);
+  });
+
+  test("preserves a well formed config", () => {
+    const json: JSONObject = {
+      metricViewConfig: {
+        queryConfigs: [queryConfig("a")],
+        formulaConfigs: [formulaConfig("b")],
+      },
+      rollingTime: RollingTime.Past7Days,
+    } as unknown as JSONObject;
+
+    const monitor: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.fromJSON(json);
+
+    expect(monitor.metricViewConfig.queryConfigs).toHaveLength(1);
+    expect(monitor.metricViewConfig.formulaConfigs).toHaveLength(1);
+    expect(monitor.rollingTime).toBe(RollingTime.Past7Days);
+  });
+
+  test("keeps unknown keys so forward-compatible fields are not dropped", () => {
+    const monitor: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.fromJSON({
+        rollingTime: RollingTime.Past1Minute,
+        someFutureField: "keep-me",
+      } as unknown as JSONObject);
+
+    expect((monitor as unknown as JSONObject)["someFutureField"]).toBe(
+      "keep-me",
+    );
+  });
+
+  test("round trips through toJSON without losing the normalization", () => {
+    const monitor: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.fromJSON({
+        rollingTime: RollingTime.Past1Minute,
+      });
+
+    const roundTripped: MonitorStepMetricMonitor =
+      MonitorStepMetricMonitorUtil.fromJSON(
+        MonitorStepMetricMonitorUtil.toJSON(monitor),
+      );
+
+    expect(roundTripped.metricViewConfig).toEqual({
+      queryConfigs: [],
+      formulaConfigs: [],
+    });
+  });
+});
+
+describe("MonitorStep.fromJSON normalizes persisted metric monitors", () => {
+  function monitorStepJSON(metricMonitor: JSONObject | undefined): JSONObject {
+    return {
+      _type: "MonitorStep",
+      value: {
+        id: "step-1",
+        monitorCriteria: {
+          _type: "MonitorCriteria",
+          value: {
+            monitorCriteriaInstanceArray: [],
+          },
+        },
+        metricMonitor: metricMonitor,
+      },
+    } as unknown as JSONObject;
+  }
+
+  test("a step whose metricMonitor has no metricViewConfig loads with one", () => {
+    const step: MonitorStep = MonitorStep.fromJSON(
+      monitorStepJSON({
+        rollingTime: RollingTime.Past1Minute,
+      } as unknown as JSONObject),
+    );
+
+    expect(step.data?.metricMonitor?.metricViewConfig).toEqual({
+      queryConfigs: [],
+      formulaConfigs: [],
+    });
+  });
+
+  test("the loaded step is safe to hand to the metric preview", () => {
+    const step: MonitorStep = MonitorStep.fromJSON(
+      monitorStepJSON({} as unknown as JSONObject),
+    );
+
+    expect(() => {
+      const config: MetricsViewConfig =
+        MonitorStepMetricMonitorUtil.getMetricViewConfig(
+          step.data?.metricMonitor,
+        );
+
+      return [config.queryConfigs.length, config.formulaConfigs.length];
+    }).not.toThrow();
+  });
+
+  test("a step with no metricMonitor at all stays undefined", () => {
+    const step: MonitorStep = MonitorStep.fromJSON(monitorStepJSON(undefined));
+
+    expect(step.data?.metricMonitor).toBeUndefined();
+  });
+
+  test("a well formed metricMonitor survives the load unchanged", () => {
+    const step: MonitorStep = MonitorStep.fromJSON(
+      monitorStepJSON({
+        metricViewConfig: {
+          queryConfigs: [queryConfig("a")],
+          formulaConfigs: [],
+        },
+        rollingTime: RollingTime.Past1Hour,
+      } as unknown as JSONObject),
+    );
+
+    expect(
+      step.data?.metricMonitor?.metricViewConfig.queryConfigs,
+    ).toHaveLength(1);
+    expect(step.data?.metricMonitor?.rollingTime).toBe(RollingTime.Past1Hour);
+  });
+});

--- a/Common/Tests/UI/Components/ErrorBoundary.test.tsx
+++ b/Common/Tests/UI/Components/ErrorBoundary.test.tsx
@@ -1,50 +1,581 @@
-import ErrorBoundary from "../../../UI/Components/ErrorBoundary";
-import "@testing-library/jest-dom/extend-expect";
-import { render, screen } from "@testing-library/react";
-import React, { FunctionComponent, useEffect } from "react";
+import ErrorBoundary, {
+  CHUNK_LOAD_RELOAD_COOLDOWN_IN_MS,
+  CHUNK_LOAD_RELOAD_STORAGE_KEY,
+  handleChunkLoadError,
+  hasRecentlyReloadedForChunkLoadError,
+  isChunkLoadError,
+  markChunkLoadErrorReload,
+} from "../../../UI/Components/ErrorBoundary";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React, { FunctionComponent, ReactElement, useEffect } from "react";
+
+/*
+ * The blank white screen users hit is React unmounting the entire tree when a
+ * render throws and nothing catches it. These tests pin down the containment
+ * contract: a throwing subtree must degrade to a readable, recoverable fallback
+ * while everything around it keeps rendering — never to an empty document.
+ *
+ * Assertions here deliberately use plain DOM checks rather than jest-dom
+ * matchers (toBeInTheDocument etc). Common's tsconfig does not list
+ * testing-library__jest-dom in "types", so those matchers do not type-check.
+ */
+
+const ORIGINAL_LOCATION: Location = window.location;
+
+let reloadMock: jest.Mock;
+
+function mockReload(): void {
+  reloadMock = jest.fn();
+
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: { ...ORIGINAL_LOCATION, reload: reloadMock },
+  });
+}
+
+function restoreLocation(): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: ORIGINAL_LOCATION,
+  });
+}
+
+/** Throws while rendering — the failure mode that blanks the screen. */
+const ThrowOnRender: FunctionComponent<{ message?: string }> = (props: {
+  message?: string;
+}): ReactElement => {
+  throw new Error(props.message || "Render exploded");
+};
+
+/** Throws from an effect, after the first paint. */
+const ThrowInEffect: FunctionComponent = (): ReactElement => {
+  useEffect(() => {
+    throw new Error("Effect exploded");
+  }, []);
+
+  return <div>Effect Throwing Component</div>;
+};
+
+const FALLBACK_TEXT: string =
+  "An unexpected error has occurred. Please reload the page to continue";
 
 describe("ErrorBoundary", () => {
-  const spy: jest.SpyInstance = jest.spyOn(console, "error");
+  const consoleErrorSpy: jest.SpyInstance = jest.spyOn(console, "error");
 
   beforeAll(() => {
-    spy.mockImplementation(() => {});
+    consoleErrorSpy.mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    consoleErrorSpy.mockClear();
+    window.sessionStorage.clear();
+    mockReload();
+  });
+
+  afterEach(() => {
+    restoreLocation();
   });
 
   afterAll(() => {
-    spy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
-  test("should render children when no error is thrown", () => {
-    render(
-      <ErrorBoundary>
-        <div>Child Component</div>
-      </ErrorBoundary>,
+  describe("happy path", () => {
+    test("renders children when no error is thrown", () => {
+      render(
+        <ErrorBoundary>
+          <div>Child Component</div>
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText("Child Component")).not.toBeNull();
+      expect(screen.queryByTestId("error-boundary-fallback")).toBeNull();
+    });
+
+    test("renders multiple children", () => {
+      render(
+        <ErrorBoundary>
+          <div>First</div>
+          <div>Second</div>
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText("First")).not.toBeNull();
+      expect(screen.queryByText("Second")).not.toBeNull();
+    });
+
+    test("does not reload the page when nothing goes wrong", () => {
+      render(
+        <ErrorBoundary>
+          <div>Child Component</div>
+        </ErrorBoundary>,
+      );
+
+      expect(reloadMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("containment", () => {
+    test("renders the fallback when a child throws during render", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowOnRender />
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+      expect(screen.queryByTestId("error-boundary-fallback")).not.toBeNull();
+    });
+
+    test("renders the fallback when a child throws from an effect", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowInEffect />
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+    });
+
+    test("THE BLANK SCREEN: the document is never left empty", () => {
+      const { container } = render(
+        <ErrorBoundary>
+          <ThrowOnRender />
+        </ErrorBoundary>,
+      );
+
+      /*
+       * Before the boundary was wired up this subtree rendered to nothing at
+       * all — the whole app painted white, with no text and no way back.
+       */
+      expect(container.textContent!.trim().length).toBeGreaterThan(0);
+      expect(container.querySelectorAll("button").length).toBeGreaterThan(0);
+    });
+
+    test("siblings outside the boundary keep rendering", () => {
+      render(
+        <div>
+          <div>Navigation Bar</div>
+          <ErrorBoundary>
+            <ThrowOnRender />
+          </ErrorBoundary>
+          <div>Footer</div>
+        </div>,
+      );
+
+      // One broken page must not take the shell down with it.
+      expect(screen.queryByText("Navigation Bar")).not.toBeNull();
+      expect(screen.queryByText("Footer")).not.toBeNull();
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+    });
+
+    test("an inner boundary keeps the error away from an outer one", () => {
+      render(
+        <ErrorBoundary>
+          <div>
+            <div>Outer Content</div>
+            <ErrorBoundary>
+              <ThrowOnRender />
+            </ErrorBoundary>
+          </div>
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText("Outer Content")).not.toBeNull();
+      expect(screen.getAllByTestId("error-boundary-fallback")).toHaveLength(1);
+    });
+
+    test("the fallback is announced to assistive technology", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowOnRender />
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByRole("alert")).not.toBeNull();
+    });
+
+    test("shows the underlying error message for support", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowOnRender message="Cannot read properties of undefined (reading 'queryConfigs')" />
+        </ErrorBoundary>,
+      );
+
+      expect(
+        screen.getByTestId("error-boundary-error-message").textContent,
+      ).toContain("reading 'queryConfigs'");
+    });
+  });
+
+  describe("reporting", () => {
+    test("calls the onError callback with the thrown error", () => {
+      const onError: jest.Mock = jest.fn();
+
+      render(
+        <ErrorBoundary onError={onError}>
+          <ThrowOnRender message="Boom" />
+        </ErrorBoundary>,
+      );
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect((onError.mock.calls[0]![0] as Error).message).toBe("Boom");
+    });
+
+    test("logs the error so it still reaches the console and RUM", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowOnRender message="Boom" />
+        </ErrorBoundary>,
+      );
+
+      const loggedOurMessage: boolean = consoleErrorSpy.mock.calls.some(
+        (call: Array<unknown>) => {
+          return call[0] === "Uncaught error rendering the app:";
+        },
+      );
+
+      expect(loggedOurMessage).toBe(true);
+    });
+
+    test("does not call onError when nothing throws", () => {
+      const onError: jest.Mock = jest.fn();
+
+      render(
+        <ErrorBoundary onError={onError}>
+          <div>Fine</div>
+        </ErrorBoundary>,
+      );
+
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recovery", () => {
+    test("'Try again' re-renders the children", () => {
+      let shouldThrow: boolean = true;
+
+      const SometimesThrows: FunctionComponent = (): ReactElement => {
+        if (shouldThrow) {
+          throw new Error("Transient failure");
+        }
+
+        return <div>Recovered Content</div>;
+      };
+
+      render(
+        <ErrorBoundary>
+          <SometimesThrows />
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+
+      shouldThrow = false;
+      fireEvent.click(screen.getByTestId("error-boundary-try-again"));
+
+      expect(screen.queryByText("Recovered Content")).not.toBeNull();
+      expect(screen.queryByTestId("error-boundary-fallback")).toBeNull();
+    });
+
+    test("'Reload page' reloads the browser", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowOnRender />
+        </ErrorBoundary>,
+      );
+
+      fireEvent.click(screen.getByTestId("error-boundary-reload"));
+
+      expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("changing the resetKey clears the error (navigating away)", () => {
+      const { rerender } = render(
+        <ErrorBoundary resetKey="/dashboard/monitors/broken">
+          <ThrowOnRender />
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+
+      // The user clicks another nav item; the route key changes.
+      rerender(
+        <ErrorBoundary resetKey="/dashboard/incidents">
+          <div>Incidents Page</div>
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText("Incidents Page")).not.toBeNull();
+      expect(screen.queryByTestId("error-boundary-fallback")).toBeNull();
+    });
+
+    test("keeping the same resetKey keeps showing the fallback", () => {
+      const { rerender } = render(
+        <ErrorBoundary resetKey="/dashboard/monitors/broken">
+          <ThrowOnRender />
+        </ErrorBoundary>,
+      );
+
+      rerender(
+        <ErrorBoundary resetKey="/dashboard/monitors/broken">
+          <div>Should Not Show</div>
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+      expect(screen.queryByText("Should Not Show")).toBeNull();
+    });
+
+    test("catches a second error after recovering from the first", () => {
+      const MaybeThrows: FunctionComponent<{ shouldThrow: boolean }> = (props: {
+        shouldThrow: boolean;
+      }): ReactElement => {
+        if (props.shouldThrow) {
+          throw new Error("Transient failure");
+        }
+
+        return <div>Recovered Content</div>;
+      };
+
+      const { rerender } = render(
+        <ErrorBoundary>
+          <MaybeThrows shouldThrow={true} />
+        </ErrorBoundary>,
+      );
+
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+
+      // The underlying cause clears, and the user retries.
+      rerender(
+        <ErrorBoundary>
+          <MaybeThrows shouldThrow={false} />
+        </ErrorBoundary>,
+      );
+      fireEvent.click(screen.getByTestId("error-boundary-try-again"));
+      expect(screen.queryByText("Recovered Content")).not.toBeNull();
+
+      // It breaks again. A boundary that only catches once is a blank screen.
+      rerender(
+        <ErrorBoundary>
+          <MaybeThrows shouldThrow={true} />
+        </ErrorBoundary>,
+      );
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+    });
+  });
+});
+
+describe("isChunkLoadError", () => {
+  test.each([
+    ["webpack", "Loading chunk 472 failed."],
+    ["webpack css", "Loading CSS chunk 12 failed."],
+    ["vite", "Failed to fetch dynamically imported module: /assets/App.js"],
+    ["safari", "Importing a module script failed."],
+    ["firefox", "error loading dynamically imported module"],
+    ["vite preload", "Unable to preload CSS for /assets/index.css"],
+  ])("detects the %s wording", (_browser: string, message: string) => {
+    expect(isChunkLoadError(new Error(message))).toBe(true);
+  });
+
+  test("detects errors identified only by name", () => {
+    const error: Error = new Error("Something went wrong");
+    error.name = "ChunkLoadError";
+
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  test.each([
+    ["the blank-screen TypeError", "Cannot read properties of undefined"],
+    ["a network failure", "Network request failed"],
+    ["an empty message", ""],
+  ])("does not misfire on %s", (_label: string, message: string) => {
+    expect(isChunkLoadError(new Error(message))).toBe(false);
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a number", 0],
+    ["an empty string", ""],
+  ])("is false for %s", (_label: string, value: unknown) => {
+    expect(isChunkLoadError(value)).toBe(false);
+  });
+
+  test("handles non-Error throwables without blowing up", () => {
+    expect(isChunkLoadError("Loading chunk 3 failed.")).toBe(true);
+    expect(isChunkLoadError({ nope: true })).toBe(false);
+  });
+});
+
+describe("chunk load reload throttling", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockReload();
+  });
+
+  afterEach(() => {
+    restoreLocation();
+    jest.restoreAllMocks();
+  });
+
+  test("has not reloaded when storage is empty", () => {
+    expect(hasRecentlyReloadedForChunkLoadError(Date.now())).toBe(false);
+  });
+
+  test("reports a reload inside the cooldown window", () => {
+    const now: number = 1_000_000;
+    markChunkLoadErrorReload(now);
+
+    expect(hasRecentlyReloadedForChunkLoadError(now)).toBe(true);
+    expect(
+      hasRecentlyReloadedForChunkLoadError(
+        now + CHUNK_LOAD_RELOAD_COOLDOWN_IN_MS - 1,
+      ),
+    ).toBe(true);
+  });
+
+  test("the cooldown expires", () => {
+    const now: number = 1_000_000;
+    markChunkLoadErrorReload(now);
+
+    expect(
+      hasRecentlyReloadedForChunkLoadError(
+        now + CHUNK_LOAD_RELOAD_COOLDOWN_IN_MS,
+      ),
+    ).toBe(false);
+  });
+
+  test("ignores a corrupt timestamp", () => {
+    window.sessionStorage.setItem(
+      CHUNK_LOAD_RELOAD_STORAGE_KEY,
+      "not-a-number",
     );
 
-    const child: HTMLElement = screen.getByText("Child Component");
-
-    expect(child).toBeInTheDocument();
+    expect(hasRecentlyReloadedForChunkLoadError(Date.now())).toBe(false);
   });
 
-  test("should render error message when an error occurs", () => {
-    const ErrorThrowingComponent: FunctionComponent = () => {
-      useEffect(() => {
-        throw new Error("Test Error");
-      }, []);
+  test("survives sessionStorage being unavailable", () => {
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
 
-      return <div>Error Throwing Component</div>;
+    expect(() => {
+      markChunkLoadErrorReload(Date.now());
+    }).not.toThrow();
+    expect(hasRecentlyReloadedForChunkLoadError(Date.now())).toBe(false);
+  });
+});
+
+describe("handleChunkLoadError", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockReload();
+  });
+
+  afterEach(() => {
+    restoreLocation();
+  });
+
+  test("reloads once for a stale bundle", () => {
+    expect(handleChunkLoadError(new Error("Loading chunk 5 failed."))).toBe(
+      true,
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("NO RELOAD LOOP: does not reload again inside the cooldown", () => {
+    handleChunkLoadError(new Error("Loading chunk 5 failed."));
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+
+    /*
+     * If the asset is genuinely gone the reload will not fix it. Reloading
+     * again would spin forever, so the second attempt must fall through to the
+     * fallback UI instead.
+     */
+    expect(handleChunkLoadError(new Error("Loading chunk 5 failed."))).toBe(
+      false,
+    );
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("never reloads for an ordinary render error", () => {
+    expect(
+      handleChunkLoadError(
+        new Error(
+          "Cannot read properties of undefined (reading 'queryConfigs')",
+        ),
+      ),
+    ).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  test("records the attempt so a later boundary sees it", () => {
+    handleChunkLoadError(new Error("Loading chunk 5 failed."));
+
+    expect(
+      window.sessionStorage.getItem(CHUNK_LOAD_RELOAD_STORAGE_KEY),
+    ).not.toBeNull();
+  });
+});
+
+describe("ErrorBoundary chunk load recovery", () => {
+  const consoleErrorSpy: jest.SpyInstance = jest.spyOn(console, "error");
+
+  beforeAll(() => {
+    consoleErrorSpy.mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockReload();
+  });
+
+  afterEach(() => {
+    restoreLocation();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("auto-reloads when a lazy route fails to load", () => {
+    const ThrowChunkError: FunctionComponent = (): ReactElement => {
+      throw new Error(
+        "Failed to fetch dynamically imported module: /assets/AllRoutes.js",
+      );
     };
 
     render(
       <ErrorBoundary>
-        <ErrorThrowingComponent />
+        <ThrowChunkError />
       </ErrorBoundary>,
     );
 
-    const errorText: HTMLElement = screen.getByText(
-      "An unexpected error has occurred. Please reload the page to continue",
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    // The fallback still renders so the user is never looking at a blank page.
+    expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
+  });
+
+  test("shows the fallback without reloading when a reload already happened", () => {
+    markChunkLoadErrorReload(Date.now());
+
+    const ThrowChunkError: FunctionComponent = (): ReactElement => {
+      throw new Error("Loading chunk 9 failed.");
+    };
+
+    render(
+      <ErrorBoundary>
+        <ThrowChunkError />
+      </ErrorBoundary>,
     );
 
-    expect(errorText).toBeInTheDocument();
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(FALLBACK_TEXT)).not.toBeNull();
   });
 });

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -1114,8 +1114,17 @@ export default class MonitorStep extends DatabaseProperty {
       logMonitor: json["logMonitor"]
         ? (json["logMonitor"] as JSONObject)
         : undefined,
+      /*
+       * Normalize rather than pass the raw JSON straight through. Steps saved
+       * by older builds can carry a metricMonitor with no metricViewConfig,
+       * and every consumer downstream assumes the type's contract holds.
+       */
       metricMonitor: json["metricMonitor"]
-        ? (json["metricMonitor"] as JSONObject)
+        ? (MonitorStepMetricMonitorUtil.toJSON(
+            MonitorStepMetricMonitorUtil.fromJSON(
+              json["metricMonitor"] as JSONObject,
+            ),
+          ) as JSONObject)
         : undefined,
       traceMonitor: json["traceMonitor"]
         ? (json["traceMonitor"] as JSONObject)

--- a/Common/Types/Monitor/MonitorStepMetricMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepMetricMonitor.ts
@@ -1,4 +1,6 @@
 import { JSONObject } from "../JSON";
+import MetricFormulaConfigData from "../Metrics/MetricFormulaConfigData";
+import MetricQueryConfigData from "../Metrics/MetricQueryConfigData";
 import MetricsViewConfig from "../Metrics/MetricsViewConfig";
 import RollingTime from "../RollingTime/RollingTime";
 
@@ -18,8 +20,51 @@ export class MonitorStepMetricMonitorUtil {
     };
   }
 
+  /**
+   * Resolve a metric view config that is ALWAYS safe to render from.
+   *
+   * `metricViewConfig` is typed as required, but nothing enforces that at
+   * runtime: monitor steps are persisted as free-form JSON and rehydrated with
+   * a plain cast (see MonitorStep.fromJSON), so a step written by an older
+   * build — or by the API, a seed, or an import — can carry a `metricMonitor`
+   * with no `metricViewConfig` at all, or with `queryConfigs` set to null.
+   *
+   * Dereferencing such a value while rendering threw "Cannot read properties
+   * of undefined (reading 'queryConfigs')", which unmounted the whole React
+   * tree and left the user on a blank white page. Always go through this
+   * helper instead of reading `metricViewConfig` directly.
+   */
+  public static getMetricViewConfig(
+    monitorStepMetricMonitor: MonitorStepMetricMonitor | undefined | null,
+  ): MetricsViewConfig {
+    const metricViewConfig: MetricsViewConfig | undefined | null =
+      monitorStepMetricMonitor?.metricViewConfig;
+
+    return {
+      queryConfigs: Array.isArray(metricViewConfig?.queryConfigs)
+        ? (metricViewConfig.queryConfigs as Array<MetricQueryConfigData>)
+        : [],
+      formulaConfigs: Array.isArray(metricViewConfig?.formulaConfigs)
+        ? (metricViewConfig.formulaConfigs as Array<MetricFormulaConfigData>)
+        : [],
+    };
+  }
+
   public static fromJSON(json: JSONObject): MonitorStepMetricMonitor {
-    return json as any as MonitorStepMetricMonitor;
+    const monitorStepMetricMonitor: MonitorStepMetricMonitor =
+      json as any as MonitorStepMetricMonitor;
+
+    /*
+     * Normalize on the way in so no consumer ever receives a half-built
+     * config. Persisted JSON is not schema-checked, so this is the single
+     * choke point where a malformed metricViewConfig becomes renderable.
+     */
+    return {
+      ...monitorStepMetricMonitor,
+      metricViewConfig: this.getMetricViewConfig(monitorStepMetricMonitor),
+      rollingTime:
+        monitorStepMetricMonitor?.rollingTime || RollingTime.Past1Minute,
+    };
   }
 
   public static toJSON(monitor: MonitorStepMetricMonitor): JSONObject {

--- a/Common/UI/Components/ErrorBoundary.tsx
+++ b/Common/UI/Components/ErrorBoundary.tsx
@@ -1,30 +1,246 @@
-import React, { FunctionComponent, ReactElement } from "react";
-import { ErrorBoundary as NativeErrorBoundary } from "react-error-boundary";
+import React, { FunctionComponent, ReactElement, ReactNode } from "react";
+import {
+  ErrorBoundary as NativeErrorBoundary,
+  FallbackProps,
+} from "react-error-boundary";
 
 export interface ComponentProps {
-  children?: ReactElement;
+  children?: ReactNode;
+  /**
+   * When this value changes the boundary clears its error and re-renders its
+   * children. Pass the current route (pathname) so navigating away from a page
+   * that crashed recovers the app instead of stranding the user on the
+   * fallback until they reload.
+   */
+  resetKey?: string | undefined;
+  /** Notified for every caught error. Used by tests and by callers that report. */
+  onError?: ((error: Error) => void) | undefined;
 }
 
-const Fallback: FunctionComponent = () => {
+/**
+ * A code-split chunk that fails to download throws during render, and — with
+ * no boundary above it — takes the entire React tree down with it. This is the
+ * usual cause of an app that "sometimes" goes blank: a user holds a tab open
+ * across a deploy, the hashed chunk filenames they were served no longer
+ * exist, and the next lazy route they visit 404s.
+ *
+ * Browsers word this failure differently, hence the list.
+ */
+const CHUNK_LOAD_ERROR_PATTERNS: Array<RegExp> = [
+  /Loading chunk \S+ failed/i,
+  /Loading CSS chunk \S+ failed/i,
+  /ChunkLoadError/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Unable to preload CSS/i,
+];
+
+/** sessionStorage key holding the timestamp of the last chunk-error reload. */
+export const CHUNK_LOAD_RELOAD_STORAGE_KEY: string =
+  "oneuptime-chunk-load-reload-at";
+
+/**
+ * If a reload does not fix the chunk error, reloading again will not either.
+ * Only auto-reload when the last attempt is older than this, so a genuinely
+ * missing asset degrades to the fallback UI instead of a reload loop.
+ */
+export const CHUNK_LOAD_RELOAD_COOLDOWN_IN_MS: number = 30 * 1000;
+
+export type IsChunkLoadErrorFunction = (error: unknown) => boolean;
+
+export const isChunkLoadError: IsChunkLoadErrorFunction = (
+  error: unknown,
+): boolean => {
+  if (!error) {
+    return false;
+  }
+
+  const name: string =
+    typeof (error as Error).name === "string" ? (error as Error).name : "";
+  const message: string =
+    typeof (error as Error).message === "string"
+      ? (error as Error).message
+      : String(error);
+
+  const text: string = `${name} ${message}`;
+
+  return CHUNK_LOAD_ERROR_PATTERNS.some((pattern: RegExp) => {
+    return pattern.test(text);
+  });
+};
+
+export type HasRecentlyReloadedFunction = (now: number) => boolean;
+
+/**
+ * sessionStorage is unavailable in some privacy modes and throws on access, so
+ * every read/write here is best-effort. Failing to read is treated as "we have
+ * not reloaded yet" — one extra reload is better than a permanently broken page.
+ */
+export const hasRecentlyReloadedForChunkLoadError: HasRecentlyReloadedFunction =
+  (now: number): boolean => {
+    try {
+      const lastReloadedAt: string | null = window.sessionStorage.getItem(
+        CHUNK_LOAD_RELOAD_STORAGE_KEY,
+      );
+
+      if (!lastReloadedAt) {
+        return false;
+      }
+
+      const lastReloadedAtInMs: number = Number(lastReloadedAt);
+
+      if (!Number.isFinite(lastReloadedAtInMs)) {
+        return false;
+      }
+
+      return now - lastReloadedAtInMs < CHUNK_LOAD_RELOAD_COOLDOWN_IN_MS;
+    } catch {
+      return false;
+    }
+  };
+
+export type MarkChunkLoadErrorReloadFunction = (now: number) => void;
+
+export const markChunkLoadErrorReload: MarkChunkLoadErrorReloadFunction = (
+  now: number,
+): void => {
+  try {
+    window.sessionStorage.setItem(
+      CHUNK_LOAD_RELOAD_STORAGE_KEY,
+      now.toString(),
+    );
+  } catch {
+    // Storage is unavailable. The reload still happens, it just is not rate limited.
+  }
+};
+
+export type ReloadPageFunction = () => void;
+
+export const reloadPage: ReloadPageFunction = (): void => {
+  window.location.reload();
+};
+
+/**
+ * Recover from a stale-bundle error by reloading once. Returns true when a
+ * reload was triggered, so the caller knows the fallback is only transient.
+ */
+export type HandleChunkLoadErrorFunction = (error: unknown) => boolean;
+
+export const handleChunkLoadError: HandleChunkLoadErrorFunction = (
+  error: unknown,
+): boolean => {
+  if (!isChunkLoadError(error)) {
+    return false;
+  }
+
+  const now: number = Date.now();
+
+  if (hasRecentlyReloadedForChunkLoadError(now)) {
+    return false;
+  }
+
+  markChunkLoadErrorReload(now);
+  reloadPage();
+
+  return true;
+};
+
+export const Fallback: FunctionComponent<FallbackProps> = (
+  props: FallbackProps,
+): ReactElement => {
+  const errorMessage: string =
+    props.error && typeof props.error.message === "string"
+      ? props.error.message
+      : "";
+
   return (
     <div
-      id="app-loading"
+      role="alert"
+      data-testid="error-boundary-fallback"
       style={{
-        position: "fixed",
-        top: "0",
-        bottom: "0",
-        left: "0",
-        right: "0",
+        minHeight: "60vh",
+        width: "100%",
+        padding: "2rem",
         backgroundColor: "var(--ou-background-primary, #fdfdfd)",
         color: "var(--ou-text-primary, #111827)",
-        zIndex: "999",
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
+        textAlign: "center",
       }}
     >
-      <div>
-        An unexpected error has occurred. Please reload the page to continue
+      <div style={{ maxWidth: "32rem" }}>
+        <div style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
+          An unexpected error has occurred. Please reload the page to continue
+        </div>
+        <div
+          style={{
+            fontSize: "0.875rem",
+            color: "var(--ou-text-secondary, #6b7280)",
+            marginBottom: "1.25rem",
+          }}
+        >
+          The rest of the app is still working. You can retry this page or
+          reload to start fresh.
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "0.75rem",
+            justifyContent: "center",
+          }}
+        >
+          <button
+            type="button"
+            data-testid="error-boundary-try-again"
+            onClick={() => {
+              props.resetErrorBoundary();
+            }}
+            style={{
+              padding: "0.5rem 1rem",
+              borderRadius: "0.375rem",
+              border: "1px solid var(--ou-border-primary, #d1d5db)",
+              backgroundColor: "transparent",
+              color: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            data-testid="error-boundary-reload"
+            onClick={() => {
+              reloadPage();
+            }}
+            style={{
+              padding: "0.5rem 1rem",
+              borderRadius: "0.375rem",
+              border: "1px solid transparent",
+              backgroundColor: "var(--ou-brand-primary, #4f46e5)",
+              color: "#ffffff",
+              cursor: "pointer",
+            }}
+          >
+            Reload page
+          </button>
+        </div>
+        {errorMessage ? (
+          <div
+            data-testid="error-boundary-error-message"
+            style={{
+              marginTop: "1.25rem",
+              fontSize: "0.75rem",
+              color: "var(--ou-text-secondary, #6b7280)",
+              wordBreak: "break-word",
+            }}
+          >
+            {errorMessage}
+          </div>
+        ) : (
+          <></>
+        )}
       </div>
     </div>
   );
@@ -32,9 +248,30 @@ const Fallback: FunctionComponent = () => {
 
 const ErrorBoundary: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
-) => {
+): ReactElement => {
+  type OnErrorFunction = (error: Error) => void;
+
+  const onError: OnErrorFunction = (error: Error): void => {
+    /*
+     * Surface the error. Without this the only trace of a crash is the blank
+     * screen itself, because the boundary swallows what React would otherwise
+     * rethrow to window.onerror (and therefore to RUM).
+     */
+    // eslint-disable-next-line no-console
+    console.error("Uncaught error rendering the app:", error);
+
+    // A stale bundle recovers by reloading, so do that instead of blaming the user.
+    handleChunkLoadError(error);
+
+    props.onError?.(error);
+  };
+
   return (
-    <NativeErrorBoundary FallbackComponent={Fallback}>
+    <NativeErrorBoundary
+      FallbackComponent={Fallback}
+      onError={onError}
+      resetKeys={[props.resetKey]}
+    >
       {props.children}
     </NativeErrorBoundary>
   );


### PR DESCRIPTION
## The bug

Opening a metric monitor painted the whole dashboard white — nav, sidebar and all. From the recording's console:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'queryConfigs')
    at MetricMonitorPreview (AllRoutes-UVI268IV.js:248051:97)
```

(The WebSocket 400s in the same recording are unrelated and untouched here.)

## Why it happened

`MetricMonitorPreview` read:

```ts
props.monitorStepMetricMonitor?.metricViewConfig.queryConfigs || []
```

The optional chain stops at `monitorStepMetricMonitor`. A step that **has** a `metricMonitor` but no `metricViewConfig` therefore dereferences `undefined` and throws *during render*.

That shape is reachable: monitor steps are persisted as free-form JSON and rehydrated with a plain cast (`MonitorStep.fromJSON` → `json["metricMonitor"] as JSONObject`), so nothing at runtime enforces that `metricViewConfig` is present. A step written by an older build, the API, a seed or an import hits it.

**Separately** — and this is what turns a broken widget into a broken product — the repo had an `ErrorBoundary` component that was **mounted nowhere**. With no boundary above it, React unmounts the entire tree on an uncaught render error. One bad component, and the whole app is a blank white page with no way back.

## The fix

### 1. Root cause

- New `MonitorStepMetricMonitorUtil.getMetricViewConfig()` — always returns array-shaped `queryConfigs` / `formulaConfigs`, tolerating a missing/null config or non-array fields.
- `MonitorStepMetricMonitorUtil.fromJSON()` and `MonitorStep.fromJSON()` normalize on the way in, so **every** downstream consumer is safe, not just the preview.
- `MetricMonitorPreview` resolves through the util.

### 2. Blank screen

`ErrorBoundary` is now actually mounted:

- **Route level** in the Dashboard, keyed on `location.pathname` — the master page and nav survive a page crash, and navigating elsewhere clears the error automatically instead of stranding the session.
- **Root level** in all five front-ends (Dashboard, Accounts, AdminDashboard, PublicDashboard, StatusPage) as a last resort.

And the boundary itself was hardened:

- Renders a readable fallback with **Try again** / **Reload page** instead of nothing.
- Logs the error, so a crash still reaches the console and RUM rather than being silently swallowed.
- Detects **stale-bundle chunk-load failures** and reloads once. This is the other common cause of a blank page: a tab held open across a deploy, then a lazy route whose hashed chunk no longer exists. `App.tsx` lazy-loads every route bundle inside a `<Suspense>` that previously had no boundary, so this failed to a white screen too. The reload is rate limited via `sessionStorage`, so a genuinely missing asset degrades to the fallback rather than a reload loop.

## Tests

**`Common/Tests/Types/Monitor/MonitorStepMetricMonitor.test.ts`** — 26 cases:
- the exact crashing shape (`metricMonitor` present, `metricViewConfig` absent)
- null config, partial config, and non-array `queryConfigs` (string / number / object / boolean / null)
- the result survives the precise array reads `MetricView` performs
- no mutation of the input; valid arrays passed through by reference
- `fromJSON` normalization, unknown-key preservation, `toJSON` round trip
- `MonitorStep.fromJSON` end-to-end: a malformed persisted step loads renderable

**`Common/Tests/UI/Components/ErrorBoundary.test.tsx`** — 44 cases:
- containment: throw-on-render and throw-in-effect; siblings outside the boundary keep rendering; nested boundaries; **the document is never left empty**
- recovery: Try again re-renders, Reload reloads, `resetKey` change clears the error, same `resetKey` does not, and a second error is still caught after recovering from the first
- reporting: `onError` fires with the error, the error is logged
- chunk detection across webpack / Vite / Safari / Firefox wordings, with negative cases (notably: the blank-screen `TypeError` must **not** be treated as a chunk error)
- reload throttling: reloads once, **no reload loop** inside the cooldown, cooldown expiry, corrupt timestamps, and `sessionStorage` being unavailable

```
Tests:       70 passed
```

Also verified: all 865 `Common/Tests/Types/Monitor` tests pass, and `App` + `Common` both type-check clean.

## Verification note

The fix is covered by deterministic unit tests that reproduce the exact throw. It was **not** exercised against a running stack — reproducing in-browser needs the full docker-compose environment plus a monitor with the specific malformed step.

## Heads up, not fixed here

`Common/tsconfig.json` does not list `testing-library__jest-dom` in `types`, so `toBeInTheDocument` fails to type-check in **every** Common UI test — including `ErrorBoundary.test.tsx` as it stood on master, which could not compile. The new tests use plain DOM assertions to stay green; repairing the config repo-wide is a separate change since it would make many currently-uncompiled suites start running.