### PR TITLE
fix(monitor-probe): keep probe attachment inside the tenant on the CRUD path

### DIFF
--- a/Common/Server/Services/MonitorProbeService.ts
+++ b/Common/Server/Services/MonitorProbeService.ts
@@ -9,6 +9,7 @@ import Monitor from "../../Models/DatabaseModels/Monitor";
 import QueryHelper from "../Types/Database/QueryHelper";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import MonitorService from "./MonitorService";
+import ProbeService from "./ProbeService";
 import { MonitorTypeHelper } from "../../Types/Monitor/MonitorType";
 import CronTab from "../Utils/CronTab";
 import logger, { LogAttributes } from "../Utils/Logger";
@@ -267,6 +268,31 @@ export class Service extends DatabaseService<MonitorProbe> {
 
       if (monitorProbe) {
         throw new BadDataException("Probe is already added to this monitor.");
+      }
+    }
+
+    /*
+     * The probe id on a create comes straight from the browser (the
+     * Monitor > Probes table posts it), so it has to be checked against the
+     * tenant exactly like the monitor-create path does - otherwise another
+     * project's probe can be attached to this monitor.
+     */
+    const probeId: ObjectID | undefined | null =
+      createBy.data.probeId || createBy.data.probe?.id;
+    const projectId: ObjectID | undefined | null =
+      createBy.data.projectId || createBy.data.project?.id;
+
+    if (probeId && projectId) {
+      const isProbeAttachable: boolean =
+        await ProbeService.isProbeAttachableToProject({
+          probeId: probeId,
+          projectId: projectId,
+        });
+
+      if (!isProbeAttachable) {
+        throw new BadDataException(
+          "Probe not found or it does not belong to this project.",
+        );
       }
     }
 

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -1207,7 +1207,8 @@ ${createdItem.description?.trim() || "No description provided."}
   /*
    * Only global probes and probes belonging to this project may be attached -
    * the id list comes from the browser, so it cannot be trusted to stay inside
-   * the tenant.
+   * the tenant. ProbeService.getProbesAttachableToProject owns that rule and
+   * MonitorProbeService enforces the same one on the CRUD path.
    */
   @CaptureSpan()
   public async addSelectedProbesToMonitor(
@@ -1215,47 +1216,16 @@ ${createdItem.description?.trim() || "No description provided."}
     monitorId: ObjectID,
     probeIds: Array<ObjectID>,
   ): Promise<void> {
-    if (probeIds.length === 0) {
-      return;
-    }
-
-    const [globalProbes, projectProbes]: [Array<Probe>, Array<Probe>] =
-      await Promise.all([
-        ProbeService.findBy({
-          query: {
-            _id: QueryHelper.any(probeIds),
-            isGlobalProbe: true,
-          },
-          select: {
-            _id: true,
-          },
-          skip: 0,
-          limit: LIMIT_PER_PROJECT,
-          props: {
-            isRoot: true,
-          },
-        }),
-        ProbeService.findBy({
-          query: {
-            _id: QueryHelper.any(probeIds),
-            isGlobalProbe: false,
-            projectId: projectId,
-          },
-          select: {
-            _id: true,
-          },
-          skip: 0,
-          limit: LIMIT_PER_PROJECT,
-          props: {
-            isRoot: true,
-          },
-        }),
-      ]);
+    const probes: Array<Probe> =
+      await ProbeService.getProbesAttachableToProject({
+        probeIds: probeIds,
+        projectId: projectId,
+      });
 
     await this.createMonitorProbes({
       projectId: projectId,
       monitorId: monitorId,
-      probes: [...globalProbes, ...projectProbes],
+      probes: probes,
     });
   }
 

--- a/Common/Server/Services/ProbeService.ts
+++ b/Common/Server/Services/ProbeService.ts
@@ -32,6 +32,7 @@ import MonitorService from "./MonitorService";
 import PushNotificationMessage from "../../Types/PushNotification/PushNotificationMessage";
 import PushNotificationUtil from "../Utils/PushNotificationUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import QueryHelper from "../Types/Database/QueryHelper";
 import { IsBillingEnabled } from "../EnvironmentConfig";
 import GlobalCache from "../Infrastructure/GlobalCache";
 import { createWhatsAppMessageFromTemplate } from "../Utils/WhatsAppTemplateUtil";
@@ -432,6 +433,71 @@ export class Service extends DatabaseService<Model> {
     }
 
     return { createBy: createBy, carryForward: [] };
+  }
+
+  /*
+   * Only global probes and probes belonging to this project may be attached to
+   * that project's monitors. Probe ids reach the server from the browser - the
+   * monitor create form and the Monitor > Probes table both post them - so
+   * they cannot be trusted to stay inside the tenant. Every path that attaches
+   * a probe to a monitor filters through here.
+   */
+  @CaptureSpan()
+  public async getProbesAttachableToProject(data: {
+    probeIds: Array<ObjectID>;
+    projectId: ObjectID;
+  }): Promise<Array<Model>> {
+    if (data.probeIds.length === 0) {
+      return [];
+    }
+
+    const [globalProbes, projectProbes]: [Array<Model>, Array<Model>] =
+      await Promise.all([
+        this.findBy({
+          query: {
+            _id: QueryHelper.any(data.probeIds),
+            isGlobalProbe: true,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        }),
+        this.findBy({
+          query: {
+            _id: QueryHelper.any(data.probeIds),
+            isGlobalProbe: false,
+            projectId: data.projectId,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        }),
+      ]);
+
+    return [...globalProbes, ...projectProbes];
+  }
+
+  @CaptureSpan()
+  public async isProbeAttachableToProject(data: {
+    probeId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<boolean> {
+    const probes: Array<Model> = await this.getProbesAttachableToProject({
+      probeIds: [data.probeId],
+      projectId: data.projectId,
+    });
+
+    return probes.length > 0;
   }
 
   @CaptureSpan()

--- a/Common/Tests/Server/Services/MonitorProbeServiceProbeTenancy.test.ts
+++ b/Common/Tests/Server/Services/MonitorProbeServiceProbeTenancy.test.ts
@@ -1,0 +1,304 @@
+import MonitorProbeService from "../../../Server/Services/MonitorProbeService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import ProbeService from "../../../Server/Services/ProbeService";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorProbe from "../../../Models/DatabaseModels/MonitorProbe";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * Tenancy of the probe attached through the MonitorProbe CRUD path.
+ *
+ * The monitor create path already refused ids from outside the tenant, but
+ * POST /api/monitor-probe - what the Monitor > Probes table posts - only
+ * checked for duplicates and for a monitor type that supports probes, so a
+ * crafted request naming another project's probe was accepted. Both paths now
+ * share ProbeService.getProbesAttachableToProject; these tests pin the CRUD
+ * half of it and the shared rule itself.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const GLOBAL_PROBE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PROJECT_PROBE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OTHER_PROJECT_PROBE_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+type MakeProbeFunction = (id: ObjectID) => Probe;
+
+const makeProbe: MakeProbeFunction = (id: ObjectID): Probe => {
+  const probe: Probe = new Probe();
+  probe.id = id;
+  return probe;
+};
+
+type MockProbeLookupFunction = (data: {
+  globalProbes: Array<Probe>;
+  projectProbes: Array<Probe>;
+}) => jest.SpyInstance<any, any>;
+
+const mockProbeLookup: MockProbeLookupFunction = (data: {
+  globalProbes: Array<Probe>;
+  projectProbes: Array<Probe>;
+}): jest.SpyInstance<any, any> => {
+  return getJestSpyOn(ProbeService, "findBy").mockImplementation(
+    async (findBy: any): Promise<Array<Probe>> => {
+      return findBy.query.isGlobalProbe === true
+        ? data.globalProbes
+        : data.projectProbes;
+    },
+  );
+};
+
+describe("MonitorProbeService probe tenancy", () => {
+  describe("onBeforeCreate", () => {
+    type MakeCreateByFunction = (data: {
+      probeId?: ObjectID | undefined;
+      projectId?: ObjectID | undefined;
+    }) => CreateBy<MonitorProbe>;
+
+    const makeCreateBy: MakeCreateByFunction = (data: {
+      probeId?: ObjectID | undefined;
+      projectId?: ObjectID | undefined;
+    }): CreateBy<MonitorProbe> => {
+      const monitorProbe: MonitorProbe = new MonitorProbe();
+      monitorProbe.monitorId = MONITOR_ID;
+
+      if (data.probeId) {
+        monitorProbe.probeId = data.probeId;
+      }
+
+      if (data.projectId) {
+        monitorProbe.projectId = data.projectId;
+      }
+
+      return {
+        data: monitorProbe,
+        props: {
+          isRoot: true,
+        },
+      } as CreateBy<MonitorProbe>;
+    };
+
+    type OnBeforeCreateFunction = (
+      createBy: CreateBy<MonitorProbe>,
+    ) => Promise<unknown>;
+
+    const onBeforeCreate: OnBeforeCreateFunction = (
+      createBy: CreateBy<MonitorProbe>,
+    ): Promise<unknown> => {
+      return (MonitorProbeService as any).onBeforeCreate(createBy);
+    };
+
+    beforeEach(() => {
+      // Not a duplicate, and a monitor type that does support probes.
+      getJestSpyOn(MonitorProbeService, "findOneBy").mockResolvedValue(null);
+
+      const monitor: Monitor = new Monitor();
+      monitor.id = MONITOR_ID;
+      monitor.monitorType = MonitorType.Website;
+
+      getJestSpyOn(MonitorService, "findOneById").mockResolvedValue(monitor);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("rejects a probe that belongs to another project", async () => {
+      /*
+       * The probe id is posted by the browser. Owning the monitor must not be
+       * enough to pull a probe out of someone else's project.
+       */
+      mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [],
+      });
+
+      await expect(
+        onBeforeCreate(
+          makeCreateBy({
+            probeId: OTHER_PROJECT_PROBE_ID,
+            projectId: PROJECT_ID,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("rejects a probe id that does not exist at all", async () => {
+      mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [],
+      });
+
+      await expect(
+        onBeforeCreate(
+          makeCreateBy({
+            probeId: new ObjectID("66666666-6666-4666-8666-666666666666"),
+            projectId: PROJECT_ID,
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("accepts a global probe", async () => {
+      mockProbeLookup({
+        globalProbes: [makeProbe(GLOBAL_PROBE_ID)],
+        projectProbes: [],
+      });
+
+      await expect(
+        onBeforeCreate(
+          makeCreateBy({
+            probeId: GLOBAL_PROBE_ID,
+            projectId: PROJECT_ID,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("accepts a probe owned by this project", async () => {
+      mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [makeProbe(PROJECT_PROBE_ID)],
+      });
+
+      await expect(
+        onBeforeCreate(
+          makeCreateBy({
+            probeId: PROJECT_PROBE_ID,
+            projectId: PROJECT_ID,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("scopes the lookup to global probes and to this project only", async () => {
+      const findBySpy: jest.SpyInstance<any, any> = mockProbeLookup({
+        globalProbes: [makeProbe(PROJECT_PROBE_ID)],
+        projectProbes: [makeProbe(PROJECT_PROBE_ID)],
+      });
+
+      await onBeforeCreate(
+        makeCreateBy({
+          probeId: PROJECT_PROBE_ID,
+          projectId: PROJECT_ID,
+        }),
+      );
+
+      const calls: Array<any> = findBySpy.mock.calls.map((call: Array<any>) => {
+        return call[0];
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0].query.isGlobalProbe).toBe(true);
+      expect(calls[0].query.projectId).toBeUndefined();
+      expect(calls[1].query.isGlobalProbe).toBe(false);
+      expect(calls[1].query.projectId).toEqual(PROJECT_ID);
+
+      for (const call of calls) {
+        expect(call.query._id).toBeDefined();
+        expect(call.props.isRoot).toBe(true);
+      }
+    });
+
+    it("skips the check when the create carries no probe id", async () => {
+      const findBySpy: jest.SpyInstance<any, any> = mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [],
+      });
+
+      await expect(
+        onBeforeCreate(
+          makeCreateBy({
+            probeId: undefined,
+            projectId: PROJECT_ID,
+          }),
+        ),
+      ).resolves.toBeDefined();
+
+      expect(findBySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ProbeService.getProbesAttachableToProject", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("keeps global and own-project probes and drops the rest", async () => {
+      mockProbeLookup({
+        globalProbes: [makeProbe(GLOBAL_PROBE_ID)],
+        projectProbes: [makeProbe(PROJECT_PROBE_ID)],
+      });
+
+      const probes: Array<Probe> =
+        await ProbeService.getProbesAttachableToProject({
+          probeIds: [GLOBAL_PROBE_ID, PROJECT_PROBE_ID, OTHER_PROJECT_PROBE_ID],
+          projectId: PROJECT_ID,
+        });
+
+      expect(
+        probes.map((probe: Probe) => {
+          return probe.id?.toString();
+        }),
+      ).toEqual([GLOBAL_PROBE_ID.toString(), PROJECT_PROBE_ID.toString()]);
+    });
+
+    it("does not query at all for an empty id list", async () => {
+      const findBySpy: jest.SpyInstance<any, any> = mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [],
+      });
+
+      await expect(
+        ProbeService.getProbesAttachableToProject({
+          probeIds: [],
+          projectId: PROJECT_ID,
+        }),
+      ).resolves.toEqual([]);
+
+      expect(findBySpy).not.toHaveBeenCalled();
+    });
+
+    it("answers the single-probe question the CRUD path asks", async () => {
+      mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [makeProbe(PROJECT_PROBE_ID)],
+      });
+
+      await expect(
+        ProbeService.isProbeAttachableToProject({
+          probeId: PROJECT_PROBE_ID,
+          projectId: PROJECT_ID,
+        }),
+      ).resolves.toBe(true);
+
+      mockProbeLookup({
+        globalProbes: [],
+        projectProbes: [],
+      });
+
+      await expect(
+        ProbeService.isProbeAttachableToProject({
+          probeId: OTHER_PROJECT_PROBE_ID,
+          projectId: PROJECT_ID,
+        }),
+      ).resolves.toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix(monitor-probe): keep probe attachment inside the tenant on the CRUD path

### Small Description?

`MonitorProbeService.onBeforeCreate` validated two things about a new `MonitorProbe` row: that the `(monitorId, probeId)` pair was not a duplicate, and that the monitor type supports probes. It never validated the probe itself — so `POST /api/monitor-probe` (what the **Monitor > Probes** table posts) accepted a crafted request naming another project's probe and attached it.

The monitor-create path already refused those ids, but its guard lived inline in `MonitorService.addSelectedProbesToMonitor` and covered only that one entry point.

**What changed**

- `ProbeService.getProbesAttachableToProject({ probeIds, projectId })` — new home for the rule. Two root-scoped lookups (one for `isGlobalProbe: true`, one for `isGlobalProbe: false` + this `projectId`), returning only the ids that survive. `isProbeAttachableToProject({ probeId, projectId })` is the single-id wrapper.
- `MonitorProbeService.onBeforeCreate` — resolves the probe id (from `probeId` or `probe.id`) and the project id, and throws `BadDataException` when the probe is neither global nor owned by that project. Sits after the duplicate check, before the monitor-type check.
- `MonitorService.addSelectedProbesToMonitor` — now calls the shared method instead of running the two queries itself. Behaviour unchanged.

**Notes for the reviewer**

- The guard reads `projectId` off `createBy.data`, which `DatabaseService._onBeforeCreate` has already overwritten with `props.tenantId` for tenant-scoped requests — so the project side of the comparison does not come from the request body.
- It delegates to the shared scoped lookup rather than fetching the probe by id and comparing `projectId` in memory. Both decide the same thing; sharing the lookup keeps exactly one copy of the rule, at the cost of two indexed single-id queries per create.
- The only other server-side caller of `MonitorProbeService.create` is `MonitorService.createMonitorProbes`, which is fed by these same filtered lookups — no internal path starts failing.
- Deliberately left alone: `monitorId` on this path also arrives from the browser and is looked up with `isRoot` without a tenant check, and `MonitorProbeService` does not run `ProjectScopedReferenceValidator` the way `IncidentService` does. Separate gap, separate change.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission? — `npm run fix` at the root, exit 0; `npx tsc --noEmit -p tsconfig.json` in `Common`, clean. (`Common/tsconfig.json` excludes `Tests/`, so the new test file was type-checked separately via a config extending it — also clean.)
- [x] Did you write tests where appropriate? — 9 new tests in `Common/Tests/Server/Services/MonitorProbeServiceProbeTenancy.test.ts`: another project's probe and an unknown id rejected; global and own-project probes accepted; the lookup scoped (global query carries no `projectId`, project query pins it, both `isRoot`); the check skipped when no probe id was sent; plus the shared method and its wrapper directly. The existing `MonitorServiceProbeSelection` suite (17 tests) still passes unchanged after the refactor.

### Related Issue?

None.

### Screenshots (if appropriate):

Not applicable — server-side validation only.
