### PR TITLE
fix: let projects with cross-project incident references be deleted

### DIFF
--- a/Common/Models/DatabaseModels/AlertEpisodeStateTimeline.ts
+++ b/Common/Models/DatabaseModels/AlertEpisodeStateTimeline.ts
@@ -401,6 +401,7 @@ export default class AlertEpisodeStateTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Models/DatabaseModels/AlertStateTimeline.ts
+++ b/Common/Models/DatabaseModels/AlertStateTimeline.ts
@@ -414,6 +414,7 @@ export default class AlertStateTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Models/DatabaseModels/IncidentEpisodeStateTimeline.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisodeStateTimeline.ts
@@ -403,6 +403,7 @@ export default class IncidentEpisodeStateTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Models/DatabaseModels/IncidentStateTimeline.ts
+++ b/Common/Models/DatabaseModels/IncidentStateTimeline.ts
@@ -417,6 +417,7 @@ export default class IncidentStateTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline.ts
@@ -414,6 +414,7 @@ export default class ScheduledMaintenanceStateTimeline extends BaseModel {
     {
       eager: false,
       nullable: true,
+      onDelete: "CASCADE",
       orphanedRowAction: "nullify",
     },
   )

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785320000000-RepairCrossProjectIncidentReferences.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785320000000-RepairCrossProjectIncidentReferences.ts
@@ -1,0 +1,444 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Deleting a project fails with "This item cannot be deleted because Incident
+ * records still reference it."
+ *
+ * An Incident stores the id of its state, its severity and the monitor status
+ * it switches monitors to. Nothing validated that those ids belong to the
+ * incident's own project — they arrive from an API call, an incident template
+ * or a monitor criteria — so an id from a *second* project could be persisted.
+ *
+ * Deleting a Project cascades into its IncidentState / IncidentSeverity /
+ * MonitorStatus rows, but the Incident row owned by the other project still
+ * points at them and those FKs are ON DELETE NO ACTION, so Postgres raises
+ * 23503 and the delete is refused. Same-project references are fine: they are
+ * removed by the same cascading statement, so the NO ACTION check passes.
+ *
+ * RepairCrossProjectMonitorStatusReferences1785240000000 fixed this shape for
+ * MonitorStatusTimeline. This migration finishes the job for every remaining
+ * ON DELETE NO ACTION reference that a project delete can trip over — the
+ * incident, alert and scheduled maintenance families, including their episodes
+ * and templates.
+ *
+ * It does two things:
+ *   1. repoints every cross-project reference at the equivalent record in the
+ *      row's own project (matched by name, then by the state's role flags,
+ *      then by nearest order/priority). Where the column is nullable and
+ *      nothing could be matched, the reference is cleared instead.
+ *   2. switches the five state-timeline FKs to ON DELETE CASCADE, which is
+ *      what they should always have been — a state timeline row is
+ *      meaningless once its state is gone.
+ *
+ * Step 1 runs before step 2 on purpose: repairing first means the timeline
+ * history stays attached to the surviving project instead of being swept up by
+ * the new cascade.
+ *
+ * Not covered on purpose:
+ *   - Monitor.currentMonitorStatusId keeps NO ACTION (deleting a status that
+ *     monitors are currently in should stay blocked) and its cross-project
+ *     rows were already repaired by the 1785240000000 migration.
+ *   - A row whose own project has no record of that kind at all cannot be
+ *     repointed and, for the not-null columns, is left as is. That needs a
+ *     project with zero incident states / severities, which project creation
+ *     does not produce.
+ */
+
+export interface CrossProjectReference {
+  // The table holding the reference, e.g. "Incident".
+  table: string;
+  // The referencing column, e.g. "currentIncidentStateId".
+  column: string;
+  // The project-scoped table it points at, e.g. "IncidentState".
+  referencedTable: string;
+  /*
+   * Column ordering the referenced table within a project — "order" for states
+   * and severities, "priority" for monitor statuses. Used for the last-resort
+   * "nearest equivalent" match.
+   */
+  orderColumn: string;
+  /*
+   * Boolean role columns that identify the same record across projects when
+   * the names differ (a renamed "Created" state is still the created state).
+   * Severities have none.
+   */
+  roleColumns: Array<string>;
+  /*
+   * Nullable columns get their leftover cross-project references cleared when
+   * no equivalent exists in the row's own project. Not-null columns cannot.
+   */
+  isNullable: boolean;
+}
+
+const INCIDENT_STATE_ROLES: Array<string> = [
+  "isCreatedState",
+  "isAcknowledgedState",
+  "isResolvedState",
+];
+
+const ALERT_STATE_ROLES: Array<string> = [
+  "isCreatedState",
+  "isAcknowledgedState",
+  "isResolvedState",
+];
+
+const SCHEDULED_MAINTENANCE_STATE_ROLES: Array<string> = [
+  "isScheduledState",
+  "isOngoingState",
+  "isEndedState",
+  "isResolvedState",
+];
+
+const MONITOR_STATUS_ROLES: Array<string> = [
+  "isOperationalState",
+  "isOfflineState",
+];
+
+/*
+ * Every ON DELETE NO ACTION reference to a project-scoped state / severity /
+ * status that a project delete can trip over, as of this migration.
+ */
+export const CROSS_PROJECT_REFERENCES: Array<CrossProjectReference> = [
+  {
+    table: "Incident",
+    column: "currentIncidentStateId",
+    referencedTable: "IncidentState",
+    orderColumn: "order",
+    roleColumns: INCIDENT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "Incident",
+    column: "incidentSeverityId",
+    referencedTable: "IncidentSeverity",
+    orderColumn: "order",
+    roleColumns: [],
+    isNullable: false,
+  },
+  {
+    table: "Incident",
+    column: "changeMonitorStatusToId",
+    referencedTable: "MonitorStatus",
+    orderColumn: "priority",
+    roleColumns: MONITOR_STATUS_ROLES,
+    isNullable: true,
+  },
+  {
+    table: "IncidentEpisode",
+    column: "currentIncidentStateId",
+    referencedTable: "IncidentState",
+    orderColumn: "order",
+    roleColumns: INCIDENT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "IncidentEpisode",
+    column: "incidentSeverityId",
+    referencedTable: "IncidentSeverity",
+    orderColumn: "order",
+    roleColumns: [],
+    isNullable: true,
+  },
+  {
+    table: "IncidentStateTimeline",
+    column: "incidentStateId",
+    referencedTable: "IncidentState",
+    orderColumn: "order",
+    roleColumns: INCIDENT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "IncidentEpisodeStateTimeline",
+    column: "incidentStateId",
+    referencedTable: "IncidentState",
+    orderColumn: "order",
+    roleColumns: INCIDENT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "IncidentTemplate",
+    column: "initialIncidentStateId",
+    referencedTable: "IncidentState",
+    orderColumn: "order",
+    roleColumns: INCIDENT_STATE_ROLES,
+    isNullable: true,
+  },
+  {
+    table: "IncidentTemplate",
+    column: "incidentSeverityId",
+    referencedTable: "IncidentSeverity",
+    orderColumn: "order",
+    roleColumns: [],
+    isNullable: true,
+  },
+  {
+    table: "IncidentTemplate",
+    column: "changeMonitorStatusToId",
+    referencedTable: "MonitorStatus",
+    orderColumn: "priority",
+    roleColumns: MONITOR_STATUS_ROLES,
+    isNullable: true,
+  },
+  {
+    table: "Alert",
+    column: "currentAlertStateId",
+    referencedTable: "AlertState",
+    orderColumn: "order",
+    roleColumns: ALERT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "Alert",
+    column: "alertSeverityId",
+    referencedTable: "AlertSeverity",
+    orderColumn: "order",
+    roleColumns: [],
+    isNullable: false,
+  },
+  {
+    table: "Alert",
+    column: "monitorStatusWhenThisAlertWasCreatedId",
+    referencedTable: "MonitorStatus",
+    orderColumn: "priority",
+    roleColumns: MONITOR_STATUS_ROLES,
+    isNullable: true,
+  },
+  {
+    table: "AlertEpisode",
+    column: "currentAlertStateId",
+    referencedTable: "AlertState",
+    orderColumn: "order",
+    roleColumns: ALERT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "AlertEpisode",
+    column: "alertSeverityId",
+    referencedTable: "AlertSeverity",
+    orderColumn: "order",
+    roleColumns: [],
+    isNullable: true,
+  },
+  {
+    table: "AlertStateTimeline",
+    column: "alertStateId",
+    referencedTable: "AlertState",
+    orderColumn: "order",
+    roleColumns: ALERT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "AlertEpisodeStateTimeline",
+    column: "alertStateId",
+    referencedTable: "AlertState",
+    orderColumn: "order",
+    roleColumns: ALERT_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "ScheduledMaintenance",
+    column: "currentScheduledMaintenanceStateId",
+    referencedTable: "ScheduledMaintenanceState",
+    orderColumn: "order",
+    roleColumns: SCHEDULED_MAINTENANCE_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "ScheduledMaintenance",
+    column: "changeMonitorStatusToId",
+    referencedTable: "MonitorStatus",
+    orderColumn: "priority",
+    roleColumns: MONITOR_STATUS_ROLES,
+    isNullable: true,
+  },
+  {
+    table: "ScheduledMaintenanceStateTimeline",
+    column: "scheduledMaintenanceStateId",
+    referencedTable: "ScheduledMaintenanceState",
+    orderColumn: "order",
+    roleColumns: SCHEDULED_MAINTENANCE_STATE_ROLES,
+    isNullable: false,
+  },
+  {
+    table: "ScheduledMaintenanceTemplate",
+    column: "changeMonitorStatusToId",
+    referencedTable: "MonitorStatus",
+    orderColumn: "priority",
+    roleColumns: MONITOR_STATUS_ROLES,
+    isNullable: true,
+  },
+];
+
+interface TimelineForeignKey {
+  table: string;
+  column: string;
+  referencedTable: string;
+  constraintName: string;
+}
+
+/*
+ * A state timeline row records "this incident/alert/event was in this state at
+ * this time". Once the state is deleted the row cannot be read back, so it
+ * should go with it rather than block the delete. This mirrors what
+ * 1785240000000 did for MonitorStatusTimeline.
+ */
+export const TIMELINE_FOREIGN_KEYS: Array<TimelineForeignKey> = [
+  {
+    table: "IncidentStateTimeline",
+    column: "incidentStateId",
+    referencedTable: "IncidentState",
+    constraintName: "FK_ff0fca6570d47798771763533a9",
+  },
+  {
+    table: "IncidentEpisodeStateTimeline",
+    column: "incidentStateId",
+    referencedTable: "IncidentState",
+    constraintName: "FK_186ef9a3c668841b1286cbb18fc",
+  },
+  {
+    table: "AlertStateTimeline",
+    column: "alertStateId",
+    referencedTable: "AlertState",
+    constraintName: "FK_dbf0191a98672bcb73f65febac5",
+  },
+  {
+    table: "AlertEpisodeStateTimeline",
+    column: "alertStateId",
+    referencedTable: "AlertState",
+    constraintName: "FK_c787c0bc5a12b94976f28d0a12c",
+  },
+  {
+    table: "ScheduledMaintenanceStateTimeline",
+    column: "scheduledMaintenanceStateId",
+    referencedTable: "ScheduledMaintenanceState",
+    constraintName: "FK_7c0f750d3a964180d1e1efa16ea",
+  },
+];
+
+/*
+ * Repoints rows whose reference belongs to another project at the equivalent
+ * record in their own project. Match order is name, then role flags, then
+ * nearest order/priority — the same ladder the 1785240000000 migration used.
+ */
+export function getRepairQuery(reference: CrossProjectReference): string {
+  const roleSelect: string = reference.roleColumns
+    .map((roleColumn: string) => {
+      return `,\n               p."${roleColumn}" AS role_${roleColumn}`;
+    })
+    .join("");
+
+  const roleMatch: string =
+    reference.roleColumns.length > 0
+      ? `
+          (SELECT x."_id" FROM "${reference.referencedTable}" x
+            WHERE x."projectId" = b.project_id
+              AND ${reference.roleColumns
+                .map((roleColumn: string) => {
+                  return `x."${roleColumn}" = b.role_${roleColumn}`;
+                })
+                .join("\n              AND ")}
+            ORDER BY x."${reference.orderColumn}" LIMIT 1),`
+      : "";
+
+  return `
+      WITH bad AS (
+        SELECT c."_id" AS row_id,
+               c."projectId" AS project_id,
+               p."name" AS ref_name,
+               p."${reference.orderColumn}" AS ref_order${roleSelect}
+        FROM "${reference.table}" c
+        JOIN "${reference.referencedTable}" p ON p."_id" = c."${reference.column}"
+        WHERE c."projectId" IS DISTINCT FROM p."projectId"
+      ), resolved AS (
+        SELECT b.row_id, COALESCE(
+          (SELECT x."_id" FROM "${reference.referencedTable}" x
+            WHERE x."projectId" = b.project_id AND lower(x."name") = lower(b.ref_name)
+            ORDER BY x."${reference.orderColumn}" LIMIT 1),${roleMatch}
+          (SELECT x."_id" FROM "${reference.referencedTable}" x
+            WHERE x."projectId" = b.project_id
+            ORDER BY abs(x."${reference.orderColumn}" - b.ref_order), x."${reference.orderColumn}" LIMIT 1)
+        ) AS good_id
+        FROM bad b
+      )
+      UPDATE "${reference.table}" c
+      SET "${reference.column}" = r.good_id
+      FROM resolved r
+      WHERE c."_id" = r.row_id AND r.good_id IS NOT NULL
+    `;
+}
+
+/*
+ * Clears whatever the repair above could not repoint. Only runs for nullable
+ * columns; leaving a dangling cross-project id there would keep the referenced
+ * project undeletable for no benefit — the reference cannot be read by the
+ * project that owns the row anyway.
+ */
+export function getClearQuery(reference: CrossProjectReference): string {
+  return `
+      UPDATE "${reference.table}" c
+      SET "${reference.column}" = NULL
+      FROM "${reference.referencedTable}" p
+      WHERE p."_id" = c."${reference.column}"
+        AND c."projectId" IS DISTINCT FROM p."projectId"
+    `;
+}
+
+export class RepairCrossProjectIncidentReferences1785320000000
+  implements MigrationInterface
+{
+  public name: string = "RepairCrossProjectIncidentReferences1785320000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    /*
+     * The repairs below scan the incident/alert/timeline tables, which run to
+     * millions of rows. The connection carries the app's 30s statement_timeout
+     * (DATABASE_STATEMENT_TIMEOUT_MS) and a loaded database should not turn
+     * this into a failed deploy.
+     */
+    await queryRunner.query(`SET LOCAL statement_timeout = '600s'`);
+
+    for (const reference of CROSS_PROJECT_REFERENCES) {
+      await queryRunner.query(getRepairQuery(reference));
+
+      if (reference.isNullable) {
+        await queryRunner.query(getClearQuery(reference));
+      }
+    }
+
+    /*
+     * Swapping a foreign key needs ACCESS EXCLUSIVE on the timeline table, and
+     * the lock is held until this migration commits. The server has no
+     * lock_timeout, so without the line below a single slow transaction
+     * holding one of these tables would make the statement queue *and* park
+     * every reader and writer behind it until the 30s statement_timeout fired.
+     * Failing fast and retrying the deploy is much cheaper than stalling the
+     * table.
+     */
+    await queryRunner.query(`SET LOCAL lock_timeout = '5s'`);
+
+    for (const foreignKey of TIMELINE_FOREIGN_KEYS) {
+      await queryRunner.query(
+        `ALTER TABLE "${foreignKey.table}" DROP CONSTRAINT "${foreignKey.constraintName}"`,
+      );
+      await queryRunner.query(
+        `ALTER TABLE "${foreignKey.table}" ADD CONSTRAINT "${foreignKey.constraintName}" FOREIGN KEY ("${foreignKey.column}") REFERENCES "${foreignKey.referencedTable}"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+      );
+    }
+  }
+
+  /*
+   * Only the constraints are reversible. The repaired references are not: the
+   * previous values pointed at another project's records and there is nothing
+   * worth restoring them to.
+   */
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    for (const foreignKey of TIMELINE_FOREIGN_KEYS) {
+      await queryRunner.query(
+        `ALTER TABLE "${foreignKey.table}" DROP CONSTRAINT "${foreignKey.constraintName}"`,
+      );
+      await queryRunner.query(
+        `ALTER TABLE "${foreignKey.table}" ADD CONSTRAINT "${foreignKey.constraintName}" FOREIGN KEY ("${foreignKey.column}") REFERENCES "${foreignKey.referencedTable}"("_id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      );
+    }
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -474,6 +474,7 @@ import { AddHotQueryIndexes1785140242697 } from "./1785140242697-AddHotQueryInde
 import { AddHotQueryIndexesSecondPass1785148065137 } from "./1785148065137-AddHotQueryIndexesSecondPass";
 import { RepairCrossProjectMonitorStatusReferences1785240000000 } from "./1785240000000-RepairCrossProjectMonitorStatusReferences";
 import { AddColumnsToTableView1785241000000 } from "./1785241000000-AddColumnsToTableView";
+import { RepairCrossProjectIncidentReferences1785320000000 } from "./1785320000000-RepairCrossProjectIncidentReferences";
 
 export default [
   InitialMigration,
@@ -952,4 +953,5 @@ export default [
   AddHotQueryIndexesSecondPass1785148065137,
   RepairCrossProjectMonitorStatusReferences1785240000000,
   AddColumnsToTableView1785241000000,
+  RepairCrossProjectIncidentReferences1785320000000,
 ];

--- a/Common/Server/Services/AlertService.ts
+++ b/Common/Server/Services/AlertService.ts
@@ -29,6 +29,9 @@ import Model from "../../Models/DatabaseModels/Alert";
 import AlertOwnerTeam from "../../Models/DatabaseModels/AlertOwnerTeam";
 import AlertOwnerUser from "../../Models/DatabaseModels/AlertOwnerUser";
 import AlertState from "../../Models/DatabaseModels/AlertState";
+import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusService from "./MonitorStatusService";
+import ProjectScopedReferenceValidator from "../Utils/Database/ProjectScopedReferenceValidator";
 import AlertStateTimeline from "../../Models/DatabaseModels/AlertStateTimeline";
 import User from "../../Models/DatabaseModels/User";
 import { IsBillingEnabled } from "../EnvironmentConfig";
@@ -258,7 +261,102 @@ export class Service extends DatabaseService<Model> {
       updateBy.query,
       updateBy.props,
     );
+
+    await this.validateProjectScopedReferences(updateBy);
+
     return { updateBy, carryForward: null };
+  }
+
+  /*
+   * An update can repoint an alert at another project's state, severity or
+   * monitor status just as easily as a create can, and the result is the same:
+   * the referenced project can no longer be deleted. Only the columns actually
+   * being written are checked, so ordinary updates cost no extra queries.
+   */
+  private async validateProjectScopedReferences(
+    updateBy: UpdateBy<Model>,
+  ): Promise<void> {
+    const alertStateId: ObjectID | string | undefined =
+      (updateBy.data.currentAlertStateId as unknown as ObjectID | undefined) ||
+      (updateBy.data.currentAlertState as unknown as AlertState | undefined)
+        ?._id;
+
+    const alertSeverityId: ObjectID | string | undefined =
+      (updateBy.data.alertSeverityId as unknown as ObjectID | undefined) ||
+      (updateBy.data.alertSeverity as unknown as AlertSeverity | undefined)
+        ?._id;
+
+    const monitorStatusId: ObjectID | string | undefined =
+      (updateBy.data.monitorStatusWhenThisAlertWasCreatedId as unknown as
+        | ObjectID
+        | undefined) ||
+      (
+        updateBy.data.monitorStatusWhenThisAlertWasCreated as unknown as
+          | MonitorStatus
+          | undefined
+      )?._id;
+
+    if (!alertStateId && !alertSeverityId && !monitorStatusId) {
+      return;
+    }
+
+    /*
+     * Root/API updates do not always carry a tenantId, so fall back to the
+     * project of each alert the query actually matches.
+     */
+    const projectIds: Array<ObjectID> = updateBy.props.tenantId
+      ? [updateBy.props.tenantId]
+      : await this.getProjectIdsForUpdateQuery(updateBy);
+
+    for (const projectId of projectIds) {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: projectId,
+        subject: "alert",
+        references: [
+          {
+            modelName: "Alert State",
+            id: alertStateId,
+            service: AlertStateService,
+          },
+          {
+            modelName: "Alert Severity",
+            id: alertSeverityId,
+            service: AlertSeverityService,
+          },
+          {
+            modelName: "Monitor Status",
+            id: monitorStatusId,
+            service: MonitorStatusService,
+          },
+        ],
+      });
+    }
+  }
+
+  private async getProjectIdsForUpdateQuery(
+    updateBy: UpdateBy<Model>,
+  ): Promise<Array<ObjectID>> {
+    const alerts: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      select: {
+        projectId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const projectIds: Dictionary<ObjectID> = {};
+
+    for (const alert of alerts) {
+      if (alert.projectId) {
+        projectIds[alert.projectId.toString()] = alert.projectId;
+      }
+    }
+
+    return Object.values(projectIds);
   }
 
   @CaptureSpan()
@@ -292,6 +390,38 @@ export class Service extends DatabaseService<Model> {
     }
 
     createBy.data.currentAlertStateId = alertState.id;
+
+    /*
+     * The severity and the monitor status stamped on the alert come from the
+     * monitor criteria or the API caller, neither of which checked that the
+     * record belongs to this project. Persisting another project's id leaves
+     * that project undeletable. Runs before the counter increment so a
+     * rejected create does not burn an alert number.
+     */
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: projectId,
+      subject: "alert",
+      references: [
+        {
+          modelName: "Alert Severity",
+          id:
+            createBy.data.alertSeverityId ||
+            (createBy.data.alertSeverity as AlertSeverity | undefined)?._id,
+          service: AlertSeverityService,
+        },
+        {
+          modelName: "Monitor Status",
+          id:
+            createBy.data.monitorStatusWhenThisAlertWasCreatedId ||
+            (
+              createBy.data.monitorStatusWhenThisAlertWasCreated as
+                | MonitorStatus
+                | undefined
+            )?._id,
+          service: MonitorStatusService,
+        },
+      ],
+    });
 
     const alertCounterResult: {
       counter: number;

--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -28,6 +28,7 @@ import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import Typeof from "../../Types/Typeof";
 import { applyIncidentSelfPrivacyFilter } from "../Utils/Incident/IncidentPrivacyFilter";
+import ProjectScopedReferenceValidator from "../Utils/Database/ProjectScopedReferenceValidator";
 import UserNotificationEventType from "../../Types/UserNotification/UserNotificationEventType";
 import StatusPageSubscriberNotificationStatus from "../../Types/StatusPage/StatusPageSubscriberNotificationStatus";
 import DockerHost from "../../Models/DatabaseModels/DockerHost";
@@ -442,6 +443,8 @@ export class Service extends DatabaseService<Model> {
       updateBy.data.isVisibleOnStatusPage = false;
     }
 
+    await this.validateProjectScopedReferences(updateBy);
+
     const carryForward: UpdateCarryForward = {};
 
     if (
@@ -550,6 +553,106 @@ export class Service extends DatabaseService<Model> {
       updateBy: updateBy,
       carryForward: carryForward,
     };
+  }
+
+  /*
+   * An update can repoint an incident at another project's state, severity or
+   * monitor status just as easily as a create can, and the result is the same:
+   * the referenced project can no longer be deleted. Only the columns actually
+   * being written are checked, so ordinary updates cost no extra queries.
+   */
+  private async validateProjectScopedReferences(
+    updateBy: UpdateBy<Model>,
+  ): Promise<void> {
+    const incidentStateId: ObjectID | string | undefined =
+      (updateBy.data.currentIncidentStateId as unknown as
+        | ObjectID
+        | undefined) ||
+      (
+        updateBy.data.currentIncidentState as unknown as
+          | IncidentState
+          | undefined
+      )?._id;
+
+    const incidentSeverityId: ObjectID | string | undefined =
+      (updateBy.data.incidentSeverityId as unknown as ObjectID | undefined) ||
+      (
+        updateBy.data.incidentSeverity as unknown as
+          | IncidentSeverity
+          | undefined
+      )?._id;
+
+    const changeMonitorStatusToId: ObjectID | string | undefined =
+      (updateBy.data.changeMonitorStatusToId as unknown as
+        | ObjectID
+        | undefined) ||
+      (
+        updateBy.data.changeMonitorStatusTo as unknown as
+          | MonitorStatus
+          | undefined
+      )?._id;
+
+    if (!incidentStateId && !incidentSeverityId && !changeMonitorStatusToId) {
+      return;
+    }
+
+    /*
+     * Root/API updates do not always carry a tenantId, so fall back to the
+     * project of each incident the query actually matches.
+     */
+    const projectIds: Array<ObjectID> = updateBy.props.tenantId
+      ? [updateBy.props.tenantId]
+      : await this.getProjectIdsForUpdateQuery(updateBy);
+
+    for (const projectId of projectIds) {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: projectId,
+        subject: "incident",
+        references: [
+          {
+            modelName: "Incident State",
+            id: incidentStateId,
+            service: IncidentStateService,
+          },
+          {
+            modelName: "Incident Severity",
+            id: incidentSeverityId,
+            service: IncidentSeverityService,
+          },
+          {
+            modelName: "Monitor Status",
+            id: changeMonitorStatusToId,
+            service: MonitorStatusService,
+          },
+        ],
+      });
+    }
+  }
+
+  private async getProjectIdsForUpdateQuery(
+    updateBy: UpdateBy<Model>,
+  ): Promise<Array<ObjectID>> {
+    const incidents: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      select: {
+        projectId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const projectIds: Dictionary<ObjectID> = {};
+
+    for (const incident of incidents) {
+      if (incident.projectId) {
+        projectIds[incident.projectId.toString()] = incident.projectId;
+      }
+    }
+
+    return Object.values(projectIds);
   }
 
   @CaptureSpan()
@@ -831,6 +934,42 @@ export class Service extends DatabaseService<Model> {
 
       initialIncidentStateId = incidentState.id;
     }
+
+    /*
+     * The severity and the monitor status to switch to can arrive from an API
+     * caller, an incident template or a monitor criteria, and none of those
+     * paths checked that the record belongs to this project. Persisting
+     * another project's id leaves that project undeletable, so reject it here.
+     * Runs before the counter increment so a rejected create does not burn an
+     * incident number.
+     */
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: projectId,
+      subject: "incident",
+      references: [
+        {
+          modelName: "Incident State",
+          id: initialIncidentStateId,
+          service: IncidentStateService,
+        },
+        {
+          modelName: "Incident Severity",
+          id:
+            createBy.data.incidentSeverityId ||
+            (createBy.data.incidentSeverity as IncidentSeverity | undefined)
+              ?._id,
+          service: IncidentSeverityService,
+        },
+        {
+          modelName: "Monitor Status",
+          id:
+            createBy.data.changeMonitorStatusToId ||
+            (createBy.data.changeMonitorStatusTo as MonitorStatus | undefined)
+              ?._id,
+          service: MonitorStatusService,
+        },
+      ],
+    });
 
     const incidentCounterResult: {
       counter: number;

--- a/Common/Server/Services/IncidentTemplateService.ts
+++ b/Common/Server/Services/IncidentTemplateService.ts
@@ -1,18 +1,142 @@
-import { OnCreate } from "../Types/Database/Hooks";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
 import DatabaseService from "./DatabaseService";
 import IncidentTemplateOwnerTeamService from "./IncidentTemplateOwnerTeamService";
 import IncidentTemplateOwnerUserService from "./IncidentTemplateOwnerUserService";
+import IncidentSeverityService from "./IncidentSeverityService";
+import IncidentStateService from "./IncidentStateService";
+import MonitorStatusService from "./MonitorStatusService";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
+import Dictionary from "../../Types/Dictionary";
 import ObjectID from "../../Types/ObjectID";
 import Typeof from "../../Types/Typeof";
 import Model from "../../Models/DatabaseModels/IncidentTemplate";
+import IncidentSeverity from "../../Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "../../Models/DatabaseModels/IncidentState";
 import IncidentTemplateOwnerTeam from "../../Models/DatabaseModels/IncidentTemplateOwnerTeam";
 import IncidentTemplateOwnerUser from "../../Models/DatabaseModels/IncidentTemplateOwnerUser";
+import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
+import ProjectScopedReferenceValidator, {
+  ProjectScopedReference,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * A template is copied onto every incident created from it, so an id
+   * belonging to another project here becomes a cross-project reference on
+   * each of those incidents — and the referenced project can then no longer be
+   * deleted. Reject it where it enters instead.
+   */
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    const projectId: ObjectID | undefined =
+      createBy.props.tenantId || createBy.data.projectId;
+
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: projectId,
+      subject: "incident template",
+      references: this.getProjectScopedReferences(createBy.data),
+    });
+
+    return { createBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    const references: Array<ProjectScopedReference> =
+      this.getProjectScopedReferences(updateBy.data);
+
+    if (
+      references.every((reference: ProjectScopedReference) => {
+        return !reference.id;
+      })
+    ) {
+      return { updateBy, carryForward: null };
+    }
+
+    /*
+     * Root/API updates do not always carry a tenantId, so fall back to the
+     * project of each template the query actually matches.
+     */
+    const projectIds: Array<ObjectID> = updateBy.props.tenantId
+      ? [updateBy.props.tenantId]
+      : await this.getProjectIdsForUpdateQuery(updateBy);
+
+    for (const projectId of projectIds) {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: projectId,
+        subject: "incident template",
+        references: references,
+      });
+    }
+
+    return { updateBy, carryForward: null };
+  }
+
+  private getProjectScopedReferences(
+    data: Model | QueryDeepPartialEntity<Model>,
+  ): Array<ProjectScopedReference> {
+    return [
+      {
+        modelName: "Incident State",
+        id:
+          (data.initialIncidentStateId as ObjectID | undefined) ||
+          (data.initialIncidentState as IncidentState | undefined)?._id,
+        service: IncidentStateService,
+      },
+      {
+        modelName: "Incident Severity",
+        id:
+          (data.incidentSeverityId as ObjectID | undefined) ||
+          (data.incidentSeverity as IncidentSeverity | undefined)?._id,
+        service: IncidentSeverityService,
+      },
+      {
+        modelName: "Monitor Status",
+        id:
+          (data.changeMonitorStatusToId as ObjectID | undefined) ||
+          (data.changeMonitorStatusTo as MonitorStatus | undefined)?._id,
+        service: MonitorStatusService,
+      },
+    ];
+  }
+
+  private async getProjectIdsForUpdateQuery(
+    updateBy: UpdateBy<Model>,
+  ): Promise<Array<ObjectID>> {
+    const templates: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      select: {
+        projectId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const projectIds: Dictionary<ObjectID> = {};
+
+    for (const template of templates) {
+      if (template.projectId) {
+        projectIds[template.projectId.toString()] = template.projectId;
+      }
+    }
+
+    return Object.values(projectIds);
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/ScheduledMaintenanceService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceService.ts
@@ -24,6 +24,9 @@ import Model from "../../Models/DatabaseModels/ScheduledMaintenance";
 import ScheduledMaintenanceOwnerTeam from "../../Models/DatabaseModels/ScheduledMaintenanceOwnerTeam";
 import ScheduledMaintenanceOwnerUser from "../../Models/DatabaseModels/ScheduledMaintenanceOwnerUser";
 import ScheduledMaintenanceState from "../../Models/DatabaseModels/ScheduledMaintenanceState";
+import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusService from "./MonitorStatusService";
+import ProjectScopedReferenceValidator from "../Utils/Database/ProjectScopedReferenceValidator";
 import ScheduledMaintenanceStateTimeline from "../../Models/DatabaseModels/ScheduledMaintenanceStateTimeline";
 import User from "../../Models/DatabaseModels/User";
 import Recurring from "../../Types/Events/Recurring";
@@ -599,10 +602,101 @@ ${resourcesAffected ? `**Resources Affected:** ${resourcesAffected}` : ""}
       }
     }
 
+    await this.validateProjectScopedReferences(updateBy);
+
     return {
       updateBy,
       carryForward: null,
     };
+  }
+
+  /*
+   * An update can repoint a scheduled maintenance event at another project's
+   * state or monitor status just as easily as a create can, and the result is
+   * the same: the referenced project can no longer be deleted. Only the
+   * columns actually being written are checked, so ordinary updates cost no
+   * extra queries.
+   */
+  private async validateProjectScopedReferences(
+    updateBy: UpdateBy<Model>,
+  ): Promise<void> {
+    const stateId: ObjectID | string | undefined =
+      (updateBy.data.currentScheduledMaintenanceStateId as unknown as
+        | ObjectID
+        | undefined) ||
+      (
+        updateBy.data.currentScheduledMaintenanceState as unknown as
+          | ScheduledMaintenanceState
+          | undefined
+      )?._id;
+
+    const monitorStatusId: ObjectID | string | undefined =
+      (updateBy.data.changeMonitorStatusToId as unknown as
+        | ObjectID
+        | undefined) ||
+      (
+        updateBy.data.changeMonitorStatusTo as unknown as
+          | MonitorStatus
+          | undefined
+      )?._id;
+
+    if (!stateId && !monitorStatusId) {
+      return;
+    }
+
+    /*
+     * Root/API updates do not always carry a tenantId, so fall back to the
+     * project of each event the query actually matches.
+     */
+    const projectIds: Array<ObjectID> = updateBy.props.tenantId
+      ? [updateBy.props.tenantId]
+      : await this.getProjectIdsForUpdateQuery(updateBy);
+
+    for (const projectId of projectIds) {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: projectId,
+        subject: "scheduled maintenance event",
+        references: [
+          {
+            modelName: "Scheduled Maintenance State",
+            id: stateId,
+            service: ScheduledMaintenanceStateService,
+          },
+          {
+            modelName: "Monitor Status",
+            id: monitorStatusId,
+            service: MonitorStatusService,
+          },
+        ],
+      });
+    }
+  }
+
+  private async getProjectIdsForUpdateQuery(
+    updateBy: UpdateBy<Model>,
+  ): Promise<Array<ObjectID>> {
+    const scheduledMaintenanceEvents: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      select: {
+        projectId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const projectIds: Dictionary<ObjectID> = {};
+
+    for (const scheduledMaintenance of scheduledMaintenanceEvents) {
+      if (scheduledMaintenance.projectId) {
+        projectIds[scheduledMaintenance.projectId.toString()] =
+          scheduledMaintenance.projectId;
+      }
+    }
+
+    return Object.values(projectIds);
   }
 
   @CaptureSpan()
@@ -757,6 +851,27 @@ ${resourcesAffected ? `**Resources Affected:** ${resourcesAffected}` : ""}
 
     createBy.data.currentScheduledMaintenanceStateId =
       scheduledMaintenanceState.id;
+
+    /*
+     * changeMonitorStatusToId comes straight from the API caller or a
+     * template, and nothing checked it belongs to this project. Persisting
+     * another project's id leaves that project undeletable. Runs before the
+     * counter increment so a rejected create does not burn an event number.
+     */
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: projectId,
+      subject: "scheduled maintenance event",
+      references: [
+        {
+          modelName: "Monitor Status",
+          id:
+            createBy.data.changeMonitorStatusToId ||
+            (createBy.data.changeMonitorStatusTo as MonitorStatus | undefined)
+              ?._id,
+          service: MonitorStatusService,
+        },
+      ],
+    });
 
     const scheduledMaintenanceCounterResult: {
       counter: number;

--- a/Common/Server/Services/ScheduledMaintenanceTemplateService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceTemplateService.ts
@@ -6,6 +6,12 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import ObjectID from "../../Types/ObjectID";
 import Typeof from "../../Types/Typeof";
 import Model from "../../Models/DatabaseModels/ScheduledMaintenanceTemplate";
+import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusService from "./MonitorStatusService";
+import Dictionary from "../../Types/Dictionary";
+import ProjectScopedReferenceValidator, {
+  ProjectScopedReference,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import ScheduledMaintenanceTemplateOwnerTeam from "../../Models/DatabaseModels/ScheduledMaintenanceTemplateOwnerTeam";
 import ScheduledMaintenanceTemplateOwnerUser from "../../Models/DatabaseModels/ScheduledMaintenanceTemplateOwnerUser";
 import CreateBy from "../Types/Database/CreateBy";
@@ -112,6 +118,12 @@ export class Service extends DatabaseService<Model> {
     createBy: CreateBy<Model>,
   ): Promise<OnCreate<Model>> {
     this.validateEventTemplate(createBy.data);
+
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: createBy.props.tenantId || createBy.data.projectId,
+      subject: "scheduled maintenance template",
+      references: this.getProjectScopedReferences(createBy.data),
+    });
 
     if (createBy.data.isRecurringEvent) {
       // if all is good then the next scheduled at time should be set.
@@ -253,10 +265,89 @@ export class Service extends DatabaseService<Model> {
 
     updateBy.data = newTemplate;
 
+    await this.validateProjectScopedReferences(updateBy);
+
     return {
       updateBy: updateBy,
       carryForward: false,
     };
+  }
+
+  /*
+   * A template is copied onto every event created from it, so an id belonging
+   * to another project here becomes a cross-project reference on each of those
+   * events — and the referenced project can then no longer be deleted.
+   */
+  private async validateProjectScopedReferences(
+    updateBy: UpdateBy<Model>,
+  ): Promise<void> {
+    const references: Array<ProjectScopedReference> =
+      this.getProjectScopedReferences(updateBy.data);
+
+    if (
+      references.every((reference: ProjectScopedReference) => {
+        return !reference.id;
+      })
+    ) {
+      return;
+    }
+
+    /*
+     * Root/API updates do not always carry a tenantId, so fall back to the
+     * project of each template the query actually matches.
+     */
+    const projectIds: Array<ObjectID> = updateBy.props.tenantId
+      ? [updateBy.props.tenantId]
+      : await this.getProjectIdsForUpdateQuery(updateBy);
+
+    for (const projectId of projectIds) {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: projectId,
+        subject: "scheduled maintenance template",
+        references: references,
+      });
+    }
+  }
+
+  private getProjectScopedReferences(
+    data: Model | QueryDeepPartialEntity<Model>,
+  ): Array<ProjectScopedReference> {
+    return [
+      {
+        modelName: "Monitor Status",
+        id:
+          (data.changeMonitorStatusToId as unknown as ObjectID | undefined) ||
+          (data.changeMonitorStatusTo as unknown as MonitorStatus | undefined)
+            ?._id,
+        service: MonitorStatusService,
+      },
+    ];
+  }
+
+  private async getProjectIdsForUpdateQuery(
+    updateBy: UpdateBy<Model>,
+  ): Promise<Array<ObjectID>> {
+    const templates: Array<Model> = await this.findBy({
+      query: updateBy.query,
+      select: {
+        projectId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const projectIds: Dictionary<ObjectID> = {};
+
+    for (const template of templates) {
+      if (template.projectId) {
+        projectIds[template.projectId.toString()] = template.projectId;
+      }
+    }
+
+    return Object.values(projectIds);
   }
 
   @CaptureSpan()

--- a/Common/Server/Utils/Database/ProjectScopedReferenceValidator.ts
+++ b/Common/Server/Utils/Database/ProjectScopedReferenceValidator.ts
@@ -1,0 +1,142 @@
+import DatabaseService from "../../Services/DatabaseService";
+import QueryHelper from "../../Types/Database/QueryHelper";
+import Select from "../../Types/Database/Select";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import DatabaseBaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+
+/*
+ * Incidents, alerts and scheduled maintenance events point at project-scoped
+ * records — the current state, the severity, the monitor status to switch to.
+ * Nothing checked that those ids belonged to the row's own project, so an id
+ * taken from a second project (an API call, a template, a monitor criteria)
+ * could be persisted.
+ *
+ * That is what makes the *referenced* project undeletable: deleting a Project
+ * cascades into its IncidentState / IncidentSeverity / MonitorStatus rows, but
+ * the Incident row owned by a different project still points at them and those
+ * FKs are ON DELETE NO ACTION, so Postgres raises 23503 and the API answers
+ * "This item cannot be deleted because Incident records still reference it."
+ *
+ * The check below is deliberately narrow, for the same reason
+ * MonitorStepsProjectValidator is: it only rejects an id that really is
+ * another project's record. An id that matches no row at all is left alone —
+ * refusing it would block users from saving their way out of a record that
+ * already references something deleted, and the not-null/foreign-key checks
+ * report that case on their own.
+ */
+
+export interface ProjectScopedReference {
+  // Human readable name of the referenced model, e.g. "Incident Severity".
+  modelName: string;
+  id: ObjectID | string | undefined | null;
+  // The service that owns the referenced model, e.g. IncidentSeverityService.
+  service: DatabaseService<DatabaseBaseModel>;
+}
+
+interface ForeignReference {
+  modelName: string;
+  name: string;
+}
+
+export default class ProjectScopedReferenceValidator {
+  public static async validateReferencesBelongToProject(data: {
+    projectId: ObjectID | undefined;
+    references: Array<ProjectScopedReference>;
+    // Used in the error message, e.g. "incident" -> "This incident references…".
+    subject?: string | undefined;
+  }): Promise<void> {
+    if (!data.projectId) {
+      /*
+       * Root/internal writes do not always carry a project. Callers resolve the
+       * project themselves where they can; when they cannot there is nothing to
+       * compare against and the check is a no-op.
+       */
+      return;
+    }
+
+    /*
+     * One lookup per referenced model rather than one per id — an incident
+     * carries three of these and they are on the create path.
+     */
+    const idsByService: Map<
+      DatabaseService<DatabaseBaseModel>,
+      Map<string, string>
+    > = new Map();
+
+    for (const reference of data.references) {
+      const id: string = reference.id?.toString() || "";
+
+      if (!id) {
+        continue;
+      }
+
+      if (!idsByService.has(reference.service)) {
+        idsByService.set(reference.service, new Map());
+      }
+
+      idsByService.get(reference.service)!.set(id, reference.modelName);
+    }
+
+    if (idsByService.size === 0) {
+      return;
+    }
+
+    const foreignReferences: Array<ForeignReference> = [];
+
+    for (const [service, idToModelName] of idsByService) {
+      const records: Array<DatabaseBaseModel> = await service.findBy({
+        query: {
+          _id: QueryHelper.any(Array.from(idToModelName.keys())),
+        },
+        /*
+         * `name` and `projectId` are not on DatabaseBaseModel, but every model
+         * passed here is project scoped and named, so the cast is safe.
+         */
+        select: {
+          _id: true,
+          name: true,
+          projectId: true,
+        } as Select<DatabaseBaseModel>,
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      for (const record of records) {
+        const recordProjectId: ObjectID | undefined =
+          record.getValue<ObjectID>("projectId") || undefined;
+
+        if (recordProjectId?.toString() === data.projectId.toString()) {
+          continue;
+        }
+
+        const id: string = record._id?.toString() || "";
+
+        foreignReferences.push({
+          modelName: idToModelName.get(id) || "Record",
+          name: record.getValue<string>("name")?.toString() || id,
+        });
+      }
+    }
+
+    if (foreignReferences.length === 0) {
+      return;
+    }
+
+    const described: string = foreignReferences
+      .map((reference: ForeignReference) => {
+        return `${reference.modelName} "${reference.name}"`;
+      })
+      .join(", ");
+
+    throw new BadDataException(
+      `This ${
+        data.subject || "request"
+      } references records that belong to a different project: ${described}. Please pick values from this project and try again.`,
+    );
+  }
+}

--- a/Common/Tests/Server/Services/CrossProjectReferenceWriteGuard.test.ts
+++ b/Common/Tests/Server/Services/CrossProjectReferenceWriteGuard.test.ts
@@ -1,0 +1,323 @@
+import AlertService from "../../../Server/Services/AlertService";
+import AlertStateService from "../../../Server/Services/AlertStateService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import IncidentStateService from "../../../Server/Services/IncidentStateService";
+import IncidentTemplateService from "../../../Server/Services/IncidentTemplateService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import ScheduledMaintenanceService from "../../../Server/Services/ScheduledMaintenanceService";
+import ScheduledMaintenanceStateService from "../../../Server/Services/ScheduledMaintenanceStateService";
+import ProjectScopedReferenceValidator from "../../../Server/Utils/Database/ProjectScopedReferenceValidator";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import AlertState from "../../../Models/DatabaseModels/AlertState";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentState from "../../../Models/DatabaseModels/IncidentState";
+import IncidentTemplate from "../../../Models/DatabaseModels/IncidentTemplate";
+import ScheduledMaintenance from "../../../Models/DatabaseModels/ScheduledMaintenance";
+import ScheduledMaintenanceState from "../../../Models/DatabaseModels/ScheduledMaintenanceState";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The undeletable project came from writes, not from deletes: an incident was
+ * saved holding another project's severity / state / monitor status id, and
+ * the ON DELETE NO ACTION foreign key then refused to let that other project
+ * go. The repair migration cleans up the rows that already exist; these tests
+ * cover the other half — the write paths that produced them must now refuse.
+ *
+ * Each service is checked twice: that it asks the validator about the columns
+ * that can carry a foreign id, and that a rejection stops the write before any
+ * side effect (notably before the project's incident/alert counter is burned).
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "0b5fbbd0-8d1c-4a72-9a2b-4b8bd1cba0e9",
+);
+const STATE_ID: ObjectID = new ObjectID("2b0a94a4-2f8c-49f0-8a2e-0f1ff5df41c9");
+const SEVERITY_ID: ObjectID = new ObjectID(
+  "6a56b0f9-6c8f-4f76-9b53-0a1a5b0ec1a2",
+);
+const MONITOR_STATUS_ID: ObjectID = new ObjectID(
+  "8ff02a3f-3f18-4c1d-9db1-6cf27bb2a4a1",
+);
+
+type ValidatorCall = {
+  projectId: ObjectID | undefined;
+  references: Array<{ modelName: string; id: unknown }>;
+};
+
+function spyOnValidator(rejects?: boolean): jest.Mock {
+  const spy: jest.Mock = jest.fn(async () => {
+    if (rejects) {
+      throw new BadDataException(
+        "This incident references records that belong to a different project.",
+      );
+    }
+    return undefined;
+  }) as unknown as jest.Mock;
+
+  jest
+    .spyOn(ProjectScopedReferenceValidator, "validateReferencesBelongToProject")
+    .mockImplementation(spy as never);
+
+  return spy;
+}
+
+function referencedIds(spy: jest.Mock): Record<string, unknown> {
+  const referenced: Record<string, unknown> = {};
+
+  for (const call of spy.mock.calls as unknown as Array<[ValidatorCall]>) {
+    for (const reference of call[0].references) {
+      if (reference.id) {
+        referenced[reference.modelName] = reference.id;
+      }
+    }
+  }
+
+  return referenced;
+}
+
+describe("cross-project reference guard on write", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("IncidentService.onBeforeCreate", () => {
+    function mockCreateDeps(): jest.Mock {
+      const createdState: IncidentState = new IncidentState();
+      createdState._id = STATE_ID.toString();
+
+      jest
+        .spyOn(IncidentStateService, "findOneBy")
+        .mockResolvedValue(createdState as never);
+
+      return jest.fn() as unknown as jest.Mock;
+    }
+
+    async function createIncident(data: Partial<Incident>): Promise<void> {
+      await (
+        IncidentService as unknown as {
+          onBeforeCreate: (createBy: unknown) => Promise<unknown>;
+        }
+      ).onBeforeCreate({
+        data: data as Incident,
+        props: { tenantId: PROJECT_ID },
+      });
+    }
+
+    test("checks the state, the severity and the monitor status against the project", async () => {
+      mockCreateDeps();
+      const validator: jest.Mock = spyOnValidator();
+      jest
+        .spyOn(ProjectService, "incrementAndGetIncidentCounter")
+        .mockResolvedValue({ counter: 1, prefix: undefined } as never);
+
+      await createIncident({
+        title: "test",
+        incidentSeverityId: SEVERITY_ID,
+        changeMonitorStatusToId: MONITOR_STATUS_ID,
+      });
+
+      expect(validator).toHaveBeenCalled();
+      expect(referencedIds(validator)).toEqual({
+        "Incident State": STATE_ID,
+        "Incident Severity": SEVERITY_ID,
+        "Monitor Status": MONITOR_STATUS_ID,
+      });
+    });
+
+    test("rejects the create, and burns no incident number, when a reference is foreign", async () => {
+      mockCreateDeps();
+      spyOnValidator(true);
+      const counter: jest.Mock = jest.fn() as unknown as jest.Mock;
+      jest
+        .spyOn(ProjectService, "incrementAndGetIncidentCounter")
+        .mockImplementation(counter as never);
+
+      await expect(
+        createIncident({ title: "test", incidentSeverityId: SEVERITY_ID }),
+      ).rejects.toThrow("belong to a different project");
+
+      expect(counter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("IncidentService.onBeforeUpdate", () => {
+    async function updateIncident(
+      data: Partial<Incident>,
+      tenantId?: ObjectID | undefined,
+    ): Promise<void> {
+      await (
+        IncidentService as unknown as {
+          onBeforeUpdate: (updateBy: unknown) => Promise<unknown>;
+        }
+      ).onBeforeUpdate({
+        data: data,
+        query: {},
+        props: tenantId ? { tenantId: tenantId } : { isRoot: true },
+      });
+    }
+
+    test("checks a severity change on update", async () => {
+      const validator: jest.Mock = spyOnValidator();
+
+      await updateIncident({ incidentSeverityId: SEVERITY_ID }, PROJECT_ID);
+
+      expect(referencedIds(validator)).toEqual({
+        "Incident Severity": SEVERITY_ID,
+      });
+    });
+
+    test("does not look anything up when no reference column is being written", async () => {
+      const validator: jest.Mock = spyOnValidator();
+
+      await updateIncident({ title: "renamed" }, PROJECT_ID);
+
+      expect(validator).not.toHaveBeenCalled();
+    });
+
+    test("falls back to the projects of the matched rows when the update has no tenant", async () => {
+      /*
+       * Root and API updates do not always carry a tenantId. Skipping the
+       * check there would leave the exact hole this guard exists to close.
+       */
+      const incident: Incident = new Incident();
+      incident.projectId = PROJECT_ID;
+
+      jest
+        .spyOn(IncidentService, "findBy")
+        .mockResolvedValue([incident] as never);
+
+      const validator: jest.Mock = spyOnValidator();
+
+      await updateIncident({ incidentSeverityId: SEVERITY_ID });
+
+      expect(validator).toHaveBeenCalledTimes(1);
+      expect(
+        (validator.mock.calls[0] as unknown as [ValidatorCall])[0].projectId,
+      ).toBe(PROJECT_ID);
+    });
+
+    test("rejects the update when a reference is foreign", async () => {
+      spyOnValidator(true);
+
+      await expect(
+        updateIncident({ incidentSeverityId: SEVERITY_ID }, PROJECT_ID),
+      ).rejects.toThrow("belong to a different project");
+    });
+  });
+
+  describe("AlertService.onBeforeCreate", () => {
+    test("checks the severity and the monitor status, and burns no alert number when rejected", async () => {
+      const createdState: AlertState = new AlertState();
+      createdState._id = STATE_ID.toString();
+
+      jest
+        .spyOn(AlertStateService, "findOneBy")
+        .mockResolvedValue(createdState as never);
+
+      spyOnValidator(true);
+
+      const counter: jest.Mock = jest.fn() as unknown as jest.Mock;
+      jest
+        .spyOn(ProjectService, "incrementAndGetAlertCounter")
+        .mockImplementation(counter as never);
+
+      await expect(
+        (
+          AlertService as unknown as {
+            onBeforeCreate: (createBy: unknown) => Promise<unknown>;
+          }
+        ).onBeforeCreate({
+          data: {
+            title: "test",
+            alertSeverityId: SEVERITY_ID,
+            monitorStatusWhenThisAlertWasCreatedId: MONITOR_STATUS_ID,
+          } as Alert,
+          props: { tenantId: PROJECT_ID },
+        }),
+      ).rejects.toThrow("belong to a different project");
+
+      expect(counter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ScheduledMaintenanceService.onBeforeCreate", () => {
+    test("checks the monitor status it switches monitors to", async () => {
+      const scheduledState: ScheduledMaintenanceState =
+        new ScheduledMaintenanceState();
+      scheduledState._id = STATE_ID.toString();
+
+      jest
+        .spyOn(ScheduledMaintenanceStateService, "findOneBy")
+        .mockResolvedValue(scheduledState as never);
+
+      spyOnValidator(true);
+
+      const counter: jest.Mock = jest.fn() as unknown as jest.Mock;
+      jest
+        .spyOn(ProjectService, "incrementAndGetScheduledMaintenanceCounter")
+        .mockImplementation(counter as never);
+
+      await expect(
+        (
+          ScheduledMaintenanceService as unknown as {
+            onBeforeCreate: (createBy: unknown) => Promise<unknown>;
+          }
+        ).onBeforeCreate({
+          data: {
+            title: "test",
+            changeMonitorStatusToId: MONITOR_STATUS_ID,
+          } as ScheduledMaintenance,
+          props: { tenantId: PROJECT_ID },
+        }),
+      ).rejects.toThrow("belong to a different project");
+
+      expect(counter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("IncidentTemplateService.onBeforeCreate", () => {
+    test("checks every reference a template copies onto the incidents it creates", async () => {
+      const validator: jest.Mock = spyOnValidator();
+
+      await (
+        IncidentTemplateService as unknown as {
+          onBeforeCreate: (createBy: unknown) => Promise<unknown>;
+        }
+      ).onBeforeCreate({
+        data: {
+          templateName: "test",
+          initialIncidentStateId: STATE_ID,
+          incidentSeverityId: SEVERITY_ID,
+          changeMonitorStatusToId: MONITOR_STATUS_ID,
+        } as IncidentTemplate,
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(referencedIds(validator)).toEqual({
+        "Incident State": STATE_ID,
+        "Incident Severity": SEVERITY_ID,
+        "Monitor Status": MONITOR_STATUS_ID,
+      });
+    });
+
+    test("rejects a template that points at another project's records", async () => {
+      spyOnValidator(true);
+
+      await expect(
+        (
+          IncidentTemplateService as unknown as {
+            onBeforeCreate: (createBy: unknown) => Promise<unknown>;
+          }
+        ).onBeforeCreate({
+          data: {
+            templateName: "test",
+            incidentSeverityId: SEVERITY_ID,
+          } as IncidentTemplate,
+          props: { tenantId: PROJECT_ID },
+        }),
+      ).rejects.toThrow("belong to a different project");
+    });
+  });
+});

--- a/Common/Tests/Server/Services/RepairCrossProjectIncidentReferencesMigration.test.ts
+++ b/Common/Tests/Server/Services/RepairCrossProjectIncidentReferencesMigration.test.ts
@@ -1,0 +1,401 @@
+import {
+  CROSS_PROJECT_REFERENCES,
+  CrossProjectReference,
+  RepairCrossProjectIncidentReferences1785320000000,
+  TIMELINE_FOREIGN_KEYS,
+  getClearQuery,
+  getRepairQuery,
+} from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1785320000000-RepairCrossProjectIncidentReferences";
+import SchemaMigrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import AlertEpisodeStateTimeline from "../../../Models/DatabaseModels/AlertEpisodeStateTimeline";
+import AlertStateTimeline from "../../../Models/DatabaseModels/AlertStateTimeline";
+import IncidentEpisodeStateTimeline from "../../../Models/DatabaseModels/IncidentEpisodeStateTimeline";
+import IncidentStateTimeline from "../../../Models/DatabaseModels/IncidentStateTimeline";
+import ScheduledMaintenanceStateTimeline from "../../../Models/DatabaseModels/ScheduledMaintenanceStateTimeline";
+import { QueryRunner, getMetadataArgsStorage } from "typeorm";
+import type { RelationMetadataArgs } from "typeorm/metadata-args/RelationMetadataArgs";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Deleting a project answered "This item cannot be deleted because Incident
+ * records still reference it": an Incident in project B held project A's
+ * IncidentSeverity id, the FK is ON DELETE NO ACTION, and the cascade from
+ * project A tripped over it (23503).
+ *
+ * These tests pin the three pieces that have to hold for that to stay fixed —
+ * a regression in any one silently brings the undeletable project back:
+ *   1. the reference list covers every ON DELETE NO ACTION column a project
+ *      delete can trip over (checked against the pinned list below),
+ *   2. the migration's SQL contract: repair every reference, clear only the
+ *      nullable leftovers, and swap exactly the five state-timeline FKs to
+ *      ON DELETE CASCADE — with down() putting NO ACTION back,
+ *   3. the matching @ManyToOne(onDelete: "CASCADE") on those five entities, so
+ *      a future schema:generate does not emit the swap back as "drift", and
+ *      the migration's registration in SchemaMigrations/Index.ts (an
+ *      unregistered migration is dead code and never runs on boot).
+ *
+ * Pure metadata/mocks — no Postgres connection anywhere.
+ */
+
+/*
+ * Every (table, column) whose FK to a project-scoped state / severity / status
+ * was ON DELETE NO ACTION when this migration was written, minus
+ * Monitor.currentMonitorStatusId which stays NO ACTION on purpose and was
+ * already repaired by RepairCrossProjectMonitorStatusReferences1785240000000.
+ */
+const EXPECTED_REFERENCES: Array<string> = [
+  "Alert.alertSeverityId",
+  "Alert.currentAlertStateId",
+  "Alert.monitorStatusWhenThisAlertWasCreatedId",
+  "AlertEpisode.alertSeverityId",
+  "AlertEpisode.currentAlertStateId",
+  "AlertEpisodeStateTimeline.alertStateId",
+  "AlertStateTimeline.alertStateId",
+  "Incident.changeMonitorStatusToId",
+  "Incident.currentIncidentStateId",
+  "Incident.incidentSeverityId",
+  "IncidentEpisode.currentIncidentStateId",
+  "IncidentEpisode.incidentSeverityId",
+  "IncidentEpisodeStateTimeline.incidentStateId",
+  "IncidentStateTimeline.incidentStateId",
+  "IncidentTemplate.changeMonitorStatusToId",
+  "IncidentTemplate.incidentSeverityId",
+  "IncidentTemplate.initialIncidentStateId",
+  "ScheduledMaintenance.changeMonitorStatusToId",
+  "ScheduledMaintenance.currentScheduledMaintenanceStateId",
+  "ScheduledMaintenanceStateTimeline.scheduledMaintenanceStateId",
+  "ScheduledMaintenanceTemplate.changeMonitorStatusToId",
+];
+
+/*
+ * The columns the schema declares NOT NULL. A leftover cross-project value can
+ * only be cleared on the others, so getting this wrong either leaves rows that
+ * still block the delete or writes NULL into a not-null column mid-migration.
+ */
+const NOT_NULL_COLUMNS: Array<string> = [
+  "Alert.alertSeverityId",
+  "Alert.currentAlertStateId",
+  "AlertEpisode.currentAlertStateId",
+  "AlertEpisodeStateTimeline.alertStateId",
+  "AlertStateTimeline.alertStateId",
+  "Incident.currentIncidentStateId",
+  "Incident.incidentSeverityId",
+  "IncidentEpisode.currentIncidentStateId",
+  "IncidentEpisodeStateTimeline.incidentStateId",
+  "IncidentStateTimeline.incidentStateId",
+  "ScheduledMaintenance.currentScheduledMaintenanceStateId",
+  "ScheduledMaintenanceStateTimeline.scheduledMaintenanceStateId",
+];
+
+type ModelClass = { new (): unknown };
+
+// [entity, the FK column its state relation writes]
+const CASCADING_TIMELINE_RELATIONS: Array<[ModelClass, string]> = [
+  [IncidentStateTimeline, "incidentStateId"],
+  [IncidentEpisodeStateTimeline, "incidentStateId"],
+  [AlertStateTimeline, "alertStateId"],
+  [AlertEpisodeStateTimeline, "alertStateId"],
+  [ScheduledMaintenanceStateTimeline, "scheduledMaintenanceStateId"],
+];
+
+function recordQueries(): {
+  queryRunner: QueryRunner;
+  queries: Array<string>;
+} {
+  const queries: Array<string> = [];
+
+  const queryRunner: QueryRunner = {
+    query: async (sql: string): Promise<void> => {
+      queries.push(sql);
+    },
+  } as unknown as QueryRunner;
+
+  return { queryRunner, queries };
+}
+
+async function runUp(): Promise<Array<string>> {
+  const { queryRunner, queries } = recordQueries();
+  await new RepairCrossProjectIncidentReferences1785320000000().up(queryRunner);
+  return queries;
+}
+
+async function runDown(): Promise<Array<string>> {
+  const { queryRunner, queries } = recordQueries();
+  await new RepairCrossProjectIncidentReferences1785320000000().down(
+    queryRunner,
+  );
+  return queries;
+}
+
+function key(reference: { table: string; column: string }): string {
+  return `${reference.table}.${reference.column}`;
+}
+
+describe("RepairCrossProjectIncidentReferences migration", () => {
+  describe("coverage of the references a project delete trips over", () => {
+    test("repairs exactly the known ON DELETE NO ACTION references", async () => {
+      expect(CROSS_PROJECT_REFERENCES.map(key).sort()).toEqual(
+        EXPECTED_REFERENCES,
+      );
+    });
+
+    test("marks nullable exactly where the schema allows NULL", async () => {
+      const notNull: Array<string> = CROSS_PROJECT_REFERENCES.filter(
+        (reference: { isNullable: boolean }) => {
+          return !reference.isNullable;
+        },
+      )
+        .map(key)
+        .sort();
+
+      expect(notNull).toEqual(NOT_NULL_COLUMNS);
+    });
+
+    test("points each reference at the table that actually owns it", async () => {
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        if (reference.referencedTable === "MonitorStatus") {
+          expect(reference.orderColumn).toBe("priority");
+        } else {
+          expect(reference.orderColumn).toBe("order");
+        }
+
+        // Severities have no role flags to fall back on; states do.
+        if (reference.referencedTable.endsWith("Severity")) {
+          expect(reference.roleColumns).toEqual([]);
+        } else {
+          expect(reference.roleColumns.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("repair query", () => {
+    test("only touches rows whose reference belongs to another project", async () => {
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        expect(getRepairQuery(reference)).toContain(
+          `WHERE c."projectId" IS DISTINCT FROM p."projectId"`,
+        );
+      }
+    });
+
+    test("matches by name first, then role, then nearest order", async () => {
+      const sql: string = getRepairQuery(CROSS_PROJECT_REFERENCES[0]!);
+
+      const byName: number = sql.indexOf(`lower(x."name") = lower(b.ref_name)`);
+      const byRole: number = sql.indexOf(`x."isCreatedState" = b.role_`);
+      const byOrder: number = sql.indexOf(`abs(x."order" - b.ref_order)`);
+
+      expect(byName).toBeGreaterThan(-1);
+      expect(byRole).toBeGreaterThan(byName);
+      expect(byOrder).toBeGreaterThan(byRole);
+    });
+
+    test("only ever repoints inside the row's own project", async () => {
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        const sql: string = getRepairQuery(reference);
+        const candidateFilters: number = (
+          sql.match(/x\."projectId" = b\.project_id/g) || []
+        ).length;
+
+        // One per branch of the COALESCE ladder.
+        expect(candidateFilters).toBe(reference.roleColumns.length > 0 ? 3 : 2);
+      }
+    });
+
+    test("leaves the row alone when nothing in its own project matches", async () => {
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        expect(getRepairQuery(reference)).toContain(
+          `WHERE c."_id" = r.row_id AND r.good_id IS NOT NULL`,
+        );
+      }
+    });
+
+    test("skips the role branch for severities, which have no role flags", async () => {
+      const severityReference: CrossProjectReference =
+        CROSS_PROJECT_REFERENCES.find(
+          (reference: { referencedTable: string }) => {
+            return reference.referencedTable === "IncidentSeverity";
+          },
+        )!;
+
+      expect(getRepairQuery(severityReference)).not.toContain("role_");
+    });
+  });
+
+  describe("clear query", () => {
+    test("clears only the cross-project leftovers", async () => {
+      const nullableReference: CrossProjectReference =
+        CROSS_PROJECT_REFERENCES.find((reference: { isNullable: boolean }) => {
+          return reference.isNullable;
+        })!;
+
+      const sql: string = getClearQuery(nullableReference);
+
+      expect(sql).toContain(`SET "${nullableReference.column}" = NULL`);
+      expect(sql).toContain(`c."projectId" IS DISTINCT FROM p."projectId"`);
+    });
+  });
+
+  describe("up()", () => {
+    test("raises the statement timeout before the table scans", async () => {
+      const queries: Array<string> = await runUp();
+
+      expect(queries[0]).toContain("SET LOCAL statement_timeout");
+    });
+
+    test("bounds the lock wait before swapping foreign keys", async () => {
+      const queries: Array<string> = await runUp();
+
+      const lockTimeoutAt: number = queries.findIndex((sql: string) => {
+        return sql.includes("SET LOCAL lock_timeout");
+      });
+      const firstAlterAt: number = queries.findIndex((sql: string) => {
+        return sql.includes("DROP CONSTRAINT");
+      });
+
+      expect(lockTimeoutAt).toBeGreaterThan(-1);
+      expect(firstAlterAt).toBeGreaterThan(lockTimeoutAt);
+    });
+
+    test("repairs every reference, and clears only the nullable ones", async () => {
+      const queries: Array<string> = await runUp();
+
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        expect(queries).toContain(getRepairQuery(reference));
+
+        expect(queries.includes(getClearQuery(reference))).toBe(
+          reference.isNullable,
+        );
+      }
+    });
+
+    test("repairs the data before the cascade can sweep it up", async () => {
+      /*
+       * Order matters: switching the timeline FKs to CASCADE first would let
+       * the project delete take another project's timeline history with it,
+       * instead of the history staying with the project that owns it.
+       */
+      const queries: Array<string> = await runUp();
+
+      const lastRepairAt: number = queries.reduce(
+        (last: number, sql: string, index: number) => {
+          return sql.includes("resolved r") ? index : last;
+        },
+        -1,
+      );
+      const firstAlterAt: number = queries.findIndex((sql: string) => {
+        return sql.includes("DROP CONSTRAINT");
+      });
+
+      expect(lastRepairAt).toBeGreaterThan(-1);
+      expect(firstAlterAt).toBeGreaterThan(lastRepairAt);
+    });
+
+    test("swaps exactly the five state-timeline foreign keys to CASCADE", async () => {
+      const queries: Array<string> = await runUp();
+
+      const added: Array<string> = queries.filter((sql: string) => {
+        return sql.includes("ADD CONSTRAINT");
+      });
+
+      expect(added).toHaveLength(TIMELINE_FOREIGN_KEYS.length);
+      expect(TIMELINE_FOREIGN_KEYS).toHaveLength(5);
+
+      for (const foreignKey of TIMELINE_FOREIGN_KEYS) {
+        expect(queries).toContain(
+          `ALTER TABLE "${foreignKey.table}" DROP CONSTRAINT "${foreignKey.constraintName}"`,
+        );
+        expect(queries).toContain(
+          `ALTER TABLE "${foreignKey.table}" ADD CONSTRAINT "${foreignKey.constraintName}" FOREIGN KEY ("${foreignKey.column}") REFERENCES "${foreignKey.referencedTable}"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+        );
+      }
+    });
+
+    test("touches no table outside the ones it declares", async () => {
+      const queries: Array<string> = await runUp();
+      const declaredTables: Array<string> = CROSS_PROJECT_REFERENCES.map(
+        (reference: { table: string }) => {
+          return reference.table;
+        },
+      ).concat(
+        CROSS_PROJECT_REFERENCES.map(
+          (reference: { referencedTable: string }) => {
+            return reference.referencedTable;
+          },
+        ),
+      );
+
+      for (const sql of queries) {
+        for (const table of sql.match(/UPDATE "([A-Za-z]+)"/g) || []) {
+          expect(declaredTables).toContain(table.replace(/UPDATE "|"/g, ""));
+        }
+      }
+    });
+  });
+
+  describe("down()", () => {
+    test("puts NO ACTION back on every foreign key up() swapped", async () => {
+      const queries: Array<string> = await runDown();
+
+      for (const foreignKey of TIMELINE_FOREIGN_KEYS) {
+        expect(queries).toContain(
+          `ALTER TABLE "${foreignKey.table}" DROP CONSTRAINT "${foreignKey.constraintName}"`,
+        );
+        expect(queries).toContain(
+          `ALTER TABLE "${foreignKey.table}" ADD CONSTRAINT "${foreignKey.constraintName}" FOREIGN KEY ("${foreignKey.column}") REFERENCES "${foreignKey.referencedTable}"("_id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+        );
+      }
+    });
+
+    test("does not try to undo the data repair", async () => {
+      const queries: Array<string> = await runDown();
+
+      expect(
+        queries.filter((sql: string) => {
+          return sql.trimStart().startsWith("UPDATE ");
+        }),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("entity metadata", () => {
+    test("the five timeline relations declare ON DELETE CASCADE", async () => {
+      /*
+       * Without this the next `schema:generate` sees the database disagreeing
+       * with the entities and emits an ALTER putting NO ACTION back.
+       */
+      const relations: Array<RelationMetadataArgs> =
+        getMetadataArgsStorage().relations;
+
+      for (const [model, column] of CASCADING_TIMELINE_RELATIONS) {
+        const relation: RelationMetadataArgs | undefined = relations.find(
+          (candidate: RelationMetadataArgs) => {
+            return (
+              candidate.target === model &&
+              candidate.propertyName === column.replace(/Id$/, "")
+            );
+          },
+        );
+
+        expect(relation).toBeDefined();
+        expect(relation?.options.onDelete).toBe("CASCADE");
+      }
+    });
+  });
+
+  describe("registration", () => {
+    test("is registered so it runs on boot", async () => {
+      expect(SchemaMigrations).toContain(
+        RepairCrossProjectIncidentReferences1785320000000,
+      );
+    });
+
+    test("runs after the migration it builds on", async () => {
+      expect(
+        SchemaMigrations.indexOf(
+          RepairCrossProjectIncidentReferences1785320000000,
+        ),
+      ).toBe(SchemaMigrations.length - 1);
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Database/ProjectScopedReferenceValidator.test.ts
+++ b/Common/Tests/Server/Utils/Database/ProjectScopedReferenceValidator.test.ts
@@ -1,0 +1,463 @@
+import ProjectScopedReferenceValidator from "../../../../Server/Utils/Database/ProjectScopedReferenceValidator";
+import IncidentSeverityService from "../../../../Server/Services/IncidentSeverityService";
+import IncidentStateService from "../../../../Server/Services/IncidentStateService";
+import MonitorStatusService from "../../../../Server/Services/MonitorStatusService";
+import IncidentSeverity from "../../../../Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "../../../../Models/DatabaseModels/IncidentState";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Contract under test: an incident (or alert, or scheduled maintenance event)
+ * stores the id of its state, its severity and the monitor status it switches
+ * monitors to. Saving one that belongs to a *different* project is what leaves
+ * the referenced project undeletable — deleting that project cascades into the
+ * record, the row here still points at it, and the ON DELETE NO ACTION foreign
+ * key refuses the delete with 23503.
+ *
+ * The check has to stay narrow in the same way MonitorStepsProjectValidator
+ * is: an id that matches no row at all must keep saving, otherwise a record
+ * that already points at something deleted can never be saved back into shape.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "4af3a31b-58b0-4746-8025-f9cd4db1945e",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "3376855b-361c-427c-8982-bad7ada30414",
+);
+
+const OWN_SEVERITY_ID: string = "59b5ab80-63f6-4ffd-b3df-31c6ad127695";
+const FOREIGN_SEVERITY_ID: string = "cfc2f04f-79cb-4344-8c54-dafe5e3a290c";
+const FOREIGN_STATE_ID: string = "a2eb67d4-bd2e-4186-9187-dad799c9316c";
+const FOREIGN_STATUS_ID: string = "1a1cf3f2-0e35-4a1e-98a1-3f0f8b5f7f9e";
+const UNKNOWN_ID: string = "9c0ba0b3-2f8e-4c02-a8d5-6a4d2f5b9c11";
+
+const incidentSeverity: (
+  id: string,
+  projectId: ObjectID,
+) => IncidentSeverity = (id: string, projectId: ObjectID): IncidentSeverity => {
+  const severity: IncidentSeverity = new IncidentSeverity();
+  severity._id = id;
+  severity.name = "Critical";
+  severity.projectId = projectId;
+  return severity;
+};
+
+const incidentState: (id: string, projectId: ObjectID) => IncidentState = (
+  id: string,
+  projectId: ObjectID,
+): IncidentState => {
+  const state: IncidentState = new IncidentState();
+  state._id = id;
+  state.name = "Created";
+  state.projectId = projectId;
+  return state;
+};
+
+const monitorStatus: (id: string, projectId: ObjectID) => MonitorStatus = (
+  id: string,
+  projectId: ObjectID,
+): MonitorStatus => {
+  const status: MonitorStatus = new MonitorStatus();
+  status._id = id;
+  status.name = "Operational";
+  status.projectId = projectId;
+  return status;
+};
+
+type FoundRecords = {
+  incidentSeverities?: Array<IncidentSeverity>;
+  incidentStates?: Array<IncidentState>;
+  monitorStatuses?: Array<MonitorStatus>;
+};
+
+const mockLookups: (found: FoundRecords) => {
+  severityFindBy: jest.Mock;
+  stateFindBy: jest.Mock;
+  statusFindBy: jest.Mock;
+} = (found: FoundRecords) => {
+  const severityFindBy: jest.Mock = jest.fn(async () => {
+    return found.incidentSeverities || [];
+  }) as unknown as jest.Mock;
+  const stateFindBy: jest.Mock = jest.fn(async () => {
+    return found.incidentStates || [];
+  }) as unknown as jest.Mock;
+  const statusFindBy: jest.Mock = jest.fn(async () => {
+    return found.monitorStatuses || [];
+  }) as unknown as jest.Mock;
+
+  jest
+    .spyOn(IncidentSeverityService, "findBy")
+    .mockImplementation(severityFindBy as never);
+  jest
+    .spyOn(IncidentStateService, "findBy")
+    .mockImplementation(stateFindBy as never);
+  jest
+    .spyOn(MonitorStatusService, "findBy")
+    .mockImplementation(statusFindBy as never);
+
+  return { severityFindBy, stateFindBy, statusFindBy };
+};
+
+describe("ProjectScopedReferenceValidator", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("rejects a reference that belongs to another project", async () => {
+    mockLookups({
+      incidentSeverities: [
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        subject: "incident",
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("names the model and the record in the rejection so the user can fix it", async () => {
+    mockLookups({
+      incidentSeverities: [
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        subject: "incident",
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      'This incident references records that belong to a different project: Incident Severity "Critical". Please pick values from this project and try again.',
+    );
+  });
+
+  it("accepts a reference that belongs to the same project", async () => {
+    mockLookups({
+      incidentSeverities: [incidentSeverity(OWN_SEVERITY_ID, PROJECT_ID)],
+    });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: OWN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("leaves an id that matches no record alone", async () => {
+    /*
+     * A record that already points at something deleted must stay saveable —
+     * refusing unknown ids would trap the user. The not-null and foreign key
+     * checks report that case on their own.
+     */
+    mockLookups({ incidentSeverities: [] });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: UNKNOWN_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reports every foreign reference in a single message", async () => {
+    mockLookups({
+      incidentSeverities: [
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+      incidentStates: [incidentState(FOREIGN_STATE_ID, OTHER_PROJECT_ID)],
+      monitorStatuses: [monitorStatus(FOREIGN_STATUS_ID, OTHER_PROJECT_ID)],
+    });
+
+    let message: string = "";
+
+    try {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        subject: "incident",
+        references: [
+          {
+            modelName: "Incident State",
+            id: FOREIGN_STATE_ID,
+            service: IncidentStateService,
+          },
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+          {
+            modelName: "Monitor Status",
+            id: FOREIGN_STATUS_ID,
+            service: MonitorStatusService,
+          },
+        ],
+      });
+    } catch (error) {
+      message = (error as BadDataException).message;
+    }
+
+    expect(message).toContain('Incident State "Created"');
+    expect(message).toContain('Incident Severity "Critical"');
+    expect(message).toContain('Monitor Status "Operational"');
+  });
+
+  it("mixes accepted and rejected references without letting the good one mask the bad one", async () => {
+    mockLookups({
+      incidentSeverities: [
+        incidentSeverity(OWN_SEVERITY_ID, PROJECT_ID),
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    let message: string = "";
+
+    try {
+      await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: OWN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      });
+    } catch (error) {
+      message = (error as BadDataException).message;
+    }
+
+    expect(message).toContain("belong to a different project");
+  });
+
+  it("looks each model up once, with every id it was asked about", async () => {
+    /*
+     * These run on the incident create path, so three references must not mean
+     * three round trips per model.
+     */
+    const { severityFindBy } = mockLookups({ incidentSeverities: [] });
+
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: PROJECT_ID,
+      references: [
+        {
+          modelName: "Incident Severity",
+          id: OWN_SEVERITY_ID,
+          service: IncidentSeverityService,
+        },
+        {
+          modelName: "Incident Severity",
+          id: FOREIGN_SEVERITY_ID,
+          service: IncidentSeverityService,
+        },
+      ],
+    });
+
+    expect(severityFindBy).toHaveBeenCalledTimes(1);
+
+    /*
+     * QueryHelper.any() builds a Raw() operator that carries the ids as bound
+     * parameters under a generated key, so assert on the serialized query
+     * rather than on that key.
+     */
+    const query: string = JSON.stringify(
+      (
+        severityFindBy.mock.calls[0] as unknown as Array<{
+          query: unknown;
+        }>
+      )[0]!.query,
+    );
+
+    expect(query).toContain(OWN_SEVERITY_ID);
+    expect(query).toContain(FOREIGN_SEVERITY_ID);
+  });
+
+  it("issues no query at all when nothing is being referenced", async () => {
+    const { severityFindBy, stateFindBy, statusFindBy } = mockLookups({});
+
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: PROJECT_ID,
+      references: [
+        {
+          modelName: "Incident Severity",
+          id: undefined,
+          service: IncidentSeverityService,
+        },
+        {
+          modelName: "Incident State",
+          id: null,
+          service: IncidentStateService,
+        },
+        {
+          modelName: "Monitor Status",
+          id: "",
+          service: MonitorStatusService,
+        },
+      ],
+    });
+
+    expect(severityFindBy).not.toHaveBeenCalled();
+    expect(stateFindBy).not.toHaveBeenCalled();
+    expect(statusFindBy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the project is unknown", async () => {
+    /*
+     * Root and internal writes do not always carry a project. There is nothing
+     * to compare against, so the check has to stay out of the way rather than
+     * guess.
+     */
+    const { severityFindBy } = mockLookups({
+      incidentSeverities: [
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: undefined,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(severityFindBy).not.toHaveBeenCalled();
+  });
+
+  it("treats an ObjectID and its string form as the same reference", async () => {
+    mockLookups({
+      incidentSeverities: [
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: new ObjectID(FOREIGN_SEVERITY_ID),
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).rejects.toThrow("belong to a different project");
+  });
+
+  it("falls back to the id when the foreign record has no name", async () => {
+    const severity: IncidentSeverity = incidentSeverity(
+      FOREIGN_SEVERITY_ID,
+      OTHER_PROJECT_ID,
+    );
+    delete severity.name;
+
+    mockLookups({ incidentSeverities: [severity] });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).rejects.toThrow(`Incident Severity "${FOREIGN_SEVERITY_ID}"`);
+  });
+
+  it("rejects a record with no project of its own", async () => {
+    /*
+     * A project-scoped record without a projectId is not this project's, and
+     * treating "no project" as "same project" would let exactly the rows this
+     * check exists for slip through.
+     */
+    const severity: IncidentSeverity = incidentSeverity(
+      FOREIGN_SEVERITY_ID,
+      OTHER_PROJECT_ID,
+    );
+    delete severity.projectId;
+
+    mockLookups({ incidentSeverities: [severity] });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).rejects.toThrow("belong to a different project");
+  });
+
+  it("says 'request' when the caller does not name the subject", async () => {
+    mockLookups({
+      incidentSeverities: [
+        incidentSeverity(FOREIGN_SEVERITY_ID, OTHER_PROJECT_ID),
+      ],
+    });
+
+    await expect(
+      ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+        projectId: PROJECT_ID,
+        references: [
+          {
+            modelName: "Incident Severity",
+            id: FOREIGN_SEVERITY_ID,
+            service: IncidentSeverityService,
+          },
+        ],
+      }),
+    ).rejects.toThrow("This request references records");
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix: let projects with cross-project incident references be deleted

### Small Description?

Deleting a project failed with **"This item cannot be deleted because Incident records still reference it."**

An `Incident` stores the id of its state, its severity and the monitor status it switches monitors to. Nothing checked that those ids belong to the incident's *own* project — they arrive from an API call, an incident template or a monitor criteria. Once a second project's id was stored, deleting **that** project cascaded into its `IncidentSeverity` / `IncidentState` / `MonitorStatus` rows while the foreign incident still pointed at them, and the `ON DELETE NO ACTION` foreign key raised Postgres 23503.

Same-project references were never the problem: they are removed by the same cascading statement, so the NO ACTION check passes. Reproduced against a full replay of the schema on Postgres:

```
ERROR:  update or delete on table "IncidentSeverity" violates foreign key constraint "FK_3f28fe3b32abed354a49b26c9cb" on table "Incident"
DETAIL:  Key (_id)=(...) is still referenced from table "Incident".
```

This is the same shape `RepairCrossProjectMonitorStatusReferences1785240000000` fixed for `MonitorStatusTimeline`. It is now finished for every remaining reference a project delete can trip over — the incident, alert and scheduled maintenance families, including their episodes and templates (21 columns in total).

**Stop new ones (`ProjectScopedReferenceValidator`)**

Incidents, alerts, scheduled maintenance events and both template models now reject a state / severity / monitor status that belongs to another project, on create *and* update. The check is deliberately narrow, like `MonitorStepsProjectValidator`: an id that matches no record at all still saves, so a record already pointing at something deleted can be saved back into shape. One lookup per referenced model, and only when such a column is actually being written. The create paths run it *before* the incident/alert/event counter is incremented, so a rejected write burns no number.

**Repair the existing ones (migration `1785320000000`)**

1. Repoints every cross-project reference at the equivalent record in the row's own project — matched by name, then by the state's role flags (`isCreatedState`, `isOperationalState`, …), then by nearest `order`/`priority`.
2. Clears the leftovers it could not match, on nullable columns only.
3. Switches the five state-timeline FKs (`IncidentStateTimeline`, `IncidentEpisodeStateTimeline`, `AlertStateTimeline`, `AlertEpisodeStateTimeline`, `ScheduledMaintenanceStateTimeline`) to `ON DELETE CASCADE` — a state timeline row is meaningless once its state is gone, and the entities were updated to match so `schema:generate` does not emit it back as drift.

Repair runs before the cascade swap on purpose, so timeline history stays with the surviving project instead of being swept up by the new cascade. `statement_timeout` and `lock_timeout` are bounded the same way the 1785240000000 migration bounds them.

Not changed on purpose: `Monitor.currentMonitorStatusId` keeps NO ACTION (deleting a status monitors are currently in should stay blocked) and was already repaired by the earlier migration.

**Verified against a real database**

All 476 schema migrations were replayed onto a scratch Postgres, then seeded with a project holding another project's incident/alert/scheduled-maintenance references:

- before the migration: the delete failed with exactly the reported 23503 error;
- after: `DELETE 1`, with every one of the other project's rows still present and repointed at its own records (nothing swept away);
- `down()` puts `NO ACTION` back on all five FKs;
- deleting a state that only timeline rows reference now cascades instead of blocking.

The one case that still blocks is a project that has *no* state/severity of its own to repoint to, on a not-null column — documented in the migration. Project creation always seeds defaults, and a state in use cannot be deleted, so this is not reachable in practice.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

43 new tests across three suites (`ProjectScopedReferenceValidator`, the migration's SQL contract + registration + entity parity, and the write guards on each service). `npm run fix` and `Common` `tsc` are clean; `Tests/Server/Services` + `Tests/Server/Utils` run 3172 passing tests. Eight suites fail to load on this machine only, from a pre-existing `isolated-vm` native-module ABI mismatch — they fail identically on a stashed tree.

### Related Issue?

None.

### Screenshots (if appropriate):

N/A
