### PR TITLE
fix(ui): keep a code editor's value when no initialValue is passed

### DIFF
--- a/Common/Tests/UI/Components/CodeEditor.test.tsx
+++ b/Common/Tests/UI/Components/CodeEditor.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test } from "@jest/globals";
+import CodeType from "../../../Types/Code/CodeType";
+
+/*
+ * Monaco cannot run in jsdom, so stand in a plain textarea that echoes the
+ * props <Editor> is given. Every prop the editor is rendered with is recorded
+ * so a test can assert what the model would have been created from - Monaco
+ * builds its model from `value || defaultValue` once its async loader
+ * resolves, which is after the component's effects have run.
+ */
+interface RecordedEditorProps {
+  value?: string | undefined;
+  defaultValue?: string | undefined;
+}
+
+const mockEditorRenders: Array<RecordedEditorProps> = [];
+
+jest.mock("@monaco-editor/react", () => {
+  return {
+    __esModule: true,
+    loader: {
+      config: jest.fn(),
+    },
+    default: (editorProps: {
+      value?: string | undefined;
+      defaultValue?: string | undefined;
+      onChange?: ((value: string | undefined) => void) | undefined;
+    }) => {
+      mockEditorRenders.push({
+        value: editorProps.value,
+        defaultValue: editorProps.defaultValue,
+      });
+
+      return (
+        <textarea
+          data-testid="monaco"
+          value={editorProps.value || ""}
+          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+            if (editorProps.onChange) {
+              editorProps.onChange(event.target.value);
+            }
+          }}
+        />
+      );
+    },
+  };
+});
+
+// Imported after the mock so the module picks up the stand-in editor.
+import CodeEditor from "../../../UI/Components/CodeEditor/CodeEditor";
+
+type GetEditor = () => HTMLTextAreaElement;
+
+const getEditor: GetEditor = (): HTMLTextAreaElement => {
+  return screen.getByTestId("monaco") as HTMLTextAreaElement;
+};
+
+describe("CodeEditor", () => {
+  test("renders the value prop when no initialValue is given", () => {
+    /*
+     * Regression: the Runbook step editors (Bash script, JavaScript script,
+     * HTTP headers and body) pass only `value`. An initialValue effect used to
+     * run after the value effect on mount and blank the editor, so saved
+     * scripts came back empty on reload.
+     */
+    const script: string = 'echo "Runbook step running"';
+
+    render(<CodeEditor type={CodeType.Text} value={script} />);
+
+    expect(getEditor().value).toBe(script);
+  });
+
+  test("seeds the editor with the value on its very first render", () => {
+    /*
+     * Monaco creates its model asynchronously from whatever value the editor
+     * has at that point, so the value has to be right from the first render -
+     * not repaired by a later effect.
+     */
+    const script: string = "df -h | head -5";
+    mockEditorRenders.length = 0;
+
+    render(<CodeEditor type={CodeType.Text} value={script} />);
+
+    expect(mockEditorRenders.length).toBeGreaterThan(0);
+    expect(
+      mockEditorRenders.every((r: RecordedEditorProps) => {
+        return r.value === script;
+      }),
+    ).toBe(true);
+  });
+
+  test("renders the initialValue prop when no value is given", () => {
+    const json: string = '{ "Authorization": "Bearer token" }';
+
+    render(<CodeEditor type={CodeType.JSON} initialValue={json} />);
+
+    expect(getEditor().value).toBe(json);
+  });
+
+  test("prefers value over initialValue when both are given", () => {
+    render(
+      <CodeEditor
+        type={CodeType.JSON}
+        initialValue={'{ "stale": true }'}
+        value={'{ "current": true }'}
+      />,
+    );
+
+    expect(getEditor().value).toBe('{ "current": true }');
+  });
+
+  test("follows the value prop when it changes after mount", () => {
+    const { rerender } = render(
+      <CodeEditor type={CodeType.JavaScript} value="return 1;" />,
+    );
+
+    expect(getEditor().value).toBe("return 1;");
+
+    rerender(<CodeEditor type={CodeType.JavaScript} value="return 2;" />);
+
+    expect(getEditor().value).toBe("return 2;");
+  });
+
+  test("picks up a value that only arrives after the first render", () => {
+    // Pages that load the model asynchronously render once with nothing.
+    const { rerender } = render(<CodeEditor type={CodeType.Text} />);
+
+    expect(getEditor().value).toBe("");
+
+    rerender(<CodeEditor type={CodeType.Text} value="uptime" />);
+
+    expect(getEditor().value).toBe("uptime");
+  });
+
+  test("follows the initialValue prop when it changes after mount", () => {
+    // Form fields recompute initialValue from currentValues on every keystroke.
+    const { rerender } = render(
+      <CodeEditor type={CodeType.JavaScript} initialValue="return 1;" />,
+    );
+
+    expect(getEditor().value).toBe("return 1;");
+
+    rerender(
+      <CodeEditor type={CodeType.JavaScript} initialValue="return 2;" />,
+    );
+
+    expect(getEditor().value).toBe("return 2;");
+  });
+
+  test("reports edits to onChange", () => {
+    const onChange: jest.Mock = jest.fn();
+
+    render(
+      <CodeEditor type={CodeType.Text} value="before" onChange={onChange} />,
+    );
+
+    fireEvent.change(getEditor(), { target: { value: "after" } });
+
+    expect(onChange).toHaveBeenCalledWith("after");
+  });
+
+  test("stringifies a non-string value", () => {
+    render(
+      <CodeEditor
+        type={CodeType.JSON}
+        value={{ hello: "world" } as unknown as string}
+      />,
+    );
+
+    expect(getEditor().value).toBe(JSON.stringify({ hello: "world" }, null, 4));
+  });
+});

--- a/Common/UI/Components/CodeEditor/CodeEditor.tsx
+++ b/Common/UI/Components/CodeEditor/CodeEditor.tsx
@@ -32,6 +32,22 @@ export interface ComponentProps {
   ariaLabelledby?: string | undefined;
 }
 
+/*
+ * Callers hand us `any` through Form's currentValues, so a non-string can
+ * still reach a prop typed as string.
+ */
+function toEditorText(value: string | undefined): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (typeof value !== "string") {
+    return JSON.stringify(value, null, 4);
+  }
+
+  return value;
+}
+
 const CodeEditor: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
@@ -42,15 +58,25 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
   const editorRef: React.MutableRefObject<any> = useRef<any>(null);
   const theme: Theme = useTheme();
 
+  /*
+   * `value` is the controlled prop; `initialValue` only seeds an uncontrolled
+   * editor. Both used to be synced from their own useEffect, and because
+   * effects run in declaration order the `initialValue` one ran last on mount
+   * and reset the state to "" - so a caller that passed only `value` mounted
+   * an empty editor even though it had text to show. Seed the state on the
+   * first render and keep the precedence in a single effect.
+   */
+  const [value, setValue] = useState<string>(() => {
+    return toEditorText(props.value ?? props.initialValue);
+  });
+
   useEffect(() => {
-    let value: string | undefined = props.value;
-
-    if (value && typeof value !== "string") {
-      value = JSON.stringify(value, null, 4);
-    }
-
-    setValue(value || "");
-  }, [props.value]);
+    setValue(
+      toEditorText(
+        props.value === undefined ? props.initialValue : props.value,
+      ),
+    );
+  }, [props.value, props.initialValue]);
 
   useEffect(() => {
     if (props.placeholder) {
@@ -95,8 +121,6 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
       "block w-full rounded-md border bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-red-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500 sm:text-sm border-red-300 pr-10 text-red-900 placeholder-red-300 focus:border-red-500 focus:outline-none focus:ring-red-500";
   }
 
-  const [value, setValue] = useState<string>("");
-
   // Handle spell check configuration for Monaco Editor
   useEffect(() => {
     if (editorRef.current && props.type === CodeType.Markdown) {
@@ -111,16 +135,6 @@ const CodeEditor: FunctionComponent<ComponentProps> = (
       }
     }
   }, [props.disableSpellCheck, props.type]);
-
-  useEffect(() => {
-    let initialValue: string | undefined = props.initialValue;
-
-    if (initialValue && typeof initialValue !== "string") {
-      initialValue = JSON.stringify(initialValue, null, 4);
-    }
-
-    setValue(initialValue || "");
-  }, [props.initialValue]);
 
   return (
     <div


### PR DESCRIPTION
## The report

A customer reported that on a Runbook's Steps page, the **Bash script**, **JavaScript script** and **HTTP request headers/body** come back empty after a reload, even though the steps still execute correctly in the background. Every other field on the page persists fine.

## Root cause

`CodeEditor` synced `props.value` and `props.initialValue` from two separate `useEffect`s that both wrote the same state:

```tsx
useEffect(() => { setValue(props.value || ""); }, [props.value]);          // declared line 45
// ...70 lines later...
useEffect(() => { setValue(props.initialValue || ""); }, [props.initialValue]);  // declared line 115
```

Effects run in declaration order, so on mount the `initialValue` one ran last and did `setValue("")` for any caller that passed only `value`.

Monaco makes this permanent rather than a first-paint glitch. It builds its model from `value || defaultValue` once its async loader resolves — after React's effects have settled — and `@monaco-editor/react`'s sync effect is update-only. Since `props.value` never changes again, the empty model sticks forever.

`Runbook/View/Steps.tsx` passes only `value` to exactly four editors: the JavaScript script, the HTTP headers, the HTTP body and the Bash script. That is precisely the customer's list. Everything else on that page uses `Input`/`TextArea`/`Dropdown`/`Toggle`, none of which share the defect — `Input.tsx:145` guards its `initialValue` effect with `if (props.initialValue)`, the exact guard `CodeEditor` was missing.

**No data was ever lost.** The `steps` jsonb column round-trips byte-for-byte; this was only ever a display bug.

## The fix

Seed the state on the first render and keep the value-over-`initialValue` precedence in a single effect:

```tsx
const [value, setValue] = useState<string>(() => {
  return toEditorText(props.value ?? props.initialValue);
});

useEffect(() => {
  setValue(
    toEditorText(props.value === undefined ? props.initialValue : props.value),
  );
}, [props.value, props.initialValue]);
```

Two details worth keeping:

- The `=== undefined` check rather than a truthiness check, so clearing a field to empty still works.
- Both paths go through `toEditorText`, which preserves the existing `JSON.stringify` of a non-string. Form fields hand `CodeEditor` an `any` from `currentValues`, and Monaco's `createTextBuffer` throws on a non-string model.

Callers that pass `initialValue` (`FormField`, `MonitorStep`, `SpanViewer`) keep their current behaviour exactly. The change also repairs the same latent blanking in `ModelFieldPicker`'s JSON view and in the example scripts seeded onto a newly added Runbook step.

## Tests

New `Common/Tests/UI/Components/CodeEditor.test.tsx` — 9 cases covering value-only, initialValue-only, both, post-mount changes to either, a value that arrives after the first render, `onChange`, and non-string normalization. Reverting the fix makes 5 of the 9 fail, so it is a genuine regression test rather than a vacuous one.

Full `Common` UI suite: **1722 / 1723 pass**. The one failure is `MonacoRuntime.test.ts`, a version-pin assertion that trips on stale local `node_modules` (monaco-editor 0.53.0 installed against a 0.52.2 pin). It fails identically on a clean tree and is unrelated to this change.

`tsc --noEmit` on `Common` is clean; ESLint is clean.