### PR TITLE
feat(dashboard): show the time of day alongside every widget date

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardAlertListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardAlertListComponent.tsx
@@ -18,7 +18,11 @@ import Alert from "Common/Models/DatabaseModels/Alert";
 import API from "Common/UI/Utils/API/API";
 import IconProp from "Common/Types/Icon/IconProp";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import OneUptimeDate from "Common/Types/Date";
+import {
+  DashboardDateTime,
+  getDashboardDateTime,
+  getDashboardDateTimeLabel,
+} from "../Utils/DashboardDateTime";
 import Query from "Common/Types/BaseDatabase/Query";
 import Includes from "Common/Types/BaseDatabase/Includes";
 import JSONFunctions from "Common/Types/JSONFunctions";
@@ -35,10 +39,11 @@ export interface ComponentProps extends DashboardBaseComponentProps {
 }
 
 const COLUMNS: Array<ResourceListColumn> = [
-  { label: "Title", widthPct: "45%" },
-  { label: "State", widthPct: "20%" },
+  { label: "Title", widthPct: "40%" },
+  { label: "State", widthPct: "17%" },
   { label: "Severity", widthPct: "15%" },
-  { label: "Created", widthPct: "20%" },
+  // Wider than the other columns because it carries a date *and* a time.
+  { label: "Created", widthPct: "28%" },
 ];
 
 const DashboardAlertListComponentElement: FunctionComponent<ComponentProps> = (
@@ -194,6 +199,16 @@ const DashboardAlertListComponentElement: FunctionComponent<ComponentProps> = (
           details: [
             { label: "State", value: stateName },
             { label: "Severity", value: severityName },
+            /*
+             * Honeycomb mode has no "Created" column, so without this the tile
+             * view is the one place a user cannot tell when an alert fired.
+             */
+            {
+              label: "Created",
+              value: getDashboardDateTimeLabel(
+                alert.createdAt as unknown as string | undefined,
+              ),
+            },
           ],
         },
       };
@@ -210,9 +225,9 @@ const DashboardAlertListComponentElement: FunctionComponent<ComponentProps> = (
     const severityColor: Color | undefined = alert.alertSeverity?.color as
       | Color
       | undefined;
-    const created: Date | undefined = alert.createdAt
-      ? OneUptimeDate.fromString(alert.createdAt as unknown as string)
-      : undefined;
+    const created: DashboardDateTime = getDashboardDateTime(
+      alert.createdAt as unknown as string | undefined,
+    );
 
     const detailRoute: Route = RouteUtil.populateRouteParams(
       RouteMap[PageMap.ALERT_VIEW] as Route,
@@ -261,10 +276,11 @@ const DashboardAlertListComponentElement: FunctionComponent<ComponentProps> = (
             {severityName}
           </span>
         </td>
-        <td className="px-3 py-2 text-xs text-gray-500 tabular-nums">
-          {created
-            ? OneUptimeDate.getDateAsLocalFormattedString(created, true)
-            : "—"}
+        <td
+          className="px-3 py-2 text-xs text-gray-500 tabular-nums whitespace-nowrap"
+          title={created.title}
+        >
+          {created.label}
         </td>
       </tr>
     );

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardHostListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardHostListComponent.tsx
@@ -30,6 +30,10 @@ import AppLink from "../../AppLink/AppLink";
 import Route from "Common/Types/API/Route";
 import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
+import {
+  getDashboardDateTime,
+  getDashboardDateTimeLabel,
+} from "../Utils/DashboardDateTime";
 import DashboardModelQueryInterpolation, {
   AttributeToColumnMap,
 } from "Common/Utils/Dashboard/ModelQueryVariableInterpolation";
@@ -217,6 +221,12 @@ const DashboardHostListComponentElement: FunctionComponent<ComponentProps> = (
             },
             { label: "CPU / Mem", value: cpuMem },
             { label: "Last Seen", value: formatRelative(lastSeenAt) },
+            /*
+             * formatRelative buckets to whole days, so "2d ago" covers a
+             * 24-hour spread. The tooltip is itself a hover surface and has
+             * nowhere to hang a title, so the exact instant gets its own row.
+             */
+            { label: "At", value: getDashboardDateTimeLabel(lastSeenAt) },
           ],
         },
       };
@@ -289,7 +299,11 @@ const DashboardHostListComponentElement: FunctionComponent<ComponentProps> = (
         <td className="px-3 py-2 text-xs text-gray-600 tabular-nums truncate">
           {cpuMem}
         </td>
-        <td className="px-3 py-2 text-xs text-gray-500 tabular-nums truncate">
+        {/* The column has no room for the instant; hover gives it up. */}
+        <td
+          className="px-3 py-2 text-xs text-gray-500 tabular-nums truncate"
+          title={getDashboardDateTime(lastSeenAt).title}
+        >
           {formatRelative(lastSeenAt)}
         </td>
       </tr>

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardIncidentListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardIncidentListComponent.tsx
@@ -18,7 +18,11 @@ import Incident from "Common/Models/DatabaseModels/Incident";
 import API from "Common/UI/Utils/API/API";
 import IconProp from "Common/Types/Icon/IconProp";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import OneUptimeDate from "Common/Types/Date";
+import {
+  DashboardDateTime,
+  getDashboardDateTime,
+  getDashboardDateTimeLabel,
+} from "../Utils/DashboardDateTime";
 import Query from "Common/Types/BaseDatabase/Query";
 import Includes from "Common/Types/BaseDatabase/Includes";
 import JSONFunctions from "Common/Types/JSONFunctions";
@@ -35,10 +39,11 @@ export interface ComponentProps extends DashboardBaseComponentProps {
 }
 
 const COLUMNS: Array<ResourceListColumn> = [
-  { label: "Title", widthPct: "45%" },
-  { label: "State", widthPct: "20%" },
+  { label: "Title", widthPct: "40%" },
+  { label: "State", widthPct: "17%" },
   { label: "Severity", widthPct: "15%" },
-  { label: "Declared", widthPct: "20%" },
+  // Wider than the other columns because it carries a date *and* a time.
+  { label: "Declared", widthPct: "28%" },
 ];
 
 const DashboardIncidentListComponentElement: FunctionComponent<
@@ -196,6 +201,17 @@ const DashboardIncidentListComponentElement: FunctionComponent<
           details: [
             { label: "State", value: stateName },
             { label: "Severity", value: severityName },
+            /*
+             * Honeycomb mode has no "Declared" column, so without this the
+             * tile view is the one place a user cannot tell when an incident
+             * started.
+             */
+            {
+              label: "Declared",
+              value: getDashboardDateTimeLabel(
+                incident.createdAt as unknown as string | undefined,
+              ),
+            },
           ],
         },
       };
@@ -213,9 +229,9 @@ const DashboardIncidentListComponentElement: FunctionComponent<
         (incident.incidentSeverity?.name as string) || "—";
       const severityColor: Color | undefined = incident.incidentSeverity
         ?.color as Color | undefined;
-      const created: Date | undefined = incident.createdAt
-        ? OneUptimeDate.fromString(incident.createdAt as unknown as string)
-        : undefined;
+      const declared: DashboardDateTime = getDashboardDateTime(
+        incident.createdAt as unknown as string | undefined,
+      );
 
       const detailRoute: Route = RouteUtil.populateRouteParams(
         RouteMap[PageMap.INCIDENT_VIEW] as Route,
@@ -268,10 +284,11 @@ const DashboardIncidentListComponentElement: FunctionComponent<
               {severityName}
             </span>
           </td>
-          <td className="px-3 py-2 text-xs text-gray-500 tabular-nums">
-            {created
-              ? OneUptimeDate.getDateAsLocalFormattedString(created, true)
-              : "—"}
+          <td
+            className="px-3 py-2 text-xs text-gray-500 tabular-nums whitespace-nowrap"
+            title={declared.title}
+          >
+            {declared.label}
           </td>
         </tr>
       );

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardLogStreamComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardLogStreamComponent.tsx
@@ -18,7 +18,10 @@ import IconProp from "Common/Types/Icon/IconProp";
 import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEndDateTime";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import OneUptimeDate from "Common/Types/Date";
+import {
+  DashboardDateTime,
+  getDashboardDateTime,
+} from "../Utils/DashboardDateTime";
 import Query from "Common/Types/BaseDatabase/Query";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import {
@@ -244,9 +247,13 @@ const DashboardLogStreamComponentElement: FunctionComponent<ComponentProps> = (
               (log.severityText as string) || "Unspecified";
             const colors: SeverityColor = getSeverityColor(severity);
             const body: string = (log.body as string) || "";
-            const time: Date | undefined = log.time
-              ? OneUptimeDate.fromString(log.time as unknown as string)
-              : undefined;
+            const time: DashboardDateTime | null = log.time
+              ? getDashboardDateTime(
+                  log.time as unknown as string,
+                  // Log lines arrive seconds apart; the minute alone cannot order them.
+                  { showSeconds: true },
+                )
+              : null;
 
             return (
               <div
@@ -266,10 +273,11 @@ const DashboardLogStreamComponentElement: FunctionComponent<ComponentProps> = (
                 </div>
                 {time && (
                   <span
-                    className="text-xs text-gray-400 shrink-0 tabular-nums"
+                    className="text-xs text-gray-400 shrink-0 tabular-nums whitespace-nowrap"
                     style={{ fontSize: "11px" }}
+                    title={time.title}
                   >
-                    {OneUptimeDate.getDateAsLocalFormattedString(time, true)}
+                    {time.label}
                   </span>
                 )}
                 <span

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTableComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTableComponent.tsx
@@ -27,6 +27,10 @@ import Icon from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
 import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEndDateTime";
 import OneUptimeDate from "Common/Types/Date";
+import {
+  DashboardDateTime,
+  getDashboardDateTime,
+} from "../Utils/DashboardDateTime";
 import DashboardVariableInterpolation from "Common/Utils/Dashboard/VariableInterpolation";
 
 export interface ComponentProps extends DashboardBaseComponentProps {
@@ -468,6 +472,7 @@ const DashboardTableComponentElement: FunctionComponent<ComponentProps> = (
   const timestampRows: Array<{
     timestampIso: string;
     timestampLabel: string;
+    timestampTitle: string;
     valuesByColumnKey: Map<string, number>;
   }> = useMemo(() => {
     if (isGroupedMode) {
@@ -500,11 +505,13 @@ const DashboardTableComponentElement: FunctionComponent<ComponentProps> = (
     };
     const rows: Array<TimestampRow> = [];
     for (const [iso, perColumn] of timestampToValues) {
+      // Same date + time shape every other widget's timestamp column uses.
+      const timestamp: DashboardDateTime = getDashboardDateTime(iso);
+
       rows.push({
         timestampIso: iso,
-        timestampLabel: OneUptimeDate.getDateAsLocalFormattedString(
-          OneUptimeDate.fromString(iso),
-        ),
+        timestampLabel: timestamp.label,
+        timestampTitle: timestamp.title,
         valuesByColumnKey: perColumn,
       });
     }
@@ -834,7 +841,10 @@ const DashboardTableComponentElement: FunctionComponent<ComponentProps> = (
                       key={`${row.timestampIso}-${index}`}
                       className="hover:bg-gray-50/50 transition-colors duration-100"
                     >
-                      <td className="px-3 py-2 text-gray-500 text-xs whitespace-nowrap">
+                      <td
+                        className="px-3 py-2 text-gray-500 text-xs whitespace-nowrap"
+                        title={row.timestampTitle}
+                      >
                         {row.timestampLabel}
                       </td>
                       {visibleValueColumns.map(

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceListComponent.tsx
@@ -25,7 +25,11 @@ import IconProp from "Common/Types/Icon/IconProp";
 import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEndDateTime";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import OneUptimeDate from "Common/Types/Date";
+import {
+  DashboardDateTime,
+  getDashboardDateTime,
+  getDashboardDateTimeLabel,
+} from "../Utils/DashboardDateTime";
 import Query from "Common/Types/BaseDatabase/Query";
 import JSONFunctions from "Common/Types/JSONFunctions";
 
@@ -34,10 +38,11 @@ export interface ComponentProps extends DashboardBaseComponentProps {
 }
 
 const COLUMNS: Array<ResourceListColumn> = [
-  { label: "Span Name", widthPct: "35%" },
-  { label: "Duration", widthPct: "20%" },
+  { label: "Span Name", widthPct: "32%" },
+  { label: "Duration", widthPct: "18%" },
   { label: "Status", widthPct: "15%" },
-  { label: "Time", widthPct: "30%" },
+  // Wider than the other columns because it carries a date *and* a time.
+  { label: "Time", widthPct: "35%" },
 ];
 
 const STATUS_COLORS: Record<number, { color: string; label: string }> = {
@@ -182,9 +187,11 @@ const DashboardTraceListComponentElement: FunctionComponent<ComponentProps> = (
       const statusInfo: { color: string; label: string } =
         STATUS_COLORS[statusCode] || STATUS_COLORS[SpanStatus.Unset]!;
       const durationNano: number = (span.durationUnixNano as number) || 0;
-      const startTime: Date | undefined = span.startTime
-        ? OneUptimeDate.fromString(span.startTime as unknown as string)
-        : undefined;
+      const startTimeLabel: string = getDashboardDateTimeLabel(
+        span.startTime as unknown as string | undefined,
+        // Spans are sub-second events, so the second is worth showing.
+        { showSeconds: true },
+      );
       const id: string =
         (span.spanId as string) || (span.traceId as string) || `${index}`;
 
@@ -198,9 +205,7 @@ const DashboardTraceListComponentElement: FunctionComponent<ComponentProps> = (
             { label: "Duration", value: formatDuration(durationNano) },
             {
               label: "Time",
-              value: startTime
-                ? OneUptimeDate.getDateAsLocalFormattedString(startTime, true)
-                : "—",
+              value: startTimeLabel,
             },
           ],
         },
@@ -214,9 +219,11 @@ const DashboardTraceListComponentElement: FunctionComponent<ComponentProps> = (
         (span.statusCode as number) || SpanStatus.Unset;
       const statusStyle: StatusStyle = getStatusStyle(statusCode);
       const durationNano: number = (span.durationUnixNano as number) || 0;
-      const startTime: Date | undefined = span.startTime
-        ? OneUptimeDate.fromString(span.startTime as unknown as string)
-        : undefined;
+      const startTime: DashboardDateTime = getDashboardDateTime(
+        span.startTime as unknown as string | undefined,
+        // Spans are sub-second events, so the second is worth showing.
+        { showSeconds: true },
+      );
 
       return (
         <tr
@@ -237,10 +244,11 @@ const DashboardTraceListComponentElement: FunctionComponent<ComponentProps> = (
               {statusStyle.label}
             </span>
           </td>
-          <td className="px-3 py-2 text-xs text-gray-500 tabular-nums">
-            {startTime
-              ? OneUptimeDate.getDateAsLocalFormattedString(startTime, true)
-              : "—"}
+          <td
+            className="px-3 py-2 text-xs text-gray-500 tabular-nums whitespace-nowrap"
+            title={startTime.title}
+          >
+            {startTime.label}
           </td>
         </tr>
       );

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime.ts
@@ -1,0 +1,113 @@
+import OneUptimeDate from "Common/Types/Date";
+
+/**
+ * Every timestamp a dashboard widget shows goes through here.
+ *
+ * Widgets used to print bare dates ("Jul 16, 2026"), which is unusable on a
+ * dashboard: three incidents declared on the same day all read identically,
+ * and a log stream where every line carries the same date tells you nothing.
+ * So a widget timestamp is always date *and* time of day.
+ *
+ * Widget columns are narrow, so the visible label stays compact (no timezone
+ * abbreviation, no seconds unless the surface needs them) and the full,
+ * timezone-qualified, second-precision timestamp goes in the cell's `title`
+ * so it is one hover away.
+ *
+ * Both parts resolve through OneUptimeDate's current-timezone helpers, so a
+ * user who picked a timezone in User Settings reads that wall clock here too,
+ * and the date and the time can never disagree about which zone they are in.
+ */
+
+// What a cell shows when there is no usable timestamp.
+export const NO_DATE_LABEL: string = "—";
+
+export interface DashboardDateTime {
+  // Compact, for the cell itself: "Jul 16, 2026 14:32".
+  label: string;
+  // Full precision, for the cell's title attribute: "Jul 16 2026, 14:32:05 PDT".
+  title: string;
+}
+
+export interface DashboardDateTimeOptions {
+  /*
+   * Surfaces where sub-minute ordering matters (log lines, spans) put seconds
+   * in the visible label too.
+   */
+  showSeconds?: boolean | undefined;
+}
+
+/**
+ * Anything a widget hands us — a Date, an ISO string off the API, null,
+ * undefined, or junk — resolved to a Date we can format, or null.
+ */
+function toDisplayableDate(
+  date: Date | string | null | undefined,
+): Date | null {
+  if (date === null || date === undefined || date === "") {
+    return null;
+  }
+
+  let parsed: Date;
+
+  try {
+    parsed = OneUptimeDate.fromString(date);
+  } catch {
+    // fromString throws on a value that is not a Date, string or date JSON.
+    return null;
+  }
+
+  if (!(parsed instanceof Date) || Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * The label + hover title a widget should render for a timestamp. Never
+ * throws: an absent or unparseable date yields the placeholder and no title.
+ */
+export function getDashboardDateTime(
+  date: Date | string | null | undefined,
+  options?: DashboardDateTimeOptions | undefined,
+): DashboardDateTime {
+  const displayableDate: Date | null = toDisplayableDate(date);
+
+  if (!displayableDate) {
+    return {
+      label: NO_DATE_LABEL,
+      title: "",
+    };
+  }
+
+  const datePart: string = OneUptimeDate.getDateAsLocalFormattedString(
+    displayableDate,
+    true,
+  );
+
+  const timePart: string = OneUptimeDate.getLocalTimeString(displayableDate, {
+    includeMinutes: true,
+    includeSeconds: options?.showSeconds === true,
+  });
+
+  return {
+    label: `${datePart} ${timePart}`,
+    title: OneUptimeDate.getDateAsLocalFormattedString(
+      displayableDate,
+      false, // onlyShowDate
+      false, // use12HourFormat
+      true, // showSeconds
+    ),
+  };
+}
+
+/**
+ * The visible label on its own, for surfaces that have nowhere to hang a
+ * title attribute (honeycomb tooltip rows, for example).
+ */
+export function getDashboardDateTimeLabel(
+  date: Date | string | null | undefined,
+  options?: DashboardDateTimeOptions | undefined,
+): string {
+  return getDashboardDateTime(date, options).label;
+}

--- a/App/Tests/Dashboard/DashboardDateTime.test.ts
+++ b/App/Tests/Dashboard/DashboardDateTime.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Dashboard widgets used to print a bare date — "Jul 16, 2026" — in every
+ * timestamp column. On a dashboard that is close to useless: three incidents
+ * declared on the same day read identically, and a log stream repeats one
+ * date down the whole pane. Every widget timestamp now goes through
+ * DashboardDateTime, which pairs the date with a time of day.
+ *
+ * These tests lock in that pairing, and — just as importantly — that the date
+ * half and the time half can never disagree about which timezone they are in.
+ * They are written in explicit-zone wall clock so they hold under whatever TZ
+ * the suite happens to run in.
+ */
+import OneUptimeDate, { Moment } from "Common/Types/Date";
+import Timezone from "Common/Types/Timezone";
+import {
+  DashboardDateTime,
+  NO_DATE_LABEL,
+  getDashboardDateTime,
+  getDashboardDateTimeLabel,
+} from "../../FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime";
+
+const NY: Timezone = Timezone.AmericaNew_York;
+const LA: Timezone = Timezone.AmericaLos_Angeles;
+const KOLKATA: Timezone = Timezone.AsiaKolkata;
+const KATHMANDU: Timezone = Timezone.AsiaKathmandu;
+const LONDON: Timezone = Timezone.EuropeLondon;
+const UTC: Timezone = Timezone.UTC;
+
+/*
+ * 2026-07-16T21:32:05Z. Deliberately late enough in UTC that the calendar
+ * DATE differs between zones — which is exactly how a date/time pair that
+ * formats its two halves in different zones gets caught.
+ */
+const INSTANT: Date = new Date("2026-07-16T21:32:05.000Z");
+
+// "MMM DD, YYYY HH:mm" with an optional ":ss".
+const LABEL_SHAPE: RegExp = /^[A-Z][a-z]{2} \d{2}, \d{4} \d{2}:\d{2}(:\d{2})?$/;
+
+describe("DashboardDateTime", () => {
+  afterEach(() => {
+    // Never leak a timezone override into another test.
+    OneUptimeDate.setUserTimezone(null);
+  });
+
+  describe("the label pairs a date with a time", () => {
+    it("shows the time of day next to the date", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      expect(getDashboardDateTime(INSTANT).label).toBe("Jul 16, 2026 14:32");
+    });
+
+    it("keeps the date half byte-identical to the old date-only rendering", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      /*
+       * The regression this guards: widening the format must not quietly
+       * restyle the date itself (e.g. to "Jul 16 2026" or "16 Jul 2026").
+       */
+      const dateOnly: string = OneUptimeDate.getDateAsLocalFormattedString(
+        INSTANT,
+        true,
+      );
+
+      expect(getDashboardDateTime(INSTANT).label.startsWith(dateOnly)).toBe(
+        true,
+      );
+      expect(dateOnly).toBe("Jul 16, 2026");
+    });
+
+    it("is never just a date — a time is always appended", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      const label: string = getDashboardDateTime(INSTANT).label;
+
+      expect(label).not.toBe(
+        OneUptimeDate.getDateAsLocalFormattedString(INSTANT, true),
+      );
+      expect(label).toMatch(LABEL_SHAPE);
+    });
+
+    it("omits seconds by default", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      expect(getDashboardDateTime(INSTANT).label).not.toContain(":05");
+    });
+
+    it("includes seconds when the surface asks for them", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      expect(getDashboardDateTime(INSTANT, { showSeconds: true }).label).toBe(
+        "Jul 16, 2026 14:32:05",
+      );
+    });
+
+    it("treats showSeconds: false and an absent option the same", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      expect(getDashboardDateTime(INSTANT, { showSeconds: false }).label).toBe(
+        getDashboardDateTime(INSTANT).label,
+      );
+    });
+
+    it("carries no stray leading or trailing whitespace", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      const label: string = getDashboardDateTime(INSTANT).label;
+
+      expect(label).toBe(label.trim());
+    });
+  });
+
+  describe("the title carries the full, unambiguous timestamp", () => {
+    it("adds seconds and the timezone the label leaves off", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      expect(getDashboardDateTime(INSTANT).title).toBe(
+        "Jul 16 2026, 14:32:05 PDT",
+      );
+    });
+
+    it("names the timezone so a bare wall clock is never ambiguous", () => {
+      OneUptimeDate.setUserTimezone(KOLKATA);
+
+      expect(getDashboardDateTime(INSTANT).title).toContain(
+        OneUptimeDate.getCurrentTimezoneString(),
+      );
+    });
+
+    it("is the same whether or not the label shows seconds", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      expect(getDashboardDateTime(INSTANT, { showSeconds: true }).title).toBe(
+        getDashboardDateTime(INSTANT).title,
+      );
+    });
+
+    it("stays 24-hour, matching the label", () => {
+      OneUptimeDate.setUserTimezone(LA);
+
+      const title: string = getDashboardDateTime(INSTANT).title;
+
+      expect(title).not.toContain("PM");
+      expect(title).not.toContain("AM");
+    });
+  });
+
+  describe("timezone resolution", () => {
+    it("reads the wall clock of the timezone the user picked in settings", () => {
+      OneUptimeDate.setUserTimezone(NY);
+      const newYork: DashboardDateTime = getDashboardDateTime(INSTANT);
+
+      OneUptimeDate.setUserTimezone(LA);
+      const losAngeles: DashboardDateTime = getDashboardDateTime(INSTANT);
+
+      // Same instant, two zones, three hours apart.
+      expect(newYork.label).toBe("Jul 16, 2026 17:32");
+      expect(losAngeles.label).toBe("Jul 16, 2026 14:32");
+    });
+
+    it("falls back to the process/browser zone when the user picked none", () => {
+      OneUptimeDate.setUserTimezone(null);
+
+      /*
+       * Computed straight from moment rather than from OneUptimeDate, so this
+       * fails if the fallback ever resolves to some other zone instead of
+       * agreeing with itself.
+       */
+      expect(getDashboardDateTime(INSTANT).label).toBe(
+        Moment.tz(INSTANT, Moment.tz.guess()).format("MMM DD, YYYY HH:mm"),
+      );
+    });
+
+    it("prefers the user timezone over the process/browser zone", () => {
+      /*
+       * Pick a zone the process is definitely not in, so the assertion cannot
+       * pass by accident on a machine that happens to run in it.
+       */
+      const processZone: string = Moment.tz.guess();
+      const elsewhere: Timezone =
+        processZone === KOLKATA.toString() ? NY : KOLKATA;
+
+      OneUptimeDate.setUserTimezone(elsewhere);
+
+      expect(getDashboardDateTime(INSTANT).label).toBe(
+        Moment.tz(INSTANT, elsewhere.toString()).format("MMM DD, YYYY HH:mm"),
+      );
+      expect(getDashboardDateTime(INSTANT).label).not.toBe(
+        Moment.tz(INSTANT, processZone).format("MMM DD, YYYY HH:mm"),
+      );
+    });
+
+    it("moves the DATE too when the zone pushes past midnight", () => {
+      /*
+       * 21:32 UTC is still the 16th in Los Angeles but already the 17th in
+       * Kolkata. A date formatted in one zone and a time in another would
+       * produce "Jul 16, 2026 03:02" here — the bug this test exists for.
+       */
+      OneUptimeDate.setUserTimezone(KOLKATA);
+
+      expect(getDashboardDateTime(INSTANT).label).toBe("Jul 17, 2026 03:02");
+    });
+
+    it("keeps date and time in the same zone across a year boundary", () => {
+      const newYearsEve: Date = new Date("2026-12-31T23:30:00.000Z");
+      OneUptimeDate.setUserTimezone(Timezone.AustraliaSydney);
+
+      // Sydney is already in 2027 while UTC is still in 2026.
+      expect(getDashboardDateTime(newYearsEve).label).toBe(
+        "Jan 01, 2027 10:30",
+      );
+    });
+
+    it("handles zones at a half-hour offset", () => {
+      OneUptimeDate.setUserTimezone(KOLKATA);
+
+      // +05:30 — the minutes must shift, not just the hours.
+      expect(getDashboardDateTime(INSTANT).label).toContain("03:02");
+    });
+
+    it("handles zones at a quarter-hour offset", () => {
+      OneUptimeDate.setUserTimezone(KATHMANDU);
+
+      // +05:45.
+      expect(getDashboardDateTime(INSTANT).label).toBe("Jul 17, 2026 03:17");
+    });
+
+    it("renders a UTC user exactly the UTC wall clock", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      expect(getDashboardDateTime(INSTANT).label).toBe("Jul 16, 2026 21:32");
+    });
+  });
+
+  describe("daylight saving time", () => {
+    const WINTER: Date = new Date("2026-01-15T18:00:00.000Z");
+    const SUMMER: Date = new Date("2026-07-15T18:00:00.000Z");
+
+    it("shifts the wall clock across the DST boundary", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      // Same 18:00Z: EST (-5) in January, EDT (-4) in July.
+      expect(getDashboardDateTime(WINTER).label).toBe("Jan 15, 2026 13:00");
+      expect(getDashboardDateTime(SUMMER).label).toBe("Jul 15, 2026 14:00");
+    });
+
+    it("names the abbreviation in effect on that date, not today's", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      expect(getDashboardDateTime(WINTER).title).toContain("EST");
+      expect(getDashboardDateTime(SUMMER).title).toContain("EDT");
+    });
+
+    it("survives the spring-forward gap", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      // 2026-03-08 07:00Z — the instant New York jumps 01:59 -> 03:00.
+      const springForward: Date = new Date("2026-03-08T07:00:00.000Z");
+
+      expect(getDashboardDateTime(springForward).label).toBe(
+        "Mar 08, 2026 03:00",
+      );
+    });
+
+    it("distinguishes the two passes of a fall-back hour", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      // 01:30 local happens twice on 2026-11-01: once at 05:30Z, once at 06:30Z.
+      const firstPass: Date = new Date("2026-11-01T05:30:00.000Z");
+      const secondPass: Date = new Date("2026-11-01T06:30:00.000Z");
+
+      expect(getDashboardDateTime(firstPass).label).toBe("Nov 01, 2026 01:30");
+      expect(getDashboardDateTime(secondPass).label).toBe("Nov 01, 2026 01:30");
+      // The wall clocks collide; the titles must not.
+      expect(getDashboardDateTime(firstPass).title).toContain("EDT");
+      expect(getDashboardDateTime(secondPass).title).toContain("EST");
+    });
+
+    it("renders London's summer offset, not a fixed GMT", () => {
+      OneUptimeDate.setUserTimezone(LONDON);
+
+      expect(getDashboardDateTime(SUMMER).label).toBe("Jul 15, 2026 19:00");
+    });
+  });
+
+  describe("clock edges", () => {
+    it("renders midnight as 00:00, never 24:00 and never blank", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      const midnight: Date = new Date("2026-07-16T00:00:00.000Z");
+      const label: string = getDashboardDateTime(midnight).label;
+
+      expect(label).toBe("Jul 16, 2026 00:00");
+      expect(label).not.toContain("24:");
+    });
+
+    it("renders noon as 12:00 on a 24-hour clock", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      expect(
+        getDashboardDateTime(new Date("2026-07-16T12:00:00.000Z")).label,
+      ).toBe("Jul 16, 2026 12:00");
+    });
+
+    it("renders the last minute of the day as 23:59", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      expect(
+        getDashboardDateTime(new Date("2026-07-16T23:59:59.000Z")).label,
+      ).toBe("Jul 16, 2026 23:59");
+    });
+
+    it("zero-pads single-digit hours, minutes and seconds", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      expect(
+        getDashboardDateTime(new Date("2026-07-06T04:05:06.000Z"), {
+          showSeconds: true,
+        }).label,
+      ).toBe("Jul 06, 2026 04:05:06");
+    });
+
+    it("does not round a timestamp up to the next minute", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      // 14:32:59 is still 14:32, not 14:33.
+      expect(
+        getDashboardDateTime(new Date("2026-07-16T14:32:59.000Z")).label,
+      ).toBe("Jul 16, 2026 14:32");
+    });
+
+    it("renders a leap day", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      expect(
+        getDashboardDateTime(new Date("2028-02-29T08:15:00.000Z")).label,
+      ).toBe("Feb 29, 2028 08:15");
+    });
+  });
+
+  describe("input shapes", () => {
+    it("accepts an ISO string and a Date interchangeably", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      expect(getDashboardDateTime("2026-07-16T21:32:05.000Z")).toEqual(
+        getDashboardDateTime(INSTANT),
+      );
+    });
+
+    it("accepts an ISO string without milliseconds", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      expect(getDashboardDateTime("2026-07-16T21:32:05Z").label).toBe(
+        "Jul 16, 2026 17:32",
+      );
+    });
+
+    it("reads an offset-bearing string as the instant it names", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      // 17:32-04:00 is 21:32Z.
+      expect(getDashboardDateTime("2026-07-16T17:32:05-04:00").label).toBe(
+        "Jul 16, 2026 21:32",
+      );
+    });
+  });
+
+  describe("missing and unusable timestamps", () => {
+    const CASES: Array<[string, Date | string | null | undefined]> = [
+      ["null", null],
+      ["undefined", undefined],
+      ["an empty string", ""],
+      ["an invalid Date", new Date("nonsense")],
+    ];
+
+    for (const [name, value] of CASES) {
+      it(`renders the placeholder for ${name}`, () => {
+        OneUptimeDate.setUserTimezone(NY);
+
+        const result: DashboardDateTime = getDashboardDateTime(value);
+
+        expect(result.label).toBe(NO_DATE_LABEL);
+        expect(result.title).toBe("");
+      });
+    }
+
+    it("renders the placeholder for an unparseable string instead of 'Invalid date'", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      const result: DashboardDateTime = getDashboardDateTime("not-a-date");
+
+      expect(result.label).toBe(NO_DATE_LABEL);
+      expect(result.label).not.toContain("Invalid");
+    });
+
+    it("never throws on a value the API should not have sent", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      const junk: Array<unknown> = [
+        {},
+        [],
+        NaN,
+        0,
+        true,
+        Number.POSITIVE_INFINITY,
+      ];
+
+      for (const value of junk) {
+        expect(() => {
+          return getDashboardDateTime(value as unknown as Date);
+        }).not.toThrow();
+      }
+    });
+
+    it("keeps the placeholder free of a hover title", () => {
+      /*
+       * A title on a placeholder would show an empty or bogus tooltip on
+       * hover, so the widget must get nothing to hang there.
+       */
+      expect(getDashboardDateTime(null).title).toBe("");
+    });
+  });
+
+  describe("getDashboardDateTimeLabel", () => {
+    it("returns exactly the label half", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      expect(getDashboardDateTimeLabel(INSTANT)).toBe(
+        getDashboardDateTime(INSTANT).label,
+      );
+    });
+
+    it("forwards the seconds option", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      expect(getDashboardDateTimeLabel(INSTANT, { showSeconds: true })).toBe(
+        "Jul 16, 2026 17:32:05",
+      );
+    });
+
+    it("returns the placeholder for a missing date", () => {
+      expect(getDashboardDateTimeLabel(undefined)).toBe(NO_DATE_LABEL);
+    });
+  });
+
+  describe("consistency across widgets", () => {
+    it("gives every widget the same shape for the same instant", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      /*
+       * The incident, alert, trace, log-stream and table widgets all render
+       * timestamps side by side on one dashboard. Two of them disagreeing on
+       * format is the thing this helper exists to prevent.
+       */
+      const withoutSeconds: string = getDashboardDateTimeLabel(INSTANT);
+      const withSeconds: string = getDashboardDateTimeLabel(INSTANT, {
+        showSeconds: true,
+      });
+
+      expect(withoutSeconds).toMatch(LABEL_SHAPE);
+      expect(withSeconds).toMatch(LABEL_SHAPE);
+      expect(withSeconds.startsWith(withoutSeconds)).toBe(true);
+    });
+
+    it("orders lexicographically the same way it orders chronologically within a month", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      /*
+       * Widgets list rows newest-first. Two rows a minute apart must not
+       * render an identical label, or the ordering looks broken to the user.
+       */
+      const earlier: string = getDashboardDateTimeLabel(
+        new Date("2026-07-16T14:32:00.000Z"),
+      );
+      const later: string = getDashboardDateTimeLabel(
+        new Date("2026-07-16T14:33:00.000Z"),
+      );
+
+      expect(earlier).not.toBe(later);
+    });
+
+    it("distinguishes two events on the same day — the whole point of the change", () => {
+      OneUptimeDate.setUserTimezone(UTC);
+
+      const morning: string = getDashboardDateTimeLabel(
+        new Date("2026-07-16T09:05:00.000Z"),
+      );
+      const evening: string = getDashboardDateTimeLabel(
+        new Date("2026-07-16T19:45:00.000Z"),
+      );
+
+      expect(morning).not.toBe(evening);
+      expect(morning).toContain("Jul 16, 2026");
+      expect(evening).toContain("Jul 16, 2026");
+    });
+  });
+});

--- a/App/Tests/Dashboard/DashboardWidgetTimestamps.test.ts
+++ b/App/Tests/Dashboard/DashboardWidgetTimestamps.test.ts
@@ -1,0 +1,370 @@
+/**
+ * A source-level guard for the whole dashboard widget family.
+ *
+ * DashboardDateTime.test.ts proves the helper formats correctly; nothing there
+ * stops a new widget from going back to printing a bare date. This does: it
+ * reads every widget component and fails if one asks OneUptimeDate for a
+ * date-only string, which is how "Jul 16, 2026" got into five widgets in the
+ * first place.
+ *
+ * The widgets themselves are React components that need a browser to render,
+ * and this suite runs under jest's node environment — so the check is static.
+ */
+import fs from "fs";
+import path from "path";
+
+const COMPONENTS_DIR: string = path.join(
+  __dirname,
+  "../../FeatureSet/Dashboard/src/Components/Dashboard/Components",
+);
+
+const UTILS_DIR: string = path.join(
+  __dirname,
+  "../../FeatureSet/Dashboard/src/Components/Dashboard/Utils",
+);
+
+/*
+ * Every way OneUptimeDate can be asked for a date with no time of day.
+ *
+ * Two take `onlyShowDate` as their second positional argument...
+ */
+const POSITIONAL_FORMATTERS: Array<string> = [
+  "getDateAsLocalFormattedString",
+  "getDateAsUserFriendlyLocalFormattedString",
+];
+
+// ...two take it inside an options object...
+const OPTIONS_FORMATTERS: Array<string> = [
+  "getDateAsFormattedString",
+  "getDateAsUserFriendlyFormattedString",
+];
+
+// ...and one is a wrapper that always passes it.
+const DATE_ONLY_WRAPPERS: Array<string> = ["OneUptimeDate.getDateString"];
+
+const DATE_ONLY_OPTION: RegExp = /onlyShowDate\s*:\s*true/;
+
+// A rendered label paired with its full timestamp on hover.
+const LABEL_WITH_HOVER_TITLE: RegExp = /title=\{[^}]*[Tt]itle\}/;
+
+interface SourceFile {
+  name: string;
+  contents: string;
+}
+
+function readSourceFiles(directory: string): Array<SourceFile> {
+  return fs
+    .readdirSync(directory)
+    .filter((name: string): boolean => {
+      return name.endsWith(".ts") || name.endsWith(".tsx");
+    })
+    .map((name: string): SourceFile => {
+      return {
+        name: name,
+        contents: fs.readFileSync(path.join(directory, name), "utf8"),
+      };
+    });
+}
+
+/**
+ * Every argument list passed to `functionName` in `source`, with each list
+ * split into its top-level arguments. Walks balanced parentheses so nested
+ * calls and object literals in the arguments do not confuse it, and collapses
+ * whitespace so prettier's line wrapping does not either.
+ */
+function argumentListsFor(
+  source: string,
+  functionName: string,
+): Array<Array<string>> {
+  const lists: Array<Array<string>> = [];
+  const needle: string = `${functionName}(`;
+
+  let searchFrom: number = 0;
+
+  for (;;) {
+    const callIndex: number = source.indexOf(needle, searchFrom);
+
+    if (callIndex === -1) {
+      return lists;
+    }
+
+    let depth: number = 0;
+    let cursor: number = callIndex + needle.length - 1;
+    let closingIndex: number = -1;
+
+    while (cursor < source.length) {
+      const character: string = source[cursor] as string;
+
+      if (character === "(") {
+        depth++;
+      } else if (character === ")") {
+        depth--;
+
+        if (depth === 0) {
+          closingIndex = cursor;
+          break;
+        }
+      }
+
+      cursor++;
+    }
+
+    if (closingIndex === -1) {
+      // Unbalanced source; nothing more to read.
+      return lists;
+    }
+
+    const inner: string = source.slice(callIndex + needle.length, closingIndex);
+    const args: Array<string> = [];
+    let current: string = "";
+    let innerDepth: number = 0;
+
+    for (const character of inner) {
+      if (character === "(" || character === "[" || character === "{") {
+        innerDepth++;
+      } else if (character === ")" || character === "]" || character === "}") {
+        innerDepth--;
+      }
+
+      if (character === "," && innerDepth === 0) {
+        args.push(current.trim());
+        current = "";
+        continue;
+      }
+
+      current += character;
+    }
+
+    if (current.trim() !== "") {
+      args.push(current.trim());
+    }
+
+    lists.push(args);
+    searchFrom = closingIndex + 1;
+  }
+}
+
+/**
+ * The text between `opener`'s bracket and its matching close, or null when
+ * `opener` is not present. Used to read one array literal out of a component
+ * without pulling in whatever follows it.
+ */
+function bracketedBlockAfter(source: string, opener: string): string | null {
+  const openerIndex: number = source.indexOf(opener);
+
+  if (openerIndex === -1) {
+    return null;
+  }
+
+  let depth: number = 0;
+  let cursor: number = openerIndex + opener.length - 1;
+
+  while (cursor < source.length) {
+    const character: string = source[cursor] as string;
+
+    if (character === "[") {
+      depth++;
+    } else if (character === "]") {
+      depth--;
+
+      if (depth === 0) {
+        return source.slice(openerIndex + opener.length, cursor);
+      }
+    }
+
+    cursor++;
+  }
+
+  return null;
+}
+
+// Strip comments so a code sample inside a comment cannot fail the suite.
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+describe("dashboard widget timestamps", () => {
+  const widgetFiles: Array<SourceFile> = readSourceFiles(COMPONENTS_DIR);
+
+  it("finds the widget components to check", () => {
+    // A wrong path would otherwise make every check below vacuously pass.
+    expect(widgetFiles.length).toBeGreaterThan(20);
+    expect(
+      widgetFiles.some((file: SourceFile): boolean => {
+        return file.name === "DashboardIncidentListComponent.tsx";
+      }),
+    ).toBe(true);
+  });
+
+  it("no widget renders a date without a time", () => {
+    const offenders: Array<string> = [];
+
+    for (const file of widgetFiles) {
+      const source: string = withoutComments(file.contents);
+
+      for (const formatter of POSITIONAL_FORMATTERS) {
+        for (const args of argumentListsFor(source, formatter)) {
+          // args[1] is `onlyShowDate`.
+          if (args[1] === "true") {
+            offenders.push(`${file.name}: ${formatter}(…, true)`);
+          }
+        }
+      }
+
+      for (const formatter of OPTIONS_FORMATTERS) {
+        for (const args of argumentListsFor(source, formatter)) {
+          // args[1] is an options object carrying `onlyShowDate`.
+          if (DATE_ONLY_OPTION.test(args[1] || "")) {
+            offenders.push(
+              `${file.name}: ${formatter}(…, { onlyShowDate: true })`,
+            );
+          }
+        }
+      }
+
+      for (const wrapper of DATE_ONLY_WRAPPERS) {
+        if (source.includes(`${wrapper}(`)) {
+          offenders.push(`${file.name}: ${wrapper}()`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("routes the widgets that show a timestamp through the shared helper", () => {
+    /*
+     * Every widget that puts a timestamp on screen. If one of them stops
+     * importing the helper it has gone back to formatting its own.
+     */
+    const timestampWidgets: Array<string> = [
+      "DashboardIncidentListComponent.tsx",
+      "DashboardAlertListComponent.tsx",
+      "DashboardTraceListComponent.tsx",
+      "DashboardLogStreamComponent.tsx",
+      "DashboardTableComponent.tsx",
+      "DashboardHostListComponent.tsx",
+    ];
+
+    for (const name of timestampWidgets) {
+      const file: SourceFile | undefined = widgetFiles.find(
+        (candidate: SourceFile): boolean => {
+          return candidate.name === name;
+        },
+      );
+
+      expect(file).toBeDefined();
+      expect(`${name}: ${(file as SourceFile).contents}`).toContain(
+        "../Utils/DashboardDateTime",
+      );
+    }
+  });
+
+  it("hangs the full, zone-qualified timestamp on a hover title", () => {
+    /*
+     * The visible label drops the timezone abbreviation to fit a narrow
+     * column. That is only acceptable because the exact, zone-qualified
+     * instant is one hover away — a widget that renders the label without
+     * wiring the title has thrown the timezone away.
+     */
+    const widgetsWithHoverTitle: Array<string> = [
+      "DashboardIncidentListComponent.tsx",
+      "DashboardAlertListComponent.tsx",
+      "DashboardTraceListComponent.tsx",
+      "DashboardLogStreamComponent.tsx",
+      "DashboardTableComponent.tsx",
+      "DashboardHostListComponent.tsx",
+    ];
+
+    const offenders: Array<string> = [];
+
+    for (const name of widgetsWithHoverTitle) {
+      const file: SourceFile = widgetFiles.find(
+        (candidate: SourceFile): boolean => {
+          return candidate.name === name;
+        },
+      ) as SourceFile;
+
+      expect(file).toBeDefined();
+
+      const source: string = withoutComments(file.contents);
+
+      if (!LABEL_WITH_HOVER_TITLE.test(source)) {
+        offenders.push(`${name}: renders a label with no title={...title}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("shows a timestamp in honeycomb view too, not just in the table", () => {
+    /*
+     * These widgets render either a table or a grid of tiles. The tile view
+     * has no columns, so its hover tooltip is the only place a timestamp can
+     * appear — and switching view mode must not silently drop it.
+     */
+    const honeycombWidgets: Array<[string, string]> = [
+      ["DashboardIncidentListComponent.tsx", "Declared"],
+      ["DashboardAlertListComponent.tsx", "Created"],
+      ["DashboardTraceListComponent.tsx", "Time"],
+      ["DashboardHostListComponent.tsx", "At"],
+    ];
+
+    for (const [name, timestampLabel] of honeycombWidgets) {
+      const file: SourceFile = widgetFiles.find(
+        (candidate: SourceFile): boolean => {
+          return candidate.name === name;
+        },
+      ) as SourceFile;
+
+      expect(file).toBeDefined();
+
+      const source: string = withoutComments(file.contents);
+
+      /*
+       * Narrow to the tooltip's detail rows when they are written inline, but
+       * fall back to the whole file rather than failing an innocent refactor
+       * that hoists them into a local or a helper.
+       */
+      const details: string =
+        bracketedBlockAfter(source, "details: [") ?? source;
+
+      // The row a user actually reads on hover.
+      expect(`${name} tooltip details: ${details}`).toContain(
+        `label: "${timestampLabel}"`,
+      );
+    }
+  });
+
+  it("keeps the formatting in the helper rather than in the widgets", () => {
+    const helperNames: Array<string> = fs.readdirSync(UTILS_DIR);
+
+    expect(helperNames).toContain("DashboardDateTime.ts");
+
+    /*
+     * Widgets should never reach for the raw time helpers themselves — that is
+     * how the date half and the time half end up resolved in different zones.
+     */
+    const rawTimeHelpers: Array<string> = [
+      "OneUptimeDate.getLocalTimeString",
+      "OneUptimeDate.getLocalHours",
+      "OneUptimeDate.getLocalMinutes",
+    ];
+
+    const offenders: Array<string> = [];
+
+    for (const file of widgetFiles) {
+      const source: string = withoutComments(file.contents);
+
+      for (const helper of rawTimeHelpers) {
+        if (source.includes(`${helper}(`)) {
+          offenders.push(`${file.name}: ${helper}()`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/Common/Tests/Types/DateUserTimezone.test.ts
+++ b/Common/Tests/Types/DateUserTimezone.test.ts
@@ -139,6 +139,58 @@ describe("OneUptimeDate user timezone", () => {
       expect(formatted).toContain("EDT");
     });
 
+    it("names the abbreviation in effect on the formatted date, not today's", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      /*
+       * The abbreviation used to be looked up for "now", so all summer every
+       * winter timestamp read "EDT" — and 13:00 EDT is a different instant
+       * than the 13:00 EST that was actually stored.
+       */
+      const winter: string = OneUptimeDate.getDateAsLocalFormattedString(
+        new Date("2026-01-15T18:00:00Z"),
+      );
+      const summer: string = OneUptimeDate.getDateAsLocalFormattedString(
+        new Date("2026-07-15T18:00:00Z"),
+      );
+
+      expect(winter).toContain("13:00");
+      expect(winter).toContain("EST");
+      expect(winter).not.toContain("EDT");
+
+      expect(summer).toContain("14:00");
+      expect(summer).toContain("EDT");
+    });
+
+    it("labels each pass of a folded fall-back hour with its own abbreviation", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      // 01:30 local happens twice on 2026-11-01 — once EDT, once EST.
+      const firstPass: string = OneUptimeDate.getDateAsLocalFormattedString(
+        new Date("2026-11-01T05:30:00Z"),
+      );
+      const secondPass: string = OneUptimeDate.getDateAsLocalFormattedString(
+        new Date("2026-11-01T06:30:00Z"),
+      );
+
+      expect(firstPass).toContain("01:30");
+      expect(secondPass).toContain("01:30");
+      // Identical wall clocks; the abbreviation is what tells them apart.
+      expect(firstPass).toContain("EDT");
+      expect(secondPass).toContain("EST");
+    });
+
+    it("still omits the abbreviation when only the date is shown", () => {
+      OneUptimeDate.setUserTimezone(NY);
+
+      const dateOnly: string = OneUptimeDate.getDateAsLocalFormattedString(
+        new Date("2026-01-15T18:00:00Z"),
+        true,
+      );
+
+      expect(dateOnly).toBe("Jan 15, 2026");
+    });
+
     it("reads the hour and minute of an instant in the user timezone", () => {
       OneUptimeDate.setUserTimezone(KOLKATA);
 

--- a/Common/Types/Date.ts
+++ b/Common/Types/Date.ts
@@ -341,7 +341,10 @@ export default class OneUptimeDate {
       const local: moment.Moment = this.inCurrentTimezone(date);
       return (
         local.format(formatString) +
-        (data.onlyShowDate ? "" : " " + this.getCurrentTimezoneString())
+        (data.onlyShowDate
+          ? ""
+          : // Same DST-aware lookup the explicit-timezone branch below uses.
+            " " + this.getZoneAbbrByTimezone(this.getCurrentTimezone(), date))
       ).trim();
     }
 
@@ -1746,11 +1749,17 @@ export default class OneUptimeDate {
 
     const momentDate: moment.Moment = this.inCurrentTimezone(date);
 
-    return (
-      momentDate.format(formatstring) +
-      " " +
-      (onlyShowDate ? "" : this.getCurrentTimezoneString())
-    ).trim();
+    /*
+     * The abbreviation has to describe THIS date's offset, not today's. Asking
+     * for it without the date labelled every January timestamp "EDT" all
+     * summer — a wall clock paired with the wrong zone names a different
+     * instant, which is worse than printing no zone at all.
+     */
+    const zoneAbbr: string = onlyShowDate
+      ? ""
+      : this.getZoneAbbrByTimezone(this.getCurrentTimezone(), date);
+
+    return (momentDate.format(formatstring) + " " + zoneAbbr).trim();
   }
 
   public static getDayInSeconds(days?: number | undefined): number {


### PR DESCRIPTION
Dashboard widgets printed a bare date in their timestamp columns. On a dashboard that is close to useless — three incidents declared on the same day all read `Jul 16, 2026`, and a log stream repeats one date down the whole pane.

Every widget timestamp now reads date **and** time.

| | before | after |
|---|---|---|
| Incident "Declared" | `Jul 16, 2026` | `Jul 16, 2026 14:32` |
| Alert "Created" | `Jul 28, 2026` | `Jul 28, 2026 09:07` |
| Trace "Time" | `Jul 16, 2026` | `Jul 16, 2026 14:32:05` |
| Log stream | `Jul 16, 2026` | `Jul 16, 2026 14:32:05` |

## How

One helper — `App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardDateTime.ts` — so the format lives in a single place and is unit-testable without rendering React:

```ts
getDashboardDateTime(date)  // { label: "Jul 16, 2026 14:32", title: "Jul 16 2026, 14:32:05 PDT" }
```

Widget columns are narrow, so the visible `label` drops the timezone abbreviation and the cell's `title` carries the full, zone-qualified, second-precision instant one hover away. Seconds appear in the label only where sub-minute ordering matters (spans and log lines, which arrive seconds apart and are sorted descending).

Both halves resolve through `OneUptimeDate`'s current-timezone helpers, so a user who picked a timezone in User Settings reads that wall clock — and the date half and the time half can never disagree about which zone they are in. (21:32 UTC is the 16th in Los Angeles but the 17th in Kolkata; formatting the two halves independently is exactly how that goes wrong.)

## Surfaces covered

Incident, alert, trace, log-stream and metric-table widgets — in **list and honeycomb view**. Switching a widget to tiles used to silently lose the column that was just fixed, so the incident and alert tile tooltips gained a `Declared` / `Created` row. The host widget's `Last Seen` stays relative (`3d ago`) but now offers the exact instant, on hover in the table and as its own tooltip row in tiles.

Deliberately **not** changed: chart axis ticks. A tick is terse on purpose and gets its context from its neighbours and the chart's own range.

## Bug fixed along the way

`getDateAsLocalFormattedString` looked the timezone abbreviation up for *now* rather than for the date being formatted, so all summer every January timestamp was labelled `EDT`. A wall clock paired with the wrong zone names a different instant — 13:00 EDT is not the 13:00 EST that was stored. `getZoneAbbrByTimezone` already accepts a reference date for exactly this; it just was not being passed one. Same one-line fix applied to `getDateAsFormattedStringInTimezone`, whose two branches disagreed with each other.

## Tests

- `App/Tests/Dashboard/DashboardDateTime.test.ts` — 46 cases: user-timezone override vs browser fallback, half-hour (Kolkata) and quarter-hour (Kathmandu) offsets, date-rolls-past-midnight, year boundary, DST shift / spring-forward gap / both passes of a folded fall-back hour, midnight / noon / 23:59 / leap day / zero-padding / no minute rounding, `Date` vs ISO string vs offset-bearing string, and null / undefined / `""` / invalid `Date` / unparseable string / junk types.
- `App/Tests/Dashboard/DashboardWidgetTimestamps.test.ts` — 6 static guards over the whole widget directory, so a *new* widget cannot reintroduce the bug: no widget may call any of the four date-only formatter spellings, every timestamp widget routes through the helper, every one wires the hover title, and the honeycomb tooltip keeps its timestamp row.
- `Common/Tests/Types/DateUserTimezone.test.ts` — 3 cases pinning the DST-abbreviation fix.

`npx tsc --noEmit` clean in `App/`; `eslint --fix` clean. The pre-existing failures in `Common/Tests/UI/Components/*.tsx` (missing `@testing-library/jest-dom` type augmentation) and `MonacoRuntime.test.ts` are untouched by this change.

## Known, out of scope

Two related defects found while mapping the surfaces, both in shared code used well beyond dashboard widgets, both worth their own PR:

1. Chart hover **tooltip headers** (`LineChart.tsx` / `BarChart.tsx`) render the axis *tick* string, so a range of a week or more shows `14 Mar` with no time and a range of a day or less shows `09:30` with no date. Terse is right for a tick and wrong for a tooltip; the raw bucket start is already on every row.
2. `getDateAsFormattedString` formats the wall clock in the process/browser zone but labels it with the *user's* configured timezone abbreviation — so a Kolkata user on a New York browser gets the New York clock stamped `IST`. Fixing that changes server-side email and notification content, so it needs its own change and its own review.