### PR TITLE
fix(billing): keep a project's trial when its subscription is reactivated

### DIFF
--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -52,6 +52,7 @@ import {
 } from "../../Types/BrandColors";
 import Color from "../../Types/Color";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
+import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
 import OneUptimeDate from "../../Types/Date";
 import EmailTemplateType from "../../Types/Email/EmailTemplateType";
 import BadDataException from "../../Types/Exception/BadDataException";
@@ -2133,6 +2134,7 @@ export class ProjectService extends DatabaseService<Model> {
         paymentProviderMeteredSubscriptionId: true,
         paymentProviderSubscriptionSeats: true,
         paymentProviderPlanId: true,
+        trialEndsAt: true,
       },
     });
 
@@ -2174,6 +2176,21 @@ export class ProjectService extends DatabaseService<Model> {
       throw new BadDataException("Subscription plan not found");
     }
 
+    /*
+     * Reactivating goes through changePlan, which cancels both subscriptions
+     * and creates new ones - so a trial the project still has to run has to be
+     * carried onto the replacements explicitly. Otherwise a customer whose
+     * trial a master admin extended as a goodwill gesture loses the extension
+     * the moment their subscription is reactivated, and is billed right away.
+     *
+     * A trial that has already lapsed is not revived: reactivation is not the
+     * place to hand out free service.
+     */
+    const endTrialAt: Date | undefined =
+      project.trialEndsAt && OneUptimeDate.isInTheFuture(project.trialEndsAt)
+        ? project.trialEndsAt
+        : undefined;
+
     const result: {
       subscriptionId: string;
       meteredSubscriptionId: string;
@@ -2186,7 +2203,7 @@ export class ProjectService extends DatabaseService<Model> {
       newPlan: subscriptionPlan,
       quantity: project.paymentProviderSubscriptionSeats,
       isYearly: SubscriptionPlan.isYearlyPlan(project.paymentProviderPlanId),
-      endTrialAt: undefined,
+      endTrialAt: endTrialAt,
     });
 
     // refresh subscription status.
@@ -2202,14 +2219,28 @@ export class ProjectService extends DatabaseService<Model> {
 
     // now update project with new subscription id.
 
+    const updateData: QueryDeepPartialEntity<Model> = {
+      paymentProviderSubscriptionId: result.subscriptionId,
+      paymentProviderMeteredSubscriptionId: result.meteredSubscriptionId,
+      paymentProviderSubscriptionStatus: subscriptionState,
+      paymentProviderMeteredSubscriptionStatus: meteredSubscriptionState,
+    };
+
+    /*
+     * The payment provider is the source of truth for the trial the new
+     * subscriptions were created with, so its date wins over the one sent.
+     * The column is left alone when there is no trial to record, rather than
+     * stamping a project whose trial lapsed long ago with a fresh date.
+     */
+    const newTrialEndsAt: Date | undefined = result.trialEndsAt || endTrialAt;
+
+    if (newTrialEndsAt) {
+      updateData.trialEndsAt = newTrialEndsAt;
+    }
+
     await this.updateOneById({
       id: project.id!,
-      data: {
-        paymentProviderSubscriptionId: result.subscriptionId,
-        paymentProviderMeteredSubscriptionId: result.meteredSubscriptionId,
-        paymentProviderSubscriptionStatus: subscriptionState,
-        paymentProviderMeteredSubscriptionStatus: meteredSubscriptionState,
-      },
+      data: updateData,
       props: {
         isRoot: true,
       },

--- a/Common/Tests/Server/Services/ProjectServiceExtendTrial.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceExtendTrial.test.ts
@@ -1,6 +1,7 @@
 import ProjectService from "../../../Server/Services/ProjectService";
 import BillingService from "../../../Server/Services/BillingService";
 import Project from "../../../Models/DatabaseModels/Project";
+import SubscriptionPlan from "../../../Types/Billing/SubscriptionPlan";
 import SubscriptionStatus from "../../../Types/Billing/SubscriptionStatus";
 import OneUptimeDate from "../../../Types/Date";
 import ObjectID from "../../../Types/ObjectID";
@@ -18,6 +19,13 @@ jest.mock("../../../Server/EnvironmentConfig", () => {
   return {
     ...jest.requireActual("../../../Server/EnvironmentConfig"),
     IsBillingEnabled: true,
+
+    /*
+     * config.env carries a real incoming webhook URL, and reactiveSubscription
+     * announces every plan change on it. Blanked so the suite cannot post to
+     * Slack.
+     */
+    NotificationSlackWebhookOnSubscriptionUpdate: "",
   };
 });
 
@@ -319,6 +327,288 @@ describe("ProjectService.extendTrial", () => {
           },
         }),
       );
+    });
+  });
+});
+
+const CUSTOMER_ID: string = "cus_789";
+const PLAN_ID: string = "monthly_growth_plan_id";
+const REACTIVATED_SUBSCRIPTION_ID: string = "sub_main_new_789";
+const REACTIVATED_METERED_SUBSCRIPTION_ID: string = "sub_metered_new_012";
+
+function fakeReactivationProject(overrides?: Record<string, unknown>): Project {
+  return {
+    id: PROJECT_ID,
+    _id: PROJECT_ID.toString(),
+    trialEndsAt: OneUptimeDate.getSomeDaysAfter(20),
+    paymentProviderCustomerId: CUSTOMER_ID,
+    paymentProviderSubscriptionId: SUBSCRIPTION_ID,
+    paymentProviderMeteredSubscriptionId: METERED_SUBSCRIPTION_ID,
+    paymentProviderSubscriptionSeats: 4,
+    paymentProviderPlanId: PLAN_ID,
+    ...overrides,
+  } as unknown as Project;
+}
+
+/*
+ * reactiveSubscription puts a project back on its plan after payment recovers.
+ * It goes through BillingService.changePlan, which cancels both subscriptions
+ * and creates replacements - so a trial the project still has to run exists
+ * only if it is handed to those replacements and then written back.
+ *
+ * These tests pin that, because dropping it bills a customer whose trial a
+ * master admin extended as a goodwill gesture on the spot.
+ */
+describe("ProjectService.reactiveSubscription", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  interface ReactivationSpies {
+    findOneById: jest.SpyInstance;
+    changePlan: jest.SpyInstance;
+    getSubscriptionStatus: jest.SpyInstance;
+    updateOneById: jest.SpyInstance;
+  }
+
+  function setupReactivation(data?: {
+    project?: Project;
+
+    /*
+     * The trial the payment provider reports on the subscriptions it created.
+     * Omitted means it reported none.
+     */
+    billingTrialEndsAt?: Date | undefined;
+  }): ReactivationSpies {
+    const findOneById: jest.SpyInstance = jest
+      .spyOn(ProjectService, "findOneById")
+      .mockResolvedValue(data?.project || fakeReactivationProject());
+
+    jest
+      .spyOn(SubscriptionPlan, "getSubscriptionPlanById")
+      .mockReturnValue(
+        new SubscriptionPlan(
+          PLAN_ID,
+          "yearly_growth_plan_id",
+          "Growth",
+          25,
+          250,
+          2,
+          14,
+        ),
+      );
+
+    const changePlan: jest.SpyInstance = jest
+      .spyOn(BillingService, "changePlan")
+      .mockResolvedValue({
+        subscriptionId: REACTIVATED_SUBSCRIPTION_ID,
+        meteredSubscriptionId: REACTIVATED_METERED_SUBSCRIPTION_ID,
+        trialEndsAt: data?.billingTrialEndsAt,
+      } as never);
+
+    const getSubscriptionStatus: jest.SpyInstance = jest
+      .spyOn(BillingService, "getSubscriptionStatus")
+      .mockResolvedValue(SubscriptionStatus.Active as never);
+
+    const updateOneById: jest.SpyInstance = jest
+      .spyOn(ProjectService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    return { findOneById, changePlan, getSubscriptionStatus, updateOneById };
+  }
+
+  function getUpdatedData(spies: ReactivationSpies): Record<string, unknown> {
+    return (
+      spies.updateOneById.mock.calls[0]![0] as {
+        data: Record<string, unknown>;
+      }
+    ).data;
+  }
+
+  describe("reading the project", () => {
+    it("should select the trial date", async () => {
+      /*
+       * Without this column in the select the trial date reads back undefined
+       * and every extension is silently dropped - which is the bug this
+       * suite exists for.
+       */
+      const spies: ReactivationSpies = setupReactivation();
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.findOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.objectContaining({
+            trialEndsAt: true,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("carrying the trial onto the new subscriptions", () => {
+    it("should send a trial that is still running as endTrialAt", async () => {
+      const trialEndsAt: Date = OneUptimeDate.getSomeDaysAfter(30);
+
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({ trialEndsAt: trialEndsAt }),
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.changePlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endTrialAt: trialEndsAt,
+        }),
+      );
+    });
+
+    it("should not send a trial that has already lapsed", async () => {
+      /*
+       * Reactivation is not the place to hand out free service: a project
+       * whose trial ran out months ago goes back onto its plan billing.
+       */
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({
+          trialEndsAt: OneUptimeDate.getSomeDaysAgo(30),
+        }),
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.changePlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endTrialAt: undefined,
+        }),
+      );
+    });
+
+    it("should not send a trial when the project has none", async () => {
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({ trialEndsAt: null }),
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.changePlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endTrialAt: undefined,
+        }),
+      );
+    });
+  });
+
+  describe("persisting the result", () => {
+    it("should persist the trial date the payment provider reports", async () => {
+      /*
+       * The payment provider is what actually charges the customer, so the
+       * date it puts on the new subscriptions wins over the one requested.
+       */
+      const billingTrialEndsAt: Date = OneUptimeDate.getSomeDaysAfter(45);
+
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({
+          trialEndsAt: OneUptimeDate.getSomeDaysAfter(20),
+        }),
+        billingTrialEndsAt: billingTrialEndsAt,
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(getUpdatedData(spies)["trialEndsAt"]).toEqual(billingTrialEndsAt);
+    });
+
+    it("should fall back to the trial it sent when the provider reports none", async () => {
+      const trialEndsAt: Date = OneUptimeDate.getSomeDaysAfter(30);
+
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({ trialEndsAt: trialEndsAt }),
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(getUpdatedData(spies)["trialEndsAt"]).toEqual(trialEndsAt);
+    });
+
+    it("should leave the stored trial date alone when there is no trial", async () => {
+      /*
+       * A project that stopped trialing long ago keeps the date it ended on
+       * rather than being stamped with a fresh one by an unrelated
+       * reactivation.
+       */
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({
+          trialEndsAt: OneUptimeDate.getSomeDaysAgo(30),
+        }),
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(Object.keys(getUpdatedData(spies))).not.toContain("trialEndsAt");
+    });
+
+    it("should still persist the new subscription ids and statuses", async () => {
+      const spies: ReactivationSpies = setupReactivation();
+
+      spies.getSubscriptionStatus
+        .mockResolvedValueOnce(SubscriptionStatus.Trialing as never)
+        .mockResolvedValueOnce(SubscriptionStatus.Active as never);
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(getUpdatedData(spies)).toEqual(
+        expect.objectContaining({
+          paymentProviderSubscriptionId: REACTIVATED_SUBSCRIPTION_ID,
+          paymentProviderMeteredSubscriptionId:
+            REACTIVATED_METERED_SUBSCRIPTION_ID,
+          paymentProviderSubscriptionStatus: SubscriptionStatus.Trialing,
+          paymentProviderMeteredSubscriptionStatus: SubscriptionStatus.Active,
+        }),
+      );
+    });
+
+    it("should write the project row as root", async () => {
+      // Project.trialEndsAt has an empty update ACL - only a root write sets it.
+      const spies: ReactivationSpies = setupReactivation();
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.updateOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: PROJECT_ID,
+          props: {
+            isRoot: true,
+          },
+        }),
+      );
+    });
+  });
+
+  describe("the goodwill extension it exists to protect", () => {
+    it("should keep an extended trial across a reactivation", async () => {
+      /*
+       * The end-to-end shape of the bug: support extends a customer's trial,
+       * their subscription is later reactivated, and the extension has to
+       * still be there afterwards - on the new subscriptions and on the row.
+       */
+      const extendedTrialEndsAt: Date = OneUptimeDate.getSomeDaysAfter(60);
+
+      const spies: ReactivationSpies = setupReactivation({
+        project: fakeReactivationProject({
+          trialEndsAt: extendedTrialEndsAt,
+        }),
+        billingTrialEndsAt: extendedTrialEndsAt,
+      });
+
+      await ProjectService.reactiveSubscription(PROJECT_ID);
+
+      expect(spies.changePlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endTrialAt: extendedTrialEndsAt,
+        }),
+      );
+
+      expect(getUpdatedData(spies)["trialEndsAt"]).toEqual(extendedTrialEndsAt);
     });
   });
 });


### PR DESCRIPTION
### Title of this pull request?

fix(billing): keep a project's trial when its subscription is reactivated

### Small Description?

`ProjectService.reactiveSubscription` reactivates a project through `BillingService.changePlan`, which **cancels both the flat-fee and metered subscriptions and creates replacements**. It passed `endTrialAt: undefined` and never wrote `trialEndsAt` back, discarding the `trialEndsAt` the billing call returned.

So the replacements were created with no trial, and the project row kept a date that no longer matched what Stripe would charge. For a customer whose trial a master admin had just extended as a goodwill gesture via **Admin Dashboard > Projects > View > Trial** (#2904), reactivation silently dropped the extension and billing started immediately — on the day support told them they had more time.

`ProjectService.changePlan` already handles this correctly; reactivation now does the same:

1. `trialEndsAt` added to the `findOneById` select — without it the field reads back `undefined` and everything downstream is a no-op.
2. `endTrialAt` derived from the project instead of the hardcoded `undefined`, guarded on `OneUptimeDate.isInTheFuture` so a lapsed trial isn't revived — reactivation is not the place to hand out free service.
3. `trialEndsAt` persisted as `result.trialEndsAt || endTrialAt`, so the date the payment provider reports wins over the one sent.

**One deliberate difference from `changePlan`**, which persists `subscription.trialEndsAt || endTrialAt || new Date()`: the `new Date()` fallback is dropped and the column written only when there is a date to write. Reactivation fires on payment recovery for long-standing paying customers, and that fallback would stamp a project whose trial ended a year ago with today's date. Since `updateOneById` takes a `QueryDeepPartialEntity<Model>`, the key is added conditionally.

`Project.onBeforeUpdate` reacts only to the SSO flags and billing-details fields, so writing `trialEndsAt` trips no hook. The existing `props: { isRoot: true }` is unchanged.

#### Reviewer note — a live Slack webhook in the test path

`config.env` sets a real `NOTIFICATION_SLACK_WEBHOOK_ON_SUBSCRIPTION_UPDATE`, and the `test-file` script exports it — so exercising `reactiveSubscription` would have posted to a real Slack channel on every test run. This PR blanks it in that suite's `EnvironmentConfig` mock. **Other suites that exercise plan-change paths may have the same exposure; I did not audit beyond this file.**

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

10 new tests alongside the existing `extendTrial` suite in `ProjectServiceExtendTrial.test.ts`, covering the select, the `endTrialAt` derivation (still running / lapsed / absent), which date wins when persisting, that the column is left alone when there is no trial, and the end-to-end goodwill scenario. Four fail against the old implementation; the rest are guards — notably the lapsed-trial case, which asserts `endTrialAt: undefined` and would also pass on the old hardcoded value.

\`\`\`
npm run test-file --prefix Common -- ./Tests/Server/Services/ProjectServiceExtendTrial.test.ts

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
\`\`\`

\`npm run compile --prefix Common\` (tsc) clean, ESLint clean on both changed files.

### Related Issue?

Follow-up to #2904, which flagged this in its own commit message: *"Subscription reactivation still discards an extension — tracked separately, it predates this change."*

### Screenshots (if appropriate):

n/a — server-side billing behaviour, no UI change.