### PR TITLE
refactor(dashboard): rename 'Authentication Security' sidebar section to 'Security'

### DIFF
--- a/App/FeatureSet/Dashboard/src/Locales/da.json
+++ b/App/FeatureSet/Dashboard/src/Locales/da.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Brugere og teams",
   "Notifications": "Notifikationer",
   "AI": "AI",
-  "Authentication Security": "Godkendelsessikkerhed",
   "Audit Logs": "Auditlogs",
   "Danger Zone": "Farezone",
   "Billing and Invoices": "Fakturering og fakturaer",

--- a/App/FeatureSet/Dashboard/src/Locales/de.json
+++ b/App/FeatureSet/Dashboard/src/Locales/de.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Benutzer und Teams",
   "Notifications": "Benachrichtigungen",
   "AI": "KI",
-  "Authentication Security": "Authentifizierungssicherheit",
   "Audit Logs": "Audit-Protokolle",
   "Danger Zone": "Gefahrenzone",
   "Billing and Invoices": "Abrechnung und Rechnungen",

--- a/App/FeatureSet/Dashboard/src/Locales/en.json
+++ b/App/FeatureSet/Dashboard/src/Locales/en.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Users and Teams",
   "Notifications": "Notifications",
   "AI": "AI",
-  "Authentication Security": "Authentication Security",
   "Audit Logs": "Audit Logs",
   "Danger Zone": "Danger Zone",
   "Billing and Invoices": "Billing and Invoices",

--- a/App/FeatureSet/Dashboard/src/Locales/es.json
+++ b/App/FeatureSet/Dashboard/src/Locales/es.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Usuarios y Equipos",
   "Notifications": "Notificaciones",
   "AI": "IA",
-  "Authentication Security": "Seguridad de Autenticación",
   "Audit Logs": "Registros de Auditoría",
   "Danger Zone": "Zona de Peligro",
   "Billing and Invoices": "Facturación y Facturas",

--- a/App/FeatureSet/Dashboard/src/Locales/fr.json
+++ b/App/FeatureSet/Dashboard/src/Locales/fr.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Utilisateurs et équipes",
   "Notifications": "Notifications",
   "AI": "IA",
-  "Authentication Security": "Sécurité d'authentification",
   "Audit Logs": "Journaux d'audit",
   "Danger Zone": "Zone de danger",
   "Billing and Invoices": "Facturation et factures",

--- a/App/FeatureSet/Dashboard/src/Locales/hi.json
+++ b/App/FeatureSet/Dashboard/src/Locales/hi.json
@@ -241,7 +241,6 @@
   "Users and Teams": "उपयोगकर्ता और टीमें",
   "Notifications": "सूचनाएं",
   "AI": "एआई",
-  "Authentication Security": "प्रमाणीकरण सुरक्षा",
   "Audit Logs": "ऑडिट लॉग",
   "Danger Zone": "खतरा क्षेत्र",
   "Billing and Invoices": "बिलिंग और चालान",

--- a/App/FeatureSet/Dashboard/src/Locales/it.json
+++ b/App/FeatureSet/Dashboard/src/Locales/it.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Utenti e team",
   "Notifications": "Notifiche",
   "AI": "IA",
-  "Authentication Security": "Sicurezza dell'autenticazione",
   "Audit Logs": "Registri di audit",
   "Danger Zone": "Zona pericolosa",
   "Billing and Invoices": "Fatturazione e fatture",

--- a/App/FeatureSet/Dashboard/src/Locales/ja.json
+++ b/App/FeatureSet/Dashboard/src/Locales/ja.json
@@ -241,7 +241,6 @@
   "Users and Teams": "ユーザーとチーム",
   "Notifications": "通知",
   "AI": "AI",
-  "Authentication Security": "認証セキュリティ",
   "Audit Logs": "監査ログ",
   "Danger Zone": "危険ゾーン",
   "Billing and Invoices": "請求と請求書",

--- a/App/FeatureSet/Dashboard/src/Locales/ko.json
+++ b/App/FeatureSet/Dashboard/src/Locales/ko.json
@@ -241,7 +241,6 @@
   "Users and Teams": "사용자 및 팀",
   "Notifications": "알림",
   "AI": "AI",
-  "Authentication Security": "인증 보안",
   "Audit Logs": "감사 로그",
   "Danger Zone": "위험 영역",
   "Billing and Invoices": "결제 및 청구서",

--- a/App/FeatureSet/Dashboard/src/Locales/nl.json
+++ b/App/FeatureSet/Dashboard/src/Locales/nl.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Gebruikers en teams",
   "Notifications": "Meldingen",
   "AI": "AI",
-  "Authentication Security": "Authenticatie-beveiliging",
   "Audit Logs": "Auditlogboeken",
   "Danger Zone": "Gevarenzone",
   "Billing and Invoices": "Facturering en facturen",

--- a/App/FeatureSet/Dashboard/src/Locales/no.json
+++ b/App/FeatureSet/Dashboard/src/Locales/no.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Brukere og team",
   "Notifications": "Varsler",
   "AI": "KI",
-  "Authentication Security": "Autentiseringssikkerhet",
   "Audit Logs": "Revisjonslogger",
   "Danger Zone": "Faresone",
   "Billing and Invoices": "Fakturering og fakturaer",

--- a/App/FeatureSet/Dashboard/src/Locales/pt.json
+++ b/App/FeatureSet/Dashboard/src/Locales/pt.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Usuários e equipes",
   "Notifications": "Notificações",
   "AI": "IA",
-  "Authentication Security": "Segurança de autenticação",
   "Audit Logs": "Registros de auditoria",
   "Danger Zone": "Zona de perigo",
   "Billing and Invoices": "Cobrança e faturas",

--- a/App/FeatureSet/Dashboard/src/Locales/ru.json
+++ b/App/FeatureSet/Dashboard/src/Locales/ru.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Пользователи и команды",
   "Notifications": "Уведомления",
   "AI": "ИИ",
-  "Authentication Security": "Безопасность аутентификации",
   "Audit Logs": "Журналы аудита",
   "Danger Zone": "Опасная зона",
   "Billing and Invoices": "Биллинг и счета",

--- a/App/FeatureSet/Dashboard/src/Locales/sv.json
+++ b/App/FeatureSet/Dashboard/src/Locales/sv.json
@@ -241,7 +241,6 @@
   "Users and Teams": "Användare och team",
   "Notifications": "Aviseringar",
   "AI": "AI",
-  "Authentication Security": "Autentiseringssäkerhet",
   "Audit Logs": "Granskningsloggar",
   "Danger Zone": "Farozon",
   "Billing and Invoices": "Fakturering och fakturor",

--- a/App/FeatureSet/Dashboard/src/Locales/zh-CN.json
+++ b/App/FeatureSet/Dashboard/src/Locales/zh-CN.json
@@ -241,7 +241,6 @@
   "Users and Teams": "用户和团队",
   "Notifications": "通知",
   "AI": "人工智能",
-  "Authentication Security": "认证安全",
   "Audit Logs": "审计日志",
   "Danger Zone": "危险区域",
   "Billing and Invoices": "账单和发票",

--- a/App/FeatureSet/Dashboard/src/Locales/zh-TW.json
+++ b/App/FeatureSet/Dashboard/src/Locales/zh-TW.json
@@ -241,7 +241,6 @@
   "Users and Teams": "使用者與團隊",
   "Notifications": "通知",
   "AI": "人工智慧",
-  "Authentication Security": "驗證安全",
   "Audit Logs": "稽核日誌",
   "Danger Zone": "危險區域",
   "Billing and Invoices": "帳單與發票",

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/SideMenu.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/SideMenu.tsx
@@ -199,7 +199,7 @@ const DashboardSideMenu: () => JSX.Element = (): ReactElement => {
       ],
     },
     {
-      title: "Authentication Security",
+      title: "Security",
       items: [
         {
           link: {
@@ -272,7 +272,7 @@ const DashboardSideMenu: () => JSX.Element = (): ReactElement => {
 
   // Conditionally add Billing section
   if (BILLING_ENABLED) {
-    // Insert Billing section before Authentication Security (second to last)
+    // Insert Billing section before Security (second to last)
     sections.splice(-2, 0, {
       title: "Billing and Invoices",
       items: [

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SideMenu.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SideMenu.tsx
@@ -254,7 +254,7 @@ const DashboardSideMenu: FunctionComponent<ComponentProps> = (
         />
       </SideMenuSection>
 
-      <SideMenuSection title="Authentication Security">
+      <SideMenuSection title="Security">
         <SideMenuItem
           link={{
             title: "Private Users",


### PR DESCRIPTION
### Title of this pull request?

refactor(dashboard): rename "Authentication Security" sidebar section to "Security"

### Small Description?

Renames the `Authentication Security` sidebar section to just `Security` in the two places it appears:

- `App/FeatureSet/Dashboard/src/Pages/Settings/SideMenu.tsx` — project Settings sidebar (SSO, OIDC, SCIM, Authentication Settings)
- `App/FeatureSet/Dashboard/src/Pages/StatusPages/View/SideMenu.tsx` — Status Page view sidebar (Private Users, SSO, OIDC, SCIM, Authentication Settings)

The longer label wrapped onto two lines in the sidebar, and the section covers general security settings rather than authentication alone.

Also removes the now-unused `"Authentication Security"` key from all 16 locale files. A `"Security"` translation already exists in every one of them, so each language picks up the correct localized string with no new translation work required.

No behavior, routing, or permissions change — display label only.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate? — N/A, static label rename with no test surface.

### Related Issue?

N/A

### Screenshots (if appropriate):

Not captured — this repo has no `.claude/launch.json` preview config, so the full stack was not started for a label-only change. The section header now reads `SECURITY` in place of `AUTHENTICATION SECURITY`; the items under it are unchanged.