### PR TITLE
feat(status-page): nest resource groups with rolled up status and uptime

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
@@ -1,13 +1,17 @@
 import PageComponentProps from "../../PageComponentProps";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import ObjectID from "Common/Types/ObjectID";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { CustomElementProps } from "Common/UI/Components/Forms/Types/Field";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
 import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
@@ -21,6 +25,60 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
   props: PageComponentProps,
 ): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID(1);
+
+  /*
+   * Groups nest, so the parent picker has to show where each candidate sits in
+   * the tree - two groups can easily be called "Region 1000" at different
+   * levels. Options are labelled with their full path and fetched every time
+   * the form opens, so a group added a moment ago is immediately selectable.
+   *
+   * Whether the chosen parent is actually legal (not the group itself, not one
+   * of its own sub groups, not past the nesting limit) is decided by
+   * StatusPageGroupService, which is the only place that can see the tree as
+   * it is at write time.
+   */
+  const fetchParentGroupOptions: () => Promise<
+    Array<DropdownOption>
+  > = async (): Promise<Array<DropdownOption>> => {
+    const listResult: ListResult<StatusPageGroup> =
+      await ModelAPI.getList<StatusPageGroup>({
+        modelType: StatusPageGroup,
+        query: {
+          statusPageId: modelId,
+          projectId: ProjectUtil.getCurrentProjectId()!,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        select: {
+          _id: true,
+          name: true,
+          order: true,
+          parentStatusPageGroupId: true,
+        },
+        sort: {
+          order: SortOrder.Ascending,
+        },
+        requestOptions: {},
+      });
+
+    const allGroups: Array<StatusPageGroup> = listResult.data;
+
+    return allGroups.map((group: StatusPageGroup) => {
+      const path: Array<string> = StatusPageGroupTreeUtil.getAncestorGroups({
+        statusPageGroup: group,
+        statusPageGroups: allGroups,
+      })
+        .reverse()
+        .map((ancestor: StatusPageGroup) => {
+          return ancestor.name || "";
+        });
+
+      return {
+        value: group._id?.toString() || "",
+        label: [...path, group.name || ""].join(" › "),
+      };
+    });
+  };
 
   return (
     <Fragment>
@@ -56,7 +114,7 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
         cardProps={{
           title: "Resource Groups",
           description:
-            "Here are different groups for your status page resources.",
+            "Here are different groups for your status page resources. Groups can be nested inside other groups, and each level shows the rolled up status and uptime of everything beneath it. Deleting a group also deletes its sub groups and the resources in them.",
         }}
         noItemsMessage={"No status page group created for this status page."}
         formSteps={[
@@ -95,6 +153,19 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
             description: MarkdownUtil.getMarkdownCheatsheet(
               "Describe the status page group here",
             ),
+          },
+          {
+            field: {
+              parentStatusPageGroup: true,
+            },
+            title: "Parent Group",
+            description:
+              "Nest this group inside another group on your status page (for example Corporate Units › Region › Market). Leave empty to keep it at the top level. Every level shows the rolled up status and uptime of everything beneath it.",
+            fieldType: FormFieldSchemaType.Dropdown,
+            fetchDropdownOptions: fetchParentGroupOptions,
+            required: false,
+            placeholder: "No parent group (top level)",
+            stepId: "group-details",
           },
           {
             field: {
@@ -273,6 +344,22 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
             },
             title: "Resource Group Name",
             type: FieldType.Text,
+          },
+          {
+            field: {
+              parentStatusPageGroup: {
+                name: true,
+              },
+            },
+            title: "Parent Group",
+            type: FieldType.Entity,
+            getElement: (item: StatusPageGroup): ReactElement => {
+              if (!item.parentStatusPageGroup?.name) {
+                return <span className="text-gray-400">Top level</span>;
+              }
+
+              return <span>{item.parentStatusPageGroup.name}</span>;
+            },
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
@@ -24,6 +24,9 @@ import Navigation from "Common/UI/Utils/Navigation";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorGroup from "Common/Models/DatabaseModels/MonitorGroup";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil, {
+  StatusPageGroupTreeNode,
+} from "Common/Utils/StatusPage/GroupTree";
 import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
 import React, {
   Fragment,
@@ -66,6 +69,8 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
           select: {
             name: true,
             _id: true,
+            order: true,
+            parentStatusPageGroupId: true,
             viewMode: true,
             rowAxisLabel: true,
             columnAxisLabel: true,
@@ -262,11 +267,60 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
     statusPageGroup: StatusPageGroup | null,
   ) => ReactElement;
 
+  /*
+   * Groups can be nested, and two groups at different levels can share a name.
+   * Show the full path so it is obvious which "Region 1000" a table belongs to.
+   */
+  /*
+   * A parent's table should sit directly above the tables of the groups nested
+   * under it, the same order the public status page renders them in - a flat
+   * sort by `order` would scatter children away from their parent.
+   */
+  type GetGroupsInTreeOrderFunction = () => Array<StatusPageGroup>;
+
+  const getGroupsInTreeOrder: GetGroupsInTreeOrderFunction =
+    (): Array<StatusPageGroup> => {
+      const flattened: Array<StatusPageGroup> = [];
+
+      const visit: (nodes: Array<StatusPageGroupTreeNode>) => void = (
+        nodes: Array<StatusPageGroupTreeNode>,
+      ): void => {
+        for (const node of nodes) {
+          flattened.push(node.group);
+          visit(node.children);
+        }
+      };
+
+      visit(StatusPageGroupTreeUtil.buildTree({ statusPageGroups: groups }));
+
+      return flattened;
+    };
+
+  type GetGroupPathFunction = (statusPageGroup: StatusPageGroup) => string;
+
+  const getGroupPath: GetGroupPathFunction = (
+    statusPageGroup: StatusPageGroup,
+  ): string => {
+    const ancestorNames: Array<string> =
+      StatusPageGroupTreeUtil.getAncestorGroups({
+        statusPageGroup: statusPageGroup,
+        statusPageGroups: groups,
+      })
+        .reverse()
+        .map((ancestor: StatusPageGroup) => {
+          return ancestor.name || "";
+        });
+
+    return [...ancestorNames, statusPageGroup.name || ""].join(" › ");
+  };
+
   const getModelTable: GetModelTableFunction = (
     statusPageGroup: StatusPageGroup | null,
   ): ReactElement => {
     const statusPageGroupId: ObjectID | null = statusPageGroup?.id || null;
-    const statusPageGroupName: string | null = statusPageGroup?.name || null;
+    const statusPageGroupName: string | null = statusPageGroup
+      ? getGroupPath(statusPageGroup)
+      : null;
 
     const tableColumns: Array<Columns<StatusPageResource>> = [
       {
@@ -433,7 +487,7 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
         {!isLoading && !error ? getModelTable(null) : <></>}
 
         {!isLoading && !error && groups && groups.length > 0 ? (
-          groups.map((group: StatusPageGroup) => {
+          getGroupsInTreeOrder().map((group: StatusPageGroup) => {
             if (group.viewMode === StatusPageGroupViewMode.Grid) {
               return (
                 <GridResourceEditor

--- a/App/FeatureSet/StatusPage/src/Locales/da.json
+++ b/App/FeatureSet/StatusPage/src/Locales/da.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Der er endnu ikke tilføjet nogen ressourcer til denne statusside. Tilføj venligst ressourcer fra kontrolpanelet.",
     "allResourcesAre": "Alle ressourcer er {{status}}",
     "someResourcesAre": "Nogle ressourcer er {{status}}",
-    "someResourcesAreUnder": "Nogle ressourcer er under {{status}}"
+    "someResourcesAreUnder": "Nogle ressourcer er under {{status}}",
+    "oneSubGroup": "1 gruppe",
+    "subGroupCount": "{{total}} grupper"
   },
   "eventItem": {
     "affectedResources": "Berørte ressourcer",

--- a/App/FeatureSet/StatusPage/src/Locales/de.json
+++ b/App/FeatureSet/StatusPage/src/Locales/de.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Dieser Statusseite wurden noch keine Ressourcen hinzugefügt. Bitte fügen Sie einige Ressourcen über das Dashboard hinzu.",
     "allResourcesAre": "Alle Ressourcen sind {{status}}",
     "someResourcesAre": "Einige Ressourcen sind {{status}}",
-    "someResourcesAreUnder": "Einige Ressourcen sind in {{status}}"
+    "someResourcesAreUnder": "Einige Ressourcen sind in {{status}}",
+    "oneSubGroup": "1 Gruppe",
+    "subGroupCount": "{{total}} Gruppen"
   },
   "eventItem": {
     "affectedResources": "Betroffene Ressourcen",

--- a/App/FeatureSet/StatusPage/src/Locales/en.json
+++ b/App/FeatureSet/StatusPage/src/Locales/en.json
@@ -40,7 +40,9 @@
     "allClearDescription": "No resources added to this status page yet. Please add some resources from the dashboard.",
     "allResourcesAre": "All Resources are {{status}}",
     "someResourcesAre": "Some Resources are {{status}}",
-    "someResourcesAreUnder": "Some Resources are under {{status}}"
+    "someResourcesAreUnder": "Some Resources are under {{status}}",
+    "oneSubGroup": "1 group",
+    "subGroupCount": "{{total}} groups"
   },
   "eventItem": {
     "affectedResources": "Affected resources",

--- a/App/FeatureSet/StatusPage/src/Locales/es.json
+++ b/App/FeatureSet/StatusPage/src/Locales/es.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Aún no se han añadido recursos a esta página de estado. Por favor, añada algunos recursos desde el panel de control.",
     "allResourcesAre": "Todos los recursos están {{status}}",
     "someResourcesAre": "Algunos recursos están {{status}}",
-    "someResourcesAreUnder": "Algunos recursos están en {{status}}"
+    "someResourcesAreUnder": "Algunos recursos están en {{status}}",
+    "oneSubGroup": "1 grupo",
+    "subGroupCount": "{{total}} grupos"
   },
   "eventItem": {
     "affectedResources": "Recursos afectados",

--- a/App/FeatureSet/StatusPage/src/Locales/fr.json
+++ b/App/FeatureSet/StatusPage/src/Locales/fr.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Aucune ressource n'a encore été ajoutée à cette page de statut. Veuillez ajouter des ressources depuis le tableau de bord.",
     "allResourcesAre": "Toutes les ressources sont {{status}}",
     "someResourcesAre": "Certaines ressources sont {{status}}",
-    "someResourcesAreUnder": "Certaines ressources sont en {{status}}"
+    "someResourcesAreUnder": "Certaines ressources sont en {{status}}",
+    "oneSubGroup": "1 groupe",
+    "subGroupCount": "{{total}} groupes"
   },
   "eventItem": {
     "affectedResources": "Ressources concernées",

--- a/App/FeatureSet/StatusPage/src/Locales/hi.json
+++ b/App/FeatureSet/StatusPage/src/Locales/hi.json
@@ -40,7 +40,9 @@
     "allClearDescription": "इस स्थिति पृष्ठ में अभी तक कोई संसाधन नहीं जोड़ा गया है। कृपया डैशबोर्ड से कुछ संसाधन जोड़ें।",
     "allResourcesAre": "सभी संसाधन {{status}} हैं",
     "someResourcesAre": "कुछ संसाधन {{status}} हैं",
-    "someResourcesAreUnder": "कुछ संसाधन {{status}} में हैं"
+    "someResourcesAreUnder": "कुछ संसाधन {{status}} में हैं",
+    "oneSubGroup": "1 समूह",
+    "subGroupCount": "{{total}} समूह"
   },
   "eventItem": {
     "affectedResources": "प्रभावित संसाधन",

--- a/App/FeatureSet/StatusPage/src/Locales/it.json
+++ b/App/FeatureSet/StatusPage/src/Locales/it.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Non sono ancora state aggiunte risorse a questa pagina di stato. Si prega di aggiungere alcune risorse dalla dashboard.",
     "allResourcesAre": "Tutte le risorse sono {{status}}",
     "someResourcesAre": "Alcune risorse sono {{status}}",
-    "someResourcesAreUnder": "Alcune risorse sono in {{status}}"
+    "someResourcesAreUnder": "Alcune risorse sono in {{status}}",
+    "oneSubGroup": "1 gruppo",
+    "subGroupCount": "{{total}} gruppi"
   },
   "eventItem": {
     "affectedResources": "Risorse interessate",

--- a/App/FeatureSet/StatusPage/src/Locales/ja.json
+++ b/App/FeatureSet/StatusPage/src/Locales/ja.json
@@ -40,7 +40,9 @@
     "allClearDescription": "このステータスページにはまだリソースが追加されていません。ダッシュボードからリソースを追加してください。",
     "allResourcesAre": "すべてのリソースは {{status}} です",
     "someResourcesAre": "一部のリソースは {{status}} です",
-    "someResourcesAreUnder": "一部のリソースは {{status}} 中です"
+    "someResourcesAreUnder": "一部のリソースは {{status}} 中です",
+    "oneSubGroup": "1 グループ",
+    "subGroupCount": "{{total}} グループ"
   },
   "eventItem": {
     "affectedResources": "影響を受けるリソース",

--- a/App/FeatureSet/StatusPage/src/Locales/ko.json
+++ b/App/FeatureSet/StatusPage/src/Locales/ko.json
@@ -40,7 +40,9 @@
     "allClearDescription": "이 상태 페이지에 아직 리소스가 추가되지 않았습니다. 대시보드에서 리소스를 추가해주세요.",
     "allResourcesAre": "모든 리소스가 {{status}}입니다",
     "someResourcesAre": "일부 리소스가 {{status}}입니다",
-    "someResourcesAreUnder": "일부 리소스가 {{status}} 중입니다"
+    "someResourcesAreUnder": "일부 리소스가 {{status}} 중입니다",
+    "oneSubGroup": "그룹 1개",
+    "subGroupCount": "그룹 {{total}}개"
   },
   "eventItem": {
     "affectedResources": "영향을 받은 리소스",

--- a/App/FeatureSet/StatusPage/src/Locales/nl.json
+++ b/App/FeatureSet/StatusPage/src/Locales/nl.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Er zijn nog geen bronnen toegevoegd aan deze statuspagina. Voeg alstublieft enkele bronnen toe vanaf het dashboard.",
     "allResourcesAre": "Alle bronnen zijn {{status}}",
     "someResourcesAre": "Sommige bronnen zijn {{status}}",
-    "someResourcesAreUnder": "Sommige bronnen zijn in {{status}}"
+    "someResourcesAreUnder": "Sommige bronnen zijn in {{status}}",
+    "oneSubGroup": "1 groep",
+    "subGroupCount": "{{total}} groepen"
   },
   "eventItem": {
     "affectedResources": "Getroffen bronnen",

--- a/App/FeatureSet/StatusPage/src/Locales/no.json
+++ b/App/FeatureSet/StatusPage/src/Locales/no.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Ingen ressurser er lagt til på denne statussiden ennå. Legg til noen ressurser fra kontrollpanelet.",
     "allResourcesAre": "Alle ressurser er {{status}}",
     "someResourcesAre": "Noen ressurser er {{status}}",
-    "someResourcesAreUnder": "Noen ressurser er under {{status}}"
+    "someResourcesAreUnder": "Noen ressurser er under {{status}}",
+    "oneSubGroup": "1 gruppe",
+    "subGroupCount": "{{total}} grupper"
   },
   "eventItem": {
     "affectedResources": "Berørte ressurser",

--- a/App/FeatureSet/StatusPage/src/Locales/pt.json
+++ b/App/FeatureSet/StatusPage/src/Locales/pt.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Nenhum recurso adicionado a esta página de status ainda. Por favor, adicione alguns recursos pelo painel.",
     "allResourcesAre": "Todos os recursos estão {{status}}",
     "someResourcesAre": "Alguns recursos estão {{status}}",
-    "someResourcesAreUnder": "Alguns recursos estão em {{status}}"
+    "someResourcesAreUnder": "Alguns recursos estão em {{status}}",
+    "oneSubGroup": "1 grupo",
+    "subGroupCount": "{{total}} grupos"
   },
   "eventItem": {
     "affectedResources": "Recursos afetados",

--- a/App/FeatureSet/StatusPage/src/Locales/ru.json
+++ b/App/FeatureSet/StatusPage/src/Locales/ru.json
@@ -40,7 +40,9 @@
     "allClearDescription": "На эту страницу статуса ещё не добавлены ресурсы. Пожалуйста, добавьте ресурсы через панель управления.",
     "allResourcesAre": "Все ресурсы — {{status}}",
     "someResourcesAre": "Некоторые ресурсы — {{status}}",
-    "someResourcesAreUnder": "Некоторые ресурсы находятся в состоянии {{status}}"
+    "someResourcesAreUnder": "Некоторые ресурсы находятся в состоянии {{status}}",
+    "oneSubGroup": "1 группа",
+    "subGroupCount": "групп: {{total}}"
   },
   "eventItem": {
     "affectedResources": "Затронутые ресурсы",

--- a/App/FeatureSet/StatusPage/src/Locales/sv.json
+++ b/App/FeatureSet/StatusPage/src/Locales/sv.json
@@ -40,7 +40,9 @@
     "allClearDescription": "Inga resurser har ännu lagts till på den här statussidan. Lägg till några resurser från kontrollpanelen.",
     "allResourcesAre": "Alla resurser är {{status}}",
     "someResourcesAre": "Vissa resurser är {{status}}",
-    "someResourcesAreUnder": "Vissa resurser är under {{status}}"
+    "someResourcesAreUnder": "Vissa resurser är under {{status}}",
+    "oneSubGroup": "1 grupp",
+    "subGroupCount": "{{total}} grupper"
   },
   "eventItem": {
     "affectedResources": "Berörda resurser",

--- a/App/FeatureSet/StatusPage/src/Locales/zh-CN.json
+++ b/App/FeatureSet/StatusPage/src/Locales/zh-CN.json
@@ -40,7 +40,9 @@
     "allClearDescription": "此状态页尚未添加任何资源。请从控制面板添加一些资源。",
     "allResourcesAre": "所有资源{{status}}",
     "someResourcesAre": "部分资源{{status}}",
-    "someResourcesAreUnder": "部分资源处于{{status}}状态"
+    "someResourcesAreUnder": "部分资源处于{{status}}状态",
+    "oneSubGroup": "1 个分组",
+    "subGroupCount": "{{total}} 个分组"
   },
   "eventItem": {
     "affectedResources": "受影响的资源",

--- a/App/FeatureSet/StatusPage/src/Locales/zh-TW.json
+++ b/App/FeatureSet/StatusPage/src/Locales/zh-TW.json
@@ -40,7 +40,9 @@
     "allClearDescription": "此狀態頁尚未新增任何資源。請從控制台新增一些資源。",
     "allResourcesAre": "所有資源{{status}}",
     "someResourcesAre": "部分資源{{status}}",
-    "someResourcesAreUnder": "部分資源處於{{status}}狀態"
+    "someResourcesAreUnder": "部分資源處於{{status}}狀態",
+    "oneSubGroup": "1 個群組",
+    "subGroupCount": "{{total}} 個群組"
   },
   "eventItem": {
     "affectedResources": "受影響的資源",

--- a/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
@@ -63,6 +63,7 @@ import { translateStatusName } from "../../Utils/StatusTranslation";
 import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
 import StatusPageResourceUptimeUtil from "Common/Utils/StatusPage/ResourceUptime";
+import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import UptimeBarTooltipIncident from "Common/Types/Monitor/UptimeBarTooltipIncident";
 import Color from "Common/Types/Color";
@@ -441,6 +442,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
           statusPageResources: statusPageResources,
           monitorStatuses: monitorStatuses,
           monitorGroupCurrentStatuses: monitorGroupCurrentStatuses,
+          allStatusPageGroups: resourceGroups,
         });
 
       if (
@@ -466,6 +468,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
               statusPageResources: statusPageResources,
               monitorsInGroup: monitorsInGroup,
               uptimeWindow: { startDate: startDate, endDate: endDate },
+              allStatusPageGroups: resourceGroups,
             },
           );
 
@@ -1096,6 +1099,147 @@ const Overview: FunctionComponent<PageComponentProps> = (
     );
   };
 
+  /*
+   * Groups can be nested (Corporate Unit -> Region -> Market -> Site), so a
+   * group renders its own resources first and then each of its sub groups
+   * below them. Every level is an accordion carrying its own rolled up status
+   * / uptime, and nesting is drawn with a left rail rather than by piling
+   * background tints on top of each other - that stays readable however deep
+   * the hierarchy goes.
+   */
+  type RenderResourceGroupFunction = (data: {
+    group: StatusPageGroup;
+    depth: number;
+  }) => ReactElement;
+
+  const renderResourceGroup: RenderResourceGroupFunction = (data: {
+    group: StatusPageGroup;
+    depth: number;
+  }): ReactElement => {
+    const group: StatusPageGroup = data.group;
+    const isRootLevel: boolean = data.depth === 0;
+
+    const childGroups: Array<StatusPageGroup> =
+      StatusPageGroupTreeUtil.getChildGroups({
+        statusPageGroupId: group._id?.toString() || null,
+        statusPageGroups: resourceGroups,
+      });
+
+    const directResources: Array<StatusPageResource> =
+      StatusPageResourceUptimeUtil.getResourcesInStatusPageGroup({
+        statusPageGroup: group,
+        statusPageResources: statusPageResources,
+      });
+
+    const isGrid: boolean = group.viewMode === StatusPageGroupViewMode.Grid;
+
+    /*
+     * A group that exists only to hold sub groups has no resources of its own,
+     * and telling the visitor it is empty would be wrong - the sub groups
+     * below it are its content.
+     */
+    const showOwnResources: boolean =
+      directResources.length > 0 || childGroups.length === 0;
+
+    /*
+     * The rolled up status / uptime lives inside the title rather than in the
+     * accordion's rightElement, which is hidden while the accordion is open.
+     * The whole point of the hierarchy is that every level always shows what it
+     * rolls up, and keeping it in one place means it does not jump around when
+     * a level is expanded.
+     */
+    const title: ReactElement = (
+      <div className="flex items-center justify-between gap-3 w-full">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="truncate">{group.name || ""}</span>
+          {childGroups.length > 0 && (
+            <span className="flex-shrink-0 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10.5px] font-medium text-gray-500 tabular-nums">
+              {/*
+               * `total` rather than `count`: i18next treats a `count` variable
+               * as a plural selector and would look for keys that do not exist
+               * here.
+               */}
+              {childGroups.length === 1
+                ? t("overview.oneSubGroup", { defaultValue: "1 group" })
+                : t("overview.subGroupCount", {
+                    total: childGroups.length,
+                    defaultValue: "{{total}} groups",
+                  })}
+            </span>
+          )}
+        </div>
+        <div className="flex-shrink-0 text-sm font-normal">
+          {getCurrentGroupStatusElement({ group: group })}
+        </div>
+      </div>
+    );
+
+    const body: ReactElement = (
+      <>
+        {showOwnResources ? (
+          isGrid ? (
+            getGridForGroup(group)
+          ) : (
+            <>{getMonitorOverviewListInGroup(group)}</>
+          )
+        ) : (
+          <></>
+        )}
+        {childGroups.length > 0 ? (
+          <div className="space-y-2.5">
+            {childGroups.map((childGroup: StatusPageGroup) => {
+              return renderResourceGroup({
+                group: childGroup,
+                depth: data.depth + 1,
+              });
+            })}
+          </div>
+        ) : (
+          <></>
+        )}
+      </>
+    );
+
+    const accordion: ReactElement = (
+      <Accordion
+        isInitiallyExpanded={group.isExpandedByDefault}
+        isLastElement={true}
+        title={title}
+        titleClassName={
+          isRootLevel
+            ? "text-base font-semibold tracking-tight"
+            : "text-sm font-semibold tracking-tight text-gray-800"
+        }
+      >
+        {body}
+      </Accordion>
+    );
+
+    if (isRootLevel) {
+      return (
+        <div
+          key={group._id?.toString() || ""}
+          className="bg-white pl-3 pr-3 sm:pl-5 sm:pr-5 rounded-xl shadow"
+          data-testid="status-page-group"
+        >
+          {accordion}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        key={group._id?.toString() || ""}
+        className="border-l-2 border-gray-100 pl-2 sm:pl-3"
+        data-testid="status-page-nested-group"
+      >
+        <div className="rounded-lg border border-gray-200 bg-white pl-3 pr-3 sm:pl-5 sm:pr-5">
+          {accordion}
+        </div>
+      </div>
+    );
+  };
+
   type GetActiveIncidentsFunction = () => Array<IncidentGroup>;
 
   const getActiveIncidents: GetActiveIncidentsFunction =
@@ -1339,35 +1483,14 @@ const Overview: FunctionComponent<PageComponentProps> = (
                 <></>
               )}
               {resourceGroups.length > 0 &&
-                resourceGroups.map(
-                  (resourceGroup: StatusPageGroup, i: number) => {
-                    const isGrid: boolean =
-                      resourceGroup.viewMode === StatusPageGroupViewMode.Grid;
-                    const groupName: string = resourceGroup.name || "";
-                    return (
-                      <div
-                        key={i}
-                        className="bg-white pl-3 pr-3 sm:pl-5 sm:pr-5 rounded-xl shadow"
-                      >
-                        <Accordion
-                          rightElement={getCurrentGroupStatusElement({
-                            group: resourceGroup,
-                          })}
-                          isInitiallyExpanded={
-                            resourceGroup.isExpandedByDefault
-                          }
-                          isLastElement={true}
-                          title={groupName}
-                          titleClassName="text-base font-semibold tracking-tight"
-                        >
-                          {isGrid
-                            ? getGridForGroup(resourceGroup)
-                            : getMonitorOverviewListInGroup(resourceGroup)}
-                        </Accordion>
-                      </div>
-                    );
-                  },
-                )}
+                StatusPageGroupTreeUtil.getRootGroups({
+                  statusPageGroups: resourceGroups,
+                }).map((resourceGroup: StatusPageGroup) => {
+                  return renderResourceGroup({
+                    group: resourceGroup,
+                    depth: 0,
+                  });
+                })}
             </div>
           )}
 

--- a/Common/Models/DatabaseModels/StatusPageGroup.ts
+++ b/Common/Models/DatabaseModels/StatusPageGroup.ts
@@ -280,6 +280,101 @@ export default class StatusPageGroup extends BaseModel {
     ],
   })
   @TableColumn({
+    manyToOneRelationColumn: "parentStatusPageGroupId",
+    type: TableColumnType.Entity,
+    modelType: StatusPageGroup,
+    title: "Parent Group",
+    description:
+      "Relation to the Status Page Group this group is nested under. Empty for top level groups.",
+  })
+  @ManyToOne(
+    () => {
+      return StatusPageGroup;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "CASCADE",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "parentStatusPageGroupId" })
+  public parentStatusPageGroup?: StatusPageGroup = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.CreateStatusPageGroup,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.StatusPageViewer,
+      Permission.ReadStatusPageGroup,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.EditStatusPageGroup,
+    ],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Parent Group ID",
+    description:
+      "ID of the Status Page Group this group is nested under. Empty for top level groups.",
+    example: "c1d2e3f4-a5b6-7890-1234-56789abcdef0",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public parentStatusPageGroupId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.CreateStatusPageGroup,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.StatusPageViewer,
+      Permission.ReadStatusPageGroup,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.EditStatusPageGroup,
+    ],
+  })
+  @TableColumn({
     required: true,
     type: TableColumnType.ShortText,
     title: "Group Name",

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -85,6 +85,7 @@ import StatusPageOIDC from "../../Models/DatabaseModels/StatusPageOidc";
 import StatusPageSubscriber from "../../Models/DatabaseModels/StatusPageSubscriber";
 import StatusPageEventType from "../../Types/StatusPage/StatusPageEventType";
 import StatusPageResourceUptimeUtil from "../../Utils/StatusPage/ResourceUptime";
+import StatusPageGroupTreeUtil from "../../Utils/StatusPage/GroupTree";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 import { Green } from "../../Types/BrandColors";
 import UptimeUtil, { UptimeWindow } from "../../Utils/Uptime/UptimeUtil";
@@ -1225,6 +1226,7 @@ export default class StatusPageAPI extends BaseAPI<
 
           type StatusPageGroupUptime = {
             statusPageGroupId: ObjectID | null;
+            parentStatusPageGroupId: ObjectID | null;
             uptimePercent: number | null;
             statusPageResourceUptimes: Array<ResourceUptime>;
             statusPageGroupName: string | null;
@@ -1244,6 +1246,8 @@ export default class StatusPageAPI extends BaseAPI<
                   data && data.statusPageGroup
                     ? data.statusPageGroup?.id
                     : null,
+                parentStatusPageGroupId:
+                  data.statusPageGroup?.parentStatusPageGroupId || null,
                 uptimePercent: null,
                 statusPageResourceUptimes: [],
                 statusPageGroupName: data.statusPageGroup?.name || null,
@@ -1382,43 +1386,6 @@ export default class StatusPageAPI extends BaseAPI<
                 }
               }
 
-              if (group?.showUptimePercent) {
-                // calculate uptime percent for the group.
-                const avgUptimePercent: number =
-                  UptimeUtil.calculateAvgUptimePercentage({
-                    uptimePercentages: groupUptime.statusPageResourceUptimes
-                      .filter((resource: ResourceUptime) => {
-                        return resource.uptimePercent !== null;
-                      })
-                      .map((resource: ResourceUptime) => {
-                        return resource.uptimePercent || 0;
-                      }),
-                    precision:
-                      group.uptimePercentPrecision ||
-                      UptimePrecision.ONE_DECIMAL,
-                  });
-
-                groupUptime.uptimePercent = avgUptimePercent;
-              }
-
-              if (group?.showCurrentStatus) {
-                const currentStatuses: Array<MonitorStatus> =
-                  groupUptime.statusPageResourceUptimes
-                    .filter((resourceUptime: ResourceUptime) => {
-                      return resourceUptime.currentStatus !== null;
-                    })
-                    .map((resourceUptime: ResourceUptime) => {
-                      return resourceUptime.currentStatus!;
-                    });
-
-                const worstStatus: MonitorStatus | null =
-                  StatusPageResourceUptimeUtil.getWorstMonitorStatus({
-                    monitorStatuses: currentStatuses,
-                  });
-
-                groupUptime.currentStatus = worstStatus;
-              }
-
               return groupUptime;
             };
 
@@ -1428,6 +1395,75 @@ export default class StatusPageAPI extends BaseAPI<
             groupUptimes.push(
               getUptimeByStatusPageGroup({ statusPageGroup: group }),
             );
+          }
+
+          /*
+           * Groups nest, so a group's own uptime % / current status has to
+           * cover every resource in its subtree, not just the resources
+           * attached directly to it. statusPageResourceUptimes stays the
+           * group's own resources - the nesting is reported through
+           * parentStatusPageGroupId so callers can rebuild the tree.
+           */
+          const resourceUptimesByGroupId: Dictionary<Array<ResourceUptime>> =
+            {};
+
+          for (const groupUptime of groupUptimes) {
+            resourceUptimesByGroupId[
+              groupUptime.statusPageGroupId?.toString() || ""
+            ] = groupUptime.statusPageResourceUptimes;
+          }
+
+          for (const group of statusPageGroups) {
+            const groupUptime: StatusPageGroupUptime | undefined =
+              groupUptimes.find((item: StatusPageGroupUptime) => {
+                return (
+                  item.statusPageGroupId?.toString() === group.id?.toString()
+                );
+              });
+
+            if (!groupUptime) {
+              continue;
+            }
+
+            const resourceUptimesInSubtree: Array<ResourceUptime> =
+              StatusPageGroupTreeUtil.getGroupAndDescendants({
+                statusPageGroup: group,
+                statusPageGroups: statusPageGroups,
+              }).flatMap((groupInSubtree: StatusPageGroup) => {
+                return (
+                  resourceUptimesByGroupId[
+                    groupInSubtree.id?.toString() || ""
+                  ] || []
+                );
+              });
+
+            if (group.showUptimePercent) {
+              groupUptime.uptimePercent =
+                UptimeUtil.calculateAvgUptimePercentage({
+                  uptimePercentages: resourceUptimesInSubtree
+                    .filter((resource: ResourceUptime) => {
+                      return resource.uptimePercent !== null;
+                    })
+                    .map((resource: ResourceUptime) => {
+                      return resource.uptimePercent || 0;
+                    }),
+                  precision:
+                    group.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL,
+                });
+            }
+
+            if (group.showCurrentStatus) {
+              groupUptime.currentStatus =
+                StatusPageResourceUptimeUtil.getWorstMonitorStatus({
+                  monitorStatuses: resourceUptimesInSubtree
+                    .filter((resourceUptime: ResourceUptime) => {
+                      return resourceUptime.currentStatus !== null;
+                    })
+                    .map((resourceUptime: ResourceUptime) => {
+                      return resourceUptime.currentStatus!;
+                    }),
+                });
+            }
           }
 
           return Response.sendJsonObjectResponse(req, res, {
@@ -4920,6 +4956,7 @@ export default class StatusPageAPI extends BaseAPI<
         columnAxisLabel: true,
         rowAxisValues: true,
         columnAxisValues: true,
+        parentStatusPageGroupId: true,
       },
       sort: {
         order: SortOrder.Ascending,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785329453269-AddParentGroupToStatusPageGroup.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785329453269-AddParentGroupToStatusPageGroup.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddParentGroupToStatusPageGroup1785329453269
+  implements MigrationInterface
+{
+  public name: string = "AddParentGroupToStatusPageGroup1785329453269";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "StatusPageGroup" ADD "parentStatusPageGroupId" uuid`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_9cf6ff1530c361e890856e80d7" ON "StatusPageGroup" ("parentStatusPageGroupId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "StatusPageGroup" ADD CONSTRAINT "FK_9cf6ff1530c361e890856e80d79" FOREIGN KEY ("parentStatusPageGroupId") REFERENCES "StatusPageGroup"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "StatusPageGroup" DROP CONSTRAINT "FK_9cf6ff1530c361e890856e80d79"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_9cf6ff1530c361e890856e80d7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "StatusPageGroup" DROP COLUMN "parentStatusPageGroupId"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -475,6 +475,7 @@ import { AddHotQueryIndexesSecondPass1785148065137 } from "./1785148065137-AddHo
 import { RepairCrossProjectMonitorStatusReferences1785240000000 } from "./1785240000000-RepairCrossProjectMonitorStatusReferences";
 import { AddColumnsToTableView1785241000000 } from "./1785241000000-AddColumnsToTableView";
 import { RepairCrossProjectIncidentReferences1785320000000 } from "./1785320000000-RepairCrossProjectIncidentReferences";
+import { AddParentGroupToStatusPageGroup1785329453269 } from "./1785329453269-AddParentGroupToStatusPageGroup";
 
 export default [
   InitialMigration,
@@ -954,4 +955,5 @@ export default [
   RepairCrossProjectMonitorStatusReferences1785240000000,
   AddColumnsToTableView1785241000000,
   RepairCrossProjectIncidentReferences1785320000000,
+  AddParentGroupToStatusPageGroup1785329453269,
 ];

--- a/Common/Server/Services/StatusPageGroupService.ts
+++ b/Common/Server/Services/StatusPageGroupService.ts
@@ -1,6 +1,8 @@
 import CreateBy from "../Types/Database/CreateBy";
+import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import DeleteBy from "../Types/Database/DeleteBy";
 import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
+import Query from "../Types/Database/Query";
 import QueryHelper from "../Types/Database/QueryHelper";
 import UpdateBy from "../Types/Database/UpdateBy";
 import DatabaseService from "./DatabaseService";
@@ -10,6 +12,7 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
+import StatusPageGroupTreeUtil from "../../Utils/StatusPage/GroupTree";
 import Model from "../../Models/DatabaseModels/StatusPageGroup";
 
 export class Service extends DatabaseService<Model> {
@@ -23,6 +26,14 @@ export class Service extends DatabaseService<Model> {
   ): Promise<OnCreate<Model>> {
     if (!createBy.data.statusPageId) {
       throw new BadDataException("Status Page Group statusPageId is required");
+    }
+
+    if (createBy.data.parentStatusPageGroupId) {
+      await this.assertParentIsValid({
+        statusPageGroupId: null,
+        parentStatusPageGroupId: createBy.data.parentStatusPageGroupId,
+        statusPageId: createBy.data.statusPageId,
+      });
     }
 
     if (!createBy.data.order) {
@@ -101,10 +112,185 @@ export class Service extends DatabaseService<Model> {
     };
   }
 
+  /*
+   * The hierarchy hooks run BEFORE DatabaseService applies tenant scoping to
+   * the caller's query, so reading the raw client query with props.isRoot
+   * would hand the hook rows from other projects. Re-apply the caller's tenant
+   * so validation can never look at a row outside the caller's project.
+   */
+  private scopeQueryToCallerTenant(
+    query: Query<Model>,
+    props: DatabaseCommonInteractionProps,
+  ): Query<Model> {
+    if (props.isRoot || !props.tenantId) {
+      return query;
+    }
+
+    return {
+      ...query,
+      projectId: props.tenantId,
+    };
+  }
+
+  /*
+   * A parent has to be a real group on the same status page, and the move must
+   * not build a loop (A under B under A) or nest deeper than the tree utils
+   * are willing to walk. A loop would make every rolled up number on the page
+   * meaningless and the group itself unreachable in the rendered tree.
+   */
+  private async assertParentIsValid(data: {
+    statusPageGroupId: ObjectID | null;
+    parentStatusPageGroupId: ObjectID;
+    statusPageId: ObjectID;
+  }): Promise<void> {
+    if (
+      data.statusPageGroupId &&
+      data.statusPageGroupId.toString() ===
+        data.parentStatusPageGroupId.toString()
+    ) {
+      throw new BadDataException("A group cannot be its own parent group.");
+    }
+
+    const parent: Model | null = await this.findOneById({
+      id: data.parentStatusPageGroupId,
+      select: {
+        _id: true,
+        statusPageId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!parent) {
+      throw new BadDataException("Parent group not found.");
+    }
+
+    if (parent.statusPageId?.toString() !== data.statusPageId.toString()) {
+      throw new BadDataException(
+        "Parent group must belong to the same status page.",
+      );
+    }
+
+    const groupsOnStatusPage: Array<Model> = await this.findBy({
+      query: {
+        statusPageId: data.statusPageId,
+      },
+      select: {
+        _id: true,
+        parentStatusPageGroupId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    const ancestorsOfParent: Array<Model> =
+      StatusPageGroupTreeUtil.getAncestorGroups({
+        statusPageGroup: parent,
+        statusPageGroups: groupsOnStatusPage,
+      });
+
+    if (
+      data.statusPageGroupId &&
+      ancestorsOfParent.some((ancestor: Model) => {
+        return ancestor._id?.toString() === data.statusPageGroupId!.toString();
+      })
+    ) {
+      throw new BadDataException(
+        "This group cannot be nested under one of its own sub groups.",
+      );
+    }
+
+    /*
+     * Depth of the parent chain, plus the group being placed. A group that is
+     * moved carries its own subtree along, so the deepest descendant has to
+     * fit under the limit too.
+     */
+    const depthOfNewParent: number = ancestorsOfParent.length + 1;
+
+    let deepestDescendantOffset: number = 0;
+
+    if (data.statusPageGroupId) {
+      const group: Model | undefined = groupsOnStatusPage.find(
+        (item: Model) => {
+          return item._id?.toString() === data.statusPageGroupId!.toString();
+        },
+      );
+
+      if (group) {
+        for (const descendant of StatusPageGroupTreeUtil.getDescendantGroups({
+          statusPageGroup: group,
+          statusPageGroups: groupsOnStatusPage,
+        })) {
+          const relativeDepth: number =
+            StatusPageGroupTreeUtil.getDepth({
+              statusPageGroup: descendant,
+              statusPageGroups: groupsOnStatusPage,
+            }) -
+            StatusPageGroupTreeUtil.getDepth({
+              statusPageGroup: group,
+              statusPageGroups: groupsOnStatusPage,
+            });
+
+          deepestDescendantOffset = Math.max(
+            deepestDescendantOffset,
+            relativeDepth,
+          );
+        }
+      }
+    }
+
+    if (
+      depthOfNewParent + deepestDescendantOffset >=
+      StatusPageGroupTreeUtil.MaxNestingDepth
+    ) {
+      throw new BadDataException(
+        `Status page groups can only be nested ${StatusPageGroupTreeUtil.MaxNestingDepth} levels deep.`,
+      );
+    }
+  }
+
   @CaptureSpan()
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
+    const newParentIdValue: unknown = (updateBy.data as any)[
+      "parentStatusPageGroupId"
+    ];
+
+    // detaching a group (parent set to null) has no parent to validate.
+    if (newParentIdValue) {
+      const newParentId: ObjectID = new ObjectID(newParentIdValue.toString());
+
+      const groupsBeingUpdated: Array<Model> = await this.findBy({
+        query: this.scopeQueryToCallerTenant(updateBy.query, updateBy.props),
+        select: {
+          _id: true,
+          statusPageId: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      for (const group of groupsBeingUpdated) {
+        if (!group.id || !group.statusPageId) {
+          continue;
+        }
+
+        await this.assertParentIsValid({
+          statusPageGroupId: group.id,
+          parentStatusPageGroupId: newParentId,
+          statusPageId: group.statusPageId,
+        });
+      }
+    }
+
     if (updateBy.data.order && !updateBy.props.isRoot && updateBy.query._id) {
       const group: Model | null = await this.findOneBy({
         query: {

--- a/Common/Tests/Server/Services/StatusPageGroupNesting.test.ts
+++ b/Common/Tests/Server/Services/StatusPageGroupNesting.test.ts
@@ -1,0 +1,395 @@
+import StatusPageGroupService from "../../../Server/Services/StatusPageGroupService";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import StatusPageGroupTreeUtil from "../../../Utils/StatusPage/GroupTree";
+import { describe, expect, it, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - the write side of nested status page groups.
+ *
+ * The parent pointer is a plain nullable column, so the service is the only
+ * thing standing between a well formed tree and one that cannot be rendered or
+ * rolled up. It has to reject, on both create and update:
+ *
+ *   - a parent on a different status page (groups roll up per page),
+ *   - a group parented to itself,
+ *   - a group parented to one of its own sub groups (a cycle - which would
+ *     make the group unreachable from any root and its rollups circular),
+ *   - a move that pushes the group, or anything already nested under it,
+ *     past the nesting limit.
+ *
+ * And it must not pay for any of that when the write does not touch the parent.
+ */
+
+const STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+function groupId(index: number): ObjectID {
+  const suffix: string = index.toString().padStart(12, "0");
+  return new ObjectID(`aaaaaaaa-aaaa-4aaa-8aaa-${suffix}`);
+}
+
+function makeGroup(data: {
+  id: ObjectID;
+  parentId?: ObjectID | undefined;
+  statusPageId?: ObjectID | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.statusPageId = data.statusPageId || STATUS_PAGE_ID;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  return group;
+}
+
+/*
+ * Wires up the reads the hooks make: findOneById resolves a parent, findBy
+ * resolves either "every group on the status page" or "the groups this update
+ * matches", and the order bookkeeping is stubbed out so these cases only
+ * exercise the hierarchy rules.
+ */
+function mockService(data: {
+  groupsOnStatusPage: Array<StatusPageGroup>;
+  groupsMatchedByUpdate?: Array<StatusPageGroup> | undefined;
+}): void {
+  jest
+    .spyOn(StatusPageGroupService, "findOneById")
+    .mockImplementation(async (findBy: any) => {
+      return (
+        data.groupsOnStatusPage.find((group: StatusPageGroup) => {
+          return group._id?.toString() === findBy.id?.toString();
+        }) || null
+      );
+    });
+
+  jest
+    .spyOn(StatusPageGroupService, "findBy")
+    .mockImplementation(async (findBy: any) => {
+      if (findBy.query && findBy.query.statusPageId) {
+        return data.groupsOnStatusPage;
+      }
+
+      return data.groupsMatchedByUpdate || [];
+    });
+
+  jest
+    .spyOn(StatusPageGroupService, "countBy")
+    .mockResolvedValue(new PositiveNumber(data.groupsOnStatusPage.length));
+
+  jest.spyOn(StatusPageGroupService, "updateOneBy").mockResolvedValue(1);
+}
+
+function createBy(data: {
+  parentStatusPageGroupId?: ObjectID | undefined;
+  statusPageId?: ObjectID | undefined;
+}): CreateBy<StatusPageGroup> {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group.name = "New Group";
+  group.projectId = PROJECT_ID;
+  group.statusPageId = data.statusPageId || STATUS_PAGE_ID;
+  group.order = 1;
+
+  if (data.parentStatusPageGroupId) {
+    group.parentStatusPageGroupId = data.parentStatusPageGroupId;
+  }
+
+  return {
+    data: group,
+    props: { isRoot: true },
+  } as CreateBy<StatusPageGroup>;
+}
+
+function updateBy(data: {
+  id: ObjectID;
+  parentStatusPageGroupId: ObjectID | null;
+}): UpdateBy<StatusPageGroup> {
+  return {
+    query: { _id: data.id.toString() },
+    data: {
+      parentStatusPageGroupId: data.parentStatusPageGroupId,
+    },
+    props: { isRoot: true },
+  } as unknown as UpdateBy<StatusPageGroup>;
+}
+
+describe("StatusPageGroupService nesting rules", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("on create", () => {
+    it("accepts a parent that lives on the same status page", async () => {
+      const parent: StatusPageGroup = makeGroup({ id: groupId(1) });
+      mockService({ groupsOnStatusPage: [parent] });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeCreate(
+          createBy({ parentStatusPageGroupId: groupId(1) }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("rejects a parent that does not exist", async () => {
+      mockService({ groupsOnStatusPage: [] });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeCreate(
+          createBy({ parentStatusPageGroupId: groupId(1) }),
+        ),
+      ).rejects.toThrow(new BadDataException("Parent group not found."));
+    });
+
+    it("rejects a parent from another status page", async () => {
+      const parent: StatusPageGroup = makeGroup({
+        id: groupId(1),
+        statusPageId: OTHER_STATUS_PAGE_ID,
+      });
+      mockService({ groupsOnStatusPage: [parent] });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeCreate(
+          createBy({ parentStatusPageGroupId: groupId(1) }),
+        ),
+      ).rejects.toThrow(
+        new BadDataException(
+          "Parent group must belong to the same status page.",
+        ),
+      );
+    });
+
+    it("rejects a parent that is already at the nesting limit", async () => {
+      // a chain 0 -> 1 -> ... -> 9, so group 9 already sits at the deepest level.
+      const chain: Array<StatusPageGroup> = [];
+
+      for (
+        let index: number = 0;
+        index < StatusPageGroupTreeUtil.MaxNestingDepth;
+        index++
+      ) {
+        chain.push(
+          makeGroup({
+            id: groupId(index),
+            parentId: index === 0 ? undefined : groupId(index - 1),
+          }),
+        );
+      }
+
+      mockService({ groupsOnStatusPage: chain });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeCreate(
+          createBy({
+            parentStatusPageGroupId: groupId(
+              StatusPageGroupTreeUtil.MaxNestingDepth - 1,
+            ),
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      // one level up is still fine.
+      await expect(
+        (StatusPageGroupService as any).onBeforeCreate(
+          createBy({
+            parentStatusPageGroupId: groupId(
+              StatusPageGroupTreeUtil.MaxNestingDepth - 2,
+            ),
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("does not look for a parent when none was supplied", async () => {
+      mockService({ groupsOnStatusPage: [] });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeCreate(createBy({})),
+      ).resolves.toBeDefined();
+
+      expect(StatusPageGroupService.findOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on update", () => {
+    it("accepts a move to another branch", async () => {
+      const branchA: StatusPageGroup = makeGroup({ id: groupId(1) });
+      const branchB: StatusPageGroup = makeGroup({ id: groupId(2) });
+      const moving: StatusPageGroup = makeGroup({
+        id: groupId(3),
+        parentId: groupId(1),
+      });
+
+      mockService({
+        groupsOnStatusPage: [branchA, branchB, moving],
+        groupsMatchedByUpdate: [moving],
+      });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(
+          updateBy({ id: groupId(3), parentStatusPageGroupId: groupId(2) }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("rejects a group being made its own parent", async () => {
+      const group: StatusPageGroup = makeGroup({ id: groupId(1) });
+
+      mockService({
+        groupsOnStatusPage: [group],
+        groupsMatchedByUpdate: [group],
+      });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(
+          updateBy({ id: groupId(1), parentStatusPageGroupId: groupId(1) }),
+        ),
+      ).rejects.toThrow(
+        new BadDataException("A group cannot be its own parent group."),
+      );
+    });
+
+    it("rejects a group being nested under its own child", async () => {
+      const parent: StatusPageGroup = makeGroup({ id: groupId(1) });
+      const child: StatusPageGroup = makeGroup({
+        id: groupId(2),
+        parentId: groupId(1),
+      });
+
+      mockService({
+        groupsOnStatusPage: [parent, child],
+        groupsMatchedByUpdate: [parent],
+      });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(
+          updateBy({ id: groupId(1), parentStatusPageGroupId: groupId(2) }),
+        ),
+      ).rejects.toThrow(
+        new BadDataException(
+          "This group cannot be nested under one of its own sub groups.",
+        ),
+      );
+    });
+
+    it("rejects a group being nested under a deeper descendant", async () => {
+      const grandparent: StatusPageGroup = makeGroup({ id: groupId(1) });
+      const parent: StatusPageGroup = makeGroup({
+        id: groupId(2),
+        parentId: groupId(1),
+      });
+      const child: StatusPageGroup = makeGroup({
+        id: groupId(3),
+        parentId: groupId(2),
+      });
+
+      mockService({
+        groupsOnStatusPage: [grandparent, parent, child],
+        groupsMatchedByUpdate: [grandparent],
+      });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(
+          updateBy({ id: groupId(1), parentStatusPageGroupId: groupId(3) }),
+        ),
+      ).rejects.toThrow(
+        new BadDataException(
+          "This group cannot be nested under one of its own sub groups.",
+        ),
+      );
+    });
+
+    /*
+     * Moving a group drags its whole subtree with it, so the limit has to be
+     * checked against the deepest descendant, not just the group itself.
+     */
+    it("rejects a move that would push the group's own subtree past the limit", async () => {
+      const chain: Array<StatusPageGroup> = [];
+
+      for (
+        let index: number = 0;
+        index < StatusPageGroupTreeUtil.MaxNestingDepth - 1;
+        index++
+      ) {
+        chain.push(
+          makeGroup({
+            id: groupId(index),
+            parentId: index === 0 ? undefined : groupId(index - 1),
+          }),
+        );
+      }
+
+      // a separate two level branch: 100 -> 101.
+      const movingRoot: StatusPageGroup = makeGroup({ id: groupId(100) });
+      const movingChild: StatusPageGroup = makeGroup({
+        id: groupId(101),
+        parentId: groupId(100),
+      });
+
+      mockService({
+        groupsOnStatusPage: [...chain, movingRoot, movingChild],
+        groupsMatchedByUpdate: [movingRoot],
+      });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(
+          updateBy({
+            id: groupId(100),
+            parentStatusPageGroupId: groupId(
+              StatusPageGroupTreeUtil.MaxNestingDepth - 2,
+            ),
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("does not validate a parent when the update detaches the group", async () => {
+      const group: StatusPageGroup = makeGroup({
+        id: groupId(1),
+        parentId: groupId(2),
+      });
+
+      mockService({
+        groupsOnStatusPage: [group],
+        groupsMatchedByUpdate: [group],
+      });
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(
+          updateBy({ id: groupId(1), parentStatusPageGroupId: null }),
+        ),
+      ).resolves.toBeDefined();
+
+      expect(StatusPageGroupService.findOneById).not.toHaveBeenCalled();
+    });
+
+    it("does not read anything when the update does not touch the parent", async () => {
+      mockService({ groupsOnStatusPage: [] });
+
+      const update: UpdateBy<StatusPageGroup> = {
+        query: { _id: groupId(1).toString() },
+        data: { name: "Renamed" },
+        props: { isRoot: true },
+      } as unknown as UpdateBy<StatusPageGroup>;
+
+      await expect(
+        (StatusPageGroupService as any).onBeforeUpdate(update),
+      ).resolves.toBeDefined();
+
+      expect(StatusPageGroupService.findOneById).not.toHaveBeenCalled();
+      expect(StatusPageGroupService.findBy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Utils/StatusPage/GroupTree.test.ts
+++ b/Common/Tests/Utils/StatusPage/GroupTree.test.ts
@@ -1,0 +1,583 @@
+import StatusPageGroupTreeUtil, {
+  StatusPageGroupTreeNode,
+} from "../../../Utils/StatusPage/GroupTree";
+import ObjectID from "../../../Types/ObjectID";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Contract under test - status page groups nest, and every read path on the
+ * status page walks that tree:
+ *
+ *   - children / roots / descendants / ancestors are derived from a single
+ *     nullable parent pointer,
+ *   - siblings come back in `order`,
+ *   - and no shape of bad data (self parent, missing parent, a cycle written
+ *     straight to the database) may drop a group from the tree or hang the
+ *     walk. A dropped group is a resource silently missing from a customer's
+ *     status page, so every helper is exercised against those shapes too.
+ */
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const REGION_TWO: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const MARKET: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const UNIT: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+const MISSING: ObjectID = new ObjectID("99999999-9999-4999-8999-999999999999");
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  if (data.order !== undefined) {
+    group.order = data.order;
+  }
+
+  return group;
+}
+
+/*
+ * Corporate
+ *   Region 1000
+ *     Market 1001
+ *       Unit 0152
+ *   Region 2000
+ */
+function makeHierarchy(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+    makeGroup({
+      id: REGION_ONE,
+      name: "Region 1000",
+      parentId: CORPORATE,
+      order: 2,
+    }),
+    makeGroup({
+      id: MARKET,
+      name: "Market 1001",
+      parentId: REGION_ONE,
+      order: 3,
+    }),
+    makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET, order: 4 }),
+    makeGroup({
+      id: REGION_TWO,
+      name: "Region 2000",
+      parentId: CORPORATE,
+      order: 5,
+    }),
+  ];
+}
+
+function namesOf(groups: Array<StatusPageGroup>): Array<string> {
+  return groups.map((group: StatusPageGroup) => {
+    return group.name || "";
+  });
+}
+
+describe("StatusPageGroupTreeUtil", () => {
+  describe("getParentId", () => {
+    test("returns null for a top level group", () => {
+      const group: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate",
+      });
+
+      expect(StatusPageGroupTreeUtil.getParentId(group)).toBeNull();
+    });
+
+    test("returns the parent id when nested", () => {
+      const group: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "Region 1000",
+        parentId: CORPORATE,
+      });
+
+      expect(StatusPageGroupTreeUtil.getParentId(group)).toBe(
+        CORPORATE.toString(),
+      );
+    });
+
+    test("treats a group that points at itself as a top level group", () => {
+      const group: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate",
+        parentId: CORPORATE,
+      });
+
+      expect(StatusPageGroupTreeUtil.getParentId(group)).toBeNull();
+    });
+  });
+
+  describe("getChildGroups", () => {
+    test("returns only direct children, not grandchildren", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const children: Array<StatusPageGroup> =
+        StatusPageGroupTreeUtil.getChildGroups({
+          statusPageGroupId: CORPORATE.toString(),
+          statusPageGroups: groups,
+        });
+
+      expect(namesOf(children)).toEqual(["Region 1000", "Region 2000"]);
+    });
+
+    test("returns children of a leaf as an empty array", () => {
+      expect(
+        StatusPageGroupTreeUtil.getChildGroups({
+          statusPageGroupId: UNIT.toString(),
+          statusPageGroups: makeHierarchy(),
+        }),
+      ).toHaveLength(0);
+    });
+
+    test("null asks for the groups with no parent", () => {
+      const roots: Array<StatusPageGroup> =
+        StatusPageGroupTreeUtil.getChildGroups({
+          statusPageGroupId: null,
+          statusPageGroups: makeHierarchy(),
+        });
+
+      expect(namesOf(roots)).toEqual(["Corporate"]);
+    });
+
+    test("siblings come back in `order`, not in insertion order", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+        makeGroup({
+          id: REGION_TWO,
+          name: "Region 2000",
+          parentId: CORPORATE,
+          order: 9,
+        }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 1000",
+          parentId: CORPORATE,
+          order: 2,
+        }),
+      ];
+
+      expect(
+        namesOf(
+          StatusPageGroupTreeUtil.getChildGroups({
+            statusPageGroupId: CORPORATE.toString(),
+            statusPageGroups: groups,
+          }),
+        ),
+      ).toEqual(["Region 1000", "Region 2000"]);
+    });
+
+    test("groups without an order keep their incoming position, after ordered ones", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+        makeGroup({ id: REGION_TWO, name: "Unordered", parentId: CORPORATE }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Ordered",
+          parentId: CORPORATE,
+          order: 4,
+        }),
+      ];
+
+      expect(
+        namesOf(
+          StatusPageGroupTreeUtil.getChildGroups({
+            statusPageGroupId: CORPORATE.toString(),
+            statusPageGroups: groups,
+          }),
+        ),
+      ).toEqual(["Ordered", "Unordered"]);
+    });
+  });
+
+  describe("getRootGroups", () => {
+    test("returns only the top of the hierarchy", () => {
+      expect(
+        namesOf(
+          StatusPageGroupTreeUtil.getRootGroups({
+            statusPageGroups: makeHierarchy(),
+          }),
+        ),
+      ).toEqual(["Corporate"]);
+    });
+
+    test("a flat list of groups is all roots", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "A", order: 1 }),
+        makeGroup({ id: REGION_ONE, name: "B", order: 2 }),
+      ];
+
+      expect(
+        StatusPageGroupTreeUtil.getRootGroups({ statusPageGroups: groups }),
+      ).toHaveLength(2);
+    });
+
+    /*
+     * A group whose parent was not fetched (or no longer exists) must still be
+     * rendered somewhere, so it is promoted rather than hidden.
+     */
+    test("a group whose parent is not in the list is promoted to a root", () => {
+      const orphan: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "Orphan",
+        parentId: MISSING,
+        order: 2,
+      });
+
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+        orphan,
+      ];
+
+      expect(
+        namesOf(
+          StatusPageGroupTreeUtil.getRootGroups({ statusPageGroups: groups }),
+        ),
+      ).toEqual(["Corporate", "Orphan"]);
+    });
+
+    test("an empty list has no roots", () => {
+      expect(
+        StatusPageGroupTreeUtil.getRootGroups({ statusPageGroups: [] }),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("getDescendantGroups", () => {
+    test("returns the whole subtree, excluding the group itself", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const descendants: Array<StatusPageGroup> =
+        StatusPageGroupTreeUtil.getDescendantGroups({
+          statusPageGroup: groups[0]!,
+          statusPageGroups: groups,
+        });
+
+      expect(namesOf(descendants).sort()).toEqual([
+        "Market 1001",
+        "Region 1000",
+        "Region 2000",
+        "Unit 0152",
+      ]);
+    });
+
+    test("returns nothing for a leaf", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupTreeUtil.getDescendantGroups({
+          statusPageGroup: groups[3]!,
+          statusPageGroups: groups,
+        }),
+      ).toHaveLength(0);
+    });
+
+    test("does not loop forever on a cycle written straight to the database", () => {
+      // A -> B -> A
+      const a: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "A",
+        parentId: REGION_ONE,
+        order: 1,
+      });
+      const b: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "B",
+        parentId: CORPORATE,
+        order: 2,
+      });
+
+      const descendants: Array<StatusPageGroup> =
+        StatusPageGroupTreeUtil.getDescendantGroups({
+          statusPageGroup: a,
+          statusPageGroups: [a, b],
+        });
+
+      expect(namesOf(descendants)).toEqual(["B"]);
+    });
+  });
+
+  describe("getGroupAndDescendants", () => {
+    test("includes the group itself first", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const subtree: Array<StatusPageGroup> =
+        StatusPageGroupTreeUtil.getGroupAndDescendants({
+          statusPageGroup: groups[1]!,
+          statusPageGroups: groups,
+        });
+
+      expect(namesOf(subtree)).toEqual([
+        "Region 1000",
+        "Market 1001",
+        "Unit 0152",
+      ]);
+    });
+
+    test("a group with no hierarchy supplied covers only itself", () => {
+      const group: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate",
+      });
+
+      expect(
+        StatusPageGroupTreeUtil.getGroupAndDescendants({
+          statusPageGroup: group,
+          statusPageGroups: [group],
+        }),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("getAncestorGroups", () => {
+    test("returns the chain to the root, closest parent first", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        namesOf(
+          StatusPageGroupTreeUtil.getAncestorGroups({
+            statusPageGroup: groups[3]!,
+            statusPageGroups: groups,
+          }),
+        ),
+      ).toEqual(["Market 1001", "Region 1000", "Corporate"]);
+    });
+
+    test("a root has no ancestors", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupTreeUtil.getAncestorGroups({
+          statusPageGroup: groups[0]!,
+          statusPageGroups: groups,
+        }),
+      ).toHaveLength(0);
+    });
+
+    test("stops at a missing parent instead of throwing", () => {
+      const orphan: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "Orphan",
+        parentId: MISSING,
+      });
+
+      expect(
+        StatusPageGroupTreeUtil.getAncestorGroups({
+          statusPageGroup: orphan,
+          statusPageGroups: [orphan],
+        }),
+      ).toHaveLength(0);
+    });
+
+    test("stops at a cycle instead of looping forever", () => {
+      const a: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "A",
+        parentId: REGION_ONE,
+      });
+      const b: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "B",
+        parentId: CORPORATE,
+      });
+
+      expect(
+        namesOf(
+          StatusPageGroupTreeUtil.getAncestorGroups({
+            statusPageGroup: a,
+            statusPageGroups: [a, b],
+          }),
+        ),
+      ).toEqual(["B"]);
+    });
+  });
+
+  describe("getDepth", () => {
+    test("counts levels from the top", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupTreeUtil.getDepth({
+          statusPageGroup: groups[0]!,
+          statusPageGroups: groups,
+        }),
+      ).toBe(0);
+
+      expect(
+        StatusPageGroupTreeUtil.getDepth({
+          statusPageGroup: groups[3]!,
+          statusPageGroups: groups,
+        }),
+      ).toBe(3);
+    });
+  });
+
+  describe("isDescendantOf", () => {
+    test("is true for a grandchild", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupTreeUtil.isDescendantOf({
+          statusPageGroup: groups[3]!,
+          possibleAncestorId: CORPORATE.toString(),
+          statusPageGroups: groups,
+        }),
+      ).toBe(true);
+    });
+
+    test("is false across branches", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupTreeUtil.isDescendantOf({
+          statusPageGroup: groups[4]!,
+          possibleAncestorId: REGION_ONE.toString(),
+          statusPageGroups: groups,
+        }),
+      ).toBe(false);
+    });
+
+    test("a group is not a descendant of itself", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupTreeUtil.isDescendantOf({
+          statusPageGroup: groups[0]!,
+          possibleAncestorId: CORPORATE.toString(),
+          statusPageGroups: groups,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("buildTree", () => {
+    test("nests each level under its parent and records depth", () => {
+      const tree: Array<StatusPageGroupTreeNode> =
+        StatusPageGroupTreeUtil.buildTree({
+          statusPageGroups: makeHierarchy(),
+        });
+
+      expect(tree).toHaveLength(1);
+
+      const corporate: StatusPageGroupTreeNode = tree[0]!;
+      expect(corporate.group.name).toBe("Corporate");
+      expect(corporate.depth).toBe(0);
+      expect(
+        corporate.children.map((node: StatusPageGroupTreeNode) => {
+          return node.group.name;
+        }),
+      ).toEqual(["Region 1000", "Region 2000"]);
+
+      const regionOne: StatusPageGroupTreeNode = corporate.children[0]!;
+      expect(regionOne.depth).toBe(1);
+      expect(regionOne.children[0]!.group.name).toBe("Market 1001");
+      expect(regionOne.children[0]!.depth).toBe(2);
+      expect(regionOne.children[0]!.children[0]!.group.name).toBe("Unit 0152");
+      expect(regionOne.children[0]!.children[0]!.depth).toBe(3);
+    });
+
+    test("every group appears exactly once", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const seen: Array<string> = [];
+
+      const visit: (nodes: Array<StatusPageGroupTreeNode>) => void = (
+        nodes: Array<StatusPageGroupTreeNode>,
+      ): void => {
+        for (const node of nodes) {
+          seen.push(node.group.name || "");
+          visit(node.children);
+        }
+      };
+
+      visit(StatusPageGroupTreeUtil.buildTree({ statusPageGroups: groups }));
+
+      expect(seen).toHaveLength(groups.length);
+      expect(new Set(seen).size).toBe(groups.length);
+    });
+
+    /*
+     * Groups caught in a cycle are reachable from no root. They must still be
+     * shown - dropping them would silently hide monitors from the page.
+     */
+    test("promotes groups stuck in a cycle to the top level rather than dropping them", () => {
+      const a: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "A",
+        parentId: REGION_ONE,
+        order: 1,
+      });
+      const b: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "B",
+        parentId: CORPORATE,
+        order: 2,
+      });
+
+      const tree: Array<StatusPageGroupTreeNode> =
+        StatusPageGroupTreeUtil.buildTree({ statusPageGroups: [a, b] });
+
+      const seen: Array<string> = [];
+
+      const visit: (nodes: Array<StatusPageGroupTreeNode>) => void = (
+        nodes: Array<StatusPageGroupTreeNode>,
+      ): void => {
+        for (const node of nodes) {
+          seen.push(node.group.name || "");
+          visit(node.children);
+        }
+      };
+
+      visit(tree);
+
+      expect(seen.sort()).toEqual(["A", "B"]);
+    });
+
+    test("an orphan renders at the top level", () => {
+      const orphan: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "Orphan",
+        parentId: MISSING,
+        order: 2,
+      });
+      const root: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate",
+        order: 1,
+      });
+
+      const tree: Array<StatusPageGroupTreeNode> =
+        StatusPageGroupTreeUtil.buildTree({
+          statusPageGroups: [root, orphan],
+        });
+
+      expect(
+        tree.map((node: StatusPageGroupTreeNode) => {
+          return node.group.name;
+        }),
+      ).toEqual(["Corporate", "Orphan"]);
+    });
+
+    test("an empty list builds an empty tree", () => {
+      expect(
+        StatusPageGroupTreeUtil.buildTree({ statusPageGroups: [] }),
+      ).toHaveLength(0);
+    });
+  });
+});

--- a/Common/Tests/Utils/StatusPage/ResourceUptime.test.ts
+++ b/Common/Tests/Utils/StatusPage/ResourceUptime.test.ts
@@ -1,7 +1,11 @@
 import StatusPageResourceUptimeUtil from "../../../Utils/StatusPage/ResourceUptime";
 import { Green, Red, Yellow } from "../../../Types/BrandColors";
 import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
 import Dictionary from "../../../Types/Dictionary";
+import UptimePrecision from "../../../Types/StatusPage/UptimePrecision";
+import { UptimeWindow } from "../../../Utils/Uptime/UptimeUtil";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
 import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
 import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
@@ -258,6 +262,413 @@ describe("StatusPageResourceUptimeUtil", () => {
         });
 
       expect(result).toHaveLength(0);
+    });
+  });
+
+  /*
+   * Groups can be nested (Corporate Unit -> Region -> Market -> Site), and the
+   * whole point of the hierarchy is that every level reports a rolled up
+   * number. These cases pin down what "rolled up" means:
+   *
+   *   - a group's status / uptime covers its own resources AND everything in
+   *     the groups below it,
+   *   - the hierarchy is opt in: without the group list the helpers behave
+   *     exactly as they did before nesting existed,
+   *   - and the page-wide average counts each resource once, however deep it
+   *     sits (a parent already averages its subtree, so descending past it
+   *     would count its children twice).
+   *
+   * A monitor that is operational for the whole window is 100%, a monitor that
+   * is offline for the whole window is 0% - so the expected averages below are
+   * exact rather than time-dependent.
+   */
+  describe("nested groups", () => {
+    const PARENT_GROUP: ObjectID = new ObjectID(
+      "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    );
+    const CHILD_GROUP: ObjectID = new ObjectID(
+      "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    );
+    const OPERATIONAL_STATUS: ObjectID = new ObjectID(
+      "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    );
+    const OFFLINE_STATUS: ObjectID = new ObjectID(
+      "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    );
+
+    const uptimeWindow: UptimeWindow = {
+      startDate: OneUptimeDate.getSomeDaysAgo(10),
+      endDate: OneUptimeDate.getCurrentDate(),
+    };
+
+    function operationalStatus(): MonitorStatus {
+      const status: MonitorStatus = new MonitorStatus();
+      status._id = OPERATIONAL_STATUS.toString();
+      status.name = "Operational";
+      status.priority = 1;
+      status.color = Green;
+      status.isOperationalState = true;
+      return status;
+    }
+
+    function offlineStatus(): MonitorStatus {
+      const status: MonitorStatus = new MonitorStatus();
+      status._id = OFFLINE_STATUS.toString();
+      status.name = "Offline";
+      status.priority = 3;
+      status.color = Red;
+      return status;
+    }
+
+    // an open timeline row covering the whole reporting window.
+    function makeTimeline(data: {
+      monitorId: ObjectID;
+      status: MonitorStatus;
+    }): MonitorStatusTimeline {
+      const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+      timeline.monitorId = data.monitorId;
+      timeline.monitorStatus = data.status;
+      timeline.monitorStatusId = data.status.id!;
+      timeline.startsAt = uptimeWindow.startDate;
+      return timeline;
+    }
+
+    function makeGroup(data: {
+      id: ObjectID;
+      name: string;
+      parentId?: ObjectID | undefined;
+      showUptimePercent: boolean;
+    }): StatusPageGroup {
+      const group: StatusPageGroup = new StatusPageGroup();
+      group._id = data.id.toString();
+      group.name = data.name;
+      group.showUptimePercent = data.showUptimePercent;
+      group.uptimePercentPrecision = UptimePrecision.TWO_DECIMAL;
+
+      if (data.parentId) {
+        group.parentStatusPageGroupId = data.parentId;
+      }
+
+      return group;
+    }
+
+    function makeResource(data: {
+      monitorId: ObjectID;
+      currentStatusId: ObjectID;
+      groupId?: ObjectID | undefined;
+    }): StatusPageResource {
+      const resource: StatusPageResource = new StatusPageResource();
+      resource.monitorId = data.monitorId;
+      resource.showUptimePercent = true;
+
+      const monitor: Monitor = new Monitor();
+      monitor._id = data.monitorId.toString();
+      monitor.currentMonitorStatusId = data.currentStatusId;
+      resource.monitor = monitor;
+
+      if (data.groupId) {
+        resource.statusPageGroupId = data.groupId;
+      }
+
+      return resource;
+    }
+
+    /*
+     * Parent (2 healthy resources) -> Child (1 offline resource).
+     * Parent on its own is 100%, the subtree is (100 + 100 + 0) / 3 = 66.66%.
+     */
+    function makeFixture(data?: {
+      parentShowsUptimePercent?: boolean | undefined;
+    }): {
+      groups: Array<StatusPageGroup>;
+      resources: Array<StatusPageResource>;
+      timelines: Array<MonitorStatusTimeline>;
+      statuses: Array<MonitorStatus>;
+    } {
+      const parent: StatusPageGroup = makeGroup({
+        id: PARENT_GROUP,
+        name: "Corporate Units",
+        showUptimePercent: data?.parentShowsUptimePercent ?? true,
+      });
+      const child: StatusPageGroup = makeGroup({
+        id: CHILD_GROUP,
+        name: "Region 1000",
+        parentId: PARENT_GROUP,
+        showUptimePercent: true,
+      });
+
+      return {
+        groups: [parent, child],
+        resources: [
+          makeResource({
+            monitorId: MONITOR_A,
+            currentStatusId: OPERATIONAL_STATUS,
+            groupId: PARENT_GROUP,
+          }),
+          makeResource({
+            monitorId: MONITOR_B,
+            currentStatusId: OPERATIONAL_STATUS,
+            groupId: PARENT_GROUP,
+          }),
+          makeResource({
+            monitorId: MONITOR_C,
+            currentStatusId: OFFLINE_STATUS,
+            groupId: CHILD_GROUP,
+          }),
+        ],
+        timelines: [
+          makeTimeline({ monitorId: MONITOR_A, status: operationalStatus() }),
+          makeTimeline({ monitorId: MONITOR_B, status: operationalStatus() }),
+          makeTimeline({ monitorId: MONITOR_C, status: offlineStatus() }),
+        ],
+        statuses: [operationalStatus(), offlineStatus()],
+      };
+    }
+
+    describe("getResourcesInStatusPageGroupAndDescendants", () => {
+      test("a parent covers its own resources and its children's", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        expect(
+          StatusPageResourceUptimeUtil.getResourcesInStatusPageGroupAndDescendants(
+            {
+              statusPageGroup: fixture.groups[0]!,
+              statusPageResources: fixture.resources,
+              allStatusPageGroups: fixture.groups,
+            },
+          ),
+        ).toHaveLength(3);
+      });
+
+      test("a child covers only its own resources", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        const resources: Array<StatusPageResource> =
+          StatusPageResourceUptimeUtil.getResourcesInStatusPageGroupAndDescendants(
+            {
+              statusPageGroup: fixture.groups[1]!,
+              statusPageResources: fixture.resources,
+              allStatusPageGroups: fixture.groups,
+            },
+          );
+
+        expect(resources).toHaveLength(1);
+        expect(resources[0]!.monitorId?.toString()).toBe(MONITOR_C.toString());
+      });
+
+      test("without the group list it falls back to the group's own resources", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        expect(
+          StatusPageResourceUptimeUtil.getResourcesInStatusPageGroupAndDescendants(
+            {
+              statusPageGroup: fixture.groups[0]!,
+              statusPageResources: fixture.resources,
+            },
+          ),
+        ).toHaveLength(2);
+      });
+
+      test("never picks up ungrouped resources", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        const ungrouped: StatusPageResource = makeResource({
+          monitorId: MONITOR_A,
+          currentStatusId: OPERATIONAL_STATUS,
+        });
+
+        expect(
+          StatusPageResourceUptimeUtil.getResourcesInStatusPageGroupAndDescendants(
+            {
+              statusPageGroup: fixture.groups[0]!,
+              statusPageResources: [...fixture.resources, ungrouped],
+              allStatusPageGroups: fixture.groups,
+            },
+          ),
+        ).toHaveLength(3);
+      });
+    });
+
+    describe("calculateAvgUptimePercentOfStatusPageGroup", () => {
+      test("a parent averages every resource in its subtree", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+            {
+              statusPageGroup: fixture.groups[0]!,
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: fixture.resources,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+              allStatusPageGroups: fixture.groups,
+            },
+          ),
+        ).toBe(66.66);
+      });
+
+      test("a child reports only its own resources", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+            {
+              statusPageGroup: fixture.groups[1]!,
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: fixture.resources,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+              allStatusPageGroups: fixture.groups,
+            },
+          ),
+        ).toBe(0);
+      });
+
+      test("without the group list a parent reports only its own resources", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+            {
+              statusPageGroup: fixture.groups[0]!,
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: fixture.resources,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+            },
+          ),
+        ).toBe(100);
+      });
+
+      test("a group that does not show uptime percent reports nothing", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture({
+          parentShowsUptimePercent: false,
+        });
+
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+            {
+              statusPageGroup: fixture.groups[0]!,
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: fixture.resources,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+              allStatusPageGroups: fixture.groups,
+            },
+          ),
+        ).toBeNull();
+      });
+    });
+
+    describe("getCurrentStatusPageGroupStatus", () => {
+      test("a parent takes the worst status in its subtree", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        const status: MonitorStatus =
+          StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus({
+            statusPageGroup: fixture.groups[0]!,
+            monitorStatusTimelines: fixture.timelines,
+            statusPageResources: fixture.resources,
+            monitorStatuses: fixture.statuses,
+            monitorGroupCurrentStatuses: {},
+            allStatusPageGroups: fixture.groups,
+          });
+
+        expect(status.name).toBe("Offline");
+      });
+
+      test("without the group list a parent only sees its own resources", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        const status: MonitorStatus =
+          StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus({
+            statusPageGroup: fixture.groups[0]!,
+            monitorStatusTimelines: fixture.timelines,
+            statusPageResources: fixture.resources,
+            monitorStatuses: fixture.statuses,
+            monitorGroupCurrentStatuses: {},
+          });
+
+        expect(status.name).toBe("Operational");
+      });
+    });
+
+    describe("calculateAvgUptimePercentageOfAllResources", () => {
+      test("counts a nested resource once, through its top most reporting ancestor", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        /*
+         * The parent already averages all three resources (66.66%). Averaging
+         * the parent and the child together would count the offline resource
+         * twice and land on 33.33%.
+         */
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentageOfAllResources(
+            {
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: fixture.resources,
+              resourceGroups: fixture.groups,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+            },
+          ),
+        ).toBe(66.66);
+      });
+
+      test("descends past a parent that does not report uptime percent", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture({
+          parentShowsUptimePercent: false,
+        });
+
+        // only the child reports, and everything in the child is offline.
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentageOfAllResources(
+            {
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: fixture.resources,
+              resourceGroups: fixture.groups,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+            },
+          ),
+        ).toBe(0);
+      });
+
+      test("still includes resources that are in no group at all", () => {
+        const fixture: ReturnType<typeof makeFixture> = makeFixture();
+
+        const ungrouped: StatusPageResource = makeResource({
+          monitorId: MONITOR_C,
+          currentStatusId: OFFLINE_STATUS,
+        });
+
+        // parent subtree 66.66%, ungrouped offline resource 0% -> 33.33%.
+        expect(
+          StatusPageResourceUptimeUtil.calculateAvgUptimePercentageOfAllResources(
+            {
+              monitorStatusTimelines: fixture.timelines,
+              precision: UptimePrecision.TWO_DECIMAL,
+              downtimeMonitorStatuses: [offlineStatus()],
+              statusPageResources: [...fixture.resources, ungrouped],
+              resourceGroups: fixture.groups,
+              monitorsInGroup: {},
+              uptimeWindow: uptimeWindow,
+            },
+          ),
+        ).toBe(33.33);
+      });
     });
   });
 });

--- a/Common/UI/Components/Accordion/Accordion.tsx
+++ b/Common/UI/Components/Accordion/Accordion.tsx
@@ -32,13 +32,21 @@ const Accordion: FunctionComponent<ComponentProps> = (
     }
   }, [props.isInitiallyExpanded]);
 
+  /*
+   * A title-less accordion has nothing to click, so it stays open. Keyed on
+   * whether there is a title rather than on the title itself: callers may pass
+   * an element, and a fresh element on every parent render would otherwise
+   * collapse an accordion the visitor had just opened.
+   */
+  const hasTitle: boolean = Boolean(props.title);
+
   useEffect(() => {
-    if (!props.title) {
+    if (!hasTitle) {
       setIsOpen(true);
     } else if (!props.isInitiallyExpanded) {
       setIsOpen(false);
     }
-  }, [props.title]);
+  }, [hasTitle]);
 
   useEffect(() => {
     if (props.onClick) {

--- a/Common/Utils/StatusPage/GroupTree.ts
+++ b/Common/Utils/StatusPage/GroupTree.ts
@@ -1,0 +1,307 @@
+import StatusPageGroup from "../../Models/DatabaseModels/StatusPageGroup";
+
+export interface StatusPageGroupTreeNode {
+  group: StatusPageGroup;
+  depth: number;
+  children: Array<StatusPageGroupTreeNode>;
+}
+
+/*
+ * Status page groups form a tree: a group may be nested under another group
+ * (Corporate Unit -> Region -> Market -> Site), and each level rolls up the
+ * status and uptime of everything below it.
+ *
+ * Everything here is defensive about the shape of the data it is handed. The
+ * parent pointer lives in a plain nullable column, so rows written directly to
+ * the database (or a group whose parent the caller did not fetch) can point at
+ * a missing parent, at themselves, or around a cycle. None of those may make a
+ * group disappear from the status page or hang the render, so every walk is
+ * bounded by a visited set and every group ends up in the tree exactly once.
+ */
+export default class StatusPageGroupTreeUtil {
+  /*
+   * How deep a group may be nested. Enforced on write (see
+   * StatusPageGroupService) - reads never drop levels beyond it, they only
+   * refuse to loop.
+   */
+  public static readonly MaxNestingDepth: number = 10;
+
+  public static getParentId(statusPageGroup: StatusPageGroup): string | null {
+    const parentId: string | null =
+      statusPageGroup.parentStatusPageGroupId?.toString() || null;
+
+    if (!parentId) {
+      return null;
+    }
+
+    // a group that points at itself is a root, not an infinite loop.
+    if (parentId === statusPageGroup._id?.toString()) {
+      return null;
+    }
+
+    return parentId;
+  }
+
+  public static getChildGroups(data: {
+    statusPageGroupId: string | null;
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroup> {
+    const children: Array<StatusPageGroup> = data.statusPageGroups.filter(
+      (group: StatusPageGroup) => {
+        return this.getParentId(group) === data.statusPageGroupId;
+      },
+    );
+
+    return this.sortByOrder(children);
+  }
+
+  /*
+   * Top level groups: no parent, or a parent that is not part of the supplied
+   * list (an orphan still has to render somewhere).
+   */
+  public static getRootGroups(data: {
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroup> {
+    const idsInList: Set<string> = this.getIdSet(data.statusPageGroups);
+
+    const roots: Array<StatusPageGroup> = data.statusPageGroups.filter(
+      (group: StatusPageGroup) => {
+        const parentId: string | null = this.getParentId(group);
+        return !parentId || !idsInList.has(parentId);
+      },
+    );
+
+    return this.sortByOrder(roots);
+  }
+
+  /*
+   * The full tree, in render order. Every supplied group appears exactly once:
+   * orphans are promoted to roots, and groups that are only reachable through a
+   * cycle are promoted too (rather than being silently dropped).
+   */
+  public static buildTree(data: {
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroupTreeNode> {
+    const visited: Set<string> = new Set<string>();
+
+    const buildNode: (
+      group: StatusPageGroup,
+      depth: number,
+    ) => StatusPageGroupTreeNode = (
+      group: StatusPageGroup,
+      depth: number,
+    ): StatusPageGroupTreeNode => {
+      const groupId: string = group._id?.toString() || "";
+      visited.add(groupId);
+
+      const children: Array<StatusPageGroupTreeNode> = this.getChildGroups({
+        statusPageGroupId: groupId,
+        statusPageGroups: data.statusPageGroups,
+      })
+        .filter((child: StatusPageGroup) => {
+          return !visited.has(child._id?.toString() || "");
+        })
+        .map((child: StatusPageGroup) => {
+          return buildNode(child, depth + 1);
+        });
+
+      return {
+        group: group,
+        depth: depth,
+        children: children,
+      };
+    };
+
+    const tree: Array<StatusPageGroupTreeNode> = this.getRootGroups({
+      statusPageGroups: data.statusPageGroups,
+    }).map((root: StatusPageGroup) => {
+      return buildNode(root, 0);
+    });
+
+    /*
+     * Anything left unvisited is inside a cycle that no root points into. Pull
+     * each one up to the top level so the page still shows it.
+     */
+    for (const group of this.sortByOrder(data.statusPageGroups)) {
+      if (!visited.has(group._id?.toString() || "")) {
+        tree.push(buildNode(group, 0));
+      }
+    }
+
+    return tree;
+  }
+
+  /*
+   * Every group below this one, at any depth. Excludes the group itself.
+   */
+  public static getDescendantGroups(data: {
+    statusPageGroup: StatusPageGroup;
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroup> {
+    const descendants: Array<StatusPageGroup> = [];
+    const visited: Set<string> = new Set<string>([
+      data.statusPageGroup._id?.toString() || "",
+    ]);
+
+    let frontier: Array<StatusPageGroup> = this.getChildGroups({
+      statusPageGroupId: data.statusPageGroup._id?.toString() || "",
+      statusPageGroups: data.statusPageGroups,
+    });
+
+    while (frontier.length > 0) {
+      const nextFrontier: Array<StatusPageGroup> = [];
+
+      for (const group of frontier) {
+        const groupId: string = group._id?.toString() || "";
+
+        if (visited.has(groupId)) {
+          continue;
+        }
+
+        visited.add(groupId);
+        descendants.push(group);
+
+        nextFrontier.push(
+          ...this.getChildGroups({
+            statusPageGroupId: groupId,
+            statusPageGroups: data.statusPageGroups,
+          }),
+        );
+      }
+
+      frontier = nextFrontier;
+    }
+
+    return descendants;
+  }
+
+  /*
+   * The group itself followed by all of its descendants - the set of groups a
+   * rolled up number has to cover.
+   */
+  public static getGroupAndDescendants(data: {
+    statusPageGroup: StatusPageGroup;
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroup> {
+    return [
+      data.statusPageGroup,
+      ...this.getDescendantGroups({
+        statusPageGroup: data.statusPageGroup,
+        statusPageGroups: data.statusPageGroups,
+      }),
+    ];
+  }
+
+  /*
+   * Ancestors, closest parent first. Stops at a cycle instead of looping.
+   */
+  public static getAncestorGroups(data: {
+    statusPageGroup: StatusPageGroup;
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroup> {
+    const byId: Map<string, StatusPageGroup> = this.getGroupsById(
+      data.statusPageGroups,
+    );
+
+    const ancestors: Array<StatusPageGroup> = [];
+    const visited: Set<string> = new Set<string>([
+      data.statusPageGroup._id?.toString() || "",
+    ]);
+
+    let parentId: string | null = this.getParentId(data.statusPageGroup);
+
+    while (parentId && !visited.has(parentId)) {
+      const parent: StatusPageGroup | undefined = byId.get(parentId);
+
+      if (!parent) {
+        break;
+      }
+
+      ancestors.push(parent);
+      visited.add(parentId);
+      parentId = this.getParentId(parent);
+    }
+
+    return ancestors;
+  }
+
+  /*
+   * 0 for a top level group, 1 for its children, and so on.
+   */
+  public static getDepth(data: {
+    statusPageGroup: StatusPageGroup;
+    statusPageGroups: Array<StatusPageGroup>;
+  }): number {
+    return this.getAncestorGroups({
+      statusPageGroup: data.statusPageGroup,
+      statusPageGroups: data.statusPageGroups,
+    }).length;
+  }
+
+  public static isDescendantOf(data: {
+    statusPageGroup: StatusPageGroup;
+    possibleAncestorId: string;
+    statusPageGroups: Array<StatusPageGroup>;
+  }): boolean {
+    return this.getAncestorGroups({
+      statusPageGroup: data.statusPageGroup,
+      statusPageGroups: data.statusPageGroups,
+    }).some((ancestor: StatusPageGroup) => {
+      return ancestor._id?.toString() === data.possibleAncestorId;
+    });
+  }
+
+  private static getGroupsById(
+    statusPageGroups: Array<StatusPageGroup>,
+  ): Map<string, StatusPageGroup> {
+    const byId: Map<string, StatusPageGroup> = new Map<
+      string,
+      StatusPageGroup
+    >();
+
+    for (const group of statusPageGroups) {
+      const groupId: string | undefined = group._id?.toString();
+
+      if (groupId) {
+        byId.set(groupId, group);
+      }
+    }
+
+    return byId;
+  }
+
+  private static getIdSet(
+    statusPageGroups: Array<StatusPageGroup>,
+  ): Set<string> {
+    const ids: Set<string> = new Set<string>();
+
+    for (const group of statusPageGroups) {
+      const groupId: string | undefined = group._id?.toString();
+
+      if (groupId) {
+        ids.add(groupId);
+      }
+    }
+
+    return ids;
+  }
+
+  /*
+   * Siblings render in `order`. Groups without an order keep their incoming
+   * position, after the ordered ones.
+   */
+  private static sortByOrder(
+    statusPageGroups: Array<StatusPageGroup>,
+  ): Array<StatusPageGroup> {
+    return [...statusPageGroups].sort(
+      (a: StatusPageGroup, b: StatusPageGroup) => {
+        const orderA: number =
+          typeof a.order === "number" ? a.order : Number.MAX_SAFE_INTEGER;
+        const orderB: number =
+          typeof b.order === "number" ? b.order : Number.MAX_SAFE_INTEGER;
+
+        return orderA - orderB;
+      },
+    );
+  }
+}

--- a/Common/Utils/StatusPage/ResourceUptime.ts
+++ b/Common/Utils/StatusPage/ResourceUptime.ts
@@ -6,6 +6,7 @@ import StatusPageResource from "../../Models/DatabaseModels/StatusPageResource";
 import Dictionary from "../../Types/Dictionary";
 import UptimePrecision from "../../Types/StatusPage/UptimePrecision";
 import StatusPageGroup from "../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil from "./GroupTree";
 import UptimeUtil, { UptimeWindow } from "../Uptime/UptimeUtil";
 
 export default class StatusPageResourceUptimeUtil {
@@ -74,15 +75,22 @@ export default class StatusPageResourceUptimeUtil {
     statusPageResources: Array<StatusPageResource>;
     monitorStatuses: Array<MonitorStatus>;
     monitorGroupCurrentStatuses: Dictionary<ObjectID>;
+    /*
+     * Every group on the status page. Supplied so a group that has nested
+     * groups under it reports the worst status of its whole subtree. Omit it
+     * (or pass only this group) to look at the group's own resources.
+     */
+    allStatusPageGroups?: Array<StatusPageGroup> | undefined;
   }): MonitorStatus {
     let currentStatus: MonitorStatus = new MonitorStatus();
     currentStatus.name = "Operational";
     currentStatus.color = Green;
 
     const resourcesInGroup: Array<StatusPageResource> =
-      this.getResourcesInStatusPageGroup({
+      this.getResourcesInStatusPageGroupAndDescendants({
         statusPageGroup: data.statusPageGroup,
         statusPageResources: data.statusPageResources,
+        allStatusPageGroups: data.allStatusPageGroups,
       });
 
     for (const resource of resourcesInGroup) {
@@ -173,15 +181,22 @@ export default class StatusPageResourceUptimeUtil {
     monitorsInGroup: Dictionary<Array<ObjectID>>;
     // if supplied, uptime is measured over this window instead of "first event -> now".
     uptimeWindow?: UptimeWindow | undefined;
+    /*
+     * Every group on the status page. Supplied so a group that has nested
+     * groups under it averages every resource in its subtree, which is what
+     * makes each level of the hierarchy show a rolled up availability.
+     */
+    allStatusPageGroups?: Array<StatusPageGroup> | undefined;
   }): number | null {
     if (!data.statusPageGroup.showUptimePercent) {
       return null;
     }
 
     const resourcesInGroup: Array<StatusPageResource> =
-      this.getResourcesInStatusPageGroup({
+      this.getResourcesInStatusPageGroupAndDescendants({
         statusPageGroup: data.statusPageGroup,
         statusPageResources: data.statusPageResources,
+        allStatusPageGroups: data.allStatusPageGroups,
       });
 
     if (resourcesInGroup.length === 0) {
@@ -251,6 +266,37 @@ export default class StatusPageResourceUptimeUtil {
     });
   }
 
+  /*
+   * Resources attached to this group plus every resource attached to a group
+   * nested under it. This is the set a rolled up number (status, uptime %) for
+   * the group has to be computed from. Without allStatusPageGroups there is no
+   * hierarchy to walk, so it degrades to the group's own resources.
+   */
+  public static getResourcesInStatusPageGroupAndDescendants(data: {
+    statusPageGroup: StatusPageGroup;
+    statusPageResources: Array<StatusPageResource>;
+    allStatusPageGroups?: Array<StatusPageGroup> | undefined;
+  }): Array<StatusPageResource> {
+    const groupsToInclude: Array<StatusPageGroup> =
+      StatusPageGroupTreeUtil.getGroupAndDescendants({
+        statusPageGroup: data.statusPageGroup,
+        statusPageGroups: data.allStatusPageGroups || [data.statusPageGroup],
+      });
+
+    const groupIds: Set<string> = new Set<string>(
+      groupsToInclude.map((group: StatusPageGroup) => {
+        return group._id?.toString() || "";
+      }),
+    );
+
+    return data.statusPageResources.filter((resource: StatusPageResource) => {
+      const resourceGroupId: string | undefined =
+        resource.statusPageGroupId?.toString();
+
+      return Boolean(resourceGroupId) && groupIds.has(resourceGroupId!);
+    });
+  }
+
   public static calculateAvgUptimePercentageOfAllResources(data: {
     monitorStatusTimelines: Array<MonitorStatusTimeline>;
     precision: UptimePrecision;
@@ -273,24 +319,51 @@ export default class StatusPageResourceUptimeUtil {
 
     const allUptimePercent: Array<number> = [];
 
-    // calculate for groups first.
+    /*
+     * Calculate for groups first. Groups nest, and a group that reports uptime
+     * already averages its whole subtree - so descend only until the first
+     * reporting group on each branch, otherwise its children would be counted
+     * twice. Groups that do not report uptime contribute nothing themselves
+     * (unchanged behaviour) but must not hide reporting groups beneath them.
+     */
+    const collectGroupUptime: (groups: Array<StatusPageGroup>) => void = (
+      groups: Array<StatusPageGroup>,
+    ): void => {
+      for (const group of groups) {
+        if (group.showUptimePercent) {
+          const groupUptimePercent: number | null =
+            this.calculateAvgUptimePercentOfStatusPageGroup({
+              statusPageGroup: group,
+              monitorStatusTimelines: data.monitorStatusTimelines,
+              precision: data.precision,
+              downtimeMonitorStatuses: data.downtimeMonitorStatuses,
+              statusPageResources: data.statusPageResources,
+              monitorsInGroup: data.monitorsInGroup,
+              uptimeWindow: data.uptimeWindow,
+              allStatusPageGroups: data.resourceGroups,
+            });
 
-    for (const group of data.resourceGroups) {
-      const calculateAvgUptimePercentOfStatusPageGroup: number | null =
-        this.calculateAvgUptimePercentOfStatusPageGroup({
-          statusPageGroup: group,
-          monitorStatusTimelines: data.monitorStatusTimelines,
-          precision: data.precision,
-          downtimeMonitorStatuses: data.downtimeMonitorStatuses,
-          statusPageResources: data.statusPageResources,
-          monitorsInGroup: data.monitorsInGroup,
-          uptimeWindow: data.uptimeWindow,
-        });
+          if (groupUptimePercent !== null) {
+            allUptimePercent.push(groupUptimePercent);
+          }
 
-      if (calculateAvgUptimePercentOfStatusPageGroup !== null) {
-        allUptimePercent.push(calculateAvgUptimePercentOfStatusPageGroup);
+          continue;
+        }
+
+        collectGroupUptime(
+          StatusPageGroupTreeUtil.getChildGroups({
+            statusPageGroupId: group._id?.toString() || "",
+            statusPageGroups: data.resourceGroups,
+          }),
+        );
       }
-    }
+    };
+
+    collectGroupUptime(
+      StatusPageGroupTreeUtil.getRootGroups({
+        statusPageGroups: data.resourceGroups,
+      }),
+    );
 
     // now fetch resources without group.
 


### PR DESCRIPTION
Closes #2902

Status page resource groups were one level deep: a group held monitors, and that was it. This adds a parent pointer to `StatusPageGroup` so groups can be nested arbitrarily (Corporate Units → Region 1000 → Market 1001 → WB Unit 0152), with every level rolling up the status and uptime of everything beneath it — the Grafana-style hierarchy the issue asks for.

## Data model

- `StatusPageGroup.parentStatusPageGroupId` — nullable self reference, indexed, `ON DELETE CASCADE` (deleting a group already deletes its resources; now it deletes its sub groups too).
- Migration `1785329453269-AddParentGroupToStatusPageGroup`, registered in `SchemaMigrations/Index.ts`.

## Rollups

New `Common/Utils/StatusPage/GroupTree.ts` owns every walk over the hierarchy (children, roots, descendants, ancestors, depth, full tree). It is deliberately defensive: the parent pointer is a plain nullable column, so a row written straight to the database can point at a missing parent, at itself, or around a cycle. None of those may drop a group off a customer's status page or hang the render, so every walk is bounded by a visited set and `buildTree` guarantees each group appears exactly once (orphans and cycle members get promoted to the top level).

`StatusPageResourceUptimeUtil` now takes an optional `allStatusPageGroups`, and when it is supplied:

- a group's current status is the worst status in its **subtree**,
- a group's uptime % averages every resource in its **subtree**,
- the page-wide average descends only to the *top most* group that reports uptime on each branch, so a nested resource is counted once instead of once per ancestor.

Without `allStatusPageGroups` the helpers behave exactly as they did before, which keeps every existing caller honest.

The `/uptime` API endpoint reports the same subtree rollups per group and now returns `parentStatusPageGroupId` so API consumers can rebuild the tree. `statusPageResourceUptimes` still lists only the group's own resources.

## Writes

`StatusPageGroupService` validates the parent on both create and update and rejects:

- a parent that does not exist, or lives on a different status page,
- a group parented to itself,
- a group parented to one of its own sub groups (a cycle),
- a move that would push the group — or anything already nested under it — past the 10 level limit.

The update path re-applies the caller's tenant to the query before reading, so the hook can never inspect a row outside the caller's project.

## UI

**Public status page** — groups render recursively. Sub groups sit inside their parent's accordion behind a left rail so the hierarchy stays readable at depth, each level is its own accordion with its own rolled up status/uptime, and a parent that only holds sub groups shows them instead of "No resources added to this group."

Two small related changes:

- The rolled up status/uptime moved from the accordion's `rightElement` into the title. `rightElement` is hidden while an accordion is open, and the whole point of the hierarchy is that every level always shows what it rolls up. It also no longer jumps position when a level is expanded.
- `Accordion` keys its reset effect on *whether* there is a title rather than on the title value, so passing an element title no longer collapses an accordion the visitor just opened on the next parent render.

**Dashboard** — the group form gets a "Parent Group" picker whose options are labelled with their full path (`Corporate Units › Region 1000`), the group table gets a "Parent Group" column, and the resources page orders its per-group tables in tree order and titles each one with the group's full path.

New strings are translated across all 16 status page locales.

## Tests

55 new cases (66 passing across the three touched suites):

- `Common/Tests/Utils/StatusPage/GroupTree.test.ts` — every helper, plus sibling ordering and the three bad-data shapes (self parent, missing parent, cycle).
- `Common/Tests/Utils/StatusPage/ResourceUptime.test.ts` — subtree resources, subtree status, subtree uptime, opt-in behaviour without the group list, and that the page-wide average counts a nested resource exactly once.
- `Common/Tests/Server/Services/StatusPageGroupNesting.test.ts` — every rejection above on both create and update, and that a write that does not touch the parent performs no extra reads.

`Common` and `App` both type-check clean.

## Note for the reviewer

The migration was hand-written because `npm run generate-postgres-migration` needs a live database and Docker was not running here. It follows TypeORM's default naming strategy, and the generated constraint names were verified by reproducing the existing `StatusPageGroup` / `NetworkSite` constraint names with the same hash. Worth a quick sanity check against the generator before merge.

I also could not exercise the rendered status page in a browser for the same reason — the UI changes are reviewed by reading, not by screenshot.
