### PR TITLE
fix(monitor-template): send the project scope on sync/link endpoints

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
@@ -180,6 +180,7 @@ const MonitorTemplatesView: FunctionComponent<
           data: {
             fields: ["monitorSteps"],
           },
+          headers: ModelAPI.getCommonHeaders(),
         });
 
       if (response.isFailure()) {
@@ -217,6 +218,7 @@ const MonitorTemplatesView: FunctionComponent<
           data: {
             fields: ["monitoringInterval", "minimumProbeAgreement"],
           },
+          headers: ModelAPI.getCommonHeaders(),
         });
 
       if (response.isFailure()) {
@@ -254,6 +256,7 @@ const MonitorTemplatesView: FunctionComponent<
           data: {
             fields: ["labels"],
           },
+          headers: ModelAPI.getCommonHeaders(),
         });
 
       if (response.isFailure()) {
@@ -292,6 +295,7 @@ const MonitorTemplatesView: FunctionComponent<
           url: URL.fromString(APP_API_URL.toString()).addRoute(
             `/monitor-template/${modelId.toString()}/sync-to-monitor/${singleSyncMonitor.id.toString()}`,
           ),
+          headers: ModelAPI.getCommonHeaders(),
         });
 
       if (response.isFailure()) {
@@ -387,6 +391,7 @@ const MonitorTemplatesView: FunctionComponent<
             url: URL.fromString(APP_API_URL.toString()).addRoute(
               `/monitor-template/${modelId.toString()}/link-monitor/${monitorId}`,
             ),
+            headers: ModelAPI.getCommonHeaders(),
           });
         if (response.isFailure()) {
           errors.push(API.getFriendlyMessage(response));
@@ -429,6 +434,7 @@ const MonitorTemplatesView: FunctionComponent<
           url: URL.fromString(APP_API_URL.toString()).addRoute(
             `/monitor-template/${modelId.toString()}/unlink-monitor/${unlinkTarget.id.toString()}`,
           ),
+          headers: ModelAPI.getCommonHeaders(),
         });
 
       if (response.isFailure()) {

--- a/App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts
+++ b/App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The Monitor Template view drives sync / link / unlink through raw
+ * `API.post` calls rather than ModelAPI, because those endpoints are custom
+ * routes rather than model CRUD. `BaseAPI.getHeaders()` does NOT add a
+ * `tenantid` header — `ModelAPI.getCommonHeaders()` is the only thing in the
+ * codebase that does. So a raw post that omits it reaches the server with no
+ * project scope at all.
+ *
+ * That is not a harmless omission. `getUserMiddleware` resolves the project
+ * only from ProjectMiddleware.getProjectId (params / query / `tenantid` /
+ * `projectid` / body.projectId), and these routes carry only
+ * `:monitorTemplateId`. With no project it never populates
+ * `userTenantAccessPermission`, so the permission-checked MonitorTemplate
+ * read inside the sync service sees only the global permissions and fails
+ * with "You do not have permissions to read Monitor Template. You need one
+ * of these permissions: Project Owner, ..." — a message that sends project
+ * owners hunting for a role they already hold.
+ *
+ * All six calls shipped without the header. This pins every one of them: the
+ * component is a React page with no extractable logic, and the App suite runs
+ * in a plain Node environment with no renderer, so this reads the source the
+ * same way the sibling *Invariants tests do.
+ */
+
+const MONITOR_TEMPLATES_VIEW: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "Monitor",
+  "Settings",
+  "MonitorTemplatesView.tsx",
+);
+
+/*
+ * Comments are stripped so the prose above (which quotes both the endpoint
+ * paths and `getCommonHeaders`) cannot satisfy an assertion about the code,
+ * and whitespace is squashed so prettier re-wrapping a call cannot turn a
+ * real regression check into a red herring.
+ */
+function readCode(): string {
+  const raw: string = fs.readFileSync(MONITOR_TEMPLATES_VIEW, "utf8");
+  return raw
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ");
+}
+
+/*
+ * Every raw `API.post({ ... })` argument object in the file, as source text.
+ * Brace-matched rather than regex-matched so nested objects (`data: {...}`)
+ * do not truncate the capture. The lookbehind keeps `ModelAPI.post` out of the
+ * results — that one attaches the tenant header itself, so requiring an
+ * explicit `headers` on it would be wrong.
+ */
+function getApiPostArguments(code: string): Array<string> {
+  const calls: Array<string> = [];
+  const marker: RegExp = /(?<![A-Za-z])API\.post<[^>]*>\(\s*\{/g;
+
+  let match: RegExpExecArray | null = marker.exec(code);
+
+  while (match !== null) {
+    const openIndex: number = code.indexOf("{", match.index);
+    let depth: number = 0;
+    let end: number = -1;
+
+    for (let i: number = openIndex; i < code.length; i++) {
+      if (code[i] === "{") {
+        depth++;
+      } else if (code[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    if (end === -1) {
+      throw new Error("Unbalanced braces in an API.post call argument.");
+    }
+
+    calls.push(code.slice(openIndex, end + 1));
+    match = marker.exec(code);
+  }
+
+  return calls;
+}
+
+describe("Monitor Template sync/link endpoints send the tenant header", () => {
+  test("the file still drives these endpoints through raw API.post", () => {
+    const code: string = readCode();
+
+    /*
+     * Guard the guard: if the page is ever migrated off raw API.post, the
+     * assertions below would vacuously pass over an empty list.
+     */
+    const calls: Array<string> = getApiPostArguments(code);
+
+    expect(calls.length).toBe(6);
+    expect(code).toContain("/sync-to-linked-monitors");
+    expect(code).toContain("/sync-to-monitor/");
+    expect(code).toContain("/link-monitor/");
+    expect(code).toContain("/unlink-monitor/");
+  });
+
+  test("every API.post passes ModelAPI.getCommonHeaders() so tenantid is sent", () => {
+    const calls: Array<string> = getApiPostArguments(readCode());
+
+    const sendsTenantHeader: RegExp = new RegExp(
+      "headers:\\s*(\\{\\s*\\.\\.\\.\\s*)?ModelAPI\\.getCommonHeaders\\(",
+    );
+
+    const missing: Array<string> = calls.filter((call: string) => {
+      return !sendsTenantHeader.test(call);
+    });
+
+    expect(missing).toEqual([]);
+  });
+
+  test("each of the four monitor-template routes is covered", () => {
+    const calls: Array<string> = getApiPostArguments(readCode());
+
+    const routes: Array<string> = [
+      "/sync-to-linked-monitors",
+      "/sync-to-monitor/",
+      "/link-monitor/",
+      "/unlink-monitor/",
+    ];
+
+    for (const route of routes) {
+      const callsForRoute: Array<string> = calls.filter((call: string) => {
+        return call.includes(route);
+      });
+
+      expect(callsForRoute.length).toBeGreaterThan(0);
+
+      for (const call of callsForRoute) {
+        expect(call).toContain("ModelAPI.getCommonHeaders(");
+      }
+    }
+  });
+});

--- a/Common/Server/API/CommonAPI.ts
+++ b/Common/Server/API/CommonAPI.ts
@@ -12,6 +12,34 @@ import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException
 
 export default class CommonAPI {
   /*
+   * Custom (non-CRUD) endpoints whose path carries only a resource id give
+   * getUserMiddleware no way to learn the project except the `tenantid`
+   * header. When a caller forgets it, the request still reaches the handler —
+   * just with no tenant permissions — and the eventual tenant-scoped read
+   * fails as "You do not have permissions to read <model>", which reads like a
+   * missing role when it is really a missing header. Assert the scope up front
+   * so the caller gets the real cause.
+   *
+   * This deliberately checks the tenant only, not the user: API-key callers
+   * are authenticated by ProjectMiddleware and carry tenant permissions
+   * without ever setting `userId`. Use assertAuthenticatedProjectMember when
+   * an endpoint must additionally be a logged-in human member.
+   */
+  public static assertTenantScoped(
+    databaseProps: DatabaseCommonInteractionProps,
+  ): ObjectID {
+    const projectId: ObjectID | undefined = databaseProps.tenantId;
+
+    if (!projectId) {
+      throw new BadDataException(
+        "Project ID is required. Please pass the project ID in the 'tenantid' header.",
+      );
+    }
+
+    return projectId;
+  }
+
+  /*
    * getUserMiddleware lets unauthenticated requests through as "public" and
    * takes the tenant id from a caller-supplied header — custom endpoints
    * that disclose project data must require an authenticated member of the

--- a/Common/Server/API/MonitorTemplateAPI.ts
+++ b/Common/Server/API/MonitorTemplateAPI.ts
@@ -61,6 +61,8 @@ export default class MonitorTemplateAPI extends BaseAPI<
           const props: DatabaseCommonInteractionProps =
             await CommonAPI.getDatabaseCommonInteractionProps(req);
 
+          CommonAPI.assertTenantScoped(props);
+
           const fields: Array<string> | undefined = readSyncFields(req);
 
           const result: SyncLinkedMonitorsResult =
@@ -98,6 +100,8 @@ export default class MonitorTemplateAPI extends BaseAPI<
           const props: DatabaseCommonInteractionProps =
             await CommonAPI.getDatabaseCommonInteractionProps(req);
 
+          CommonAPI.assertTenantScoped(props);
+
           const fields: Array<string> | undefined = readSyncFields(req);
 
           await MonitorTemplateService.syncToMonitor({
@@ -133,6 +137,8 @@ export default class MonitorTemplateAPI extends BaseAPI<
           const props: DatabaseCommonInteractionProps =
             await CommonAPI.getDatabaseCommonInteractionProps(req);
 
+          CommonAPI.assertTenantScoped(props);
+
           await MonitorTemplateService.linkMonitor({
             monitorTemplateId,
             monitorId,
@@ -164,6 +170,8 @@ export default class MonitorTemplateAPI extends BaseAPI<
 
           const props: DatabaseCommonInteractionProps =
             await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+          CommonAPI.assertTenantScoped(props);
 
           await MonitorTemplateService.unlinkMonitor({
             monitorTemplateId,

--- a/Common/Tests/Server/API/CommonAPIAuthGuard.test.ts
+++ b/Common/Tests/Server/API/CommonAPIAuthGuard.test.ts
@@ -315,3 +315,61 @@ describe("CommonAPI.assertAuthenticatedProjectMember", () => {
     });
   });
 });
+
+/*
+ * Tests for CommonAPI.assertTenantScoped — the lighter guard for custom
+ * endpoints whose path carries only a resource id, so the project can only
+ * come from the `tenantid` header. Without it the request still reaches the
+ * handler, just with no tenant permissions, and the eventual tenant-scoped
+ * read fails as "You do not have permissions to read <model>" — a message
+ * that sends project owners hunting for a role they already hold. The guard
+ * exists to surface the real cause (a missing header) instead.
+ */
+describe("CommonAPI.assertTenantScoped", () => {
+  test("throws BadDataException naming the tenantid header when tenantId is missing", () => {
+    const props: DatabaseCommonInteractionProps = buildProps({
+      tenantId: undefined,
+      userId: ObjectID.generate(),
+    });
+
+    const thrown: unknown = captureThrown(() => {
+      CommonAPI.assertTenantScoped(props);
+    });
+
+    expect(thrown).toBeInstanceOf(BadDataException);
+    expect((thrown as Exception).message).toContain("Project ID is required");
+    expect((thrown as Exception).message).toContain("tenantid");
+  });
+
+  test("returns the tenant id when the request is project scoped", () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const props: DatabaseCommonInteractionProps = buildProps({
+      tenantId: projectId,
+      userId: ObjectID.generate(),
+    });
+
+    expect(CommonAPI.assertTenantScoped(props)).toBe(projectId);
+  });
+
+  /*
+   * API-key callers are authenticated by ProjectMiddleware, which sets
+   * userType/tenantId and the tenant permission map but never userId. This
+   * guard must not lock them out — that is what separates it from
+   * assertAuthenticatedProjectMember.
+   */
+  test("accepts an API-key caller that has a tenant but no userId", () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const permissions: Dictionary<UserTenantAccessPermission> = {};
+    permissions[projectId.toString()] = buildTenantPermission(projectId);
+
+    const props: DatabaseCommonInteractionProps = buildProps({
+      tenantId: projectId,
+      userId: undefined,
+      userTenantAccessPermission: permissions,
+    });
+
+    expect(() => {
+      CommonAPI.assertTenantScoped(props);
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## The bug

Syncing anything from a Monitor Template to its linked monitors — criteria, monitoring
interval, labels — failed with:

> You do not have permissions to read Monitor Template. You need one of these permissions:
> Project Owner, Project Admin, Project Member, Viewer, Monitor Admin, Monitor Member,
> Monitor Viewer, Read Monitor Template.

…even for the project owner, on a project they created and are the only member of.

## Root cause

The Monitor Template page drives sync / link / unlink through raw `API.post` calls, because
those are custom routes rather than model CRUD. All six of them omitted `headers`.

`BaseAPI.getHeaders()` does not add a `tenantid` header — `ModelAPI.getCommonHeaders()`
(`Common/UI/Utils/ModelAPI/ModelAPI.ts:322-346`) is the only thing in
the codebase that does. So these requests reached the server with **no project scope at all**:

1. The routes carry only `:monitorTemplateId`, so
   `Common/Server/Middleware/ProjectAuthorization.ts:23-42`
   — which reads params / query / `tenantid` / `projectid` / `body.projectId` — returns `null`.
2. With no tenant, `Common/Server/Middleware/UserAuthorization.ts:412-419`
   takes the else-branch and sets only `userGlobalAccessPermission`;
   `userTenantAccessPermission` is never populated.
3. The permission-checked template read in
   `Common/Server/Services/MonitorTemplateService.ts:122-135` then hits
   `Common/Server/Types/Database/Permissions/TenantPermission.ts:73-79`'s
   multi-project fallback, which recurses per project while still forwarding the undefined
   `userTenantAccessPermission`.
4. `Common/Types/BaseDatabase/DatabaseCommonInteractionPropsUtil.ts:73`
   requires **both** `tenantId` and `userTenantAccessPermission`, so each recursion sees only the
   global permissions (Public / User / CurrentUser), fails the table check, and every attempt
   throws.
5. All attempts having failed, the loop re-throws `lastException.message` verbatim — which is why
   an inner table-level message surfaces as the outer error, naming permissions the user actually
   holds.

The error is HTTP 422, which the client neither retries nor redirects on, so it renders inline in
the confirm modal.

## The fix

- **Client** — pass `headers: ModelAPI.getCommonHeaders()` on all six `API.post` calls in
  `MonitorTemplatesView.tsx`, matching the pattern already used everywhere else in the dashboard
  for raw API calls. This is the actual fix: the request genuinely lacked project scope, and only
  the client knows which project the user is looking at.
- **Server** — add `CommonAPI.assertTenantScoped(props)` and call it on the four custom Monitor
  Template routes, so a missing project scope fails immediately with *"Project ID is required.
  Please pass the project ID in the `tenantid` header."* instead of masquerading as a permission
  denial. This is what cost the most time to diagnose.

`assertTenantScoped` deliberately checks the tenant only, **not** the user — unlike its sibling
`assertAuthenticatedProjectMember`. API-key callers are authenticated by `ProjectMiddleware` and
carry tenant permissions without ever setting `userId`, so the stricter guard would have broken
API-key access to these routes.

## On the "after idle" framing

The reported trigger was "after I'm idle for some time". This chain is **time-invariant** — the
sync buttons fail on every click, including immediately after login. Idle does change the first
hop: the access-token cookie's browser `maxAge` equals the JWT lifetime
(`Common/Server/Utils/Cookie.ts:185` vs `Common/Server/Utils/Cookie.ts:190`,
both 15 minutes), so after ~15 min the cookie is gone, the request is admitted as `Public`, and
the permission layer returns a 401 that the client's existing refresh-and-retry consumes — landing
back on the same 422. So ordinary dashboard traffic self-heals after idle while these buttons do
not, which is plausibly why they were reached for at that moment.

I could find no code path where elapsed time is what causes `userTenantAccessPermission` to go
missing on a request that *does* carry `tenantid`. If sync ever succeeded for you rather than
always failing, that would point to a second factor still to find.

I deliberately did **not** change the cookie lifetime here. It buys nothing for this bug (HTTP
already self-heals), and because cookies are host-only with `path: "/"` and nginx serves
`/status-page` from the same server block, a persistent expired token would make
`getUserMiddleware` hard-401 anonymous **public status page** reads before
`StatusPageService.hasReadAccess` can grant them — with no way for the status page app to recover,
since its refresh only rotates `token-<statusPageId>`. Worth fixing separately at the middleware,
not the cookie.

## Testing

- `App/Tests/Dashboard/MonitorTemplateSyncTenantHeader.test.ts` (new) pins that every `API.post`
  in the page sends the tenant header, and that all four routes are covered. Verified it fails on
  the pre-fix source.
- `Common/Tests/Server/API/CommonAPIAuthGuard.test.ts` extended with three cases for
  `assertTenantScoped`, including that an API-key caller with a tenant but no `userId` is accepted.
- `npx eslint` clean on all changed files; `tsc --noEmit` clean in both `Common` and `App`.

## Adjacent findings, deliberately left out of this PR

Both are real and reproducible, but neither is the reported bug and each deserves its own change:

1. **Same missing-header pattern elsewhere.** A handful of other dashboard pages call project-scoped
   custom routes with raw `API.post` and no tenant header — `/workspace-notification-rule/test/:id`,
   `/notification/recharge`, `/ai/recharge`, `/monitor/refresh-status/:id`, and the three
   `generate-note-from-ai` routes. (The `/user-*` notification-method endpoints in the same sweep are
   user-scoped and need no tenant.)
2. **Tenant-permission dictionary indexed by the wrong key.** `Common/Server/API/IncidentAPI.ts:168`
   and `:276`, `AlertAPI.ts:67` and `ScheduledMaintenanceAPI.ts:73` read
   `props.userTenantAccessPermission?.["permissions"]`, but that dictionary is keyed by **project
   id** — the `as Array<Permission>` cast is what hides it from the type checker. The value is always
   `undefined`, so the check always fails and every non-master-admin is rejected from the AI-note
   endpoints.
