### PR TITLE
fix(runbook): make step execution timeouts configurable in the UI

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Runbook/View/Steps.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Runbook/View/Steps.tsx
@@ -38,6 +38,11 @@ import {
   RunbookStep,
 } from "Common/Types/Runbook/RunbookStep";
 import RunbookStepType from "Common/Types/Runbook/RunbookStepType";
+import StepTimeoutInput from "Common/UI/Components/Runbook/StepTimeoutInput";
+import {
+  AGENT_CLAIM_TIMEOUT_BOUNDS,
+  STEP_EXECUTION_TIMEOUT_BOUNDS,
+} from "Common/Types/Runbook/RunbookStepTimeout";
 import UUID from "Common/Utils/UUID";
 import { useAsyncEffect } from "use-async-effect";
 import React, {
@@ -665,6 +670,49 @@ const Steps: FunctionComponent<PageComponentProps> = (): ReactElement => {
     );
   };
 
+  /*
+   * Bash and JavaScript are dispatched to an agent, so they carry two
+   * timeouts: how long the Worker waits for an agent to pick the job up, and
+   * how long the agent lets the script run once it has.
+   */
+  const renderAgentTimeouts: (args: {
+    idx: number;
+    config: BashStepConfig | JavaScriptStepConfig;
+    executionDescription: ReactElement;
+  }) => ReactElement = (args: {
+    idx: number;
+    config: BashStepConfig | JavaScriptStepConfig;
+    executionDescription: ReactElement;
+  }): ReactElement => {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <StepTimeoutInput
+          label="Execution timeout"
+          value={args.config.timeoutInMs}
+          bounds={STEP_EXECUTION_TIMEOUT_BOUNDS}
+          description={args.executionDescription}
+          onChange={(timeoutInMs: number | undefined) => {
+            updateConfig(args.idx, { timeoutInMs });
+          }}
+        />
+        <StepTimeoutInput
+          label="Claim timeout"
+          value={args.config.claimTimeoutInMs}
+          bounds={AGENT_CLAIM_TIMEOUT_BOUNDS}
+          description={
+            <>
+              How long the Worker waits for the selected agent to pick this job
+              up before failing the step as timed out.
+            </>
+          }
+          onChange={(claimTimeoutInMs: number | undefined) => {
+            updateConfig(args.idx, { claimTimeoutInMs });
+          }}
+        />
+      </div>
+    );
+  };
+
   const addMenu: ReactElement = (
     <Button
       title="Add Step"
@@ -954,9 +1002,8 @@ const Steps: FunctionComponent<PageComponentProps> = (): ReactElement => {
                                                 <code>isolated-vm</code> on the
                                                 agent. Use{" "}
                                                 <code>return value</code> to
-                                                capture output. Default timeout
-                                                30s. No filesystem, network, or
-                                                process access.
+                                                capture output. No filesystem,
+                                                network, or process access.
                                               </p>
                                               <div className="mt-2">
                                                 {renderScriptExamples({
@@ -969,6 +1016,18 @@ const Steps: FunctionComponent<PageComponentProps> = (): ReactElement => {
                                                 })}
                                               </div>
                                             </div>
+                                            {renderAgentTimeouts({
+                                              idx,
+                                              config:
+                                                step.config as JavaScriptStepConfig,
+                                              executionDescription: (
+                                                <>
+                                                  How long the agent lets the
+                                                  script run before tearing the
+                                                  isolate down.
+                                                </>
+                                              ),
+                                            })}
                                           </div>
                                         )}
 
@@ -1072,6 +1131,31 @@ const Steps: FunctionComponent<PageComponentProps> = (): ReactElement => {
                                                 />
                                               </div>
                                             </div>
+                                            <StepTimeoutInput
+                                              label="Request timeout"
+                                              value={
+                                                (
+                                                  step.config as HttpRequestStepConfig
+                                                ).timeoutInMs
+                                              }
+                                              bounds={
+                                                STEP_EXECUTION_TIMEOUT_BOUNDS
+                                              }
+                                              description={
+                                                <>
+                                                  How long to wait for the
+                                                  endpoint to respond before
+                                                  failing the step.
+                                                </>
+                                              }
+                                              onChange={(
+                                                timeoutInMs: number | undefined,
+                                              ) => {
+                                                updateConfig(idx, {
+                                                  timeoutInMs,
+                                                });
+                                              }}
+                                            />
                                           </div>
                                         )}
 
@@ -1133,6 +1217,18 @@ const Steps: FunctionComponent<PageComponentProps> = (): ReactElement => {
                                                 })}
                                               </div>
                                             </div>
+                                            {renderAgentTimeouts({
+                                              idx,
+                                              config:
+                                                step.config as BashStepConfig,
+                                              executionDescription: (
+                                                <>
+                                                  How long the agent lets the
+                                                  script run before killing it
+                                                  with <code>SIGKILL</code>.
+                                                </>
+                                              ),
+                                            })}
                                           </div>
                                         )}
 

--- a/App/FeatureSet/Docs/Content/en/runbooks/agents.md
+++ b/App/FeatureSet/Docs/Content/en/runbooks/agents.md
@@ -84,7 +84,9 @@ Two timeouts apply to every Bash or JavaScript step:
 | Timeout               | Default    | What it controls                                                                                                                                                                                                      |
 | --------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Claim timeout**     | 2 minutes  | How long the Worker waits for the selected agent to claim the job. If the agent doesn't pick it up in time, the step fails with `TimedOut` and the runbook moves on (or stops, depending on **Continue on failure**). |
-| **Execution timeout** | 30 seconds | How long the agent will let the script run before terminating it. Configurable per step. (Bash gets `SIGKILL`; JavaScript's isolate is torn down.)                                                                    |
+| **Execution timeout** | 30 seconds | How long the agent will let the script run before terminating it. (Bash gets `SIGKILL`; JavaScript's isolate is torn down.)                                                                                           |
+
+Both are configurable per step. Open **Runbooks &rsaquo; your runbook &rsaquo; Steps**, expand a Bash or JavaScript step, and set **Execution timeout** and **Claim timeout** (in seconds) below the script. Leave a field blank to use the default. Each accepts 1 second to 1 hour; values outside that range are clamped when the step runs.
 
 The Worker's overall wait window is `claim timeout + execution timeout + a few seconds`. Pick numbers that match the step.
 

--- a/App/FeatureSet/Docs/Content/en/runbooks/authoring.md
+++ b/App/FeatureSet/Docs/Content/en/runbooks/authoring.md
@@ -39,11 +39,11 @@ const start = Date.now();
 return { durationMs: Date.now() - start };
 ```
 
-The returned value is captured on the step execution. `console.log` output is captured as log lines. Default execution timeout: 30 seconds. Default claim timeout (how long the Worker waits for the agent to pick the job up): 2 minutes.
+The returned value is captured on the step execution. `console.log` output is captured as log lines. Default execution timeout: 30 seconds. Default claim timeout (how long the Worker waits for the agent to pick the job up): 2 minutes. Both are editable on the step — see **Execution timeout** and **Claim timeout** below the script.
 
 ### HTTP request
 
-Make an outbound HTTP call. Configure method (GET/POST/PUT/PATCH/DELETE/HEAD), URL, optional JSON headers, and optional body. Response status, headers, and body are captured (capped at 50KB total).
+Make an outbound HTTP call. Configure method (GET/POST/PUT/PATCH/DELETE/HEAD), URL, optional JSON headers, optional body, and a **Request timeout** (default 30 seconds). Response status, headers, and body are captured (capped at 50KB total).
 
 Useful for: kicking off a PagerDuty incident, posting to Slack, calling your own admin API, etc. HTTP steps run on the OneUptime Worker directly; no agent required.
 
@@ -51,10 +51,12 @@ Useful for: kicking off a PagerDuty incident, posting to Slack, calling your own
 
 A bash script (`bash -c <script>`) run on a [Runbook Agent](/docs/runbooks/agents) in your own infrastructure. Bash never executes on the OneUptime Worker.
 
-Configure two things on a Bash step:
+Configure these on a Bash step:
 
 - **Runbook Agent** — pick the agent that should run this step from the dropdown. Only the selected agent may claim the job.
 - **Script** — the bash to run. Output (stdout + stderr) is captured up to 50 KB; the process is killed on timeout.
+- **Execution timeout** — how long the agent lets the script run before killing it with `SIGKILL`. Defaults to 30 seconds; raise it for steps that legitimately take minutes.
+- **Claim timeout** — how long the Worker waits for the agent to pick the job up. Defaults to 2 minutes.
 
 If the selected agent is offline when the runbook reaches this step, the step waits up to the **claim timeout** (default 2 minutes) and then fails with `TimedOut`. Add an agent under **Runbooks → Settings → Agents** before relying on a Bash step.
 

--- a/App/FeatureSet/Docs/Content/en/runbooks/configuration.md
+++ b/App/FeatureSet/Docs/Content/en/runbooks/configuration.md
@@ -16,8 +16,9 @@ There is no `RUNBOOK_BASH_ENABLED` environment flag any more. Whether Bash or Ja
 ## Output caps and timeouts
 
 - Per-step output: **50&nbsp;KB**. Larger output is truncated with a marker.
-- Per-step execution timeout default: **30 seconds** for JavaScript, Bash, and HTTP. Configurable per step.
-- Per-step **claim timeout** for Bash and JavaScript steps: **2 minutes** — how long the Worker waits for the selected agent to pick up the job before failing it.
+- Per-step execution timeout default: **30 seconds** for JavaScript, Bash, and HTTP. Set it per step on the runbook's **Steps** page — leave the field blank to keep the default.
+- Per-step **claim timeout** for Bash and JavaScript steps: **2 minutes** — how long the Worker waits for the selected agent to pick up the job before failing it. Also set per step.
+- Both timeouts accept **1 second to 1 hour**. A value outside that range is clamped when the step runs, so a mistyped config can neither disable the timeout nor pin a Worker slot open indefinitely.
 
 ## Permissions
 

--- a/App/FeatureSet/Runbook/Services/StepExecutors.ts
+++ b/App/FeatureSet/Runbook/Services/StepExecutors.ts
@@ -7,6 +7,10 @@ import {
   RunbookStep,
 } from "Common/Types/Runbook/RunbookStep";
 import RunbookStepType from "Common/Types/Runbook/RunbookStepType";
+import {
+  resolveAgentClaimTimeoutInMs,
+  resolveStepExecutionTimeoutInMs,
+} from "Common/Types/Runbook/RunbookStepTimeout";
 import ObjectID from "Common/Types/ObjectID";
 import RunbookAgentJobService from "Common/Server/Services/RunbookAgentJobService";
 import RunbookAgentJobStatus from "Common/Types/Runbook/RunbookAgentJobStatus";
@@ -36,9 +40,6 @@ export interface StepExecutionContext {
 }
 
 const MAX_OUTPUT_BYTES: number = 50_000;
-const DEFAULT_SCRIPT_TIMEOUT_MS: number = 30_000;
-const DEFAULT_HTTP_TIMEOUT_MS: number = 30_000;
-const DEFAULT_AGENT_CLAIM_TIMEOUT_MS: number = 2 * 60_000;
 
 export function truncate(s: string): string {
   if (Buffer.byteLength(s, "utf8") <= MAX_OUTPUT_BYTES) {
@@ -145,8 +146,8 @@ export async function runJavaScriptStep(
     step,
     ctx,
     script: config.script || "",
-    timeoutInMs: config.timeoutInMs || DEFAULT_SCRIPT_TIMEOUT_MS,
-    claimTimeoutInMs: config.claimTimeoutInMs || DEFAULT_AGENT_CLAIM_TIMEOUT_MS,
+    timeoutInMs: resolveStepExecutionTimeoutInMs(config.timeoutInMs),
+    claimTimeoutInMs: resolveAgentClaimTimeoutInMs(config.claimTimeoutInMs),
     agentId: config.agentId || "",
     missingAgentError:
       "JavaScript step is missing a Runbook Agent. Pick an agent under Runbooks → Agents. JavaScript no longer runs on the OneUptime Worker.",
@@ -155,7 +156,7 @@ export async function runJavaScriptStep(
 
 export async function runHttpStep(step: RunbookStep): Promise<StepRunResult> {
   const config: HttpRequestStepConfig = step.config as HttpRequestStepConfig;
-  const timeout: number = config.timeoutInMs || DEFAULT_HTTP_TIMEOUT_MS;
+  const timeout: number = resolveStepExecutionTimeoutInMs(config.timeoutInMs);
 
   let headers: Record<string, string> = {};
   if (config.headersJson) {
@@ -232,8 +233,8 @@ export async function runBashStep(
     step,
     ctx,
     script: config.script || "",
-    timeoutInMs: config.timeoutInMs || DEFAULT_SCRIPT_TIMEOUT_MS,
-    claimTimeoutInMs: config.claimTimeoutInMs || DEFAULT_AGENT_CLAIM_TIMEOUT_MS,
+    timeoutInMs: resolveStepExecutionTimeoutInMs(config.timeoutInMs),
+    claimTimeoutInMs: resolveAgentClaimTimeoutInMs(config.claimTimeoutInMs),
     agentId: config.agentId || "",
     missingAgentError:
       "Bash step is missing a Runbook Agent. Pick an agent under Runbooks → Agents.",

--- a/App/Tests/Runbook/StepExecutors.test.ts
+++ b/App/Tests/Runbook/StepExecutors.test.ts
@@ -11,6 +11,14 @@ import {
   JavaScriptStepConfig,
   RunbookStep,
 } from "Common/Types/Runbook/RunbookStep";
+import {
+  DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+  DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+  MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+  MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+  MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
+  MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
+} from "Common/Types/Runbook/RunbookStepTimeout";
 import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
 import {
   runBashStep,
@@ -403,5 +411,282 @@ describe("agent-dispatched steps (Bash / JavaScript)", () => {
 
     expect(result.success).toBe(false);
     expect(result.errorMessage).toContain("queue unavailable");
+  });
+});
+
+describe("per-step timeouts", () => {
+  beforeEach(() => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function stubAgentDispatch(): {
+    enqueueSpy: jest.SpyInstance;
+    pollSpy: jest.SpyInstance;
+  } {
+    return {
+      enqueueSpy: jest
+        .spyOn(RunbookAgentJobService, "enqueue")
+        .mockResolvedValue(makeTerminalJob()),
+      pollSpy: jest
+        .spyOn(RunbookAgentJobService, "pollUntilTerminal")
+        .mockResolvedValue(makeTerminalJob()),
+    };
+  }
+
+  function firstCallArgs(spy: jest.SpyInstance): Record<string, unknown> {
+    return spy.mock.calls[0]![0] as Record<string, unknown>;
+  }
+
+  describe("HTTP steps", () => {
+    test("an unset timeout uses the documented 30 second default", async () => {
+      const requestSpy: jest.SpyInstance = jest
+        .spyOn(axios, "request")
+        .mockResolvedValue({
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          data: "",
+        } as never);
+
+      await runHttpStep(makeHttpStep());
+
+      expect(firstCallArgs(requestSpy)["timeout"]).toBe(
+        DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("a configured timeout is handed to the HTTP client", async () => {
+      const requestSpy: jest.SpyInstance = jest
+        .spyOn(axios, "request")
+        .mockResolvedValue({
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          data: "",
+        } as never);
+
+      await runHttpStep(makeHttpStep({ timeoutInMs: 90_000 }));
+
+      expect(firstCallArgs(requestSpy)["timeout"]).toBe(90_000);
+    });
+
+    test("a zero timeout falls back to the default instead of waiting forever", async () => {
+      const requestSpy: jest.SpyInstance = jest
+        .spyOn(axios, "request")
+        .mockResolvedValue({
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          data: "",
+        } as never);
+
+      await runHttpStep(makeHttpStep({ timeoutInMs: 0 }));
+
+      expect(firstCallArgs(requestSpy)["timeout"]).toBe(
+        DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("an absurd timeout is capped at the maximum", async () => {
+      const requestSpy: jest.SpyInstance = jest
+        .spyOn(axios, "request")
+        .mockResolvedValue({
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          data: "",
+        } as never);
+
+      await runHttpStep(makeHttpStep({ timeoutInMs: Number.MAX_SAFE_INTEGER }));
+
+      expect(firstCallArgs(requestSpy)["timeout"]).toBe(
+        MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("a sub-second timeout is raised to the minimum", async () => {
+      const requestSpy: jest.SpyInstance = jest
+        .spyOn(axios, "request")
+        .mockResolvedValue({
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          data: "",
+        } as never);
+
+      await runHttpStep(makeHttpStep({ timeoutInMs: 5 }));
+
+      expect(firstCallArgs(requestSpy)["timeout"]).toBe(
+        MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+    });
+  });
+
+  describe("Bash steps", () => {
+    test("unset timeouts dispatch with the documented defaults", async () => {
+      const { enqueueSpy, pollSpy } = stubAgentDispatch();
+
+      await runBashStep(makeBashStep(), makeCtx());
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(
+        DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(
+        DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+      );
+      expect(firstCallArgs(pollSpy)["executionTimeoutInMs"]).toBe(
+        DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+      expect(firstCallArgs(pollSpy)["claimTimeoutInMs"]).toBe(
+        DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("configured timeouts reach both the enqueued job and the poll window", async () => {
+      const { enqueueSpy, pollSpy } = stubAgentDispatch();
+
+      await runBashStep(
+        makeBashStep({ timeoutInMs: 600_000, claimTimeoutInMs: 900_000 }),
+        makeCtx(),
+      );
+
+      /*
+       * The job row carries the execution timeout to the agent; the poll
+       * window has to cover both. If these ever diverge, a long step would be
+       * abandoned by the Worker while the agent was still running it.
+       */
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(600_000);
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(900_000);
+      expect(firstCallArgs(pollSpy)["executionTimeoutInMs"]).toBe(600_000);
+      expect(firstCallArgs(pollSpy)["claimTimeoutInMs"]).toBe(900_000);
+    });
+
+    test("a long-running step keeps a timeout well past the default", async () => {
+      /*
+       * The reason this feature exists: a database restore or a log sweep
+       * takes longer than 30 seconds and must not be killed at 30 seconds.
+       */
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runBashStep(makeBashStep({ timeoutInMs: 45 * 60_000 }), makeCtx());
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(2_700_000);
+    });
+
+    test("an out-of-range execution timeout is clamped, not passed through", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runBashStep(
+        makeBashStep({ timeoutInMs: 24 * 60 * 60_000 }),
+        makeCtx(),
+      );
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(
+        MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("an out-of-range claim timeout is clamped, not passed through", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runBashStep(makeBashStep({ claimTimeoutInMs: 1 }), makeCtx());
+
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(
+        MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("a negative timeout falls back to the default rather than disabling the timeout", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runBashStep(
+        makeBashStep({ timeoutInMs: -1, claimTimeoutInMs: -1 }),
+        makeCtx(),
+      );
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(
+        DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(
+        DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("a timeout stored as a string still resolves — step configs are untyped JSON at rest", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runBashStep(
+        makeBashStep({ timeoutInMs: "120000" as unknown as number }),
+        makeCtx(),
+      );
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(120_000);
+    });
+
+    test("the two timeouts stay independent of one another", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runBashStep(
+        makeBashStep({ timeoutInMs: 5_000, claimTimeoutInMs: 600_000 }),
+        makeCtx(),
+      );
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(5_000);
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(600_000);
+    });
+  });
+
+  describe("JavaScript steps", () => {
+    test("unset timeouts dispatch with the documented defaults", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runJavaScriptStep(makeJsStep(), makeCtx());
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(
+        DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(
+        DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+      );
+    });
+
+    test("configured timeouts reach the enqueued job", async () => {
+      const { enqueueSpy, pollSpy } = stubAgentDispatch();
+
+      await runJavaScriptStep(
+        makeJsStep({ timeoutInMs: 180_000, claimTimeoutInMs: 300_000 }),
+        makeCtx(),
+      );
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(180_000);
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(300_000);
+      expect(firstCallArgs(pollSpy)["executionTimeoutInMs"]).toBe(180_000);
+      expect(firstCallArgs(pollSpy)["claimTimeoutInMs"]).toBe(300_000);
+    });
+
+    test("out-of-range timeouts are clamped on both axes", async () => {
+      const { enqueueSpy } = stubAgentDispatch();
+
+      await runJavaScriptStep(
+        makeJsStep({
+          timeoutInMs: Number.MAX_SAFE_INTEGER,
+          claimTimeoutInMs: Number.MAX_SAFE_INTEGER,
+        }),
+        makeCtx(),
+      );
+
+      expect(firstCallArgs(enqueueSpy)["timeoutInMs"]).toBe(
+        MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+      expect(firstCallArgs(enqueueSpy)["claimTimeoutInMs"]).toBe(
+        MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+      );
+    });
   });
 });

--- a/Common/Tests/Types/Runbook/RunbookStepTimeout.test.ts
+++ b/Common/Tests/Types/Runbook/RunbookStepTimeout.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  AGENT_CLAIM_TIMEOUT_BOUNDS,
+  DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+  DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+  MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+  MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+  MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
+  MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
+  STEP_EXECUTION_TIMEOUT_BOUNDS,
+  TimeoutBounds,
+  getTimeoutValidationError,
+  resolveAgentClaimTimeoutInMs,
+  resolveStepExecutionTimeoutInMs,
+  resolveTimeoutInMs,
+  secondsInputValueToTimeoutInMs,
+  timeoutInMsToSecondsInputValue,
+} from "../../../Types/Runbook/RunbookStepTimeout";
+
+describe("Runbook step timeout bounds", () => {
+  test("documented defaults stay put — the docs promise 30s execution and 2m claim", () => {
+    expect(DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS).toBe(30_000);
+    expect(DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS).toBe(120_000);
+  });
+
+  test("each bound set is internally consistent: min <= default <= max", () => {
+    const boundSets: Array<TimeoutBounds> = [
+      STEP_EXECUTION_TIMEOUT_BOUNDS,
+      AGENT_CLAIM_TIMEOUT_BOUNDS,
+    ];
+
+    for (const bounds of boundSets) {
+      expect(bounds.minInMs).toBeLessThanOrEqual(bounds.defaultInMs);
+      expect(bounds.defaultInMs).toBeLessThanOrEqual(bounds.maxInMs);
+      expect(bounds.minInMs).toBeGreaterThan(0);
+    }
+  });
+
+  test("the exported bound objects mirror the individual constants", () => {
+    expect(STEP_EXECUTION_TIMEOUT_BOUNDS).toEqual({
+      defaultInMs: DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      minInMs: MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
+      maxInMs: MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+    });
+    expect(AGENT_CLAIM_TIMEOUT_BOUNDS).toEqual({
+      defaultInMs: DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+      minInMs: MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
+      maxInMs: MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+    });
+  });
+});
+
+describe("resolveTimeoutInMs", () => {
+  const bounds: TimeoutBounds = {
+    defaultInMs: 30_000,
+    minInMs: 1_000,
+    maxInMs: 60_000,
+  };
+
+  test("a value inside the range is used as configured", () => {
+    expect(resolveTimeoutInMs(45_000, bounds)).toBe(45_000);
+  });
+
+  test("the boundaries themselves are accepted, not clamped away", () => {
+    expect(resolveTimeoutInMs(bounds.minInMs, bounds)).toBe(bounds.minInMs);
+    expect(resolveTimeoutInMs(bounds.maxInMs, bounds)).toBe(bounds.maxInMs);
+  });
+
+  test("unset values fall back to the default", () => {
+    expect(resolveTimeoutInMs(undefined, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs(null, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs("", bounds)).toBe(30_000);
+  });
+
+  test("zero and negatives fall back to the default rather than disabling the timeout", () => {
+    expect(resolveTimeoutInMs(0, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs(-1, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs(-999_999, bounds)).toBe(30_000);
+  });
+
+  test("junk values fall back to the default instead of throwing", () => {
+    expect(resolveTimeoutInMs(NaN, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs(Infinity, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs(-Infinity, bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs("not a number", bounds)).toBe(30_000);
+    expect(resolveTimeoutInMs({} as unknown as number, bounds)).toBe(30_000);
+  });
+
+  test("numeric strings are accepted — JSON step configs are not type-checked at rest", () => {
+    expect(resolveTimeoutInMs("5000", bounds)).toBe(5_000);
+    expect(resolveTimeoutInMs(" 5000 ", bounds)).toBe(5_000);
+  });
+
+  test("values below the minimum are raised to the minimum", () => {
+    expect(resolveTimeoutInMs(1, bounds)).toBe(1_000);
+    expect(resolveTimeoutInMs(999, bounds)).toBe(1_000);
+  });
+
+  test("values above the maximum are capped so one step cannot pin a Worker slot open", () => {
+    expect(resolveTimeoutInMs(60_001, bounds)).toBe(60_000);
+    expect(resolveTimeoutInMs(Number.MAX_SAFE_INTEGER, bounds)).toBe(60_000);
+  });
+
+  test("fractional milliseconds are rounded to whole milliseconds", () => {
+    expect(resolveTimeoutInMs(5_000.4, bounds)).toBe(5_000);
+    expect(resolveTimeoutInMs(5_000.6, bounds)).toBe(5_001);
+  });
+
+  test("a fractional value below the minimum still lands on the minimum", () => {
+    expect(resolveTimeoutInMs(0.5, bounds)).toBe(1_000);
+  });
+});
+
+describe("resolveStepExecutionTimeoutInMs", () => {
+  test("defaults to 30 seconds when unset", () => {
+    expect(resolveStepExecutionTimeoutInMs(undefined)).toBe(
+      DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+    );
+  });
+
+  test("honours a configured value", () => {
+    expect(resolveStepExecutionTimeoutInMs(5 * 60_000)).toBe(300_000);
+  });
+
+  test("clamps to the execution bounds", () => {
+    expect(resolveStepExecutionTimeoutInMs(1)).toBe(
+      MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
+    );
+    expect(resolveStepExecutionTimeoutInMs(999 * 60 * 60_000)).toBe(
+      MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+    );
+  });
+});
+
+describe("resolveAgentClaimTimeoutInMs", () => {
+  test("defaults to 2 minutes when unset", () => {
+    expect(resolveAgentClaimTimeoutInMs(undefined)).toBe(
+      DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+    );
+  });
+
+  test("honours a configured value", () => {
+    expect(resolveAgentClaimTimeoutInMs(10 * 60_000)).toBe(600_000);
+  });
+
+  test("clamps to the claim bounds", () => {
+    expect(resolveAgentClaimTimeoutInMs(10)).toBe(
+      MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
+    );
+    expect(resolveAgentClaimTimeoutInMs(Number.MAX_SAFE_INTEGER)).toBe(
+      MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+    );
+  });
+
+  test("execution and claim timeouts are resolved independently", () => {
+    /*
+     * A 45 minute execution timeout is legal; the same number as a claim
+     * timeout is also legal. Resolving one must not leak the other's bounds.
+     */
+    expect(resolveStepExecutionTimeoutInMs(45 * 60_000)).toBe(2_700_000);
+    expect(resolveAgentClaimTimeoutInMs(45 * 60_000)).toBe(2_700_000);
+  });
+});
+
+describe("timeoutInMsToSecondsInputValue", () => {
+  test("milliseconds render as seconds", () => {
+    expect(timeoutInMsToSecondsInputValue(30_000)).toBe("30");
+    expect(timeoutInMsToSecondsInputValue(120_000)).toBe("120");
+  });
+
+  test("unset values render as an empty field, which reads as 'use the default'", () => {
+    expect(timeoutInMsToSecondsInputValue(undefined)).toBe("");
+    expect(timeoutInMsToSecondsInputValue(null)).toBe("");
+  });
+
+  test("zero and negatives render as empty rather than as a literal 0", () => {
+    expect(timeoutInMsToSecondsInputValue(0)).toBe("");
+    expect(timeoutInMsToSecondsInputValue(-5_000)).toBe("");
+  });
+
+  test("non-numeric values render as empty", () => {
+    expect(timeoutInMsToSecondsInputValue(NaN)).toBe("");
+  });
+
+  test("sub-second values keep their decimal instead of collapsing to 0", () => {
+    expect(timeoutInMsToSecondsInputValue(500)).toBe("0.5");
+    expect(timeoutInMsToSecondsInputValue(1_500)).toBe("1.5");
+  });
+});
+
+describe("secondsInputValueToTimeoutInMs", () => {
+  test("seconds are stored as milliseconds", () => {
+    expect(secondsInputValueToTimeoutInMs("30")).toBe(30_000);
+    expect(secondsInputValueToTimeoutInMs("120")).toBe(120_000);
+  });
+
+  test("a blank field means unset, not zero", () => {
+    expect(secondsInputValueToTimeoutInMs("")).toBeUndefined();
+    expect(secondsInputValueToTimeoutInMs("   ")).toBeUndefined();
+  });
+
+  test("zero, negatives and junk mean unset", () => {
+    expect(secondsInputValueToTimeoutInMs("0")).toBeUndefined();
+    expect(secondsInputValueToTimeoutInMs("-5")).toBeUndefined();
+    expect(secondsInputValueToTimeoutInMs("abc")).toBeUndefined();
+  });
+
+  test("decimals are converted to whole milliseconds", () => {
+    expect(secondsInputValueToTimeoutInMs("0.5")).toBe(500);
+    expect(secondsInputValueToTimeoutInMs("1.25")).toBe(1_250);
+    expect(secondsInputValueToTimeoutInMs("0.0004")).toBe(0);
+  });
+
+  test("surrounding whitespace is tolerated", () => {
+    expect(secondsInputValueToTimeoutInMs(" 45 ")).toBe(45_000);
+  });
+
+  test("round-trips with the seconds renderer", () => {
+    const values: Array<number> = [1_000, 30_000, 120_000, 500, 3_600_000];
+
+    for (const ms of values) {
+      expect(
+        secondsInputValueToTimeoutInMs(timeoutInMsToSecondsInputValue(ms)),
+      ).toBe(ms);
+    }
+  });
+});
+
+describe("getTimeoutValidationError", () => {
+  const bounds: TimeoutBounds = {
+    defaultInMs: 30_000,
+    minInMs: 1_000,
+    maxInMs: 3_600_000,
+  };
+
+  test("a blank field is valid — it means 'use the default'", () => {
+    expect(getTimeoutValidationError("", bounds)).toBeNull();
+    expect(getTimeoutValidationError("   ", bounds)).toBeNull();
+  });
+
+  test("in-range values are valid", () => {
+    expect(getTimeoutValidationError("30", bounds)).toBeNull();
+    expect(getTimeoutValidationError("1", bounds)).toBeNull();
+    expect(getTimeoutValidationError("3600", bounds)).toBeNull();
+  });
+
+  test("non-numeric input is rejected", () => {
+    expect(getTimeoutValidationError("abc", bounds)).toContain("number");
+  });
+
+  test("zero and negatives are rejected", () => {
+    expect(getTimeoutValidationError("0", bounds)).toContain("greater than 0");
+    expect(getTimeoutValidationError("-3", bounds)).toContain("greater than 0");
+  });
+
+  test("below-minimum values report the minimum", () => {
+    expect(getTimeoutValidationError("0.5", bounds)).toContain("Minimum is 1");
+  });
+
+  test("above-maximum values report the maximum", () => {
+    expect(getTimeoutValidationError("3601", bounds)).toContain("Maximum is");
+  });
+
+  test("the minimum message is singular for a one-second floor", () => {
+    expect(getTimeoutValidationError("0.5", bounds)).toBe(
+      "Minimum is 1 second.",
+    );
+  });
+
+  test("the minimum message is plural for a multi-second floor", () => {
+    expect(
+      getTimeoutValidationError("1", {
+        defaultInMs: 30_000,
+        minInMs: 5_000,
+        maxInMs: 60_000,
+      }),
+    ).toBe("Minimum is 5 seconds.");
+  });
+
+  test("anything the validator accepts survives resolution unchanged", () => {
+    /*
+     * The editor's guard rails and the Worker's clamp have to agree: an input
+     * the UI calls valid must not be silently rewritten at run time.
+     */
+    const acceptedInputs: Array<string> = ["1", "30", "120", "600", "3600"];
+
+    for (const input of acceptedInputs) {
+      expect(getTimeoutValidationError(input, bounds)).toBeNull();
+      const inMs: number | undefined = secondsInputValueToTimeoutInMs(input);
+      expect(resolveTimeoutInMs(inMs, bounds)).toBe(inMs);
+    }
+  });
+
+  test("anything the validator rejects is still made safe by resolution", () => {
+    const rejectedInputs: Array<string> = ["0", "-10", "abc", "0.5", "999999"];
+
+    for (const input of rejectedInputs) {
+      expect(getTimeoutValidationError(input, bounds)).not.toBeNull();
+      const resolved: number = resolveTimeoutInMs(
+        secondsInputValueToTimeoutInMs(input),
+        bounds,
+      );
+      expect(resolved).toBeGreaterThanOrEqual(bounds.minInMs);
+      expect(resolved).toBeLessThanOrEqual(bounds.maxInMs);
+    }
+  });
+});

--- a/Common/Tests/UI/Components/Runbook/StepTimeoutInput.test.tsx
+++ b/Common/Tests/UI/Components/Runbook/StepTimeoutInput.test.tsx
@@ -1,0 +1,269 @@
+import StepTimeoutInput from "../../../../UI/Components/Runbook/StepTimeoutInput";
+import {
+  AGENT_CLAIM_TIMEOUT_BOUNDS,
+  STEP_EXECUTION_TIMEOUT_BOUNDS,
+  TimeoutBounds,
+} from "../../../../Types/Runbook/RunbookStepTimeout";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+const BOUNDS: TimeoutBounds = STEP_EXECUTION_TIMEOUT_BOUNDS;
+
+interface RenderArgs {
+  value?: number | undefined;
+  bounds?: TimeoutBounds | undefined;
+}
+
+interface RenderedInput {
+  input: HTMLInputElement;
+  onChange: MockFunction;
+  rerenderWithValue: (value: number | undefined) => void;
+}
+
+function renderInput(args: RenderArgs = {}): RenderedInput {
+  const onChange: MockFunction = getJestMockFunction();
+  const bounds: TimeoutBounds = args.bounds || BOUNDS;
+
+  type OnChangeFunction = (value: number | undefined) => void;
+
+  const { rerender } = render(
+    <StepTimeoutInput
+      label="Execution timeout"
+      value={args.value}
+      bounds={bounds}
+      onChange={onChange as unknown as OnChangeFunction}
+      dataTestId="timeout-input"
+    />,
+  );
+
+  return {
+    input: screen.getByTestId("timeout-input") as HTMLInputElement,
+    onChange,
+    rerenderWithValue: (value: number | undefined): void => {
+      rerender(
+        <StepTimeoutInput
+          label="Execution timeout"
+          value={value}
+          bounds={bounds}
+          onChange={onChange as unknown as OnChangeFunction}
+          dataTestId="timeout-input"
+        />,
+      );
+    },
+  };
+}
+
+describe("StepTimeoutInput", () => {
+  test("renders a labelled field so the timeout is discoverable in the step editor", () => {
+    renderInput();
+
+    expect(screen.getByLabelText(/Execution timeout/i)).not.toBeNull();
+  });
+
+  test("an unset timeout shows an empty field placeholdered with the default", () => {
+    const { input } = renderInput({ value: undefined });
+
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe("30");
+  });
+
+  test("a stored timeout is displayed in seconds, not milliseconds", () => {
+    const { input } = renderInput({ value: 45_000 });
+
+    expect(input.value).toBe("45");
+  });
+
+  test("a stored claim timeout of 2 minutes displays as 120 seconds", () => {
+    const { input } = renderInput({
+      value: 120_000,
+      bounds: AGENT_CLAIM_TIMEOUT_BOUNDS,
+    });
+
+    expect(input.value).toBe("120");
+  });
+
+  test("typing seconds reports milliseconds back to the step config", () => {
+    const { input, onChange } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "90" } });
+
+    expect(onChange).toHaveBeenCalledWith(90_000);
+  });
+
+  test("clearing the field reports undefined, so the step falls back to the default", () => {
+    const { input, onChange } = renderInput({ value: 45_000 });
+
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  test("decimal seconds are stored as whole milliseconds", () => {
+    const { input, onChange } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "1.5" } });
+
+    expect(onChange).toHaveBeenCalledWith(1_500);
+  });
+
+  test("a partially typed 0 is not erased mid-edit", () => {
+    /*
+     * "0" resolves to "unset", so a field whose text was derived from props on
+     * every render would blank itself the moment the author typed the first
+     * character of "0.5". The typed text has to survive that round trip.
+     */
+    const { input, rerenderWithValue } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "0" } });
+    rerenderWithValue(undefined);
+
+    expect(input.value).toBe("0");
+  });
+
+  test("the field re-syncs when a different step's value is supplied", () => {
+    const { input, rerenderWithValue } = renderInput({ value: 45_000 });
+
+    expect(input.value).toBe("45");
+    rerenderWithValue(300_000);
+
+    expect(input.value).toBe("300");
+  });
+
+  test("the field clears when the supplied value is reset to unset", () => {
+    const { input, rerenderWithValue } = renderInput({ value: 45_000 });
+
+    rerenderWithValue(undefined);
+
+    expect(input.value).toBe("");
+  });
+
+  test("the helper text states the default and the allowed range", () => {
+    renderInput();
+
+    const help: HTMLElement = screen.getByText(
+      /Leave blank to use the default/i,
+    );
+    expect(help.textContent).toContain("30 seconds");
+    expect(help.textContent).toContain("1–3600");
+  });
+
+  test("an optional description is rendered alongside the range help", () => {
+    render(
+      <StepTimeoutInput
+        label="Execution timeout"
+        value={undefined}
+        bounds={BOUNDS}
+        onChange={() => {}}
+        description="How long the agent lets the script run."
+      />,
+    );
+
+    expect(
+      screen.getByText(/How long the agent lets the script run/i),
+    ).not.toBeNull();
+  });
+
+  test("an in-range value raises no validation error", () => {
+    const { input } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "600" } });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(input.getAttribute("aria-invalid")).toBeNull();
+  });
+
+  test("a below-minimum value is flagged, and the author is told it will be clamped", () => {
+    const { input } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "0.5" } });
+
+    const alert: HTMLElement = screen.getByRole("alert");
+    expect(alert.textContent).toContain("Minimum is 1 second.");
+    expect(alert.textContent).toContain("clamped");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  test("an above-maximum value is flagged with the maximum", () => {
+    const { input } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "99999" } });
+
+    expect(screen.getByRole("alert").textContent).toContain("Maximum is 3600");
+  });
+
+  test("a zero is flagged rather than silently meaning 'no timeout'", () => {
+    const { input } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "0" } });
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Timeout must be greater than 0 seconds.",
+    );
+  });
+
+  test("out-of-range input still reports a value, so the author's intent is saved and clamped later", () => {
+    const { input, onChange } = renderInput({ value: undefined });
+
+    fireEvent.change(input, { target: { value: "99999" } });
+
+    expect(onChange).toHaveBeenCalledWith(99_999_000);
+  });
+
+  test("the native min/max mirror the bounds so browser spinners agree with validation", () => {
+    const { input } = renderInput({ bounds: AGENT_CLAIM_TIMEOUT_BOUNDS });
+
+    expect(input.getAttribute("min")).toBe("1");
+    expect(input.getAttribute("max")).toBe("3600");
+    expect(input.getAttribute("type")).toBe("number");
+  });
+
+  test("a disabled field cannot be edited", () => {
+    render(
+      <StepTimeoutInput
+        label="Execution timeout"
+        value={30_000}
+        bounds={BOUNDS}
+        onChange={() => {}}
+        dataTestId="disabled-timeout-input"
+        disabled={true}
+      />,
+    );
+
+    expect(
+      (screen.getByTestId("disabled-timeout-input") as HTMLInputElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  test("two fields on the same step get distinct ids so both labels stay clickable", () => {
+    render(
+      <>
+        <StepTimeoutInput
+          label="Execution timeout"
+          value={30_000}
+          bounds={STEP_EXECUTION_TIMEOUT_BOUNDS}
+          onChange={() => {}}
+        />
+        <StepTimeoutInput
+          label="Claim timeout"
+          value={120_000}
+          bounds={AGENT_CLAIM_TIMEOUT_BOUNDS}
+          onChange={() => {}}
+        />
+      </>,
+    );
+
+    const execution: HTMLInputElement = screen.getByLabelText(
+      /Execution timeout/i,
+    ) as HTMLInputElement;
+    const claim: HTMLInputElement = screen.getByLabelText(
+      /Claim timeout/i,
+    ) as HTMLInputElement;
+
+    expect(execution.id).not.toBe(claim.id);
+    expect(execution.value).toBe("30");
+    expect(claim.value).toBe("120");
+  });
+});

--- a/Common/Types/Runbook/RunbookStepTimeout.ts
+++ b/Common/Types/Runbook/RunbookStepTimeout.ts
@@ -1,0 +1,160 @@
+/*
+ * Timeouts are configured per step and stored on the step config in
+ * milliseconds. Both the dashboard (which edits them) and the Worker (which
+ * enforces them) resolve values through this module so a step never runs with
+ * a bound the author could not see, and never with one that would pin a
+ * Worker slot open indefinitely.
+ */
+
+// How long the step itself may run before it is killed.
+export const DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS: number = 30 * 1000;
+export const MIN_STEP_EXECUTION_TIMEOUT_IN_MS: number = 1000;
+export const MAX_STEP_EXECUTION_TIMEOUT_IN_MS: number = 60 * 60 * 1000;
+
+/*
+ * How long the Worker waits for the selected agent to claim the job. Only
+ * meaningful for Bash and JavaScript steps, which never run on the Worker.
+ */
+export const DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS: number = 2 * 60 * 1000;
+export const MIN_AGENT_CLAIM_TIMEOUT_IN_MS: number = 1000;
+export const MAX_AGENT_CLAIM_TIMEOUT_IN_MS: number = 60 * 60 * 1000;
+
+export interface TimeoutBounds {
+  defaultInMs: number;
+  minInMs: number;
+  maxInMs: number;
+}
+
+export const STEP_EXECUTION_TIMEOUT_BOUNDS: TimeoutBounds = {
+  defaultInMs: DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+  minInMs: MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
+  maxInMs: MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+};
+
+export const AGENT_CLAIM_TIMEOUT_BOUNDS: TimeoutBounds = {
+  defaultInMs: DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+  minInMs: MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
+  maxInMs: MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+};
+
+/*
+ * Resolve a configured timeout to the value execution should actually use.
+ *
+ * Anything unusable — unset, blank, non-numeric, zero or negative — falls back
+ * to the default rather than failing the step, because a runbook that runs
+ * with the documented default is more useful during an incident than one that
+ * refuses to run at all. Usable values are rounded to whole milliseconds and
+ * clamped into range.
+ */
+export function resolveTimeoutInMs(
+  value: number | string | null | undefined,
+  bounds: TimeoutBounds,
+): number {
+  if (value === null || value === undefined || value === "") {
+    return bounds.defaultInMs;
+  }
+
+  const parsed: number = typeof value === "number" ? value : Number(value);
+
+  if (!isFinite(parsed) || parsed <= 0) {
+    return bounds.defaultInMs;
+  }
+
+  return Math.min(Math.max(Math.round(parsed), bounds.minInMs), bounds.maxInMs);
+}
+
+export function resolveStepExecutionTimeoutInMs(
+  value: number | string | null | undefined,
+): number {
+  return resolveTimeoutInMs(value, STEP_EXECUTION_TIMEOUT_BOUNDS);
+}
+
+export function resolveAgentClaimTimeoutInMs(
+  value: number | string | null | undefined,
+): number {
+  return resolveTimeoutInMs(value, AGENT_CLAIM_TIMEOUT_BOUNDS);
+}
+
+/*
+ * Milliseconds are the storage unit; seconds are what people think in. The
+ * two helpers below bridge the step editor's seconds input and the stored
+ * value. An empty input means "unset" — the step then uses the default — so
+ * it round-trips to undefined rather than to zero.
+ */
+export function timeoutInMsToSecondsInputValue(
+  value: number | null | undefined,
+): string {
+  if (value === null || value === undefined || !isFinite(Number(value))) {
+    return "";
+  }
+
+  const seconds: number = Number(value) / 1000;
+
+  if (seconds <= 0) {
+    return "";
+  }
+
+  // Sub-second values would render as "0" and read as "no timeout"; keep the decimal.
+  return String(Math.round(seconds * 1000) / 1000);
+}
+
+export function secondsInputValueToTimeoutInMs(
+  value: string,
+): number | undefined {
+  const trimmed: string = (value || "").trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const seconds: number = Number(trimmed);
+
+  if (!isFinite(seconds) || seconds <= 0) {
+    return undefined;
+  }
+
+  return Math.round(seconds * 1000);
+}
+
+/*
+ * Validation message for the step editor. Returns null when the input is
+ * acceptable — including when it is blank, which simply means "use the
+ * default". Out-of-range values are still saved and then clamped at run time;
+ * the message is what tells the author that will happen.
+ */
+export function getTimeoutValidationError(
+  value: string,
+  bounds: TimeoutBounds,
+): string | null {
+  const trimmed: string = (value || "").trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const seconds: number = Number(trimmed);
+
+  if (!isFinite(seconds)) {
+    return "Enter a number of seconds.";
+  }
+
+  if (seconds <= 0) {
+    return "Timeout must be greater than 0 seconds.";
+  }
+
+  const inMs: number = Math.round(seconds * 1000);
+
+  if (inMs < bounds.minInMs) {
+    return `Minimum is ${bounds.minInMs / 1000} second${
+      bounds.minInMs === 1000 ? "" : "s"
+    }.`;
+  }
+
+  if (inMs > bounds.maxInMs) {
+    return `Maximum is ${bounds.maxInMs / 1000} seconds (${
+      bounds.maxInMs / 60000
+    } minutes).`;
+  }
+
+  return null;
+}

--- a/Common/UI/Components/Runbook/StepTimeoutInput.tsx
+++ b/Common/UI/Components/Runbook/StepTimeoutInput.tsx
@@ -1,0 +1,130 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useId,
+  useState,
+} from "react";
+import {
+  TimeoutBounds,
+  getTimeoutValidationError,
+  secondsInputValueToTimeoutInMs,
+  timeoutInMsToSecondsInputValue,
+} from "../../../Types/Runbook/RunbookStepTimeout";
+
+export interface ComponentProps {
+  label: string;
+  // Stored value, in milliseconds. Undefined means "use the default".
+  value: number | undefined;
+  bounds: TimeoutBounds;
+  onChange: (timeoutInMs: number | undefined) => void;
+  description?: ReactNode | undefined;
+  dataTestId?: string | undefined;
+  disabled?: boolean | undefined;
+}
+
+/*
+ * Seconds-in, milliseconds-out editor for a per-step timeout.
+ *
+ * The typed text is held locally rather than derived from the stored value on
+ * every keystroke: deriving it would fight the author mid-edit, because a
+ * partially typed "0" or an emptied field both resolve to "unset" and would
+ * erase what they were typing. The stored value only moves when the text
+ * parses to something usable.
+ */
+const StepTimeoutInput: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const uniqueId: string = useId();
+  const inputId: string = `step-timeout-${uniqueId}`;
+  const describedById: string = `step-timeout-help-${uniqueId}`;
+
+  const [text, setText] = useState<string>(
+    timeoutInMsToSecondsInputValue(props.value),
+  );
+
+  /*
+   * Re-sync when the step being edited changes underneath us (collapse /
+   * reorder / reload). Skipped while the text still represents the stored
+   * value so the author's in-progress typing survives re-renders.
+   */
+  useEffect(() => {
+    const storedAsText: string = timeoutInMsToSecondsInputValue(props.value);
+    setText((currentText: string) => {
+      return secondsInputValueToTimeoutInMs(currentText) === props.value
+        ? currentText
+        : storedAsText;
+    });
+  }, [props.value]);
+
+  const validationError: string | null = getTimeoutValidationError(
+    text,
+    props.bounds,
+  );
+
+  const defaultInSeconds: number = props.bounds.defaultInMs / 1000;
+
+  const handleChange: (value: string) => void = (value: string): void => {
+    setText(value);
+    props.onChange(secondsInputValueToTimeoutInMs(value));
+  };
+
+  let inputClassName: string =
+    "block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm";
+
+  if (validationError) {
+    inputClassName +=
+      " border-red-300 text-red-900 placeholder-red-300 focus:border-red-500 focus:ring-red-500";
+  }
+
+  if (props.disabled) {
+    inputClassName += " bg-gray-100 text-gray-500 cursor-not-allowed";
+  }
+
+  return (
+    <div>
+      <label
+        htmlFor={inputId}
+        className="block text-xs font-medium text-gray-700 mb-1.5"
+      >
+        {props.label}
+        <span className="ml-2 text-[10px] font-normal text-gray-400">
+          seconds
+        </span>
+      </label>
+      <input
+        id={inputId}
+        type="number"
+        inputMode="decimal"
+        min={props.bounds.minInMs / 1000}
+        max={props.bounds.maxInMs / 1000}
+        step="1"
+        disabled={props.disabled}
+        className={inputClassName}
+        value={text}
+        placeholder={`${defaultInSeconds}`}
+        aria-describedby={describedById}
+        aria-invalid={validationError ? true : undefined}
+        data-testid={props.dataTestId}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          handleChange(e.target.value);
+        }}
+      />
+      <p id={describedById} className="text-xs text-gray-500 mt-1.5">
+        {props.description ? <>{props.description} </> : null}
+        Leave blank to use the default of {defaultInSeconds} seconds. Allowed
+        range: {props.bounds.minInMs / 1000}–{props.bounds.maxInMs / 1000}{" "}
+        seconds.
+      </p>
+      {validationError ? (
+        <p role="alert" className="text-xs text-red-600 mt-1">
+          {validationError} Values outside the range are clamped when the step
+          runs.
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+export default StepTimeoutInput;


### PR DESCRIPTION
Fixes #2920

## The bug

The docs say the execution timeout is configurable per step, and `RunbookStep`'s config types have carried `timeoutInMs` / `claimTimeoutInMs` since the agent work landed — but the Steps editor never rendered a field for either. The only way to set one was to write the runbook's `steps` JSON through the API, so in practice every Bash and JavaScript step ran with the 30 second default. That's too short for a restore, a log sweep, or anything else that legitimately takes minutes.

## The fix

**UI** — `Steps.tsx` now renders the timeouts it was already capable of saving:

- Bash and JavaScript steps: **Execution timeout** and **Claim timeout**
- HTTP steps: **Request timeout**

Entered in seconds, stored in milliseconds. A blank field means "use the default", so existing steps are untouched and nothing is written until an author actually sets a value. Out-of-range input is flagged inline against the same bounds the Worker enforces.

**Server** — timeout resolution moved out of `config.timeoutInMs || DEFAULT` at each call site and into `Common/Types/Runbook/RunbookStepTimeout.ts`, shared by the editor and the executor so they cannot drift:

- Unusable values — unset, zero, negative, non-numeric, or a string left behind by an older API write — fall back to the documented default rather than failing the step. During an incident a runbook that runs with the default beats one that refuses to run.
- Usable values are clamped to **1 second – 1 hour**. A mistyped config can neither disable the timeout nor pin one of the 25 Runbook queue slots open indefinitely.

Defaults are unchanged: 30s execution, 2m claim.

## Tests

**77 new tests**, all passing.

- `Common/Tests/Types/Runbook/RunbookStepTimeout.test.ts` (41) — resolution and clamping across the boundaries, zero/negative/NaN/Infinity/string/object inputs, rounding, seconds↔milliseconds round-tripping, and two cross-checks that the editor's validator and the Worker's clamp agree: anything the UI accepts survives resolution unchanged, anything it rejects still resolves into range.
- `Common/Tests/UI/Components/Runbook/StepTimeoutInput.test.tsx` (20) — DOM tests: seconds render from stored milliseconds, edits report milliseconds back, clearing reports `undefined`, a partially typed `0` isn't erased mid-edit, re-sync when a different step's value arrives, validation messaging, and distinct ids so both labels on a step stay clickable.
- `App/Tests/Runbook/StepExecutors.test.ts` (16 added) — configured timeouts reach both the enqueued job **and** the poll window for Bash and JavaScript (if those diverged, a long step would be abandoned by the Worker while the agent was still running it); HTTP timeouts reach the client; defaults, clamping, and fallbacks on every path.

`App/Tests/Runbook/AIStepExecutor.test.ts` fails to compile in my environment, but it fails identically on a clean `master` checkout — a local TypeScript 5.9 / `@types/node` mismatch in `Common/Server/Utils/CodeRepository/GitHub/GitHub.ts`, unrelated to this change.

## Verification

`Common` and `App/FeatureSet/Dashboard` both pass `tsc --noEmit`; lint is clean on every changed file. I did not bring up the docker-compose stack to click through the page — the change is covered by the DOM tests above rather than by a live run.

## Docs

Updated the English runbook docs (`agents.md`, `authoring.md`, `configuration.md`) to say where the fields are and what range they accept. The 15 translated copies still carry the old wording and would need a follow-up pass.