### PR TITLE
fix(ui): repair the master compile broken by three parallel merges

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Pages/Health/BackgroundQueues.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Health/BackgroundQueues.tsx
@@ -11,7 +11,7 @@ import {
   ButtonStyleType,
 } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
-import Icon, { IconType, SizeProp } from "Common/UI/Components/Icon/Icon";
+import Icon, { SizeProp } from "Common/UI/Components/Icon/Icon";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import Statusbubble from "Common/UI/Components/StatusBubble/StatusBubble";
 import API from "Common/UI/Utils/API/API";
@@ -416,8 +416,6 @@ const QueueFailedJobsModal: FunctionComponent<FailedJobsModalProps> = (
     <Modal
       title={`Failed jobs · ${props.queueName} queue`}
       description="The most recent jobs this queue's workers failed to process, with full detail. Use the failure reason, stack trace, job body and logs to diagnose what is wedging the worker."
-      icon={IconProp.Error}
-      iconType={IconType.Danger}
       modalWidth={ModalWidth.Large}
       isBodyLoading={isLoading}
       submitButtonText="Refresh"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTableComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTableComponent.tsx
@@ -501,6 +501,7 @@ const DashboardTableComponentElement: FunctionComponent<ComponentProps> = (
     type TimestampRow = {
       timestampIso: string;
       timestampLabel: string;
+      timestampTitle: string;
       valuesByColumnKey: Map<string, number>;
     };
     const rows: Array<TimestampRow> = [];
@@ -832,6 +833,7 @@ const DashboardTableComponentElement: FunctionComponent<ComponentProps> = (
                   row: {
                     timestampIso: string;
                     timestampLabel: string;
+                    timestampTitle: string;
                     valuesByColumnKey: Map<string, number>;
                   },
                   index: number,

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/ImportSitesFromCsvModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/ImportSitesFromCsvModal.tsx
@@ -20,7 +20,6 @@ import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import { PromiseVoidFunction, VoidFunction } from "Common/Types/FunctionTypes";
-import IconProp from "Common/Types/Icon/IconProp";
 import ObjectID from "Common/Types/ObjectID";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
@@ -350,7 +349,6 @@ const ImportSitesFromCsvModal: FunctionComponent<ComponentProps> = (
     <Modal
       title="Import Sites from CSV"
       description="Bulk-create your site hierarchy from a CSV file."
-      icon={IconProp.Upload}
       modalWidth={ModalWidth.Large}
       isBodyLoading={isLoadingSiteTypes}
       error={siteTypesError || undefined}

--- a/App/FeatureSet/Dashboard/src/Pages/Runbook/Agents.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Runbook/Agents.tsx
@@ -2,10 +2,8 @@ import RunbookAgentInstallInstructions from "../../Components/RunbookAgent/Insta
 import PageComponentProps from "../PageComponentProps";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { ErrorFunction, VoidFunction } from "Common/Types/FunctionTypes";
-import IconProp from "Common/Types/Icon/IconProp";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
-import { IconType } from "Common/UI/Components/Icon/Icon";
 import LabelsElement from "Common/UI/Components/Label/Labels";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
@@ -206,8 +204,6 @@ const RunbookAgentsPage: FunctionComponent<
       {showSetupAgent ? (
         <Modal
           title="Runbook Agent setup"
-          icon={IconProp.Terminal}
-          iconType={IconType.Info}
           modalWidth={ModalWidth.Medium}
           submitButtonText="Done"
           submitButtonStyleType={ButtonStyleType.PRIMARY}


### PR DESCRIPTION
## Why

The **Compile** workflow has been failing on master since 84b6d5e — `compile-dashboard`, `compile-admin-dashboard` and `compile-public-dashboard` are all red.

No individual PR was wrong. Three of them were written against a base that had already moved, and `tsc` only sees the combination.

## What was broken

**1. `Modal` no longer takes `icon`/`iconType`.** `abb09c1c5e` removed those props and swept every caller visible at the time. Three callers on parallel branches weren't in that sweep:

- `ImportSitesFromCsvModal` (`icon`)
- `Pages/Runbook/Agents` (`icon`, `iconType`)
- AdminDashboard `Pages/Health/BackgroundQueues` (`icon`, `iconType`)

```
error TS2322: Property 'icon' does not exist on type 'IntrinsicAttributes & ComponentProps'.
```

**2. `DashboardTableComponent` — `timestampTitle` declared nowhere.** One branch added the `timestampTitle` field to the timestamp rows; another introduced the local `TimestampRow` type and the inline row type on the render callback. The field was written and read but present in neither declaration:

```
error TS2322: Property 'timestampTitle' is missing in type 'TimestampRow'...
error TS2353: Object literal may only specify known properties, and 'timestampTitle' does not exist...
error TS2339: Property 'timestampTitle' does not exist on type '{ timestampIso: string; ... }'.
```

## The fix

Drop the three `icon`/`iconType` prop pairs plus the imports they left unused, and add `timestampTitle: string` to both type declarations. The icons were decorative, so nothing changes for those modals beyond their headers matching every other modal in the product. No behavior changes anywhere — this is the type layer catching up with the merges.

## Verification

- `tsc --noEmit` clean on **Dashboard**, **AdminDashboard** and **PublicDashboard** — the three projects that were failing. Reproduced the exact CI errors locally first, then confirmed they're gone.
- `eslint` clean on all four changed files.

`dep-check` couldn't run locally (it needs a global `npm install -g depcheck`), but it only inspects `package.json` dependencies and no dependency changed.

## Also checked

One **Push Test Images** run also shows failure, but it's a transient Alpine mirror error (`TLS: unspecified error` fetching `APKINDEX.tar.gz`), not a code problem — the next run of that workflow passed. Compile was the only real failure on master.