### PR TITLE
fix: resolve tenant permissions by project id on AI generation routes

### DIFF
--- a/Common/Server/API/AlertAPI.ts
+++ b/Common/Server/API/AlertAPI.ts
@@ -62,22 +62,29 @@ export default class AlertAPI extends BaseAPI<Alert, AlertServiceType> {
     const props: DatabaseCommonInteractionProps =
       await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-    // Verify user has permission
-    const permissions: Array<Permission> | undefined = props
-      .userTenantAccessPermission?.["permissions"] as
-      | Array<Permission>
-      | undefined;
+    /*
+     * The project comes from the caller-supplied `tenantid` header, so scope
+     * the request to a project this user is a member of before checking
+     * permissions — a missing header should report a missing project id
+     * rather than a misleading permission error. Master admins keep the
+     * bypass they already have on the permission check below.
+     */
+    if (!props.isMasterAdmin) {
+      CommonAPI.assertAuthenticatedProjectMember(props);
+    }
 
-    const hasPermission: boolean = permissions
-      ? permissions.some((p: Permission) => {
-          return (
-            p === Permission.ProjectOwner ||
-            p === Permission.ProjectAdmin ||
-            p === Permission.EditAlert ||
-            p === Permission.CreateAlertInternalNote
-          );
-        })
-      : false;
+    // Verify user has permission
+    const permissions: Array<Permission> =
+      CommonAPI.getUserTenantPermissions(props);
+
+    const hasPermission: boolean = permissions.some((p: Permission) => {
+      return (
+        p === Permission.ProjectOwner ||
+        p === Permission.ProjectAdmin ||
+        p === Permission.EditAlert ||
+        p === Permission.CreateAlertInternalNote
+      );
+    });
 
     if (!hasPermission && !props.isMasterAdmin) {
       throw new BadDataException(

--- a/Common/Server/API/CommonAPI.ts
+++ b/Common/Server/API/CommonAPI.ts
@@ -9,6 +9,10 @@ import SpanUtil from "../Utils/Telemetry/SpanUtil";
 import ObjectID from "../../Types/ObjectID";
 import BadDataException from "../../Types/Exception/BadDataException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../Types/Permission";
 
 export default class CommonAPI {
   /*
@@ -38,6 +42,36 @@ export default class CommonAPI {
     }
 
     return projectId;
+  }
+
+  /*
+   * userTenantAccessPermission is a dictionary keyed by project id whose
+   * entries hold UserPermission rows — not bare Permission values. Custom
+   * endpoints that roll their own permission check must resolve the entry
+   * for the current tenant; indexing the dictionary by anything else
+   * silently yields undefined and rejects every caller.
+   */
+  public static getUserTenantPermissions(
+    databaseProps: DatabaseCommonInteractionProps,
+  ): Array<Permission> {
+    const projectId: ObjectID | undefined = databaseProps.tenantId;
+
+    if (!projectId) {
+      return [];
+    }
+
+    const tenantPermission: UserTenantAccessPermission | undefined =
+      databaseProps.userTenantAccessPermission?.[projectId.toString()];
+
+    if (!tenantPermission || !tenantPermission.permissions) {
+      return [];
+    }
+
+    return tenantPermission.permissions.map(
+      (userPermission: UserPermission) => {
+        return userPermission.permission;
+      },
+    );
   }
 
   @CaptureSpan()

--- a/Common/Server/API/IncidentAPI.ts
+++ b/Common/Server/API/IncidentAPI.ts
@@ -163,21 +163,28 @@ export default class IncidentAPI extends BaseAPI<
     const props: DatabaseCommonInteractionProps =
       await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-    // Verify user has permission to edit the incident
-    const permissions: Array<Permission> | undefined = props
-      .userTenantAccessPermission?.["permissions"] as
-      | Array<Permission>
-      | undefined;
+    /*
+     * The project comes from the caller-supplied `tenantid` header, so scope
+     * the request to a project this user is a member of before checking
+     * permissions — a missing header should report a missing project id
+     * rather than a misleading permission error. Master admins keep the
+     * bypass they already have on the permission check below.
+     */
+    if (!props.isMasterAdmin) {
+      CommonAPI.assertAuthenticatedProjectMember(props);
+    }
 
-    const hasPermission: boolean = permissions
-      ? permissions.some((p: Permission) => {
-          return (
-            p === Permission.ProjectOwner ||
-            p === Permission.ProjectAdmin ||
-            p === Permission.EditProjectIncident
-          );
-        })
-      : false;
+    // Verify user has permission to edit the incident
+    const permissions: Array<Permission> =
+      CommonAPI.getUserTenantPermissions(props);
+
+    const hasPermission: boolean = permissions.some((p: Permission) => {
+      return (
+        p === Permission.ProjectOwner ||
+        p === Permission.ProjectAdmin ||
+        p === Permission.EditProjectIncident
+      );
+    });
 
     if (!hasPermission && !props.isMasterAdmin) {
       throw new BadDataException(
@@ -271,23 +278,30 @@ export default class IncidentAPI extends BaseAPI<
     const props: DatabaseCommonInteractionProps =
       await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-    // Verify user has permission to edit the incident
-    const permissions: Array<Permission> | undefined = props
-      .userTenantAccessPermission?.["permissions"] as
-      | Array<Permission>
-      | undefined;
+    /*
+     * The project comes from the caller-supplied `tenantid` header, so scope
+     * the request to a project this user is a member of before checking
+     * permissions — a missing header should report a missing project id
+     * rather than a misleading permission error. Master admins keep the
+     * bypass they already have on the permission check below.
+     */
+    if (!props.isMasterAdmin) {
+      CommonAPI.assertAuthenticatedProjectMember(props);
+    }
 
-    const hasPermission: boolean = permissions
-      ? permissions.some((p: Permission) => {
-          return (
-            p === Permission.ProjectOwner ||
-            p === Permission.ProjectAdmin ||
-            p === Permission.EditProjectIncident ||
-            p === Permission.CreateIncidentInternalNote ||
-            p === Permission.CreateIncidentPublicNote
-          );
-        })
-      : false;
+    // Verify user has permission to edit the incident
+    const permissions: Array<Permission> =
+      CommonAPI.getUserTenantPermissions(props);
+
+    const hasPermission: boolean = permissions.some((p: Permission) => {
+      return (
+        p === Permission.ProjectOwner ||
+        p === Permission.ProjectAdmin ||
+        p === Permission.EditProjectIncident ||
+        p === Permission.CreateIncidentInternalNote ||
+        p === Permission.CreateIncidentPublicNote
+      );
+    });
 
     if (!hasPermission && !props.isMasterAdmin) {
       throw new BadDataException(

--- a/Common/Server/API/IncidentEpisodeAPI.ts
+++ b/Common/Server/API/IncidentEpisodeAPI.ts
@@ -67,21 +67,28 @@ export default class IncidentEpisodeAPI extends BaseAPI<
     const props: DatabaseCommonInteractionProps =
       await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-    // Verify user has permission to edit the episode
-    const permissions: Array<Permission> | undefined = props
-      .userTenantAccessPermission?.["permissions"] as
-      | Array<Permission>
-      | undefined;
+    /*
+     * The project comes from the caller-supplied `tenantid` header, so scope
+     * the request to a project this user is a member of before checking
+     * permissions — a missing header should report a missing project id
+     * rather than a misleading permission error. Master admins keep the
+     * bypass they already have on the permission check below.
+     */
+    if (!props.isMasterAdmin) {
+      CommonAPI.assertAuthenticatedProjectMember(props);
+    }
 
-    const hasPermission: boolean = permissions
-      ? permissions.some((p: Permission) => {
-          return (
-            p === Permission.ProjectOwner ||
-            p === Permission.ProjectAdmin ||
-            p === Permission.EditIncidentEpisode
-          );
-        })
-      : false;
+    // Verify user has permission to edit the episode
+    const permissions: Array<Permission> =
+      CommonAPI.getUserTenantPermissions(props);
+
+    const hasPermission: boolean = permissions.some((p: Permission) => {
+      return (
+        p === Permission.ProjectOwner ||
+        p === Permission.ProjectAdmin ||
+        p === Permission.EditIncidentEpisode
+      );
+    });
 
     if (!hasPermission && !props.isMasterAdmin) {
       throw new BadDataException(

--- a/Common/Server/API/ScheduledMaintenanceAPI.ts
+++ b/Common/Server/API/ScheduledMaintenanceAPI.ts
@@ -68,23 +68,30 @@ export default class ScheduledMaintenanceAPI extends BaseAPI<
     const props: DatabaseCommonInteractionProps =
       await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-    // Verify user has permission
-    const permissions: Array<Permission> | undefined = props
-      .userTenantAccessPermission?.["permissions"] as
-      | Array<Permission>
-      | undefined;
+    /*
+     * The project comes from the caller-supplied `tenantid` header, so scope
+     * the request to a project this user is a member of before checking
+     * permissions — a missing header should report a missing project id
+     * rather than a misleading permission error. Master admins keep the
+     * bypass they already have on the permission check below.
+     */
+    if (!props.isMasterAdmin) {
+      CommonAPI.assertAuthenticatedProjectMember(props);
+    }
 
-    const hasPermission: boolean = permissions
-      ? permissions.some((p: Permission) => {
-          return (
-            p === Permission.ProjectOwner ||
-            p === Permission.ProjectAdmin ||
-            p === Permission.EditProjectScheduledMaintenance ||
-            p === Permission.CreateScheduledMaintenanceInternalNote ||
-            p === Permission.CreateScheduledMaintenancePublicNote
-          );
-        })
-      : false;
+    // Verify user has permission
+    const permissions: Array<Permission> =
+      CommonAPI.getUserTenantPermissions(props);
+
+    const hasPermission: boolean = permissions.some((p: Permission) => {
+      return (
+        p === Permission.ProjectOwner ||
+        p === Permission.ProjectAdmin ||
+        p === Permission.EditProjectScheduledMaintenance ||
+        p === Permission.CreateScheduledMaintenanceInternalNote ||
+        p === Permission.CreateScheduledMaintenancePublicNote
+      );
+    });
 
     if (!hasPermission && !props.isMasterAdmin) {
       throw new BadDataException(

--- a/Common/Tests/Server/API/AIGenerationPermissions.test.ts
+++ b/Common/Tests/Server/API/AIGenerationPermissions.test.ts
@@ -1,0 +1,477 @@
+/* eslint-disable no-loop-func */
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import { mockRouter } from "./Helpers";
+import IncidentAPI from "../../../Server/API/IncidentAPI";
+import AlertAPI from "../../../Server/API/AlertAPI";
+import ScheduledMaintenanceAPI from "../../../Server/API/ScheduledMaintenanceAPI";
+import IncidentEpisodeAPI from "../../../Server/API/IncidentEpisodeAPI";
+import Response from "../../../Server/Utils/Response";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import UserType from "../../../Types/UserType";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+
+/*
+ * End-to-end regression for the "generate from AI" endpoints on Incident,
+ * Alert, Scheduled Maintenance and Incident Episode.
+ *
+ * These handlers roll their own permission check instead of going through
+ * BaseAPI. They used to read props.userTenantAccessPermission["permissions"]
+ * - but that dictionary is keyed by PROJECT ID, so the lookup always produced
+ * undefined and every caller who was not a master admin was rejected,
+ * including Project Owners. The handlers are invoked directly off the mock
+ * router here so the real permission logic runs.
+ */
+
+type MockedModule = {
+  __esModule: boolean;
+  default: Dictionary<unknown>;
+};
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendEntityArrayResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+    sendFileResponse: jest.fn(),
+    setNoCacheHeaders: jest.fn(),
+  };
+});
+
+jest.mock("../../../Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentPlan: jest.fn(async () => {
+        return { plan: null, isSubscriptionUnpaid: false };
+      }),
+      updateLastActive: jest.fn(async () => {
+        return undefined;
+      }),
+      getRequireSsoForLogin: jest.fn(async () => {
+        return false;
+      }),
+    },
+  };
+});
+
+/*
+ * Every resource lookup succeeds - these tests are about the permission
+ * gate that runs before the lookup, not about the lookup itself.
+ */
+function mockResourceService(): MockedModule {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(async () => {
+        return {
+          _id: ObjectID.generate().toString(),
+          projectId: ObjectID.generate(),
+        };
+      }),
+    },
+  };
+}
+
+jest.mock("../../../Server/Services/IncidentService", () => {
+  return mockResourceService();
+});
+jest.mock("../../../Server/Services/AlertService", () => {
+  return mockResourceService();
+});
+jest.mock("../../../Server/Services/ScheduledMaintenanceService", () => {
+  return mockResourceService();
+});
+jest.mock("../../../Server/Services/IncidentEpisodeService", () => {
+  return mockResourceService();
+});
+
+jest.mock("../../../Server/Services/AIService", () => {
+  return {
+    __esModule: true,
+    default: {
+      executeWithLogging: jest.fn(async () => {
+        return { content: "generated-content", llmLog: {} };
+      }),
+    },
+  };
+});
+
+function mockContextBuilder(formatMethodNames: Array<string>): MockedModule {
+  const builder: Dictionary<unknown> = {
+    buildIncidentContext: jest.fn(async () => {
+      return {};
+    }),
+    buildAlertContext: jest.fn(async () => {
+      return {};
+    }),
+    buildScheduledMaintenanceContext: jest.fn(async () => {
+      return {};
+    }),
+    buildEpisodeContext: jest.fn(async () => {
+      return {};
+    }),
+  };
+
+  for (const methodName of formatMethodNames) {
+    builder[methodName] = jest.fn(() => {
+      return { messages: [{ role: "user", content: "context" }] };
+    });
+  }
+
+  return { __esModule: true, default: builder };
+}
+
+jest.mock("../../../Server/Utils/AI/IncidentAIContextBuilder", () => {
+  return mockContextBuilder([
+    "formatIncidentContextForPostmortem",
+    "formatIncidentContextForNote",
+  ]);
+});
+jest.mock("../../../Server/Utils/AI/AlertAIContextBuilder", () => {
+  return mockContextBuilder(["formatAlertContextForNote"]);
+});
+jest.mock(
+  "../../../Server/Utils/AI/ScheduledMaintenanceAIContextBuilder",
+  () => {
+    return mockContextBuilder(["formatScheduledMaintenanceContextForNote"]);
+  },
+);
+jest.mock("../../../Server/Utils/AI/IncidentEpisodeAIContextBuilder", () => {
+  return mockContextBuilder(["formatEpisodeContextForPostmortem"]);
+});
+
+/*
+ * The API classes register their routes on the shared mockRouter as a side
+ * effect of construction, so build them once and then look handlers up by uri.
+ */
+const REGISTERED_APIS: Array<unknown> = [
+  new IncidentAPI(),
+  new AlertAPI(),
+  new ScheduledMaintenanceAPI(),
+  new IncidentEpisodeAPI(),
+];
+
+type RouteHandler = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => Promise<void>;
+
+function getHandlerByUriSuffix(uriSuffix: string): RouteHandler {
+  const matches: Array<{ uri: string; handlerFunction: unknown }> =
+    mockRouter.routes.filter((route: { method: string; uri: string }) => {
+      return route.method === "POST" && route.uri.endsWith(uriSuffix);
+    });
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one POST route ending in ${uriSuffix}, found ${matches.length}`,
+    );
+  }
+
+  return matches[0]!.handlerFunction as RouteHandler;
+}
+
+function buildTenantPermission(
+  projectId: ObjectID,
+  permissions: Array<Permission>,
+): UserTenantAccessPermission {
+  return {
+    _type: "UserTenantAccessPermission",
+    projectId: projectId,
+    permissions: permissions.map((permission: Permission): UserPermission => {
+      return {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+      };
+    }),
+  };
+}
+
+function buildRequest(data: {
+  params: Dictionary<string>;
+  tenantId?: ObjectID | undefined;
+  userId?: ObjectID | undefined;
+  userTenantAccessPermission?:
+    | Dictionary<UserTenantAccessPermission>
+    | undefined;
+  userType?: UserType | undefined;
+}): ExpressRequest {
+  return {
+    params: data.params,
+    body: {},
+    headers: {},
+    tenantId: data.tenantId,
+    userId: data.userId,
+    userAuthorization: data.userId ? { userId: data.userId } : undefined,
+    userTenantAccessPermission: data.userTenantAccessPermission,
+    userType: data.userType,
+  } as unknown as ExpressRequest;
+}
+
+type RouteCase = {
+  title: string;
+  uriSuffix: string;
+  params: Dictionary<string>;
+  /* A route-specific permission that should be accepted. */
+  grantedPermission: Permission;
+  /* The denial message this route throws when the permission is missing. */
+  deniedMessage: string;
+};
+
+const ROUTE_CASES: Array<RouteCase> = [
+  {
+    title: "Incident postmortem",
+    uriSuffix: "/generate-postmortem-from-ai/:incidentId",
+    params: { incidentId: ObjectID.generate().toString() },
+    grantedPermission: Permission.EditProjectIncident,
+    deniedMessage:
+      "You do not have permission to generate postmortem for this incident.",
+  },
+  {
+    title: "Incident note",
+    uriSuffix: "/generate-note-from-ai/:incidentId",
+    params: { incidentId: ObjectID.generate().toString() },
+    grantedPermission: Permission.CreateIncidentInternalNote,
+    deniedMessage:
+      "You do not have permission to generate notes for this incident.",
+  },
+  {
+    title: "Alert note",
+    uriSuffix: "/generate-note-from-ai/:alertId",
+    params: { alertId: ObjectID.generate().toString() },
+    grantedPermission: Permission.CreateAlertInternalNote,
+    deniedMessage:
+      "You do not have permission to generate notes for this alert.",
+  },
+  {
+    title: "Scheduled Maintenance note",
+    uriSuffix: "/generate-note-from-ai/:scheduledMaintenanceId",
+    params: { scheduledMaintenanceId: ObjectID.generate().toString() },
+    grantedPermission: Permission.CreateScheduledMaintenanceInternalNote,
+    deniedMessage:
+      "You do not have permission to generate notes for this scheduled maintenance.",
+  },
+  {
+    title: "Incident Episode postmortem",
+    uriSuffix: "/generate-postmortem-from-ai/:episodeId",
+    params: { episodeId: ObjectID.generate().toString() },
+    grantedPermission: Permission.EditIncidentEpisode,
+    deniedMessage:
+      "You do not have permission to generate postmortem for this episode.",
+  },
+];
+
+beforeEach(() => {
+  (Response.sendJsonObjectResponse as unknown as jest.Mock).mockClear();
+});
+
+describe("AI generation route registration", () => {
+  test("all four API classes registered their routes", () => {
+    expect(REGISTERED_APIS.length).toBe(4);
+
+    for (const routeCase of ROUTE_CASES) {
+      expect(typeof getHandlerByUriSuffix(routeCase.uriSuffix)).toBe(
+        "function",
+      );
+    }
+  });
+});
+
+for (const routeCase of ROUTE_CASES) {
+  describe(`${routeCase.title} - AI generation permission check`, () => {
+    test("a Project Owner of the tenant project is allowed through", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: projectId,
+          userId: ObjectID.generate(),
+          userTenantAccessPermission: {
+            [projectId.toString()]: buildTenantPermission(projectId, [
+              Permission.ProjectOwner,
+            ]),
+          },
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      /*
+       * The regression: before the fix this reached next() with
+       * "You do not have permission ..." even for a Project Owner.
+       */
+      expect(next).not.toHaveBeenCalled();
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+    });
+
+    test("the route-specific permission is also accepted", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: projectId,
+          userId: ObjectID.generate(),
+          userTenantAccessPermission: {
+            [projectId.toString()]: buildTenantPermission(projectId, [
+              Permission.ProjectMember,
+              routeCase.grantedPermission,
+            ]),
+          },
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      expect(next).not.toHaveBeenCalled();
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+    });
+
+    test("a project member without the required permission is rejected", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: projectId,
+          userId: ObjectID.generate(),
+          userTenantAccessPermission: {
+            [projectId.toString()]: buildTenantPermission(projectId, [
+              Permission.ProjectMember,
+            ]),
+          },
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+
+      const thrown: unknown = next.mock.calls[0]![0];
+      expect(thrown).toBeInstanceOf(BadDataException);
+      expect((thrown as BadDataException).message).toContain(
+        routeCase.deniedMessage,
+      );
+    });
+
+    test("a missing tenantid header reports a missing project id, not a permission error", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: undefined,
+          userId: ObjectID.generate(),
+          userTenantAccessPermission: {
+            [projectId.toString()]: buildTenantPermission(projectId, [
+              Permission.ProjectOwner,
+            ]),
+          },
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+
+      const thrown: unknown = next.mock.calls[0]![0];
+      expect(thrown).toBeInstanceOf(BadDataException);
+      expect((thrown as BadDataException).message).toBe(
+        "Project ID is required",
+      );
+    });
+
+    test("permissions held on a DIFFERENT project do not grant access", async () => {
+      const requestedProjectId: ObjectID = ObjectID.generate();
+      const otherProjectId: ObjectID = ObjectID.generate();
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: requestedProjectId,
+          userId: ObjectID.generate(),
+          userTenantAccessPermission: {
+            [otherProjectId.toString()]: buildTenantPermission(otherProjectId, [
+              Permission.ProjectOwner,
+            ]),
+          },
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next.mock.calls[0]![0]).toBeInstanceOf(NotAuthorizedException);
+    });
+
+    test("an unauthenticated caller carrying only a tenantid header is rejected", async () => {
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: ObjectID.generate(),
+          userId: undefined,
+          userTenantAccessPermission: undefined,
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next.mock.calls[0]![0]).toBeInstanceOf(NotAuthorizedException);
+    });
+
+    test("a master admin keeps the bypass it had before the fix", async () => {
+      const next: jest.Mock = jest.fn();
+
+      await getHandlerByUriSuffix(routeCase.uriSuffix)(
+        buildRequest({
+          params: routeCase.params,
+          tenantId: undefined,
+          userId: ObjectID.generate(),
+          userTenantAccessPermission: undefined,
+          userType: UserType.MasterAdmin,
+        }),
+        {} as ExpressResponse,
+        next as unknown as NextFunction,
+      );
+
+      expect(next).not.toHaveBeenCalled();
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+    });
+  });
+}

--- a/Common/Tests/Server/API/CommonAPITenantPermissions.test.ts
+++ b/Common/Tests/Server/API/CommonAPITenantPermissions.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from "@jest/globals";
+import CommonAPI from "../../../Server/API/CommonAPI";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import PermissionScope from "../../../Types/Database/AccessControl/PermissionScope";
+
+/*
+ * Tests for CommonAPI.getUserTenantPermissions.
+ *
+ * userTenantAccessPermission is a Dictionary<UserTenantAccessPermission>
+ * keyed by PROJECT ID, and each entry holds UserPermission rows (objects),
+ * not bare Permission values. Several custom endpoints used to index the
+ * dictionary with the literal key "permissions" and `as`-cast the result to
+ * Array<Permission> - the cast hid the mistake from the type checker, the
+ * lookup always produced undefined, and every non-master-admin caller was
+ * rejected. These tests pin the corrected resolution.
+ */
+
+function buildUserPermission(permission: Permission): UserPermission {
+  return {
+    _type: "UserPermission",
+    permission: permission,
+    labelIds: [],
+  };
+}
+
+function buildTenantPermission(
+  projectId: ObjectID,
+  permissions: Array<Permission>,
+): UserTenantAccessPermission {
+  return {
+    _type: "UserTenantAccessPermission",
+    projectId: projectId,
+    permissions: permissions.map(buildUserPermission),
+  };
+}
+
+function buildProps(overrides?: {
+  tenantId?: ObjectID | undefined;
+  userId?: ObjectID | undefined;
+  userTenantAccessPermission?:
+    | Dictionary<UserTenantAccessPermission>
+    | undefined;
+}): DatabaseCommonInteractionProps {
+  return {
+    tenantId: overrides?.tenantId,
+    userId: overrides?.userId,
+    userTenantAccessPermission: overrides?.userTenantAccessPermission,
+  };
+}
+
+describe("CommonAPI.getUserTenantPermissions", () => {
+  describe("regression: permissions resolve for the current tenant", () => {
+    test("a Project Owner's permission is returned (the old literal-key lookup returned nothing)", () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: projectId,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [projectId.toString()]: buildTenantPermission(projectId, [
+            Permission.ProjectOwner,
+          ]),
+        },
+      });
+
+      const permissions: Array<Permission> =
+        CommonAPI.getUserTenantPermissions(props);
+
+      expect(permissions).toEqual([Permission.ProjectOwner]);
+
+      /*
+       * The exact predicate the AI note/postmortem endpoints run. Before the
+       * fix this was false for a Project Owner, so the endpoints rejected
+       * everyone who was not a master admin.
+       */
+      const hasPermission: boolean = permissions.some((p: Permission) => {
+        return p === Permission.ProjectOwner || p === Permission.ProjectAdmin;
+      });
+      expect(hasPermission).toBe(true);
+    });
+
+    test("the old broken lookup - indexing by the literal string 'permissions' - yields undefined", () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const permissionMap: Dictionary<UserTenantAccessPermission> = {
+        [projectId.toString()]: buildTenantPermission(projectId, [
+          Permission.ProjectOwner,
+        ]),
+      };
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: projectId,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: permissionMap,
+      });
+
+      /*
+       * Pins the defect itself: "permissions" is not a project id, so it is
+       * never a key of this dictionary. Kept as a guard against the pattern
+       * being reintroduced by copy-paste.
+       */
+      expect(permissionMap["permissions"]).toBeUndefined();
+      expect(CommonAPI.getUserTenantPermissions(props).length).toBe(1);
+    });
+
+    test("every permission row is mapped, in order", () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: projectId,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [projectId.toString()]: buildTenantPermission(projectId, [
+            Permission.ProjectMember,
+            Permission.CreateIncidentInternalNote,
+            Permission.EditProjectIncident,
+          ]),
+        },
+      });
+
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([
+        Permission.ProjectMember,
+        Permission.CreateIncidentInternalNote,
+        Permission.EditProjectIncident,
+      ]);
+    });
+
+    test("label-scoped and block permission rows are still returned as permissions", () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const labelScopedRow: UserPermission = {
+        _type: "UserPermission",
+        permission: Permission.EditProjectIncident,
+        labelIds: [ObjectID.generate()],
+        scope: PermissionScope.Labels,
+      };
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: projectId,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [projectId.toString()]: {
+            _type: "UserTenantAccessPermission",
+            projectId: projectId,
+            permissions: [labelScopedRow],
+          },
+        },
+      });
+
+      /*
+       * getUserTenantPermissions is a plain projection of the rows - it does
+       * not apply label filtering. Row-level access control still happens in
+       * the database layer when the endpoint reads the resource.
+       */
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([
+        Permission.EditProjectIncident,
+      ]);
+    });
+
+    test("lookup is by string value, not ObjectID instance identity", () => {
+      const projectIdString: string = ObjectID.generate().toString();
+      const tenantInstance: ObjectID = new ObjectID(projectIdString);
+      const keyInstance: ObjectID = new ObjectID(projectIdString);
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: tenantInstance,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [keyInstance.toString()]: buildTenantPermission(keyInstance, [
+            Permission.ProjectAdmin,
+          ]),
+        },
+      });
+
+      expect(tenantInstance).not.toBe(keyInstance);
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([
+        Permission.ProjectAdmin,
+      ]);
+    });
+
+    test("only the requested tenant's permissions are returned when the user belongs to several projects", () => {
+      const projectA: ObjectID = ObjectID.generate();
+      const projectB: ObjectID = ObjectID.generate();
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: projectB,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [projectA.toString()]: buildTenantPermission(projectA, [
+            Permission.ProjectOwner,
+          ]),
+          [projectB.toString()]: buildTenantPermission(projectB, [
+            Permission.ProjectMember,
+          ]),
+        },
+      });
+
+      const permissions: Array<Permission> =
+        CommonAPI.getUserTenantPermissions(props);
+
+      expect(permissions).toEqual([Permission.ProjectMember]);
+      expect(permissions).not.toContain(Permission.ProjectOwner);
+    });
+  });
+
+  describe("callers with nothing to resolve get an empty array", () => {
+    test("returns [] when tenantId is undefined", () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: undefined,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [projectId.toString()]: buildTenantPermission(projectId, [
+            Permission.ProjectOwner,
+          ]),
+        },
+      });
+
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([]);
+    });
+
+    test("returns [] when the permission map is undefined", () => {
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: ObjectID.generate(),
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: undefined,
+      });
+
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([]);
+    });
+
+    test("returns [] when the map is keyed by a different project", () => {
+      const requestedProjectId: ObjectID = ObjectID.generate();
+      const otherProjectId: ObjectID = ObjectID.generate();
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: requestedProjectId,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [otherProjectId.toString()]: buildTenantPermission(otherProjectId, [
+            Permission.ProjectOwner,
+          ]),
+        },
+      });
+
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([]);
+    });
+
+    test("returns [] for an empty permission map and for an entry with no rows", () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      expect(
+        CommonAPI.getUserTenantPermissions(
+          buildProps({
+            tenantId: projectId,
+            userTenantAccessPermission: {},
+          }),
+        ),
+      ).toEqual([]);
+
+      expect(
+        CommonAPI.getUserTenantPermissions(
+          buildProps({
+            tenantId: projectId,
+            userTenantAccessPermission: {
+              [projectId.toString()]: buildTenantPermission(projectId, []),
+            },
+          }),
+        ),
+      ).toEqual([]);
+    });
+
+    test("returns [] for completely empty props", () => {
+      expect(CommonAPI.getUserTenantPermissions({})).toEqual([]);
+    });
+
+    test("does not throw when a tenant entry is missing its permissions array", () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const props: DatabaseCommonInteractionProps = buildProps({
+        tenantId: projectId,
+        userId: ObjectID.generate(),
+        userTenantAccessPermission: {
+          [projectId.toString()]: {
+            _type: "UserTenantAccessPermission",
+            projectId: projectId,
+          } as UserTenantAccessPermission,
+        },
+      });
+
+      expect(() => {
+        CommonAPI.getUserTenantPermissions(props);
+      }).not.toThrow();
+      expect(CommonAPI.getUserTenantPermissions(props)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix: resolve tenant permissions by project id on AI generation routes

### Small Description?

The "generate from AI" endpoints roll their own permission check instead of going through `BaseAPI`. They indexed `props.userTenantAccessPermission` with the literal key `"permissions"` and `as`-cast the result to `Array<Permission>`:

```ts
const permissions: Array<Permission> | undefined = props
  .userTenantAccessPermission?.["permissions"] as Array<Permission> | undefined;
```

That dictionary is a `Dictionary<UserTenantAccessPermission>` keyed by **project id**, and its entries hold `UserPermission` rows rather than bare `Permission` values. The lookup therefore always produced `undefined` — the cast is what hid this from the type checker — so `hasPermission` was always `false` and every caller who was not a master admin was rejected, **including Project Owners**.

**What changed**

- New `CommonAPI.getUserTenantPermissions(props)` reads the entry for the current tenant and maps its rows to permissions. All call sites now use it.
- Each route calls `CommonAPI.assertAuthenticatedProjectMember(props)` first. These routes take the project from the caller-supplied `tenantid` header, so a missing header now reports `"Project ID is required"` instead of a misleading permission error, and permissions held on a *different* project no longer reach the check.
- That guard deliberately does not honor `isMasterAdmin` (pinned by an existing test in `CommonAPIAuthGuard.test.ts`), so it is skipped for master admins to preserve the bypass these routes already had.

**Affected endpoints**

| Route | File |
| --- | --- |
| `POST /incident/generate-postmortem-from-ai/:incidentId` | `Common/Server/API/IncidentAPI.ts` |
| `POST /incident/generate-note-from-ai/:incidentId` | `Common/Server/API/IncidentAPI.ts` |
| `POST /alert/generate-note-from-ai/:alertId` | `Common/Server/API/AlertAPI.ts` |
| `POST /scheduled-maintenance/generate-note-from-ai/:scheduledMaintenanceId` | `Common/Server/API/ScheduledMaintenanceAPI.ts` |
| `POST /incident-episode/generate-postmortem-from-ai/:episodeId` | `Common/Server/API/IncidentEpisodeAPI.ts` |

### Notes for reviewers

- **A fourth call site was found.** `IncidentEpisodeAPI.ts` had the identical defect and is fixed alongside the three that were originally reported. A repo-wide grep confirms no `["permissions"]` lookups against a tenant-permission dictionary remain.
- **The regression tests were confirmed to bite.** With the original `AlertAPI.ts` restored, 5 of its 7 route tests fail — including *"a Project Owner of the tenant project is allowed through"*. The master-admin test passes both before and after, confirming that path is unchanged.

### Tests

Two new files under `Common/Tests/Server/API/`, 48 tests, all passing:

- `CommonAPITenantPermissions.test.ts` — unit coverage of the resolver: correct-tenant resolution, cross-project isolation, string-vs-instance lookup, label-scoped rows, and the empty cases.
- `AIGenerationPermissions.test.ts` — drives all five handlers through the existing `mockRouter` harness so the real permission logic runs. Per route: Project Owner allowed, route-specific permission allowed, bare project member rejected, missing header → `"Project ID is required"`, other-project permissions rejected, anonymous caller rejected, master-admin bypass preserved.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission? (`npx eslint` clean on all 7 changed files; `npm run compile` in `Common` clean)
- [x] Did you write tests where appropriate?

### Related Issue?

None.

### Screenshots (if appropriate):

N/A — server-side permission logic.
