### PR TITLE
feat(probe): say WHERE a request to the server timed out, not just that it did

### DIFF
--- a/App/FeatureSet/Docs/Content/en/probe/custom-probe.md
+++ b/App/FeatureSet/Docs/Content/en/probe/custom-probe.md
@@ -208,6 +208,8 @@ The probe supports the following environment variables:
 - `PROBE_MONITOR_RETRY_LIMIT` - Number of retries for failed monitors (default: 3)
 - `PROBE_SYNTHETIC_MONITOR_SCRIPT_TIMEOUT_IN_MS` - Timeout for synthetic monitor scripts in milliseconds (default: 60000)
 - `PROBE_CUSTOM_CODE_MONITOR_SCRIPT_TIMEOUT_IN_MS` - Timeout for custom code monitor scripts in milliseconds (default: 60000)
+- `PROBE_API_REQUEST_TIMEOUT_IN_MS` - Deadline for each request the probe sends to OneUptime (default: 45000)
+- `PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS` - Log a warning for requests to OneUptime slower than this (default: 10000)
 
 #### Proxy Configuration
 
@@ -237,3 +239,28 @@ http://[username:password@]proxy.server.com:port
 ### Verify
 
 If the probe is running successfully. It should show as `Connected` on your OneUptime dashboard. If it does not show as connected. You need to check logs of the container. If you're still having trouble. Please create an issue on [GitHub](https://github.com/oneuptime/oneuptime) or [contact support](https://oneuptime.com/support)
+
+### Diagnosing a Disconnected Probe
+
+A probe is flagged `Disconnected` when its requests to OneUptime stop succeeding. The probe's log says where each failed request got stuck, so you rarely have to guess.
+
+**1. Read the environment block printed at startup.** Every probe prints one JSON block at boot with the OneUptime URL it is using, its request deadline, its proxy settings, the DNS resolvers it inherited, the Node/OS version, and whether TLS verification has been disabled. Include this block whenever you report a problem.
+
+**2. Find the failure report.** Every failed request to OneUptime logs a block containing `stalledAt` and `whatThisMeans`. `stalledAt` is the phase the request never got past:
+
+| `stalledAt` | What it means |
+| --- | --- |
+| `SocketAssignment` | Nothing left the machine. The socket pool was saturated, or a configured proxy never completed its CONNECT tunnel. |
+| `TcpConnect` | The machine sent SYN and got nothing back — a firewall or security appliance is dropping packets, or the host is unreachable. |
+| `TlsHandshake` | TCP connected, TLS never finished. Usually a TLS-inspecting middlebox. |
+| `RequestSend` | Connected, but the request was never fully written — the far end stopped reading. |
+| `WaitingForServerResponse` | The request was delivered and the server sent nothing back. **The probe's network is fine** — check the OneUptime server, its load balancer and its reverse proxy. |
+| `ResponseBody` | The server started answering and stalled part-way through. |
+
+The same block also reports `deadlineOverrunInMs`. If a 45000ms deadline took much longer than 45000ms of wall clock, the probe process itself was blocked — check `probeProcess.eventLoopMaxDriftInMs` in the block before investigating the network.
+
+**3. Read the connectivity self-test.** After three consecutive failures the probe tests the same server one layer at a time — DNS, then TCP, then TLS, then a real HTTP round trip — and logs each stage with its timing. The first stage that fails is your answer. When a proxy is configured, the probe tests the hop to the proxy, because that is the only hop it actually makes.
+
+**4. Watch for slow requests before they become failures.** Requests that succeed but take longer than `PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS` are logged with their elapsed time. A probe that starts logging 20-second requests is on its way to crossing the 45-second deadline.
+
+On the OneUptime server side, a probe request that is answered slowly — or that the probe gave up on before a response was sent — is logged there too, with the probe's id. Those two logs together tell you which side of the connection is at fault.

--- a/App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts
+++ b/App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts
@@ -9,8 +9,76 @@ import logger, {
 } from "Common/Server/Utils/Logger";
 import Response from "Common/Server/Utils/Response";
 import Probe from "Common/Models/DatabaseModels/Probe";
+import NumberUtil from "Common/Utils/Number";
+
+/*
+ * Probe-side logs can prove a request left the probe and got no answer, but
+ * only this side can say whether the server ever started working on it. Any
+ * probe request slower than this is logged with the probe's id, so a
+ * "probe is Disconnected" report can be checked against the server's own
+ * view instead of guessing.
+ */
+const SLOW_PROBE_REQUEST_THRESHOLD_IN_MS: number =
+  NumberUtil.parseNumberWithDefault({
+    value: process.env["PROBE_INGEST_SLOW_REQUEST_THRESHOLD_IN_MS"],
+    defaultValue: 10000,
+    min: 100,
+  });
 
 export default class ProbeAuthorization {
+  /*
+   * Times the request from this middleware to the response, and reports the
+   * two outcomes that matter for a Disconnected probe: a slow answer, and no
+   * answer at all because the probe hit its own deadline and hung up first.
+   * The latter is the definitive proof that a probe timeout is server-side.
+   */
+  private static observeRequestDuration(
+    req: ProbeExpressRequest,
+    res: ExpressResponse,
+    probeIdForLogging: string,
+  ): void {
+    const responseEmitter: {
+      on?: (event: string, listener: () => void) => void;
+    } = res as unknown as {
+      on?: (event: string, listener: () => void) => void;
+    };
+
+    // Unit tests hand in a bare object; there is nothing to listen to there.
+    if (typeof responseEmitter.on !== "function") {
+      return;
+    }
+
+    const startedAtInMs: number = Date.now();
+    const route: string = req.url || "unknown route";
+    let hasSettled: boolean = false;
+
+    responseEmitter.on("finish", (): void => {
+      hasSettled = true;
+
+      const durationInMs: number = Date.now() - startedAtInMs;
+
+      if (durationInMs < SLOW_PROBE_REQUEST_THRESHOLD_IN_MS) {
+        return;
+      }
+
+      logger.warn(
+        `Slow probe request: ${route} for probe ${probeIdForLogging} took ${durationInMs}ms to answer. Probes give up on their own deadline (45s by default) and are flagged Disconnected shortly after.`,
+      );
+    });
+
+    responseEmitter.on("close", (): void => {
+      if (hasSettled) {
+        return;
+      }
+
+      logger.warn(
+        `Probe ${probeIdForLogging} gave up on ${route} after ${
+          Date.now() - startedAtInMs
+        }ms — this server never sent a response. The probe's timeout is server-side, not a network fault on the probe's end.`,
+      );
+    });
+  }
+
   public static async isAuthorizedServiceMiddleware(
     req: ProbeExpressRequest,
     res: ExpressResponse,
@@ -41,6 +109,8 @@ export default class ProbeAuthorization {
       const probeId: ObjectID = new ObjectID(data["probeId"] as string);
 
       const probeKey: string = data["probeKey"] as string;
+
+      ProbeAuthorization.observeRequestDuration(req, res, probeId.toString());
 
       /*
        * Cache-backed verification: repeat requests from a probe skip the

--- a/App/Tests/Telemetry/ProbeAuthorizationMiddleware.test.ts
+++ b/App/Tests/Telemetry/ProbeAuthorizationMiddleware.test.ts
@@ -87,8 +87,9 @@ const responseUtil: { sendErrorResponse: jest.Mock } = Response as unknown as {
   sendErrorResponse: jest.Mock;
 };
 
-const loggerMock: { error: jest.Mock } = logger as unknown as {
+const loggerMock: { error: jest.Mock; warn: jest.Mock } = logger as unknown as {
   error: jest.Mock;
+  warn: jest.Mock;
 };
 
 const mockResponse: ExpressResponse = {} as ExpressResponse;
@@ -328,5 +329,93 @@ describe("ProbeAuthorization.isAuthorizedServiceMiddleware", () => {
     expect(next).toHaveBeenCalledWith(boom);
     expect(responseUtil.sendErrorResponse).not.toHaveBeenCalled();
     expect(probeService.updateLastAlive).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * The other half of diagnosing a Disconnected probe. The probe's own log can
+ * prove a request left the machine and got no answer; only the server can
+ * say whether it ever produced one. Without these two lines, "the probe timed
+ * out" is an unfalsifiable claim about whose fault it is.
+ */
+describe("server-side timing of probe requests", () => {
+  const probeId: ObjectID = ObjectID.generate();
+  const probeKey: string = "test-probe-key";
+
+  type ResponseListeners = Record<string, Array<() => void>>;
+
+  function callMiddlewareWithEmitterResponse(): {
+    listeners: ResponseListeners;
+    middlewarePromise: Promise<void>;
+  } {
+    const listeners: ResponseListeners = {};
+
+    const res: ExpressResponse = {
+      on: (event: string, listener: () => void): void => {
+        listeners[event] = [...(listeners[event] || []), listener];
+      },
+    } as unknown as ExpressResponse;
+
+    const req: ProbeExpressRequest = {
+      body: { probeId: probeId.toString(), probeKey: probeKey },
+      url: "/alive",
+    } as unknown as ProbeExpressRequest;
+
+    return {
+      listeners: listeners,
+      middlewarePromise: ProbeAuthorization.isAuthorizedServiceMiddleware(
+        req,
+        res,
+        jest.fn() as unknown as NextFunction,
+      ),
+    };
+  }
+
+  function fire(listeners: ResponseListeners, event: string): void {
+    for (const listener of listeners[event] || []) {
+      listener();
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    probeService.verifyProbeKey.mockResolvedValue(true as never);
+    probeService.updateLastAlive.mockResolvedValue(undefined as never);
+  });
+
+  test("a request answered promptly is not logged", async () => {
+    const { listeners, middlewarePromise } =
+      callMiddlewareWithEmitterResponse();
+    await middlewarePromise;
+
+    fire(listeners, "finish");
+    // 'close' always follows 'finish' on a normal response.
+    fire(listeners, "close");
+
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  test("a probe that hangs up before the response is sent is called out by id", async () => {
+    const { listeners, middlewarePromise } =
+      callMiddlewareWithEmitterResponse();
+    await middlewarePromise;
+
+    // 'close' with no preceding 'finish': the probe hit its own deadline.
+    fire(listeners, "close");
+
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+    const message: string = String(loggerMock.warn.mock.calls[0]![0]);
+    expect(message).toContain(probeId.toString());
+    expect(message).toContain("/alive");
+  });
+
+  test("a bare response object — as unit tests supply — is not listened to", async () => {
+    const { middlewarePromise } = callMiddleware({
+      probeId: probeId.toString(),
+      probeKey: probeKey,
+    });
+
+    // mockResponse has no .on; attaching listeners to it would throw.
+    await expect(middlewarePromise).resolves.toBeUndefined();
   });
 });

--- a/Common/Utils/API.ts
+++ b/Common/Utils/API.ts
@@ -24,6 +24,30 @@ import Sleep from "../Types/Sleep";
 import type { Agent as HttpAgent } from "http";
 import type { Agent as HttpsAgent } from "https";
 
+/*
+ * Diagnostic summary of one settled fetch() call, retries included. Handed
+ * to RequestOptions.onRequestComplete so a caller can log WHERE a request
+ * went wrong without having to wrap every one of its call sites.
+ */
+export interface RequestOutcome {
+  method: HTTPMethod;
+  url: string;
+  elapsedInMs: number;
+  attempts: number;
+  timeoutInMs?: number | undefined;
+  // Set whenever the server answered at all — including 4xx/5xx.
+  statusCode?: number | undefined;
+  // Set when the request failed without a usable response.
+  error?: Error | undefined;
+  /*
+   * The raw axios error, when there was one. It carries the ClientRequest
+   * and its socket, which is what tells "we never got a socket" apart from
+   * "we connected and the server never replied" — the difference between a
+   * client-side and a server-side timeout.
+   */
+  axiosError?: AxiosError | undefined;
+}
+
 export interface RequestOptions {
   retries?: number | undefined;
   exponentialBackoff?: boolean | undefined;
@@ -35,6 +59,12 @@ export interface RequestOptions {
   skipAuthRefresh?: boolean | undefined;
   hasAttemptedAuthRefresh?: boolean | undefined;
   onUploadProgress?: ((event: AxiosProgressEvent) => void) | undefined;
+  /*
+   * Purely diagnostic observer, called once after the request settles. It
+   * cannot change the result and anything it throws is swallowed, so a
+   * broken logger can never break a request.
+   */
+  onRequestComplete?: ((outcome: RequestOutcome) => void) | undefined;
 }
 
 export interface APIRequestOptions {
@@ -366,6 +396,9 @@ export default class API {
       url.addQueryParams(params);
     }
 
+    const requestStartedAtInMs: number = Date.now();
+    let attempts: number = 0;
+
     try {
       const finalHeaders: Dictionary<string> = {
         ...apiHeaders,
@@ -392,6 +425,7 @@ export default class API {
 
       while (currentRetry <= maxRetries) {
         currentRetry++;
+        attempts++;
         try {
           const axiosOptions: AxiosRequestConfig = {
             method: method,
@@ -451,15 +485,63 @@ export default class API {
         result.headers as Dictionary<string>,
       );
 
+      this.notifyRequestComplete(options, {
+        method: method,
+        url: url.toString(),
+        elapsedInMs: Date.now() - requestStartedAtInMs,
+        attempts: attempts,
+        ...(options?.timeout === undefined
+          ? {}
+          : { timeoutInMs: options.timeout }),
+        statusCode: result.status,
+      });
+
       return response;
     } catch (e) {
       const error: Error | AxiosError = e as Error | AxiosError;
 
+      const elapsedInMs: number = Date.now() - requestStartedAtInMs;
+
+      const baseOutcome: RequestOutcome = {
+        method: method,
+        url: url.toString(),
+        elapsedInMs: elapsedInMs,
+        attempts: attempts,
+        ...(options?.timeout === undefined
+          ? {}
+          : { timeoutInMs: options.timeout }),
+      };
+
       if (!axios.isAxiosError(error)) {
-        throw new APIException(error.message);
+        const apiException: APIException = new APIException(error.message);
+
+        this.notifyRequestComplete(options, {
+          ...baseOutcome,
+          error: apiException,
+        });
+
+        throw apiException;
       }
 
-      const errorResponse: HTTPErrorResponse = this.getErrorResponse(error);
+      let errorResponse: HTTPErrorResponse;
+
+      /*
+       * getErrorResponse THROWS for a request that never produced a
+       * response (timeout, DNS failure, connection refused) — which is
+       * precisely the case worth reporting, so it has to be observed here
+       * rather than on the return path below.
+       */
+      try {
+        errorResponse = this.getErrorResponse(error);
+      } catch (thrownError) {
+        this.notifyRequestComplete(options, {
+          ...baseOutcome,
+          error: thrownError as Error,
+          axiosError: error,
+        });
+
+        throw thrownError;
+      }
 
       if (
         error.response?.status === 401 &&
@@ -512,7 +594,29 @@ export default class API {
       }
 
       this.handleError(errorResponse);
+
+      this.notifyRequestComplete(options, {
+        ...baseOutcome,
+        statusCode: errorResponse.statusCode,
+        axiosError: error,
+      });
+
       return errorResponse;
+    }
+  }
+
+  private static notifyRequestComplete(
+    options: RequestOptions | undefined,
+    outcome: RequestOutcome,
+  ): void {
+    if (!options?.onRequestComplete) {
+      return;
+    }
+
+    try {
+      options.onRequestComplete(outcome);
+    } catch {
+      // Diagnostics must never change the fate of the request they describe.
     }
   }
 

--- a/Probe/API/IncomingRequestIngress.ts
+++ b/Probe/API/IncomingRequestIngress.ts
@@ -3,8 +3,8 @@ import {
   PROBE_INGRESS_FORWARD_RETRY_LIMIT,
   PROBE_INGRESS_FORWARD_TIMEOUT_MS,
 } from "../Config";
+import ProbeAPIRequest from "../Utils/ProbeAPIRequest";
 import ProbeUtil from "../Utils/Probe";
-import ProxyConfig from "../Utils/ProxyConfig";
 import Express, {
   ExpressRequest,
   ExpressResponse,
@@ -89,10 +89,9 @@ async function forwardWithRetry(
           url: forwardUrl,
           data,
           headers,
-          options: {
+          options: ProbeAPIRequest.getDefaultRequestOptions(forwardUrl, {
             timeout: PROBE_INGRESS_FORWARD_TIMEOUT_MS,
-            ...ProxyConfig.getRequestProxyAgents(forwardUrl),
-          },
+          }),
         });
 
       if (result instanceof HTTPErrorResponse) {

--- a/Probe/Config.ts
+++ b/Probe/Config.ts
@@ -100,6 +100,19 @@ export const PROBE_API_REQUEST_TIMEOUT_IN_MS: number =
     min: 1000,
   });
 
+/*
+ * A control-plane request that is merely SLOW is the leading indicator of
+ * the one that eventually crosses the deadline above and gets this probe
+ * flagged Disconnected. Anything over this threshold is logged with its
+ * elapsed time so the trend is visible before the cliff.
+ */
+export const PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS: number =
+  NumberUtil.parseNumberWithDefault({
+    value: process.env["PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS"],
+    defaultValue: 10000,
+    min: 100,
+  });
+
 export const PORT: Port = new Port(
   NumberUtil.parseNumberWithDefault({
     value: process.env["PORT"],

--- a/Probe/Index.ts
+++ b/Probe/Index.ts
@@ -18,6 +18,7 @@ import SnmpTrapReceiver from "./Services/SnmpTrapReceiver";
 import SyslogReceiver from "./Services/SyslogReceiver";
 import MetricsAPI from "./API/Metrics";
 import IncomingRequestIngressAPI from "./API/IncomingRequestIngress";
+import ProbeApiDiagnostics from "./Utils/ProbeApiDiagnostics";
 import ProxyConfig from "./Utils/ProxyConfig";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import logger from "Common/Server/Utils/Logger";
@@ -69,6 +70,15 @@ const init: PromiseVoidFunction = async (): Promise<void> => {
     logger.info(
       `Probe Service - Monitoring workers: ${PROBE_MONITORING_WORKERS}, Monitor fetch limit: ${PROBE_MONITOR_FETCH_LIMIT}, Script timeout: ${PROBE_SYNTHETIC_MONITOR_SCRIPT_TIMEOUT_IN_MS}ms / ${PROBE_CUSTOM_CODE_MONITOR_SCRIPT_TIMEOUT_IN_MS}ms, Retry limit: ${PROBE_MONITOR_RETRY_LIMIT}`,
     );
+
+    /*
+     * Print the whole connectivity-relevant environment once, and start
+     * watching for event-loop stalls — a probe that cannot talk to the
+     * server is nearly always explained by one of the two, and asking a
+     * customer for this after the fact costs a support round trip each time.
+     */
+    ProbeApiDiagnostics.logStartupEnvironment();
+    ProbeApiDiagnostics.startProcessMonitor();
 
     // init the app
     await App.init({

--- a/Probe/Services/NetFlowReceiver.ts
+++ b/Probe/Services/NetFlowReceiver.ts
@@ -13,7 +13,6 @@ import NetFlowV9Parser, {
   ParsedNetFlowV9Datagram,
 } from "../Utils/NetFlow/NetFlowV9Parser";
 import ProbeAPIRequest from "../Utils/ProbeAPIRequest";
-import ProxyConfig from "../Utils/ProxyConfig";
 import URL from "Common/Types/API/URL";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
 import { JSONObject } from "Common/Types/JSON";
@@ -342,10 +341,9 @@ export default class NetFlowReceiver {
               ...ProbeAPIRequest.getDefaultRequestBody(),
               flowRecords: batch as unknown as Array<JSONObject>,
             },
-            options: {
-              ...ProxyConfig.getRequestProxyAgents(ingestUrl),
+            options: ProbeAPIRequest.getDefaultRequestOptions(ingestUrl, {
               timeout: FLUSH_REQUEST_TIMEOUT_MS,
-            },
+            }),
           });
         } catch (err) {
           /*

--- a/Probe/Services/SnmpTrapReceiver.ts
+++ b/Probe/Services/SnmpTrapReceiver.ts
@@ -5,7 +5,6 @@ import {
   PROBE_SNMP_TRAP_RECEIVER_PORT,
 } from "../Config";
 import ProbeAPIRequest from "../Utils/ProbeAPIRequest";
-import ProxyConfig from "../Utils/ProxyConfig";
 import URL from "Common/Types/API/URL";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
 import { JSONObject } from "Common/Types/JSON";
@@ -210,10 +209,9 @@ export default class SnmpTrapReceiver {
         ...ProbeAPIRequest.getDefaultRequestBody(),
         snmpTrap: trap as unknown as JSONObject,
       },
-      options: {
-        ...ProxyConfig.getRequestProxyAgents(ingestUrl),
+      options: ProbeAPIRequest.getDefaultRequestOptions(ingestUrl, {
         timeout: FORWARD_REQUEST_TIMEOUT_MS,
-      },
+      }),
     });
   }
 

--- a/Probe/Services/SyslogReceiver.ts
+++ b/Probe/Services/SyslogReceiver.ts
@@ -5,7 +5,6 @@ import {
   PROBE_SYSLOG_RECEIVER_PORT,
 } from "../Config";
 import ProbeAPIRequest from "../Utils/ProbeAPIRequest";
-import ProxyConfig from "../Utils/ProxyConfig";
 import URL from "Common/Types/API/URL";
 import HTTPMethod from "Common/Types/API/HTTPMethod";
 import { JSONObject } from "Common/Types/JSON";
@@ -431,10 +430,9 @@ export default class SyslogReceiver {
               ...ProbeAPIRequest.getDefaultRequestBody(),
               syslogMessages: batch as unknown as Array<JSONObject>,
             },
-            options: {
-              ...ProxyConfig.getRequestProxyAgents(ingestUrl),
+            options: ProbeAPIRequest.getDefaultRequestOptions(ingestUrl, {
               timeout: FLUSH_REQUEST_TIMEOUT_MS,
-            },
+            }),
           });
         } catch (err) {
           /*

--- a/Probe/Tests/Utils/ProbeAPIRequest.test.ts
+++ b/Probe/Tests/Utils/ProbeAPIRequest.test.ts
@@ -49,9 +49,41 @@ describe("getDefaultRequestOptions", () => {
      * exact shape: an accidental httpAgent/httpsAgent key here would apply
      * to every control-plane request the probe makes.
      */
-    expect(options).toEqual({ timeout: 45000 });
+    expect(Object.keys(options).sort()).toEqual([
+      "onRequestComplete",
+      "timeout",
+    ]);
     expect("httpAgent" in options).toBe(false);
     expect("httpsAgent" in options).toBe(false);
+  });
+
+  test("a caller's own deadline wins over the 45s default", () => {
+    /*
+     * The syslog / NetFlow / SNMP-trap forwarders flush on a much shorter
+     * deadline than the control-plane default, and they still have to get
+     * the diagnostics observer.
+     */
+    const options: RequestOptions = ProbeAPIRequest.getDefaultRequestOptions(
+      aliveUrl,
+      { timeout: 30000 },
+    );
+
+    expect(options.timeout).toBe(30000);
+    expect(typeof options.onRequestComplete).toBe("function");
+  });
+
+  test("every request carries the diagnostics observer", () => {
+    /*
+     * This hook is the only reason a failed control-plane request can say
+     * WHERE it stalled. It is attached here, once, rather than at each of
+     * the probe's call sites — so losing it here silently reverts every
+     * route to the bare "timeout of 45000ms exceeded" that told support
+     * nothing.
+     */
+    const options: RequestOptions =
+      ProbeAPIRequest.getDefaultRequestOptions(aliveUrl);
+
+    expect(typeof options.onRequestComplete).toBe("function");
   });
 });
 

--- a/Probe/Tests/Utils/ProbeApiDiagnostics.test.ts
+++ b/Probe/Tests/Utils/ProbeApiDiagnostics.test.ts
@@ -1,0 +1,381 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import HTTPMethod from "Common/Types/API/HTTPMethod";
+import { JSONObject } from "Common/Types/JSON";
+import { RequestOutcome } from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import ProbeApiDiagnostics, {
+  ProbeRequestStallPhase,
+} from "../../Utils/ProbeApiDiagnostics";
+
+/*
+ * A probe that cannot reach the server logs `timeout of 45000ms exceeded`
+ * and nothing else — the same sentence whether it never got a socket, never
+ * finished the TCP handshake, never finished TLS, or connected perfectly and
+ * the server never answered. Those are four different tickets. These tests
+ * pin the classification that tells them apart, because that classification
+ * is the entire point of the failure report.
+ */
+
+interface FakeSocket {
+  connecting?: boolean;
+  bytesWritten?: number;
+  bytesRead?: number;
+  remoteAddress?: string;
+  remotePort?: number;
+  getProtocol?: () => string | null;
+  getCipher?: () => { name: string };
+  authorized?: boolean;
+}
+
+function buildTimeoutOutcome(options: {
+  socket?: FakeSocket | null;
+  hasResponse?: boolean;
+  useFollowRedirectsWrapper?: boolean;
+  elapsedInMs?: number;
+  timeoutInMs?: number;
+}): RequestOutcome {
+  const clientRequest: JSONObject = {
+    socket: (options.socket ?? null) as unknown as JSONObject,
+    res: options.hasResponse ? ({ statusCode: 200 } as JSONObject) : null,
+  };
+
+  /*
+   * axios goes through follow-redirects, whose RedirectableRequest wraps the
+   * ClientRequest that actually owns the socket — both shapes have to be
+   * unwrapped or every real failure reads as "no socket".
+   */
+  const request: JSONObject = options.useFollowRedirectsWrapper
+    ? ({ _currentRequest: clientRequest, _redirectCount: 0 } as JSONObject)
+    : clientRequest;
+
+  return {
+    method: HTTPMethod.POST,
+    url: "https://oneuptime.example.com/probe-ingest/alive",
+    elapsedInMs: options.elapsedInMs ?? 45010,
+    attempts: 1,
+    timeoutInMs: options.timeoutInMs ?? 45000,
+    error: new Error("timeout of 45000ms exceeded"),
+    axiosError: {
+      code: "ECONNABORTED",
+      request: request,
+    } as never,
+  };
+}
+
+function connectedTlsSocket(overrides?: Partial<FakeSocket>): FakeSocket {
+  return {
+    connecting: false,
+    bytesWritten: 412,
+    bytesRead: 0,
+    remoteAddress: "10.1.2.3",
+    remotePort: 443,
+    getProtocol: (): string | null => {
+      return "TLSv1.3";
+    },
+    getCipher: (): { name: string } => {
+      return { name: "TLS_AES_256_GCM_SHA384" };
+    },
+    authorized: true,
+    ...(overrides || {}),
+  };
+}
+
+beforeEach(() => {
+  ProbeApiDiagnostics.reset();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  ProbeApiDiagnostics.reset();
+});
+
+describe("where the request stalled", () => {
+  test("no socket at all: nothing ever left this machine", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({ socket: null }),
+    );
+
+    expect(report["stalledAt"]).toBe(ProbeRequestStallPhase.SocketAssignment);
+    expect((report["connection"] as JSONObject)["socketAssigned"]).toBe(false);
+  });
+
+  test("socket still connecting: the TCP handshake never completed", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: { connecting: true, bytesWritten: 0, bytesRead: 0 },
+      }),
+    );
+
+    expect(report["stalledAt"]).toBe(ProbeRequestStallPhase.TcpConnect);
+  });
+
+  test("TLS socket with nothing negotiated: stuck in the handshake", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: connectedTlsSocket({
+          getProtocol: (): string | null => {
+            return null;
+          },
+        }),
+      }),
+    );
+
+    expect(report["stalledAt"]).toBe(ProbeRequestStallPhase.TlsHandshake);
+  });
+
+  test("request written, zero bytes back: the SERVER is the one that stalled", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({ socket: connectedTlsSocket() }),
+    );
+
+    /*
+     * This is the case that matters most in the field: the probe's network
+     * path is healthy and the request is sitting on the server. Saying so
+     * stops the customer from re-auditing their firewall.
+     */
+    expect(report["stalledAt"]).toBe(
+      ProbeRequestStallPhase.WaitingForServerResponse,
+    );
+
+    const connection: JSONObject = report["connection"] as JSONObject;
+    expect(connection["remoteAddress"]).toBe("10.1.2.3");
+    expect(connection["bytesWrittenToServer"]).toBe(412);
+    expect(connection["bytesReadFromServer"]).toBe(0);
+    expect((connection["tls"] as JSONObject)["protocol"]).toBe("TLSv1.3");
+  });
+
+  test("nothing written to a connected socket: the far end stopped reading", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: connectedTlsSocket({ bytesWritten: 0 }),
+      }),
+    );
+
+    expect(report["stalledAt"]).toBe(ProbeRequestStallPhase.RequestSend);
+  });
+
+  test("headers arrived but the body never finished", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: connectedTlsSocket({ bytesRead: 120 }),
+        hasResponse: true,
+      }),
+    );
+
+    expect(report["stalledAt"]).toBe(ProbeRequestStallPhase.ResponseBody);
+  });
+
+  test("the follow-redirects wrapper is unwrapped to reach the real socket", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: connectedTlsSocket(),
+        useFollowRedirectsWrapper: true,
+      }),
+    );
+
+    expect(report["stalledAt"]).toBe(
+      ProbeRequestStallPhase.WaitingForServerResponse,
+    );
+    expect((report["connection"] as JSONObject)["socketAssigned"]).toBe(true);
+  });
+
+  test("an error with no request object is Unknown, not a false SocketAssignment", () => {
+    /*
+     * Absence of evidence is not evidence: a failure raised before axios
+     * built a request (or a non-axios throw) must not be reported as
+     * "nothing left this machine", which would send the customer after a
+     * firewall that has nothing to do with it.
+     */
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport({
+      method: HTTPMethod.POST,
+      url: "https://oneuptime.example.com/probe-ingest/alive",
+      elapsedInMs: 5,
+      attempts: 1,
+      timeoutInMs: 45000,
+      error: new Error("URL is required for static method"),
+    });
+
+    expect(report["stalledAt"]).toBe(ProbeRequestStallPhase.Unknown);
+  });
+
+  test("every phase comes with an explanation, not just a label", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({ socket: connectedTlsSocket() }),
+    );
+
+    expect(String(report["whatThisMeans"]).length).toBeGreaterThan(0);
+  });
+});
+
+describe("a deadline that fires late means the probe was blocked", () => {
+  test("a large overrun is called out explicitly", () => {
+    /*
+     * axios starts its timer when the request is created, so 45s of deadline
+     * taking 120s of wall clock means this process could not run its own
+     * timer — a blocked event loop or a suspended VM, NOT a network fault.
+     */
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: connectedTlsSocket(),
+        elapsedInMs: 120000,
+        timeoutInMs: 45000,
+      }),
+    );
+
+    expect((report["request"] as JSONObject)["deadlineOverrunInMs"]).toBe(
+      75000,
+    );
+    expect(report["alsoNote"]).toBeDefined();
+  });
+
+  test("a timeout that fired on schedule adds no such note", () => {
+    const report: JSONObject = ProbeApiDiagnostics.buildFailureReport(
+      buildTimeoutOutcome({
+        socket: connectedTlsSocket(),
+        elapsedInMs: 45010,
+        timeoutInMs: 45000,
+      }),
+    );
+
+    expect(report["alsoNote"]).toBeUndefined();
+  });
+});
+
+describe("contact history", () => {
+  test("consecutive transport failures accumulate, per route", () => {
+    // The self-test opens real sockets; this suite is about the counters.
+    jest
+      .spyOn(ProbeApiDiagnostics, "maybeRunConnectivitySelfTest")
+      .mockImplementation((): void => {});
+    jest.spyOn(logger, "error").mockImplementation((): void => {});
+
+    const outcome: RequestOutcome = buildTimeoutOutcome({ socket: null });
+
+    ProbeApiDiagnostics.onRequestComplete(1, outcome);
+    ProbeApiDiagnostics.onRequestComplete(2, outcome);
+
+    const contact: JSONObject = ProbeApiDiagnostics.getServerContactSnapshot();
+
+    expect(contact["consecutiveFailures"]).toBe(2);
+    expect(
+      (contact["failuresByRoute"] as JSONObject)["/probe-ingest/alive"],
+    ).toBe(2);
+    expect(contact["lastSuccessfulContactAt"]).toBe(
+      "never since this probe started",
+    );
+  });
+
+  test("any HTTP status — 500 included — counts as reaching the server", () => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {});
+    jest
+      .spyOn(ProbeApiDiagnostics, "maybeRunConnectivitySelfTest")
+      .mockImplementation((): void => {});
+
+    ProbeApiDiagnostics.onRequestComplete(1, buildTimeoutOutcome({}));
+
+    /*
+     * A 500 proves DNS, TCP, TLS, the proxy and the ingress all work, so it
+     * must clear the connectivity streak — otherwise the self-test fires at
+     * a network that is demonstrably fine.
+     */
+    ProbeApiDiagnostics.onRequestComplete(2, {
+      method: HTTPMethod.POST,
+      url: "https://oneuptime.example.com/probe-ingest/alive",
+      elapsedInMs: 40,
+      attempts: 1,
+      statusCode: 500,
+    });
+
+    const contact: JSONObject = ProbeApiDiagnostics.getServerContactSnapshot();
+
+    expect(contact["consecutiveFailures"]).toBe(0);
+    expect(contact["secondsSinceLastSuccessfulContact"]).toBe(0);
+  });
+});
+
+describe("slow-but-successful requests", () => {
+  test("a request over the threshold is warned about, with its elapsed time", () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const warnSpy = jest
+      .spyOn(logger, "warn")
+      .mockImplementation((): void => {});
+
+    ProbeApiDiagnostics.onRequestComplete(1, {
+      method: HTTPMethod.POST,
+      url: "https://oneuptime.example.com/probe-ingest/alive",
+      elapsedInMs: 22000,
+      attempts: 1,
+      timeoutInMs: 45000,
+      statusCode: 200,
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain("22000ms");
+  });
+
+  test("a fast request stays silent", () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const warnSpy = jest
+      .spyOn(logger, "warn")
+      .mockImplementation((): void => {});
+
+    ProbeApiDiagnostics.onRequestComplete(1, {
+      method: HTTPMethod.POST,
+      url: "https://oneuptime.example.com/probe-ingest/alive",
+      elapsedInMs: 120,
+      attempts: 1,
+      timeoutInMs: 45000,
+      statusCode: 200,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("in-flight requests", () => {
+  test("requests still in flight are listed, so a pile-up is visible", () => {
+    ProbeApiDiagnostics.beginRequest({
+      toString: (): string => {
+        return "https://oneuptime.example.com/probe-ingest/monitor/list";
+      },
+    } as never);
+
+    const snapshot: JSONObject = ProbeApiDiagnostics.getProcessSnapshot();
+
+    expect(snapshot["inFlightRequestCount"]).toBe(1);
+  });
+
+  test("a settled request is no longer in flight", () => {
+    jest.spyOn(logger, "warn").mockImplementation((): void => {});
+
+    const id: number = ProbeApiDiagnostics.beginRequest({
+      toString: (): string => {
+        return "https://oneuptime.example.com/probe-ingest/monitor/list";
+      },
+    } as never);
+
+    ProbeApiDiagnostics.onRequestComplete(id, {
+      method: HTTPMethod.POST,
+      url: "https://oneuptime.example.com/probe-ingest/monitor/list",
+      elapsedInMs: 30,
+      attempts: 1,
+      statusCode: 200,
+    });
+
+    const snapshot: JSONObject = ProbeApiDiagnostics.getProcessSnapshot();
+
+    expect(snapshot["inFlightRequestCount"]).toBe(0);
+  });
+});

--- a/Probe/Utils/ProbeAPIRequest.ts
+++ b/Probe/Utils/ProbeAPIRequest.ts
@@ -1,8 +1,9 @@
 import { PROBE_API_REQUEST_TIMEOUT_IN_MS, PROBE_KEY } from "../Config";
 import ProbeUtil from "./Probe";
+import ProbeApiDiagnostics from "./ProbeApiDiagnostics";
 import ProxyConfig from "./ProxyConfig";
 import URL from "Common/Types/API/URL";
-import { RequestOptions } from "Common/Utils/API";
+import { RequestOptions, RequestOutcome } from "Common/Utils/API";
 import { JSONObject } from "Common/Types/JSON";
 
 export default class ProbeAPIRequest {
@@ -19,11 +20,25 @@ export default class ProbeAPIRequest {
    * non-responding server produces a logged failure instead of an
    * infinitely hung request (axios's default timeout is 0 = no timeout,
    * and a hung request from a cron tick piles onto the next tick's).
+   *
+   * It is also the one place every probe→server request passes through, so
+   * the diagnostics observer is attached here rather than at fourteen call
+   * sites: whatever route is added next gets the same failure reporting for
+   * free. `timeout` may be overridden by callers with their own deadline
+   * (the syslog/NetFlow/SNMP-trap forwarders flush on a much shorter one).
    */
-  public static getDefaultRequestOptions(url: URL): RequestOptions {
+  public static getDefaultRequestOptions(
+    url: URL,
+    options?: { timeout?: number },
+  ): RequestOptions {
+    const inFlightRequestId: number = ProbeApiDiagnostics.beginRequest(url);
+
     return {
       ...ProxyConfig.getRequestProxyAgents(url),
-      timeout: PROBE_API_REQUEST_TIMEOUT_IN_MS,
+      timeout: options?.timeout ?? PROBE_API_REQUEST_TIMEOUT_IN_MS,
+      onRequestComplete: (outcome: RequestOutcome): void => {
+        ProbeApiDiagnostics.onRequestComplete(inFlightRequestId, outcome);
+      },
     };
   }
 }

--- a/Probe/Utils/ProbeApiDiagnostics.ts
+++ b/Probe/Utils/ProbeApiDiagnostics.ts
@@ -1,0 +1,982 @@
+import {
+  HTTPS_PROXY_URL,
+  HTTP_PROXY_URL,
+  NO_PROXY,
+  PROBE_API_REQUEST_TIMEOUT_IN_MS,
+  PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS,
+  PROBE_INGEST_URL,
+} from "../Config";
+import ProxyConfig, { ProxyAgents } from "./ProxyConfig";
+import URL from "Common/Types/API/URL";
+import { JSONObject } from "Common/Types/JSON";
+import API, { RequestOutcome } from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import dns from "dns";
+import net from "net";
+import os from "os";
+import tls from "tls";
+import { URL as NodeURL } from "url";
+
+/*
+ * Everything in this file exists to answer one support question that the
+ * probe could not answer before: "the probe says
+ * `timeout of 45000ms exceeded` — timed out WHERE?".
+ *
+ * An axios timeout is the same string whether the probe never got a socket,
+ * never completed the TCP handshake, never finished the TLS handshake, or
+ * connected fine and the server simply never wrote a byte back. Those are
+ * four completely different tickets — firewall, proxy, TLS interception,
+ * overloaded server — and the probe used to dump a 200-line axios object
+ * that distinguishes none of them.
+ *
+ * So on every failed control-plane request the probe now prints:
+ *   - which phase the request was stuck in, read off the real socket,
+ *   - how long it ACTUALLY took vs the deadline it was given (a big overrun
+ *     means this probe's event loop was blocked, not that the network was),
+ *   - whether a proxy was in play for that URL,
+ *   - the probe's own health (event-loop stalls, memory, in-flight requests),
+ *   - how long it has been since anything reached the server at all,
+ * and, once failures start repeating, a staged DNS → TCP → TLS → HTTP
+ * connectivity test against the same server so the break point is named
+ * outright.
+ */
+
+export enum ProbeRequestStallPhase {
+  // The request never got a TCP socket from the agent / proxy at all.
+  SocketAssignment = "SocketAssignment",
+  // A socket was created but the TCP handshake never completed.
+  TcpConnect = "TcpConnect",
+  // TCP connected, but TLS never finished negotiating.
+  TlsHandshake = "TlsHandshake",
+  // Connected, but the request body was never fully written out.
+  RequestSend = "RequestSend",
+  // Request sent in full; the server never sent a single byte back.
+  WaitingForServerResponse = "WaitingForServerResponse",
+  // Response headers arrived; the body never finished.
+  ResponseBody = "ResponseBody",
+  // The socket state did not survive the failure (nothing to read).
+  Unknown = "Unknown",
+}
+
+const STALL_PHASE_EXPLANATION: Record<ProbeRequestStallPhase, string> = {
+  [ProbeRequestStallPhase.SocketAssignment]:
+    "The request never got a TCP socket. Nothing left this machine. Either the HTTP agent's socket pool was saturated by other in-flight requests (see probeProcess.inFlightRequestCount below), or — when a proxy is configured — the proxy never completed the CONNECT tunnel. Check the proxy first if one is listed under `proxy` below.",
+  [ProbeRequestStallPhase.TcpConnect]:
+    "A socket was opened but the TCP handshake never completed: this machine sent SYN and nothing came back. That is a dropped-packet signature — a firewall, security appliance or NAT/routing problem between this probe and the OneUptime server, or a server that is not listening on that port. Confirm with the connectivity self-test below (`tcpConnect`).",
+  [ProbeRequestStallPhase.TlsHandshake]:
+    "TCP connected but the TLS handshake never completed. Usually a TLS-inspecting middlebox, a server under so much load that it accepts connections it cannot service, or a protocol/cipher mismatch. The connectivity self-test below (`tlsHandshake`) reproduces this in isolation.",
+  [ProbeRequestStallPhase.RequestSend]:
+    "The connection was established but the request body was never fully written to the socket. The far end stopped reading (its receive window closed), which points at a stalled proxy or load balancer rather than at this probe.",
+  [ProbeRequestStallPhase.WaitingForServerResponse]:
+    "The request was delivered in full and the server never sent back a single byte before the deadline. This probe's network path is FINE — the request is sitting on the OneUptime server, its load balancer or its reverse proxy. Look at the server-side logs for this route at the timestamp below, and at server database/queue latency.",
+  [ProbeRequestStallPhase.ResponseBody]:
+    "Response headers arrived but the body never completed. The server started answering and then stalled part-way — usually a backend that is streaming a slow query result, or a proxy that dropped the connection mid-response.",
+  [ProbeRequestStallPhase.Unknown]:
+    "The socket state could not be read off this failure, so the stall point is unknown. The connectivity self-test below is the next thing to read.",
+};
+
+interface InFlightRequest {
+  url: string;
+  startedAtInMs: number;
+}
+
+/*
+ * Sampling interval for the event-loop drift check. Anything the probe does
+ * synchronously for longer than this (a big subnet sweep, a synthetic
+ * monitor script, JSON.parse of a huge payload) shows up as drift — and a
+ * blocked event loop makes axios report a timeout that never actually
+ * elapsed on the wire.
+ */
+const EVENT_LOOP_SAMPLE_INTERVAL_IN_MS: number = 1000;
+const EVENT_LOOP_SAMPLE_WINDOW: number = 60;
+const EVENT_LOOP_DRIFT_WARN_THRESHOLD_IN_MS: number = 2000;
+
+// Consecutive transport failures before the staged self-test is worth running.
+const SELF_TEST_FAILURE_THRESHOLD: number = 3;
+// ...and how often it may run, so a fully offline probe does not spam its log.
+const SELF_TEST_MIN_INTERVAL_IN_MS: number = 5 * 60 * 1000;
+
+const SELF_TEST_STAGE_TIMEOUT_IN_MS: number = 10000;
+
+// An options object built but never fetched would otherwise leak an entry.
+const IN_FLIGHT_ENTRY_MAX_AGE_IN_MS: number = 10 * 60 * 1000;
+
+export default class ProbeApiDiagnostics {
+  private static inFlightRequests: Map<number, InFlightRequest> = new Map();
+  private static nextInFlightRequestId: number = 1;
+
+  private static consecutiveFailureCount: number = 0;
+  private static lastSuccessfulContactAtInMs: number | null = null;
+  private static lastFailureAtInMs: number | null = null;
+  private static failureCountByRoute: Map<string, number> = new Map();
+
+  private static eventLoopDriftSamplesInMs: Array<number> = [];
+  private static eventLoopSampler: NodeJS.Timeout | null = null;
+
+  private static lastSelfTestAtInMs: number | null = null;
+  private static isSelfTestRunning: boolean = false;
+
+  // Exported for tests: wipes every counter this module accumulates.
+  public static reset(): void {
+    this.inFlightRequests.clear();
+    this.nextInFlightRequestId = 1;
+    this.consecutiveFailureCount = 0;
+    this.lastSuccessfulContactAtInMs = null;
+    this.lastFailureAtInMs = null;
+    this.failureCountByRoute.clear();
+    this.eventLoopDriftSamplesInMs = [];
+    this.lastSelfTestAtInMs = null;
+    this.isSelfTestRunning = false;
+  }
+
+  /*
+   * Starts the event-loop drift sampler. Unref'd, so it never keeps the
+   * process alive on its own.
+   */
+  public static startProcessMonitor(): void {
+    if (this.eventLoopSampler) {
+      return;
+    }
+
+    let lastTickAtInMs: number = Date.now();
+
+    this.eventLoopSampler = setInterval((): void => {
+      const nowInMs: number = Date.now();
+      const driftInMs: number = Math.max(
+        0,
+        nowInMs - lastTickAtInMs - EVENT_LOOP_SAMPLE_INTERVAL_IN_MS,
+      );
+      lastTickAtInMs = nowInMs;
+
+      this.eventLoopDriftSamplesInMs.push(driftInMs);
+
+      if (this.eventLoopDriftSamplesInMs.length > EVENT_LOOP_SAMPLE_WINDOW) {
+        this.eventLoopDriftSamplesInMs.shift();
+      }
+
+      if (driftInMs >= EVENT_LOOP_DRIFT_WARN_THRESHOLD_IN_MS) {
+        logger.warn(
+          `Probe event loop was blocked for ${driftInMs}ms. While it is blocked no HTTP response can be read and no timer can fire, so requests to the OneUptime server can report a timeout that never elapsed on the network.`,
+        );
+      }
+    }, EVENT_LOOP_SAMPLE_INTERVAL_IN_MS);
+
+    this.eventLoopSampler.unref();
+  }
+
+  public static stopProcessMonitor(): void {
+    if (!this.eventLoopSampler) {
+      return;
+    }
+
+    clearInterval(this.eventLoopSampler);
+    this.eventLoopSampler = null;
+  }
+
+  /*
+   * Called as the request options are built — i.e. immediately before the
+   * fetch — so the probe knows what is in flight when a later request
+   * fails. Returns the id to hand back to onRequestComplete.
+   */
+  public static beginRequest(url: URL): number {
+    const id: number = this.nextInFlightRequestId++;
+
+    this.pruneStaleInFlightRequests();
+
+    this.inFlightRequests.set(id, {
+      url: url.toString(),
+      startedAtInMs: Date.now(),
+    });
+
+    return id;
+  }
+
+  public static onRequestComplete(
+    inFlightRequestId: number,
+    outcome: RequestOutcome,
+  ): void {
+    this.inFlightRequests.delete(inFlightRequestId);
+
+    /*
+     * A 4xx/5xx still proves the whole network path works, so it counts as
+     * contact with the server: only a transport failure resets the streak.
+     */
+    if (outcome.statusCode !== undefined) {
+      this.recordServerContact();
+      this.logSlowSuccess(outcome);
+      return;
+    }
+
+    this.recordTransportFailure(outcome);
+  }
+
+  private static logSlowSuccess(outcome: RequestOutcome): void {
+    if (outcome.elapsedInMs < PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS) {
+      return;
+    }
+
+    /*
+     * Slow-but-successful requests are the leading indicator of the failure
+     * this whole file is about: the server gets slower, then crosses the
+     * request deadline, then the probe is marked Disconnected. Logging them
+     * gives support a trend instead of a cliff.
+     */
+    logger.warn(
+      `Slow request to the OneUptime server: ${outcome.method} ${outcome.url} took ${outcome.elapsedInMs}ms (status ${outcome.statusCode}, deadline ${
+        outcome.timeoutInMs ?? PROBE_API_REQUEST_TIMEOUT_IN_MS
+      }ms). Requests that cross the deadline are what mark this probe Disconnected.`,
+    );
+  }
+
+  private static recordServerContact(): void {
+    this.consecutiveFailureCount = 0;
+    this.lastSuccessfulContactAtInMs = Date.now();
+  }
+
+  private static recordTransportFailure(outcome: RequestOutcome): void {
+    this.consecutiveFailureCount++;
+    this.lastFailureAtInMs = Date.now();
+
+    const route: string = ProbeApiDiagnostics.getRouteFromUrl(outcome.url);
+
+    this.failureCountByRoute.set(
+      route,
+      (this.failureCountByRoute.get(route) || 0) + 1,
+    );
+
+    const report: JSONObject = this.buildFailureReport(outcome);
+
+    logger.error(
+      `Request to the OneUptime server FAILED: ${outcome.method} ${outcome.url} after ${outcome.elapsedInMs}ms — ${
+        outcome.error?.message || "unknown error"
+      }`,
+    );
+    logger.error(JSON.stringify(report, null, 2));
+
+    this.maybeRunConnectivitySelfTest();
+  }
+
+  public static buildFailureReport(outcome: RequestOutcome): JSONObject {
+    const connection: JSONObject = this.getConnectionSnapshot(
+      outcome.axiosError,
+    );
+
+    const stallPhase: ProbeRequestStallPhase = this.getStallPhase(
+      outcome,
+      connection,
+    );
+
+    const deadlineInMs: number =
+      outcome.timeoutInMs ?? PROBE_API_REQUEST_TIMEOUT_IN_MS;
+
+    /*
+     * How late the client-side deadline fired. axios starts its timer when
+     * the request is created, so an overrun means this process could not run
+     * the timer callback on time — the probe was blocked, and the network may
+     * be blameless.
+     */
+    const deadlineOverrunInMs: number = Math.max(
+      0,
+      outcome.elapsedInMs - deadlineInMs,
+    );
+
+    const report: JSONObject = {
+      request: {
+        method: outcome.method,
+        url: outcome.url,
+        attempts: outcome.attempts,
+        elapsedInMs: outcome.elapsedInMs,
+        deadlineInMs: deadlineInMs,
+        deadlineOverrunInMs: deadlineOverrunInMs,
+        failedAt: new Date().toISOString(),
+      },
+      error: {
+        message: outcome.error?.message || "",
+        code: (outcome.axiosError as any)?.code || null,
+      },
+      stalledAt: stallPhase,
+      whatThisMeans: STALL_PHASE_EXPLANATION[stallPhase],
+      connection: connection,
+      proxy: this.getProxySnapshot(outcome.url),
+      probeProcess: this.getProcessSnapshot(),
+      serverContact: this.getServerContactSnapshot(),
+    };
+
+    if (deadlineOverrunInMs > 1000) {
+      report["alsoNote"] =
+        `The ${deadlineInMs}ms deadline fired ${deadlineOverrunInMs}ms late. Node.js could not run its own timer on time, which means this probe process was blocked (busy event loop) or the machine was suspended/throttled. Check probeProcess.eventLoopMaxDriftInMs below before blaming the network.`;
+    }
+
+    return report;
+  }
+
+  /*
+   * Reads the real socket off the failed request. This is the part that
+   * turns "timeout" into a phase: bytesRead === 0 on a connected TLS socket
+   * is a server-side stall, no socket at all is a client-side one.
+   */
+  public static getConnectionSnapshot(axiosError: unknown): JSONObject {
+    const clientRequest: any = this.getClientRequest(axiosError);
+
+    if (!clientRequest) {
+      /*
+       * No ClientRequest to read — an error raised before axios ever built
+       * one, or a non-axios failure. Distinguished from "a request was made
+       * and got no socket": the latter is a real finding, this is an absence
+       * of evidence and must not be reported as one.
+       */
+      return {
+        requestObjectAvailable: false,
+        socketAssigned: false,
+        detail: "No request object to inspect.",
+      };
+    }
+
+    const socket: any = clientRequest.socket || null;
+
+    const snapshot: JSONObject = {
+      requestObjectAvailable: true,
+      socketAssigned: Boolean(socket),
+      responseHeadersReceived: Boolean(clientRequest.res),
+      redirectCount: this.readNumber(
+        (axiosError as any)?.request?._redirectCount,
+      ),
+      requestBodyLengthInBytes: this.readNumber(
+        (axiosError as any)?.request?._requestBodyLength,
+      ),
+    };
+
+    if (clientRequest.res && clientRequest.res.statusCode) {
+      snapshot["responseStatusCode"] = clientRequest.res.statusCode;
+    }
+
+    if (!socket) {
+      return snapshot;
+    }
+
+    /*
+     * Node clears a socket's address fields once its handle is gone, and
+     * axios destroys the socket as it raises the timeout — so these are
+     * present for an error that surfaced with the socket still open, and
+     * absent otherwise. Reported only when real: a hardcoded null next to
+     * "remoteAddress" reads as "we could not resolve the host", which is a
+     * different and much more alarming claim.
+     */
+    if (socket.remoteAddress) {
+      snapshot["remoteAddress"] = socket.remoteAddress;
+      snapshot["remotePort"] = this.readNumber(socket.remotePort);
+    }
+
+    if (socket.localAddress) {
+      snapshot["localAddress"] = socket.localAddress;
+      snapshot["localPort"] = this.readNumber(socket.localPort);
+    }
+
+    snapshot["tcpHandshakeStillPending"] = Boolean(socket.connecting);
+    snapshot["socketReused"] = Boolean(clientRequest.reusedSocket);
+    snapshot["bytesWrittenToServer"] = this.readNumber(socket.bytesWritten);
+    snapshot["bytesReadFromServer"] = this.readNumber(socket.bytesRead);
+    snapshot["socketReadyState"] = socket.readyState || null;
+    snapshot["socketDestroyed"] = Boolean(socket.destroyed);
+
+    if (typeof socket.getProtocol === "function") {
+      const negotiatedProtocol: string | null = socket.getProtocol() || null;
+
+      const tlsSnapshot: JSONObject = {
+        negotiated: Boolean(negotiatedProtocol),
+        protocol: negotiatedProtocol,
+        authorized: Boolean(socket.authorized),
+      };
+
+      if (socket.authorizationError) {
+        tlsSnapshot["authorizationError"] = String(socket.authorizationError);
+      }
+
+      if (typeof socket.getCipher === "function") {
+        tlsSnapshot["cipher"] = socket.getCipher()?.name || null;
+      }
+
+      snapshot["tls"] = tlsSnapshot;
+    }
+
+    return snapshot;
+  }
+
+  private static getStallPhase(
+    outcome: RequestOutcome,
+    connection: JSONObject,
+  ): ProbeRequestStallPhase {
+    // A response arrived, so this was not a stall at all.
+    if (outcome.statusCode !== undefined) {
+      return ProbeRequestStallPhase.Unknown;
+    }
+
+    if (connection["requestObjectAvailable"] !== true) {
+      return ProbeRequestStallPhase.Unknown;
+    }
+
+    if (connection["socketAssigned"] !== true) {
+      return ProbeRequestStallPhase.SocketAssignment;
+    }
+
+    if (connection["tcpHandshakeStillPending"] === true) {
+      return ProbeRequestStallPhase.TcpConnect;
+    }
+
+    const tlsSnapshot: JSONObject | undefined = connection["tls"] as
+      | JSONObject
+      | undefined;
+
+    if (tlsSnapshot && tlsSnapshot["negotiated"] !== true) {
+      return ProbeRequestStallPhase.TlsHandshake;
+    }
+
+    if (connection["responseHeadersReceived"] === true) {
+      return ProbeRequestStallPhase.ResponseBody;
+    }
+
+    const bytesWritten: unknown = connection["bytesWrittenToServer"];
+    const bytesRead: unknown = connection["bytesReadFromServer"];
+
+    if (typeof bytesRead !== "number" || typeof bytesWritten !== "number") {
+      return ProbeRequestStallPhase.Unknown;
+    }
+
+    if (bytesWritten === 0) {
+      return ProbeRequestStallPhase.RequestSend;
+    }
+
+    if (bytesRead === 0) {
+      return ProbeRequestStallPhase.WaitingForServerResponse;
+    }
+
+    return ProbeRequestStallPhase.ResponseBody;
+  }
+
+  private static getClientRequest(axiosError: unknown): any | null {
+    try {
+      const request: any = (axiosError as any)?.request;
+
+      if (!request) {
+        return null;
+      }
+
+      /*
+       * axios routes through follow-redirects, whose RedirectableRequest
+       * wraps the ClientRequest that actually owns the socket.
+       */
+      return request._currentRequest || request;
+    } catch {
+      return null;
+    }
+  }
+
+  public static getProxySnapshot(targetUrl: string): JSONObject {
+    const isProxyConfigured: boolean = ProxyConfig.isProxyConfigured();
+
+    const snapshot: JSONObject = {
+      configured: isProxyConfigured,
+    };
+
+    if (!isProxyConfigured) {
+      return snapshot;
+    }
+
+    const agents: Readonly<ProxyAgents> =
+      ProxyConfig.getRequestProxyAgents(targetUrl);
+
+    snapshot["usedForThisRequest"] = Object.keys(agents).length > 0;
+    snapshot["httpProxyUrl"] = this.redactCredentials(HTTP_PROXY_URL);
+    snapshot["httpsProxyUrl"] = this.redactCredentials(HTTPS_PROXY_URL);
+    snapshot["noProxy"] = NO_PROXY;
+
+    return snapshot;
+  }
+
+  public static getProcessSnapshot(): JSONObject {
+    const memory: NodeJS.MemoryUsage = process.memoryUsage();
+
+    const toMb: (bytes: number) => number = (bytes: number): number => {
+      return Math.round(bytes / 1024 / 1024);
+    };
+
+    const inFlight: Array<JSONObject> = [];
+
+    for (const request of this.inFlightRequests.values()) {
+      inFlight.push({
+        url: request.url,
+        inFlightForMs: Date.now() - request.startedAtInMs,
+      });
+    }
+
+    const snapshot: JSONObject = {
+      eventLoopMaxDriftInMs: this.getMaxEventLoopDriftInMs(),
+      inFlightRequestCount: inFlight.length,
+      inFlightRequests: inFlight,
+      rssInMb: toMb(memory.rss),
+      heapUsedInMb: toMb(memory.heapUsed),
+      heapTotalInMb: toMb(memory.heapTotal),
+      freeSystemMemoryInMb: toMb(os.freemem()),
+      uptimeInSeconds: Math.round(process.uptime()),
+    };
+
+    /*
+     * getActiveResourcesInfo lands in Node 17.3; on anything older the probe
+     * simply reports one fewer field rather than crashing its own error path.
+     */
+    const getActiveResourcesInfo: unknown = (process as any)
+      .getActiveResourcesInfo;
+
+    if (typeof getActiveResourcesInfo === "function") {
+      try {
+        snapshot["activeHandleCount"] = (
+          getActiveResourcesInfo.call(process) as Array<string>
+        ).length;
+      } catch {
+        // Best effort only.
+      }
+    }
+
+    return snapshot;
+  }
+
+  private static getMaxEventLoopDriftInMs(): number {
+    if (this.eventLoopDriftSamplesInMs.length === 0) {
+      return 0;
+    }
+
+    return Math.max(...this.eventLoopDriftSamplesInMs);
+  }
+
+  public static getServerContactSnapshot(): JSONObject {
+    const failuresByRoute: JSONObject = {};
+
+    for (const [route, count] of this.failureCountByRoute.entries()) {
+      failuresByRoute[route] = count;
+    }
+
+    return {
+      consecutiveFailures: this.consecutiveFailureCount,
+      lastSuccessfulContactAt: this.lastSuccessfulContactAtInMs
+        ? new Date(this.lastSuccessfulContactAtInMs).toISOString()
+        : "never since this probe started",
+      secondsSinceLastSuccessfulContact: this.lastSuccessfulContactAtInMs
+        ? Math.round((Date.now() - this.lastSuccessfulContactAtInMs) / 1000)
+        : null,
+      lastFailureAt: this.lastFailureAtInMs
+        ? new Date(this.lastFailureAtInMs).toISOString()
+        : null,
+      failuresByRoute: failuresByRoute,
+    };
+  }
+
+  private static pruneStaleInFlightRequests(): void {
+    const nowInMs: number = Date.now();
+
+    for (const [id, request] of this.inFlightRequests.entries()) {
+      if (nowInMs - request.startedAtInMs > IN_FLIGHT_ENTRY_MAX_AGE_IN_MS) {
+        this.inFlightRequests.delete(id);
+      }
+    }
+  }
+
+  private static getRouteFromUrl(url: string): string {
+    try {
+      return new NodeURL(url).pathname;
+    } catch {
+      return url;
+    }
+  }
+
+  private static redactCredentials(proxyUrl: string | null): string | null {
+    if (!proxyUrl) {
+      return null;
+    }
+
+    try {
+      const parsed: NodeURL = new NodeURL(proxyUrl);
+
+      if (parsed.username || parsed.password) {
+        parsed.username = "***";
+        parsed.password = "***";
+      }
+
+      return parsed.toString();
+    } catch {
+      return "unparseable proxy url";
+    }
+  }
+
+  private static readNumber(value: unknown): number | null {
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
+  }
+
+  /*
+   * Runs the staged self-test once failures start repeating, rate-limited so
+   * a probe that is genuinely offline logs one block every few minutes
+   * instead of one per failed request.
+   */
+  public static maybeRunConnectivitySelfTest(): void {
+    if (this.consecutiveFailureCount < SELF_TEST_FAILURE_THRESHOLD) {
+      return;
+    }
+
+    if (this.isSelfTestRunning) {
+      return;
+    }
+
+    if (
+      this.lastSelfTestAtInMs !== null &&
+      Date.now() - this.lastSelfTestAtInMs < SELF_TEST_MIN_INTERVAL_IN_MS
+    ) {
+      return;
+    }
+
+    this.lastSelfTestAtInMs = Date.now();
+    this.isSelfTestRunning = true;
+
+    this.runConnectivitySelfTest()
+      .then((result: JSONObject): void => {
+        logger.error(
+          `Connectivity self-test against ${PROBE_INGEST_URL.toString()} (run after ${this.consecutiveFailureCount} consecutive failures):`,
+        );
+        logger.error(JSON.stringify(result, null, 2));
+      })
+      .catch((err: unknown): void => {
+        logger.error("Connectivity self-test could not be completed");
+        logger.error(err);
+      })
+      .finally((): void => {
+        this.isSelfTestRunning = false;
+      });
+  }
+
+  /*
+   * Walks the connection up one layer at a time against the same server the
+   * failing request used. The first stage that fails IS the answer, and each
+   * stage is timed so "works but takes 9 seconds" is visible too.
+   */
+  public static async runConnectivitySelfTest(): Promise<JSONObject> {
+    const ingestUrl: string = PROBE_INGEST_URL.toString();
+
+    let parsedUrl: NodeURL;
+
+    try {
+      parsedUrl = new NodeURL(ingestUrl);
+    } catch {
+      return { error: `Could not parse PROBE_INGEST_URL: ${ingestUrl}` };
+    }
+
+    const isHttps: boolean = parsedUrl.protocol === "https:";
+    const serverHost: string = parsedUrl.hostname;
+    const serverPort: number = parsedUrl.port
+      ? Number(parsedUrl.port)
+      : isHttps
+        ? 443
+        : 80;
+
+    const proxyAgents: Readonly<ProxyAgents> =
+      ProxyConfig.getRequestProxyAgents(ingestUrl);
+    const isProxied: boolean = Object.keys(proxyAgents).length > 0;
+
+    /*
+     * With a proxy in the path, a direct socket to the OneUptime server
+     * proves nothing (the probe never opens one) — the hop that matters is
+     * the one to the proxy, so that is what gets tested.
+     */
+    const proxyUrl: string | null = isProxied
+      ? HTTPS_PROXY_URL || HTTP_PROXY_URL
+      : null;
+
+    let tcpTarget: { host: string; port: number } = {
+      host: serverHost,
+      port: serverPort,
+    };
+
+    if (proxyUrl) {
+      try {
+        const parsedProxy: NodeURL = new NodeURL(proxyUrl);
+        tcpTarget = {
+          host: parsedProxy.hostname,
+          port: parsedProxy.port
+            ? Number(parsedProxy.port)
+            : parsedProxy.protocol === "https:"
+              ? 443
+              : 80,
+        };
+      } catch {
+        // Fall through to testing the server directly.
+      }
+    }
+
+    const testedHopNote: string = proxyUrl
+      ? " (the proxy — with one configured the probe never connects to the server directly)"
+      : "";
+
+    const tcpConnect: JSONObject = await this.testTcpConnect(
+      tcpTarget.host,
+      tcpTarget.port,
+    );
+
+    const result: JSONObject = {
+      target: ingestUrl,
+      throughProxy: isProxied,
+      testedHop: `${tcpTarget.host}:${tcpTarget.port}${testedHopNote}`,
+      dnsResolution: await this.testDnsResolution(tcpTarget.host),
+      tcpConnect: tcpConnect,
+    };
+
+    /*
+     * TLS is only meaningful end-to-end when the probe speaks it directly;
+     * through a CONNECT tunnel the handshake belongs to the proxy hop.
+     */
+    if (isHttps && !isProxied) {
+      /*
+       * Attempting TLS on a hop that would not even connect burns another
+       * stage timeout to report the same fact twice — and worse, its "TCP
+       * connects but TLS never finishes" reading would contradict the stage
+       * above it.
+       */
+      result["tlsHandshake"] =
+        tcpConnect["ok"] === true
+          ? await this.testTlsHandshake(serverHost, serverPort)
+          : {
+              ok: false,
+              skipped:
+                "Not attempted: the TCP stage above never connected, so there is nothing to negotiate TLS over.",
+            };
+    }
+
+    result["httpRequest"] = await this.testHttpRequest(parsedUrl);
+
+    return result;
+  }
+
+  private static async testDnsResolution(
+    hostname: string,
+  ): Promise<JSONObject> {
+    const startedAtInMs: number = Date.now();
+
+    /*
+     * An IP literal has nothing to resolve; saying so is clearer than a
+     * lookup that trivially "passes".
+     */
+    if (net.isIP(hostname) !== 0) {
+      return {
+        ok: true,
+        skipped: "Host is an IP literal, so there is no DNS step.",
+      };
+    }
+
+    try {
+      const addresses: Array<dns.LookupAddress> = await dns.promises.lookup(
+        hostname,
+        { all: true },
+      );
+
+      return {
+        ok: true,
+        elapsedInMs: Date.now() - startedAtInMs,
+        hostname: hostname,
+        addresses: addresses.map((address: dns.LookupAddress): string => {
+          return `${address.address} (IPv${address.family})`;
+        }),
+        systemResolvers: dns.getServers(),
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        elapsedInMs: Date.now() - startedAtInMs,
+        hostname: hostname,
+        error: (err as Error).message || String(err),
+        systemResolvers: dns.getServers(),
+        meaning:
+          "This machine cannot resolve the OneUptime server's hostname. Nothing else can work until DNS does.",
+      };
+    }
+  }
+
+  private static testTcpConnect(
+    host: string,
+    port: number,
+  ): Promise<JSONObject> {
+    return new Promise<JSONObject>((resolve: (value: JSONObject) => void) => {
+      const startedAtInMs: number = Date.now();
+
+      const socket: net.Socket = new net.Socket();
+
+      const settle: (value: JSONObject) => void = (value: JSONObject): void => {
+        socket.destroy();
+        resolve(value);
+      };
+
+      socket.setTimeout(SELF_TEST_STAGE_TIMEOUT_IN_MS);
+
+      socket.once("connect", (): void => {
+        settle({
+          ok: true,
+          elapsedInMs: Date.now() - startedAtInMs,
+          target: `${host}:${port}`,
+          connectedTo: socket.remoteAddress || null,
+          localPort: socket.localPort ?? null,
+        });
+      });
+
+      socket.once("timeout", (): void => {
+        settle({
+          ok: false,
+          elapsedInMs: Date.now() - startedAtInMs,
+          target: `${host}:${port}`,
+          error: `No TCP handshake within ${SELF_TEST_STAGE_TIMEOUT_IN_MS}ms`,
+          meaning:
+            "SYN packets are leaving this machine and nothing is coming back — a firewall or security appliance is dropping them silently, or the host is unreachable.",
+        });
+      });
+
+      socket.once("error", (err: Error): void => {
+        settle({
+          ok: false,
+          elapsedInMs: Date.now() - startedAtInMs,
+          target: `${host}:${port}`,
+          error: err.message,
+        });
+      });
+
+      socket.connect(port, host);
+    });
+  }
+
+  private static testTlsHandshake(
+    host: string,
+    port: number,
+  ): Promise<JSONObject> {
+    return new Promise<JSONObject>((resolve: (value: JSONObject) => void) => {
+      const startedAtInMs: number = Date.now();
+
+      const socket: tls.TLSSocket = tls.connect({
+        host: host,
+        port: port,
+        // SNI with an IP literal is disallowed by RFC 6066 and Node warns.
+        ...(net.isIP(host) === 0 ? { servername: host } : {}),
+        timeout: SELF_TEST_STAGE_TIMEOUT_IN_MS,
+      });
+
+      const settle: (value: JSONObject) => void = (value: JSONObject): void => {
+        socket.destroy();
+        resolve(value);
+      };
+
+      socket.once("secureConnect", (): void => {
+        const certificate: tls.PeerCertificate = socket.getPeerCertificate();
+
+        settle({
+          ok: true,
+          elapsedInMs: Date.now() - startedAtInMs,
+          protocol: socket.getProtocol(),
+          cipher: socket.getCipher()?.name || null,
+          authorized: socket.authorized,
+          authorizationError: socket.authorizationError
+            ? String(socket.authorizationError)
+            : null,
+          certificate: {
+            subject: certificate?.subject?.CN || null,
+            issuer: certificate?.issuer?.CN || null,
+            validFrom: certificate?.valid_from || null,
+            validTo: certificate?.valid_to || null,
+          },
+        });
+      });
+
+      socket.once("timeout", (): void => {
+        settle({
+          ok: false,
+          elapsedInMs: Date.now() - startedAtInMs,
+          error: `TLS handshake did not complete within ${SELF_TEST_STAGE_TIMEOUT_IN_MS}ms`,
+          meaning:
+            "TCP connects but TLS never finishes. A TLS-inspecting middlebox in the path is the usual cause.",
+        });
+      });
+
+      socket.once("error", (err: Error): void => {
+        settle({
+          ok: false,
+          elapsedInMs: Date.now() - startedAtInMs,
+          error: err.message,
+        });
+      });
+    });
+  }
+
+  /*
+   * The last stage: a real, unauthenticated HTTP round trip over the same
+   * path (proxy included) the probe's control-plane requests take. Any
+   * status code is a pass — it proves the far end answers HTTP; only a
+   * transport failure here is a finding.
+   */
+  private static async testHttpRequest(
+    parsedUrl: NodeURL,
+  ): Promise<JSONObject> {
+    const statusUrl: URL = URL.fromString(
+      `${parsedUrl.protocol}//${parsedUrl.host}/status`,
+    );
+
+    const startedAtInMs: number = Date.now();
+
+    try {
+      const response: { statusCode: number } = await API.get<JSONObject>({
+        url: statusUrl,
+        options: {
+          ...ProxyConfig.getRequestProxyAgents(statusUrl),
+          timeout: SELF_TEST_STAGE_TIMEOUT_IN_MS,
+        },
+      });
+
+      return {
+        ok: true,
+        url: statusUrl.toString(),
+        elapsedInMs: Date.now() - startedAtInMs,
+        statusCode: response.statusCode,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        url: statusUrl.toString(),
+        elapsedInMs: Date.now() - startedAtInMs,
+        error: (err as Error).message || String(err),
+        meaning:
+          "The lower layers may be fine but no HTTP response came back. If DNS/TCP/TLS above all passed, the OneUptime server or whatever sits in front of it is not answering.",
+      };
+    }
+  }
+
+  /*
+   * One block, printed at startup, that captures everything support
+   * otherwise has to ask for: which server, which deadline, which proxy,
+   * which Node/OS, and whether TLS verification has been tampered with.
+   */
+  public static logStartupEnvironment(): void {
+    const environment: JSONObject = {
+      probeIngestUrl: PROBE_INGEST_URL.toString(),
+      apiRequestDeadlineInMs: PROBE_API_REQUEST_TIMEOUT_IN_MS,
+      slowRequestWarningThresholdInMs: PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS,
+      proxy: this.getProxySnapshot(PROBE_INGEST_URL.toString()),
+      host: {
+        hostname: os.hostname(),
+        platform: `${os.platform()} ${os.release()}`,
+        arch: os.arch(),
+        cpuCount: os.cpus().length,
+        totalMemoryInMb: Math.round(os.totalmem() / 1024 / 1024),
+        nodeVersion: process.version,
+      },
+      tls: {
+        nodeExtraCaCerts: process.env["NODE_EXTRA_CA_CERTS"] || null,
+        certificateVerificationDisabled:
+          process.env["NODE_TLS_REJECT_UNAUTHORIZED"] === "0",
+      },
+      systemResolvers: dns.getServers(),
+    };
+
+    logger.info("Probe environment (include this when reporting an issue):");
+    logger.info(JSON.stringify(environment, null, 2));
+  }
+}


### PR DESCRIPTION
### Title of this pull request?

feat(probe): say WHERE a request to the server timed out, not just that it did

### Small Description?

A customer's probes were being flagged `Disconnected` with logs like this, on every control-plane route at once:

```
APIException [Error]: Request failed to https://<host>/probe-ingest/monitor-test/list. timeout of 45000ms exceeded
  ... 200 more lines of axios object ...
```

`timeout of 45000ms exceeded` is the **same sentence** whether the probe never got a socket, never completed the TCP handshake, never finished TLS, or connected perfectly and the server never wrote a byte back. Those are four different tickets — firewall, proxy, TLS interception, overloaded server — and the axios dump distinguishes none of them. Every report started from zero.

This PR makes the probe answer "timed out *where*".

**1. A failure report on every failed probe→server request.** Built from the real socket, with a `stalledAt` phase and a plain-English `whatThisMeans`:

| `stalledAt` | Meaning |
| --- | --- |
| `SocketAssignment` | Nothing left the machine — pool saturated, or a proxy never completed CONNECT |
| `TcpConnect` | SYN sent, nothing back — packets are being dropped |
| `TlsHandshake` | TCP connected, TLS never finished — usually a TLS-inspecting middlebox |
| `RequestSend` | Connected, request never fully written — the far end stopped reading |
| `WaitingForServerResponse` | Delivered, zero bytes back — **the probe's network is fine**, it's the server |
| `ResponseBody` | Server started answering and stalled part-way |

Verified end to end against a server that accepts and never answers:

```json
"stalledAt": "WaitingForServerResponse",
"connection": { "bytesWrittenToServer": 310, "bytesReadFromServer": 0,
                "tcpHandshakeStillPending": false, "socketReused": false }
```

The report also carries `deadlineOverrunInMs`. axios starts its timer when the request is created, so a 45s deadline that took 120s of wall clock means Node could not run its own timer — the probe process was blocked, and the network may be blameless. An event-loop sampler warns about that independently, which matters on a probe that also runs subnet sweeps and SNMP polls. Plus: the proxy in effect for that URL (credentials redacted), other in-flight requests and their ages (pile-up), consecutive failures, and time since anything last reached the server.

**2. A staged connectivity self-test** after three consecutive failures, rate-limited to once per 5 min. Walks the same server one layer at a time — DNS → TCP → TLS → a real HTTP round trip — timing each. The first stage that fails is the answer. Reports every A/AAAA record, the resolvers in use, *which* address it actually connected to, and cert subject/issuer/expiry. With a proxy configured it tests the proxy hop and says so, since that is the only hop the probe makes. Exercised against a reachable host, an unresolvable host, and a blackholed IP.

**3. A startup environment block** — ingest URL, deadline, proxy, resolvers, Node/OS, and whether TLS verification was disabled — so support stops spending a round trip asking for it.

**4. Slow-but-successful requests** over `PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS` (default 10s) are warned about with their elapsed time. That is the leading indicator: a probe logging 20-second requests is on its way to crossing 45s.

**5. Server side gets the other half.** `App/FeatureSet/Telemetry/Middleware/ProbeAuthorization.ts` now logs a slow-answered probe request with the probe's id — and, decisively, logs a probe that *hung up before a response was sent*. That second line is the proof a probe timeout is server-side; the probe's own log can never establish that alone.

**How it's wired.** One new optional `RequestOptions.onRequestComplete` hook in `Common/Utils/API.ts` (additive, no-op when absent), attached centrally in `ProbeAPIRequest.getDefaultRequestOptions` — the single place every probe→server request already passes through. **No call sites changed**, and any route added later is covered for free. The three UDP receivers and the ingress forwarder now route through it too, keeping their own shorter deadlines via a new options argument.

**Reviewer notes**

- `Common/Utils/API.ts` is shared with the whole app. The change is additive: a new optional callback, plus a restructured `catch` so the throwing path (`getErrorResponse` throws for a request that never produced a response — exactly the case worth reporting) can be observed before it propagates. Behaviour is otherwise identical, and the 401 auth-refresh recursion deliberately notifies once, from the recursive call.
- Diagnostics can never break a request: the hook is invoked inside a `try {} catch {}` that swallows everything.
- Peer IP and local port are only present when the error surfaces with the socket still open — axios destroys it as it raises a timeout and Node clears those fields. They are omitted rather than printed as `null` (a `null` next to `remoteAddress` reads as "could not resolve the host", a different and more alarming claim). The self-test's DNS/TCP stages answer "which address" for any sustained problem.
- Docs are English-only; the other 15 locales carry the older text and would need the usual translation pass.
- New env vars: `PROBE_API_SLOW_REQUEST_THRESHOLD_IN_MS` (default 10000), `PROBE_INGEST_SLOW_REQUEST_THRESHOLD_IN_MS` (server side, default 10000). Both documented.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verified locally: `tsc --noEmit` clean on Probe, Common and App; **556** Probe tests, **1300** Common util tests, **213** App telemetry tests pass; eslint clean on every touched file. New logic covered by 17 tests in `Probe/Tests/Utils/ProbeApiDiagnostics.test.ts` (one per stall phase, the deadline-overrun note, contact-history streaks, slow-request warnings) and 3 in the middleware test.

### Related Issue?

None — raised from a customer support thread about probes reporting `Disconnected` with 45s timeouts on every route.

### Screenshots (if appropriate):

N/A — log output only; representative output is quoted above.
