### PR TITLE
feat(ui): drop the modal header icon and rebuild the column picker

### DIFF
--- a/Common/Tests/UI/Components/Modal.test.tsx
+++ b/Common/Tests/UI/Components/Modal.test.tsx
@@ -2,9 +2,13 @@ import { ButtonStyleType } from "../../../UI/Components/Button/Button";
 import ButtonType from "../../../UI/Components/Button/ButtonTypes";
 import Modal, { ModalWidth } from "../../../UI/Components/Modal/Modal";
 import { describe, expect, it, test } from "@jest/globals";
-import "@testing-library/jest-dom/extend-expect";
+/*
+ * The main entry, not "/extend-expect": the latter no longer ships type
+ * declarations, so every jest-dom matcher in this file fails to typecheck and
+ * the whole suite is skipped before a single assertion runs.
+ */
+import "@testing-library/jest-dom";
 import { fireEvent, render } from "@testing-library/react";
-import IconProp from "../../../Types/Icon/IconProp";
 import React from "react";
 import getJestMockFunction, { MockFunction } from "../../../Tests/MockType";
 
@@ -338,16 +342,50 @@ describe("Modal", () => {
     expect(submitButton).toBeDisabled();
   });
 
-  it("displays the icon when icon is set", () => {
+  /*
+   * The header carries the title, the description and the close button, and
+   * nothing else. A decorative icon beside the title said nothing the title did
+   * not already say, so there is no longer anywhere for one to be rendered.
+   */
+  it("renders no decorative icon in the header", () => {
     const onSubmitMock: MockFunction = getJestMockFunction();
 
-    const { getByTestId } = render(
-      <Modal title="Test Modal" onSubmit={onSubmitMock} icon={IconProp.SMS}>
+    const { queryByTestId, getByTestId } = render(
+      <Modal
+        title="Test Modal"
+        description="Test modal description"
+        onSubmit={onSubmitMock}
+        onClose={getJestMockFunction()}
+      >
         <div>Modal content</div>
       </Modal>,
     );
 
-    expect(getByTestId("icon")).toBeInTheDocument();
+    expect(queryByTestId("icon")).not.toBeInTheDocument();
+
+    // The rest of the header is untouched.
+    expect(getByTestId("modal-title")).toHaveTextContent("Test Modal");
+    expect(getByTestId("modal-description")).toHaveTextContent(
+      "Test modal description",
+    );
+    expect(getByTestId("close-button")).toBeInTheDocument();
+  });
+
+  it("keeps the title as the first thing inside the header", () => {
+    const { getByTestId } = render(
+      <Modal title="Test Modal" onSubmit={getJestMockFunction()}>
+        <div>Modal content</div>
+      </Modal>,
+    );
+
+    const title: HTMLElement = getByTestId("modal-title");
+    const header: HTMLElement = title.parentElement!.parentElement!;
+
+    /*
+     * With the icon gone the title block is the header's first child. Anything
+     * else in that slot would push the title out of line with the body.
+     */
+    expect(header.firstElementChild).toContainElement(title);
   });
 
   it("displays the submit button with the default style when submitButtonStyleType is not set", () => {

--- a/Common/Tests/UI/Components/ModelTable/ColumnCustomizationModal.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/ColumnCustomizationModal.test.tsx
@@ -569,4 +569,431 @@ describe("ColumnCustomizationModal", () => {
       "Customize Columns",
     );
   });
+
+  test("the header carries the title and description, and no icon", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("modal-description")).toHaveTextContent(
+      "Choose which columns to show and drag them into the order you want.",
+    );
+
+    // The header icon was decorative; it repeated what the title already said.
+    expect(view.queryByTestId("icon")).not.toBeInTheDocument();
+  });
+
+  test("uses a custom description when one is given", () => {
+    const onSave: MockFunction = getJestMockFunction();
+    const onClose: MockFunction = getJestMockFunction();
+    const onReset: MockFunction = getJestMockFunction();
+
+    const view: RenderResult = render(
+      <ColumnCustomizationModal<Monitor>
+        columns={getDefaultColumns()}
+        onSave={onSave}
+        onClose={onClose}
+        onReset={onReset}
+        description="Pick the ones you care about."
+      />,
+    );
+
+    expect(view.getByTestId("modal-description")).toHaveTextContent(
+      "Pick the ones you care about.",
+    );
+  });
+
+  /*
+   * Below: the state the two bulk actions and the search box put the rest of
+   * the body into. These are the parts a viewer reads to work out why a
+   * control did nothing, so each one is pinned rather than left to the styling.
+   */
+
+  test("Show all is inert once every column is already on", () => {
+    const { view }: RenderedModal = renderModal();
+
+    const showAll: HTMLElement = view.getByTestId(
+      "column-customization-show-all",
+    );
+
+    expect(showAll).not.toBeDisabled();
+
+    fireEvent.click(showAll);
+
+    // Nothing left to show, so the control says so rather than doing nothing.
+    expect(showAll).toBeDisabled();
+  });
+
+  test("Show all comes back to life as soon as a column is switched off", () => {
+    const { view }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-customization-show-all"));
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+
+    expect(
+      view.getByTestId("column-customization-show-all"),
+    ).not.toBeDisabled();
+  });
+
+  test("Hide all is inert once only the one required column is left", () => {
+    const { view }: RenderedModal = renderModal();
+
+    const hideAll: HTMLElement = view.getByTestId(
+      "column-customization-hide-all",
+    );
+
+    fireEvent.click(hideAll);
+
+    /*
+     * A second press could only try to hide the column that has to stay, so
+     * the button is switched off instead of quietly refusing.
+     */
+    expect(hideAll).toBeDisabled();
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "1 of 4 columns shown",
+    );
+  });
+
+  test("Hide all starts out inert when the caller opens with a single column on", () => {
+    const { view }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+        makeEntry({
+          id: "description",
+          title: "Description",
+          isVisible: false,
+        }),
+      ],
+    });
+
+    expect(view.getByTestId("column-customization-hide-all")).toBeDisabled();
+    expect(
+      view.getByTestId("column-customization-show-all"),
+    ).not.toBeDisabled();
+  });
+
+  test("the column that cannot be switched off is marked as required", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.queryByTestId("column-locked-name")).not.toBeInTheDocument();
+
+    fireEvent.click(view.getByTestId("column-customization-hide-all"));
+
+    /*
+     * The disabled checkbox alone reads as a glitch. The badge is the only
+     * thing on the row that explains why it will not move.
+     */
+    expect(view.getByTestId("column-locked-name")).toHaveTextContent(
+      "Required",
+    );
+  });
+
+  test("the required badge follows the column that is actually locked", () => {
+    const { view }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+        makeEntry({ id: "description", title: "Description", isVisible: true }),
+      ],
+    });
+
+    fireEvent.click(view.getByTestId("column-toggle-name"));
+
+    expect(view.getByTestId("column-locked-description")).toBeInTheDocument();
+    expect(view.queryByTestId("column-locked-name")).not.toBeInTheDocument();
+  });
+
+  test("the clear button only exists while there is something to clear", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(
+      view.queryByTestId("column-customization-search-clear"),
+    ).not.toBeInTheDocument();
+
+    typeSearch(view, "desc");
+
+    expect(
+      view.getByTestId("column-customization-search-clear"),
+    ).toBeInTheDocument();
+  });
+
+  test("the clear button empties the box and brings the whole list back", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "desc");
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(1);
+
+    fireEvent.click(view.getByTestId("column-customization-search-clear"));
+
+    expect(view.getByTestId("column-customization-search")).toHaveValue("");
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(4);
+    expect(
+      view.queryByTestId("column-customization-search-clear"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("clearing through the button re-arms the move buttons", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    typeSearch(view, "desc");
+    fireEvent.click(view.getByTestId("column-customization-search-clear"));
+    fireEvent.click(view.getByTestId("column-move-down-name"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "currentMonitorStatus",
+      "name",
+      "description",
+      "createdAt",
+    ]);
+  });
+
+  test("a search that matches nothing still offers a way out", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "no-such-column");
+
+    expect(
+      view.getByTestId("column-customization-no-results"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(view.getByTestId("column-customization-search-clear"));
+
+    expect(
+      view.queryByTestId("column-customization-no-results"),
+    ).not.toBeInTheDocument();
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(4);
+  });
+
+  test("the hint explains reordering, and explains its absence while searching", () => {
+    const { view }: RenderedModal = renderModal();
+
+    expect(view.getByTestId("column-customization-hint")).toHaveTextContent(
+      "Drag a row, or use the arrows, to change the column order.",
+    );
+
+    typeSearch(view, "desc");
+
+    /*
+     * The move buttons go grey during a search. Without this line the viewer
+     * is left to guess whether that is deliberate.
+     */
+    expect(view.getByTestId("column-customization-hint")).toHaveTextContent(
+      "Clear the search to reorder columns.",
+    );
+
+    typeSearch(view, "");
+
+    expect(view.getByTestId("column-customization-hint")).toHaveTextContent(
+      "Drag a row, or use the arrows, to change the column order.",
+    );
+  });
+
+  test("whitespace alone is not a search", () => {
+    const { view }: RenderedModal = renderModal();
+
+    typeSearch(view, "   ");
+
+    // Nothing is filtered out, so nothing about the list should change either.
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(4);
+    expect(view.getByTestId("column-customization-hint")).toHaveTextContent(
+      "Drag a row, or use the arrows, to change the column order.",
+    );
+    expect(view.getByTestId("column-move-down-name")).not.toBeDisabled();
+  });
+
+  test("a search that matches everything leaves every row in place", () => {
+    const { view }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "one", title: "Alpha One", isVisible: true }),
+        makeEntry({ id: "two", title: "Alpha Two", isVisible: true }),
+      ],
+    });
+
+    typeSearch(view, "alpha");
+
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(2);
+    // Still a search, so reordering stays off.
+    expect(view.getByTestId("column-move-down-one")).toBeDisabled();
+  });
+
+  test("a column can be toggled from inside a filtered list", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    typeSearch(view, "description");
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "2 of 4 columns shown",
+    );
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).find((entry: CustomizableColumn<Monitor>) => {
+        return entry.id === "description";
+      })?.isVisible,
+    ).toBe(false);
+  });
+
+  test("bulk actions reach the columns a search is hiding", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    typeSearch(view, "name");
+    fireEvent.click(view.getByTestId("column-customization-show-all"));
+    typeSearch(view, "");
+
+    /*
+     * "Show all" is not "show all of the matches" - it works on the layout,
+     * not on what happens to be on screen.
+     */
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "4 of 4 columns shown",
+    );
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).every((entry: CustomizableColumn<Monitor>) => {
+        return entry.isVisible;
+      }),
+    ).toBe(true);
+  });
+
+  test("Save reports the entries untouched when nothing was changed", () => {
+    const { view, onSave }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(getSavedIds(onSave)).toEqual([
+      "name",
+      "currentMonitorStatus",
+      "description",
+      "createdAt",
+    ]);
+    expect(
+      getSaved(onSave).map((entry: CustomizableColumn<Monitor>) => {
+        return entry.isVisible;
+      }),
+    ).toEqual([true, true, true, false]);
+  });
+
+  test("Escape closes the modal without saving", () => {
+    const { onSave, onClose }: RenderedModal = renderModal();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test("the header close button closes without saving", () => {
+    const { view, onSave, onClose }: RenderedModal = renderModal();
+
+    fireEvent.click(view.getByTestId("column-toggle-description"));
+    fireEvent.click(view.getByTestId("close-button"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test("a single-column table opens with everything locked down", () => {
+    const { view }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+      ],
+    });
+
+    expect(view.getByTestId("column-toggle-name")).toBeDisabled();
+    expect(view.getByTestId("column-move-up-name")).toBeDisabled();
+    expect(view.getByTestId("column-move-down-name")).toBeDisabled();
+    expect(view.getByTestId("column-customization-show-all")).toBeDisabled();
+    expect(view.getByTestId("column-customization-hide-all")).toBeDisabled();
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "1 of 1 columns shown",
+    );
+  });
+
+  test("an empty column list renders without falling over", () => {
+    const { view }: RenderedModal = renderModal({ columns: [] });
+
+    expect(view.getByTestId("column-customization-modal")).toBeInTheDocument();
+    expect(view.queryAllByTestId(/^column-toggle-/)).toHaveLength(0);
+    expect(view.getByTestId("column-customization-count")).toHaveTextContent(
+      "0 of 0 columns shown",
+    );
+  });
+
+  test("columns with the same title are still addressed individually", () => {
+    const { view, onSave }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "createdAt", title: "Date", isVisible: true }),
+        makeEntry({ id: "updatedAt", title: "Date", isVisible: true }),
+      ],
+    });
+
+    // The row is keyed by id, not by the title the viewer happens to see.
+    fireEvent.click(view.getByTestId("column-toggle-updatedAt"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    expect(
+      getSaved(onSave).map((entry: CustomizableColumn<Monitor>) => {
+        return { id: entry.id, isVisible: entry.isVisible };
+      }),
+    ).toEqual([
+      { id: "createdAt", isVisible: true },
+      { id: "updatedAt", isVisible: false },
+    ]);
+  });
+
+  test("a column with no title is searchable without breaking the filter", () => {
+    const untitled: CustomizableColumn<Monitor> = makeEntry({
+      id: "untitled",
+      title: "",
+      isVisible: true,
+    });
+
+    const { view }: RenderedModal = renderModal({
+      columns: [
+        makeEntry({ id: "name", title: "Monitor Name", isVisible: true }),
+        untitled,
+      ],
+    });
+
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(2);
+
+    typeSearch(view, "monitor");
+
+    // The untitled column simply does not match; it does not throw.
+    expect(view.getAllByTestId(/^column-toggle-/)).toHaveLength(1);
+    expect(view.getByTestId("column-toggle-name")).toBeInTheDocument();
+  });
+
+  test("Reset does not close the modal on the viewer's behalf", () => {
+    const { view, onReset, onClose }: RenderedModal = renderModal({
+      isDefaultLayout: false,
+    });
+
+    fireEvent.click(view.getByTestId("column-customization-reset"));
+
+    /*
+     * Closing is the caller's decision - it owns the stored layout and this
+     * modal only reports the click.
+     */
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test("the props handed to Save are a fresh list, not the caller's array", () => {
+    const columns: Array<CustomizableColumn<Monitor>> = getDefaultColumns();
+    const { view, onSave }: RenderedModal = renderModal({ columns });
+
+    fireEvent.click(view.getByTestId("column-move-down-name"));
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    // The caller's own array is left exactly as it was passed in.
+    expect(
+      columns.map((entry: CustomizableColumn<Monitor>) => {
+        return entry.id;
+      }),
+    ).toEqual(["name", "currentMonitorStatus", "description", "createdAt"]);
+    expect(getSaved(onSave)).not.toBe(columns);
+  });
 });

--- a/Common/UI/Components/AI/GenerateFromAIModal.tsx
+++ b/Common/UI/Components/AI/GenerateFromAIModal.tsx
@@ -9,7 +9,6 @@ import AILoader from "./AILoader";
 import Alert, { AlertType } from "../Alerts/Alert";
 import ButtonType from "../Button/ButtonTypes";
 import { ButtonStyleType } from "../Button/Button";
-import IconProp from "../../../Types/Icon/IconProp";
 import Dropdown, { DropdownOption, DropdownValue } from "../Dropdown/Dropdown";
 import MarkdownEditor from "../Markdown.tsx/MarkdownEditor";
 
@@ -112,7 +111,6 @@ const GenerateFromAIModal: FunctionComponent<GenerateFromAIModalProps> = (
       disableSubmitButton={isGenerating}
       onSubmit={handleGenerate}
       modalWidth={ModalWidth.Large}
-      icon={IconProp.Bolt}
     >
       <>
         {error && (

--- a/Common/UI/Components/BulkUpdate/BulkLabelActions.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkLabelActions.tsx
@@ -370,7 +370,6 @@ function useBulkLabelActions<T extends BaseModel>(
           <Modal
             title="No Labels to Remove"
             description="The selected items don't have any labels to remove."
-            icon={IconProp.Label}
             onClose={closeRemoveModal}
             closeButtonText="Close"
           >

--- a/Common/UI/Components/Date/RangeStartAndEndDateView.tsx
+++ b/Common/UI/Components/Date/RangeStartAndEndDateView.tsx
@@ -103,7 +103,6 @@ const DashboardStartAndEndDateView: FunctionComponent<ComponentProps> = (
           <Modal
             title="Select Time Range"
             description="Choose a quick range or set an exact start and end date & time."
-            icon={IconProp.Clock}
             modalWidth={ModalWidth.Medium}
             submitButtonText="Apply"
             disableSubmitButton={!isSelectionValid(tempStartAndEndDate)}

--- a/Common/UI/Components/EditionLabel/EditionLabel.tsx
+++ b/Common/UI/Components/EditionLabel/EditionLabel.tsx
@@ -1,5 +1,5 @@
 import Modal, { ModalWidth } from "../Modal/Modal";
-import Icon, { IconType } from "../Icon/Icon";
+import Icon from "../Icon/Icon";
 import IconProp from "../../../Types/Icon/IconProp";
 import Input from "../Input/Input";
 import Button, { ButtonStyleType } from "../Button/Button";
@@ -759,30 +759,6 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
     globalConfig?.enterpriseLicenseKey,
   ]);
 
-  const modalIcon: IconProp = useMemo(() => {
-    if (!IS_ENTERPRISE_EDITION || isConfigLoading) {
-      return IconProp.Cube;
-    }
-
-    if (!licenseValid || isUserLimitBreached) {
-      return IconProp.Alert;
-    }
-
-    return IconProp.ShieldCheck;
-  }, [isConfigLoading, licenseValid, isUserLimitBreached]);
-
-  const modalIconType: IconType = useMemo(() => {
-    if (!IS_ENTERPRISE_EDITION || isConfigLoading) {
-      return IconType.Info;
-    }
-
-    if (!licenseValid || isUserLimitBreached) {
-      return IconType.Danger;
-    }
-
-    return IconType.Success;
-  }, [isConfigLoading, licenseValid, isUserLimitBreached]);
-
   const modalDescription: string = useMemo(() => {
     if (!IS_ENTERPRISE_EDITION) {
       return "You are running the free, open-source build of OneUptime.";
@@ -1326,8 +1302,6 @@ const EditionLabel: FunctionComponent<ComponentProps> = (
         <Modal
           title={editionName}
           description={modalDescription}
-          icon={modalIcon}
-          iconType={modalIconType}
           rightElement={modalRightElement}
           submitButtonText={modalSubmitButtonText}
           closeButtonText="Close"

--- a/Common/UI/Components/Error/PageError.tsx
+++ b/Common/UI/Components/Error/PageError.tsx
@@ -1,8 +1,6 @@
 import Navigation from "../../Utils/Navigation";
 import { ButtonStyleType } from "../Button/Button";
-import { IconType } from "../Icon/Icon";
 import Modal from "../Modal/Modal";
-import IconProp from "../../../Types/Icon/IconProp";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
@@ -22,8 +20,6 @@ const PageError: FunctionComponent<ComponentProps> = (
   return (
     <Modal
       title={props.title || "Oops, something went wrong."}
-      icon={IconProp.Alert}
-      iconType={IconType.Danger}
       onSubmit={() => {
         Navigation.reload();
       }}

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import { ButtonStyleType } from "../Button/Button";
 import ButtonType from "../Button/ButtonTypes";
-import Icon, { IconType, SizeProp, ThickProp } from "../Icon/Icon";
+import Icon from "../Icon/Icon";
 import Loader, { LoaderType } from "../Loader/Loader";
 import ModalBody from "./ModalBody";
 import ModalFooter from "./ModalFooter";
@@ -35,8 +35,6 @@ export interface ComponentProps {
   disableSubmitButton?: undefined | boolean;
   error?: string | undefined;
   isBodyLoading?: boolean | undefined;
-  icon?: IconProp | undefined;
-  iconType?: IconType | undefined;
   modalWidth?: ModalWidth | undefined;
   rightElement?: ReactElement | undefined;
   closeButtonText?: string | undefined;
@@ -172,28 +170,6 @@ const Modal: FunctionComponent<ComponentProps> = (
     };
   }, []);
 
-  let iconBgColor: string = "bg-indigo-50";
-  let iconColor: string = "text-indigo-600";
-  let iconRingColor: string = "ring-indigo-100";
-
-  if (props.iconType === IconType.Info) {
-    iconBgColor = "bg-indigo-50";
-    iconColor = "text-indigo-600";
-    iconRingColor = "ring-indigo-100";
-  } else if (props.iconType === IconType.Warning) {
-    iconBgColor = "bg-yellow-50";
-    iconColor = "text-yellow-700";
-    iconRingColor = "ring-yellow-100";
-  } else if (props.iconType === IconType.Success) {
-    iconBgColor = "bg-green-50";
-    iconColor = "text-green-600";
-    iconRingColor = "ring-green-100";
-  } else if (props.iconType === IconType.Danger) {
-    iconBgColor = "bg-red-50";
-    iconColor = "text-red-600";
-    iconRingColor = "ring-red-100";
-  }
-
   let modalWidthClassName: string = "sm:max-w-lg md:max-w-lg";
 
   if (props.modalWidth === ModalWidth.Medium) {
@@ -224,46 +200,26 @@ const Modal: FunctionComponent<ComponentProps> = (
           >
             <div className="relative flex shrink-0 flex-col gap-4 rounded-t-2xl border-b border-gray-100 bg-white px-5 py-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6 sm:rounded-t-xl sm:px-6">
               <div
-                className={`flex min-w-0 flex-1 items-start gap-3 ${
+                className={`min-w-0 flex-1 ${
                   props.onClose ? "pr-9 sm:pr-0" : ""
                 }`}
               >
-                {props.icon && (
-                  <div
-                    className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg ${iconBgColor} ring-1 ring-inset ${iconRingColor}`}
-                    data-testid="icon"
+                <h3
+                  data-testid="modal-title"
+                  className="text-base font-semibold leading-6 tracking-tight text-gray-900"
+                  id={titleId}
+                >
+                  {translatedTitle}
+                </h3>
+                {translatedDescription && (
+                  <p
+                    id={descriptionId}
+                    data-testid="modal-description"
+                    className="mt-0.5 text-sm leading-5 text-gray-500"
                   >
-                    <Icon
-                      thick={ThickProp.Thick}
-                      type={
-                        props.iconType === undefined
-                          ? IconType.Info
-                          : props.iconType
-                      }
-                      className={`${iconColor} h-5 w-5`}
-                      icon={props.icon}
-                      size={SizeProp.Five}
-                    />
-                  </div>
+                    {translatedDescription}
+                  </p>
                 )}
-                <div className="min-w-0 flex-1">
-                  <h3
-                    data-testid="modal-title"
-                    className="text-base font-semibold leading-6 tracking-tight text-gray-900"
-                    id={titleId}
-                  >
-                    {translatedTitle}
-                  </h3>
-                  {translatedDescription && (
-                    <p
-                      id={descriptionId}
-                      data-testid="modal-description"
-                      className="mt-0.5 text-sm leading-5 text-gray-500"
-                    >
-                      {translatedDescription}
-                    </p>
-                  )}
-                </div>
               </div>
               {props.rightElement && (
                 <div

--- a/Common/UI/Components/ModelFormModal/ModelFormModal.tsx
+++ b/Common/UI/Components/ModelFormModal/ModelFormModal.tsx
@@ -7,10 +7,8 @@ import ModelForm, {
   ComponentProps as ModelFormComponentProps,
 } from "../Forms/ModelForm";
 import FormValues from "../Forms/Types/FormValues";
-import { IconType } from "../Icon/Icon";
 import Modal, { ModalWidth } from "../Modal/Modal";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
-import IconProp from "../../../Types/Icon/IconProp";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import React, { MutableRefObject, ReactElement, useRef, useState } from "react";
@@ -33,12 +31,6 @@ export interface ComponentProps<TBaseModel extends BaseModel> {
     | ((item: TBaseModel, miscDataProps: JSONObject) => Promise<TBaseModel>)
     | undefined;
   footer?: ReactElement | undefined;
-  /*
-   * A header icon (rendered in a colored circle) to make the modal feel
-   * purpose-built. Forwarded to the underlying <Modal> via the props spread.
-   */
-  icon?: IconProp | undefined;
-  iconType?: IconType | undefined;
   formRef?: undefined | MutableRefObject<FormProps<FormValues<TBaseModel>>>;
 }
 

--- a/Common/UI/Components/ModelTable/ColumnCustomizationModal.tsx
+++ b/Common/UI/Components/ModelTable/ColumnCustomizationModal.tsx
@@ -12,6 +12,7 @@ import {
   DragDropContext,
   Draggable,
   DraggableProvided,
+  DraggableStateSnapshot,
   Droppable,
   DroppableProvided,
   DropResult,
@@ -87,6 +88,14 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
         .includes(normalizedSearch);
     });
   }, [entries, normalizedSearch, isSearching]);
+
+  /*
+   * Both bulk actions are switched off when they have nothing left to do -
+   * "Show all" with everything already on is a no-op, and "Hide all" cannot go
+   * below the one column that has to stay.
+   */
+  const isEverythingVisible: boolean = visibleCount === entries.length;
+  const isOnlyOneVisible: boolean = visibleCount <= 1;
 
   type ToggleFunction = (id: string, isVisible: boolean) => void;
 
@@ -183,6 +192,37 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
     });
   };
 
+  type GetBulkActionFunction = (data: {
+    title: string;
+    dataTestId: string;
+    disabled: boolean;
+    onClick: () => void;
+  }) => ReactElement;
+
+  /*
+   * Rendered as plain buttons rather than through <Button>: these sit inside
+   * the body as a compact pair, and the shared button styles are sized for a
+   * footer.
+   */
+  const getBulkAction: GetBulkActionFunction = (data: {
+    title: string;
+    dataTestId: string;
+    disabled: boolean;
+    onClick: () => void;
+  }): ReactElement => {
+    return (
+      <button
+        type="button"
+        data-testid={data.dataTestId}
+        disabled={data.disabled}
+        onClick={data.onClick}
+        className="rounded-md px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-white hover:text-gray-900 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent disabled:hover:shadow-none"
+      >
+        {data.title}
+      </button>
+    );
+  };
+
   type GetRowFunction = (data: {
     entry: CustomizableColumn<TBaseModel>;
     index: number;
@@ -199,27 +239,50 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
     const isOnlyVisibleColumn: boolean = entry.isVisible && visibleCount <= 1;
 
     return (
-      <div className="flex items-center gap-3 px-3 py-2">
-        {data.dragHandle || <div className="w-4" />}
+      <div className="group flex items-center gap-2 px-3 py-2 transition-colors hover:bg-gray-50">
+        {data.dragHandle || <div className="w-5 flex-none" />}
 
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex-1">
           <CheckboxElement
             value={entry.isVisible}
             disabled={isOnlyVisibleColumn}
             dataTestId={`column-toggle-${entry.id}`}
-            title={entry.column.title}
+            outerDivClassName="relative flex items-center"
+            title={
+              <span
+                className={
+                  entry.isVisible
+                    ? "text-sm font-medium text-gray-900"
+                    : "text-sm font-normal text-gray-400"
+                }
+              >
+                {entry.column.title}
+              </span>
+            }
             onChange={(value: boolean) => {
               toggleColumn(entry.id, value);
             }}
           />
         </div>
 
-        <div className="flex flex-none items-center gap-1">
+        {isOnlyVisibleColumn && (
+          <span
+            className="flex-none rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500"
+            data-testid={`column-locked-${entry.id}`}
+          >
+            Required
+          </span>
+        )}
+
+        <div className="flex flex-none items-center gap-0.5">
           <Button
             buttonSize={ButtonSize.Small}
             buttonStyle={ButtonStyleType.ICON}
             icon={IconProp.ChevronUp}
             title=""
+            tooltip="Move up"
+            ariaLabel={`Move ${entry.column.title} up`}
+            className="text-gray-400 hover:bg-gray-200 hover:text-gray-700 disabled:text-gray-200 disabled:hover:bg-transparent"
             dataTestId={`column-move-up-${entry.id}`}
             disabled={isSearching || index === 0}
             onClick={() => {
@@ -231,6 +294,9 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
             buttonStyle={ButtonStyleType.ICON}
             icon={IconProp.ChevronDown}
             title=""
+            tooltip="Move down"
+            ariaLabel={`Move ${entry.column.title} down`}
+            className="text-gray-400 hover:bg-gray-200 hover:text-gray-700 disabled:text-gray-200 disabled:hover:bg-transparent"
             dataTestId={`column-move-down-${entry.id}`}
             disabled={isSearching || index === entries.length - 1}
             onClick={() => {
@@ -248,10 +314,13 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
     if (shownEntries.length === 0) {
       return (
         <div
-          className="px-3 py-6 text-center text-sm text-gray-400"
+          className="flex flex-col items-center gap-2 px-3 py-10 text-center"
           data-testid="column-customization-no-results"
         >
-          No columns match &quot;{searchText}&quot;.
+          <Icon icon={IconProp.Search} className="h-6 w-6 text-gray-300" />
+          <p className="text-sm text-gray-500">
+            No columns match &quot;{searchText}&quot;.
+          </p>
         </div>
       );
     }
@@ -287,6 +356,7 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
                 ref={droppableProvided.innerRef}
                 {...droppableProvided.droppableProps}
                 className="divide-y divide-gray-100"
+                aria-label="Columns"
               >
                 {shownEntries.map(
                   (entry: CustomizableColumn<TBaseModel>, index: number) => {
@@ -296,12 +366,19 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
                         index={index}
                         key={entry.id}
                       >
-                        {(draggableProvided: DraggableProvided) => {
+                        {(
+                          draggableProvided: DraggableProvided,
+                          draggableSnapshot: DraggableStateSnapshot,
+                        ) => {
                           return (
                             <div
                               ref={draggableProvided.innerRef}
                               {...draggableProvided.draggableProps}
-                              className="bg-white"
+                              className={
+                                draggableSnapshot.isDragging
+                                  ? "rounded-md bg-white shadow-lg ring-1 ring-gray-200"
+                                  : "bg-white"
+                              }
                             >
                               {getRowContents({
                                 entry,
@@ -309,7 +386,7 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
                                 dragHandle: (
                                   <div
                                     {...draggableProvided.dragHandleProps}
-                                    className="flex-none cursor-grab text-gray-400 hover:text-gray-600 active:cursor-grabbing"
+                                    className="flex w-5 flex-none cursor-grab justify-center text-gray-300 transition-colors group-hover:text-gray-500 active:cursor-grabbing"
                                     aria-label={`Drag to reorder ${entry.column.title}`}
                                     title="Drag to reorder"
                                   >
@@ -344,7 +421,6 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
         "Choose which columns to show and drag them into the order you want."
       }
       modalWidth={ModalWidth.Medium}
-      icon={IconProp.TableCells}
       submitButtonText="Save"
       closeButtonText="Cancel"
       onClose={props.onClose}
@@ -357,8 +433,9 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
         ) : (
           <Button
             title="Reset to default"
+            icon={IconProp.Refresh}
             buttonSize={ButtonSize.Normal}
-            buttonStyle={ButtonStyleType.OUTLINE}
+            buttonStyle={ButtonStyleType.NORMAL}
             dataTestId="column-customization-reset"
             onClick={() => {
               props.onReset();
@@ -368,50 +445,76 @@ const ColumnCustomizationModal: ColumnCustomizationModalFunction = <
       }
     >
       <div className="space-y-3" data-testid="column-customization-modal">
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <Icon icon={IconProp.Search} className="h-4 w-4 text-gray-400" />
+          </div>
+          <Input
+            type={InputType.TEXT}
+            placeholder="Search columns..."
+            value={searchText}
+            dataTestId="column-customization-search"
+            outerDivClassName="w-full"
+            className="block w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-9 text-sm placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            onChange={(value: string) => {
+              setSearchText(value);
+            }}
+          />
+          {searchText.length > 0 && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              title="Clear search"
+              data-testid="column-customization-search-clear"
+              onClick={() => {
+                setSearchText("");
+              }}
+              className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 transition-colors hover:text-gray-600 focus:outline-none focus-visible:text-gray-600"
+            >
+              <Icon icon={IconProp.Close} className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
         <div className="flex items-center justify-between gap-3">
-          <div className="flex-1">
-            <Input
-              type={InputType.TEXT}
-              placeholder="Search columns..."
-              value={searchText}
-              dataTestId="column-customization-search"
-              onChange={(value: string) => {
-                setSearchText(value);
-              }}
-            />
+          <div
+            className="text-xs font-medium text-gray-500"
+            data-testid="column-customization-count"
+          >
+            {visibleCount} of {entries.length} columns shown
           </div>
-          <div className="flex flex-none gap-2">
-            <Button
-              title="Show all"
-              buttonSize={ButtonSize.Small}
-              buttonStyle={ButtonStyleType.OUTLINE}
-              dataTestId="column-customization-show-all"
-              onClick={() => {
+          <div className="flex flex-none items-center gap-1 rounded-md bg-gray-50 p-0.5 ring-1 ring-inset ring-gray-200">
+            {getBulkAction({
+              title: "Show all",
+              dataTestId: "column-customization-show-all",
+              disabled: isEverythingVisible,
+              onClick: () => {
                 setAllVisible(true);
-              }}
-            />
-            <Button
-              title="Hide all"
-              buttonSize={ButtonSize.Small}
-              buttonStyle={ButtonStyleType.OUTLINE}
-              dataTestId="column-customization-hide-all"
-              onClick={() => {
+              },
+            })}
+            {getBulkAction({
+              title: "Hide all",
+              dataTestId: "column-customization-hide-all",
+              disabled: isOnlyOneVisible,
+              onClick: () => {
                 setAllVisible(false);
-              }}
-            />
+              },
+            })}
           </div>
         </div>
 
-        <div
-          className="text-xs text-gray-500"
-          data-testid="column-customization-count"
-        >
-          {visibleCount} of {entries.length} columns shown
-        </div>
-
-        <div className="rounded-md border border-gray-200 overflow-hidden">
+        <div className="max-h-80 overflow-y-auto overscroll-contain rounded-md border border-gray-200 bg-white">
           {getList()}
         </div>
+
+        <p
+          className="text-xs text-gray-400"
+          data-testid="column-customization-hint"
+        >
+          {isSearching
+            ? "Clear the search to reorder columns."
+            : "Drag a row, or use the arrows, to change the column order."}
+        </p>
       </div>
     </Modal>
   );


### PR DESCRIPTION
## What

Two things, one of which forced the other.

**The modal header no longer renders an icon.** It was decorative — it repeated what the title next to it already said, and it pushed the title out of line with the body below. `Modal`'s `icon` and `iconType` props are gone, along with the colour-by-`IconType` block behind them, and every caller that passed either.

**The "Customize Columns" picker is rebuilt around the new header.**

| | before | after |
|---|---|---|
| search | plain box | magnifier inside, clear button once there is something to clear |
| bulk actions | two outline buttons rendering as bare text (`btn-outline-secondary` is not defined anywhere in the repo) | a compact pair that switches off when it has nothing left to do |
| locked column | a disabled checkbox with no explanation | a `Required` badge on the row |
| list | grew without limit | capped at `max-h-80` and scrolls, so a wide table stops pushing the footer off screen |
| hidden columns | identical to visible ones | muted |
| reordering | no explanation | a line under the list, which changes to say why the arrows are grey during a search |

Drag-and-drop now lifts the row it is dragging, and the handle darkens on row hover instead of sitting at full contrast all the time.

## Tests

`Common/Tests/UI/Components/ModelTable/ColumnCustomizationModal.test.tsx` grows from 24 to 50 tests. The new ones cover the states the redesign introduced — both bulk actions going inert and coming back, the `Required` badge following whichever column is actually locked, the clear button, the hint text switching during a search — plus the edges the old suite did not reach: an empty column list, a single-column table, two columns sharing a title, a column with no title, whitespace-only search, Escape and the header close button, and that the caller's own array is never mutated.

`Modal.test.tsx` swaps its assertion that an icon renders for one that no icon can render, and checks the title is now the header's first child.

That file also switches from `@testing-library/jest-dom/extend-expect` to `@testing-library/jest-dom`. The former no longer ships type declarations, so **every** matcher in `Modal.test.tsx` failed to typecheck and ts-jest skipped the suite before a single assertion ran — 23 tests that looked green by absence. They run now.

## Verification

- `Common`, and the `Dashboard` / `AdminDashboard` / `StatusPage` / `Accounts` / `PublicDashboard` feature sets all typecheck clean. TypeScript is what found the callers: JSX attribute checking flags every `icon=` on a component that no longer declares it.
- `Common` UI suite: 1519 passed. The 4 failing suites (`FilePicker`, `Input`, `Toggle`, `MonacoRuntime`) fail identically on `master` and are untouched here.
- The redesign was checked by rendering the real component and screenshotting the output, not by eye over the source.
- eslint clean on every changed file.
