### PR TITLE
fix(global-probes): honour the list payload on /probe/global-probes

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorProbes.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorProbes.tsx
@@ -60,6 +60,10 @@ const ProbePage: FunctionComponent<PageComponentProps> = (): ReactElement => {
           noItemsMessage={"No probes found."}
           showRefreshButton={true}
           searchableFields={["name", "description"]}
+          selectMoreFields={{
+            // The Name cell renders the probe logo, which no column declares.
+            iconFileId: true,
+          }}
           filters={[
             {
               field: {

--- a/Common/Server/API/ProbeAPI.ts
+++ b/Common/Server/API/ProbeAPI.ts
@@ -2,6 +2,9 @@ import UserMiddleware from "../Middleware/UserAuthorization";
 import ProbeService, {
   Service as ProbeServiceType,
 } from "../Services/ProbeService";
+import Query from "../Types/Database/Query";
+import Select from "../Types/Database/Select";
+import Sort from "../Types/Database/Sort";
 import {
   ExpressRequest,
   ExpressResponse,
@@ -9,9 +12,47 @@ import {
 } from "../Utils/Express";
 import Response from "../Utils/Response";
 import BaseAPI from "./BaseAPI";
-import LIMIT_MAX from "../../Types/Database/LimitMax";
+import MultiSearch from "../../Types/BaseDatabase/MultiSearch";
+import {
+  DEFAULT_LIMIT,
+  LIMIT_PER_PROJECT,
+} from "../../Types/Database/LimitMax";
+import Dictionary from "../../Types/Dictionary";
+import BadDataException from "../../Types/Exception/BadDataException";
+import BadRequestException from "../../Types/Exception/BadRequestException";
+import { JSONObject, JSONValue } from "../../Types/JSON";
+import JSONFunctions from "../../Types/JSONFunctions";
 import PositiveNumber from "../../Types/PositiveNumber";
 import Probe from "../../Models/DatabaseModels/Probe";
+
+// What a caller that asks for no fields in particular gets back.
+const DEFAULT_GLOBAL_PROBE_SELECT: Select<Probe> = {
+  name: true,
+  description: true,
+  lastAlive: true,
+  iconFileId: true,
+  connectionStatus: true,
+  // The monitor create form pre-selects the auto-enabled probes.
+  shouldAutoEnableProbeOnNewMonitors: true,
+};
+
+/*
+ * Global probes are not project rows, so this endpoint has to read them as
+ * root - which means none of the usual per-column permission checks run.
+ * Every field a caller may select, filter or sort on is therefore listed
+ * here, and nothing else is reachable: `key` in particular is a probe's
+ * shared secret, and a root-privileged query on it would be an oracle for
+ * reading it back one character at a time.
+ */
+const GLOBAL_PROBE_FIELDS: Array<string> = [
+  ...Object.keys(DEFAULT_GLOBAL_PROBE_SELECT),
+  "_id",
+  /*
+   * Readable, but not something a caller can steer: the query below pins it
+   * to true whatever the caller sent.
+   */
+  "isGlobalProbe",
+];
 
 export default class ProbeAPI extends BaseAPI<Probe, ProbeServiceType> {
   public constructor() {
@@ -22,31 +63,72 @@ export default class ProbeAPI extends BaseAPI<Probe, ProbeServiceType> {
       UserMiddleware.getUserMiddleware,
       async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
         try {
+          const body: JSONObject = (req.body as JSONObject) || {};
+
+          const skip: PositiveNumber = new PositiveNumber(
+            ProbeAPI.getPaginationValue(req, "skip", 0),
+          );
+
+          const limit: PositiveNumber = new PositiveNumber(
+            ProbeAPI.getPaginationValue(req, "limit", DEFAULT_LIMIT),
+          );
+
+          if (limit.toNumber() > LIMIT_PER_PROJECT) {
+            throw new BadRequestException(
+              "Limit should be less than " + LIMIT_PER_PROJECT,
+            );
+          }
+
+          if (skip.toNumber() < 0) {
+            throw new BadRequestException(
+              "Skip should be greater than or equal to 0",
+            );
+          }
+
+          if (limit.toNumber() <= 0) {
+            throw new BadRequestException("Limit should be greater than 0");
+          }
+
+          const query: Query<Probe> = {
+            ...ProbeAPI.getQuery(body["query"] as JSONObject),
+            /*
+             * Last, so a caller cannot widen the read past the global probes
+             * by sending isGlobalProbe themselves.
+             */
+            isGlobalProbe: true,
+          };
+
+          const select: Select<Probe> = ProbeAPI.getSelect(
+            body["select"] as JSONObject,
+          );
+
+          const sort: Sort<Probe> = ProbeAPI.getSort(
+            body["sort"] as JSONObject,
+          );
+
           const probes: Array<Probe> = await ProbeService.findBy({
-            query: {
-              isGlobalProbe: true,
-            },
-            select: {
-              name: true,
-              description: true,
-              lastAlive: true,
-              iconFileId: true,
-              connectionStatus: true,
-              // The monitor create form pre-selects the auto-enabled probes.
-              shouldAutoEnableProbeOnNewMonitors: true,
-            },
+            query,
+            select,
+            sort,
             props: {
               isRoot: true,
             },
-            skip: 0,
-            limit: LIMIT_MAX,
+            skip,
+            limit,
+          });
+
+          const count: PositiveNumber = await ProbeService.countBy({
+            query,
+            props: {
+              isRoot: true,
+            },
           });
 
           return Response.sendEntityArrayResponse(
             req,
             res,
             probes,
-            new PositiveNumber(probes.length),
+            count,
             Probe,
           );
         } catch (err) {
@@ -54,5 +136,104 @@ export default class ProbeAPI extends BaseAPI<Probe, ProbeServiceType> {
         }
       },
     );
+  }
+
+  /*
+   * skip/limit arrive as query params from ModelAPI.getList and in the body
+   * from anything hand-rolled, so both are read - same precedence as
+   * BaseAPI.getList.
+   */
+  private static getPaginationValue(
+    req: ExpressRequest,
+    key: "skip" | "limit",
+    defaultValue: number,
+  ): number {
+    if (req.query && req.query[key]) {
+      return parseInt(req.query[key] as string, 10) || defaultValue;
+    }
+
+    if (req.body && (req.body as JSONObject)[key] !== undefined) {
+      return (
+        parseInt((req.body as JSONObject)[key] as string, 10) || defaultValue
+      );
+    }
+
+    return defaultValue;
+  }
+
+  private static getQuery(query: JSONObject | undefined): Query<Probe> {
+    const deserialized: JSONObject = JSONFunctions.deserialize(
+      query as JSONObject,
+    );
+
+    for (const key in deserialized) {
+      const value: JSONValue = deserialized[key] as JSONValue;
+
+      /*
+       * MultiSearch is the free-text search operator. Its key is synthetic -
+       * the columns it reads are the ones it carries - so those are what get
+       * checked against the allow-list.
+       */
+      if (value instanceof MultiSearch) {
+        for (const field of value.fields) {
+          if (!GLOBAL_PROBE_FIELDS.includes(field)) {
+            throw new BadDataException(
+              `Global probes cannot be searched on ${field}.`,
+            );
+          }
+        }
+
+        continue;
+      }
+
+      if (!GLOBAL_PROBE_FIELDS.includes(key)) {
+        throw new BadDataException(
+          `Global probes cannot be filtered on ${key}.`,
+        );
+      }
+    }
+
+    return deserialized as Query<Probe>;
+  }
+
+  private static getSelect(select: JSONObject | undefined): Select<Probe> {
+    const requested: Dictionary<boolean> = {};
+
+    for (const key in select) {
+      if (!GLOBAL_PROBE_FIELDS.includes(key) || !select[key]) {
+        continue;
+      }
+
+      /*
+       * Coerced rather than copied: every selectable field here is a scalar,
+       * so a nested (relation) select on one of them is not something the
+       * caller gets to ask for.
+       */
+      requested[key] = true;
+    }
+
+    /*
+     * A caller that asks for nothing gets what this endpoint returned before
+     * it honoured select at all.
+     */
+    if (Object.keys(requested).length === 0) {
+      return { ...DEFAULT_GLOBAL_PROBE_SELECT };
+    }
+
+    return requested as Select<Probe>;
+  }
+
+  private static getSort(sort: JSONObject | undefined): Sort<Probe> {
+    const deserialized: JSONObject = JSONFunctions.deserialize(
+      sort as JSONObject,
+    );
+
+    for (const key in deserialized) {
+      if (!GLOBAL_PROBE_FIELDS.includes(key)) {
+        throw new BadDataException(`Global probes cannot be sorted on ${key}.`);
+      }
+    }
+
+    return deserialized as Sort<Probe>;
   }
 }

--- a/Common/Tests/Server/API/ProbeAPI.test.ts
+++ b/Common/Tests/Server/API/ProbeAPI.test.ts
@@ -8,9 +8,14 @@ import {
 import Response from "../../../Server/Utils/Response";
 import { mockRouter } from "./Helpers";
 import { describe, expect, it } from "@jest/globals";
-import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import MultiSearch from "../../../Types/BaseDatabase/MultiSearch";
+import { DEFAULT_LIMIT } from "../../../Types/Database/LimitMax";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import BadRequestException from "../../../Types/Exception/BadRequestException";
+import { JSONObject } from "../../../Types/JSON";
 import PositiveNumber from "../../../Types/PositiveNumber";
 import Probe from "../../../Models/DatabaseModels/Probe";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 
 jest.mock("../../../Server/Utils/Express", () => {
   return {
@@ -37,77 +42,441 @@ jest.mock("../../../Server/Utils/Response", () => {
 
 jest.mock("../../../Server/Services/ProbeService");
 
+type RequestOverrides = {
+  body?: JSONObject | undefined;
+  query?: JSONObject | undefined;
+};
+
 describe("ProbeAPI", () => {
-  let mockRequest: ExpressRequest;
   let mockResponse: ExpressResponse;
   let nextFunction: NextFunction;
 
+  const buildRequest: (overrides?: RequestOverrides) => ExpressRequest = (
+    overrides: RequestOverrides = {},
+  ): ExpressRequest => {
+    return {
+      body: overrides.body || {},
+      query: overrides.query || {},
+    } as unknown as ExpressRequest;
+  };
+
+  type CallGlobalProbesFunction = (
+    overrides?: RequestOverrides,
+  ) => Promise<ExpressRequest>;
+
+  const callGlobalProbes: CallGlobalProbesFunction = async (
+    overrides: RequestOverrides = {},
+  ): Promise<ExpressRequest> => {
+    const request: ExpressRequest = buildRequest(overrides);
+
+    await mockRouter
+      .match("post", "/probe/global-probes")
+      .handlerFunction(request, mockResponse, nextFunction);
+
+    return request;
+  };
+
   beforeEach(() => {
     new ProbeAPI();
-    mockRequest = {} as ExpressRequest;
     mockResponse = {
       send: jest.fn(),
       json: jest.fn(),
       status: jest.fn().mockReturnThis(),
     } as unknown as ExpressResponse;
     nextFunction = jest.fn();
+
+    ProbeService.findBy = jest.fn().mockResolvedValue([]);
+    ProbeService.countBy = jest.fn().mockResolvedValue(new PositiveNumber(0));
   });
 
-  it("should correctly handle global probes request", async () => {
-    // eslint-disable-next-line @typescript-eslint/typedef
-    const mockProbes = [{ id: "probe" }];
-    ProbeService.findBy = jest.fn().mockResolvedValue(mockProbes);
-    await mockRouter
-      .match("post", "/probe/global-probes")
-      .handlerFunction(mockRequest, mockResponse, nextFunction);
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    expect(ProbeService.findBy).toHaveBeenCalledWith({
-      query: {
-        isGlobalProbe: true,
-      },
-      select: {
-        name: true,
-        description: true,
-        connectionStatus: true,
-        lastAlive: true,
-        iconFileId: true,
-        /*
-         * The monitor create form pre-selects the probes that auto-enable on
-         * new monitors, and global probes are not project rows - this endpoint
-         * is the only place the browser can learn the flag for them.
-         */
-        shouldAutoEnableProbeOnNewMonitors: true,
-      },
-      props: {
-        isRoot: true,
-      },
-      skip: 0,
-      limit: LIMIT_MAX,
+  describe("defaults", () => {
+    it("should read the full select list when the caller asks for no fields", async () => {
+      const mockProbes: Array<Probe> = [{ id: "probe" } as unknown as Probe];
+      ProbeService.findBy = jest.fn().mockResolvedValue(mockProbes);
+
+      const request: ExpressRequest = await callGlobalProbes();
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith({
+        query: {
+          isGlobalProbe: true,
+        },
+        select: {
+          name: true,
+          description: true,
+          lastAlive: true,
+          iconFileId: true,
+          connectionStatus: true,
+          shouldAutoEnableProbeOnNewMonitors: true,
+        },
+        sort: {},
+        props: {
+          isRoot: true,
+        },
+        skip: new PositiveNumber(0),
+        limit: new PositiveNumber(DEFAULT_LIMIT),
+      });
+
+      const response: jest.SpyInstance = jest.spyOn(
+        Response,
+        "sendEntityArrayResponse",
+      );
+      expect(response).toHaveBeenCalledWith(
+        request,
+        mockResponse,
+        mockProbes,
+        expect.any(PositiveNumber),
+        Probe,
+      );
+    });
+  });
+
+  describe("query", () => {
+    it("should pass the caller's query through alongside isGlobalProbe", async () => {
+      await callGlobalProbes({
+        body: {
+          query: {
+            name: "probe-1",
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            name: "probe-1",
+            isGlobalProbe: true,
+          },
+        }),
+      );
     });
 
-    const response: jest.SpyInstance = jest.spyOn(
-      Response,
-      "sendEntityArrayResponse",
-    );
-    expect(response).toHaveBeenCalledWith(
-      mockRequest,
-      mockResponse,
-      mockProbes,
-      expect.any(PositiveNumber),
-      Probe,
-    );
+    it("should not let the caller widen the read past global probes", async () => {
+      await callGlobalProbes({
+        body: {
+          query: {
+            isGlobalProbe: false,
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {
+            isGlobalProbe: true,
+          },
+        }),
+      );
+    });
+
+    it("should reject a filter on a field outside the select list", async () => {
+      await callGlobalProbes({
+        body: {
+          query: {
+            key: "secret-probe-key",
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).not.toHaveBeenCalled();
+      expect(nextFunction).toHaveBeenCalledWith(expect.any(BadDataException));
+    });
+
+    it("should allow a multi field search over allowed fields", async () => {
+      const search: MultiSearch = new MultiSearch({
+        fields: ["name", "description"],
+        value: "probe",
+      });
+
+      await callGlobalProbes({
+        body: {
+          query: {
+            _multiFieldSearch: search.toJSON(),
+          },
+        },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            _multiFieldSearch: expect.any(MultiSearch),
+            isGlobalProbe: true,
+          }),
+        }),
+      );
+    });
+
+    it("should reject a multi field search that reaches a field outside the select list", async () => {
+      const search: MultiSearch = new MultiSearch({
+        fields: ["name", "key"],
+        value: "a",
+      });
+
+      await callGlobalProbes({
+        body: {
+          query: {
+            _multiFieldSearch: search.toJSON(),
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).not.toHaveBeenCalled();
+      expect(nextFunction).toHaveBeenCalledWith(expect.any(BadDataException));
+    });
+  });
+
+  describe("select", () => {
+    it("should honour the caller's select", async () => {
+      await callGlobalProbes({
+        body: {
+          select: {
+            name: true,
+            shouldAutoEnableProbeOnNewMonitors: true,
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: {
+            name: true,
+            shouldAutoEnableProbeOnNewMonitors: true,
+          },
+        }),
+      );
+    });
+
+    it("should drop selected fields outside the select list", async () => {
+      await callGlobalProbes({
+        body: {
+          select: {
+            name: true,
+            key: true,
+            slug: true,
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: {
+            name: true,
+          },
+        }),
+      );
+    });
+
+    it("should not let an allowed field be turned into a relation select", async () => {
+      await callGlobalProbes({
+        body: {
+          select: {
+            name: {
+              key: true,
+            },
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: {
+            name: true,
+          },
+        }),
+      );
+    });
+
+    it("should fall back to the default select when nothing selectable is asked for", async () => {
+      await callGlobalProbes({
+        body: {
+          select: {
+            key: true,
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: {
+            name: true,
+            description: true,
+            lastAlive: true,
+            iconFileId: true,
+            connectionStatus: true,
+            shouldAutoEnableProbeOnNewMonitors: true,
+          },
+        }),
+      );
+    });
+  });
+
+  describe("sort", () => {
+    it("should honour the caller's sort", async () => {
+      await callGlobalProbes({
+        body: {
+          sort: {
+            name: SortOrder.Descending,
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort: {
+            name: SortOrder.Descending,
+          },
+        }),
+      );
+    });
+
+    it("should reject a sort on a field outside the select list", async () => {
+      await callGlobalProbes({
+        body: {
+          sort: {
+            key: SortOrder.Ascending,
+          },
+        },
+      });
+
+      expect(ProbeService.findBy).not.toHaveBeenCalled();
+      expect(nextFunction).toHaveBeenCalledWith(expect.any(BadDataException));
+    });
+  });
+
+  describe("pagination", () => {
+    it("should read skip and limit from the query string", async () => {
+      await callGlobalProbes({
+        query: {
+          skip: "20",
+          limit: "5",
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: new PositiveNumber(20),
+          limit: new PositiveNumber(5),
+        }),
+      );
+    });
+
+    it("should read skip and limit from the body", async () => {
+      await callGlobalProbes({
+        body: {
+          skip: 10,
+          limit: 25,
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: new PositiveNumber(10),
+          limit: new PositiveNumber(25),
+        }),
+      );
+    });
+
+    it("should prefer the query string over the body", async () => {
+      await callGlobalProbes({
+        body: {
+          skip: 10,
+          limit: 25,
+        },
+        query: {
+          skip: "30",
+          limit: "40",
+        },
+      });
+
+      expect(ProbeService.findBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: new PositiveNumber(30),
+          limit: new PositiveNumber(40),
+        }),
+      );
+    });
+
+    it("should reject a limit above the per project maximum", async () => {
+      await callGlobalProbes({
+        body: {
+          limit: 10001,
+        },
+      });
+
+      expect(ProbeService.findBy).not.toHaveBeenCalled();
+      expect(nextFunction).toHaveBeenCalledWith(
+        expect.any(BadRequestException),
+      );
+    });
+  });
+
+  describe("count", () => {
+    it("should return the real count rather than the size of the page", async () => {
+      const mockProbes: Array<Probe> = [{ id: "probe" } as unknown as Probe];
+      ProbeService.findBy = jest.fn().mockResolvedValue(mockProbes);
+      ProbeService.countBy = jest
+        .fn()
+        .mockResolvedValue(new PositiveNumber(137));
+
+      const request: ExpressRequest = await callGlobalProbes({
+        query: {
+          limit: "1",
+        },
+      });
+
+      expect(ProbeService.countBy).toHaveBeenCalledWith({
+        query: {
+          isGlobalProbe: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      const response: jest.SpyInstance = jest.spyOn(
+        Response,
+        "sendEntityArrayResponse",
+      );
+      expect(response).toHaveBeenCalledWith(
+        request,
+        mockResponse,
+        mockProbes,
+        new PositiveNumber(137),
+        Probe,
+      );
+    });
+
+    it("should count against the same filtered query the list used", async () => {
+      await callGlobalProbes({
+        body: {
+          query: {
+            name: "probe-1",
+          },
+        },
+      });
+
+      expect(ProbeService.countBy).toHaveBeenCalledWith({
+        query: {
+          name: "probe-1",
+          isGlobalProbe: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+    });
   });
 
   it("should call next with an error if findBy throws", async () => {
     const testError: Error = new Error("Test error");
     ProbeService.findBy = jest.fn().mockRejectedValue(testError);
-    await mockRouter
-      .match("post", "/probe/global-probes")
-      .handlerFunction(mockRequest, mockResponse, nextFunction);
-    expect(nextFunction).toHaveBeenCalledWith(testError);
-  });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
+    await callGlobalProbes();
+
+    expect(nextFunction).toHaveBeenCalledWith(testError);
   });
 });


### PR DESCRIPTION
### Title of this pull request?

fix(global-probes): honour the list payload on `/probe/global-probes`

### Small Description?

The **Global Probes** table on Settings > Probes redirects its list fetch to `POST /probe/global-probes` (via `fetchRequestOptions.overrideRequestUrl`) while still declaring `searchableFields={["name","description"]}` and Name/Description filters — but the handler never read `req.body`. It hard-coded `query: { isGlobalProbe: true }`, `skip: 0`, `limit: LIMIT_MAX`, sorted not at all, and returned `new PositiveNumber(probes.length)` as the total count.

So the search box, both filters, column sorting and pagination were all inert, and the count was wrong whenever the result set was truncated.

**What changed**

- `Common/Server/API/ProbeAPI.ts` now parses `query`, `select`, `sort`, `skip` and `limit` out of the request the way `BaseAPI.getList` does — `skip`/`limit` from the query string first and then the body, since `ModelAPI.getList` sends them as params — and takes the count from `ProbeService.countBy` against the same query.
- `isGlobalProbe: true` is spread in **last**, so a caller cannot widen the read past the global probes.
- The handler's original select list is now the ceiling on what a caller may ask for; the read stays `isRoot: true` because global probes are not project rows.

**Two things worth a reviewer's attention**

1. **The ceiling also gates `query` and `sort`, not just `select`.** Because the read runs as root, `QueryPermission` is bypassed entirely — and `Probe.key` is a shared secret, so accepting an arbitrary caller query would have turned this into an oracle for reading it back one character at a time (`query: { key: startsWith("a") }`). Query keys, `MultiSearch` inner fields (the search box's `_multiFieldSearch`) and sort keys are all checked against the same field list, with a `BadDataException` on anything outside it. The UI's filters, search and column sorts all fall inside it.

2. **`MonitorProbes.tsx` gained `selectMoreFields={{ iconFileId: true }}`.** The Global Probes table declares no `iconFileId` column, but its Name cell renders `<ProbeElement>`, which reads `iconFileId` for the logo. Once the select stopped being hard-coded the table had to ask for it, or the icons would have silently gone missing.

**Behaviour change to be aware of:** a caller that sends no `limit` now gets `DEFAULT_LIMIT` (10) rather than `LIMIT_MAX` (10000). Both in-tree callers — the table and `ProbeUtil.getAllProbes` — send an explicit limit, so neither is affected.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verified locally:

| Check | Result |
|---|---|
| `npx jest Tests/Server/API/ProbeAPI.test.ts` (Common) | 19 passed |
| `npx tsc --noEmit -p tsconfig.json` (Common) | exit 0, no output |
| `npm run fix` (root) | exit 0, no errors |

The 19 tests in `Common/Tests/Server/API/ProbeAPI.test.ts` cover defaults, query pass-through and the anti-widening merge, the select ceiling (honoured / dropped / fallback / no relation-select escalation), sort, all four pagination paths, and the real count.

### Related Issue?

None.

### Screenshots (if appropriate):

N/A — no visual change intended. The Name-cell logo is preserved by the `selectMoreFields` addition described above.
