### PR TITLE
fix(table): stop a stale `labels` URL slice from drawing a phantom search chip

### DIFF
--- a/Common/Tests/UI/Components/ModelTable/BaseModelTableSearchLabels.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/BaseModelTableSearchLabels.test.tsx
@@ -1,0 +1,397 @@
+import "@testing-library/jest-dom/extend-expect";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Same stubs as BaseModelTableUrlState.test.tsx — permissions, the current
+ * project and i18n are not what these tests are about. The subject here is the
+ * `labels` slice of the table's `-view` URL param and the in-search label
+ * chips it feeds.
+ */
+jest.mock("../../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return true;
+      },
+      getUserId: () => {
+        return null;
+      },
+    },
+  };
+});
+
+jest.mock("../../../../UI/Utils/Translation", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return {
+        translateString: (value: string | undefined) => {
+          return value;
+        },
+        translateValue: (value: unknown) => {
+          return value;
+        },
+      };
+    },
+  };
+});
+
+import BaseModelTable, {
+  BaseTableCallbacks,
+  ComponentProps as BaseModelTableProps,
+} from "../../../../UI/Components/ModelTable/BaseModelTable";
+import TableFilterUrlState from "../../../../UI/Utils/TableFilterUrlState";
+import Filter from "../../../../UI/Components/ModelFilter/Filter";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Label from "../../../../Models/DatabaseModels/Label";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import Query from "../../../../Types/BaseDatabase/Query";
+import ListResult from "../../../../Types/BaseDatabase/ListResult";
+import { JSONObject } from "../../../../Types/JSON";
+
+const LABEL_ID: string = "0192f2ce-1b1a-7000-8000-0000000000aa";
+
+type GetListCall = {
+  modelType: unknown;
+  query: Query<Monitor>;
+};
+
+/*
+ * The Labels filter as it is still declared on tables that kept it in the
+ * filter popup (Telemetry Services, On-Call Schedules, ...). Its presence is
+ * the only thing that switches on in-search label chips.
+ */
+const LABEL_FILTER: Filter<Monitor> = {
+  title: "Labels",
+  type: FieldType.EntityArray,
+  field: { labels: { name: true, color: true } },
+  filterEntityType: Label,
+  filterQuery: {},
+  filterDropdownField: { label: "name", value: "_id" },
+} as unknown as Filter<Monitor>;
+
+const PLAIN_FILTERS: Array<Filter<Monitor>> = [
+  { title: "Name", type: FieldType.Text, field: { name: true } },
+] as unknown as Array<Filter<Monitor>>;
+
+/*
+ * A table that has moved its Labels filter out to the facet bar — Monitors and
+ * Network Devices — has no Label entry left in `filters` at all.
+ */
+const FACETED_FILTERS: Array<Filter<Monitor>> = PLAIN_FILTERS;
+
+const WITH_LABEL_FILTERS: Array<Filter<Monitor>> = [
+  ...PLAIN_FILTERS,
+  LABEL_FILTER,
+];
+
+type SetUrlFunction = (url: string) => void;
+
+const setUrl: SetUrlFunction = (url: string): void => {
+  window.history.replaceState(window.history.state, "", url);
+};
+
+describe("BaseModelTable in-search label chips", () => {
+  let calls: Array<GetListCall> = [];
+
+  type MakeCallbacksFunction = () => BaseTableCallbacks<Monitor>;
+
+  const makeCallbacks: MakeCallbacksFunction =
+    (): BaseTableCallbacks<Monitor> => {
+      return {
+        deleteItem: async () => {
+          return undefined;
+        },
+        getModelFromJSON: (item: JSONObject) => {
+          return item as unknown as Monitor;
+        },
+        getJSONFromModel: (item: Monitor) => {
+          return item as unknown as JSONObject;
+        },
+        addSlugToSelect: (select: unknown) => {
+          return select;
+        },
+        getList: async (data: {
+          modelType: unknown;
+          query: Query<Monitor>;
+          limit: number;
+        }): Promise<ListResult<Monitor>> => {
+          calls.push({ modelType: data.modelType, query: data.query });
+          return { data: [], count: 0, skip: 0, limit: data.limit };
+        },
+        toJSONArray: () => {
+          return [];
+        },
+        updateById: async () => {
+          return undefined;
+        },
+        showCreateEditModal: () => {
+          return <></>;
+        },
+      } as unknown as BaseTableCallbacks<Monitor>;
+    };
+
+  /*
+   * The label-suggestion fetch goes through the same `getList` callback with
+   * `modelType: Label`, so the row requests have to be picked out explicitly.
+   */
+  type RowCallsFunction = () => Array<GetListCall>;
+
+  const rowCalls: RowCallsFunction = (): Array<GetListCall> => {
+    return calls.filter((c: GetListCall) => {
+      return c.modelType === Monitor;
+    });
+  };
+
+  type MakePropsFunction = (
+    filters: Array<Filter<Monitor>>,
+  ) => BaseModelTableProps<Monitor>;
+
+  const makeProps: MakePropsFunction = (
+    filters: Array<Filter<Monitor>>,
+  ): BaseModelTableProps<Monitor> => {
+    return {
+      modelType: Monitor,
+      id: "monitors-table",
+      name: "Monitors",
+      userPreferencesKey: "monitors-table",
+      columns: [],
+      filters: filters,
+      isDeleteable: false,
+      isCreateable: false,
+      isViewable: false,
+      isEditable: false,
+      callbacks: makeCallbacks(),
+      searchableFields: ["name"] as Array<keyof Monitor>,
+    } as unknown as BaseModelTableProps<Monitor>;
+  };
+
+  type RenderTableFunction = (
+    filters: Array<Filter<Monitor>>,
+  ) => ReturnType<typeof render>;
+
+  const renderTable: RenderTableFunction = (
+    filters: Array<Filter<Monitor>>,
+  ): ReturnType<typeof render> => {
+    return render(<BaseModelTable<Monitor> {...makeProps(filters)} />);
+  };
+
+  beforeEach(() => {
+    calls = [];
+    setUrl("/dashboard/monitors");
+    TableFilterUrlState.resetClaimedKeys();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+  });
+
+  describe("when the table still has a Labels filter", () => {
+    test("the restored ids constrain the first fetch", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+      });
+
+      renderTable(WITH_LABEL_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      const labelsConstraint: unknown = (
+        rowCalls()[0]?.query as unknown as JSONObject
+      )["labels"];
+
+      expect(labelsConstraint).toBeInstanceOf(Includes);
+      expect((labelsConstraint as Includes).values).toEqual([LABEL_ID]);
+    });
+
+    test("a chip is rendered for each restored id", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+      });
+
+      const view: ReturnType<typeof render> = renderTable(WITH_LABEL_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      /*
+       * Before the label list lands the chip is captioned with the raw id —
+       * that is the documented behaviour here, because the constraint IS
+       * applied and dropping it from a shared link would be worse.
+       */
+      expect(view.queryByLabelText(`Remove ${LABEL_ID}`)).not.toBeNull();
+    });
+
+    test("the labels key stays on the URL", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+      });
+
+      renderTable(WITH_LABEL_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      expect(TableFilterUrlState.read("monitors-table", "view")).toEqual({
+        labels: [LABEL_ID],
+      });
+    });
+  });
+
+  describe("when the Labels filter has moved to the facet bar", () => {
+    test("the restored ids do not constrain the fetch", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+      });
+
+      renderTable(FACETED_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      expect(
+        (rowCalls()[0]?.query as unknown as JSONObject)["labels"],
+      ).toBeUndefined();
+    });
+
+    test("no phantom chip is rendered", async () => {
+      /*
+       * The regression this guards: the chip was seeded from the URL but
+       * `availableLabels` is never fetched without a Labels filter, so it
+       * could never hydrate past the raw UUID — a pill the table could not
+       * name, could not apply, and that the user had to dismiss by hand.
+       */
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+      });
+
+      const view: ReturnType<typeof render> = renderTable(FACETED_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      expect(view.queryByLabelText(`Remove ${LABEL_ID}`)).toBeNull();
+      expect(view.queryByText(LABEL_ID)).toBeNull();
+    });
+
+    test("the search box is not forced open", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+      });
+
+      const view: ReturnType<typeof render> = renderTable(FACETED_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      // Only shown while the search has text or chips behind it.
+      expect(view.queryByLabelText("Clear search")).toBeNull();
+    });
+
+    test("the stale labels key is dropped from the URL", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+        page: 2,
+      });
+
+      renderTable(FACETED_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      /*
+       * The rest of the view slice is untouched — only the key this table can
+       * no longer honour is healed away, so the link keeps working.
+       */
+      await waitFor(() => {
+        expect(TableFilterUrlState.read("monitors-table", "view")).toEqual({
+          page: 2,
+        });
+      });
+    });
+
+    test("a search term restored alongside the stale key still applies", async () => {
+      TableFilterUrlState.write("monitors-table", "view", {
+        labels: [LABEL_ID],
+        search: "api",
+      });
+
+      renderTable(FACETED_FILTERS);
+
+      await waitFor(() => {
+        expect(rowCalls().length).toBeGreaterThan(0);
+      });
+
+      expect(
+        (rowCalls()[0]?.query as unknown as JSONObject)["_multiFieldSearch"],
+      ).toBeDefined();
+      expect(
+        (rowCalls()[0]?.query as unknown as JSONObject)["labels"],
+      ).toBeUndefined();
+    });
+  });
+
+  test("chips are cleared when the Labels filter is removed after mount", async () => {
+    TableFilterUrlState.write("monitors-table", "view", {
+      labels: [LABEL_ID],
+    });
+
+    const view: ReturnType<typeof render> = renderTable(WITH_LABEL_FILTERS);
+
+    await waitFor(() => {
+      expect(view.queryByLabelText(`Remove ${LABEL_ID}`)).not.toBeNull();
+    });
+
+    await act(async () => {
+      view.rerender(
+        <BaseModelTable<Monitor> {...makeProps(FACETED_FILTERS)} />,
+      );
+    });
+
+    await waitFor(() => {
+      expect(view.queryByLabelText(`Remove ${LABEL_ID}`)).toBeNull();
+    });
+
+    await waitFor(() => {
+      expect(TableFilterUrlState.read("monitors-table", "view")).toBeNull();
+    });
+  });
+});

--- a/Common/UI/Components/ModelTable/BaseModelTable.tsx
+++ b/Common/UI/Components/ModelTable/BaseModelTable.tsx
@@ -665,6 +665,66 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [error, setError] = useState<string>("");
   const [tableFilterError, setTableFilterError] = useState<string>("");
 
+  /*
+   * Auto-detect label support from the existing filters array. We look for
+   * the filter whose `filterEntityType` class name is "Label" and reuse its
+   * dropdown wiring (entity type, fetch query, label/value field names) so
+   * search inherits whatever scoping the filter popup already had.
+   *
+   * Computed before the search state below because the `labels` slice of a
+   * restored URL is only meaningful when this is non-null.
+   */
+  type LabelFilterConfig = {
+    fieldKey: string;
+    entityType: any;
+    fetchQuery: any;
+    labelField: string;
+  };
+
+  const labelFilterConfig: LabelFilterConfig | null = useMemo(() => {
+    const filter: Filter<TBaseModel> | undefined = props.filters.find(
+      (f: Filter<TBaseModel>) => {
+        return (
+          f.filterEntityType &&
+          (f.filterEntityType as any).name === "Label" &&
+          f.field &&
+          f.filterDropdownField
+        );
+      },
+    );
+    if (!filter || !filter.field || !filter.filterDropdownField) {
+      return null;
+    }
+    const fieldKey: string | undefined = Object.keys(filter.field)[0];
+    if (!fieldKey) {
+      return null;
+    }
+    return {
+      fieldKey,
+      entityType: filter.filterEntityType,
+      fetchQuery: filter.filterQuery || {},
+      labelField: filter.filterDropdownField.label,
+    };
+  }, [props.filters]);
+
+  /*
+   * The label chips are a feature of the in-search Label filter, so a table
+   * without one has to ignore the URL's `labels` slice entirely.
+   *
+   * Tables that have since moved Labels out to a facet chip (Monitors,
+   * Network Devices) still receive `labels` from older shared/bookmarked
+   * links. Seeding those ids anyway produced a chip the table could neither
+   * name (`availableLabels` is only fetched when there *is* a config) nor
+   * apply (`buildSearchQueryFragment` skips the constraint for the same
+   * reason): a force-expanded search box with a raw-UUID pill sitting above a
+   * completely unfiltered list, re-persisted on every write until the user
+   * clicked its ×. Dropping it here also means the next view write omits the
+   * key, so the URL heals itself.
+   */
+  const restoredLabelIds: Array<string> = labelFilterConfig
+    ? initialUrlState.view.labels || []
+    : [];
+
   const [searchText, setSearchText] = useState<string>(
     initialUrlState.view.search || "",
   );
@@ -673,9 +733,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   );
   const [isSearchFocused, setIsSearchFocused] = useState<boolean>(false);
   const [isSearchExpanded, setIsSearchExpanded] = useState<boolean>(
-    Boolean(
-      initialUrlState.view.search || (initialUrlState.view.labels || []).length,
-    ),
+    Boolean(initialUrlState.view.search || restoredLabelIds.length),
   );
   const searchInputRef: React.RefObject<HTMLInputElement> =
     React.useRef<HTMLInputElement>(null!);
@@ -697,7 +755,7 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   const [selectedLabels, setSelectedLabels] = useState<
     Array<SearchLabelOption>
   >(() => {
-    return (initialUrlState.view.labels || []).map((id: string) => {
+    return restoredLabelIds.map((id: string) => {
       return { id: id, name: id, color: "#94a3b8" };
     });
   });
@@ -793,43 +851,24 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
   }, [debouncedSearchText, selectedLabelIdsKey]);
 
   /*
-   * Auto-detect label support from the existing filters array. We look for
-   * the filter whose `filterEntityType` class name is "Label" and reuse its
-   * dropdown wiring (entity type, fetch query, label/value field names) so
-   * search inherits whatever scoping the filter popup already had.
+   * `props.filters` is not frozen — a page can rebuild it after mount, and
+   * that is exactly how a Labels filter leaves the popup for the facet bar.
+   * Chips left over from a config that no longer exists are unnameable and
+   * unappliable, so drop them here too rather than only at mount.
    */
-  type LabelFilterConfig = {
-    fieldKey: string;
-    entityType: any;
-    fetchQuery: any;
-    labelField: string;
-  };
+  useEffect(() => {
+    if (labelFilterConfig) {
+      return;
+    }
 
-  const labelFilterConfig: LabelFilterConfig | null = useMemo(() => {
-    const filter: Filter<TBaseModel> | undefined = props.filters.find(
-      (f: Filter<TBaseModel>) => {
-        return (
-          f.filterEntityType &&
-          (f.filterEntityType as any).name === "Label" &&
-          f.field &&
-          f.filterDropdownField
-        );
-      },
-    );
-    if (!filter || !filter.field || !filter.filterDropdownField) {
-      return null;
-    }
-    const fieldKey: string | undefined = Object.keys(filter.field)[0];
-    if (!fieldKey) {
-      return null;
-    }
-    return {
-      fieldKey,
-      entityType: filter.filterEntityType,
-      fetchQuery: filter.filterQuery || {},
-      labelField: filter.filterDropdownField.label,
-    };
-  }, [props.filters]);
+    setSelectedLabels((existing: Array<SearchLabelOption>) => {
+      /*
+       * Same array when there is nothing to clear, so this costs an idle table
+       * no re-render.
+       */
+      return existing.length === 0 ? existing : [];
+    });
+  }, [labelFilterConfig]);
 
   // Fetch labels on first search expansion if this resource supports them.
   useEffect(() => {
@@ -3263,36 +3302,46 @@ const BaseModelTable: <TBaseModel extends BaseModel | AnalyticsBaseModel>(
             />
             {/* Pills + input wrap row */}
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-              {selectedLabels.map((label: SearchLabelOption) => {
-                return (
-                  <span
-                    key={label.id}
-                    className="inline-flex items-center gap-1 rounded-full bg-gray-50 py-0.5 pl-2 pr-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200 transition-all hover:bg-gray-100"
-                    title={`Label: ${label.name}`}
-                  >
+              {/*
+               * Gated on label support as well as on the chips themselves: a
+               * pill this table cannot name, apply or refill is never worth
+               * drawing, whatever left it in state.
+               */}
+              {hasLabelSupport &&
+                selectedLabels.map((label: SearchLabelOption) => {
+                  return (
                     <span
-                      className="h-2 w-2 flex-none rounded-full"
-                      style={{ backgroundColor: label.color }}
-                      aria-hidden="true"
-                    />
-                    <span className="max-w-[8rem] truncate">{label.name}</span>
-                    <button
-                      type="button"
-                      onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
-                        e.preventDefault();
-                      }}
-                      onClick={() => {
-                        removeLabel(label.id);
-                      }}
-                      title="Remove label"
-                      aria-label={`Remove ${label.name}`}
-                      className="ml-0.5 flex-none rounded-full p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700"
+                      key={label.id}
+                      className="inline-flex items-center gap-1 rounded-full bg-gray-50 py-0.5 pl-2 pr-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200 transition-all hover:bg-gray-100"
+                      title={`Label: ${label.name}`}
                     >
-                      <Icon icon={IconProp.Close} className="h-3 w-3" />
-                    </button>
-                  </span>
-                );
-              })}
+                      <span
+                        className="h-2 w-2 flex-none rounded-full"
+                        style={{ backgroundColor: label.color }}
+                        aria-hidden="true"
+                      />
+                      <span className="max-w-[8rem] truncate">
+                        {label.name}
+                      </span>
+                      <button
+                        type="button"
+                        onMouseDown={(
+                          e: React.MouseEvent<HTMLButtonElement>,
+                        ) => {
+                          e.preventDefault();
+                        }}
+                        onClick={() => {
+                          removeLabel(label.id);
+                        }}
+                        title="Remove label"
+                        aria-label={`Remove ${label.name}`}
+                        className="ml-0.5 flex-none rounded-full p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700"
+                      >
+                        <Icon icon={IconProp.Close} className="h-3 w-3" />
+                      </button>
+                    </span>
+                  );
+                })}
               <input
                 ref={searchInputRef}
                 type="text"


### PR DESCRIPTION
### Title of this pull request?

fix(table): stop a stale `labels` URL slice from drawing a phantom search chip

### Small Description?

The in-search label pills in `BaseModelTable` are driven by `labelFilterConfig`, which is only non-null when the table declares a filter whose `filterEntityType` is `Label`. `buildSearchQueryFragment` honours that — without a config it skips the label constraint entirely, and `availableLabels` is never fetched.

`selectedLabels` was seeded from the table's `-view` URL slice regardless, and the pills rendered unconditionally.

**The bug.** On any table that has since moved its Labels filter out of the popup and onto a facet chip (Monitors, and now Network Devices), opening an older shared or bookmarked URL carrying `<tableId>-view={"labels":["<uuid>"]}` showed:

- the search box force-expanded,
- a pill captioned with the raw UUID — `availableLabels` is only fetched when `labelFilterConfig` exists, so it could never hydrate to a name,
- the table listing **everything**, because the constraint was silently dropped,
- the facet bar's own Labels chip reading empty.

The write effect kept re-persisting the key, so the phantom pill survived reloads until the user clicked its ×.

**The fix**, in the shared component rather than on a page, since it affects every table that migrated Labels to the facet bar:

- `labelFilterConfig` moves above the search state — a pure relocation, it only ever depended on `props.filters` — so the restore can be gated on it.
- `restoredLabelIds` is the URL's `labels` when a Label filter exists and `[]` otherwise. It feeds both the `selectedLabels` seed and the `isSearchExpanded` seed, so a facet-bar table no longer force-expands the search box or seeds a chip.
- **The URL heals itself.** With the chips empty, `selectedLabelIds` is `[]`, and `TableViewUrlState.toJSON` already omits an empty `labels` array — so the first view write after mount drops the stale key while leaving the rest of the slice (`page`, `search`, sort) intact.
- A new effect clears the chips if `labelFilterConfig` goes null *after* mount, covering pages that rebuild `filters` at runtime rather than only the mount path.
- The pill render is additionally gated on `hasLabelSupport`, so nothing can draw a chip the table can neither name nor apply.

Tables that still declare a Labels filter in the popup are untouched: restored ids still produce an `Includes` constraint on the first fetch, still render a chip, and still round-trip through the URL.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

N/A

### Screenshots (if appropriate):

N/A — not verified in a browser. Exercising this needs the dashboard against a live backend and a project with labels; the new tests assert the same surface more directly (chip presence, the Clear-search affordance, the outgoing query, and the resulting URL).

### Testing

New suite: `Common/Tests/UI/Components/ModelTable/BaseModelTableSearchLabels.test.tsx` (9 tests), alongside the existing ModelTable tests.

Four are regression guards, each verified to **fail against the unpatched component** and pass with it:

- no phantom chip is rendered
- the search box is not forced open
- the stale `labels` key is dropped from the URL (and `page` survives)
- chips are cleared when the Labels filter is removed after mount

The other five pin the behaviour that must not change — with a Labels filter still in the popup, restored ids constrain the first fetch via `Includes`, render a chip, and round-trip through the URL; and a `search` term restored alongside a stale `labels` key still applies.

- `Tests/UI/Components/ModelTable` — 329/329 passing across 10 suites
- `tsc --noEmit`, eslint and prettier clean