### PR TITLE
Make the network device and site summary tiles filter their lists

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Network/SummaryFilterChip.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Network/SummaryFilterChip.tsx
@@ -1,0 +1,63 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon, { SizeProp } from "Common/UI/Components/Icon/Icon";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  // What the table is currently narrowed to, e.g. "Devices down / stale".
+  label: string;
+  /*
+   * Optional qualifier shown next to the chip — used where the filter is a
+   * snapshot rather than a live predicate, so the user can see how old it is
+   * instead of wondering why a row disagrees with its own status column.
+   */
+  detail?: string | undefined;
+  onClear: () => void;
+  // Suffix for the chip's `data-testid`, so both pages stay distinguishable.
+  testIdSuffix: string;
+}
+
+/*
+ * The one visible sign that a table is showing a subset. A tile click narrows
+ * the list below it, and without something like this the user is left staring
+ * at a short table with no explanation and no way back other than reloading
+ * the page.
+ *
+ * Rendered through ModelTable's `topContent`, so it sits inside the table
+ * card, directly above the rows it describes.
+ */
+const SummaryFilterChip: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  return (
+    <div
+      data-testid={`summary-filter-chip-${props.testIdSuffix}`}
+      className="mb-4 flex items-center gap-2"
+    >
+      <span className="text-sm text-gray-500">Filtered by</span>
+      <span className="inline-flex items-center gap-2 rounded-full border border-indigo-200 bg-indigo-50 py-1 pl-3 pr-1 text-sm font-medium text-indigo-700">
+        {props.label}
+        <button
+          type="button"
+          aria-label={`Clear the ${props.label} filter`}
+          data-testid={`summary-filter-chip-clear-${props.testIdSuffix}`}
+          onClick={props.onClear}
+          className="flex h-5 w-5 items-center justify-center rounded-full text-indigo-500 hover:bg-indigo-100 hover:text-indigo-800"
+        >
+          <Icon icon={IconProp.Close} size={SizeProp.ExtraSmall} />
+        </button>
+      </span>
+      {props.detail ? (
+        <span
+          data-testid={`summary-filter-chip-detail-${props.testIdSuffix}`}
+          className="text-sm text-gray-500"
+        >
+          {props.detail}
+        </span>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+};
+
+export default SummaryFilterChip;

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards.tsx
@@ -1,6 +1,10 @@
-import { DEVICE_FRESH_WINDOW_MINUTES } from "./DeviceStatusUtil";
+import {
+  DEVICE_SUMMARY_TILES,
+  DeviceSummaryFilterKey,
+  DeviceSummaryTile,
+  getDeviceFreshCutoff,
+} from "./DeviceSummaryFilter";
 import ObjectID from "Common/Types/ObjectID";
-import OneUptimeDate from "Common/Types/Date";
 import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
 import LessThan from "Common/Types/BaseDatabase/LessThan";
@@ -25,18 +29,21 @@ interface SummaryCounts {
   interfacesDown: number;
 }
 
-interface SummaryTile {
-  key: string;
-  label: string;
-  count: number;
-  // css class for the count when it needs attention (count > 0).
-  attentionClassName: string;
-  // css class for the count when everything is fine (count === 0).
-  allClearClassName: string;
-  caption: string;
+export interface ComponentProps {
+  // The tile currently drilled into, or null when the list is unfiltered.
+  selectedFilterKey?: DeviceSummaryFilterKey | null | undefined;
+  /*
+   * Clicking the selected tile again passes null — the tiles are toggles, so
+   * the same click that drilled in gets the user back out.
+   */
+  onFilterKeyChange?:
+    | ((filterKey: DeviceSummaryFilterKey | null) => void)
+    | undefined;
 }
 
-const DeviceSummaryCards: FunctionComponent = (): ReactElement => {
+const DeviceSummaryCards: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
   const [counts, setCounts] = useState<SummaryCounts | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [hasError, setHasError] = useState<boolean>(false);
@@ -47,10 +54,12 @@ const DeviceSummaryCards: FunctionComponent = (): ReactElement => {
     try {
       const projectId: ObjectID = ProjectUtil.getCurrentProjectId()!;
 
-      // Same freshness window the topology API uses to decide up vs down.
-      const freshCutoff: Date = OneUptimeDate.getSomeMinutesAgo(
-        DEVICE_FRESH_WINDOW_MINUTES,
-      );
+      /*
+       * Same freshness window the topology API uses to decide up vs down, and
+       * the same one DeviceSummaryFilter builds the drill-down queries from —
+       * so the rows a tile opens are the rows it counted.
+       */
+      const freshCutoff: Date = getDeviceFreshCutoff();
 
       const [
         devicesUp,
@@ -131,51 +140,51 @@ const DeviceSummaryCards: FunctionComponent = (): ReactElement => {
     return <></>;
   }
 
-  const tiles: Array<SummaryTile> = [
-    {
-      key: "devices-up",
-      label: "Devices Up",
-      count: counts?.devicesUp || 0,
-      attentionClassName: "text-emerald-600",
-      allClearClassName: "text-gray-900",
-      caption: `Polled within the last ${DEVICE_FRESH_WINDOW_MINUTES} minutes.`,
-    },
-    {
-      key: "devices-down",
-      label: "Devices Down / Stale",
-      count: counts?.devicesDown || 0,
-      attentionClassName: "text-red-600",
-      allClearClassName: "text-gray-900",
-      caption: `No successful poll in the last ${DEVICE_FRESH_WINDOW_MINUTES} minutes.`,
-    },
-    {
-      key: "devices-pending",
-      label: "Devices Pending",
-      count: counts?.devicesPending || 0,
-      attentionClassName: "text-gray-500",
-      allClearClassName: "text-gray-900",
-      caption: "Never polled successfully yet.",
-    },
-    {
-      key: "interfaces-down",
-      label: "Total Interfaces Down",
-      count: counts?.interfacesDown || 0,
-      attentionClassName: "text-red-600",
-      allClearClassName: "text-gray-900",
-      caption: "Across all devices in this project.",
-    },
-  ];
+  const selectedFilterKey: DeviceSummaryFilterKey | null =
+    props.selectedFilterKey || null;
+
+  type OnTileClickFunction = (tile: DeviceSummaryTile) => void;
+
+  const onTileClick: OnTileClickFunction = (tile: DeviceSummaryTile): void => {
+    if (!props.onFilterKeyChange) {
+      return;
+    }
+
+    props.onFilterKeyChange(
+      selectedFilterKey === tile.filterKey ? null : tile.filterKey,
+    );
+  };
 
   return (
     <div
       data-testid="network-device-summary-cards"
       className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4"
     >
-      {tiles.map((tile: SummaryTile) => {
+      {DEVICE_SUMMARY_TILES.map((tile: DeviceSummaryTile) => {
+        const count: number = counts?.[tile.countField] || 0;
+        const isSelected: boolean = selectedFilterKey === tile.filterKey;
+
         return (
           <InfoCard
             key={tile.key}
             title={tile.label}
+            /*
+             * The tiles stay inert until the counts land: clicking a skeleton
+             * would filter the list to a number nobody has read yet.
+             */
+            onClick={
+              props.onFilterKeyChange && !isLoading
+                ? () => {
+                    onTileClick(tile);
+                  }
+                : undefined
+            }
+            isSelected={isSelected}
+            ariaLabel={
+              isSelected
+                ? `${tile.label}: ${count}. Showing these in the list below — activate to clear the filter.`
+                : `${tile.label}: ${count}. Activate to show these in the list below.`
+            }
             value={
               isLoading ? (
                 <div className="mt-1 space-y-2">
@@ -187,12 +196,12 @@ const DeviceSummaryCards: FunctionComponent = (): ReactElement => {
                   <div
                     data-testid={`network-device-stat-${tile.key}`}
                     className={`text-3xl font-semibold ${
-                      tile.count > 0
+                      count > 0
                         ? tile.attentionClassName
                         : tile.allClearClassName
                     }`}
                   >
-                    {tile.count}
+                    {count}
                   </div>
                   <div className="mt-2 text-sm text-gray-500">
                     {tile.caption}

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilter.ts
@@ -1,0 +1,276 @@
+import { DEVICE_FRESH_WINDOW_MINUTES } from "./DeviceStatusUtil";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
+import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import LessThan from "Common/Types/BaseDatabase/LessThan";
+import Query from "Common/Types/BaseDatabase/Query";
+import OneUptimeDate from "Common/Types/Date";
+
+/*
+ * The summary strip above the device list is a set of counts, and every one
+ * of them answers a question the user immediately wants the rows for — "three
+ * devices are down, which three?". This module is the single place that maps
+ * a tile to the query that produces exactly the rows it counted, so the tile
+ * and the list can never drift apart.
+ *
+ * It is deliberately free of React: the counts are fetched in
+ * DeviceSummaryCards, the rows are fetched by the ModelTable on the Devices
+ * page, and both build their query from here.
+ */
+
+export enum DeviceSummaryFilterKey {
+  Up = "up",
+  Down = "down",
+  Pending = "pending",
+  InterfacesDown = "interfaces-down",
+  /*
+   * Not one of the device tiles — this is where the Sites page's "Unassigned
+   * Devices" tile lands, because the rows behind that count are devices, and
+   * the device list is the only page that shows them.
+   */
+  NoSite = "no-site",
+}
+
+// The query-string parameter the selected tile is mirrored into.
+export const DEVICE_SUMMARY_FILTER_URL_PARAM: string = "deviceFilter";
+
+export interface DeviceSummaryFilterDefinition {
+  key: DeviceSummaryFilterKey;
+  // Shown on the chip above the table while this filter is applied.
+  chipLabel: string;
+  // Replaces the table's generic "no items" copy while this filter is applied.
+  emptyMessage: string;
+}
+
+const DEFINITIONS: Record<
+  DeviceSummaryFilterKey,
+  DeviceSummaryFilterDefinition
+> = {
+  [DeviceSummaryFilterKey.Up]: {
+    key: DeviceSummaryFilterKey.Up,
+    chipLabel: "Devices up",
+    emptyMessage: `No device has been polled successfully in the last ${DEVICE_FRESH_WINDOW_MINUTES} minutes.`,
+  },
+  [DeviceSummaryFilterKey.Down]: {
+    key: DeviceSummaryFilterKey.Down,
+    chipLabel: "Devices down / stale",
+    emptyMessage: `Every device has been polled successfully in the last ${DEVICE_FRESH_WINDOW_MINUTES} minutes.`,
+  },
+  [DeviceSummaryFilterKey.Pending]: {
+    key: DeviceSummaryFilterKey.Pending,
+    chipLabel: "Devices pending",
+    emptyMessage: "Every device has been polled successfully at least once.",
+  },
+  [DeviceSummaryFilterKey.InterfacesDown]: {
+    key: DeviceSummaryFilterKey.InterfacesDown,
+    chipLabel: "Devices with interfaces down",
+    emptyMessage: "No device in this project has an interface down.",
+  },
+  [DeviceSummaryFilterKey.NoSite]: {
+    key: DeviceSummaryFilterKey.NoSite,
+    chipLabel: "Devices not assigned to a site",
+    emptyMessage: "Every device is assigned to a site.",
+  },
+};
+
+export function getDeviceSummaryFilterDefinition(
+  key: DeviceSummaryFilterKey,
+): DeviceSummaryFilterDefinition {
+  return DEFINITIONS[key];
+}
+
+/*
+ * Anything arriving from the URL is user-editable, so an unknown value has to
+ * read as "no filter" rather than reaching the query builder.
+ */
+export function parseDeviceSummaryFilterKey(
+  raw: string | null | undefined,
+): DeviceSummaryFilterKey | null {
+  if (!raw) {
+    return null;
+  }
+
+  const match: DeviceSummaryFilterKey | undefined = Object.values(
+    DeviceSummaryFilterKey,
+  ).find((key: DeviceSummaryFilterKey) => {
+    return key === raw;
+  });
+
+  return match || null;
+}
+
+/*
+ * The instant that separates "up" from "stale". Shared with
+ * DeviceSummaryCards so the tile's count and the rows behind it are computed
+ * against the same window — mirrors DeviceStatusUtil.getStatus, which is what
+ * decides the pill in the Status column.
+ */
+export function getDeviceFreshCutoff(): Date {
+  return OneUptimeDate.getSomeMinutesAgo(DEVICE_FRESH_WINDOW_MINUTES);
+}
+
+/*
+ * The query fragment for a tile, to merge into the device table's base query.
+ * `null` means no tile is selected, which is an empty fragment rather than a
+ * special case at every call site.
+ *
+ * Up / Down / Pending partition the fleet exactly: >= cutoff, < cutoff, and
+ * NULL. SQL drops NULLs from both comparisons, so a never-polled device lands
+ * in Pending only, and the three counts always sum to the fleet size.
+ */
+export function getDeviceSummaryFilterQuery(
+  key: DeviceSummaryFilterKey | null,
+): Query<NetworkDevice> {
+  if (!key) {
+    return {};
+  }
+
+  switch (key) {
+    case DeviceSummaryFilterKey.Up:
+      return {
+        lastSeenAt: new GreaterThanOrEqual(getDeviceFreshCutoff()),
+      };
+
+    case DeviceSummaryFilterKey.Down:
+      return {
+        lastSeenAt: new LessThan(getDeviceFreshCutoff()),
+      };
+
+    case DeviceSummaryFilterKey.Pending:
+      return {
+        lastSeenAt: new IsNull(),
+      };
+
+    /*
+     * The tile counts interfaces, not devices, so the row count under it will
+     * be smaller than the number on the tile whenever a device has more than
+     * one interface down. The chip says "devices with interfaces down" for
+     * exactly that reason.
+     */
+    case DeviceSummaryFilterKey.InterfacesDown:
+      return {
+        interfacesDown: new GreaterThan(0),
+      };
+
+    case DeviceSummaryFilterKey.NoSite:
+      return {
+        siteId: new IsNull(),
+      };
+
+    default:
+      return {};
+  }
+}
+
+/*
+ * The table-column filters a tile filter would end up fighting with, named by
+ * the field key the ModelTable declares them under.
+ *
+ * BaseModelTable builds its request as `{...props.query, ...columnFilterQuery}`
+ * — the user's column filters are spread OVER the page's query. A column
+ * filter on the same field therefore replaces the tile's constraint outright,
+ * silently, while the chip and the lit-up tile keep claiming it applies. And
+ * where the two use different keys for the same relation (`siteId` vs `site`)
+ * they survive as an AND that can never match, emptying the table.
+ *
+ * So the page drops these from the filter set for as long as a tile filter is
+ * active: the drill-down and the column filter are alternatives, not layers.
+ */
+export function getDeviceSummaryFilterConflictingFilterFields(
+  key: DeviceSummaryFilterKey | null,
+): Array<string> {
+  if (!key) {
+    return [];
+  }
+
+  switch (key) {
+    case DeviceSummaryFilterKey.Up:
+    case DeviceSummaryFilterKey.Down:
+    case DeviceSummaryFilterKey.Pending:
+      return ["lastSeenAt"];
+
+    /*
+     * The device list filters sites through the relation ("Site"), while the
+     * count and this filter use the foreign key — different keys, same column.
+     */
+    case DeviceSummaryFilterKey.NoSite:
+      return ["site", "siteId"];
+
+    // No column filter is offered over interface counts.
+    case DeviceSummaryFilterKey.InterfacesDown:
+      return [];
+
+    default:
+      return [];
+  }
+}
+
+/*
+ * Whether this filter is defined against the freshness window, and so against
+ * a cutoff taken at the moment the tile was activated. The page tells the user
+ * when that was, because the Status column recomputes the same window on every
+ * render — leave the page open long enough and an "up" row paints a Down pill
+ * unless the snapshot is labelled.
+ */
+export function isDeviceSummaryFilterTimeBased(
+  key: DeviceSummaryFilterKey | null,
+): boolean {
+  return (
+    key === DeviceSummaryFilterKey.Up || key === DeviceSummaryFilterKey.Down
+  );
+}
+
+export interface DeviceSummaryTile {
+  // Also the `data-testid` suffix and the React key.
+  key: string;
+  label: string;
+  // Which count from the summary fetch this tile displays.
+  countField: "devicesUp" | "devicesDown" | "devicesPending" | "interfacesDown";
+  // css class for the count when it needs attention (count > 0).
+  attentionClassName: string;
+  // css class for the count when everything is fine (count === 0).
+  allClearClassName: string;
+  caption: string;
+  // The rows behind this count. Every device tile has one.
+  filterKey: DeviceSummaryFilterKey;
+}
+
+export const DEVICE_SUMMARY_TILES: Array<DeviceSummaryTile> = [
+  {
+    key: "devices-up",
+    label: "Devices Up",
+    countField: "devicesUp",
+    attentionClassName: "text-emerald-600",
+    allClearClassName: "text-gray-900",
+    caption: `Polled within the last ${DEVICE_FRESH_WINDOW_MINUTES} minutes.`,
+    filterKey: DeviceSummaryFilterKey.Up,
+  },
+  {
+    key: "devices-down",
+    label: "Devices Down / Stale",
+    countField: "devicesDown",
+    attentionClassName: "text-red-600",
+    allClearClassName: "text-gray-900",
+    caption: `No successful poll in the last ${DEVICE_FRESH_WINDOW_MINUTES} minutes.`,
+    filterKey: DeviceSummaryFilterKey.Down,
+  },
+  {
+    key: "devices-pending",
+    label: "Devices Pending",
+    countField: "devicesPending",
+    attentionClassName: "text-gray-500",
+    allClearClassName: "text-gray-900",
+    caption: "Never polled successfully yet.",
+    filterKey: DeviceSummaryFilterKey.Pending,
+  },
+  {
+    key: "interfaces-down",
+    label: "Total Interfaces Down",
+    countField: "interfacesDown",
+    attentionClassName: "text-red-600",
+    allClearClassName: "text-gray-900",
+    caption: "Across all devices in this project.",
+    filterKey: DeviceSummaryFilterKey.InterfacesDown,
+  },
+];

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilterRoute.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilterRoute.ts
@@ -1,0 +1,27 @@
+import PageMap from "../../Utils/PageMap";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import {
+  DEVICE_SUMMARY_FILTER_URL_PARAM,
+  DeviceSummaryFilterKey,
+} from "./DeviceSummaryFilter";
+import Route from "Common/Types/API/Route";
+
+/*
+ * A link to the device list already drilled into one of its summary tiles.
+ *
+ * This is how a count shown somewhere else in the product reaches the rows
+ * behind it: the Sites page's "Unassigned Devices" tile counts devices, and
+ * devices are only listed on this page, so activating that tile navigates
+ * here rather than filtering the sites table to nothing.
+ *
+ * Kept out of DeviceSummaryFilter.ts on purpose — RouteMap pulls in the app
+ * config, which reads `window` at import time, and the filter/query mapping
+ * has to stay importable without a browser.
+ */
+export function getDeviceListRouteForFilter(
+  filterKey: DeviceSummaryFilterKey,
+): Route {
+  return RouteUtil.populateRouteParams(
+    RouteMap[PageMap.NETWORK_DEVICES] as Route,
+  ).addQueryParams({ [DEVICE_SUMMARY_FILTER_URL_PARAM]: filterKey });
+}

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryCards.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryCards.tsx
@@ -1,3 +1,9 @@
+import {
+  SITE_SUMMARY_TILES,
+  SiteSummaryFilterKey,
+  SiteSummaryTile,
+  SiteSummaryTileAction,
+} from "./SiteSummaryFilter";
 import ObjectID from "Common/Types/ObjectID";
 import IsNull from "Common/Types/BaseDatabase/IsNull";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
@@ -19,10 +25,22 @@ import React, {
  * are rolling up unhealthy, and how many devices are still unassigned —
  * the number that tells you whether the hierarchy actually covers the
  * fleet.
+ *
+ * Every tile is a drill-down. Three of them narrow the sites table below;
+ * Unassigned Devices counts devices, so it hands over to the device list.
+ * SiteSummaryFilter owns that mapping.
  */
 
 export interface ComponentProps {
   refreshToggle?: string | undefined;
+  // The tile the sites table is currently drilled into, if any.
+  selectedFilterKey?: SiteSummaryFilterKey | null | undefined;
+  /*
+   * Fired with the tile the user activated. The page decides what that
+   * means — narrowing the table, clearing it, or leaving for the device
+   * list — because only the page can navigate.
+   */
+  onTileClick?: ((tile: SiteSummaryTile) => void) | undefined;
 }
 
 interface SummaryCounts {
@@ -110,55 +128,82 @@ const SiteSummaryCards: FunctionComponent<ComponentProps> = (
     return <></>;
   }
 
-  interface SummaryTile {
-    key: string;
-    label: string;
-    count: number;
-    attentionClassName: string;
-    caption: string;
-  }
+  const selectedFilterKey: SiteSummaryFilterKey | null =
+    props.selectedFilterKey || null;
 
-  const tiles: Array<SummaryTile> = [
-    {
-      key: "total-sites",
-      label: "Sites",
-      count: counts?.totalSites || 0,
-      attentionClassName: "text-gray-900",
-      caption: "Across the whole hierarchy.",
-    },
-    {
-      key: "unhealthy-sites",
-      label: "Unhealthy Sites",
-      count: counts?.unhealthySites || 0,
-      attentionClassName: "text-red-600",
-      caption: "Rolling up a non-operational status.",
-    },
-    {
-      key: "sites-no-data",
-      label: "Sites Without Data",
-      count: counts?.sitesWithNoData || 0,
-      attentionClassName: "text-gray-500",
-      caption: "No health rollup yet — no monitored devices below.",
-    },
-    {
-      key: "devices-without-site",
-      label: "Unassigned Devices",
-      count: counts?.devicesWithoutSite || 0,
-      attentionClassName: "text-amber-600",
-      caption: "Devices not assigned to any site.",
-    },
-  ];
+  type IsTileSelectedFunction = (tile: SiteSummaryTile) => boolean | undefined;
+
+  /*
+   * Only the tiles that describe the table below can be "on". The total reads
+   * as selected when nothing is filtered — it is the unfiltered list, which is
+   * what the table is showing.
+   *
+   * Unassigned Devices returns undefined rather than false: it navigates away
+   * instead of toggling, and `undefined` is what keeps InfoCard from
+   * announcing it as a toggle button that is currently off.
+   */
+  const isTileSelected: IsTileSelectedFunction = (
+    tile: SiteSummaryTile,
+  ): boolean | undefined => {
+    if (tile.action === SiteSummaryTileAction.FilterSites) {
+      return Boolean(tile.filterKey) && tile.filterKey === selectedFilterKey;
+    }
+
+    if (tile.action === SiteSummaryTileAction.ClearFilter) {
+      return selectedFilterKey === null;
+    }
+
+    return undefined;
+  };
+
+  type TileAriaLabelFunction = (
+    tile: SiteSummaryTile,
+    count: number,
+    isSelected: boolean | undefined,
+  ) => string;
+
+  const getTileAriaLabel: TileAriaLabelFunction = (
+    tile: SiteSummaryTile,
+    count: number,
+    isSelected: boolean | undefined,
+  ): string => {
+    if (tile.action === SiteSummaryTileAction.ShowUnassignedDevices) {
+      return `${tile.label}: ${count}. Activate to open these on the device list.`;
+    }
+
+    if (isSelected) {
+      return `${tile.label}: ${count}. Showing these in the list below.`;
+    }
+
+    return `${tile.label}: ${count}. Activate to show these in the list below.`;
+  };
 
   return (
     <div
       data-testid="network-site-summary-cards"
       className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4"
     >
-      {tiles.map((tile: SummaryTile) => {
+      {SITE_SUMMARY_TILES.map((tile: SiteSummaryTile) => {
+        const count: number = counts?.[tile.countField] || 0;
+        const isSelected: boolean | undefined = isTileSelected(tile);
+
         return (
           <InfoCard
             key={tile.key}
             title={tile.label}
+            /*
+             * The tiles stay inert until the counts land: clicking a skeleton
+             * would filter the list to a number nobody has read yet.
+             */
+            onClick={
+              props.onTileClick && !isLoading
+                ? () => {
+                    props.onTileClick?.(tile);
+                  }
+                : undefined
+            }
+            isSelected={isSelected}
+            ariaLabel={getTileAriaLabel(tile, count, isSelected)}
             value={
               isLoading ? (
                 <div className="mt-1 space-y-2">
@@ -170,10 +215,10 @@ const SiteSummaryCards: FunctionComponent<ComponentProps> = (
                   <div
                     data-testid={`network-site-stat-${tile.key}`}
                     className={`text-3xl font-semibold ${
-                      tile.count > 0 ? tile.attentionClassName : "text-gray-900"
+                      count > 0 ? tile.attentionClassName : "text-gray-900"
                     }`}
                   >
-                    {tile.count}
+                    {count}
                   </div>
                   <div className="mt-2 text-sm text-gray-500">
                     {tile.caption}

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryFilter.ts
@@ -1,0 +1,178 @@
+import { DeviceSummaryFilterKey } from "../NetworkDevice/DeviceSummaryFilter";
+import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import Query from "Common/Types/BaseDatabase/Query";
+
+/*
+ * The Sites page counterpart of DeviceSummaryFilter: maps each tile in the
+ * summary strip to the rows it counted.
+ *
+ * Three of the four tiles count sites and narrow the sites table. The fourth
+ * — Unassigned Devices — counts devices, and its rows only exist on the
+ * device list, so that tile navigates there instead of filtering in place.
+ */
+
+export enum SiteSummaryFilterKey {
+  Unhealthy = "unhealthy",
+  NoData = "no-data",
+}
+
+// The query-string parameter the selected tile is mirrored into.
+export const SITE_SUMMARY_FILTER_URL_PARAM: string = "siteFilter";
+
+export interface SiteSummaryFilterDefinition {
+  key: SiteSummaryFilterKey;
+  // Shown on the chip above the table while this filter is applied.
+  chipLabel: string;
+  // Replaces the table's generic "no items" copy while this filter is applied.
+  emptyMessage: string;
+}
+
+const DEFINITIONS: Record<SiteSummaryFilterKey, SiteSummaryFilterDefinition> = {
+  [SiteSummaryFilterKey.Unhealthy]: {
+    key: SiteSummaryFilterKey.Unhealthy,
+    chipLabel: "Unhealthy sites",
+    emptyMessage: "Every site with a health rollup is operational.",
+  },
+  [SiteSummaryFilterKey.NoData]: {
+    key: SiteSummaryFilterKey.NoData,
+    chipLabel: "Sites without data",
+    emptyMessage: "Every site is rolling up a status.",
+  },
+};
+
+export function getSiteSummaryFilterDefinition(
+  key: SiteSummaryFilterKey,
+): SiteSummaryFilterDefinition {
+  return DEFINITIONS[key];
+}
+
+/*
+ * Anything arriving from the URL is user-editable, so an unknown value has to
+ * read as "no filter" rather than reaching the query builder.
+ */
+export function parseSiteSummaryFilterKey(
+  raw: string | null | undefined,
+): SiteSummaryFilterKey | null {
+  if (!raw) {
+    return null;
+  }
+
+  const match: SiteSummaryFilterKey | undefined = Object.values(
+    SiteSummaryFilterKey,
+  ).find((key: SiteSummaryFilterKey) => {
+    return key === raw;
+  });
+
+  return match || null;
+}
+
+/*
+ * The query fragment for a tile, to merge into the site table's base query.
+ * `null` means no tile is selected.
+ *
+ * The two are mutually exclusive by construction: "unhealthy" joins the
+ * rolled-up status and asks for a non-operational one, which requires the FK
+ * to be set; "no data" is that same FK being NULL. A site with an operational
+ * rollup matches neither, which is why the two counts do not sum to the site
+ * total.
+ */
+export function getSiteSummaryFilterQuery(
+  key: SiteSummaryFilterKey | null,
+): Query<NetworkSite> {
+  if (!key) {
+    return {};
+  }
+
+  switch (key) {
+    case SiteSummaryFilterKey.Unhealthy:
+      return {
+        currentMonitorStatus: {
+          isOperationalState: false,
+        },
+      };
+
+    /*
+     * Filtered on the FK rather than the relation: a site with no rollup has
+     * no MonitorStatus row to match against, so there is nothing to join.
+     */
+    case SiteSummaryFilterKey.NoData:
+      return {
+        currentMonitorStatusId: new IsNull(),
+      };
+
+    default:
+      return {};
+  }
+}
+
+export enum SiteSummaryTileAction {
+  // The total — clicking it takes the user back to the unfiltered list.
+  ClearFilter = "clear-filter",
+  // Narrows the sites table in place.
+  FilterSites = "filter-sites",
+  // Leaves for the device list, which is where these rows live.
+  ShowUnassignedDevices = "show-unassigned-devices",
+}
+
+export interface SiteSummaryTile {
+  // Also the `data-testid` suffix and the React key.
+  key: string;
+  label: string;
+  // Which count from the summary fetch this tile displays.
+  countField:
+    | "totalSites"
+    | "unhealthySites"
+    | "sitesWithNoData"
+    | "devicesWithoutSite";
+  attentionClassName: string;
+  caption: string;
+  action: SiteSummaryTileAction;
+  // Set only when the action is FilterSites.
+  filterKey?: SiteSummaryFilterKey | undefined;
+}
+
+export const SITE_SUMMARY_TILES: Array<SiteSummaryTile> = [
+  {
+    key: "total-sites",
+    label: "Sites",
+    countField: "totalSites",
+    attentionClassName: "text-gray-900",
+    caption: "Across the whole hierarchy.",
+    action: SiteSummaryTileAction.ClearFilter,
+  },
+  {
+    key: "unhealthy-sites",
+    label: "Unhealthy Sites",
+    countField: "unhealthySites",
+    attentionClassName: "text-red-600",
+    caption: "Rolling up a non-operational status.",
+    action: SiteSummaryTileAction.FilterSites,
+    filterKey: SiteSummaryFilterKey.Unhealthy,
+  },
+  {
+    key: "sites-no-data",
+    label: "Sites Without Data",
+    countField: "sitesWithNoData",
+    attentionClassName: "text-gray-500",
+    caption: "No health rollup yet — no monitored devices below.",
+    action: SiteSummaryTileAction.FilterSites,
+    filterKey: SiteSummaryFilterKey.NoData,
+  },
+  {
+    key: "devices-without-site",
+    label: "Unassigned Devices",
+    countField: "devicesWithoutSite",
+    attentionClassName: "text-amber-600",
+    caption: "Devices not assigned to any site.",
+    action: SiteSummaryTileAction.ShowUnassignedDevices,
+  },
+];
+
+/*
+ * The device filter the Unassigned Devices tile hands over to the device
+ * list. Named here so the two pages cannot disagree about which filter that
+ * tile means.
+ */
+export const UNASSIGNED_DEVICES_FILTER_KEY: DeviceSummaryFilterKey =
+  DeviceSummaryFilterKey.NoSite;

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
@@ -13,6 +13,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
@@ -33,12 +34,34 @@ import Pill, { PillSize } from "Common/UI/Components/Pill/Pill";
 import ProbeElement from "Common/UI/Components/Probe/Probe";
 import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 import ProjectUtil from "Common/UI/Utils/Project";
+import Navigation from "Common/UI/Utils/Navigation";
+import Query from "Common/Types/BaseDatabase/Query";
 import DeviceSummaryCards from "../../Components/NetworkDevice/DeviceSummaryCards";
+import SummaryFilterChip from "../../Components/Network/SummaryFilterChip";
 import DeviceStatusUtil, {
   DEVICE_FRESH_WINDOW_MINUTES,
   NetworkDeviceStatus,
 } from "../../Components/NetworkDevice/DeviceStatusUtil";
+import {
+  DEVICE_SUMMARY_FILTER_URL_PARAM,
+  DeviceSummaryFilterDefinition,
+  DeviceSummaryFilterKey,
+  getDeviceSummaryFilterConflictingFilterFields,
+  getDeviceSummaryFilterDefinition,
+  getDeviceSummaryFilterQuery,
+  isDeviceSummaryFilterTimeBased,
+  parseDeviceSummaryFilterKey,
+} from "../../Components/NetworkDevice/DeviceSummaryFilter";
+import TableFilterUrlState from "Common/UI/Utils/TableFilterUrlState";
+import Filter from "Common/UI/Components/ModelFilter/Filter";
 import { getSnmpConfigFormFields } from "./SnmpConfigFormFields";
+
+/*
+ * Shared by the table's `id`, its `userPreferencesKey` and the URL namespace
+ * its filter/sort/page state is persisted under. Named here because the
+ * summary drill-down has to clear that state (see changeSummaryFilter).
+ */
+const NETWORK_DEVICES_TABLE_ID: string = "network-devices-table";
 
 const NetworkDevices: FunctionComponent<
   PageComponentProps
@@ -46,6 +69,112 @@ const NetworkDevices: FunctionComponent<
   const [probes, setProbes] = useState<Array<Probe>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>("");
+
+  /*
+   * Which summary tile the list is drilled into. Seeded from the URL — read
+   * once, synchronously, so the very first fetch already carries the filter
+   * (an effect would fetch the whole fleet first and throw it away), and so
+   * the Sites page's "Unassigned Devices" tile can hand its rows over by
+   * linking here.
+   */
+  const [summaryFilterKey, setSummaryFilterKey] =
+    useState<DeviceSummaryFilterKey | null>(() => {
+      return parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(DEVICE_SUMMARY_FILTER_URL_PARAM),
+      );
+    });
+
+  type ChangeSummaryFilterFunction = (
+    filterKey: DeviceSummaryFilterKey | null,
+  ) => void;
+
+  const changeSummaryFilter: ChangeSummaryFilterFunction = (
+    filterKey: DeviceSummaryFilterKey | null,
+  ): void => {
+    /*
+     * Drop whatever the column-filter popup was holding, and the page number
+     * that went with it.
+     *
+     * A drill-down and a column filter over the same field cannot both apply:
+     * BaseModelTable spreads the column filters over the page's query, so an
+     * already-set "Last Seen At" filter would silently replace the tile's
+     * constraint while the chip carried on claiming it. The table is
+     * remounted on the selection (see its `key` below), and it re-reads this
+     * state on mount — so clearing it here is what makes the two exclusive
+     * whichever order the user reaches for them in.
+     */
+    TableFilterUrlState.clear(NETWORK_DEVICES_TABLE_ID);
+
+    setSummaryFilterKey(filterKey);
+    /*
+     * replaceState, so a drill-down is shareable and survives viewing a
+     * device and coming back, without burying the previous page under a
+     * history entry per tile click.
+     */
+    Navigation.setQueryString({
+      [DEVICE_SUMMARY_FILTER_URL_PARAM]: filterKey,
+    });
+  };
+
+  /*
+   * Memoised because "up" and "down" carry a cutoff Date built at call time,
+   * and ModelTable decides whether to refetch by JSON-comparing this prop
+   * against the previous render's. A fresh cutoff every render would compare
+   * unequal every render — an endless refetch loop.
+   *
+   * The consequence is that the window is a snapshot taken when the tile was
+   * activated, not a live one. Re-deriving it on a timer instead would send
+   * anyone reading page 3 back to page 1 every tick and drop any bulk
+   * selection they had made, which is worse than the drift — so the chip says
+   * when the snapshot was taken, and re-activating the tile takes a new one.
+   */
+  const tableQuery: Query<NetworkDevice> = useMemo(() => {
+    return {
+      isArchived: false,
+      ...getDeviceSummaryFilterQuery(summaryFilterKey),
+    };
+  }, [summaryFilterKey]);
+
+  const summaryFilterDefinition: DeviceSummaryFilterDefinition | null =
+    summaryFilterKey
+      ? getDeviceSummaryFilterDefinition(summaryFilterKey)
+      : null;
+
+  /*
+   * The instant the snapshot above was taken, shown next to the chip. Keyed on
+   * the same selection as the query, so it is re-taken exactly when the cutoff
+   * is and cannot end up naming a different moment.
+   */
+  const summaryFilterDetail: string | undefined = useMemo(() => {
+    if (!isDeviceSummaryFilterTimeBased(summaryFilterKey)) {
+      return undefined;
+    }
+
+    return `as of ${OneUptimeDate.getLocalHourAndMinuteFromDate(
+      OneUptimeDate.getCurrentDate(),
+    )}`;
+  }, [summaryFilterKey]);
+
+  /*
+   * A drill-down owns its field, so the popup stops offering a filter that
+   * would overwrite it. `filters` is also what BaseModelTable sanitises
+   * URL-restored filter data against, so dropping an entry here drops any
+   * stale value for it from a shared link too.
+   */
+  const conflictingFilterFields: Array<string> =
+    getDeviceSummaryFilterConflictingFilterFields(summaryFilterKey);
+
+  type IsFilterOfferedFunction = (filter: Filter<NetworkDevice>) => boolean;
+
+  const isFilterOffered: IsFilterOfferedFunction = (
+    filter: Filter<NetworkDevice>,
+  ): boolean => {
+    const field: string | undefined = filter.field
+      ? Object.keys(filter.field)[0]
+      : undefined;
+
+    return !field || !conflictingFilterFields.includes(field);
+  };
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
     useBulkLabelActions<NetworkDevice>({ modelType: NetworkDevice });
@@ -81,12 +210,34 @@ const NetworkDevices: FunctionComponent<
 
   return (
     <Fragment>
-      <DeviceSummaryCards />
+      <DeviceSummaryCards
+        selectedFilterKey={summaryFilterKey}
+        onFilterKeyChange={changeSummaryFilter}
+      />
       <ModelTable<NetworkDevice>
+        /*
+         * Remounted when the drill-down changes, so the table re-reads its
+         * (just-cleared) filter and page state instead of carrying a column
+         * filter that would silently override the tile's constraint.
+         */
+        key={`${NETWORK_DEVICES_TABLE_ID}-${summaryFilterKey || "all"}`}
         modelType={NetworkDevice}
-        id="network-devices-table"
-        userPreferencesKey="network-devices-table"
-        query={{ isArchived: false }}
+        id={NETWORK_DEVICES_TABLE_ID}
+        userPreferencesKey={NETWORK_DEVICES_TABLE_ID}
+        query={tableQuery}
+        topContent={
+          summaryFilterDefinition ? (
+            <SummaryFilterChip
+              testIdSuffix="network-devices"
+              label={summaryFilterDefinition.chipLabel}
+              detail={summaryFilterDetail}
+              onClear={() => {
+                changeSummaryFilter(null);
+              }}
+            />
+          ) : undefined
+        }
+        noItemsMessage={summaryFilterDefinition?.emptyMessage}
         isDeleteable={false}
         isEditable={false}
         isCreateable={true}
@@ -178,7 +329,11 @@ const NetworkDevices: FunctionComponent<
             title: "Last Seen At",
             type: FieldType.Date,
           },
-        ]}
+          /*
+           * The drill-down owns its field while it is active, so the popup
+           * never offers a filter that would quietly replace it.
+           */
+        ].filter(isFilterOffered)}
         cardProps={{
           title: "Network Devices",
           description:

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Sites.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/Sites.tsx
@@ -6,20 +6,36 @@ import MonitorStatusElement from "../../Components/MonitorStatus/MonitorStatusEl
 import ImportSitesFromCsvModal from "../../Components/NetworkSite/ImportSitesFromCsvModal";
 import SiteHierarchyTree from "../../Components/NetworkSite/SiteHierarchyTree";
 import SiteSummaryCards from "../../Components/NetworkSite/SiteSummaryCards";
+import SummaryFilterChip from "../../Components/Network/SummaryFilterChip";
+import { getDeviceListRouteForFilter } from "../../Components/NetworkDevice/DeviceSummaryFilterRoute";
+import {
+  SITE_SUMMARY_FILTER_URL_PARAM,
+  SiteSummaryFilterDefinition,
+  SiteSummaryFilterKey,
+  SiteSummaryTile,
+  SiteSummaryTileAction,
+  UNASSIGNED_DEVICES_FILTER_KEY,
+  getSiteSummaryFilterDefinition,
+  getSiteSummaryFilterQuery,
+  parseSiteSummaryFilterKey,
+} from "../../Components/NetworkSite/SiteSummaryFilter";
 import Route from "Common/Types/API/Route";
 import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
 import IconProp from "Common/Types/Icon/IconProp";
 import ObjectID from "Common/Types/ObjectID";
+import Query from "Common/Types/BaseDatabase/Query";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import { CardButtonSchema } from "Common/UI/Components/Card/Card";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import Navigation from "Common/UI/Utils/Navigation";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
+  useMemo,
   useState,
 } from "react";
 
@@ -35,14 +51,104 @@ const NetworkSites: FunctionComponent<
 
   const [showImportModal, setShowImportModal] = useState<boolean>(false);
 
+  /*
+   * Which summary tile the table is drilled into. Seeded from the URL — read
+   * once, synchronously, so the first fetch already carries the filter rather
+   * than loading every site and throwing the response away.
+   */
+  const [summaryFilterKey, setSummaryFilterKey] =
+    useState<SiteSummaryFilterKey | null>(() => {
+      return parseSiteSummaryFilterKey(
+        Navigation.getQueryStringByName(SITE_SUMMARY_FILTER_URL_PARAM),
+      );
+    });
+
+  type ChangeSummaryFilterFunction = (
+    filterKey: SiteSummaryFilterKey | null,
+  ) => void;
+
+  const changeSummaryFilter: ChangeSummaryFilterFunction = (
+    filterKey: SiteSummaryFilterKey | null,
+  ): void => {
+    setSummaryFilterKey(filterKey);
+    /*
+     * replaceState, so a drill-down is shareable and survives viewing a site
+     * and coming back, without burying the previous page under a history
+     * entry per tile click.
+     */
+    Navigation.setQueryString({
+      [SITE_SUMMARY_FILTER_URL_PARAM]: filterKey,
+    });
+  };
+
+  type OnSummaryTileClickFunction = (tile: SiteSummaryTile) => void;
+
+  const onSummaryTileClick: OnSummaryTileClickFunction = (
+    tile: SiteSummaryTile,
+  ): void => {
+    /*
+     * The rows behind "Unassigned Devices" are devices, and this page lists
+     * sites — so that tile leaves for the device list already filtered,
+     * instead of narrowing the sites table to something the count never
+     * described.
+     */
+    if (tile.action === SiteSummaryTileAction.ShowUnassignedDevices) {
+      Navigation.navigate(
+        getDeviceListRouteForFilter(UNASSIGNED_DEVICES_FILTER_KEY),
+      );
+      return;
+    }
+
+    if (tile.action === SiteSummaryTileAction.ClearFilter) {
+      changeSummaryFilter(null);
+      return;
+    }
+
+    // Clicking the tile the table is already showing toggles back to all sites.
+    changeSummaryFilter(
+      tile.filterKey && tile.filterKey !== summaryFilterKey
+        ? tile.filterKey
+        : null,
+    );
+  };
+
+  /*
+   * Memoised because ModelTable decides whether to refetch by JSON-comparing
+   * this prop against the previous render's, and callers that hand it a fresh
+   * object literal every render make every render look like a change.
+   */
+  const tableQuery: Query<NetworkSite> = useMemo(() => {
+    return getSiteSummaryFilterQuery(summaryFilterKey);
+  }, [summaryFilterKey]);
+
+  const summaryFilterDefinition: SiteSummaryFilterDefinition | null =
+    summaryFilterKey ? getSiteSummaryFilterDefinition(summaryFilterKey) : null;
+
   return (
     <Fragment>
-      <SiteSummaryCards refreshToggle={refreshToggle} />
+      <SiteSummaryCards
+        refreshToggle={refreshToggle}
+        selectedFilterKey={summaryFilterKey}
+        onTileClick={onSummaryTileClick}
+      />
       <div className="mb-5">
         <SiteHierarchyTree refreshToggle={refreshToggle} />
       </div>
       <ModelTable<NetworkSite>
         refreshToggle={refreshToggle}
+        query={tableQuery}
+        topContent={
+          summaryFilterDefinition ? (
+            <SummaryFilterChip
+              testIdSuffix="network-sites"
+              label={summaryFilterDefinition.chipLabel}
+              onClear={() => {
+                changeSummaryFilter(null);
+              }}
+            />
+          ) : undefined
+        }
+        noItemsMessage={summaryFilterDefinition?.emptyMessage}
         onCreateSuccess={(item: NetworkSite): Promise<NetworkSite> => {
           setRefreshToggle(Date.now().toString());
           return Promise.resolve(item);

--- a/App/Tests/Dashboard/DeviceSummaryFilter.test.ts
+++ b/App/Tests/Dashboard/DeviceSummaryFilter.test.ts
@@ -1,0 +1,639 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import {
+  DEVICE_SUMMARY_FILTER_URL_PARAM,
+  DEVICE_SUMMARY_TILES,
+  DeviceSummaryFilterDefinition,
+  DeviceSummaryFilterKey,
+  DeviceSummaryTile,
+  getDeviceFreshCutoff,
+  getDeviceSummaryFilterConflictingFilterFields,
+  getDeviceSummaryFilterDefinition,
+  getDeviceSummaryFilterQuery,
+  isDeviceSummaryFilterTimeBased,
+  parseDeviceSummaryFilterKey,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilter";
+import { DEVICE_FRESH_WINDOW_MINUTES } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusUtil";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
+import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import LessThan from "Common/Types/BaseDatabase/LessThan";
+import Query from "Common/Types/BaseDatabase/Query";
+
+/*
+ * DeviceSummaryFilter is the contract between a number on a tile and the rows
+ * that number counted. If the two ever describe different sets, the product
+ * lies: the tile says "3 devices down", the list it opens shows 5, and there
+ * is nothing on screen to explain the difference.
+ *
+ * So these tests pin the query fragments field-by-field and operator-by-
+ * operator against the count queries in DeviceSummaryCards.tsx, rather than
+ * merely checking that "some query" comes back.
+ */
+
+// The frozen "now" the time-dependent tests run at.
+const NOW: Date = new Date("2026-07-16T12:00:00.000Z");
+const MS_PER_MINUTE: number = 60 * 1000;
+
+/*
+ * Only Date needs faking; the sinon backend jest 28 uses cannot hijack the
+ * read-only `performance` global on current Node. Same list as
+ * DeviceStatusUtil.test.ts, which freezes time for the same reason.
+ */
+function freezeTime(at: Date): void {
+  jest.useFakeTimers({
+    doNotFake: [
+      "performance",
+      "hrtime",
+      "queueMicrotask",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+      "requestIdleCallback",
+      "cancelIdleCallback",
+      "setImmediate",
+      "clearImmediate",
+      "setInterval",
+      "clearInterval",
+      "setTimeout",
+      "clearTimeout",
+    ],
+  });
+  jest.setSystemTime(at);
+}
+
+const ALL_KEYS: Array<DeviceSummaryFilterKey> = Object.values(
+  DeviceSummaryFilterKey,
+);
+
+describe("DeviceSummaryFilterKey", () => {
+  /*
+   * These strings are in shared URLs. Renaming one silently breaks every link
+   * already pasted into a ticket or a chat, so the rename has to be a
+   * conscious edit of this test.
+   */
+  test("the wire values are stable", () => {
+    expect(DeviceSummaryFilterKey.Up).toBe("up");
+    expect(DeviceSummaryFilterKey.Down).toBe("down");
+    expect(DeviceSummaryFilterKey.Pending).toBe("pending");
+    expect(DeviceSummaryFilterKey.InterfacesDown).toBe("interfaces-down");
+    expect(DeviceSummaryFilterKey.NoSite).toBe("no-site");
+  });
+
+  test("there are exactly five, and they are distinct", () => {
+    expect(ALL_KEYS).toHaveLength(5);
+    expect(new Set(ALL_KEYS).size).toBe(5);
+  });
+
+  test("the URL parameter name is stable", () => {
+    expect(DEVICE_SUMMARY_FILTER_URL_PARAM).toBe("deviceFilter");
+  });
+});
+
+describe("parseDeviceSummaryFilterKey", () => {
+  test.each(ALL_KEYS)("round-trips %s", (key: DeviceSummaryFilterKey) => {
+    expect(parseDeviceSummaryFilterKey(key)).toBe(key);
+  });
+
+  describe("absent values read as no filter", () => {
+    test.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["empty string", ""],
+    ])("%s", (_label: string, raw: string | null | undefined) => {
+      expect(parseDeviceSummaryFilterKey(raw)).toBeNull();
+    });
+  });
+
+  /*
+   * The parameter is in the address bar, so its value is whatever anyone
+   * chooses to type. Nothing but an exact key may reach the query builder —
+   * an unrecognised value has to degrade to the unfiltered list, never to a
+   * malformed query or a thrown error that blanks the page.
+   */
+  describe("hostile and stale values read as no filter", () => {
+    test.each([
+      ["unknown word", "banana"],
+      ["a key that used to exist", "devices-up"],
+      ["wrong case", "UP"],
+      ["mixed case", "Down"],
+      ["leading whitespace", " up"],
+      ["trailing whitespace", "up "],
+      ["a prefix of a real key", "pen"],
+      ["a real key with a suffix", "up-x"],
+      ["an Object.prototype member", "constructor"],
+      ["a prototype-pollution attempt", "__proto__"],
+      ["another prototype member", "toString"],
+      ["a number", "0"],
+      ["a JSON payload", '{"lastSeenAt":null}'],
+      ["a SQL fragment", "1' OR '1'='1"],
+    ])("%s", (_label: string, raw: string) => {
+      expect(parseDeviceSummaryFilterKey(raw)).toBeNull();
+    });
+  });
+
+  test("never returns a value that is not one of the keys", () => {
+    for (const raw of ["up", "down", "nonsense", "", "__proto__"]) {
+      const parsed: DeviceSummaryFilterKey | null =
+        parseDeviceSummaryFilterKey(raw);
+      if (parsed !== null) {
+        expect(ALL_KEYS).toContain(parsed);
+      }
+    }
+  });
+});
+
+describe("getDeviceFreshCutoff", () => {
+  beforeEach(() => {
+    freezeTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("is the freshness window ago", () => {
+    expect(getDeviceFreshCutoff().getTime()).toBe(
+      NOW.getTime() - DEVICE_FRESH_WINDOW_MINUTES * MS_PER_MINUTE,
+    );
+  });
+
+  /*
+   * The Status column's pill, the tile counts and the drill-down query all
+   * have to agree on where "up" ends. They agree because all three read this
+   * one constant.
+   */
+  test("uses the same window as the Status pill", () => {
+    expect(DEVICE_FRESH_WINDOW_MINUTES).toBe(15);
+  });
+});
+
+describe("getDeviceSummaryFilterQuery", () => {
+  beforeEach(() => {
+    freezeTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("no selection is an empty fragment, not a special case", () => {
+    expect(getDeviceSummaryFilterQuery(null)).toEqual({});
+  });
+
+  test("every key produces a fragment naming exactly one column", () => {
+    for (const key of ALL_KEYS) {
+      expect(Object.keys(getDeviceSummaryFilterQuery(key))).toHaveLength(1);
+    }
+  });
+
+  /*
+   * The fragment is merged over the page's base query, which is what carries
+   * `isArchived: false`. If the fragment started carrying scoping of its own,
+   * one of the two would eventually be edited without the other.
+   */
+  test.each(ALL_KEYS)(
+    "%s carries no scoping of its own",
+    (key: DeviceSummaryFilterKey) => {
+      const query: Query<NetworkDevice> = getDeviceSummaryFilterQuery(key);
+      expect(query.projectId).toBeUndefined();
+      expect(query.isArchived).toBeUndefined();
+    },
+  );
+
+  describe("Up — the devices the 'Devices Up' tile counted", () => {
+    /*
+     * DeviceSummaryCards counts these with
+     * `lastSeenAt: new GreaterThanOrEqual(freshCutoff)`. Anything else here
+     * and the tile opens a different set than it counted.
+     */
+    test("is lastSeenAt >= the fresh cutoff", () => {
+      const query: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Up,
+      );
+
+      expect(query.lastSeenAt).toBeInstanceOf(GreaterThanOrEqual);
+      expect(
+        (query.lastSeenAt as GreaterThanOrEqual<Date>).value.getTime(),
+      ).toBe(getDeviceFreshCutoff().getTime());
+    });
+
+    test("is inclusive of the boundary, matching DeviceStatusUtil", () => {
+      // getStatus() calls a device seen exactly at the cutoff "Up".
+      expect(
+        getDeviceSummaryFilterQuery(DeviceSummaryFilterKey.Up).lastSeenAt,
+      ).not.toBeInstanceOf(GreaterThan);
+    });
+  });
+
+  describe("Down — the devices the 'Devices Down / Stale' tile counted", () => {
+    test("is lastSeenAt < the fresh cutoff", () => {
+      const query: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Down,
+      );
+
+      expect(query.lastSeenAt).toBeInstanceOf(LessThan);
+      expect((query.lastSeenAt as LessThan<Date>).value.getTime()).toBe(
+        getDeviceFreshCutoff().getTime(),
+      );
+    });
+  });
+
+  describe("Pending — the devices the 'Devices Pending' tile counted", () => {
+    test("is lastSeenAt IS NULL", () => {
+      const query: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Pending,
+      );
+
+      expect(query.lastSeenAt).toBeInstanceOf(IsNull);
+    });
+
+    /*
+     * A never-polled device has to land in Pending and nowhere else. SQL
+     * evaluates both `NULL >= x` and `NULL < x` as unknown, so it is dropped
+     * from Up and Down — but only as long as those two stay comparisons.
+     * The moment either becomes a coalescing operator (GreaterThanOrNull,
+     * LessThanOrNull) pending devices get counted twice.
+     */
+    test("Up and Down stay plain comparisons, so pending devices match neither", () => {
+      const up: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Up,
+      );
+      const down: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Down,
+      );
+
+      expect(up.lastSeenAt!.constructor.name).toBe("GreaterThanOrEqual");
+      expect(down.lastSeenAt!.constructor.name).toBe("LessThan");
+    });
+  });
+
+  describe("the three status filters partition the fleet", () => {
+    test("all three filter the same column", () => {
+      for (const key of [
+        DeviceSummaryFilterKey.Up,
+        DeviceSummaryFilterKey.Down,
+        DeviceSummaryFilterKey.Pending,
+      ]) {
+        expect(Object.keys(getDeviceSummaryFilterQuery(key))).toEqual([
+          "lastSeenAt",
+        ]);
+      }
+    });
+
+    /*
+     * Up is >= cutoff and Down is < cutoff at the SAME instant. If the two
+     * ever drifted apart — a rounded cutoff on one side, a different window
+     * on the other — devices in the gap would appear in neither list while
+     * still being counted by one of the tiles.
+     */
+    test("Up and Down meet exactly at one instant, with no gap and no overlap", () => {
+      const up: GreaterThanOrEqual<Date> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Up,
+      ).lastSeenAt as GreaterThanOrEqual<Date>;
+      const down: LessThan<Date> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.Down,
+      ).lastSeenAt as LessThan<Date>;
+
+      expect(up.value.getTime()).toBe(down.value.getTime());
+    });
+  });
+
+  describe("InterfacesDown — the 'Total Interfaces Down' tile", () => {
+    /*
+     * The tile counts interfaces; the list can only show devices. So the
+     * filter is "devices with at least one interface down" — the same query
+     * DeviceSummaryCards uses to fetch the devices it sums over.
+     */
+    test("is interfacesDown > 0", () => {
+      const query: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.InterfacesDown,
+      );
+
+      expect(query.interfacesDown).toBeInstanceOf(GreaterThan);
+      expect((query.interfacesDown as GreaterThan<number>).value).toBe(0);
+    });
+
+    test("does not touch lastSeenAt — a stale device can still have interfaces down", () => {
+      expect(
+        getDeviceSummaryFilterQuery(DeviceSummaryFilterKey.InterfacesDown)
+          .lastSeenAt,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("NoSite — where the Sites page's 'Unassigned Devices' tile lands", () => {
+    /*
+     * Matches the count query in SiteSummaryCards, which is
+     * `siteId: new IsNull()` — the FK, not the relation. A site-less device
+     * has no NetworkSite row to join against.
+     */
+    test("is siteId IS NULL", () => {
+      const query: Query<NetworkDevice> = getDeviceSummaryFilterQuery(
+        DeviceSummaryFilterKey.NoSite,
+      );
+
+      expect(query.siteId).toBeInstanceOf(IsNull);
+      expect(query.site).toBeUndefined();
+    });
+  });
+
+  /*
+   * The Devices page memoises this fragment on the selected key. These two
+   * tests are why: the value embeds the wall clock, and ModelTable decides
+   * whether to refetch by JSON-comparing the previous `query` prop with the
+   * next one. Rebuilt on every render, it would compare unequal on every
+   * render — an unbounded refetch loop against the API.
+   *
+   * If the memo is ever "simplified" away, the second test below is the
+   * standing explanation of what that costs.
+   */
+  describe("serialised stability (why the page memoises)", () => {
+    test("two calls at the same instant serialise identically", () => {
+      expect(
+        JSON.stringify(getDeviceSummaryFilterQuery(DeviceSummaryFilterKey.Up)),
+      ).toBe(
+        JSON.stringify(getDeviceSummaryFilterQuery(DeviceSummaryFilterKey.Up)),
+      );
+    });
+
+    test("two calls a second apart do not", () => {
+      const first: string = JSON.stringify(
+        getDeviceSummaryFilterQuery(DeviceSummaryFilterKey.Up),
+      );
+
+      jest.setSystemTime(new Date(NOW.getTime() + 1000));
+
+      expect(
+        JSON.stringify(getDeviceSummaryFilterQuery(DeviceSummaryFilterKey.Up)),
+      ).not.toBe(first);
+    });
+
+    test("the clock-free filters are stable whenever they are built", () => {
+      for (const key of [
+        DeviceSummaryFilterKey.Pending,
+        DeviceSummaryFilterKey.InterfacesDown,
+        DeviceSummaryFilterKey.NoSite,
+      ]) {
+        const first: string = JSON.stringify(getDeviceSummaryFilterQuery(key));
+        jest.setSystemTime(new Date(NOW.getTime() + 60 * MS_PER_MINUTE));
+        expect(JSON.stringify(getDeviceSummaryFilterQuery(key))).toBe(first);
+      }
+    });
+  });
+});
+
+describe("getDeviceSummaryFilterDefinition", () => {
+  test.each(ALL_KEYS)(
+    "%s has a chip label and empty-state copy",
+    (key: DeviceSummaryFilterKey) => {
+      const definition: DeviceSummaryFilterDefinition =
+        getDeviceSummaryFilterDefinition(key);
+
+      expect(definition.key).toBe(key);
+      expect(definition.chipLabel.length).toBeGreaterThan(0);
+      expect(definition.emptyMessage.length).toBeGreaterThan(0);
+    },
+  );
+
+  test("no two filters present the same chip", () => {
+    const labels: Array<string> = ALL_KEYS.map(
+      (key: DeviceSummaryFilterKey) => {
+        return getDeviceSummaryFilterDefinition(key).chipLabel;
+      },
+    );
+
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  /*
+   * The tile says "Total Interfaces Down" and its count is a number of
+   * interfaces; the rows underneath are devices. The chip is the only place
+   * that discrepancy can be explained, so it has to name devices.
+   */
+  test("the interfaces chip says devices, because that is what the rows are", () => {
+    expect(
+      getDeviceSummaryFilterDefinition(DeviceSummaryFilterKey.InterfacesDown)
+        .chipLabel,
+    ).toBe("Devices with interfaces down");
+  });
+
+  test("the empty-state copy explains the filtered set, not the fleet", () => {
+    expect(
+      getDeviceSummaryFilterDefinition(DeviceSummaryFilterKey.Down)
+        .emptyMessage,
+    ).toContain(`${DEVICE_FRESH_WINDOW_MINUTES} minutes`);
+  });
+});
+
+/*
+ * BaseModelTable builds its request as `{...props.query, ...columnFilterQuery}`
+ * — the popup's filters are spread OVER the page's query. So a tile filter and
+ * a column filter naming the same field cannot coexist: the column filter wins
+ * outright and the chip is left claiming a constraint that was dropped. The
+ * Devices page removes the offending column filter for as long as the tile
+ * filter is active, and this is the list it removes.
+ */
+describe("getDeviceSummaryFilterConflictingFilterFields", () => {
+  test("no selection conflicts with nothing", () => {
+    expect(getDeviceSummaryFilterConflictingFilterFields(null)).toEqual([]);
+  });
+
+  test.each([
+    DeviceSummaryFilterKey.Up,
+    DeviceSummaryFilterKey.Down,
+    DeviceSummaryFilterKey.Pending,
+  ])(
+    "%s owns the Last Seen At column filter",
+    (key: DeviceSummaryFilterKey) => {
+      expect(getDeviceSummaryFilterConflictingFilterFields(key)).toEqual([
+        "lastSeenAt",
+      ]);
+    },
+  );
+
+  /*
+   * The count and this filter use the foreign key; the device table's "Site"
+   * filter goes through the relation. Different keys, same column — so they
+   * survive the merge as an AND that can never match, emptying the table under
+   * a chip that says these are the unassigned devices. Both names have to go.
+   */
+  test("the no-site filter owns both spellings of the site column", () => {
+    expect(
+      getDeviceSummaryFilterConflictingFilterFields(
+        DeviceSummaryFilterKey.NoSite,
+      ),
+    ).toEqual(["site", "siteId"]);
+  });
+
+  test("the interfaces filter conflicts with nothing the table offers", () => {
+    expect(
+      getDeviceSummaryFilterConflictingFilterFields(
+        DeviceSummaryFilterKey.InterfacesDown,
+      ),
+    ).toEqual([]);
+  });
+
+  /*
+   * The real invariant: whatever column a filter constrains, the field the
+   * table offers over that same column must be listed. Checked against the
+   * query fragments themselves so a new filter cannot be added without either
+   * declaring its conflicts or being deliberately exempted here.
+   */
+  test.each(ALL_KEYS)(
+    "%s declares a conflict for every column it constrains",
+    (key: DeviceSummaryFilterKey) => {
+      const declared: Array<string> =
+        getDeviceSummaryFilterConflictingFilterFields(key);
+
+      for (const column of Object.keys(getDeviceSummaryFilterQuery(key))) {
+        if (column === "interfacesDown") {
+          // The device table offers no filter over interface counts.
+          continue;
+        }
+
+        expect(declared).toContain(column);
+      }
+    },
+  );
+});
+
+/*
+ * Up and Down are the only two defined against the wall clock, so they are the
+ * only two whose result set is a snapshot. The page labels those with the
+ * moment the snapshot was taken; labelling the others would be noise.
+ */
+describe("isDeviceSummaryFilterTimeBased", () => {
+  test("up and down are", () => {
+    expect(isDeviceSummaryFilterTimeBased(DeviceSummaryFilterKey.Up)).toBe(
+      true,
+    );
+    expect(isDeviceSummaryFilterTimeBased(DeviceSummaryFilterKey.Down)).toBe(
+      true,
+    );
+  });
+
+  test.each([
+    DeviceSummaryFilterKey.Pending,
+    DeviceSummaryFilterKey.InterfacesDown,
+    DeviceSummaryFilterKey.NoSite,
+  ])("%s is not", (key: DeviceSummaryFilterKey) => {
+    expect(isDeviceSummaryFilterTimeBased(key)).toBe(false);
+  });
+
+  test("no selection is not", () => {
+    expect(isDeviceSummaryFilterTimeBased(null)).toBe(false);
+  });
+
+  /*
+   * The two lists have to agree: a filter is time-based exactly when its query
+   * carries a cutoff Date. Pinned by serialising the same filter at two
+   * different instants — only a clock-dependent one changes.
+   */
+  test("matches which filters actually read the clock", () => {
+    freezeTime(NOW);
+
+    try {
+      for (const key of ALL_KEYS) {
+        const first: string = JSON.stringify(getDeviceSummaryFilterQuery(key));
+        jest.setSystemTime(new Date(NOW.getTime() + 60 * MS_PER_MINUTE));
+        const second: string = JSON.stringify(getDeviceSummaryFilterQuery(key));
+
+        expect(isDeviceSummaryFilterTimeBased(key)).toBe(first !== second);
+        jest.setSystemTime(NOW);
+      }
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe("DEVICE_SUMMARY_TILES", () => {
+  test("is the four tiles the page has always shown, in order", () => {
+    expect(
+      DEVICE_SUMMARY_TILES.map((tile: DeviceSummaryTile) => {
+        return tile.key;
+      }),
+    ).toEqual([
+      "devices-up",
+      "devices-down",
+      "devices-pending",
+      "interfaces-down",
+    ]);
+  });
+
+  /*
+   * The labels are the product surface, unchanged by this feature — the
+   * tiles became clickable, they did not become different tiles.
+   */
+  test("keeps the original labels", () => {
+    expect(
+      DEVICE_SUMMARY_TILES.map((tile: DeviceSummaryTile) => {
+        return tile.label;
+      }),
+    ).toEqual([
+      "Devices Up",
+      "Devices Down / Stale",
+      "Devices Pending",
+      "Total Interfaces Down",
+    ]);
+  });
+
+  test("every tile drills into a distinct filter", () => {
+    const filterKeys: Array<DeviceSummaryFilterKey> = DEVICE_SUMMARY_TILES.map(
+      (tile: DeviceSummaryTile) => {
+        return tile.filterKey;
+      },
+    );
+
+    expect(new Set(filterKeys).size).toBe(DEVICE_SUMMARY_TILES.length);
+    for (const filterKey of filterKeys) {
+      expect(ALL_KEYS).toContain(filterKey);
+    }
+  });
+
+  test("each tile reads a distinct count", () => {
+    const countFields: Array<string> = DEVICE_SUMMARY_TILES.map(
+      (tile: DeviceSummaryTile) => {
+        return tile.countField;
+      },
+    );
+
+    expect(countFields).toEqual([
+      "devicesUp",
+      "devicesDown",
+      "devicesPending",
+      "interfacesDown",
+    ]);
+  });
+
+  /*
+   * NoSite is reachable only by following the Sites page's Unassigned
+   * Devices tile. Adding it to the strip here would put a fifth card on a
+   * four-column grid and duplicate a count that belongs to the other page.
+   */
+  test("does not surface the cross-page 'no site' filter as a tile", () => {
+    expect(
+      DEVICE_SUMMARY_TILES.some((tile: DeviceSummaryTile) => {
+        return tile.filterKey === DeviceSummaryFilterKey.NoSite;
+      }),
+    ).toBe(false);
+  });
+
+  test("every tile keeps both a resting and an attention colour", () => {
+    for (const tile of DEVICE_SUMMARY_TILES) {
+      expect(tile.attentionClassName.length).toBeGreaterThan(0);
+      expect(tile.allClearClassName).toBe("text-gray-900");
+      expect(tile.caption.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("the captions still quote the freshness window", () => {
+    const upTile: DeviceSummaryTile = DEVICE_SUMMARY_TILES[0]!;
+    const downTile: DeviceSummaryTile = DEVICE_SUMMARY_TILES[1]!;
+
+    expect(upTile.caption).toContain(`${DEVICE_FRESH_WINDOW_MINUTES} minutes`);
+    expect(downTile.caption).toContain(
+      `${DEVICE_FRESH_WINDOW_MINUTES} minutes`,
+    );
+  });
+});

--- a/App/Tests/Dashboard/DeviceSummaryFilterRoute.test.ts
+++ b/App/Tests/Dashboard/DeviceSummaryFilterRoute.test.ts
@@ -1,0 +1,337 @@
+import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The cross-page hand-off: the Sites page's "Unassigned Devices" tile counts
+ * devices, and devices are only listed on the Devices page. Activating it has
+ * to land the user on that page already filtered — otherwise the click drops
+ * them into an unfiltered list of the whole fleet and they have to find the
+ * rows themselves, which is the exact problem the tile was supposed to solve.
+ *
+ * These drive the real Navigation, RouteMap and ProjectUtil against a stubbed
+ * browser rather than reading the source, so they fail if the link stops being
+ * a live, filtered navigation however it is spelled.
+ */
+
+const PROJECT_ID: string = "0193a1b2-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+const SITES_PATH: string = `/dashboard/${PROJECT_ID}/network-sites`;
+const DEVICES_PATH: string = `/dashboard/${PROJECT_ID}/network-devices`;
+
+const browser: {
+  location: { pathname: string; search: string; hash: string };
+  history: { state: unknown; replaceState: () => void };
+} = {
+  location: { pathname: SITES_PATH, search: "", hash: "" },
+  history: {
+    state: null,
+    replaceState: (): void => {
+      // no-op; these tests never assert on replaceState.
+    },
+  },
+};
+
+type RouteModule =
+  typeof import("../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilterRoute");
+type FilterModule =
+  typeof import("../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilter");
+type SiteFilterModule =
+  typeof import("../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryFilter");
+type DeviceFilterKeyValue =
+  FilterModule["DeviceSummaryFilterKey"][keyof FilterModule["DeviceSummaryFilterKey"]];
+type NavigationClass = (typeof import("Common/UI/Utils/Navigation"))["default"];
+type RouteClass = (typeof import("Common/Types/API/Route"))["default"];
+
+let routeModule: RouteModule;
+let filterModule: FilterModule;
+let siteFilterModule: SiteFilterModule;
+let Navigation: NavigationClass;
+let Route: RouteClass;
+let navigatedTo: Array<string> = [];
+
+/*
+ * Common/UI/Config reads `window` the moment it loads, and RouteMap pulls it
+ * in transitively, so the browser stub has to exist before any of them do —
+ * hence the deferred imports. A static import would be hoisted above the stub
+ * and throw. Same approach as NetworkSitePageInvariants.test.ts.
+ */
+beforeAll(async () => {
+  (globalThis as Record<string, unknown>)["window"] = browser;
+  /*
+   * Node 26 ships real sessionStorage/localStorage globals and plain
+   * assignment over them throws inside jest's vm context; defining the
+   * property works on every version. ProjectUtil falls through to these when
+   * the URL carries no project id.
+   */
+  for (const storageName of ["sessionStorage", "localStorage"]) {
+    Object.defineProperty(globalThis, storageName, {
+      value: {
+        getItem: (): null => {
+          return null;
+        },
+        setItem: (): void => {
+          // no-op
+        },
+        removeItem: (): void => {
+          // no-op
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  routeModule = await import(
+    "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilterRoute"
+  );
+  filterModule = await import(
+    "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilter"
+  );
+  siteFilterModule = await import(
+    "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryFilter"
+  );
+  Navigation = (await import("Common/UI/Utils/Navigation")).default;
+  Route = (await import("Common/Types/API/Route")).default;
+});
+
+function standAt(pathname: string, search: string = ""): void {
+  browser.location.pathname = pathname;
+  browser.location.search = search;
+  /*
+   * react-router's types are not resolvable from the App suite, so the
+   * router's Location and NavigateFunction are supplied structurally —
+   * pathname and the call signature are all Navigation reads off them.
+   */
+  Navigation.setLocation({ pathname: pathname } as unknown as Parameters<
+    typeof Navigation.setLocation
+  >[0]);
+  navigatedTo = [];
+  Navigation.setNavigateHook(((to: string): void => {
+    navigatedTo.push(to);
+  }) as unknown as Parameters<typeof Navigation.setNavigateHook>[0]);
+}
+
+beforeEach(() => {
+  standAt(SITES_PATH);
+});
+
+describe("getDeviceListRouteForFilter", () => {
+  test("points at the device list for the current project", () => {
+    const route: InstanceType<RouteClass> =
+      routeModule.getDeviceListRouteForFilter(
+        filterModule.DeviceSummaryFilterKey.NoSite,
+      );
+
+    expect(route.toString()).toBe(`${DEVICES_PATH}?deviceFilter=no-site`);
+  });
+
+  /*
+   * The project id has to be substituted, not left as the `:projectId`
+   * placeholder — a link to a literal ":projectId" path 404s in the router.
+   */
+  test("substitutes the project id rather than leaving the placeholder", () => {
+    expect(
+      routeModule
+        .getDeviceListRouteForFilter(filterModule.DeviceSummaryFilterKey.NoSite)
+        .toString(),
+    ).not.toContain(":projectId");
+  });
+
+  test("lands on the device list, not the network overview or topology", () => {
+    const path: string = routeModule
+      .getDeviceListRouteForFilter(filterModule.DeviceSummaryFilterKey.NoSite)
+      .toString()
+      .split("?")[0]!;
+
+    expect(path).toBe(DEVICES_PATH);
+    expect(path.endsWith("/network-devices")).toBe(true);
+  });
+
+  test("carries every filter key it is given", () => {
+    for (const key of Object.values(filterModule.DeviceSummaryFilterKey)) {
+      expect(routeModule.getDeviceListRouteForFilter(key).toString()).toBe(
+        `${DEVICES_PATH}?deviceFilter=${key}`,
+      );
+    }
+  });
+
+  test("produces a distinct route per filter", () => {
+    const routes: Array<string> = Object.values(
+      filterModule.DeviceSummaryFilterKey,
+    ).map((key: DeviceFilterKeyValue) => {
+      return routeModule.getDeviceListRouteForFilter(key).toString();
+    });
+
+    expect(new Set(routes).size).toBe(routes.length);
+  });
+
+  /*
+   * The parameter name has to be the one the Devices page reads. Building it
+   * from the shared constant is what guarantees that; this asserts the
+   * constant actually made it into the URL.
+   */
+  test("names the parameter the device page reads", () => {
+    expect(
+      routeModule
+        .getDeviceListRouteForFilter(filterModule.DeviceSummaryFilterKey.Down)
+        .toString(),
+    ).toContain(`${filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM}=`);
+  });
+});
+
+describe("the Unassigned Devices tile's hand-off", () => {
+  /*
+   * End to end: the Sites page builds the link from the shared constant, the
+   * user follows it, and the Devices page reads its filter back off the URL.
+   * A break anywhere along that chain shows up here as an unfiltered list.
+   */
+  test("round-trips from the Sites page to a filtered device list", () => {
+    const route: InstanceType<RouteClass> =
+      routeModule.getDeviceListRouteForFilter(
+        siteFilterModule.UNASSIGNED_DEVICES_FILTER_KEY,
+      );
+
+    Navigation.navigate(route);
+
+    expect(navigatedTo).toEqual([`${DEVICES_PATH}?deviceFilter=no-site`]);
+
+    // The user has now landed there.
+    const [pathname, search] = navigatedTo[0]!.split("?") as [string, string];
+    standAt(pathname, `?${search}`);
+
+    expect(
+      filterModule.parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBe(filterModule.DeviceSummaryFilterKey.NoSite);
+  });
+
+  /*
+   * Navigation.navigate() drops any navigation whose target it judges to be
+   * the current page, and it judges that on the pathname alone. The query
+   * string is what keeps this a live navigation even from the device page
+   * itself — otherwise a link followed from a bookmark bar while already on
+   * the device list would do nothing at all.
+   */
+  test("is still a live navigation from the device page itself", () => {
+    standAt(DEVICES_PATH);
+
+    Navigation.navigate(
+      routeModule.getDeviceListRouteForFilter(
+        filterModule.DeviceSummaryFilterKey.NoSite,
+      ),
+    );
+
+    expect(navigatedTo).toEqual([`${DEVICES_PATH}?deviceFilter=no-site`]);
+  });
+
+  test("every device filter survives the trip through a URL", () => {
+    for (const key of Object.values(filterModule.DeviceSummaryFilterKey)) {
+      const route: string = routeModule
+        .getDeviceListRouteForFilter(key)
+        .toString();
+      const [pathname, search] = route.split("?") as [string, string];
+
+      standAt(pathname, `?${search}`);
+
+      expect(
+        filterModule.parseDeviceSummaryFilterKey(
+          Navigation.getQueryStringByName(
+            filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+          ),
+        ),
+      ).toBe(key);
+    }
+  });
+});
+
+describe("reading the filter back off a URL", () => {
+  test("a bare device list URL is unfiltered", () => {
+    standAt(DEVICES_PATH);
+
+    expect(
+      filterModule.parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  /*
+   * The parameter is user-editable. A hand-typed or truncated value has to
+   * open the plain list rather than throw on a page the user asked for.
+   */
+  test("a junk parameter opens the unfiltered list", () => {
+    standAt(DEVICES_PATH, "?deviceFilter=whatever");
+
+    expect(
+      filterModule.parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  test("the filter survives alongside the table's own URL state", () => {
+    /*
+     * BaseModelTable mirrors its column filters, search and page into their
+     * own namespaced parameters. Both sets share one query string, so the
+     * tile filter has to be readable with them present.
+     */
+    standAt(
+      DEVICES_PATH,
+      "?network-devices-table_filter=%7B%7D&network-devices-table_view=%7B%22page%22%3A2%7D&deviceFilter=pending",
+    );
+
+    expect(
+      filterModule.parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBe(filterModule.DeviceSummaryFilterKey.Pending);
+  });
+
+  test("the site filter parameter is not mistaken for a device filter", () => {
+    standAt(DEVICES_PATH, "?siteFilter=unhealthy");
+
+    expect(
+      filterModule.parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  test("both pages' filters can sit in one URL without colliding", () => {
+    standAt(DEVICES_PATH, "?siteFilter=unhealthy&deviceFilter=down");
+
+    expect(
+      filterModule.parseDeviceSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          filterModule.DEVICE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBe(filterModule.DeviceSummaryFilterKey.Down);
+    expect(
+      siteFilterModule.parseSiteSummaryFilterKey(
+        Navigation.getQueryStringByName(
+          siteFilterModule.SITE_SUMMARY_FILTER_URL_PARAM,
+        ),
+      ),
+    ).toBe(siteFilterModule.SiteSummaryFilterKey.Unhealthy);
+  });
+});
+
+describe("Route construction", () => {
+  test("the helper returns a Route, so callers can keep composing it", () => {
+    expect(
+      routeModule.getDeviceListRouteForFilter(
+        filterModule.DeviceSummaryFilterKey.Up,
+      ),
+    ).toBeInstanceOf(Route);
+  });
+});

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -183,9 +183,13 @@ describe("Sites table owns the CSV import", () => {
       .split("}}")[0]!;
     expect(completeBody).toContain("setRefreshToggle(Date.now().toString());");
 
-    // The same toggle has to be wired into all three consumers.
+    /*
+     * The same toggle has to be wired into all three consumers. The summary
+     * strip carries the tile drill-down props too, so match the opening tag
+     * and its toggle rather than the whole (now longer) prop list.
+     */
     expect(source).toContain(
-      "<SiteSummaryCards refreshToggle={refreshToggle} />",
+      squash("<SiteSummaryCards refreshToggle={refreshToggle}"),
     );
     expect(source).toContain(
       "<SiteHierarchyTree refreshToggle={refreshToggle} />",

--- a/App/Tests/Dashboard/SiteSummaryFilter.test.ts
+++ b/App/Tests/Dashboard/SiteSummaryFilter.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  SITE_SUMMARY_FILTER_URL_PARAM,
+  SITE_SUMMARY_TILES,
+  SiteSummaryFilterDefinition,
+  SiteSummaryFilterKey,
+  SiteSummaryTile,
+  SiteSummaryTileAction,
+  UNASSIGNED_DEVICES_FILTER_KEY,
+  getSiteSummaryFilterDefinition,
+  getSiteSummaryFilterQuery,
+  parseSiteSummaryFilterKey,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteSummaryFilter";
+import { DeviceSummaryFilterKey } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryFilter";
+import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import Query from "Common/Types/BaseDatabase/Query";
+
+/*
+ * SiteSummaryFilter is the Sites-page counterpart of DeviceSummaryFilter: the
+ * contract between a count on a tile and the rows behind it.
+ *
+ * The wrinkle this file exists to pin is the fourth tile. Three tiles count
+ * sites and narrow the sites table; "Unassigned Devices" counts DEVICES, and
+ * the only page that lists devices is the device page. Filtering the sites
+ * table by a device predicate would produce an empty table and no explanation,
+ * so that tile navigates instead — and the two pages have to agree on which
+ * filter it means.
+ */
+
+const ALL_KEYS: Array<SiteSummaryFilterKey> =
+  Object.values(SiteSummaryFilterKey);
+
+describe("SiteSummaryFilterKey", () => {
+  /*
+   * These strings are in shared URLs. Renaming one silently breaks every link
+   * already pasted into a ticket, so the rename has to be a conscious edit.
+   */
+  test("the wire values are stable", () => {
+    expect(SiteSummaryFilterKey.Unhealthy).toBe("unhealthy");
+    expect(SiteSummaryFilterKey.NoData).toBe("no-data");
+  });
+
+  test("there are exactly two, and they are distinct", () => {
+    expect(ALL_KEYS).toHaveLength(2);
+    expect(new Set(ALL_KEYS).size).toBe(2);
+  });
+
+  test("the URL parameter name is stable", () => {
+    expect(SITE_SUMMARY_FILTER_URL_PARAM).toBe("siteFilter");
+  });
+
+  /*
+   * The Sites page and the Devices page can both be filtered, and a user can
+   * arrive at one from the other. Distinct parameter names are what keeps a
+   * site filter from being read as a device filter.
+   */
+  test("does not share a parameter name with the device filter", () => {
+    expect(SITE_SUMMARY_FILTER_URL_PARAM).not.toBe("deviceFilter");
+  });
+});
+
+describe("parseSiteSummaryFilterKey", () => {
+  test.each(ALL_KEYS)("round-trips %s", (key: SiteSummaryFilterKey) => {
+    expect(parseSiteSummaryFilterKey(key)).toBe(key);
+  });
+
+  describe("absent values read as no filter", () => {
+    test.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["empty string", ""],
+    ])("%s", (_label: string, raw: string | null | undefined) => {
+      expect(parseSiteSummaryFilterKey(raw)).toBeNull();
+    });
+  });
+
+  /*
+   * The parameter is in the address bar, so its value is whatever anyone
+   * chooses to type. Nothing but an exact key may reach the query builder.
+   */
+  describe("hostile and stale values read as no filter", () => {
+    test.each([
+      ["unknown word", "banana"],
+      ["a tile key rather than a filter key", "unhealthy-sites"],
+      ["the other tile key", "sites-no-data"],
+      ["wrong case", "UNHEALTHY"],
+      ["mixed case", "NoData"],
+      ["leading whitespace", " unhealthy"],
+      ["trailing whitespace", "no-data "],
+      ["a device filter key", "no-site"],
+      ["an Object.prototype member", "constructor"],
+      ["a prototype-pollution attempt", "__proto__"],
+      ["another prototype member", "valueOf"],
+      ["a JSON payload", '{"currentMonitorStatusId":null}'],
+      ["a SQL fragment", "1' OR '1'='1"],
+    ])("%s", (_label: string, raw: string) => {
+      expect(parseSiteSummaryFilterKey(raw)).toBeNull();
+    });
+  });
+
+  /*
+   * The two pages use different vocabularies on purpose, and a link carrying
+   * one page's key must not accidentally filter the other page.
+   */
+  test("no device filter key parses as a site filter key", () => {
+    for (const deviceKey of Object.values(DeviceSummaryFilterKey)) {
+      expect(parseSiteSummaryFilterKey(deviceKey)).toBeNull();
+    }
+  });
+});
+
+describe("getSiteSummaryFilterQuery", () => {
+  test("no selection is an empty fragment, not a special case", () => {
+    expect(getSiteSummaryFilterQuery(null)).toEqual({});
+  });
+
+  test("every key produces a fragment naming exactly one column", () => {
+    for (const key of ALL_KEYS) {
+      expect(Object.keys(getSiteSummaryFilterQuery(key))).toHaveLength(1);
+    }
+  });
+
+  test.each(ALL_KEYS)(
+    "%s carries no scoping of its own",
+    (key: SiteSummaryFilterKey) => {
+      const query: Query<NetworkSite> = getSiteSummaryFilterQuery(key);
+      expect(query.projectId).toBeUndefined();
+    },
+  );
+
+  describe("Unhealthy — the sites the 'Unhealthy Sites' tile counted", () => {
+    /*
+     * SiteSummaryCards counts a site as unhealthy when it HAS a rolled-up
+     * status and that status is not operational. The nested relation query is
+     * how that same predicate is expressed to the API — the same shape
+     * NotOperationalMonitors.tsx uses for monitors.
+     */
+    test("is currentMonitorStatus.isOperationalState = false", () => {
+      expect(getSiteSummaryFilterQuery(SiteSummaryFilterKey.Unhealthy)).toEqual(
+        {
+          currentMonitorStatus: {
+            isOperationalState: false,
+          },
+        },
+      );
+    });
+
+    /*
+     * `false`, not a falsy stand-in: `undefined` would drop the predicate and
+     * silently return every site, and `null` would ask for rows whose flag is
+     * NULL — a different set again.
+     */
+    test("asks for the boolean false, not a falsy stand-in", () => {
+      const query: Query<NetworkSite> = getSiteSummaryFilterQuery(
+        SiteSummaryFilterKey.Unhealthy,
+      );
+      const nested: { isOperationalState?: unknown } =
+        query.currentMonitorStatus as { isOperationalState?: unknown };
+
+      expect(nested.isOperationalState).toBe(false);
+      expect(typeof nested.isOperationalState).toBe("boolean");
+    });
+
+    /*
+     * Joining the status is what excludes sites with no rollup at all — they
+     * have no MonitorStatus row to match, so they stay in the "no data" tile
+     * where they were counted, and are not double-counted as unhealthy.
+     */
+    test("goes through the relation, so sites with no rollup are excluded", () => {
+      expect(
+        getSiteSummaryFilterQuery(SiteSummaryFilterKey.Unhealthy)
+          .currentMonitorStatusId,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("NoData — the sites the 'Sites Without Data' tile counted", () => {
+    /*
+     * The FK, not the relation: a site with no rollup has no MonitorStatus
+     * row, so there is nothing to join and nothing a nested predicate could
+     * match against.
+     */
+    test("is currentMonitorStatusId IS NULL", () => {
+      const query: Query<NetworkSite> = getSiteSummaryFilterQuery(
+        SiteSummaryFilterKey.NoData,
+      );
+
+      expect(query.currentMonitorStatusId).toBeInstanceOf(IsNull);
+      expect(query.currentMonitorStatus).toBeUndefined();
+    });
+  });
+
+  describe("the two site filters are mutually exclusive", () => {
+    test("they filter different columns, so no site can match both", () => {
+      expect(
+        Object.keys(getSiteSummaryFilterQuery(SiteSummaryFilterKey.Unhealthy)),
+      ).toEqual(["currentMonitorStatus"]);
+      expect(
+        Object.keys(getSiteSummaryFilterQuery(SiteSummaryFilterKey.NoData)),
+      ).toEqual(["currentMonitorStatusId"]);
+    });
+  });
+
+  /*
+   * The Sites page memoises this fragment on the selected key, and ModelTable
+   * decides whether to refetch by JSON-comparing the previous query prop with
+   * the next. Nothing here reads the clock, so the same key always serialises
+   * the same way — which is what makes the memo sufficient.
+   */
+  test("serialises identically on every call", () => {
+    for (const key of [...ALL_KEYS, null]) {
+      expect(JSON.stringify(getSiteSummaryFilterQuery(key))).toBe(
+        JSON.stringify(getSiteSummaryFilterQuery(key)),
+      );
+    }
+  });
+});
+
+describe("getSiteSummaryFilterDefinition", () => {
+  test.each(ALL_KEYS)(
+    "%s has a chip label and empty-state copy",
+    (key: SiteSummaryFilterKey) => {
+      const definition: SiteSummaryFilterDefinition =
+        getSiteSummaryFilterDefinition(key);
+
+      expect(definition.key).toBe(key);
+      expect(definition.chipLabel.length).toBeGreaterThan(0);
+      expect(definition.emptyMessage.length).toBeGreaterThan(0);
+    },
+  );
+
+  test("no two filters present the same chip", () => {
+    const labels: Array<string> = ALL_KEYS.map((key: SiteSummaryFilterKey) => {
+      return getSiteSummaryFilterDefinition(key).chipLabel;
+    });
+
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  /*
+   * "Every site is operational" would be a false claim while sites with no
+   * rollup exist — they are neither operational nor counted here.
+   */
+  test("the unhealthy empty state does not overstate what it checked", () => {
+    expect(
+      getSiteSummaryFilterDefinition(SiteSummaryFilterKey.Unhealthy)
+        .emptyMessage,
+    ).toBe("Every site with a health rollup is operational.");
+  });
+});
+
+describe("SITE_SUMMARY_TILES", () => {
+  test("is the four tiles the page has always shown, in order", () => {
+    expect(
+      SITE_SUMMARY_TILES.map((tile: SiteSummaryTile) => {
+        return tile.key;
+      }),
+    ).toEqual([
+      "total-sites",
+      "unhealthy-sites",
+      "sites-no-data",
+      "devices-without-site",
+    ]);
+  });
+
+  test("keeps the original labels and captions", () => {
+    expect(
+      SITE_SUMMARY_TILES.map((tile: SiteSummaryTile) => {
+        return tile.label;
+      }),
+    ).toEqual([
+      "Sites",
+      "Unhealthy Sites",
+      "Sites Without Data",
+      "Unassigned Devices",
+    ]);
+
+    expect(SITE_SUMMARY_TILES[3]!.caption).toBe(
+      "Devices not assigned to any site.",
+    );
+  });
+
+  test("each tile reads a distinct count", () => {
+    expect(
+      SITE_SUMMARY_TILES.map((tile: SiteSummaryTile) => {
+        return tile.countField;
+      }),
+    ).toEqual([
+      "totalSites",
+      "unhealthySites",
+      "sitesWithNoData",
+      "devicesWithoutSite",
+    ]);
+  });
+
+  describe("what each tile does when it is activated", () => {
+    /*
+     * The total is not a subset — clicking it means "show me everything
+     * again", which is the only sensible drill-down for a total and doubles
+     * as a second way out of a filtered view.
+     */
+    test("the total clears the filter", () => {
+      expect(SITE_SUMMARY_TILES[0]!.action).toBe(
+        SiteSummaryTileAction.ClearFilter,
+      );
+      expect(SITE_SUMMARY_TILES[0]!.filterKey).toBeUndefined();
+    });
+
+    test("the two site counts narrow the table in place", () => {
+      expect(SITE_SUMMARY_TILES[1]!.action).toBe(
+        SiteSummaryTileAction.FilterSites,
+      );
+      expect(SITE_SUMMARY_TILES[1]!.filterKey).toBe(
+        SiteSummaryFilterKey.Unhealthy,
+      );
+
+      expect(SITE_SUMMARY_TILES[2]!.action).toBe(
+        SiteSummaryTileAction.FilterSites,
+      );
+      expect(SITE_SUMMARY_TILES[2]!.filterKey).toBe(
+        SiteSummaryFilterKey.NoData,
+      );
+    });
+
+    /*
+     * This is the tile that counts something the sites table cannot show. If
+     * it were ever wired to FilterSites, its filterKey would be undefined and
+     * the click would silently clear the filter instead of opening the rows.
+     */
+    test("the device count leaves for the device list", () => {
+      expect(SITE_SUMMARY_TILES[3]!.action).toBe(
+        SiteSummaryTileAction.ShowUnassignedDevices,
+      );
+      expect(SITE_SUMMARY_TILES[3]!.filterKey).toBeUndefined();
+    });
+
+    test("every FilterSites tile carries a real filter key", () => {
+      for (const tile of SITE_SUMMARY_TILES) {
+        if (tile.action !== SiteSummaryTileAction.FilterSites) {
+          continue;
+        }
+        expect(tile.filterKey).toBeDefined();
+        expect(ALL_KEYS).toContain(tile.filterKey!);
+      }
+    });
+
+    test("no two tiles drill into the same filter", () => {
+      const filterKeys: Array<SiteSummaryFilterKey> = SITE_SUMMARY_TILES.filter(
+        (tile: SiteSummaryTile) => {
+          return Boolean(tile.filterKey);
+        },
+      ).map((tile: SiteSummaryTile) => {
+        return tile.filterKey!;
+      });
+
+      expect(new Set(filterKeys).size).toBe(filterKeys.length);
+    });
+
+    test("exactly one tile leaves the page", () => {
+      expect(
+        SITE_SUMMARY_TILES.filter((tile: SiteSummaryTile) => {
+          return tile.action === SiteSummaryTileAction.ShowUnassignedDevices;
+        }),
+      ).toHaveLength(1);
+    });
+
+    test("every tile declares an action, so none is silently inert", () => {
+      const actions: Array<string> = Object.values(SiteSummaryTileAction);
+      for (const tile of SITE_SUMMARY_TILES) {
+        expect(actions).toContain(tile.action);
+      }
+    });
+  });
+});
+
+describe("UNASSIGNED_DEVICES_FILTER_KEY", () => {
+  /*
+   * The hand-off between the two pages. The Sites page names the filter, the
+   * Devices page resolves it — pinning it here is what stops the two from
+   * drifting into a link that lands on an unfiltered device list.
+   */
+  test("is the device list's 'no site' filter", () => {
+    expect(UNASSIGNED_DEVICES_FILTER_KEY).toBe(DeviceSummaryFilterKey.NoSite);
+  });
+
+  test("is a key the device page will actually accept", () => {
+    expect(Object.values(DeviceSummaryFilterKey)).toContain(
+      UNASSIGNED_DEVICES_FILTER_KEY,
+    );
+  });
+});

--- a/App/Tests/Dashboard/SummaryTileFilteringInvariants.test.ts
+++ b/App/Tests/Dashboard/SummaryTileFilteringInvariants.test.ts
@@ -1,0 +1,688 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Clicking a summary tile narrows the table under it. The query mapping is
+ * pure and unit-tested (DeviceSummaryFilter.test.ts, SiteSummaryFilter.test.ts);
+ * what is left is the wiring — a prop, a hook dependency, an early return —
+ * and the App suite runs in a plain Node environment with no renderer.
+ *
+ * So these read the sources and assert the exact expressions, the same way
+ * NetworkSitePageInvariants.test.ts pins the Network Site pages. Every
+ * assertion here corresponds to a way the feature can be broken while every
+ * other test in the repo stays green. Sources are whitespace-squashed first so
+ * prettier re-wrapping a line cannot turn a real regression check into a red
+ * herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+const COMMON_UI: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "Common",
+  "UI",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readSource(root: string, ...relativeParts: Array<string>): string {
+  return squash(fs.readFileSync(path.join(root, ...relativeParts), "utf8"));
+}
+
+const DEVICES_PAGE: string = readSource(
+  DASHBOARD_SRC,
+  "Pages",
+  "NetworkDevice",
+  "Devices.tsx",
+);
+const SITES_PAGE: string = readSource(
+  DASHBOARD_SRC,
+  "Pages",
+  "NetworkSite",
+  "Sites.tsx",
+);
+const DEVICE_CARDS: string = readSource(
+  DASHBOARD_SRC,
+  "Components",
+  "NetworkDevice",
+  "DeviceSummaryCards.tsx",
+);
+const SITE_CARDS: string = readSource(
+  DASHBOARD_SRC,
+  "Components",
+  "NetworkSite",
+  "SiteSummaryCards.tsx",
+);
+const CHIP: string = readSource(
+  DASHBOARD_SRC,
+  "Components",
+  "Network",
+  "SummaryFilterChip.tsx",
+);
+const INFO_CARD: string = readSource(
+  COMMON_UI,
+  "Components",
+  "InfoCard",
+  "InfoCard.tsx",
+);
+
+describe("the Devices page turns a tile click into a filtered list", () => {
+  /*
+   * The whole feature. Without the callback the tiles render inert and the
+   * click does nothing at all — which is the bug this change fixes.
+   */
+  test("the summary strip is handed the selection and a way to change it", () => {
+    expect(DEVICES_PAGE).toContain(
+      squash(
+        "<DeviceSummaryCards selectedFilterKey={summaryFilterKey} onFilterKeyChange={changeSummaryFilter} />",
+      ),
+    );
+  });
+
+  /*
+   * The table has to read the memoised query. An inline literal here would
+   * rebuild the cutoff Date on every render, and BaseModelTable decides
+   * whether to refetch by JSON-comparing this prop with the previous render's
+   * — so every render would look like a change and refetch forever.
+   */
+  test("the table reads the memoised query, not an inline literal", () => {
+    expect(DEVICES_PAGE).toContain("query={tableQuery}");
+    expect(DEVICES_PAGE).not.toContain(squash("query={{ isArchived: false }}"));
+  });
+
+  test("the memo is keyed on the selected tile and nothing else", () => {
+    expect(DEVICES_PAGE).toContain(
+      squash(
+        "const tableQuery: Query<NetworkDevice> = useMemo(() => { return { isArchived: false, ...getDeviceSummaryFilterQuery(summaryFilterKey), }; }, [summaryFilterKey]);",
+      ),
+    );
+  });
+
+  /*
+   * Archived devices are excluded from every count on the strip, so they have
+   * to stay excluded from the rows a tile opens. The filter fragment is
+   * spread AFTER the base, but no fragment names isArchived — pinned in
+   * DeviceSummaryFilter.test.ts.
+   */
+  test("the base query still hides archived devices", () => {
+    expect(DEVICES_PAGE).toContain("isArchived: false");
+  });
+
+  /*
+   * Read synchronously in the useState initializer. Restoring in an effect
+   * instead would fire the first fetch against the whole fleet and throw that
+   * response away — a visible flash of the wrong rows plus a wasted request.
+   */
+  test("the selection is seeded from the URL during the first render", () => {
+    expect(DEVICES_PAGE).toContain(
+      squash(
+        "useState<DeviceSummaryFilterKey | null>(() => { return parseDeviceSummaryFilterKey( Navigation.getQueryStringByName(DEVICE_SUMMARY_FILTER_URL_PARAM), ); });",
+      ),
+    );
+  });
+
+  // The raw parameter is user-editable; only a parsed key may reach the query.
+  test("the raw parameter never reaches the query builder", () => {
+    expect(DEVICES_PAGE).toContain("parseDeviceSummaryFilterKey(");
+    expect(DEVICES_PAGE).not.toContain(
+      squash("getDeviceSummaryFilterQuery( Navigation.getQueryStringByName("),
+    );
+  });
+
+  test("changing the filter updates the state and the URL together", () => {
+    const body: string = DEVICES_PAGE.split(
+      "const changeSummaryFilter: ChangeSummaryFilterFunction = (",
+    )[1]!.split("};")[0]!;
+
+    expect(body).toContain("setSummaryFilterKey(filterKey);");
+    expect(body).toContain(
+      squash(
+        "Navigation.setQueryString({ [DEVICE_SUMMARY_FILTER_URL_PARAM]: filterKey, });",
+      ),
+    );
+  });
+
+  /*
+   * A tile filter and a column filter over the same field cannot both apply.
+   * BaseModelTable builds its request as `{...props.query, ...columnFilter}`,
+   * so a "Last Seen At" filter the user had already set silently replaces the
+   * tile's `lastSeenAt` constraint while the chip and the lit tile carry on
+   * claiming it — the table then shows Up devices under a "Devices down"
+   * chip. Three things together make the two exclusive in both orders.
+   */
+  describe("a drill-down cannot be silently overridden by a column filter", () => {
+    test("selecting a tile drops the column filter and page the table was holding", () => {
+      const body: string = DEVICES_PAGE.split(
+        "const changeSummaryFilter: ChangeSummaryFilterFunction = (",
+      )[1]!.split("};")[0]!;
+
+      expect(body).toContain(
+        "TableFilterUrlState.clear(NETWORK_DEVICES_TABLE_ID);",
+      );
+    });
+
+    /*
+     * Clearing the persisted state is only half of it: the mounted table
+     * keeps its own live filter state, and re-reads the URL only on mount.
+     */
+    test("the table is remounted on the selection so it re-reads that state", () => {
+      expect(DEVICES_PAGE).toContain(
+        squash(
+          'key={`${NETWORK_DEVICES_TABLE_ID}-${summaryFilterKey || "all"}`}',
+        ),
+      );
+    });
+
+    /*
+     * And the other order: while the drill-down is active the popup must not
+     * offer the filter that would overwrite it. `filters` is also what
+     * BaseModelTable sanitises URL-restored filter data against, so dropping
+     * an entry here drops a stale value for it out of a shared link too.
+     */
+    test("the popup stops offering the fields the active tile owns", () => {
+      expect(DEVICES_PAGE).toContain("].filter(isFilterOffered)}");
+      expect(DEVICES_PAGE).toContain(
+        squash(
+          "const conflictingFilterFields: Array<string> = getDeviceSummaryFilterConflictingFilterFields(summaryFilterKey);",
+        ),
+      );
+      expect(DEVICES_PAGE).toContain(
+        squash("return !field || !conflictingFilterFields.includes(field);"),
+      );
+    });
+
+    /*
+     * The table id is the URL namespace its filter/sort/page state lives
+     * under. If the literal drifted from the one passed to the table, the
+     * clear above would silently wipe nothing.
+     */
+    test("the cleared namespace is the one the table actually uses", () => {
+      expect(DEVICES_PAGE).toContain(
+        squash(
+          'const NETWORK_DEVICES_TABLE_ID: string = "network-devices-table";',
+        ),
+      );
+      expect(DEVICES_PAGE).toContain("id={NETWORK_DEVICES_TABLE_ID}");
+      expect(DEVICES_PAGE).toContain(
+        "userPreferencesKey={NETWORK_DEVICES_TABLE_ID}",
+      );
+    });
+  });
+
+  /*
+   * The up/down window is a snapshot: the cutoff is built when the tile is
+   * activated and frozen by the memo (rebuilding it on a timer would send
+   * anyone reading page 3 back to page 1 every tick and drop their bulk
+   * selection). The Status column recomputes the same window live, so without
+   * a label a long-lived page shows Down pills inside the "up" list with
+   * nothing to explain it.
+   */
+  test("a time-based drill-down says when its snapshot was taken", () => {
+    expect(DEVICES_PAGE).toContain("detail={summaryFilterDetail}");
+    expect(DEVICES_PAGE).toContain(
+      squash(
+        "const summaryFilterDetail: string | undefined = useMemo(() => { if (!isDeviceSummaryFilterTimeBased(summaryFilterKey)) { return undefined; }",
+      ),
+    );
+    // Re-taken exactly when the cutoff is, so the two can never disagree.
+    expect(DEVICES_PAGE).toContain(
+      squash(
+        "return `as of ${OneUptimeDate.getLocalHourAndMinuteFromDate( OneUptimeDate.getCurrentDate(), )}`; }, [summaryFilterKey]);",
+      ),
+    );
+  });
+
+  /*
+   * A short table with no explanation is the failure mode this chip exists to
+   * prevent — and its clear button is the only way back out for someone who
+   * cannot find the tile they clicked.
+   */
+  test("a filtered table says so, and offers a way out", () => {
+    expect(DEVICES_PAGE).toContain(
+      squash(
+        'topContent={ summaryFilterDefinition ? ( <SummaryFilterChip testIdSuffix="network-devices" label={summaryFilterDefinition.chipLabel} detail={summaryFilterDetail} onClear={() => { changeSummaryFilter(null); }} /> ) : undefined }',
+      ),
+    );
+  });
+
+  /*
+   * "No devices found" under a filter that matched nothing reads as an empty
+   * project. The filter-specific copy is what tells the user their fleet is
+   * fine rather than missing.
+   */
+  test("an empty filtered table explains itself", () => {
+    expect(DEVICES_PAGE).toContain(
+      "noItemsMessage={summaryFilterDefinition?.emptyMessage}",
+    );
+  });
+});
+
+describe("the Sites page turns a tile click into a filtered list", () => {
+  test("the summary strip is handed the selection and a click handler", () => {
+    expect(SITES_PAGE).toContain(
+      squash(
+        "<SiteSummaryCards refreshToggle={refreshToggle} selectedFilterKey={summaryFilterKey} onTileClick={onSummaryTileClick} />",
+      ),
+    );
+  });
+
+  test("the table reads the memoised query", () => {
+    expect(SITES_PAGE).toContain("query={tableQuery}");
+    expect(SITES_PAGE).toContain(
+      squash(
+        "const tableQuery: Query<NetworkSite> = useMemo(() => { return getSiteSummaryFilterQuery(summaryFilterKey); }, [summaryFilterKey]);",
+      ),
+    );
+  });
+
+  /*
+   * A CSV import bumps refreshToggle to refetch the table, the strip and the
+   * hierarchy tree. Losing it while adding the query prop would leave the
+   * user staring at a table that does not contain what they just imported.
+   */
+  test("the import refresh still reaches the table", () => {
+    expect(SITES_PAGE).toContain("refreshToggle={refreshToggle}");
+    expect(SITES_PAGE).toContain(
+      "<SiteHierarchyTree refreshToggle={refreshToggle} />",
+    );
+  });
+
+  test("the selection is seeded from the URL during the first render", () => {
+    expect(SITES_PAGE).toContain(
+      squash(
+        "useState<SiteSummaryFilterKey | null>(() => { return parseSiteSummaryFilterKey( Navigation.getQueryStringByName(SITE_SUMMARY_FILTER_URL_PARAM), ); });",
+      ),
+    );
+  });
+
+  test("changing the filter updates the state and the URL together", () => {
+    const body: string = SITES_PAGE.split(
+      "const changeSummaryFilter: ChangeSummaryFilterFunction = (",
+    )[1]!.split("};")[0]!;
+
+    expect(body).toContain("setSummaryFilterKey(filterKey);");
+    expect(body).toContain(
+      squash(
+        "Navigation.setQueryString({ [SITE_SUMMARY_FILTER_URL_PARAM]: filterKey, });",
+      ),
+    );
+  });
+
+  test("a filtered table says so, and offers a way out", () => {
+    expect(SITES_PAGE).toContain(
+      squash(
+        'topContent={ summaryFilterDefinition ? ( <SummaryFilterChip testIdSuffix="network-sites" label={summaryFilterDefinition.chipLabel} onClear={() => { changeSummaryFilter(null); }} /> ) : undefined }',
+      ),
+    );
+    expect(SITES_PAGE).toContain(
+      "noItemsMessage={summaryFilterDefinition?.emptyMessage}",
+    );
+  });
+
+  describe("the tile that counts devices", () => {
+    const handler: string = SITES_PAGE.split(
+      "const onSummaryTileClick: OnSummaryTileClickFunction = (",
+    )[1]!.split("const tableQuery")[0]!;
+
+    /*
+     * "Unassigned Devices" counts devices; this page lists sites. Filtering
+     * the sites table by a device predicate would empty it with no
+     * explanation, so the tile leaves for the device list instead.
+     */
+    test("navigates to the device list rather than filtering sites", () => {
+      expect(handler).toContain(
+        squash(
+          "if (tile.action === SiteSummaryTileAction.ShowUnassignedDevices) { Navigation.navigate( getDeviceListRouteForFilter(UNASSIGNED_DEVICES_FILTER_KEY), ); return; }",
+        ),
+      );
+    });
+
+    /*
+     * The early return is load-bearing: without it the click would also fall
+     * through to changeSummaryFilter and leave a site filter mirrored into
+     * the URL of a page the user is walking away from.
+     */
+    test("returns before the filter branches run", () => {
+      const navigateBranch: string = handler.split(
+        "SiteSummaryTileAction.ShowUnassignedDevices",
+      )[1]!;
+      expect(navigateBranch.indexOf("return;")).toBeLessThan(
+        navigateBranch.indexOf("changeSummaryFilter"),
+      );
+    });
+
+    test("names the filter through the shared constant, not a literal", () => {
+      expect(handler).toContain("UNASSIGNED_DEVICES_FILTER_KEY");
+      expect(handler).not.toContain('"no-site"');
+    });
+  });
+
+  test("the total tile clears the filter", () => {
+    expect(SITES_PAGE).toContain(
+      squash(
+        "if (tile.action === SiteSummaryTileAction.ClearFilter) { changeSummaryFilter(null); return; }",
+      ),
+    );
+  });
+
+  /*
+   * Clicking the tile the table is already showing has to toggle back to
+   * every site. Without the equality check the click is a no-op and the tile
+   * becomes a one-way door.
+   */
+  test("clicking the active tile toggles the filter off", () => {
+    expect(SITES_PAGE).toContain(
+      squash(
+        "changeSummaryFilter( tile.filterKey && tile.filterKey !== summaryFilterKey ? tile.filterKey : null, );",
+      ),
+    );
+  });
+
+  /*
+   * The Devices page has to disarm its "Last Seen At" column filter while a
+   * tile filter is active, because both name `lastSeenAt` and the column
+   * filter is spread over the page's query. The Sites table needs none of
+   * that machinery only because it offers no filter over the columns its
+   * tiles constrain — Name, Site Type and Created.
+   *
+   * This is the tripwire. Adding a Status filter to the sites table would
+   * reintroduce exactly the collision the Devices page has to work around,
+   * and would do it silently.
+   */
+  test("no site column filter collides with what the tiles constrain", () => {
+    const filters: string =
+      SITES_PAGE.split("filters={[")[1]!.split("formSteps={[")[0]!;
+
+    expect(filters).toContain("name: true");
+    expect(filters).not.toContain("currentMonitorStatus");
+    expect(filters).not.toContain("currentMonitorStatusId");
+  });
+});
+
+describe("DeviceSummaryCards", () => {
+  /*
+   * One source of truth for the tiles. A second, local list here is how the
+   * strip and the drill-down queries would drift apart.
+   */
+  test("renders the shared tile definitions", () => {
+    expect(DEVICE_CARDS).toContain(
+      "DEVICE_SUMMARY_TILES.map((tile: DeviceSummaryTile) => {",
+    );
+    expect(DEVICE_CARDS).not.toContain("const tiles: Array<SummaryTile>");
+  });
+
+  test("each tile reads its own count off the shared definition", () => {
+    expect(DEVICE_CARDS).toContain(
+      squash("const count: number = counts?.[tile.countField] || 0;"),
+    );
+  });
+
+  /*
+   * Clicking a skeleton would filter the list by a number nobody has read.
+   * The counts and the rows would then disagree with no way to tell why.
+   */
+  test("tiles are inert until the counts land", () => {
+    expect(DEVICE_CARDS).toContain(
+      squash(
+        "onClick={ props.onFilterKeyChange && !isLoading ? () => { onTileClick(tile); } : undefined }",
+      ),
+    );
+  });
+
+  test("clicking the selected tile clears the filter", () => {
+    expect(DEVICE_CARDS).toContain(
+      squash(
+        "props.onFilterKeyChange( selectedFilterKey === tile.filterKey ? null : tile.filterKey, );",
+      ),
+    );
+  });
+
+  test("the selected tile is marked as such", () => {
+    expect(DEVICE_CARDS).toContain(
+      squash(
+        "const isSelected: boolean = selectedFilterKey === tile.filterKey;",
+      ),
+    );
+    expect(DEVICE_CARDS).toContain("isSelected={isSelected}");
+  });
+
+  /*
+   * The card is a div, so its label is the only thing a screen reader gets
+   * beyond the number. It has to say what activating it does.
+   */
+  test("each tile announces what activating it does", () => {
+    expect(DEVICE_CARDS).toContain("ariaLabel={");
+    expect(DEVICE_CARDS).toContain("Activate to show these in the list below.");
+    expect(DEVICE_CARDS).toContain("activate to clear the filter.");
+  });
+
+  // Existing selectors in the wild.
+  test("keeps its test ids", () => {
+    expect(DEVICE_CARDS).toContain(
+      'data-testid="network-device-summary-cards"',
+    );
+    expect(DEVICE_CARDS).toContain(
+      "data-testid={`network-device-stat-${tile.key}`}",
+    );
+  });
+});
+
+describe("SiteSummaryCards", () => {
+  test("renders the shared tile definitions", () => {
+    expect(SITE_CARDS).toContain(
+      "SITE_SUMMARY_TILES.map((tile: SiteSummaryTile) => {",
+    );
+    expect(SITE_CARDS).not.toContain("const tiles: Array<SummaryTile>");
+  });
+
+  test("each tile reads its own count off the shared definition", () => {
+    expect(SITE_CARDS).toContain(
+      squash("const count: number = counts?.[tile.countField] || 0;"),
+    );
+  });
+
+  test("tiles are inert until the counts land", () => {
+    expect(SITE_CARDS).toContain(
+      squash(
+        "onClick={ props.onTileClick && !isLoading ? () => { props.onTileClick?.(tile); } : undefined }",
+      ),
+    );
+  });
+
+  /*
+   * The card reports which tile was activated and lets the page decide what
+   * that means — it is the page, not the strip, that can navigate.
+   */
+  test("hands the whole tile to the page rather than deciding itself", () => {
+    expect(SITE_CARDS).toContain(
+      "onTileClick?: ((tile: SiteSummaryTile) => void) | undefined;",
+    );
+    expect(SITE_CARDS).not.toContain("Navigation.navigate");
+  });
+
+  /*
+   * The total is the unfiltered list, so it reads as selected when nothing is
+   * filtered; the device tile leaves the page and can never be the state the
+   * table is in.
+   */
+  test("only the tiles that describe the table can look selected", () => {
+    const body: string = SITE_CARDS.split(
+      "const isTileSelected: IsTileSelectedFunction = (",
+    )[1]!.split("type TileAriaLabelFunction")[0]!;
+
+    expect(body).toContain(
+      squash(
+        "if (tile.action === SiteSummaryTileAction.FilterSites) { return Boolean(tile.filterKey) && tile.filterKey === selectedFilterKey; }",
+      ),
+    );
+    expect(body).toContain(
+      squash(
+        "if (tile.action === SiteSummaryTileAction.ClearFilter) { return selectedFilterKey === null; }",
+      ),
+    );
+  });
+
+  /*
+   * Undefined, not false. The Unassigned Devices tile navigates away rather
+   * than toggling, and `false` would have InfoCard announce it as a toggle
+   * button that is currently off — a state it can never reach.
+   */
+  test("the tile that navigates is not announced as an unpressed toggle", () => {
+    const body: string = SITE_CARDS.split(
+      "const isTileSelected: IsTileSelectedFunction = (",
+    )[1]!.split("type TileAriaLabelFunction")[0]!;
+
+    expect(body).toContain("return undefined;");
+    expect(body).not.toContain("return false;");
+    expect(SITE_CARDS).toContain(
+      "const isSelected: boolean | undefined = isTileSelected(tile);",
+    );
+  });
+
+  /*
+   * "Activate to show these in the list below" would be a lie on the one tile
+   * that navigates away.
+   */
+  test("the tile that leaves the page says so", () => {
+    expect(SITE_CARDS).toContain("Activate to open these on the device list.");
+  });
+
+  test("keeps its test ids", () => {
+    expect(SITE_CARDS).toContain('data-testid="network-site-summary-cards"');
+    expect(SITE_CARDS).toContain(
+      "data-testid={`network-site-stat-${tile.key}`}",
+    );
+  });
+});
+
+describe("SummaryFilterChip", () => {
+  test("names what the table is narrowed to", () => {
+    expect(CHIP).toContain("{props.label}");
+    expect(CHIP).toContain("Filtered by");
+  });
+
+  /*
+   * A real <button>, not another click handler on a div — this is the escape
+   * hatch from a filtered view and has to be reachable by keyboard.
+   */
+  test("the clear control is a labelled button", () => {
+    expect(CHIP).toContain('<button type="button"');
+    expect(CHIP).toContain("aria-label={`Clear the ${props.label} filter`}");
+    expect(CHIP).toContain("onClick={props.onClear}");
+  });
+
+  test("both pages can be told apart in the DOM", () => {
+    expect(CHIP).toContain(
+      "data-testid={`summary-filter-chip-${props.testIdSuffix}`}",
+    );
+    expect(CHIP).toContain(
+      "data-testid={`summary-filter-chip-clear-${props.testIdSuffix}`}",
+    );
+  });
+
+  /*
+   * The qualifier is what lets the Devices page say its up/down window is a
+   * snapshot. It has to stay optional — the Sites page passes none, and an
+   * empty span next to every chip would read as a missing value.
+   */
+  test("the snapshot qualifier is optional and rendered only when given", () => {
+    expect(CHIP).toContain("detail?: string | undefined;");
+    expect(CHIP).toContain("{props.detail ? (");
+    expect(CHIP).toContain(
+      "data-testid={`summary-filter-chip-detail-${props.testIdSuffix}`}",
+    );
+  });
+});
+
+describe("InfoCard as a toggle", () => {
+  /*
+   * InfoCard is shared. Everything the tiles need is gated on the card
+   * actually having a click handler, so the many cards that are plain
+   * containers keep rendering as plain containers — no bogus button role, no
+   * tab stop, no aria-pressed on something that does not toggle.
+   */
+  test("only a clickable card becomes a button", () => {
+    expect(INFO_CARD).toContain(
+      "const isClickable: boolean = Boolean(props.onClick);",
+    );
+    expect(INFO_CARD).toContain('role={isClickable ? "button" : undefined}');
+    expect(INFO_CARD).toContain("tabIndex={isClickable ? 0 : undefined}");
+  });
+
+  /*
+   * Every InfoCard that was clickable before this change — the Home overview
+   * stats, the Kubernetes and Proxmox summaries, the monitor summary views —
+   * navigates rather than toggling. `aria-pressed="false"` on those announces
+   * a toggle button that is currently off, promising a state that activating
+   * it never reaches. So the attribute is gated on the caller having actually
+   * opted in, not on the card merely being clickable.
+   */
+  test("only a card that opted into toggle semantics announces them", () => {
+    expect(INFO_CARD).toContain(
+      squash(
+        "aria-pressed={ isClickable && props.isSelected !== undefined ? Boolean(props.isSelected) : undefined }",
+      ),
+    );
+    expect(INFO_CARD).not.toContain(
+      "aria-pressed={isClickable ? Boolean(props.isSelected) : undefined}",
+    );
+  });
+
+  /*
+   * A div with an onClick is unreachable by keyboard. Enter and Space are
+   * what a real button responds to, and Space has to have its default taken
+   * away or the page scrolls instead.
+   */
+  test("Enter and Space activate it, and Space does not scroll the page", () => {
+    const handler: string =
+      INFO_CARD.split("onKeyDown={")[1]!.split("className={")[0]!;
+
+    expect(handler).toContain(
+      squash('if (event.key !== "Enter" && event.key !== " ") { return; }'),
+    );
+    expect(handler).toContain("event.preventDefault();");
+    expect(handler).toContain("props.onClick?.();");
+  });
+
+  /*
+   * Tailwind emits both border-colour utilities at the same specificity, so
+   * appending a selected border to the default one leaves the winner up to
+   * stylesheet order. The class has to be swapped, not stacked.
+   */
+  test("the selected border replaces the default rather than stacking on it", () => {
+    expect(INFO_CARD).toContain(
+      squash(
+        'const borderClassName: string = isClickable && props.isSelected ? "border-indigo-500 ring-1 ring-indigo-500" : "border-gray-200";',
+      ),
+    );
+    expect(INFO_CARD).toContain("border ${borderClassName}");
+  });
+
+  test("a keyboard user can see where they are", () => {
+    expect(INFO_CARD).toContain("focus-visible:ring-2");
+  });
+
+  /*
+   * The cards that were already clickable before this change (the Home
+   * overview stats, the Kubernetes and Proxmox detail pages) pass no
+   * isSelected, so Boolean(undefined) leaves them announced as un-pressed
+   * buttons — which is what they are.
+   */
+  test("isSelected is optional, so existing clickable cards are unaffected", () => {
+    expect(INFO_CARD).toContain("isSelected?: boolean | undefined;");
+    expect(INFO_CARD).toContain("ariaLabel?: string | undefined;");
+  });
+});

--- a/Common/Tests/UI/Components/InfoCard.test.tsx
+++ b/Common/Tests/UI/Components/InfoCard.test.tsx
@@ -1,0 +1,358 @@
+import InfoCard from "../../../UI/Components/InfoCard/InfoCard";
+/*
+ * The package entry, not the `/extend-expect` subpath the older tests use:
+ * the matchers are already registered by Tests/jest.setup.ts, and only this
+ * specifier resolves to the type augmentation that makes them visible to
+ * TypeScript.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * InfoCard is the stat card used across the product. Most of them are inert
+ * containers, a handful navigate somewhere when clicked, and the network
+ * summary strips use them as toggles that filter the table below.
+ *
+ * The three have to stay distinguishable to a screen reader and to the
+ * keyboard, and the distinctions are all driven off which props were passed —
+ * so that is what these cover, end to end through a real render.
+ */
+
+/*
+ * The card's own root element. Taken off the render container rather than
+ * walked up from the title, because a card with no click handler has no role
+ * to query it by — which is exactly what several of these assert.
+ */
+function getCard(): HTMLElement {
+  return document.body.firstElementChild!.firstElementChild as HTMLElement;
+}
+
+describe("InfoCard", () => {
+  describe("a card with no click handler", () => {
+    test("renders its title and value", () => {
+      render(<InfoCard title="Devices Up" value="12" />);
+
+      expect(screen.getByText("Devices Up")).toBeInTheDocument();
+      expect(screen.getByText("12")).toBeInTheDocument();
+    });
+
+    /*
+     * The majority of InfoCards in the product are read-only. Announcing one
+     * as a button would put a tab stop on every tile of every dashboard.
+     */
+    test("is not a button, and is not focusable", () => {
+      render(<InfoCard title="Devices Up" value="12" />);
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      expect(getCard()).not.toHaveAttribute("tabindex");
+      expect(getCard()).not.toHaveAttribute("aria-pressed");
+      expect(getCard()).not.toHaveAttribute("aria-label");
+    });
+
+    test("does not look clickable", () => {
+      render(<InfoCard title="Devices Up" value="12" />);
+
+      expect(getCard()).not.toHaveClass("cursor-pointer");
+    });
+  });
+
+  describe("a card that navigates when clicked", () => {
+    /*
+     * The pre-existing clickable cards — the Home overview stats, the
+     * Kubernetes and Proxmox summaries — all navigate. They pass onClick and
+     * no isSelected.
+     */
+    test("is a real button, reachable by keyboard", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      const card: HTMLElement = screen.getByRole("button");
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveAttribute("tabindex", "0");
+      expect(card).toHaveClass("cursor-pointer");
+    });
+
+    /*
+     * The regression this guards: `aria-pressed="false"` asserts the control
+     * is a toggle that is currently off. On a card that navigates away, that
+     * is a state activating it can never reach — the user is told to expect
+     * something the product never does.
+     */
+    test("is not announced as an unpressed toggle", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("button")).not.toHaveAttribute("aria-pressed");
+    });
+
+    test("keeps the plain border", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("button")).toHaveClass("border-gray-200");
+    });
+  });
+
+  describe("a card used as a toggle", () => {
+    test("announces itself as pressed when selected", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          isSelected={true}
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    /*
+     * Explicit `false` is a real state here — the tile exists, it is simply
+     * not the one the table is filtered by — so it must still announce as a
+     * toggle, unlike the navigation card above.
+     */
+    test("announces itself as unpressed when explicitly not selected", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          isSelected={false}
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("button")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    /*
+     * Tailwind emits both border-colour utilities at the same specificity, so
+     * a selected card that merely *added* a border colour would leave the
+     * winner up to stylesheet order. The class is swapped.
+     */
+    test("swaps its border rather than stacking a second one", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          isSelected={true}
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      const card: HTMLElement = screen.getByRole("button");
+      expect(card).toHaveClass("border-indigo-500");
+      expect(card).not.toHaveClass("border-gray-200");
+    });
+
+    test("carries the caller's label for screen readers", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          isSelected={true}
+          ariaLabel="Devices Up: 12. Showing these in the list below."
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", {
+          name: "Devices Up: 12. Showing these in the list below.",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    // A label on an inert card would announce a control that is not there.
+    test("ignores the label when there is nothing to activate", () => {
+      render(
+        <InfoCard title="Devices Up" value="12" ariaLabel="Should not apply" />,
+      );
+
+      expect(getCard()).not.toHaveAttribute("aria-label");
+    });
+
+    // Selection styling is meaningless without a handler to toggle it.
+    test("a non-clickable card ignores isSelected", () => {
+      render(<InfoCard title="Devices Up" value="12" isSelected={true} />);
+
+      expect(getCard()).toHaveClass("border-gray-200");
+      expect(getCard()).not.toHaveAttribute("aria-pressed");
+    });
+  });
+
+  describe("activation", () => {
+    test("a click fires the handler", () => {
+      const onClick: () => void = jest.fn();
+      render(<InfoCard title="Devices Up" value="12" onClick={onClick} />);
+
+      fireEvent.click(screen.getByRole("button"));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * A div with an onClick is invisible to the keyboard. Enter and Space are
+     * what a real button responds to, and both have to work here or the tiles
+     * are mouse-only.
+     */
+    test("Enter fires the handler", () => {
+      const onClick: () => void = jest.fn();
+      render(<InfoCard title="Devices Up" value="12" onClick={onClick} />);
+
+      fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    test("Space fires the handler", () => {
+      const onClick: () => void = jest.fn();
+      render(<InfoCard title="Devices Up" value="12" onClick={onClick} />);
+
+      fireEvent.keyDown(screen.getByRole("button"), { key: " " });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * Space scrolls the page by default. Without preventDefault, activating a
+     * tile from the keyboard would also jump the view down a screen.
+     */
+    test("Space does not also scroll the page", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      // fireEvent returns false when the handler called preventDefault.
+      const notCancelled: boolean = fireEvent.keyDown(
+        screen.getByRole("button"),
+        { key: " ", cancelable: true },
+      );
+
+      expect(notCancelled).toBe(false);
+    });
+
+    test("Enter does not swallow the default either way it is used", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(
+        fireEvent.keyDown(screen.getByRole("button"), {
+          key: "Enter",
+          cancelable: true,
+        }),
+      ).toBe(false);
+    });
+
+    test.each([["Tab"], ["Escape"], ["a"], ["ArrowDown"], ["Shift"]])(
+      "%s does not activate it",
+      (key: string) => {
+        const onClick: () => void = jest.fn();
+        render(<InfoCard title="Devices Up" value="12" onClick={onClick} />);
+
+        const notCancelled: boolean = fireEvent.keyDown(
+          screen.getByRole("button"),
+          { key: key, cancelable: true },
+        );
+
+        expect(onClick).not.toHaveBeenCalled();
+        // And the key still does whatever it normally does.
+        expect(notCancelled).toBe(true);
+      },
+    );
+  });
+
+  describe("styling passthrough", () => {
+    test("the caller's className still lands on the card", () => {
+      render(<InfoCard title="Devices Up" value="12" className="col-span-2" />);
+
+      expect(getCard()).toHaveClass("col-span-2");
+    });
+
+    test("the caller's text class still wraps the value", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          textClassName="text-emerald-600"
+        />,
+      );
+
+      expect(screen.getByText("12")).toHaveClass("text-emerald-600");
+    });
+
+    /*
+     * A keyboard user has to be able to see which card they are on — the
+     * focus ring is the only cue, since the card has no other focus styling.
+     */
+    test("a clickable card shows a focus ring", () => {
+      render(
+        <InfoCard
+          title="Devices Up"
+          value="12"
+          onClick={() => {
+            // no-op
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("button")).toHaveClass("focus-visible:ring-2");
+    });
+
+    test("an inert card does not", () => {
+      render(<InfoCard title="Devices Up" value="12" />);
+
+      expect(getCard()).not.toHaveClass("focus-visible:ring-2");
+    });
+  });
+});

--- a/Common/UI/Components/InfoCard/InfoCard.tsx
+++ b/Common/UI/Components/InfoCard/InfoCard.tsx
@@ -7,15 +7,72 @@ export interface ComponentProps {
   className?: string;
   textClassName?: string;
   onClick?: (() => void) | undefined;
+  /*
+   * Only meaningful alongside `onClick`: renders the card as a pressed toggle
+   * — outlined, and announced as such. Used by summary strips where clicking a
+   * tile narrows the table below it, so the tile has to show which subset the
+   * user is looking at.
+   *
+   * Leave it undefined on a card that navigates instead of toggling. Most
+   * clickable InfoCards in the product are one-way links, and announcing one
+   * as an unpressed toggle promises a state that activating it never produces.
+   */
+  isSelected?: boolean | undefined;
+  // Announced in place of the title when the card is clickable.
+  ariaLabel?: string | undefined;
 }
 
 const InfoCard: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const isClickable: boolean = Boolean(props.onClick);
+
+  /*
+   * A selected card swaps its border rather than adding one: Tailwind emits
+   * both border-color utilities at the same specificity, so stacking them
+   * leaves the winner up to stylesheet order.
+   */
+  const borderClassName: string =
+    isClickable && props.isSelected
+      ? "border-indigo-500 ring-1 ring-indigo-500"
+      : "border-gray-200";
+
   return (
     <div
       onClick={props.onClick}
-      className={`rounded-xl bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow duration-200 p-5 ${props.onClick ? "cursor-pointer" : ""} ${props.className || ""}`}
+      /*
+       * Click handlers on a div are invisible to the keyboard and to screen
+       * readers. Everything below turns a clickable card into a real toggle
+       * button; a card with no handler is left as the plain container it is.
+       */
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      /*
+       * Gated on the prop being supplied, not merely on clickability: the
+       * cards that were already clickable before toggles existed (the Home
+       * overview stats, the Kubernetes and Proxmox summaries) all navigate,
+       * and `aria-pressed="false"` would announce each of them as a toggle
+       * that is currently off — a state activating it never reaches.
+       */
+      aria-pressed={
+        isClickable && props.isSelected !== undefined
+          ? Boolean(props.isSelected)
+          : undefined
+      }
+      aria-label={isClickable ? props.ariaLabel : undefined}
+      onKeyDown={
+        isClickable
+          ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (event.key !== "Enter" && event.key !== " ") {
+                return;
+              }
+              // Space scrolls the page unless the default is taken away.
+              event.preventDefault();
+              props.onClick?.();
+            }
+          : undefined
+      }
+      className={`rounded-xl bg-white border ${borderClassName} shadow-sm hover:shadow-md transition-shadow duration-200 p-5 ${isClickable ? "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2" : ""} ${props.className || ""}`}
     >
       <div className="mb-2">
         <FieldLabelElement title={props.title} />


### PR DESCRIPTION
## The problem

Both the Network Devices page and the Network Sites page open with a strip of four count tiles. Every count is a question the user immediately wants the rows for — *"three devices are down, which three?"* — but the tiles were inert. The only way to answer was to reconstruct the filter by hand from the column-filter popup, and for two of the tiles there was no column filter that could express it at all.

## What this does

Clicking a tile narrows the table below it to exactly the rows that tile counted. Clicking it again clears the filter, as does the ✕ on the chip that appears above the table.

| Tile | Rows it opens |
| --- | --- |
| Devices Up | `lastSeenAt >= cutoff` |
| Devices Down / Stale | `lastSeenAt < cutoff` |
| Devices Pending | `lastSeenAt IS NULL` |
| Total Interfaces Down | devices with at least one interface down |
| Sites | all sites (clears the filter) |
| Unhealthy Sites | `currentMonitorStatus.isOperationalState = false` |
| Sites Without Data | `currentMonitorStatusId IS NULL` |
| Unassigned Devices | opens the **device** list filtered to devices with no site |

The cutoff is the same 15-minute freshness window the counts and the Status pill already use, so a tile and its rows describe the same set.

`Unassigned Devices` counts devices, and devices are only listed on the device page — filtering the sites table by a device predicate would empty it with no explanation — so that tile navigates instead of filtering in place.

`Total Interfaces Down` counts interfaces but the list can only show devices, so its chip reads "Devices with interfaces down" rather than repeating the tile's label.

## Shape

`DeviceSummaryFilter.ts` and `SiteSummaryFilter.ts` own the tile → query mapping, and the tile definitions moved there too, so the strip and the drill-down read one list and cannot drift apart. Both are pure — no React, no `window` — which is what makes them exhaustively testable in the App suite's plain Node environment.

The selection is mirrored into the URL (`deviceFilter` / `siteFilter`) and seeded back synchronously during the first render, so a drilled-in view survives opening a device and pressing Back, and can be pasted to a teammate. Unknown or hand-edited values degrade to the unfiltered list.

## Three things the drill-down has to get right

**A tile filter and a column filter over the same field cannot both apply.** `BaseModelTable` builds its request as `{...props.query, ...columnFilterQuery}` — the popup's filters are spread *over* the page's query. An already-set "Last Seen At" filter would therefore replace the tile's `lastSeenAt` constraint outright while the chip and the lit-up tile carried on claiming it. The Devices page clears the table's persisted filter/page state and remounts the table on selection, and drops the colliding entry from the filter set while a tile filter is active, so the two are exclusive whichever order the user reaches for them in. (The Sites table needs none of this — it offers no filter over the columns its tiles constrain — and there is a test that fails if one is ever added.)

**The query is memoised on the selection.** The up/down cutoff is a `Date` built at call time, and the table decides whether to refetch by JSON-comparing this prop against the previous render's; rebuilding it on every render would refetch forever. The trade-off is that the window is a snapshot taken when the tile was activated rather than a live one — re-deriving it on a timer instead would send anyone reading page 3 back to page 1 every tick and drop any bulk selection they had made, which is worse than the drift. So the chip says when the snapshot was taken, and re-activating the tile takes a new one.

**`InfoCard` is shared.** It gained real toggle semantics — button role, tab stop, Enter/Space activation, focus ring, and a swapped (not stacked) selected border. `aria-pressed` is emitted only when the caller passes `isSelected`, so the many InfoCards elsewhere in the product that navigate rather than toggle are not announced as toggle buttons that never toggle.

## Tests

- `DeviceSummaryFilter.test.ts` / `SiteSummaryFilter.test.ts` — query shapes pinned operator-by-operator against the count queries, the up/down boundary, the up/down/pending partition, which filters read the clock, hostile and stale URL values, and the tile→filter mapping.
- `DeviceSummaryFilterRoute.test.ts` — the Sites → Devices hand-off driven through the real `Navigation` and `RouteMap` against a stubbed browser, including the full round trip back out of the URL and both pages' filters coexisting in one query string.
- `SummaryTileFilteringInvariants.test.ts` — the page wiring the App suite has no renderer for: the memo and its deps, the synchronous URL seed, the mutual exclusion above, the chip, and the accessibility gating.
- `Common/Tests/UI/Components/InfoCard.test.tsx` — the shared component's keyboard and ARIA behaviour through a real render, including that a navigation card is *not* announced as an unpressed toggle.

`npm run compile` passes in App and Common; the full `App/Tests/Dashboard` suite and the new Common test are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)