### PR TITLE
fix(api): reject update payloads that would write nothing instead of answering 200

### DIFF
--- a/App/FeatureSet/Docs/Content/en/workflows/variables.md
+++ b/App/FeatureSet/Docs/Content/en/workflows/variables.md
@@ -94,6 +94,29 @@ The first call gives you an ID the second one needs:
 
 If `LookupOrder` fails, its **error** output fires instead of **success**. Connect that to an Email or Slack block so failures don't go unnoticed.
 
+## Updating a variable from a workflow
+
+A common pattern is rotating a credential on a schedule: fetch a fresh token from a third party, then store it back in the variable so the next run picks it up. Do that with an **API** block calling the OneUptime API.
+
+`PUT /api/workflow-variable/<variable-id>` with an `ApiKey` header, and — this is the part that trips people up — the fields you want to change **wrapped in a `data` object**:
+
+```json
+{
+  "data": {
+    "content": "{{local.components.get-token.returnValues.response-body.access_token}}"
+  }
+}
+```
+
+A flat body without the `data` wrapper is rejected with a 400. Send only the fields you actually want to change; `name` and `description` can stay out of the payload.
+
+The API key needs **Edit Workflow Variables** to write `content`, and **Read Workflow Variables** as well, since the update is scoped by a read on the project.
+
+Two things to watch:
+
+- **Don't rename a variable you reference.** `name` is part of `{{local.variables.NAME}}`. Changing it leaves every existing reference resolving to an empty string, silently.
+- **A variable marked secret can still be written this way** — it just can't be read back. That's what makes it a safe place to park a rotating token.
+
 ## Gotchas
 
 - **Use the pickers.** They insert the exact component, return-value, and variable IDs expected by the runner and keep references independent of display labels.

--- a/App/FeatureSet/Workflow/Services/RunWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/RunWorkflow.ts
@@ -422,7 +422,7 @@ export default class RunWorkflow {
             stackItem.node.metadata.returnValues,
           ),
         );
-        this.log("Executing Port: " + result.executePort?.title || "<None>");
+        this.log("Executing Port: " + (result.executePort?.title || "<None>"));
 
         storageMap.local.components[stackItem.node.id] = {
           returnValues: result.returnValues,

--- a/Common/Models/DatabaseModels/WorkflowVariable.ts
+++ b/Common/Models/DatabaseModels/WorkflowVariable.ts
@@ -298,7 +298,11 @@ export default class WorkflowVariable extends BaseModel {
       Permission.CreateWorkflowVariable,
     ],
     read: [],
-    update: [Permission.ProjectOwner, Permission.ProjectAdmin],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditWorkflowVariable,
+    ],
   })
   @TableColumn({
     required: true,

--- a/Common/Server/API/BaseAPI.ts
+++ b/Common/Server/API/BaseAPI.ts
@@ -22,9 +22,10 @@ import {
   LIMIT_PER_PROJECT,
 } from "../../Types/Database/LimitMax";
 import PartialEntity from "../../Types/Database/PartialEntity";
+import BadDataException from "../../Types/Exception/BadDataException";
 import BadRequestException from "../../Types/Exception/BadRequestException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
-import { JSONObject } from "../../Types/JSON";
+import { JSONObject, JSONValue } from "../../Types/JSON";
 import JSONFunctions from "../../Types/JSONFunctions";
 import ObjectID from "../../Types/ObjectID";
 import { UserPermission } from "../../Types/Permission";
@@ -398,14 +399,42 @@ export default class BaseAPI<
     const objectId: ObjectID = new ObjectID(idParam);
     const objectIdString: string = objectId.toString();
     const body: JSONObject = req.body;
+    const dataInBody: JSONValue | undefined = body["data"];
+
+    /*
+     * The update payload has to be wrapped as { "data": { ...columns... } }.
+     * A flat body has no "data" key, and deserializing that undefined handed
+     * back an empty object: the update then matched the row, wrote no columns
+     * at all, and still answered 200. Callers were told the write succeeded
+     * while their fields were dropped on the floor.
+     */
+    if (
+      !dataInBody ||
+      typeof dataInBody !== "object" ||
+      Array.isArray(dataInBody)
+    ) {
+      throw new BadDataException(
+        'Invalid request body. The update payload should be an object of the form { "data": { ...fields to update... } }.',
+      );
+    }
 
     const item: PartialEntity<TBaseModel> = JSONFunctions.deserialize(
-      body["data"] as JSONObject,
+      dataInBody as JSONObject,
     ) as PartialEntity<TBaseModel>;
 
     delete (item as any)["_id"];
     delete (item as any)["createdAt"];
     delete (item as any)["updatedAt"];
+
+    /*
+     * An update that carries no columns writes nothing. Saying 200 to that is
+     * the same lie in a different shape, so ask for at least one field.
+     */
+    if (Object.keys(item).length === 0) {
+      throw new BadDataException(
+        'No fields to update. Please include at least one field to update in the "data" object of the request body.',
+      );
+    }
 
     const numberOfDocsAffected: number = await this.service.updateOneById({
       id: new ObjectID(objectIdString),

--- a/Common/Server/API/BaseAnalyticsAPI.ts
+++ b/Common/Server/API/BaseAnalyticsAPI.ts
@@ -21,8 +21,9 @@ import {
   DEFAULT_LIMIT,
   LIMIT_PER_PROJECT,
 } from "../../Types/Database/LimitMax";
+import BadDataException from "../../Types/Exception/BadDataException";
 import BadRequestException from "../../Types/Exception/BadRequestException";
-import { JSONObject } from "../../Types/JSON";
+import { JSONObject, JSONValue } from "../../Types/JSON";
 import JSONFunctions from "../../Types/JSONFunctions";
 import ObjectID from "../../Types/ObjectID";
 import { UserPermission } from "../../Types/Permission";
@@ -542,10 +543,43 @@ export default class BaseAnalyticsAPI<
     const objectId: ObjectID = new ObjectID(req.params["id"] as string);
     const objectIdString: string = objectId.toString();
     const body: JSONObject = req.body;
+    const dataInBody: JSONValue | undefined = body["data"];
+
+    /*
+     * Same contract as BaseAPI.updateItem: the payload has to be wrapped as
+     * { "data": { ...columns... } }. Reject anything else here rather than
+     * letting an empty model reach the service.
+     */
+    if (
+      !dataInBody ||
+      typeof dataInBody !== "object" ||
+      Array.isArray(dataInBody)
+    ) {
+      throw new BadDataException(
+        'Invalid request body. The update payload should be an object of the form { "data": { ...fields to update... } }.',
+      );
+    }
+
+    /*
+     * Count the fields on the raw payload, not on the model: an analytics
+     * model instance always carries its own internal properties, so
+     * Object.keys() on it is never empty.
+     */
+    const fieldsToUpdate: Array<string> = Object.keys(
+      dataInBody as JSONObject,
+    ).filter((key: string) => {
+      return key !== "_id" && key !== "createdAt" && key !== "updatedAt";
+    });
+
+    if (fieldsToUpdate.length === 0) {
+      throw new BadDataException(
+        'No fields to update. Please include at least one field to update in the "data" object of the request body.',
+      );
+    }
 
     const item: TAnalyticsDataModel =
       AnalyticsDataModel.fromJSON<TAnalyticsDataModel>(
-        body["data"] as JSONObject,
+        dataInBody as JSONObject,
         this.entityType,
       ) as TAnalyticsDataModel;
 

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1841,6 +1841,14 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
 
       const dataColumns: [string, boolean][] = [];
       const dataKeys: string[] = Object.keys(data);
+
+      /*
+       * An update that carries no columns writes nothing, yet it would still
+       * match rows - so returning the matched count reported a write that
+       * never happened. Treat it like a query that matched nothing instead.
+       */
+      const hasColumnsToUpdate: boolean = dataKeys.length > 0;
+
       for (const key of dataKeys) {
         dataColumns.push([key, true]);
       }
@@ -1879,13 +1887,15 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
         }
       }
 
-      const items: Array<TBaseModel> = await this._findBy({
-        query: beforeUpdateBy.query,
-        skip: updateBy.skip.toNumber(),
-        limit: updateBy.limit.toNumber(),
-        select: selectColumns,
-        props: { isRoot: true, ignoreHooks: true },
-      });
+      const items: Array<TBaseModel> = hasColumnsToUpdate
+        ? await this._findBy({
+            query: beforeUpdateBy.query,
+            skip: updateBy.skip.toNumber(),
+            limit: updateBy.limit.toNumber(),
+            select: selectColumns,
+            props: { isRoot: true, ignoreHooks: true },
+          })
+        : [];
 
       for (const item of items) {
         /*

--- a/Common/Server/Types/Workflow/Components/API/Delete.ts
+++ b/Common/Server/Types/Workflow/Components/API/Delete.ts
@@ -48,6 +48,18 @@ export default class ApiDelete extends ComponentCode {
         headers: args["request-headers"] as Dictionary<string>,
       });
 
+      /*
+       * On the server API resolves with an HTTPErrorResponse instead of
+       * throwing, so the catch below never sees an HTTP error - a 4xx/5xx used
+       * to take the success port.
+       */
+      if (apiResult instanceof HTTPErrorResponse) {
+        return Promise.resolve({
+          returnValues: ApiComponentUtils.getReturnValues(apiResult),
+          executePort: result.errorPort,
+        });
+      }
+
       return Promise.resolve({
         returnValues: ApiComponentUtils.getReturnValues(apiResult),
         executePort: result.successPort,

--- a/Common/Server/Types/Workflow/Components/API/Get.ts
+++ b/Common/Server/Types/Workflow/Components/API/Get.ts
@@ -48,6 +48,18 @@ export default class ApiGet extends ComponentCode {
         headers: args["request-headers"] as Dictionary<string>,
       });
 
+      /*
+       * On the server API resolves with an HTTPErrorResponse instead of
+       * throwing, so the catch below never sees an HTTP error - a 4xx/5xx used
+       * to take the success port.
+       */
+      if (apiResult instanceof HTTPErrorResponse) {
+        return Promise.resolve({
+          returnValues: ApiComponentUtils.getReturnValues(apiResult),
+          executePort: result.errorPort,
+        });
+      }
+
       return Promise.resolve({
         returnValues: ApiComponentUtils.getReturnValues(apiResult),
         executePort: result.successPort,

--- a/Common/Server/Types/Workflow/Components/API/Patch.ts
+++ b/Common/Server/Types/Workflow/Components/API/Patch.ts
@@ -48,6 +48,18 @@ export default class ApiPut extends ComponentCode {
         headers: args["request-headers"] as Dictionary<string>,
       });
 
+      /*
+       * On the server API resolves with an HTTPErrorResponse instead of
+       * throwing, so the catch below never sees an HTTP error - a 4xx/5xx used
+       * to take the success port.
+       */
+      if (apiResult instanceof HTTPErrorResponse) {
+        return Promise.resolve({
+          returnValues: ApiComponentUtils.getReturnValues(apiResult),
+          executePort: result.errorPort,
+        });
+      }
+
       return Promise.resolve({
         returnValues: ApiComponentUtils.getReturnValues(apiResult),
         executePort: result.successPort,

--- a/Common/Server/Types/Workflow/Components/API/Post.ts
+++ b/Common/Server/Types/Workflow/Components/API/Post.ts
@@ -81,6 +81,18 @@ export default class ApiPost extends ComponentCode {
 
       logger.debug("API Post Component is done.", workflowLogAttributes);
 
+      /*
+       * On the server API resolves with an HTTPErrorResponse instead of
+       * throwing, so the catch below never sees an HTTP error - a 4xx/5xx used
+       * to take the success port.
+       */
+      if (apiResult instanceof HTTPErrorResponse) {
+        return Promise.resolve({
+          returnValues: ApiComponentUtils.getReturnValues(apiResult),
+          executePort: result.errorPort,
+        });
+      }
+
       return Promise.resolve({
         returnValues: ApiComponentUtils.getReturnValues(apiResult),
         executePort: result.successPort,

--- a/Common/Server/Types/Workflow/Components/API/Put.ts
+++ b/Common/Server/Types/Workflow/Components/API/Put.ts
@@ -48,6 +48,19 @@ export default class ApiPut extends ComponentCode {
         headers: args["request-headers"] as Dictionary<string>,
       });
 
+      /*
+       * On the server API resolves with an HTTPErrorResponse instead of
+       * throwing (only the UI subclass throws), so the catch below never sees
+       * an HTTP error - a 4xx/5xx used to take the success port and log
+       * "Success" at the customer.
+       */
+      if (apiResult instanceof HTTPErrorResponse) {
+        return Promise.resolve({
+          returnValues: ApiComponentUtils.getReturnValues(apiResult),
+          executePort: result.errorPort,
+        });
+      }
+
       return Promise.resolve({
         returnValues: ApiComponentUtils.getReturnValues(apiResult),
         executePort: result.successPort,

--- a/Common/Tests/Server/API/BaseAPIUpdatePayloadValidation.test.ts
+++ b/Common/Tests/Server/API/BaseAPIUpdatePayloadValidation.test.ts
@@ -1,0 +1,320 @@
+import BaseAPI from "../../../Server/API/BaseAPI";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import {
+  ExpressResponse,
+  OneUptimeRequest,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import { mockRouter } from "./Helpers";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import { getJestSpyOn } from "../../Spy";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+/*
+ * PUT /<model>/:id takes its payload wrapped as { "data": { ...columns... } }.
+ *
+ * A caller that sent the columns flat instead - no "data" key - got HTTP 200
+ * and an empty body, and nothing was written. body["data"] was undefined,
+ * deserializing that handed back {}, and an update carrying no columns still
+ * matched the row, so the "matched nothing" guard never fired. The fields were
+ * dropped on the floor and the caller was told the write succeeded.
+ *
+ * A customer hit this rotating an API token from a Workflow: every run
+ * reported success and every run read back the previous token.
+ */
+
+const TEST_ID: string = "550e8400-e29b-41d4-a716-446655440009";
+
+describe("BaseAPI.updateItem payload validation", () => {
+  let service: DatabaseService<Probe>;
+  let api: BaseAPI<Probe, DatabaseService<Probe>>;
+  let response: ExpressResponse;
+
+  type RequestWithBodyFunction = (body: JSONObject) => OneUptimeRequest;
+
+  const requestWithBody: RequestWithBodyFunction = (
+    body: JSONObject,
+  ): OneUptimeRequest => {
+    return {
+      params: { id: TEST_ID },
+      body: body,
+      headers: {},
+    } as unknown as OneUptimeRequest;
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    service = new DatabaseService<Probe>(Probe);
+    api = new BaseAPI<Probe, DatabaseService<Probe>>(Probe, service);
+
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+
+    getJestSpyOn(service, "updateOneById").mockResolvedValue(1);
+  });
+
+  describe("when the payload is not wrapped in a data object", () => {
+    /*
+     * This is the customer's exact request body, minus the token value. It is
+     * the case the whole fix exists for.
+     */
+    it("refuses a flat body that puts the columns at the top level", async () => {
+      const request: OneUptimeRequest = requestWithBody({
+        content: "new-token-value",
+        name: "Airflow-Token",
+        description: "Token to connect to Airflow.",
+      });
+
+      await expect(api.updateItem(request, response)).rejects.toThrow(
+        BadDataException,
+      );
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+      expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    });
+
+    it("names the shape it wants so the caller can fix the request", async () => {
+      const request: OneUptimeRequest = requestWithBody({
+        content: "new-token-value",
+      });
+
+      await expect(api.updateItem(request, response)).rejects.toThrow(/data/);
+    });
+
+    it("refuses an empty body", async () => {
+      await expect(
+        api.updateItem(requestWithBody({}), response),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("refuses a null data payload", async () => {
+      await expect(
+        api.updateItem(requestWithBody({ data: null }), response),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+
+    /*
+     * A string used to survive deserialization as its own index map -
+     * "abc" became { "0": "a", "1": "b", "2": "c" } - and went to the service
+     * as three nonsense columns.
+     */
+    it("refuses a string data payload rather than indexing it into columns", async () => {
+      await expect(
+        api.updateItem(
+          requestWithBody({ data: "abc" } as JSONObject),
+          response,
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("refuses a numeric data payload", async () => {
+      await expect(
+        api.updateItem(requestWithBody({ data: 42 } as JSONObject), response),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("refuses a boolean data payload", async () => {
+      await expect(
+        api.updateItem(requestWithBody({ data: true } as JSONObject), response),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("refuses an empty array data payload", async () => {
+      await expect(
+        api.updateItem(requestWithBody({ data: [] } as JSONObject), response),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("refuses an array of objects, which updates one row not many", async () => {
+      await expect(
+        api.updateItem(
+          requestWithBody({ data: [{ name: "renamed-probe" }] } as JSONObject),
+          response,
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the payload carries no fields to write", () => {
+    it("refuses an empty data object", async () => {
+      await expect(
+        api.updateItem(requestWithBody({ data: {} }), response),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+      expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    });
+
+    it("says there is nothing to update", async () => {
+      await expect(
+        api.updateItem(requestWithBody({ data: {} }), response),
+      ).rejects.toThrow(/No fields to update/i);
+    });
+
+    /*
+     * _id, createdAt and updatedAt are stripped before the write, so a payload
+     * of nothing but those leaves zero columns. The emptiness check has to run
+     * after the strip to catch it.
+     */
+    it("refuses a payload of only the fields it strips", async () => {
+      const request: OneUptimeRequest = requestWithBody({
+        data: {
+          _id: TEST_ID,
+          createdAt: "2026-07-28T20:58:55.000Z",
+          updatedAt: "2026-07-28T20:58:55.000Z",
+        },
+      });
+
+      await expect(api.updateItem(request, response)).rejects.toThrow(
+        /No fields to update/i,
+      );
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the payload is well formed", () => {
+    it("writes the update and reports success", async () => {
+      const request: OneUptimeRequest = requestWithBody({
+        data: { name: "renamed-probe" },
+      });
+
+      await api.updateItem(request, response);
+
+      expect(service.updateOneById).toHaveBeenCalledTimes(1);
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+        request,
+        response,
+      );
+    });
+
+    it("passes the payload through to the service untouched", async () => {
+      await api.updateItem(
+        requestWithBody({ data: { name: "renamed-probe" } }),
+        response,
+      );
+
+      expect(service.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { name: "renamed-probe" },
+        }),
+      );
+    });
+
+    /*
+     * The strip has to survive the new guard: a real client payload echoes
+     * _id/createdAt/updatedAt back and only the remaining columns may be
+     * written.
+     */
+    it("still strips _id, createdAt and updatedAt from a payload that also has real fields", async () => {
+      await api.updateItem(
+        requestWithBody({
+          data: {
+            _id: TEST_ID,
+            createdAt: "2026-07-28T20:58:55.000Z",
+            updatedAt: "2026-07-28T20:58:55.000Z",
+            name: "renamed-probe",
+          },
+        }),
+        response,
+      );
+
+      expect(service.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { name: "renamed-probe" },
+        }),
+      );
+    });
+  });
+
+  /*
+   * PUT /:id, POST /:id/update-item and GET /:id/update-item all land on this
+   * one handler, so none of them can be left answering 200 to a payload that
+   * writes nothing. GET carries no body at all.
+   */
+  describe("across every route that reaches updateItem", () => {
+    it("refuses the flat body on the POST update-item route", async () => {
+      const request: OneUptimeRequest = requestWithBody({
+        content: "new-token-value",
+        name: "Airflow-Token",
+      });
+
+      await expect(api.updateItem(request, response)).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    it("refuses the bodyless GET update-item route instead of quietly writing nothing", async () => {
+      await expect(
+        api.updateItem(requestWithBody({}), response),
+      ).rejects.toThrow(BadDataException);
+
+      expect(service.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("registers all three update routes", () => {
+      const crudPath: string = new Probe().getCrudApiPath()!.toString();
+
+      expect(mockRouter.match("PUT", `${crudPath}/:id`)).toBeTruthy();
+      expect(
+        mockRouter.match("POST", `${crudPath}/:id/update-item`),
+      ).toBeTruthy();
+      expect(
+        mockRouter.match("GET", `${crudPath}/:id/update-item`),
+      ).toBeTruthy();
+    });
+  });
+
+  /*
+   * The original symptom, stated as an assertion: the customer saw
+   * "response-status":200,"response-body":{} on every run while the variable
+   * never changed.
+   */
+  it("never reports success for a request that would write nothing", async () => {
+    const request: OneUptimeRequest = requestWithBody({
+      content: "new-token-value",
+      name: "Airflow-Token",
+      description: "Token to connect to Airflow.",
+    });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/API/BaseAnalyticsAPIUpdatePayloadValidation.test.ts
+++ b/Common/Tests/Server/API/BaseAnalyticsAPIUpdatePayloadValidation.test.ts
@@ -1,0 +1,293 @@
+import "../TestingUtils/Init";
+import BaseAnalyticsAPI from "../../../Server/API/BaseAnalyticsAPI";
+import AnalyticsDatabaseService from "../../../Server/Services/AnalyticsDatabaseService";
+import MonitorLog from "../../../Models/AnalyticsModels/MonitorLog";
+import {
+  ExpressResponse,
+  OneUptimeRequest,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import { mockRouter } from "./Helpers";
+import { getJestSpyOn } from "../../Spy";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+/*
+ * PUT /<analytics-model>/:id answered 200 with an empty body while writing
+ * nothing at all.
+ *
+ * The wire contract is a WRAPPED payload - { "data": { ...columns... } } - but
+ * nothing enforced it. A client that sent the columns flat (the shape a
+ * hand-written Workflow naturally produces) had body["data"] === undefined,
+ * which deserialized into an empty model, which matched the row and updated
+ * zero columns. The request looked successful and the edit silently vanished.
+ *
+ * These tests pin the guards in BaseAnalyticsAPI.updateItem: the payload must
+ * be a wrapped plain object, and it must still carry at least one updatable
+ * field once _id / createdAt / updatedAt are stripped.
+ *
+ * Note the emptiness check has to count fields on the RAW body, not on the
+ * hydrated model: an analytics model instance always carries its own internal
+ * properties (data, _tableColumns), so Object.keys() on the instance is never
+ * empty and could never detect a no-op update.
+ */
+
+const TEST_ID: string = "550e8400-e29b-41d4-a716-446655440011";
+
+describe("BaseAnalyticsAPI.updateItem payload validation", () => {
+  let service: AnalyticsDatabaseService<MonitorLog>;
+  let api: BaseAnalyticsAPI<MonitorLog, AnalyticsDatabaseService<MonitorLog>>;
+  let response: ExpressResponse;
+
+  type MakeRequestFunction = (body: unknown) => OneUptimeRequest;
+
+  const makeRequest: MakeRequestFunction = (
+    body: unknown,
+  ): OneUptimeRequest => {
+    return {
+      params: { id: TEST_ID },
+      body: body as JSONObject,
+      headers: {},
+    } as unknown as OneUptimeRequest;
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    service = new AnalyticsDatabaseService<MonitorLog>({
+      modelType: MonitorLog,
+    });
+
+    api = new BaseAnalyticsAPI<
+      MonitorLog,
+      AnalyticsDatabaseService<MonitorLog>
+    >(MonitorLog, service);
+
+    /*
+     * Stubbed so a payload that WRONGLY gets past the guards still fails the
+     * assertion rather than trying to reach ClickHouse.
+     */
+    getJestSpyOn(service, "updateBy").mockResolvedValue(undefined);
+
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+  });
+
+  it("rejects a flat body that forgot to wrap its columns in data", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      logBody: { message: "flat-payload" },
+      monitorId: TEST_ID,
+    });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  it("tells the caller the payload has to look like { data: { ... } }", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      logBody: { message: "flat-payload" },
+    });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(/"data"/);
+  });
+
+  it("rejects a completely empty body", async () => {
+    const request: OneUptimeRequest = makeRequest({});
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  it("rejects data: {} and says there are no fields to update", async () => {
+    const request: OneUptimeRequest = makeRequest({ data: {} });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      /no fields to update/i,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  it("rejects data: null", async () => {
+    const request: OneUptimeRequest = makeRequest({ data: null });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A string is iterable and `for (const key in "abc")` yields "0", "1", "2",
+   * so a lenient implementation could quietly treat it as an object with
+   * numeric keys. Assert both that it is refused AND that nothing about it
+   * looked like a field set worth forwarding.
+   */
+  it("rejects a string data payload instead of treating it as an object", async () => {
+    const request: OneUptimeRequest = makeRequest({ data: "some string" });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+    expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty array data payload", async () => {
+    const request: OneUptimeRequest = makeRequest({ data: [] });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an array of objects data payload", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      data: [{ logBody: { message: "one" } }, { logBody: { message: "two" } }],
+    });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a numeric data payload", async () => {
+    const request: OneUptimeRequest = makeRequest({ data: 42 });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a boolean data payload", async () => {
+    const request: OneUptimeRequest = makeRequest({ data: true });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * _id / createdAt / updatedAt are stripped before the update is issued, so a
+   * payload made only of those would write nothing. This proves the emptiness
+   * check runs on the STRIPPED field set, not on the raw key count.
+   */
+  it("rejects a payload of only _id, createdAt and updatedAt because nothing updatable survives stripping", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      data: {
+        _id: TEST_ID,
+        createdAt: "2026-07-29T00:00:00.000Z",
+        updatedAt: "2026-07-29T00:00:00.000Z",
+      },
+    });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      /no fields to update/i,
+    );
+
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * No-regression guard: the guards above must not have made the happy path
+   * stricter. A correctly wrapped payload with one real column of the model
+   * still reaches the service and still reports success.
+   */
+  it("still updates and reports success for a correctly wrapped payload", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      data: { logBody: { message: "wrapped-payload" } },
+    });
+
+    await api.updateItem(request, response);
+
+    expect(service.updateBy).toHaveBeenCalledTimes(1);
+    expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+      request,
+      response,
+    );
+  });
+
+  it("keeps the _id in the update query and out of the written columns", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      data: { _id: TEST_ID, logBody: { message: "wrapped-payload" } },
+    });
+
+    await api.updateItem(request, response);
+
+    expect(service.updateBy).toHaveBeenCalledTimes(1);
+
+    const updateBy: { query: JSONObject; data: MonitorLog } = (
+      service.updateBy as unknown as jest.Mock
+    ).mock.calls[0]![0] as { query: JSONObject; data: MonitorLog };
+
+    expect(updateBy.query["_id"]).toBe(TEST_ID);
+    expect(updateBy.data.getColumnValue("logBody")).toEqual({
+      message: "wrapped-payload",
+    });
+  });
+
+  /*
+   * Named for the original symptom: the customer's Workflow PUT a flat body,
+   * got HTTP 200 with an empty object back, and nothing was written. The 200
+   * came from sendEmptySuccessResponse, so that is the exact call that must
+   * never happen for an unwrapped payload.
+   */
+  it("never reports an empty success for the flat body that silently wrote nothing", async () => {
+    const request: OneUptimeRequest = makeRequest({
+      content: "<token>",
+      name: "Airflow-Token",
+      description: "token used by the airflow workflow",
+    });
+
+    await expect(api.updateItem(request, response)).rejects.toThrow(
+      BadDataException,
+    );
+
+    expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    expect(service.updateBy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/DatabaseServiceEmptyUpdate.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceEmptyUpdate.test.ts
@@ -1,0 +1,277 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import ObjectID from "../../../Types/ObjectID";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { getJestSpyOn } from "../../Spy";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * A customer's workflow PUT a flat body to /api/workflow-variable/<id>, so
+ * BaseAPI read `body["data"]` as undefined and handed DatabaseService an empty
+ * update payload. _updateBy still ran its internal find, matched the row, wrote
+ * no columns at all, and returned the MATCHED count (1). Every caller - the API
+ * included - reads that number as "rows written", so the request answered 200
+ * while the database was untouched, and the guard that exists precisely for
+ * this ("numberOfDocsAffected === 0") could never fire.
+ *
+ * The fix: when the sanitized update data carries no columns, _updateBy skips
+ * the find entirely and reports 0. These tests pin that down, and pin down that
+ * it did not change anything about updates that DO carry columns.
+ */
+
+type ProbeUpdateData = UpdateBy<Probe>["data"];
+
+const EMPTY_DATA: ProbeUpdateData = {} as ProbeUpdateData;
+
+const TEST_ID: string = "550e8400-e29b-41d4-a716-446655440021";
+const OTHER_ID: string = "550e8400-e29b-41d4-a716-446655440022";
+
+const matchedRow: (id: string) => Probe = (id: string): Probe => {
+  const probe: Probe = new Probe();
+  probe._id = id;
+  return probe;
+};
+
+describe("DatabaseService._updateBy when the update carries no columns", () => {
+  let service: DatabaseService<Probe>;
+  let findBySpy: jest.SpyInstance;
+  let saveMock: MockFunction;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    service = new DatabaseService<Probe>(Probe);
+
+    /*
+     * Only the two surfaces that need a live Postgres are stubbed - the
+     * internal find (`_findBy`) and the repository behind `save()`. Mocking
+     * the TypeORM repository itself is impractical here because `_findBy`
+     * builds real query metadata against a DataSource that does not exist in
+     * a unit test; stubbing `_findBy` keeps the mock at the exact boundary the
+     * fix is about (was the find run at all?) while leaving every line of
+     * _updateBy under test - sanitizing, the hooks and the return arithmetic.
+     *
+     * The stub deliberately returns a MATCHING row, because that is what a
+     * real database does here: the row exists and the query finds it, there is
+     * simply nothing to write to it. That is the whole trap - so if _updateBy
+     * ever runs this find again for an empty payload, every expectation below
+     * reports the old, wrong answer (1 row "changed") instead of 0.
+     */
+    findBySpy = getJestSpyOn(service as any, "_findBy").mockResolvedValue([
+      matchedRow(TEST_ID),
+    ]);
+
+    saveMock = getJestMockFunction();
+    saveMock.mockImplementation((item: unknown) => {
+      return Promise.resolve(item);
+    });
+    getJestSpyOn(service, "getRepository").mockReturnValue({
+      save: saveMock,
+    });
+
+    // The permission layer is not what these tests are about, and needs a DB.
+    getJestSpyOn(
+      ModelPermission,
+      "checkUpdateQueryPermissions",
+    ).mockImplementation((_modelType: unknown, query: unknown) => {
+      return Promise.resolve(query);
+    });
+    getJestSpyOn(
+      ModelPermission,
+      "checkUpdatePermissionByModel",
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reports zero rows changed when updateOneBy is handed an empty payload", async () => {
+    const numberOfDocsAffected: number = await service.updateOneBy({
+      query: { _id: TEST_ID } as any,
+      data: EMPTY_DATA,
+      props: { isRoot: true },
+    });
+
+    expect(numberOfDocsAffected).toBe(0);
+  });
+
+  it("reports zero rows changed when updateBy is handed an empty payload", async () => {
+    const numberOfDocsAffected: number = await service.updateBy({
+      query: {} as any,
+      data: EMPTY_DATA,
+      props: { isRoot: true },
+      limit: 10,
+      skip: 0,
+    });
+
+    expect(numberOfDocsAffected).toBe(0);
+  });
+
+  it("reports zero rows changed when the empty payload arrives through updateOneById, which is the path the API takes", async () => {
+    const numberOfDocsAffected: number = await service.updateOneById({
+      id: new ObjectID(TEST_ID),
+      data: EMPTY_DATA,
+      props: { isRoot: true },
+    });
+
+    /*
+     * This is the exact number BaseAPI.updateItem checks before answering
+     * 200, so a no-column update can no longer be reported as a save.
+     */
+    expect(numberOfDocsAffected).toBe(0);
+  });
+
+  it("never runs the find, because a payload with no columns cannot change any row", async () => {
+    await service.updateOneBy({
+      query: { _id: TEST_ID } as any,
+      data: EMPTY_DATA,
+      props: { isRoot: true },
+    });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("never writes anything, so the count it reports and the rows it touched agree", async () => {
+    /*
+     * The semantic in prose: an update that writes no columns must not be
+     * reported as a successful write. Nothing is saved AND the caller is told
+     * zero - previously the second half of that sentence was a lie, because
+     * `items.length` counted rows the query MATCHED, not rows it changed, and
+     * the row matched here (see the `_findBy` stub above).
+     */
+    const numberOfDocsAffected: number = await service.updateOneBy({
+      query: { _id: TEST_ID } as any,
+      data: EMPTY_DATA,
+      props: { isRoot: true },
+    });
+
+    expect(saveMock).not.toHaveBeenCalled();
+    expect(numberOfDocsAffected).toBe(0);
+  });
+
+  it("still calls onUpdateSuccess, with an empty list of ids, so hooks behave exactly as they do when the query matches nothing", async () => {
+    const onUpdateSuccessSpy: jest.SpyInstance = getJestSpyOn(
+      service as any,
+      "onUpdateSuccess",
+    );
+
+    await service.updateOneBy({
+      query: { _id: TEST_ID } as any,
+      data: EMPTY_DATA,
+      props: { isRoot: true, ignoreHooks: false },
+    });
+
+    /*
+     * Skipping the find must not quietly skip the hooks too: subclasses
+     * override onUpdateSuccess and some of them rely on being told about
+     * every update attempt. The id list is empty because nothing was written -
+     * before the fix this hook was handed the id of the row that merely
+     * matched, telling every subclass a write had happened.
+     */
+    expect(onUpdateSuccessSpy).toHaveBeenCalledTimes(1);
+    expect(onUpdateSuccessSpy.mock.calls[0]![1]).toEqual([]);
+  });
+});
+
+describe("DatabaseService._updateBy when the update does carry columns", () => {
+  let service: DatabaseService<Probe>;
+  let findBySpy: jest.SpyInstance;
+  let saveMock: MockFunction;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    service = new DatabaseService<Probe>(Probe);
+
+    findBySpy = getJestSpyOn(service as any, "_findBy").mockResolvedValue([
+      matchedRow(TEST_ID),
+      matchedRow(OTHER_ID),
+    ]);
+
+    saveMock = getJestMockFunction();
+    saveMock.mockImplementation((item: unknown) => {
+      return Promise.resolve(item);
+    });
+    getJestSpyOn(service, "getRepository").mockReturnValue({
+      save: saveMock,
+    });
+
+    getJestSpyOn(
+      ModelPermission,
+      "checkUpdateQueryPermissions",
+    ).mockImplementation((_modelType: unknown, query: unknown) => {
+      return Promise.resolve(query);
+    });
+    getJestSpyOn(
+      ModelPermission,
+      "checkUpdatePermissionByModel",
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("still runs the find and still reports the number of rows it matched", async () => {
+    const numberOfDocsAffected: number = await service.updateBy({
+      query: {} as any,
+      data: { name: "renamed-probe" } as ProbeUpdateData,
+      props: { isRoot: true },
+      limit: 10,
+      skip: 0,
+    });
+
+    /*
+     * This assertion is also what proves the `_findBy` spy in the sibling
+     * describe is wired to the method _updateBy really calls: the same spy,
+     * on the same private method, IS exercised as soon as the payload has a
+     * column. "not.toHaveBeenCalled()" over there is therefore meaningful.
+     */
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(numberOfDocsAffected).toBe(2);
+  });
+
+  it("still writes every row the find returned", async () => {
+    await service.updateOneBy({
+      query: { _id: TEST_ID } as any,
+      data: { name: "renamed-probe" } as ProbeUpdateData,
+      props: { isRoot: true },
+    });
+
+    expect(saveMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("still calls onUpdateSuccess with the ids of the rows it updated", async () => {
+    const onUpdateSuccessSpy: jest.SpyInstance = getJestSpyOn(
+      service as any,
+      "onUpdateSuccess",
+    );
+
+    await service.updateOneBy({
+      query: { _id: TEST_ID } as any,
+      data: { name: "renamed-probe" } as ProbeUpdateData,
+      props: { isRoot: true, ignoreHooks: false },
+    });
+
+    const updatedIds: Array<ObjectID> = onUpdateSuccessSpy.mock
+      .calls[0]![1] as Array<ObjectID>;
+
+    expect(
+      updatedIds.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([TEST_ID, OTHER_ID]);
+  });
+});

--- a/Common/Tests/Server/Types/Database/Permissions/WorkflowVariableColumnPermission.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/WorkflowVariableColumnPermission.test.ts
@@ -1,0 +1,227 @@
+import DatabaseRequestType from "../../../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import ColumnPermissions from "../../../../../Server/Types/Database/Permissions/ColumnPermission";
+import WorkflowVariable from "../../../../../Models/DatabaseModels/WorkflowVariable";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Columns from "../../../../../Types/Database/Columns";
+import BadDataException from "../../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../../../Types/Permission";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * A customer's Workflow could not rotate the secret it stored in a Workflow
+ * Variable. The API key carried Permission.EditWorkflowVariable - which is the
+ * table-level update grant on WorkflowVariable - but the "content" column's
+ * ColumnAccessControl.update listed only ProjectOwner and ProjectAdmin. So the
+ * one column the caller actually wanted to write was the one column its
+ * permission did not cover.
+ *
+ * "content" is the secret itself, so its read list is deliberately empty: not
+ * even a ProjectOwner may read it back. Widening update must not widen read -
+ * ColumnAccessControl keeps create/read/update as three independent arrays, and
+ * these tests pin that independence so a future edit cannot quietly turn a
+ * write grant into a way to exfiltrate the secret.
+ */
+
+const projectId: ObjectID = ObjectID.generate();
+const userId: ObjectID = ObjectID.generate();
+
+/*
+ * DatabaseCommonInteractionPropsUtil.getUserPermissions drops every permission
+ * whose isBlockPermission does not match the requested PermissionType, and it
+ * only reads the tenant bucket when props.tenantId is set. Getting either wrong
+ * yields an empty permission set, which would make the "does not throw" cases
+ * below pass for entirely the wrong reason. Every permission built here is an
+ * explicit allow, keyed under the tenant this request runs as.
+ */
+function makeProps(
+  permissions: Array<Permission>,
+): DatabaseCommonInteractionProps {
+  const tenantPermission: UserTenantAccessPermission = {
+    projectId,
+    _type: "UserTenantAccessPermission",
+    permissions: permissions.map((permission: Permission) => {
+      return {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+        isBlockPermission: false,
+      };
+    }),
+  };
+
+  return {
+    userId,
+    tenantId: projectId,
+    userTenantAccessPermission: {
+      [projectId.toString()]: tenantPermission,
+    },
+  };
+}
+
+function makeUserPermissions(
+  permissions: Array<Permission>,
+): Array<UserPermission> {
+  return permissions.map((permission: Permission) => {
+    return {
+      _type: "UserPermission",
+      permission: permission,
+      labelIds: [],
+      isBlockPermission: false,
+    };
+  });
+}
+
+type CheckFunction = () => void;
+
+function checkUpdate(
+  data: Partial<WorkflowVariable>,
+  permissions: Array<Permission>,
+): CheckFunction {
+  return () => {
+    ColumnPermissions.checkDataColumnPermissions(
+      WorkflowVariable,
+      data as WorkflowVariable,
+      makeProps(permissions),
+      DatabaseRequestType.Update,
+    );
+  };
+}
+
+describe("ColumnPermissions on WorkflowVariable", () => {
+  describe("harness guard", () => {
+    /*
+     * Runs first on purpose. Every other update assertion in this file is a
+     * "does not throw", which an empty or mis-shaped permission set would also
+     * satisfy - getModelColumnsByPermissions would return no columns, but so
+     * would a props object the util silently ignored. This case has a caller
+     * that genuinely lacks the update grant, so it MUST throw. If it stops
+     * throwing, the props factory above is broken, not the model.
+     */
+    it("still refuses a read-only key that tries to write content", () => {
+      expect(
+        checkUpdate({ content: "rotated-token" }, [
+          Permission.ReadWorkflowVariable,
+        ]),
+      ).toThrow(BadDataException);
+
+      expect(
+        checkUpdate({ content: "rotated-token" }, [
+          Permission.ReadWorkflowVariable,
+        ]),
+      ).toThrow(
+        "User is not allowed to update on content column of Workflow Variable",
+      );
+    });
+  });
+
+  describe("update", () => {
+    /*
+     * The fix. EditWorkflowVariable is the table-level update grant, so a key
+     * holding it was already allowed to reach the update path - it just could
+     * not write the only column worth writing.
+     */
+    it("lets a key with EditWorkflowVariable write the content column", () => {
+      expect(
+        checkUpdate({ content: "rotated-token" }, [
+          Permission.EditWorkflowVariable,
+        ]),
+      ).not.toThrow();
+    });
+
+    it("still lets a key with EditWorkflowVariable write name and description", () => {
+      expect(
+        checkUpdate({ name: "Airflow-Token" }, [
+          Permission.EditWorkflowVariable,
+        ]),
+      ).not.toThrow();
+
+      expect(
+        checkUpdate({ description: "Token used by the Airflow workflow" }, [
+          Permission.EditWorkflowVariable,
+        ]),
+      ).not.toThrow();
+    });
+
+    it("still lets a project admin write the content column", () => {
+      expect(
+        checkUpdate({ content: "rotated-token" }, [Permission.ProjectAdmin]),
+      ).not.toThrow();
+    });
+
+    it("still lets a project owner write the content column", () => {
+      expect(
+        checkUpdate({ content: "rotated-token" }, [Permission.ProjectOwner]),
+      ).not.toThrow();
+    });
+  });
+
+  describe("create", () => {
+    /*
+     * The create list already carried CreateWorkflowVariable, so a variable
+     * could always be created with its content and then never edited. Pinned
+     * here so the update widening is not mistaken for having changed create.
+     */
+    it("leaves the create path alone for CreateWorkflowVariable", () => {
+      expect(() => {
+        ColumnPermissions.checkDataColumnPermissions(
+          WorkflowVariable,
+          {
+            content: "initial-token",
+            name: "Airflow-Token",
+          } as WorkflowVariable,
+          makeProps([Permission.CreateWorkflowVariable]),
+          DatabaseRequestType.Create,
+        );
+      }).not.toThrow();
+    });
+  });
+
+  describe("read", () => {
+    /*
+     * content.read is [] - the secret is write-only by design, and the UI reads
+     * it back through nothing. Asserting "name" is present in the same call
+     * proves the read list was genuinely evaluated rather than the whole model
+     * coming back empty, which would make the content assertion vacuous.
+     */
+    it("keeps content unreadable even for a project owner", () => {
+      const columns: Columns = ColumnPermissions.getModelColumnsByPermissions(
+        WorkflowVariable,
+        makeUserPermissions([
+          Permission.ProjectOwner,
+          Permission.ReadWorkflowVariable,
+        ]),
+        DatabaseRequestType.Read,
+      );
+
+      expect(columns.columns).not.toContain("content");
+      expect(columns.columns).toContain("name");
+    });
+
+    it("reports content as updatable but not readable for the same key", () => {
+      const userPermissions: Array<UserPermission> = makeUserPermissions([
+        Permission.EditWorkflowVariable,
+      ]);
+
+      const updatableColumns: Columns =
+        ColumnPermissions.getModelColumnsByPermissions(
+          WorkflowVariable,
+          userPermissions,
+          DatabaseRequestType.Update,
+        );
+
+      const readableColumns: Columns =
+        ColumnPermissions.getModelColumnsByPermissions(
+          WorkflowVariable,
+          userPermissions,
+          DatabaseRequestType.Read,
+        );
+
+      expect(updatableColumns.columns).toContain("content");
+      expect(readableColumns.columns).not.toContain("content");
+    });
+  });
+});

--- a/Common/Tests/Server/Types/Workflow/Components/ApiComponentErrorPort.test.ts
+++ b/Common/Tests/Server/Types/Workflow/Components/ApiComponentErrorPort.test.ts
@@ -1,0 +1,285 @@
+import ApiDelete from "../../../../../Server/Types/Workflow/Components/API/Delete";
+import ApiGet from "../../../../../Server/Types/Workflow/Components/API/Get";
+import ApiPatch from "../../../../../Server/Types/Workflow/Components/API/Patch";
+import ApiPost from "../../../../../Server/Types/Workflow/Components/API/Post";
+import ApiPut from "../../../../../Server/Types/Workflow/Components/API/Put";
+import ComponentCode, {
+  RunOptions,
+  RunReturnType,
+} from "../../../../../Server/Types/Workflow/ComponentCode";
+import HTTPErrorResponse from "../../../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../../../Types/API/HTTPResponse";
+import URL from "../../../../../Types/API/URL";
+import Exception from "../../../../../Types/Exception/Exception";
+import { JSONObject } from "../../../../../Types/JSON";
+import ObjectID from "../../../../../Types/ObjectID";
+import ComponentID from "../../../../../Types/Workflow/ComponentID";
+import API from "../../../../../Utils/API";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The default export of Utils/API is the only thing these components talk to,
+ * so it is replaced wholesale. Everything else - sanitizeArgs, URL parsing,
+ * HTTPResponse/HTTPErrorResponse and the component metadata - stays real,
+ * because the ports and the return values are exactly what is under test.
+ */
+jest.mock("../../../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+});
+
+/*
+ * A customer's workflow did PUT /api/workflow-variable/<id> with a body the
+ * server rejected, and the workflow log still said "Executing Port: Success".
+ *
+ * The reason is that on the server Utils/API RESOLVES with an
+ * HTTPErrorResponse for a 4xx/5xx (only the UI subclass throws), so the
+ * try/catch in these components never saw the failure and the response fell
+ * through to the success port. These tests pin the resolved-error path, the
+ * ordinary success path, and the thrown-transport-error path for every HTTP
+ * verb the workflow builder exposes.
+ */
+
+type ApiMethodName = "get" | "post" | "put" | "patch" | "delete";
+
+type ComponentFactory = () => ComponentCode;
+
+interface OptionsFixture {
+  options: RunOptions;
+  log: jest.Mock;
+  onError: jest.Mock;
+}
+
+const TEST_URL: string = "https://oneuptime.com/api/workflow-variable/abc";
+
+function makeOptions(): OptionsFixture {
+  const log: jest.Mock = jest.fn();
+  const onError: jest.Mock = jest.fn((exception: Exception): Exception => {
+    return exception;
+  });
+
+  return {
+    log,
+    onError,
+    options: {
+      log: log as RunOptions["log"],
+      workflowLogId: ObjectID.generate(),
+      workflowId: ObjectID.generate(),
+      projectId: ObjectID.generate(),
+      onError: onError as RunOptions["onError"],
+      executeWorkflow: async (): Promise<void> => {},
+    },
+  };
+}
+
+/*
+ * The workflow builder hands every argument over as a string, so the JSON
+ * bodies and headers are supplied the way the runner really supplies them and
+ * sanitizeArgs is exercised for real.
+ */
+function makeArgs(): JSONObject {
+  return {
+    url: TEST_URL,
+    "request-body": '{"content":"the-token","name":"Airflow-Token"}',
+    "request-headers": '{"apikey":"a-project-api-key"}',
+  };
+}
+
+function getApiMock(apiMethodName: ApiMethodName): jest.Mock {
+  return API[apiMethodName] as unknown as jest.Mock;
+}
+
+const apiComponents: Array<[string, ApiMethodName, ComponentFactory, string]> =
+  [
+    [
+      "Get",
+      "get",
+      (): ComponentCode => {
+        return new ApiGet();
+      },
+      ComponentID.ApiGet,
+    ],
+    [
+      "Post",
+      "post",
+      (): ComponentCode => {
+        return new ApiPost();
+      },
+      ComponentID.ApiPost,
+    ],
+    [
+      "Put",
+      "put",
+      (): ComponentCode => {
+        return new ApiPut();
+      },
+      ComponentID.ApiPut,
+    ],
+    [
+      "Patch",
+      "patch",
+      (): ComponentCode => {
+        return new ApiPatch();
+      },
+      ComponentID.ApiPatch,
+    ],
+    [
+      "Delete",
+      "delete",
+      (): ComponentCode => {
+        return new ApiDelete();
+      },
+      ComponentID.ApiDelete,
+    ],
+  ];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe.each(apiComponents)(
+  "API %s workflow component port routing",
+  (
+    _label: string,
+    apiMethodName: ApiMethodName,
+    createComponent: ComponentFactory,
+    componentId: string,
+  ) => {
+    test("is wired to the matching component metadata and both of its ports", () => {
+      const component: ComponentCode = createComponent();
+
+      expect(component.getMetadata().id).toBe(componentId);
+      expect(
+        component.getMetadata().outPorts.map((port: { id: string }): string => {
+          return port.id;
+        }),
+      ).toEqual(expect.arrayContaining(["success", "error"]));
+    });
+
+    test("routes an HTTP error the API resolved with - never throws - to the error port", async () => {
+      getApiMock(apiMethodName).mockResolvedValue(
+        new HTTPErrorResponse(
+          400,
+          { message: "Data in request body is missing or invalid." },
+          {},
+        ),
+      );
+      const fixture: OptionsFixture = makeOptions();
+
+      const result: RunReturnType = await createComponent().run(
+        makeArgs(),
+        fixture.options,
+      );
+
+      expect(result.executePort?.id).toBe("error");
+      expect(result.returnValues["response-status"]).toBe(400);
+      expect(result.returnValues["error"]).toBeTruthy();
+      expect(result.returnValues["error"]).toBe(
+        "Data in request body is missing or invalid.",
+      );
+      expect(result.returnValues["response-body"]).toEqual({
+        message: "Data in request body is missing or invalid.",
+      });
+      expect(getApiMock(apiMethodName)).toHaveBeenCalledTimes(1);
+      expect(fixture.onError).not.toHaveBeenCalled();
+    });
+
+    test("keeps a 2xx response on the success port with no error value", async () => {
+      getApiMock(apiMethodName).mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, { updated: true }, {}),
+      );
+      const fixture: OptionsFixture = makeOptions();
+
+      const result: RunReturnType = await createComponent().run(
+        makeArgs(),
+        fixture.options,
+      );
+
+      expect(result.executePort?.id).toBe("success");
+      expect(result.returnValues["response-status"]).toBe(200);
+      expect(result.returnValues["response-body"]).toEqual({ updated: true });
+      expect(result.returnValues["error"]).toBeNull();
+      expect(fixture.onError).not.toHaveBeenCalled();
+
+      /*
+       * The verb actually sent has to be the verb the component advertises -
+       * a component that quietly called a different method would still satisfy
+       * the port assertions above.
+       */
+      expect(getApiMock(apiMethodName)).toHaveBeenCalledTimes(1);
+      const request: {
+        url: URL;
+        data: JSONObject;
+        headers: JSONObject;
+      } = getApiMock(apiMethodName).mock.calls[0]![0] as {
+        url: URL;
+        data: JSONObject;
+        headers: JSONObject;
+      };
+      expect(request.url.toString()).toBe(TEST_URL);
+      expect(request.data).toEqual({
+        content: "the-token",
+        name: "Airflow-Token",
+      });
+      expect(request.headers).toEqual({ apikey: "a-project-api-key" });
+    });
+
+    test("routes a thrown transport error to the error port with an error message", async () => {
+      getApiMock(apiMethodName).mockRejectedValue(
+        new Error("connect ECONNREFUSED 127.0.0.1:443"),
+      );
+      const fixture: OptionsFixture = makeOptions();
+
+      const result: RunReturnType = await createComponent().run(
+        makeArgs(),
+        fixture.options,
+      );
+
+      expect(result.executePort?.id).toBe("error");
+      expect(result.returnValues["errorMessage"]).toBe(
+        "connect ECONNREFUSED 127.0.0.1:443",
+      );
+      expect(fixture.onError).not.toHaveBeenCalled();
+    });
+
+    test("routes an HTTP error the API threw to the error port", async () => {
+      getApiMock(apiMethodName).mockRejectedValue(
+        new HTTPErrorResponse(503, { message: "Service Unavailable" }, {}),
+      );
+      const fixture: OptionsFixture = makeOptions();
+
+      const result: RunReturnType = await createComponent().run(
+        makeArgs(),
+        fixture.options,
+      );
+
+      expect(result.executePort?.id).toBe("error");
+      expect(result.returnValues["response-status"]).toBe(503);
+      expect(result.returnValues["error"]).toBe("Service Unavailable");
+    });
+
+    test("reports a 5xx with an empty body as an error rather than as success", async () => {
+      getApiMock(apiMethodName).mockResolvedValue(
+        new HTTPErrorResponse(500, {}, {}),
+      );
+
+      const result: RunReturnType = await createComponent().run(
+        makeArgs(),
+        makeOptions().options,
+      );
+
+      expect(result.executePort?.id).toBe("error");
+      expect(result.returnValues["response-status"]).toBe(500);
+      /* getReturnValues falls back to a generic message so the port is never silent. */
+      expect(result.returnValues["error"]).toBe("Server Error.");
+    });
+  },
+);

--- a/Scripts/TerraformProvider/Core/ResourceGenerator.ts
+++ b/Scripts/TerraformProvider/Core/ResourceGenerator.ts
@@ -1065,6 +1065,12 @@ func (r *${resourceTypeName}Resource) Update(ctx context.Context, req resource.U
     }
 ${this.generateConditionalUpdateRequestBodyWithDeclaration(resource, resourceVarName)}
 
+    // Nothing to send. The API rejects an update that carries no fields, so keep the current state and skip the call.
+    if len(${resourceVarName}Request["data"].(map[string]interface{})) == 0 {
+        resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+        return
+    }
+
     // Make API call
     httpResp, err := r.client.${httpMethod}(${finalUpdatePath}, ${resourceVarName}Request)
     if err != nil {


### PR DESCRIPTION
## The report

A customer's workflow rotates an API token every 18 hours: fetch a new token, write it to a Monitor secret, then write it back to the workflow variable so the next run picks it up. The `PUT /api/workflow-variable/<id>` returned `200` with `{}` on every run — and every run read back the *previous* token.

```
Data Returned
{"response-status":200,"response-body":{},...,"error":null}
Executing Port: Success
```

Both statements in that log were wrong.

## Root cause

`PUT /api/<model>/:id` takes its payload wrapped as `{ "data": { ...columns... } }` — `OpenAPI.ts` has always advertised `required: ["data"]`. The customer sent the columns flat.

[`BaseAPI.updateItem`](Common/Server/API/BaseAPI.ts) read `body["data"]`, which was `undefined`. `JSONFunctions.deserialize(undefined)` returns `{}` rather than throwing — `for...in` over `undefined` is a spec-level no-op. So the columns were dropped on the floor and an *empty* update went to the service.

An empty update still **matches** the row. `_updateBy` returns `items.length` — rows matched, not rows changed — so it returned `1`. The `numberOfDocsAffected === 0` guard added in a previous fix is structurally incapable of catching this: nothing was written, but one row matched. TypeORM's `save({ _id })` produced no change maps and issued no `UPDATE` at all — it did not even open a transaction.

The API then reported success for a write that never happened.

## What changed

**The payload guard** — `BaseAPI.updateItem` and `BaseAnalyticsAPI.updateItem` now answer `400` instead of `200` when `data` is missing, `null`, a non-object, or an array, and when the payload has no fields left after `_id`/`createdAt`/`updatedAt` are stripped. The message names the shape it wants. All three routes that reach `updateItem` are covered, including the bodyless `GET /:id/update-item`, which has never written anything for any model.

**Defence in depth** — `DatabaseService._updateBy` now treats a columnless update as matching nothing rather than returning the matched count, so an internal caller can't resurrect the same lie. Hooks still run exactly as they do on a zero match (`onUpdateSuccess` with an empty array); the find is skipped because it cannot change anything.

**The permission that would have blocked it anyway** — `WorkflowVariable.content` was updatable only by `ProjectOwner`/`ProjectAdmin`, while `name` and `description` already allowed `EditWorkflowVariable` and `create` already allowed `CreateWorkflowVariable`. Even a correctly shaped request from a properly scoped API key would have been refused. `git blame` shows the line is byte-identical to the original commit — a copy-paste from the sibling `isSecret` block, never a decision. `read: []` is untouched, so the secret still cannot be read back; `ColumnAccessControl` keeps read and update as independent arrays and there is a test pinning that.

**The port that lied** — the workflow API components took the *success* port on a 4xx/5xx. On the server `Utils/API` **resolves** with an `HTTPErrorResponse` rather than throwing (only the UI subclass throws), so the `catch` never saw it. That is why the run log said `Executing Port: Success` for a request the server rejected — and it contradicted the documented contract in `docs/workflows/components`: *"**Error** — fires on a network failure or non-2xx response."* `Get`, `Post`, `Put`, `Patch` and `Delete` now route a resolved error response to the error port, so the code matches the docs.

Without this, the payload guard alone would have turned a silent success into a `400` that the customer's workflow *still* logged as Success.

**Terraform** — the generated provider seeds an empty `"data"` map and can reach the wire with it when every diffed attribute is computed or server-inferred. It is the only first-party emitter of `{"data":{}}`, so the generator now skips the call rather than sending a request the API will now reject. **Providers must be regenerated and republished with this release.**

**Two small ones** — `RunWorkflow` logged `undefined` for a missing port name (`+` binds tighter than `||`), and there was no documentation for updating a variable from a workflow, which is the case that surfaced all of this.

## Tests

Five suites, 80 cases. **Verified non-vacuous**: reverting the source changes while keeping the tests fails 44 of them across all five suites.

| Suite | Covers |
|---|---|
| `BaseAPIUpdatePayloadValidation` | the customer's literal flat body, `{}`, `null`, string, number, boolean, array, array-of-objects, only-stripped-keys, the happy path, that the strip still works, and all three routes |
| `BaseAnalyticsAPIUpdatePayloadValidation` | the same contract for analytics models |
| `WorkflowVariableColumnPermission` | `EditWorkflowVariable` can now write `content`; a read-only key still cannot; `content` stays unreadable |
| `ApiComponentErrorPort` | resolved-error, success, and thrown-transport-error paths for all five verbs |
| `DatabaseServiceEmptyUpdate` | a columnless update reports 0, skips the find, still runs hooks; non-empty updates unchanged |

Full `Common` suite: **10,355 passed / 10,356**. The one failure (`MonacoRuntime`) and 8 suite-level `isolated-vm` load errors are pre-existing local environment issues — stale `node_modules` (`monaco-editor` 0.53.0 installed against a 0.52.2 pin) and a native module built for a different V8. Neither touches any file in this PR.

## Compatibility

No first-party client sends a flat body — web UI, analytics UI, CLI, MCP, Terraform and E2E all wrap, and this was verified caller by caller. Third-party integrations sending a flat body are **already** silent no-ops today; a `400` with an actionable message is strictly better than a lie.

Two visible behaviour changes worth calling out in release notes:
- Workflows whose API block gets a non-2xx now take the **error** branch instead of success. This is the documented behaviour, but anyone with an unwired error port will see that branch simply end.
- `oneuptime ... update --data '{}'` now returns a clear `400` rather than a silent success.

## Not in this PR

While tracing how `body["data"]` flows into a query, I found two **unauthenticated auth bypasses** of the same root mechanism (a missing field becomes `undefined`, and TypeORM drops the predicate rather than throwing) in `App/FeatureSet/Identity/`. They are unrelated to this bug, more urgent than it, and should not ride along in a routine PR. Reported separately.
