### PR TITLE
fix(network-map): show the site hierarchy on the map, at every level

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkSiteHierarchy.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkSiteHierarchy.ts
@@ -35,6 +35,13 @@ import NetworkSiteHierarchyUtil, {
   ChildAggregate,
   SiteLinkRow,
 } from "../Utils/NetworkSiteHierarchyUtil";
+import NetworkSiteMapUtil, {
+  MapChildRow,
+  MapMarkerAggregate,
+  MapStatusInfo,
+  MapSubtreeRow,
+  isUsableCoordinate,
+} from "../Utils/NetworkSiteMapUtil";
 
 /*
  * Drill-down and map endpoints for the Network Site hierarchy. Both are
@@ -97,6 +104,13 @@ const NETWORK_SITE_TYPE_SELECT: Select<NetworkSiteType> = {
   name: true,
   isUnitLevel: true,
 };
+
+/*
+ * How the map endpoint answers: one marker per child of the level in view
+ * ("grouped" — what the drill-down page draws), or every located site in
+ * that level's subtree individually ("all").
+ */
+type MapMode = "grouped" | "all";
 
 type StatusMap = Map<string, StatusInfo>;
 
@@ -668,6 +682,30 @@ export default class NetworkSiteHierarchyAPI {
       },
     );
 
+    /*
+     * The map, scoped to one drill level.
+     *
+     * This endpoint used to answer with every coordinate-bearing site in the
+     * project, flat, whatever the user was looking at. Screen-proximity
+     * clustering then merged them into numbered blobs, so a franchise
+     * network's map showed counts that match nothing the customer named —
+     * while the cards under the map showed the real hierarchy. The two
+     * halves of the page described different networks, and the levels a
+     * customer actually models (Region, Market, "Corp") never appeared at
+     * all, because organizational rows carry no coordinates.
+     *
+     * Now it answers with ONE ROW PER CHILD of the requested level — the
+     * same set /network-site/children returns — each positioned at its own
+     * coordinates or, failing that, at the centroid of the located sites
+     * beneath it, and each carrying the rollups the marker is sized and
+     * colored by. "all" mode keeps the every-site view for anyone who wants
+     * to see individual stores, but scoped to the subtree in view rather
+     * than to the whole project.
+     *
+     * It also used to require a "mapRegion" of "us" or "world" and then
+     * ignore it. The map has no regions; an old client still sending it is
+     * simply answered.
+     */
     router.post(
       "/network-site/map",
       UserMiddleware.getUserMiddleware,
@@ -685,61 +723,141 @@ export default class NetworkSiteHierarchyAPI {
           }
           const projectId: ObjectID = props.tenantId;
 
+          const body: JSONObject = (req.body || {}) as JSONObject;
+
+          const siteIdRaw: unknown = body["siteId"];
+          if (
+            siteIdRaw !== undefined &&
+            siteIdRaw !== null &&
+            typeof siteIdRaw !== "string"
+          ) {
+            throw new BadDataException("siteId must be a string");
+          }
+          const siteId: string | null =
+            typeof siteIdRaw === "string" && siteIdRaw ? siteIdRaw : null;
+
           /*
-           * All sites in one query: the coordinate-less ones only lend
-           * their names to ancestor breadcrumbs; only sites with BOTH
-           * latitude and longitude become pins. The client projects the
-           * coordinates and decides which part of the world to frame — no
-           * projection and no geography here.
-           *
-           * This endpoint used to require a "mapRegion" of "us" or "world"
-           * in the body and then ignore it: the response was identical
-           * either way. The map no longer has regions, and the parameter is
-           * not read — an old client still sending it is simply answered.
+           * Anything that is not exactly "all" reads as the grouped view:
+           * an unknown mode must degrade to the hierarchy the page is built
+           * around, not to the flat view this endpoint was changed to stop
+           * being.
            */
-          const siteRows: Array<NetworkSite> = await NetworkSiteService.findBy({
-            query: {
-              projectId: projectId,
-            },
-            select: {
-              _id: true,
-              name: true,
-              siteType: true,
-              networkSiteType: NETWORK_SITE_TYPE_SELECT,
-              latitude: true,
-              longitude: true,
-              currentMonitorStatusId: true,
-              materializedPath: true,
-            },
-            sort: {
-              name: SortOrder.Ascending,
-            },
-            limit: LIMIT_PER_PROJECT,
-            skip: 0,
-            props: props,
-          });
+          const mode: MapMode = body["mode"] === "all" ? "all" : "grouped";
+
+          /*
+           * Resolve the requested level first — it proves the caller can
+           * read it before any subtree query runs.
+           */
+          if (siteId) {
+            const requestedSite: NetworkSite | null =
+              await NetworkSiteService.findOneBy({
+                query: {
+                  _id: new ObjectID(siteId),
+                  projectId: projectId,
+                },
+                select: {
+                  _id: true,
+                },
+                props: props,
+              });
+            if (!requestedSite) {
+              throw new BadDataException("Network site not found");
+            }
+          }
+
+          /*
+           * Two batch queries, mirroring /network-site/children: the direct
+           * children of this level, and everything beneath it. At the root
+           * the subtree is the whole project (the roots themselves
+           * included — the aggregator skips rows it has already seeded).
+           */
+          const [childRows, subtreeRows]: [
+            Array<NetworkSite>,
+            Array<NetworkSite>,
+          ] = await Promise.all([
+            NetworkSiteService.findBy({
+              query: {
+                projectId: projectId,
+                parentSiteId: siteId
+                  ? new ObjectID(siteId)
+                  : QueryHelper.isNull(),
+              },
+              select: {
+                _id: true,
+                name: true,
+                siteType: true,
+                networkSiteType: NETWORK_SITE_TYPE_SELECT,
+                latitude: true,
+                longitude: true,
+                currentMonitorStatusId: true,
+              },
+              sort: {
+                name: SortOrder.Ascending,
+              },
+              limit: LIMIT_PER_PROJECT,
+              skip: 0,
+              props: props,
+            }),
+            NetworkSiteService.findBy({
+              query: siteId
+                ? {
+                    projectId: projectId,
+                    materializedPath: QueryHelper.search(`/${siteId}/`),
+                  }
+                : {
+                    projectId: projectId,
+                  },
+              select: {
+                _id: true,
+                name: true,
+                siteType: true,
+                networkSiteType: NETWORK_SITE_TYPE_SELECT,
+                parentSiteId: true,
+                materializedPath: true,
+                latitude: true,
+                longitude: true,
+                currentMonitorStatusId: true,
+              },
+              sort: {
+                name: SortOrder.Ascending,
+              },
+              limit: LIMIT_PER_PROJECT,
+              skip: 0,
+              props: props,
+            }),
+          ]);
+
+          /*
+           * Defensive: some writers append a site's own id to its
+           * materialized path, which would make the level's own row come
+           * back as one of its descendants.
+           */
+          const descendantRows: Array<NetworkSite> = siteId
+            ? subtreeRows.filter((row: NetworkSite) => {
+                return row._id?.toString() !== siteId;
+              })
+            : subtreeRows;
 
           const nameById: Map<string, string> = new Map<string, string>();
-          for (const site of siteRows) {
+          for (const site of descendantRows) {
+            if (site._id && site.name) {
+              nameById.set(site._id.toString(), site.name);
+            }
+          }
+          for (const site of childRows) {
             if (site._id && site.name) {
               nameById.set(site._id.toString(), site.name);
             }
           }
 
-          const pinRows: Array<NetworkSite> = siteRows.filter(
-            (site: NetworkSite) => {
-              return Boolean(
-                site._id &&
-                  site.latitude !== undefined &&
-                  site.latitude !== null &&
-                  site.longitude !== undefined &&
-                  site.longitude !== null,
-              );
-            },
-          );
-
+          // Every status any part of the response reasons about, fetched once.
           const statusIds: Set<string> = new Set<string>();
-          for (const site of pinRows) {
+          for (const site of childRows) {
+            if (site.currentMonitorStatusId) {
+              statusIds.add(site.currentMonitorStatusId.toString());
+            }
+          }
+          for (const site of descendantRows) {
             if (site.currentMonitorStatusId) {
               statusIds.add(site.currentMonitorStatusId.toString());
             }
@@ -750,33 +868,166 @@ export default class NetworkSiteHierarchyAPI {
             props,
           );
 
-          const sites: Array<JSONObject> = pinRows.map(
-            (site: NetworkSite): JSONObject => {
-              const pinSiteId: string = site._id!.toString();
+          const statusInfoById: Map<string, MapStatusInfo> = new Map<
+            string,
+            MapStatusInfo
+          >();
+          for (const status of statusById.values()) {
+            statusInfoById.set(status.id, {
+              priority: status.priority,
+              isOperationalState: status.isOperationalState,
+            });
+          }
+
+          const sites: Array<JSONObject> = [];
+          const unplacedSites: Array<JSONObject> = [];
+
+          if (mode === "all") {
+            /*
+             * Every located site in the subtree, one marker each — the old
+             * flat view, but bounded by the level in view. Rollups stay at
+             * their own-row values: each marker IS one site here, so there
+             * is nothing under it to roll up.
+             */
+            for (const site of descendantRows) {
+              if (!site._id) {
+                continue;
+              }
+              const rowSiteId: string = site._id.toString();
+              if (!isUsableCoordinate(site.latitude, site.longitude)) {
+                continue;
+              }
               const status: StatusInfo | undefined = site.currentMonitorStatusId
                 ? statusById.get(site.currentMonitorStatusId.toString())
                 : undefined;
-              return {
-                id: pinSiteId,
+              const typeInfo: SiteTypeInfo = getSiteTypeInfo(site);
+              const isOperational: boolean | null = status
+                ? status.isOperationalState
+                : null;
+
+              sites.push({
+                id: rowSiteId,
                 name: site.name || "Unnamed site",
-                ...getSiteTypeInfo(site),
+                ...typeInfo,
                 latitude: site.latitude,
                 longitude: site.longitude,
                 statusPriority: status ? status.priority : 0,
-                isOperational: status ? status.isOperationalState : null,
+                isOperational: isOperational,
                 parentBreadcrumb:
                   NetworkSiteHierarchyUtil.buildParentBreadcrumbString(
                     site.materializedPath,
-                    pinSiteId,
+                    rowSiteId,
                     nameById,
                   ),
-              } as unknown as JSONObject;
-            },
-          );
+                isContainer: false,
+                isDerivedLocation: false,
+                locatedDescendantCount: 1,
+                unlocatedDescendantCount: 0,
+                totalUnits: typeInfo.isUnitLevel ? 1 : 0,
+                operationalUnits:
+                  typeInfo.isUnitLevel && isOperational === true ? 1 : 0,
+                childSiteCount: 0,
+              } as unknown as JSONObject);
+            }
+          } else {
+            const aggregates: Map<string, MapMarkerAggregate> =
+              NetworkSiteMapUtil.aggregateMapMarkers({
+                children: childRows
+                  .filter((child: NetworkSite) => {
+                    return Boolean(child._id);
+                  })
+                  .map((child: NetworkSite): MapChildRow => {
+                    return {
+                      id: child._id!.toString(),
+                      name: child.name || "Unnamed site",
+                      ...getSiteTypeInfo(child),
+                      latitude: child.latitude,
+                      longitude: child.longitude,
+                      currentMonitorStatusId:
+                        child.currentMonitorStatusId?.toString(),
+                    };
+                  }),
+                descendants: descendantRows
+                  .filter((row: NetworkSite) => {
+                    return Boolean(row._id);
+                  })
+                  .map((row: NetworkSite): MapSubtreeRow => {
+                    return {
+                      id: row._id!.toString(),
+                      name: row.name,
+                      isUnitLevel: getSiteTypeInfo(row).isUnitLevel,
+                      parentSiteId: row.parentSiteId?.toString(),
+                      materializedPath: row.materializedPath,
+                      latitude: row.latitude,
+                      longitude: row.longitude,
+                      currentMonitorStatusId:
+                        row.currentMonitorStatusId?.toString(),
+                    };
+                  }),
+                statusById: statusInfoById,
+              });
+
+            for (const child of childRows) {
+              if (!child._id) {
+                continue;
+              }
+              const childId: string = child._id.toString();
+              const typeInfo: SiteTypeInfo = getSiteTypeInfo(child);
+              const aggregate: MapMarkerAggregate | undefined =
+                aggregates.get(childId);
+              if (!aggregate) {
+                continue;
+              }
+
+              /*
+               * A child with nothing locatable anywhere beneath it cannot go
+               * on the map. It is reported rather than dropped: a region
+               * that silently vanishes from the map, while its card sits
+               * right underneath, is the exact confusion this endpoint was
+               * rewritten to end.
+               */
+              if (aggregate.latitude === null || aggregate.longitude === null) {
+                unplacedSites.push({
+                  id: childId,
+                  name: child.name || "Unnamed site",
+                  ...typeInfo,
+                } as unknown as JSONObject);
+                continue;
+              }
+
+              sites.push({
+                id: childId,
+                name: child.name || "Unnamed site",
+                ...typeInfo,
+                latitude: aggregate.latitude,
+                longitude: aggregate.longitude,
+                statusPriority: aggregate.worstStatusPriority,
+                isOperational: aggregate.isOperational,
+                /*
+                 * The breadcrumb bar above the map already names every
+                 * ancestor of this level, so a marker repeating them would
+                 * be noise. These rows are the level's own children.
+                 */
+                parentBreadcrumb: "",
+                isContainer: !typeInfo.isUnitLevel,
+                isDerivedLocation: aggregate.isDerivedLocation,
+                locatedDescendantCount: aggregate.locatedDescendantCount,
+                unlocatedDescendantCount: aggregate.unlocatedDescendantCount,
+                totalUnits: aggregate.totalUnits,
+                operationalUnits: aggregate.operationalUnits,
+                childSiteCount: aggregate.childSiteCount,
+              } as unknown as JSONObject);
+            }
+          }
 
           return Response.sendJsonObjectResponse(req, res, {
+            mode: mode,
+            siteId: siteId,
             sites: sites,
-            isTruncated: siteRows.length >= LIMIT_PER_PROJECT,
+            unplacedSites: unplacedSites,
+            isTruncated:
+              childRows.length >= LIMIT_PER_PROJECT ||
+              subtreeRows.length >= LIMIT_PER_PROJECT,
           } as unknown as JSONObject);
         } catch (err) {
           return next(err);

--- a/App/FeatureSet/BaseAPI/Utils/NetworkSiteMapUtil.ts
+++ b/App/FeatureSet/BaseAPI/Utils/NetworkSiteMapUtil.ts
@@ -1,0 +1,447 @@
+/*
+ * Pure aggregation logic behind the /network-site/map endpoint — the half
+ * that turns a hierarchy into MARKERS.
+ *
+ * WHY THIS EXISTS
+ *
+ * The map used to plot every coordinate-bearing site in the project, flat,
+ * and let screen-proximity clustering decide what a marker meant. On a
+ * franchise network that produced numbered blobs ("104", "58") that
+ * correspond to nothing a customer has ever named: they are however many
+ * stores happened to fall in one grid cell at that zoom. Meanwhile the cards
+ * under the map showed the actual hierarchy — the regions, the markets — so
+ * the two halves of the page disagreed about what the network is.
+ *
+ * Worse, the levels a customer actually models — Region, Market, "Corp",
+ * "Franchise Units" — are organizational rows with no coordinates of their
+ * own, so they could never appear on the map at all. The one thing the map
+ * was for, seeing the shape of the estate, was the one thing it could not
+ * show.
+ *
+ * So the map is now LEVEL-SCOPED: one marker per child of the level being
+ * viewed, exactly the set the cards below it list. A container child that
+ * carries no coordinates of its own is placed at the centroid of the
+ * descendants that do, and reports what is under it (units, how many are
+ * operational, direct sites) so the marker can be sized and colored by its
+ * rollup rather than by an accident of geography.
+ *
+ * Everything here is data-in/data-out so the centroid math, the subtree
+ * assignment and the rollups are unit-testable without a database. Same
+ * input, same output: no clock, no randomness.
+ *
+ * siteType is carried as a plain display string. isUnitLevel is the
+ * load-bearing half — site types are per-project rows a customer can rename
+ * ("Unit" → "Store" → "Restaurant"), so nothing here may compare siteType to
+ * a literal. See NetworkSiteHierarchyUtil for the same rule on the
+ * /network-site/children side.
+ */
+
+// A geographic position that has passed isUsableCoordinate.
+export interface GeoPoint {
+  latitude: number;
+  longitude: number;
+}
+
+/*
+ * Any site inside the viewed level's subtree, including the direct children
+ * themselves — the aggregator seeds children first and skips them when it
+ * walks this list, exactly like NetworkSiteHierarchyUtil.aggregateChildStats.
+ */
+export interface MapSubtreeRow {
+  id: string;
+  name?: string | undefined;
+  isUnitLevel: boolean;
+  parentSiteId?: string | undefined;
+  materializedPath?: string | undefined;
+  latitude?: number | null | undefined;
+  longitude?: number | null | undefined;
+  currentMonitorStatusId?: string | undefined;
+}
+
+// A direct child of the viewed level — one marker each.
+export interface MapChildRow {
+  id: string;
+  name: string;
+  siteType: string;
+  isUnitLevel: boolean;
+  latitude?: number | null | undefined;
+  longitude?: number | null | undefined;
+  currentMonitorStatusId?: string | undefined;
+}
+
+// What one marker reports about the subtree hanging off it.
+export interface MapMarkerAggregate {
+  /*
+   * Where the marker goes. Null when neither the child nor anything under
+   * it carries usable coordinates — such a child has no place on the map and
+   * is reported separately rather than dropped silently.
+   */
+  latitude: number | null;
+  longitude: number | null;
+  /*
+   * True when the position is the centroid of descendants rather than the
+   * site's own coordinates. The UI says so: an inferred position must not
+   * be presented with the same confidence as one somebody typed in.
+   */
+  isDerivedLocation: boolean;
+  // Descendants (the child itself included) that could be placed, and not.
+  locatedDescendantCount: number;
+  unlocatedDescendantCount: number;
+  // Unit-level rollup, the same figures the site card leads with.
+  totalUnits: number;
+  operationalUnits: number;
+  // Direct children of the child — the next drill level's size.
+  childSiteCount: number;
+  // Worst (= highest priority) status anywhere in the child's subtree.
+  worstStatusPriority: number;
+  /*
+   * Tri-state health of the subtree: false if anything in it is known
+   * non-operational, true if everything carrying a status is operational,
+   * null when nothing in it reports a status at all.
+   */
+  isOperational: boolean | null;
+}
+
+// The status columns the aggregator reasons about, keyed by status id.
+export interface MapStatusInfo {
+  priority: number;
+  isOperationalState: boolean;
+}
+
+export const MIN_LATITUDE: number = -90;
+export const MAX_LATITUDE: number = 90;
+export const MIN_LONGITUDE: number = -180;
+export const MAX_LONGITUDE: number = 180;
+
+const DEGREES_TO_RADIANS: number = Math.PI / 180;
+const RADIANS_TO_DEGREES: number = 180 / Math.PI;
+
+/*
+ * Below this the averaged unit vector has no meaningful direction — the
+ * points cancelled each other out (the textbook case is two exactly
+ * antipodal sites). Compared against the vector's LENGTH, which is 1 for a
+ * single point and falls toward 0 as the points spread over the sphere.
+ */
+const DEGENERATE_CENTROID_EPSILON: number = 1e-9;
+
+/**
+ * Whether a latitude/longitude pair can be put on a map at all: both finite
+ * numbers, and inside the real ranges.
+ *
+ * The range check is not pedantry. A CSV import that shifts a column by one
+ * lands a longitude in the latitude field, and 1246.7 projected as a
+ * latitude silently drags a marker (and the frame fitted around it) off to
+ * a place no site is. Rejecting it puts the site in the "cannot be placed"
+ * list, where the customer can see and fix it.
+ */
+export function isUsableCoordinate(
+  latitude: number | null | undefined,
+  longitude: number | null | undefined,
+): boolean {
+  if (typeof latitude !== "number" || typeof longitude !== "number") {
+    return false;
+  }
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return false;
+  }
+  if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE) {
+    return false;
+  }
+  return longitude >= MIN_LONGITUDE && longitude <= MAX_LONGITUDE;
+}
+
+/**
+ * The centroid of a set of points ON THE SPHERE: each is converted to a unit
+ * vector, the vectors are averaged, and the mean direction is converted back
+ * to a latitude and longitude.
+ *
+ * Averaging the raw numbers instead would be wrong in the two places it most
+ * matters to a network that spans a country. Longitudes wrap: the mean of
+ * +179 and -179 is 0 — the Gulf of Guinea — for two sites that are 2 degrees
+ * apart in the Pacific. And latitudes converge: near the poles equal steps
+ * in longitude are not equal distances, so a flat mean drifts. Unit vectors
+ * have neither problem, and for the ordinary case of a few dozen stores in
+ * one state they agree with the naive mean to well under a pixel.
+ *
+ * Returns null for an empty input, and for the degenerate case where the
+ * points cancel out (antipodal), where no centroid exists to report.
+ */
+export function sphericalCentroid(points: Array<GeoPoint>): GeoPoint | null {
+  if (points.length === 0) {
+    return null;
+  }
+
+  let x: number = 0;
+  let y: number = 0;
+  let z: number = 0;
+  let count: number = 0;
+
+  for (const point of points) {
+    if (!isUsableCoordinate(point.latitude, point.longitude)) {
+      continue;
+    }
+    const latitude: number = point.latitude * DEGREES_TO_RADIANS;
+    const longitude: number = point.longitude * DEGREES_TO_RADIANS;
+    const cosLatitude: number = Math.cos(latitude);
+    x += cosLatitude * Math.cos(longitude);
+    y += cosLatitude * Math.sin(longitude);
+    z += Math.sin(latitude);
+    count++;
+  }
+
+  if (count === 0) {
+    return null;
+  }
+
+  x /= count;
+  y /= count;
+  z /= count;
+
+  const length: number = Math.sqrt(x * x + y * y + z * z);
+  if (!Number.isFinite(length) || length < DEGENERATE_CENTROID_EPSILON) {
+    return null;
+  }
+
+  const hypotenuse: number = Math.sqrt(x * x + y * y);
+  const latitude: number = Math.atan2(z, hypotenuse) * RADIANS_TO_DEGREES;
+  const longitude: number = Math.atan2(y, x) * RADIANS_TO_DEGREES;
+
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+
+  return { latitude: latitude, longitude: longitude };
+}
+
+/*
+ * Mutable accumulator — the public aggregate plus the points the centroid
+ * is averaged from and the flags the health verdict is folded up from.
+ */
+interface MarkerAccumulator {
+  ownPoint: GeoPoint | null;
+  points: Array<GeoPoint>;
+  locatedDescendantCount: number;
+  unlocatedDescendantCount: number;
+  totalUnits: number;
+  operationalUnits: number;
+  childSiteCount: number;
+  worstStatusPriority: number;
+  anyNonOperational: boolean;
+  anyOperational: boolean;
+  anyStatus: boolean;
+}
+
+function newAccumulator(): MarkerAccumulator {
+  return {
+    ownPoint: null,
+    points: [],
+    locatedDescendantCount: 0,
+    unlocatedDescendantCount: 0,
+    totalUnits: 0,
+    operationalUnits: 0,
+    childSiteCount: 0,
+    worstStatusPriority: 0,
+    anyNonOperational: false,
+    anyOperational: false,
+    anyStatus: false,
+  };
+}
+
+function applyStatus(
+  accumulator: MarkerAccumulator,
+  statusId: string | undefined,
+  statusById: Map<string, MapStatusInfo>,
+): boolean {
+  if (!statusId) {
+    return false;
+  }
+  const status: MapStatusInfo | undefined = statusById.get(statusId);
+  if (!status) {
+    // Status row deleted since — no priority or verdict to reason with.
+    return false;
+  }
+  accumulator.anyStatus = true;
+  accumulator.worstStatusPriority = Math.max(
+    accumulator.worstStatusPriority,
+    Number.isFinite(status.priority) ? status.priority : 0,
+  );
+  if (status.isOperationalState) {
+    accumulator.anyOperational = true;
+  } else {
+    accumulator.anyNonOperational = true;
+  }
+  return status.isOperationalState;
+}
+
+/**
+ * Which of the viewed level's children a subtree row belongs under.
+ *
+ * Children are siblings, so at most one of their ids can appear in a
+ * descendant's materialized path. Rows whose path is missing or has not
+ * been backfilled fall back to a direct parent match, which at least places
+ * the grandchildren correctly.
+ */
+function findSubtreeRoot(
+  row: MapSubtreeRow,
+  childIds: Set<string>,
+): string | undefined {
+  if (row.materializedPath) {
+    for (const segment of row.materializedPath.split("/")) {
+      if (segment && childIds.has(segment)) {
+        return segment;
+      }
+    }
+  }
+  if (row.parentSiteId && childIds.has(row.parentSiteId)) {
+    return row.parentSiteId;
+  }
+  return undefined;
+}
+
+export default class NetworkSiteMapUtil {
+  /**
+   * One marker aggregate per direct child of the viewed level.
+   *
+   * Position: the child's own coordinates when it has them — somebody typed
+   * those in and they outrank anything inferred — otherwise the spherical
+   * centroid of every located site in its subtree. A child with neither gets
+   * a null position and is reported to the caller as unplaceable rather than
+   * quietly dropped, because "Region 2100 is missing from the map" with no
+   * explanation is the bug this whole endpoint exists to stop shipping.
+   *
+   * Rollups mirror the site card's, so the marker and the card under it
+   * cannot disagree: unit-level descendants counted by the isUnitLevel FLAG
+   * (never by a type name), operational ones counted against the caller's
+   * set of operational status ids, and direct children counted for the
+   * "what happens if I click this" figure. A child that is itself unit-level
+   * reports exactly itself as its unit rollup — its own descendants, if it
+   * somehow has any, do not add.
+   */
+  public static aggregateMapMarkers(data: {
+    children: Array<MapChildRow>;
+    descendants: Array<MapSubtreeRow>;
+    statusById: Map<string, MapStatusInfo>;
+  }): Map<string, MapMarkerAggregate> {
+    const childIds: Set<string> = new Set<string>();
+    const childIsUnitLevelById: Map<string, boolean> = new Map<
+      string,
+      boolean
+    >();
+    const accumulators: Map<string, MarkerAccumulator> = new Map<
+      string,
+      MarkerAccumulator
+    >();
+
+    for (const child of data.children) {
+      childIds.add(child.id);
+      childIsUnitLevelById.set(child.id, child.isUnitLevel);
+
+      const accumulator: MarkerAccumulator = newAccumulator();
+      const isOperational: boolean = applyStatus(
+        accumulator,
+        child.currentMonitorStatusId,
+        data.statusById,
+      );
+
+      if (isUsableCoordinate(child.latitude, child.longitude)) {
+        const point: GeoPoint = {
+          latitude: child.latitude as number,
+          longitude: child.longitude as number,
+        };
+        accumulator.ownPoint = point;
+        accumulator.points.push(point);
+        accumulator.locatedDescendantCount++;
+      } else {
+        accumulator.unlocatedDescendantCount++;
+      }
+
+      if (child.isUnitLevel) {
+        accumulator.totalUnits = 1;
+        accumulator.operationalUnits = isOperational ? 1 : 0;
+      }
+
+      accumulators.set(child.id, accumulator);
+    }
+
+    for (const row of data.descendants) {
+      if (childIds.has(row.id)) {
+        // The children themselves — already seeded above.
+        continue;
+      }
+
+      const subtreeRoot: string | undefined = findSubtreeRoot(row, childIds);
+
+      if (row.parentSiteId) {
+        const parentAccumulator: MarkerAccumulator | undefined =
+          accumulators.get(row.parentSiteId);
+        if (parentAccumulator) {
+          parentAccumulator.childSiteCount++;
+        }
+      }
+
+      if (!subtreeRoot) {
+        continue;
+      }
+      const accumulator: MarkerAccumulator = accumulators.get(subtreeRoot)!;
+
+      const isOperational: boolean = applyStatus(
+        accumulator,
+        row.currentMonitorStatusId,
+        data.statusById,
+      );
+
+      if (isUsableCoordinate(row.latitude, row.longitude)) {
+        accumulator.points.push({
+          latitude: row.latitude as number,
+          longitude: row.longitude as number,
+        });
+        accumulator.locatedDescendantCount++;
+      } else {
+        accumulator.unlocatedDescendantCount++;
+      }
+
+      if (row.isUnitLevel && !childIsUnitLevelById.get(subtreeRoot)) {
+        accumulator.totalUnits++;
+        if (isOperational) {
+          accumulator.operationalUnits++;
+        }
+      }
+    }
+
+    const result: Map<string, MapMarkerAggregate> = new Map<
+      string,
+      MapMarkerAggregate
+    >();
+
+    for (const [childId, accumulator] of accumulators) {
+      /*
+       * Explicit coordinates beat an inferred centroid: a customer who
+       * pinned their regional office meant the marker to sit there, not at
+       * the middle of the stores it happens to own.
+       */
+      const derived: GeoPoint | null = accumulator.ownPoint
+        ? null
+        : sphericalCentroid(accumulator.points);
+      const position: GeoPoint | null = accumulator.ownPoint || derived;
+
+      result.set(childId, {
+        latitude: position ? position.latitude : null,
+        longitude: position ? position.longitude : null,
+        isDerivedLocation: Boolean(!accumulator.ownPoint && position),
+        locatedDescendantCount: accumulator.locatedDescendantCount,
+        unlocatedDescendantCount: accumulator.unlocatedDescendantCount,
+        totalUnits: accumulator.totalUnits,
+        operationalUnits: accumulator.operationalUnits,
+        childSiteCount: accumulator.childSiteCount,
+        worstStatusPriority: accumulator.worstStatusPriority,
+        isOperational: accumulator.anyNonOperational
+          ? false
+          : accumulator.anyStatus && accumulator.anyOperational
+            ? true
+            : null,
+      });
+    }
+
+    return result;
+  }
+}

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteCard.tsx
@@ -1,6 +1,10 @@
 import React, { FunctionComponent, ReactElement } from "react";
 import { SiteChildView, SiteStatusInfo } from "./SiteHierarchyTypes";
-import { formatUptimePercent } from "./SiteMapViewModel";
+import {
+  HealthTone,
+  formatUptimePercent,
+  unitRollupTone,
+} from "./SiteMapViewModel";
 
 /*
  * Shared card body for one network site: name, site-type label, health
@@ -29,42 +33,20 @@ const NO_STATUS_COLOR: string = "#9ca3af"; // gray-400
  * Derived from the unit rollup, NOT from the status row's color: the
  * status color is arbitrary project-configured hex, while the tone drives
  * Tailwind semantic classes that must stay legible in both themes.
+ *
+ * The rule itself lives in SiteMapViewModel because the MAP now colors its
+ * hierarchy markers by exactly the same rollup. A region whose card reads
+ * "63 of 63 units down" and whose marker is a calm dot is the disagreement
+ * between the two halves of this page that the shared function prevents.
  */
-type UnitRollupTone = "ok" | "warn" | "down" | "none";
-
-const rollupTone: (site: SiteChildView) => UnitRollupTone = (
-  site: SiteChildView,
-): UnitRollupTone => {
-  const total: number = site.unitStats.totalUnits;
-  if (total <= 0) {
-    return "none";
-  }
-  const operational: number = Math.min(
-    Math.max(site.unitStats.operationalUnits, 0),
-    total,
-  );
-  if (operational >= total) {
-    return "ok";
-  }
-  /*
-   * Half or more of the units down is an outage, not a wobble — red, so a
-   * "1 of 4 up" site never reads calmer than the red status dot beside it.
-   * A minority down stays amber (degraded).
-   */
-  if (operational * 2 <= total) {
-    return "down";
-  }
-  return "warn";
-};
-
-const TONE_TEXT_CLASS: Record<UnitRollupTone, string> = {
+const TONE_TEXT_CLASS: Record<HealthTone, string> = {
   ok: "text-emerald-600",
   warn: "text-amber-600",
   down: "text-red-600",
   none: "text-gray-400",
 };
 
-const TONE_BAR_CLASS: Record<UnitRollupTone, string> = {
+const TONE_BAR_CLASS: Record<HealthTone, string> = {
   ok: "bg-emerald-500",
   warn: "bg-amber-500",
   down: "bg-red-500",
@@ -91,7 +73,7 @@ export const SiteCardBody: FunctionComponent<SiteCardBodyProps> = (
     totalUnits,
   );
   const downUnits: number = totalUnits - operationalUnits;
-  const tone: UnitRollupTone = rollupTone(site);
+  const tone: HealthTone = unitRollupTone(site.unitStats);
   const hasRollup: boolean = totalUnits > 0;
   const operationalPercent: number = hasRollup
     ? (operationalUnits / totalUnits) * 100

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
@@ -18,23 +18,34 @@ import {
   countPointsInViewport,
   fitViewportToPoints,
   panViewport,
+  screenLengthToViewportLength,
   shouldUseDetailGeometry,
   viewBoxOfViewport,
   viewportsMatch,
   zoomOfViewport,
   zoomViewport,
 } from "./Geo/GeoViewport";
-import { GeoCluster, clusterPoints } from "./Geo/GeoClusterUtil";
 import {
   BuildPinsResult,
   ClusterColorKey,
+  MapMarker,
+  LABEL_FONT_SIZE,
+  LABEL_GAP,
+  LabelPlacement,
+  buildMapMarkers,
   buildPins,
+  GENERIC_SITE_TYPE_LABEL,
   clusterCellSize,
-  clusterRadius,
-  decideClusterColorKey,
+  describeMapCoverage,
   mapPinFingerprint,
+  pluralizeSiteType,
+  resolveMarkerLabels,
 } from "./SiteMapViewModel";
-import { MapSiteView } from "./SiteHierarchyTypes";
+import {
+  MapSiteView,
+  MapUnplacedSiteView,
+  SiteMapMode,
+} from "./SiteHierarchyTypes";
 
 /*
  * Inline-SVG world map of network sites: checked-in country outlines
@@ -155,6 +166,14 @@ const KEYBOARD_PAN_FRACTION: number = 0.2;
  */
 const DRAG_THRESHOLD_PX: number = 4;
 
+/*
+ * How many unplaceable children are named under the map before the rest
+ * collapse into a count. Enough to be actionable on a normal level, few
+ * enough that a hierarchy imported entirely without coordinates does not
+ * push the map off the screen.
+ */
+const UNPLACED_NAMES_SHOWN: number = 6;
+
 const dotColorForSite: (site: MapSiteView) => string = (
   site: MapSiteView,
 ): string => {
@@ -245,8 +264,125 @@ const MapControlButton: FunctionComponent<{
 
 export interface ComponentProps {
   sites: Array<MapSiteView>;
+  /*
+   * What the rows in `sites` ARE — grouped markers (one per child of the
+   * level in view) or every located site under it. This drives the drawing.
+   */
+  mode: SiteMapMode;
+  /*
+   * What the reader last ASKED for. The two differ for the moment between
+   * pressing the switch and the new payload landing, and the switch has to
+   * follow the press rather than the payload: a control that springs back
+   * under the pointer reads as a control that did not work.
+   */
+  selectedMode: SiteMapMode;
+  onModeChange: (mode: SiteMapMode) => void;
+  /*
+   * Children of this level that have no coordinates anywhere beneath them.
+   * Listed under the map instead of being silently absent — "where did
+   * Region 2100 go" is a support ticket, and the answer is actionable.
+   */
+  unplacedSites: Array<MapUnplacedSiteView>;
+  /*
+   * What the markers are, in this project's own words ("Regions",
+   * "Markets", "Sites") — used in the switch and the counts so the map
+   * never invents vocabulary the customer has not used.
+   */
+  childTypeLabel: string;
   onSiteClick: (siteId: string) => void;
 }
+
+/*
+ * The grouped/all switch. Two options, both always meaningful, so this is a
+ * segmented control rather than a dropdown: the alternative is visible
+ * without a click, which is the whole point when a customer's first
+ * reaction to the map is "this is not my network".
+ */
+const MapModeSwitch: FunctionComponent<{
+  mode: SiteMapMode;
+  childTypeLabel: string;
+  onModeChange: (mode: SiteMapMode) => void;
+}> = (props: {
+  mode: SiteMapMode;
+  childTypeLabel: string;
+  onModeChange: (mode: SiteMapMode) => void;
+}): ReactElement => {
+  /*
+   * A level whose children are all Regions gets "Regions | All sites",
+   * which says exactly what the two views are. A level that MIXES types has
+   * no name of its own to offer, and "Sites | All sites" is two labels for
+   * what reads as the same thing — so it falls back to naming the
+   * behaviour instead.
+   */
+  const isGenericLabel: boolean =
+    props.childTypeLabel.toLowerCase() === GENERIC_SITE_TYPE_LABEL;
+
+  const options: Array<{ value: SiteMapMode; label: string; hint: string }> = [
+    {
+      value: "grouped",
+      /*
+       * The button says the plural; the sentence under it says the
+       * singular. Both are built from the customer's own singular type
+       * name — pre-pluralizing at the call site is what turns the hint into
+       * "One marker per regions at this level".
+       */
+      label: isGenericLabel
+        ? "Grouped"
+        : pluralizeSiteType(props.childTypeLabel),
+      hint: `One marker per ${props.childTypeLabel.toLowerCase()} at this level`,
+    },
+    {
+      value: "all",
+      label: "All sites",
+      hint: "Every site below this level, individually",
+    },
+  ];
+
+  return (
+    <div
+      role="group"
+      aria-label="Map grouping"
+      className="inline-flex flex-shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-0.5"
+    >
+      {options.map(
+        (option: {
+          value: SiteMapMode;
+          label: string;
+          hint: string;
+        }): ReactElement => {
+          const isActive: boolean = props.mode === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              title={option.hint}
+              aria-pressed={isActive}
+              data-testid={`site-geo-map-mode-${option.value}`}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                /*
+                 * The ring is load-bearing in dark mode: the "raised" pill
+                 * (--ou-surface-primary) is actually DARKER than the track
+                 * it sits in (--ou-surface-secondary), so without a border
+                 * the selected option is a 1.1:1 edge — invisible. Every
+                 * other segmented control in the Dashboard carries the same
+                 * ring for the same reason.
+                 */
+                isActive
+                  ? "bg-white text-gray-900 shadow-sm ring-1 ring-gray-200"
+                  : "text-gray-500 hover:text-gray-800"
+              }`}
+              onClick={() => {
+                props.onModeChange(option.value);
+              }}
+            >
+              {option.label}
+            </button>
+          );
+        },
+      )}
+    </div>
+  );
+};
 
 const SiteGeoMap: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -289,14 +425,65 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   /*
    * A new set of sites is a new map: re-frame it, and drop a popover that is
    * anchored to a cluster which may no longer exist.
+   *
+   * A change of MODE is not a new map, though — both modes cover the same
+   * subtree and the same ground, so switching to "All sites" to look at the
+   * stores inside the region you just zoomed into must not throw that zoom
+   * away and bounce you back out to the whole estate.
    */
+  const framedMode: React.MutableRefObject<SiteMapMode> = useRef<SiteMapMode>(
+    props.mode,
+  );
   useEffect(() => {
-    setViewport(fittedViewport);
+    const isModeChange: boolean = framedMode.current !== props.mode;
+    framedMode.current = props.mode;
+    if (!isModeChange) {
+      setViewport(fittedViewport);
+    }
     setOpenCluster(null);
     setHovered(null);
-  }, [fittedViewport]);
+  }, [fittedViewport, props.mode]);
 
   const zoom: number = zoomOfViewport(viewport);
+
+  /*
+   * Clustering depends on the zoom but NOT on where the frame sits — the
+   * grid is anchored to the world, so panning never re-buckets anything.
+   * Memoizing on the cell size rather than on the viewport keeps a drag
+   * from re-bucketing every site on every pointer move.
+   *
+   * Grouped markers are never clustered, so the cell size is pinned to 0
+   * there: without that, every zoom step would rebuild a marker set that
+   * cannot change.
+   */
+  const cellSize: number = props.mode === "all" ? clusterCellSize(viewport) : 0;
+
+  /*
+   * Keyed on the SITES, not on the pin fingerprint. The fingerprint is
+   * deliberately geometry-only — a site going down recolours its marker but
+   * does not move it, and re-framing the map or closing a popover under
+   * someone every minute would be worse than a stale colour. But a marker's
+   * colour, its rollup and its tooltip are all baked in here, so keying this
+   * memo on geometry would freeze exactly the thing the 60-second poll
+   * exists to refresh: an outage would never reach the map.
+   */
+  const markers: Array<MapMarker> = useMemo(() => {
+    return buildMapMarkers({
+      sites: props.sites,
+      mode: props.mode,
+      cellSize: cellSize,
+    });
+  }, [props.sites, props.mode, cellSize]);
+
+  /*
+   * Which names fit without landing on each other. Keyed on the zoom rather
+   * than on the whole viewport: markers keep their relative distances as the
+   * frame moves, so panning must not re-decide which names are shown — that
+   * would make labels flicker in and out under the pointer.
+   */
+  const labelPlacements: Map<string, LabelPlacement> = useMemo(() => {
+    return resolveMarkerLabels(markers, zoom);
+  }, [markers, zoom]);
 
   /*
    * Zoom changes which sites share a marker, so an open picker's list can go
@@ -376,17 +563,6 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
     }
     return map;
   }, [props.sites]);
-
-  /*
-   * Clustering depends on the zoom but NOT on where the frame sits — the
-   * grid is anchored to the world, so panning never re-buckets anything.
-   * Memoizing on the cell size rather than on the viewport keeps a drag
-   * from re-clustering every site on every pointer move.
-   */
-  const cellSize: number = clusterCellSize(viewport);
-  const clusters: Array<GeoCluster> = useMemo(() => {
-    return clusterPoints(pins, cellSize);
-  }, [pins, cellSize]);
 
   /*
    * Pan by dragging, zoom by wheel — the same interaction model, and the
@@ -573,36 +749,15 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
     event.preventDefault();
   };
 
-  const tooltipForCluster: (cluster: GeoCluster) => string = (
-    cluster: GeoCluster,
-  ): string => {
-    if (cluster.ids.length === 1) {
-      const site: MapSiteView | undefined = siteById.get(cluster.ids[0]!);
-      if (!site) {
-        return "";
-      }
-      return site.parentBreadcrumb
-        ? `${site.name} — ${site.parentBreadcrumb}`
-        : site.name;
-    }
-    const names: Array<string> = cluster.ids
-      .slice(0, 5)
-      .map((id: string): string => {
-        return siteById.get(id)?.name || "Unnamed site";
-      });
-    const more: number = cluster.ids.length - names.length;
-    return `${cluster.totalCount} sites: ${names.join(", ")}${
-      more > 0 ? `, +${more} more` : ""
-    }`;
-  };
-
   /*
-   * Nothing to draw: say so instead of shipping a blank map. Every finite
-   * coordinate has a place on this projection, so the only way to get here
-   * with sites in hand is coordinates that are not usable numbers.
+   * Nothing to draw: say so instead of shipping a blank map. With grouped
+   * markers this is a genuinely common state — a hierarchy imported without
+   * coordinates has plenty of sites and no geography — so the empty state
+   * names the sites it could not place and says what to do about it.
    */
-  if (clusters.length === 0) {
+  if (markers.length === 0) {
     const hasSites: boolean = props.sites.length > 0;
+    const unplacedCount: number = props.unplacedSites.length;
     return (
       <div className="w-full rounded-lg border border-gray-200 bg-white shadow-sm">
         <EmptyState
@@ -611,30 +766,74 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
           title={
             hasSites
               ? "No sites can be placed on the map"
-              : "No sites on the map yet"
+              : "Nothing to put on the map yet"
           }
           description={
-            hasSites
-              ? `${unmappableCount} site${
-                  unmappableCount === 1 ? " has" : "s have"
-                } coordinates the map cannot read. Check the latitude and longitude on ${
-                  unmappableCount === 1 ? "that site" : "those sites"
-                }.`
-              : "Sites with a latitude and longitude appear here. Add coordinates to a site to place it on the map."
+            hasSites ? (
+              <span className="mx-auto block max-w-md">
+                {unmappableCount} site
+                {unmappableCount === 1 ? " has" : "s have"} coordinates the map
+                cannot read. Check the latitude and longitude on{" "}
+                {unmappableCount === 1 ? "that site" : "those sites"}.
+              </span>
+            ) : (
+              <span className="mx-auto block max-w-md">
+                {unplacedCount > 0
+                  ? `${unplacedCount} ${
+                      unplacedCount === 1 ? "site has" : "sites have"
+                    } no coordinates — neither on ${
+                      unplacedCount === 1 ? "it" : "them"
+                    } nor on anything beneath. Add a latitude and longitude to the sites at the bottom of your hierarchy and everything above them lands on the map automatically.`
+                  : "Sites with a latitude and longitude appear here. Add coordinates to a site to place it on the map."}
+              </span>
+            )
           }
         />
       </div>
     );
   }
 
-  const mappedCount: number = pins.length;
-  const inViewCount: number = countPointsInViewport(pins, viewport);
+  /*
+   * Count the same thing the coverage line NAMES. In "all" mode it talks
+   * about sites, and a marker there can stand for a dozen of them — counting
+   * markers against a site total would report "40 of 1400 sites in view" for
+   * a frame holding every one of them.
+   */
+  const inViewCount: number = countPointsInViewport(
+    props.mode === "all" ? pins : markers,
+    viewport,
+  );
   const isFitted: boolean = viewportsMatch(viewport, fittedViewport);
   const isWholeWorld: boolean = viewportsMatch(viewport, WORLD_VIEWPORT);
+  const coverageLabel: string = describeMapCoverage({
+    mode: props.mode,
+    markerCount: markers.length,
+    inViewCount: inViewCount,
+    siteCount: pins.length,
+    childTypeLabel: props.childTypeLabel,
+  });
 
   return (
     <div className="w-full rounded-lg border border-gray-200 bg-white shadow-sm">
       <div className="p-3 sm:p-4">
+        {/*
+         * What the markers mean, and the one control that changes it. A
+         * customer looking at a map that does not match their network needs
+         * the answer to "what am I looking at" before anything else — so it
+         * is written above the map, not buried in a legend below it.
+         */}
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+          <p className="text-xs text-gray-500">
+            {props.mode === "grouped"
+              ? `Each marker is one ${props.childTypeLabel.toLowerCase()} — click to open it.`
+              : "Each marker is one site. Nearby sites share a marker; zoom in to separate them."}
+          </p>
+          <MapModeSwitch
+            mode={props.selectedMode}
+            childTypeLabel={props.childTypeLabel}
+            onModeChange={props.onModeChange}
+          />
+        </div>
         {/*
          * This wrapper is exactly the SVG's box, so the percentage-anchored
          * overlays below line up with the markers they point at. It also
@@ -709,57 +908,52 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
               )}
             </g>
 
-            {/* Clustered site markers. */}
+            {/*
+             * The markers. A CONTAINER — a region, a market, "Corp" — is
+             * drawn as a rounded square, the same shape as the cards it
+             * opens into; a single site stays a round pin. The difference is
+             * a shape, not a hue, so "this is a level you can go into"
+             * survives both a color-blind reader and a grayscale print.
+             */}
             <g>
-              {clusters.map((cluster: GeoCluster): ReactElement => {
-                const members: Array<MapSiteView> = cluster.ids
-                  .map((id: string): MapSiteView | undefined => {
-                    return siteById.get(id);
-                  })
-                  .filter(
-                    (site: MapSiteView | undefined): site is MapSiteView => {
-                      return site !== undefined;
-                    },
-                  );
-                const colorKey: ClusterColorKey = decideClusterColorKey(
-                  members.map((site: MapSiteView) => {
-                    return {
-                      statusPriority: site.statusPriority,
-                      isOperational: site.isOperational,
-                    };
-                  }),
-                );
-                const color: string = CLUSTER_COLORS[colorKey];
+              {markers.map((marker: MapMarker): ReactElement => {
+                const color: string = CLUSTER_COLORS[marker.colorKey];
                 /*
                  * Sized on screen, then converted for this zoom: the marker
                  * is UI, not geography, so it must not grow with the map.
                  */
-                const screenRadius: number = clusterRadius(cluster.totalCount);
-                const radius: number = clusterRadius(
-                  cluster.totalCount,
+                const radius: number = screenLengthToViewportLength(
+                  marker.screenRadius,
                   viewport,
                 );
-                const isCluster: boolean = cluster.totalCount > 1;
-                const label: string = tooltipForCluster(cluster);
-                const key: string = `${cluster.x}:${cluster.y}:${cluster.ids[0]}`;
+                const hasCount: boolean = marker.count > 1;
+                const key: string = marker.key;
                 const activate: () => void = (): void => {
-                  if (cluster.ids.length === 1) {
+                  if (marker.ids.length === 1) {
                     setOpenCluster(null);
-                    props.onSiteClick(cluster.ids[0]!);
+                    props.onSiteClick(marker.ids[0]!);
                   } else {
                     setOpenCluster({
-                      x: cluster.x,
-                      y: cluster.y,
-                      ids: cluster.ids,
+                      x: marker.x,
+                      y: marker.y,
+                      ids: marker.ids,
                     });
                   }
                 };
+                /*
+                 * A square of side 2r covers a good deal more ink than a
+                 * circle of radius r, so containers are drawn slightly
+                 * tighter to keep the two shapes reading at one weight.
+                 */
+                const side: number = radius * 1.78;
+                const haloSide: number = side + ((hasCount ? 4 : 3) * 2) / zoom;
+
                 return (
                   <g
                     key={key}
                     role="button"
                     tabIndex={0}
-                    aria-label={label}
+                    aria-label={marker.tooltip}
                     style={{ cursor: "pointer", outline: "none" }}
                     onClick={() => {
                       // A pan that happened to end on a marker is not a click.
@@ -779,14 +973,22 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                       if (dragState.current) {
                         return;
                       }
-                      setHovered({ x: cluster.x, y: cluster.y, label: label });
+                      setHovered({
+                        x: marker.x,
+                        y: marker.y,
+                        label: marker.tooltip,
+                      });
                     }}
                     onMouseLeave={() => {
                       setHovered(null);
                     }}
                     onFocus={() => {
                       setFocusedKey(key);
-                      setHovered({ x: cluster.x, y: cluster.y, label: label });
+                      setHovered({
+                        x: marker.x,
+                        y: marker.y,
+                        label: marker.tooltip,
+                      });
                     }}
                     onBlur={() => {
                       setFocusedKey(null);
@@ -794,36 +996,74 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                     }}
                   >
                     {/*
-                     * Soft halo in the marker's own color: lifts the pin off
-                     * both a pale landmass and a dark one, and gives a
-                     * multi-site cluster visible extra weight.
+                     * Soft halo in the marker's own color: lifts the marker
+                     * off both a pale landmass and a dark one, and gives a
+                     * marker that stands for many sites visible extra weight.
                      */}
-                    <circle
-                      cx={cluster.x}
-                      cy={cluster.y}
-                      r={radius + (isCluster ? 4 : 3) / zoom}
-                      fill={color}
-                      fillOpacity={0.18}
-                    />
-                    <circle
-                      cx={cluster.x}
-                      cy={cluster.y}
-                      r={radius}
-                      fill={color}
-                      fillOpacity={0.95}
-                      stroke="var(--ou-chart-marker-ring, #ffffff)"
-                      strokeWidth={(isCluster ? 2.5 : 2) / zoom}
-                    />
-                    {isCluster ? (
+                    {marker.isContainer ? (
+                      <rect
+                        x={marker.x - haloSide / 2}
+                        y={marker.y - haloSide / 2}
+                        width={haloSide}
+                        height={haloSide}
+                        rx={haloSide * 0.28}
+                        fill={color}
+                        fillOpacity={0.18}
+                      />
+                    ) : (
+                      <circle
+                        cx={marker.x}
+                        cy={marker.y}
+                        r={radius + (hasCount ? 4 : 3) / zoom}
+                        fill={color}
+                        fillOpacity={0.18}
+                      />
+                    )}
+
+                    {marker.isContainer ? (
+                      <rect
+                        x={marker.x - side / 2}
+                        y={marker.y - side / 2}
+                        width={side}
+                        height={side}
+                        rx={side * 0.26}
+                        fill={color}
+                        fillOpacity={0.95}
+                        stroke="var(--ou-chart-marker-ring, #ffffff)"
+                        strokeWidth={(hasCount ? 2.5 : 2) / zoom}
+                        /*
+                         * An inferred position is drawn as a dashed edge —
+                         * the marker is where this region's sites average
+                         * out, not somewhere anybody pinned.
+                         */
+                        strokeDasharray={
+                          marker.isApproximate
+                            ? `${5 / zoom} ${3 / zoom}`
+                            : undefined
+                        }
+                      />
+                    ) : (
+                      <circle
+                        cx={marker.x}
+                        cy={marker.y}
+                        r={radius}
+                        fill={color}
+                        fillOpacity={0.95}
+                        stroke="var(--ou-chart-marker-ring, #ffffff)"
+                        strokeWidth={(hasCount ? 2.5 : 2) / zoom}
+                      />
+                    )}
+
+                    {hasCount ? (
                       <text
-                        x={cluster.x}
-                        y={cluster.y}
+                        x={marker.x}
+                        y={marker.y}
                         dy="0.36em"
                         textAnchor="middle"
                         fontSize={
-                          (screenRadius >= 14
+                          (marker.screenRadius >= 14
                             ? 13
-                            : screenRadius >= 10
+                            : marker.screenRadius >= 10
                               ? 11
                               : 10) / zoom
                         }
@@ -831,22 +1071,79 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                         fill="#ffffff"
                         style={{ pointerEvents: "none" }}
                       >
-                        {cluster.totalCount}
+                        {marker.count}
                       </text>
                     ) : (
                       <></>
                     )}
+
+                    {/*
+                     * The name, under the marker. This is the difference
+                     * between a map of your network and a scatter of dots:
+                     * "Region 1000" is on the map, where the customer put
+                     * it, instead of only in a tooltip.
+                     *
+                     * paint-order draws the stroke first, so the halo sits
+                     * BEHIND the glyphs and the label stays readable over a
+                     * coastline, a landmass or another marker.
+                     */}
+                    {marker.label && labelPlacements.has(key) ? (
+                      <text
+                        x={marker.x}
+                        /*
+                         * The label's CENTRE, matching the box
+                         * resolveMarkerLabels reserved for it — dy centres
+                         * the glyphs on it the same way the count inside the
+                         * marker is centred.
+                         */
+                        y={
+                          marker.y +
+                          (labelPlacements.get(key) === "above" ? -1 : 1) *
+                            ((marker.isContainer ? side / 2 : radius) +
+                              LABEL_GAP / zoom)
+                        }
+                        dy="0.36em"
+                        textAnchor="middle"
+                        fontSize={LABEL_FONT_SIZE / zoom}
+                        fontWeight={600}
+                        fill="var(--ou-text-secondary, #374151)"
+                        stroke="var(--ou-surface-primary, #ffffff)"
+                        strokeWidth={3 / zoom}
+                        strokeLinejoin="round"
+                        paintOrder="stroke"
+                        style={{ pointerEvents: "none" }}
+                      >
+                        {marker.label}
+                      </text>
+                    ) : (
+                      <></>
+                    )}
+
                     {/* Keyboard focus ring — the marker has no CSS box to outline. */}
                     {focusedKey === key ? (
-                      <circle
-                        cx={cluster.x}
-                        cy={cluster.y}
-                        r={radius + 5 / zoom}
-                        fill="none"
-                        stroke="var(--ou-link, #4f46e5)"
-                        strokeWidth={2 / zoom}
-                        style={{ pointerEvents: "none" }}
-                      />
+                      marker.isContainer ? (
+                        <rect
+                          x={marker.x - side / 2 - 5 / zoom}
+                          y={marker.y - side / 2 - 5 / zoom}
+                          width={side + 10 / zoom}
+                          height={side + 10 / zoom}
+                          rx={(side + 10 / zoom) * 0.26}
+                          fill="none"
+                          stroke="var(--ou-link, #4f46e5)"
+                          strokeWidth={2 / zoom}
+                          style={{ pointerEvents: "none" }}
+                        />
+                      ) : (
+                        <circle
+                          cx={marker.x}
+                          cy={marker.y}
+                          r={radius + 5 / zoom}
+                          fill="none"
+                          stroke="var(--ou-link, #4f46e5)"
+                          strokeWidth={2 / zoom}
+                          style={{ pointerEvents: "none" }}
+                        />
+                      )
                     ) : (
                       <></>
                     )}
@@ -997,17 +1294,52 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
           )}
         </ul>
 
+        {/*
+         * The shape key. Color says how it is doing; SHAPE says what it is —
+         * a level you can open, or a single place. Without this line the
+         * square is decoration.
+         */}
+        {props.mode === "grouped" ? (
+          <ul
+            role="list"
+            className="flex flex-wrap items-center gap-x-3 gap-y-1"
+            aria-label="Marker shape key"
+          >
+            {/*
+             * Colored inline from the marker palette, like the status
+             * swatches above: a Tailwind gray class here would be one of the
+             * steps the dark theme does not recolor, and the swatch has to
+             * be the same neutral in both themes anyway — it is standing in
+             * for a SHAPE, not for a state.
+             */}
+            <li className="flex items-center gap-1.5 text-xs text-gray-600">
+              <span
+                aria-hidden="true"
+                className="h-2.5 w-2.5 flex-shrink-0 rounded-[3px] ring-2 ring-white"
+                style={{ backgroundColor: CLUSTER_COLORS["none"] }}
+              />
+              Group — opens
+            </li>
+            <li className="flex items-center gap-1.5 text-xs text-gray-600">
+              <span
+                aria-hidden="true"
+                className="h-2.5 w-2.5 flex-shrink-0 rounded-full ring-2 ring-white"
+                style={{ backgroundColor: CLUSTER_COLORS["none"] }}
+              />
+              Single site
+            </li>
+          </ul>
+        ) : (
+          <></>
+        )}
+
         <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 sm:ml-auto">
           {/*
            * Once the frame no longer holds everything, say what it does hold
            * — a count that quietly shrinks as you zoom reads as sites
            * disappearing.
            */}
-          <span data-testid="site-geo-map-count">
-            {inViewCount < mappedCount
-              ? `${inViewCount} of ${mappedCount} sites in view`
-              : `${mappedCount} site${mappedCount === 1 ? "" : "s"} mapped`}
-          </span>
+          <span data-testid="site-geo-map-count">{coverageLabel}</span>
           {/* Coordinates the projection cannot read at all. */}
           {unmappableCount > 0 ? (
             <span className="inline-flex items-center rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs text-gray-600">
@@ -1018,6 +1350,58 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
           )}
         </div>
       </div>
+
+      {/*
+       * What the map is NOT showing. A level whose card sits right under the
+       * map but whose marker is nowhere on it is the single most confusing
+       * thing this page can do, so the omission is stated, named, and made
+       * fixable — every one of these needs coordinates on something beneath
+       * it.
+       */}
+      {props.unplacedSites.length > 0 ? (
+        <div
+          data-testid="site-geo-map-unplaced"
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-gray-100 px-3 py-2.5 text-xs text-gray-500 sm:px-4"
+        >
+          <Icon
+            className="h-3.5 w-3.5 flex-shrink-0 text-gray-400"
+            icon={IconProp.MapPin}
+          />
+          <span>
+            Not on the map — no coordinates yet
+            {props.unplacedSites.length > UNPLACED_NAMES_SHOWN
+              ? ` (${props.unplacedSites.length})`
+              : ""}
+            :
+          </span>
+          {props.unplacedSites
+            .slice(0, UNPLACED_NAMES_SHOWN)
+            .map((site: MapUnplacedSiteView): ReactElement => {
+              return (
+                <button
+                  key={site.id}
+                  type="button"
+                  title={`${site.name} — ${site.siteType}. Open it and add coordinates to a site beneath it.`}
+                  className="inline-flex max-w-full items-center rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 font-medium text-gray-600 transition hover:border-indigo-300 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                  onClick={() => {
+                    props.onSiteClick(site.id);
+                  }}
+                >
+                  <span className="truncate">{site.name}</span>
+                </button>
+              );
+            })}
+          {props.unplacedSites.length > UNPLACED_NAMES_SHOWN ? (
+            <span className="text-gray-400">
+              +{props.unplacedSites.length - UNPLACED_NAMES_SHOWN} more
+            </span>
+          ) : (
+            <></>
+          )}
+        </div>
+      ) : (
+        <></>
+      )}
     </div>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes.ts
@@ -79,7 +79,21 @@ export interface SiteChildrenResponse {
   descendantCountsTruncated: boolean;
 }
 
-// One pin row of /network-site/map.
+/*
+ * How the map is showing the level in view:
+ *
+ *   grouped — one marker per child of this level, the same set the cards
+ *             below it list. A container child with no coordinates of its
+ *             own sits at the centroid of the sites beneath it.
+ *   all     — every located site in this level's subtree, individually.
+ *
+ * Grouped is the default because it is the only one of the two that can
+ * answer "what does my network look like": the flat view turns a franchise
+ * estate into proximity blobs whose counts match nothing anybody named.
+ */
+export type SiteMapMode = "grouped" | "all";
+
+// One marker row of /network-site/map.
 export interface MapSiteView {
   id: string;
   name: string;
@@ -90,10 +104,37 @@ export interface MapSiteView {
   statusPriority: number;
   isOperational: boolean | null;
   parentBreadcrumb: string;
+  /*
+   * This marker stands for a level of the hierarchy rather than for one
+   * place — it is drawn as a container, and clicking it drills.
+   */
+  isContainer: boolean;
+  // The position is the centroid of what is beneath it, not its own pin.
+  isDerivedLocation: boolean;
+  locatedDescendantCount: number;
+  unlocatedDescendantCount: number;
+  totalUnits: number;
+  operationalUnits: number;
+  childSiteCount: number;
+}
+
+/*
+ * A child of this level that has no place on the map: neither it nor
+ * anything beneath it carries coordinates. Reported rather than dropped —
+ * a region missing from the map while its card sits right underneath is a
+ * bug report waiting to happen.
+ */
+export interface MapUnplacedSiteView {
+  id: string;
+  name: string;
+  siteType: string;
+  isUnitLevel: boolean;
 }
 
 export interface SiteMapResponse {
+  mode: SiteMapMode;
   sites: Array<MapSiteView>;
+  unplacedSites: Array<MapUnplacedSiteView>;
   isTruncated: boolean;
 }
 
@@ -248,10 +289,51 @@ export const parseSiteChildrenResponse: (
   };
 };
 
+/*
+ * Real latitude and longitude ranges. A CSV import that shifts a column by
+ * one puts a longitude in the latitude field, and a latitude of 1246.7
+ * projects to a marker — and a frame fitted around it — somewhere no site
+ * is. Out-of-range rows are dropped here for the same reason the server
+ * refuses to place them.
+ */
+const MAX_LATITUDE: number = 90;
+const MAX_LONGITUDE: number = 180;
+
+const asCoordinate: (value: unknown, limit: number) => number | null = (
+  value: unknown,
+  limit: number,
+): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return value >= -limit && value <= limit ? value : null;
+};
+
+const parseUnplacedRow: (value: unknown) => MapUnplacedSiteView | null = (
+  value: unknown,
+): MapUnplacedSiteView | null => {
+  const row: JSONObject = (value || {}) as JSONObject;
+  const id: string = asString(row["id"], "");
+  if (!id) {
+    return null;
+  }
+  return {
+    id: id,
+    name: asString(row["name"], "Unnamed site"),
+    siteType: asString(row["siteType"], "Other"),
+    isUnitLevel: row["isUnitLevel"] === true,
+  };
+};
+
 /**
- * Narrow an untyped /network-site/map payload. Rows without an id or with
- * non-finite coordinates are dropped — a pin that cannot be projected is
- * noise, and the projection math requires finite inputs.
+ * Narrow an untyped /network-site/map payload. Rows without an id, or whose
+ * coordinates are not usable numbers in the real latitude/longitude ranges,
+ * are dropped — a marker that cannot be projected is noise, and the
+ * projection math requires finite inputs.
+ *
+ * Every rollup field defaults to a shape the map can render: a payload from
+ * a server that predates grouped markers narrows to plain, non-container
+ * markers rather than to holes.
  */
 export const parseSiteMapResponse: (
   data: JSONObject | undefined,
@@ -263,16 +345,21 @@ export const parseSiteMapResponse: (
       if (!id) {
         return null;
       }
-      const latitude: unknown = row["latitude"];
-      const longitude: unknown = row["longitude"];
-      if (
-        typeof latitude !== "number" ||
-        !Number.isFinite(latitude) ||
-        typeof longitude !== "number" ||
-        !Number.isFinite(longitude)
-      ) {
+      const latitude: number | null = asCoordinate(
+        row["latitude"],
+        MAX_LATITUDE,
+      );
+      const longitude: number | null = asCoordinate(
+        row["longitude"],
+        MAX_LONGITUDE,
+      );
+      if (latitude === null || longitude === null) {
         return null;
       }
+      const totalUnits: number = Math.max(
+        0,
+        asFiniteNumber(row["totalUnits"], 0),
+      );
       return {
         id: id,
         name: asString(row["name"], "Unnamed site"),
@@ -286,13 +373,42 @@ export const parseSiteMapResponse: (
             ? (row["isOperational"] as boolean)
             : null,
         parentBreadcrumb: asString(row["parentBreadcrumb"], ""),
+        isContainer: row["isContainer"] === true,
+        isDerivedLocation: row["isDerivedLocation"] === true,
+        locatedDescendantCount: Math.max(
+          0,
+          asFiniteNumber(row["locatedDescendantCount"], 0),
+        ),
+        unlocatedDescendantCount: Math.max(
+          0,
+          asFiniteNumber(row["unlocatedDescendantCount"], 0),
+        ),
+        totalUnits: totalUnits,
+        /*
+         * Clamped into its own total: a marker can never report more
+         * healthy units than it has, however the rollup arrived.
+         */
+        operationalUnits: Math.min(
+          totalUnits,
+          Math.max(0, asFiniteNumber(row["operationalUnits"], 0)),
+        ),
+        childSiteCount: Math.max(0, asFiniteNumber(row["childSiteCount"], 0)),
       };
     })
     .filter((site: MapSiteView | null): site is MapSiteView => {
       return site !== null;
     });
+  const unplacedSites: Array<MapUnplacedSiteView> = asRows(
+    data?.["unplacedSites"],
+  )
+    .map(parseUnplacedRow)
+    .filter((site: MapUnplacedSiteView | null): site is MapUnplacedSiteView => {
+      return site !== null;
+    });
   return {
+    mode: data?.["mode"] === "all" ? "all" : "grouped",
     sites: sites,
+    unplacedSites: unplacedSites,
     isTruncated: data?.["isTruncated"] === true,
   };
 };

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
@@ -1,6 +1,11 @@
 import { ProjectedPoint, projectRobinson } from "./Geo/GeoProjection";
 import { MapViewport, screenLengthToViewportLength } from "./Geo/GeoViewport";
-import { GeoClusterPoint } from "./Geo/GeoClusterUtil";
+import {
+  GeoCluster,
+  GeoClusterPoint,
+  clusterPoints,
+} from "./Geo/GeoClusterUtil";
+import { MapSiteView, SiteMapMode } from "./SiteHierarchyTypes";
 
 /*
  * Pure, react-free view-model for the SiteGeoMap component: projecting map
@@ -18,6 +23,12 @@ export interface PinnableSite {
   latitude: number;
   longitude: number;
   statusPriority: number;
+  /*
+   * How many underlying sites this row stands for. A grouped marker is one
+   * row that represents a whole region, so the cluster it seeds has to
+   * carry that weight rather than counting as a single site.
+   */
+  count?: number | undefined;
 }
 
 export interface BuildPinsResult {
@@ -61,6 +72,12 @@ export const buildPins: (sites: Array<PinnableSite>) => BuildPinsResult = (
       statusPriority: Number.isFinite(site.statusPriority)
         ? site.statusPriority
         : 0,
+      count:
+        typeof site.count === "number" &&
+        Number.isFinite(site.count) &&
+        site.count > 0
+          ? Math.round(site.count)
+          : 1,
     });
   }
 
@@ -234,4 +251,680 @@ export const formatUptimePercent: (
     return "—";
   }
   return `${uptimePercent.toFixed(1)}%`;
+};
+
+/*
+ * ── Hierarchy markers ──────────────────────────────────────────────────
+ *
+ * The map draws one marker per CHILD of the level in view, so a marker
+ * stands for a region, a market or a store — something the customer named —
+ * rather than for however many pins fell in one grid cell. Everything that
+ * decides what a marker looks like lives here, in plain functions over
+ * plain data, so the component is left with nothing but drawing.
+ */
+
+/*
+ * Health of a site or a rollup, in the vocabulary the site CARD already
+ * speaks. The map reuses it deliberately: a region whose card reads "63 of
+ * 63 units down" must not be a calm dot on the map above it. That
+ * disagreement between the two halves of the page is what this whole
+ * change is fixing.
+ */
+export type HealthTone = "ok" | "warn" | "down" | "none";
+
+/**
+ * Tone for a unit rollup, from the counts alone.
+ *
+ * Half or more of the units down is an outage, not a wobble — red. A
+ * minority down is degraded — amber. This is the rule SiteCard has always
+ * used for its lead figure and meter; both now read it from here so the
+ * card and the marker above it can never drift apart.
+ */
+export const unitRollupTone: (rollup: {
+  totalUnits: number;
+  operationalUnits: number;
+}) => HealthTone = (rollup: {
+  totalUnits: number;
+  operationalUnits: number;
+}): HealthTone => {
+  const total: number = rollup.totalUnits;
+  if (!Number.isFinite(total) || total <= 0) {
+    return "none";
+  }
+  const operational: number = Math.min(
+    Math.max(
+      Number.isFinite(rollup.operationalUnits) ? rollup.operationalUnits : 0,
+      0,
+    ),
+    total,
+  );
+  if (operational >= total) {
+    return "ok";
+  }
+  if (operational * 2 <= total) {
+    return "down";
+  }
+  return "warn";
+};
+
+/*
+ * The card's four tones onto the map's four marker colors. "warn" and
+ * "mixed" are the same amber: on a card the word is about units, on a
+ * marker it is about a cluster, and both mean "partly bad".
+ */
+export const colorKeyForTone: (tone: HealthTone) => ClusterColorKey = (
+  tone: HealthTone,
+): ClusterColorKey => {
+  return tone === "warn" ? "mixed" : tone;
+};
+
+const toneFromOperational: (isOperational: boolean | null) => HealthTone = (
+  isOperational: boolean | null,
+): HealthTone => {
+  if (isOperational === false) {
+    return "down";
+  }
+  return isOperational === true ? "ok" : "none";
+};
+
+/**
+ * Tone of one grouped marker: a container with units under it is colored by
+ * its rollup (so a region 3% down is amber, not the same red as one that is
+ * entirely dark), and anything else falls back to its own reported health.
+ */
+export const markerToneForSite: (site: MapSiteView) => HealthTone = (
+  site: MapSiteView,
+): HealthTone => {
+  if (site.isContainer && site.totalUnits > 0) {
+    return unitRollupTone(site);
+  }
+  return toneFromOperational(site.isOperational);
+};
+
+/**
+ * The figure printed inside a grouped marker: how many units are under it,
+ * or — for a level that has no unit-level descendants yet — how many sites
+ * are. 1 means there is nothing to count, and the marker draws as a plain
+ * pin with no number in it.
+ */
+export const markerCountForSite: (site: MapSiteView) => number = (
+  site: MapSiteView,
+): number => {
+  if (site.totalUnits > 0) {
+    return site.totalUnits;
+  }
+  return site.childSiteCount > 0 ? site.childSiteCount : 1;
+};
+
+const pluralize: (count: number, singular: string) => string = (
+  count: number,
+  singular: string,
+): string => {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+};
+
+/*
+ * The fallback name for a level whose children are of mixed types. Site
+ * types are per-project rows, so there is no safe generic to borrow from
+ * one of them.
+ */
+export const GENERIC_SITE_TYPE_LABEL: string = "site";
+
+const CONSONANT_Y_ENDING: RegExp = new RegExp("[^aeiou]y$");
+const SIBILANT_ENDING: RegExp = new RegExp("(s|x|z|ch|sh)$");
+
+/**
+ * Plural of a site-type name the CUSTOMER wrote.
+ *
+ * Site types are free text on a per-project row, so the naive "+ s" that is
+ * fine for the hardcoded English nouns elsewhere in this file produces
+ * "Facilitys", "Branchs" and "Franchise Unitss" on a real customer's map.
+ * This handles the endings that actually show up in franchise estates, and
+ * leaves a name that is already plural alone.
+ */
+export const pluralizeSiteType: (word: string) => string = (
+  word: string,
+): string => {
+  const trimmed: string = word.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  const lower: string = trimmed.toLowerCase();
+
+  /*
+   * Already plural — "Units", "Premises". The exclusions are the singulars
+   * that merely end in s: "Business", "Campus", "Chassis".
+   */
+  if (
+    lower.endsWith("s") &&
+    !lower.endsWith("ss") &&
+    !lower.endsWith("us") &&
+    !lower.endsWith("is")
+  ) {
+    return trimmed;
+  }
+  // Consonant + y → -ies: "Facility", "Territory".
+  if (CONSONANT_Y_ENDING.test(lower)) {
+    return `${trimmed.slice(0, -1)}ies`;
+  }
+  // Sibilant endings take -es: "Business", "Branch", "Box", "Dish".
+  if (SIBILANT_ENDING.test(lower)) {
+    return `${trimmed}es`;
+  }
+  return `${trimmed}s`;
+};
+
+/**
+ * What to call the children of the level in view, in the customer's own
+ * words: the shared site-type name when they all agree ("Region",
+ * "Market", "Store"), and a plain "site" when the level mixes types.
+ *
+ * The map must never invent vocabulary. A customer who renamed "Unit" to
+ * "Restaurant" should read "12 restaurants on the map", and a customer
+ * whose top level holds both regions and a stray unit should read "sites"
+ * rather than have one of the two names put in their mouth.
+ */
+export const childTypeLabelFor: (
+  sites: Array<{ siteType: string }>,
+) => string = (sites: Array<{ siteType: string }>): string => {
+  let label: string | null = null;
+  for (const site of sites) {
+    const siteType: string = (site.siteType || "").trim();
+    if (!siteType) {
+      return GENERIC_SITE_TYPE_LABEL;
+    }
+    if (label === null) {
+      label = siteType;
+      continue;
+    }
+    if (label.toLowerCase() !== siteType.toLowerCase()) {
+      return GENERIC_SITE_TYPE_LABEL;
+    }
+  }
+  return label === null ? GENERIC_SITE_TYPE_LABEL : label;
+};
+
+/**
+ * The map's coverage line: how much of the network the frame is holding.
+ *
+ * A count that quietly shrinks as somebody zooms reads as sites
+ * disappearing, so once the frame stops holding everything the line says
+ * what it does hold. In grouped mode it counts the LEVEL's children by
+ * their own type name — counting them as "sites" would be the same
+ * category error the flat map made, one marker standing for a thousand
+ * stores while the footer calls it one site.
+ */
+export const describeMapCoverage: (input: {
+  mode: SiteMapMode;
+  markerCount: number;
+  inViewCount: number;
+  siteCount: number;
+  childTypeLabel: string;
+}) => string = (input: {
+  mode: SiteMapMode;
+  markerCount: number;
+  inViewCount: number;
+  siteCount: number;
+  childTypeLabel: string;
+}): string => {
+  if (input.mode === "all") {
+    return input.inViewCount < input.siteCount
+      ? `${input.inViewCount} of ${input.siteCount} sites in view`
+      : `${pluralize(input.siteCount, "site")} mapped`;
+  }
+  const noun: string = input.childTypeLabel || GENERIC_SITE_TYPE_LABEL;
+  const counted: string =
+    input.markerCount === 1
+      ? noun.toLowerCase()
+      : pluralizeSiteType(noun).toLowerCase();
+  if (input.inViewCount < input.markerCount) {
+    return `${input.inViewCount} of ${input.markerCount} ${counted} in view`;
+  }
+  return `${input.markerCount} ${counted} on the map`;
+};
+
+/**
+ * One phrase describing a marker's health, in the same shape the card uses:
+ * a healthy thing counts what is up, an unhealthy one counts what is down.
+ */
+export const describeMarkerHealth: (site: MapSiteView) => string = (
+  site: MapSiteView,
+): string => {
+  if (!site.isContainer || site.totalUnits <= 0) {
+    if (site.isOperational === true) {
+      return "Operational";
+    }
+    return site.isOperational === false ? "Down" : "No status yet";
+  }
+  const total: number = site.totalUnits;
+  const operational: number = Math.min(
+    Math.max(site.operationalUnits, 0),
+    total,
+  );
+  if (operational >= total) {
+    return `${pluralize(total, "unit")} operational`;
+  }
+  return `${total - operational} of ${pluralize(total, "unit")} down`;
+};
+
+/**
+ * Hover/accessible text for one grouped marker: what it is, how it is
+ * doing, how big it is, and — when the position was inferred rather than
+ * given — that the map is only approximately right about where it sits.
+ */
+export const describeMarkerSite: (site: MapSiteView) => string = (
+  site: MapSiteView,
+): string => {
+  const parts: Array<string> = [
+    `${site.name} — ${site.siteType}`,
+    describeMarkerHealth(site),
+  ];
+  if (site.isContainer && site.childSiteCount > 0) {
+    parts.push(pluralize(site.childSiteCount, "site"));
+  }
+  if (site.isDerivedLocation) {
+    parts.push(
+      site.locatedDescendantCount > 0
+        ? `centered on ${pluralize(site.locatedDescendantCount, "located site")}`
+        : "approximate location",
+    );
+  }
+  return parts.join(" · ");
+};
+
+/*
+ * Grouped marker sizing, in whole-world viewBox units — the same units
+ * clusterRadius returns, so the two modes draw at a comparable weight.
+ *
+ * The size is RELATIVE to the biggest marker on screen rather than
+ * absolute. A franchise where every region holds 60-110 units would
+ * otherwise saturate the absolute sqrt scale and render thirteen identical
+ * maximum-size discs, throwing away the one thing size is for. Scaling to
+ * the largest keeps the comparison alive at any estate size, and sqrt keeps
+ * AREA proportional to the count so the reading stays honest.
+ */
+export const groupedMarkerRadius: (
+  count: number,
+  maxCount: number,
+) => number = (count: number, maxCount: number): number => {
+  const safeCount: number = Number.isFinite(count) && count > 1 ? count : 1;
+  const safeMax: number =
+    Number.isFinite(maxCount) && maxCount > 1 ? maxCount : 1;
+  if (safeMax <= 1) {
+    return MIN_CLUSTER_RADIUS;
+  }
+  const fraction: number = Math.sqrt(Math.min(safeCount, safeMax) / safeMax);
+  return (
+    MIN_CLUSTER_RADIUS + (MAX_CLUSTER_RADIUS - MIN_CLUSTER_RADIUS) * fraction
+  );
+};
+
+/*
+ * Past this many markers the name labels come off: they would overlap into
+ * an unreadable mat, and the hover tooltip still names every one. Levels
+ * with this many children are rare — it is the deep, unit-heavy levels that
+ * get busy, and those are exactly the ones whose markers are single stores.
+ */
+export const MAX_LABELLED_MARKERS: number = 48;
+
+/*
+ * Names are free text. Past this many characters a label spans further than
+ * the markers either side of it; the full name stays in the tooltip and in
+ * the marker's accessible name.
+ */
+export const MAX_MARKER_LABEL_CHARS: number = 22;
+
+/**
+ * Shorten a marker's label to something that fits under a marker.
+ */
+export const truncateMarkerLabel: (value: string) => string = (
+  value: string,
+): string => {
+  if (value.length <= MAX_MARKER_LABEL_CHARS) {
+    return value;
+  }
+  return `${value.slice(0, MAX_MARKER_LABEL_CHARS - 1).trimEnd()}…`;
+};
+
+/*
+ * Label geometry, in screen units — the same units screenRadius is in.
+ * The character width is an approximation of a 600-weight sans glyph at
+ * LABEL_FONT_SIZE; it only has to be close enough to decide overlap, and
+ * erring slightly wide means the map drops a label rather than printing two
+ * on top of each other.
+ */
+export const LABEL_FONT_SIZE: number = 10;
+const LABEL_CHAR_WIDTH: number = 5.6;
+const LABEL_HEIGHT: number = 12;
+export const LABEL_GAP: number = 10;
+// Labels this close to each other read as collided even when they do not touch.
+const LABEL_PADDING: number = 2;
+
+interface LabelRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/*
+ * Where a marker's name sits relative to it. Below reads best — the eye
+ * goes marker-then-name — so it is always tried first; above is the escape
+ * hatch for a marker with a neighbour directly beneath it.
+ */
+export type LabelPlacement = "below" | "above";
+
+export const LABEL_PLACEMENTS: Array<LabelPlacement> = ["below", "above"];
+
+/*
+ * A container is drawn as a square of side 1.78r, so its label clears the
+ * corner rather than the circumscribed circle.
+ */
+const markerLabelRect: (
+  marker: MapMarker,
+  zoom: number,
+  placement: LabelPlacement,
+) => LabelRect = (
+  marker: MapMarker,
+  zoom: number,
+  placement: LabelPlacement,
+): LabelRect => {
+  const width: number = Math.max(
+    marker.label.length * LABEL_CHAR_WIDTH,
+    LABEL_CHAR_WIDTH,
+  );
+  const centerX: number = marker.x * zoom;
+  const offset: number =
+    (marker.isContainer
+      ? (marker.screenRadius * 1.78) / 2
+      : marker.screenRadius) + LABEL_GAP;
+  const centerY: number =
+    marker.y * zoom + (placement === "above" ? -offset : offset);
+  return {
+    left: centerX - width / 2 - LABEL_PADDING,
+    right: centerX + width / 2 + LABEL_PADDING,
+    top: centerY - LABEL_HEIGHT / 2 - LABEL_PADDING,
+    bottom: centerY + LABEL_HEIGHT / 2 + LABEL_PADDING,
+  };
+};
+
+// The marker's own body, in the same screen units as its label rect.
+const markerBodyRect: (marker: MapMarker, zoom: number) => LabelRect = (
+  marker: MapMarker,
+  zoom: number,
+): LabelRect => {
+  const half: number = marker.isContainer
+    ? (marker.screenRadius * 1.78) / 2
+    : marker.screenRadius;
+  const centerX: number = marker.x * zoom;
+  const centerY: number = marker.y * zoom;
+  return {
+    left: centerX - half,
+    right: centerX + half,
+    top: centerY - half,
+    bottom: centerY + half,
+  };
+};
+
+const rectsOverlap: (a: LabelRect, b: LabelRect) => boolean = (
+  a: LabelRect,
+  b: LabelRect,
+): boolean => {
+  return !(
+    a.right <= b.left ||
+    a.left >= b.right ||
+    a.bottom <= b.top ||
+    a.top >= b.bottom
+  );
+};
+
+/**
+ * Where each marker draws its name at this zoom — and which markers do not
+ * get to draw one at all.
+ *
+ * Three regions whose centroids fall in the same corner of a state print
+ * their names on top of each other, which is worse than printing none of
+ * them: an overlapped label is unreadable AND it hides its neighbour. So
+ * names are placed greedily in paint order — biggest marker first, since
+ * that is the one a reader is most likely to be looking for — trying below
+ * the marker and then above it, and a name that fits in neither position is
+ * dropped rather than stacked on something.
+ *
+ * A label must clear the other MARKERS too, not just the other labels: a
+ * name half-covered by the neighbouring region's disc reads as a rendering
+ * bug, not as a dense map.
+ *
+ * Zoom is the only thing this depends on, not the pan: markers keep their
+ * relative distances as the frame moves, so a drag never re-decides which
+ * names are on the map. Zooming in genuinely separates them and the dropped
+ * names come back.
+ */
+export const resolveMarkerLabels: (
+  markers: Array<MapMarker>,
+  zoom: number,
+) => Map<string, LabelPlacement> = (
+  markers: Array<MapMarker>,
+  zoom: number,
+): Map<string, LabelPlacement> => {
+  const safeZoom: number = Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+  const resolved: Map<string, LabelPlacement> = new Map<
+    string,
+    LabelPlacement
+  >();
+  const placed: Array<LabelRect> = [];
+
+  const bodies: Array<LabelRect> = markers.map(
+    (marker: MapMarker): LabelRect => {
+      return markerBodyRect(marker, safeZoom);
+    },
+  );
+
+  const fits: (rect: LabelRect, index: number) => boolean = (
+    rect: LabelRect,
+    index: number,
+  ): boolean => {
+    for (const other of placed) {
+      if (rectsOverlap(rect, other)) {
+        return false;
+      }
+    }
+    for (let other: number = 0; other < bodies.length; other++) {
+      /*
+       * Its own body never counts: the label is deliberately placed hard
+       * against it, and a generous glyph-width estimate can graze it.
+       */
+      if (other !== index && rectsOverlap(rect, bodies[other]!)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  for (let index: number = 0; index < markers.length; index++) {
+    const marker: MapMarker = markers[index]!;
+    if (!marker.label) {
+      continue;
+    }
+    for (const placement of LABEL_PLACEMENTS) {
+      const rect: LabelRect = markerLabelRect(marker, safeZoom, placement);
+      if (fits(rect, index)) {
+        placed.push(rect);
+        resolved.set(marker.key, placement);
+        break;
+      }
+    }
+  }
+
+  return resolved;
+};
+
+// One drawable marker. Positions are viewBox units; radius is screen units.
+export interface MapMarker {
+  // Stable across re-renders for the same geometry — React's key.
+  key: string;
+  x: number;
+  y: number;
+  // The sites this marker stands for. Exactly one in grouped mode.
+  ids: Array<string>;
+  /*
+   * The figure drawn inside the marker. 1 renders as a plain pin with no
+   * number — there is nothing to count.
+   */
+  count: number;
+  screenRadius: number;
+  colorKey: ClusterColorKey;
+  // Draw as a container (a level you can open) rather than as a place.
+  isContainer: boolean;
+  // Position inferred from descendants — the marker says so.
+  isApproximate: boolean;
+  /** Name drawn under the marker, or "" when this marker gets no label. */
+  label: string;
+  tooltip: string;
+}
+
+const clusterTooltip: (
+  cluster: GeoCluster,
+  siteById: Map<string, MapSiteView>,
+) => string = (
+  cluster: GeoCluster,
+  siteById: Map<string, MapSiteView>,
+): string => {
+  if (cluster.ids.length === 1) {
+    const site: MapSiteView | undefined = siteById.get(cluster.ids[0]!);
+    if (!site) {
+      return "";
+    }
+    return site.parentBreadcrumb
+      ? `${site.name} — ${site.parentBreadcrumb}`
+      : site.name;
+  }
+  const names: Array<string> = cluster.ids
+    .slice(0, 5)
+    .map((id: string): string => {
+      return siteById.get(id)?.name || "Unnamed site";
+    });
+  const more: number = cluster.ids.length - names.length;
+  return `${cluster.totalCount} sites: ${names.join(", ")}${
+    more > 0 ? `, +${more} more` : ""
+  }`;
+};
+
+export interface BuildMarkersInput {
+  sites: Array<MapSiteView>;
+  mode: SiteMapMode;
+  // Grid cell size for "all" mode clustering, in viewBox units.
+  cellSize: number;
+}
+
+/**
+ * Turn map rows into drawable markers.
+ *
+ * GROUPED never clusters. A marker is one child of the level in view, and
+ * merging two of them because they happen to sit close together would
+ * recreate the exact defect this mode exists to fix: a number on the map
+ * that stands for nothing the customer has a name for. They can overlap;
+ * zoom separates them, and the smaller marker is painted last so it stays
+ * reachable under the bigger one.
+ *
+ * ALL clusters by screen proximity, which is the right thing when every
+ * marker really is one store.
+ *
+ * Output order is paint order, and it is deterministic: markers are sorted
+ * by descending count with the id as the tie-break, so the same data always
+ * draws the same way.
+ */
+export const buildMapMarkers: (input: BuildMarkersInput) => Array<MapMarker> = (
+  input: BuildMarkersInput,
+): Array<MapMarker> => {
+  const { pins }: BuildPinsResult = buildPins(
+    input.sites.map((site: MapSiteView): PinnableSite => {
+      return {
+        id: site.id,
+        latitude: site.latitude,
+        longitude: site.longitude,
+        statusPriority: site.statusPriority,
+        count: input.mode === "grouped" ? markerCountForSite(site) : 1,
+      };
+    }),
+  );
+
+  const siteById: Map<string, MapSiteView> = new Map<string, MapSiteView>();
+  for (const site of input.sites) {
+    siteById.set(site.id, site);
+  }
+
+  if (input.mode === "all") {
+    return clusterPoints(pins, input.cellSize).map(
+      (cluster: GeoCluster): MapMarker => {
+        const members: Array<MapSiteView> = cluster.ids
+          .map((id: string): MapSiteView | undefined => {
+            return siteById.get(id);
+          })
+          .filter((site: MapSiteView | undefined): site is MapSiteView => {
+            return site !== undefined;
+          });
+        return {
+          key: `${cluster.x}:${cluster.y}:${cluster.ids[0]}`,
+          x: cluster.x,
+          y: cluster.y,
+          ids: cluster.ids,
+          count: cluster.totalCount,
+          screenRadius: clusterRadius(cluster.totalCount),
+          colorKey: decideClusterColorKey(
+            members.map((site: MapSiteView): ClusterColorMember => {
+              return {
+                statusPriority: site.statusPriority,
+                isOperational: site.isOperational,
+              };
+            }),
+          ),
+          isContainer: false,
+          isApproximate: false,
+          label: "",
+          tooltip: clusterTooltip(cluster, siteById),
+        };
+      },
+    );
+  }
+
+  const counts: Array<number> = pins.map((pin: GeoClusterPoint): number => {
+    return pin.count ?? 1;
+  });
+  const maxCount: number = counts.length > 0 ? Math.max(...counts) : 1;
+  const showLabels: boolean = pins.length <= MAX_LABELLED_MARKERS;
+
+  const markers: Array<MapMarker> = [];
+  for (const pin of pins) {
+    const site: MapSiteView | undefined = siteById.get(pin.id);
+    if (!site) {
+      continue;
+    }
+    const count: number = pin.count ?? 1;
+    markers.push({
+      key: site.id,
+      x: pin.x,
+      y: pin.y,
+      ids: [site.id],
+      count: count,
+      screenRadius: groupedMarkerRadius(count, maxCount),
+      colorKey: colorKeyForTone(markerToneForSite(site)),
+      isContainer: site.isContainer,
+      isApproximate: site.isDerivedLocation,
+      label: showLabels ? truncateMarkerLabel(site.name) : "",
+      tooltip: describeMarkerSite(site),
+    });
+  }
+
+  /*
+   * Biggest first, so the smallest marker is painted last and a single
+   * store never disappears under the region that contains its neighbours.
+   */
+  markers.sort((a: MapMarker, b: MapMarker): number => {
+    if (a.count !== b.count) {
+      return b.count - a.count;
+    }
+    return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  });
+
+  return markers;
 };

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/NetworkMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/NetworkMap.tsx
@@ -10,14 +10,17 @@ import {
 } from "../../Components/NetworkSite/NetworkMapDrillState";
 import {
   MapSiteView,
+  MapUnplacedSiteView,
   SiteBreadcrumbEntry,
   SiteChildView,
   SiteChildrenResponse,
   SiteLinkView,
+  SiteMapMode,
   SiteMapResponse,
   parseSiteChildrenResponse,
   parseSiteMapResponse,
 } from "../../Components/NetworkSite/SiteHierarchyTypes";
+import { childTypeLabelFor } from "../../Components/NetworkSite/SiteMapViewModel";
 import NetworkTopologyLiveView from "../../Components/Topology/NetworkTopologyLiveView";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
@@ -72,6 +75,13 @@ import { Location, useLocation } from "react-router-dom";
  */
 
 const REFRESH_INTERVAL_MS: number = 60 * 1000;
+
+/*
+ * How a load ended. "superseded" is not a failure — it means a newer
+ * request (a drill, a refresh) took ownership of the page state while this
+ * one was in flight, and whatever it loads is the right answer.
+ */
+type FetchOutcome = "loaded" | "failed" | "superseded";
 
 // Debounce for mirroring drill state into the URL (see Navigation.setQueryString).
 const QUERY_STRING_DEBOUNCE_MS: number = 200;
@@ -132,6 +142,18 @@ const NetworkSiteMap: FunctionComponent<
   const [error, setError] = useState<string>("");
 
   /*
+   * How the map groups what it draws. Deliberately NOT in the URL: the
+   * drill state is the shareable part of this page (see
+   * NetworkMapDrillState), and whether one viewer prefers to see regions or
+   * every individual store is a preference, not a place. A link stays a
+   * link to a level.
+   */
+  const [mapMode, setMapMode] = useState<SiteMapMode>("grouped");
+  const mapModeRef: React.MutableRefObject<SiteMapMode> =
+    useRef<SiteMapMode>(mapMode);
+  mapModeRef.current = mapMode;
+
+  /*
    * Cancel-stale: every fetch takes a sequence number; only the latest
    * one may write state, so a slow response for the previous drill level
    * can never clobber the current one. The mounted flag keeps background
@@ -177,15 +199,25 @@ const NetworkSiteMap: FunctionComponent<
 
   const location: Location = useLocation();
 
+  /*
+   * Reports how the load ended. Only the mode switch acts on it — see the
+   * effect below for why a FAILED switch has to be undone, and why a
+   * SUPERSEDED one (the reader drilled while it was in flight) must not be:
+   * putting the choice back then would fight a newer request that is
+   * already loading the right thing.
+   */
   const fetchData: (
     siteId: string | null,
+    mapMode: SiteMapMode,
     isBackgroundRefresh: boolean,
-  ) => Promise<void> = useCallback(
+  ) => Promise<FetchOutcome> = useCallback(
     async (
       siteId: string | null,
+      mapMode: SiteMapMode,
       isBackgroundRefresh: boolean,
-    ): Promise<void> => {
+    ): Promise<FetchOutcome> => {
       const seq: number = ++requestSeq.current;
+      let outcome: FetchOutcome = "failed";
       if (!isBackgroundRefresh) {
         setIsLoading(true);
         setError("");
@@ -202,9 +234,14 @@ const NetworkSiteMap: FunctionComponent<
         /*
          * Project scoping is attached automatically via the tenantid
          * header that ModelAPI.getCommonHeaders() sets from the current
-         * project. The map is only fetched at the root level — it shows
-         * every pinned site in the project, so a drill level never needs
-         * it.
+         * project.
+         *
+         * Both endpoints are asked about the SAME level. The map used to be
+         * fetched only at the root, because it answered with every pinned
+         * site in the project however deep you had drilled — which is
+         * exactly why the map and the cards under it described different
+         * networks. It is now scoped like the cards are, so drilling moves
+         * both.
          */
         const childrenPromise: Promise<
           HTTPResponse<JSONObject> | HTTPErrorResponse
@@ -215,46 +252,40 @@ const NetworkSiteMap: FunctionComponent<
         });
         const mapPromise: Promise<
           HTTPResponse<JSONObject> | HTTPErrorResponse
-        > | null = siteId
-          ? null
-          : API.post<JSONObject>({
-              url: mapUrl,
-              data: {},
-              headers: { ...ModelAPI.getCommonHeaders() },
-            });
+        > = API.post<JSONObject>({
+          url: mapUrl,
+          data: siteId ? { siteId: siteId, mode: mapMode } : { mode: mapMode },
+          headers: { ...ModelAPI.getCommonHeaders() },
+        });
 
         const [childrenResponse, mapResponse]: [
           HTTPResponse<JSONObject> | HTTPErrorResponse,
-          HTTPResponse<JSONObject> | HTTPErrorResponse | null,
-        ] = await Promise.all([
-          childrenPromise,
-          mapPromise || Promise.resolve(null),
-        ]);
+          HTTPResponse<JSONObject> | HTTPErrorResponse,
+        ] = await Promise.all([childrenPromise, mapPromise]);
 
         if (!isMounted.current || seq !== requestSeq.current) {
-          return; // A newer fetch owns the state now.
+          return "superseded"; // A newer fetch owns the state now.
         }
 
         if (childrenResponse instanceof HTTPErrorResponse) {
           throw childrenResponse;
         }
-        if (mapResponse && mapResponse instanceof HTTPErrorResponse) {
+        if (mapResponse instanceof HTTPErrorResponse) {
           throw mapResponse;
         }
 
         setChildrenData(parseSiteChildrenResponse(childrenResponse.data));
-        setMapData(mapResponse ? parseSiteMapResponse(mapResponse.data) : null);
+        setMapData(parseSiteMapResponse(mapResponse.data));
         setError("");
+        outcome = "loaded";
       } catch (err) {
         /*
          * A failed background poll keeps showing the last good view —
          * only a foreground load surfaces the error state.
          */
-        if (
-          isMounted.current &&
-          seq === requestSeq.current &&
-          !isBackgroundRefresh
-        ) {
+        if (!isMounted.current || seq !== requestSeq.current) {
+          outcome = "superseded";
+        } else if (!isBackgroundRefresh) {
           setError(API.getFriendlyMessage(err));
         }
       }
@@ -266,6 +297,8 @@ const NetworkSiteMap: FunctionComponent<
       ) {
         setIsLoading(false);
       }
+
+      return outcome;
     },
     [],
   );
@@ -297,7 +330,7 @@ const NetworkSiteMap: FunctionComponent<
   }, [isUnitView]);
 
   useEffect(() => {
-    fetchData(currentSiteId, false).catch((err: Error) => {
+    fetchData(currentSiteId, mapModeRef.current, false).catch((err: Error) => {
       setError(API.getFriendlyMessage(err));
     });
 
@@ -305,7 +338,7 @@ const NetworkSiteMap: FunctionComponent<
       if (isUnitViewRef.current) {
         return;
       }
-      fetchData(currentSiteId, true).catch(() => {
+      fetchData(currentSiteId, mapModeRef.current, true).catch(() => {
         // Background refresh failures are non-fatal; keep the last view.
       });
     }, REFRESH_INTERVAL_MS);
@@ -314,6 +347,51 @@ const NetworkSiteMap: FunctionComponent<
       clearInterval(interval);
     };
   }, [currentSiteId, fetchData]);
+
+  /*
+   * Switching how the map groups reloads quietly — as a background refresh,
+   * not a foreground one. The choice changes one panel; raising the
+   * full-page loader for it would blank the breadcrumbs, the cards and the
+   * link strip the reader is looking at in order to swap the map inside
+   * them. The switch itself is the feedback that something happened.
+   *
+   * The guard makes this effect a no-op on mount and on every drill (the
+   * effect above already loaded that level with this mode), so it fires
+   * only for an actual change of mode.
+   *
+   * A load that does not land puts the choice BACK. Leaving it would strand
+   * the reader on a switch that says "All sites" over a map that is still
+   * grouped, with the obvious remedy — pressing the same option again —
+   * doing nothing, because from the page's point of view nothing changed.
+   */
+  const loadedMapMode: React.MutableRefObject<SiteMapMode> =
+    useRef<SiteMapMode>(mapMode);
+  useEffect(() => {
+    if (loadedMapMode.current === mapMode) {
+      return;
+    }
+    const previousMode: SiteMapMode = loadedMapMode.current;
+    const requestedMode: SiteMapMode = mapMode;
+    loadedMapMode.current = requestedMode;
+
+    const revert: () => void = (): void => {
+      if (!isMounted.current || loadedMapMode.current !== requestedMode) {
+        return; // The reader has already asked for something else.
+      }
+      loadedMapMode.current = previousMode;
+      setMapMode(previousMode);
+    };
+
+    fetchData(currentSiteId, requestedMode, true)
+      .then((outcome: FetchOutcome) => {
+        if (outcome === "failed") {
+          revert();
+        }
+      })
+      .catch(() => {
+        revert();
+      });
+  }, [mapMode, currentSiteId, fetchData]);
 
   /*
    * Drill transitions are made atomic here rather than left to fetchData:
@@ -382,7 +460,7 @@ const NetworkSiteMap: FunctionComponent<
     buttonStyle: ButtonStyleType.NORMAL,
     icon: IconProp.Refresh,
     onClick: () => {
-      fetchData(currentSiteId, false).catch((err: Error) => {
+      fetchData(currentSiteId, mapMode, false).catch((err: Error) => {
         setError(API.getFriendlyMessage(err));
       });
     },
@@ -429,7 +507,32 @@ const NetworkSiteMap: FunctionComponent<
     );
   }
 
-  // CONTAINER level: this site's children and the links between them.
+  /*
+   * The map's inputs, shared by every level that draws one. The type label
+   * comes from the CHILD LIST rather than from the markers, so a level whose
+   * children are all Regions still says "regions" while some of them are
+   * missing from the map for want of coordinates.
+   */
+  const levelSites: Array<SiteChildView> = childrenData?.children || [];
+  const levelLinks: Array<SiteLinkView> = childrenData?.links || [];
+  const pinnedSites: Array<MapSiteView> = mapData?.sites || [];
+  const unplacedSites: Array<MapUnplacedSiteView> =
+    mapData?.unplacedSites || [];
+  const childTypeLabel: string = childTypeLabelFor(levelSites);
+
+  const geoMap: ReactElement = (
+    <SiteGeoMap
+      sites={pinnedSites}
+      mode={mapData?.mode || mapMode}
+      selectedMode={mapMode}
+      onModeChange={setMapMode}
+      unplacedSites={unplacedSites}
+      childTypeLabel={childTypeLabel}
+      onSiteClick={changeSite}
+    />
+  );
+
+  // CONTAINER level: this site's children, on the map and as a linked graph.
   if (currentSiteId && currentSite) {
     return (
       <Fragment>
@@ -444,24 +547,38 @@ const NetworkSiteMap: FunctionComponent<
           description={`${currentSite.siteType} — click a site to drill down; a unit opens its device topology.`}
           buttons={[refreshButton]}
         >
-          <SiteContainerGraph
-            sites={childrenData?.children || []}
-            links={childrenData?.links || []}
-            childrenTruncated={Boolean(childrenData?.childrenTruncated)}
-            descendantCountsTruncated={Boolean(
-              childrenData?.descendantCountsTruncated,
-            )}
-            onSiteClick={changeSite}
-          />
+          {/*
+           * The map comes first at every level, and it is the SAME map:
+           * drilling re-frames it onto this site's children instead of
+           * swapping it out for a diagram. The graph below it is the other
+           * half of the picture — it is where the links between these
+           * children live, which geography cannot show.
+           */}
+          {geoMap}
+
+          <MapSection
+            title="Sites"
+            count={levelSites.length}
+            hint="Click a site to drill in; a unit opens its device topology."
+          >
+            <SiteContainerGraph
+              sites={levelSites}
+              links={levelLinks}
+              childrenTruncated={Boolean(childrenData?.childrenTruncated)}
+              descendantCountsTruncated={Boolean(
+                childrenData?.descendantCountsTruncated,
+              )}
+              onSiteClick={changeSite}
+            />
+          </MapSection>
         </Card>
       </Fragment>
     );
   }
 
   // ROOT level: geo map + root-site cards + WAN link strip.
-  const rootSites: Array<SiteChildView> = childrenData?.children || [];
-  const rootLinks: Array<SiteLinkView> = childrenData?.links || [];
-  const pinnedSites: Array<MapSiteView> = mapData?.sites || [];
+  const rootSites: Array<SiteChildView> = levelSites;
+  const rootLinks: Array<SiteLinkView> = levelLinks;
 
   if (rootSites.length === 0 && pinnedSites.length === 0) {
     return (
@@ -529,7 +646,7 @@ const NetworkSiteMap: FunctionComponent<
         <></>
       )}
 
-      <SiteGeoMap sites={pinnedSites} onSiteClick={changeSite} />
+      {geoMap}
 
       {rootSites.length > 0 ? (
         <MapSection

--- a/App/Tests/BaseAPI/NetworkSiteMapUtil.test.ts
+++ b/App/Tests/BaseAPI/NetworkSiteMapUtil.test.ts
@@ -1,0 +1,661 @@
+import { describe, expect, test } from "@jest/globals";
+import NetworkSiteMapUtil, {
+  GeoPoint,
+  MapChildRow,
+  MapMarkerAggregate,
+  MapStatusInfo,
+  MapSubtreeRow,
+  isUsableCoordinate,
+  sphericalCentroid,
+} from "../../FeatureSet/BaseAPI/Utils/NetworkSiteMapUtil";
+
+/*
+ * Pure-logic tests for the /network-site/map marker aggregation: where a
+ * container goes on the map, what it reports about the estate under it, and
+ * which children have no place on the map at all.
+ *
+ * These exist because the map used to plot every coordinate-bearing site in
+ * the project, flat, and let screen-proximity clustering decide what a
+ * marker meant. A franchise network got numbered blobs matching nothing the
+ * customer had named, and the levels they actually model — Region, Market,
+ * "Corp" — carry no coordinates of their own, so they could not appear at
+ * all. Every assertion below is one half of that fix.
+ *
+ * Site types are per-project rows a customer may rename, so the fixtures
+ * deliberately use type NAMES that would break any name-based leaf check
+ * ("Store", "Location" — never "Unit") while flagging the leaf level through
+ * isUnitLevel. If the rollups ever regress to comparing siteType strings,
+ * these tests fail.
+ */
+
+const OPERATIONAL: string = "status-up";
+const OFFLINE: string = "status-down";
+
+const STATUS_BY_ID: Map<string, MapStatusInfo> = new Map<string, MapStatusInfo>(
+  [
+    [OPERATIONAL, { priority: 1, isOperationalState: true }],
+    [OFFLINE, { priority: 5, isOperationalState: false }],
+  ],
+);
+
+describe("isUsableCoordinate", () => {
+  test("accepts a finite pair inside the real ranges", () => {
+    expect(isUsableCoordinate(39.1, -94.58)).toBe(true);
+    expect(isUsableCoordinate(0, 0)).toBe(true);
+  });
+
+  test("accepts the exact range boundaries", () => {
+    expect(isUsableCoordinate(90, 180)).toBe(true);
+    expect(isUsableCoordinate(-90, -180)).toBe(true);
+  });
+
+  /*
+   * A CSV import that shifts a column by one puts a longitude in the
+   * latitude field. Projected, a latitude of 1246.7 drags the marker — and
+   * the frame the map fits around it — somewhere no site is.
+   */
+  test("rejects coordinates outside the real ranges", () => {
+    expect(isUsableCoordinate(90.0001, 0)).toBe(false);
+    expect(isUsableCoordinate(-90.5, 0)).toBe(false);
+    expect(isUsableCoordinate(0, 180.5)).toBe(false);
+    expect(isUsableCoordinate(0, -181)).toBe(false);
+    expect(isUsableCoordinate(1246.7, -94.58)).toBe(false);
+  });
+
+  test("rejects anything that is not a finite number", () => {
+    expect(isUsableCoordinate(null, null)).toBe(false);
+    expect(isUsableCoordinate(undefined, undefined)).toBe(false);
+    expect(isUsableCoordinate(Number.NaN, 0)).toBe(false);
+    expect(isUsableCoordinate(0, Number.NaN)).toBe(false);
+    expect(isUsableCoordinate(Number.POSITIVE_INFINITY, 0)).toBe(false);
+    expect(isUsableCoordinate(39.1, undefined)).toBe(false);
+  });
+
+  test("rejects numeric strings", () => {
+    expect(
+      isUsableCoordinate(
+        "39.1" as unknown as number,
+        "-94.58" as unknown as number,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("sphericalCentroid", () => {
+  test("has nothing to report for an empty set", () => {
+    expect(sphericalCentroid([])).toBeNull();
+  });
+
+  test("a single point is its own centroid", () => {
+    const centroid: GeoPoint | null = sphericalCentroid([
+      { latitude: 39.0997, longitude: -94.5786 },
+    ]);
+    expect(centroid).not.toBeNull();
+    expect(centroid!.latitude).toBeCloseTo(39.0997, 9);
+    expect(centroid!.longitude).toBeCloseTo(-94.5786, 9);
+  });
+
+  test("repeated identical points stay put", () => {
+    const point: GeoPoint = { latitude: -33.8688, longitude: 151.2093 };
+    const centroid: GeoPoint | null = sphericalCentroid([point, point, point]);
+    expect(centroid!.latitude).toBeCloseTo(-33.8688, 9);
+    expect(centroid!.longitude).toBeCloseTo(151.2093, 9);
+  });
+
+  /*
+   * The whole reason this is not an arithmetic mean. Two sites two degrees
+   * apart across the antimeridian average to 180, not to 0 — a flat mean
+   * would put the marker for a Pacific region in the Gulf of Guinea.
+   */
+  test("points either side of the antimeridian average across it", () => {
+    const centroid: GeoPoint | null = sphericalCentroid([
+      { latitude: 0, longitude: 179 },
+      { latitude: 0, longitude: -179 },
+    ]);
+    expect(centroid).not.toBeNull();
+    expect(centroid!.latitude).toBeCloseTo(0, 9);
+    expect(Math.abs(centroid!.longitude)).toBeCloseTo(180, 9);
+  });
+
+  /*
+   * For the ordinary case — stores in one state — the spherical mean and
+   * the naive mean agree to well under a pixel, so nothing about the
+   * everyday map changed when this replaced a flat average.
+   */
+  test("agrees with a flat average for a tight cluster", () => {
+    const points: Array<GeoPoint> = [
+      { latitude: 39.0997, longitude: -94.5786 },
+      { latitude: 39.1155, longitude: -94.6268 },
+      { latitude: 38.9822, longitude: -94.6708 },
+    ];
+    const centroid: GeoPoint | null = sphericalCentroid(points);
+    const flatLatitude: number =
+      points.reduce((total: number, point: GeoPoint): number => {
+        return total + point.latitude;
+      }, 0) / points.length;
+    const flatLongitude: number =
+      points.reduce((total: number, point: GeoPoint): number => {
+        return total + point.longitude;
+      }, 0) / points.length;
+    expect(centroid!.latitude).toBeCloseTo(flatLatitude, 3);
+    expect(centroid!.longitude).toBeCloseTo(flatLongitude, 3);
+  });
+
+  test("antipodal points have no centroid to report", () => {
+    expect(
+      sphericalCentroid([
+        { latitude: 0, longitude: 0 },
+        { latitude: 0, longitude: 180 },
+      ]),
+    ).toBeNull();
+    expect(
+      sphericalCentroid([
+        { latitude: 90, longitude: 0 },
+        { latitude: -90, longitude: 0 },
+      ]),
+    ).toBeNull();
+  });
+
+  test("unusable points are skipped, and an all-unusable set reports nothing", () => {
+    const centroid: GeoPoint | null = sphericalCentroid([
+      { latitude: Number.NaN, longitude: 0 },
+      { latitude: 10, longitude: 20 },
+      { latitude: 1246.7, longitude: 0 },
+    ]);
+    expect(centroid!.latitude).toBeCloseTo(10, 9);
+    expect(centroid!.longitude).toBeCloseTo(20, 9);
+
+    expect(
+      sphericalCentroid([
+        { latitude: Number.NaN, longitude: Number.NaN },
+        { latitude: 0, longitude: 999 },
+      ]),
+    ).toBeNull();
+  });
+
+  test("is independent of input order", () => {
+    const points: Array<GeoPoint> = [
+      { latitude: 51.5074, longitude: -0.1278 },
+      { latitude: 48.8566, longitude: 2.3522 },
+      { latitude: 52.52, longitude: 13.405 },
+    ];
+    const forward: GeoPoint | null = sphericalCentroid(points);
+    const reversed: GeoPoint | null = sphericalCentroid(
+      points.slice().reverse(),
+    );
+    expect(forward!.latitude).toBeCloseTo(reversed!.latitude, 12);
+    expect(forward!.longitude).toBeCloseTo(reversed!.longitude, 12);
+  });
+
+  test("always returns a placeable coordinate", () => {
+    const centroid: GeoPoint | null = sphericalCentroid([
+      { latitude: 89.9, longitude: 12 },
+      { latitude: 89.8, longitude: -170 },
+    ]);
+    expect(centroid).not.toBeNull();
+    expect(isUsableCoordinate(centroid!.latitude, centroid!.longitude)).toBe(
+      true,
+    );
+  });
+});
+
+/*
+ * The fixture is the customer's shape, shrunk: a level whose children are
+ * regions with no coordinates of their own, holding markets that also have
+ * none, holding the stores that do.
+ *
+ *   (the level in view)
+ *   ├── Region A            no coords
+ *   │   ├── Market A1       no coords
+ *   │   │   ├── Store A1a   40, -74   operational
+ *   │   │   └── Store A1b   42, -71   OFFLINE
+ *   │   └── Market A2       no coords
+ *   │       └── Store A2a   41, -73   operational
+ *   ├── Region B            34, -118  (its own pin)
+ *   │   └── Store B1        37, -122  operational
+ *   ├── Region C            no coords
+ *   │   └── Market C1       no coords          <- nothing locatable at all
+ *   └── Store D             30, -97   OFFLINE  (a unit-level child)
+ */
+const CHILDREN: Array<MapChildRow> = [
+  { id: "regionA", name: "Region A", siteType: "Region", isUnitLevel: false },
+  {
+    id: "regionB",
+    name: "Region B",
+    siteType: "Region",
+    isUnitLevel: false,
+    latitude: 34,
+    longitude: -118,
+  },
+  { id: "regionC", name: "Region C", siteType: "Region", isUnitLevel: false },
+  {
+    id: "storeD",
+    name: "Store D",
+    siteType: "Store",
+    isUnitLevel: true,
+    latitude: 30,
+    longitude: -97,
+    currentMonitorStatusId: OFFLINE,
+  },
+];
+
+const DESCENDANTS: Array<MapSubtreeRow> = [
+  {
+    id: "marketA1",
+    name: "Market A1",
+    isUnitLevel: false,
+    parentSiteId: "regionA",
+    materializedPath: "/regionA/",
+  },
+  {
+    id: "marketA2",
+    name: "Market A2",
+    isUnitLevel: false,
+    parentSiteId: "regionA",
+    materializedPath: "/regionA/",
+  },
+  {
+    id: "storeA1a",
+    name: "Store A1a",
+    isUnitLevel: true,
+    parentSiteId: "marketA1",
+    materializedPath: "/regionA/marketA1/",
+    latitude: 40,
+    longitude: -74,
+    currentMonitorStatusId: OPERATIONAL,
+  },
+  {
+    id: "storeA1b",
+    name: "Store A1b",
+    isUnitLevel: true,
+    parentSiteId: "marketA1",
+    materializedPath: "/regionA/marketA1/",
+    latitude: 42,
+    longitude: -71,
+    currentMonitorStatusId: OFFLINE,
+  },
+  {
+    id: "storeA2a",
+    name: "Store A2a",
+    isUnitLevel: true,
+    parentSiteId: "marketA2",
+    materializedPath: "/regionA/marketA2/",
+    latitude: 41,
+    longitude: -73,
+    currentMonitorStatusId: OPERATIONAL,
+  },
+  {
+    id: "storeB1",
+    name: "Store B1",
+    isUnitLevel: true,
+    parentSiteId: "regionB",
+    materializedPath: "/regionB/",
+    latitude: 37,
+    longitude: -122,
+    currentMonitorStatusId: OPERATIONAL,
+  },
+  {
+    id: "marketC1",
+    name: "Market C1",
+    isUnitLevel: false,
+    parentSiteId: "regionC",
+    materializedPath: "/regionC/",
+  },
+];
+
+function aggregate(
+  children: Array<MapChildRow> = CHILDREN,
+  descendants: Array<MapSubtreeRow> = DESCENDANTS,
+): Map<string, MapMarkerAggregate> {
+  return NetworkSiteMapUtil.aggregateMapMarkers({
+    children: children,
+    descendants: descendants,
+    statusById: STATUS_BY_ID,
+  });
+}
+
+describe("aggregateMapMarkers", () => {
+  test("returns exactly one aggregate per child, and nothing else", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate();
+    expect(Array.from(result.keys()).sort()).toEqual([
+      "regionA",
+      "regionB",
+      "regionC",
+      "storeD",
+    ]);
+  });
+
+  /*
+   * The headline behaviour: a region with no coordinates of its own lands
+   * at the middle of its stores, which is the only reason it can be on the
+   * map at all.
+   */
+  test("a container with no coordinates lands on the centroid of its located sites", () => {
+    const regionA: MapMarkerAggregate = aggregate().get("regionA")!;
+    const expected: GeoPoint | null = sphericalCentroid([
+      { latitude: 40, longitude: -74 },
+      { latitude: 42, longitude: -71 },
+      { latitude: 41, longitude: -73 },
+    ]);
+    expect(regionA.isDerivedLocation).toBe(true);
+    expect(regionA.latitude).toBeCloseTo(expected!.latitude, 9);
+    expect(regionA.longitude).toBeCloseTo(expected!.longitude, 9);
+  });
+
+  /*
+   * Somebody who pinned their regional office meant the marker to sit
+   * there, not at the middle of the stores it happens to own.
+   */
+  test("a container's own coordinates beat the centroid of its descendants", () => {
+    const regionB: MapMarkerAggregate = aggregate().get("regionB")!;
+    expect(regionB.latitude).toBe(34);
+    expect(regionB.longitude).toBe(-118);
+    expect(regionB.isDerivedLocation).toBe(false);
+  });
+
+  test("a child with nothing locatable beneath it has no position", () => {
+    const regionC: MapMarkerAggregate = aggregate().get("regionC")!;
+    expect(regionC.latitude).toBeNull();
+    expect(regionC.longitude).toBeNull();
+    expect(regionC.isDerivedLocation).toBe(false);
+    expect(regionC.locatedDescendantCount).toBe(0);
+    // Region C itself plus Market C1.
+    expect(regionC.unlocatedDescendantCount).toBe(2);
+  });
+
+  test("unit-level descendants are counted by the flag, never by the type name", () => {
+    const regionA: MapMarkerAggregate = aggregate().get("regionA")!;
+    expect(regionA.totalUnits).toBe(3);
+    expect(regionA.operationalUnits).toBe(2);
+  });
+
+  test("a unit-level child reports exactly itself", () => {
+    const storeD: MapMarkerAggregate = aggregate().get("storeD")!;
+    expect(storeD.totalUnits).toBe(1);
+    expect(storeD.operationalUnits).toBe(0);
+    expect(storeD.childSiteCount).toBe(0);
+    expect(storeD.isDerivedLocation).toBe(false);
+  });
+
+  /*
+   * A unit-level child that somehow has descendants must not start
+   * counting them as units — the card next to it says "1 unit", and the
+   * marker has to agree.
+   */
+  test("a unit-level child does not roll up units from beneath it", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate(
+      [
+        {
+          id: "storeD",
+          name: "Store D",
+          siteType: "Store",
+          isUnitLevel: true,
+          latitude: 30,
+          longitude: -97,
+          currentMonitorStatusId: OPERATIONAL,
+        },
+      ],
+      [
+        {
+          id: "subStore",
+          name: "Sub store",
+          isUnitLevel: true,
+          parentSiteId: "storeD",
+          materializedPath: "/storeD/",
+          latitude: 31,
+          longitude: -98,
+          currentMonitorStatusId: OPERATIONAL,
+        },
+      ],
+    );
+    expect(result.get("storeD")!.totalUnits).toBe(1);
+    expect(result.get("storeD")!.operationalUnits).toBe(1);
+  });
+
+  test("childSiteCount counts DIRECT children only", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate();
+    // Market A1 and Market A2 — not the three stores under them.
+    expect(result.get("regionA")!.childSiteCount).toBe(2);
+    expect(result.get("regionB")!.childSiteCount).toBe(1);
+    expect(result.get("regionC")!.childSiteCount).toBe(1);
+  });
+
+  test("located and unlocated descendants are counted separately", () => {
+    const regionA: MapMarkerAggregate = aggregate().get("regionA")!;
+    // The three stores.
+    expect(regionA.locatedDescendantCount).toBe(3);
+    // Region A itself and its two markets.
+    expect(regionA.unlocatedDescendantCount).toBe(3);
+  });
+
+  /*
+   * The marker's colour comes off these. A region with one dark store is
+   * not operational, and the card beneath it says the same.
+   */
+  test("health folds up: anything down makes the whole subtree not operational", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate();
+    expect(result.get("regionA")!.isOperational).toBe(false);
+    expect(result.get("regionA")!.worstStatusPriority).toBe(5);
+    expect(result.get("regionB")!.isOperational).toBe(true);
+    expect(result.get("regionB")!.worstStatusPriority).toBe(1);
+    expect(result.get("storeD")!.isOperational).toBe(false);
+  });
+
+  test("a subtree where nothing reports a status is neither up nor down", () => {
+    const regionC: MapMarkerAggregate = aggregate().get("regionC")!;
+    expect(regionC.isOperational).toBeNull();
+    expect(regionC.worstStatusPriority).toBe(0);
+  });
+
+  test("a status id with no row behind it is ignored rather than guessed at", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate(
+      [
+        {
+          id: "regionZ",
+          name: "Region Z",
+          siteType: "Region",
+          isUnitLevel: false,
+        },
+      ],
+      [
+        {
+          id: "storeZ",
+          name: "Store Z",
+          isUnitLevel: true,
+          parentSiteId: "regionZ",
+          materializedPath: "/regionZ/",
+          latitude: 1,
+          longitude: 1,
+          currentMonitorStatusId: "status-deleted-since",
+        },
+      ],
+    );
+    const regionZ: MapMarkerAggregate = result.get("regionZ")!;
+    expect(regionZ.isOperational).toBeNull();
+    expect(regionZ.worstStatusPriority).toBe(0);
+    expect(regionZ.totalUnits).toBe(1);
+    expect(regionZ.operationalUnits).toBe(0);
+  });
+
+  /*
+   * Rows whose materialized path has not been backfilled still have to land
+   * under the right child, or a region's whole estate silently vanishes
+   * from its marker.
+   */
+  test("a descendant with no materialized path falls back to its parent", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate(
+      [
+        {
+          id: "regionA",
+          name: "Region A",
+          siteType: "Region",
+          isUnitLevel: false,
+        },
+      ],
+      [
+        {
+          id: "storeNoPath",
+          name: "Store with no path",
+          isUnitLevel: true,
+          parentSiteId: "regionA",
+          latitude: 12,
+          longitude: 34,
+          currentMonitorStatusId: OPERATIONAL,
+        },
+      ],
+    );
+    const regionA: MapMarkerAggregate = result.get("regionA")!;
+    expect(regionA.totalUnits).toBe(1);
+    expect(regionA.latitude).toBeCloseTo(12, 9);
+    expect(regionA.longitude).toBeCloseTo(34, 9);
+  });
+
+  test("descendants belonging to no listed child are ignored", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate(
+      [
+        {
+          id: "regionA",
+          name: "Region A",
+          siteType: "Region",
+          isUnitLevel: false,
+        },
+      ],
+      [
+        {
+          id: "strayStore",
+          name: "Somewhere else entirely",
+          isUnitLevel: true,
+          parentSiteId: "someOtherRegion",
+          materializedPath: "/someOtherRegion/",
+          latitude: 60,
+          longitude: 60,
+          currentMonitorStatusId: OFFLINE,
+        },
+      ],
+    );
+    const regionA: MapMarkerAggregate = result.get("regionA")!;
+    expect(regionA.totalUnits).toBe(0);
+    expect(regionA.latitude).toBeNull();
+    expect(regionA.isOperational).toBeNull();
+  });
+
+  test("a descendant's unusable coordinates count as unlocated, not as a position", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate(
+      [
+        {
+          id: "regionA",
+          name: "Region A",
+          siteType: "Region",
+          isUnitLevel: false,
+        },
+      ],
+      [
+        {
+          id: "brokenStore",
+          name: "Broken coordinates",
+          isUnitLevel: true,
+          parentSiteId: "regionA",
+          materializedPath: "/regionA/",
+          latitude: 1246.7,
+          longitude: -94.58,
+        },
+        {
+          id: "goodStore",
+          name: "Good coordinates",
+          isUnitLevel: true,
+          parentSiteId: "regionA",
+          materializedPath: "/regionA/",
+          latitude: 20,
+          longitude: 30,
+        },
+      ],
+    );
+    const regionA: MapMarkerAggregate = result.get("regionA")!;
+    expect(regionA.locatedDescendantCount).toBe(1);
+    // Region A itself, plus the store whose coordinates cannot be read.
+    expect(regionA.unlocatedDescendantCount).toBe(2);
+    expect(regionA.latitude).toBeCloseTo(20, 9);
+    expect(regionA.longitude).toBeCloseTo(30, 9);
+  });
+
+  test("an empty level aggregates to nothing without throwing", () => {
+    expect(
+      NetworkSiteMapUtil.aggregateMapMarkers({
+        children: [],
+        descendants: DESCENDANTS,
+        statusById: STATUS_BY_ID,
+      }).size,
+    ).toBe(0);
+  });
+
+  test("children with no descendants at all still get an aggregate", () => {
+    const result: Map<string, MapMarkerAggregate> = aggregate(CHILDREN, []);
+    expect(result.size).toBe(4);
+    expect(result.get("regionA")!.latitude).toBeNull();
+    expect(result.get("regionA")!.totalUnits).toBe(0);
+    expect(result.get("regionB")!.latitude).toBe(34);
+    expect(result.get("storeD")!.totalUnits).toBe(1);
+  });
+
+  test("is independent of the order rows arrive in", () => {
+    const forward: Map<string, MapMarkerAggregate> = aggregate();
+    const reversed: Map<string, MapMarkerAggregate> = aggregate(
+      CHILDREN.slice().reverse(),
+      DESCENDANTS.slice().reverse(),
+    );
+    for (const childId of forward.keys()) {
+      const a: MapMarkerAggregate = forward.get(childId)!;
+      const b: MapMarkerAggregate = reversed.get(childId)!;
+      expect(b.totalUnits).toBe(a.totalUnits);
+      expect(b.operationalUnits).toBe(a.operationalUnits);
+      expect(b.childSiteCount).toBe(a.childSiteCount);
+      expect(b.locatedDescendantCount).toBe(a.locatedDescendantCount);
+      expect(b.isOperational).toBe(a.isOperational);
+      if (a.latitude === null) {
+        expect(b.latitude).toBeNull();
+      } else {
+        expect(b.latitude).toBeCloseTo(a.latitude, 9);
+        expect(b.longitude!).toBeCloseTo(a.longitude!, 9);
+      }
+    }
+  });
+
+  /*
+   * The customer's actual numbers: thirteen regions, every unit down. The
+   * marker for such a region has to report the whole estate and read as an
+   * outage — not as one grey dot among proximity blobs.
+   */
+  test("a wholly-down region reports its whole estate", () => {
+    const stores: Array<MapSubtreeRow> = [];
+    for (let index: number = 0; index < 69; index++) {
+      stores.push({
+        id: `store-${index}`,
+        name: `Unit ${1000 + index}`,
+        isUnitLevel: true,
+        parentSiteId: "region1000",
+        materializedPath: "/region1000/",
+        latitude: 32 + index * 0.01,
+        longitude: -96 - index * 0.01,
+        currentMonitorStatusId: OFFLINE,
+      });
+    }
+    const result: Map<string, MapMarkerAggregate> = aggregate(
+      [
+        {
+          id: "region1000",
+          name: "Region 1000",
+          siteType: "Region",
+          isUnitLevel: false,
+        },
+      ],
+      stores,
+    );
+    const region: MapMarkerAggregate = result.get("region1000")!;
+    expect(region.totalUnits).toBe(69);
+    expect(region.operationalUnits).toBe(0);
+    expect(region.isOperational).toBe(false);
+    expect(region.isDerivedLocation).toBe(true);
+    expect(region.locatedDescendantCount).toBe(69);
+    expect(isUsableCoordinate(region.latitude, region.longitude)).toBe(true);
+  });
+});

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -309,9 +309,8 @@ describe("the Network Map names no country", () => {
   });
 
   test("the map component takes sites and a click handler, and no region", () => {
-    expect(PAGE).toContain(
-      squash("<SiteGeoMap sites={pinnedSites} onSiteClick={changeSite} />"),
-    );
+    expect(PAGE).toContain(squash("sites={pinnedSites}"));
+    expect(PAGE).toContain(squash("onSiteClick={changeSite}"));
     expect(MAP).not.toContain("region: MapRegion;");
   });
 
@@ -326,6 +325,56 @@ describe("the Network Map names no country", () => {
         "queueQueryStringUpdate({ [LEGACY_NETWORK_MAP_REGION_PARAM]: null });",
       ),
     );
+  });
+});
+
+/*
+ * The map used to answer with every coordinate-bearing site in the project,
+ * flat, however deep the user had drilled — and it was only fetched at the
+ * root at all. So the map showed proximity blobs whose counts matched
+ * nothing the customer had named, while the cards directly underneath
+ * showed the real hierarchy, and drilling replaced the map with a diagram.
+ * Two halves of one page describing two different networks.
+ *
+ * These pin the three things that fixed it. Each one fails if its line is
+ * reverted.
+ */
+describe("the Network Map follows the drill", () => {
+  const PAGE: string = readSource("Pages", "NetworkSite", "NetworkMap.tsx");
+
+  test("the map endpoint is asked about the level in view", () => {
+    expect(PAGE).toContain(
+      squash(
+        "data: siteId ? { siteId: siteId, mode: mapMode } : { mode: mapMode },",
+      ),
+    );
+  });
+
+  /*
+   * The map is fetched at every level now. The old code skipped it whenever
+   * a siteId was set, which is what made a drilled view mapless.
+   */
+  test("the map is no longer skipped once you drill in", () => {
+    const code: string = readCode("Pages", "NetworkSite", "NetworkMap.tsx");
+    expect(code).not.toContain(
+      squash(
+        "const mapPromise: Promise< HTTPResponse<JSONObject> | HTTPErrorResponse > | null = siteId ? null",
+      ),
+    );
+    expect(code).toContain(
+      squash("await Promise.all([childrenPromise, mapPromise]);"),
+    );
+  });
+
+  /*
+   * One map element, rendered by BOTH the container branch and the root
+   * branch — drilling re-frames the same map instead of swapping it for
+   * something else.
+   */
+  test("the same map is rendered at the container level and at the root", () => {
+    const code: string = readCode("Pages", "NetworkSite", "NetworkMap.tsx");
+    expect(code).toContain("const geoMap: ReactElement = (");
+    expect(code.split("{geoMap}").length - 1).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -638,10 +687,51 @@ describe("SiteGeoMap", () => {
    * the map, zooming in to separate two sites would produce two bigger
    * overlapping blobs instead of two markers.
    */
+  /*
+   * A marker's colour, its count and its tooltip are all computed inside
+   * buildMapMarkers from the rollup fields. The pin fingerprint next door is
+   * deliberately geometry-only — a site going down must not re-frame the map
+   * — so keying the MARKER memo on it froze the markers: a region could go
+   * entirely dark and its square stayed green until the page was reloaded,
+   * while the card right underneath turned red. That disagreement between
+   * the two halves of the page is the whole defect this feature exists to
+   * fix, so the memo has to watch the sites themselves.
+   */
+  test("markers are rebuilt when the sites change, not only when they move", () => {
+    const memo: string = source
+      .split("const markers: Array<MapMarker> = useMemo(() => {")[1]!
+      .split("]);")[0]!;
+    expect(memo).toContain("sites: props.sites,");
+    expect(memo).toContain(squash("}, [props.sites, props.mode, cellSize"));
+    expect(memo).not.toContain("sitesRef.current");
+    expect(memo).not.toContain("pinFingerprint");
+  });
+
+  /*
+   * ...while the FIT stays keyed on geometry alone, or the 60-second poll
+   * re-frames the map under someone who has zoomed in.
+   */
+  test("the fit still ignores everything but where the sites are", () => {
+    expect(source).toContain("return mapPinFingerprint(props.sites);");
+    expect(source).toContain(
+      squash("return buildPins(sitesRef.current); }, [pinFingerprint]);"),
+    );
+  });
+
   test("marker geometry is divided by the zoom", () => {
-    expect(source).toContain("clusterRadius( cluster.totalCount, viewport, )");
+    /*
+     * Marker sizing moved into the view model when markers stopped being
+     * only proximity clusters, but the conversion still has to happen: a
+     * radius chosen in SCREEN units is meaningless until it is expressed in
+     * the viewBox units the SVG actually draws in.
+     */
+    expect(source).toContain(
+      squash("screenLengthToViewportLength( marker.screenRadius, viewport, )"),
+    );
     expect(source).toContain("strokeWidth={0.6 / zoom}");
-    expect(source).toContain("strokeWidth={(isCluster ? 2.5 : 2) / zoom}");
+    expect(source).toContain("strokeWidth={(hasCount ? 2.5 : 2) / zoom}");
+    // The name labels are UI too — they must not grow with the map.
+    expect(source).toContain("fontSize={LABEL_FONT_SIZE / zoom}");
   });
 
   /*

--- a/App/Tests/Dashboard/SiteHierarchyTypes.test.ts
+++ b/App/Tests/Dashboard/SiteHierarchyTypes.test.ts
@@ -224,14 +224,81 @@ describe("parseSiteChildrenResponse", () => {
   });
 });
 
+/*
+ * The map payload grew a hierarchy: /network-site/map answers with one row
+ * per CHILD of the level in view, each carrying where it sits, what is
+ * under it and how that is doing. The parser has to narrow all of it
+ * defensively, and — because the rollups drive both the size and the color
+ * of a marker — it has to refuse to pass through numbers that would draw a
+ * marker claiming something untrue.
+ */
 describe("parseSiteMapResponse", () => {
-  test("undefined/empty payloads narrow to an empty response", () => {
-    const expected: SiteMapResponse = { sites: [], isTruncated: false };
+  test("undefined/empty payloads narrow to an empty grouped response", () => {
+    const expected: SiteMapResponse = {
+      mode: "grouped",
+      sites: [],
+      unplacedSites: [],
+      isTruncated: false,
+    };
     expect(parseSiteMapResponse(undefined)).toEqual(expected);
     expect(parseSiteMapResponse({})).toEqual(expected);
+    expect(
+      parseSiteMapResponse({
+        sites: "nope",
+        unplacedSites: 42,
+      } as unknown as JSONObject),
+    ).toEqual(expected);
   });
 
-  test("a well-formed pin narrows faithfully", () => {
+  test("a well-formed container marker narrows faithfully", () => {
+    const parsed: SiteMapResponse = parseSiteMapResponse({
+      mode: "grouped",
+      sites: [
+        {
+          id: "r1",
+          name: "Region 1000",
+          siteType: "Region",
+          isUnitLevel: false,
+          latitude: 39.1,
+          longitude: -94.58,
+          statusPriority: 3,
+          isOperational: false,
+          parentBreadcrumb: "",
+          isContainer: true,
+          isDerivedLocation: true,
+          locatedDescendantCount: 69,
+          unlocatedDescendantCount: 2,
+          totalUnits: 69,
+          operationalUnits: 0,
+          childSiteCount: 4,
+        },
+      ],
+      isTruncated: true,
+    } as unknown as JSONObject);
+    expect(parsed.isTruncated).toBe(true);
+    expect(parsed.sites).toEqual([
+      {
+        id: "r1",
+        name: "Region 1000",
+        siteType: "Region",
+        isUnitLevel: false,
+        latitude: 39.1,
+        longitude: -94.58,
+        statusPriority: 3,
+        isOperational: false,
+        parentBreadcrumb: "",
+        isContainer: true,
+        isDerivedLocation: true,
+        locatedDescendantCount: 69,
+        unlocatedDescendantCount: 2,
+        totalUnits: 69,
+        operationalUnits: 0,
+        childSiteCount: 4,
+      },
+    ]);
+  });
+
+  test("a flat pin from a server that predates grouping is not a container", () => {
     const parsed: SiteMapResponse = parseSiteMapResponse({
       sites: [
         {
@@ -246,25 +313,28 @@ describe("parseSiteMapResponse", () => {
           parentBreadcrumb: "East / Acme / KC",
         },
       ],
-      isTruncated: true,
     } as unknown as JSONObject);
-    expect(parsed.isTruncated).toBe(true);
-    expect(parsed.sites).toEqual([
-      {
-        id: "u1",
-        name: "Store #42",
-        siteType: "Unit",
-        isUnitLevel: true,
-        latitude: 39.1,
-        longitude: -94.58,
-        statusPriority: 3,
-        isOperational: false,
-        parentBreadcrumb: "East / Acme / KC",
-      },
-    ]);
+    expect(parsed.sites[0]).toEqual({
+      id: "u1",
+      name: "Store #42",
+      siteType: "Unit",
+      isUnitLevel: true,
+      latitude: 39.1,
+      longitude: -94.58,
+      statusPriority: 3,
+      isOperational: false,
+      parentBreadcrumb: "East / Acme / KC",
+      isContainer: false,
+      isDerivedLocation: false,
+      locatedDescendantCount: 0,
+      unlocatedDescendantCount: 0,
+      totalUnits: 0,
+      operationalUnits: 0,
+      childSiteCount: 0,
+    });
   });
 
-  test("pins without an id or with non-finite coordinates are dropped", () => {
+  test("markers without an id or with non-finite coordinates are dropped", () => {
     const parsed: SiteMapResponse = parseSiteMapResponse({
       sites: [
         { name: "No id", latitude: 1, longitude: 2 },
@@ -276,6 +346,30 @@ describe("parseSiteMapResponse", () => {
     } as unknown as JSONObject);
     expect(parsed.sites).toHaveLength(1);
     expect(parsed.sites[0]!.id).toBe("ok");
+  });
+
+  /*
+   * A CSV import that shifts a column by one lands a longitude in the
+   * latitude field. Projected, that drags the marker — and the frame the
+   * map fits around it — somewhere no site is, taking every other marker
+   * off screen with it. Out of range is not a coordinate.
+   */
+  test("coordinates outside the real latitude/longitude ranges are dropped", () => {
+    const parsed: SiteMapResponse = parseSiteMapResponse({
+      sites: [
+        { id: "lat-too-high", latitude: 1246.7, longitude: 0 },
+        { id: "lat-too-low", latitude: -90.5, longitude: 0 },
+        { id: "lon-too-high", latitude: 0, longitude: 180.001 },
+        { id: "lon-too-low", latitude: 0, longitude: -181 },
+        { id: "north-pole", latitude: 90, longitude: 180 },
+        { id: "south-pole", latitude: -90, longitude: -180 },
+      ],
+    } as unknown as JSONObject);
+    expect(
+      parsed.sites.map((site: { id: string }) => {
+        return site.id;
+      }),
+    ).toEqual(["north-pole", "south-pole"]);
   });
 
   test("missing optional fields fall back to safe defaults", () => {
@@ -292,6 +386,13 @@ describe("parseSiteMapResponse", () => {
       statusPriority: 0,
       isOperational: null,
       parentBreadcrumb: "",
+      isContainer: false,
+      isDerivedLocation: false,
+      locatedDescendantCount: 0,
+      unlocatedDescendantCount: 0,
+      totalUnits: 0,
+      operationalUnits: 0,
+      childSiteCount: 0,
     });
   });
 
@@ -309,5 +410,95 @@ describe("parseSiteMapResponse", () => {
         return site.isOperational;
       }),
     ).toEqual([true, false, null, null]);
+  });
+
+  test("isContainer and isDerivedLocation are strictly boolean", () => {
+    const parsed: SiteMapResponse = parseSiteMapResponse({
+      sites: [
+        {
+          id: "a",
+          latitude: 0,
+          longitude: 0,
+          isContainer: "yes",
+          isDerivedLocation: 1,
+        },
+      ],
+    } as unknown as JSONObject);
+    expect(parsed.sites[0]!.isContainer).toBe(false);
+    expect(parsed.sites[0]!.isDerivedLocation).toBe(false);
+  });
+
+  /*
+   * A marker whose rollup says more units are healthy than exist would
+   * color itself "all operational" over a level that is half dark. The
+   * clamp is what makes the marker's color trustworthy.
+   */
+  test("operationalUnits can never exceed totalUnits", () => {
+    const parsed: SiteMapResponse = parseSiteMapResponse({
+      sites: [
+        {
+          id: "a",
+          latitude: 0,
+          longitude: 0,
+          totalUnits: 4,
+          operationalUnits: 99,
+        },
+      ],
+    } as unknown as JSONObject);
+    expect(parsed.sites[0]!.totalUnits).toBe(4);
+    expect(parsed.sites[0]!.operationalUnits).toBe(4);
+  });
+
+  test("negative and non-finite rollup counts fall back to zero", () => {
+    const parsed: SiteMapResponse = parseSiteMapResponse({
+      sites: [
+        {
+          id: "a",
+          latitude: 0,
+          longitude: 0,
+          totalUnits: -3,
+          operationalUnits: -9,
+          childSiteCount: Number.NaN,
+          locatedDescendantCount: "12",
+          unlocatedDescendantCount: -1,
+        },
+      ],
+    } as unknown as JSONObject);
+    expect(parsed.sites[0]).toMatchObject({
+      totalUnits: 0,
+      operationalUnits: 0,
+      childSiteCount: 0,
+      locatedDescendantCount: 0,
+      unlocatedDescendantCount: 0,
+    });
+  });
+
+  /*
+   * An unrecognised mode has to read as the hierarchy view. Degrading to
+   * "all" would put the flat every-store map — the thing this endpoint was
+   * changed to stop being — back in front of the customer.
+   */
+  test("only the exact string all selects the flat mode", () => {
+    expect(parseSiteMapResponse({ mode: "all" }).mode).toBe("all");
+    expect(parseSiteMapResponse({ mode: "grouped" }).mode).toBe("grouped");
+    expect(parseSiteMapResponse({ mode: "ALL" }).mode).toBe("grouped");
+    expect(parseSiteMapResponse({ mode: "flat" }).mode).toBe("grouped");
+    expect(
+      parseSiteMapResponse({ mode: 1 } as unknown as JSONObject).mode,
+    ).toBe("grouped");
+  });
+
+  test("unplaced sites narrow, and rows without an id are dropped", () => {
+    const parsed: SiteMapResponse = parseSiteMapResponse({
+      unplacedSites: [
+        { id: "r7", name: "Region 2100", siteType: "Region" },
+        { name: "no id", siteType: "Region" },
+        { id: "u9", isUnitLevel: true },
+      ],
+    } as unknown as JSONObject);
+    expect(parsed.unplacedSites).toEqual([
+      { id: "r7", name: "Region 2100", siteType: "Region", isUnitLevel: false },
+      { id: "u9", name: "Unnamed site", siteType: "Other", isUnitLevel: true },
+    ]);
   });
 });

--- a/App/Tests/Dashboard/SiteMapViewModel.test.ts
+++ b/App/Tests/Dashboard/SiteMapViewModel.test.ts
@@ -4,17 +4,37 @@ import {
   CLUSTER_CELL_SIZE,
   ClusterColorKey,
   ClusterColorMember,
+  GENERIC_SITE_TYPE_LABEL,
+  HealthTone,
   MAX_CLUSTER_RADIUS,
+  MAX_LABELLED_MARKERS,
+  MAX_MARKER_LABEL_CHARS,
   MIN_CLUSTER_RADIUS,
   FingerprintableSite,
+  LabelPlacement,
+  MapMarker,
   PinnableSite,
+  buildMapMarkers,
   buildPins,
+  childTypeLabelFor,
   clusterCellSize,
   clusterRadius,
+  colorKeyForTone,
   decideClusterColorKey,
+  describeMapCoverage,
+  describeMarkerHealth,
+  describeMarkerSite,
   formatUptimePercent,
+  groupedMarkerRadius,
   mapPinFingerprint,
+  pluralizeSiteType,
+  markerCountForSite,
+  markerToneForSite,
+  resolveMarkerLabels,
+  truncateMarkerLabel,
+  unitRollupTone,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel";
+import { MapSiteView } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes";
 import {
   ROBINSON_VIEW_BOX_HEIGHT,
   ROBINSON_VIEW_BOX_WIDTH,
@@ -525,5 +545,1031 @@ describe("mapPinFingerprint", () => {
     expect(mapPinFingerprint([pin("a", 1, 2), pin("b", 3, 9)])).not.toBe(
       mapPinFingerprint(base),
     );
+  });
+});
+
+/*
+ * ── Hierarchy markers ──────────────────────────────────────────────────
+ *
+ * The map draws one marker per CHILD of the level in view. Everything that
+ * decides what such a marker looks like — its colour, its size, the figure
+ * inside it, the name under it — is a plain function over plain data, and
+ * every one of them is pinned below.
+ *
+ * The defect they exist to stop coming back: the map plotted every
+ * coordinate-bearing site in the project, flat, and let screen-proximity
+ * clustering decide what a marker meant. The customer's regions were
+ * nowhere on it, and the numbers on it ("104", "58") counted nothing
+ * anybody had named.
+ */
+
+function mapSite(
+  overrides: Partial<MapSiteView> & { id: string },
+): MapSiteView {
+  return {
+    name: `Site ${overrides.id}`,
+    siteType: "Region",
+    isUnitLevel: false,
+    latitude: 0,
+    longitude: 0,
+    statusPriority: 0,
+    isOperational: null,
+    parentBreadcrumb: "",
+    isContainer: true,
+    isDerivedLocation: false,
+    locatedDescendantCount: 0,
+    unlocatedDescendantCount: 0,
+    totalUnits: 0,
+    operationalUnits: 0,
+    childSiteCount: 0,
+    ...overrides,
+  };
+}
+
+describe("unitRollupTone", () => {
+  test("a level with no units has no tone to report", () => {
+    expect(unitRollupTone({ totalUnits: 0, operationalUnits: 0 })).toBe("none");
+    expect(unitRollupTone({ totalUnits: -4, operationalUnits: 2 })).toBe(
+      "none",
+    );
+    expect(
+      unitRollupTone({ totalUnits: Number.NaN, operationalUnits: 0 }),
+    ).toBe("none");
+  });
+
+  test("everything up is ok", () => {
+    expect(unitRollupTone({ totalUnits: 69, operationalUnits: 69 })).toBe("ok");
+    expect(unitRollupTone({ totalUnits: 1, operationalUnits: 1 })).toBe("ok");
+  });
+
+  /*
+   * Half or more down is an outage, not a wobble. This is the exact rule
+   * the site card leads with, and the map reads it from the same function
+   * so a region cannot be red on its card and amber on its marker.
+   */
+  test("half or more down is an outage", () => {
+    expect(unitRollupTone({ totalUnits: 4, operationalUnits: 2 })).toBe("down");
+    expect(unitRollupTone({ totalUnits: 4, operationalUnits: 1 })).toBe("down");
+    expect(unitRollupTone({ totalUnits: 69, operationalUnits: 0 })).toBe(
+      "down",
+    );
+    expect(unitRollupTone({ totalUnits: 1, operationalUnits: 0 })).toBe("down");
+  });
+
+  test("a minority down is degraded", () => {
+    expect(unitRollupTone({ totalUnits: 4, operationalUnits: 3 })).toBe("warn");
+    expect(unitRollupTone({ totalUnits: 100, operationalUnits: 99 })).toBe(
+      "warn",
+    );
+  });
+
+  test("more healthy units than exist cannot invent a healthier tone", () => {
+    expect(unitRollupTone({ totalUnits: 4, operationalUnits: 99 })).toBe("ok");
+    expect(unitRollupTone({ totalUnits: 4, operationalUnits: -2 })).toBe(
+      "down",
+    );
+  });
+});
+
+describe("colorKeyForTone", () => {
+  test("the card's warn is the map's mixed; everything else is itself", () => {
+    expect(colorKeyForTone("warn")).toBe("mixed");
+    expect(colorKeyForTone("ok")).toBe("ok");
+    expect(colorKeyForTone("down")).toBe("down");
+    expect(colorKeyForTone("none")).toBe("none");
+  });
+});
+
+describe("markerToneForSite", () => {
+  test("a container with units is coloured by its rollup", () => {
+    expect(
+      markerToneForSite(
+        mapSite({ id: "a", totalUnits: 100, operationalUnits: 97 }),
+      ),
+    ).toBe("warn");
+    expect(
+      markerToneForSite(
+        mapSite({ id: "b", totalUnits: 69, operationalUnits: 0 }),
+      ),
+    ).toBe("down");
+  });
+
+  /*
+   * A region 3% down must not look identical to one that is entirely dark.
+   * The old map coloured any cluster containing a down site solid red,
+   * which made every marker on a large estate red and the colour useless.
+   */
+  test("a mostly-healthy container does not read as an outage", () => {
+    const tone: HealthTone = markerToneForSite(
+      mapSite({
+        id: "a",
+        totalUnits: 200,
+        operationalUnits: 197,
+        isOperational: false,
+      }),
+    );
+    expect(tone).toBe("warn");
+  });
+
+  test("a container with no units falls back to its own health", () => {
+    expect(markerToneForSite(mapSite({ id: "a", isOperational: false }))).toBe(
+      "down",
+    );
+    expect(markerToneForSite(mapSite({ id: "b", isOperational: true }))).toBe(
+      "ok",
+    );
+    expect(markerToneForSite(mapSite({ id: "c", isOperational: null }))).toBe(
+      "none",
+    );
+  });
+
+  test("a single site is coloured by its own status, not by a rollup", () => {
+    expect(
+      markerToneForSite(
+        mapSite({
+          id: "u1",
+          isContainer: false,
+          isUnitLevel: true,
+          totalUnits: 1,
+          operationalUnits: 0,
+          isOperational: true,
+        }),
+      ),
+    ).toBe("ok");
+  });
+});
+
+describe("markerCountForSite", () => {
+  test("counts the units under it", () => {
+    expect(markerCountForSite(mapSite({ id: "a", totalUnits: 69 }))).toBe(69);
+  });
+
+  test("falls back to direct sites when there are no units yet", () => {
+    expect(
+      markerCountForSite(
+        mapSite({ id: "a", totalUnits: 0, childSiteCount: 12 }),
+      ),
+    ).toBe(12);
+  });
+
+  test("an empty level counts as one marker, not as zero", () => {
+    expect(markerCountForSite(mapSite({ id: "a" }))).toBe(1);
+  });
+});
+
+describe("describeMarkerHealth", () => {
+  test("a healthy container counts what is up", () => {
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "a", totalUnits: 12, operationalUnits: 12 }),
+      ),
+    ).toBe("12 units operational");
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "b", totalUnits: 1, operationalUnits: 1 }),
+      ),
+    ).toBe("1 unit operational");
+  });
+
+  test("an unhealthy container counts what is down", () => {
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "a", totalUnits: 69, operationalUnits: 0 }),
+      ),
+    ).toBe("69 of 69 units down");
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "b", totalUnits: 4, operationalUnits: 3 }),
+      ),
+    ).toBe("1 of 4 units down");
+  });
+
+  test("a single site says how it is, not how many of it there are", () => {
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "u", isContainer: false, isOperational: true }),
+      ),
+    ).toBe("Operational");
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "u", isContainer: false, isOperational: false }),
+      ),
+    ).toBe("Down");
+    expect(
+      describeMarkerHealth(
+        mapSite({ id: "u", isContainer: false, isOperational: null }),
+      ),
+    ).toBe("No status yet");
+  });
+});
+
+describe("describeMarkerSite", () => {
+  test("names the site, its type and its state", () => {
+    expect(
+      describeMarkerSite(
+        mapSite({
+          id: "r1",
+          name: "Region 1000",
+          siteType: "Region",
+          totalUnits: 69,
+          operationalUnits: 0,
+          childSiteCount: 4,
+        }),
+      ),
+    ).toBe("Region 1000 — Region · 69 of 69 units down · 4 sites");
+  });
+
+  /*
+   * An inferred position must not be presented with the same confidence as
+   * one somebody typed in.
+   */
+  test("says so when the position was inferred from what is beneath", () => {
+    expect(
+      describeMarkerSite(
+        mapSite({
+          id: "r1",
+          name: "Region 1000",
+          isDerivedLocation: true,
+          locatedDescendantCount: 69,
+          totalUnits: 69,
+          operationalUnits: 69,
+        }),
+      ),
+    ).toBe(
+      "Region 1000 — Region · 69 units operational · centered on 69 located sites",
+    );
+  });
+
+  test("a single site's description carries no rollup", () => {
+    expect(
+      describeMarkerSite(
+        mapSite({
+          id: "u1",
+          name: "Unit 1042",
+          siteType: "Store",
+          isContainer: false,
+          isUnitLevel: true,
+          isOperational: true,
+        }),
+      ),
+    ).toBe("Unit 1042 — Store · Operational");
+  });
+});
+
+describe("groupedMarkerRadius", () => {
+  test("a level where nothing has more than one site draws at the minimum", () => {
+    expect(groupedMarkerRadius(1, 1)).toBe(MIN_CLUSTER_RADIUS);
+    expect(groupedMarkerRadius(5, 1)).toBe(MIN_CLUSTER_RADIUS);
+  });
+
+  test("the largest marker on screen draws at the maximum", () => {
+    expect(groupedMarkerRadius(110, 110)).toBeCloseTo(MAX_CLUSTER_RADIUS, 9);
+  });
+
+  /*
+   * The absolute sqrt scale saturates at ten sites, so a franchise whose
+   * regions hold 63-110 units each would render thirteen identical maximum
+   * discs and throw away the one thing size is for. Scaling to the largest
+   * marker keeps the comparison alive at any estate size.
+   */
+  test("regions of different sizes stay distinguishable at franchise scale", () => {
+    const small: number = groupedMarkerRadius(63, 110);
+    const large: number = groupedMarkerRadius(110, 110);
+    expect(small).toBeLessThan(large);
+    expect(large - small).toBeGreaterThan(1);
+  });
+
+  test("stays inside the marker size bounds for any input", () => {
+    const cases: Array<Array<number>> = [
+      [0, 0],
+      [-5, 10],
+      [Number.NaN, 10],
+      [10, Number.NaN],
+      [1, 100000],
+      [100000, 100000],
+    ];
+    for (const pair of cases) {
+      const radius: number = groupedMarkerRadius(pair[0]!, pair[1]!);
+      expect(Number.isFinite(radius)).toBe(true);
+      expect(radius).toBeGreaterThanOrEqual(MIN_CLUSTER_RADIUS);
+      expect(radius).toBeLessThanOrEqual(MAX_CLUSTER_RADIUS);
+    }
+  });
+
+  test("area tracks the count, so the reading stays honest", () => {
+    // Four times the count is twice the linear scale above the minimum.
+    const quarter: number = groupedMarkerRadius(25, 100) - MIN_CLUSTER_RADIUS;
+    const full: number = groupedMarkerRadius(100, 100) - MIN_CLUSTER_RADIUS;
+    expect(full / quarter).toBeCloseTo(2, 9);
+  });
+});
+
+describe("childTypeLabelFor", () => {
+  test("uses the customer's own word when the level agrees on one", () => {
+    expect(
+      childTypeLabelFor([{ siteType: "Region" }, { siteType: "Region" }]),
+    ).toBe("Region");
+    expect(childTypeLabelFor([{ siteType: "Restaurant" }])).toBe("Restaurant");
+  });
+
+  test("case is not a difference of type", () => {
+    expect(
+      childTypeLabelFor([{ siteType: "Region" }, { siteType: "region" }]),
+    ).toBe("Region");
+  });
+
+  /*
+   * The map must never put a word in the customer's mouth. A level holding
+   * both regions and a stray unit is a level of "sites".
+   */
+  test("falls back to a generic word when the level mixes types", () => {
+    expect(
+      childTypeLabelFor([{ siteType: "Region" }, { siteType: "Unit" }]),
+    ).toBe(GENERIC_SITE_TYPE_LABEL);
+  });
+
+  test("an empty or unnamed level gets the generic word", () => {
+    expect(childTypeLabelFor([])).toBe(GENERIC_SITE_TYPE_LABEL);
+    expect(childTypeLabelFor([{ siteType: "" }])).toBe(GENERIC_SITE_TYPE_LABEL);
+    expect(childTypeLabelFor([{ siteType: "   " }])).toBe(
+      GENERIC_SITE_TYPE_LABEL,
+    );
+  });
+});
+
+describe("describeMapCoverage", () => {
+  test("grouped mode counts the level's children by their own type name", () => {
+    expect(
+      describeMapCoverage({
+        mode: "grouped",
+        markerCount: 13,
+        inViewCount: 13,
+        siteCount: 13,
+        childTypeLabel: "Region",
+      }),
+    ).toBe("13 regions on the map");
+  });
+
+  test("grouped mode says what the frame holds once it stops holding all of it", () => {
+    expect(
+      describeMapCoverage({
+        mode: "grouped",
+        markerCount: 13,
+        inViewCount: 4,
+        siteCount: 13,
+        childTypeLabel: "Region",
+      }),
+    ).toBe("4 of 13 regions in view");
+  });
+
+  test("one of something is not plural", () => {
+    expect(
+      describeMapCoverage({
+        mode: "grouped",
+        markerCount: 1,
+        inViewCount: 1,
+        siteCount: 1,
+        childTypeLabel: "Market",
+      }),
+    ).toBe("1 market on the map");
+  });
+
+  /*
+   * In the flat view a marker really is one site, so the old wording is
+   * still the true one — and counting containers as "sites" would be the
+   * same category error the flat map made.
+   */
+  test("all-sites mode counts sites", () => {
+    expect(
+      describeMapCoverage({
+        mode: "all",
+        markerCount: 40,
+        inViewCount: 900,
+        siteCount: 900,
+        childTypeLabel: "Region",
+      }),
+    ).toBe("900 sites mapped");
+    expect(
+      describeMapCoverage({
+        mode: "all",
+        markerCount: 40,
+        inViewCount: 120,
+        siteCount: 900,
+        childTypeLabel: "Region",
+      }),
+    ).toBe("120 of 900 sites in view");
+  });
+});
+
+describe("buildMapMarkers", () => {
+  const REGIONS: Array<MapSiteView> = [
+    mapSite({
+      id: "r1",
+      name: "Region 1000",
+      latitude: 32,
+      longitude: -96,
+      totalUnits: 69,
+      operationalUnits: 0,
+      isDerivedLocation: true,
+    }),
+    mapSite({
+      id: "r2",
+      name: "Region 1100",
+      latitude: 40,
+      longitude: -74,
+      totalUnits: 79,
+      operationalUnits: 79,
+    }),
+    mapSite({
+      id: "u1",
+      name: "WB Unit 1382",
+      siteType: "Unit",
+      isContainer: false,
+      isUnitLevel: true,
+      latitude: 34,
+      longitude: -118,
+      totalUnits: 1,
+      operationalUnits: 1,
+      isOperational: true,
+    }),
+  ];
+
+  test("grouped mode draws exactly one marker per child", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: REGIONS,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    expect(markers).toHaveLength(3);
+    expect(
+      markers
+        .map((marker: MapMarker) => {
+          return marker.ids[0]!;
+        })
+        .sort(),
+    ).toEqual(["r1", "r2", "u1"]);
+    for (const marker of markers) {
+      expect(marker.ids).toHaveLength(1);
+    }
+  });
+
+  /*
+   * THE defect. Two regions whose centroids fall close together must stay
+   * two markers: merging them by proximity puts a number back on the map
+   * that stands for nothing the customer has a name for.
+   */
+  test("grouped mode never merges two children, however close they sit", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: [
+        mapSite({ id: "r1", name: "Region A", latitude: 32, longitude: -96 }),
+        mapSite({
+          id: "r2",
+          name: "Region B",
+          latitude: 32.0001,
+          longitude: -96.0001,
+        }),
+      ],
+      mode: "grouped",
+      cellSize: CLUSTER_CELL_SIZE,
+    });
+    expect(markers).toHaveLength(2);
+  });
+
+  test("all-sites mode still merges nearby sites into one marker", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: [
+        mapSite({
+          id: "s1",
+          isContainer: false,
+          latitude: 32,
+          longitude: -96,
+        }),
+        mapSite({
+          id: "s2",
+          isContainer: false,
+          latitude: 32.0001,
+          longitude: -96.0001,
+        }),
+      ],
+      mode: "all",
+      cellSize: CLUSTER_CELL_SIZE,
+    });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.count).toBe(2);
+    expect(markers[0]!.ids).toEqual(["s1", "s2"]);
+  });
+
+  test("a marker knows whether it is a level or a place", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: REGIONS,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    const byId: Map<string, MapMarker> = new Map<string, MapMarker>(
+      markers.map((marker: MapMarker): [string, MapMarker] => {
+        return [marker.ids[0]!, marker];
+      }),
+    );
+    expect(byId.get("r1")!.isContainer).toBe(true);
+    expect(byId.get("u1")!.isContainer).toBe(false);
+    expect(byId.get("r1")!.isApproximate).toBe(true);
+    expect(byId.get("r2")!.isApproximate).toBe(false);
+  });
+
+  test("grouped markers carry their name and their rollup colour", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: REGIONS,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    const byId: Map<string, MapMarker> = new Map<string, MapMarker>(
+      markers.map((marker: MapMarker): [string, MapMarker] => {
+        return [marker.ids[0]!, marker];
+      }),
+    );
+    expect(byId.get("r1")!.label).toBe("Region 1000");
+    expect(byId.get("r1")!.count).toBe(69);
+    expect(byId.get("r1")!.colorKey).toBe("down");
+    expect(byId.get("r2")!.colorKey).toBe("ok");
+    expect(byId.get("r1")!.tooltip).toContain("69 of 69 units down");
+  });
+
+  test("clusters in all-sites mode carry no name label", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: REGIONS,
+      mode: "all",
+      cellSize: CLUSTER_CELL_SIZE,
+    });
+    for (const marker of markers) {
+      expect(marker.label).toBe("");
+      expect(marker.isContainer).toBe(false);
+    }
+  });
+
+  /*
+   * The smallest marker is painted last so a single store never disappears
+   * under the region that contains its neighbours.
+   */
+  test("markers are painted biggest first", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: REGIONS,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    const counts: Array<number> = markers.map((marker: MapMarker): number => {
+      return marker.count;
+    });
+    expect(counts).toEqual([79, 69, 1]);
+  });
+
+  test("paint order is deterministic when counts tie", () => {
+    const tied: Array<MapSiteView> = [
+      mapSite({ id: "zzz", latitude: 1, longitude: 1, totalUnits: 5 }),
+      mapSite({ id: "aaa", latitude: 2, longitude: 2, totalUnits: 5 }),
+      mapSite({ id: "mmm", latitude: 3, longitude: 3, totalUnits: 5 }),
+    ];
+    const forward: Array<MapMarker> = buildMapMarkers({
+      sites: tied,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    const reversed: Array<MapMarker> = buildMapMarkers({
+      sites: tied.slice().reverse(),
+      mode: "grouped",
+      cellSize: 0,
+    });
+    expect(
+      forward.map((marker: MapMarker) => {
+        return marker.key;
+      }),
+    ).toEqual(["aaa", "mmm", "zzz"]);
+    expect(
+      reversed.map((marker: MapMarker) => {
+        return marker.key;
+      }),
+    ).toEqual(
+      forward.map((marker: MapMarker) => {
+        return marker.key;
+      }),
+    );
+  });
+
+  /*
+   * Past the threshold the labels would overlap into an unreadable mat.
+   * The hover tooltip still names every marker.
+   */
+  test("labels come off once a level is too busy for them", () => {
+    const many: Array<MapSiteView> = [];
+    for (let index: number = 0; index <= MAX_LABELLED_MARKERS; index++) {
+      many.push(
+        mapSite({
+          id: `s${index}`,
+          name: `Site ${index}`,
+          latitude: index * 0.5,
+          longitude: index * 0.5,
+        }),
+      );
+    }
+    const overBudget: Array<MapMarker> = buildMapMarkers({
+      sites: many,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    expect(overBudget.length).toBeGreaterThan(MAX_LABELLED_MARKERS);
+    for (const marker of overBudget) {
+      expect(marker.label).toBe("");
+      expect(marker.tooltip).not.toBe("");
+    }
+
+    const withinBudget: Array<MapMarker> = buildMapMarkers({
+      sites: many.slice(0, MAX_LABELLED_MARKERS),
+      mode: "grouped",
+      cellSize: 0,
+    });
+    expect(withinBudget[0]!.label).not.toBe("");
+  });
+
+  test("sites the projection cannot place are left off rather than guessed at", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: [
+        mapSite({ id: "good", latitude: 10, longitude: 20 }),
+        mapSite({ id: "broken", latitude: Number.NaN, longitude: 20 }),
+      ],
+      mode: "grouped",
+      cellSize: 0,
+    });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.ids).toEqual(["good"]);
+  });
+
+  test("an empty level draws nothing without throwing", () => {
+    expect(
+      buildMapMarkers({ sites: [], mode: "grouped", cellSize: 0 }),
+    ).toEqual([]);
+    expect(
+      buildMapMarkers({ sites: [], mode: "all", cellSize: CLUSTER_CELL_SIZE }),
+    ).toEqual([]);
+  });
+
+  test("every marker lands inside the world it is drawn on", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: REGIONS,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    for (const marker of markers) {
+      expect(marker.x).toBeGreaterThanOrEqual(0);
+      expect(marker.x).toBeLessThanOrEqual(ROBINSON_VIEW_BOX_WIDTH);
+      expect(marker.y).toBeGreaterThanOrEqual(0);
+      expect(marker.y).toBeLessThanOrEqual(ROBINSON_VIEW_BOX_HEIGHT);
+      expect(Number.isFinite(marker.screenRadius)).toBe(true);
+    }
+  });
+});
+
+/*
+ * A grouped marker stands for a whole region, so the pin it seeds has to
+ * carry that weight — and a weight that is not a usable number must not
+ * reach the cluster maths, where it would silently become a NaN badge or a
+ * zero-count marker.
+ */
+describe("buildPins carries a marker's weight", () => {
+  test("a site's count travels onto its pin", () => {
+    const result: BuildPinsResult = buildPins([
+      { id: "a", latitude: 10, longitude: 20, statusPriority: 0, count: 69 },
+    ]);
+    expect(result.pins[0]!.count).toBe(69);
+  });
+
+  test("a missing or unusable count reads as one site", () => {
+    const result: BuildPinsResult = buildPins([
+      { id: "a", latitude: 10, longitude: 20, statusPriority: 0 },
+      {
+        id: "b",
+        latitude: 10,
+        longitude: 20,
+        statusPriority: 0,
+        count: Number.NaN,
+      },
+      { id: "c", latitude: 10, longitude: 20, statusPriority: 0, count: 0 },
+      { id: "d", latitude: 10, longitude: 20, statusPriority: 0, count: -7 },
+      { id: "e", latitude: 10, longitude: 20, statusPriority: 0, count: 2.6 },
+    ]);
+    expect(
+      result.pins.map((pin: { count?: number | undefined }) => {
+        return pin.count;
+      }),
+    ).toEqual([1, 1, 1, 1, 3]);
+  });
+});
+
+describe("truncateMarkerLabel", () => {
+  test("a name that fits is left alone", () => {
+    expect(truncateMarkerLabel("Region 1000")).toBe("Region 1000");
+    expect(
+      truncateMarkerLabel("a".repeat(MAX_MARKER_LABEL_CHARS)),
+    ).toHaveLength(MAX_MARKER_LABEL_CHARS);
+  });
+
+  test("a long name is cut with an ellipsis and no trailing space", () => {
+    const label: string = truncateMarkerLabel(
+      "Midwest Franchise Group — Northern Division",
+    );
+    expect(label).toHaveLength(MAX_MARKER_LABEL_CHARS);
+    expect(label.endsWith("…")).toBe(true);
+    expect(label).not.toContain(" …");
+  });
+
+  test("handles an empty name", () => {
+    expect(truncateMarkerLabel("")).toBe("");
+  });
+});
+
+/*
+ * Names on the map are the whole point of the grouped view — "Region 1000"
+ * belongs where the customer put it, not only in a tooltip. But three
+ * regions whose centroids land in one corner of a state would print their
+ * names on top of each other, which hides two of them AND makes the third
+ * unreadable.
+ */
+describe("resolveMarkerLabels", () => {
+  function markerAt(
+    key: string,
+    x: number,
+    y: number,
+    overrides: Partial<MapMarker> = {},
+  ): MapMarker {
+    return {
+      key: key,
+      x: x,
+      y: y,
+      ids: [key],
+      count: 10,
+      screenRadius: MIN_CLUSTER_RADIUS,
+      colorKey: "ok",
+      isContainer: true,
+      isApproximate: false,
+      label: key,
+      tooltip: key,
+      ...overrides,
+    };
+  }
+
+  test("well-separated markers all keep their names, below them", () => {
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [markerAt("A", 100, 100), markerAt("B", 300, 300)],
+      1,
+    );
+    expect(placements.get("A")).toBe("below");
+    expect(placements.get("B")).toBe("below");
+  });
+
+  test("a marker with no label is never placed", () => {
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [markerAt("A", 100, 100, { label: "" })],
+      1,
+    );
+    expect(placements.has("A")).toBe(false);
+  });
+
+  /*
+   * Below is tried first because the eye reads marker-then-name; above is
+   * the escape hatch, so a name is only lost when neither position is free.
+   */
+  test("a label blocked from below flips above rather than disappearing", () => {
+    const blocker: MapMarker = markerAt("blocker", 100, 118, { label: "" });
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [markerAt("A", 100, 100), blocker],
+      1,
+    );
+    expect(placements.get("A")).toBe("above");
+  });
+
+  test("a label with nowhere to go is dropped, not stacked", () => {
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [
+        markerAt("A", 100, 100),
+        markerAt("above", 100, 82, { label: "" }),
+        markerAt("below", 100, 118, { label: "" }),
+      ],
+      1,
+    );
+    expect(placements.has("A")).toBe(false);
+  });
+
+  /*
+   * Paint order is biggest-first, so the region a reader is most likely to
+   * be looking for is the one that keeps its name.
+   */
+  test("when two names collide the first in paint order keeps the better spot", () => {
+    /*
+     * Far enough apart that neither marker BODY blocks a label — the
+     * collision under test is name-against-name. The bigger marker comes
+     * first in paint order and keeps the preferred position below it; its
+     * neighbour is pushed above rather than dropped.
+     */
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [markerAt("Big", 100, 100), markerAt("Small", 118, 100)],
+      1,
+    );
+    expect(placements.get("Big")).toBe("below");
+    expect(placements.get("Small")).toBe("above");
+  });
+
+  /*
+   * Zooming in genuinely separates markers, so names dropped at a wide
+   * frame come back — that is what makes dropping them acceptable.
+   */
+  test("zooming in brings dropped names back", () => {
+    const markers: Array<MapMarker> = [
+      markerAt("A", 100, 100),
+      markerAt("above", 100, 84, { label: "" }),
+      markerAt("below", 100, 116, { label: "" }),
+    ];
+    expect(resolveMarkerLabels(markers, 1).size).toBe(0);
+    expect(resolveMarkerLabels(markers, 12).size).toBe(1);
+  });
+
+  test("a non-finite or zero zoom does not throw or lose every name", () => {
+    const markers: Array<MapMarker> = [
+      markerAt("A", 100, 100),
+      markerAt("B", 400, 400),
+    ];
+    expect(resolveMarkerLabels(markers, Number.NaN).size).toBe(2);
+    expect(resolveMarkerLabels(markers, 0).size).toBe(2);
+    expect(resolveMarkerLabels(markers, -3).size).toBe(2);
+  });
+
+  test("an empty marker list resolves to no labels", () => {
+    expect(resolveMarkerLabels([], 1).size).toBe(0);
+  });
+
+  test("is deterministic for the same markers and zoom", () => {
+    const markers: Array<MapMarker> = [
+      markerAt("A", 100, 100),
+      markerAt("B", 106, 100),
+      markerAt("C", 300, 300),
+    ];
+    expect(Array.from(resolveMarkerLabels(markers, 4).entries())).toEqual(
+      Array.from(resolveMarkerLabels(markers, 4).entries()),
+    );
+  });
+
+  /*
+   * A longer name reserves a wider box, so it collides where a short one
+   * would have fitted. This is what keeps the estimate honest.
+   */
+  test("a longer name needs more room", () => {
+    const short: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [
+        markerAt("A", 100, 100, { label: "A" }),
+        markerAt("B", 118, 100, { label: "B" }),
+      ],
+      1,
+    );
+    const long: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [
+        markerAt("A", 100, 100, { label: "Midwest Franchise Gr" }),
+        markerAt("B", 118, 100, { label: "Southern Franchise G" }),
+      ],
+      1,
+    );
+    // Two short names both sit below their markers; two long ones cannot.
+    expect(short.get("A")).toBe("below");
+    expect(short.get("B")).toBe("below");
+    expect(long.get("A")).toBe("below");
+    expect(long.get("B")).toBe("above");
+  });
+});
+
+/*
+ * Site types are free text on a per-project row, so the naive "+ s" that is
+ * fine for this file's hardcoded English nouns put "Facilitys", "Branchs"
+ * and "Franchise Unitss" on real customers' maps.
+ */
+describe("pluralizeSiteType", () => {
+  test.each([
+    ["Region", "Regions"],
+    ["Market", "Markets"],
+    ["Unit", "Units"],
+    ["Store", "Stores"],
+    ["Facility", "Facilities"],
+    ["Territory", "Territories"],
+    ["Branch", "Branches"],
+    ["Business", "Businesses"],
+    ["Campus", "Campuses"],
+    ["Box", "Boxes"],
+    ["Dish", "Dishes"],
+  ])("%s becomes %s", (singular: string, plural: string) => {
+    expect(pluralizeSiteType(singular)).toBe(plural);
+  });
+
+  // A customer who already named the type in the plural is left alone.
+  test.each([["Units"], ["Premises"], ["Franchise Units"], ["Sites"]])(
+    "%s is already plural",
+    (word: string) => {
+      expect(pluralizeSiteType(word)).toBe(word);
+    },
+  );
+
+  test("keeps the customer's capitalisation", () => {
+    expect(pluralizeSiteType("FRANCHISE")).toBe("FRANCHISEs");
+    expect(pluralizeSiteType("region")).toBe("regions");
+  });
+
+  test("an empty or blank name stays empty", () => {
+    expect(pluralizeSiteType("")).toBe("");
+    expect(pluralizeSiteType("   ")).toBe("");
+  });
+});
+
+describe("describeMapCoverage pluralises the customer's own words", () => {
+  test.each([
+    ["Facility", 13, "13 facilities on the map"],
+    ["Branch", 4, "4 branches on the map"],
+    ["Territory", 7, "7 territories on the map"],
+    ["Franchise Units", 3, "3 franchise units on the map"],
+    ["Region", 1, "1 region on the map"],
+  ])("%s x%i reads as %s", (label: string, count: number, expected: string) => {
+    expect(
+      describeMapCoverage({
+        mode: "grouped",
+        markerCount: count,
+        inViewCount: count,
+        siteCount: count,
+        childTypeLabel: label,
+      }),
+    ).toBe(expected);
+  });
+
+  test("the partial-frame line pluralises too", () => {
+    expect(
+      describeMapCoverage({
+        mode: "grouped",
+        markerCount: 13,
+        inViewCount: 5,
+        siteCount: 13,
+        childTypeLabel: "Facility",
+      }),
+    ).toBe("5 of 13 facilities in view");
+  });
+});
+
+/*
+ * A grouped marker's SIZE is how a reader compares one region against
+ * another at a glance. It is computed inside buildMapMarkers, so asserting
+ * groupedMarkerRadius alone would leave the wiring free to regress with the
+ * suite green.
+ */
+describe("buildMapMarkers sizes markers by what is under them", () => {
+  test("a bigger estate draws a bigger marker, all the way down the level", () => {
+    const sites: Array<MapSiteView> = [110, 97, 69, 41, 1].map(
+      (units: number, index: number): MapSiteView => {
+        return mapSite({
+          id: `r${index}`,
+          name: `Region ${index}`,
+          latitude: 30 + index * 3,
+          longitude: -100 + index * 3,
+          totalUnits: units,
+          operationalUnits: units,
+        });
+      },
+    );
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: sites,
+      mode: "grouped",
+      cellSize: 0,
+    });
+    const radii: Array<number> = markers.map((marker: MapMarker): number => {
+      return marker.screenRadius;
+    });
+    // Paint order is biggest first, so radii descend with it.
+    for (let index: number = 1; index < radii.length; index++) {
+      expect(radii[index]!).toBeLessThan(radii[index - 1]!);
+    }
+    expect(radii[0]!).toBeCloseTo(MAX_CLUSTER_RADIUS, 9);
+    expect(radii[radii.length - 1]!).toBeGreaterThanOrEqual(MIN_CLUSTER_RADIUS);
+  });
+
+  test("a level where every child is the same size draws them the same", () => {
+    const sites: Array<MapSiteView> = [0, 1, 2].map(
+      (index: number): MapSiteView => {
+        return mapSite({
+          id: `r${index}`,
+          latitude: 30 + index * 5,
+          longitude: -100 + index * 5,
+          totalUnits: 50,
+          operationalUnits: 50,
+        });
+      },
+    );
+    const radii: Set<number> = new Set<number>(
+      buildMapMarkers({ sites: sites, mode: "grouped", cellSize: 0 }).map(
+        (marker: MapMarker): number => {
+          return marker.screenRadius;
+        },
+      ),
+    );
+    expect(radii.size).toBe(1);
   });
 });


### PR DESCRIPTION
## The report

> The map does not show the parent/child drill down we were expecting. The boxes below are correct but the map is off. We named the import Corp and Franchise Units — I'd want that to show on the map as containers, just like what it creates: regions, markets and unit containers. When I drill down to the boxes this seems right but the same picture is not on the map.

## What was actually wrong

Three separate defects, all in the same place:

1. **The map was never scoped to the level you were looking at.** `POST /network-site/map` answered with *every* coordinate-bearing site in the project, flat, however deep you had drilled. Screen-proximity clustering then merged them into numbered blobs — the `104` and `58` in the screenshots are "how many stores fell in one grid cell at this zoom", which corresponds to nothing anybody named. Meanwhile the cards underneath listed the real hierarchy. The two halves of one page described two different networks.

2. **Containers could never appear at all.** Regions, markets, "Corp", "Franchise Units" are organizational rows with no latitude or longitude, so they had no place on the map by construction. The one thing the map is for — seeing the shape of the estate — was the one thing it could not show.

3. **Drilling threw the map away.** Opening a region replaced the map with a React Flow box diagram, so "the same picture is not on the map" was literally true: there was no map.

## The fix

**The map is now a level-scoped view of the hierarchy, present at every level.** One marker per child of the level you are on — exactly the set the cards below it list.

- A **container** with no coordinates of its own is placed at the **spherical centroid** of the located sites beneath it, drawn as a **rounded square** (the shape of the card it opens into) with its **name on the map**, sized by the units under it and colored by their rollup. A single site stays a round pin. Shape, not hue, carries "this is a level you can open", so it survives a color-blind reader.
- An inferred position is drawn with a **dashed edge** and says so on hover — an inferred location must not be presented with the confidence of one somebody typed in.
- **Drilling re-frames the same map** instead of swapping it for a diagram. The box graph stays underneath, where the links between the children live.
- A **Regions / All sites** switch keeps the every-store view for anyone who wants it, now scoped to the subtree in view rather than the whole project.
- Children with **nothing locatable anywhere beneath them** are named under the map instead of silently vanishing — "Region 2100 is missing and I don't know why" is the confusion this whole endpoint change exists to end.
- Marker color now comes from the **same rollup function the card uses** (`unitRollupTone`, moved into the shared view-model), so a region reading "63 of 63 units down" can no longer be a calm dot on the map above it. A region 3% down is amber, not the same red as one that is entirely dark.

### On the import naming

There is no "import name" field in the CSV importer — it creates whatever hierarchy the rows describe. With this change, whatever your **top-level rows** are becomes the top level of the map. If you want a literal `Corp` and `Franchise Units` above the regions, add those two rows to the CSV with an empty `parentName` and set each region's `parentName` to one of them; the map will then open on those two containers and drill into regions, markets and units beneath them.

## Changes

**Server**
- `App/FeatureSet/BaseAPI/Utils/NetworkSiteMapUtil.ts` *(new)* — pure centroid + rollup aggregation. Spherical (unit-vector) centroid rather than an arithmetic mean, because longitudes wrap: the flat mean of +179 and −179 is the Gulf of Guinea.
- `App/FeatureSet/BaseAPI/API/NetworkSiteHierarchy.ts` — `/network-site/map` takes optional `siteId` and `mode`, returns one row per child with rollups plus an `unplacedSites` list. Coordinates outside the real lat/long ranges are refused rather than projected.

**Client**
- `SiteMapViewModel.ts` — `buildMapMarkers` and every marker decision (tone, count, size, label, tooltip, label collision resolution) as pure functions.
- `SiteGeoMap.tsx` — container markers, on-map names with collision avoidance (below, else flipped above, else dropped), the mode switch, the unplaced-sites footer.
- `NetworkMap.tsx` — fetches the map at every level and renders it at container levels.
- `SiteCard.tsx` — now imports the shared rollup tone.

## Testing

`App/Tests/BaseAPI/NetworkSiteMapUtil.test.ts` *(new, 33 tests)* — coordinate validation, spherical centroid (antimeridian, poles, antipodal, order-independence), and rollup aggregation against a fixture shaped like the reported estate. Type names in the fixtures are deliberately "Store"/"Location", never "Unit", so any regression to name-based leaf detection fails.

`App/Tests/Dashboard/SiteMapViewModel.test.ts` — grew from 45 to 130 tests: marker building (grouped never clusters, all-sites still does), tone/size/count/label decisions, label placement, and pluralization of customer-renamed site types.

`App/Tests/Dashboard/SiteHierarchyTypes.test.ts` — parser coverage for the new fields, out-of-range coordinate rejection, and the `operationalUnits ≤ totalUnits` clamp.

`App/Tests/Dashboard/NetworkSitePageInvariants.test.ts` — updated for the new prop shape, plus new pins on the three behaviours that fix this bug: the map endpoint is asked about the level in view, the map is no longer skipped on drill, and the marker memo watches the sites (not just their geometry) so an outage actually reaches the map.

Full `App` suite passes; both `App` and `Dashboard` typecheck clean; eslint clean.

Beyond the tests, the change went through an adversarial review pass that raised 52 findings and confirmed 12 after verification — all 12 are fixed here, including a marker-memo staleness bug that would have frozen marker colors between polls, a use-before-declaration in the label placement, and an "N of M sites in view" count that compared clusters against sites.
