### PR TITLE
fix(reminders): select the sort column on the reminder rule queries, and close the class in DatabaseService

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Reminders/NextReminderCountdown.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Reminders/NextReminderCountdown.tsx
@@ -146,6 +146,15 @@ const NextReminderCountdown: FunctionComponent<ComponentProps> = (
               limit: LIMIT_PER_PROJECT,
               skip: 0,
               select: {
+                /*
+                 * A sorted column has to be selected. This query also selects
+                 * the severity and label relations, and a join plus a limit
+                 * sends it down TypeORM's paginated path, which orders the
+                 * outer query by a column the inner query only emits if it was
+                 * selected - so leaving order out fails the whole request and
+                 * blanks the page.
+                 */
+                order: true,
                 reminderIntervalInMinutes: true,
                 incidentSeverities: {
                   _id: true,
@@ -185,6 +194,8 @@ const NextReminderCountdown: FunctionComponent<ComponentProps> = (
               limit: LIMIT_PER_PROJECT,
               skip: 0,
               select: {
+                // Selected because we sort by it - see the incident query above.
+                order: true,
                 reminderIntervalInMinutes: true,
                 alertSeverities: {
                   _id: true,
@@ -224,6 +235,8 @@ const NextReminderCountdown: FunctionComponent<ComponentProps> = (
               limit: LIMIT_PER_PROJECT,
               skip: 0,
               select: {
+                // Selected because we sort by it - see the incident query above.
+                order: true,
                 reminderIntervalInMinutes: true,
                 labels: {
                   _id: true,

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1552,21 +1552,10 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     try {
       this.setTelemetryContextFromProps(findBy.props);
 
-      let automaticallyAddedCreatedAtInSelect: boolean = false;
-
       if (!findBy.sort || Object.keys(findBy.sort).length === 0) {
         findBy.sort = {
           createdAt: SortOrder.Descending,
         };
-
-        if (!findBy.select) {
-          findBy.select = {} as any;
-        }
-
-        if (!(findBy.select as any)["createdAt"]) {
-          (findBy.select as any)["createdAt"] = true;
-          automaticallyAddedCreatedAtInSelect = true;
-        }
       }
 
       const onFind: OnFind<TBaseModel> = findBy.props.ignoreHooks
@@ -1599,6 +1588,9 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
 
       onBeforeFind.query = result.query;
       onBeforeFind.select = result.select || undefined;
+
+      const sortColumnsAddedToSelect: Array<string> =
+        this.addSortColumnsToSelect(onBeforeFind);
 
       if (!(onBeforeFind.skip instanceof PositiveNumber)) {
         onBeforeFind.skip = new PositiveNumber(onBeforeFind.skip);
@@ -1634,8 +1626,8 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       decryptedItems = this.sanitizeFindByItems(decryptedItems, onBeforeFind);
 
       for (const item of decryptedItems) {
-        if (automaticallyAddedCreatedAtInSelect) {
-          delete (item as any).createdAt;
+        for (const sortColumn of sortColumnsAddedToSelect) {
+          delete (item as any)[sortColumn];
         }
       }
 
@@ -1650,6 +1642,67 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       await this.onFindError(error as Exception);
       throw this.getException(error as Exception);
     }
+  }
+
+  /**
+   * Adds every sorted column to the select, and returns the ones it added so
+   * `_findBy` can strip them back off the results.
+   *
+   * A column can be ordered by without being selected in a plain SELECT, but
+   * not once a relation is also selected: the join sends the query down
+   * TypeORM's paginated path, which wraps it and orders the outer SELECT by a
+   * column the inner query only emits when that column was selected. The
+   * request then fails outright with `column distinctAlias.<Alias>_<column>
+   * does not exist`. Callers should not have to know that, so close the gap
+   * here for every sort rather than leaving each call site to remember.
+   *
+   * Deliberately runs *after* the read-permission check. ORDER BY is not
+   * permission-checked, so a column being sorted on is already reaching the
+   * database - adding it to the select must not be able to turn a query that
+   * worked into a permission error. The values never reach the caller.
+   */
+  private addSortColumnsToSelect(findBy: FindBy<TBaseModel>): Array<string> {
+    /*
+     * No select at all means every column is selected, so there is nothing to
+     * fill in.
+     */
+    if (!findBy.select) {
+      return [];
+    }
+
+    const sortColumnsToAdd: Array<string> = Object.keys(
+      findBy.sort || {},
+    ).filter((sortColumn: string) => {
+      if ((findBy.select as any)[sortColumn] !== undefined) {
+        return false;
+      }
+
+      /*
+       * Sorting by a relation orders through the joined table, which has its
+       * own alias - adding the relation to the select here would instead turn
+       * it into a fetched relation.
+       */
+      return (
+        this.model.hasColumn(sortColumn) &&
+        !this.model.isEntityColumn(sortColumn)
+      );
+    });
+
+    if (sortColumnsToAdd.length === 0) {
+      return [];
+    }
+
+    /*
+     * Copied rather than mutated: sanitizeSelect hands back the caller's own
+     * select object, and callers reuse those across queries.
+     */
+    findBy.select = { ...(findBy.select as any) };
+
+    for (const sortColumn of sortColumnsToAdd) {
+      (findBy.select as any)[sortColumn] = true;
+    }
+
+    return sortColumnsToAdd;
   }
 
   private sanitizeFindByItems(

--- a/Common/Tests/Server/Services/DatabaseServiceSortColumnSelect.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceSortColumnSelect.test.ts
@@ -1,0 +1,201 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import IncidentReminderRule from "../../../Models/DatabaseModels/IncidentReminderRule";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * A column can be ordered by without being selected in a plain SELECT, but not
+ * once a relation is also selected: the join sends the query down TypeORM's
+ * paginated path, which wraps it and orders the outer SELECT by a column the
+ * inner query only emits when that column was selected. Postgres then rejects
+ * the whole request with `column distinctAlias.<Alias>_<column> does not
+ * exist`, which surfaces as a 500 and blanks the page.
+ *
+ * It went wrong twice: the monitor overview's probe query sorting by createdAt,
+ * then the reminder countdown's three rule queries sorting by `order`.
+ * _findBy used to fill the sort column in only for callers that passed NO sort
+ * at all, so an explicit sort bypassed the safety net entirely. It now fills in
+ * every sorted column and strips the ones it added back off the results, so no
+ * call site has to know about any of this.
+ */
+
+type FindArgs = {
+  select?: Record<string, unknown> | undefined;
+  order?: Record<string, unknown> | undefined;
+};
+
+describe("DatabaseService._findBy selects the columns it sorts by", () => {
+  let service: DatabaseService<IncidentReminderRule>;
+  let find: jest.Mock;
+  let rowsReturnedByDatabase: Array<IncidentReminderRule>;
+
+  type MakeRowFunction = (data: {
+    order: number;
+    reminderIntervalInMinutes: number;
+  }) => IncidentReminderRule;
+
+  const makeRow: MakeRowFunction = (data: {
+    order: number;
+    reminderIntervalInMinutes: number;
+  }): IncidentReminderRule => {
+    const rule: IncidentReminderRule = new IncidentReminderRule();
+    rule.order = data.order;
+    rule.reminderIntervalInMinutes = data.reminderIntervalInMinutes;
+    return rule;
+  };
+
+  type FindByFunction = (data: {
+    select?: Record<string, unknown> | undefined;
+    sort?: Record<string, unknown> | undefined;
+  }) => Promise<Array<IncidentReminderRule>>;
+
+  const findBy: FindByFunction = (data: {
+    select?: Record<string, unknown> | undefined;
+    sort?: Record<string, unknown> | undefined;
+  }): Promise<Array<IncidentReminderRule>> => {
+    return service.findBy({
+      query: {},
+      limit: 10,
+      skip: 0,
+      select: data.select as any,
+      sort: data.sort as any,
+      props: { isRoot: true },
+    });
+  };
+
+  const selectPassedToDatabase: () => Record<string, unknown> = (): Record<
+    string,
+    unknown
+  > => {
+    return (find.mock.calls[0]![0] as FindArgs).select || {};
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    service = new DatabaseService<IncidentReminderRule>(IncidentReminderRule);
+
+    /*
+     * The row the database hands back always carries the sorted column,
+     * because _findBy asked for it - that is the point. Whether the caller
+     * gets to see it is what these tests are about.
+     */
+    rowsReturnedByDatabase = [
+      makeRow({ order: 1, reminderIntervalInMinutes: 15 }),
+      makeRow({ order: 2, reminderIntervalInMinutes: 30 }),
+    ];
+
+    find = jest
+      .fn()
+      .mockImplementation(async (): Promise<Array<IncidentReminderRule>> => {
+        return rowsReturnedByDatabase;
+      });
+
+    jest.spyOn(service, "getRepository").mockReturnValue({ find: find } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("adds an explicitly sorted column that the caller did not select", async () => {
+    await findBy({
+      select: {
+        reminderIntervalInMinutes: true,
+        incidentSeverities: { _id: true },
+        labels: { _id: true },
+      },
+      sort: { order: SortOrder.Ascending },
+    });
+
+    expect(selectPassedToDatabase()["order"]).toBe(true);
+  });
+
+  it("hides the added column from the caller", async () => {
+    const rules: Array<IncidentReminderRule> = await findBy({
+      select: {
+        reminderIntervalInMinutes: true,
+        labels: { _id: true },
+      },
+      sort: { order: SortOrder.Ascending },
+    });
+
+    expect(rules).toHaveLength(2);
+
+    for (const rule of rules) {
+      expect(rule.order).toBeUndefined();
+      expect(rule.reminderIntervalInMinutes).toBeDefined();
+    }
+  });
+
+  it("keeps the column when the caller selected it themselves", async () => {
+    const rules: Array<IncidentReminderRule> = await findBy({
+      select: {
+        order: true,
+        reminderIntervalInMinutes: true,
+        labels: { _id: true },
+      },
+      sort: { order: SortOrder.Ascending },
+    });
+
+    expect(
+      rules.map((rule: IncidentReminderRule) => {
+        return rule.order;
+      }),
+    ).toEqual([1, 2]);
+  });
+
+  it("adds every column of a multi-column sort", async () => {
+    await findBy({
+      select: { labels: { _id: true } },
+      sort: {
+        order: SortOrder.Ascending,
+        reminderIntervalInMinutes: SortOrder.Descending,
+      },
+    });
+
+    expect(selectPassedToDatabase()["order"]).toBe(true);
+    expect(selectPassedToDatabase()["reminderIntervalInMinutes"]).toBe(true);
+  });
+
+  it("does not add a relation that is being sorted on", async () => {
+    await findBy({
+      select: { reminderIntervalInMinutes: true },
+      sort: { labels: SortOrder.Ascending },
+    });
+
+    expect(selectPassedToDatabase()["labels"]).toBeUndefined();
+  });
+
+  it("leaves the caller's own select object untouched", async () => {
+    const callerSelect: Record<string, unknown> = {
+      reminderIntervalInMinutes: true,
+      labels: { _id: true },
+    };
+
+    await findBy({
+      select: callerSelect,
+      sort: { order: SortOrder.Ascending },
+    });
+
+    expect(callerSelect["order"]).toBeUndefined();
+  });
+
+  it("still fills in and hides createdAt for callers that pass no sort", async () => {
+    const rules: Array<IncidentReminderRule> = await findBy({
+      select: {
+        reminderIntervalInMinutes: true,
+        labels: { _id: true },
+      },
+    });
+
+    expect(selectPassedToDatabase()["createdAt"]).toBe(true);
+    expect((find.mock.calls[0]![0] as FindArgs).order?.["createdAt"]).toBe(
+      SortOrder.Descending,
+    );
+
+    for (const rule of rules) {
+      expect(rule.createdAt).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix(reminders): select the sort column on the reminder rule queries, and close the class in DatabaseService

### Small Description?

The Settings tab of every incident, alert and scheduled maintenance rendered its next-reminder countdown without the interval progress bar, because `POST /api/incident-reminder-rule/get-list` (and the alert and scheduled maintenance equivalents) returned 500 on every load.

All three queries in `NextReminderCountdown.tsx` sort by `order` but did not select it. On its own that is fine, but each also selects relations — the severity and label lists — and the join sends the query down TypeORM's paginated path, which wraps the query and orders the outer `SELECT` by a column the inner query only emits when it was selected. Postgres rejects the whole statement with `column distinctAlias.<Model>_order does not exist`.

This is the same class of bug as 846b962 on the monitor overview's probe query. The relations here are many-to-many rather than the probe's many-to-one, but that makes no difference — TypeORM takes the paginated path whenever there is a limit and at least one join (`(skip || take) && joinAttributes.length > 0`), and find options join every relation under the default `"join"` load strategy regardless of cardinality.

**Two commits, independently reviewable:**

1. **`fix(reminders)`** — selects `order` in all three queries. The narrow fix.
2. **`fix(database)`** — generalises `DatabaseService._findBy` to add *every* sorted column to the select and strip the added ones back off the results. It already did this, but only for callers that passed no sort at all, as a side effect of applying the default `createdAt` ordering; any caller passing its own sort bypassed the safety net, which is the shape both bugs took.

### Anything a reviewer should know?

**Verified against a real database, not by reading code.** Each of the three queries fails; the same query with the relation select removed succeeds; and both fixes independently make them pass.

**On the `DatabaseService` change specifically** — two deliberate choices:

- It runs **after** the read-permission check. `ORDER BY` is not permission-checked, so a sorted column already reaches the database. Adding it to the select must not be able to turn a query that worked into a permission error. The values never reach the caller either way.
- It **copies** the select instead of mutating it, because `sanitizeSelect` hands back the caller's own object and callers reuse those across queries.

Relations are skipped — sorting by one orders through the joined table's own alias, so adding it here would turn it into a fetched relation instead.

**Audit of the rest of the tree** (TypeScript-parser based, validated by confirming it flags all four historical instances including `MonitorIndex.tsx:419`): no third live instance. But **94 call sites** sort on an unselected column while selecting no relation — correct today, one relation column away from being this bug. `BaseModelTable`'s main fetch is in the same position: it relies on `sortBy` naming a declared, and therefore selected, column, and never validates that it does. Its bulk-select path already handles the invariant explicitly. Commit 2 neutralises all of these.

**On `order` permissions:** it carries the same `ColumnAccessControl.read` list as the columns these queries already select, so selecting it cannot convert the 500 into a permission error for a viewer.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Checks run locally: `Common` and `Dashboard` `tsc --noEmit` clean; eslint + prettier clean on all three files; `Common/Tests/Server/Services` 1357 passed; `Common/Tests/Server/API` + `Types` + `UI` 2053 passed. Two failures in those runs (`MonitorResourceProbeAgreementReuse` — `isolated-vm` native ABI mismatch with local Node 24 — and `MonacoRuntime`) reproduce on unmodified `master`, so they are environmental. The e2e suite only runs on `master`, so it has not run against these changes.

New tests: `Common/Tests/Server/Services/DatabaseServiceSortColumnSelect.test.ts` (7 tests). Three fail against the old code; the one covering the pre-existing no-sort behaviour passes against both, pinning down that the default ordering path still fills `createdAt` in and still hides it.

### Related Issue?

None — found while reviewing 846b962.

### Screenshots (if appropriate):

n/a — the visible effect is the countdown's interval progress bar rendering instead of being silently dropped.
