### PR TITLE
fix(status-page): draw nested resource groups as a tree, not cards inside cards

### DIFF
--- a/App/FeatureSet/StatusPage/src/Components/Monitor/MonitorOverview.tsx
+++ b/App/FeatureSet/StatusPage/src/Components/Monitor/MonitorOverview.tsx
@@ -13,6 +13,7 @@ import MonitorStatusTimelne from "Common/Models/DatabaseModels/MonitorStatusTime
 import StatusPageHistoryChartBarColorRule from "Common/Models/DatabaseModels/StatusPageHistoryChartBarColorRule";
 import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import UptimeBarTooltipIncident from "Common/Types/Monitor/UptimeBarTooltipIncident";
+import StatusPageGroupNestingLayoutUtil from "Common/Utils/StatusPage/GroupNestingLayout";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { translateStatusName } from "../../Utils/StatusTranslation";
@@ -37,6 +38,13 @@ export interface ComponentProps {
   uptimeHistoryDays?: number | undefined;
   incidents?: Array<UptimeBarTooltipIncident> | undefined;
   onIncidentClick?: ((incidentId: string) => void) | undefined;
+  /*
+   * "90 days ago ... Today" under the bars. Every bar in a block is drawn over
+   * the same window, so the overview turns this off and draws the axis once for
+   * the whole block instead of once per resource per nesting level. Defaults to
+   * on for anything that renders a resource on its own.
+   */
+  showTimeAxisLabels?: boolean | undefined;
 }
 
 const MonitorOverview: FunctionComponent<ComponentProps> = (
@@ -119,7 +127,15 @@ const MonitorOverview: FunctionComponent<ComponentProps> = (
           style={{ marginBottom: "3px" }}
         >
           <div className="flex items-center mb-2 sm:mb-0">
-            <div className="text-base md:text-lg font-medium">
+            {/*
+             * Deliberately not larger than a group title: a resource is a leaf
+             * of the group hierarchy and must not out-weigh the group heading
+             * above it. The class lives in the layout util so that floor is
+             * checked against the string that actually renders here.
+             */}
+            <div
+              className={StatusPageGroupNestingLayoutUtil.getResourceTitleClassName()}
+            >
               {props.monitorName}
             </div>
             {props.tooltip && (
@@ -177,7 +193,7 @@ const MonitorOverview: FunctionComponent<ComponentProps> = (
       )}
 
       {/* Time labels: Visible on all screen sizes */}
-      {props.showHistoryChart && (
+      {props.showHistoryChart && props.showTimeAxisLabels !== false && (
         <div className="text-xs sm:text-sm text-gray-500 mt-1 justify-between flex">
           <div>
             {t("monitorOverview.daysAgo", {

--- a/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Overview/Overview.tsx
@@ -26,7 +26,6 @@ import IconProp from "Common/Types/Icon/IconProp";
 import { JSONArray, JSONObject } from "Common/Types/JSON";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import ObjectID from "Common/Types/ObjectID";
-import Accordion from "Common/UI/Components/Accordion/Accordion";
 import Alert, { AlertSize } from "Common/UI/Components/Alerts/Alert";
 import EmptyState from "Common/UI/Components/EmptyState/EmptyState";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
@@ -63,7 +62,13 @@ import { translateStatusName } from "../../Utils/StatusTranslation";
 import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
 import StatusPageResourceUptimeUtil from "Common/Utils/StatusPage/ResourceUptime";
-import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import StatusPageGroupTreeUtil, {
+  StatusPageGroupTreeNode,
+} from "Common/Utils/StatusPage/GroupTree";
+import StatusPageGroupNestingLayoutUtil, {
+  StatusPageGroupRollupKind,
+} from "Common/Utils/StatusPage/GroupNestingLayout";
+import ResourceGroupSection from "Common/UI/Components/StatusPage/ResourceGroupSection";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import UptimeBarTooltipIncident from "Common/Types/Monitor/UptimeBarTooltipIncident";
 import Color from "Common/Types/Color";
@@ -429,82 +434,122 @@ const Overview: FunctionComponent<PageComponentProps> = (
     StatusPageUtil.isPrivateStatusPage(),
   ]);
 
-  type GetCurrentGroupStatusElementFunction = (data: {
+  /*
+   * A group's rolled up status or uptime. Which of the two (or neither) is
+   * StatusPageGroupNestingLayoutUtil.getRollupKind's decision; this only reads
+   * the numbers it needs and formats the label.
+   */
+  interface GroupRollup {
+    label: string;
+    color: string;
+  }
+
+  type GetGroupRollupFunction = (data: {
     group: StatusPageGroup;
-  }) => ReactElement;
+  }) => GroupRollup | null;
 
-  const getCurrentGroupStatusElement: GetCurrentGroupStatusElementFunction =
-    (data: { group: StatusPageGroup }): ReactElement => {
-      const currentStatus: MonitorStatus =
-        StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus({
-          statusPageGroup: data.group,
-          monitorStatusTimelines: monitorStatusTimelines,
-          statusPageResources: statusPageResources,
-          monitorStatuses: monitorStatuses,
-          monitorGroupCurrentStatuses: monitorGroupCurrentStatuses,
-          allStatusPageGroups: resourceGroups,
-        });
+  const getGroupRollup: GetGroupRollupFunction = (data: {
+    group: StatusPageGroup;
+  }): GroupRollup | null => {
+    const currentStatus: MonitorStatus =
+      StatusPageResourceUptimeUtil.getCurrentStatusPageGroupStatus({
+        statusPageGroup: data.group,
+        monitorStatusTimelines: monitorStatusTimelines,
+        statusPageResources: statusPageResources,
+        monitorStatuses: monitorStatuses,
+        monitorGroupCurrentStatuses: monitorGroupCurrentStatuses,
+        allStatusPageGroups: resourceGroups,
+      });
 
-      if (
-        !(statusPage?.downtimeMonitorStatuses || []).find(
-          (downtimeStatus: MonitorStatus) => {
-            return (
-              currentStatus?.id?.toString() === downtimeStatus?.id?.toString()
-            );
-          },
-        ) &&
-        data.group.showUptimePercent
-      ) {
-        const uptimePercent: number | null =
-          StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
-            {
-              statusPageGroup: data.group,
-              monitorStatusTimelines: monitorStatusTimelines,
-              precision:
-                data.group.uptimePercentPrecision ||
-                UptimePrecision.ONE_DECIMAL,
-              downtimeMonitorStatuses:
-                statusPage?.downtimeMonitorStatuses || [],
-              statusPageResources: statusPageResources,
-              monitorsInGroup: monitorsInGroup,
-              uptimeWindow: { startDate: startDate, endDate: endDate },
-              allStatusPageGroups: resourceGroups,
-            },
+    const color: string = currentStatus?.color?.toString() || Green.toString();
+
+    const isCurrentlyDown: boolean = Boolean(
+      (statusPage?.downtimeMonitorStatuses || []).find(
+        (downtimeStatus: MonitorStatus) => {
+          return (
+            currentStatus?.id?.toString() === downtimeStatus?.id?.toString()
           );
+        },
+      ),
+    );
 
-        if (uptimePercent === null) {
-          return <></>;
-        }
+    const uptimePercent: number | null = data.group.showUptimePercent
+      ? StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup(
+          {
+            statusPageGroup: data.group,
+            monitorStatusTimelines: monitorStatusTimelines,
+            precision:
+              data.group.uptimePercentPrecision || UptimePrecision.ONE_DECIMAL,
+            downtimeMonitorStatuses: statusPage?.downtimeMonitorStatuses || [],
+            statusPageResources: statusPageResources,
+            monitorsInGroup: monitorsInGroup,
+            uptimeWindow: { startDate: startDate, endDate: endDate },
+            allStatusPageGroups: resourceGroups,
+          },
+        )
+      : null;
 
-        return (
-          <div
-            className="font-medium"
-            style={{
-              color: currentStatus?.color?.toString() || Green.toString(),
-            }}
-          >
-            {uptimePercent}
-            {t("overview.uptimeSuffix")}
-          </div>
-        );
-      }
+    const kind: StatusPageGroupRollupKind =
+      StatusPageGroupNestingLayoutUtil.getRollupKind({
+        showUptimePercent: Boolean(data.group.showUptimePercent),
+        showCurrentStatus: Boolean(data.group.showCurrentStatus),
+        isCurrentlyDown: isCurrentlyDown,
+        uptimePercent: uptimePercent,
+      });
 
-      if (data.group.showCurrentStatus) {
-        return (
-          <div
-            className=""
-            style={{
-              color: currentStatus?.color?.toString() || Green.toString(),
-            }}
-          >
-            {translateStatusName(currentStatus?.name) ||
-              t("overview.operational")}
-          </div>
-        );
-      }
+    if (kind === StatusPageGroupRollupKind.UptimePercent) {
+      return {
+        label: `${uptimePercent}${t("overview.uptimeSuffix")}`,
+        color: color,
+      };
+    }
 
-      return <></>;
-    };
+    if (kind === StatusPageGroupRollupKind.CurrentStatus) {
+      return {
+        label:
+          translateStatusName(currentStatus?.name) || t("overview.operational"),
+        color: color,
+      };
+    }
+
+    return null;
+  };
+
+  /*
+   * Every bar in one resource list is drawn over the same window and sits in the
+   * same column, so the axis is drawn once under the list instead of once under
+   * every resource. Sub groups draw their own, next to their own bars.
+   */
+  type GetUptimeTimeAxisFunction = (data: {
+    statusPageGroup: StatusPageGroup | null;
+  }) => ReactElement | null;
+
+  const getUptimeTimeAxis: GetUptimeTimeAxisFunction = (data: {
+    statusPageGroup: StatusPageGroup | null;
+  }): ReactElement | null => {
+    if (
+      !StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+        statusPageGroup: data.statusPageGroup,
+        statusPageResources: statusPageResources,
+      })
+    ) {
+      return null;
+    }
+
+    return (
+      <div
+        className={StatusPageGroupNestingLayoutUtil.getTimeAxisClassName()}
+        data-testid="uptime-time-axis"
+      >
+        <div>
+          {t("monitorOverview.daysAgo", {
+            days: uptimeHistoryDays,
+          })}
+        </div>
+        <div>{t("monitorOverview.today")}</div>
+      </div>
+    );
+  };
 
   if (isLoading) {
     return <PageLoader isVisible={true} />;
@@ -538,6 +583,17 @@ const Overview: FunctionComponent<PageComponentProps> = (
           continue;
         }
 
+        /*
+         * Keyed on the resource rather than on a fresh random number, so a
+         * resource is not torn down and remounted on every render - that used
+         * to throw away an open incident day modal. A resource with no id of
+         * its own falls back to its position, and the two branches below are
+         * namespaced apart because nothing stops one resource from carrying
+         * both a monitor and a monitor group.
+         */
+        const resourceKey: string =
+          resource._id?.toString() || `position-${elements.length}`;
+
         // if it's a monitor
 
         if (resource.monitor) {
@@ -567,8 +623,8 @@ const Overview: FunctionComponent<PageComponentProps> = (
 
           elements.push(
             <MonitorOverview
-              key={Math.random()}
-              className="mb-3 sm:mb-5"
+              key={`monitor-${resourceKey}`}
+              showTimeAxisLabels={false}
               monitorName={resource.displayName || resource.monitor?.name || ""}
               statusPageHistoryChartBarColorRules={
                 statusPageHistoryChartBarColorRules
@@ -648,8 +704,8 @@ const Overview: FunctionComponent<PageComponentProps> = (
 
           elements.push(
             <MonitorOverview
-              key={Math.random()}
-              className="mb-3 sm:mb-5"
+              key={`monitor-group-${resourceKey}`}
+              showTimeAxisLabels={false}
               monitorName={resource.displayName || resource.monitor?.name || ""}
               showUptimePercent={Boolean(resource.showUptimePercent)}
               uptimePrecision={
@@ -1101,29 +1157,26 @@ const Overview: FunctionComponent<PageComponentProps> = (
 
   /*
    * Groups can be nested (Corporate Unit -> Region -> Market -> Site), so a
-   * group renders its own resources first and then each of its sub groups
-   * below them. Every level is an accordion carrying its own rolled up status
-   * / uptime, and nesting is drawn with a left rail rather than by piling
-   * background tints on top of each other - that stays readable however deep
-   * the hierarchy goes.
+   * group renders its own resources first and then each of its sub groups below
+   * them. Only the top level is a card: everything under it hangs off a tree
+   * rail, because a card inside a card inside a card runs out of horizontal
+   * room and wraps four borders around one uptime bar. See
+   * StatusPageGroupNestingLayoutUtil for the layout itself.
    */
   type RenderResourceGroupFunction = (data: {
-    group: StatusPageGroup;
-    depth: number;
+    node: StatusPageGroupTreeNode;
   }) => ReactElement;
 
   const renderResourceGroup: RenderResourceGroupFunction = (data: {
-    group: StatusPageGroup;
-    depth: number;
+    node: StatusPageGroupTreeNode;
   }): ReactElement => {
-    const group: StatusPageGroup = data.group;
-    const isRootLevel: boolean = data.depth === 0;
+    const group: StatusPageGroup = data.node.group;
 
-    const childGroups: Array<StatusPageGroup> =
-      StatusPageGroupTreeUtil.getChildGroups({
-        statusPageGroupId: group._id?.toString() || null,
-        statusPageGroups: resourceGroups,
-      });
+    const childGroups: Array<StatusPageGroup> = data.node.children.map(
+      (child: StatusPageGroupTreeNode) => {
+        return child.group;
+      },
+    );
 
     const directResources: Array<StatusPageResource> =
       StatusPageResourceUptimeUtil.getResourcesInStatusPageGroup({
@@ -1133,110 +1186,67 @@ const Overview: FunctionComponent<PageComponentProps> = (
 
     const isGrid: boolean = group.viewMode === StatusPageGroupViewMode.Grid;
 
-    /*
-     * A group that exists only to hold sub groups has no resources of its own,
-     * and telling the visitor it is empty would be wrong - the sub groups
-     * below it are its content.
-     */
     const showOwnResources: boolean =
-      directResources.length > 0 || childGroups.length === 0;
+      StatusPageGroupNestingLayoutUtil.shouldRenderOwnResources({
+        ownResourceCount: directResources.length,
+        subGroupCount: childGroups.length,
+      });
 
     /*
-     * The rolled up status / uptime lives inside the title rather than in the
-     * accordion's rightElement, which is hidden while the accordion is open.
-     * The whole point of the hierarchy is that every level always shows what it
-     * rolls up, and keeping it in one place means it does not jump around when
-     * a level is expanded.
+     * `total` rather than `count`: i18next treats a `count` variable as a plural
+     * selector and would look for keys that do not exist here.
      */
-    const title: ReactElement = (
-      <div className="flex items-center justify-between gap-3 w-full">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="truncate">{group.name || ""}</span>
-          {childGroups.length > 0 && (
-            <span className="flex-shrink-0 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10.5px] font-medium text-gray-500 tabular-nums">
-              {/*
-               * `total` rather than `count`: i18next treats a `count` variable
-               * as a plural selector and would look for keys that do not exist
-               * here.
-               */}
-              {childGroups.length === 1
-                ? t("overview.oneSubGroup", { defaultValue: "1 group" })
-                : t("overview.subGroupCount", {
-                    total: childGroups.length,
-                    defaultValue: "{{total}} groups",
-                  })}
-            </span>
-          )}
-        </div>
-        <div className="flex-shrink-0 text-sm font-normal">
-          {getCurrentGroupStatusElement({ group: group })}
-        </div>
-      </div>
-    );
+    let subGroupCountLabel: string | undefined = undefined;
 
-    const body: ReactElement = (
-      <>
-        {showOwnResources ? (
-          isGrid ? (
-            getGridForGroup(group)
-          ) : (
-            <>{getMonitorOverviewListInGroup(group)}</>
-          )
-        ) : (
-          <></>
-        )}
-        {childGroups.length > 0 ? (
-          <div className="space-y-2.5">
-            {childGroups.map((childGroup: StatusPageGroup) => {
-              return renderResourceGroup({
-                group: childGroup,
-                depth: data.depth + 1,
-              });
-            })}
-          </div>
-        ) : (
-          <></>
-        )}
-      </>
-    );
-
-    const accordion: ReactElement = (
-      <Accordion
-        isInitiallyExpanded={group.isExpandedByDefault}
-        isLastElement={true}
-        title={title}
-        titleClassName={
-          isRootLevel
-            ? "text-base font-semibold tracking-tight"
-            : "text-sm font-semibold tracking-tight text-gray-800"
-        }
-      >
-        {body}
-      </Accordion>
-    );
-
-    if (isRootLevel) {
-      return (
-        <div
-          key={group._id?.toString() || ""}
-          className="bg-white pl-3 pr-3 sm:pl-5 sm:pr-5 rounded-xl shadow"
-          data-testid="status-page-group"
-        >
-          {accordion}
-        </div>
-      );
+    if (childGroups.length === 1) {
+      subGroupCountLabel = t("overview.oneSubGroup", {
+        defaultValue: "1 group",
+      });
+    } else if (childGroups.length > 1) {
+      subGroupCountLabel = t("overview.subGroupCount", {
+        total: childGroups.length,
+        defaultValue: "{{total}} groups",
+      });
     }
 
+    const rollup: GroupRollup | null = getGroupRollup({ group: group });
+
     return (
-      <div
+      <ResourceGroupSection
         key={group._id?.toString() || ""}
-        className="border-l-2 border-gray-100 pl-2 sm:pl-3"
-        data-testid="status-page-nested-group"
-      >
-        <div className="rounded-lg border border-gray-200 bg-white pl-3 pr-3 sm:pl-5 sm:pr-5">
-          {accordion}
-        </div>
-      </div>
+        depth={data.node.depth}
+        name={group.name || ""}
+        description={group.description || undefined}
+        subGroupCount={childGroups.length}
+        subGroupCountLabel={subGroupCountLabel}
+        hasOwnResources={showOwnResources}
+        rollupLabel={rollup?.label}
+        rollupColor={rollup?.color}
+        isInitiallyExpanded={group.isExpandedByDefault}
+        resourcesElement={
+          showOwnResources ? (
+            isGrid ? (
+              getGridForGroup(group)
+            ) : (
+              <div
+                className={StatusPageGroupNestingLayoutUtil.getResourceListClassName()}
+              >
+                {getMonitorOverviewListInGroup(group)}
+                {getUptimeTimeAxis({ statusPageGroup: group })}
+              </div>
+            )
+          ) : undefined
+        }
+        subGroupsElement={
+          data.node.children.length > 0 ? (
+            <>
+              {data.node.children.map((childNode: StatusPageGroupTreeNode) => {
+                return renderResourceGroup({ node: childNode });
+              })}
+            </>
+          ) : undefined
+        }
+      />
     );
   };
 
@@ -1470,26 +1480,33 @@ const Overview: FunctionComponent<PageComponentProps> = (
               {statusPageResources.filter((resources: StatusPageResource) => {
                 return !resources.statusPageGroupId;
               }).length > 0 ? (
-                <div className="bg-white pl-3 pr-3 sm:pl-5 sm:pr-5 rounded-xl shadow">
-                  <Accordion
-                    key={Math.random()}
-                    title={undefined}
-                    isLastElement={true}
+                <div
+                  className={StatusPageGroupNestingLayoutUtil.getUngroupedResourcesCardClassName()}
+                  data-testid="status-page-ungrouped-resources"
+                >
+                  <div
+                    className={StatusPageGroupNestingLayoutUtil.getResourceListClassName()}
                   >
                     {getMonitorOverviewListInGroup(null)}
-                  </Accordion>
+                    {getUptimeTimeAxis({ statusPageGroup: null })}
+                  </div>
                 </div>
               ) : (
                 <></>
               )}
+              {/*
+               * buildTree rather than getRootGroups: a parent pointer written
+               * straight to the database can put a group in a cycle, and a
+               * cycle has no root, so walking down from the roots would drop
+               * those groups off the page entirely. buildTree promotes them to
+               * the top level instead - a group nobody can see is worse than a
+               * group in the wrong place.
+               */}
               {resourceGroups.length > 0 &&
-                StatusPageGroupTreeUtil.getRootGroups({
+                StatusPageGroupTreeUtil.buildTree({
                   statusPageGroups: resourceGroups,
-                }).map((resourceGroup: StatusPageGroup) => {
-                  return renderResourceGroup({
-                    group: resourceGroup,
-                    depth: 0,
-                  });
+                }).map((node: StatusPageGroupTreeNode) => {
+                  return renderResourceGroup({ node: node });
                 })}
             </div>
           )}

--- a/Common/Tests/UI/Components/StatusPage/ResourceGroupSection.test.tsx
+++ b/Common/Tests/UI/Components/StatusPage/ResourceGroupSection.test.tsx
@@ -1,0 +1,671 @@
+import ResourceGroupSection from "../../../../UI/Components/StatusPage/ResourceGroupSection";
+import StatusPageGroupNestingLayoutUtil from "../../../../Utils/StatusPage/GroupNestingLayout";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import React, { ReactElement } from "react";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Contract under test - one level of the status page resource group hierarchy.
+ *
+ * The nesting this replaces drew every level as a card inside a card inside a
+ * card: at three levels deep a visitor saw four borders wrapped around one
+ * uptime bar, the bars lost the width they need on a phone, and the header was a
+ * div with role="button" wrapping markdown that may contain links. So the
+ * assertions here are about structure rather than looks:
+ *
+ *   - only the top level is a card, and nothing nested adds a surface,
+ *   - nested levels hang off a rail,
+ *   - the header is a real button that reports its expanded state,
+ *   - the rolled up reading stays visible when the level is expanded,
+ *   - and a description never ends up inside the button.
+ */
+
+function renderSection(
+  props: Partial<React.ComponentProps<typeof ResourceGroupSection>> = {},
+): ReturnType<typeof render> {
+  return render(
+    <ResourceGroupSection
+      depth={props.depth === undefined ? 0 : props.depth}
+      name={props.name === undefined ? "Corporate" : props.name}
+      description={props.description}
+      subGroupCount={props.subGroupCount}
+      subGroupCountLabel={props.subGroupCountLabel}
+      rollupLabel={props.rollupLabel}
+      rollupColor={props.rollupColor}
+      isInitiallyExpanded={props.isInitiallyExpanded}
+      resourcesElement={props.resourcesElement}
+      subGroupsElement={props.subGroupsElement}
+      hasOwnResources={props.hasOwnResources}
+      testId={props.testId}
+    />,
+  );
+}
+
+function header(): HTMLElement {
+  return screen.getByTestId("status-page-group-header");
+}
+
+describe("ResourceGroupSection", () => {
+  describe("the header", () => {
+    test("renders the group name", () => {
+      renderSection({ name: "Region 1000" });
+
+      expect(screen.getByText("Region 1000")).toBeInTheDocument();
+    });
+
+    /*
+     * It used to be a div with role="button". A real button gets Enter, Space,
+     * focus and the accessible name for free.
+     */
+    test("is a real button, not a div wearing a role", () => {
+      renderSection();
+
+      expect(header().tagName).toBe("BUTTON");
+      expect(header()).toHaveAttribute("type", "button");
+    });
+
+    test("reports its collapsed and expanded state", () => {
+      renderSection();
+
+      expect(header()).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.click(header());
+
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+    });
+
+    test("toggles the body open and shut", () => {
+      renderSection({
+        resourcesElement: <div>Corporate API</div>,
+      });
+
+      expect(screen.queryByText("Corporate API")).not.toBeInTheDocument();
+
+      fireEvent.click(header());
+      expect(screen.getByText("Corporate API")).toBeInTheDocument();
+
+      fireEvent.click(header());
+      expect(screen.queryByText("Corporate API")).not.toBeInTheDocument();
+    });
+
+    /*
+     * aria-controls may only name an element that exists, and the body is not
+     * rendered while the section is shut.
+     */
+    test("points aria-controls at the body only while the body exists", () => {
+      renderSection({ resourcesElement: <div>Corporate API</div> });
+
+      expect(header()).not.toHaveAttribute("aria-controls");
+
+      fireEvent.click(header());
+
+      const bodyId: string | null = header().getAttribute("aria-controls");
+
+      expect(bodyId).toBeTruthy();
+      expect(screen.getByTestId("status-page-group-body")).toHaveAttribute(
+        "id",
+        bodyId,
+      );
+    });
+
+    /*
+     * A native button is focusable and activates on Enter and Space without
+     * anything being wired up. The div with role="button" it replaces needed
+     * tabIndex and a hand-rolled keydown handler to get halfway there.
+     */
+    test("is reachable by keyboard without a tabindex of its own", () => {
+      renderSection();
+
+      header().focus();
+
+      expect(header()).toHaveFocus();
+      expect(header()).not.toHaveAttribute("tabindex");
+    });
+
+    test("opens on Enter", async () => {
+      const user: UserEvent = userEvent.setup();
+
+      renderSection({ resourcesElement: <div>Corporate API</div> });
+
+      header().focus();
+      await user.keyboard("{Enter}");
+
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByText("Corporate API")).toBeInTheDocument();
+    });
+
+    test("opens on Space", async () => {
+      const user: UserEvent = userEvent.setup();
+
+      renderSection({ resourcesElement: <div>Corporate API</div> });
+
+      header().focus();
+      await user.keyboard("{ }");
+
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+
+  describe("expansion state", () => {
+    test("is shut by default", () => {
+      renderSection({ resourcesElement: <div>Corporate API</div> });
+
+      expect(
+        screen.queryByTestId("status-page-group-body"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("opens when the group is configured to expand by default", () => {
+      renderSection({
+        isInitiallyExpanded: true,
+        resourcesElement: <div>Corporate API</div>,
+      });
+
+      expect(screen.getByText("Corporate API")).toBeInTheDocument();
+    });
+
+    /*
+     * Groups arrive with the page payload, so the flag can flip after the first
+     * render.
+     */
+    test("follows isInitiallyExpanded when it arrives late", () => {
+      const { rerender } = render(
+        <ResourceGroupSection depth={0} name="Corporate" />,
+      );
+
+      expect(header()).toHaveAttribute("aria-expanded", "false");
+
+      rerender(
+        <ResourceGroupSection
+          depth={0}
+          name="Corporate"
+          isInitiallyExpanded={true}
+        />,
+      );
+
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+    });
+
+    /*
+     * The hazard the effect is keyed on a boolean for: isExpandedByDefault is an
+     * optional column, so it routinely arrives undefined and settles to false.
+     * Keyed on the prop, that identity change fires the effect and slams shut a
+     * section the visitor had just opened.
+     */
+    test("undefined settling to false does not shut a section the visitor opened", () => {
+      const { rerender } = render(
+        <ResourceGroupSection depth={0} name="Corporate" />,
+      );
+
+      fireEvent.click(header());
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+
+      rerender(
+        <ResourceGroupSection
+          depth={0}
+          name="Corporate"
+          isInitiallyExpanded={false}
+        />,
+      );
+
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+    });
+
+    /*
+     * A re-render that does not change the flag must not collapse a section the
+     * visitor just opened.
+     */
+    test("keeps a section the visitor opened open across a re-render", () => {
+      const { rerender } = render(
+        <ResourceGroupSection depth={0} name="Corporate" />,
+      );
+
+      fireEvent.click(header());
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+
+      rerender(<ResourceGroupSection depth={0} name="Corporate updated" />);
+
+      expect(header()).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+
+  describe("the top level", () => {
+    test("is a card", () => {
+      renderSection({ depth: 0 });
+
+      const container: HTMLElement = screen.getByTestId("status-page-group");
+
+      expect(container).toHaveClass("bg-white");
+      expect(container).toHaveClass("rounded-xl");
+      expect(container).toHaveClass("shadow");
+    });
+
+    test("carries its depth for anything reading the DOM", () => {
+      renderSection({ depth: 0 });
+
+      expect(screen.getByTestId("status-page-group")).toHaveAttribute(
+        "data-depth",
+        "0",
+      );
+    });
+
+    test("its body has no rail - the card edge is the boundary", () => {
+      renderSection({
+        depth: 0,
+        isInitiallyExpanded: true,
+        resourcesElement: <div>Corporate API</div>,
+      });
+
+      expect(
+        screen.getByTestId("status-page-group-body").className,
+      ).not.toMatch(/border-l/);
+    });
+  });
+
+  describe("a nested level", () => {
+    /*
+     * The headline regression. A nested group is a row on a rail, not another
+     * surface - no background, no border, no rounding, no shadow.
+     */
+    test.each([[1], [2], [3], [4], [7]])(
+      "at depth %i adds no card of its own",
+      (depth: number) => {
+        renderSection({ depth: depth });
+
+        const container: HTMLElement = screen.getByTestId(
+          "status-page-nested-group",
+        );
+
+        /*
+         * Asserted as the absence of each surface rather than as an empty class
+         * string, so a future non-surface utility does not fail this while a
+         * returning card still does.
+         */
+        expect(container.className).not.toMatch(/\bbg-/);
+        expect(container.className).not.toMatch(/\bborder/);
+        expect(container.className).not.toMatch(/\brounded/);
+        expect(container.className).not.toMatch(/\bshadow/);
+        expect(container.className).not.toMatch(/\bp[xytblr]?-\d/);
+      },
+    );
+
+    test("hangs its body off exactly one hairline rail", () => {
+      renderSection({
+        depth: 1,
+        isInitiallyExpanded: true,
+        resourcesElement: <div>Region 1000 API</div>,
+      });
+
+      const body: HTMLElement = screen.getByTestId("status-page-group-body");
+
+      expect(body).toHaveClass("border-l");
+      expect(body).toHaveClass("border-gray-200");
+      expect(body.className).not.toMatch(/border-l-2/);
+    });
+
+    test("carries its depth for anything reading the DOM", () => {
+      renderSection({ depth: 3 });
+
+      expect(screen.getByTestId("status-page-nested-group")).toHaveAttribute(
+        "data-depth",
+        "3",
+      );
+    });
+
+    test("a title is never smaller than the resources it contains", () => {
+      renderSection({ depth: 5, name: "Unit 0152" });
+
+      const title: HTMLElement = screen.getByText("Unit 0152");
+
+      expect(title.className).toContain("text-base");
+      expect(title.className).not.toMatch(/(^|\s)text-sm(\s|$)/);
+    });
+
+    /*
+     * Wrapping was tried here and is worse: the title is the only shrinkable
+     * item in the header row, so beside a badge and a rollup it collapsed to a
+     * ~30px column and broke the name one character per line on a phone.
+     */
+    test("a long title ellipsizes and keeps the full name reachable", () => {
+      renderSection({ depth: 1, name: "Corporate Unit Northwest" });
+
+      const title: HTMLElement = screen.getByText("Corporate Unit Northwest");
+
+      expect(title.className).toContain("truncate");
+      expect(title.className).toContain("min-w-0");
+      expect(title.className).not.toContain("break-words");
+      expect(title).toHaveAttribute("title", "Corporate Unit Northwest");
+    });
+  });
+
+  describe("the rolled up reading", () => {
+    test("is rendered when the group has one", () => {
+      renderSection({ rollupLabel: "99.9% uptime" });
+
+      expect(screen.getByText("99.9% uptime")).toBeInTheDocument();
+    });
+
+    /*
+     * It used to live in the accordion's rightElement, which is hidden while the
+     * accordion is open - so expanding a level hid the number you expanded it to
+     * compare against.
+     */
+    test("stays visible while the level is expanded", () => {
+      renderSection({ rollupLabel: "99.9% uptime" });
+
+      fireEvent.click(header());
+
+      expect(screen.getByText("99.9% uptime")).toBeInTheDocument();
+    });
+
+    test("leaves no empty slot behind when the group shows neither status nor uptime", () => {
+      renderSection({});
+
+      expect(
+        screen.queryByTestId("status-page-group-rollup"),
+      ).not.toBeInTheDocument();
+    });
+
+    /*
+     * The dot is what stops a group rollup reading as one more resource figure -
+     * "100% uptime" on a group and on a resource are otherwise identical.
+     */
+    test("carries a status dot in the rolled up status colour", () => {
+      renderSection({ rollupLabel: "Operational", rollupColor: "#2ab57d" });
+
+      const dot: HTMLElement = screen.getByTestId(
+        "status-page-group-rollup-dot",
+      );
+
+      expect(dot).toHaveStyle({ backgroundColor: "#2ab57d" });
+      expect(dot).toHaveAttribute("aria-hidden", "true");
+      expect(screen.getByText("Operational")).toHaveStyle({
+        color: "#2ab57d",
+      });
+    });
+
+    test("the dot is decoration - the reading itself is the text", () => {
+      renderSection({ rollupLabel: "Operational", rollupColor: "#2ab57d" });
+
+      expect(screen.getByTestId("status-page-group-rollup")).toHaveTextContent(
+        "Operational",
+      );
+    });
+
+    test("renders without a colour rather than crashing", () => {
+      renderSection({ rollupLabel: "Operational" });
+
+      expect(screen.getByText("Operational")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("status-page-group-rollup-dot"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("the sub group count", () => {
+    test("is shown when the caller supplies a label", () => {
+      renderSection({ subGroupCountLabel: "3 groups", subGroupCount: 3 });
+
+      expect(
+        screen.getByTestId("status-page-group-sub-group-count"),
+      ).toHaveTextContent("3 groups");
+    });
+
+    test("is absent for a group with no sub groups", () => {
+      renderSection({ subGroupCount: 0 });
+
+      expect(
+        screen.queryByTestId("status-page-group-sub-group-count"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("the description", () => {
+    /*
+     * The markdown itself renders through a lazily imported viewer, so what is
+     * asserted here is this component's part: that a group with a description
+     * gets the slot, aligned with the title, and a group without one does not.
+     */
+    test("is rendered when the group has one", () => {
+      renderSection({ description: "Everything in the corporate unit." });
+
+      const description: HTMLElement = screen.getByTestId(
+        "status-page-group-description",
+      );
+
+      expect(description).toBeInTheDocument();
+      expect(description.className).toBe(
+        StatusPageGroupNestingLayoutUtil.getDescriptionClassName(),
+      );
+    });
+
+    test("is absent for a group with no description", () => {
+      renderSection({});
+
+      expect(
+        screen.queryByTestId("status-page-group-description"),
+      ).not.toBeInTheDocument();
+    });
+
+    /*
+     * A description is markdown and may contain a link. A link inside a button
+     * is not something a browser or a screen reader can make sense of, so the
+     * description sits outside the header.
+     */
+    test("never ends up inside the header button", () => {
+      renderSection({ description: "Everything in the corporate unit." });
+
+      expect(
+        header().contains(screen.getByTestId("status-page-group-description")),
+      ).toBe(false);
+    });
+
+    test("is announced with the header rather than read as part of its name", () => {
+      renderSection({ description: "Everything in the corporate unit." });
+
+      expect(header().getAttribute("aria-describedby")).toBe(
+        screen.getByTestId("status-page-group-description").getAttribute("id"),
+      );
+    });
+
+    test("adds no describedby when there is no description", () => {
+      renderSection({});
+
+      expect(header()).not.toHaveAttribute("aria-describedby");
+    });
+  });
+
+  describe("the body", () => {
+    test("renders a group's own resources above its sub groups", () => {
+      renderSection({
+        isInitiallyExpanded: true,
+        hasOwnResources: true,
+        subGroupCount: 1,
+        resourcesElement: <div>Corporate API</div>,
+        subGroupsElement: <div>Region 1000</div>,
+      });
+
+      const body: HTMLElement = screen.getByTestId("status-page-group-body");
+      const text: string = body.textContent || "";
+
+      expect(text.indexOf("Corporate API")).toBeGreaterThanOrEqual(0);
+      expect(text.indexOf("Corporate API")).toBeLessThan(
+        text.indexOf("Region 1000"),
+      );
+    });
+
+    /*
+     * Without the line, a group's last resource reads as the first row of the
+     * first sub group below it.
+     */
+    test("draws a line between own resources and sub groups", () => {
+      renderSection({
+        isInitiallyExpanded: true,
+        hasOwnResources: true,
+        subGroupCount: 1,
+        resourcesElement: <div>Corporate API</div>,
+        subGroupsElement: <div>Region 1000</div>,
+      });
+
+      expect(screen.getByTestId("status-page-sub-group-list")).toHaveClass(
+        "border-t",
+      );
+    });
+
+    test("draws no line for a group that only holds sub groups", () => {
+      renderSection({
+        isInitiallyExpanded: true,
+        hasOwnResources: false,
+        subGroupCount: 2,
+        subGroupsElement: <div>Region 1000</div>,
+      });
+
+      expect(
+        screen.getByTestId("status-page-sub-group-list").className,
+      ).not.toMatch(/border-t/);
+    });
+
+    test("has no sub group list when there are no sub groups", () => {
+      renderSection({
+        isInitiallyExpanded: true,
+        hasOwnResources: true,
+        resourcesElement: <div>Corporate API</div>,
+      });
+
+      expect(
+        screen.queryByTestId("status-page-sub-group-list"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("an expanded group with nothing in it still opens", () => {
+      renderSection({ isInitiallyExpanded: true });
+
+      expect(screen.getByTestId("status-page-group-body")).toBeInTheDocument();
+    });
+  });
+
+  describe("a real hierarchy", () => {
+    /*
+     * Corporate -> Region -> Market -> Site -> Rack -> Node, all expanded. This
+     * is the shape that used to produce six stacked cards.
+     */
+    type RenderNestedFunction = (depth: number) => ReactElement;
+
+    const renderNested: RenderNestedFunction = (
+      depth: number,
+    ): ReactElement => {
+      return (
+        <ResourceGroupSection
+          depth={depth}
+          name={`Level ${depth}`}
+          isInitiallyExpanded={true}
+          subGroupCount={depth < 5 ? 1 : 0}
+          testId={`level-${depth}`}
+          subGroupsElement={depth < 5 ? renderNested(depth + 1) : undefined}
+          resourcesElement={depth === 5 ? <div>Leaf API</div> : undefined}
+          hasOwnResources={depth === 5}
+        />
+      );
+    };
+
+    test("renders every level and reaches the leaf", () => {
+      render(renderNested(0));
+
+      for (let depth: number = 0; depth <= 5; depth++) {
+        expect(screen.getByTestId(`level-${depth}`)).toBeInTheDocument();
+      }
+
+      expect(screen.getByText("Leaf API")).toBeInTheDocument();
+    });
+
+    test("only one card is drawn, however deep the hierarchy goes", () => {
+      const { container } = render(renderNested(0));
+
+      const cards: Array<Element> = Array.from(
+        container.querySelectorAll("[data-testid^='level-']"),
+      ).filter((element: Element) => {
+        return element.className.includes("bg-white");
+      });
+
+      expect(cards).toHaveLength(1);
+      expect(cards[0]!.getAttribute("data-testid")).toBe("level-0");
+    });
+
+    test("every level below the top hangs off its own rail", () => {
+      render(renderNested(0));
+
+      for (let depth: number = 1; depth <= 5; depth++) {
+        const level: HTMLElement = screen.getByTestId(`level-${depth}`);
+        const body: Element | null = level.querySelector(
+          "[data-testid='status-page-group-body']",
+        );
+
+        expect(body).not.toBeNull();
+        expect(body!.className).toContain("border-l");
+      }
+    });
+
+    /*
+     * The indent has to stop growing at some point or a deep tree runs the
+     * uptime bars off the right of a phone.
+     */
+    test("the indent stops growing once the cap is reached", () => {
+      render(renderNested(0));
+
+      const bodyClassAt: (depth: number) => string = (
+        depth: number,
+      ): string => {
+        return (
+          screen
+            .getByTestId(`level-${depth}`)
+            .querySelector("[data-testid='status-page-group-body']")
+            ?.className || ""
+        );
+      };
+
+      expect(bodyClassAt(1)).toBe(
+        StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: 1 }),
+      );
+      expect(
+        bodyClassAt(StatusPageGroupNestingLayoutUtil.MaxIndentedDepth + 1),
+      ).toBe(bodyClassAt(StatusPageGroupNestingLayoutUtil.MaxIndentedDepth));
+      /*
+       * The step is smaller past the cap, which is what keeps a ten level tree
+       * inside the content column. The px arithmetic lives in the util's own
+       * suite; here it is enough that the two are not the same class.
+       */
+      expect(
+        bodyClassAt(StatusPageGroupNestingLayoutUtil.MaxIndentedDepth),
+      ).not.toBe(bodyClassAt(1));
+    });
+
+    test("collapsing a level hides everything under it", () => {
+      render(renderNested(0));
+
+      expect(screen.getByText("Leaf API")).toBeInTheDocument();
+
+      fireEvent.click(
+        screen
+          .getByTestId("level-2")
+          .querySelector(
+            "[data-testid='status-page-group-header']",
+          ) as HTMLElement,
+      );
+
+      expect(screen.queryByText("Leaf API")).not.toBeInTheDocument();
+      expect(screen.getByTestId("level-2")).toBeInTheDocument();
+    });
+  });
+
+  describe("test ids", () => {
+    test("the caller can override the default", () => {
+      renderSection({ testId: "my-group" });
+
+      expect(screen.getByTestId("my-group")).toBeInTheDocument();
+      expect(screen.queryByTestId("status-page-group")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/Common/Tests/Utils/StatusPage/GroupNestingLayout.test.ts
+++ b/Common/Tests/Utils/StatusPage/GroupNestingLayout.test.ts
@@ -1,0 +1,1072 @@
+import StatusPageGroupNestingLayoutUtil, {
+  StatusPageGroupRollupKind,
+} from "../../../Utils/StatusPage/GroupNestingLayout";
+import ObjectID from "../../../Types/ObjectID";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import StatusPageGroupViewMode from "../../../Types/StatusPage/StatusPageGroupViewMode";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Every measurement below is taken from the class strings the util actually
+ * emits, not from a number written down beside them. A number kept alongside the
+ * classes can drift from them silently - and did: an earlier version of these
+ * tests passed unchanged with the real indent inflated six fold.
+ *
+ * Tailwind's default scale: a spacing step is 0.25rem, so `pl-5` is 20px and
+ * `ml-2.5` is 10px. Arbitrary values (`pl-[34px]`) are read literally. Where a
+ * class has an `sm:` variant, the variant is the wide viewport value.
+ */
+const TAILWIND_FONT_SIZE_PX: Record<string, number> = {
+  "text-xs": 12,
+  "text-sm": 14,
+  "text-base": 16,
+  "text-lg": 18,
+  "text-xl": 20,
+  "text-2xl": 24,
+};
+
+function tokensOf(className: string): Array<string> {
+  return className.split(/\s+/).filter((token: string) => {
+    return token.length > 0;
+  });
+}
+
+/*
+ * The value that wins at the wide viewport: the `sm:` variant when there is one,
+ * otherwise the unprefixed class.
+ */
+function wideValueOf(
+  className: string,
+  prefix: string,
+  read: (value: string) => number | null,
+): number | null {
+  let unprefixed: number | null = null;
+  let atSm: number | null = null;
+
+  for (const token of tokensOf(className)) {
+    if (token.startsWith(`sm:${prefix}`)) {
+      atSm = read(token.substring(`sm:${prefix}`.length));
+    } else if (token.startsWith(prefix)) {
+      unprefixed = read(token.substring(prefix.length));
+    }
+  }
+
+  return atSm === null ? unprefixed : atSm;
+}
+
+function readSpacing(value: string): number | null {
+  const arbitrary: RegExpMatchArray | null = value.match(
+    /^\[(\d+(?:\.\d+)?)px]$/,
+  );
+
+  if (arbitrary) {
+    return Number(arbitrary[1]);
+  }
+
+  const step: number = Number(value);
+
+  return Number.isFinite(step) ? step * 4 : null;
+}
+
+/* The px value of `pl-*` / `ml-*` / `pt-*` in a class string. */
+function spacingPx(className: string, prefix: string): number {
+  return wideValueOf(className, prefix, readSpacing) || 0;
+}
+
+/* The px font size a class string renders at, at the wide viewport. */
+function fontSizePx(className: string): number {
+  for (const token of tokensOf(className)) {
+    const bare: string = token.startsWith("sm:") ? token.substring(3) : token;
+
+    if (TAILWIND_FONT_SIZE_PX[bare] !== undefined && token.startsWith("sm:")) {
+      return TAILWIND_FONT_SIZE_PX[bare]!;
+    }
+  }
+
+  for (const token of tokensOf(className)) {
+    if (TAILWIND_FONT_SIZE_PX[token] !== undefined) {
+      return TAILWIND_FONT_SIZE_PX[token]!;
+    }
+  }
+
+  return 0;
+}
+
+/*
+ * How far one nesting step moves its contents right: the rail's own offset, the
+ * 1px rail itself, and the padding that clears it. Read off the body class, so
+ * changing the class changes the number.
+ */
+function nestingStepPx(depth: number): number {
+  const bodyClassName: string =
+    StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: depth });
+
+  if (!bodyClassName.includes("border-l")) {
+    return spacingPx(bodyClassName, "ml-") + spacingPx(bodyClassName, "pl-");
+  }
+
+  return spacingPx(bodyClassName, "ml-") + 1 + spacingPx(bodyClassName, "pl-");
+}
+
+/* Where a group title's text starts: the chevron box plus the gap after it. */
+function titleTextOffsetPx(): number {
+  return (
+    spacingPx(StatusPageGroupNestingLayoutUtil.getChevronBoxClassName(), "w-") +
+    spacingPx(StatusPageGroupNestingLayoutUtil.getHeaderRowClassName(), "gap-")
+  );
+}
+
+/*
+ * Contract under test - how the overview page draws nested resource groups.
+ *
+ * The nesting used to be drawn as a card inside a card inside a card, and at
+ * three levels deep that puts four borders around one uptime bar, squeezes the
+ * bars off the right of a phone, and renders a leaf resource larger than the
+ * group heading above it. Every rule below is one of those failures turned into
+ * an assertion:
+ *
+ *   - only the top level is a card; nothing nested adds a surface,
+ *   - a group title is never smaller than the resources inside it,
+ *   - the indent stops growing before a deep tree runs out of width,
+ *   - and no shape of bad data (a negative depth, a parent pointer cycle) may
+ *     break the layout or hang the walk.
+ */
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const REGION_TWO: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const MARKET: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const UNIT: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+
+/* Depths well past anything the write path allows. */
+const ABSURD_DEPTHS: Array<number> = [5, 6, 9, 10, 11, 25, 100, 1000];
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+  viewMode?: StatusPageGroupViewMode | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  if (data.order !== undefined) {
+    group.order = data.order;
+  }
+
+  if (data.viewMode) {
+    group.viewMode = data.viewMode;
+  }
+
+  return group;
+}
+
+function makeResource(data: {
+  id: ObjectID;
+  name: string;
+  groupId?: ObjectID | undefined;
+  showStatusHistoryChart?: boolean | undefined;
+  withMonitor?: boolean | undefined;
+  monitorGroupId?: ObjectID | undefined;
+}): StatusPageResource {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource._id = data.id.toString();
+  resource.displayName = data.name;
+
+  if (data.groupId) {
+    resource.statusPageGroupId = data.groupId;
+  }
+
+  if (data.showStatusHistoryChart !== undefined) {
+    resource.showStatusHistoryChart = data.showStatusHistoryChart;
+  }
+
+  /*
+   * The page only draws a resource that resolves to a monitor or a monitor
+   * group, so a fixture without one is how "nothing to draw" is expressed.
+   */
+  if (data.withMonitor !== false && !data.monitorGroupId) {
+    const monitor: Monitor = new Monitor();
+    monitor._id = data.id.toString();
+    resource.monitor = monitor;
+  }
+
+  if (data.monitorGroupId) {
+    resource.monitorGroupId = data.monitorGroupId;
+  }
+
+  return resource;
+}
+
+/*
+ * Corporate
+ *   Region 1000
+ *     Market 1001
+ *       Unit 0152
+ *   Region 2000
+ */
+function makeHierarchy(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+    makeGroup({
+      id: REGION_ONE,
+      name: "Region 1000",
+      parentId: CORPORATE,
+      order: 2,
+    }),
+    makeGroup({
+      id: MARKET,
+      name: "Market 1001",
+      parentId: REGION_ONE,
+      order: 3,
+    }),
+    makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET, order: 4 }),
+    makeGroup({
+      id: REGION_TWO,
+      name: "Region 2000",
+      parentId: CORPORATE,
+      order: 5,
+    }),
+  ];
+}
+
+describe("StatusPageGroupNestingLayoutUtil", () => {
+  describe("getVisualDepth", () => {
+    test("passes a normal depth straight through", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: 0 }),
+      ).toBe(0);
+      expect(
+        StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: 1 }),
+      ).toBe(1);
+      expect(
+        StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: 3 }),
+      ).toBe(3);
+    });
+
+    test("clamps at MaxIndentedDepth so a deep tree keeps its width", () => {
+      for (const depth of ABSURD_DEPTHS) {
+        expect(
+          StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: depth }),
+        ).toBe(StatusPageGroupNestingLayoutUtil.MaxIndentedDepth);
+      }
+    });
+
+    /*
+     * Depth comes from a recursive render today, but a bad number must degrade
+     * to the top level rather than produce a class like `pl-NaN`.
+     */
+    test.each([[-1], [-10], [Number.NEGATIVE_INFINITY], [Number.NaN]])(
+      "treats %p as the top level",
+      (depth: number) => {
+        expect(
+          StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: depth }),
+        ).toBe(0);
+      },
+    );
+
+    test("treats positive infinity as the top level rather than returning it", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getVisualDepth({
+          depth: Number.POSITIVE_INFINITY,
+        }),
+      ).toBe(0);
+    });
+
+    test("floors a fractional depth", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: 2.9 }),
+      ).toBe(2);
+      expect(
+        StatusPageGroupNestingLayoutUtil.getVisualDepth({ depth: 0.9 }),
+      ).toBe(0);
+    });
+
+    test("never decreases as depth increases", () => {
+      let previous: number = StatusPageGroupNestingLayoutUtil.getVisualDepth({
+        depth: 0,
+      });
+
+      for (let depth: number = 1; depth <= 30; depth++) {
+        const current: number = StatusPageGroupNestingLayoutUtil.getVisualDepth(
+          {
+            depth: depth,
+          },
+        );
+
+        expect(current).toBeGreaterThanOrEqual(previous);
+        previous = current;
+      }
+    });
+  });
+
+  describe("isRootLevel", () => {
+    test("only the top level, and anything that degrades to it, is root", () => {
+      expect(StatusPageGroupNestingLayoutUtil.isRootLevel({ depth: 0 })).toBe(
+        true,
+      );
+      expect(StatusPageGroupNestingLayoutUtil.isRootLevel({ depth: -5 })).toBe(
+        true,
+      );
+      expect(
+        StatusPageGroupNestingLayoutUtil.isRootLevel({ depth: Number.NaN }),
+      ).toBe(true);
+      expect(StatusPageGroupNestingLayoutUtil.isRootLevel({ depth: 1 })).toBe(
+        false,
+      );
+      expect(StatusPageGroupNestingLayoutUtil.isRootLevel({ depth: 12 })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("title sizing", () => {
+    /*
+     * The regression this guards: resource names rendered at text-lg while a
+     * nested group heading rendered at text-sm, so the leaf looked more
+     * important than the branch it hung off. Both sides are measured off the
+     * class strings that render, so shrinking either one fails here.
+     */
+    test("a group title is never smaller than the resources inside it", () => {
+      const resourcePx: number = fontSizePx(
+        StatusPageGroupNestingLayoutUtil.getResourceTitleClassName(),
+      );
+
+      expect(resourcePx).toBeGreaterThan(0);
+
+      for (let depth: number = 0; depth <= 30; depth++) {
+        expect(
+          fontSizePx(
+            StatusPageGroupNestingLayoutUtil.getTitleClassName({
+              depth: depth,
+            }),
+          ),
+        ).toBeGreaterThanOrEqual(resourcePx);
+      }
+    });
+
+    test("title size never grows as the hierarchy gets deeper", () => {
+      let previous: number = fontSizePx(
+        StatusPageGroupNestingLayoutUtil.getTitleClassName({ depth: 0 }),
+      );
+
+      expect(previous).toBeGreaterThan(0);
+
+      for (let depth: number = 1; depth <= 30; depth++) {
+        const current: number = fontSizePx(
+          StatusPageGroupNestingLayoutUtil.getTitleClassName({ depth: depth }),
+        );
+
+        expect(current).toBeGreaterThan(0);
+        expect(current).toBeLessThanOrEqual(previous);
+        previous = current;
+      }
+    });
+
+    test("the top level outranks everything below it", () => {
+      expect(
+        fontSizePx(
+          StatusPageGroupNestingLayoutUtil.getTitleClassName({ depth: 0 }),
+        ),
+      ).toBeGreaterThan(
+        fontSizePx(
+          StatusPageGroupNestingLayoutUtil.getTitleClassName({ depth: 1 }),
+        ),
+      );
+    });
+
+    /*
+     * A group title is heavier than a resource name at the same size - that is
+     * what separates a heading from a reading when the rail is the only other
+     * cue.
+     */
+    test("a group title is heavier than a resource name", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getResourceTitleClassName(),
+      ).toContain("font-medium");
+
+      for (let depth: number = 0; depth <= 12; depth++) {
+        const className: string =
+          StatusPageGroupNestingLayoutUtil.getTitleClassName({ depth: depth });
+
+        expect(className).toContain("font-semibold");
+        expect(className).toContain("text-gray-900");
+      }
+    });
+
+    test("nested titles are all styled the same - depth is shown by the rail", () => {
+      const atOne: string = StatusPageGroupNestingLayoutUtil.getTitleClassName({
+        depth: 1,
+      });
+
+      for (let depth: number = 2; depth <= 12; depth++) {
+        expect(
+          StatusPageGroupNestingLayoutUtil.getTitleClassName({ depth: depth }),
+        ).toBe(atOne);
+      }
+    });
+  });
+
+  describe("getContainerClassName", () => {
+    test("the top level is a card", () => {
+      const className: string =
+        StatusPageGroupNestingLayoutUtil.getContainerClassName({ depth: 0 });
+
+      expect(className).toContain("bg-white");
+      expect(className).toContain("rounded-xl");
+      expect(className).toContain("shadow");
+    });
+
+    /*
+     * The headline regression: a nested group must not introduce a surface of
+     * its own. Asserted as the absence of each surface class rather than as an
+     * empty string, so a future non-surface class (`relative`, say) does not
+     * fail the test while a returning card still does.
+     */
+    test("nothing nested adds a card, a border or a background", () => {
+      for (let depth: number = 1; depth <= 12; depth++) {
+        const className: string =
+          StatusPageGroupNestingLayoutUtil.getContainerClassName({
+            depth: depth,
+          });
+
+        expect(className).not.toMatch(/\bbg-/);
+        expect(className).not.toMatch(/\bborder/);
+        expect(className).not.toMatch(/\brounded/);
+        expect(className).not.toMatch(/\bshadow/);
+        expect(className).not.toMatch(/\bp[xytblr]?-/);
+      }
+    });
+  });
+
+  describe("getBodyClassName", () => {
+    test("the top level body has no rail - the card edge is the boundary", () => {
+      const className: string =
+        StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: 0 });
+
+      expect(className).not.toContain("border-l");
+      expect(className).not.toContain("pl-");
+      expect(StatusPageGroupNestingLayoutUtil.showRail({ depth: 0 })).toBe(
+        false,
+      );
+    });
+
+    test("every nested body hangs off exactly one hairline rail", () => {
+      for (let depth: number = 1; depth <= 12; depth++) {
+        const className: string =
+          StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: depth });
+
+        expect(className).toContain("border-l");
+        // border-l, not border-l-2: one hairline, however deep it goes.
+        expect(className).not.toContain("border-l-2");
+        expect(className).toContain("border-gray-200");
+        expect(className).toMatch(/pl-/);
+        expect(
+          StatusPageGroupNestingLayoutUtil.showRail({ depth: depth }),
+        ).toBe(true);
+      }
+    });
+
+    test("the indent tightens past MaxIndentedDepth instead of growing", () => {
+      expect(
+        nestingStepPx(StatusPageGroupNestingLayoutUtil.MaxIndentedDepth),
+      ).toBeLessThan(nestingStepPx(1));
+    });
+
+    /*
+     * A sub group is meant to read as hanging off its parent's title, not off
+     * the parent's chevron, so one nesting step moves its contents to where the
+     * parent's title text starts. Both sides are measured off the classes that
+     * render: the chevron box and header gap on one side, the body's margin,
+     * rail and padding on the other.
+     */
+    test("a nesting step lands a sub group's contents at its parent's title", () => {
+      const offset: number = titleTextOffsetPx();
+
+      expect(offset).toBeGreaterThan(0);
+      expect(nestingStepPx(1)).toBeGreaterThan(offset - 3);
+      expect(nestingStepPx(1)).toBeLessThanOrEqual(offset);
+    });
+
+    test("the top level costs no indent at all", () => {
+      expect(nestingStepPx(0)).toBe(0);
+    });
+
+    test("every nesting step costs something, so the rails stay apart", () => {
+      for (let depth: number = 1; depth <= 12; depth++) {
+        expect(nestingStepPx(depth)).toBeGreaterThan(0);
+      }
+    });
+
+    test("the indent never grows as the hierarchy gets deeper", () => {
+      let previous: number = nestingStepPx(1);
+
+      for (let depth: number = 2; depth <= 30; depth++) {
+        const current: number = nestingStepPx(depth);
+
+        expect(current).toBeLessThanOrEqual(previous);
+        previous = current;
+      }
+    });
+
+    /*
+     * The write path caps nesting at StatusPageGroupTreeUtil.MaxNestingDepth
+     * (10), so a fully nested resource is indented by the sum of ten steps. The
+     * status page content column is max-w-5xl minus padding, about 984px, and
+     * the uptime bars have to stay readable inside what is left.
+     */
+    test("the deepest nesting the write path allows costs a quarter of the column", () => {
+      let total: number = 0;
+
+      for (let depth: number = 1; depth <= 10; depth++) {
+        total += nestingStepPx(depth);
+      }
+
+      expect(total).toBeGreaterThan(0);
+      expect(total).toBeLessThan(250);
+    });
+
+    /* Every step past the cap has to be cheap, or depth 20 runs off the page. */
+    test("a step past the cap costs no more than 20px", () => {
+      expect(
+        nestingStepPx(StatusPageGroupNestingLayoutUtil.MaxIndentedDepth + 5),
+      ).toBeLessThanOrEqual(20);
+    });
+
+    test("the rail is placed under its parent's chevron, not flush left", () => {
+      expect(
+        spacingPx(
+          StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: 1 }),
+          "ml-",
+        ),
+      ).toBeGreaterThan(0);
+    });
+
+    test("depths beyond the cap all render the same tightened indent", () => {
+      const atCap: string = StatusPageGroupNestingLayoutUtil.getBodyClassName({
+        depth: StatusPageGroupNestingLayoutUtil.MaxIndentedDepth,
+      });
+
+      for (const depth of ABSURD_DEPTHS) {
+        expect(
+          StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: depth }),
+        ).toBe(atCap);
+      }
+    });
+
+    test("a bad depth falls back to the top level body", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getBodyClassName({
+          depth: Number.NaN,
+        }),
+      ).toBe(StatusPageGroupNestingLayoutUtil.getBodyClassName({ depth: 0 }));
+    });
+  });
+
+  describe("getHeaderClassName", () => {
+    test("the header is a focusable control that pushes its two ends apart", () => {
+      for (let depth: number = 0; depth <= 12; depth++) {
+        const className: string =
+          StatusPageGroupNestingLayoutUtil.getHeaderClassName({ depth: depth });
+
+        expect(tokensOf(className)).toContain("flex");
+        expect(className).toContain("justify-between");
+        expect(className).toContain("focus-visible:ring-2");
+      }
+    });
+
+    /*
+     * The hover background bleeds to the edge of the content column via equal
+     * and opposite margin and padding, and the width has to pay for both margins
+     * or the box is over-constrained: the browser then drops margin-right (CSS
+     * 2.1 10.3.3) and every rollup lands 16px short of the card edge the resource
+     * readings sit on. `w-full` is exactly that mistake.
+     */
+    test("the bleed is symmetric and paid for, so the rollup lines up with the readings below", () => {
+      for (let depth: number = 0; depth <= 12; depth++) {
+        const className: string =
+          StatusPageGroupNestingLayoutUtil.getHeaderClassName({ depth: depth });
+
+        const bleedPerSide: number = spacingPx(className, "-mx-");
+
+        expect(bleedPerSide).toBeGreaterThan(0);
+        expect(spacingPx(className, "px-")).toBe(bleedPerSide);
+
+        /* A button shrink wraps without a width, even as a flex container. */
+        expect(tokensOf(className)).not.toContain("w-full");
+        expect(className).toContain(
+          `w-[calc(100%+${(bleedPerSide * 2) / 16}rem)]`,
+        );
+      }
+    });
+  });
+
+  describe("spacing and chrome tokens", () => {
+    /*
+     * Measured, not restated: the description's indent has to equal the chevron
+     * box plus the gap after it, both of which are classes on the header.
+     */
+    test("the description lines up with the title, not the chevron", () => {
+      const offset: number = titleTextOffsetPx();
+
+      expect(offset).toBeGreaterThan(0);
+      expect(
+        spacingPx(
+          StatusPageGroupNestingLayoutUtil.getDescriptionClassName(),
+          "pl-",
+        ),
+      ).toBe(offset);
+    });
+
+    test("the ungrouped card is the same surface as a top level group", () => {
+      const card: string =
+        StatusPageGroupNestingLayoutUtil.getUngroupedResourcesCardClassName();
+
+      expect(card).toContain("bg-white");
+      expect(card).toContain("rounded-xl");
+      expect(card).toContain("shadow");
+    });
+
+    /*
+     * A rollup and a resource reading are the same kind of number, so they are
+     * set at the same size - measured off both class strings rather than
+     * asserting the literals one of them happens to contain.
+     */
+    test("a rollup is sized like the resource readings below it", () => {
+      expect(
+        fontSizePx(StatusPageGroupNestingLayoutUtil.getRollupClassName()),
+      ).toBe(
+        fontSizePx(
+          StatusPageGroupNestingLayoutUtil.getResourceTitleClassName(),
+        ),
+      );
+      expect(StatusPageGroupNestingLayoutUtil.getRollupClassName()).toContain(
+        "flex-shrink-0",
+      );
+    });
+
+    test("a rollup is marked with a dot so it does not read as a resource's own", () => {
+      const dot: string =
+        StatusPageGroupNestingLayoutUtil.getRollupDotClassName();
+
+      expect(dot).toContain("rounded-full");
+      expect(dot).toContain("flex-shrink-0");
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupLabelClassName(),
+      ).toContain("tabular-nums");
+    });
+
+    test("the sub group list is spaced at every depth", () => {
+      for (let depth: number = 0; depth <= 12; depth++) {
+        expect(
+          StatusPageGroupNestingLayoutUtil.getSubGroupListClassName({
+            depth: depth,
+          }),
+        ).toMatch(/space-y-/);
+      }
+    });
+
+    /*
+     * justify-between is inert without flex, and the axis exists precisely to
+     * push "90 days ago" and "Today" to opposite ends.
+     */
+    test("the time axis pushes its two ends apart", () => {
+      const axis: string =
+        StatusPageGroupNestingLayoutUtil.getTimeAxisClassName();
+
+      expect(tokensOf(axis)).toContain("flex");
+      expect(tokensOf(axis)).toContain("justify-between");
+    });
+
+    test("the resource list carries its own rhythm", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getResourceListClassName(),
+      ).toMatch(/space-y-/);
+    });
+
+    test("the sub group count badge is a quiet pill", () => {
+      const badge: string =
+        StatusPageGroupNestingLayoutUtil.getSubGroupCountBadgeClassName();
+
+      expect(badge).toContain("rounded-full");
+      expect(badge).toContain("text-gray-500");
+      expect(badge).toContain("flex-shrink-0");
+    });
+  });
+
+  describe("getRollupKind", () => {
+    test("a healthy group configured for uptime shows its uptime percent", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: true,
+          showCurrentStatus: true,
+          isCurrentlyDown: false,
+          uptimePercent: 99.9,
+        }),
+      ).toBe(StatusPageGroupRollupKind.UptimePercent);
+    });
+
+    /*
+     * "99.9% uptime" next to a group that is down right now is not what a
+     * visitor came to read.
+     */
+    test("a group that is down shows its status, not a percent", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: true,
+          showCurrentStatus: true,
+          isCurrentlyDown: true,
+          uptimePercent: 99.9,
+        }),
+      ).toBe(StatusPageGroupRollupKind.CurrentStatus);
+    });
+
+    /*
+     * A group with nothing under it has no uptime to average. Showing a zero
+     * would read as an outage.
+     */
+    test("a group with no uptime to report shows nothing rather than a zero", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: true,
+          showCurrentStatus: true,
+          isCurrentlyDown: false,
+          uptimePercent: null,
+        }),
+      ).toBe(StatusPageGroupRollupKind.None);
+    });
+
+    test("a group configured for status only shows its status", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: false,
+          showCurrentStatus: true,
+          isCurrentlyDown: false,
+          uptimePercent: 100,
+        }),
+      ).toBe(StatusPageGroupRollupKind.CurrentStatus);
+    });
+
+    test("a group configured for neither shows nothing", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: false,
+          showCurrentStatus: false,
+          isCurrentlyDown: false,
+          uptimePercent: 100,
+        }),
+      ).toBe(StatusPageGroupRollupKind.None);
+    });
+
+    test("a group that is down and shows no status shows nothing", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: true,
+          showCurrentStatus: false,
+          isCurrentlyDown: true,
+          uptimePercent: 99.9,
+        }),
+      ).toBe(StatusPageGroupRollupKind.None);
+    });
+
+    test("a zero percent uptime is still a percent, not nothing", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.getRollupKind({
+          showUptimePercent: true,
+          showCurrentStatus: true,
+          isCurrentlyDown: false,
+          uptimePercent: 0,
+        }),
+      ).toBe(StatusPageGroupRollupKind.UptimePercent);
+    });
+  });
+
+  describe("shouldShowSubGroupDivider", () => {
+    /*
+     * Without the line, a group's last resource reads as the first row of the
+     * first sub group below it.
+     */
+    test("a line is drawn only between own resources and sub groups", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldShowSubGroupDivider({
+          hasOwnResources: true,
+          subGroupCount: 1,
+        }),
+      ).toBe(true);
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldShowSubGroupDivider({
+          hasOwnResources: true,
+          subGroupCount: 0,
+        }),
+      ).toBe(false);
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldShowSubGroupDivider({
+          hasOwnResources: false,
+          subGroupCount: 3,
+        }),
+      ).toBe(false);
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldShowSubGroupDivider({
+          hasOwnResources: false,
+          subGroupCount: 0,
+        }),
+      ).toBe(false);
+    });
+
+    test("the divider is a hairline with padding, not a margin", () => {
+      const divider: string =
+        StatusPageGroupNestingLayoutUtil.getSubGroupDividerClassName();
+
+      expect(divider).toContain("border-t");
+      expect(divider).toMatch(/pt-/);
+    });
+  });
+
+  describe("shouldRenderOwnResources", () => {
+    /*
+     * A group that exists only to hold sub groups is not empty - the sub groups
+     * are its content - so it must not render the "no resources" message.
+     */
+    test("a holder group with sub groups renders no resource list of its own", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderOwnResources({
+          ownResourceCount: 0,
+          subGroupCount: 2,
+        }),
+      ).toBe(false);
+    });
+
+    test("a group with resources always renders them", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderOwnResources({
+          ownResourceCount: 1,
+          subGroupCount: 0,
+        }),
+      ).toBe(true);
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderOwnResources({
+          ownResourceCount: 4,
+          subGroupCount: 3,
+        }),
+      ).toBe(true);
+    });
+
+    /*
+     * A truly empty group still renders the list, because that is where the
+     * "no resources added to this group" message lives.
+     */
+    test("a group with neither resources nor sub groups still renders the list", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderOwnResources({
+          ownResourceCount: 0,
+          subGroupCount: 0,
+        }),
+      ).toBe(true);
+    });
+  });
+  describe("shouldRenderTimeAxis", () => {
+    const CHARTED: ObjectID = new ObjectID(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    );
+    const UNCHARTED: ObjectID = new ObjectID(
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    );
+
+    test("a group with a charted resource of its own draws one axis", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: groups[0]!,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Corporate API",
+              groupId: CORPORATE,
+              showStatusHistoryChart: true,
+            }),
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    /*
+     * The axis belongs next to the bars it labels. A sub group's bars are
+     * indented past this group's, and a sub group may be collapsed, so this
+     * group's axis must not claim to describe them.
+     */
+    test("a descendant's charted resource does not put an axis on the parent", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: groups[0]!,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Unit 0152 API",
+              groupId: UNIT,
+              showStatusHistoryChart: true,
+            }),
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    test("a group whose resources draw no history chart draws no axis", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: groups[0]!,
+          statusPageResources: [
+            makeResource({
+              id: UNCHARTED,
+              name: "Corporate API",
+              groupId: CORPORATE,
+              showStatusHistoryChart: false,
+            }),
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    /*
+     * A grid group draws a matrix of cells rather than bars over a window, so a
+     * "90 days ago ... Today" axis would be labelling something that is not
+     * there.
+     */
+    test("a grid view group draws no axis", () => {
+      const gridGroup: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate",
+        order: 1,
+        viewMode: StatusPageGroupViewMode.Grid,
+      });
+
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: gridGroup,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Corporate API",
+              groupId: CORPORATE,
+              showStatusHistoryChart: true,
+            }),
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    test("a list view group draws one", () => {
+      const listGroup: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate",
+        order: 1,
+        viewMode: StatusPageGroupViewMode.List,
+      });
+
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: listGroup,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Corporate API",
+              groupId: CORPORATE,
+              showStatusHistoryChart: true,
+            }),
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    test("the ungrouped block draws an axis for its own resources", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: null,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Ungrouped",
+              showStatusHistoryChart: true,
+            }),
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    test("a grouped resource does not put an axis on the ungrouped block", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: null,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Corporate API",
+              groupId: CORPORATE,
+              showStatusHistoryChart: true,
+            }),
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    test("a resource with nothing to draw cannot bring an axis with it", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: null,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Ungrouped",
+              showStatusHistoryChart: true,
+              withMonitor: false,
+            }),
+          ],
+        }),
+      ).toBe(false);
+    });
+
+    test("a monitor group resource can bring an axis with it", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: null,
+          statusPageResources: [
+            makeResource({
+              id: CHARTED,
+              name: "Ungrouped",
+              showStatusHistoryChart: true,
+              withMonitor: false,
+              monitorGroupId: UNCHARTED,
+            }),
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    test("an empty page has no axis", () => {
+      expect(
+        StatusPageGroupNestingLayoutUtil.shouldRenderTimeAxis({
+          statusPageGroup: null,
+          statusPageResources: [],
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/Common/UI/Components/StatusPage/ResourceGroupSection.tsx
+++ b/Common/UI/Components/StatusPage/ResourceGroupSection.tsx
@@ -1,0 +1,231 @@
+import Icon, { ThickProp } from "../Icon/Icon";
+import MarkdownViewer from "../Markdown.tsx/LazyMarkdownViewer";
+import IconProp from "../../../Types/Icon/IconProp";
+import StatusPageGroupNestingLayoutUtil from "../../../Utils/StatusPage/GroupNestingLayout";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useState,
+} from "react";
+
+export interface ComponentProps {
+  /*
+   * 0 for a top level group, 1 for its children, and so on. Everything about
+   * how this section is drawn comes from it - see GroupNestingLayout.
+   */
+  depth: number;
+  name: string;
+  /*
+   * Markdown. Rendered below the header rather than inside it - a description
+   * may contain links, and a link inside a button is not something a browser or
+   * a screen reader can make sense of.
+   */
+  description?: string | undefined;
+  /*
+   * Rendered next to the name when the group has sub groups. Pre-translated by
+   * the caller: this component has no i18n of its own.
+   */
+  subGroupCountLabel?: string | undefined;
+  /*
+   * The group's rolled up status or uptime, already formatted and translated by
+   * the caller ("99.9% uptime", "Operational"). Drawn with a status dot so it
+   * reads as a rollup of everything below rather than as one more resource
+   * reading, and it stays visible while the section is open - the point of the
+   * hierarchy is that every level always shows what it rolls up, and a number
+   * that disappears on expand is a number you cannot compare against the level
+   * below it.
+   */
+  rollupLabel?: string | undefined;
+  /* Hex or css colour for the rollup, from the rolled up status. */
+  rollupColor?: string | undefined;
+  isInitiallyExpanded?: boolean | undefined;
+  /* The group's own resources. */
+  resourcesElement?: ReactElement | undefined;
+  /* Nested sections, normally one per sub group. */
+  subGroupsElement?: ReactElement | undefined;
+  hasOwnResources?: boolean | undefined;
+  subGroupCount?: number | undefined;
+  testId?: string | undefined;
+}
+
+/*
+ * One level of the status page resource group hierarchy.
+ *
+ * A top level group is a card. Everything under it is a row on a tree rail -
+ * no card, no second border, no background tint stacked on the last one - so
+ * the hierarchy stays readable however deep it goes and the uptime bars keep
+ * the width they need.
+ */
+const ResourceGroupSection: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [isOpen, setIsOpen] = useState<boolean>(
+    Boolean(props.isInitiallyExpanded),
+  );
+
+  /*
+   * Groups arrive with the page payload, so isInitiallyExpanded can flip after
+   * the first render. Keyed on the *boolean*, not on the prop: the column is an
+   * optional boolean, so it routinely arrives as undefined and settles to false,
+   * and keying on the prop would fire on that and slam shut a section the
+   * visitor had just opened.
+   */
+  const initiallyExpanded: boolean = Boolean(props.isInitiallyExpanded);
+
+  useEffect(() => {
+    setIsOpen(initiallyExpanded);
+  }, [initiallyExpanded]);
+
+  const generatedId: string = React.useId();
+  const bodyId: string = `status-page-group-body-${generatedId}`;
+  const descriptionId: string = `status-page-group-description-${generatedId}`;
+
+  const isRootLevel: boolean = StatusPageGroupNestingLayoutUtil.isRootLevel({
+    depth: props.depth,
+  });
+
+  const subGroupCount: number = props.subGroupCount || 0;
+
+  const showSubGroupDivider: boolean =
+    StatusPageGroupNestingLayoutUtil.shouldShowSubGroupDivider({
+      hasOwnResources: Boolean(props.hasOwnResources),
+      subGroupCount: subGroupCount,
+    });
+
+  return (
+    <div
+      className={StatusPageGroupNestingLayoutUtil.getContainerClassName({
+        depth: props.depth,
+      })}
+      data-testid={
+        props.testId ||
+        (isRootLevel ? "status-page-group" : "status-page-nested-group")
+      }
+      data-depth={props.depth}
+    >
+      <button
+        type="button"
+        className={StatusPageGroupNestingLayoutUtil.getHeaderClassName({
+          depth: props.depth,
+        })}
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? bodyId : undefined}
+        aria-describedby={props.description ? descriptionId : undefined}
+        data-testid="status-page-group-header"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        <span
+          className={StatusPageGroupNestingLayoutUtil.getHeaderRowClassName()}
+        >
+          <span
+            className={`${StatusPageGroupNestingLayoutUtil.getChevronBoxClassName()} ${
+              isOpen ? "bg-gray-900/5 text-gray-700" : "text-gray-400"
+            }`}
+            data-testid="status-page-group-chevron"
+            aria-hidden="true"
+          >
+            <Icon
+              className={`h-3.5 w-3.5 transition-transform duration-200 ease-out ${
+                isOpen ? "rotate-90" : ""
+              }`}
+              icon={IconProp.ChevronRight}
+              thick={ThickProp.Thick}
+            />
+          </span>
+          <span
+            className={StatusPageGroupNestingLayoutUtil.getTitleClassName({
+              depth: props.depth,
+            })}
+            title={props.name}
+          >
+            {props.name}
+          </span>
+          {props.subGroupCountLabel ? (
+            <span
+              className={StatusPageGroupNestingLayoutUtil.getSubGroupCountBadgeClassName()}
+              data-testid="status-page-group-sub-group-count"
+            >
+              {props.subGroupCountLabel}
+            </span>
+          ) : (
+            <></>
+          )}
+        </span>
+        {props.rollupLabel ? (
+          <span
+            className={StatusPageGroupNestingLayoutUtil.getRollupClassName()}
+            data-testid="status-page-group-rollup"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                className={StatusPageGroupNestingLayoutUtil.getRollupDotClassName()}
+                style={
+                  props.rollupColor
+                    ? { backgroundColor: props.rollupColor }
+                    : undefined
+                }
+                data-testid="status-page-group-rollup-dot"
+                aria-hidden="true"
+              />
+              <span
+                className={StatusPageGroupNestingLayoutUtil.getRollupLabelClassName()}
+                style={
+                  props.rollupColor ? { color: props.rollupColor } : undefined
+                }
+              >
+                {props.rollupLabel}
+              </span>
+            </span>
+          </span>
+        ) : (
+          <></>
+        )}
+      </button>
+      {props.description ? (
+        <div
+          id={descriptionId}
+          className={StatusPageGroupNestingLayoutUtil.getDescriptionClassName()}
+          data-testid="status-page-group-description"
+        >
+          <MarkdownViewer text={props.description} />
+        </div>
+      ) : (
+        <></>
+      )}
+      {isOpen ? (
+        <div
+          id={bodyId}
+          className={StatusPageGroupNestingLayoutUtil.getBodyClassName({
+            depth: props.depth,
+          })}
+          data-testid="status-page-group-body"
+        >
+          {props.resourcesElement || <></>}
+          {props.subGroupsElement ? (
+            <div
+              className={`${
+                showSubGroupDivider
+                  ? StatusPageGroupNestingLayoutUtil.getSubGroupDividerClassName()
+                  : ""
+              } ${StatusPageGroupNestingLayoutUtil.getSubGroupListClassName({
+                depth: props.depth,
+              })}`.trim()}
+              data-testid="status-page-sub-group-list"
+            >
+              {props.subGroupsElement}
+            </div>
+          ) : (
+            <></>
+          )}
+        </div>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+};
+
+export default ResourceGroupSection;

--- a/Common/Utils/StatusPage/GroupNestingLayout.ts
+++ b/Common/Utils/StatusPage/GroupNestingLayout.ts
@@ -1,0 +1,343 @@
+import StatusPageGroup from "../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "../../Models/DatabaseModels/StatusPageResource";
+import StatusPageGroupViewMode from "../../Types/StatusPage/StatusPageGroupViewMode";
+
+/*
+ * Status page groups nest (Corporate Unit -> Region -> Market -> Site) and the
+ * overview page draws that nesting.
+ *
+ * Drawing each level as a card inside a card inside a card is what it used to
+ * do, and it does not survive contact with a real hierarchy: four borders end
+ * up wrapped around one uptime bar, every level eats horizontal room the bars
+ * need, and a leaf resource ends up rendered larger than the group that
+ * contains it. Below the top level a group is therefore drawn as a row hanging
+ * off a tree rail - one hairline down the left, one indent step, no extra card.
+ *
+ * The numbers live here rather than inline in the page because they are the
+ * part that has to hold at depth 1 and still hold at depth 12, and that is
+ * worth pinning down in tests.
+ */
+
+/* What a group header shows on its right hand side, if anything. */
+export enum StatusPageGroupRollupKind {
+  UptimePercent = "UptimePercent",
+  CurrentStatus = "CurrentStatus",
+  None = "None",
+}
+
+export default class StatusPageGroupNestingLayoutUtil {
+  /*
+   * Beyond this depth the indent step shrinks instead of growing. Nesting is
+   * capped on write at StatusPageGroupTreeUtil.MaxNestingDepth, but rows
+   * written straight to the database are not, so the layout is not allowed to
+   * assume any particular ceiling.
+   */
+  public static readonly MaxIndentedDepth: number = 4;
+
+  /*
+   * A depth that is not a whole number >= 0 is treated as the top level. The
+   * page derives depth from a recursive render, but nothing stops a caller (or
+   * a future refactor) from handing over -1 or NaN, and a broken indent is not
+   * worth a broken page.
+   */
+  public static getVisualDepth(data: { depth: number }): number {
+    if (!Number.isFinite(data.depth)) {
+      return 0;
+    }
+
+    const depth: number = Math.floor(data.depth);
+
+    if (depth <= 0) {
+      return 0;
+    }
+
+    return Math.min(depth, this.MaxIndentedDepth);
+  }
+
+  public static isRootLevel(data: { depth: number }): boolean {
+    return this.getVisualDepth({ depth: data.depth }) === 0;
+  }
+
+  /*
+   * Nesting is expressed with the rail, so the title only ever steps down once
+   * - and never below the size a resource name renders at. That inversion, a
+   * text-sm group heading over a text-lg resource, is what made the old nesting
+   * read upside down.
+   */
+  /*
+   * Truncates at every width, including on a phone. Wrapping was tried and is
+   * worse: the title is the only shrinkable item in the header row, so next to a
+   * sub group badge and a rollup it collapses to a ~30px column and breaks a
+   * name one character per line. An ellipsis with the full name in `title` is the
+   * lesser evil.
+   */
+  public static getTitleClassName(data: { depth: number }): string {
+    const base: string = "min-w-0 truncate font-semibold text-gray-900";
+
+    if (this.isRootLevel(data)) {
+      return `${base} text-base sm:text-lg tracking-tight`;
+    }
+
+    return `${base} text-base tracking-tight`;
+  }
+
+  /*
+   * A resource name, as rendered by MonitorOverview. It lives here so the floor
+   * a group title has to clear is the same string the resource actually renders
+   * with, rather than a number written down next to it.
+   */
+  public static getResourceTitleClassName(): string {
+    return "text-base font-medium";
+  }
+
+  /*
+   * The chevron box and the gap after it are what set where a title starts, and
+   * a sub group's contents and a group description are both aligned to that. All
+   * three are derived from these two, so moving the chevron moves them with it.
+   */
+  public static getChevronBoxClassName(): string {
+    return "flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-md transition-colors";
+  }
+
+  public static getHeaderRowClassName(): string {
+    return "flex min-w-0 flex-1 items-center gap-2.5";
+  }
+
+  /*
+   * A nested group is not a card. It is a block in the parent's body, so all it
+   * gets is the vertical rhythm that separates it from its siblings.
+   */
+  public static getContainerClassName(data: { depth: number }): string {
+    if (this.isRootLevel(data)) {
+      return "bg-white rounded-xl shadow px-4 py-3 sm:px-6 sm:py-4";
+    }
+
+    return "";
+  }
+
+  /*
+   * Resources that belong to no group at all get their own card at the top of
+   * the page. It is the same surface as a top level group, minus the header.
+   */
+  public static getUngroupedResourcesCardClassName(): string {
+    return "bg-white rounded-xl shadow px-4 py-4 sm:px-6 sm:py-5";
+  }
+
+  /* Vertical rhythm between the resources of one group. */
+  public static getResourceListClassName(): string {
+    return "space-y-4 sm:space-y-5";
+  }
+
+  /*
+   * Quieter than the per-resource labels it replaces. It is a scale, not a
+   * reading, and it is what made a nested block look shouty when it appeared
+   * three times in one screen.
+   */
+  public static getTimeAxisClassName(): string {
+    return "flex justify-between text-[11px] text-gray-400";
+  }
+
+  /*
+   * The rolled up reading on the right of a group header. Sized to match the
+   * per-resource readings below it: a rollup and a resource reading are the same
+   * kind of number, and the status dot is what tells them apart.
+   */
+  public static getRollupClassName(): string {
+    return "flex-shrink-0 text-sm sm:text-base font-medium";
+  }
+
+  public static getHeaderClassName(data: { depth: number }): string {
+    /*
+     * The whole row is the disclosure control, so it carries the hover state.
+     * Negative horizontal margin with matching padding lets that hover reach the
+     * edge of the content column while the row's contents stay aligned with the
+     * resources below it.
+     *
+     * The width has to pay for both margins explicitly. A button shrink wraps
+     * even as a flex container, so it needs a width; but `w-full` with both
+     * negative margins over-constrains the box, and the browser resolves that by
+     * dropping margin-right (CSS 2.1 10.3.3) - which leaves every rollup 16px
+     * short of the card edge the resource readings below it sit on. 100% + 1rem
+     * satisfies the equation exactly, so nothing is dropped.
+     */
+    const base: string =
+      "flex w-[calc(100%+1rem)] items-center justify-between gap-3 text-left rounded-lg -mx-2 px-2 transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300";
+
+    return this.isRootLevel(data) ? `${base} py-2` : `${base} py-1.5`;
+  }
+
+  /*
+   * The rail and the indent that carry one nesting step.
+   *
+   * `ml` moves the rail under its parent's chevron and `pl` pushes the contents
+   * clear of it, so the two together land a sub group's contents at the parent's
+   * title. Past MaxIndentedDepth the step tightens rather than stops: the rails
+   * have to stay distinguishable, but a deep tree still has to leave room for
+   * the uptime bars on a phone.
+   */
+  private static getIndentClassName(data: { depth: number }): string {
+    const visualDepth: number = this.getVisualDepth(data);
+
+    if (visualDepth === 0) {
+      return "";
+    }
+
+    if (visualDepth < this.MaxIndentedDepth) {
+      return "ml-2.5 sm:ml-3 pl-4 sm:pl-5";
+    }
+
+    return "ml-1.5 pl-3";
+  }
+
+  /*
+   * Everything a group contains - its own resources and then its sub groups -
+   * lives in one body so a single rail covers all of it.
+   */
+  public static getBodyClassName(data: { depth: number }): string {
+    if (this.isRootLevel(data)) {
+      // The card's own padding is the boundary at the top level; no rail.
+      return "mt-3 space-y-4";
+    }
+
+    return `mt-2.5 space-y-3.5 border-l border-gray-200 ${this.getIndentClassName(
+      data,
+    )}`;
+  }
+
+  public static showRail(data: { depth: number }): boolean {
+    return !this.isRootLevel(data);
+  }
+
+  public static getSubGroupListClassName(data: { depth: number }): string {
+    return this.isRootLevel(data) ? "space-y-3" : "space-y-2.5";
+  }
+
+  /*
+   * A group with resources of its own *and* sub groups needs a line between the
+   * two, otherwise its last resource reads as belonging to the first sub group.
+   */
+  public static shouldShowSubGroupDivider(data: {
+    hasOwnResources: boolean;
+    subGroupCount: number;
+  }): boolean {
+    return data.hasOwnResources && data.subGroupCount > 0;
+  }
+
+  public static getSubGroupDividerClassName(): string {
+    return "border-t border-gray-100 pt-3.5";
+  }
+
+  /*
+   * The group description hangs under the title, indented past the chevron so
+   * it lines up with the name rather than with the disclosure control. It sits
+   * outside the header button on purpose: a description is markdown and may
+   * contain links, which cannot live inside a button.
+   *
+   * The indent is 34px: the 24px chevron box (w-6, see getChevronBoxClassName)
+   * plus the 10px gap after it (gap-2.5, see getHeaderRowClassName).
+   *
+   * Alignment only. Type and vertical rhythm are MarkdownViewer's - it sets
+   * them on the paragraph it renders, which beats anything inherited from here,
+   * so declaring a size or a colour on this wrapper would just be a comment that
+   * looks like code.
+   */
+  public static getDescriptionClassName(): string {
+    return "pl-[34px] pr-2";
+  }
+
+  public static getSubGroupCountBadgeClassName(): string {
+    return "flex-shrink-0 inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500 tabular-nums";
+  }
+
+  /* The status dot that marks a reading as a rollup rather than a resource's own. */
+  public static getRollupDotClassName(): string {
+    return "h-1.5 w-1.5 flex-shrink-0 rounded-full";
+  }
+
+  public static getRollupLabelClassName(): string {
+    return "font-semibold tabular-nums";
+  }
+
+  /*
+   * A group that only exists to hold sub groups has no resources of its own,
+   * and telling the visitor it is empty would be wrong - the sub groups below
+   * it are its content. A group with neither still renders its (empty) resource
+   * list, because that is where the "no resources" message belongs.
+   */
+  public static shouldRenderOwnResources(data: {
+    ownResourceCount: number;
+    subGroupCount: number;
+  }): boolean {
+    return data.ownResourceCount > 0 || data.subGroupCount === 0;
+  }
+
+  /*
+   * Whether a group draws the time axis under its own resource list.
+   *
+   * Once per resource list rather than once per resource: every bar in one list
+   * is drawn over the same window and sits in the same column, so one axis
+   * describes all of them. It deliberately does not cover sub groups - their
+   * bars are indented past this one, and they may be collapsed, so an axis up
+   * here would be labelling a column that is not there.
+   *
+   * A group in grid view draws a matrix of cells instead of bars, so its
+   * resources are not something a time axis describes.
+   */
+  public static shouldRenderTimeAxis(data: {
+    statusPageGroup: StatusPageGroup | null;
+    statusPageResources: Array<StatusPageResource>;
+  }): boolean {
+    if (data.statusPageGroup?.viewMode === StatusPageGroupViewMode.Grid) {
+      return false;
+    }
+
+    const groupId: string | null =
+      data.statusPageGroup?._id?.toString() || null;
+
+    return (
+      data.statusPageResources.find((resource: StatusPageResource) => {
+        if (!resource.showStatusHistoryChart) {
+          return false;
+        }
+
+        /*
+         * Skipped for the same reason the page skips them - a resource that
+         * resolves to neither a monitor nor a monitor group draws nothing.
+         */
+        if (!resource.monitor && !resource.monitorGroupId) {
+          return false;
+        }
+
+        const resourceGroupId: string | null =
+          resource.statusPageGroupId?.toString() || null;
+
+        return resourceGroupId === groupId;
+      }) !== undefined
+    );
+  }
+
+  /*
+   * Which rolled up reading a group header shows.
+   *
+   * A group that is currently down shows its status rather than an uptime
+   * percent - "99.9% uptime" next to a red group is not the thing a visitor came
+   * to read - and a group whose uptime cannot be worked out (no resources under
+   * it at all) shows nothing rather than a zero.
+   */
+  public static getRollupKind(data: {
+    showUptimePercent: boolean;
+    showCurrentStatus: boolean;
+    isCurrentlyDown: boolean;
+    uptimePercent: number | null;
+  }): StatusPageGroupRollupKind {
+    if (data.showUptimePercent && !data.isCurrentlyDown) {
+      return data.uptimePercent === null
+        ? StatusPageGroupRollupKind.None
+        : StatusPageGroupRollupKind.UptimePercent;
+    }
+
+    return data.showCurrentStatus
+      ? StatusPageGroupRollupKind.CurrentStatus
+      : StatusPageGroupRollupKind.None;
+  }
+}


### PR DESCRIPTION
## Why

Nested resource groups on a status page were drawn as a card inside a card inside a card. Three levels deep that puts four borders around one uptime bar, every level eats horizontal room the bars need, and a leaf resource name (`text-lg`) renders *larger* than the group heading above it (`text-sm`) — so the hierarchy reads upside down. The same screen also repeated `90 days ago … Today` once per resource per level.

## Before / after

The same three level tree that was reported, rendered with the real component markup and the same vendored Tailwind build the status page loads.

**Before**

<img src="https://raw.githubusercontent.com/OneUptime/oneuptime/e47729a53b1d8383e8b56e7646ef7ae6e9ef997d/nesting-before-card.png" width="900" alt="Before: three nested cards, resource names larger than their group headings, three copies of the day axis">

**After**

<img src="https://raw.githubusercontent.com/OneUptime/oneuptime/e47729a53b1d8383e8b56e7646ef7ae6e9ef997d/nesting-after-card.png" width="900" alt="After: one card, a tree rail per level, group headings outranking their resources, one quiet axis per resource list">

Full page, with a second four level tree that has resources at more than one level (so the divider and the indent cap are both in shot):

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/e47729a53b1d8383e8b56e7646ef7ae6e9ef997d/nesting-before-full.png" width="420"> | <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/e47729a53b1d8383e8b56e7646ef7ae6e9ef997d/nesting-after-full.png" width="420"> |

The after page is about 22% shorter than the before page for the same content.

On a phone (390px), where the old nesting squeezed the bars hardest:

<img src="https://raw.githubusercontent.com/OneUptime/oneuptime/e47729a53b1d8383e8b56e7646ef7ae6e9ef997d/nesting-after-mobile.png" width="330">

## What changed

**Only the top level is a card.** Every nested group is a row hanging off a single hairline tree rail — no second surface, no second border, no background tint stacked on the last one. A sub group's contents are indented to line up with its parent's *title*, so it reads as hanging off the name rather than off the chevron. Measured at 1280px: sub group content lands within 1px of the parent title at every depth.

**The indent is capped.** Past depth 4 the step tightens instead of growing, so the ten levels the write path allows cost ~230px of the ~984px content column rather than running the bars off the page.

**Group headings outrank their resources.** Group titles are `text-lg` at the top level and `text-base` below it; the resource name dropped `md:text-lg` so it is never larger than the group containing it. Deeper levels are told apart by the rail, not by shrinking type — shrinking type is what produced `text-sm` headings over `text-lg` resources.

**One time axis per resource list, still next to its own bars.** `90 days ago … Today` is drawn once under a group's own resources instead of once per resource, in that group's own indentation, and quieter (`text-[11px] text-gray-400`) because it is a scale rather than a reading. A group in grid view draws none — it draws cells, not bars. Measured at 1280px: every axis's left edge matches its bar strip's left edge exactly, at every depth.

**Rolled up readings are marked as rollups, and line up.** A group's status/uptime now carries a status dot, so `● 100% uptime` on a group is distinguishable from `100% uptime` on a resource. It stays visible while the group is expanded — it used to live in the accordion's `rightElement`, which is hidden when open, so expanding a level hid the number you expanded it to compare against. The header's width also pays for its own negative margins now; with `w-full` the box was over-constrained, the browser dropped `margin-right`, and every rollup stopped 16px short of the card edge the resource readings sit on.

**Group descriptions render.** `StatusPageGroup.description` documents itself as *"visible on Status Page"*, has been editable in the dashboard and selected by the API all along, but the overview never rendered it. It now shows under the group name.

**A group in a parent-pointer cycle no longer vanishes.** The overview walked down from `getRootGroups`, and a cycle has no root, so a cycle written straight to the database dropped those groups off the page entirely. It renders from `StatusPageGroupTreeUtil.buildTree` now, which promotes them to the top level.

### Accessibility and correctness

- The group header is a real `<button>` with `aria-expanded`, instead of a `div` with `role="button"` and a hand-rolled keydown handler. Enter and Space are covered by tests.
- `aria-controls` is only set while the body it names is actually in the DOM.
- The group description is rendered *outside* the header button and referenced with `aria-describedby`. It is markdown and may contain a link, and a link inside a button is not something a browser or a screen reader can make sense of.
- The expand effect is keyed on the *boolean*, not the prop. `isExpandedByDefault` is an optional column, so it routinely arrives `undefined` and settles to `false`; keyed on the prop, that identity change fired the effect and shut a section the visitor had just opened.
- `MonitorOverview` keys moved from `key={Math.random()}` to the resource id, so a resource is no longer torn down and remounted on every render (which was discarding any open incident-day modal). The monitor and monitor-group branches are namespaced apart, since nothing stops one resource from carrying both.

## Structure

- `Common/Utils/StatusPage/GroupNestingLayout.ts` — every depth-derived decision (indent, rail, typography, dividers, which rollup to show, whether a list needs a time axis), as pure functions.
- `Common/UI/Components/StatusPage/ResourceGroupSection.tsx` — one level of the hierarchy: header button, rollup, rail, body.
- `Overview.tsx` keeps the recursion and the data, and holds no layout strings of its own.

## Tests

164 passing (110 new, plus the existing `GroupTree` and `ResourceUptime` suites unchanged and still green).

```
Test Suites: 4 passed, 4 total
Tests:       164 passed, 164 total
```

`Common/Tests/Utils/StatusPage/GroupNestingLayout.test.ts` (69) pins invariants rather than pixels:

- nothing nested adds a card, a border, a background or padding — at any depth,
- a group title is never smaller than the resources inside it, and never grows with depth,
- the indent never grows with depth, every step still costs something so the rails stay apart, and ten levels stay under 250px,
- a sub group's contents land at its parent's title,
- the header's bleed is symmetric *and* paid for by its width,
- a grid-view group asks for no axis; a group asks for one only for its own charted resources, never for a descendant's,
- and all five branches of the rollup decision, including "down, so show status not a percent" and "no uptime to report, so show nothing rather than a zero".

`Common/Tests/UI/Components/StatusPage/ResourceGroupSection.test.tsx` (41) covers the component, including a six level hierarchy asserting exactly one card is drawn, every level below the top hangs off its own rail, and collapsing level 2 hides the leaf.

**Every measurement is read off the class strings that actually render**, not from a number stored beside them. The first version of this suite did the latter and was vacuous: it passed unchanged with the real indent inflated six fold, with a nested title shrunk below its resources, and with the chevron widened out from under the alignment it defines. All three mutations now fail. Verified by re-running each one.

`npx tsc --noEmit` clean for `Common` and for the `StatusPage` feature set; `eslint` clean on every changed file.

## Notes for review

- The screenshots are rendered from a static harness that uses the real component markup and the status page's own vendored Tailwind build, not captured from a live page — this worktree's database has no status page in it. Class strings are transcribed from the components on both sides, so the comparison is apples to apples, but it is a render of the markup rather than a photo of production. The alignment numbers quoted above are `getBoundingClientRect` measurements from that harness.
- The images live on a branch of their own, `claude/status-page-nesting-ui-98a775-screenshots`, purely so they stay out of this diff — GitHub has no API for attaching images to a PR. Safe to delete with this branch.
- Not covered by tests: the grid-view vs list-view branch inside `Overview.renderResourceGroup`. `Overview` is a 1600 line page component and the `App` jest project runs in a `node` environment with no jsdom, so there is no harness for it here; the pieces it composes are each tested, the composition is not.
