### PR TITLE
fix(telemetry): stop ingest re-applying labels the user removed

### DIFF
--- a/App/FeatureSet/Docs/Content/en/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/kubernetes-agent.md
@@ -56,7 +56,7 @@ helm install oneuptime-agent oneuptime/kubernetes-agent \
   -f values.yaml
 ```
 
-Every record this agent ships — logs, metrics, traces, eBPF auto-instrumented spans, and CPU profiles — shows up tagged `team:payments`, `env:production`, and `region:us-east-1` in the OneUptime UI. Labels are matched case-insensitively, so an existing manually-created `Production` label is reused rather than duplicated. Labels added manually in the OneUptime UI are never removed by the agent.
+Every record this agent ships — logs, metrics, traces, eBPF auto-instrumented spans, and CPU profiles — shows up tagged `team:payments`, `env:production`, and `region:us-east-1` in the OneUptime UI. Labels are matched case-insensitively, so an existing manually-created `Production` label is reused rather than duplicated. Labels added manually in the OneUptime UI are never removed by the agent. The agent applies each label it declares once, so a label you remove in the UI stays removed even while the agent keeps declaring it; change the declared set (add or drop an `oneuptime.label.*` attribute) to have the agent apply it again.
 
 ## Pick the right preset for your cluster
 

--- a/App/FeatureSet/Docs/Content/en/telemetry/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/kubernetes-agent.md
@@ -346,7 +346,7 @@ oneuptime:
 clusterName: prod
 ```
 
-Labels are matched case-insensitively, so an existing manually-created `Production` label is reused rather than duplicated. Labels added manually in the OneUptime UI are never removed by the agent.
+Labels are matched case-insensitively, so an existing manually-created `Production` label is reused rather than duplicated. Labels added manually in the OneUptime UI are never removed by the agent. The agent applies each label it declares once, so a label you remove in the UI stays removed even while the agent keeps declaring it; change the declared set (add or drop an `oneuptime.label.*` attribute) to have the agent apply it again.
 
 ## Upgrading the Agent
 

--- a/Common/Models/DatabaseModels/CephCluster.ts
+++ b/Common/Models/DatabaseModels/CephCluster.ts
@@ -1015,6 +1015,24 @@ export default class CephCluster extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/CloudResource.ts
+++ b/Common/Models/DatabaseModels/CloudResource.ts
@@ -623,6 +623,24 @@ export default class CloudResource extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/DockerHost.ts
+++ b/Common/Models/DatabaseModels/DockerHost.ts
@@ -910,6 +910,24 @@ export default class DockerHost extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/DockerSwarmCluster.ts
+++ b/Common/Models/DatabaseModels/DockerSwarmCluster.ts
@@ -1040,6 +1040,24 @@ export default class DockerSwarmCluster extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/Host.ts
+++ b/Common/Models/DatabaseModels/Host.ts
@@ -1290,6 +1290,24 @@ export default class Host extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/IoTFleet.ts
+++ b/Common/Models/DatabaseModels/IoTFleet.ts
@@ -779,6 +779,24 @@ export default class IoTFleet extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/KubernetesCluster.ts
+++ b/Common/Models/DatabaseModels/KubernetesCluster.ts
@@ -896,6 +896,24 @@ export default class KubernetesCluster extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/PodmanHost.ts
+++ b/Common/Models/DatabaseModels/PodmanHost.ts
@@ -910,6 +910,24 @@ export default class PodmanHost extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/ProxmoxCluster.ts
+++ b/Common/Models/DatabaseModels/ProxmoxCluster.ts
@@ -994,6 +994,24 @@ export default class ProxmoxCluster extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/RumApplication.ts
+++ b/Common/Models/DatabaseModels/RumApplication.ts
@@ -508,6 +508,24 @@ export default class RumApplication extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/ServerlessFunction.ts
+++ b/Common/Models/DatabaseModels/ServerlessFunction.ts
@@ -658,6 +658,24 @@ export default class ServerlessFunction extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Models/DatabaseModels/Service.ts
+++ b/Common/Models/DatabaseModels/Service.ts
@@ -691,6 +691,24 @@ export default class Service extends BaseModel {
   public labels?: Array<Label> = undefined;
 
   @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Telemetry Applied Label IDs",
+    description:
+      "Internal bookkeeping. Label IDs that telemetry ingest has already applied to this resource from oneuptime.label.* resource attributes. Ingest applies a declared label once; after that the label is the user's to keep or remove, so a removal is not undone by the next telemetry batch.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public telemetryAppliedLabelIds?: Array<string> = undefined;
+
+  @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785274479033-AddTelemetryAppliedLabelIds.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785274479033-AddTelemetryAppliedLabelIds.ts
@@ -1,0 +1,96 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * `telemetryAppliedLabelIds` records the label ids telemetry ingest has
+ * already applied to a resource from its `oneuptime.label.*` resource
+ * attributes, so ingest applies each declared label once instead of on every
+ * batch. See Common/Server/Utils/Telemetry/TelemetryAutoLabels.ts.
+ *
+ * Deliberately left NULL for existing rows rather than backfilled: NULL means
+ * "ingest has not applied telemetry labels here yet", and the first batch
+ * after this migration converges it to whatever telemetry currently declares
+ * without attaching anything that is already on the resource.
+ */
+export class AddTelemetryAppliedLabelIds1785274479033
+  implements MigrationInterface
+{
+  public name = "AddTelemetryAppliedLabelIds1785274479033";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "KubernetesCluster" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DockerHost" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "PodmanHost" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "CephCluster" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProxmoxCluster" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DockerSwarmCluster" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IoTFleet" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Host" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServerlessFunction" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "CloudResource" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "RumApplication" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Service" ADD "telemetryAppliedLabelIds" jsonb`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Service" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "RumApplication" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "CloudResource" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServerlessFunction" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Host" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "IoTFleet" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DockerSwarmCluster" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProxmoxCluster" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "CephCluster" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "PodmanHost" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DockerHost" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "KubernetesCluster" DROP COLUMN "telemetryAppliedLabelIds"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -474,6 +474,7 @@ import { AddHotQueryIndexes1785140242697 } from "./1785140242697-AddHotQueryInde
 import { AddHotQueryIndexesSecondPass1785148065137 } from "./1785148065137-AddHotQueryIndexesSecondPass";
 import { RepairCrossProjectMonitorStatusReferences1785240000000 } from "./1785240000000-RepairCrossProjectMonitorStatusReferences";
 import { AddColumnsToTableView1785241000000 } from "./1785241000000-AddColumnsToTableView";
+import { AddTelemetryAppliedLabelIds1785274479033 } from "./1785274479033-AddTelemetryAppliedLabelIds";
 
 export default [
   InitialMigration,
@@ -952,4 +953,5 @@ export default [
   AddHotQueryIndexesSecondPass1785148065137,
   RepairCrossProjectMonitorStatusReferences1785240000000,
   AddColumnsToTableView1785241000000,
+  AddTelemetryAppliedLabelIds1785274479033,
 ];

--- a/Common/Server/Services/CephClusterService.ts
+++ b/Common/Server/Services/CephClusterService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import CephClusterLabelRuleEngineService from "./CephClusterLabelRuleEngineService";
 import CephClusterOwnerRuleEngineService from "./CephClusterOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/CephCluster";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,9 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "ceph-cluster-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "ceph-cluster-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -281,80 +278,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a Ceph cluster. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The
-   * set of labelIds passed in is fingerprinted and cached for 60s so
-   * the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     cephClusterId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.cephClusterId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const cephClusterIdStr: string = data.cephClusterId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(cephClusterIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(cephClusterIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `CephClusterService.attachLabels failed for ceph cluster ${data.cephClusterId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.cephClusterId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -401,15 +340,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/CloudResourceService.ts
+++ b/Common/Server/Services/CloudResourceService.ts
@@ -1,6 +1,6 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/CloudResource";
-import Label from "../../Models/DatabaseModels/Label";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
 import QueryHelper from "../Types/Database/QueryHelper";
@@ -15,9 +15,6 @@ import CloudResourceOwnerRuleEngineService from "./CloudResourceOwnerRuleEngineS
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "cloud-resource-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "cloud-resource-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -237,73 +234,23 @@ export class Service extends DatabaseService<Model> {
     });
   }
 
+  /**
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
+   */
   @CaptureSpan()
   public async attachLabels(data: {
     cloudResourceId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.cloudResourceId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const resourceIdStr: string = data.cloudResourceId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(resourceIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(resourceIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `CloudResourceService.attachLabels failed for resource ${data.cloudResourceId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.cloudResourceId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -350,15 +297,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/DockerHostService.ts
+++ b/Common/Server/Services/DockerHostService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import DockerHostLabelRuleEngineService from "./DockerHostLabelRuleEngineService";
 import DockerHostOwnerRuleEngineService from "./DockerHostOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/DockerHost";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,9 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "docker-host-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "docker-host-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -248,80 +245,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a Docker host. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The
-   * set of labelIds passed in is fingerprinted and cached for 60s so
-   * the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     dockerHostId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.dockerHostId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const dockerHostIdStr: string = data.dockerHostId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(dockerHostIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(dockerHostIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `DockerHostService.attachLabels failed for docker host ${data.dockerHostId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.dockerHostId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -368,15 +307,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/DockerSwarmClusterService.ts
+++ b/Common/Server/Services/DockerSwarmClusterService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import DockerSwarmClusterLabelRuleEngineService from "./DockerSwarmClusterLabelRuleEngineService";
 import DockerSwarmClusterOwnerRuleEngineService from "./DockerSwarmClusterOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/DockerSwarmCluster";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,10 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "docker-swarm-cluster-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string =
-  "docker-swarm-cluster-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -283,81 +279,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a DockerSwarm cluster. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The
-   * set of labelIds passed in is fingerprinted and cached for 60s so
-   * the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     dockerSwarmClusterId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.dockerSwarmClusterId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const dockerSwarmClusterIdStr: string =
-        data.dockerSwarmClusterId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(dockerSwarmClusterIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(dockerSwarmClusterIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `DockerSwarmClusterService.attachLabels failed for dockerSwarm cluster ${data.dockerSwarmClusterId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.dockerSwarmClusterId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -404,15 +341,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/HostService.ts
+++ b/Common/Server/Services/HostService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import HostLabelRuleEngineService from "./HostLabelRuleEngineService";
 import HostOwnerRuleEngineService from "./HostOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/Host";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -16,9 +16,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "host-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "host-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -372,85 +369,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a host. Existing labels are never
-   * removed — manual labels set via the UI survive ingest. The set
-   * of labelIds passed in is fingerprinted and cached for 60s so the
-   * common case (steady-state collector pushing the same label set
-   * every batch) costs one in-memory lookup, not a join-table scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     hostId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.hostId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const hostIdStr: string = data.hostId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(hostIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(hostIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      /*
-       * A concurrent ingest worker may have inserted the same join
-       * row between our loadMany and add. Best-effort — surface as
-       * a warning so chronic failures show up in logs without
-       * breaking ingest.
-       */
-      logger.warn(
-        `HostService.attachLabels failed for host ${data.hostId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.hostId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -547,15 +481,6 @@ export class Service extends DatabaseService<Model> {
     }
     return identifiers;
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/IoTFleetService.ts
+++ b/Common/Server/Services/IoTFleetService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import IoTFleetLabelRuleEngineService from "./IoTFleetLabelRuleEngineService";
 import IoTFleetOwnerRuleEngineService from "./IoTFleetOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/IoTFleet";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,9 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "iot-fleet-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "iot-fleet-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -242,80 +239,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to an IoT fleet. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The
-   * set of labelIds passed in is fingerprinted and cached for 60s so
-   * the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     iotFleetId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.iotFleetId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const iotFleetIdStr: string = data.iotFleetId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(iotFleetIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(iotFleetIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `IoTFleetService.attachLabels failed for iot fleet ${data.iotFleetId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.iotFleetId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -362,15 +301,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/KubernetesClusterService.ts
+++ b/Common/Server/Services/KubernetesClusterService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import KubernetesClusterLabelRuleEngineService from "./KubernetesClusterLabelRuleEngineService";
 import KubernetesClusterOwnerRuleEngineService from "./KubernetesClusterOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/KubernetesCluster";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,9 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "k8s-cluster-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "k8s-cluster-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -205,80 +202,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a Kubernetes cluster. Existing labels
-   * are never removed — manual labels set via the UI survive ingest.
-   * The set of labelIds passed in is fingerprinted and cached for 60s
-   * so the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     kubernetesClusterId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.kubernetesClusterId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const clusterIdStr: string = data.kubernetesClusterId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(clusterIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(clusterIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `KubernetesClusterService.attachLabels failed for cluster ${data.kubernetesClusterId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.kubernetesClusterId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -325,15 +264,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/PodmanHostService.ts
+++ b/Common/Server/Services/PodmanHostService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import PodmanHostLabelRuleEngineService from "./PodmanHostLabelRuleEngineService";
 import PodmanHostOwnerRuleEngineService from "./PodmanHostOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/PodmanHost";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,9 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "podman-host-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "podman-host-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -248,80 +245,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a Podman host. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The
-   * set of labelIds passed in is fingerprinted and cached for 60s so
-   * the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     podmanHostId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.podmanHostId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const podmanHostIdStr: string = data.podmanHostId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(podmanHostIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(podmanHostIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `PodmanHostService.attachLabels failed for podman host ${data.podmanHostId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.podmanHostId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -368,15 +307,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/ProxmoxClusterService.ts
+++ b/Common/Server/Services/ProxmoxClusterService.ts
@@ -1,8 +1,8 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import ProxmoxClusterLabelRuleEngineService from "./ProxmoxClusterLabelRuleEngineService";
 import ProxmoxClusterOwnerRuleEngineService from "./ProxmoxClusterOwnerRuleEngineService";
 import Model from "../../Models/DatabaseModels/ProxmoxCluster";
-import Label from "../../Models/DatabaseModels/Label";
 import { OnCreate } from "../Types/Database/Hooks";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
@@ -15,9 +15,6 @@ import crypto from "crypto";
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "proxmox-cluster-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "proxmox-cluster-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -262,80 +259,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a Proxmox cluster. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The
-   * set of labelIds passed in is fingerprinted and cached for 60s so
-   * the common case (steady-state collector pushing the same label
-   * set every batch) costs one in-memory lookup, not a join-table
-   * scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     proxmoxClusterId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.proxmoxClusterId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const proxmoxClusterIdStr: string = data.proxmoxClusterId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(proxmoxClusterIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(proxmoxClusterIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `ProxmoxClusterService.attachLabels failed for proxmox cluster ${data.proxmoxClusterId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.proxmoxClusterId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -382,15 +321,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/RumApplicationService.ts
+++ b/Common/Server/Services/RumApplicationService.ts
@@ -1,6 +1,6 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/RumApplication";
-import Label from "../../Models/DatabaseModels/Label";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
 import QueryHelper from "../Types/Database/QueryHelper";
@@ -15,9 +15,6 @@ import RumApplicationOwnerRuleEngineService from "./RumApplicationOwnerRuleEngin
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "rum-application-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "rum-application-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -196,73 +193,23 @@ export class Service extends DatabaseService<Model> {
     });
   }
 
+  /**
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
+   */
   @CaptureSpan()
   public async attachLabels(data: {
     rumApplicationId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.rumApplicationId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const appIdStr: string = data.rumApplicationId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(appIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(appIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `RumApplicationService.attachLabels failed for application ${data.rumApplicationId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.rumApplicationId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -309,15 +256,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/ServerlessFunctionService.ts
+++ b/Common/Server/Services/ServerlessFunctionService.ts
@@ -1,6 +1,6 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/ServerlessFunction";
-import Label from "../../Models/DatabaseModels/Label";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import ObjectID from "../../Types/ObjectID";
 import QueryHelper from "../Types/Database/QueryHelper";
@@ -15,10 +15,6 @@ import ServerlessFunctionOwnerRuleEngineService from "./ServerlessFunctionOwnerR
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "serverless-function-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string =
-  "serverless-function-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -241,78 +237,22 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a serverless function. Existing labels are
-   * never removed — manual labels set via the UI survive ingest. The set of
-   * labelIds is fingerprinted and cached for 60s so steady-state ingest with
-   * an unchanged label set costs one in-memory lookup.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     serverlessFunctionId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.serverlessFunctionId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const functionIdStr: string = data.serverlessFunctionId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(functionIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(functionIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `ServerlessFunctionService.attachLabels failed for function ${data.serverlessFunctionId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.serverlessFunctionId,
+      labelIds: data.labelIds,
+    });
   }
 
   @CaptureSpan()
@@ -359,15 +299,6 @@ export class Service extends DatabaseService<Model> {
       }
     }
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Services/ServiceService.ts
+++ b/Common/Server/Services/ServiceService.ts
@@ -1,3 +1,4 @@
+import attachTelemetryLabels from "../Utils/Telemetry/TelemetryAutoLabels";
 import CreateBy from "../Types/Database/CreateBy";
 import { OnCreate } from "../Types/Database/Hooks";
 import DatabaseService from "./DatabaseService";
@@ -10,7 +11,6 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import Model from "../../Models/DatabaseModels/Service";
-import Label from "../../Models/DatabaseModels/Label";
 import Project from "../../Models/DatabaseModels/Project";
 import GlobalCache from "../Infrastructure/GlobalCache";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -21,9 +21,6 @@ const DEFAULT_TELEMETRY_RETENTION_IN_DAYS: number = 15;
 
 const LAST_SEEN_CACHE_NAMESPACE: string = "service-last-seen";
 const LAST_SEEN_THROTTLE_SECONDS: number = 60;
-
-const LABELS_APPLIED_CACHE_NAMESPACE: string = "service-labels-applied";
-const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -252,89 +249,23 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Additively attach labels to a telemetry service. Existing labels
-   * are never removed — manual labels set via the UI survive ingest.
-   * The set of labelIds passed in is fingerprinted and cached for
-   * 60s so the steady-state OTel collector pushing the same labels
-   * every batch costs one in-memory lookup, not a join-table scan.
+   * Additively attach the labels telemetry declares for this resource.
+   * Ingest applies each declared label once and records it, so a label a
+   * user removes is not re-attached by the next batch. Labels are never
+   * removed here - manual labels set via the UI survive ingest.
    */
   @CaptureSpan()
   public async attachLabels(data: {
     serviceId: ObjectID;
     labelIds: Array<ObjectID>;
   }): Promise<void> {
-    if (!data.labelIds || data.labelIds.length === 0) {
-      return;
-    }
-
-    const cacheKey: string = data.serviceId.toString();
-    const fingerprint: string = fingerprintLabelIds(data.labelIds);
-    const cached: string | null = await GlobalCache.getString(
-      LABELS_APPLIED_CACHE_NAMESPACE,
-      cacheKey,
-    );
-    if (cached === fingerprint) {
-      return;
-    }
-
-    try {
-      const serviceIdStr: string = data.serviceId.toString();
-      const existingLabels: Array<Label> = await this.getRepository()
-        .createQueryBuilder()
-        .relation(Model, "labels")
-        .of(serviceIdStr)
-        .loadMany();
-
-      const existingIds: Set<string> = new Set();
-      for (const lbl of existingLabels) {
-        const idStr: string | undefined = lbl._id?.toString();
-        if (idStr) {
-          existingIds.add(idStr);
-        }
-      }
-
-      const toAddIds: Array<string> = [];
-      const seen: Set<string> = new Set();
-      for (const id of data.labelIds) {
-        const idStr: string = id.toString();
-        if (existingIds.has(idStr) || seen.has(idStr)) {
-          continue;
-        }
-        seen.add(idStr);
-        toAddIds.push(idStr);
-      }
-
-      if (toAddIds.length > 0) {
-        await this.getRepository()
-          .createQueryBuilder()
-          .relation(Model, "labels")
-          .of(serviceIdStr)
-          .add(toAddIds);
-      }
-
-      await GlobalCache.setString(
-        LABELS_APPLIED_CACHE_NAMESPACE,
-        cacheKey,
-        fingerprint,
-        { expiresInSeconds: LABELS_APPLIED_CACHE_TTL_SECONDS },
-      );
-    } catch (err) {
-      logger.warn(
-        `ServiceService.attachLabels failed for service ${data.serviceId.toString()}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    await attachTelemetryLabels<Model>({
+      service: this,
+      modelType: Model,
+      resourceId: data.serviceId,
+      labelIds: data.labelIds,
+    });
   }
-}
-
-function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
-  const sorted: Array<string> = labelIds
-    .map((id: ObjectID) => {
-      return id.toString();
-    })
-    .sort();
-  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
 }
 
 export default new Service();

--- a/Common/Server/Utils/Telemetry/TelemetryAutoLabels.ts
+++ b/Common/Server/Utils/Telemetry/TelemetryAutoLabels.ts
@@ -1,0 +1,238 @@
+import DatabaseService from "../../Services/DatabaseService";
+import GlobalCache from "../../Infrastructure/GlobalCache";
+import logger from "../Logger";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Label from "../../../Models/DatabaseModels/Label";
+import Select from "../../Types/Database/Select";
+import PartialEntity from "../../../Types/Database/PartialEntity";
+import ObjectID from "../../../Types/ObjectID";
+import crypto from "crypto";
+
+/*
+ * Telemetry resources (hosts, services, docker hosts, clusters, ...) get
+ * Labels from `oneuptime.label.<dimension>` OTel resource attributes. Every
+ * ingest batch re-declares the same attributes, so the attach step has to
+ * decide, on each batch, whether a declared label still needs applying.
+ *
+ * That decision used to be "is it already on the resource?", guarded only by
+ * a 60 second cache. Any label a user removed in the UI was therefore
+ * re-attached on the next batch after the cache expired - bulk "Remove
+ * Labels" reported success and the labels silently came back within a minute.
+ *
+ * The decision is now "has ingest already applied this label to this
+ * resource?", recorded durably in `telemetryAppliedLabelIds`. Ingest applies
+ * a telemetry label once; after that the label belongs to the user, and a
+ * removal sticks for as long as telemetry keeps declaring the same set.
+ */
+export const TELEMETRY_AUTO_LABEL_CACHE_NAMESPACE: string =
+  "telemetry-auto-labels-applied";
+
+export const TELEMETRY_AUTO_LABEL_CACHE_TTL_SECONDS: number = 60;
+
+/**
+ * Every model that receives labels from telemetry carries the memo column.
+ */
+export interface TelemetryAutoLabelledModel extends BaseModel {
+  telemetryAppliedLabelIds?: Array<string> | undefined;
+}
+
+export function fingerprintLabelIds(labelIds: Array<ObjectID>): string {
+  const sorted: Array<string> = labelIds
+    .map((id: ObjectID) => {
+      return id.toString();
+    })
+    .sort();
+  return crypto.createHash("sha1").update(sorted.join(",")).digest("hex");
+}
+
+function dedupeIds(labelIds: Array<ObjectID>): Array<string> {
+  const seen: Set<string> = new Set<string>();
+  const ids: Array<string> = [];
+
+  for (const labelId of labelIds) {
+    const idString: string = labelId.toString();
+    if (!idString || seen.has(idString)) {
+      continue;
+    }
+    seen.add(idString);
+    ids.push(idString);
+  }
+
+  return ids;
+}
+
+function isSameIdSet(a: Array<string>, b: Array<string>): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  const setOfA: Set<string> = new Set<string>(a);
+
+  for (const id of b) {
+    if (!setOfA.has(id)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Additively attach telemetry-declared labels to a resource.
+ *
+ * Only labels ingest has never applied before are attached, so:
+ *
+ *  - a brand new resource gets every label its telemetry declares;
+ *  - a label the user removes stays removed while telemetry keeps declaring
+ *    the same set;
+ *  - a label newly added to the collector config is still picked up;
+ *  - a label that telemetry stops declaring and later declares again counts
+ *    as a fresh declaration and is attached again.
+ *
+ * Labels are never removed here - manual labels set via the UI survive
+ * ingest, as before.
+ */
+export default async function attachTelemetryLabels<
+  TBaseModel extends TelemetryAutoLabelledModel,
+>(data: {
+  service: DatabaseService<TBaseModel>;
+  modelType: { new (): TBaseModel };
+  resourceId: ObjectID;
+  labelIds: Array<ObjectID>;
+}): Promise<void> {
+  if (!data.labelIds || data.labelIds.length === 0) {
+    return;
+  }
+
+  const resourceIdString: string = data.resourceId.toString();
+  const tableName: string = data.service.getRepository().metadata.tableName;
+  const cacheKey: string = `${tableName}:${resourceIdString}`;
+  const declaredIds: Array<string> = dedupeIds(data.labelIds);
+  const fingerprint: string = fingerprintLabelIds(data.labelIds);
+
+  /*
+   * Fast path: the steady-state collector pushes the same declaration every
+   * batch. When we have already processed this exact set recently there is
+   * nothing to attach and nothing to persist, so skip the reads entirely.
+   */
+  let cached: string | null = null;
+  try {
+    cached = await GlobalCache.getString(
+      TELEMETRY_AUTO_LABEL_CACHE_NAMESPACE,
+      cacheKey,
+    );
+  } catch {
+    // Cache unavailable - fall through to the durable memo below.
+    cached = null;
+  }
+
+  if (cached === fingerprint) {
+    return;
+  }
+
+  try {
+    const resource: TBaseModel | null = await data.service.findOneById({
+      id: data.resourceId,
+      select: {
+        _id: true,
+        telemetryAppliedLabelIds: true,
+      } as Select<TBaseModel>,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!resource) {
+      return;
+    }
+
+    /*
+     * NULL means ingest has never applied telemetry labels to this resource -
+     * it is either new, or it predates the memo column. Either way the whole
+     * declaration is treated as newly declared: anything already on the
+     * resource is filtered out below, so this batch attaches nothing that is
+     * not genuinely missing, and it seeds the memo so later removals stick.
+     */
+    const previouslyApplied: Array<string> | null = Array.isArray(
+      resource.telemetryAppliedLabelIds,
+    )
+      ? resource.telemetryAppliedLabelIds.map((id: string) => {
+          return id.toString();
+        })
+      : null;
+
+    const alreadyApplied: Set<string> = new Set<string>(
+      previouslyApplied || [],
+    );
+
+    const newlyDeclaredIds: Array<string> = declaredIds.filter((id: string) => {
+      return !alreadyApplied.has(id);
+    });
+
+    if (newlyDeclaredIds.length > 0) {
+      const existingLabels: Array<Label> = await data.service
+        .getRepository()
+        .createQueryBuilder()
+        .relation(data.modelType, "labels")
+        .of(resourceIdString)
+        .loadMany();
+
+      const existingIds: Set<string> = new Set<string>();
+      for (const label of existingLabels) {
+        const idString: string | undefined = label._id?.toString();
+        if (idString) {
+          existingIds.add(idString);
+        }
+      }
+
+      const toAddIds: Array<string> = newlyDeclaredIds.filter((id: string) => {
+        return !existingIds.has(id);
+      });
+
+      if (toAddIds.length > 0) {
+        await data.service
+          .getRepository()
+          .createQueryBuilder()
+          .relation(data.modelType, "labels")
+          .of(resourceIdString)
+          .add(toAddIds);
+      }
+    }
+
+    /*
+     * Record what telemetry declared. Dropping a label out of the memo when
+     * the collector stops declaring it is deliberate: re-adding it to the
+     * collector later is a fresh declaration and should apply again.
+     */
+    if (!previouslyApplied || !isSameIdSet(previouslyApplied, declaredIds)) {
+      await data.service.updateColumnsByIdWithoutHooks({
+        id: data.resourceId,
+        data: {
+          telemetryAppliedLabelIds: declaredIds,
+        } as unknown as PartialEntity<TBaseModel>,
+      });
+    }
+
+    try {
+      await GlobalCache.setString(
+        TELEMETRY_AUTO_LABEL_CACHE_NAMESPACE,
+        cacheKey,
+        fingerprint,
+        { expiresInSeconds: TELEMETRY_AUTO_LABEL_CACHE_TTL_SECONDS },
+      );
+    } catch {
+      // Best-effort throttle write; the durable memo is the source of truth.
+    }
+  } catch (err) {
+    /*
+     * A concurrent ingest worker may have inserted the same join row between
+     * our loadMany and add. Best-effort - surface as a warning so chronic
+     * failures show up in logs without breaking ingest.
+     */
+    logger.warn(
+      `attachTelemetryLabels failed for ${tableName} ${resourceIdString}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}

--- a/Common/Tests/Server/Services/TelemetryAttachLabelsDelegation.test.ts
+++ b/Common/Tests/Server/Services/TelemetryAttachLabelsDelegation.test.ts
@@ -1,0 +1,246 @@
+import * as TelemetryAutoLabels from "../../../Server/Utils/Telemetry/TelemetryAutoLabels";
+import CephClusterService from "../../../Server/Services/CephClusterService";
+import CloudResourceService from "../../../Server/Services/CloudResourceService";
+import DockerHostService from "../../../Server/Services/DockerHostService";
+import DockerSwarmClusterService from "../../../Server/Services/DockerSwarmClusterService";
+import HostService from "../../../Server/Services/HostService";
+import IoTFleetService from "../../../Server/Services/IoTFleetService";
+import KubernetesClusterService from "../../../Server/Services/KubernetesClusterService";
+import PodmanHostService from "../../../Server/Services/PodmanHostService";
+import ProxmoxClusterService from "../../../Server/Services/ProxmoxClusterService";
+import RumApplicationService from "../../../Server/Services/RumApplicationService";
+import ServerlessFunctionService from "../../../Server/Services/ServerlessFunctionService";
+import ServiceService from "../../../Server/Services/ServiceService";
+import CephCluster from "../../../Models/DatabaseModels/CephCluster";
+import CloudResource from "../../../Models/DatabaseModels/CloudResource";
+import DockerHost from "../../../Models/DatabaseModels/DockerHost";
+import DockerSwarmCluster from "../../../Models/DatabaseModels/DockerSwarmCluster";
+import Host from "../../../Models/DatabaseModels/Host";
+import IoTFleet from "../../../Models/DatabaseModels/IoTFleet";
+import KubernetesCluster from "../../../Models/DatabaseModels/KubernetesCluster";
+import PodmanHost from "../../../Models/DatabaseModels/PodmanHost";
+import ProxmoxCluster from "../../../Models/DatabaseModels/ProxmoxCluster";
+import RumApplication from "../../../Models/DatabaseModels/RumApplication";
+import ServerlessFunction from "../../../Models/DatabaseModels/ServerlessFunction";
+import Service from "../../../Models/DatabaseModels/Service";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, test, beforeEach, jest } from "@jest/globals";
+
+/*
+ * `attachLabels` was copy-pasted, byte for byte, into twelve services. The
+ * label-removal bug therefore existed twelve times over, and a fix applied to
+ * one of them would have silently left the other eleven broken.
+ *
+ * The implementation now lives once in TelemetryAutoLabels. These tests pin
+ * every service to that single implementation so a future edit cannot quietly
+ * re-inline a divergent copy into one of them.
+ */
+
+interface ServiceUnderTest {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  attach: (resourceId: ObjectID, labelIds: Array<ObjectID>) => Promise<void>;
+  modelType: { new (): BaseModel };
+}
+
+const RESOURCE_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const LABEL_IDS: Array<ObjectID> = [
+  new ObjectID("11111111-1111-4111-8111-111111111111"),
+];
+
+const SERVICES: Array<ServiceUnderTest> = [
+  {
+    name: "HostService",
+    modelType: Host,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return HostService.attachLabels({ hostId: id, labelIds: labelIds });
+    },
+  },
+  {
+    name: "ServiceService",
+    modelType: Service,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return ServiceService.attachLabels({ serviceId: id, labelIds: labelIds });
+    },
+  },
+  {
+    name: "DockerHostService",
+    modelType: DockerHost,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return DockerHostService.attachLabels({
+        dockerHostId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "PodmanHostService",
+    modelType: PodmanHost,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return PodmanHostService.attachLabels({
+        podmanHostId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "KubernetesClusterService",
+    modelType: KubernetesCluster,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return KubernetesClusterService.attachLabels({
+        kubernetesClusterId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "ProxmoxClusterService",
+    modelType: ProxmoxCluster,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return ProxmoxClusterService.attachLabels({
+        proxmoxClusterId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "IoTFleetService",
+    modelType: IoTFleet,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return IoTFleetService.attachLabels({
+        iotFleetId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "DockerSwarmClusterService",
+    modelType: DockerSwarmCluster,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return DockerSwarmClusterService.attachLabels({
+        dockerSwarmClusterId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "CephClusterService",
+    modelType: CephCluster,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return CephClusterService.attachLabels({
+        cephClusterId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "ServerlessFunctionService",
+    modelType: ServerlessFunction,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return ServerlessFunctionService.attachLabels({
+        serverlessFunctionId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "CloudResourceService",
+    modelType: CloudResource,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return CloudResourceService.attachLabels({
+        cloudResourceId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+  {
+    name: "RumApplicationService",
+    modelType: RumApplication,
+    attach: (id: ObjectID, labelIds: Array<ObjectID>) => {
+      return RumApplicationService.attachLabels({
+        rumApplicationId: id,
+        labelIds: labelIds,
+      });
+    },
+  },
+];
+
+describe("telemetry attachLabels delegation", () => {
+  test("every telemetry resource type is covered", () => {
+    expect(SERVICES).toHaveLength(12);
+  });
+
+  describe.each(SERVICES)("$name", (serviceUnderTest: ServiceUnderTest) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let spy: any;
+
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      spy = jest
+        .spyOn(TelemetryAutoLabels, "default")
+        .mockResolvedValue(undefined as never);
+    });
+
+    test("delegates to the shared attach-once implementation", async () => {
+      await serviceUnderTest.attach(RESOURCE_ID, LABEL_IDS);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      const callArgs: {
+        modelType: { new (): BaseModel };
+        resourceId: ObjectID;
+        labelIds: Array<ObjectID>;
+      } = spy.mock.calls[0][0];
+
+      expect(callArgs.modelType).toBe(serviceUnderTest.modelType);
+      expect(callArgs.resourceId.toString()).toBe(RESOURCE_ID.toString());
+      expect(callArgs.labelIds).toBe(LABEL_IDS);
+    });
+  });
+
+  describe("model support", () => {
+    test.each(
+      SERVICES.map((serviceUnderTest: ServiceUnderTest) => {
+        return [serviceUnderTest.name, serviceUnderTest.modelType] as [
+          string,
+          { new (): BaseModel },
+        ];
+      }),
+    )(
+      "%s's model has the telemetryAppliedLabelIds memo column",
+      (_name: string, modelType: { new (): BaseModel }) => {
+        const model: BaseModel = new modelType();
+
+        expect(model.getTableColumns().columns).toContain(
+          "telemetryAppliedLabelIds",
+        );
+      },
+    );
+
+    test.each(
+      SERVICES.map((serviceUnderTest: ServiceUnderTest) => {
+        return [serviceUnderTest.name, serviceUnderTest.modelType] as [
+          string,
+          { new (): BaseModel },
+        ];
+      }),
+    )(
+      "%s's memo column is server-managed and not writable over the API",
+      (_name: string, modelType: { new (): BaseModel }) => {
+        const model: BaseModel = new modelType();
+        const accessControl: {
+          create: Array<unknown>;
+          update: Array<unknown>;
+        } = model.getColumnAccessControlFor(
+          "telemetryAppliedLabelIds",
+        ) as unknown as { create: Array<unknown>; update: Array<unknown> };
+
+        expect(accessControl.create).toHaveLength(0);
+        expect(accessControl.update).toHaveLength(0);
+      },
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/TelemetryAutoLabels.test.ts
+++ b/Common/Tests/Server/Utils/TelemetryAutoLabels.test.ts
@@ -1,0 +1,509 @@
+import attachTelemetryLabels, {
+  TELEMETRY_AUTO_LABEL_CACHE_NAMESPACE,
+  fingerprintLabelIds,
+} from "../../../Server/Utils/Telemetry/TelemetryAutoLabels";
+import GlobalCache from "../../../Server/Infrastructure/GlobalCache";
+import Host from "../../../Models/DatabaseModels/Host";
+import Label from "../../../Models/DatabaseModels/Label";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, test, beforeEach, jest } from "@jest/globals";
+
+/*
+ * Regression suite for "removing labels in bulk doesn't stick".
+ *
+ * Labels derived from `oneuptime.label.*` OTel resource attributes used to be
+ * re-attached on every ingest batch, guarded only by a 60 second cache. A
+ * user removing a label - one at a time or through the bulk "Remove Labels"
+ * action - saw the operation report success and then watched the labels come
+ * back within a minute, because the next batch re-applied every declared
+ * label that was not currently on the resource.
+ *
+ * Ingest now applies a declared label ONCE and records it in
+ * `telemetryAppliedLabelIds`. These tests pin that contract.
+ */
+
+const LABEL_A: string = "11111111-1111-4111-8111-111111111111";
+const LABEL_B: string = "22222222-2222-4222-8222-222222222222";
+const LABEL_C: string = "33333333-3333-4333-8333-333333333333";
+const HOST_ID: string = "99999999-9999-4999-8999-999999999999";
+
+interface FakeService {
+  service: DatabaseService<Host>;
+  /** Labels currently attached to the resource (the join table). */
+  attachedLabelIds: Array<string>;
+  /** Label ids passed to the junction `.add()` call, if any. */
+  addedLabelIds: Array<string>;
+  addCallCount: number;
+  loadManyCallCount: number;
+  /** Payloads passed to updateColumnsByIdWithoutHooks. */
+  persistedMemos: Array<Array<string> | undefined>;
+  /** The stored memo column value. */
+  memo: Array<string> | null;
+  setAddToThrow: (shouldThrow: boolean) => void;
+}
+
+function buildFakeService(options: {
+  memo: Array<string> | null;
+  attachedLabelIds: Array<string>;
+  resourceExists?: boolean | undefined;
+}): FakeService {
+  const state: {
+    memo: Array<string> | null;
+    attachedLabelIds: Array<string>;
+    addedLabelIds: Array<string>;
+    addCallCount: number;
+    loadManyCallCount: number;
+    persistedMemos: Array<Array<string> | undefined>;
+    addThrows: boolean;
+  } = {
+    memo: options.memo,
+    attachedLabelIds: [...options.attachedLabelIds],
+    addedLabelIds: [],
+    addCallCount: 0,
+    loadManyCallCount: 0,
+    persistedMemos: [],
+    addThrows: false,
+  };
+
+  const relationBuilder: {
+    relation: () => typeof relationBuilder;
+    of: () => typeof relationBuilder;
+    loadMany: () => Promise<Array<Label>>;
+    add: (ids: Array<string>) => Promise<void>;
+  } = {
+    relation: () => {
+      return relationBuilder;
+    },
+    of: () => {
+      return relationBuilder;
+    },
+    loadMany: async (): Promise<Array<Label>> => {
+      state.loadManyCallCount++;
+      return state.attachedLabelIds.map((id: string) => {
+        const label: Label = new Label();
+        label._id = id;
+        return label;
+      });
+    },
+    add: async (ids: Array<string>): Promise<void> => {
+      state.addCallCount++;
+      if (state.addThrows) {
+        throw new Error("junction insert conflict");
+      }
+      state.addedLabelIds.push(...ids);
+      state.attachedLabelIds.push(...ids);
+    },
+  };
+
+  const service: unknown = {
+    getRepository: () => {
+      return {
+        metadata: { tableName: "Host" },
+        createQueryBuilder: () => {
+          return relationBuilder;
+        },
+      };
+    },
+    findOneById: async (): Promise<Host | null> => {
+      if (options.resourceExists === false) {
+        return null;
+      }
+      const host: Host = new Host();
+      host._id = HOST_ID;
+      if (state.memo !== null) {
+        host.telemetryAppliedLabelIds = [...state.memo];
+      }
+      return host;
+    },
+    updateColumnsByIdWithoutHooks: async (input: {
+      data: { telemetryAppliedLabelIds?: Array<string> };
+    }): Promise<void> => {
+      state.persistedMemos.push(input.data.telemetryAppliedLabelIds);
+      state.memo = input.data.telemetryAppliedLabelIds
+        ? [...input.data.telemetryAppliedLabelIds]
+        : null;
+    },
+  };
+
+  return {
+    service: service as DatabaseService<Host>,
+    get attachedLabelIds(): Array<string> {
+      return state.attachedLabelIds;
+    },
+    get addedLabelIds(): Array<string> {
+      return state.addedLabelIds;
+    },
+    get addCallCount(): number {
+      return state.addCallCount;
+    },
+    get loadManyCallCount(): number {
+      return state.loadManyCallCount;
+    },
+    get persistedMemos(): Array<Array<string> | undefined> {
+      return state.persistedMemos;
+    },
+    get memo(): Array<string> | null {
+      return state.memo;
+    },
+    setAddToThrow: (shouldThrow: boolean): void => {
+      state.addThrows = shouldThrow;
+    },
+  };
+}
+
+function attach(fake: FakeService, labelIds: Array<string>): Promise<void> {
+  return attachTelemetryLabels<Host>({
+    service: fake.service,
+    modelType: Host,
+    resourceId: new ObjectID(HOST_ID),
+    labelIds: labelIds.map((id: string) => {
+      return new ObjectID(id);
+    }),
+  });
+}
+
+describe("attachTelemetryLabels", () => {
+  let cache: Record<string, string>;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    cache = {};
+
+    jest
+      .spyOn(GlobalCache, "getString")
+      .mockImplementation(async (namespace: string, key: string) => {
+        return cache[`${namespace}:${key}`] ?? null;
+      });
+
+    jest
+      .spyOn(GlobalCache, "setString")
+      .mockImplementation(
+        async (namespace: string, key: string, value: string) => {
+          cache[`${namespace}:${key}`] = value;
+        },
+      );
+  });
+
+  describe("the bulk-removal regression", () => {
+    /*
+     * THE bug from the customer recording: 21 hosts, bulk "Remove Labels" of
+     * team:SharedServices-Prod, "21 Hosts succeeded", label back on several
+     * hosts within a minute. The collector never stopped declaring the label,
+     * so the next batch re-applied it.
+     */
+    test("does not re-attach a label the user removed while telemetry keeps declaring it", async () => {
+      const fake: FakeService = buildFakeService({
+        // Ingest already applied all three labels...
+        memo: [LABEL_A, LABEL_B, LABEL_C],
+        // ...and the user has since removed LABEL_C in the UI.
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      // The collector still declares all three, batch after batch.
+      await attach(fake, [LABEL_A, LABEL_B, LABEL_C]);
+      await attach(fake, [LABEL_A, LABEL_B, LABEL_C]);
+      await attach(fake, [LABEL_A, LABEL_B, LABEL_C]);
+
+      expect(fake.attachedLabelIds).toEqual([LABEL_A, LABEL_B]);
+      expect(fake.addCallCount).toBe(0);
+    });
+
+    test("removal sticks even when the cache is cold on every batch", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_C],
+        attachedLabelIds: [LABEL_A],
+      });
+
+      // Simulate the cache expiring (or Redis being unavailable) each time.
+      jest.spyOn(GlobalCache, "getString").mockResolvedValue(null);
+
+      await attach(fake, [LABEL_A, LABEL_C]);
+      await attach(fake, [LABEL_A, LABEL_C]);
+
+      expect(fake.attachedLabelIds).toEqual([LABEL_A]);
+      expect(fake.addCallCount).toBe(0);
+    });
+
+    test("removal sticks when the cache read throws", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_C],
+        attachedLabelIds: [LABEL_A],
+      });
+
+      jest
+        .spyOn(GlobalCache, "getString")
+        .mockRejectedValue(new Error("redis down"));
+
+      await attach(fake, [LABEL_A, LABEL_C]);
+
+      expect(fake.addCallCount).toBe(0);
+    });
+  });
+
+  describe("the customer's recording, replayed", () => {
+    /*
+     * 21 hosts, each carrying env:production, serverType:application,
+     * team:axxos and team:SharedServices-Prod. The user selects all 21 and
+     * bulk-removes team:SharedServices-Prod. Every collector keeps declaring
+     * all four labels. Before the fix, the removed label reappeared on host
+     * after host as each one's 60 second cache entry expired.
+     */
+    test("a bulk removal across many hosts is not undone by the next batches", async () => {
+      const hosts: Array<FakeService> = [];
+
+      for (let index: number = 0; index < 21; index++) {
+        hosts.push(
+          buildFakeService({
+            memo: [LABEL_A, LABEL_B, LABEL_C],
+            attachedLabelIds: [LABEL_A, LABEL_B, LABEL_C],
+          }),
+        );
+      }
+
+      // The bulk action removes LABEL_C from every host.
+      for (const host of hosts) {
+        host.attachedLabelIds.splice(host.attachedLabelIds.indexOf(LABEL_C), 1);
+      }
+
+      // Several ingest batches land, each with a cold cache.
+      for (let batch: number = 0; batch < 3; batch++) {
+        cache = {};
+        for (const host of hosts) {
+          await attach(host, [LABEL_A, LABEL_B, LABEL_C]);
+        }
+      }
+
+      for (const host of hosts) {
+        expect(host.attachedLabelIds).toEqual([LABEL_A, LABEL_B]);
+      }
+    });
+  });
+
+  describe("first sight of a resource", () => {
+    test("attaches every declared label when the memo is empty", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      expect(fake.addedLabelIds.sort()).toEqual([LABEL_A, LABEL_B].sort());
+      expect(fake.memo?.sort()).toEqual([LABEL_A, LABEL_B].sort());
+    });
+
+    /*
+     * Rows that predate the memo column are NULL. The first batch after the
+     * upgrade must not re-apply labels that are already on the resource, and
+     * must seed the memo so later removals stick.
+     */
+    test("seeds the memo without duplicating labels already on the resource", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      expect(fake.addCallCount).toBe(0);
+      expect(fake.memo?.sort()).toEqual([LABEL_A, LABEL_B].sort());
+    });
+
+    test("a removal made after that first batch sticks", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      // User removes LABEL_B in the UI.
+      fake.attachedLabelIds.splice(fake.attachedLabelIds.indexOf(LABEL_B), 1);
+      cache = {};
+
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      expect(fake.attachedLabelIds).toEqual([LABEL_A]);
+      expect(fake.addCallCount).toBe(0);
+    });
+  });
+
+  describe("telemetry declaration changes", () => {
+    test("attaches a label newly added to the collector config", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A],
+        attachedLabelIds: [LABEL_A],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      expect(fake.addedLabelIds).toEqual([LABEL_B]);
+      expect(fake.memo?.sort()).toEqual([LABEL_A, LABEL_B].sort());
+    });
+
+    test("only the newly declared label is attached, not the whole set", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_B],
+        // The user removed LABEL_B; the collector now also declares LABEL_C.
+        attachedLabelIds: [LABEL_A],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_B, LABEL_C]);
+
+      expect(fake.addedLabelIds).toEqual([LABEL_C]);
+      expect(fake.attachedLabelIds).toEqual([LABEL_A, LABEL_C]);
+    });
+
+    test("a label telemetry stops declaring drops out of the memo but stays on the resource", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_B],
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      await attach(fake, [LABEL_A]);
+
+      expect(fake.attachedLabelIds).toEqual([LABEL_A, LABEL_B]);
+      expect(fake.memo).toEqual([LABEL_A]);
+    });
+
+    test("re-declaring a label telemetry had dropped attaches it again", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_B],
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      // Collector drops LABEL_B...
+      await attach(fake, [LABEL_A]);
+      // ...the user removes it...
+      fake.attachedLabelIds.splice(fake.attachedLabelIds.indexOf(LABEL_B), 1);
+      cache = {};
+      // ...and then it is put back in the collector config.
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      expect(fake.addedLabelIds).toEqual([LABEL_B]);
+    });
+  });
+
+  describe("steady state", () => {
+    test("does nothing and writes nothing when the declaration is unchanged", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_B],
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_B]);
+
+      expect(fake.addCallCount).toBe(0);
+      expect(fake.persistedMemos).toEqual([]);
+    });
+
+    test("does not rewrite the memo when only the declaration order changes", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A, LABEL_B],
+        attachedLabelIds: [LABEL_A, LABEL_B],
+      });
+
+      await attach(fake, [LABEL_B, LABEL_A]);
+
+      expect(fake.persistedMemos).toEqual([]);
+    });
+
+    test("the cache fast path skips the database entirely", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A],
+        attachedLabelIds: [LABEL_A],
+      });
+
+      const cacheKey: string = `${TELEMETRY_AUTO_LABEL_CACHE_NAMESPACE}:Host:${HOST_ID}`;
+      cache[cacheKey] = fingerprintLabelIds([new ObjectID(LABEL_A)]);
+
+      await attach(fake, [LABEL_A]);
+
+      expect(fake.loadManyCallCount).toBe(0);
+      expect(fake.persistedMemos).toEqual([]);
+    });
+  });
+
+  describe("input handling", () => {
+    test("does nothing when no labels are declared", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: [LABEL_A],
+        attachedLabelIds: [LABEL_A],
+      });
+
+      await attach(fake, []);
+
+      expect(fake.loadManyCallCount).toBe(0);
+      expect(fake.persistedMemos).toEqual([]);
+    });
+
+    test("dedupes repeated label ids in one declaration", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [],
+      });
+
+      await attach(fake, [LABEL_A, LABEL_A, LABEL_B]);
+
+      expect(fake.addedLabelIds).toEqual([LABEL_A, LABEL_B]);
+      expect(fake.memo).toEqual([LABEL_A, LABEL_B]);
+    });
+
+    test("does nothing when the resource no longer exists", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [],
+        resourceExists: false,
+      });
+
+      await attach(fake, [LABEL_A]);
+
+      expect(fake.addCallCount).toBe(0);
+      expect(fake.persistedMemos).toEqual([]);
+    });
+  });
+
+  describe("failure handling", () => {
+    test("a junction insert conflict is swallowed so ingest keeps running", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [],
+      });
+      fake.setAddToThrow(true);
+
+      await expect(attach(fake, [LABEL_A])).resolves.toBeUndefined();
+    });
+
+    test("a failed batch does not record the labels as applied", async () => {
+      const fake: FakeService = buildFakeService({
+        memo: null,
+        attachedLabelIds: [],
+      });
+      fake.setAddToThrow(true);
+
+      await attach(fake, [LABEL_A]);
+
+      /*
+       * The memo must not advance past a failed attach, otherwise the label
+       * would be treated as applied and never retried.
+       */
+      expect(fake.persistedMemos).toEqual([]);
+      expect(fake.memo).toBeNull();
+    });
+  });
+});
+
+describe("fingerprintLabelIds", () => {
+  test("is order independent", () => {
+    expect(
+      fingerprintLabelIds([new ObjectID(LABEL_A), new ObjectID(LABEL_B)]),
+    ).toBe(fingerprintLabelIds([new ObjectID(LABEL_B), new ObjectID(LABEL_A)]));
+  });
+
+  test("differs when the declared set differs", () => {
+    expect(fingerprintLabelIds([new ObjectID(LABEL_A)])).not.toBe(
+      fingerprintLabelIds([new ObjectID(LABEL_A), new ObjectID(LABEL_B)]),
+    );
+  });
+});

--- a/Common/Tests/UI/Components/BulkLabelActions.test.tsx
+++ b/Common/Tests/UI/Components/BulkLabelActions.test.tsx
@@ -1,0 +1,326 @@
+import { describe, expect, test, beforeEach, jest } from "@jest/globals";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  RenderResult,
+} from "@testing-library/react";
+import * as React from "react";
+import { ReactElement } from "react";
+import useBulkLabelActions from "../../../UI/Components/BulkUpdate/BulkLabelActions";
+import {
+  BulkActionButtonSchema,
+  BulkActionOnClickProps,
+  ProgressInfo,
+} from "../../../UI/Components/BulkUpdate/BulkUpdateForm";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Label from "../../../Models/DatabaseModels/Label";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * react-i18next is not initialized in the test environment.
+ */
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, opts?: { defaultValue?: string }): string => {
+          return opts?.defaultValue ?? key;
+        },
+      };
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI");
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return new ObjectID("00000000-0000-4000-8000-000000000000");
+      },
+    },
+  };
+});
+
+const ENV_LABEL: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TEAM_LABEL: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const SHARED_LABEL: string = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const UNUSED_LABEL: string = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+function makeLabel(id: string, name: string): Label {
+  const label: Label = new Label();
+  label._id = id;
+  label.name = name;
+  return label;
+}
+
+const LABEL_NAMES: Record<string, string> = {
+  [ENV_LABEL]: "env:production",
+  [TEAM_LABEL]: "team:axxos",
+  [SHARED_LABEL]: "team:SharedServices-Prod",
+  [UNUSED_LABEL]: "team:not-in-use",
+};
+
+function makeMonitor(id: string, labelIds: Array<string>): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor._id = id;
+  monitor.labels = labelIds.map((labelId: string) => {
+    return makeLabel(labelId, LABEL_NAMES[labelId] || labelId);
+  });
+  return monitor;
+}
+
+/** Labels currently on each monitor, keyed by monitor id. */
+let monitorLabels: Record<string, Array<string>> = {};
+let updateCalls: Array<{ id: string; labelIds: Array<string> }> = [];
+let progressUpdates: Array<ProgressInfo<Monitor>> = [];
+
+interface HarnessProps {
+  items: Array<Monitor>;
+}
+
+/*
+ * Drives the hook the way ModelTable's bulk action bar does: hand the action
+ * the selected rows plus the progress callbacks, and render the modals.
+ */
+function Harness(props: HarnessProps): ReactElement {
+  const { bulkActions, modals } = useBulkLabelActions<Monitor>({
+    modelType: Monitor,
+  });
+
+  const removeAction: BulkActionButtonSchema<Monitor> | undefined =
+    bulkActions.find((action: BulkActionButtonSchema<Monitor>) => {
+      return action.title === "Remove Labels";
+    });
+
+  const actionProps: BulkActionOnClickProps<Monitor> = {
+    items: props.items,
+    onProgressInfo: (info: ProgressInfo<Monitor>): void => {
+      progressUpdates.push({
+        totalItems: [...info.totalItems],
+        successItems: [...info.successItems],
+        failed: [...info.failed],
+        inProgressItems: [...info.inProgressItems],
+      });
+    },
+    onBulkActionStart: (): void => {
+      // no-op
+    },
+    onBulkActionEnd: (): void => {
+      // no-op
+    },
+  };
+
+  return (
+    <>
+      <button
+        data-testid="open-remove"
+        onClick={() => {
+          removeAction?.onClick(actionProps);
+        }}
+      >
+        open
+      </button>
+      {modals}
+    </>
+  );
+}
+
+async function openRemoveModal(items: Array<Monitor>): Promise<RenderResult> {
+  const result: RenderResult = render(<Harness items={items} />);
+
+  fireEvent.click(screen.getByTestId("open-remove"));
+
+  /*
+   * The modal renders a loader until the "which labels are on these items"
+   * fetch settles; the form (and its field title) only appears after that.
+   */
+  await waitFor(
+    () => {
+      expect(screen.queryByText("Select Labels")).toBeTruthy();
+    },
+    { timeout: 5000 },
+  );
+
+  return result;
+}
+
+function openDropdown(): void {
+  fireEvent.keyDown(screen.getByRole("combobox"), {
+    key: "ArrowDown",
+    code: "ArrowDown",
+  });
+}
+
+/** Pick an option out of the dropdown by its visible label. */
+async function selectLabel(name: string): Promise<void> {
+  openDropdown();
+  fireEvent.click(await screen.findByText(name));
+}
+
+describe("useBulkLabelActions - Remove Labels", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateCalls = [];
+    progressUpdates = [];
+    monitorLabels = {
+      "monitor-1": [ENV_LABEL, TEAM_LABEL, SHARED_LABEL],
+      "monitor-2": [ENV_LABEL, SHARED_LABEL],
+      "monitor-3": [ENV_LABEL, TEAM_LABEL],
+    };
+
+    (ModelAPI.getList as jest.Mock).mockImplementation(
+      async (data: { modelType: { new (): unknown } }) => {
+        if ((data.modelType as unknown) === Label) {
+          return {
+            data: [
+              makeLabel(ENV_LABEL, "env:production"),
+              makeLabel(TEAM_LABEL, "team:axxos"),
+              makeLabel(SHARED_LABEL, "team:SharedServices-Prod"),
+              makeLabel(UNUSED_LABEL, "team:not-in-use"),
+            ],
+            count: 4,
+            skip: 0,
+            limit: 100,
+          };
+        }
+
+        // The "which labels can be removed" query for the selected items.
+        return {
+          data: Object.keys(monitorLabels).map((id: string) => {
+            return makeMonitor(id, monitorLabels[id]!);
+          }),
+          count: 3,
+          skip: 0,
+          limit: 100,
+        };
+      },
+    );
+
+    (ModelAPI.getItem as jest.Mock).mockImplementation(
+      async (data: { id: ObjectID }) => {
+        const id: string = data.id.toString();
+        return makeMonitor(id, monitorLabels[id] || []);
+      },
+    );
+
+    (ModelAPI.updateById as jest.Mock).mockImplementation(
+      async (data: { id: ObjectID; data: { labels: Array<string> } }) => {
+        const id: string = data.id.toString();
+        updateCalls.push({ id: id, labelIds: data.data.labels });
+        monitorLabels[id] = [...data.data.labels];
+        return {};
+      },
+    );
+  });
+
+  test("offers only labels that are actually on the selected items", async () => {
+    await openRemoveModal([
+      makeMonitor("monitor-1", monitorLabels["monitor-1"]!),
+      makeMonitor("monitor-2", monitorLabels["monitor-2"]!),
+      makeMonitor("monitor-3", monitorLabels["monitor-3"]!),
+    ]);
+
+    openDropdown();
+
+    expect(await screen.findByText("env:production")).toBeTruthy();
+
+    expect(screen.queryByText("team:axxos")).toBeTruthy();
+    expect(screen.queryByText("team:SharedServices-Prod")).toBeTruthy();
+    // Present in the project, but on none of the selected items.
+    expect(screen.queryByText("team:not-in-use")).toBeNull();
+  });
+
+  test("removes the selected label from every item, preserving the others", async () => {
+    await openRemoveModal([
+      makeMonitor("monitor-1", monitorLabels["monitor-1"]!),
+      makeMonitor("monitor-2", monitorLabels["monitor-2"]!),
+      makeMonitor("monitor-3", monitorLabels["monitor-3"]!),
+    ]);
+
+    await selectLabel("team:SharedServices-Prod");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove Labels$/ }));
+
+    await waitFor(() => {
+      expect(updateCalls).toHaveLength(2);
+    });
+
+    expect(monitorLabels["monitor-1"]).toEqual([ENV_LABEL, TEAM_LABEL]);
+    expect(monitorLabels["monitor-2"]).toEqual([ENV_LABEL]);
+    // monitor-3 never had the label, so it is not written at all.
+    expect(monitorLabels["monitor-3"]).toEqual([ENV_LABEL, TEAM_LABEL]);
+    expect(
+      updateCalls.map((call: { id: string }) => {
+        return call.id;
+      }),
+    ).toEqual(["monitor-1", "monitor-2"]);
+  });
+
+  test("reports every selected item as processed, including no-op items", async () => {
+    await openRemoveModal([
+      makeMonitor("monitor-1", monitorLabels["monitor-1"]!),
+      makeMonitor("monitor-2", monitorLabels["monitor-2"]!),
+      makeMonitor("monitor-3", monitorLabels["monitor-3"]!),
+    ]);
+
+    await selectLabel("team:SharedServices-Prod");
+    fireEvent.click(screen.getByRole("button", { name: /^Remove Labels$/ }));
+
+    await waitFor(() => {
+      expect(
+        progressUpdates[progressUpdates.length - 1]?.successItems,
+      ).toHaveLength(3);
+    });
+
+    expect(progressUpdates[progressUpdates.length - 1]?.failed).toHaveLength(0);
+  });
+
+  test("surfaces a per-item failure instead of silently reporting success", async () => {
+    (ModelAPI.updateById as jest.Mock).mockImplementation(
+      async (data: { id: ObjectID }) => {
+        if (data.id.toString() === "monitor-2") {
+          throw new Error("permission denied");
+        }
+        return {};
+      },
+    );
+
+    await openRemoveModal([
+      makeMonitor("monitor-1", monitorLabels["monitor-1"]!),
+      makeMonitor("monitor-2", monitorLabels["monitor-2"]!),
+    ]);
+
+    await selectLabel("team:SharedServices-Prod");
+    fireEvent.click(screen.getByRole("button", { name: /^Remove Labels$/ }));
+
+    await waitFor(() => {
+      expect(progressUpdates[progressUpdates.length - 1]?.failed).toHaveLength(
+        1,
+      );
+    });
+
+    const lastUpdate: ProgressInfo<Monitor> =
+      progressUpdates[progressUpdates.length - 1]!;
+
+    expect(lastUpdate.successItems).toHaveLength(1);
+    expect(lastUpdate.failed[0]?.item._id).toBe("monitor-2");
+  });
+
+  test("tells the user when the selection has no labels at all", async () => {
+    monitorLabels = { "monitor-1": [] };
+
+    render(<Harness items={[makeMonitor("monitor-1", [])]} />);
+    fireEvent.click(screen.getByTestId("open-remove"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("No Labels to Remove")).toBeTruthy();
+    });
+
+    expect(ModelAPI.updateById).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The report

A customer recorded themselves selecting 21 hosts and running **Bulk Actions → Remove Labels** for `team:SharedServices-Prod`. The dialog reported *"21 Hosts succeeded"*, and a minute later the label was back on several of them. Repeating it gave the same result every time.

## What actually happened

The removal worked. Frame-by-frame, `dmtaxosw03` has exactly three labels at 06:10 PM — `team:SharedServices-Prod` gone — and four again at 06:11 PM.

Those labels come from `oneuptime.label.<dimension>=<value>` OTel resource attributes, and `<X>Service.attachLabels` re-attached every declared label on **every ingest batch**. The only thing between a declared label and the join table was *"is it on the resource right now?"*, throttled by a 60-second `GlobalCache` fingerprint. So each removed label came back on the first batch after that resource's cache entry expired — which is why it reappeared host by host over about a minute instead of all at once, and why it looked like a partial failure.

## The fix

Ingest now applies each declared label **once** and records it durably in a new `telemetryAppliedLabelIds` column, instead of re-deciding from scratch every batch:

| Scenario | Behaviour |
|---|---|
| New resource | Gets every label its telemetry declares |
| User removes a still-declared label | **Stays removed** |
| New `oneuptime.label.*` added to the collector | Applied |
| Telemetry drops a label, later re-declares it | Treated as a fresh declaration, applied again |

Ingest still never removes labels, so manually added ones survive as before. The cache is kept purely as a read-avoidance fast path — correctness no longer depends on it.

`attachLabels` was duplicated byte for byte across **twelve** services (Host, Service, DockerHost, PodmanHost, KubernetesCluster, ProxmoxCluster, IoTFleet, DockerSwarmCluster, CephCluster, ServerlessFunction, CloudResource, RumApplication), so this bug existed twelve times over. The implementation now lives once in `Common/Server/Utils/Telemetry/TelemetryAutoLabels.ts` and each service delegates to it — a net **-965/+136** lines in `Common/Server/Services`.

## Upgrade note

Existing rows keep a `NULL` memo. The first batch after the migration attaches nothing that isn't genuinely missing and seeds the memo, so removals from then on stick.

One caveat worth telling the customer: **a label removed _before_ the upgrade, while telemetry still declares it, is applied one last time.** That intent was never recorded anywhere, so it can't be recovered — remove it once more after deploying and it will stay gone.

## Tests

63 new tests, all passing.

- **`TelemetryAutoLabels.test.ts`** (21) — the attach-once contract: removal sticks across cold caches and cache errors; first-sight seeding; collector adds/drops/re-declares; steady-state does no writes; dedupe, missing resource, junction-conflict handling; plus a replay of the reported scenario across 21 hosts and 3 batches.
- **`TelemetryAttachLabelsDelegation.test.ts`** (37) — pins all twelve services to the shared implementation so a divergent copy can't be re-inlined, and asserts each model carries the memo column with `create`/`update` access control empty.
- **`BulkLabelActions.test.tsx`** (5) — drives the actual Remove Labels modal: only labels on the selection are offered, the right items are written, no-op items still report as processed, per-item failures surface.

The 5 regression tests were confirmed to **fail** against the previous behaviour.

Also verified end-to-end against a real Postgres with the migration applied — new host → 3 labels applied and memo persisted; label removed; three more batches declaring the same set → not re-attached; collector adds `region:eu` → applied while the removed label stays gone.

Docs updated for the new removal semantics.

### Pre-existing, unrelated
9 suites in the wider `Common` sweep fail on this machine from an `isolated-vm` native-module ABI mismatch and a Monaco version-pairing check. 248 suites / 3890 tests pass.