### PR TITLE
fix: harden the cross-project incident reference fix after adversarial review

### DIFF
--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785320000000-RepairCrossProjectIncidentReferences.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785320000000-RepairCrossProjectIncidentReferences.ts
@@ -1,3 +1,4 @@
+import logger from "../../../Utils/Logger";
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 /*
@@ -34,14 +35,26 @@ import { MigrationInterface, QueryRunner } from "typeorm";
  * history stays attached to the surviving project instead of being swept up by
  * the new cascade.
  *
+ * The cascade has a second, deliberate effect: deleting a *custom* state now
+ * removes that state's timeline rows project-wide instead of failing with
+ * 23503, and does so below IncidentStateTimelineService.onBeforeDelete, so the
+ * surrounding rows' `endsAt` is not stitched over the gap. The default
+ * created / acknowledged / resolved states cannot be deleted (the dashboard
+ * blocks it) and a state any incident is currently in is still protected by
+ * Incident.currentIncidentStateId, which keeps NO ACTION.
+ *
  * Not covered on purpose:
- *   - Monitor.currentMonitorStatusId keeps NO ACTION (deleting a status that
- *     monitors are currently in should stay blocked) and its cross-project
- *     rows were already repaired by the 1785240000000 migration.
+ *   - Monitor.currentMonitorStatusId keeps NO ACTION: deleting a status that
+ *     monitors are currently in should stay blocked, and its cross-project
+ *     rows were already repaired by the 1785240000000 migration. Note that
+ *     repair was one-shot — MonitorService now validates the column on write
+ *     so the state cannot come back.
  *   - A row whose own project has no record of that kind at all cannot be
- *     repointed and, for the not-null columns, is left as is. That needs a
- *     project with zero incident states / severities, which project creation
- *     does not produce.
+ *     repointed and, for the not-null columns, is left as is. This is
+ *     reachable: nothing stops a project from deleting its last incident
+ *     severity while its only incident references another project's. Those
+ *     rows are counted and logged at the end of up() rather than skipped
+ *     silently, because the project stays undeletable until someone acts.
  */
 
 export interface CrossProjectReference {
@@ -317,8 +330,15 @@ export const TIMELINE_FOREIGN_KEYS: Array<TimelineForeignKey> = [
 
 /*
  * Repoints rows whose reference belongs to another project at the equivalent
- * record in their own project. Match order is name, then role flags, then
- * nearest order/priority — the same ladder the 1785240000000 migration used.
+ * record in their own project.
+ *
+ * The ladder is: same name AND same role, then same role, then same name, then
+ * nearest order/priority. Role outranks a bare name match on purpose — a
+ * project is free to have a custom state literally called "Resolved" that is
+ * NOT its resolved state, and matching that one would quietly un-resolve a
+ * resolved incident. The 1785240000000 migration tried name before role; that
+ * ordering is only safe for records with no role at all (severities), which is
+ * why it never bit there.
  */
 export function getRepairQuery(reference: CrossProjectReference): string {
   const roleSelect: string = reference.roleColumns
@@ -327,16 +347,23 @@ export function getRepairQuery(reference: CrossProjectReference): string {
     })
     .join("");
 
-  const roleMatch: string =
+  const rolePredicate: string = reference.roleColumns
+    .map((roleColumn: string) => {
+      return `x."${roleColumn}" = b.role_${roleColumn}`;
+    })
+    .join("\n              AND ");
+
+  const roleMatches: string =
     reference.roleColumns.length > 0
       ? `
           (SELECT x."_id" FROM "${reference.referencedTable}" x
             WHERE x."projectId" = b.project_id
-              AND ${reference.roleColumns
-                .map((roleColumn: string) => {
-                  return `x."${roleColumn}" = b.role_${roleColumn}`;
-                })
-                .join("\n              AND ")}
+              AND lower(x."name") = lower(b.ref_name)
+              AND ${rolePredicate}
+            ORDER BY x."${reference.orderColumn}" LIMIT 1),
+          (SELECT x."_id" FROM "${reference.referencedTable}" x
+            WHERE x."projectId" = b.project_id
+              AND ${rolePredicate}
             ORDER BY x."${reference.orderColumn}" LIMIT 1),`
       : "";
 
@@ -350,10 +377,10 @@ export function getRepairQuery(reference: CrossProjectReference): string {
         JOIN "${reference.referencedTable}" p ON p."_id" = c."${reference.column}"
         WHERE c."projectId" IS DISTINCT FROM p."projectId"
       ), resolved AS (
-        SELECT b.row_id, COALESCE(
+        SELECT b.row_id, COALESCE(${roleMatches}
           (SELECT x."_id" FROM "${reference.referencedTable}" x
             WHERE x."projectId" = b.project_id AND lower(x."name") = lower(b.ref_name)
-            ORDER BY x."${reference.orderColumn}" LIMIT 1),${roleMatch}
+            ORDER BY x."${reference.orderColumn}" LIMIT 1),
           (SELECT x."_id" FROM "${reference.referencedTable}" x
             WHERE x."projectId" = b.project_id
             ORDER BY abs(x."${reference.orderColumn}" - b.ref_order), x."${reference.orderColumn}" LIMIT 1)
@@ -364,6 +391,22 @@ export function getRepairQuery(reference: CrossProjectReference): string {
       SET "${reference.column}" = r.good_id
       FROM resolved r
       WHERE c."_id" = r.row_id AND r.good_id IS NOT NULL
+    `;
+}
+
+/*
+ * Counts what is still cross-project after the repair and the clear. A row
+ * only survives both when its own project has no record of that kind to point
+ * at — rare, but silent: the project stays undeletable and the user retries
+ * and sees the identical error with nothing to act on. Log it so an operator
+ * has a name to chase.
+ */
+export function getRemainingQuery(reference: CrossProjectReference): string {
+  return `
+      SELECT count(*)::int AS remaining
+      FROM "${reference.table}" c
+      JOIN "${reference.referencedTable}" p ON p."_id" = c."${reference.column}"
+      WHERE c."projectId" IS DISTINCT FROM p."projectId"
     `;
 }
 
@@ -391,11 +434,16 @@ export class RepairCrossProjectIncidentReferences1785320000000
   public async up(queryRunner: QueryRunner): Promise<void> {
     /*
      * The repairs below scan the incident/alert/timeline tables, which run to
-     * millions of rows. The connection carries the app's 30s statement_timeout
-     * (DATABASE_STATEMENT_TIMEOUT_MS) and a loaded database should not turn
-     * this into a failed deploy.
+     * millions of rows. Raising the server-side statement_timeout only helps
+     * when the operator has also raised DATABASE_QUERY_TIMEOUT_MS: that one is
+     * a client-side deadline in node-postgres (DataSourceOptions passes it as
+     * `extra.query_timeout`) and no SET can lift it. When the client gives up
+     * first the server keeps executing, so the ceiling here is deliberately
+     * reset before the DDL below rather than left in place.
      */
     await queryRunner.query(`SET LOCAL statement_timeout = '600s'`);
+
+    const unrepaired: Array<string> = [];
 
     for (const reference of CROSS_PROJECT_REFERENCES) {
       await queryRunner.query(getRepairQuery(reference));
@@ -403,14 +451,49 @@ export class RepairCrossProjectIncidentReferences1785320000000
       if (reference.isNullable) {
         await queryRunner.query(getClearQuery(reference));
       }
+
+      const remaining: Array<{ remaining: number }> = await queryRunner.query(
+        getRemainingQuery(reference),
+      );
+
+      const remainingCount: number = remaining?.[0]?.remaining || 0;
+
+      if (remainingCount > 0) {
+        unrepaired.push(
+          `${reference.table}.${reference.column} (${remainingCount})`,
+        );
+      }
     }
+
+    if (unrepaired.length > 0) {
+      /*
+       * Not fatal: these rows keep their project undeletable, but failing the
+       * deploy over them would be worse than reporting them. Each one needs a
+       * record of that kind to exist in the row's own project before it can be
+       * repointed.
+       */
+      logger.warn(
+        `RepairCrossProjectIncidentReferences: could not repoint every cross-project reference; the projects they point at stay undeletable until a matching record exists in the owning project. Remaining: ${unrepaired.join(
+          ", ",
+        )}`,
+      );
+    }
+
+    /*
+     * Back to the connection's configured ceiling before taking any lock. A
+     * slow ADD CONSTRAINT that outlives the client timeout would otherwise sit
+     * there holding ACCESS EXCLUSIVE — with the queued ROLLBACK timing out too
+     * — long after the deploy already reported failure. Aborting server-side
+     * is the cheaper failure.
+     */
+    await queryRunner.query(`SET LOCAL statement_timeout = DEFAULT`);
 
     /*
      * Swapping a foreign key needs ACCESS EXCLUSIVE on the timeline table, and
      * the lock is held until this migration commits. The server has no
      * lock_timeout, so without the line below a single slow transaction
      * holding one of these tables would make the statement queue *and* park
-     * every reader and writer behind it until the 30s statement_timeout fired.
+     * every reader and writer behind it until the statement timeout fired.
      * Failing fast and retrying the deploy is much cheaper than stalling the
      * table.
      */

--- a/Common/Server/Services/AlertEpisodeService.ts
+++ b/Common/Server/Services/AlertEpisodeService.ts
@@ -32,6 +32,9 @@ import {
 import URL from "../../Types/API/URL";
 import DatabaseConfig from "../DatabaseConfig";
 import AlertSeverityService from "./AlertSeverityService";
+import ProjectScopedReferenceValidator, {
+  resolveReferenceId,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import AlertEpisodeMemberService from "./AlertEpisodeMemberService";
 import AlertEpisodeOwnerUserService from "./AlertEpisodeOwnerUserService";
 import AlertEpisodeOwnerTeamService from "./AlertEpisodeOwnerTeamService";
@@ -94,6 +97,36 @@ export class Service extends DatabaseService<Model> {
       updateBy.query,
       updateBy.props,
     );
+
+    /*
+     * An episode carries the same project-scoped state and severity an alert
+     * does, on FKs that are equally ON DELETE NO ACTION, so an id from another
+     * project here leaves that project undeletable in exactly the same way.
+     * onBeforeCreate overwrites currentAlertStateId with this project's
+     * created state, which leaves the severity as the only create-reachable
+     * column — but an update can write either.
+     */
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: updateBy.props.tenantId,
+      subject: "alert episode",
+      references: [
+        {
+          modelName: "Alert State",
+          id:
+            resolveReferenceId(updateBy.data.currentAlertStateId) ||
+            resolveReferenceId(updateBy.data.currentAlertState),
+          service: AlertStateService,
+        },
+        {
+          modelName: "Alert Severity",
+          id:
+            resolveReferenceId(updateBy.data.alertSeverityId) ||
+            resolveReferenceId(updateBy.data.alertSeverity),
+          service: AlertSeverityService,
+        },
+      ],
+    });
+
     return { updateBy, carryForward: null };
   }
 
@@ -140,6 +173,20 @@ export class Service extends DatabaseService<Model> {
     }
 
     createBy.data.currentAlertStateId = alertState.id;
+
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: projectId,
+      subject: "alert episode",
+      references: [
+        {
+          modelName: "Alert Severity",
+          id:
+            resolveReferenceId(createBy.data.alertSeverityId) ||
+            resolveReferenceId(createBy.data.alertSeverity),
+          service: AlertSeverityService,
+        },
+      ],
+    });
 
     // Auto-generate episode number
     const episodeCounterResult: {

--- a/Common/Server/Services/AlertService.ts
+++ b/Common/Server/Services/AlertService.ts
@@ -29,9 +29,10 @@ import Model from "../../Models/DatabaseModels/Alert";
 import AlertOwnerTeam from "../../Models/DatabaseModels/AlertOwnerTeam";
 import AlertOwnerUser from "../../Models/DatabaseModels/AlertOwnerUser";
 import AlertState from "../../Models/DatabaseModels/AlertState";
-import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusService from "./MonitorStatusService";
-import ProjectScopedReferenceValidator from "../Utils/Database/ProjectScopedReferenceValidator";
+import ProjectScopedReferenceValidator, {
+  resolveReferenceId,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import AlertStateTimeline from "../../Models/DatabaseModels/AlertStateTimeline";
 import User from "../../Models/DatabaseModels/User";
 import { IsBillingEnabled } from "../EnvironmentConfig";
@@ -277,24 +278,18 @@ export class Service extends DatabaseService<Model> {
     updateBy: UpdateBy<Model>,
   ): Promise<void> {
     const alertStateId: ObjectID | string | undefined =
-      (updateBy.data.currentAlertStateId as unknown as ObjectID | undefined) ||
-      (updateBy.data.currentAlertState as unknown as AlertState | undefined)
-        ?._id;
+      resolveReferenceId(updateBy.data.currentAlertStateId) ||
+      resolveReferenceId(updateBy.data.currentAlertState);
 
     const alertSeverityId: ObjectID | string | undefined =
-      (updateBy.data.alertSeverityId as unknown as ObjectID | undefined) ||
-      (updateBy.data.alertSeverity as unknown as AlertSeverity | undefined)
-        ?._id;
+      resolveReferenceId(updateBy.data.alertSeverityId) ||
+      resolveReferenceId(updateBy.data.alertSeverity);
 
     const monitorStatusId: ObjectID | string | undefined =
-      (updateBy.data.monitorStatusWhenThisAlertWasCreatedId as unknown as
-        | ObjectID
-        | undefined) ||
-      (
-        updateBy.data.monitorStatusWhenThisAlertWasCreated as unknown as
-          | MonitorStatus
-          | undefined
-      )?._id;
+      resolveReferenceId(
+        updateBy.data.monitorStatusWhenThisAlertWasCreatedId,
+      ) ||
+      resolveReferenceId(updateBy.data.monitorStatusWhenThisAlertWasCreated);
 
     if (!alertStateId && !alertSeverityId && !monitorStatusId) {
       return;
@@ -405,19 +400,19 @@ export class Service extends DatabaseService<Model> {
         {
           modelName: "Alert Severity",
           id:
-            createBy.data.alertSeverityId ||
-            (createBy.data.alertSeverity as AlertSeverity | undefined)?._id,
+            resolveReferenceId(createBy.data.alertSeverityId) ||
+            resolveReferenceId(createBy.data.alertSeverity),
           service: AlertSeverityService,
         },
         {
           modelName: "Monitor Status",
           id:
-            createBy.data.monitorStatusWhenThisAlertWasCreatedId ||
-            (
-              createBy.data.monitorStatusWhenThisAlertWasCreated as
-                | MonitorStatus
-                | undefined
-            )?._id,
+            resolveReferenceId(
+              createBy.data.monitorStatusWhenThisAlertWasCreatedId,
+            ) ||
+            resolveReferenceId(
+              createBy.data.monitorStatusWhenThisAlertWasCreated,
+            ),
           service: MonitorStatusService,
         },
       ],

--- a/Common/Server/Services/IncidentEpisodeService.ts
+++ b/Common/Server/Services/IncidentEpisodeService.ts
@@ -27,6 +27,9 @@ import { Red500, Yellow500, Purple500 } from "../../Types/BrandColors";
 import URL from "../../Types/API/URL";
 import DatabaseConfig from "../DatabaseConfig";
 import IncidentSeverityService from "./IncidentSeverityService";
+import ProjectScopedReferenceValidator, {
+  resolveReferenceId,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import IncidentEpisodeMemberService from "./IncidentEpisodeMemberService";
 import IncidentEpisodeOwnerUserService from "./IncidentEpisodeOwnerUserService";
 import IncidentEpisodeOwnerTeamService from "./IncidentEpisodeOwnerTeamService";
@@ -90,6 +93,36 @@ export class Service extends DatabaseService<Model> {
       updateBy.query,
       updateBy.props,
     );
+
+    /*
+     * An episode carries the same project-scoped state and severity an
+     * incident does, on FKs that are equally ON DELETE NO ACTION, so an id
+     * from another project here leaves that project undeletable in exactly
+     * the same way. onBeforeCreate overwrites currentIncidentStateId with
+     * this project's created state, which leaves the severity as the only
+     * create-reachable column — but an update can write either.
+     */
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: updateBy.props.tenantId,
+      subject: "incident episode",
+      references: [
+        {
+          modelName: "Incident State",
+          id:
+            resolveReferenceId(updateBy.data.currentIncidentStateId) ||
+            resolveReferenceId(updateBy.data.currentIncidentState),
+          service: IncidentStateService,
+        },
+        {
+          modelName: "Incident Severity",
+          id:
+            resolveReferenceId(updateBy.data.incidentSeverityId) ||
+            resolveReferenceId(updateBy.data.incidentSeverity),
+          service: IncidentSeverityService,
+        },
+      ],
+    });
+
     return { updateBy, carryForward: null };
   }
 
@@ -139,6 +172,20 @@ export class Service extends DatabaseService<Model> {
     }
 
     createBy.data.currentIncidentStateId = incidentState.id;
+
+    await ProjectScopedReferenceValidator.validateReferencesBelongToProject({
+      projectId: projectId,
+      subject: "incident episode",
+      references: [
+        {
+          modelName: "Incident Severity",
+          id:
+            resolveReferenceId(createBy.data.incidentSeverityId) ||
+            resolveReferenceId(createBy.data.incidentSeverity),
+          service: IncidentSeverityService,
+        },
+      ],
+    });
 
     // Auto-generate episode number
     const episodeCounterResult: {

--- a/Common/Server/Services/IncidentService.ts
+++ b/Common/Server/Services/IncidentService.ts
@@ -28,7 +28,9 @@ import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import Typeof from "../../Types/Typeof";
 import { applyIncidentSelfPrivacyFilter } from "../Utils/Incident/IncidentPrivacyFilter";
-import ProjectScopedReferenceValidator from "../Utils/Database/ProjectScopedReferenceValidator";
+import ProjectScopedReferenceValidator, {
+  resolveReferenceId,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import UserNotificationEventType from "../../Types/UserNotification/UserNotificationEventType";
 import StatusPageSubscriberNotificationStatus from "../../Types/StatusPage/StatusPageSubscriberNotificationStatus";
 import DockerHost from "../../Models/DatabaseModels/DockerHost";
@@ -565,32 +567,16 @@ export class Service extends DatabaseService<Model> {
     updateBy: UpdateBy<Model>,
   ): Promise<void> {
     const incidentStateId: ObjectID | string | undefined =
-      (updateBy.data.currentIncidentStateId as unknown as
-        | ObjectID
-        | undefined) ||
-      (
-        updateBy.data.currentIncidentState as unknown as
-          | IncidentState
-          | undefined
-      )?._id;
+      resolveReferenceId(updateBy.data.currentIncidentStateId) ||
+      resolveReferenceId(updateBy.data.currentIncidentState);
 
     const incidentSeverityId: ObjectID | string | undefined =
-      (updateBy.data.incidentSeverityId as unknown as ObjectID | undefined) ||
-      (
-        updateBy.data.incidentSeverity as unknown as
-          | IncidentSeverity
-          | undefined
-      )?._id;
+      resolveReferenceId(updateBy.data.incidentSeverityId) ||
+      resolveReferenceId(updateBy.data.incidentSeverity);
 
     const changeMonitorStatusToId: ObjectID | string | undefined =
-      (updateBy.data.changeMonitorStatusToId as unknown as
-        | ObjectID
-        | undefined) ||
-      (
-        updateBy.data.changeMonitorStatusTo as unknown as
-          | MonitorStatus
-          | undefined
-      )?._id;
+      resolveReferenceId(updateBy.data.changeMonitorStatusToId) ||
+      resolveReferenceId(updateBy.data.changeMonitorStatusTo);
 
     if (!incidentStateId && !incidentSeverityId && !changeMonitorStatusToId) {
       return;
@@ -955,17 +941,15 @@ export class Service extends DatabaseService<Model> {
         {
           modelName: "Incident Severity",
           id:
-            createBy.data.incidentSeverityId ||
-            (createBy.data.incidentSeverity as IncidentSeverity | undefined)
-              ?._id,
+            resolveReferenceId(createBy.data.incidentSeverityId) ||
+            resolveReferenceId(createBy.data.incidentSeverity),
           service: IncidentSeverityService,
         },
         {
           modelName: "Monitor Status",
           id:
-            createBy.data.changeMonitorStatusToId ||
-            (createBy.data.changeMonitorStatusTo as MonitorStatus | undefined)
-              ?._id,
+            resolveReferenceId(createBy.data.changeMonitorStatusToId) ||
+            resolveReferenceId(createBy.data.changeMonitorStatusTo),
           service: MonitorStatusService,
         },
       ],

--- a/Common/Server/Services/IncidentTemplateService.ts
+++ b/Common/Server/Services/IncidentTemplateService.ts
@@ -13,13 +13,11 @@ import Dictionary from "../../Types/Dictionary";
 import ObjectID from "../../Types/ObjectID";
 import Typeof from "../../Types/Typeof";
 import Model from "../../Models/DatabaseModels/IncidentTemplate";
-import IncidentSeverity from "../../Models/DatabaseModels/IncidentSeverity";
-import IncidentState from "../../Models/DatabaseModels/IncidentState";
 import IncidentTemplateOwnerTeam from "../../Models/DatabaseModels/IncidentTemplateOwnerTeam";
 import IncidentTemplateOwnerUser from "../../Models/DatabaseModels/IncidentTemplateOwnerUser";
-import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import ProjectScopedReferenceValidator, {
   ProjectScopedReference,
+  resolveReferenceId,
 } from "../Utils/Database/ProjectScopedReferenceValidator";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
@@ -92,22 +90,22 @@ export class Service extends DatabaseService<Model> {
       {
         modelName: "Incident State",
         id:
-          (data.initialIncidentStateId as ObjectID | undefined) ||
-          (data.initialIncidentState as IncidentState | undefined)?._id,
+          resolveReferenceId(data.initialIncidentStateId) ||
+          resolveReferenceId(data.initialIncidentState),
         service: IncidentStateService,
       },
       {
         modelName: "Incident Severity",
         id:
-          (data.incidentSeverityId as ObjectID | undefined) ||
-          (data.incidentSeverity as IncidentSeverity | undefined)?._id,
+          resolveReferenceId(data.incidentSeverityId) ||
+          resolveReferenceId(data.incidentSeverity),
         service: IncidentSeverityService,
       },
       {
         modelName: "Monitor Status",
         id:
-          (data.changeMonitorStatusToId as ObjectID | undefined) ||
-          (data.changeMonitorStatusTo as MonitorStatus | undefined)?._id,
+          resolveReferenceId(data.changeMonitorStatusToId) ||
+          resolveReferenceId(data.changeMonitorStatusTo),
         service: MonitorStatusService,
       },
     ];

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -70,6 +70,9 @@ import WorkspaceNotificationRuleService, {
   MessageBlocksByWorkspaceType,
 } from "./WorkspaceNotificationRuleService";
 import MonitorStepsProjectValidator from "../Utils/Monitor/MonitorStepsProjectValidator";
+import ProjectScopedReferenceValidator, {
+  resolveReferenceId,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import MonitorWorkspaceMessages from "../Utils/Workspace/WorkspaceMessages/Monitor";
 import MonitorFeedService from "./MonitorFeedService";
 import { MonitorFeedEventType } from "../../Models/DatabaseModels/MonitorFeed";
@@ -388,7 +391,19 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
-    if (updateBy.data.monitorSteps) {
+    /*
+     * currentMonitorStatusId is writable by any project member and its FK is
+     * ON DELETE NO ACTION, so an id from another project here leaves that
+     * project undeletable — the same shape monitorSteps had. The
+     * 1785240000000 migration repaired the rows that existed then; this stops
+     * new ones. It stays NO ACTION on purpose: deleting a status monitors are
+     * currently in should be blocked, not cascaded.
+     */
+    const currentMonitorStatusId: ObjectID | string | undefined =
+      resolveReferenceId(updateBy.data.currentMonitorStatusId) ||
+      resolveReferenceId(updateBy.data.currentMonitorStatus);
+
+    if (updateBy.data.monitorSteps || currentMonitorStatusId) {
       /*
        * Root/API updates do not always carry a tenantId, so fall back to the
        * project of each monitor the query actually matches.
@@ -398,10 +413,30 @@ export class Service extends DatabaseService<Model> {
         : await this.getProjectIdsForUpdateQuery(updateBy);
 
       for (const projectId of projectIds) {
-        await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject({
-          monitorSteps: updateBy.data.monitorSteps as MonitorSteps | JSONObject,
-          projectId: projectId,
-        });
+        if (updateBy.data.monitorSteps) {
+          await MonitorStepsProjectValidator.validateMonitorStepsBelongToProject(
+            {
+              monitorSteps: updateBy.data.monitorSteps as
+                | MonitorSteps
+                | JSONObject,
+              projectId: projectId,
+            },
+          );
+        }
+
+        await ProjectScopedReferenceValidator.validateReferencesBelongToProject(
+          {
+            projectId: projectId,
+            subject: "monitor",
+            references: [
+              {
+                modelName: "Monitor Status",
+                id: currentMonitorStatusId,
+                service: MonitorStatusService,
+              },
+            ],
+          },
+        );
       }
     }
 

--- a/Common/Server/Services/ScheduledMaintenanceService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceService.ts
@@ -24,9 +24,10 @@ import Model from "../../Models/DatabaseModels/ScheduledMaintenance";
 import ScheduledMaintenanceOwnerTeam from "../../Models/DatabaseModels/ScheduledMaintenanceOwnerTeam";
 import ScheduledMaintenanceOwnerUser from "../../Models/DatabaseModels/ScheduledMaintenanceOwnerUser";
 import ScheduledMaintenanceState from "../../Models/DatabaseModels/ScheduledMaintenanceState";
-import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusService from "./MonitorStatusService";
-import ProjectScopedReferenceValidator from "../Utils/Database/ProjectScopedReferenceValidator";
+import ProjectScopedReferenceValidator, {
+  resolveReferenceId,
+} from "../Utils/Database/ProjectScopedReferenceValidator";
 import ScheduledMaintenanceStateTimeline from "../../Models/DatabaseModels/ScheduledMaintenanceStateTimeline";
 import User from "../../Models/DatabaseModels/User";
 import Recurring from "../../Types/Events/Recurring";
@@ -621,24 +622,12 @@ ${resourcesAffected ? `**Resources Affected:** ${resourcesAffected}` : ""}
     updateBy: UpdateBy<Model>,
   ): Promise<void> {
     const stateId: ObjectID | string | undefined =
-      (updateBy.data.currentScheduledMaintenanceStateId as unknown as
-        | ObjectID
-        | undefined) ||
-      (
-        updateBy.data.currentScheduledMaintenanceState as unknown as
-          | ScheduledMaintenanceState
-          | undefined
-      )?._id;
+      resolveReferenceId(updateBy.data.currentScheduledMaintenanceStateId) ||
+      resolveReferenceId(updateBy.data.currentScheduledMaintenanceState);
 
     const monitorStatusId: ObjectID | string | undefined =
-      (updateBy.data.changeMonitorStatusToId as unknown as
-        | ObjectID
-        | undefined) ||
-      (
-        updateBy.data.changeMonitorStatusTo as unknown as
-          | MonitorStatus
-          | undefined
-      )?._id;
+      resolveReferenceId(updateBy.data.changeMonitorStatusToId) ||
+      resolveReferenceId(updateBy.data.changeMonitorStatusTo);
 
     if (!stateId && !monitorStatusId) {
       return;
@@ -865,9 +854,8 @@ ${resourcesAffected ? `**Resources Affected:** ${resourcesAffected}` : ""}
         {
           modelName: "Monitor Status",
           id:
-            createBy.data.changeMonitorStatusToId ||
-            (createBy.data.changeMonitorStatusTo as MonitorStatus | undefined)
-              ?._id,
+            resolveReferenceId(createBy.data.changeMonitorStatusToId) ||
+            resolveReferenceId(createBy.data.changeMonitorStatusTo),
           service: MonitorStatusService,
         },
       ],

--- a/Common/Server/Services/ScheduledMaintenanceTemplateService.ts
+++ b/Common/Server/Services/ScheduledMaintenanceTemplateService.ts
@@ -6,11 +6,11 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import ObjectID from "../../Types/ObjectID";
 import Typeof from "../../Types/Typeof";
 import Model from "../../Models/DatabaseModels/ScheduledMaintenanceTemplate";
-import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusService from "./MonitorStatusService";
 import Dictionary from "../../Types/Dictionary";
 import ProjectScopedReferenceValidator, {
   ProjectScopedReference,
+  resolveReferenceId,
 } from "../Utils/Database/ProjectScopedReferenceValidator";
 import ScheduledMaintenanceTemplateOwnerTeam from "../../Models/DatabaseModels/ScheduledMaintenanceTemplateOwnerTeam";
 import ScheduledMaintenanceTemplateOwnerUser from "../../Models/DatabaseModels/ScheduledMaintenanceTemplateOwnerUser";
@@ -316,9 +316,8 @@ export class Service extends DatabaseService<Model> {
       {
         modelName: "Monitor Status",
         id:
-          (data.changeMonitorStatusToId as unknown as ObjectID | undefined) ||
-          (data.changeMonitorStatusTo as unknown as MonitorStatus | undefined)
-            ?._id,
+          resolveReferenceId(data.changeMonitorStatusToId) ||
+          resolveReferenceId(data.changeMonitorStatusTo),
         service: MonitorStatusService,
       },
     ];

--- a/Common/Server/Utils/Database/ProjectScopedReferenceValidator.ts
+++ b/Common/Server/Utils/Database/ProjectScopedReferenceValidator.ts
@@ -1,4 +1,5 @@
 import DatabaseService from "../../Services/DatabaseService";
+import Query from "../../Types/Database/Query";
 import QueryHelper from "../../Types/Database/QueryHelper";
 import Select from "../../Types/Database/Select";
 import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
@@ -38,6 +39,35 @@ export interface ProjectScopedReference {
 interface ForeignReference {
   modelName: string;
   name: string;
+}
+
+/*
+ * The same reference reaches a service hook in several shapes: the id column
+ * (`incidentSeverityId`), a relation object (`incidentSeverity: { _id }`), an
+ * ObjectID in either slot, or — on the update path — a bare uuid string in the
+ * relation slot, which DatabaseService.sanitizeCreateOrUpdate only turns into
+ * a relation entity *after* onBeforeUpdate has run. Reading `?._id` alone
+ * misses the string shape and the guard would silently pass.
+ */
+export function resolveReferenceId(
+  value: unknown,
+): ObjectID | string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof ObjectID) {
+    return value;
+  }
+
+  const relation: { _id?: string | undefined; id?: ObjectID | undefined } =
+    value as { _id?: string | undefined; id?: ObjectID | undefined };
+
+  return relation._id || relation.id || undefined;
 }
 
 export default class ProjectScopedReferenceValidator {
@@ -138,5 +168,45 @@ export default class ProjectScopedReferenceValidator {
         data.subject || "request"
       } references records that belong to a different project: ${described}. Please pick values from this project and try again.`,
     );
+  }
+
+  /*
+   * "Can this project actually use this record?" — for callers that must not
+   * throw. The probe and telemetry ingest workers build incidents and alerts
+   * from monitor criteria, whose stored ids may still point at another
+   * project (monitorSteps repair could not always resolve them). Throwing
+   * there fails the whole ingest job for that monitor, so those callers ask
+   * this instead and fall back to their project's own default.
+   *
+   * Note the deliberate difference from validateReferencesBelongToProject: an
+   * id that matches NO record is unusable here (false), while the write guard
+   * lets it pass so a record already pointing at something deleted stays
+   * saveable.
+   */
+  public static async isUsableInProject(data: {
+    projectId: ObjectID | undefined;
+    id: ObjectID | string | undefined | null;
+    service: DatabaseService<DatabaseBaseModel>;
+  }): Promise<boolean> {
+    const id: string = data.id?.toString() || "";
+
+    if (!id || !data.projectId) {
+      return false;
+    }
+
+    const record: DatabaseBaseModel | null = await data.service.findOneBy({
+      query: {
+        _id: id,
+        projectId: data.projectId,
+      } as Query<DatabaseBaseModel>,
+      select: {
+        _id: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return Boolean(record);
   }
 }

--- a/Common/Server/Utils/Monitor/MonitorAlert.ts
+++ b/Common/Server/Utils/Monitor/MonitorAlert.ts
@@ -22,6 +22,7 @@ import { TelemetryQuery } from "../../../Types/Telemetry/TelemetryQuery";
 import { DisableAutomaticAlertCreation } from "../../EnvironmentConfig";
 import AlertService from "../../Services/AlertService";
 import AlertSeverityService from "../../Services/AlertSeverityService";
+import ProjectScopedReferenceValidator from "../Database/ProjectScopedReferenceValidator";
 import AlertStateTimelineService from "../../Services/AlertStateTimelineService";
 import HostService from "../../Services/HostService";
 import NetworkDeviceOwnerUserService, {
@@ -420,7 +421,33 @@ export default class MonitorAlert {
           storageMap,
         });
 
-        if (!criteriaAlert.alertSeverityId) {
+        /*
+         * A criteria severity belonging to *another* project is rejected by
+         * AlertService on create. Throwing here would fail the whole
+         * probe/telemetry ingest job for this monitor, so treat it as
+         * "missing" and fall back to this project's own default — which is
+         * also what stops the bad id spreading onto new alerts. See the same
+         * fallback in MonitorIncident.
+         */
+        const isCriteriaSeverityUsable: boolean =
+          await ProjectScopedReferenceValidator.isUsableInProject({
+            projectId: input.monitor.projectId!,
+            id: criteriaAlert.alertSeverityId,
+            service: AlertSeverityService,
+          });
+
+        if (
+          criteriaAlert.alertSeverityId?.toString() &&
+          !isCriteriaSeverityUsable
+        ) {
+          logger.error(
+            `${input.monitor.id?.toString()} - Criteria "${
+              input.criteriaInstance.data?.name
+            }" references alert severity ${criteriaAlert.alertSeverityId.toString()}, which does not belong to project ${input.monitor.projectId?.toString()}. Falling back to this project's default severity.`,
+          );
+        }
+
+        if (!isCriteriaSeverityUsable) {
           // pick the critical criteria.
 
           const severity: AlertSeverity | null =

--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -34,6 +34,7 @@ import PodmanHostService from "../../Services/PodmanHostService";
 import ProxmoxClusterService from "../../Services/ProxmoxClusterService";
 import ServiceService from "../../Services/ServiceService";
 import IncidentSeverityService from "../../Services/IncidentSeverityService";
+import ProjectScopedReferenceValidator from "../Database/ProjectScopedReferenceValidator";
 import IncidentStateTimelineService from "../../Services/IncidentStateTimelineService";
 import IncidentMemberService from "../../Services/IncidentMemberService";
 import NetworkDeviceOwnerUserService, {
@@ -505,7 +506,35 @@ export default class MonitorIncident {
          * Use `?.toString()` truthiness so an empty/blank ObjectID is treated
          * the same as "missing" and falls through to the project-default lookup.
          */
-        if (!criteriaIncident.incidentSeverityId?.toString()) {
+        /*
+         * A criteria severity that belongs to *another* project is rejected by
+         * IncidentService on create. Throwing here would fail the whole
+         * probe/telemetry ingest job for this monitor — no incident, and no
+         * payload or monitor log persisted either, because those run after the
+         * create. Treat it as "missing" and fall back to this project's own
+         * default, which is also what stops the bad id spreading onto new
+         * incidents. monitorSteps can still hold one: the 1785240000000
+         * repair skipped ids it could not resolve.
+         */
+        const isCriteriaSeverityUsable: boolean =
+          await ProjectScopedReferenceValidator.isUsableInProject({
+            projectId: input.monitor.projectId!,
+            id: criteriaIncident.incidentSeverityId,
+            service: IncidentSeverityService,
+          });
+
+        if (
+          criteriaIncident.incidentSeverityId?.toString() &&
+          !isCriteriaSeverityUsable
+        ) {
+          logger.error(
+            `${input.monitor.id?.toString()} - Criteria "${
+              input.criteriaInstance.data?.name
+            }" references incident severity ${criteriaIncident.incidentSeverityId.toString()}, which does not belong to project ${input.monitor.projectId?.toString()}. Falling back to this project's default severity.`,
+          );
+        }
+
+        if (!isCriteriaSeverityUsable) {
           // pick the critical (first/lowest-order root) severity.
 
           const severity: IncidentSeverity | null =
@@ -550,7 +579,7 @@ export default class MonitorIncident {
 
           incident.incidentSeverityId = severity.id!;
         } else {
-          incident.incidentSeverityId = criteriaIncident.incidentSeverityId;
+          incident.incidentSeverityId = criteriaIncident.incidentSeverityId!;
         }
 
         incident.monitors = [input.monitor];

--- a/Common/Tests/Server/Services/CrossProjectReferenceWriteGuard.test.ts
+++ b/Common/Tests/Server/Services/CrossProjectReferenceWriteGuard.test.ts
@@ -1,33 +1,54 @@
+import AlertEpisodeService from "../../../Server/Services/AlertEpisodeService";
 import AlertService from "../../../Server/Services/AlertService";
+import AlertSeverityService from "../../../Server/Services/AlertSeverityService";
 import AlertStateService from "../../../Server/Services/AlertStateService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
 import IncidentService from "../../../Server/Services/IncidentService";
+import IncidentSeverityService from "../../../Server/Services/IncidentSeverityService";
 import IncidentStateService from "../../../Server/Services/IncidentStateService";
 import IncidentTemplateService from "../../../Server/Services/IncidentTemplateService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorStatusService from "../../../Server/Services/MonitorStatusService";
 import ProjectService from "../../../Server/Services/ProjectService";
 import ScheduledMaintenanceService from "../../../Server/Services/ScheduledMaintenanceService";
 import ScheduledMaintenanceStateService from "../../../Server/Services/ScheduledMaintenanceStateService";
+import ScheduledMaintenanceTemplateService from "../../../Server/Services/ScheduledMaintenanceTemplateService";
+import DatabaseService from "../../../Server/Services/DatabaseService";
 import ProjectScopedReferenceValidator from "../../../Server/Utils/Database/ProjectScopedReferenceValidator";
+import DatabaseBaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import Alert from "../../../Models/DatabaseModels/Alert";
+import AlertEpisode from "../../../Models/DatabaseModels/AlertEpisode";
 import AlertState from "../../../Models/DatabaseModels/AlertState";
 import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentEpisode from "../../../Models/DatabaseModels/IncidentEpisode";
 import IncidentState from "../../../Models/DatabaseModels/IncidentState";
 import IncidentTemplate from "../../../Models/DatabaseModels/IncidentTemplate";
 import ScheduledMaintenance from "../../../Models/DatabaseModels/ScheduledMaintenance";
 import ScheduledMaintenanceState from "../../../Models/DatabaseModels/ScheduledMaintenanceState";
+import ScheduledMaintenanceTemplate from "../../../Models/DatabaseModels/ScheduledMaintenanceTemplate";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
-import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
 
 /*
- * The undeletable project came from writes, not from deletes: an incident was
- * saved holding another project's severity / state / monitor status id, and
+ * The undeletable project came from writes, not from deletes: a record was
+ * saved holding another project's state / severity / monitor status id, and
  * the ON DELETE NO ACTION foreign key then refused to let that other project
  * go. The repair migration cleans up the rows that already exist; these tests
  * cover the other half — the write paths that produced them must now refuse.
  *
- * Each service is checked twice: that it asks the validator about the columns
- * that can carry a foreign id, and that a rejection stops the write before any
- * side effect (notably before the project's incident/alert counter is burned).
+ * Each captured reference is asserted as the full triple (model name, id,
+ * lookup service). The service is the part that picks the table the id is
+ * checked against, so a test that ignores it passes even when a column is
+ * validated against the wrong model — which is exactly what a mutation run
+ * showed the first version of this file doing.
  */
 
 const PROJECT_ID: ObjectID = new ObjectID(
@@ -41,93 +62,142 @@ const MONITOR_STATUS_ID: ObjectID = new ObjectID(
   "8ff02a3f-3f18-4c1d-9db1-6cf27bb2a4a1",
 );
 
-type ValidatorCall = {
-  projectId: ObjectID | undefined;
-  references: Array<{ modelName: string; id: unknown }>;
+// Identity -> readable name, so an assertion can name the service it expects.
+const SERVICE_NAMES: Map<unknown, string> = new Map<unknown, string>([
+  [IncidentStateService, "IncidentStateService"],
+  [IncidentSeverityService, "IncidentSeverityService"],
+  [AlertStateService, "AlertStateService"],
+  [AlertSeverityService, "AlertSeverityService"],
+  [ScheduledMaintenanceStateService, "ScheduledMaintenanceStateService"],
+  [MonitorStatusService, "MonitorStatusService"],
+]);
+
+type CapturedReference = {
+  subject: string;
+  modelName: string;
+  id: string;
+  service: string;
 };
 
-function spyOnValidator(rejects?: boolean): jest.Mock {
-  const spy: jest.Mock = jest.fn(async () => {
-    if (rejects) {
-      throw new BadDataException(
-        "This incident references records that belong to a different project.",
-      );
-    }
-    return undefined;
-  }) as unknown as jest.Mock;
+type ValidatorCall = {
+  projectId: ObjectID | undefined;
+  subject?: string | undefined;
+  references: Array<{
+    modelName: string;
+    id: ObjectID | string | undefined | null;
+    service: DatabaseService<DatabaseBaseModel>;
+  }>;
+};
 
+let captured: Array<CapturedReference> = [];
+let validatorCalls: Array<ValidatorCall> = [];
+
+/*
+ * Records every (subject, model, id, service) the production code asks about,
+ * and optionally rejects. `rejects` throws only when the call carries at least
+ * one id, so a guard that has been emptied out cannot masquerade as a working
+ * one by throwing anyway.
+ */
+function spyOnValidator(rejects?: boolean): void {
   jest
     .spyOn(ProjectScopedReferenceValidator, "validateReferencesBelongToProject")
-    .mockImplementation(spy as never);
+    .mockImplementation((async (data: ValidatorCall): Promise<void> => {
+      validatorCalls.push(data);
 
-  return spy;
+      let hasId: boolean = false;
+
+      for (const reference of data.references) {
+        if (!reference.id) {
+          continue;
+        }
+
+        hasId = true;
+
+        captured.push({
+          subject: data.subject || "",
+          modelName: reference.modelName,
+          id: reference.id.toString(),
+          service: SERVICE_NAMES.get(reference.service) || "UNKNOWN_SERVICE",
+        });
+      }
+
+      if (rejects && hasId) {
+        throw new BadDataException(
+          "This record references records that belong to a different project.",
+        );
+      }
+    }) as never);
 }
 
-function referencedIds(spy: jest.Mock): Record<string, unknown> {
-  const referenced: Record<string, unknown> = {};
-
-  for (const call of spy.mock.calls as unknown as Array<[ValidatorCall]>) {
-    for (const reference of call[0].references) {
-      if (reference.id) {
-        referenced[reference.modelName] = reference.id;
-      }
-    }
-  }
-
-  return referenced;
+function callHook(
+  service: unknown,
+  hook: "onBeforeCreate" | "onBeforeUpdate",
+  payload: unknown,
+): Promise<unknown> {
+  return (service as Record<string, (input: unknown) => Promise<unknown>>)[
+    hook
+  ]!(payload);
 }
 
 describe("cross-project reference guard on write", () => {
+  beforeEach(() => {
+    captured = [];
+    validatorCalls = [];
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe("IncidentService.onBeforeCreate", () => {
-    function mockCreateDeps(): jest.Mock {
+  describe("IncidentService", () => {
+    function mockCreatedState(): void {
       const createdState: IncidentState = new IncidentState();
       createdState._id = STATE_ID.toString();
-
       jest
         .spyOn(IncidentStateService, "findOneBy")
         .mockResolvedValue(createdState as never);
-
-      return jest.fn() as unknown as jest.Mock;
     }
 
-    async function createIncident(data: Partial<Incident>): Promise<void> {
-      await (
-        IncidentService as unknown as {
-          onBeforeCreate: (createBy: unknown) => Promise<unknown>;
-        }
-      ).onBeforeCreate({
-        data: data as Incident,
-        props: { tenantId: PROJECT_ID },
-      });
-    }
-
-    test("checks the state, the severity and the monitor status against the project", async () => {
-      mockCreateDeps();
-      const validator: jest.Mock = spyOnValidator();
+    test("create checks state, severity and monitor status against the right models", async () => {
+      mockCreatedState();
+      spyOnValidator();
       jest
         .spyOn(ProjectService, "incrementAndGetIncidentCounter")
         .mockResolvedValue({ counter: 1, prefix: undefined } as never);
 
-      await createIncident({
-        title: "test",
-        incidentSeverityId: SEVERITY_ID,
-        changeMonitorStatusToId: MONITOR_STATUS_ID,
+      await callHook(IncidentService, "onBeforeCreate", {
+        data: {
+          title: "test",
+          incidentSeverityId: SEVERITY_ID,
+          changeMonitorStatusToId: MONITOR_STATUS_ID,
+        } as Incident,
+        props: { tenantId: PROJECT_ID },
       });
 
-      expect(validator).toHaveBeenCalled();
-      expect(referencedIds(validator)).toEqual({
-        "Incident State": STATE_ID,
-        "Incident Severity": SEVERITY_ID,
-        "Monitor Status": MONITOR_STATUS_ID,
-      });
+      expect(captured).toEqual([
+        {
+          subject: "incident",
+          modelName: "Incident State",
+          id: STATE_ID.toString(),
+          service: "IncidentStateService",
+        },
+        {
+          subject: "incident",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+        {
+          subject: "incident",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
     });
 
-    test("rejects the create, and burns no incident number, when a reference is foreign", async () => {
-      mockCreateDeps();
+    test("create is rejected, and burns no incident number, when a reference is foreign", async () => {
+      mockCreatedState();
       spyOnValidator(true);
       const counter: jest.Mock = jest.fn() as unknown as jest.Mock;
       jest
@@ -135,48 +205,108 @@ describe("cross-project reference guard on write", () => {
         .mockImplementation(counter as never);
 
       await expect(
-        createIncident({ title: "test", incidentSeverityId: SEVERITY_ID }),
+        callHook(IncidentService, "onBeforeCreate", {
+          data: { title: "test", incidentSeverityId: SEVERITY_ID } as Incident,
+          props: { tenantId: PROJECT_ID },
+        }),
       ).rejects.toThrow("belong to a different project");
 
       expect(counter).not.toHaveBeenCalled();
     });
-  });
 
-  describe("IncidentService.onBeforeUpdate", () => {
-    async function updateIncident(
-      data: Partial<Incident>,
-      tenantId?: ObjectID | undefined,
-    ): Promise<void> {
-      await (
-        IncidentService as unknown as {
-          onBeforeUpdate: (updateBy: unknown) => Promise<unknown>;
-        }
-      ).onBeforeUpdate({
-        data: data,
+    test("update checks every reference column it writes", async () => {
+      spyOnValidator();
+
+      /*
+       * Writing changeMonitorStatusToId also sends onBeforeUpdate into its
+       * monitor-status-propagation branch, which reads the matched incidents
+       * with the caller's own props. Unrelated to the guard — stub it out.
+       */
+      jest.spyOn(IncidentService, "findBy").mockResolvedValue([] as never);
+
+      await callHook(IncidentService, "onBeforeUpdate", {
+        data: {
+          currentIncidentStateId: STATE_ID,
+          incidentSeverityId: SEVERITY_ID,
+          changeMonitorStatusToId: MONITOR_STATUS_ID,
+        },
         query: {},
-        props: tenantId ? { tenantId: tenantId } : { isRoot: true },
+        props: { tenantId: PROJECT_ID },
       });
-    }
 
-    test("checks a severity change on update", async () => {
-      const validator: jest.Mock = spyOnValidator();
-
-      await updateIncident({ incidentSeverityId: SEVERITY_ID }, PROJECT_ID);
-
-      expect(referencedIds(validator)).toEqual({
-        "Incident Severity": SEVERITY_ID,
-      });
+      expect(captured).toEqual([
+        {
+          subject: "incident",
+          modelName: "Incident State",
+          id: STATE_ID.toString(),
+          service: "IncidentStateService",
+        },
+        {
+          subject: "incident",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+        {
+          subject: "incident",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
     });
 
-    test("does not look anything up when no reference column is being written", async () => {
-      const validator: jest.Mock = spyOnValidator();
+    test("update catches the bare-string relation shape the API accepts", async () => {
+      /*
+       * PUT /api/incident with {"incidentSeverity": "<uuid>"} leaves a plain
+       * string in the relation slot until sanitizeCreateOrUpdate turns it into
+       * an entity — which happens after this hook. Reading ?._id alone missed
+       * it and the guard silently passed.
+       */
+      spyOnValidator();
 
-      await updateIncident({ title: "renamed" }, PROJECT_ID);
+      await callHook(IncidentService, "onBeforeUpdate", {
+        data: { incidentSeverity: SEVERITY_ID.toString() },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
 
-      expect(validator).not.toHaveBeenCalled();
+      expect(captured).toEqual([
+        {
+          subject: "incident",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+      ]);
     });
 
-    test("falls back to the projects of the matched rows when the update has no tenant", async () => {
+    test("update catches the relation-object shape", async () => {
+      spyOnValidator();
+
+      await callHook(IncidentService, "onBeforeUpdate", {
+        data: { incidentSeverity: { _id: SEVERITY_ID.toString() } },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.id).toBe(SEVERITY_ID.toString());
+    });
+
+    test("update looks nothing up when no reference column is written", async () => {
+      spyOnValidator();
+
+      await callHook(IncidentService, "onBeforeUpdate", {
+        data: { title: "renamed" },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(validatorCalls).toHaveLength(0);
+    });
+
+    test("update falls back to the projects of the matched rows when there is no tenant", async () => {
       /*
        * Root and API updates do not always carry a tenantId. Skipping the
        * check there would leave the exact hole this guard exists to close.
@@ -188,83 +318,171 @@ describe("cross-project reference guard on write", () => {
         .spyOn(IncidentService, "findBy")
         .mockResolvedValue([incident] as never);
 
-      const validator: jest.Mock = spyOnValidator();
+      spyOnValidator();
 
-      await updateIncident({ incidentSeverityId: SEVERITY_ID });
+      await callHook(IncidentService, "onBeforeUpdate", {
+        data: { incidentSeverityId: SEVERITY_ID },
+        query: {},
+        props: { isRoot: true },
+      });
 
-      expect(validator).toHaveBeenCalledTimes(1);
-      expect(
-        (validator.mock.calls[0] as unknown as [ValidatorCall])[0].projectId,
-      ).toBe(PROJECT_ID);
+      expect(validatorCalls).toHaveLength(1);
+      expect(validatorCalls[0]?.projectId).toBe(PROJECT_ID);
     });
 
-    test("rejects the update when a reference is foreign", async () => {
+    test("update is rejected when a reference is foreign", async () => {
       spyOnValidator(true);
 
       await expect(
-        updateIncident({ incidentSeverityId: SEVERITY_ID }, PROJECT_ID),
+        callHook(IncidentService, "onBeforeUpdate", {
+          data: { incidentSeverityId: SEVERITY_ID },
+          query: {},
+          props: { tenantId: PROJECT_ID },
+        }),
       ).rejects.toThrow("belong to a different project");
     });
   });
 
-  describe("AlertService.onBeforeCreate", () => {
-    test("checks the severity and the monitor status, and burns no alert number when rejected", async () => {
+  describe("AlertService", () => {
+    function mockCreatedState(): void {
       const createdState: AlertState = new AlertState();
       createdState._id = STATE_ID.toString();
-
       jest
         .spyOn(AlertStateService, "findOneBy")
         .mockResolvedValue(createdState as never);
+    }
 
+    test("create checks severity and monitor status against the right models", async () => {
+      mockCreatedState();
+      spyOnValidator();
+      jest
+        .spyOn(ProjectService, "incrementAndGetAlertCounter")
+        .mockResolvedValue({ counter: 1, prefix: undefined } as never);
+
+      await callHook(AlertService, "onBeforeCreate", {
+        data: {
+          title: "test",
+          alertSeverityId: SEVERITY_ID,
+          monitorStatusWhenThisAlertWasCreatedId: MONITOR_STATUS_ID,
+        } as Alert,
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "alert",
+          modelName: "Alert Severity",
+          id: SEVERITY_ID.toString(),
+          service: "AlertSeverityService",
+        },
+        {
+          subject: "alert",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
+    });
+
+    test("create is rejected, and burns no alert number, when a reference is foreign", async () => {
+      mockCreatedState();
       spyOnValidator(true);
-
       const counter: jest.Mock = jest.fn() as unknown as jest.Mock;
       jest
         .spyOn(ProjectService, "incrementAndGetAlertCounter")
         .mockImplementation(counter as never);
 
       await expect(
-        (
-          AlertService as unknown as {
-            onBeforeCreate: (createBy: unknown) => Promise<unknown>;
-          }
-        ).onBeforeCreate({
-          data: {
-            title: "test",
-            alertSeverityId: SEVERITY_ID,
-            monitorStatusWhenThisAlertWasCreatedId: MONITOR_STATUS_ID,
-          } as Alert,
+        callHook(AlertService, "onBeforeCreate", {
+          data: { title: "test", alertSeverityId: SEVERITY_ID } as Alert,
           props: { tenantId: PROJECT_ID },
         }),
       ).rejects.toThrow("belong to a different project");
 
       expect(counter).not.toHaveBeenCalled();
     });
+
+    test("update checks state, severity and monitor status", async () => {
+      spyOnValidator();
+
+      await callHook(AlertService, "onBeforeUpdate", {
+        data: {
+          currentAlertStateId: STATE_ID,
+          alertSeverityId: SEVERITY_ID,
+          monitorStatusWhenThisAlertWasCreatedId: MONITOR_STATUS_ID,
+        },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "alert",
+          modelName: "Alert State",
+          id: STATE_ID.toString(),
+          service: "AlertStateService",
+        },
+        {
+          subject: "alert",
+          modelName: "Alert Severity",
+          id: SEVERITY_ID.toString(),
+          service: "AlertSeverityService",
+        },
+        {
+          subject: "alert",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
+    });
   });
 
-  describe("ScheduledMaintenanceService.onBeforeCreate", () => {
-    test("checks the monitor status it switches monitors to", async () => {
+  describe("ScheduledMaintenanceService", () => {
+    function mockScheduledState(): void {
       const scheduledState: ScheduledMaintenanceState =
         new ScheduledMaintenanceState();
       scheduledState._id = STATE_ID.toString();
-
       jest
         .spyOn(ScheduledMaintenanceStateService, "findOneBy")
         .mockResolvedValue(scheduledState as never);
+    }
 
+    test("create checks the monitor status it switches monitors to", async () => {
+      mockScheduledState();
+      spyOnValidator();
+      jest
+        .spyOn(ProjectService, "incrementAndGetScheduledMaintenanceCounter")
+        .mockResolvedValue({ counter: 1, prefix: undefined } as never);
+
+      await callHook(ScheduledMaintenanceService, "onBeforeCreate", {
+        data: {
+          title: "test",
+          changeMonitorStatusToId: MONITOR_STATUS_ID,
+        } as ScheduledMaintenance,
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "scheduled maintenance event",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
+    });
+
+    test("create is rejected, and burns no event number, when the status is foreign", async () => {
+      mockScheduledState();
       spyOnValidator(true);
-
       const counter: jest.Mock = jest.fn() as unknown as jest.Mock;
       jest
         .spyOn(ProjectService, "incrementAndGetScheduledMaintenanceCounter")
         .mockImplementation(counter as never);
 
       await expect(
-        (
-          ScheduledMaintenanceService as unknown as {
-            onBeforeCreate: (createBy: unknown) => Promise<unknown>;
-          }
-        ).onBeforeCreate({
+        callHook(ScheduledMaintenanceService, "onBeforeCreate", {
           data: {
             title: "test",
             changeMonitorStatusToId: MONITOR_STATUS_ID,
@@ -275,17 +493,41 @@ describe("cross-project reference guard on write", () => {
 
       expect(counter).not.toHaveBeenCalled();
     });
+
+    test("update checks the state and the monitor status", async () => {
+      spyOnValidator();
+
+      await callHook(ScheduledMaintenanceService, "onBeforeUpdate", {
+        data: {
+          currentScheduledMaintenanceStateId: STATE_ID,
+          changeMonitorStatusToId: MONITOR_STATUS_ID,
+        },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "scheduled maintenance event",
+          modelName: "Scheduled Maintenance State",
+          id: STATE_ID.toString(),
+          service: "ScheduledMaintenanceStateService",
+        },
+        {
+          subject: "scheduled maintenance event",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
+    });
   });
 
-  describe("IncidentTemplateService.onBeforeCreate", () => {
-    test("checks every reference a template copies onto the incidents it creates", async () => {
-      const validator: jest.Mock = spyOnValidator();
+  describe("IncidentTemplateService", () => {
+    test("create checks every reference the template copies onto its incidents", async () => {
+      spyOnValidator();
 
-      await (
-        IncidentTemplateService as unknown as {
-          onBeforeCreate: (createBy: unknown) => Promise<unknown>;
-        }
-      ).onBeforeCreate({
+      await callHook(IncidentTemplateService, "onBeforeCreate", {
         data: {
           templateName: "test",
           initialIncidentStateId: STATE_ID,
@@ -295,22 +537,52 @@ describe("cross-project reference guard on write", () => {
         props: { tenantId: PROJECT_ID },
       });
 
-      expect(referencedIds(validator)).toEqual({
-        "Incident State": STATE_ID,
-        "Incident Severity": SEVERITY_ID,
-        "Monitor Status": MONITOR_STATUS_ID,
-      });
+      expect(captured).toEqual([
+        {
+          subject: "incident template",
+          modelName: "Incident State",
+          id: STATE_ID.toString(),
+          service: "IncidentStateService",
+        },
+        {
+          subject: "incident template",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+        {
+          subject: "incident template",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
     });
 
-    test("rejects a template that points at another project's records", async () => {
+    test("update checks the same references", async () => {
+      spyOnValidator();
+
+      await callHook(IncidentTemplateService, "onBeforeUpdate", {
+        data: { incidentSeverityId: SEVERITY_ID },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "incident template",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+      ]);
+    });
+
+    test("create is rejected when a reference is foreign", async () => {
       spyOnValidator(true);
 
       await expect(
-        (
-          IncidentTemplateService as unknown as {
-            onBeforeCreate: (createBy: unknown) => Promise<unknown>;
-          }
-        ).onBeforeCreate({
+        callHook(IncidentTemplateService, "onBeforeCreate", {
           data: {
             templateName: "test",
             incidentSeverityId: SEVERITY_ID,
@@ -318,6 +590,221 @@ describe("cross-project reference guard on write", () => {
           props: { tenantId: PROJECT_ID },
         }),
       ).rejects.toThrow("belong to a different project");
+    });
+  });
+
+  describe("ScheduledMaintenanceTemplateService", () => {
+    test("create checks the monitor status the template carries", async () => {
+      spyOnValidator();
+
+      await callHook(ScheduledMaintenanceTemplateService, "onBeforeCreate", {
+        data: {
+          templateName: "test",
+          title: "test",
+          description: "test",
+          changeMonitorStatusToId: MONITOR_STATUS_ID,
+        } as ScheduledMaintenanceTemplate,
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "scheduled maintenance template",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
+    });
+
+    test("create is rejected when the status is foreign", async () => {
+      spyOnValidator(true);
+
+      await expect(
+        callHook(ScheduledMaintenanceTemplateService, "onBeforeCreate", {
+          data: {
+            templateName: "test",
+            title: "test",
+            description: "test",
+            changeMonitorStatusToId: MONITOR_STATUS_ID,
+          } as ScheduledMaintenanceTemplate,
+          props: { tenantId: PROJECT_ID },
+        }),
+      ).rejects.toThrow("belong to a different project");
+    });
+  });
+
+  describe("episodes", () => {
+    /*
+     * IncidentEpisode and AlertEpisode hold the same state and severity
+     * columns on equally NO ACTION foreign keys. Leaving them unguarded means
+     * a single API call re-creates the undeletable project the migration just
+     * repaired, and there is no second repair scheduled.
+     */
+    test("incident episode create checks the severity", async () => {
+      const createdState: IncidentState = new IncidentState();
+      createdState._id = STATE_ID.toString();
+      jest
+        .spyOn(IncidentStateService, "findOneBy")
+        .mockResolvedValue(createdState as never);
+      jest
+        .spyOn(ProjectService, "incrementAndGetIncidentEpisodeCounter")
+        .mockResolvedValue({ counter: 1, prefix: undefined } as never);
+      spyOnValidator();
+
+      await callHook(IncidentEpisodeService, "onBeforeCreate", {
+        data: {
+          title: "test",
+          incidentSeverityId: SEVERITY_ID,
+        } as IncidentEpisode,
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "incident episode",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+      ]);
+    });
+
+    test("incident episode update checks state and severity", async () => {
+      spyOnValidator();
+
+      await callHook(IncidentEpisodeService, "onBeforeUpdate", {
+        data: {
+          currentIncidentStateId: STATE_ID,
+          incidentSeverityId: SEVERITY_ID,
+        },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "incident episode",
+          modelName: "Incident State",
+          id: STATE_ID.toString(),
+          service: "IncidentStateService",
+        },
+        {
+          subject: "incident episode",
+          modelName: "Incident Severity",
+          id: SEVERITY_ID.toString(),
+          service: "IncidentSeverityService",
+        },
+      ]);
+    });
+
+    test("alert episode update checks state and severity", async () => {
+      spyOnValidator();
+
+      await callHook(AlertEpisodeService, "onBeforeUpdate", {
+        data: {
+          currentAlertStateId: STATE_ID,
+          alertSeverityId: SEVERITY_ID,
+        },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "alert episode",
+          modelName: "Alert State",
+          id: STATE_ID.toString(),
+          service: "AlertStateService",
+        },
+        {
+          subject: "alert episode",
+          modelName: "Alert Severity",
+          id: SEVERITY_ID.toString(),
+          service: "AlertSeverityService",
+        },
+      ]);
+    });
+
+    test("alert episode create checks the severity", async () => {
+      const createdState: AlertState = new AlertState();
+      createdState._id = STATE_ID.toString();
+      jest
+        .spyOn(AlertStateService, "findOneBy")
+        .mockResolvedValue(createdState as never);
+      jest
+        .spyOn(ProjectService, "incrementAndGetAlertEpisodeCounter")
+        .mockResolvedValue({ counter: 1, prefix: undefined } as never);
+      spyOnValidator();
+
+      await callHook(AlertEpisodeService, "onBeforeCreate", {
+        data: {
+          title: "test",
+          alertSeverityId: SEVERITY_ID,
+        } as AlertEpisode,
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "alert episode",
+          modelName: "Alert Severity",
+          id: SEVERITY_ID.toString(),
+          service: "AlertSeverityService",
+        },
+      ]);
+    });
+  });
+
+  describe("MonitorService", () => {
+    /*
+     * Monitor.currentMonitorStatusId is the one project-scoped reference that
+     * intentionally keeps ON DELETE NO ACTION, and it is writable by any
+     * project member — so it can block a project delete on its own. The
+     * 1785240000000 migration repaired the rows that existed then; this is
+     * what stops new ones.
+     */
+    test("update checks currentMonitorStatusId", async () => {
+      spyOnValidator();
+
+      await callHook(MonitorService, "onBeforeUpdate", {
+        data: { currentMonitorStatusId: MONITOR_STATUS_ID },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(captured).toEqual([
+        {
+          subject: "monitor",
+          modelName: "Monitor Status",
+          id: MONITOR_STATUS_ID.toString(),
+          service: "MonitorStatusService",
+        },
+      ]);
+    });
+
+    test("update is rejected when the status belongs to another project", async () => {
+      spyOnValidator(true);
+
+      await expect(
+        callHook(MonitorService, "onBeforeUpdate", {
+          data: { currentMonitorStatusId: MONITOR_STATUS_ID },
+          query: {},
+          props: { tenantId: PROJECT_ID },
+        }),
+      ).rejects.toThrow("belong to a different project");
+    });
+
+    test("update looks nothing up when neither monitorSteps nor the status is written", async () => {
+      spyOnValidator();
+
+      await callHook(MonitorService, "onBeforeUpdate", {
+        data: { description: "renamed" },
+        query: {},
+        props: { tenantId: PROJECT_ID },
+      });
+
+      expect(validatorCalls).toHaveLength(0);
     });
   });
 });

--- a/Common/Tests/Server/Services/RepairCrossProjectIncidentReferencesMigration.test.ts
+++ b/Common/Tests/Server/Services/RepairCrossProjectIncidentReferencesMigration.test.ts
@@ -6,6 +6,7 @@ import {
   getClearQuery,
   getRepairQuery,
 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1785320000000-RepairCrossProjectIncidentReferences";
+import { RepairCrossProjectMonitorStatusReferences1785240000000 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1785240000000-RepairCrossProjectMonitorStatusReferences";
 import SchemaMigrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
 import AlertEpisodeStateTimeline from "../../../Models/DatabaseModels/AlertEpisodeStateTimeline";
 import AlertStateTimeline from "../../../Models/DatabaseModels/AlertStateTimeline";
@@ -178,16 +179,65 @@ describe("RepairCrossProjectIncidentReferences migration", () => {
       }
     });
 
-    test("matches by name first, then role, then nearest order", async () => {
-      const sql: string = getRepairQuery(CROSS_PROJECT_REFERENCES[0]!);
+    test("never lets a name match cross a role boundary", async () => {
+      /*
+       * A project may have a custom state literally called "Resolved" that is
+       * NOT its resolved state. If a bare name match can win, a resolved
+       * incident is silently repointed at a non-resolved state — and the
+       * migration is one-way. So every branch that can win before the bare
+       * name match must carry the role predicate.
+       */
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        if (reference.roleColumns.length === 0) {
+          continue;
+        }
 
-      const byName: number = sql.indexOf(`lower(x."name") = lower(b.ref_name)`);
-      const byRole: number = sql.indexOf(`x."isCreatedState" = b.role_`);
-      const byOrder: number = sql.indexOf(`abs(x."order" - b.ref_order)`);
+        const sql: string = getRepairQuery(reference);
+        const roleColumn: string = reference.roleColumns[0]!;
 
-      expect(byName).toBeGreaterThan(-1);
-      expect(byRole).toBeGreaterThan(byName);
-      expect(byOrder).toBeGreaterThan(byRole);
+        const nameAndRole: number = sql.indexOf(
+          `AND lower(x."name") = lower(b.ref_name)`,
+        );
+        const bareName: number = sql.indexOf(
+          `x."projectId" = b.project_id AND lower(x."name") = lower(b.ref_name)`,
+        );
+        const firstRole: number = sql.indexOf(
+          `x."${roleColumn}" = b.role_${roleColumn}`,
+        );
+
+        expect(nameAndRole).toBeGreaterThan(-1);
+        expect(firstRole).toBeGreaterThan(-1);
+        expect(bareName).toBeGreaterThan(-1);
+
+        // Both role-bearing branches are ahead of the bare name match.
+        expect(bareName).toBeGreaterThan(nameAndRole);
+        expect(bareName).toBeGreaterThan(firstRole);
+
+        // And the role predicate appears in exactly the two leading branches.
+        expect(
+          (
+            sql.match(
+              new RegExp(`x\\."${roleColumn}" = b\\.role_${roleColumn}`, "g"),
+            ) || []
+          ).length,
+        ).toBe(2);
+      }
+    });
+
+    test("falls back to nearest order only after every targeted match", async () => {
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        const sql: string = getRepairQuery(reference);
+
+        const byOrder: number = sql.indexOf(
+          `abs(x."${reference.orderColumn}" - b.ref_order)`,
+        );
+        const byName: number = sql.indexOf(
+          `lower(x."name") = lower(b.ref_name)`,
+        );
+
+        expect(byName).toBeGreaterThan(-1);
+        expect(byOrder).toBeGreaterThan(byName);
+      }
     });
 
     test("only ever repoints inside the row's own project", async () => {
@@ -198,7 +248,7 @@ describe("RepairCrossProjectIncidentReferences migration", () => {
         ).length;
 
         // One per branch of the COALESCE ladder.
-        expect(candidateFilters).toBe(reference.roleColumns.length > 0 ? 3 : 2);
+        expect(candidateFilters).toBe(reference.roleColumns.length > 0 ? 4 : 2);
       }
     });
 
@@ -257,15 +307,83 @@ describe("RepairCrossProjectIncidentReferences migration", () => {
       expect(firstAlterAt).toBeGreaterThan(lockTimeoutAt);
     });
 
+    test("drops the raised statement timeout before taking any lock", async () => {
+      /*
+       * DATABASE_QUERY_TIMEOUT_MS is a client-side deadline no SET can lift.
+       * If the client gives up while an ADD CONSTRAINT is still running, the
+       * server keeps going and the queued ROLLBACK times out too — holding
+       * ACCESS EXCLUSIVE for as long as the raised ceiling allows, long after
+       * the deploy already failed. Aborting server-side is the cheaper
+       * failure, so the ceiling must be back to default before the DDL.
+       */
+      const queries: Array<string> = await runUp();
+
+      const resetAt: number = queries.findIndex((sql: string) => {
+        return sql.includes("SET LOCAL statement_timeout = DEFAULT");
+      });
+      const firstAlterAt: number = queries.findIndex((sql: string) => {
+        return sql.includes("DROP CONSTRAINT");
+      });
+      const lastRepairAt: number = queries.reduce(
+        (last: number, sql: string, index: number) => {
+          return sql.includes("resolved r") ? index : last;
+        },
+        -1,
+      );
+
+      expect(resetAt).toBeGreaterThan(lastRepairAt);
+      expect(firstAlterAt).toBeGreaterThan(resetAt);
+    });
+
     test("repairs every reference, and clears only the nullable ones", async () => {
       const queries: Array<string> = await runUp();
 
       for (const reference of CROSS_PROJECT_REFERENCES) {
-        expect(queries).toContain(getRepairQuery(reference));
+        /*
+         * Asserted structurally rather than by comparing against
+         * getRepairQuery's own output, which would pass for any SQL the
+         * builder happened to emit.
+         */
+        const repairs: Array<string> = queries.filter((sql: string) => {
+          return (
+            sql.includes(`UPDATE "${reference.table}" c`) &&
+            sql.includes(`SET "${reference.column}" = r.good_id`) &&
+            sql.includes(`JOIN "${reference.referencedTable}" p`)
+          );
+        });
 
-        expect(queries.includes(getClearQuery(reference))).toBe(
-          reference.isNullable,
-        );
+        expect(repairs).toHaveLength(1);
+
+        const clears: Array<string> = queries.filter((sql: string) => {
+          return (
+            sql.includes(`UPDATE "${reference.table}" c`) &&
+            sql.includes(`SET "${reference.column}" = NULL`)
+          );
+        });
+
+        expect(clears).toHaveLength(reference.isNullable ? 1 : 0);
+      }
+    });
+
+    test("counts what it could not repair, for every reference", async () => {
+      /*
+       * A row survives both the repair and the clear only when its own
+       * project has nothing to point at. That keeps the project undeletable,
+       * so it must not pass silently — the user would retry the delete and
+       * see a byte-identical error with nothing to act on.
+       */
+      const queries: Array<string> = await runUp();
+
+      for (const reference of CROSS_PROJECT_REFERENCES) {
+        const counts: Array<string> = queries.filter((sql: string) => {
+          return (
+            sql.includes("count(*)::int AS remaining") &&
+            sql.includes(`FROM "${reference.table}" c`) &&
+            sql.includes(`p."_id" = c."${reference.column}"`)
+          );
+        });
+
+        expect(counts).toHaveLength(1);
       }
     });
 
@@ -391,11 +509,20 @@ describe("RepairCrossProjectIncidentReferences migration", () => {
     });
 
     test("runs after the migration it builds on", async () => {
+      /*
+       * It must land after the monitor-status repair, whose cross-project
+       * cleanup it assumes. Pinning it to the last slot instead would turn
+       * red the moment anyone appends an unrelated migration.
+       */
       expect(
         SchemaMigrations.indexOf(
           RepairCrossProjectIncidentReferences1785320000000,
         ),
-      ).toBe(SchemaMigrations.length - 1);
+      ).toBeGreaterThan(
+        SchemaMigrations.indexOf(
+          RepairCrossProjectMonitorStatusReferences1785240000000,
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
### Title of this pull request?

fix: harden the cross-project incident reference fix after adversarial review

### Small Description?

Follow-up to #2898 (merged). An adversarial multi-agent audit of that change — six independent review lenses, a skeptic per finding, then experiments against a scratch Postgres with all 477 migrations applied — found seven defects in it. All are fixed here. #2898 works, but three of these are things you would not want to discover in production.

**1. The create guard could take a monitor's ingest path down** — `MonitorIncident.ts` / `MonitorAlert.ts`

`monitorSteps` can still embed another project's severity: the `1785240000000` repair skipped ids it could not resolve, and this was reproduced by running that migration's own repair block against such a monitor — `monitorSteps` came back byte-identical. #2898's create guard then throws inside `IncidentService.create`, called at `MonitorIncident.ts` from the probe/telemetry queue with no `catch` above it. The monitor flips Offline (the status timeline write already committed), then creates no incident — and persists no payload and no monitor log either, because both run *after* the create. Bounded to that monitor and retried 3× with backoff, but it is a live regression on exactly the corrupt data #2898 exists to clean up.

Both call sites now treat an unusable criteria severity the way they already treat a missing one: log it and fall back to the project's own default. That also stops the bad id spreading onto new incidents.

**2. The repair ladder could silently un-resolve a resolved incident** — migration `1785320000000`

The ladder was `COALESCE(name, role, nearest order)`, and the name match carried no role filter. Confirmed on a real database: a project holding both a *custom* state literally named "Resolved" (`isResolvedState = false`) and its actual resolved state named "Closed" repointed the incident at the decoy. A second case fell through to nearest-order and landed on "Ack". The migration is one-way — `down()` restores only the constraints — so every such flip would be permanent.

Now `name+role → role → name → nearest order`. Re-run on the same fixture: it picks "Closed", `isResolvedState = t`.

**3. The raised `statement_timeout` made the failure tail worse, not better** — migration `1785320000000`

`DATABASE_QUERY_TIMEOUT_MS` is a client-side deadline in node-postgres (`extra.query_timeout`) that no `SET` can lift. Measured against the app's real settings:

```
query_timeout=30000  SHOW statement_timeout=10min  -> client gave up after 30001 ms
  +46s server backend still {"state":"active","q":"SELECT pg_sleep(120)"}
  ROLLBACK err Query read timeout      <- the rollback times out too
```

So a slow `ADD CONSTRAINT` outliving the client deadline leaves the transaction open — holding ACCESS EXCLUSIVE on a timeline table — for the whole raised ceiling, after the deploy has already reported failure. The ceiling is now reset to `DEFAULT` before the DDL, so the server aborts promptly instead. The comment also named the wrong env var.

**4. Three write paths were still open** — `IncidentEpisodeService`, `AlertEpisodeService`, `MonitorService`

All four episode FKs stay `NO ACTION`, and inserting a project-A `IncidentEpisode` holding a project-B severity reproduced the original error verbatim *with the full 21-statement repair already applied*. Same for `Monitor.currentMonitorStatusId`, which `onBeforeUpdate` never looked at and any project member can write. Guarded now — so #2898's claim to cover "episodes and templates" is finally true of the write guards and not just the repair.

**5. The guards missed a shape the API accepts** — `resolveReferenceId`

`PUT /api/incident` with `{"incidentSeverity": "<uuid>"}` leaves a bare string in the relation slot; `sanitizeCreateOrUpdate` only turns it into an entity *after* `onBeforeUpdate` runs, so reading `?._id` saw nothing and the guard passed. One shared helper now handles id column, relation object, `ObjectID` and bare string, and replaces the `as unknown as` casts at all ten resolution sites.

**6 & 7. Two claims corrected, and the tests were not earning their keep**

Rows the repair cannot repoint are now counted and logged — #2898 called that case unreachable and it is not (nothing stops a project from deleting its last severity), and silence there means the user retries the delete and sees a byte-identical error with nothing to act on. The cascade's second effect — deleting a *custom* state now removes its timeline history project-wide, below `onBeforeDelete`, leaving an unstitched `endsAt` gap — is documented rather than implicit.

The write-guard tests asserted only that the validator was called with some model name and id. A mutation run showed that emptying a guard, or checking a column against the wrong model, still passed everything. They now assert the full (model, id, **lookup service**) triple and cover every guarded service.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Verification**

- All 477 migrations replayed onto a fresh scratch Postgres with the updated migration. Seeded cross-project data: the delete failed with the reported 23503 before, `DELETE 1` after, every one of the other project's rows still present and repointed inside its own project. 17 `NO ACTION` FKs remain — 16 repaired, plus `Monitor.currentMonitorStatusId`, which keeps `NO ACTION` on purpose and is now guarded on write.
- All 51 generated repair / clear / count statements executed against the real schema, so no table or column name is misspelled.
- The "custom state named Resolved" fixture now resolves to the real resolved state.
- 62 tests, `tsc` clean, `npm run fix` clean.
- **Mutation-tested:** 12 seeded defects — emptied reference lists, a column checked against the wrong model, each guard removed one at a time, the ladder reverted to name-before-role, the timeout reset removed, the unrepaired-row count removed, the bare-string shape no longer resolved. All 12 caught (10 by a failing test, 2 by the compiler); none survived.

**Known and accepted:** creating a state timeline that points at another project's state is now rejected on the follow-up incident update, after the timeline row is written — a partially applied write. Rejecting still beats re-creating the undeletable project.

### Related Issue?

Follows #2898.

### Screenshots (if appropriate):

N/A
