### PR TITLE
Add Kubernetes autoscaling and container-limit saturation alert templates

### DIFF
--- a/App/FeatureSet/Docs/Content/en/monitor/kubernetes-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/kubernetes-monitor.md
@@ -140,20 +140,36 @@ Select the time window for metric evaluation:
 
 OneUptime provides templates for common Kubernetes monitoring scenarios:
 
-| Template                    | Description                 | Threshold       |
-| --------------------------- | --------------------------- | --------------- |
-| CrashLoopBackOff Detection  | Container restart count     | > 5 restarts    |
-| Pod Stuck in Pending        | Pods in Pending phase       | > 0 pods        |
-| Node Not Ready              | Node readiness condition    | = 0 (not ready) |
-| High Node CPU               | Node CPU utilization        | > 90%           |
-| High Node Memory            | Node memory utilization     | > 85%           |
-| Deployment Replica Mismatch | Unavailable replicas        | > 0 replicas    |
-| Job Failures                | Failed pods in a job        | > 0 failures    |
-| etcd No Leader              | etcd cluster leader missing | = 0 (no leader) |
-| API Server Throttling       | Dropped API requests        | > 0 requests    |
-| Scheduler Backlog           | Pending pods in scheduler   | > 0 pods        |
-| High Node Disk Usage        | Node filesystem usage       | > 90%           |
-| DaemonSet Unavailable       | Misscheduled nodes          | > 0 nodes       |
+| Template                            | Description                                | Threshold       |
+| ----------------------------------- | ------------------------------------------ | --------------- |
+| CrashLoopBackOff Detection          | Container restart count                    | > 5 restarts    |
+| Pod Stuck in Pending                | Pods in Pending phase                      | > 0 pods        |
+| Node Not Ready                      | Node readiness condition                   | = 0 (not ready) |
+| High Node CPU                       | Node CPU utilization                       | > 90%           |
+| High Node Memory                    | Node memory utilization                    | > 85%           |
+| Deployment Replica Mismatch         | Unavailable replicas                       | > 0 replicas    |
+| Job Failures                        | Failed pods in a job                       | > 0 failures    |
+| etcd No Leader                      | etcd cluster leader missing                | = 0 (no leader) |
+| API Server Throttling               | Dropped API requests                       | > 0 requests    |
+| Scheduler Backlog                   | Pending pods in scheduler                  | > 0 pods        |
+| High Node Disk Usage                | Node filesystem usage                      | > 90%           |
+| DaemonSet Unavailable               | Misscheduled nodes                         | > 0 nodes       |
+| High Node CPU Request Commitment    | Summed pod CPU requests ÷ node allocatable | > 90%           |
+| High Node Memory Request Commitment | Summed pod memory requests ÷ allocatable   | > 90%           |
+| HPA Saturated at Max Replicas       | HPA current ÷ max replicas                 | >= 90%          |
+| Pod Memory Saturating Limit         | Pod memory usage ÷ container memory limit  | > 90%           |
+| Pod CPU Saturating Limit            | Pod CPU usage ÷ container CPU limit        | > 90%           |
+
+### Catching causes, not just symptoms
+
+The node-level templates (High Node CPU/Memory, Node Not Ready, Pod Stuck in Pending) fire at the _end_ of a resource-exhaustion chain, when the cluster is already degraded. The last three templates in the table fire at the _start_ of it, which is usually where the fix is:
+
+- **Pod Memory / CPU Saturating Limit** catch a workload pinned against its own container limits. Crossing a memory limit is an immediate OOMKill; crossing a CPU limit means the kernel throttles the pod, so it gets slower without ever erroring. Both are the usual cause behind CrashLoopBackOff and unexplained latency.
+- **HPA Saturated at Max Replicas** catches an autoscaler with no headroom left. A workload whose per-pod limits are too low gets throttled or killed, which inflates the very metric the HPA scales on — so the autoscaler keeps adding replicas that are each equally starved, until it hits its ceiling or fills the cluster. Raising the limits is the fix; raising `maxReplicas` makes it worse.
+
+Enable them together on any namespace running an autoscaled workload — the combination distinguishes "genuinely needs more capacity" from "under-resourced per pod".
+
+> **Note on multi-container pods:** the two pod-limit templates compare a pod-level usage metric against a container-level limit metric. For single-container pods (the common case) the ratio is exact. For multi-container pods the denominator is the mean container limit rather than their sum, so the ratio over-reports and the alert fires early — the safe direction for an OOMKill warning, but worth knowing before you tune the threshold down.
 
 ## Setup Requirements
 

--- a/Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts
+++ b/Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts
@@ -7,17 +7,21 @@ import {
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
 import MonitorStepKubernetesMonitor from "../../../Types/Monitor/MonitorStepKubernetesMonitor";
 import MetricsAggregationType from "../../../Types/Metrics/MetricsAggregationType";
+import { FilterType } from "../../../Types/Monitor/CriteriaFilter";
 import ObjectID from "../../../Types/ObjectID";
 
 /*
- * These tests lock in the subtle, easy-to-regress decisions in the per-node
- * ratio alert templates (request utilization + usage utilization):
+ * These tests lock in the subtle, easy-to-regress decisions in the
+ * per-series ratio alert templates (node request/usage utilization, plus
+ * the autoscaling and container-limit saturation templates):
  *
  *   1. Group-by uses the ClickHouse-stored `resource.`-prefixed attribute
  *      name (`resource.k8s.node.name`), not the bare `k8s.node.name`.
  *      OneUptime stamps OTel resource attributes with a `resource.` prefix
  *      at ingest, so the bare key would match nothing and collapse every
- *      node into one mislabeled series.
+ *      node into one mislabeled series. The key differs per template — the
+ *      HPA template groups per HPA and the pod-limit templates per pod —
+ *      so each case carries its own expected key.
  *
  *   2. The aggregation differs by numerator shape:
  *        - Request utilization sums MANY container series per node, and both
@@ -27,9 +31,17 @@ import ObjectID from "../../../Types/ObjectID";
  *          (kubeletstats) and denominator (k8s_cluster) come from different
  *          receivers, so `Avg` on both sides gives the correct per-minute
  *          ratio regardless of each receiver's scrape count.
+ *        - The saturation templates are all `Avg` — see the pod-memory
+ *          template's note in KubernetesAlertTemplates.ts for the
+ *          multi-container trade-off that choice accepts.
  *
  *   3. The criteria reference the FORMULA alias (the computed percentage),
  *      not a raw query alias.
+ *
+ *   4. The unhealthy and healthy criteria PARTITION the value range — no
+ *      gap (a value that matches neither leaves the monitor stuck in its
+ *      previous status) and no overlap (a value that matches both makes the
+ *      resulting status depend on evaluation order).
  */
 
 interface RatioTemplateCase {
@@ -41,6 +53,7 @@ interface RatioTemplateCase {
   resultAlias: string;
   aggregation: MetricsAggregationType;
   threshold: number;
+  groupBy: string;
 }
 
 const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
@@ -54,6 +67,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_cpu_request_utilization",
     aggregation: MetricsAggregationType.Sum,
     threshold: 90,
+    groupBy: "resource.k8s.node.name",
   },
   {
     id: "k8s-node-memory-request-utilization",
@@ -64,6 +78,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_memory_request_utilization",
     aggregation: MetricsAggregationType.Sum,
     threshold: 90,
+    groupBy: "resource.k8s.node.name",
   },
   // Usage utilization — Avg/Avg (one series per node, cross-receiver).
   {
@@ -75,6 +90,7 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_cpu_utilization",
     aggregation: MetricsAggregationType.Avg,
     threshold: 90,
+    groupBy: "resource.k8s.node.name",
   },
   {
     id: "k8s-high-memory",
@@ -85,6 +101,50 @@ const RATIO_TEMPLATES: Array<RatioTemplateCase> = [
     resultAlias: "node_memory_utilization",
     aggregation: MetricsAggregationType.Avg,
     threshold: 85,
+    groupBy: "resource.k8s.node.name",
+  },
+  /*
+   * Autoscaling / limit saturation — Avg/Avg, and NOT keyed on the node.
+   *
+   * The HPA ratio groups per HPA object; the two pod-limit ratios group
+   * per pod. Locking the group-by key here is the point of these cases:
+   * these were the first ratio templates in this file not keyed on
+   * `resource.k8s.node.name`, so a copy-paste of the node key would
+   * silently collapse every HPA (or every pod) into one mislabeled
+   * series that still renders and still alerts.
+   */
+  {
+    id: "k8s-hpa-at-max-replicas",
+    numerator: "k8s.hpa.current_replicas",
+    denominator: "k8s.hpa.max_replicas",
+    numAlias: "current_replicas",
+    denAlias: "max_replicas",
+    resultAlias: "hpa_replica_saturation",
+    aggregation: MetricsAggregationType.Avg,
+    threshold: 90,
+    groupBy: "resource.k8s.hpa.name",
+  },
+  {
+    id: "k8s-pod-memory-limit-saturation",
+    numerator: "k8s.pod.memory.usage",
+    denominator: "k8s.container.memory_limit",
+    numAlias: "used_mem",
+    denAlias: "limit_mem",
+    resultAlias: "pod_memory_limit_saturation",
+    aggregation: MetricsAggregationType.Avg,
+    threshold: 90,
+    groupBy: "resource.k8s.pod.name",
+  },
+  {
+    id: "k8s-pod-cpu-limit-saturation",
+    numerator: "k8s.pod.cpu.utilization",
+    denominator: "k8s.container.cpu_limit",
+    numAlias: "used_cpu",
+    denAlias: "limit_cpu",
+    resultAlias: "pod_cpu_limit_saturation",
+    aggregation: MetricsAggregationType.Avg,
+    threshold: 90,
+    groupBy: "resource.k8s.pod.name",
   },
 ];
 
@@ -108,8 +168,8 @@ function getKubernetesMonitor(step: MonitorStep): MonitorStepKubernetesMonitor {
   return kubernetesMonitor;
 }
 
-describe("KubernetesAlertTemplates - per-node ratio templates", () => {
-  test("all four ratio templates are registered", () => {
+describe("KubernetesAlertTemplates - per-series ratio templates", () => {
+  test("all ratio templates are registered", () => {
     const ids: Array<string> = getAllKubernetesAlertTemplates().map(
       (t: KubernetesAlertTemplate) => {
         return t.id;
@@ -121,7 +181,7 @@ describe("KubernetesAlertTemplates - per-node ratio templates", () => {
   });
 
   test.each(RATIO_TEMPLATES)(
-    "$id is a per-node ($aggregation/$aggregation) ratio keyed on resource.k8s.node.name",
+    "$id is a ($aggregation/$aggregation) ratio keyed on $groupBy",
     (tc: RatioTemplateCase) => {
       const template: KubernetesAlertTemplate | undefined =
         getKubernetesAlertTemplateById(tc.id);
@@ -162,15 +222,18 @@ describe("KubernetesAlertTemplates - per-node ratio templates", () => {
       );
 
       /*
-       * Decision (1): group by the resource-prefixed node attribute on BOTH
+       * Decision (1): group by the resource-prefixed attribute on BOTH
        * queries so the per-series fingerprints line up for the formula join.
        */
       expect(numerator.metricQueryData.groupByAttributeKeys).toEqual([
-        "resource.k8s.node.name",
+        tc.groupBy,
       ]);
       expect(denominator.metricQueryData.groupByAttributeKeys).toEqual([
-        "resource.k8s.node.name",
+        tc.groupBy,
       ]);
+
+      // The `resource.` prefix is load-bearing — a bare OTel key matches nothing.
+      expect(tc.groupBy.startsWith("resource.")).toBe(true);
 
       // Formula divides numerator by denominator and scales to a percentage.
       expect(formulaConfigs[0].metricFormulaData.metricFormula).toBe(
@@ -190,4 +253,109 @@ describe("KubernetesAlertTemplates - per-node ratio templates", () => {
       expect(offlineFilters[0].value).toBe(tc.threshold);
     },
   );
+
+  /*
+   * Decision (4): unhealthy and healthy must be exact complements at the
+   * same threshold. Both halves are hand-written per template, so the
+   * failure mode is a strict/non-strict slip — pairing `> 90` with
+   * `< 90` leaves exactly 90 matching neither criterion (the monitor
+   * silently holds its previous status), and pairing `>= 90` with
+   * `<= 90` makes 90 match both (status depends on evaluation order).
+   */
+  const COMPLEMENT_OF: Record<string, string> = {
+    [FilterType.GreaterThan]: FilterType.LessThanOrEqualTo,
+    [FilterType.GreaterThanOrEqualTo]: FilterType.LessThan,
+  };
+
+  test.each(RATIO_TEMPLATES)(
+    "$id unhealthy/healthy criteria partition the range at $threshold",
+    (tc: RatioTemplateCase) => {
+      const template: KubernetesAlertTemplate | undefined =
+        getKubernetesAlertTemplateById(tc.id);
+      const step: MonitorStep = template!.getMonitorStep(buildArgs());
+
+      const instances: Array<any> = step.data?.monitorCriteria.data
+        ?.monitorCriteriaInstanceArray as Array<any>;
+      const [offline, online] = instances;
+
+      const offlineFilter: any = offline.data.filters[0];
+      const onlineFilter: any = online.data.filters[0];
+
+      // Same metric, same threshold — only the comparison direction differs.
+      expect(onlineFilter.metricMonitorOptions.metricAlias).toBe(
+        tc.resultAlias,
+      );
+      expect(onlineFilter.value).toBe(tc.threshold);
+
+      expect(COMPLEMENT_OF[offlineFilter.filterType]).toBe(
+        onlineFilter.filterType,
+      );
+
+      // The unhealthy criterion is the one that opens incidents/alerts.
+      expect(offline.data.createIncidents).toBe(true);
+      expect(offline.data.createAlerts).toBe(true);
+      expect(online.data.createIncidents).toBe(false);
+      expect(online.data.createAlerts).toBe(false);
+    },
+  );
+});
+
+/*
+ * The three saturation templates exist to catch the CAUSE of the
+ * "under-resourced workload behind an autoscaler" failure — limits too
+ * low, HPA driven to its ceiling, cluster filled — rather than its
+ * downstream symptoms (node pressure, pending pods, NotReady), which the
+ * older node-side templates already cover. These assertions pin the
+ * properties that make them useful for that: they must be discoverable in
+ * the picker under a category, and severity must reflect that memory
+ * saturation ends in an OOMKill while CPU saturation only throttles.
+ */
+describe("KubernetesAlertTemplates - autoscaling & limit saturation", () => {
+  const SATURATION_TEMPLATES: Array<{
+    id: string;
+    category: string;
+    severity: string;
+  }> = [
+    {
+      id: "k8s-hpa-at-max-replicas",
+      category: "Workload",
+      severity: "Critical",
+    },
+    {
+      id: "k8s-pod-memory-limit-saturation",
+      category: "Workload",
+      // Crossing a memory limit is an immediate kill, not a slowdown.
+      severity: "Critical",
+    },
+    {
+      id: "k8s-pod-cpu-limit-saturation",
+      category: "Workload",
+      // CFS throttling degrades latency; it never kills the container.
+      severity: "Warning",
+    },
+  ];
+
+  test.each(SATURATION_TEMPLATES)(
+    "$id is registered as a $severity $category template",
+    (tc: { id: string; category: string; severity: string }) => {
+      const template: KubernetesAlertTemplate | undefined =
+        getKubernetesAlertTemplateById(tc.id);
+
+      expect(template).toBeDefined();
+      expect(template!.category).toBe(tc.category);
+      expect(template!.severity).toBe(tc.severity);
+      expect(template!.name.length).toBeGreaterThan(0);
+      expect(template!.description.length).toBeGreaterThan(0);
+    },
+  );
+
+  test("every template id is unique", () => {
+    const ids: Array<string> = getAllKubernetesAlertTemplates().map(
+      (t: KubernetesAlertTemplate) => {
+        return t.id;
+      },
+    );
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });

--- a/Common/Types/Monitor/KubernetesAlertTemplates.ts
+++ b/Common/Types/Monitor/KubernetesAlertTemplates.ts
@@ -959,6 +959,208 @@ const nodeMemoryRequestUtilizationTemplate: KubernetesAlertTemplate = {
   },
 };
 
+/*
+ * --- Autoscaling / limit-saturation templates ---
+ *
+ * These three close the detection gap for the classic "under-resourced
+ * workload behind an autoscaler" failure: limits are set too low, so the
+ * containers sit pinned against them (OOMKilled on memory, CFS-throttled
+ * on CPU), the resulting latency/restarts drive the HPA up, and the HPA
+ * fills the cluster until nodes go NotReady.
+ *
+ * The node-side templates above catch the END of that chain (high node
+ * CPU/memory, NotReady, pending pods) — by which point the RCA is several
+ * hops from the cause. These catch the START: the HPA running out of
+ * headroom, and the containers pinned at their own limits.
+ *
+ * All three are per-series ratios, grouped by the ClickHouse-stored
+ * `resource.`-prefixed attribute (see buildKubernetesRatioMonitorConfig).
+ */
+
+const hpaAtMaxReplicasTemplate: KubernetesAlertTemplate = {
+  id: "k8s-hpa-at-max-replicas",
+  name: "HPA Saturated at Max Replicas",
+  description:
+    "Alert when a HorizontalPodAutoscaler is running at 90% or more of its maxReplicas. Computed per HPA as k8s.hpa.current_replicas ÷ k8s.hpa.max_replicas × 100. An HPA at its ceiling has no headroom left: load it cannot absorb by scaling turns straight into latency and errors, and a workload that reaches the ceiling and stays there is usually under-resourced per pod rather than genuinely at capacity.",
+  category: "Workload",
+  severity: "Critical",
+  getMonitorStep: (args: KubernetesAlertTemplateArgs): MonitorStep => {
+    const metricAlias: string = "hpa_replica_saturation";
+
+    return buildKubernetesMonitorStep({
+      kubernetesMonitor: buildKubernetesRatioMonitorConfig({
+        clusterIdentifier: args.clusterIdentifier,
+        numeratorMetricName: "k8s.hpa.current_replicas",
+        denominatorMetricName: "k8s.hpa.max_replicas",
+        groupByAttributeKey: "resource.k8s.hpa.name",
+        numeratorAlias: "current_replicas",
+        denominatorAlias: "max_replicas",
+        resultAlias: metricAlias,
+        resultLegend: "HPA Replica Saturation (%)",
+        resourceScope: KubernetesResourceScope.Workload,
+        rollingTime: RollingTime.Past5Minutes,
+        /*
+         * ONE series per HPA on both sides (they are the same object's
+         * status/spec fields), so Avg gives the representative per-minute
+         * ratio independent of scrape count. Both come from the same
+         * k8s_cluster scrape, so Sum would also cancel — but Avg stays
+         * correct across restarts and missed scrapes. See
+         * buildKubernetesRatioMonitorConfig.
+         */
+        aggregationType: MetricsAggregationType.Avg,
+      }),
+      offlineCriteriaInstance: buildOfflineCriteriaInstance({
+        offlineMonitorStatusId: args.offlineMonitorStatusId,
+        incidentSeverityId: args.defaultIncidentSeverityId,
+        alertSeverityId: args.defaultAlertSeverityId,
+        monitorName: args.monitorName,
+        metricAlias,
+        filterType: FilterType.GreaterThanOrEqualTo,
+        value: 90,
+        incidentTitle: `[K8s] HPA Saturated at Max Replicas (>=90%) - ${args.monitorName}`,
+        incidentDescription: `A HorizontalPodAutoscaler is running at 90% or more of its maxReplicas and has effectively no scaling headroom left. Any further load cannot be absorbed by scaling out, so it will surface as latency and errors instead. Check whether the workload is genuinely at capacity or whether its per-pod CPU/memory limits are set too low — an under-resourced pod gets throttled or OOMKilled, which inflates the metric the HPA scales on and drives it to the ceiling. Check the root cause for the specific HPA, its target workload, and current vs max replicas.`,
+        criteriaName: "HPA Saturation - Current/Max Replicas >= 90%",
+        criteriaDescription:
+          "Triggers when any HPA's current replica count reaches 90% or more of its configured maxReplicas.",
+      }),
+      onlineCriteriaInstance: buildOnlineCriteriaInstance({
+        onlineMonitorStatusId: args.onlineMonitorStatusId,
+        metricAlias,
+        filterType: FilterType.LessThan,
+        value: 90,
+      }),
+    });
+  },
+};
+
+const podMemoryLimitSaturationTemplate: KubernetesAlertTemplate = {
+  id: "k8s-pod-memory-limit-saturation",
+  name: "Pod Memory Saturating Container Limit",
+  description:
+    "Alert when a pod's memory usage exceeds 90% of its configured container memory limit — the state immediately preceding an OOMKill. Computed per pod as k8s.pod.memory.usage ÷ k8s.container.memory_limit × 100 (both bytes). This is the cause-side signal for CrashLoopBackOff and restart storms: a limit set too low shows up here minutes before the container is killed.",
+  category: "Workload",
+  severity: "Critical",
+  getMonitorStep: (args: KubernetesAlertTemplateArgs): MonitorStep => {
+    const metricAlias: string = "pod_memory_limit_saturation";
+
+    return buildKubernetesMonitorStep({
+      kubernetesMonitor: buildKubernetesRatioMonitorConfig({
+        clusterIdentifier: args.clusterIdentifier,
+        numeratorMetricName: "k8s.pod.memory.usage",
+        denominatorMetricName: "k8s.container.memory_limit",
+        groupByAttributeKey: "resource.k8s.pod.name",
+        numeratorAlias: "used_mem",
+        denominatorAlias: "limit_mem",
+        resultAlias: metricAlias,
+        resultLegend: "Pod Memory vs Limit (%)",
+        resourceScope: KubernetesResourceScope.Pod,
+        rollingTime: RollingTime.Past5Minutes,
+        /*
+         * Avg, deliberately — and the one case in this file where the two
+         * sides have different series shapes, so the trade-off is worth
+         * stating.
+         *
+         * Numerator (k8s.pod.memory.usage, kubeletstats) is ONE series per
+         * pod. Denominator (k8s.container.memory_limit, k8s_cluster) is one
+         * series per CONTAINER, so a multi-container pod contributes
+         * several.
+         *
+         * Sum is definitively wrong here: the two metrics ride different
+         * receivers on independent scrape cycles, so the scrape multiple
+         * would not cancel. Avg is exact for single-container pods (the
+         * overwhelming majority, and the case this template exists for).
+         *
+         * For multi-container pods Avg takes the MEAN container limit
+         * rather than their sum, so the ratio over-reports and the alert
+         * fires early. That is the safe direction for an "OOMKill is
+         * imminent" warning — a false early page beats a missed kill — but
+         * it is a real caveat, not a rounding detail. A per-container
+         * variant needs a container-scoped usage metric to pair against
+         * (`container.memory.usage`), which the shipped catalog does not
+         * carry today.
+         */
+        aggregationType: MetricsAggregationType.Avg,
+      }),
+      offlineCriteriaInstance: buildOfflineCriteriaInstance({
+        offlineMonitorStatusId: args.offlineMonitorStatusId,
+        incidentSeverityId: args.defaultIncidentSeverityId,
+        alertSeverityId: args.defaultAlertSeverityId,
+        monitorName: args.monitorName,
+        metricAlias,
+        filterType: FilterType.GreaterThan,
+        value: 90,
+        incidentTitle: `[K8s] Pod Memory Saturating Container Limit (>90%) - ${args.monitorName}`,
+        incidentDescription: `A pod's memory usage has exceeded 90% of its configured container memory limit. The kubelet OOMKills a container the moment it crosses its limit, so this is the state immediately preceding a restart — and, if the workload sits behind an autoscaler, the start of a restart/scale-up loop. Either the limit is set too low for the workload's real footprint or the workload has a memory leak. Check the root cause for the specific pod, its limit, and its usage trend.`,
+        criteriaName: "Pod Memory Saturation - Usage/Limit > 90%",
+        criteriaDescription:
+          "Triggers when any pod's memory usage exceeds 90% of its container memory limit.",
+      }),
+      onlineCriteriaInstance: buildOnlineCriteriaInstance({
+        onlineMonitorStatusId: args.onlineMonitorStatusId,
+        metricAlias,
+        filterType: FilterType.LessThanOrEqualTo,
+        value: 90,
+      }),
+    });
+  },
+};
+
+const podCpuLimitSaturationTemplate: KubernetesAlertTemplate = {
+  id: "k8s-pod-cpu-limit-saturation",
+  name: "Pod CPU Saturating Container Limit",
+  description:
+    "Alert when a pod's CPU usage exceeds 90% of its configured container CPU limit — the point at which the kernel's CFS quota starts throttling it. Computed per pod as k8s.pod.cpu.utilization ÷ k8s.container.cpu_limit × 100; both are CPU cores, so this is a true percentage (k8s.pod.cpu.utilization is a misnamed cores gauge, not a percent). A throttled pod gets slower, not louder — behind an HPA that reads CPU, throttling drives the replica count up while every pod stays equally starved.",
+  category: "Workload",
+  severity: "Warning",
+  getMonitorStep: (args: KubernetesAlertTemplateArgs): MonitorStep => {
+    const metricAlias: string = "pod_cpu_limit_saturation";
+
+    return buildKubernetesMonitorStep({
+      kubernetesMonitor: buildKubernetesRatioMonitorConfig({
+        clusterIdentifier: args.clusterIdentifier,
+        numeratorMetricName: "k8s.pod.cpu.utilization",
+        denominatorMetricName: "k8s.container.cpu_limit",
+        groupByAttributeKey: "resource.k8s.pod.name",
+        numeratorAlias: "used_cpu",
+        denominatorAlias: "limit_cpu",
+        resultAlias: metricAlias,
+        resultLegend: "Pod CPU vs Limit (%)",
+        resourceScope: KubernetesResourceScope.Pod,
+        rollingTime: RollingTime.Past5Minutes,
+        /*
+         * Avg, for the same reason as the memory template above: ONE
+         * numerator series per pod (kubeletstats) against a per-container
+         * denominator (k8s_cluster) on an independent scrape cycle. Exact
+         * for single-container pods; over-reports (fires early) for
+         * multi-container pods. See that template's note for the full
+         * trade-off.
+         */
+        aggregationType: MetricsAggregationType.Avg,
+      }),
+      offlineCriteriaInstance: buildOfflineCriteriaInstance({
+        offlineMonitorStatusId: args.offlineMonitorStatusId,
+        incidentSeverityId: args.defaultIncidentSeverityId,
+        alertSeverityId: args.defaultAlertSeverityId,
+        monitorName: args.monitorName,
+        metricAlias,
+        filterType: FilterType.GreaterThan,
+        value: 90,
+        incidentTitle: `[K8s] Pod CPU Saturating Container Limit (>90%) - ${args.monitorName}`,
+        incidentDescription: `A pod's CPU usage has exceeded 90% of its configured container CPU limit and is being throttled by the kernel's CFS quota. Throttling is silent — the pod does not crash, it just gets slower, so this usually surfaces as request latency rather than as an error. If the workload sits behind a CPU-based HorizontalPodAutoscaler, throttling also inflates the metric the HPA scales on, so the autoscaler adds replicas that are each equally starved. Check whether the CPU limit is set too low for the workload rather than adding replicas.`,
+        criteriaName: "Pod CPU Saturation - Usage/Limit > 90%",
+        criteriaDescription:
+          "Triggers when any pod's CPU usage exceeds 90% of its container CPU limit.",
+      }),
+      onlineCriteriaInstance: buildOnlineCriteriaInstance({
+        onlineMonitorStatusId: args.onlineMonitorStatusId,
+        metricAlias,
+        filterType: FilterType.LessThanOrEqualTo,
+        value: 90,
+      }),
+    });
+  },
+};
+
 export function getAllKubernetesAlertTemplates(): Array<KubernetesAlertTemplate> {
   return [
     crashLoopBackOffTemplate,
@@ -975,6 +1177,9 @@ export function getAllKubernetesAlertTemplates(): Array<KubernetesAlertTemplate>
     daemonSetUnavailableTemplate,
     nodeCpuRequestUtilizationTemplate,
     nodeMemoryRequestUtilizationTemplate,
+    hpaAtMaxReplicasTemplate,
+    podMemoryLimitSaturationTemplate,
+    podCpuLimitSaturationTemplate,
   ];
 }
 


### PR DESCRIPTION
## Why

Every shipped Kubernetes alert template fires at the **end** of a resource-exhaustion chain — high node CPU/memory, NotReady nodes, pending pods, CrashLoopBackOff. By the time those trigger, the cluster is already degraded and the RCA is several hops from the cause.

The most common cause has no template at all. When a deployment's per-pod limits are set too low behind an HPA, the containers get throttled or OOMKilled, which inflates the very metric the autoscaler scales on, so the HPA adds replicas that are each equally starved — until it hits its ceiling or fills the cluster and takes nodes down. The four `k8s.hpa.*` metrics are collected by the agent and queryable today, but nothing watches them.

## What

Three new per-series ratio templates that fire at the **start** of that chain:

| Template | Severity | Signal |
|---|---|---|
| HPA Saturated at Max Replicas | Critical | `k8s.hpa.current_replicas ÷ k8s.hpa.max_replicas` >= 90% |
| Pod Memory Saturating Container Limit | Critical | `k8s.pod.memory.usage ÷ k8s.container.memory_limit` > 90% |
| Pod CPU Saturating Container Limit | Warning | `k8s.pod.cpu.utilization ÷ k8s.container.cpu_limit` > 90% |

Severity split is deliberate: crossing a memory limit is an immediate OOMKill, while crossing a CPU limit only means CFS throttling — the pod gets slower without ever erroring.

They're picked up by the template picker automatically (it enumerates `getAllKubernetesAlertTemplates()` by category), so there's no UI change.

## Aggregation trade-off — the one thing worth reviewing

All three are `Avg/Avg`. The HPA template is exact: one series per HPA on both sides, same `k8s_cluster` scrape.

The two pod templates pair a **pod-level** usage metric (kubeletstats) against a **container-level** limit metric (`k8s_cluster`):

- `Sum` would be wrong outright — the two metrics ride different receivers on independent scrape cycles, so the scrape multiple wouldn't cancel.
- `Avg` is exact for single-container pods, which is the common case and the one these templates exist for.
- For multi-container pods the denominator becomes the *mean* container limit rather than their sum, so the ratio over-reports and the alert fires early. That's the safe direction for an "OOMKill is imminent" warning, but it is a real caveat — stated in the code comment and in the docs, not buried.

A per-container variant would need a container-scoped usage metric (`container.memory.usage`) to pair against, which the shipped catalog doesn't carry.

## Tests

`Common/Tests/Types/Monitor/KubernetesAlertTemplates.test.ts` — 19 tests, all passing; full `Tests/Types/Monitor` suite green (941 tests).

Two things the new cases pin down:

1. **Group-by key per template.** These are the first ratio templates in the file not keyed on `resource.k8s.node.name` — HPA groups per HPA, the pod ones per pod. A copy-pasted node key would silently collapse every HPA into one mislabeled series that still renders and still alerts, so the expected key now travels with each case rather than being hardcoded in the assertion.
2. **Unhealthy/healthy criteria partition the range.** Both halves are hand-written per template, so the failure mode is a strict/non-strict slip: `> 90` paired with `< 90` leaves exactly 90 matching neither criterion (the monitor silently holds its previous status), and `>= 90` with `<= 90` makes 90 match both (status depends on evaluation order). Applied to all seven ratio templates — the four pre-existing ones already partitioned correctly.

## Docs

Adds the three templates to the Kubernetes monitor page, plus the two node request-commitment templates that shipped earlier without a docs entry, and a short section on why the cause-side templates are worth enabling together on autoscaled workloads.

## Scope

Detection only. This is the first of the gaps identified while tracing the identify → investigate → RCA → remediate loop for Kubernetes; the remaining ones (a read-only cluster-state tool for investigations, and binding an RCA to a runbook rather than to a regex on the incident title) are separate changes. Nothing under `Common/Server/Utils/AI/` or `AIAgent/` is touched, so no roadmap status row applies.
