### PR TITLE
feat(discovery): accept octet ranges as a network discovery scan target

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -27,6 +27,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
+import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
 import { getSnmpConfigFormFields } from "./SnmpConfigFormFields";
 import { isImportableDiscoveredHost } from "../../Components/NetworkDevice/DiscoveryImportEligibility";
 import React, {
@@ -282,10 +283,10 @@ const NetworkDeviceDiscovery: FunctionComponent<
         cardProps={{
           title: "Discovery Scans",
           description:
-            "Scan a subnet for SNMP devices from a probe, then review the results and import the devices you want to monitor.",
+            "Scan a subnet or octet range for SNMP devices from a probe, then review the results and import the devices you want to monitor.",
         }}
         noItemsMessage={
-          "No discovery scans yet. Start one to sweep a subnet for SNMP devices."
+          "No discovery scans yet. Start one to sweep a subnet or octet range for SNMP devices."
         }
         formSteps={[
           { title: "Scan Target", id: "scan-target" },
@@ -297,12 +298,20 @@ const NetworkDeviceDiscovery: FunctionComponent<
             field: {
               cidr: true,
             },
-            title: "Subnet (CIDR)",
+            title: "Scan Target",
             stepId: "scan-target",
             fieldType: FormFieldSchemaType.Text,
             required: true,
             placeholder: "192.168.1.0/24",
-            description: "Subnet to scan in CIDR notation, e.g. 192.168.1.0/24",
+            /*
+             * Both notations are described here rather than only CIDR because
+             * octet ranges are the only way to express the common real-world
+             * shape "the same handful of addresses in every one of these
+             * /24s" without creating hundreds of separate scans.
+             */
+            description:
+              "Either a subnet in CIDR notation (192.168.1.0/24), or an octet range where any octet may be an inclusive low-high range — 10.16-22.0-255.51-66 sweeps .51 to .66 in every /24 from 10.16 to 10.22. " +
+              `A single scan may cover at most ${ScanTargetUtil.MAX_SCAN_HOSTS.toLocaleString("en-US")} addresses.`,
           },
           {
             field: {
@@ -390,7 +399,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
             field: {
               cidr: true,
             },
-            title: "Subnet",
+            title: "Scan Target",
             type: FieldType.Text,
           },
           {
@@ -546,7 +555,7 @@ const NetworkDeviceDiscovery: FunctionComponent<
         <Modal
           title="Review Discovered Devices"
           description={`Hosts that responded in ${
-            scanToReview.cidr || "the scanned subnet"
+            scanToReview.cidr || "the scanned address range"
           }. Select the ones you want to import as Network Devices — hosts without SNMP cannot be imported.`}
           modalWidth={ModalWidth.Medium}
           isLoading={isImporting}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Overview.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Overview.tsx
@@ -501,7 +501,7 @@ const NetworkOverview: FunctionComponent<
 
         <Card
           title="Recent discovery scans"
-          description="Subnet sweeps that find SNMP devices to import."
+          description="Address-range sweeps that find SNMP devices to import."
           rightElement={
             <Button
               title="Run a Scan"
@@ -519,7 +519,8 @@ const NetworkOverview: FunctionComponent<
         >
           {recentScans.length === 0 ? (
             <p className="py-6 text-center text-sm text-gray-500">
-              No scans yet. Point one at a subnet and import what answers.
+              No scans yet. Point one at a subnet or octet range and import what
+              answers.
             </p>
           ) : (
             <div className="divide-y divide-gray-100">

--- a/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
@@ -12,7 +12,7 @@ The split of responsibilities is simple:
 The Network Devices product is made up of:
 
 - **Device inventory** — register each device once with its hostname, SNMP credentials, and polling settings. The assigned probe polls it on schedule and OneUptime enriches the record with the device's system identity (name, description, location, vendor, model, serial number), interfaces, and health metrics.
-- **Subnet discovery** — sweep a subnet (CIDR) for SNMP devices from a probe and import the responders in bulk. Imported devices start getting polled immediately.
+- **Network discovery** — sweep a subnet (CIDR) or an octet range (`10.16-22.0-255.51-66`) for SNMP devices from a probe and import the responders in bulk. Imported devices start getting polled immediately.
 - **Network Device monitors** — the alerting layer: evaluate each device poll and trap against criteria and open incidents or alerts.
 - **SNMP traps** — probes run a trap receiver, so link-down events raise incidents in seconds instead of waiting for the next poll.
 - **Topology view** — a live network map built from LLDP neighbor data, complemented by CDP on Cisco estates.
@@ -107,9 +107,9 @@ Collected values are charted on the device's **Metrics** tab and can be alerted 
 
 After the first successful poll, OneUptime reads the SNMPv2 system group and (where supported) the ENTITY-MIB, and fills in the device record automatically: system name, description, location, contact, uptime, vendor, model, serial number, and firmware version. The vendor's registered enterprise OID (`sysObjectId`) is used as the device fingerprint to derive the vendor name and suggest a matching vendor OID template.
 
-## Discovering Devices with a Subnet Scan
+## Discovering Devices with a Network Scan
 
-Instead of registering devices one at a time, you can sweep a subnet:
+Instead of registering devices one at a time, you can sweep a range of addresses:
 
 1. Go to **Network Devices** -> **Discovery**
 2. Click **Create Discovery Scan**
@@ -117,12 +117,46 @@ Instead of registering devices one at a time, you can sweep a subnet:
 
 | Field         | Description                                              | Required |
 | ------------- | -------------------------------------------------------- | -------- |
-| Subnet (CIDR) | Subnet to scan in CIDR notation, e.g. 192.168.1.0/24     | Yes      |
-| Probe         | Which probe should scan this subnet                      | Yes      |
-| SNMP credentials | Same fields as device registration (v1/v2c community string, or the full v3 credential set) — tried against every host in the subnet | Yes |
+| Scan Target   | The address space to scan, in [CIDR or octet-range notation](#scan-target-notation) | Yes      |
+| Probe         | Which probe should run the sweep                         | Yes      |
+| SNMP credentials | Same fields as device registration (v1/v2c community string, or the full v3 credential set) — tried against every host in the range | Yes |
 
 4. The scan runs from the selected probe and reports how many hosts were scanned and how many responded to SNMP
 5. Click **Review Results** on a completed scan, select the devices you want, and click **Import Selected**
+
+### Scan Target Notation
+
+The scan target accepts two notations. Both are IPv4-only.
+
+**CIDR** — a contiguous subnet:
+
+```
+192.168.1.0/24
+10.0.5.0/28
+```
+
+The network and broadcast addresses are skipped, so a `/24` sweeps 254 hosts. `/31` and `/32` have no network or broadcast address to skip, so every address in them is scanned.
+
+**Octet range** — any of the four octets may be an inclusive `low-high` range instead of a single number:
+
+```
+10.16-22.0-255.51-66
+10.48-50.0-255.51-66
+192.168.1.10-40
+10.0.0.5
+```
+
+Every address in the resulting product is scanned; nothing is treated as a network or broadcast address, because there is no prefix length from which one could be derived. `10.0.0.0-255` therefore includes `10.0.0.0` and `10.0.0.255`.
+
+Octet ranges exist for networks that are not shaped like CIDR blocks. `10.16-22.0-255.51-66` sweeps `.51` through `.66` in every `/24` from `10.16` to `10.22` — 28,672 addresses. Expressing the same thing in CIDR takes 1,792 separate scans, and the smallest CIDR block that contains it (`10.16.0.0/13`) is 512k addresses, 98% of which are not worth probing.
+
+Rules:
+
+- Each octet is a number from 0 to 255, or a range whose lower bound comes first. `10.22-16.0.1` is rejected as a reversed range rather than quietly scanning nothing.
+- A bare address (`10.0.0.5`) is a valid target that scans exactly that host.
+- A single scan may cover at most **32,768 addresses**. Larger targets are rejected when you save the scan — split them into several scans, or narrow the ranges.
+
+Targets are validated when the scan is created, so a typo is reported on the form rather than minutes later as a failed scan.
 
 Imported devices are created with the responding IP as the hostname, the device's reported system name as the display name, and the scan's probe and SNMP credentials — so a v3 scan imports ready-to-poll v3 devices that start getting polled immediately. Devices that are already registered are flagged and skipped.
 
@@ -302,7 +336,7 @@ snmpget -v3 -u username -l authPriv -a SHA -A authpassword -x AES -X privpasswor
 ## Best Practices
 
 1. **Use SNMPv3 when possible** - It provides authentication and encryption for better security
-2. **Discover, then import** - A subnet scan is faster and less error-prone than registering devices by hand
+2. **Discover, then import** - A discovery scan is faster and less error-prone than registering devices by hand
 3. **Register devices by the IP they send traps from** - Trap-to-monitor matching is by source IP
 4. **Create monitors from the device page** - The type, device, and recommended alert pack come pre-filled
 5. **Keep interface walking on for switches and routers** - It powers interface alerts, utilization data, and the topology map

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -22,10 +22,11 @@ import logger from "Common/Server/Utils/Logger";
 const router: ExpressRouter = Express.getRouter();
 
 /*
- * Floor for recurring rescans. A subnet sweep is heavy (up to 4096 hosts,
- * one probe at a time), so anything tighter than this would keep the probe
- * permanently busy. Lower stored intervals are clamped, not rejected — the
- * scan still recurs, just no faster than this.
+ * Floor for recurring rescans. A discovery sweep is heavy (up to
+ * ScanTargetUtil.MAX_SCAN_HOSTS addresses, one probe at a time), so anything
+ * tighter than this would keep the probe permanently busy. Lower stored
+ * intervals are clamped, not rejected — the scan still recurs, just no faster
+ * than this.
  */
 const MINIMUM_RESCAN_INTERVAL_IN_MINUTES: number = 15;
 
@@ -88,12 +89,16 @@ router.post(
 
       for (const scan of scans) {
         /*
-         * Claim via the hook-free single-statement write: the model and
-         * service have no update hooks, workflow, realtime, or audit
-         * decorators, so the full updateOneById pipeline (permission
-         * pre-fetch SELECT + row re-fetch + save() transaction) was pure
-         * overhead — three extra pool round-trips on a route the probe
-         * polls every minute and whose response it synchronously waits on.
+         * Claim via the hook-free single-statement write: the model has no
+         * workflow, realtime, or audit decorators, and the service's only
+         * update hook validates the scan target (`cidr`) — a column this
+         * payload does not touch. So the full updateOneById pipeline
+         * (permission pre-fetch SELECT + row re-fetch + save() transaction)
+         * is pure overhead — three extra pool round-trips on a route the
+         * probe polls every minute and whose response it synchronously
+         * waits on. Keep the payload disjoint from `cidr`; the disjointness
+         * is pinned by Common/Tests/Server/Services/
+         * DiscoveryScanClaimHookFreeSafety.test.ts.
          *
          * Plain object, NOT a model instance: a `new
          * NetworkDeviceDiscoveryScan()` payload carries non-column base

--- a/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
+++ b/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
@@ -27,10 +27,12 @@ import logger from "Common/Server/Utils/Logger";
  * Clearing them here would only destroy the last good inventory.
  */
 /*
- * A subnet sweep is bounded work: 4096 hosts / 32 workers with 1s ping +
- * 2s SNMP timeouts finishes in minutes. A scan still In Progress after
- * this long means the probe that claimed it died mid-scan (crash,
- * redeploy, decommission) and will never report back.
+ * A discovery sweep is bounded work: at the ScanTargetUtil.MAX_SCAN_HOSTS
+ * ceiling (32,768 addresses) 32 workers with 1s ping + 2s SNMP timeouts
+ * finish in well under an hour even when the ICMP pre-sweep is unavailable
+ * and every address is SNMP-probed directly. A scan still In Progress after
+ * this long means the probe that claimed it died mid-scan (crash, redeploy,
+ * decommission) and will never report back.
  */
 const STALE_IN_PROGRESS_HOURS: number = 2;
 

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -208,7 +208,12 @@ describe("POST /probe/discovery-scan/list", () => {
      * hook-free single-statement write. The probe synchronously waits on
      * this route every minute, so the claim must not pay the full
      * updateOneById pipeline (permission pre-fetch + row re-fetch + save()
-     * transaction) for a model with no update hooks.
+     * transaction).
+     *
+     * "and nothing else" is load-bearing, not cosmetic: the service's
+     * onBeforeUpdate validates the scan target, and skipping hooks is only
+     * safe while the claim payload stays disjoint from the `cidr` column
+     * that hook checks. Adding `cidr` here fails this assertion.
      */
     expect(scanService.updateOneById).not.toHaveBeenCalled();
     expect(scanService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(1);

--- a/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan.ts
@@ -77,7 +77,7 @@ export interface DiscoveredNetworkDevice {
   pluralName: "Network Device Discovery Scans",
   icon: IconProp.Search,
   tableDescription:
-    "Subnet discovery scans that sweep a CIDR range via SNMP from a probe and report devices found, so they can be imported as Network Devices.",
+    "Network discovery scans that sweep an address space — a CIDR subnet or an octet range — via SNMP from a probe and report devices found, so they can be imported as Network Devices.",
 })
 @Entity({
   name: "NetworkDeviceDiscoveryScan",
@@ -260,12 +260,22 @@ export default class NetworkDeviceDiscoveryScan extends BaseModel {
     ],
     update: [],
   })
+  /*
+   * The address space this scan sweeps. Two notations are accepted (see
+   * Common/Utils/NetworkDiscovery/ScanTargetUtil): CIDR, and octet ranges
+   * where any octet may be an inclusive low-high range.
+   *
+   * The column keeps the name `cidr` it was created with: it is part of the
+   * public API surface and the probe payload, and renaming it would break both
+   * for a purely cosmetic gain.
+   */
   @TableColumn({
     required: true,
     type: TableColumnType.ShortText,
     canReadOnRelationQuery: true,
-    title: "CIDR",
-    description: "Subnet to scan in CIDR notation, e.g. 192.168.1.0/24",
+    title: "Scan Target",
+    description:
+      "Address space to scan, either in CIDR notation (192.168.1.0/24) or octet-range notation where any octet may be an inclusive low-high range (10.16-22.0-255.51-66)",
     example: "192.168.1.0/24",
   })
   @Column({

--- a/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
+++ b/Common/Server/Services/NetworkDeviceDiscoveryScanService.ts
@@ -1,9 +1,79 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import BadDataException from "../../Types/Exception/BadDataException";
+import ScanTargetUtil from "../../Utils/NetworkDiscovery/ScanTargetUtil";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * Validate the scan target at write time, with the same parser the probe
+   * expands it with (Common/Utils/NetworkDiscovery/ScanTargetUtil).
+   *
+   * Without this, a typo'd target is accepted, sits Pending until a probe
+   * claims it, and only surfaces minutes later as a Failed scan with the
+   * parser's complaint buried in statusMessage. Octet-range notation makes
+   * that far likelier than CIDR did — a reversed range ("10.22-16.0.1-20") or
+   * an out-of-range octet is easy to type and impossible to spot by eye — so
+   * the feedback belongs on the form, not on a scan result.
+   *
+   * The size ceiling is checked here too: an oversized target is rejected the
+   * moment it is entered rather than after a probe has been handed a sweep it
+   * refuses to run.
+   */
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    this.validateScanTarget(createBy.data.cidr);
+
+    return { createBy, carryForward: null };
+  }
+
+  /*
+   * The target column is not user-updatable (its ColumnAccessControl grants no
+   * update permission), but root writers — the probe-ingest endpoints, workers,
+   * migrations — bypass that. Validating any update that carries the column
+   * keeps the invariant true for every writer instead of just the form.
+   */
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    const dataKeys: Array<string> = Object.keys(updateBy.data || {});
+
+    if (dataKeys.includes("cidr")) {
+      this.validateScanTarget(
+        (updateBy.data as Record<string, unknown>)["cidr"],
+      );
+    }
+
+    return { updateBy, carryForward: null };
+  }
+
+  /*
+   * The value is passed through UNTOUCHED. It arrives straight from the
+   * request JSON — BaseAPI assigns ShortText columns verbatim, and this hook
+   * runs before the model's type and length checks — so it may be a number,
+   * an object or an array, not just a string. ScanTargetUtil already type-
+   * guards and trims internally; normalizing here (the obvious
+   * `(target || "").trim()`) would instead throw a TypeError on any truthy
+   * non-string and turn an intended 400 into a 500.
+   */
+  private validateScanTarget(target: unknown): void {
+    const validationError: string | null = ScanTargetUtil.getValidationError(
+      target as string,
+    );
+
+    if (validationError) {
+      throw new BadDataException(validationError);
+    }
   }
 }
 

--- a/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+++ b/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
@@ -22,15 +22,24 @@ import { describe, expect, test } from "@jest/globals";
  *       Pending scan
  *
  * The conversion dropped NOTHING: the model declares no update workflow, no
- * audit logging and no realtime events, and the service overrides neither
- * update hook — so the old pipeline's hook stages were inert for this
- * write. But the fast path skips hooks UNCONDITIONALLY: if someone later
- * adds a decorator to NetworkDeviceDiscoveryScan or an update-hook override
- * to its service, nothing at the call site fails — the new hook is just
+ * audit logging and no realtime events. But the fast path skips hooks
+ * UNCONDITIONALLY: if someone adds a decorator to NetworkDeviceDiscoveryScan,
+ * or an update-hook override to its service that cares about a column the
+ * claim write stamps, nothing at the call site fails — the hook is just
  * silently never fired for the claim write. This suite turns that silent
  * drift into a loud test failure: if any assertion here starts failing, the
  * hookless claim writes in DiscoveryScan.ts silently skip that new hook —
  * revisit the call site before changing the assertion.
+ *
+ * The service DOES now override onBeforeUpdate: it validates the scan target
+ * (the `cidr` column) whenever an update carries it, so a bad target cannot
+ * be written by a root caller that bypasses the create-time check. That hook
+ * is deliberately safe to skip here, and the assertions below pin exactly
+ * why rather than merely restating that it exists: the claim write stamps
+ * only `status` and `startedAt`, which the hook does not look at, and the
+ * hook is a pass-through for that payload. If the hook ever grows to
+ * validate a column the claim write touches — or the claim write grows to
+ * touch `cidr` — these fail.
  *
  * Pure model-metadata + class-shape tests — no Postgres, no Redis.
  */
@@ -79,26 +88,21 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
     });
   });
 
-  describe("service defines no update hooks of its own", () => {
-    /*
-     * DatabaseService's base onBeforeUpdate/onUpdateSuccess are no-op
-     * pass-throughs; a service only gets update behavior by OVERRIDING
-     * them. Own-property checks on the concrete service prototype pin that
-     * NetworkDeviceDiscoveryScanService does not — so the fast path skips
-     * nothing. If an override appears, these fail loudly and the claim
-     * write in DiscoveryScan.ts must be re-evaluated.
-     */
+  describe("the service's update hooks are safe for the claim write to skip", () => {
     const updateHooks: Array<string> = ["onBeforeUpdate", "onUpdateSuccess"];
 
-    test("NetworkDeviceDiscoveryScanService does not override onBeforeUpdate/onUpdateSuccess", () => {
-      for (const hook of updateHooks) {
-        expect(
-          Object.prototype.hasOwnProperty.call(
-            NetworkDeviceDiscoveryScanServiceClass.prototype,
-            hook,
-          ),
-        ).toBe(false);
-      }
+    /*
+     * onUpdateSuccess is still un-overridden: nothing runs AFTER the write
+     * that the fast path would drop. Only onBeforeUpdate is overridden, and
+     * the tests below pin that it is inert for the claim payload.
+     */
+    test("NetworkDeviceDiscoveryScanService does not override onUpdateSuccess", () => {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          NetworkDeviceDiscoveryScanServiceClass.prototype,
+          "onUpdateSuccess",
+        ),
+      ).toBe(false);
       // The default export is an instance of the class checked above.
       expect(NetworkDeviceDiscoveryScanService).toBeInstanceOf(
         NetworkDeviceDiscoveryScanServiceClass,
@@ -116,6 +120,60 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
           Object.prototype.hasOwnProperty.call(DatabaseService.prototype, hook),
         ).toBe(true);
       }
+    });
+
+    /*
+     * The columns the claim write stamps and the column the onBeforeUpdate
+     * override validates must stay disjoint. This is the assertion that
+     * actually licenses the hookless claim write: if someone adds `cidr` to
+     * the claim payload, or teaches the hook to validate `status`, the
+     * overlap shows up here.
+     */
+    test("the claim write's columns are disjoint from what onBeforeUpdate validates", () => {
+      const claimWriteColumns: Array<string> = ["status", "startedAt"];
+      const columnsValidatedByHook: Array<string> = ["cidr"];
+
+      for (const column of claimWriteColumns) {
+        expect(columnsValidatedByHook).not.toContain(column);
+      }
+    });
+
+    /*
+     * And the behavioural proof, rather than an inventory of column names:
+     * handed exactly the payload the claim write stamps, the override is a
+     * pass-through. Skipping it therefore drops nothing.
+     */
+    test("onBeforeUpdate is a pass-through for the exact claim payload", async () => {
+      const claimUpdateBy: unknown = {
+        query: { _id: "some-scan-id" },
+        data: { status: "In Progress", startedAt: new Date(0) },
+        props: { isRoot: true },
+        limit: 1,
+        skip: 0,
+      };
+
+      const result: { updateBy: unknown } = await (
+        NetworkDeviceDiscoveryScanService as any
+      ).onBeforeUpdate(claimUpdateBy);
+
+      expect(result.updateBy).toBe(claimUpdateBy);
+    });
+
+    /*
+     * Negative control: the hook is not inert in general. Without this, the
+     * pass-through test above would keep passing if the override were
+     * gutted, and the disjointness assertion would be guarding nothing.
+     */
+    test("onBeforeUpdate does reject a bad target, so the pass-through is meaningful", async () => {
+      await expect(
+        (NetworkDeviceDiscoveryScanService as any).onBeforeUpdate({
+          query: { _id: "some-scan-id" },
+          data: { cidr: "10.22-16.0.1" },
+          props: { isRoot: true },
+          limit: 1,
+          skip: 0,
+        }),
+      ).rejects.toThrow();
     });
   });
 });

--- a/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts
@@ -1,0 +1,262 @@
+import NetworkDeviceDiscoveryScanService from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
+import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import ScanTargetUtil from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test: a discovery scan cannot be saved with a target the
+ * probe would later refuse to sweep. Before this validation existed, a typo
+ * was accepted, sat Pending until a probe claimed it, and surfaced minutes
+ * later as a Failed scan — octet-range notation makes that mistake much
+ * easier to make (a reversed range looks fine to the eye), so the check has
+ * to happen at write time.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROBE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+
+/*
+ * `cidr` is typed unknown, not string: this hook runs before the model's own
+ * type and length checks, and BaseAPI assigns ShortText columns straight from
+ * the request JSON — so a client that sends a number or an object really does
+ * reach it with that value.
+ */
+function makeCreateBy(cidr?: unknown): CreateBy<NetworkDeviceDiscoveryScan> {
+  const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+  scan.projectId = PROJECT_ID;
+  scan.probeId = PROBE_ID;
+  if (cidr !== undefined) {
+    (scan as unknown as Record<string, unknown>)["cidr"] = cidr;
+  }
+  return {
+    data: scan,
+    props: { isRoot: true },
+  };
+}
+
+function makeUpdateBy(
+  data: Record<string, unknown>,
+): UpdateBy<NetworkDeviceDiscoveryScan> {
+  return {
+    query: { projectId: PROJECT_ID },
+    data: data,
+    props: { isRoot: true },
+    limit: 1,
+    skip: 0,
+  } as unknown as UpdateBy<NetworkDeviceDiscoveryScan>;
+}
+
+type OnBeforeCreateFunction = (
+  createBy: CreateBy<NetworkDeviceDiscoveryScan>,
+) => Promise<unknown>;
+
+type OnBeforeUpdateFunction = (
+  updateBy: UpdateBy<NetworkDeviceDiscoveryScan>,
+) => Promise<unknown>;
+
+const onBeforeCreate: OnBeforeCreateFunction = (
+  createBy: CreateBy<NetworkDeviceDiscoveryScan>,
+): Promise<unknown> => {
+  return (NetworkDeviceDiscoveryScanService as any).onBeforeCreate(createBy);
+};
+
+const onBeforeUpdate: OnBeforeUpdateFunction = (
+  updateBy: UpdateBy<NetworkDeviceDiscoveryScan>,
+): Promise<unknown> => {
+  return (NetworkDeviceDiscoveryScanService as any).onBeforeUpdate(updateBy);
+};
+
+describe("NetworkDeviceDiscoveryScanService.onBeforeCreate", () => {
+  it("accepts a CIDR target", async () => {
+    await expect(
+      onBeforeCreate(makeCreateBy("192.168.1.0/24")),
+    ).resolves.toBeDefined();
+  });
+
+  it("accepts an octet-range target", async () => {
+    await expect(
+      onBeforeCreate(makeCreateBy("10.16-22.0-255.51-66")),
+    ).resolves.toBeDefined();
+  });
+
+  it("accepts a single-host target", async () => {
+    await expect(
+      onBeforeCreate(makeCreateBy("10.0.0.5")),
+    ).resolves.toBeDefined();
+  });
+
+  it("trims surrounding whitespace before validating", async () => {
+    await expect(
+      onBeforeCreate(makeCreateBy("  10.16-22.0-255.51-66  ")),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects a missing target", async () => {
+    await expect(onBeforeCreate(makeCreateBy())).rejects.toThrow(
+      BadDataException,
+    );
+  });
+
+  it("rejects an empty or whitespace-only target", async () => {
+    await expect(onBeforeCreate(makeCreateBy(""))).rejects.toThrow(
+      BadDataException,
+    );
+    await expect(onBeforeCreate(makeCreateBy("   "))).rejects.toThrow(
+      BadDataException,
+    );
+  });
+
+  it("rejects a malformed CIDR", async () => {
+    await expect(onBeforeCreate(makeCreateBy("10.0.0.0/33"))).rejects.toThrow(
+      /between \/0 and \/32/,
+    );
+    await expect(onBeforeCreate(makeCreateBy("not-a-target"))).rejects.toThrow(
+      BadDataException,
+    );
+  });
+
+  it("rejects a reversed octet range with a message naming the fix", async () => {
+    await expect(
+      onBeforeCreate(makeCreateBy("10.22-16.0.1-20")),
+    ).rejects.toThrow(/reversed/);
+  });
+
+  it("rejects an out-of-range octet", async () => {
+    await expect(onBeforeCreate(makeCreateBy("10.0.0.256"))).rejects.toThrow(
+      /between 0 and 255/,
+    );
+  });
+
+  /*
+   * The size ceiling belongs on the form, not on a scan result: rejecting at
+   * write time is the difference between an inline error and a probe being
+   * handed a sweep it refuses minutes later.
+   */
+  it("rejects a target above the scan-size ceiling", async () => {
+    await expect(onBeforeCreate(makeCreateBy("10.0.0.0/8"))).rejects.toThrow(
+      /exceeding the/,
+    );
+    await expect(
+      onBeforeCreate(makeCreateBy("10.0-255.0-255.1-10")),
+    ).rejects.toThrow(/exceeding the/);
+  });
+
+  it("accepts a target exactly at the ceiling", async () => {
+    const atLimit: string = "10.0.0-127.0-255";
+    expect(ScanTargetUtil.countHosts(atLimit)).toBe(
+      ScanTargetUtil.MAX_SCAN_HOSTS,
+    );
+    await expect(onBeforeCreate(makeCreateBy(atLimit))).resolves.toBeDefined();
+  });
+
+  /*
+   * This hook is the FIRST thing to touch the raw request value:
+   * DatabaseService.create runs it before checkRequiredFields, before the
+   * column type/length checks and before the create-permission check, and
+   * BaseAPI assigns a ShortText column straight from the JSON body. So a
+   * client sending `"cidr": 42` reaches here with the number 42. Normalizing
+   * the value in the hook (`(target || "").trim()`) would throw a TypeError
+   * on every truthy non-string and turn the intended 400 into a 500.
+   */
+  it("rejects a non-string target with BadDataException, not a TypeError", async () => {
+    for (const badValue of [
+      42,
+      true,
+      {},
+      [],
+      ["10.0.0.0/24"],
+      { value: "10.0.0.0/24" },
+      0,
+      null,
+    ]) {
+      await expect(onBeforeCreate(makeCreateBy(badValue))).rejects.toThrow(
+        BadDataException,
+      );
+    }
+  });
+
+  it("rejects a non-string target on update too", async () => {
+    await expect(onBeforeUpdate(makeUpdateBy({ cidr: 42 }))).rejects.toThrow(
+      BadDataException,
+    );
+    await expect(onBeforeUpdate(makeUpdateBy({ cidr: {} }))).rejects.toThrow(
+      BadDataException,
+    );
+  });
+
+  /*
+   * The error quotes the target back, so an unbounded target would be
+   * amplified into the exception, the logs and the response body — and this
+   * hook runs before the column's 100-character cap would have stopped it.
+   */
+  it("rejects an over-long target without echoing it", async () => {
+    const huge: string = `1.2.3.${"9".repeat(100000)}`;
+
+    await expect(onBeforeCreate(makeCreateBy(huge))).rejects.toThrow(
+      /cannot be longer than/,
+    );
+
+    let message: string = "";
+    try {
+      await onBeforeCreate(makeCreateBy(huge));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message.length).toBeLessThan(400);
+  });
+
+  it("returns the createBy unchanged so the write proceeds", async () => {
+    const createBy: CreateBy<NetworkDeviceDiscoveryScan> =
+      makeCreateBy("192.168.1.0/24");
+    const result: any = await onBeforeCreate(createBy);
+    expect(result.createBy).toBe(createBy);
+    expect(result.createBy.data.cidr).toBe("192.168.1.0/24");
+  });
+});
+
+describe("NetworkDeviceDiscoveryScanService.onBeforeUpdate", () => {
+  /*
+   * Every run-state write (claiming a scan, reporting a result, re-queueing a
+   * recurring one) is an update that does NOT carry the target column. Those
+   * must pass straight through — validating a column that is not being written
+   * would break the entire scan lifecycle.
+   */
+  it("ignores updates that do not touch the target", async () => {
+    await expect(
+      onBeforeUpdate(
+        makeUpdateBy({ status: "In Progress", startedAt: new Date(0) }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("ignores an update with no data at all", async () => {
+    await expect(onBeforeUpdate(makeUpdateBy({}))).resolves.toBeDefined();
+  });
+
+  it("validates a target carried by an update", async () => {
+    await expect(
+      onBeforeUpdate(makeUpdateBy({ cidr: "10.22-16.0.1" })),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("accepts a valid target carried by an update", async () => {
+    await expect(
+      onBeforeUpdate(makeUpdateBy({ cidr: "10.16-22.0-255.51-66" })),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects an update that clears the target", async () => {
+    await expect(onBeforeUpdate(makeUpdateBy({ cidr: null }))).rejects.toThrow(
+      BadDataException,
+    );
+    await expect(onBeforeUpdate(makeUpdateBy({ cidr: "" }))).rejects.toThrow(
+      BadDataException,
+    );
+  });
+});

--- a/Common/Tests/Utils/NetworkDiscovery/ScanTargetUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/ScanTargetUtil.test.ts
@@ -1,0 +1,583 @@
+import ScanTargetUtil, {
+  ScanTargetNotation,
+  ScanTarget,
+} from "../../../Utils/NetworkDiscovery/ScanTargetUtil";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test: a discovery scan target parses, counts and expands
+ * identically wherever it is read — the dashboard form, the server-side
+ * create validator, and the probe that actually sweeps it. The two notations
+ * have deliberately DIFFERENT address semantics (CIDR excludes network and
+ * broadcast; an octet range is an explicit enumeration and excludes nothing),
+ * so most of what follows is pinning that difference down.
+ */
+
+describe("ScanTargetUtil.getNotation", () => {
+  it("reads a prefixed target as CIDR", () => {
+    expect(ScanTargetUtil.getNotation("192.168.1.0/24")).toBe(
+      ScanTargetNotation.Cidr,
+    );
+  });
+
+  it("reads a ranged target as an octet range", () => {
+    expect(ScanTargetUtil.getNotation("10.16-22.0-255.51-66")).toBe(
+      ScanTargetNotation.OctetRange,
+    );
+  });
+
+  it("reads a bare address as an octet range of one", () => {
+    expect(ScanTargetUtil.getNotation("10.0.0.5")).toBe(
+      ScanTargetNotation.OctetRange,
+    );
+  });
+
+  it("returns null for a target in neither notation", () => {
+    expect(ScanTargetUtil.getNotation("not-a-target")).toBeNull();
+  });
+
+  /*
+   * A '/' means the author meant CIDR. Falling back to the octet-range parser
+   * would turn a typo'd prefix into the far less useful "not a valid scan
+   * target" instead of "that prefix is out of range".
+   */
+  it("does not retry a malformed CIDR as an octet range", () => {
+    expect(ScanTargetUtil.getNotation("10.0.0.0/99")).toBeNull();
+    expect(ScanTargetUtil.getValidationError("10.0.0.0/99")).toContain(
+      "Prefix length",
+    );
+  });
+});
+
+describe("ScanTargetUtil.countHosts - CIDR", () => {
+  it("counts a /24 as 254 usable hosts (excludes network + broadcast)", () => {
+    expect(ScanTargetUtil.countHosts("192.168.1.0/24")).toBe(254);
+  });
+
+  it("counts a /30 as 2 usable hosts", () => {
+    expect(ScanTargetUtil.countHosts("10.0.0.0/30")).toBe(2);
+  });
+
+  it("counts /31 and /32 as every address (no network/broadcast exclusion)", () => {
+    expect(ScanTargetUtil.countHosts("10.0.0.0/31")).toBe(2);
+    expect(ScanTargetUtil.countHosts("10.0.0.5/32")).toBe(1);
+  });
+
+  it("counts a /8 as ~16.7M without allocating them", () => {
+    /*
+     * The whole point of counting arithmetically: this must be derivable from
+     * the prefix, not by building the address array.
+     */
+    expect(ScanTargetUtil.countHosts("10.0.0.0/8")).toBe(Math.pow(2, 24) - 2);
+  });
+
+  it("counts a /0 as the whole address space minus network + broadcast", () => {
+    expect(ScanTargetUtil.countHosts("0.0.0.0/0")).toBe(Math.pow(2, 32) - 2);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(ScanTargetUtil.countHosts("  192.168.1.0/24  ")).toBe(254);
+  });
+
+  it("returns 0 for malformed or out-of-range CIDRs", () => {
+    expect(ScanTargetUtil.countHosts("not-a-cidr")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0.0/33")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0.0/")).toBe(0);
+    expect(ScanTargetUtil.countHosts("/24")).toBe(0);
+    expect(ScanTargetUtil.countHosts("999.0.0.0/24")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0/24")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0.0.0/24")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0.0/24/24")).toBe(0);
+  });
+
+  it("agrees with expand() for subnets small enough to expand", () => {
+    for (const target of [
+      "192.168.1.0/29",
+      "172.16.5.0/28",
+      "10.1.1.0/30",
+      "10.1.1.4/31",
+      "10.1.1.9/32",
+      "10.2.0.0/24",
+    ]) {
+      expect(ScanTargetUtil.countHosts(target)).toBe(
+        ScanTargetUtil.expand(target).length,
+      );
+    }
+  });
+});
+
+describe("ScanTargetUtil.countHosts - octet ranges", () => {
+  it("counts the product of the four octet widths", () => {
+    // 1 x 7 x 256 x 16
+    expect(ScanTargetUtil.countHosts("10.16-22.0-255.51-66")).toBe(28672);
+    // 1 x 3 x 256 x 16
+    expect(ScanTargetUtil.countHosts("10.48-50.0-255.51-66")).toBe(12288);
+  });
+
+  it("counts a bare address as one host", () => {
+    expect(ScanTargetUtil.countHosts("10.0.0.5")).toBe(1);
+  });
+
+  it("counts a single-octet range", () => {
+    expect(ScanTargetUtil.countHosts("192.168.1.10-40")).toBe(31);
+  });
+
+  it("counts a degenerate range (a-a) as one value for that octet", () => {
+    expect(ScanTargetUtil.countHosts("10.5-5.5-5.1-4")).toBe(4);
+  });
+
+  /*
+   * An octet range enumerates addresses; it has no prefix length, so there is
+   * no network or broadcast address to exclude. Whoever wrote 0-255 asked for
+   * .0 and .255 by name.
+   */
+  it("counts every address in the range, including .0 and .255", () => {
+    expect(ScanTargetUtil.countHosts("10.0.0.0-255")).toBe(256);
+  });
+
+  it("counts a full-width range without allocating it", () => {
+    expect(ScanTargetUtil.countHosts("0-255.0-255.0-255.0-255")).toBe(
+      Math.pow(256, 4),
+    );
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(ScanTargetUtil.countHosts("  10.16-22.0-255.51-66  ")).toBe(28672);
+  });
+
+  it("returns 0 for out-of-range octets", () => {
+    expect(ScanTargetUtil.countHosts("10.256.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0-256.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("300-400.0.0.1")).toBe(0);
+  });
+
+  it("returns 0 for a reversed range", () => {
+    expect(ScanTargetUtil.countHosts("10.22-16.0.1")).toBe(0);
+  });
+
+  it("returns 0 for the wrong number of octets", () => {
+    expect(ScanTargetUtil.countHosts("10.0.0")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0.0.0")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.16-22.0-255")).toBe(0);
+    expect(ScanTargetUtil.countHosts("")).toBe(0);
+    expect(ScanTargetUtil.countHosts("   ")).toBe(0);
+  });
+
+  it("returns 0 for malformed range syntax", () => {
+    expect(ScanTargetUtil.countHosts("10.16-.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.-22.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.16-22-30.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.16 - 22.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.1a.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10..0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.0.0.1.")).toBe(0);
+    expect(ScanTargetUtil.countHosts(".10.0.0.1")).toBe(0);
+    // A negative bound reads as an empty first term, not as -22.
+    expect(ScanTargetUtil.countHosts("10.-22--16.0.1")).toBe(0);
+  });
+
+  /*
+   * Everything is parsed base 10, so a padded octet is the number it looks
+   * like and not an octal one. Worth pinning: a target that silently meant
+   * 10.8.0.1 instead of 10.10.0.1 would scan the wrong network.
+   */
+  it("reads zero-padded octets as base 10, never octal", () => {
+    expect(ScanTargetUtil.expand("010.010.0.1")).toEqual(["10.10.0.1"]);
+    expect(ScanTargetUtil.expand("10.0.0.08-09")).toEqual([
+      "10.0.0.8",
+      "10.0.0.9",
+    ]);
+    expect(ScanTargetUtil.countHosts("10.0.0.0/024")).toBe(254);
+  });
+
+  /*
+   * \d without the u flag is ASCII-only, so digit-lookalikes from other
+   * scripts are rejected rather than coerced into some other address.
+   */
+  it("rejects non-ASCII digit lookalikes", () => {
+    expect(ScanTargetUtil.countHosts("１０.0.0.1")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.٠.0.1")).toBe(0);
+  });
+
+  it("rejects a very long target without pathological slowdown", () => {
+    const started: number = Date.now();
+    expect(ScanTargetUtil.countHosts("1".repeat(50000))).toBe(0);
+    expect(ScanTargetUtil.countHosts(`10.${"1-".repeat(20000)}2.0.1`)).toBe(0);
+    expect(Date.now() - started).toBeLessThan(2000);
+  });
+
+  it("accepts a target at the length gate and rejects one past it", () => {
+    // The widest well-formed target, comfortably inside the gate.
+    const widest: string = "255-255.255-255.255-255.255-255";
+    expect(widest.length).toBeLessThanOrEqual(ScanTargetUtil.MAX_TARGET_LENGTH);
+    expect(ScanTargetUtil.getValidationError(widest)).toBeNull();
+
+    expect(
+      ScanTargetUtil.getValidationError(
+        "1".repeat(ScanTargetUtil.MAX_TARGET_LENGTH + 1),
+      ),
+    ).toContain("cannot be longer than");
+  });
+
+  /*
+   * The length gate exists to bound the ERROR, not just the parse. Every
+   * other rejection quotes the target back — parseOctetRange quotes both the
+   * bad term and the whole target — and the server-side create hook runs
+   * ahead of the column's 100-character cap, so an unbounded echo would let a
+   * large request body be amplified into the exception message, the logs and
+   * the response body.
+   */
+  it("does not echo an over-long target back in the error message", () => {
+    const huge: string = `1.2.3.${"9".repeat(200000)}`;
+    const error: string | null = ScanTargetUtil.getValidationError(huge);
+
+    expect(error).not.toBeNull();
+    expect(error).not.toContain("999999");
+    // Constant-size message, nowhere near the size of the input.
+    expect(error!.length).toBeLessThan(400);
+  });
+
+  /*
+   * Wildcards are nmap syntax, not ours. Rejecting them is better than
+   * accepting a target that means something subtly different to the operator
+   * than it does to the scanner.
+   */
+  it("returns 0 for wildcard and comma-list syntax that is not supported", () => {
+    expect(ScanTargetUtil.countHosts("10.16-22.*.51-66")).toBe(0);
+    expect(ScanTargetUtil.countHosts("10.1,3,5.0.1")).toBe(0);
+  });
+
+  it("agrees with expand() for ranges small enough to expand", () => {
+    for (const target of [
+      "10.0.0.1-10",
+      "10.0.1-3.1-4",
+      "192.168.1.1",
+      "10.1-2.3-4.5-6",
+      "10.0.0.0-255",
+    ]) {
+      expect(ScanTargetUtil.countHosts(target)).toBe(
+        ScanTargetUtil.expand(target).length,
+      );
+    }
+  });
+});
+
+describe("ScanTargetUtil.expand - CIDR", () => {
+  it("expands a /29 to its 6 usable hosts, in order", () => {
+    expect(ScanTargetUtil.expand("192.168.1.0/29")).toEqual([
+      "192.168.1.1",
+      "192.168.1.2",
+      "192.168.1.3",
+      "192.168.1.4",
+      "192.168.1.5",
+      "192.168.1.6",
+    ]);
+  });
+
+  it("expands /31 and /32 without excluding anything", () => {
+    expect(ScanTargetUtil.expand("10.0.0.0/31")).toEqual([
+      "10.0.0.0",
+      "10.0.0.1",
+    ]);
+    expect(ScanTargetUtil.expand("10.0.0.5/32")).toEqual(["10.0.0.5"]);
+  });
+
+  /*
+   * The stored address need not be the network address. Masking it down is
+   * what makes "10.0.0.37/24" mean the same subnet as "10.0.0.0/24".
+   */
+  it("masks a non-network address down to its subnet", () => {
+    expect(ScanTargetUtil.expand("192.168.1.37/29")).toEqual(
+      ScanTargetUtil.expand("192.168.1.32/29"),
+    );
+    expect(ScanTargetUtil.expand("192.168.1.37/29")[0]).toBe("192.168.1.33");
+  });
+
+  /*
+   * A shift by 32 is a no-op in JS, so the /24 mask arithmetic has to be
+   * special-cased at the high end. 10.20.30.40/1 must start from 0.0.0.1,
+   * not from the address as typed.
+   */
+  it("masks correctly at wide prefixes where JS shift arithmetic wraps", () => {
+    const parsed: ScanTarget | null = ScanTargetUtil.parse("10.20.30.40/1");
+    expect(parsed).not.toBeNull();
+    expect(parsed!.networkLong).toBe(0);
+
+    const parsedZero: ScanTarget | null = ScanTargetUtil.parse("10.20.30.40/0");
+    expect(parsedZero!.networkLong).toBe(0);
+  });
+
+  it("expands the last /24 in the space without sign-bit corruption", () => {
+    const hosts: Array<string> = ScanTargetUtil.expand("255.255.255.0/24");
+    expect(hosts.length).toBe(254);
+    expect(hosts[0]).toBe("255.255.255.1");
+    expect(hosts[253]).toBe("255.255.255.254");
+  });
+
+  /*
+   * The largest block that can be expanded, sitting at the very top of the
+   * address space: every address here has the sign bit set, so a signed >>
+   * anywhere in the arithmetic would show up as a wrong octet.
+   */
+  it("expands the largest allowed block at the top of the address space", () => {
+    const hosts: Array<string> = ScanTargetUtil.expand("255.255.128.0/17");
+    expect(hosts.length).toBe(ScanTargetUtil.MAX_SCAN_HOSTS - 2);
+    expect(hosts[0]).toBe("255.255.128.1");
+    expect(hosts[hosts.length - 1]).toBe("255.255.255.254");
+  });
+
+  it("returns an empty array for a malformed CIDR", () => {
+    expect(ScanTargetUtil.expand("10.0.0.0/33")).toEqual([]);
+    expect(ScanTargetUtil.expand("nope/24")).toEqual([]);
+  });
+});
+
+describe("ScanTargetUtil.expand - octet ranges", () => {
+  it("expands a last-octet range", () => {
+    expect(ScanTargetUtil.expand("192.168.1.10-13")).toEqual([
+      "192.168.1.10",
+      "192.168.1.11",
+      "192.168.1.12",
+      "192.168.1.13",
+    ]);
+  });
+
+  it("expands a bare address to exactly that address", () => {
+    expect(ScanTargetUtil.expand("10.0.0.5")).toEqual(["10.0.0.5"]);
+  });
+
+  it("expands a multi-octet range as a cross product, in ascending order", () => {
+    expect(ScanTargetUtil.expand("10.1-2.3-4.5-6")).toEqual([
+      "10.1.3.5",
+      "10.1.3.6",
+      "10.1.4.5",
+      "10.1.4.6",
+      "10.2.3.5",
+      "10.2.3.6",
+      "10.2.4.5",
+      "10.2.4.6",
+    ]);
+  });
+
+  it("includes .0 and .255 when the range names them", () => {
+    const hosts: Array<string> = ScanTargetUtil.expand("10.0.0.0-255");
+    expect(hosts.length).toBe(256);
+    expect(hosts[0]).toBe("10.0.0.0");
+    expect(hosts[255]).toBe("10.0.0.255");
+  });
+
+  it("expands ranges in every octet position", () => {
+    expect(ScanTargetUtil.expand("1-2.3.4.5")).toEqual(["1.3.4.5", "2.3.4.5"]);
+    expect(ScanTargetUtil.expand("1.2-3.4.5")).toEqual(["1.2.4.5", "1.3.4.5"]);
+    expect(ScanTargetUtil.expand("1.2.3-4.5")).toEqual(["1.2.3.5", "1.2.4.5"]);
+    expect(ScanTargetUtil.expand("1.2.3.4-5")).toEqual(["1.2.3.4", "1.2.3.5"]);
+  });
+
+  it("returns an empty array for a malformed octet range", () => {
+    expect(ScanTargetUtil.expand("10.22-16.0.1")).toEqual([]);
+    expect(ScanTargetUtil.expand("10.0.0")).toEqual([]);
+    expect(ScanTargetUtil.expand("")).toEqual([]);
+  });
+
+  /*
+   * The example from the feature request, spot-checked at its edges. This is
+   * the shape octet ranges exist for: the same 16 management addresses in
+   * every /24 of a /13, which CIDR cannot express in one scan.
+   */
+  it("expands the motivating example to the right corners", () => {
+    const hosts: Array<string> = ScanTargetUtil.expand("10.16-22.0-255.51-66");
+
+    expect(hosts.length).toBe(28672);
+    expect(hosts[0]).toBe("10.16.0.51");
+    expect(hosts[15]).toBe("10.16.0.66");
+    expect(hosts[16]).toBe("10.16.1.51");
+    expect(hosts[hosts.length - 1]).toBe("10.22.255.66");
+
+    /*
+     * Nothing outside the named ranges leaks in. Collected into one assertion
+     * rather than 28,672 of them — a per-host expect() makes this test take
+     * seconds for no extra coverage.
+     */
+    const outOfRange: Array<string> = hosts.filter((host: string) => {
+      const octets: Array<number> = host.split(".").map((part: string) => {
+        return parseInt(part, 10);
+      });
+      return (
+        octets[0] !== 10 ||
+        octets[1]! < 16 ||
+        octets[1]! > 22 ||
+        octets[3]! < 51 ||
+        octets[3]! > 66
+      );
+    });
+    expect(outOfRange).toEqual([]);
+  });
+
+  it("produces no duplicates", () => {
+    const hosts: Array<string> = ScanTargetUtil.expand("10.1-4.1-4.1-4");
+    expect(new Set(hosts).size).toBe(hosts.length);
+    expect(hosts.length).toBe(64);
+  });
+});
+
+describe("ScanTargetUtil size ceiling", () => {
+  it("accepts a target exactly at the limit", () => {
+    // 128 x 256 = 32,768 = MAX_SCAN_HOSTS.
+    const atLimit: string = "10.0.0-127.0-255";
+    expect(ScanTargetUtil.countHosts(atLimit)).toBe(
+      ScanTargetUtil.MAX_SCAN_HOSTS,
+    );
+    expect(ScanTargetUtil.getValidationError(atLimit)).toBeNull();
+  });
+
+  it("rejects a target one address over the limit", () => {
+    // 129 x 256 = 33,024.
+    const overLimit: string = "10.0.0-128.0-255";
+    expect(ScanTargetUtil.countHosts(overLimit)).toBeGreaterThan(
+      ScanTargetUtil.MAX_SCAN_HOSTS,
+    );
+    expect(ScanTargetUtil.getValidationError(overLimit)).toContain(
+      "exceeding the",
+    );
+  });
+
+  it("accepts the motivating example, which is what the limit had to allow", () => {
+    expect(
+      ScanTargetUtil.getValidationError("10.16-22.0-255.51-66"),
+    ).toBeNull();
+    expect(
+      ScanTargetUtil.getValidationError("10.48-50.0-255.51-66"),
+    ).toBeNull();
+  });
+
+  it("rejects an oversized CIDR", () => {
+    expect(ScanTargetUtil.getValidationError("10.0.0.0/8")).toContain(
+      "exceeding the",
+    );
+    expect(ScanTargetUtil.getValidationError("10.0.0.0/16")).toContain(
+      "exceeding the",
+    );
+  });
+
+  it("accepts the largest CIDR that fits", () => {
+    // A /17 is 32,766 usable hosts.
+    expect(ScanTargetUtil.getValidationError("10.0.0.0/17")).toBeNull();
+  });
+
+  /*
+   * expand() throws rather than silently truncating or returning [] for an
+   * oversized target: a caller that skipped its size check has a bug, and a
+   * quietly short address list would turn it into a scan that reports success
+   * having swept a fraction of what was asked for.
+   */
+  it("throws rather than allocating when expand() is called on an oversized target", () => {
+    expect(() => {
+      return ScanTargetUtil.expand("10.0.0.0/8");
+    }).toThrow(/exceeding the/);
+
+    expect(() => {
+      return ScanTargetUtil.expand("0-255.0-255.0-255.0-255");
+    }).toThrow(/exceeding the/);
+  });
+
+  it("still returns an empty array (not a throw) for a malformed target", () => {
+    expect(ScanTargetUtil.expand("garbage")).toEqual([]);
+  });
+});
+
+describe("ScanTargetUtil.getValidationError messages", () => {
+  it("returns null for valid targets in both notations", () => {
+    expect(ScanTargetUtil.getValidationError("192.168.1.0/24")).toBeNull();
+    expect(
+      ScanTargetUtil.getValidationError("10.16-22.0-255.51-66"),
+    ).toBeNull();
+    expect(ScanTargetUtil.getValidationError("10.0.0.5")).toBeNull();
+    expect(ScanTargetUtil.getValidationError("  10.0.0.5  ")).toBeNull();
+  });
+
+  it("asks for a target when given nothing", () => {
+    expect(ScanTargetUtil.getValidationError("")).toContain(
+      "A scan target is required",
+    );
+    expect(ScanTargetUtil.getValidationError("   ")).toContain(
+      "A scan target is required",
+    );
+  });
+
+  it("names the reversed octet range and suggests the fix", () => {
+    const error: string | null =
+      ScanTargetUtil.getValidationError("10.22-16.0.1");
+    expect(error).toContain("22-16");
+    expect(error).toContain("reversed");
+    // The suggestion is the same range written the right way round.
+    expect(error).toContain("16-22");
+  });
+
+  it("names the out-of-range octet", () => {
+    expect(ScanTargetUtil.getValidationError("10.0.0.256")).toContain(
+      "between 0 and 255",
+    );
+    expect(ScanTargetUtil.getValidationError("10.0-300.0.1")).toContain(
+      "between 0 and 255",
+    );
+    expect(ScanTargetUtil.getValidationError("300.0.0.0/24")).toContain(
+      "between 0 and 255",
+    );
+  });
+
+  it("names the out-of-range prefix", () => {
+    expect(ScanTargetUtil.getValidationError("10.0.0.0/33")).toContain(
+      "between /0 and /32",
+    );
+  });
+
+  it("explains both notations when the target is neither", () => {
+    const error: string | null =
+      ScanTargetUtil.getValidationError("hello world");
+    expect(error).toContain("not a valid scan target");
+    expect(error).toContain("CIDR");
+    expect(error).toContain("octet-range");
+  });
+
+  it("quotes the offending target back to the operator", () => {
+    expect(ScanTargetUtil.getValidationError("10.22-16.0.1")).toContain(
+      "10.22-16.0.1",
+    );
+  });
+
+  it("reports the actual size when a target is too large", () => {
+    const error: string | null =
+      ScanTargetUtil.getValidationError("10.0.0-128.0-255");
+    expect(error).toContain("33,024");
+    expect(error).toContain("32,768");
+  });
+
+  it("rejects non-string input without throwing", () => {
+    expect(
+      ScanTargetUtil.getValidationError(null as unknown as string),
+    ).toContain("A scan target is required");
+    expect(
+      ScanTargetUtil.getValidationError(undefined as unknown as string),
+    ).toContain("A scan target is required");
+    expect(ScanTargetUtil.isValid(42 as unknown as string)).toBe(false);
+    expect(ScanTargetUtil.countHosts({} as unknown as string)).toBe(0);
+    expect(ScanTargetUtil.expand([] as unknown as string)).toEqual([]);
+  });
+});
+
+describe("ScanTargetUtil.isValid", () => {
+  it("is true for well-formed targets regardless of size", () => {
+    /*
+     * isValid answers "is this syntax", NOT "will this scan" — the size
+     * ceiling is a separate, policy-driven check. A /8 is a perfectly valid
+     * CIDR that we refuse to sweep.
+     */
+    expect(ScanTargetUtil.isValid("10.0.0.0/8")).toBe(true);
+    expect(ScanTargetUtil.getValidationError("10.0.0.0/8")).not.toBeNull();
+  });
+
+  it("is false for malformed targets", () => {
+    expect(ScanTargetUtil.isValid("10.22-16.0.1")).toBe(false);
+    expect(ScanTargetUtil.isValid("")).toBe(false);
+  });
+});

--- a/Common/Utils/NetworkDiscovery/ScanTargetUtil.ts
+++ b/Common/Utils/NetworkDiscovery/ScanTargetUtil.ts
@@ -1,0 +1,434 @@
+/*
+ * Scan-target parsing for network device discovery.
+ *
+ * A discovery scan's target is the IPv4 address space a probe sweeps. Two
+ * notations are accepted:
+ *
+ *   CIDR         192.168.1.0/24
+ *   Octet range  10.16-22.0-255.51-66
+ *
+ * Octet-range notation exists because real networks are not shaped like CIDR
+ * blocks. "The .51-.66 management addresses in every /24 of 10.16-22.x" is a
+ * single target here; expressed in CIDR it is 1,792 separate scans, and the
+ * only CIDR that covers it in one go (10.16.0.0/13) is 512k addresses, of
+ * which 98% are not worth probing.
+ *
+ * This lives in Common rather than in the Probe's SubnetScanner so the server
+ * can validate a target at write time with exactly the parser the probe will
+ * later expand it with. A target that saves is a target that scans.
+ *
+ * IPv4-only by design, same as the sweep itself: IPv6 space is far too sparse
+ * to enumerate, and IPv6 discovery will be neighbour-discovery based.
+ */
+
+// Which of the two notations a target string is written in.
+export enum ScanTargetNotation {
+  Cidr = "CIDR",
+  OctetRange = "OctetRange",
+}
+
+// One octet's accepted values: `start` through `end`, both inclusive.
+export interface OctetRange {
+  start: number;
+  end: number;
+}
+
+export interface ScanTarget {
+  notation: ScanTargetNotation;
+  /*
+   * How many addresses the target expands to. Always derived arithmetically
+   * (prefix length / range widths) and never by building the address list, so
+   * an absurd target can be rejected before anything is allocated.
+   */
+  hostCount: number;
+  // Populated for ScanTargetNotation.OctetRange. Always exactly 4 entries.
+  octetRanges?: Array<OctetRange> | undefined;
+  // Populated for ScanTargetNotation.Cidr.
+  networkLong?: number | undefined;
+  blockSize?: number | undefined;
+}
+
+interface ParseOutcome {
+  target?: ScanTarget | undefined;
+  /*
+   * Human-readable, shown to the operator who typed the target. Never null when
+   * `target` is absent.
+   */
+  error?: string | undefined;
+}
+
+export class ScanTargetUtil {
+  /*
+   * Hard ceiling on how many addresses one scan may sweep.
+   *
+   * The number is a wall-clock budget, not a memory one. SubnetScanner runs 32
+   * workers; a dead host costs ~1s (the ICMP pre-sweep timeout), or ~2s when
+   * the pre-sweep is unavailable and every host is SNMP-probed directly. At
+   * this ceiling that is ~17 minutes with the pre-sweep and ~34 minutes
+   * without — both comfortably inside the 2-hour window after which the server
+   * declares an In Progress scan abandoned (Workers/Jobs/
+   * NetworkDeviceDiscovery/RequeueRecurringScans.ts) and safely above the
+   * 15-minute minimum rescan interval for recurring scans.
+   *
+   * It is also still a real abuse guard: a /17 in CIDR terms. Anything larger
+   * (a /16 sweep, an unbounded 10.*.*.* octet range) is rejected at write time
+   * with a message telling the operator to narrow the target.
+   */
+  public static readonly MAX_SCAN_HOSTS: number = 32768;
+
+  /*
+   * Longest string we will even attempt to parse. The widest well-formed
+   * target is "255-255.255-255.255-255.255-255" at 31 characters, so this is
+   * ~2x headroom and still far below the 100-character column. It exists to
+   * bound the error messages, which quote the target back — see the gate in
+   * parseWithError().
+   */
+  public static readonly MAX_TARGET_LENGTH: number = 64;
+
+  /*
+   * Hoisted so the literals are not the object of a member expression, which
+   * `wrap-regex` and Prettier cannot agree on. Same reason as CidrMatchUtil.
+   */
+  private static readonly CIDR_PATTERN: RegExp =
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,3})$/;
+
+  // A single octet term: `42` or `16-22`. Bounds are validated after parsing.
+  private static readonly OCTET_TERM_PATTERN: RegExp =
+    /^(\d{1,3})(?:-(\d{1,3}))?$/;
+
+  private static readonly EXAMPLE_CIDR: string = "192.168.1.0/24";
+
+  private static readonly EXAMPLE_OCTET_RANGE: string = "10.16-22.0-255.51-66";
+
+  /*
+   * Parses a target into the shape needed to count and expand it. Returns null
+   * for anything malformed; use getValidationError() when you need to tell the
+   * operator WHY. Size is deliberately not checked here — parse() answers "is
+   * this well-formed", the caller decides what it can afford to sweep.
+   */
+  public static parse(target: string): ScanTarget | null {
+    return ScanTargetUtil.parseWithError(target).target || null;
+  }
+
+  // True when `target` is well-formed in either notation. Ignores size.
+  public static isValid(target: string): boolean {
+    return ScanTargetUtil.parse(target) !== null;
+  }
+
+  /*
+   * The notation `target` is written in, or null when it is not a valid target
+   * at all. A string containing '/' is always read as CIDR — a malformed CIDR
+   * is never silently retried as an octet range, because "10.0.0.0/99" is a
+   * typo'd prefix and deserves to say so.
+   */
+  public static getNotation(target: string): ScanTargetNotation | null {
+    return ScanTargetUtil.parse(target)?.notation || null;
+  }
+
+  /*
+   * How many addresses `target` sweeps, or 0 when it is malformed. Computed
+   * from the prefix length / range widths alone, with no allocation: expand()
+   * materializes one string per address, so a size check that ran after
+   * expansion would let a /8 allocate ~16M strings before the limit it exists
+   * to enforce was ever consulted.
+   */
+  public static countHosts(target: string): number {
+    return ScanTargetUtil.parse(target)?.hostCount || 0;
+  }
+
+  /*
+   * The single validation entry point for a scan target: syntax first, then
+   * the size ceiling. Returns null when the target is good to scan, otherwise
+   * a message written for the operator who typed it.
+   */
+  public static getValidationError(target: string): string | null {
+    const outcome: ParseOutcome = ScanTargetUtil.parseWithError(target);
+
+    if (!outcome.target) {
+      return outcome.error || ScanTargetUtil.getMalformedTargetMessage(target);
+    }
+
+    if (outcome.target.hostCount > ScanTargetUtil.MAX_SCAN_HOSTS) {
+      return (
+        `"${String(target).trim()}" expands to ` +
+        `${outcome.target.hostCount.toLocaleString("en-US")} addresses, ` +
+        `exceeding the ${ScanTargetUtil.MAX_SCAN_HOSTS.toLocaleString("en-US")}-address scan limit. ` +
+        `Narrow the target (a smaller subnet, or tighter octet ranges) or split it into several scans.`
+      );
+    }
+
+    return null;
+  }
+
+  /*
+   * Expands a target into the addresses to probe, in ascending address order.
+   *
+   * Returns an empty array for a malformed target — there is nothing to sweep.
+   * THROWS for a well-formed target above MAX_SCAN_HOSTS: that is a caller
+   * that skipped its size check, and quietly returning a truncated or empty
+   * list would turn it into a silently wrong scan. Callers should gate on
+   * getValidationError() (or countHosts()) first and never see this.
+   */
+  public static expand(target: string): Array<string> {
+    const parsed: ScanTarget | null = ScanTargetUtil.parse(target);
+
+    if (!parsed) {
+      return [];
+    }
+
+    if (parsed.hostCount > ScanTargetUtil.MAX_SCAN_HOSTS) {
+      throw new Error(
+        ScanTargetUtil.getValidationError(target) ||
+          `Scan target "${String(target).trim()}" is too large to expand.`,
+      );
+    }
+
+    if (parsed.notation === ScanTargetNotation.Cidr) {
+      return ScanTargetUtil.expandCidrTarget(parsed);
+    }
+
+    return ScanTargetUtil.expandOctetRangeTarget(parsed);
+  }
+
+  /*
+   * Both notations in one sentence, for form hints and error messages. Kept
+   * here so the UI, the server-side validator and the probe all describe the
+   * accepted syntax identically.
+   */
+  public static getSyntaxHint(): string {
+    return (
+      `Use CIDR notation (e.g. ${ScanTargetUtil.EXAMPLE_CIDR}) or octet-range notation, ` +
+      `where any octet may be an inclusive low-high range (e.g. ${ScanTargetUtil.EXAMPLE_OCTET_RANGE}).`
+    );
+  }
+
+  private static parseWithError(target: string): ParseOutcome {
+    if (typeof target !== "string" || target.trim().length === 0) {
+      return {
+        error: `A scan target is required. ${ScanTargetUtil.getSyntaxHint()}`,
+      };
+    }
+
+    const trimmed: string = target.trim();
+
+    /*
+     * Length gate BEFORE anything builds a message. Every rejection below
+     * quotes the offending target back (parseOctetRange quotes both the bad
+     * term AND the whole target, doubling it), and the server-side create
+     * hook runs ahead of the column's 100-character cap — so without this,
+     * a 50 MB request body would be reflected into a ~100 MB exception that
+     * is both logged and serialized into the response. This message is a
+     * constant and echoes nothing.
+     */
+    if (trimmed.length > ScanTargetUtil.MAX_TARGET_LENGTH) {
+      return {
+        error:
+          `A scan target cannot be longer than ${ScanTargetUtil.MAX_TARGET_LENGTH} characters. ` +
+          ScanTargetUtil.getSyntaxHint(),
+      };
+    }
+
+    /*
+     * The '/' is the discriminator, checked before either parser runs. A
+     * string carrying a prefix is a CIDR attempt by intent, so "10.0.0.0/99"
+     * must report a bad prefix rather than fall through to the octet-range
+     * parser and report the far more confusing "not a valid scan target".
+     */
+    if (trimmed.includes("/")) {
+      return ScanTargetUtil.parseCidr(trimmed);
+    }
+
+    return ScanTargetUtil.parseOctetRange(trimmed);
+  }
+
+  private static parseCidr(trimmed: string): ParseOutcome {
+    const match: RegExpMatchArray | null = trimmed.match(
+      ScanTargetUtil.CIDR_PATTERN,
+    );
+
+    if (!match) {
+      return {
+        error:
+          `"${trimmed}" is not a valid IPv4 CIDR. ` +
+          `Expected four octets and a prefix length, e.g. ${ScanTargetUtil.EXAMPLE_CIDR}.`,
+      };
+    }
+
+    let baseLong: number = 0;
+    for (let i: number = 1; i <= 4; i++) {
+      const octet: number = parseInt(match[i]!, 10);
+      if (octet > 255) {
+        return {
+          error:
+            `Octet "${match[i]}" in "${trimmed}" is out of range. ` +
+            `Each octet must be between 0 and 255.`,
+        };
+      }
+      baseLong = baseLong * 256 + octet;
+    }
+
+    const prefix: number = parseInt(match[5]!, 10);
+    if (prefix > 32) {
+      return {
+        error:
+          `Prefix length "/${match[5]}" in "${trimmed}" is out of range. ` +
+          `An IPv4 prefix must be between /0 and /32.`,
+      };
+    }
+
+    const hostBits: number = 32 - prefix;
+    const blockSize: number = Math.pow(2, hostBits);
+
+    /*
+     * Shifting by 32 is a no-op in JS (the shift count is taken mod 32), so a
+     * /0 would mask with 0xffffffff and "expand" from the address as typed
+     * rather than from 0.0.0.0. Special-cased rather than relied upon.
+     */
+    const mask: number = hostBits >= 32 ? 0 : (0xffffffff << hostBits) >>> 0;
+    const networkLong: number = (baseLong & mask) >>> 0;
+
+    return {
+      target: {
+        notation: ScanTargetNotation.Cidr,
+        /*
+         * /31 and /32 have no network/broadcast addresses to exclude (RFC
+         * 3021), so every address in them is a host. Larger blocks drop the
+         * first and last.
+         */
+        hostCount: blockSize <= 2 ? blockSize : blockSize - 2,
+        networkLong: networkLong,
+        blockSize: blockSize,
+      },
+    };
+  }
+
+  private static parseOctetRange(trimmed: string): ParseOutcome {
+    const terms: Array<string> = trimmed.split(".");
+
+    if (terms.length !== 4) {
+      return { error: ScanTargetUtil.getMalformedTargetMessage(trimmed) };
+    }
+
+    const octetRanges: Array<OctetRange> = [];
+    let hostCount: number = 1;
+
+    for (const term of terms) {
+      const match: RegExpMatchArray | null = term.match(
+        ScanTargetUtil.OCTET_TERM_PATTERN,
+      );
+
+      if (!match) {
+        return {
+          error:
+            `"${term}" in "${trimmed}" is not a valid octet. ` +
+            `Each octet must be a number (42) or an inclusive range (16-22).`,
+        };
+      }
+
+      const start: number = parseInt(match[1]!, 10);
+      // No '-' in the term means a single value: a zero-width range.
+      const end: number =
+        match[2] === undefined ? start : parseInt(match[2], 10);
+
+      if (start > 255 || end > 255) {
+        return {
+          error:
+            `Octet "${term}" in "${trimmed}" is out of range. ` +
+            `Each octet must be between 0 and 255.`,
+        };
+      }
+
+      /*
+       * Reversed bounds are a typo, not an empty set. Silently accepting
+       * "22-16" as zero addresses would produce a scan that sweeps nothing
+       * and reports success — the least debuggable outcome available.
+       */
+      if (start > end) {
+        return {
+          error:
+            `Octet range "${term}" in "${trimmed}" is reversed. ` +
+            `Write the lower bound first, e.g. ${end}-${start}.`,
+        };
+      }
+
+      octetRanges.push({ start: start, end: end });
+      hostCount = hostCount * (end - start + 1);
+    }
+
+    return {
+      target: {
+        notation: ScanTargetNotation.OctetRange,
+        /*
+         * Every address in the product is swept, with no network/broadcast
+         * exclusion. An octet range is an explicit enumeration, not a subnet:
+         * whoever wrote "10.0.0.0-255" asked for .0 and .255 by name, and
+         * there is no prefix length here from which a broadcast address could
+         * even be derived.
+         */
+        hostCount: hostCount,
+        octetRanges: octetRanges,
+      },
+    };
+  }
+
+  private static expandCidrTarget(parsed: ScanTarget): Array<string> {
+    const networkLong: number = parsed.networkLong!;
+    const blockSize: number = parsed.blockSize!;
+    const hosts: Array<string> = [];
+
+    if (blockSize <= 2) {
+      // /31 and /32: every address is usable.
+      for (let i: number = 0; i < blockSize; i++) {
+        hosts.push(ScanTargetUtil.longToIp(networkLong + i));
+      }
+      return hosts;
+    }
+
+    // Skip network (first) and broadcast (last).
+    for (let i: number = 1; i < blockSize - 1; i++) {
+      hosts.push(ScanTargetUtil.longToIp(networkLong + i));
+    }
+    return hosts;
+  }
+
+  private static expandOctetRangeTarget(parsed: ScanTarget): Array<string> {
+    const ranges: Array<OctetRange> = parsed.octetRanges!;
+    const hosts: Array<string> = [];
+
+    // Outer-to-inner octet order, so the result comes out address-ascending.
+    for (let a: number = ranges[0]!.start; a <= ranges[0]!.end; a++) {
+      for (let b: number = ranges[1]!.start; b <= ranges[1]!.end; b++) {
+        for (let c: number = ranges[2]!.start; c <= ranges[2]!.end; c++) {
+          for (let d: number = ranges[3]!.start; d <= ranges[3]!.end; d++) {
+            hosts.push(`${a}.${b}.${c}.${d}`);
+          }
+        }
+      }
+    }
+
+    return hosts;
+  }
+
+  private static getMalformedTargetMessage(target: string): string {
+    const shown: string =
+      typeof target === "string" ? target.trim() : String(target);
+
+    return (
+      `"${shown}" is not a valid scan target. ` + ScanTargetUtil.getSyntaxHint()
+    );
+  }
+
+  private static longToIp(long: number): string {
+    return (
+      ((long >>> 24) & 0xff) +
+      "." +
+      ((long >>> 16) & 0xff) +
+      "." +
+      ((long >>> 8) & 0xff) +
+      "." +
+      (long & 0xff)
+    );
+  }
+}
+
+export default ScanTargetUtil;

--- a/Probe/Tests/Utils/Discovery/SubnetScanner.test.ts
+++ b/Probe/Tests/Utils/Discovery/SubnetScanner.test.ts
@@ -40,23 +40,42 @@ describe("SubnetScanner.countHosts", () => {
     expect(SubnetScanner.countHosts("10.0.0.0/8")).toBe(Math.pow(2, 24) - 2);
   });
 
-  it("returns 0 for malformed or out-of-range CIDRs", () => {
-    expect(SubnetScanner.countHosts("not-a-cidr")).toBe(0);
-    expect(SubnetScanner.countHosts("10.0.0.0")).toBe(0);
-    expect(SubnetScanner.countHosts("10.0.0.0/33")).toBe(0);
-    expect(SubnetScanner.countHosts("999.0.0.0/24")).toBe(0);
+  it("counts an octet-range target as the product of its octet widths", () => {
+    // 1 x 7 x 256 x 16.
+    expect(SubnetScanner.countHosts("10.16-22.0-255.51-66")).toBe(28672);
   });
 
-  it("agrees with expandCidr for reasonable subnets", () => {
-    for (const cidr of ["192.168.1.0/29", "172.16.5.0/28", "10.1.1.0/30"]) {
-      expect(SubnetScanner.countHosts(cidr)).toBe(
-        SubnetScanner.expandCidr(cidr).length,
+  /*
+   * A bare address is the degenerate octet range and now scans exactly that
+   * one host. It used to count 0 (rejected), when only CIDR was accepted.
+   */
+  it("counts a bare address as a single host", () => {
+    expect(SubnetScanner.countHosts("10.0.0.5")).toBe(1);
+  });
+
+  it("returns 0 for malformed or out-of-range targets", () => {
+    expect(SubnetScanner.countHosts("not-a-cidr")).toBe(0);
+    expect(SubnetScanner.countHosts("10.0.0.0/33")).toBe(0);
+    expect(SubnetScanner.countHosts("999.0.0.0/24")).toBe(0);
+    expect(SubnetScanner.countHosts("10.22-16.0.1")).toBe(0);
+  });
+
+  it("agrees with expandTarget for reasonable targets", () => {
+    for (const target of [
+      "192.168.1.0/29",
+      "172.16.5.0/28",
+      "10.1.1.0/30",
+      "10.0.0.1-10",
+      "10.1-2.3-4.5-6",
+    ]) {
+      expect(SubnetScanner.countHosts(target)).toBe(
+        SubnetScanner.expandTarget(target).length,
       );
     }
   });
 });
 
-describe("SubnetScanner.scan oversized-subnet guard", () => {
+describe("SubnetScanner.scan oversized-target guard", () => {
   it("rejects an oversized subnet before expanding it (no OOM)", async () => {
     // A /8 would materialize ~16.7M strings if the guard ran after expansion.
     await expect(SubnetScanner.scan({ cidr: "10.0.0.0/8" })).rejects.toThrow(
@@ -64,10 +83,155 @@ describe("SubnetScanner.scan oversized-subnet guard", () => {
     );
   });
 
-  it("rejects a malformed CIDR", async () => {
+  it("rejects an oversized octet range before expanding it", async () => {
+    await expect(
+      SubnetScanner.scan({ cidr: "10.0-255.0-255.1-10" }),
+    ).rejects.toThrow(/exceeding the/);
+  });
+
+  it("rejects a malformed target", async () => {
     await expect(SubnetScanner.scan({ cidr: "not-a-cidr" })).rejects.toThrow(
-      /Invalid or empty CIDR/,
+      /not a valid scan target/,
     );
+  });
+
+  it("rejects a reversed octet range rather than sweeping nothing", async () => {
+    await expect(
+      SubnetScanner.scan({ cidr: "10.22-16.0.1-20" }),
+    ).rejects.toThrow(/reversed/);
+  });
+
+  it("rejects an empty target", async () => {
+    await expect(SubnetScanner.scan({ cidr: "" })).rejects.toThrow(
+      /scan target is required/,
+    );
+  });
+});
+
+/*
+ * Octet-range notation reaches the SNMP layer as plain addresses, exactly as
+ * a CIDR sweep does — the notation is a front end on the address list and
+ * nothing downstream of expansion knows which notation produced it.
+ */
+describe("SubnetScanner octet-range sweeps", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockSnmpAnsweringEverywhere(): Array<string> {
+    const probed: Array<string> = [];
+
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        probed.push(config.hostname || "");
+        return { sysName: "device-" + config.hostname };
+      });
+
+    return probed;
+  }
+
+  it("sweeps exactly the addresses the range enumerates", async () => {
+    const probed: Array<string> = mockSnmpAnsweringEverywhere();
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: "10.1-2.0.5-6" });
+
+    expect([...probed].sort()).toEqual([
+      "10.1.0.5",
+      "10.1.0.6",
+      "10.2.0.5",
+      "10.2.0.6",
+    ]);
+    expect(result.scannedHostCount).toBe(4);
+  });
+
+  /*
+   * A range is an explicit enumeration: .0 and .255 are swept when named,
+   * where the equivalent /24 would drop them as network and broadcast.
+   */
+  it("sweeps .0 and .255 when the range names them, unlike the equivalent CIDR", async () => {
+    const probed: Array<string> = mockSnmpAnsweringEverywhere();
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+
+    await SubnetScanner.scan({ cidr: "10.0.0.0-255" });
+
+    expect(probed).toContain("10.0.0.0");
+    expect(probed).toContain("10.0.0.255");
+    expect(probed.length).toBe(256);
+    // The CIDR spelling of the same block drops both.
+    expect(SubnetScanner.countHosts("10.0.0.0/24")).toBe(254);
+  });
+
+  it("sweeps a single bare address", async () => {
+    const probed: Array<string> = mockSnmpAnsweringEverywhere();
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: "10.9.8.7" });
+
+    expect(probed).toEqual(["10.9.8.7"]);
+    expect(result.scannedHostCount).toBe(1);
+  });
+
+  it("returns discovered hosts in ascending address order", async () => {
+    mockSnmpAnsweringEverywhere();
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: "10.1-2.0.8-9" });
+
+    expect(
+      result.discoveredHosts.map((discovered: { ipAddress: string }) => {
+        return discovered.ipAddress;
+      }),
+    ).toEqual(["10.1.0.8", "10.1.0.9", "10.2.0.8", "10.2.0.9"]);
+  });
+
+  it("applies the ICMP gate to a range sweep the same way it does to a subnet", async () => {
+    const probed: Array<string> = mockSnmpAnsweringEverywhere();
+    jest
+      .spyOn(SubnetScanner, "isHostAliveByPing")
+      .mockImplementation(async (host: string) => {
+        return host === "10.1.0.6";
+      });
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: "10.1-2.0.5-6" });
+
+    expect(probed).toEqual(["10.1.0.6"]);
+    expect(result.scannedHostCount).toBe(4);
+    expect(result.respondedToPingCount).toBe(1);
+  });
+
+  it("carries SNMP credentials into a range sweep unchanged", async () => {
+    const captured: Array<MonitorStepSnmpMonitor> = [];
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        captured.push(config);
+        return null;
+      });
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+
+    await SubnetScanner.scan({
+      cidr: "10.0.0.1-2",
+      snmpVersion: "V3",
+      snmpV3Auth: {
+        securityLevel: SnmpSecurityLevel.AuthNoPriv,
+        username: "monitoring",
+        authProtocol: SnmpAuthProtocol.SHA,
+        authKey: "auth-passphrase",
+      },
+      snmpPort: 1610,
+    });
+
+    expect(captured.length).toBe(2);
+    for (const config of captured) {
+      expect(config.snmpVersion).toBe(SnmpVersion.V3);
+      expect(config.port).toBe(1610);
+    }
   });
 });
 

--- a/Probe/Utils/Discovery/SubnetScanner.ts
+++ b/Probe/Utils/Discovery/SubnetScanner.ts
@@ -2,6 +2,7 @@ import SnmpMonitor from "../Monitors/MonitorTypes/SnmpMonitor";
 import MonitorStepSnmpMonitor from "Common/Types/Monitor/MonitorStepSnmpMonitor";
 import { SnmpVersionUtil } from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
 import SnmpV3Auth from "Common/Types/Monitor/SnmpMonitor/SnmpV3Auth";
+import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
 import logger from "Common/Server/Utils/Logger";
 import ping from "ping";
 
@@ -19,6 +20,11 @@ export interface DiscoveredHost {
 }
 
 export interface SubnetScanConfig {
+  /*
+   * The address space to sweep, in either notation ScanTargetUtil accepts:
+   * CIDR ("192.168.1.0/24") or octet range ("10.16-22.0-255.51-66"). Named
+   * `cidr` to match the NetworkDeviceDiscoveryScan column it is read from.
+   */
   cidr: string;
   snmpVersion?: string | undefined;
   snmpCommunityString?: string | undefined;
@@ -44,8 +50,6 @@ export interface SubnetScanResult {
 
 // Sweeping the whole subnet at once would exhaust sockets; probe in waves.
 const CONCURRENCY: number = 32;
-// Guard against someone entering a /8 — an IPv4 sweep that size is abuse.
-const MAX_HOSTS: number = 4096;
 /*
  * ICMP pre-sweep timeout. The `ping` library takes seconds (it maps this to
  * the OS ping's reply-wait flag). Kept short: this is a reachability gate,
@@ -59,32 +63,27 @@ export default class SubnetScanner {
     config: SubnetScanConfig,
   ): Promise<SubnetScanResult> {
     /*
-     * Reject oversized subnets by prefix BEFORE expanding. expandCidr()
-     * materializes one string per host, so validating after expansion would
-     * let a /8 allocate ~16M strings (OOM) before the limit is ever checked.
+     * Validate syntax AND size BEFORE expanding. expandTarget() materializes
+     * one string per host, so validating after expansion would let a /8
+     * allocate ~16M strings (OOM) before the limit is ever checked.
+     *
+     * The server already rejects a bad target at write time using this same
+     * validator (NetworkDeviceDiscoveryScanService), so reaching this throw
+     * means the row predates that check or was written out of band. Either
+     * way the message ends up on the scan as its failure reason.
      */
-    const expectedHostCount: number = SubnetScanner.countHosts(config.cidr);
+    const validationError: string | null = ScanTargetUtil.getValidationError(
+      config.cidr,
+    );
 
-    if (expectedHostCount === 0) {
-      throw new Error("Invalid or empty CIDR: " + config.cidr);
+    if (validationError) {
+      throw new Error(validationError);
     }
 
-    if (expectedHostCount > MAX_HOSTS) {
-      throw new Error(
-        "CIDR " +
-          config.cidr +
-          " expands to " +
-          expectedHostCount +
-          " hosts, exceeding the " +
-          MAX_HOSTS +
-          "-host scan limit. Use a smaller subnet.",
-      );
-    }
-
-    const hosts: Array<string> = SubnetScanner.expandCidr(config.cidr);
+    const hosts: Array<string> = SubnetScanner.expandTarget(config.cidr);
 
     if (hosts.length === 0) {
-      throw new Error("Invalid or empty CIDR: " + config.cidr);
+      throw new Error("Scan target expands to no addresses: " + config.cidr);
     }
 
     const discoveredHosts: Array<DiscoveredHost> = [];
@@ -261,78 +260,23 @@ export default class SubnetScanner {
   }
 
   /*
-   * Returns how many usable host addresses a CIDR expands to, computed from
-   * the prefix alone (no allocation). Returns 0 for a malformed CIDR. Mirrors
-   * expandCidr's rule: /31 and /32 count every address, larger blocks exclude
-   * the network and broadcast addresses.
+   * How many addresses a scan target expands to, computed arithmetically with
+   * no allocation. Returns 0 for a malformed target. Accepts either notation:
+   * CIDR ("192.168.1.0/24"), where /31 and /32 count every address and larger
+   * blocks exclude the network and broadcast addresses; or an octet range
+   * ("10.16-22.0-255.51-66"), where every enumerated address counts.
    */
-  public static countHosts(cidr: string): number {
-    const match: RegExpMatchArray | null = cidr
-      .trim()
-      .match(/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\/(\d{1,2})$/);
-
-    if (!match) {
-      return 0;
-    }
-
-    const prefix: number = parseInt(match[2]!, 10);
-    if (prefix < 0 || prefix > 32) {
-      return 0;
-    }
-
-    if (isNaN(SubnetScanner.ipToLong(match[1]!))) {
-      return 0;
-    }
-
-    const blockSize: number = Math.pow(2, 32 - prefix);
-    return blockSize <= 2 ? blockSize : blockSize - 2;
+  public static countHosts(target: string): number {
+    return ScanTargetUtil.countHosts(target);
   }
 
   /*
-   * Expands an IPv4 CIDR into its usable host addresses. For prefixes /31
-   * and shorter, the network and broadcast addresses are excluded.
+   * Expands a scan target into the addresses to probe, in ascending order.
+   * Empty for a malformed target. Callers must gate on countHosts() (or
+   * ScanTargetUtil.getValidationError()) first — see scan() above.
    */
-  public static expandCidr(cidr: string): Array<string> {
-    // IPv4-only by design: IPv6 subnets are too sparse to sweep; IPv6 discovery will be ND-based (roadmap), not a CIDR sweep.
-    const match: RegExpMatchArray | null = cidr
-      .trim()
-      .match(/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\/(\d{1,2})$/);
-
-    if (!match) {
-      return [];
-    }
-
-    const baseIp: string = match[1]!;
-    const prefix: number = parseInt(match[2]!, 10);
-
-    if (prefix < 0 || prefix > 32) {
-      return [];
-    }
-
-    const baseLong: number = SubnetScanner.ipToLong(baseIp);
-    if (isNaN(baseLong)) {
-      return [];
-    }
-
-    const hostBits: number = 32 - prefix;
-    const blockSize: number = Math.pow(2, hostBits);
-    const networkLong: number = baseLong & (0xffffffff << hostBits);
-
-    const hosts: Array<string> = [];
-
-    if (blockSize <= 2) {
-      // /31 and /32: every address is usable.
-      for (let i: number = 0; i < blockSize; i++) {
-        hosts.push(SubnetScanner.longToIp(networkLong + i));
-      }
-      return hosts;
-    }
-
-    // Skip network (first) and broadcast (last).
-    for (let i: number = 1; i < blockSize - 1; i++) {
-      hosts.push(SubnetScanner.longToIp(networkLong + i));
-    }
-    return hosts;
+  public static expandTarget(target: string): Array<string> {
+    return ScanTargetUtil.expand(target);
   }
 
   private static ipToLong(ip: string): number {
@@ -349,17 +293,5 @@ export default class SubnetScanner {
       long = long * 256 + octet;
     }
     return long >>> 0;
-  }
-
-  private static longToIp(long: number): string {
-    return (
-      ((long >>> 24) & 0xff) +
-      "." +
-      ((long >>> 16) & 0xff) +
-      "." +
-      ((long >>> 8) & 0xff) +
-      "." +
-      (long & 0xff)
-    );
   }
 }


### PR DESCRIPTION
## Why

Network discovery scans could only target a CIDR subnet. Real networks are not shaped like CIDR blocks. Expressing "the `.51`–`.66` management addresses in every `/24` of `10.16-22.x`" took **1,792 separate scans**, and the one CIDR that covers it in a single scan (`10.16.0.0/13`) is 512k addresses, 98% of which are not worth probing.

## What

The scan target now accepts **octet-range notation** alongside CIDR — any of the four octets may be an inclusive `low-high` range:

```
10.16-22.0-255.51-66
10.48-50.0-255.51-66
192.168.1.10-40
10.0.0.5
```

Parsing, counting and expansion move out of the probe into `Common/Utils/NetworkDiscovery/ScanTargetUtil`, so the **server validates a target at write time using exactly the parser the probe later expands it with**. A typo now fails inline on the form instead of surfacing minutes later as a Failed scan — which matters more here than it did for CIDR, since a reversed range looks fine to the eye.

### Deliberate semantics

| | CIDR | Octet range |
|---|---|---|
| `.0` / `.255` | excluded (network + broadcast) | **swept** — an explicit enumeration has no prefix length to derive a broadcast from |
| `192.168.1.0/24` | 254 hosts | `192.168.1.0-255` → 256 hosts |

A bare address (`10.0.0.5`) is a valid one-host target. Wildcards (`*`) and comma lists (`1,3,5`) are nmap syntax and are **not** supported — accepting them would mean something subtly different to the operator than to the scanner.

### Scan-size ceiling: 4,096 → 32,768

Without this the motivating example (28,672 addresses) would not fit, and the feature would not serve the case it was asked for. At 32 workers that is ~17 min of wall clock with the ICMP pre-sweep and ~34 min without — inside the 2-hour stale-scan reaper and above the 15-minute recurring rescan floor — and it remains a `/17`-sized abuse guard. Oversized targets are now rejected on the form rather than by a probe minutes later.

### No migration

The `cidr` column keeps its name. It is public API surface and part of the probe payload, so renaming it would break both for a cosmetic gain. Only its title/description change (**"Scan Target"**).

## Defects found and fixed during review

Both were introduced by this change and are fixed here rather than shipped:

1. **`validateScanTarget` turned an intended 400 into a 500.** The hook runs *before* the model's type and length checks and BaseAPI assigns ShortText columns straight from request JSON, so `{"cidr": 42}` reached it as a number — and the obvious-looking `(target || "").trim()` threw a `TypeError` on any truthy non-string. The value is now passed through untouched; the parser already type-guards.
2. **Unbounded echo of the target in error messages.** Every rejection quotes the target back (the octet-range path quotes both the bad term *and* the whole target, doubling it), and this hook runs ahead of the column's 100-char cap — so a large request body was amplified into the exception, the logs *and* the response. The parser now length-gates before building any message, with a constant that echoes nothing.

## Canary test

Adding `onBeforeUpdate` trips `DiscoveryScanClaimHookFreeSafety` by design — that suite exists to force exactly this re-evaluation. Re-evaluated the call site: the claim write stamps only `status` and `startedAt`, which the hook does not look at. The blunt "service defines no update hooks" assertion is replaced with the sharper invariant it stood in for — **the claim payload and the validated column are disjoint** — proven behaviourally, with a negative control so it cannot pass vacuously.

## Tests

- `Common/Tests/Utils/NetworkDiscovery/ScanTargetUtil.test.ts` (new, 73 cases) — both notations; the `countHosts` ≡ `expand().length` invariant; CIDR masking at prefixes where JS shift arithmetic wraps (`/0`, `/1`) and at the top of the address space; ordering; reversed ranges; out-of-range octets; malformed range syntax; zero-padded octets read base 10, never octal; non-ASCII digit lookalikes; 50k-char input without pathological slowdown; the exact size boundary (at, and one address over); error-message contracts; non-string input.
- `Common/Tests/Server/Services/NetworkDeviceDiscoveryScanService.test.ts` (new, 20 cases) — create + update validation, non-string and over-long input, and that lifecycle updates not carrying the target pass straight through.
- `Probe/Tests/Utils/Discovery/SubnetScanner.test.ts` (extended) — end-to-end octet-range sweeps: the exact addresses probed, `.0`/`.255` swept where the equivalent `/24` drops them, ICMP gating, and SNMP credential passthrough.

Full suites green: Probe 537/537, Common `Tests/Server/Services` 1222/1222, App Telemetry + Dashboard 854/854. `tsc --noEmit` and `eslint` clean on Common, Probe and App.

> One pre-existing unrelated failure locally, `MonitorResourceProbeAgreementReuse.test.ts` — an `isolated-vm` native ABI mismatch that reproduces identically on `master`.

## Docs

`App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md` gains a **Scan Target Notation** section covering both notations, the `.0`/`.255` difference, the rules, and the address ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
