### PR TITLE
fix(identity): reject empty credentials before they become dropped WHERE predicates

### DIFF
--- a/App/FeatureSet/Identity/API/Authentication.ts
+++ b/App/FeatureSet/Identity/API/Authentication.ts
@@ -1,4 +1,5 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
+import CredentialGuard from "../Utils/CredentialGuard";
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import { AccountsRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
@@ -191,6 +192,13 @@ router.post(
         User,
       ) as User;
 
+      /*
+       * A missing email would drop the predicate below and resolve `alreadySavedUser` to the
+       * newest user in the instance. If that user has no password yet (invited but not signed
+       * up), the update branch would hand the caller a real session for that account.
+       */
+      CredentialGuard.assertPresent(partialUser.email, "Email");
+
       if (IsBillingEnabled) {
         //ALERT: Delete data.role so user don't accidently sign up as master-admin from the API.
         partialUser.isMasterAdmin = false;
@@ -367,6 +375,13 @@ router.post(
 
       const user: User = BaseModel.fromJSON(data as JSONObject, User) as User;
 
+      /*
+       * A missing email would drop the predicate and select the newest user in the instance,
+       * writing a fresh reset token onto an unrelated account (and invalidating the one that
+       * account may legitimately be using).
+       */
+      CredentialGuard.assertPresent(user.email, "Email");
+
       const alreadySavedUser: User | null = await UserService.findOneBy({
         query: { email: user.email! },
         select: {
@@ -462,6 +477,13 @@ router.post(
         data as JSONObject,
         EmailVerificationToken,
       ) as EmailVerificationToken;
+
+      /*
+       * Without this an empty body yields `token.token === undefined`, TypeORM drops the
+       * predicate, and the query returns the newest verification token in the instance --
+       * verifying an address the caller never proved they control.
+       */
+      CredentialGuard.assertPresent(token.token, "Verification token");
 
       const alreadySavedToken: EmailVerificationToken | null =
         await EmailVerificationTokenService.findOneBy({
@@ -569,6 +591,15 @@ router.post(
       const data: JSONObject = req.body["data"];
 
       const user: User = BaseModel.fromJSON(data as JSONObject, User) as User;
+
+      /*
+       * The `|| ""` below already stops the token predicate from being dropped, but an absent
+       * password would silently reset the matched account's password to `undefined`.
+       */
+      CredentialGuard.assertAllPresent([
+        { value: user.resetPasswordToken, label: "Reset password token" },
+        { value: user.password, label: "Password" },
+      ]);
 
       await user.password?.hashValue(EncryptionSecret);
 

--- a/App/FeatureSet/Identity/API/StatusPageAuthentication.ts
+++ b/App/FeatureSet/Identity/API/StatusPageAuthentication.ts
@@ -1,3 +1,4 @@
+import CredentialGuard from "../Utils/CredentialGuard";
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import { StatusPageApiRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
@@ -459,6 +460,12 @@ router.post(
         throw new BadDataException("Status Page ID is required.");
       }
 
+      /*
+       * The `data["email"]` check above reads the raw body; re-check the deserialized value so
+       * the guard covers what actually reaches the query.
+       */
+      CredentialGuard.assertPresent(user.email, "Email");
+
       const statusPage: StatusPage | null = await StatusPageService.findOneById(
         {
           id: user.statusPageId!,
@@ -612,6 +619,15 @@ router.post(
         data as JSONObject,
         StatusPagePrivateUser,
       ) as StatusPagePrivateUser;
+
+      /*
+       * The `|| ""` below already stops the token predicate from being dropped, but an absent
+       * password would silently reset the matched account's password to `undefined`.
+       */
+      CredentialGuard.assertAllPresent([
+        { value: user.resetPasswordToken, label: "Reset password token" },
+        { value: user.password, label: "Password" },
+      ]);
 
       await user.password?.hashValue(EncryptionSecret);
 
@@ -774,6 +790,17 @@ router.post(
       if (!user.statusPageId) {
         throw new BadDataException("Status Page ID not found");
       }
+
+      /*
+       * statusPageId alone is not a secret, and the guard above is the only one an empty
+       * credential pair used to hit. Without these, `email` and `password` arrive undefined,
+       * TypeORM drops both predicates, and the query below degrades to "newest private user of
+       * this status page" -- who is then handed a real session and access-token cookie.
+       */
+      CredentialGuard.assertAllPresent([
+        { value: user.email, label: "Email" },
+        { value: user.password, label: "Password" },
+      ]);
 
       const statusPage: StatusPage | null = await StatusPageService.findOneById(
         {

--- a/App/FeatureSet/Identity/Utils/CredentialGuard.ts
+++ b/App/FeatureSet/Identity/Utils/CredentialGuard.ts
@@ -1,0 +1,82 @@
+import BadDataException from "Common/Types/Exception/BadDataException";
+
+/*
+ * Guards for identifiers that unauthenticated identity routes use as query predicates.
+ *
+ * Why this exists:
+ *
+ * Unauthenticated routes build their lookup from `BaseModel.fromJSON(req.body["data"], T)`.
+ * `fromJSON` accepts `undefined` without complaining -- `JSONFunctions.deserialize(undefined)`
+ * returns `{}` because `for...in` over `undefined` is a spec no-op -- so it hands back a bare
+ * model whose every field is `undefined`.
+ *
+ * Nothing downstream rejects that. `QueryUtil.serializeQuery` has no `undefined` handling, and
+ * TypeORM defaults `invalidWhereValuesBehavior.undefined` to "ignore", which silently DROPS the
+ * predicate instead of matching nothing. Combined with `_findBy`'s default sort
+ * (`createdAt: Descending`, limit 1), `findOneBy({ token: undefined })` stops meaning
+ * "the row with this token" and starts meaning "the newest row in the table".
+ *
+ * On an authentication route that is an auth bypass: an empty request body matches somebody
+ * else's credential row. So every credential or identifier that reaches a WHERE clause on an
+ * unauthenticated route must be proven present *before* the query runs.
+ */
+export default class CredentialGuard {
+  /**
+   * True when the value can be safely used as a query predicate.
+   *
+   * Rejects `undefined` and `null` (dropped by TypeORM), and empty/whitespace-only strings.
+   * Domain types used as predicates here (Email, ObjectID, HashedString) all carry a custom
+   * `toString()`, so an "empty" instance -- e.g. `new HashedString("")`, which `hashValue()`
+   * leaves unhashed -- is rejected too.
+   */
+  public static isPresent(value: unknown): boolean {
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    if (typeof value === "string") {
+      return value.trim().length > 0;
+    }
+
+    if (typeof value === "object") {
+      const toStringImpl: unknown = (value as { toString?: unknown }).toString;
+
+      const hasCustomToString: boolean =
+        typeof toStringImpl === "function" &&
+        toStringImpl !== Object.prototype.toString;
+
+      if (hasCustomToString) {
+        return String(value).trim().length > 0;
+      }
+
+      // A plain object carries no stringifiable identity, but it is still a value.
+      return true;
+    }
+
+    return true;
+  }
+
+  /**
+   * Throws BadDataException unless the value is usable as a query predicate.
+   *
+   * `fieldLabel` is echoed to the caller, so keep it to the field's public name -- never
+   * interpolate the value itself, which would turn the guard into an oracle.
+   */
+  public static assertPresent(value: unknown, fieldLabel: string): void {
+    if (!this.isPresent(value)) {
+      throw new BadDataException(`${fieldLabel} is required.`);
+    }
+  }
+
+  /**
+   * Asserts every entry is present. Reports the first missing field so the error stays
+   * deterministic regardless of which combination the caller omitted.
+   */
+  public static assertAllPresent(
+    fields: Array<{ value: unknown; label: string }>,
+  ): void {
+    for (const field of fields) {
+      this.assertPresent(field.value, field.label);
+    }
+  }
+}

--- a/App/Tests/FeatureSet/Identity/AuthenticationBypass.test.ts
+++ b/App/Tests/FeatureSet/Identity/AuthenticationBypass.test.ts
@@ -1,0 +1,627 @@
+import {
+  buildRequest,
+  buildResponse,
+  createMockIdentityRouter,
+  MockIdentityRouter,
+  RouteHandler,
+} from "./IdentityRouterTestUtil";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import Exception from "Common/Types/Exception/Exception";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import ObjectID from "Common/Types/ObjectID";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+const mockRouter: MockIdentityRouter = createMockIdentityRouter();
+
+/*
+ * ---------------------------------------------------------------------------------------------
+ * Regression tests for the unauthenticated-identity auth bypasses.
+ *
+ * The bug class, end to end:
+ *
+ *   1. `BaseModel.fromJSON(undefined, T)` does not throw. It routes into
+ *      `JSONFunctions.deserialize(undefined)`, and `for...in` over `undefined` is a spec no-op,
+ *      so it returns `{}` -- a bare model with every field `undefined`.
+ *   2. `QueryUtil.serializeQuery` has no `undefined` handling. Every branch is guarded by
+ *      `query[key] && ...` with no catch-all else, so the `undefined` survives untouched.
+ *   3. TypeORM 0.3.30 defaults `invalidWhereValuesBehavior.undefined` to "ignore", which SILENTLY
+ *      DROPS the predicate instead of matching nothing.
+ *   4. `_findBy` defaults to `createdAt: Descending` with limit 1.
+ *
+ * Net effect: `findOneBy({ token: undefined })` returns the NEWEST row in the table.
+ *
+ * These tests deliberately do NOT mock BaseModel, JSONFunctions or CredentialGuard -- the real
+ * deserialization path has to run, otherwise the test proves nothing about the real bug.
+ *
+ * The load-bearing assertion in every attack case is that the *service was never called*. An
+ * error response alone is not enough: the fix has to stop the dangerous query from ever running.
+ * ---------------------------------------------------------------------------------------------
+ */
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      getRouter: (): MockIdentityRouter => {
+        return mockRouter;
+      },
+    },
+    getClientIp: (): string => {
+      return "127.0.0.1";
+    },
+    extractDeviceInfo: (): Record<string, unknown> => {
+      return {};
+    },
+    headerValueToString: (): string => {
+      return "";
+    },
+  };
+});
+
+const findOneByEmailVerificationToken: jest.Mock = jest.fn();
+const createEmailVerificationToken: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/EmailVerificationTokenService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return findOneByEmailVerificationToken(...args);
+      },
+      create: (...args: Array<unknown>): unknown => {
+        return createEmailVerificationToken(...args);
+      },
+    },
+  };
+});
+
+const userFindOneBy: jest.Mock = jest.fn();
+const userUpdateOneBy: jest.Mock = jest.fn();
+const userUpdateOneById: jest.Mock = jest.fn();
+const userUpdateOneByIdAndFetch: jest.Mock = jest.fn();
+const userCreate: jest.Mock = jest.fn();
+const userCountBy: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return userFindOneBy(...args);
+      },
+      updateOneBy: (...args: Array<unknown>): unknown => {
+        return userUpdateOneBy(...args);
+      },
+      updateOneById: (...args: Array<unknown>): unknown => {
+        return userUpdateOneById(...args);
+      },
+      updateOneByIdAndFetch: (...args: Array<unknown>): unknown => {
+        return userUpdateOneByIdAndFetch(...args);
+      },
+      create: (...args: Array<unknown>): unknown => {
+        return userCreate(...args);
+      },
+      countBy: (...args: Array<unknown>): unknown => {
+        return userCountBy(...args);
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/TeamMemberService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/AccessTokenService", () => {
+  return {
+    __esModule: true,
+    default: { refreshUserAllPermissions: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/UserTotpAuthService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserWebAuthnService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      verifyAuthentication: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserSessionService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createSession: jest.fn(),
+      findActiveSessionByRefreshToken: jest.fn(),
+      revokeSessionById: jest.fn(),
+      revokeSessionByRefreshToken: jest.fn(),
+      renewSessionWithNewRefreshToken: jest.fn(),
+    },
+  };
+});
+
+const sendMail: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: (...args: Array<unknown>): Promise<void> => {
+        sendMail(...args);
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/DatabaseConfig", () => {
+  return {
+    __esModule: true,
+    default: {
+      shouldDisableSignup: (): Promise<boolean> => {
+        return Promise.resolve(false);
+      },
+      getHost: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "localhost";
+          },
+        });
+      },
+      getHttpProtocol: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "http://";
+          },
+        });
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Cookie", () => {
+  return {
+    __esModule: true,
+    default: {
+      setUserCookie: jest.fn(),
+      removeAllCookies: jest.fn(),
+      removeCookie: jest.fn(),
+      getRefreshTokenFromExpressRequest: jest.fn(),
+      getUserTokenKey: jest.fn(),
+      getRefreshTokenKey: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Captcha", () => {
+  return {
+    __esModule: true,
+    default: {
+      verifyCaptcha: (): Promise<void> => {
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/JsonWebToken", () => {
+  return {
+    __esModule: true,
+    default: {
+      sign: (): string => {
+        return "signed-token";
+      },
+      signUserLoginToken: (): string => {
+        return "signed-user-token";
+      },
+    },
+  };
+});
+
+jest.mock("../../../FeatureSet/Identity/Utils/AuthenticationEmail", () => {
+  return {
+    __esModule: true,
+    default: { sendVerificationEmail: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+    getLogAttributesFromRequest: (): Record<string, unknown> => {
+      return {};
+    },
+  };
+});
+
+const sendErrorResponse: jest.Mock = jest.fn();
+const sendEmptySuccessResponse: jest.Mock = jest.fn();
+const sendEntityResponse: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: (...args: Array<unknown>): unknown => {
+        return sendErrorResponse(...args);
+      },
+      sendEmptySuccessResponse: (...args: Array<unknown>): unknown => {
+        return sendEmptySuccessResponse(...args);
+      },
+      sendEntityResponse: (...args: Array<unknown>): unknown => {
+        return sendEntityResponse(...args);
+      },
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+// Importing the router registers every handler on the mock router above.
+import "../../../FeatureSet/Identity/API/Authentication";
+
+type InvokeResult = {
+  nextError: Exception | null;
+};
+
+type InvokeFunction = (uri: string, body: unknown) => Promise<InvokeResult>;
+
+const invoke: InvokeFunction = async (
+  uri: string,
+  body: unknown,
+): Promise<InvokeResult> => {
+  const handler: RouteHandler = mockRouter.match("post", uri);
+  const req: ExpressRequest = buildRequest(body);
+  const res: ExpressResponse = buildResponse();
+
+  let nextError: Exception | null = null;
+
+  const next: NextFunction = ((err?: Exception): void => {
+    if (err) {
+      nextError = err;
+    }
+  }) as unknown as NextFunction;
+
+  await handler(req, res, next);
+
+  return { nextError };
+};
+
+describe("Identity /verify-email - email verification bypass", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /*
+   * Attack: sign up with an address you do not control, then immediately POST an empty body.
+   * The dropped `token` predicate matched the newest EmailVerificationToken in the WHOLE
+   * INSTANCE -- in practice your own, since you just created it -- and the handler then marked
+   * the address on that token verified.
+   */
+  it("rejects an empty body without ever querying for a token", async () => {
+    const result: InvokeResult = await invoke("/verify-email", {});
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(userUpdateOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Verification token is required.",
+    );
+  });
+
+  it("rejects a body with no data key at all", async () => {
+    const result: InvokeResult = await invoke("/verify-email", {});
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects data: undefined, the case BaseModel.fromJSON silently accepts", async () => {
+    const result: InvokeResult = await invoke("/verify-email", {
+      data: undefined,
+    });
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects data: {} - an explicitly empty payload", async () => {
+    const result: InvokeResult = await invoke("/verify-email", { data: {} });
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects a payload carrying only a non-secret field", async () => {
+    /*
+     * `email` is not a secret and is not the lookup key. Supplying it must not buy the caller a
+     * query, because the `token` predicate would still be dropped.
+     */
+    const result: InvokeResult = await invoke("/verify-email", {
+      data: { email: "attacker@example.com" },
+    });
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects an explicitly null token", async () => {
+    const result: InvokeResult = await invoke("/verify-email", {
+      data: { token: null },
+    });
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects an empty-string token", async () => {
+    const result: InvokeResult = await invoke("/verify-email", {
+      data: { token: "" },
+    });
+
+    expect(findOneByEmailVerificationToken).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("still queries with the real predicate on the happy path", async () => {
+    const token: string = ObjectID.generate().toString();
+
+    findOneByEmailVerificationToken.mockResolvedValue(null);
+
+    await invoke("/verify-email", { data: { token: token } });
+
+    expect(findOneByEmailVerificationToken).toHaveBeenCalledTimes(1);
+
+    const call: Record<string, any> = findOneByEmailVerificationToken.mock
+      .calls[0]![0] as Record<string, any>;
+
+    // The predicate must be the caller's token -- present, and not undefined.
+    expect(call["query"].token).toBeDefined();
+    expect(call["query"].token.toString()).toBe(token);
+  });
+
+  it("reports an unknown-but-present token as an invalid link, not a bypass", async () => {
+    findOneByEmailVerificationToken.mockResolvedValue(null);
+
+    await invoke("/verify-email", {
+      data: { token: ObjectID.generate().toString() },
+    });
+
+    expect(findOneByEmailVerificationToken).toHaveBeenCalledTimes(1);
+    expect(sendErrorResponse).toHaveBeenCalled();
+    expect(userUpdateOneBy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Identity /signup - passwordless-account takeover via dropped email predicate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /*
+   * With the email predicate dropped, `alreadySavedUser` resolved to the newest user in the
+   * instance. A user invited to a team but not yet signed up has no password, which sent the
+   * handler down the update branch and then into finalizeUserLogin -- a real session for an
+   * account the caller never authenticated as.
+   */
+  it("rejects an empty body without ever looking a user up", async () => {
+    const result: InvokeResult = await invoke("/signup", { data: {} });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneByIdAndFetch).not.toHaveBeenCalled();
+    expect(userCreate).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Email is required.",
+    );
+  });
+
+  it("rejects a payload carrying only a password", async () => {
+    const result: InvokeResult = await invoke("/signup", {
+      data: { password: "attacker-chosen" },
+    });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneByIdAndFetch).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects an empty-string email", async () => {
+    const result: InvokeResult = await invoke("/signup", {
+      data: { email: "", password: "attacker-chosen" },
+    });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("still looks the user up by the supplied email on the happy path", async () => {
+    userFindOneBy.mockResolvedValue(null);
+    userCountBy.mockResolvedValue({
+      isZero: (): boolean => {
+        return false;
+      },
+    });
+    userCreate.mockResolvedValue(null);
+
+    await invoke("/signup", {
+      data: { email: "new-user@example.com", password: "hunter2" },
+    });
+
+    expect(userFindOneBy).toHaveBeenCalledTimes(1);
+
+    const call: Record<string, any> = userFindOneBy.mock.calls[0]![0] as Record<
+      string,
+      any
+    >;
+
+    expect(call["query"].email).toBeDefined();
+    expect(call["query"].email.toString()).toBe("new-user@example.com");
+  });
+});
+
+describe("Identity /forgot-password - reset token written to an arbitrary account", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /*
+   * A dropped email predicate selected the newest user in the instance and wrote a fresh
+   * resetPasswordToken onto that account, invalidating any legitimate one in flight. The mail
+   * itself went to the attacker-supplied `user.email`, so this was account disruption rather
+   * than takeover -- but the account picked was still not the caller's to touch.
+   */
+  it("rejects an empty body without ever querying or writing a reset token", async () => {
+    const result: InvokeResult = await invoke("/forgot-password", { data: {} });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Email is required.",
+    );
+  });
+
+  it("rejects a null email", async () => {
+    const result: InvokeResult = await invoke("/forgot-password", {
+      data: { email: null },
+    });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("still queries by the supplied email on the happy path", async () => {
+    userFindOneBy.mockResolvedValue(null);
+
+    await invoke("/forgot-password", {
+      data: { email: "known-user@example.com" },
+    });
+
+    expect(userFindOneBy).toHaveBeenCalledTimes(1);
+
+    const call: Record<string, any> = userFindOneBy.mock.calls[0]![0] as Record<
+      string,
+      any
+    >;
+
+    expect(call["query"].email.toString()).toBe("known-user@example.com");
+  });
+});
+
+describe("Identity /reset-password - password must be present", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects an empty body without querying", async () => {
+    const result: InvokeResult = await invoke("/reset-password", { data: {} });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneById).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Reset password token is required.",
+    );
+  });
+
+  it("rejects a token with no accompanying password, which would blank the password", async () => {
+    const result: InvokeResult = await invoke("/reset-password", {
+      data: { resetPasswordToken: "some-token" },
+    });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneById).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Password is required.",
+    );
+  });
+
+  it("rejects an empty-string password", async () => {
+    const result: InvokeResult = await invoke("/reset-password", {
+      data: { resetPasswordToken: "some-token", password: "" },
+    });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects a typed-but-empty HashedString password", async () => {
+    /*
+     * HashedString.hashValue() short-circuits on an empty value and returns "" WITHOUT hashing,
+     * so this payload would otherwise reach the update as a literal empty password.
+     */
+    const result: InvokeResult = await invoke("/reset-password", {
+      data: {
+        resetPasswordToken: "some-token",
+        password: { _type: "HashedString", value: "" },
+      },
+    });
+
+    expect(userFindOneBy).not.toHaveBeenCalled();
+    expect(userUpdateOneById).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("still queries by the hashed token on the happy path", async () => {
+    userFindOneBy.mockResolvedValue(null);
+
+    /*
+     * A real client serializes a password as a typed HashedString -- that is the form
+     * JSONFunctions.deserialize revives into an instance with hashValue() on it.
+     */
+    await invoke("/reset-password", {
+      data: {
+        resetPasswordToken: "a-real-token",
+        password: { _type: "HashedString", value: "new-password" },
+      },
+    });
+
+    expect(userFindOneBy).toHaveBeenCalledTimes(1);
+
+    const call: Record<string, any> = userFindOneBy.mock.calls[0]![0] as Record<
+      string,
+      any
+    >;
+
+    // The stored token is a hash, so the predicate must be a non-empty hash of the input.
+    expect(typeof call["query"].resetPasswordToken).toBe("string");
+    expect(call["query"].resetPasswordToken.length).toBeGreaterThan(0);
+    expect(call["query"].resetPasswordToken).not.toBe("a-real-token");
+  });
+});

--- a/App/Tests/FeatureSet/Identity/CredentialGuard.test.ts
+++ b/App/Tests/FeatureSet/Identity/CredentialGuard.test.ts
@@ -1,0 +1,152 @@
+import CredentialGuard from "../../../FeatureSet/Identity/Utils/CredentialGuard";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import Email from "Common/Types/Email";
+import HashedString from "Common/Types/HashedString";
+import ObjectID from "Common/Types/ObjectID";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * CredentialGuard is the gate that keeps `undefined` out of WHERE clauses on unauthenticated
+ * identity routes. TypeORM DROPS an undefined predicate rather than matching nothing, so a
+ * guard that returns true for a value the query layer will discard is itself an auth bypass.
+ *
+ * The cases below therefore pin down the exact boundary: what reaches a query, and what does not.
+ */
+describe("CredentialGuard", () => {
+  describe("isPresent - values that must be rejected", () => {
+    it("rejects undefined, which is what BaseModel.fromJSON({}) leaves on every field", () => {
+      expect(CredentialGuard.isPresent(undefined)).toBe(false);
+    });
+
+    it("rejects null, which TypeORM also drops by default", () => {
+      expect(CredentialGuard.isPresent(null)).toBe(false);
+    });
+
+    it("rejects the empty string", () => {
+      expect(CredentialGuard.isPresent("")).toBe(false);
+    });
+
+    it("rejects whitespace-only strings", () => {
+      expect(CredentialGuard.isPresent("   ")).toBe(false);
+      expect(CredentialGuard.isPresent("\t\n")).toBe(false);
+    });
+
+    it("rejects an empty HashedString, which hashValue() leaves unhashed", async () => {
+      const password: HashedString = new HashedString("");
+
+      /*
+       * HashedString.hashValue() short-circuits on a falsy value and returns "" without
+       * hashing, so an empty password would reach the query as a literal empty string.
+       */
+      await password.hashValue(new ObjectID("secret"));
+
+      expect(password.toString()).toBe("");
+      expect(CredentialGuard.isPresent(password)).toBe(false);
+    });
+
+    it("rejects an ObjectID carrying an empty id", () => {
+      expect(CredentialGuard.isPresent(new ObjectID(""))).toBe(false);
+    });
+  });
+
+  describe("isPresent - values that must be accepted", () => {
+    it("accepts a non-empty string", () => {
+      expect(CredentialGuard.isPresent("a-token")).toBe(true);
+    });
+
+    it("accepts a valid Email", () => {
+      expect(CredentialGuard.isPresent(new Email("user@example.com"))).toBe(
+        true,
+      );
+    });
+
+    it("accepts a populated ObjectID", () => {
+      expect(CredentialGuard.isPresent(ObjectID.generate())).toBe(true);
+    });
+
+    it("accepts a populated HashedString both before and after hashing", async () => {
+      const password: HashedString = new HashedString("correct-horse");
+      expect(CredentialGuard.isPresent(password)).toBe(true);
+
+      await password.hashValue(new ObjectID("secret"));
+      expect(CredentialGuard.isPresent(password)).toBe(true);
+    });
+
+    it("accepts a plain object, which carries no stringifiable identity to check", () => {
+      expect(CredentialGuard.isPresent({ some: "value" })).toBe(true);
+    });
+  });
+
+  describe("isPresent - falsy primitives that are still real values", () => {
+    /*
+     * A bare `if (!value)` guard would reject these. They are not credentials today, but the
+     * guard is generic and must not silently reject a legitimate zero/false predicate.
+     */
+    it("accepts 0", () => {
+      expect(CredentialGuard.isPresent(0)).toBe(true);
+    });
+
+    it("accepts false", () => {
+      expect(CredentialGuard.isPresent(false)).toBe(true);
+    });
+  });
+
+  describe("assertPresent", () => {
+    it("throws BadDataException naming the field when the value is missing", () => {
+      expect(() => {
+        return CredentialGuard.assertPresent(undefined, "Verification token");
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return CredentialGuard.assertPresent(undefined, "Verification token");
+      }).toThrow("Verification token is required.");
+    });
+
+    it("does not leak the rejected value back to the caller", () => {
+      let message: string = "";
+
+      try {
+        CredentialGuard.assertPresent("", "Password");
+      } catch (err) {
+        message = (err as BadDataException).message;
+      }
+
+      expect(message).toBe("Password is required.");
+    });
+
+    it("stays silent for a present value", () => {
+      expect(() => {
+        return CredentialGuard.assertPresent("token", "Verification token");
+      }).not.toThrow();
+    });
+  });
+
+  describe("assertAllPresent", () => {
+    it("throws on the first missing field, regardless of later ones", () => {
+      expect(() => {
+        return CredentialGuard.assertAllPresent([
+          { value: undefined, label: "Email" },
+          { value: undefined, label: "Password" },
+        ]);
+      }).toThrow("Email is required.");
+    });
+
+    it("reports the missing field even when earlier fields are present", () => {
+      expect(() => {
+        return CredentialGuard.assertAllPresent([
+          { value: new Email("user@example.com"), label: "Email" },
+          { value: undefined, label: "Password" },
+        ]);
+      }).toThrow("Password is required.");
+    });
+
+    it("stays silent when every field is present", () => {
+      expect(() => {
+        return CredentialGuard.assertAllPresent([
+          { value: new Email("user@example.com"), label: "Email" },
+          { value: new HashedString("pw"), label: "Password" },
+        ]);
+      }).not.toThrow();
+    });
+  });
+});

--- a/App/Tests/FeatureSet/Identity/IdentityRouterTestUtil.ts
+++ b/App/Tests/FeatureSet/Identity/IdentityRouterTestUtil.ts
@@ -1,0 +1,111 @@
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+
+export type RouteHandler = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+export type CapturedRoute = {
+  method: string;
+  uri: string;
+  handler: RouteHandler;
+};
+
+/*
+ * The identity routers register handlers as `router.post(uri, handler)` -- two arguments, no
+ * middleware -- so the shared mockRouter in Common/Tests/Server/API/Helpers.ts (which assumes
+ * three) cannot capture them. This one takes the LAST function argument as the handler, so it
+ * works for both arities.
+ */
+export type MockIdentityRouter = {
+  get: jest.Mock;
+  post: jest.Mock;
+  put: jest.Mock;
+  delete: jest.Mock;
+  routes: Array<CapturedRoute>;
+  match: (method: string, uri: string) => RouteHandler;
+};
+
+type RegisterForMethod = (
+  method: string,
+) => (uri: string, ...handlers: Array<RouteHandler>) => void;
+
+export type CreateMockIdentityRouterFunction = () => MockIdentityRouter;
+
+export const createMockIdentityRouter: CreateMockIdentityRouterFunction =
+  (): MockIdentityRouter => {
+    const routes: Array<CapturedRoute> = [];
+
+    const registerForMethod: RegisterForMethod = (method: string) => {
+      return (uri: string, ...handlers: Array<RouteHandler>): void => {
+        const handler: RouteHandler | undefined = handlers[handlers.length - 1];
+
+        if (!handler) {
+          throw new Error(`No handler registered for ${method} ${uri}`);
+        }
+
+        routes.push({ method: method.toUpperCase(), uri, handler });
+      };
+    };
+
+    return {
+      get: jest.fn(registerForMethod("get")),
+      post: jest.fn(registerForMethod("post")),
+      put: jest.fn(registerForMethod("put")),
+      delete: jest.fn(registerForMethod("delete")),
+      routes,
+      match: (method: string, uri: string): RouteHandler => {
+        const route: CapturedRoute | undefined = routes.find(
+          (route: CapturedRoute) => {
+            return route.method === method.toUpperCase() && route.uri === uri;
+          },
+        );
+
+        if (!route) {
+          throw new Error(
+            `Route ${method} ${uri} not registered. Registered: ${routes
+              .map((r: CapturedRoute) => {
+                return `${r.method} ${r.uri}`;
+              })
+              .join(", ")}`,
+          );
+        }
+
+        return route.handler;
+      },
+    };
+  };
+
+export type BuildRequestFunction = (body: unknown) => ExpressRequest;
+
+export const buildRequest: BuildRequestFunction = (
+  body: unknown,
+): ExpressRequest => {
+  return {
+    body: body,
+    params: {},
+    query: {},
+    headers: {},
+    get: (): undefined => {
+      return undefined;
+    },
+  } as unknown as ExpressRequest;
+};
+
+export type BuildResponseFunction = () => ExpressResponse;
+
+export const buildResponse: BuildResponseFunction = (): ExpressResponse => {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    cookie: jest.fn().mockReturnThis(),
+    clearCookie: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  } as unknown as ExpressResponse;
+};

--- a/App/Tests/FeatureSet/Identity/StatusPageAuthenticationBypass.test.ts
+++ b/App/Tests/FeatureSet/Identity/StatusPageAuthenticationBypass.test.ts
@@ -1,0 +1,613 @@
+import {
+  buildRequest,
+  buildResponse,
+  createMockIdentityRouter,
+  MockIdentityRouter,
+  RouteHandler,
+} from "./IdentityRouterTestUtil";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import Exception from "Common/Types/Exception/Exception";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import ObjectID from "Common/Types/ObjectID";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+const mockRouter: MockIdentityRouter = createMockIdentityRouter();
+
+/*
+ * ---------------------------------------------------------------------------------------------
+ * Regression tests for the status page private-user login bypass.
+ *
+ * This was the more severe of the two originally-reported bypasses, because it minted a REAL
+ * session rather than just flipping a verification flag.
+ *
+ * The `if (!user.statusPageId)` guard caught a fully empty body, so it looked defended. It was
+ * not: statusPageId is NOT a secret -- it is public in status page URLs and page config. A body
+ * of `{"data": {"statusPageId": "<any valid status page id>"}}` sailed past that guard, and then
+ *
+ *   - `await user.password?.hashValue(...)` was a silent no-op on `undefined`, and
+ *   - the lookup became `{ email: undefined, password: undefined, statusPageId: <id> }`.
+ *
+ * TypeORM dropped both credential predicates, leaving `WHERE statusPageId = <id>` sorted newest
+ * first -- so the query returned the most recently created private user of that status page, and
+ * finalizeStatusPageLogin handed the caller their session and access-token cookie.
+ *
+ * Only `requireSsoForLogin` mitigated it, and only where enabled.
+ * ---------------------------------------------------------------------------------------------
+ */
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      getRouter: (): MockIdentityRouter => {
+        return mockRouter;
+      },
+    },
+    getClientIp: (): string => {
+      return "127.0.0.1";
+    },
+    extractDeviceInfo: (): Record<string, unknown> => {
+      return {};
+    },
+    headerValueToString: (): string => {
+      return "";
+    },
+  };
+});
+
+const privateUserFindOneBy: jest.Mock = jest.fn();
+const privateUserFindOneById: jest.Mock = jest.fn();
+const privateUserUpdateOneBy: jest.Mock = jest.fn();
+const privateUserUpdateOneById: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/StatusPagePrivateUserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return privateUserFindOneBy(...args);
+      },
+      findOneById: (...args: Array<unknown>): unknown => {
+        return privateUserFindOneById(...args);
+      },
+      updateOneBy: (...args: Array<unknown>): unknown => {
+        return privateUserUpdateOneBy(...args);
+      },
+      updateOneById: (...args: Array<unknown>): unknown => {
+        return privateUserUpdateOneById(...args);
+      },
+    },
+  };
+});
+
+const statusPageFindOneById: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/StatusPageService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: (...args: Array<unknown>): unknown => {
+        return statusPageFindOneById(...args);
+      },
+      getStatusPageURL: (): Promise<string> => {
+        return Promise.resolve("https://status.example.com");
+      },
+    },
+  };
+});
+
+const createSession: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/StatusPagePrivateUserSessionService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createSession: (...args: Array<unknown>): unknown => {
+        createSession(...args);
+        return Promise.resolve({
+          session: { id: new ObjectID("session-id") },
+          refreshToken: "refresh-token",
+          refreshTokenExpiresAt: new Date(),
+        });
+      },
+      findActiveSessionByRefreshToken: jest.fn(),
+      revokeSessionById: jest.fn(),
+      revokeSessionByRefreshToken: jest.fn(),
+      renewSessionWithNewRefreshToken: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectSmtpConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      toEmailServer: (): undefined => {
+        return undefined;
+      },
+    },
+  };
+});
+
+const sendMail: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: (...args: Array<unknown>): Promise<void> => {
+        sendMail(...args);
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/DatabaseConfig", () => {
+  return {
+    __esModule: true,
+    default: {
+      getHost: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "localhost";
+          },
+        });
+      },
+      getHttpProtocol: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "http://";
+          },
+        });
+      },
+    },
+  };
+});
+
+const setStatusPagePrivateUserCookie: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Utils/Cookie", () => {
+  return {
+    __esModule: true,
+    default: {
+      setStatusPagePrivateUserCookie: (...args: Array<unknown>): string => {
+        setStatusPagePrivateUserCookie(...args);
+        return "status-page-access-token";
+      },
+      setUserCookie: jest.fn(),
+      removeAllCookies: jest.fn(),
+      removeCookie: jest.fn(),
+      removeStatusPageMasterPasswordCookie: jest.fn(),
+      getCookieFromExpressRequest: jest.fn(),
+      getRefreshTokenFromExpressRequest: jest.fn(),
+      getUserTokenKey: jest.fn(),
+      getRefreshTokenKey: jest.fn(),
+      getStatusPageMasterPasswordKey: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/JsonWebToken", () => {
+  return {
+    __esModule: true,
+    default: {
+      sign: (): string => {
+        return "signed-token";
+      },
+      signStatusPageLoginToken: (): string => {
+        return "signed-status-page-token";
+      },
+      decode: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+    getLogAttributesFromRequest: (): Record<string, unknown> => {
+      return {};
+    },
+  };
+});
+
+const sendErrorResponse: jest.Mock = jest.fn();
+const sendEmptySuccessResponse: jest.Mock = jest.fn();
+const sendEntityResponse: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: (...args: Array<unknown>): unknown => {
+        return sendErrorResponse(...args);
+      },
+      sendEmptySuccessResponse: (...args: Array<unknown>): unknown => {
+        return sendEmptySuccessResponse(...args);
+      },
+      sendEntityResponse: (...args: Array<unknown>): unknown => {
+        return sendEntityResponse(...args);
+      },
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+// Importing the router registers every handler on the mock router above.
+import "../../../FeatureSet/Identity/API/StatusPageAuthentication";
+
+// A status page id is public information -- it appears in status page URLs.
+const PUBLIC_STATUS_PAGE_ID: string = "e7f4d2a0-1b3c-4d5e-8f90-a1b2c3d4e5f6";
+
+type InvokeResult = {
+  nextError: Exception | null;
+};
+
+type InvokeFunction = (uri: string, body: unknown) => Promise<InvokeResult>;
+
+const invoke: InvokeFunction = async (
+  uri: string,
+  body: unknown,
+): Promise<InvokeResult> => {
+  const handler: RouteHandler = mockRouter.match("post", uri);
+  const req: ExpressRequest = buildRequest(body);
+  const res: ExpressResponse = buildResponse();
+
+  let nextError: Exception | null = null;
+
+  const next: NextFunction = ((err?: Exception): void => {
+    if (err) {
+      nextError = err;
+    }
+  }) as unknown as NextFunction;
+
+  await handler(req, res, next);
+
+  return { nextError };
+};
+
+type ExpectNoSessionFunction = () => void;
+
+/*
+ * The whole point of this endpoint's bug was that it minted a session. Asserting only on the
+ * error response would miss a regression that errors AFTER issuing the cookie.
+ */
+const expectNoSessionIssued: ExpectNoSessionFunction = (): void => {
+  expect(privateUserFindOneBy).not.toHaveBeenCalled();
+  expect(createSession).not.toHaveBeenCalled();
+  expect(setStatusPagePrivateUserCookie).not.toHaveBeenCalled();
+  expect(sendEntityResponse).not.toHaveBeenCalled();
+};
+
+describe("Status page /login - private user login bypass", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    statusPageFindOneById.mockResolvedValue({
+      id: new ObjectID(PUBLIC_STATUS_PAGE_ID),
+      requireSsoForLogin: false,
+    });
+  });
+
+  it("rejects an empty body", async () => {
+    const result: InvokeResult = await invoke("/login", { data: {} });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  /*
+   * THE ORIGINAL EXPLOIT. statusPageId alone used to be enough to reach the query.
+   */
+  it("rejects a body carrying only the (public) statusPageId", async () => {
+    const result: InvokeResult = await invoke("/login", {
+      data: { statusPageId: PUBLIC_STATUS_PAGE_ID },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Email is required.",
+    );
+  });
+
+  it("rejects statusPageId plus an email but no password", async () => {
+    const result: InvokeResult = await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "victim@example.com",
+      },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Password is required.",
+    );
+  });
+
+  it("rejects statusPageId plus a password but no email", async () => {
+    const result: InvokeResult = await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        password: { _type: "HashedString", value: "guess" },
+      },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Email is required.",
+    );
+  });
+
+  it("rejects explicitly null credentials", async () => {
+    const result: InvokeResult = await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: null,
+        password: null,
+      },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects empty-string credentials", async () => {
+    const result: InvokeResult = await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "",
+        password: "",
+      },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects a typed-but-empty HashedString password", async () => {
+    /*
+     * hashValue() returns "" without hashing when the value is empty, so this payload would
+     * reach the query as a literal empty password rather than a hash.
+     */
+    const result: InvokeResult = await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "victim@example.com",
+        password: { _type: "HashedString", value: "" },
+      },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Password is required.",
+    );
+  });
+
+  it("still rejects credential-less payloads on an SSO-only status page", async () => {
+    /*
+     * requireSsoForLogin was the only thing standing between this endpoint and a bypass. The
+     * credential guard must not depend on it -- and must fire before the status page lookup.
+     */
+    statusPageFindOneById.mockResolvedValue({
+      id: new ObjectID(PUBLIC_STATUS_PAGE_ID),
+      requireSsoForLogin: true,
+    });
+
+    const result: InvokeResult = await invoke("/login", {
+      data: { statusPageId: PUBLIC_STATUS_PAGE_ID },
+    });
+
+    expectNoSessionIssued();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("queries with all three predicates present on the happy path", async () => {
+    privateUserFindOneBy.mockResolvedValue(null);
+
+    await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "real-user@example.com",
+        password: { _type: "HashedString", value: "correct-password" },
+      },
+    });
+
+    expect(privateUserFindOneBy).toHaveBeenCalledTimes(1);
+
+    const query: Record<string, any> = (
+      privateUserFindOneBy.mock.calls[0]![0] as Record<string, any>
+    )["query"] as Record<string, any>;
+
+    // None of the three may be undefined -- an undefined one is silently dropped by TypeORM.
+    expect(query["email"]).toBeDefined();
+    expect(query["password"]).toBeDefined();
+    expect(query["statusPageId"]).toBeDefined();
+
+    expect(query["email"].toString()).toBe("real-user@example.com");
+    expect(query["statusPageId"].toString()).toBe(PUBLIC_STATUS_PAGE_ID);
+
+    // The password predicate must be the hash, never the plaintext the caller sent.
+    expect(query["password"].toString()).not.toBe("correct-password");
+    expect(query["password"].toString().length).toBeGreaterThan(0);
+  });
+
+  /*
+   * Positive control. Every other case in this block asserts a session was NOT issued; without
+   * this one, a typo in the mocked cookie/session names would make those assertions pass
+   * vacuously. This proves the same probes do fire when a login genuinely succeeds.
+   */
+  it("issues a session when the credentials match a real user", async () => {
+    privateUserFindOneBy.mockResolvedValue({
+      id: new ObjectID("private-user-id"),
+      _id: "private-user-id",
+      email: "real-user@example.com",
+      statusPageId: new ObjectID(PUBLIC_STATUS_PAGE_ID),
+      projectId: new ObjectID("project-id"),
+    });
+    privateUserFindOneById.mockResolvedValue(null);
+
+    await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "real-user@example.com",
+        password: { _type: "HashedString", value: "correct-password" },
+      },
+    });
+
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(setStatusPagePrivateUserCookie).toHaveBeenCalledTimes(1);
+    expect(sendEntityResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues no session when credentials are present but wrong", async () => {
+    privateUserFindOneBy.mockResolvedValue(null);
+
+    await invoke("/login", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "real-user@example.com",
+        password: { _type: "HashedString", value: "wrong-password" },
+      },
+    });
+
+    expect(privateUserFindOneBy).toHaveBeenCalledTimes(1);
+    expect(createSession).not.toHaveBeenCalled();
+    expect(setStatusPagePrivateUserCookie).not.toHaveBeenCalled();
+  });
+});
+
+describe("Status page /forgot-password - email must survive deserialization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    statusPageFindOneById.mockResolvedValue({
+      id: new ObjectID(PUBLIC_STATUS_PAGE_ID),
+      requireSsoForLogin: false,
+      projectId: new ObjectID("project-id"),
+    });
+  });
+
+  it("rejects a payload with only the public statusPageId", async () => {
+    const result: InvokeResult = await invoke("/forgot-password", {
+      data: { statusPageId: PUBLIC_STATUS_PAGE_ID },
+    });
+
+    expect(privateUserFindOneBy).not.toHaveBeenCalled();
+    expect(privateUserUpdateOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("rejects an empty-string email", async () => {
+    const result: InvokeResult = await invoke("/forgot-password", {
+      data: { statusPageId: PUBLIC_STATUS_PAGE_ID, email: "" },
+    });
+
+    expect(privateUserFindOneBy).not.toHaveBeenCalled();
+    expect(privateUserUpdateOneBy).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+  });
+
+  it("queries by both email and statusPageId on the happy path", async () => {
+    privateUserFindOneBy.mockResolvedValue(null);
+
+    await invoke("/forgot-password", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        email: "subscriber@example.com",
+      },
+    });
+
+    expect(privateUserFindOneBy).toHaveBeenCalledTimes(1);
+
+    const query: Record<string, any> = (
+      privateUserFindOneBy.mock.calls[0]![0] as Record<string, any>
+    )["query"] as Record<string, any>;
+
+    expect(query["email"].toString()).toBe("subscriber@example.com");
+    expect(query["statusPageId"].toString()).toBe(PUBLIC_STATUS_PAGE_ID);
+  });
+});
+
+describe("Status page /reset-password - token and password must be present", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    statusPageFindOneById.mockResolvedValue({
+      id: new ObjectID(PUBLIC_STATUS_PAGE_ID),
+      requireSsoForLogin: false,
+      projectId: new ObjectID("project-id"),
+    });
+  });
+
+  it("rejects a payload with only the public statusPageId", async () => {
+    const result: InvokeResult = await invoke("/reset-password", {
+      data: { statusPageId: PUBLIC_STATUS_PAGE_ID },
+    });
+
+    expect(privateUserFindOneBy).not.toHaveBeenCalled();
+    expect(privateUserUpdateOneById).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Reset password token is required.",
+    );
+  });
+
+  it("rejects a token with no accompanying password", async () => {
+    const result: InvokeResult = await invoke("/reset-password", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        resetPasswordToken: "some-token",
+      },
+    });
+
+    expect(privateUserFindOneBy).not.toHaveBeenCalled();
+    expect(privateUserUpdateOneById).not.toHaveBeenCalled();
+    expect(result.nextError).toBeInstanceOf(BadDataException);
+    expect((result.nextError as unknown as Exception).message).toBe(
+      "Password is required.",
+    );
+  });
+
+  it("queries by the hashed token scoped to the status page on the happy path", async () => {
+    privateUserFindOneBy.mockResolvedValue(null);
+
+    await invoke("/reset-password", {
+      data: {
+        statusPageId: PUBLIC_STATUS_PAGE_ID,
+        resetPasswordToken: "a-real-token",
+        password: { _type: "HashedString", value: "new-password" },
+      },
+    });
+
+    expect(privateUserFindOneBy).toHaveBeenCalledTimes(1);
+
+    const query: Record<string, any> = (
+      privateUserFindOneBy.mock.calls[0]![0] as Record<string, any>
+    )["query"] as Record<string, any>;
+
+    expect(query["statusPageId"].toString()).toBe(PUBLIC_STATUS_PAGE_ID);
+    expect(typeof query["resetPasswordToken"]).toBe("string");
+    expect(query["resetPasswordToken"]).not.toBe("a-real-token");
+    expect(query["resetPasswordToken"].length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two confirmed unauthenticated auth bypasses in the identity endpoints, plus two more instances of the same bug class found while auditing the rest of `App/FeatureSet/Identity/API/`.

Found while investigating an unrelated workflow-variable bug and deliberately kept out of that PR.

## Root mechanism

All four share one chain, verified end to end against the source:

1. **`BaseModel.fromJSON(undefined, T)` does not throw.** `DatabaseBaseModel.ts:739` → `_fromJSON` at `:679` → `JSONFunctions.deserialize(undefined)` (`Common/Types/JSONFunctions.ts:409`) returns `{}`, because `for...in` over `undefined` is a spec no-op. Result: a bare model with every field `undefined`.
2. **Nothing strips or rejects undefined query values.** `QueryUtil.serializeQuery` (`Common/Server/Types/Database/QueryUtil.ts:39`) has no undefined handling — every branch is guarded by `query[key] && ...` with no catch-all else.
3. **TypeORM 0.3.30 silently drops an undefined WHERE predicate.** `SelectQueryBuilder.js:2496` defaults `invalidWhereValuesBehavior.undefined` to `"ignore"` and `continue`s past the predicate. `DataSourceOptions.ts` never sets it. (The `OrmUtils.normalizeWhereCriteria` guard is wired into update/delete/softDelete/restore, **not** into `find`.)
4. **`_findBy` defaults to `createdAt: Descending` with limit 1.**

Net effect: `findOneBy({ token: undefined })` stops meaning *"the row with this token"* and starts meaning *"the newest row in the table."*

## The bypasses

### A. Email verification bypass — `POST /api/identity/verify-email`

`Authentication.ts:459` reads `req.body["data"]`, then `:468` queries `{ token: token.token! }`. An empty body drops the predicate, matching the newest `EmailVerificationToken` in the **whole instance**; `:497` then looks up the user by that token's email and `:523` sets `isEmailVerified: true`.

No session is issued, so this is verification bypass rather than takeover: sign up with an address you don't control, immediately POST `{}`, and your own (newest) token verifies the account without the email ever arriving.

### B. Status page private user login bypass — `POST /login` (more severe)

`StatusPageAuthentication.ts:767`. An empty body was caught by the existing `if (!user.statusPageId)` guard, so the endpoint looked defended. It wasn't — **statusPageId is not a secret**; it's public in status page URLs. A body of `{"data": {"statusPageId": "<any valid status page id>"}}` passed that guard, and then:

- `await user.password?.hashValue(...)` is a silent no-op on `undefined`
- the query became `{ email: undefined, password: undefined, statusPageId: <id> }`

Both credential predicates were dropped, leaving `WHERE statusPageId = <id>` sorted newest-first — so it matched the most recently created private user of that status page, and `finalizeStatusPageLogin` issued a **real session and access-token cookie**. Only `requireSsoForLogin` mitigated it, and only where enabled.

### Found in the audit

**`/signup`** — queried `{ email: partialUser.email }` with no guard. With the predicate dropped, `alreadySavedUser` resolved to the newest user in the instance. If that user had no password yet (invited to a team but not signed up), the handler took the update branch and called `finalizeUserLogin` — a real session for an account the caller never authenticated as.

**`/forgot-password`** — queried `{ email: user.email }` and wrote a fresh `resetPasswordToken` onto whichever account matched, invalidating any legitimate token in flight. The mail goes to the attacker-supplied `user.email`, so this is account disruption rather than takeover, but the account picked still isn't the caller's to touch.

## The fix

A shared `CredentialGuard` rejects absent identifiers **before** the query runs, following the approach the reset-password handler already used (`Authentication.ts:576`, `(user.resetPasswordToken as string) || ""`).

| Route | Guarded |
|---|---|
| `/verify-email` | `token` |
| status page `/login` | `email`, `password` |
| `/signup` | `email` |
| `/forgot-password` | `email` |
| `/reset-password` | `resetPasswordToken`, `password` |
| status page `/forgot-password` | `email` (post-deserialization) |
| status page `/reset-password` | `resetPasswordToken`, `password` |

The last three are hardening: the `|| ""` idiom already stopped the token predicate from being dropped, but an absent password would have been written to the matched account. The status page forgot-password guard re-checks the *deserialized* value, since the existing check reads the raw body.

The guard also rejects empty and whitespace-only values, and typed-but-empty domain objects — notably `new HashedString("")`, whose `hashValue()` short-circuits and returns `""` **without hashing**, so an empty password would otherwise reach the query as a literal empty string.

## Audit scope

Every route in `App/FeatureSet/Identity/API/` was checked. The rest don't share the pattern:

- `Reseller.ts` already guards `username` and `password`
- SSO/OIDC/SCIM take their identifiers from `req.params` (always strings, and guarded) or from `SSOUtil.getEmail`, which either throws or returns a valid `Email` — so the predicate can never be `undefined`

## Not included, deliberately

Setting `invalidWhereValuesBehavior: { undefined: "throw", null: "throw" }` in `DataSourceOptions.ts` would convert this entire bug class into a loud error, and TypeORM 0.3.30 supports it. It's the right long-term fix, but it will surface latent breakage anywhere the codebase relies on undefined-drop semantics, so it belongs in its own change behind a full test run rather than bundled into a security fix.

## Tests

57 new tests across three suites.

The route tests deliberately **do not** mock `BaseModel`, `JSONFunctions` or `CredentialGuard` — the real deserialization path has to run, otherwise they prove nothing about the real bug. The load-bearing assertion in every attack case is that **the service was never called**: an error response alone wouldn't prove the dangerous query was skipped. The status page suite also asserts no session was created and no cookie set, with a positive-control test proving those probes do fire on a genuine login (so the negative assertions can't pass vacuously).

Coverage per route: empty body, `data: undefined`, `data: {}`, body carrying only a non-secret field, explicit `null`, empty string, typed-but-empty `HashedString`, and the valid happy path.

**Verified to actually catch the bug:** reverting the two API files turns **24 of these tests red**, while every happy-path test stays green.

```
Test Suites: 3 passed, 3 total
Tests:       57 passed, 57 total
```

Full App suite: **1634 passed, 0 failed.** Three suites (`RunWorkflow`, `QueueWorkflow`, `ProcessTelemetryBodyLifecycle`) fail to *load* on this machine with a pre-existing `isolated-vm` native ABI mismatch (`dlopen ... symbol not found in flat namespace`) — unrelated to this change and untouched by it.

`npx tsc --noEmit` and `eslint` are clean on all changed files.
