### PR TITLE
fix(build): repair absolute tsconfig include globs and finish RunbookAgent boot fix

### DIFF
--- a/AIAgent/tsconfig.json
+++ b/AIAgent/tsconfig.json
@@ -38,6 +38,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["/**/*.ts"],
+  "include": ["./**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/Common/Tests/Server/Infrastructure/ContainerBootConfiguration.test.ts
+++ b/Common/Tests/Server/Infrastructure/ContainerBootConfiguration.test.ts
@@ -46,6 +46,14 @@ const TRANSPILE_ONLY_ENV: RegExp = /ENV\s+TS_NODE_TRANSPILE_ONLY=1/;
 const CMD_PRECOMPILED_ENTRYPOINT: RegExp =
   /CMD\s*\[\s*"node"\s*,\s*"build\/dist\/Index\.js"\s*\]/;
 const TS_NODE_ANYWHERE: RegExp = /ts-node\/register/;
+/*
+ * The actual build step, anchored to a RUN instruction. A plain substring
+ * search would also match a comment that merely mentions `npm run compile`.
+ */
+const RUN_COMPILE_INSTRUCTION: RegExp = /^\s*RUN\s+npm\s+run\s+compile\s*$/m;
+// Captures the body of a tsconfig `"include": [ ... ]` array.
+const INCLUDE_ARRAY_BLOCK: RegExp = /"include"\s*:\s*\[([^\]]*)\]/;
+const QUOTED_STRING: RegExp = /"[^"]*"/g;
 
 const listServiceImages: () => Array<ServiceImage> =
   (): Array<ServiceImage> => {
@@ -141,26 +149,16 @@ describe("Container boot configuration", () => {
   });
 
   describe("images that boot through ts-node must not re-type-check at boot", () => {
-    /*
-     * Skipping the boot-time check is only safe when tsc already ran at build
-     * time. That is the precondition, so the rule is scoped to images that meet
-     * it -- see the "known gap" block below for the ones that do not.
-     */
     const tsNodeImages: Array<ServiceImage> = SERVICE_IMAGES.filter(
       bootsThroughTsNodeIncludingWrappers,
     );
-    const typeCheckedAtBuild: Array<ServiceImage> = tsNodeImages.filter(
-      (image: ServiceImage) => {
-        return image.productionStanza.includes("npm run compile");
-      },
-    );
 
     test("at least one such image exists", () => {
-      expect(typeCheckedAtBuild.length).toBeGreaterThan(0);
+      expect(tsNodeImages.length).toBeGreaterThan(0);
     });
 
     test.each(
-      typeCheckedAtBuild.map((i: ServiceImage) => {
+      tsNodeImages.map((i: ServiceImage) => {
         return i.service;
       }),
     )(
@@ -178,34 +176,25 @@ describe("Container boot configuration", () => {
     );
   });
 
-  describe("known gap: images that boot through ts-node without a build-time check", () => {
+  describe("no image disables the boot check without a build-time check", () => {
     /*
-     * RunbookAgent boots `npm start` through ts-node but its Dockerfile never
-     * runs `npm run compile`, so its types are verified NOWHERE except at
-     * container boot. It therefore pays the full type-check on every start AND
-     * cannot simply have that check disabled -- the fix is to add the build-time
-     * compile step first, which needs its own verification that the package
-     * actually compiles clean.
-     *
-     * It is not part of the OneUptime Helm chart, so it is not on the rolling
-     * update path this change targets. This test pins the gap so a NEW service
-     * cannot quietly join the category.
+     * The two halves must stay together. Disabling the boot-time type-check on a
+     * service whose image never runs `npm run compile` would leave its types
+     * verified NOWHERE -- not at build, not at boot, not in CI.
      */
-    const KNOWN_GAP_SERVICES: Array<string> = ["RunbookAgent"];
-
-    test("no service other than the known ones skips the build-time type check", () => {
+    test("every ts-node image type-checks at build time", () => {
       const gaps: Array<string> = SERVICE_IMAGES.filter(
         (image: ServiceImage) => {
           return (
             bootsThroughTsNodeIncludingWrappers(image) &&
-            !image.productionStanza.includes("npm run compile")
+            !RUN_COMPILE_INSTRUCTION.test(image.productionStanza)
           );
         },
       ).map((image: ServiceImage) => {
         return image.service;
       });
 
-      expect(gaps.sort()).toEqual([...KNOWN_GAP_SERVICES].sort());
+      expect(gaps).toEqual([]);
     });
   });
 
@@ -268,7 +257,7 @@ describe("Container boot configuration", () => {
       );
 
       expect(image).toBeDefined();
-      expect(image?.productionStanza).toContain("npm run compile");
+      expect(image?.productionStanza).toMatch(RUN_COMPILE_INSTRUCTION);
     });
   });
 
@@ -294,6 +283,76 @@ describe("Container boot configuration", () => {
         expect(fs.readFileSync(nodemonPath, "utf8")).toContain(
           "TS_NODE_TRANSPILE_ONLY",
         );
+      },
+    );
+  });
+
+  describe("build-time type checking actually has inputs to check", () => {
+    /*
+     * A tsconfig `include` entry beginning with "/" is an ABSOLUTE glob rooted
+     * at the filesystem, not at the tsconfig's directory. AIAgent, Probe and
+     * RunbookAgent all shipped `["/**\/*.ts"]`, which meant `npm run compile`
+     * matched whatever .ts files happened to lie within tsc's glob reach of `/`
+     * -- nothing at all on a developer machine (tsc exits 2 with TS18003), and
+     * an arbitrary set inside the container, where /usr/src/app sits shallow
+     * enough to match.
+     *
+     * That made the build-time type-check environment-dependent and, on the
+     * services above, effectively absent -- while the CI compile jobs stayed
+     * green. Since TS_NODE_TRANSPILE_ONLY hands ALL type verification to that
+     * build step, a broken `include` silently means no type checking anywhere.
+     */
+    const tsConfigPaths: Array<string> = fs
+      .readdirSync(REPO_ROOT, { withFileTypes: true })
+      .filter((entry: fs.Dirent) => {
+        return entry.isDirectory() && entry.name !== "node_modules";
+      })
+      .map((entry: fs.Dirent) => {
+        return path.join(entry.name, "tsconfig.json");
+      })
+      .filter((candidate: string) => {
+        return fs.existsSync(path.join(REPO_ROOT, candidate));
+      });
+
+    test("there are tsconfigs to check", () => {
+      expect(tsConfigPaths.length).toBeGreaterThan(0);
+    });
+
+    test.each(tsConfigPaths)(
+      "%s has no absolute include glob",
+      (tsConfigPath: string) => {
+        /*
+         * These tsconfigs are JSONC (comments and trailing commas), so they are
+         * not valid JSON. Extract the include array textually instead of
+         * hand-rolling a JSONC parser.
+         */
+        const raw: string = fs.readFileSync(
+          path.join(REPO_ROOT, tsConfigPath),
+          "utf8",
+        );
+        const includeBlock: RegExpMatchArray | null =
+          raw.match(INCLUDE_ARRAY_BLOCK);
+
+        if (includeBlock === null) {
+          // No `include` at all: tsc defaults to the tsconfig's own directory.
+          return;
+        }
+
+        const patterns: Array<string> = (
+          includeBlock[1]?.match(QUOTED_STRING) ?? []
+        ).map((quoted: string) => {
+          return quoted.slice(1, -1);
+        });
+
+        expect(patterns.length).toBeGreaterThan(0);
+
+        for (const pattern of patterns) {
+          expect({
+            tsConfigPath,
+            pattern,
+            absolute: pattern.startsWith("/"),
+          }).toEqual({ tsConfigPath, pattern, absolute: false });
+        }
       },
     );
   });

--- a/Probe/tsconfig.json
+++ b/Probe/tsconfig.json
@@ -109,6 +109,6 @@
                 "skipLibCheck": true, /* Skip type checking all .d.ts files. */
         "resolveJsonModule": true
     },
-    "include": ["/**/*.ts"],
+    "include": ["./**/*.ts"],
     "exclude": ["node_modules"]
 }

--- a/RunbookAgent/Dockerfile.tpl
+++ b/RunbookAgent/Dockerfile.tpl
@@ -76,6 +76,10 @@ CMD [ "npm", "run", "dev" ]
 # avoid a slow recursive `chown -R` over node_modules; deps stay root-owned and
 # world-readable.
 COPY --chown=1000:1000 ./RunbookAgent /usr/src/app
+# Bundle app source. This type-checks the package at build time, which is the
+# precondition for TS_NODE_TRANSPILE_ONLY below: without it, disabling the
+# boot-time check would leave this service's types verified nowhere at all.
+RUN npm run compile
 USER node
 # Per-build metadata last so the npm ci layers above stay cacheable across commits.
 ARG GIT_SHA
@@ -84,6 +88,10 @@ ENV GIT_SHA=${GIT_SHA}
 ENV APP_VERSION=${APP_VERSION}
 LABEL org.opencontainers.image.revision="${GIT_SHA}"
 LABEL org.opencontainers.image.version="${APP_VERSION}"
+# The full TypeScript type-check already ran at build time (`npm run compile`
+# above). Without this, ts-node/register redoes it on every container start.
+# See App/Dockerfile.tpl for the full rationale.
+ENV TS_NODE_TRANSPILE_ONLY=1
 #Run the app
 CMD [ "npm", "start" ]
 {{ end }}

--- a/RunbookAgent/tsconfig.json
+++ b/RunbookAgent/tsconfig.json
@@ -109,6 +109,6 @@
                 "skipLibCheck": true, /* Skip type checking all .d.ts files. */
         "resolveJsonModule": true
     },
-    "include": ["/**/*.ts"],
+    "include": ["./**/*.ts"],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Follow-up to #2933. Completes RunbookAgent — and fixes the root cause that made its exclusion necessary, which turned out to affect two services #2933 had **already changed**.

## Why RunbookAgent was excluded, and what that uncovered

#2933 left RunbookAgent out because its Dockerfile never ran `npm run compile`, so disabling the boot-time type-check would have left its types verified nowhere. Adding the compile step revealed why it was missing:

```jsonc
// RunbookAgent/tsconfig.json
"include": ["/**/*.ts"]
```

The leading slash makes that an **absolute** glob rooted at the filesystem, not at the tsconfig's directory. So:

- On a developer machine, `npm run compile` exits 2 with `TS18003: No inputs were found`.
- Inside the container it matches whatever `.ts` files lie within tsc's glob reach of `/` — `/usr/src/app` sits shallow enough to match, so the image build succeeds *by accident*.

## The part that affects #2933

**AIAgent and Probe carry the same malformed include, and both already run `npm run compile` in their Dockerfiles.**

```
$ cd AIAgent && npm run compile
error TS18003: No inputs were found in config file 'AIAgent/tsconfig.json'.
  Specified 'include' paths were '["/**/*.ts"]'
EXIT=2
```

Meanwhile `compile-ai-agent` and `compile-probe` are **green on master** — the runner's checkout path also happens to fall within the glob's reach, so CI finds inputs where a laptop does not.

This matters directly: `TS_NODE_TRANSPILE_ONLY` hands *all* type verification to the build step. Shipping it against a build step that checks nothing would have left AIAgent and Probe with **no type checking at all** — not at build, not at boot, not in CI. That was a live regression introduced by #2933, not a pre-existing curiosity.

## Changes

- `include` corrected to `"./**/*.ts"` in **RunbookAgent, AIAgent, Probe**. All three now compile clean locally — exit 0, zero TS errors (`npm install` + `npm run compile` run against each).
- **RunbookAgent** gains `RUN npm run compile` and `ENV TS_NODE_TRANSPILE_ONLY=1`, matching every other ts-node service.

Full audit after this change — every ts-node image now has all three properties:

| Service | build compile | transpile-only | exec-safe start |
|---|---|---|---|
| AIAgent, App, Home, Nginx, Probe, RunbookAgent, TestServer | ✅ | ✅ | ✅ |

`KubernetesCostAgent` / `KubernetesLogTailer` remain correctly excluded — they run `CMD ["node", "build/dist/Index.js"]`, no ts-node in the image.

## Tests

- The "known gap" block pinning RunbookAgent is gone, replaced by a flat invariant: **every** ts-node image must type-check at build time, no exceptions.
- **New:** no tsconfig may use an absolute include glob — the root cause, otherwise invisible because CI stays green.
- **Tightened:** the build-time check now matches an anchored `RUN npm run compile` *instruction* rather than the bare substring. The previous version was satisfied by a comment merely mentioning the phrase — I caught this when reverting the compile step failed to turn the test red.

Each guard was verified by reverting the corresponding fix and confirming it fires:

```
✕ every ts-node image type-checks at build time
✕ RunbookAgent still runs `npm run compile` at build time
✕ Probe/tsconfig.json has no absolute include glob
```

61 tests green with the fixes in place (57 Common + 4 App).