### PR TITLE
fix(api): authorize two custom routes that acted on any project's resource

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Workspace/WorkspaceNotificationRulesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Workspace/WorkspaceNotificationRulesTable.tsx
@@ -123,6 +123,13 @@ const WorkspaceNotificationRuleTable: FunctionComponent<ComponentProps> = (
             `/workspace-notification-rule/test/${ruleId.toString()}`,
           ),
           data: {},
+          /*
+           * This is a custom route, so BaseAPI.getHeaders() adds no
+           * `tenantid` — ModelAPI.getCommonHeaders() is the only thing that
+           * does. The route requires an authenticated member of the rule's
+           * project, and without the header there is no project to check.
+           */
+          headers: ModelAPI.getCommonHeaders(),
         });
       if (response.isSuccess()) {
         setIsTestLoading(false);

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -172,6 +172,13 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         url: URL.fromString(APP_API_URL.toString()).addRoute(
           "/monitor/refresh-status/" + modelId.toString(),
         ),
+        /*
+         * refresh-status is a custom route, so BaseAPI.getHeaders() adds no
+         * `tenantid` — ModelAPI.getCommonHeaders() is the only thing that
+         * does. The route requires an authenticated member of the monitor's
+         * project, and without the header there is no project to check.
+         */
+        headers: ModelAPI.getCommonHeaders(),
       });
 
       const monitorStatus: ListResult<MonitorStatusTimeline> =

--- a/App/Tests/Dashboard/ProjectScopedCustomRouteTenantHeader.test.ts
+++ b/App/Tests/Dashboard/ProjectScopedCustomRouteTenantHeader.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * `/monitor/refresh-status/:monitorId` and
+ * `/workspace-notification-rule/test/:ruleId` are custom routes rather than
+ * model CRUD, so the dashboard drives them through raw `API.get`.
+ * `BaseAPI.getHeaders()` does NOT add a `tenantid` header —
+ * `ModelAPI.getCommonHeaders()` is the only thing in the codebase that does,
+ * and both calls originally omitted it.
+ *
+ * Both routes now require an authenticated member of the resource's own
+ * project (CommonAPI.assertAuthenticatedProjectMember plus a check that the
+ * resource's projectId matches). With no `tenantid` there is no project to
+ * check, so dropping the header again would not merely lose scope — it would
+ * fail every request with "Project ID is required". These pages are React
+ * components with no extractable logic, and the App suite runs in a plain
+ * Node environment with no renderer, so this reads the source the same way
+ * the sibling MonitorTemplateSyncTenantHeader test does.
+ */
+
+const MONITOR_VIEW_PAGE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "Monitor",
+  "View",
+  "Index.tsx",
+);
+
+const NOTIFICATION_RULES_TABLE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "Workspace",
+  "WorkspaceNotificationRulesTable.tsx",
+);
+
+/*
+ * Comments are stripped so the prose above a call (which may quote both the
+ * endpoint path and `getCommonHeaders`) cannot satisfy an assertion about the
+ * code, and whitespace is squashed so prettier re-wrapping a call cannot turn
+ * a real regression check into a red herring.
+ */
+function readCode(filePath: string): string {
+  const raw: string = fs.readFileSync(filePath, "utf8");
+  return raw
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ");
+}
+
+/*
+ * Every raw `API.get({ ... })` argument object in the file, as source text.
+ * Brace-matched rather than regex-matched so nested objects (`data: {}`) do
+ * not truncate the capture. The lookbehind keeps `ModelAPI.get` out of the
+ * results — that one attaches the tenant header itself.
+ */
+function getApiGetArguments(code: string): Array<string> {
+  const calls: Array<string> = [];
+  const marker: RegExp = /(?<![A-Za-z])API\.get(?:<[^>]*>)?\(\s*\{/g;
+
+  let match: RegExpExecArray | null = marker.exec(code);
+
+  while (match !== null) {
+    const openIndex: number = code.indexOf("{", match.index);
+    let depth: number = 0;
+    let end: number = -1;
+
+    for (let i: number = openIndex; i < code.length; i++) {
+      if (code[i] === "{") {
+        depth++;
+      } else if (code[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    if (end === -1) {
+      throw new Error("Unbalanced braces in an API.get call argument.");
+    }
+
+    calls.push(code.slice(openIndex, end + 1));
+    match = marker.exec(code);
+  }
+
+  return calls;
+}
+
+function getCallsForRoute(data: {
+  filePath: string;
+  route: string;
+}): Array<string> {
+  return getApiGetArguments(readCode(data.filePath)).filter((call: string) => {
+    return call.includes(data.route);
+  });
+}
+
+describe("Project-scoped custom GET routes send the tenant header", () => {
+  const cases: Array<{ name: string; filePath: string; route: string }> = [
+    {
+      name: "the monitor view page refreshing monitor status",
+      filePath: MONITOR_VIEW_PAGE,
+      route: "/monitor/refresh-status/",
+    },
+    {
+      name: "the workspace notification rules table testing a rule",
+      filePath: NOTIFICATION_RULES_TABLE,
+      route: "/workspace-notification-rule/test/",
+    },
+  ];
+
+  for (const testCase of cases) {
+    /*
+     * Guard the guard: if a page is ever migrated off raw API.get, the header
+     * assertion below would vacuously pass over an empty list.
+     */
+    test(`${testCase.name} still uses raw API.get`, () => {
+      expect(
+        getCallsForRoute({
+          filePath: testCase.filePath,
+          route: testCase.route,
+        }).length,
+      ).toBe(1);
+    });
+
+    test(`${testCase.name} passes ModelAPI.getCommonHeaders() so tenantid is sent`, () => {
+      const sendsTenantHeader: RegExp = new RegExp(
+        "headers:\\s*(\\{\\s*\\.\\.\\.\\s*)?ModelAPI\\.getCommonHeaders\\(",
+      );
+
+      const missing: Array<string> = getCallsForRoute({
+        filePath: testCase.filePath,
+        route: testCase.route,
+      }).filter((call: string) => {
+        return !sendsTenantHeader.test(call);
+      });
+
+      expect(missing).toEqual([]);
+    });
+  }
+});

--- a/Common/Server/API/CommonAPI.ts
+++ b/Common/Server/API/CommonAPI.ts
@@ -68,6 +68,32 @@ export default class CommonAPI {
     return projectId;
   }
 
+  /*
+   * assertAuthenticatedProjectMember only proves the caller belongs to the
+   * project it *claimed* in the `tenantid` header — it never looks at the
+   * resource the path names. A custom route that then reads or mutates that
+   * resource as root must also confirm the resource's own projectId is the
+   * project the caller was authorized for, otherwise a member of project A
+   * reaches project B's resource id just by sending their own header.
+   *
+   * A resource that does not exist (or carries no projectId) is rejected the
+   * same way, so the endpoint cannot be used to confirm which ids exist in
+   * other projects.
+   */
+  public static assertResourceBelongsToProject(data: {
+    resourceProjectId: ObjectID | undefined | null;
+    projectId: ObjectID;
+  }): void {
+    if (
+      !data.resourceProjectId ||
+      data.resourceProjectId.toString() !== data.projectId.toString()
+    ) {
+      throw new NotAuthorizedException(
+        "You are not authorized to access this project's data.",
+      );
+    }
+  }
+
   @CaptureSpan()
   public static async getDatabaseCommonInteractionProps(
     req: ExpressRequest,

--- a/Common/Server/API/MonitorAPI.ts
+++ b/Common/Server/API/MonitorAPI.ts
@@ -9,6 +9,8 @@ import {
 } from "../Utils/Express";
 import Response from "../Utils/Response";
 import BaseAPI from "./BaseAPI";
+import CommonAPI from "./CommonAPI";
+import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import Monitor from "../../Models/DatabaseModels/Monitor";
 import ObjectID from "../../Types/ObjectID";
 
@@ -21,9 +23,37 @@ export default class MonitorAPI extends BaseAPI<Monitor, MonitorServiceType> {
       UserMiddleware.getUserMiddleware,
       async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
         try {
+          const databaseProps: DatabaseCommonInteractionProps =
+            await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+          /*
+           * getUserMiddleware lets unauthenticated requests through as
+           * "public", and refreshMonitorCurrentStatus reads and writes the
+           * monitor as root. Require an authenticated member of the
+           * monitor's own project — the caller-supplied tenant says nothing
+           * about which project the monitor id in the path belongs to.
+           */
+          const projectId: ObjectID =
+            CommonAPI.assertAuthenticatedProjectMember(databaseProps);
+
           const monitorId: ObjectID = new ObjectID(
             req.params["monitorId"] as string,
           );
+
+          const monitor: Monitor | null = await MonitorService.findOneById({
+            id: monitorId,
+            select: {
+              projectId: true,
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+
+          CommonAPI.assertResourceBelongsToProject({
+            resourceProjectId: monitor?.projectId,
+            projectId: projectId,
+          });
 
           await MonitorService.refreshMonitorCurrentStatus(monitorId);
           return Response.sendEmptySuccessResponse(req, res);

--- a/Common/Server/API/WorkspaceNotificationRuleAPI.ts
+++ b/Common/Server/API/WorkspaceNotificationRuleAPI.ts
@@ -29,12 +29,42 @@ export default class WorkspaceNotificationRuleAPI extends BaseAPI<
           const databaseProps: DatabaseCommonInteractionProps =
             await CommonAPI.getDatabaseCommonInteractionProps(req);
 
+          /*
+           * getUserMiddleware lets unauthenticated requests through as
+           * "public", and testRule loads the rule as root and then posts a
+           * test message into that project's Slack / Teams channels — it can
+           * even create channels. Require an authenticated member of the
+           * project, and of the rule's own project at that: testRule takes
+           * the project from the rule it loaded, so the caller-supplied
+           * tenant alone proves nothing about the rule id in the path.
+           */
+          const projectId: ObjectID =
+            CommonAPI.assertAuthenticatedProjectMember(databaseProps);
+
+          const ruleId: ObjectID = new ObjectID(
+            req.params["workspaceNotifcationRuleId"] as string,
+          );
+
+          const rule: WorkspaceNotificationRule | null =
+            await this.service.findOneById({
+              id: ruleId,
+              select: {
+                projectId: true,
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          CommonAPI.assertResourceBelongsToProject({
+            resourceProjectId: rule?.projectId,
+            projectId: projectId,
+          });
+
           await this.service.testRule({
-            ruleId: new ObjectID(
-              req.params["workspaceNotifcationRuleId"] as string,
-            ),
+            ruleId: ruleId,
             props: databaseProps,
-            projectId: databaseProps.tenantId!,
+            projectId: projectId,
             testByUserId: databaseProps.userId!,
           });
 

--- a/Common/Tests/Server/API/CommonAPIAuthGuard.test.ts
+++ b/Common/Tests/Server/API/CommonAPIAuthGuard.test.ts
@@ -317,6 +317,81 @@ describe("CommonAPI.assertAuthenticatedProjectMember", () => {
 });
 
 /*
+ * Tests for CommonAPI.assertResourceBelongsToProject — the companion guard
+ * for custom routes whose path carries a resource id.
+ * assertAuthenticatedProjectMember only proves the caller belongs to the
+ * project it claimed in the `tenantid` header; without this second check a
+ * member of project A could hand the route project B's resource id and have
+ * it acted on as root.
+ */
+describe("CommonAPI.assertResourceBelongsToProject", () => {
+  test("does not throw when the resource belongs to the authorized project", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: projectId,
+        projectId: projectId,
+      });
+    }).not.toThrow();
+  });
+
+  test("compares by string value, not by ObjectID instance", () => {
+    const projectIdString: string = ObjectID.generate().toString();
+
+    expect(() => {
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: new ObjectID(projectIdString),
+        projectId: new ObjectID(projectIdString),
+      });
+    }).not.toThrow();
+  });
+
+  test("throws NotAuthorizedException when the resource belongs to another project", () => {
+    const thrown: unknown = captureThrown(() => {
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: ObjectID.generate(),
+        projectId: ObjectID.generate(),
+      });
+    });
+
+    expect(thrown).toBeInstanceOf(NotAuthorizedException);
+    expect((thrown as Exception).message).toBe(
+      "You are not authorized to access this project's data.",
+    );
+  });
+
+  /*
+   * A row that was not found reaches the guard as undefined. It must be
+   * rejected exactly like a cross-project row, so the endpoint cannot be
+   * used to tell "id exists in another project" apart from "id does not
+   * exist".
+   */
+  test("throws NotAuthorizedException when the resource was not found", () => {
+    const thrown: unknown = captureThrown(() => {
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: undefined,
+        projectId: ObjectID.generate(),
+      });
+    });
+
+    expect(thrown).toBeInstanceOf(NotAuthorizedException);
+    expect((thrown as Exception).message).toBe(
+      "You are not authorized to access this project's data.",
+    );
+  });
+
+  test("throws NotAuthorizedException when the resource carries a null projectId", () => {
+    expect(() => {
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: null,
+        projectId: ObjectID.generate(),
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+});
+
+/*
  * Tests for CommonAPI.assertTenantScoped — the lighter guard for custom
  * endpoints whose path carries only a resource id, so the project can only
  * come from the `tenantid` header. Without it the request still reaches the

--- a/Common/Tests/Server/API/ProjectScopedCustomRouteAuth.test.ts
+++ b/Common/Tests/Server/API/ProjectScopedCustomRouteAuth.test.ts
@@ -1,0 +1,458 @@
+import CommonAPI from "../../../Server/API/CommonAPI";
+import MonitorAPI from "../../../Server/API/MonitorAPI";
+import WorkspaceNotificationRuleAPI from "../../../Server/API/WorkspaceNotificationRuleAPI";
+import MonitorService from "../../../Server/Services/MonitorService";
+import WorkspaceNotificationRuleService from "../../../Server/Services/WorkspaceNotificationRuleService";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import WorkspaceNotificationRule from "../../../Models/DatabaseModels/WorkspaceNotificationRule";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import { mockRouter } from "./Helpers";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "../../../Types/Dictionary";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+/*
+ * Both routes covered here are custom (non-CRUD) routes mounted with only
+ * UserMiddleware.getUserMiddleware, which lets unauthenticated requests
+ * through as "public" and takes the project from a caller-supplied
+ * `tenantid` header. The work they trigger runs as root:
+ *
+ * - /workspace-notification-rule/test/:id loads the rule as root, takes the
+ *   project from the rule itself, and posts a test message into that
+ *   project's Slack / Teams channels (it can even create channels).
+ * - /monitor/refresh-status/:id reads and writes the monitor as root.
+ *
+ * So each route has to prove two things itself: the caller is an
+ * authenticated member of the project it claimed, AND the resource in the
+ * path belongs to that same project. Checking only the first would let a
+ * member of project A send their own tenant header while targeting project
+ * B's resource id.
+ */
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendJsonObjectResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendErrorResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+  };
+});
+
+const MONITOR_REFRESH_ROUTE: string = "/monitor/refresh-status/:monitorId";
+const TEST_RULE_ROUTE: string =
+  "/workspace-notification-rule/test/:workspaceNotifcationRuleId";
+
+function buildMemberProps(data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+}): DatabaseCommonInteractionProps {
+  const memberPermission: UserPermission = {
+    _type: "UserPermission",
+    permission: Permission.ProjectMember,
+    labelIds: [],
+  };
+
+  const tenantPermission: UserTenantAccessPermission = {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: [memberPermission],
+  };
+
+  const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+  permissionMap[data.projectId.toString()] = tenantPermission;
+
+  return {
+    tenantId: data.projectId,
+    userId: data.userId,
+    userTenantAccessPermission: permissionMap,
+  };
+}
+
+type RouteCallResult = {
+  thrownToNext: unknown;
+  nextCallCount: number;
+};
+
+async function callGetRoute(data: {
+  uri: string;
+  params: Dictionary<string>;
+}): Promise<RouteCallResult> {
+  const req: ExpressRequest = {
+    params: data.params,
+    query: {},
+    body: {},
+    headers: {},
+  } as unknown as ExpressRequest;
+
+  const res: ExpressResponse = {
+    send: jest.fn(),
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as ExpressResponse;
+
+  const next: jest.Mock = jest.fn();
+
+  await mockRouter
+    .match("GET", data.uri)
+    .handlerFunction(req, res, next as unknown as NextFunction);
+
+  return {
+    thrownToNext: next.mock.calls[0] ? next.mock.calls[0][0] : undefined,
+    nextCallCount: next.mock.calls.length,
+  };
+}
+
+describe("Project-scoped custom routes require an authenticated member of the resource's project", () => {
+  let callerProjectId: ObjectID;
+  let otherProjectId: ObjectID;
+  let callerUserId: ObjectID;
+
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new MonitorAPI();
+    new WorkspaceNotificationRuleAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    callerProjectId = ObjectID.generate();
+    otherProjectId = ObjectID.generate();
+    callerUserId = ObjectID.generate();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("GET /monitor/refresh-status/:monitorId", () => {
+    let monitorId: ObjectID;
+    let refreshSpy: jest.SpyInstance;
+    let findOneByIdSpy: jest.SpyInstance;
+
+    function mockProps(props: DatabaseCommonInteractionProps): void {
+      jest
+        .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+        .mockResolvedValue(props);
+    }
+
+    function mockMonitorInProject(projectId: ObjectID | null): void {
+      if (!projectId) {
+        findOneByIdSpy.mockResolvedValue(null);
+        return;
+      }
+
+      const monitor: Monitor = new Monitor();
+      monitor.id = monitorId;
+      monitor.projectId = projectId;
+      findOneByIdSpy.mockResolvedValue(monitor);
+    }
+
+    beforeEach(() => {
+      monitorId = ObjectID.generate();
+      findOneByIdSpy = jest.spyOn(MonitorService, "findOneById");
+      refreshSpy = jest
+        .spyOn(MonitorService, "refreshMonitorCurrentStatus")
+        .mockResolvedValue(undefined);
+    });
+
+    test("refreshes the monitor for a member of the monitor's own project", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockMonitorInProject(callerProjectId);
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: MONITOR_REFRESH_ROUTE,
+        params: { monitorId: monitorId.toString() },
+      });
+
+      expect(result.nextCallCount).toBe(0);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect((refreshSpy.mock.calls[0]![0] as ObjectID).toString()).toBe(
+        monitorId.toString(),
+      );
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The owning project has to come off the monitor row, not off the
+     * caller-supplied header — pin the read that derives it.
+     */
+    test("derives the owning project from the monitor row itself", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockMonitorInProject(callerProjectId);
+
+      await callGetRoute({
+        uri: MONITOR_REFRESH_ROUTE,
+        params: { monitorId: monitorId.toString() },
+      });
+
+      expect(findOneByIdSpy).toHaveBeenCalledTimes(1);
+      const readArgs: {
+        id: ObjectID;
+        select: Dictionary<boolean>;
+        props: Dictionary<boolean>;
+      } = findOneByIdSpy.mock.calls[0]![0] as {
+        id: ObjectID;
+        select: Dictionary<boolean>;
+        props: Dictionary<boolean>;
+      };
+      expect(readArgs.id.toString()).toBe(monitorId.toString());
+      expect(readArgs.select["projectId"]).toBe(true);
+      expect(readArgs.props["isRoot"]).toBe(true);
+    });
+
+    test("rejects an unauthenticated caller with BadDataException and never reads the monitor", async () => {
+      mockProps({});
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: MONITOR_REFRESH_ROUTE,
+        params: { monitorId: monitorId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+      expect(findOneByIdSpy).not.toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a public caller that supplies a tenant header it is not a member of", async () => {
+      mockProps({
+        tenantId: callerProjectId,
+        userId: undefined,
+        userTenantAccessPermission: undefined,
+      });
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: MONITOR_REFRESH_ROUTE,
+        params: { monitorId: monitorId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(findOneByIdSpy).not.toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a member of one project targeting another project's monitor id", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockMonitorInProject(otherProjectId);
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: MONITOR_REFRESH_ROUTE,
+        params: { monitorId: monitorId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a monitor id that does not exist", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockMonitorInProject(null);
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: MONITOR_REFRESH_ROUTE,
+        params: { monitorId: monitorId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /workspace-notification-rule/test/:workspaceNotifcationRuleId", () => {
+    let ruleId: ObjectID;
+    let testRuleSpy: jest.SpyInstance;
+    let findOneByIdSpy: jest.SpyInstance;
+
+    function mockProps(props: DatabaseCommonInteractionProps): void {
+      jest
+        .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+        .mockResolvedValue(props);
+    }
+
+    function mockRuleInProject(projectId: ObjectID | null): void {
+      if (!projectId) {
+        findOneByIdSpy.mockResolvedValue(null);
+        return;
+      }
+
+      const rule: WorkspaceNotificationRule = new WorkspaceNotificationRule();
+      rule.id = ruleId;
+      rule.projectId = projectId;
+      findOneByIdSpy.mockResolvedValue(rule);
+    }
+
+    beforeEach(() => {
+      ruleId = ObjectID.generate();
+      findOneByIdSpy = jest.spyOn(
+        WorkspaceNotificationRuleService,
+        "findOneById",
+      );
+      testRuleSpy = jest
+        .spyOn(WorkspaceNotificationRuleService, "testRule")
+        .mockResolvedValue(undefined);
+    });
+
+    test("tests the rule for a member of the rule's own project", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockRuleInProject(callerProjectId);
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: TEST_RULE_ROUTE,
+        params: { workspaceNotifcationRuleId: ruleId.toString() },
+      });
+
+      expect(result.nextCallCount).toBe(0);
+      expect(testRuleSpy).toHaveBeenCalledTimes(1);
+
+      const testRuleArgs: {
+        ruleId: ObjectID;
+        projectId: ObjectID;
+        testByUserId: ObjectID;
+      } = testRuleSpy.mock.calls[0]![0] as {
+        ruleId: ObjectID;
+        projectId: ObjectID;
+        testByUserId: ObjectID;
+      };
+      expect(testRuleArgs.ruleId.toString()).toBe(ruleId.toString());
+      expect(testRuleArgs.projectId.toString()).toBe(
+        callerProjectId.toString(),
+      );
+      expect(testRuleArgs.testByUserId.toString()).toBe(
+        callerUserId.toString(),
+      );
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledTimes(1);
+    });
+
+    test("rejects an unauthenticated caller with BadDataException and never reads the rule", async () => {
+      mockProps({});
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: TEST_RULE_ROUTE,
+        params: { workspaceNotifcationRuleId: ruleId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+      expect(findOneByIdSpy).not.toHaveBeenCalled();
+      expect(testRuleSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a public caller that supplies a tenant header it is not a member of", async () => {
+      mockProps({
+        tenantId: callerProjectId,
+        userId: undefined,
+        userTenantAccessPermission: undefined,
+      });
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: TEST_RULE_ROUTE,
+        params: { workspaceNotifcationRuleId: ruleId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(findOneByIdSpy).not.toHaveBeenCalled();
+      expect(testRuleSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * testRule overwrites the project it is handed with the rule's own
+     * projectId, so a member of project A targeting project B's rule id
+     * would otherwise get a test message posted into project B's Slack /
+     * Teams channels.
+     */
+    test("rejects a member of one project targeting another project's rule id", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockRuleInProject(otherProjectId);
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: TEST_RULE_ROUTE,
+        params: { workspaceNotifcationRuleId: ruleId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(testRuleSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a rule id that does not exist", async () => {
+      mockProps(
+        buildMemberProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+        }),
+      );
+      mockRuleInProject(null);
+
+      const result: RouteCallResult = await callGetRoute({
+        uri: TEST_RULE_ROUTE,
+        params: { workspaceNotifcationRuleId: ruleId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(testRuleSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix(api): authorize two custom routes that acted on any project's resource

### Small Description?

Two custom routes in `Common/Server/API` did all their reads with `props: { isRoot: true }` and never checked that the caller belongs to the project that owns the resource in the path. Both are mounted with only `UserMiddleware.getUserMiddleware`, which lets unauthenticated requests through as "public" and takes the project from a caller-supplied `tenantid` header.

**`GET /workspace-notification-rule/test/:workspaceNotifcationRuleId`** — `testRule` loads the rule with `isRoot` and then *overwrites* the `projectId` it was handed with the rule's own, so the caller-supplied tenant was ignored entirely. Any rule id in any project was reachable, and the method goes on to post a test message into that project's Slack / Teams channels — it can create channels too.

**`GET /monitor/refresh-status/:monitorId`** — `refreshMonitorCurrentStatus` was called with no props at all and both reads and writes with `isRoot`, so any monitor id in any project could be refreshed.

**The fix.** Both routes now assert an authenticated project member, then derive the owning project from the resource itself and require it to match. The membership check runs first, so an unauthenticated caller never reaches a database read.

The second half of that pair is a new `CommonAPI.assertResourceBelongsToProject`. `assertAuthenticatedProjectMember` compares `props.tenantId` against `props.userTenantAccessPermission`, so on its own it only proves the caller belongs to the project it *claimed* — a member of project A could still send their own tenant header while targeting project B's resource id. A row that is missing (or carries no `projectId`) is rejected the same way as a cross-project row, so neither endpoint can be used to tell "id exists in another project" apart from "id does not exist".

**One thing worth a reviewer's attention.** Both endpoints' only callers are dashboard pages driving them through raw `API.get`, and neither sent a `tenantid` header at all — `BaseAPI.getHeaders()` does not add one, `ModelAPI.getCommonHeaders()` is the only thing that does, and the earlier header pass (d1c84d59a7) covered only the Monitor Template routes. Without the header the new guard would fail every request with "Project ID is required", so both calls now pass `ModelAPI.getCommonHeaders()`, matching that commit's pattern. These endpoints are dashboard-only — they appear in no docs or API reference — so requiring a logged-in member (rather than the looser `assertTenantScoped`, which also admits API-key callers) is the right level; `testRule` already needs a `userId` to look up the caller's workspace auth token.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Tests**

- `Common/Tests/Server/API/CommonAPIAuthGuard.test.ts` — 5 unit tests for the new guard, alongside the existing ones for its two siblings.
- `Common/Tests/Server/API/ProjectScopedCustomRouteAuth.test.ts` (new) — 11 route tests through `mockRouter`: happy path, anonymous caller, a tenant header the caller is not a member of, a member of project A targeting project B's resource id, and a non-existent id. Verified against the pre-fix routes: **9 of the 11 fail**. The two that pass are the happy paths, which are regression guards rather than security assertions.
- `App/Tests/Dashboard/ProjectScopedCustomRouteTenantHeader.test.ts` (new) — source pin on the two `API.get` calls, following the sibling `MonitorTemplateSyncTenantHeader` test. Both header assertions fail without the UI change.

**Verification**

- `npx eslint` clean on all eight changed files.
- `npm run compile` in `Common` clean; `npx tsc --noEmit` in `App` clean.
- Full `Common/Tests/Server/API` suite passes (199 tests, 16 files).
- Full `App/Tests/Dashboard` suite passes (1078 tests, 47 files).

### Related Issue?

None — found while auditing project-scoped custom routes for a missing `tenantid` header. Those header fixes shipped separately in d1c84d59a7; this authorization gap was deliberately out of scope there.

### Screenshots (if appropriate):

N/A — no visual change. The two dashboard calls behave identically for a legitimate member.
