### PR TITLE
fix(monitor): stop the probe picker offering probes that do not monitor the resource

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/ProbePicker.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/ProbePicker.tsx
@@ -4,30 +4,55 @@ import Dropdown, {
 } from "Common/UI/Components/Dropdown/Dropdown";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import Probe from "Common/Models/DatabaseModels/Probe";
+import MonitorSummaryProbeUtil, {
+  AttachedProbe,
+} from "Common/Utils/Monitor/MonitorSummaryProbeUtil";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
   onProbeSelected?: (probe: Probe) => void;
+  /*
+   * Only the probes attached to the monitor being viewed. This is a view
+   * filter over data that already exists - it does not change which probe
+   * monitors the resource, so it must never offer a probe that does not.
+   */
   probes: Array<Probe>;
+  disabledProbeIds?: Array<string> | undefined;
   selectedProbe?: Probe;
 }
 
 const ProbePicker: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const dropdownOptions: Array<DropdownOption> = props.probes.map(
-    (probe: Probe) => {
-      return {
-        label: probe.name?.toString() || "Unknown",
-        value: probe._id?.toString() || "",
-      };
-    },
-  );
+  const disabledProbeIdSet: Set<string> = new Set(props.disabledProbeIds || []);
+
+  const dropdownOptions: Array<DropdownOption> =
+    MonitorSummaryProbeUtil.getProbeDropdownOptions({
+      probes: props.probes.map((probe: Probe): AttachedProbe => {
+        const id: string = probe._id?.toString() || "";
+
+        return {
+          id: id,
+          name: probe.name?.toString() || "Unknown",
+          isEnabled: !disabledProbeIdSet.has(id),
+        };
+      }),
+    });
 
   return (
     <div className="flex">
       <div className="w-fit mr-2 flex h-full align-middle items-center mt-4">
-        <FieldLabelElement title="Select Probe:" required={true} />
+        {/*
+         * Deliberately not `required`: this is a filter on what the card
+         * displays, not a setting. Chroming it like a required form field
+         * invited users to treat changing it as editing the monitor's probe,
+         * and to read the (unsaved, because there is nothing to save)
+         * selection as an edit that was thrown away.
+         */}
+        <FieldLabelElement
+          title="Showing results from:"
+          hideOptionalLabel={true}
+        />
       </div>
       <div>
         <Dropdown

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/Summary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/Summary.tsx
@@ -15,6 +15,10 @@ import TelemetryMonitorSummary from "./Types/TelemetryMonitorSummary";
 import MonitorEvaluationSummary from "Common/Types/Monitor/MonitorEvaluationSummary";
 import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
 import MonitorStep from "Common/Types/Monitor/MonitorStep";
+import MonitorSummaryProbeUtil, {
+  AttachedProbe,
+  MonitorSummaryProbeState,
+} from "Common/Utils/Monitor/MonitorSummaryProbeUtil";
 
 export interface ComponentProps {
   probeMonitorResponses?: Array<MonitorStepProbeResponse> | undefined;
@@ -23,7 +27,14 @@ export interface ComponentProps {
   incomingEmailMonitorRequest?: IncomingEmailMonitorRequest | undefined;
   incomingEmailMonitorHeartbeatCheckedAt?: Date | undefined;
   serverMonitorResponse?: ServerMonitorResponse | undefined;
+  /*
+   * The probes attached to this monitor - NOT every probe in the project.
+   * Offering unattached probes here told users to wait a few minutes for a
+   * summary that could never arrive.
+   */
   probes?: Array<Probe>;
+  // Of those, the ones that are attached but switched off for this monitor.
+  disabledProbeIds?: Array<string> | undefined;
   monitorType: MonitorType;
   monitorSteps?: MonitorSteps | undefined;
   telemetryMonitorSummary?: TelemetryMonitorSummary | undefined;
@@ -37,13 +48,43 @@ const Summary: FunctionComponent<ComponentProps> = (
     undefined,
   );
 
-  useEffect(() => {
-    // slect first probe if exists
+  const disabledProbeIdSet: Set<string> = new Set(props.disabledProbeIds || []);
 
-    if (props.probes && props.probes.length > 0) {
-      setSelectedProbe(props.probes[0]);
-    }
-  }, [props.probes]);
+  const attachedProbes: Array<AttachedProbe> = (props.probes || []).map(
+    (probe: Probe): AttachedProbe => {
+      const id: string = probe._id?.toString() || "";
+
+      return {
+        id: id,
+        name: probe.name?.toString() || "Unknown",
+        isEnabled: !disabledProbeIdSet.has(id),
+      };
+    },
+  );
+
+  useEffect(() => {
+    setSelectedProbe((currentlySelected: Probe | undefined) => {
+      /*
+       * Keep whatever the user picked as long as it is still attached. This
+       * effect re-runs every time the probe list is handed down again, and
+       * unconditionally resetting to the first entry is indistinguishable
+       * from a selection that refuses to stick.
+       */
+      const selectedProbeId: string | null =
+        MonitorSummaryProbeUtil.resolveSelectedProbeId({
+          probes: attachedProbes,
+          currentlySelectedProbeId: currentlySelected?._id?.toString(),
+        });
+
+      if (!selectedProbeId) {
+        return undefined;
+      }
+
+      return (props.probes || []).find((probe: Probe) => {
+        return probe._id?.toString() === selectedProbeId;
+      });
+    });
+  }, [props.probes, props.disabledProbeIds]);
 
   if (props.monitorType === MonitorType.Manual) {
     return <></>;
@@ -87,17 +128,29 @@ const Summary: FunctionComponent<ComponentProps> = (
     }
   }
 
+  const isProbableMonitor: boolean = MonitorTypeHelper.isProbableMonitor(
+    props.monitorType,
+  );
+
+  const probeSummaryState: MonitorSummaryProbeState =
+    MonitorSummaryProbeUtil.getProbeState({
+      isProbeableMonitor: isProbableMonitor,
+      attachedProbeCount: attachedProbes.length,
+      isSelectedProbeEnabled: !disabledProbeIdSet.has(
+        selectedProbe?._id?.toString() || "",
+      ),
+      probeResponseCount: probeResponses.length,
+    });
+
   return (
     <Card
       title="Monitor Summary"
       description="Here is how your monitor is performing at this moment."
       rightElement={
-        MonitorTypeHelper.isProbableMonitor(props.monitorType) &&
-        props.probes &&
-        props.probes.length > 0 &&
-        selectedProbe ? (
+        isProbableMonitor && attachedProbes.length > 0 && selectedProbe ? (
           <ProbePicker
-            probes={props.probes}
+            probes={props.probes!}
+            disabledProbeIds={props.disabledProbeIds}
             selectedProbe={selectedProbe}
             onProbeSelected={(probe: Probe) => {
               setSelectedProbe(probe);
@@ -113,6 +166,7 @@ const Summary: FunctionComponent<ComponentProps> = (
           monitorType={props.monitorType}
           probeMonitorResponses={probeResponses}
           probeName={selectedProbe?.name?.toString()}
+          probeSummaryState={probeSummaryState}
           incomingMonitorRequest={props.incomingMonitorRequest}
           serverMonitorResponse={props.serverMonitorResponse}
           telemetryMonitorSummary={props.telemetryMonitorSummary}

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
@@ -25,6 +25,7 @@ import TelemetryMonitorSummary from "./Types/TelemetryMonitorSummary";
 import CustomCodeMonitorSummaryView from "./CustomCodeMonitorSummaryView";
 import MonitorEvaluationSummary from "Common/Types/Monitor/MonitorEvaluationSummary";
 import EvaluationLogList from "./EvaluationLogList";
+import { MonitorSummaryProbeState } from "Common/Utils/Monitor/MonitorSummaryProbeUtil";
 
 export interface ComponentProps {
   monitorType: MonitorType;
@@ -37,6 +38,15 @@ export interface ComponentProps {
   telemetryMonitorSummary?: TelemetryMonitorSummary | undefined;
   evaluationSummary?: MonitorEvaluationSummary | undefined;
   probeName?: string | undefined;
+  /*
+   * Optional so the callers that render one probe's log in isolation (the
+   * Probes tab, the monitoring-log modal) keep their existing wording. The
+   * monitor overview passes it, because "no data yet", "this probe is
+   * switched off" and "nothing is watching this monitor" are three different
+   * situations - and telling the user to wait a few minutes for the last two
+   * is how a probe change comes to read as never having applied.
+   */
+  probeSummaryState?: MonitorSummaryProbeState | undefined;
 }
 
 const SummaryInfo: FunctionComponent<ComponentProps> = (
@@ -200,6 +210,28 @@ const SummaryInfo: FunctionComponent<ComponentProps> = (
     MonitorTypeHelper.isProbableMonitor(props.monitorType) &&
     (!props.probeMonitorResponses || props.probeMonitorResponses.length === 0)
   ) {
+    if (props.probeSummaryState === MonitorSummaryProbeState.NoProbesAttached) {
+      return (
+        <ErrorMessage
+          message={
+            "No probes are monitoring this resource. Add one under Probes to start collecting data."
+          }
+        />
+      );
+    }
+
+    if (
+      props.probeSummaryState === MonitorSummaryProbeState.SelectedProbeDisabled
+    ) {
+      return (
+        <ErrorMessage
+          message={`${
+            props.probeName || "This probe"
+          } is disabled for this monitor, so it is not collecting any data. Enable it under Probes.`}
+        />
+      );
+    }
+
     return (
       <ErrorMessage
         message={

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -4,7 +4,6 @@ import IncomingMonitorLink from "../../../Components/Monitor/IncomingRequestMoni
 import IncomingEmailMonitorLink from "../../../Components/Monitor/IncomingEmailMonitor/IncomingEmailMonitorLink";
 import ServerMonitorDocumentation from "../../../Components/Monitor/ServerMonitor/Documentation";
 import Summary from "../../../Components/Monitor/SummaryView/Summary";
-import ProbeUtil from "../../../Utils/Probe";
 import PageComponentProps from "../../PageComponentProps";
 import GreaterThanOrNull from "Common/Types/BaseDatabase/GreaterThanOrNull";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
@@ -96,6 +95,9 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [monitor, setMonitor] = useState<Monitor | null>(null);
 
   const [probes, setProbes] = useState<Array<Probe>>([]);
+
+  // Probes attached to this monitor but switched off, so the picker can say so.
+  const [disabledProbeIds, setDisabledProbeIds] = useState<Array<string>>([]);
 
   const [probeResponses, setProbeResponses] = useState<
     Array<MonitorStepProbeResponse> | undefined
@@ -397,12 +399,16 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         : false;
 
       if (isMonitoredByProbe) {
-        // get a list of probes
-        const probes: Array<Probe> = await ProbeUtil.getAllProbes();
-        setProbes(probes);
-
-        // get probe responses for this monitor
-
+        /*
+         * The probes this monitor is actually watched by - which is the set the
+         * summary picker offers. It used to be fed the project's whole probe
+         * list plus every global probe, so the card offered probes that had
+         * never touched this resource. Picking one of them answered "no summary
+         * available ... should be a few minutes" for data that was never going
+         * to arrive, and because that list is project-probes-first the picker
+         * frequently *defaulted* to one. That is what reads as "I changed the
+         * probe and it did not apply".
+         */
         const monitorProbes: ListResult<MonitorProbe> = await ModelAPI.getList({
           modelType: MonitorProbe,
           query: {
@@ -415,11 +421,18 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
           },
           select: {
             probeId: true,
+            isEnabled: true,
             lastMonitoringLog: true,
+            probe: {
+              name: true,
+              iconFileId: true,
+            },
           },
         });
 
         const probeMonitorResponses: Array<MonitorStepProbeResponse> = [];
+        const attachedProbes: Array<Probe> = [];
+        const disabledProbeIds: Array<string> = [];
 
         for (let i: number = 0; i < monitorProbes.data.length; i++) {
           const monitorProbe: MonitorProbe | undefined = monitorProbes.data[i];
@@ -432,6 +445,22 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             continue;
           }
 
+          if (monitorProbe.probe) {
+            const probe: Probe = monitorProbe.probe;
+
+            /*
+             * The relation select carries _id back on its own, but the join row
+             * is the authority on which probe this is - and the picker keys its
+             * options on that id.
+             */
+            probe._id = monitorProbe.probeId.toString();
+            attachedProbes.push(probe);
+
+            if (monitorProbe.isEnabled === false) {
+              disabledProbeIds.push(monitorProbe.probeId.toString());
+            }
+          }
+
           if (!monitorProbe.lastMonitoringLog) {
             continue;
           }
@@ -439,6 +468,8 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
           probeMonitorResponses.push(monitorProbe?.lastMonitoringLog);
         }
 
+        setProbes(attachedProbes);
+        setDisabledProbeIds(disabledProbeIds);
         setProbeResponses(probeMonitorResponses);
       }
     } catch (err) {
@@ -748,6 +779,7 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
       <Summary
         monitorType={monitorType!}
         probes={probes}
+        disabledProbeIds={disabledProbeIds}
         monitorSteps={monitor?.monitorSteps}
         incomingMonitorRequest={incomingMonitorRequest}
         incomingRequestMonitorHeartbeatCheckedAt={

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Probes.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Probes.tsx
@@ -131,12 +131,19 @@ const MonitorProbes: FunctionComponent<
         saveFilterProps={{
           tableId: "monitor-view-probes-table",
         }}
-        isDeleteable={false}
+        /*
+         * Which probe a row points at is fixed once the row exists
+         * (MonitorProbe.probe/probeId are create-only), so removing the row is
+         * the only way to undo attaching the wrong probe. Without this the
+         * table could add probes and never take one away.
+         */
+        isDeleteable={true}
         isEditable={true}
         isCreateable={true}
         cardProps={{
           title: "Probes",
-          description: "List of probes that help you monitor this resource.",
+          description:
+            "List of probes that help you monitor this resource. Only these probes monitor it - adding one here is what puts a probe to work on this resource.",
         }}
         noItemsMessage={
           "No probes found for this resource. However, you can add some probes to monitor this resource."
@@ -174,8 +181,17 @@ const MonitorProbes: FunctionComponent<
               probe: true,
             },
             title: "Probe",
-            stepId: "incident-details",
             description: "Which probe do you want to use?",
+            /*
+             * MonitorProbe.probe is create-only, so ModelForm drops this field
+             * from an Update form - and from the request - with no error. The
+             * modal used to render a "Save Changes" button over a Probe
+             * dropdown that was silently missing, so a user who came here to
+             * change which probe watches the resource found no control and no
+             * explanation. Say so up front instead: to point a row at a
+             * different probe, delete it and add the right one.
+             */
+            doNotShowWhenEditing: true,
             fieldType: FormFieldSchemaType.Dropdown,
             dropdownOptions: probes.map((probe: Probe) => {
               if (!probe.name || !probe._id) {
@@ -196,6 +212,8 @@ const MonitorProbes: FunctionComponent<
               isEnabled: true,
             },
             title: "Enabled",
+            description:
+              "When off, this probe stops monitoring this resource. It stays on the list so you can turn it back on.",
             fieldType: FormFieldSchemaType.Toggle,
             required: false,
           },

--- a/App/Tests/Dashboard/MonitorProbeSummaryPages.test.ts
+++ b/App/Tests/Dashboard/MonitorProbeSummaryPages.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * https://github.com/OneUptime/oneuptime/issues/2899
+ *
+ * "No Save/Discard confirmation after editing Probe settings - changes not
+ * actually applied." Two distinct dead ends produced that report, and both
+ * live in props and field lists rather than in extractable logic - the App
+ * suite runs in a plain Node environment with no renderer, so these read the
+ * sources and assert the exact expressions, the same way
+ * MonitorProbeSelectionPages.test.ts does. The behaviour that *is* extractable
+ * is covered properly in
+ * Common/Tests/Utils/Monitor/MonitorSummaryProbeUtil.test.ts.
+ *
+ * 1. The Monitor Summary card's probe picker was fed ProbeUtil.getAllProbes() -
+ *    every probe in the project plus every global probe - instead of the probes
+ *    attached to the monitor. Picking a stranger answered "should be few
+ *    minutes for summary to show up" about data that could never arrive, and
+ *    since the list is project-probes-first the card often opened on one.
+ *
+ * 2. Monitor > Probes offered a required "Probe" dropdown on an editable table
+ *    whose probe relation is create-only, so ModelForm silently dropped the
+ *    field from the edit form and from the request. With deletion off too,
+ *    a probe attached by mistake could never be changed or removed.
+ *
+ * Sources are whitespace-squashed first so prettier re-wrapping a line cannot
+ * turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+  );
+}
+
+describe("Monitor overview feeds the summary picker only the monitor's own probes", () => {
+  const source: string = readSource("Pages", "Monitor", "View", "Index.tsx");
+
+  test("no longer pulls the whole project's probe list into this page", () => {
+    /*
+     * The single most important line of the fix. ProbeUtil.getAllProbes()
+     * returns project probes plus global probes with no monitor filter at all.
+     */
+    expect(source).not.toContain("ProbeUtil.getAllProbes()");
+    expect(source).not.toContain(
+      'import ProbeUtil from "../../../Utils/Probe"',
+    );
+  });
+
+  test("selects the probe relation on the monitor's own MonitorProbe rows", () => {
+    expect(source).toContain(
+      squash("probe: { name: true, iconFileId: true, },"),
+    );
+    expect(source).toContain(squash("isEnabled: true,"));
+    expect(source).toContain(squash("query: { monitorId: modelId, },"));
+  });
+
+  test("builds the picker list from those rows", () => {
+    expect(source).toContain("setProbes(attachedProbes)");
+    expect(source).toContain("attachedProbes.push(probe)");
+  });
+
+  test("keys each option on the join row's probeId", () => {
+    // The relation select carries _id, but the join row is the authority.
+    expect(source).toContain("probe._id = monitorProbe.probeId.toString()");
+  });
+
+  test("tracks which attached probes are switched off", () => {
+    /*
+     * Without this the card cannot tell "no data yet" from "this probe is
+     * disabled", and tells the user to wait for data that will never come.
+     */
+    expect(source).toContain("setDisabledProbeIds(disabledProbeIds)");
+    expect(source).toContain(squash("if (monitorProbe.isEnabled === false) {"));
+  });
+
+  test("hands both down to the Summary card", () => {
+    expect(source).toContain(squash("probes={probes}"));
+    expect(source).toContain(squash("disabledProbeIds={disabledProbeIds}"));
+  });
+
+  test("still collects the monitoring logs it always did", () => {
+    expect(source).toContain(
+      "probeMonitorResponses.push(monitorProbe?.lastMonitoringLog)",
+    );
+    expect(source).toContain("setProbeResponses(probeMonitorResponses)");
+  });
+});
+
+describe("Summary card keeps the picked probe and explains an empty summary", () => {
+  const source: string = readSource(
+    "Components",
+    "Monitor",
+    "SummaryView",
+    "Summary.tsx",
+  );
+
+  test("resolves the selection through the shared rule instead of always taking probes[0]", () => {
+    /*
+     * The effect re-runs on every new probes array. `setSelectedProbe(
+     * props.probes[0])` there is indistinguishable, to a user, from a
+     * selection that refuses to stick.
+     */
+    expect(source).toContain(
+      "MonitorSummaryProbeUtil.resolveSelectedProbeId({",
+    );
+    expect(source).toContain("currentlySelectedProbeId:");
+    expect(source).not.toContain(squash("setSelectedProbe(props.probes[0]);"));
+  });
+
+  test("classifies the empty state instead of leaving SummaryInfo to guess", () => {
+    expect(source).toContain("MonitorSummaryProbeUtil.getProbeState({");
+    expect(source).toContain(squash("probeSummaryState={probeSummaryState}"));
+  });
+
+  test("passes the disabled set to the picker so it can label those options", () => {
+    expect(source).toContain(
+      squash("disabledProbeIds={props.disabledProbeIds}"),
+    );
+  });
+});
+
+describe("Probe picker reads as a view filter, not a setting", () => {
+  const source: string = readSource(
+    "Components",
+    "Monitor",
+    "SummaryView",
+    "ProbePicker.tsx",
+  );
+
+  test("is not chromed as a required form field", () => {
+    /*
+     * FieldLabelElement with required={true} is exactly what an editable
+     * required field renders, which invited users to treat changing this as
+     * editing the monitor's probe - and the (unsaved, because there is nothing
+     * to save) reset as a lost edit.
+     */
+    expect(source).not.toContain("required={true}");
+    expect(source).toContain('title="Showing results from:"');
+    expect(source).toContain("hideOptionalLabel={true}");
+  });
+
+  test("builds its options through the shared rule", () => {
+    expect(source).toContain(
+      "MonitorSummaryProbeUtil.getProbeDropdownOptions({",
+    );
+  });
+});
+
+describe("Summary info tells the three empty states apart", () => {
+  const source: string = readSource(
+    "Components",
+    "Monitor",
+    "SummaryView",
+    "SummaryInfo.tsx",
+  );
+
+  test("says so when nothing is monitoring the resource", () => {
+    expect(source).toContain("MonitorSummaryProbeState.NoProbesAttached");
+    expect(source).toContain("No probes are monitoring this resource.");
+  });
+
+  test("says so when the selected probe is switched off", () => {
+    expect(source).toContain("MonitorSummaryProbeState.SelectedProbeDisabled");
+    expect(source).toContain("is disabled for this monitor");
+  });
+
+  test("keeps the wait-a-few-minutes message for the case where waiting helps", () => {
+    expect(source).toContain(
+      "No summary available for the selected probe. Should be few minutes for summary to show up.",
+    );
+  });
+});
+
+describe("Monitor > Probes can undo attaching the wrong probe", () => {
+  const source: string = readSource("Pages", "Monitor", "View", "Probes.tsx");
+
+  test("does not offer a Probe dropdown the edit form cannot save", () => {
+    /*
+     * MonitorProbe.probe is create-only, so ModelForm drops this field from an
+     * Update form - and from the request - with no error at all. Declaring it
+     * without doNotShowWhenEditing is what produced a "Save Changes" modal
+     * with the control the user came for silently missing.
+     */
+    expect(source).toContain("doNotShowWhenEditing: true");
+  });
+
+  test("drops the orphaned stepId, which matches no declared form step", () => {
+    expect(source).not.toContain('stepId: "incident-details"');
+  });
+
+  test("allows removing a probe from the monitor", () => {
+    // Otherwise probes can only ever be added, and a mistake is permanent.
+    expect(source).toContain("isDeleteable={true}");
+    expect(source).not.toContain("isDeleteable={false}");
+  });
+
+  test("still allows adding one and toggling it", () => {
+    expect(source).toContain("isCreateable={true}");
+    expect(source).toContain("isEditable={true}");
+  });
+
+  test("explains what the Enabled toggle actually does", () => {
+    expect(source).toContain(
+      "When off, this probe stops monitoring this resource.",
+    );
+  });
+});

--- a/Common/Server/Services/MonitorProbeService.ts
+++ b/Common/Server/Services/MonitorProbeService.ts
@@ -1,6 +1,7 @@
 import ObjectID from "../../Types/ObjectID";
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import DeleteBy from "../Types/Database/DeleteBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import DatabaseService, { EntityManager } from "./DatabaseService";
 import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
@@ -363,11 +364,74 @@ export class Service extends DatabaseService<MonitorProbe> {
   }
 
   /*
+   * Removing a probe from a monitor changes the same aggregate that adding one
+   * or toggling isEnabled changes - Monitor.isNoProbeEnabledOnThisMonitor and
+   * isAllProbesDisconnectedFromThisMonitor. Without these hooks, deleting the
+   * last probe left the monitor claiming it was still being watched: no
+   * "Probes Not Enabled" banner and no owner notification, even though nothing
+   * was monitoring it any more.
+   *
+   * The monitorIds have to be read before the delete, because after it the
+   * rows are gone.
+   */
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<MonitorProbe>,
+  ): Promise<OnDelete<MonitorProbe>> {
+    const itemsToDelete: Array<MonitorProbe> = await this.findBy({
+      query: deleteBy.query,
+      limit: deleteBy.limit,
+      skip: deleteBy.skip,
+      select: {
+        monitorId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return {
+      deleteBy,
+      carryForward: {
+        monitorIds: itemsToDelete
+          .map((item: MonitorProbe) => {
+            return item.monitorId;
+          })
+          .filter((monitorId: ObjectID | undefined) => {
+            return Boolean(monitorId);
+          }) as Array<ObjectID>,
+      },
+    };
+  }
+
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<MonitorProbe>,
+    _itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<MonitorProbe>> {
+    const monitorIds: Array<ObjectID> =
+      (onDelete.carryForward?.monitorIds as Array<ObjectID>) || [];
+
+    const refreshedMonitorIds: Set<string> = new Set();
+
+    for (const monitorId of monitorIds) {
+      // A bulk delete can touch the same monitor many times over.
+      if (refreshedMonitorIds.has(monitorId.toString())) {
+        continue;
+      }
+
+      refreshedMonitorIds.add(monitorId.toString());
+
+      await this.refreshMonitorStatusSafely(monitorId);
+    }
+
+    return onDelete;
+  }
+
+  /*
    * Refresh a single monitor's aggregate probe status without letting a
    * failure bubble up. These refreshes run in post-commit hooks
-   * (onCreateSuccess / onUpdateSuccess) after the MonitorProbe row is already
-   * persisted, so a status-refresh error must not turn a successful save into
-   * a 500 for the user — log it instead.
+   * (onCreateSuccess / onUpdateSuccess / onDeleteSuccess) after the
+   * MonitorProbe row is already persisted, so a status-refresh error must not
+   * turn a successful save into a 500 for the user — log it instead.
    */
   private async refreshMonitorStatusSafely(monitorId: ObjectID): Promise<void> {
     try {

--- a/Common/Tests/Models/DatabaseModels/MonitorProbeColumnAccessControl.test.ts
+++ b/Common/Tests/Models/DatabaseModels/MonitorProbeColumnAccessControl.test.ts
@@ -1,0 +1,196 @@
+import MonitorProbe from "../../../Models/DatabaseModels/MonitorProbe";
+import { ColumnAccessControl } from "../../../Types/BaseDatabase/AccessControl";
+import Permission, { PermissionHelper } from "../../../Types/Permission";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * https://github.com/OneUptime/oneuptime/issues/2899
+ *
+ * Monitor > Probes is where a user goes to change which probe watches a
+ * resource. The table is editable and declares a required "Probe" dropdown -
+ * but MonitorProbe.probe and MonitorProbe.probeId are create-only, so ModelForm
+ * applied the column's *update* ACL, found it empty, and dropped the field from
+ * the form and from the request. The Edit modal opened with nothing but an
+ * "Enabled" toggle, no message, and a "Save Changes" button; the table could
+ * not delete either. So a probe attached by mistake was permanent, and every
+ * attempt to change it looked like an edit that was thrown away.
+ *
+ * The fix keeps the columns create-only (a MonitorProbe row *is* the
+ * assignment; replacing it means deleting the row) and instead marks the form
+ * field doNotShowWhenEditing and turns row deletion on. These tests pin both
+ * halves of that contract, because breaking either one silently restores the
+ * original symptom.
+ */
+
+// What a signed-in project owner actually carries.
+const OWNER_PERMISSIONS: Array<Permission> = [
+  Permission.Public,
+  Permission.User,
+  Permission.CurrentUser,
+  Permission.ProjectOwner,
+];
+
+/*
+ * ModelForm.hasPermissionOnField, reproduced. It reads the create ACL on a
+ * Create form and the update ACL on an Update form, and drops the field when
+ * the user's permissions do not intersect it - with no error unless *every*
+ * field is dropped.
+ */
+type WouldFormShowFieldFunction = (data: {
+  accessControl: Record<string, ColumnAccessControl>;
+  columnName: string;
+  isUpdateForm: boolean;
+  userPermissions: Array<Permission>;
+}) => boolean;
+
+const wouldFormShowField: WouldFormShowFieldFunction = (data: {
+  accessControl: Record<string, ColumnAccessControl>;
+  columnName: string;
+  isUpdateForm: boolean;
+  userPermissions: Array<Permission>;
+}): boolean => {
+  const column: ColumnAccessControl | undefined =
+    data.accessControl[data.columnName];
+
+  const fieldPermissions: Array<Permission> =
+    (data.isUpdateForm ? column?.update : column?.create) || [];
+
+  return PermissionHelper.doesPermissionsIntersect(
+    data.userPermissions,
+    fieldPermissions,
+  );
+};
+
+describe("MonitorProbe column access control", () => {
+  const accessControl: Record<string, ColumnAccessControl> =
+    new MonitorProbe().getColumnAccessControlForAllColumns();
+
+  it("lets a project owner choose the probe when attaching one", () => {
+    expect(
+      wouldFormShowField({
+        accessControl,
+        columnName: "probe",
+        isUpdateForm: false,
+        userPermissions: OWNER_PERMISSIONS,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the probe relation create-only, so a row always points at one probe", () => {
+    /*
+     * This is the assumption Pages/Monitor/View/Probes.tsx has to encode with
+     * doNotShowWhenEditing. If someone later gives these columns an update
+     * ACL, that flag becomes wrong and should be removed with it.
+     */
+    expect(accessControl["probe"]?.update || []).toEqual([]);
+    expect(accessControl["probeId"]?.update || []).toEqual([]);
+  });
+
+  it("would silently drop a Probe field from the edit form for anyone at all", () => {
+    /*
+     * The exact mechanism behind the bug report: not "you may not do that",
+     * but a field that renders on create and vanishes on edit. Even a project
+     * owner loses it - which is why the form must not offer it when editing.
+     */
+    const everyPermission: Array<Permission> = Object.values(Permission);
+
+    expect(
+      wouldFormShowField({
+        accessControl,
+        columnName: "probe",
+        isUpdateForm: true,
+        userPermissions: everyPermission,
+      }),
+    ).toBe(false);
+  });
+
+  it("still lets a project owner toggle isEnabled, so the edit form is not empty", () => {
+    /*
+     * ModelForm only surfaces a permission error when it drops *every* field.
+     * isEnabled surviving is why the silent drop of "Probe" produced no
+     * message at all.
+     */
+    expect(
+      wouldFormShowField({
+        accessControl,
+        columnName: "isEnabled",
+        isUpdateForm: true,
+        userPermissions: OWNER_PERMISSIONS,
+      }),
+    ).toBe(true);
+  });
+
+  it("lets a user with only granular monitor-probe permissions manage the row", () => {
+    const granularPermissions: Array<Permission> = [
+      Permission.Public,
+      Permission.User,
+      Permission.CurrentUser,
+      Permission.CreateMonitorProbe,
+      Permission.ReadMonitorProbe,
+      Permission.EditMonitorProbe,
+      Permission.DeleteMonitorProbe,
+    ];
+
+    expect(
+      wouldFormShowField({
+        accessControl,
+        columnName: "probe",
+        isUpdateForm: false,
+        userPermissions: granularPermissions,
+      }),
+    ).toBe(true);
+
+    expect(
+      wouldFormShowField({
+        accessControl,
+        columnName: "isEnabled",
+        isUpdateForm: true,
+        userPermissions: granularPermissions,
+      }),
+    ).toBe(true);
+  });
+
+  it("reads back the probe relation, so the table can name the probe it shows", () => {
+    for (const columnName of ["probe", "probeId", "isEnabled"]) {
+      expect(
+        PermissionHelper.doesPermissionsIntersect(
+          OWNER_PERMISSIONS,
+          accessControl[columnName]?.read || [],
+        ),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("MonitorProbe table access control", () => {
+  const model: MonitorProbe = new MonitorProbe();
+
+  it("allows deletion, which is the only way to undo attaching the wrong probe", () => {
+    /*
+     * Monitor > Probes sets isDeleteable, and BaseModelTable gates that button
+     * on these permissions. Without them the button never renders and the dead
+     * end this issue reported comes straight back.
+     */
+    expect(model.deleteRecordPermissions).toContain(Permission.ProjectOwner);
+    expect(model.deleteRecordPermissions).toContain(Permission.ProjectAdmin);
+    expect(model.deleteRecordPermissions).toContain(
+      Permission.DeleteMonitorProbe,
+    );
+  });
+
+  it("allows creation, so the removed probe can be replaced with the right one", () => {
+    expect(model.createRecordPermissions).toContain(
+      Permission.CreateMonitorProbe,
+    );
+  });
+
+  it("keeps the Edit button reachable for the roles that can update a row", () => {
+    // BaseModelTable renders Edit on the table-level update permission.
+    expect(
+      PermissionHelper.doesPermissionsIntersect(
+        OWNER_PERMISSIONS,
+        model.updateRecordPermissions,
+      ),
+    ).toBe(true);
+  });
+});

--- a/Common/Tests/Server/Services/MonitorProbeDeleteHooks.test.ts
+++ b/Common/Tests/Server/Services/MonitorProbeDeleteHooks.test.ts
@@ -1,0 +1,280 @@
+import MonitorProbeService from "../../../Server/Services/MonitorProbeService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorProbe from "../../../Models/DatabaseModels/MonitorProbe";
+import DeleteBy from "../../../Server/Types/Database/DeleteBy";
+import { OnDelete } from "../../../Server/Types/Database/Hooks";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * https://github.com/OneUptime/oneuptime/issues/2899
+ *
+ * Monitor > Probes can now remove a probe from a monitor - previously it could
+ * only add one, so a probe attached by mistake was permanent.
+ *
+ * Removing one changes the same aggregate that adding one or toggling
+ * isEnabled changes: Monitor.isNoProbeEnabledOnThisMonitor (the "Probes Not
+ * Enabled" banner on the monitor page, and the owner notification behind it).
+ * MonitorProbeService had create and update hooks for that and no delete hook,
+ * so deleting the last probe left the monitor still claiming it was watched.
+ *
+ * The monitorIds have to be read *before* the delete - afterwards the rows are
+ * gone - which is what these tests pin.
+ */
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_MONITOR_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+
+type MakeDeleteByFunction = (
+  query: Record<string, unknown>,
+) => DeleteBy<MonitorProbe>;
+
+const makeDeleteBy: MakeDeleteByFunction = (
+  query: Record<string, unknown>,
+): DeleteBy<MonitorProbe> => {
+  return {
+    query: query as any,
+    limit: 10,
+    skip: 0,
+    props: { isRoot: false },
+  } as DeleteBy<MonitorProbe>;
+};
+
+type MakeRowFunction = (monitorId: ObjectID | undefined) => MonitorProbe;
+
+const makeRow: MakeRowFunction = (
+  monitorId: ObjectID | undefined,
+): MonitorProbe => {
+  const monitorProbe: MonitorProbe = new MonitorProbe();
+
+  if (monitorId) {
+    monitorProbe.monitorId = monitorId;
+  }
+
+  return monitorProbe;
+};
+
+/*
+ * onBeforeDelete / onDeleteSuccess are protected: DatabaseService is what calls
+ * them. Reaching them directly is the only way to test them without a database.
+ */
+type CallOnBeforeDeleteFunction = (
+  deleteBy: DeleteBy<MonitorProbe>,
+) => Promise<OnDelete<MonitorProbe>>;
+
+const callOnBeforeDelete: CallOnBeforeDeleteFunction = (
+  deleteBy: DeleteBy<MonitorProbe>,
+): Promise<OnDelete<MonitorProbe>> => {
+  return (MonitorProbeService as any).onBeforeDelete(deleteBy);
+};
+
+type CallOnDeleteSuccessFunction = (
+  onDelete: OnDelete<MonitorProbe>,
+) => Promise<OnDelete<MonitorProbe>>;
+
+const callOnDeleteSuccess: CallOnDeleteSuccessFunction = (
+  onDelete: OnDelete<MonitorProbe>,
+): Promise<OnDelete<MonitorProbe>> => {
+  return (MonitorProbeService as any).onDeleteSuccess(onDelete, []);
+};
+
+describe("MonitorProbeService delete hooks", () => {
+  let refreshedMonitorIds: Array<string> = [];
+  let findByCalls: Array<any> = [];
+  let rowsToReturn: Array<MonitorProbe> = [];
+
+  beforeEach(() => {
+    refreshedMonitorIds = [];
+    findByCalls = [];
+    rowsToReturn = [];
+
+    getJestSpyOn(MonitorProbeService, "findBy").mockImplementation(
+      async (findBy: any): Promise<Array<MonitorProbe>> => {
+        findByCalls.push(findBy);
+        return rowsToReturn;
+      },
+    );
+
+    getJestSpyOn(
+      MonitorService,
+      "refreshMonitorProbeStatus",
+    ).mockImplementation(async (monitorId: any): Promise<void> => {
+      refreshedMonitorIds.push(monitorId.toString());
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("onBeforeDelete", () => {
+    it("carries forward the monitors whose rows are about to disappear", async () => {
+      rowsToReturn = [makeRow(MONITOR_ID)];
+
+      const onDelete: OnDelete<MonitorProbe> = await callOnBeforeDelete(
+        makeDeleteBy({ monitorId: MONITOR_ID }),
+      );
+
+      expect(
+        (onDelete.carryForward.monitorIds as Array<ObjectID>).map(
+          (id: ObjectID) => {
+            return id.toString();
+          },
+        ),
+      ).toEqual([MONITOR_ID.toString()]);
+    });
+
+    it("looks the rows up with the caller's own delete query", async () => {
+      const query: Record<string, unknown> = { monitorId: MONITOR_ID };
+
+      await callOnBeforeDelete(makeDeleteBy(query));
+
+      expect(findByCalls).toHaveLength(1);
+      expect(findByCalls[0].query).toEqual(query);
+      expect(findByCalls[0].select).toEqual({ monitorId: true });
+    });
+
+    it("reads as root, because the caller's scope has not been applied yet", async () => {
+      /*
+       * DatabaseService narrows the query for permissions *after* this hook
+       * runs, so the hook has to be able to see the rows it is asked about.
+       */
+      await callOnBeforeDelete(makeDeleteBy({ monitorId: MONITOR_ID }));
+
+      expect(findByCalls[0].props.isRoot).toBe(true);
+    });
+
+    it("passes the delete's own limit and skip so a bulk delete is covered", async () => {
+      const deleteBy: DeleteBy<MonitorProbe> = makeDeleteBy({
+        monitorId: MONITOR_ID,
+      });
+      deleteBy.limit = 250;
+      deleteBy.skip = 10;
+
+      await callOnBeforeDelete(deleteBy);
+
+      expect(findByCalls[0].limit).toBe(250);
+      expect(findByCalls[0].skip).toBe(10);
+    });
+
+    it("returns the deleteBy unchanged, so it does not narrow the delete", async () => {
+      const deleteBy: DeleteBy<MonitorProbe> = makeDeleteBy({
+        monitorId: MONITOR_ID,
+      });
+
+      const onDelete: OnDelete<MonitorProbe> =
+        await callOnBeforeDelete(deleteBy);
+
+      expect(onDelete.deleteBy).toBe(deleteBy);
+    });
+
+    it("drops rows with no monitorId rather than carrying an undefined forward", async () => {
+      rowsToReturn = [makeRow(undefined), makeRow(MONITOR_ID)];
+
+      const onDelete: OnDelete<MonitorProbe> = await callOnBeforeDelete(
+        makeDeleteBy({}),
+      );
+
+      expect(onDelete.carryForward.monitorIds).toHaveLength(1);
+    });
+
+    it("carries nothing forward when the delete matches nothing", async () => {
+      rowsToReturn = [];
+
+      const onDelete: OnDelete<MonitorProbe> = await callOnBeforeDelete(
+        makeDeleteBy({ monitorId: MONITOR_ID }),
+      );
+
+      expect(onDelete.carryForward.monitorIds).toEqual([]);
+    });
+  });
+
+  describe("onDeleteSuccess", () => {
+    it("refreshes the monitor, so the 'Probes Not Enabled' banner appears", async () => {
+      await callOnDeleteSuccess({
+        deleteBy: makeDeleteBy({ monitorId: MONITOR_ID }),
+        carryForward: { monitorIds: [MONITOR_ID] },
+      });
+
+      expect(refreshedMonitorIds).toEqual([MONITOR_ID.toString()]);
+    });
+
+    it("refreshes every monitor a bulk delete touched", async () => {
+      await callOnDeleteSuccess({
+        deleteBy: makeDeleteBy({}),
+        carryForward: { monitorIds: [MONITOR_ID, OTHER_MONITOR_ID] },
+      });
+
+      expect(refreshedMonitorIds).toEqual([
+        MONITOR_ID.toString(),
+        OTHER_MONITOR_ID.toString(),
+      ]);
+    });
+
+    it("refreshes a monitor once even when several of its rows went", async () => {
+      /*
+       * Removing three probes from one monitor is one aggregate to recompute,
+       * and refreshMonitorProbeStatus writes to the monitor and can notify its
+       * owners.
+       */
+      await callOnDeleteSuccess({
+        deleteBy: makeDeleteBy({ monitorId: MONITOR_ID }),
+        carryForward: { monitorIds: [MONITOR_ID, MONITOR_ID, MONITOR_ID] },
+      });
+
+      expect(refreshedMonitorIds).toEqual([MONITOR_ID.toString()]);
+    });
+
+    it("does nothing when nothing was carried forward", async () => {
+      await callOnDeleteSuccess({
+        deleteBy: makeDeleteBy({}),
+        carryForward: { monitorIds: [] },
+      });
+
+      expect(refreshedMonitorIds).toEqual([]);
+    });
+
+    it("survives a carryForward that never ran onBeforeDelete", async () => {
+      // props.ignoreHooks makes DatabaseService pass carryForward: [].
+      await callOnDeleteSuccess({
+        deleteBy: makeDeleteBy({}),
+        carryForward: [],
+      });
+
+      expect(refreshedMonitorIds).toEqual([]);
+    });
+
+    it("does not turn a failed status refresh into a failed delete", async () => {
+      /*
+       * The rows are already gone by the time this runs. Throwing here would
+       * report a 500 for a delete that actually succeeded.
+       */
+      jest.restoreAllMocks();
+      getJestSpyOn(
+        MonitorService,
+        "refreshMonitorProbeStatus",
+      ).mockImplementation(async (): Promise<void> => {
+        throw new Error("refresh exploded");
+      });
+
+      await expect(
+        callOnDeleteSuccess({
+          deleteBy: makeDeleteBy({ monitorId: MONITOR_ID }),
+          carryForward: { monitorIds: [MONITOR_ID] },
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/Common/Tests/Utils/Monitor/MonitorSummaryProbeUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorSummaryProbeUtil.test.ts
@@ -1,0 +1,263 @@
+import MonitorSummaryProbeUtil, {
+  AttachedProbe,
+  MonitorSummaryProbeState,
+} from "../../../Utils/Monitor/MonitorSummaryProbeUtil";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * https://github.com/OneUptime/oneuptime/issues/2899
+ *
+ * The Monitor Summary card carries a "Select Probe" dropdown. It was fed every
+ * probe in the project plus every global probe - not the probes attached to the
+ * monitor being viewed. So a project with a global probe "Probe" and a custom
+ * probe "WBHQ" offered both on a monitor that only "Probe" watched, and picking
+ * "WBHQ" answered "No summary available for the selected probe. Should be few
+ * minutes for summary to show up." about data that was never going to arrive.
+ * Worse, the list is project-probes-first, so the card often *opened* on the
+ * stranger. The reporter's conclusion: "i have changed the probe, but the
+ * change was not actually applied".
+ *
+ * These pin the three rules that make the picker honest: it only offers
+ * attached probes, it keeps the user's choice, and it says which of the three
+ * empty states it is in.
+ */
+
+const GLOBAL_PROBE: AttachedProbe = {
+  id: "33333333-3333-4333-8333-333333333333",
+  name: "Probe",
+  isEnabled: true,
+};
+
+const CUSTOM_PROBE: AttachedProbe = {
+  id: "44444444-4444-4444-8444-444444444444",
+  name: "WBHQ",
+  isEnabled: true,
+};
+
+const DISABLED_PROBE: AttachedProbe = {
+  id: "55555555-5555-4555-8555-555555555555",
+  name: "Retired Probe",
+  isEnabled: false,
+};
+
+describe("MonitorSummaryProbeUtil.resolveSelectedProbeId", () => {
+  it("returns null when the monitor has no probes attached", () => {
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({ probes: [] }),
+    ).toBeNull();
+  });
+
+  it("returns null for a missing probe list rather than throwing", () => {
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: undefined as unknown as Array<AttachedProbe>,
+      }),
+    ).toBeNull();
+  });
+
+  it("selects the first probe when nothing is selected yet", () => {
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [CUSTOM_PROBE, GLOBAL_PROBE],
+      }),
+    ).toBe(CUSTOM_PROBE.id);
+  });
+
+  it("keeps the probe the user picked when the list is handed down again", () => {
+    /*
+     * The effect that calls this re-runs on every new probes array. Resetting
+     * to the first entry there is indistinguishable, to a user, from a
+     * selection that refuses to stick.
+     */
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [CUSTOM_PROBE, GLOBAL_PROBE],
+        currentlySelectedProbeId: GLOBAL_PROBE.id,
+      }),
+    ).toBe(GLOBAL_PROBE.id);
+  });
+
+  it("keeps the selection even when that probe has since been disabled", () => {
+    // The user asked to look at it; showing something else would be surprising.
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [GLOBAL_PROBE, DISABLED_PROBE],
+        currentlySelectedProbeId: DISABLED_PROBE.id,
+      }),
+    ).toBe(DISABLED_PROBE.id);
+  });
+
+  it("falls back when the selected probe has been detached from the monitor", () => {
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [GLOBAL_PROBE],
+        currentlySelectedProbeId: CUSTOM_PROBE.id,
+      }),
+    ).toBe(GLOBAL_PROBE.id);
+  });
+
+  it("prefers an enabled probe over a disabled one when defaulting", () => {
+    /*
+     * A disabled probe has nothing to show, so opening the card on one reads
+     * as broken even though everything is working as configured.
+     */
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [DISABLED_PROBE, GLOBAL_PROBE],
+      }),
+    ).toBe(GLOBAL_PROBE.id);
+  });
+
+  it("still selects something when every attached probe is disabled", () => {
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [DISABLED_PROBE],
+      }),
+    ).toBe(DISABLED_PROBE.id);
+  });
+
+  it("ignores rows with no id, which cannot be selected", () => {
+    const noId: AttachedProbe = { id: "", name: "Broken", isEnabled: true };
+
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [noId, GLOBAL_PROBE],
+      }),
+    ).toBe(GLOBAL_PROBE.id);
+  });
+
+  it("treats an empty currently-selected id as no selection", () => {
+    expect(
+      MonitorSummaryProbeUtil.resolveSelectedProbeId({
+        probes: [DISABLED_PROBE, GLOBAL_PROBE],
+        currentlySelectedProbeId: "",
+      }),
+    ).toBe(GLOBAL_PROBE.id);
+  });
+});
+
+describe("MonitorSummaryProbeUtil.getProbeDropdownOptions", () => {
+  it("offers exactly the probes it is given, in order", () => {
+    /*
+     * The whole defect: the picker used to be handed every probe in the
+     * project. It can only ever offer what actually monitors this resource.
+     */
+    expect(
+      MonitorSummaryProbeUtil.getProbeDropdownOptions({
+        probes: [GLOBAL_PROBE, CUSTOM_PROBE],
+      }),
+    ).toEqual([
+      { label: "Probe", value: GLOBAL_PROBE.id },
+      { label: "WBHQ", value: CUSTOM_PROBE.id },
+    ]);
+  });
+
+  it("marks a disabled probe so its empty summary is explained", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeDropdownOptions({
+        probes: [DISABLED_PROBE],
+      }),
+    ).toEqual([
+      { label: "Retired Probe (disabled)", value: DISABLED_PROBE.id },
+    ]);
+  });
+
+  it("falls back to a placeholder name rather than rendering an empty option", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeDropdownOptions({
+        probes: [{ id: GLOBAL_PROBE.id, name: "", isEnabled: true }],
+      }),
+    ).toEqual([{ label: "Unknown", value: GLOBAL_PROBE.id }]);
+  });
+
+  it("drops rows with no id, which would produce an unselectable option", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeDropdownOptions({
+        probes: [{ id: "", name: "Broken", isEnabled: true }, GLOBAL_PROBE],
+      }),
+    ).toEqual([{ label: "Probe", value: GLOBAL_PROBE.id }]);
+  });
+
+  it("returns nothing for a monitor with no probes", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeDropdownOptions({ probes: [] }),
+    ).toEqual([]);
+  });
+});
+
+describe("MonitorSummaryProbeUtil.getProbeState", () => {
+  it("reports results whenever there is anything to render", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeState({
+        isProbeableMonitor: true,
+        attachedProbeCount: 1,
+        isSelectedProbeEnabled: true,
+        probeResponseCount: 1,
+      }),
+    ).toBe(MonitorSummaryProbeState.HasResults);
+  });
+
+  it("prefers showing results over any empty-state explanation", () => {
+    /*
+     * A probe switched off after it reported still has data worth looking at.
+     */
+    expect(
+      MonitorSummaryProbeUtil.getProbeState({
+        isProbeableMonitor: true,
+        attachedProbeCount: 1,
+        isSelectedProbeEnabled: false,
+        probeResponseCount: 2,
+      }),
+    ).toBe(MonitorSummaryProbeState.HasResults);
+  });
+
+  it("says nothing is monitoring the resource when no probe is attached", () => {
+    // Not "wait a few minutes" - waiting will never help.
+    expect(
+      MonitorSummaryProbeUtil.getProbeState({
+        isProbeableMonitor: true,
+        attachedProbeCount: 0,
+        isSelectedProbeEnabled: true,
+        probeResponseCount: 0,
+      }),
+    ).toBe(MonitorSummaryProbeState.NoProbesAttached);
+  });
+
+  it("says the probe is switched off when it is attached but disabled", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeState({
+        isProbeableMonitor: true,
+        attachedProbeCount: 1,
+        isSelectedProbeEnabled: false,
+        probeResponseCount: 0,
+      }),
+    ).toBe(MonitorSummaryProbeState.SelectedProbeDisabled);
+  });
+
+  it("asks the user to wait only when waiting is actually the answer", () => {
+    expect(
+      MonitorSummaryProbeUtil.getProbeState({
+        isProbeableMonitor: true,
+        attachedProbeCount: 1,
+        isSelectedProbeEnabled: true,
+        probeResponseCount: 0,
+      }),
+    ).toBe(MonitorSummaryProbeState.AwaitingFirstResult);
+  });
+
+  it("does not blame probes on a monitor type that has none", () => {
+    /*
+     * Server, incoming-request and telemetry monitors are not watched by
+     * probes at all, so "no probes are monitoring this resource" would be
+     * nonsense there.
+     */
+    expect(
+      MonitorSummaryProbeUtil.getProbeState({
+        isProbeableMonitor: false,
+        attachedProbeCount: 0,
+        isSelectedProbeEnabled: true,
+        probeResponseCount: 0,
+      }),
+    ).toBe(MonitorSummaryProbeState.AwaitingFirstResult);
+  });
+});

--- a/Common/Utils/Monitor/MonitorSummaryProbeUtil.ts
+++ b/Common/Utils/Monitor/MonitorSummaryProbeUtil.ts
@@ -1,0 +1,130 @@
+/*
+ * The rules behind the "Monitor Summary" probe picker.
+ *
+ * That card used to be fed every probe in the project plus every global probe,
+ * not the probes attached to the monitor being viewed. Choosing one of the
+ * strangers answered "No summary available for the selected probe. Should be
+ * few minutes for summary to show up." about data that could never arrive -
+ * and because the list is project-probes-first, the card frequently *opened*
+ * on one. Users read that as "I changed the probe and it was not applied".
+ *
+ * The picker is a view filter over data that already exists. It cannot change
+ * which probe monitors a resource (that is a MonitorProbe row, edited under
+ * Monitor > Probes), so it must never offer a probe that does not.
+ */
+
+export interface AttachedProbe {
+  id: string;
+  name: string;
+  isEnabled: boolean;
+}
+
+export enum MonitorSummaryProbeState {
+  // Nothing is monitoring this resource at all.
+  NoProbesAttached = "NoProbesAttached",
+  // The selected probe is attached but switched off, so it will never report.
+  SelectedProbeDisabled = "SelectedProbeDisabled",
+  // Attached and enabled, but it has not reported yet. Waiting is the answer.
+  AwaitingFirstResult = "AwaitingFirstResult",
+  // There is something to render.
+  HasResults = "HasResults",
+}
+
+export default class MonitorSummaryProbeUtil {
+  /*
+   * Which probe the card should show. Keeps the user's choice as long as that
+   * probe is still attached: this runs whenever the probe list is handed down
+   * again, and unconditionally resetting to the first entry is indistinguishable
+   * from a selection that refuses to stick.
+   *
+   * With no usable previous choice it prefers an enabled probe, because a
+   * disabled one has nothing to show and opening there reads as broken.
+   */
+  public static resolveSelectedProbeId(data: {
+    probes: Array<AttachedProbe>;
+    currentlySelectedProbeId?: string | null | undefined;
+  }): string | null {
+    const probes: Array<AttachedProbe> = (data.probes || []).filter(
+      (probe: AttachedProbe) => {
+        return Boolean(probe && probe.id);
+      },
+    );
+
+    if (probes.length === 0) {
+      return null;
+    }
+
+    if (data.currentlySelectedProbeId) {
+      const stillAttached: AttachedProbe | undefined = probes.find(
+        (probe: AttachedProbe) => {
+          return probe.id === data.currentlySelectedProbeId;
+        },
+      );
+
+      if (stillAttached) {
+        return stillAttached.id;
+      }
+    }
+
+    const firstEnabledProbe: AttachedProbe | undefined = probes.find(
+      (probe: AttachedProbe) => {
+        return probe.isEnabled;
+      },
+    );
+
+    return (firstEnabledProbe || (probes[0] as AttachedProbe)).id;
+  }
+
+  /*
+   * The option labels. A disabled probe stays on the list - the user may well
+   * want to look at what it collected before it was switched off - but saying
+   * so is what stops "no summary" from looking like a bug.
+   */
+  public static getProbeDropdownOptions(data: {
+    probes: Array<AttachedProbe>;
+  }): Array<{ label: string; value: string }> {
+    return (data.probes || [])
+      .filter((probe: AttachedProbe) => {
+        return Boolean(probe && probe.id);
+      })
+      .map((probe: AttachedProbe) => {
+        const name: string = probe.name || "Unknown";
+
+        return {
+          label: probe.isEnabled ? name : `${name} (disabled)`,
+          value: probe.id,
+        };
+      });
+  }
+
+  /*
+   * Why the card has nothing to render. "No data yet", "this probe is off" and
+   * "nothing is watching this monitor" are three different situations, and
+   * telling the user to wait a few minutes for the last two is exactly how a
+   * probe change comes to look like it never applied.
+   */
+  public static getProbeState(data: {
+    isProbeableMonitor: boolean;
+    attachedProbeCount: number;
+    isSelectedProbeEnabled: boolean;
+    probeResponseCount: number;
+  }): MonitorSummaryProbeState {
+    if (data.probeResponseCount > 0) {
+      return MonitorSummaryProbeState.HasResults;
+    }
+
+    /*
+     * Non-probeable monitors (server, incoming request, telemetry...) have no
+     * probes by design, so their empty state is not a probe problem.
+     */
+    if (data.isProbeableMonitor && data.attachedProbeCount === 0) {
+      return MonitorSummaryProbeState.NoProbesAttached;
+    }
+
+    if (!data.isSelectedProbeEnabled) {
+      return MonitorSummaryProbeState.SelectedProbeDisabled;
+    }
+
+    return MonitorSummaryProbeState.AwaitingFirstResult;
+  }
+}

--- a/E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts
@@ -1,0 +1,474 @@
+import { BASE_URL } from "../../Config";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import { toId } from "./Helpers/MonitorAlerting";
+import {
+  APIResponse,
+  Browser,
+  Locator,
+  Page,
+  expect,
+  test,
+} from "@playwright/test";
+import URL from "Common/Types/API/URL";
+import Faker from "Common/Utils/Faker";
+
+/*
+ * https://github.com/OneUptime/oneuptime/issues/2899 - "No Save/Discard
+ * confirmation after editing Probe settings - changes not actually applied",
+ * end to end.
+ *
+ * The reporter had a global probe "Probe" and a custom probe "WBHQ", changed
+ * the monitor's probe, refreshed, and found nothing had changed. Two dead ends
+ * produced that:
+ *
+ * (A) The "Monitor Summary" card's probe picker was fed every probe in the
+ *     project plus every global probe rather than the probes attached to the
+ *     monitor. Selecting a probe that was not monitoring the resource answered
+ *     "should be few minutes for summary to show up" about data that could
+ *     never arrive - and since the list is project-probes-first, the card often
+ *     opened on one. Test: attach exactly one of two custom probes, then assert
+ *     the picker offers only that one.
+ *
+ * (B) Monitor > Probes declared a required "Probe" dropdown on an editable
+ *     table whose probe relation is create-only, so ModelForm silently dropped
+ *     it from the edit form and the request; and the table could not delete, so
+ *     a probe attached by mistake was permanent. Test: the edit modal offers
+ *     only the toggle it can actually save, that toggle persists across a
+ *     reload, and the row can be removed.
+ *
+ * To run locally against a full stack:
+ *
+ *   cd E2E && HOST=localhost npx playwright test \
+ *     Tests/Dashboard/MonitorProbeSummary.spec.ts --project=chromium
+ */
+test.describe.configure({ mode: "serial" });
+
+const monitorCreateFormSelector: string = "#create-monitor-form";
+const submitButtonTestId: string = "Create Monitor";
+
+interface SharedContext {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+  attachedProbeName: string;
+  attachedProbeId: string;
+  unattachedProbeName: string;
+  unattachedProbeId: string;
+}
+
+type ApiUrlFunction = (path: string) => string;
+
+const apiUrl: ApiUrlFunction = (path: string): string => {
+  return URL.fromString(BASE_URL.toString()).addRoute(path).toString();
+};
+
+type DashboardUrlFunction = (path: string) => string;
+
+const dashboardUrl: DashboardUrlFunction = (path: string): string => {
+  return URL.fromString(BASE_URL.toString()).addRoute(path).toString();
+};
+
+type SeedCustomProbeFunction = (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+}) => Promise<string>;
+
+const seedCustomProbe: SeedCustomProbeFunction = async (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+}): Promise<string> => {
+  const response: APIResponse = await data.page.request.post(
+    apiUrl("/api/probe"),
+    {
+      headers: {
+        "content-type": "application/json",
+        tenantid: data.projectId,
+      },
+      data: {
+        data: {
+          name: data.name,
+          description: "Seeded by the probe summary e2e spec.",
+          projectId: data.projectId,
+          /*
+           * Off, so neither probe is attached automatically - the create form's
+           * picker is what decides, and that is what this spec relies on.
+           */
+          shouldAutoEnableProbeOnNewMonitors: false,
+        },
+      },
+    },
+  );
+
+  expect(
+    response.ok(),
+    `Seed custom probe failed: ${response.status()} ${await response.text()}`,
+  ).toBe(true);
+
+  const body: any = await response.json();
+
+  // Ids come back as a bare string or { _type: "ObjectID", value }; normalise.
+  return toId(body?.data?._id ?? body?._id);
+};
+
+type ListMonitorProbesFunction = (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+}) => Promise<Array<any>>;
+
+const listMonitorProbes: ListMonitorProbesFunction = async (data: {
+  page: Page;
+  projectId: string;
+  monitorId: string;
+}): Promise<Array<any>> => {
+  const response: APIResponse = await data.page.request.post(
+    apiUrl("/api/monitor-probe/get-list"),
+    {
+      headers: {
+        "content-type": "application/json",
+        tenantid: data.projectId,
+      },
+      data: {
+        query: { monitorId: data.monitorId, projectId: data.projectId },
+        select: { probeId: true, isEnabled: true },
+        limit: 50,
+        skip: 0,
+        sort: {},
+      },
+    },
+  );
+
+  expect(
+    response.ok(),
+    `List monitor probes failed: ${response.status()} ${await response.text()}`,
+  ).toBe(true);
+
+  const body: any = await response.json();
+
+  return (body?.data || []) as Array<any>;
+};
+
+test.describe("Monitor summary probe picker", () => {
+  const ctx: SharedContext = {
+    page: undefined as unknown as Page,
+    projectId: "",
+    monitorId: "",
+    attachedProbeName: "",
+    attachedProbeId: "",
+    unattachedProbeName: "",
+    unattachedProbeId: "",
+  };
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    test.setTimeout(300000);
+    ctx.page = await browser.newPage();
+    ctx.projectId = await registerAndCreateProject({
+      page: ctx.page,
+      projectNamePrefix: "E2E Probe Summary Project",
+      /*
+       * Custom probes are gated behind the Growth plan when billing is enabled
+       * (TableBillingAccessControl.create on the Probe model).
+       */
+      preferredPlanName: "Growth",
+    });
+
+    ctx.attachedProbeName = `e2e-attached-${Faker.generateRandomString(6)}`;
+    ctx.attachedProbeId = await seedCustomProbe({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      name: ctx.attachedProbeName,
+    });
+
+    ctx.unattachedProbeName = `e2e-stranger-${Faker.generateRandomString(6)}`;
+    ctx.unattachedProbeId = await seedCustomProbe({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      name: ctx.unattachedProbeName,
+    });
+
+    expect(ctx.attachedProbeId).not.toEqual("");
+    expect(ctx.unattachedProbeId).not.toEqual("");
+  });
+
+  test.afterAll(async () => {
+    await ctx.page?.close();
+  });
+
+  test("creates a monitor watched by exactly one of the project's probes", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+    const monitorName: string = `e2e-summary-monitor-${Faker.generateRandomString(6)}`;
+
+    await page.goto(
+      dashboardUrl(`/dashboard/${ctx.projectId}/monitors/create`),
+      {
+        waitUntil: "domcontentloaded",
+      },
+    );
+    await page
+      .locator(monitorCreateFormSelector)
+      .waitFor({ state: "visible", timeout: 60000 });
+
+    // Step 1: name + type.
+    await page
+      .locator(`${monitorCreateFormSelector} input[placeholder='Monitor Name']`)
+      .fill(monitorName);
+    const card: Locator = page.getByTestId("card-select-option-Website");
+    await expect(card).toBeVisible({ timeout: 30000 });
+    await card.click();
+    await page.getByTestId(submitButtonTestId).click();
+
+    // Step 2: criteria.
+    await expect(page.getByText("Monitor Criteria").first()).toBeVisible({
+      timeout: 60000,
+    });
+    const destination: Locator = page
+      .locator(monitorCreateFormSelector)
+      .getByRole("textbox")
+      .first();
+    await destination.waitFor({ state: "visible", timeout: 30000 });
+    await destination.fill("https://oneuptime.com");
+    await page.getByTestId(submitButtonTestId).click();
+
+    // Step 3: probes + interval. Clear the defaults, pick one probe only.
+    const probesCombo: Locator = page.getByRole("combobox", { name: "Probes" });
+    await expect(probesCombo).toBeVisible({ timeout: 60000 });
+    await probesCombo.click();
+    for (let clearAttempt: number = 0; clearAttempt < 6; clearAttempt++) {
+      await page.keyboard.press("Backspace");
+    }
+    await probesCombo.fill(ctx.attachedProbeName);
+    await page
+      .getByRole("option", { name: ctx.attachedProbeName, exact: true })
+      .click();
+
+    const intervalCombo: Locator = page.getByRole("combobox", {
+      name: "Monitoring Interval",
+    });
+    await intervalCombo.click();
+    await page
+      .getByRole("option", { name: "Every 5 Minutes", exact: true })
+      .click();
+
+    await page.getByTestId(submitButtonTestId).click();
+
+    await page.waitForURL(
+      new RegExp(
+        `/dashboard/${ctx.projectId}/monitors/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`,
+        "i",
+      ),
+      { timeout: 120000 },
+    );
+
+    ctx.monitorId =
+      page
+        .url()
+        .match(
+          /\/monitors\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+        )?.[1] || "";
+
+    expect(ctx.monitorId).not.toEqual("");
+
+    const monitorProbes: Array<any> = await listMonitorProbes({
+      page,
+      projectId: ctx.projectId,
+      monitorId: ctx.monitorId,
+    });
+
+    expect(
+      monitorProbes.map((monitorProbe: any) => {
+        return toId(monitorProbe.probeId ?? monitorProbe.probe?._id);
+      }),
+    ).toEqual([ctx.attachedProbeId]);
+  });
+
+  test("the summary picker offers only the probes that monitor this resource", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+
+    await page.goto(
+      dashboardUrl(`/dashboard/${ctx.projectId}/monitors/${ctx.monitorId}`),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    /*
+     * Labelled as what it is - a filter on what the card shows - rather than
+     * chromed as a required form field, which is what invited users to read
+     * changing it as editing the monitor's probe.
+     */
+    await expect(page.getByText("Showing results from:").first()).toBeVisible({
+      timeout: 90000,
+    });
+
+    const probeCombo: Locator = page
+      .getByRole("combobox")
+      .filter({ hasText: ctx.attachedProbeName })
+      .first();
+    await probeCombo.click();
+
+    // The probe that watches this monitor is offered.
+    await expect(
+      page.getByRole("option", { name: ctx.attachedProbeName, exact: true }),
+    ).toBeVisible({ timeout: 30000 });
+
+    /*
+     * The one that does not is NOT - this is the defect. Offering it produced
+     * "no summary available ... should be few minutes", which the reporter read
+     * as a probe change that had not been applied.
+     */
+    await expect(
+      page.getByRole("option", { name: ctx.unattachedProbeName, exact: true }),
+    ).toHaveCount(0);
+
+    await page.keyboard.press("Escape");
+  });
+
+  test("the probe row's edit form offers only what it can actually save", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+
+    await page.goto(
+      dashboardUrl(
+        `/dashboard/${ctx.projectId}/monitors/${ctx.monitorId}/probes`,
+      ),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await expect(page.getByText(ctx.attachedProbeName).first()).toBeVisible({
+      timeout: 90000,
+    });
+
+    await page
+      .getByRole("button", { name: /^Edit$/ })
+      .first()
+      .click();
+
+    const saveButton: Locator = page.getByRole("button", {
+      name: /Save Changes/i,
+    });
+    await expect(saveButton).toBeVisible({ timeout: 30000 });
+
+    /*
+     * No Probe dropdown: MonitorProbe's probe relation is create-only, so
+     * ModelForm dropped that field from the form and from the request with no
+     * message at all. Rendering "Save Changes" over a silently missing control
+     * is what the bug report describes.
+     */
+    await expect(page.getByRole("combobox", { name: "Probe" })).toHaveCount(0);
+
+    // The toggle it CAN save is there.
+    const enabledToggle: Locator = page.getByRole("switch", {
+      name: /Enabled/i,
+    });
+    await expect(enabledToggle).toBeVisible({ timeout: 30000 });
+    await expect(enabledToggle).toHaveAttribute("aria-checked", "true");
+
+    await enabledToggle.click();
+    await saveButton.click();
+
+    // And it survives a reload - the actual claim in the report.
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.getByText(ctx.attachedProbeName).first()).toBeVisible({
+      timeout: 90000,
+    });
+
+    const monitorProbes: Array<any> = await listMonitorProbes({
+      page,
+      projectId: ctx.projectId,
+      monitorId: ctx.monitorId,
+    });
+
+    expect(monitorProbes).toHaveLength(1);
+    expect(monitorProbes[0].isEnabled).toBe(false);
+  });
+
+  test("a disabled probe is labelled instead of pretending data is on its way", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+
+    await page.goto(
+      dashboardUrl(`/dashboard/${ctx.projectId}/monitors/${ctx.monitorId}`),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await expect(page.getByText("Showing results from:").first()).toBeVisible({
+      timeout: 90000,
+    });
+
+    // The option says why it has nothing to show.
+    await expect(
+      page.getByText(`${ctx.attachedProbeName} (disabled)`).first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    // And so does the card, rather than "should be few minutes".
+    await expect(
+      page.getByText(/is disabled for this monitor/).first(),
+    ).toBeVisible({ timeout: 30000 });
+  });
+
+  test("a probe attached by mistake can be removed", async () => {
+    test.setTimeout(180000);
+
+    const page: Page = ctx.page;
+
+    await page.goto(
+      dashboardUrl(
+        `/dashboard/${ctx.projectId}/monitors/${ctx.monitorId}/probes`,
+      ),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await expect(page.getByText(ctx.attachedProbeName).first()).toBeVisible({
+      timeout: 90000,
+    });
+
+    /*
+     * The table used to set isDeleteable={false}, so with the probe relation
+     * create-only there was no way at all to undo attaching the wrong probe.
+     */
+    await page
+      .getByRole("button", { name: /^Delete$/ })
+      .first()
+      .click();
+    await page
+      .getByRole("button", { name: /^Delete$/ })
+      .last()
+      .click();
+
+    await expect
+      .poll(
+        async () => {
+          return (
+            await listMonitorProbes({
+              page,
+              projectId: ctx.projectId,
+              monitorId: ctx.monitorId,
+            })
+          ).length;
+        },
+        { timeout: 60000 },
+      )
+      .toBe(0);
+
+    /*
+     * And the monitor notices: removing the last probe has to recompute
+     * Monitor.isNoProbeEnabledOnThisMonitor, which is the banner below. Without
+     * the delete hook on MonitorProbeService the monitor went on claiming it
+     * was being watched.
+     */
+    await page.goto(
+      dashboardUrl(`/dashboard/${ctx.projectId}/monitors/${ctx.monitorId}`),
+      { waitUntil: "domcontentloaded" },
+    );
+
+    await expect(page.getByText("Probes Not Enabled").first()).toBeVisible({
+      timeout: 90000,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2899 (re-open of #2859).

The reporter is on 11.7.2, which already carries dbb2f892 ("make probe edits actually save"), and the symptom persists — so this is a different pair of dead ends behind the same sentence: *"i have changed the probe, but the change was not actually applied"*.

Their project has a global probe **Probe** and a custom probe **WBHQ**. The screenshots on the issue are of the **Monitor Summary** card's "Select Probe" dropdown, which offered **both** on a monitor that only "Probe" watched — and answered "No summary available for the selected probe. Should be few minutes for summary to show up." when WBHQ was picked.

## What was wrong

### 1. The summary picker offered probes that do not monitor the resource

[`Index.tsx`](App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx) fed the picker `ProbeUtil.getAllProbes()` — every probe in the project plus every global probe, with no monitor filter anywhere in that path. Picking a stranger promised data that was never going to arrive. And since that helper returns **project probes first**, the card frequently *opened* on one, so the user did not even have to touch the picker to see it.

The page already fetches the monitor's own `MonitorProbe` rows for the response logs. It now selects the `probe` relation and `isEnabled` off those rows and builds the picker from them — two list requests fewer per page load.

### 2. The picker looked like a setting

[`ProbePicker.tsx`](App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/ProbePicker.tsx) rendered `FieldLabelElement … required={true}` over the same `Dropdown` that `ModelForm` renders for a real form field. It is a filter on what the card displays and cannot change anything, so there is nothing to save — but nothing said so, which is how the reset reads as a discarded edit. It is now labelled "Showing results from:" with no required marker, and a disabled probe is marked `(disabled)`.

Selection also resolved to `props.probes[0]` on every new probes array. It now keeps the user's choice while that probe is still attached, and otherwise prefers an enabled probe over one that can never report.

### 3. One message for three different situations

[`SummaryInfo.tsx`](App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx) said "should be few minutes for summary to show up" for *no data yet*, *this probe is switched off*, and *nothing is monitoring this resource*. Each now says what it is; only the first asks the user to wait.

The rules live in [`MonitorSummaryProbeUtil`](Common/Utils/Monitor/MonitorSummaryProbeUtil.ts) so they are unit-testable, in the same shape as the existing `MonitorProbeSelectionUtil`.

### 4. Monitor › Probes could add a probe but never change or remove one

[`Probes.tsx`](App/FeatureSet/Dashboard/src/Pages/Monitor/View/Probes.tsx) declared a `required` **Probe** dropdown on an editable table. `MonitorProbe.probe` is create-only (`update: []`), so `ModelForm` resolved the column's *update* ACL, found it empty, and dropped the field from the form **and** from the request — silently, because `ModelForm` only reports a permission problem when it drops *every* field, and `isEnabled` survives. Someone who came here to change which probe watches the resource got a "Save Changes" modal with the control they wanted missing and no explanation.

The field is now `doNotShowWhenEditing` (the established idiom for create-only columns), and `isDeleteable` is on so a probe attached by mistake can be removed — which the table previously could not do at all.

### 5. Deleting a MonitorProbe never refreshed the monitor

[`MonitorProbeService`](Common/Server/Services/MonitorProbeService.ts) refreshes `Monitor.isNoProbeEnabledOnThisMonitor` in `onCreateSuccess` and `onUpdateSuccess`, and had no delete hook — so removing the last probe left the monitor claiming it was still being watched: no "Probes Not Enabled" banner and no owner notification. It now reads the `monitorId`s before the delete (afterwards the rows are gone), dedupes them, and refreshes through the existing failure-swallowing wrapper.

Also dropped a vestigial `stepId: "incident-details"` on a table that declares no form steps.

## Tests

**63 unit tests**, all passing:

| Suite | Covers |
| --- | --- |
| `Common/Tests/Utils/Monitor/MonitorSummaryProbeUtil.test.ts` (21) | selection stickiness, enabled-first defaulting, option labels, empty-state classification |
| `Common/Tests/Models/DatabaseModels/MonitorProbeColumnAccessControl.test.ts` (9) | the create/update column ACLs, a reproduction of `ModelForm`'s field-drop rule proving the Probe field can never render on edit, and the table-level delete permission the new button depends on |
| `Common/Tests/Server/Services/MonitorProbeDeleteHooks.test.ts` (13) | carry-forward, the root-scoped read, bulk limit/skip, per-monitor dedupe, and that a failed refresh cannot fail an already-committed delete |
| `App/Tests/Dashboard/MonitorProbeSummaryPages.test.ts` (20) | page invariants for the four Dashboard sources (App's jest runs in a Node env with no renderer, so these follow the existing `MonitorProbeSelectionPages.test.ts` pattern) |

Plus `E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts`, which seeds two custom probes, attaches one, and walks the whole report end to end: the picker offers only the attached probe, the edit modal offers only what it can save, the toggle survives a reload, a disabled probe is labelled, and removing the row raises the banner.

The pre-existing `ProbeColumnAccessControl`, `MonitorProbeSelectionUtil`, `MonitorServiceProbeSelection` and `MonitorProbeSelectionPages` suites still pass. `tsc --noEmit` is clean in App, Common and E2E; `eslint --fix` clean.

## Noticed but deliberately left alone

Confirmed while tracing this, out of scope here:

- `POST /probe/global-probes` never reads the request body, so the Global Probes table's search box, both filters, sorting and pagination are inert and the returned count is wrong.
- `MonitorProbeService.onBeforeCreate` does not check that the probe being attached is global or belongs to the project — `MonitorService.addSelectedProbesToMonitor` has exactly that guard, the CRUD path does not.
- `Probe.key` is readable only by owner/admin, so Settings-role users get a blank key from "Show ID and Key" and lose the connect-instructions section entirely.
- `ModelForm.fetchDropdownOptions` wraps the whole loop in one try/catch that only calls `setError`, leaving a fully submittable form with empty option lists after a transient failure.
- `MonitorProbe.isEnabled`'s column ACL grants update to ProjectMember/MonitorAdmin/MonitorMember, which the table-level ACL does not — a dead grant.
