### PR TITLE
fix(runbook): make executions durable across a Worker restart

### DIFF
--- a/App/FeatureSet/Docs/Content/en/runbooks/agents.md
+++ b/App/FeatureSet/Docs/Content/en/runbooks/agents.md
@@ -101,6 +101,15 @@ When an agent claims a job, it gets a short lease (30 seconds by default). While
 
 Bash child processes are **not** automatically cancelled when the lease expires (a JavaScript isolate is also left to finish if it ever does) — but the Worker stops waiting for them, and the agent will not be able to submit a result once another claim has taken over. Design scripts to be safe to re-run if you care about exactly-once.
 
+### If the OneUptime Worker restarts mid-step
+
+A runbook execution runs on one Worker from start to finish, so a deploy or a crash can interrupt it while a step is in flight. What happens next depends on whether the execution gets picked back up:
+
+- **It resumes.** The Worker that picks it up finds the job row your step already created and **re-attaches to it** — it waits on that job rather than sending your agent a second copy of the script. If the agent had already finished, the recorded result is used as-is. A step is dispatched to an agent at most once per execution.
+- **It does not resume.** If the execution is never picked back up, a sweep marks it `Failed` once it has outlived the claim + execution window its current step was configured for, with a message naming that step. An execution never hangs in `Running`.
+
+The one thing this cannot tell you is how far a script got before the Worker vanished. A step that was mid-run is reported as failed with a note that it may have partially run — check the target system before running the runbook again.
+
 ### No agent online
 
 If the selected agent is offline at the moment the step runs, the job sits `Pending` until the claim timeout elapses, then fails with a clear "no agent claimed the job" message. The agents page is where you confirm coverage before running a runbook in anger.
@@ -111,7 +120,7 @@ Combined stdout + stderr is capped at **50 KB** per step. Larger output is trunc
 
 ### Cancellation
 
-Cancelling a runbook execution (from the execution view or the API) immediately marks all of its `Pending`/`Claimed`/`Running` Bash and JavaScript jobs as `Cancelled`. An agent that's already mid-script will finish its work, but its result will not be accepted by the server.
+Cancelling a runbook execution (from the execution view or the API) immediately marks all of its `Pending`/`Claimed`/`Running` Bash and JavaScript jobs as `Cancelled`. An agent that's already mid-script will finish its work, but its result will not be accepted by the server, and no later step in the runbook is dispatched.
 
 ### Concurrency
 

--- a/App/FeatureSet/Runbook/Index.ts
+++ b/App/FeatureSet/Runbook/Index.ts
@@ -54,7 +54,30 @@ const RunbookFeatureSet: FeatureSet = {
               runbookExecutionId: new ObjectID(runbookExecutionId),
             });
           },
-          { concurrency: 25 },
+          {
+            concurrency: 25,
+            /*
+             * A runbook execution occupies its job for the whole run, and a
+             * single step may now be configured to wait up to an hour for an
+             * agent and run for another hour. BullMQ renews the lock while the
+             * process is alive, so this is not a cap on job length — it is how
+             * long after a Worker dies before the job is treated as stalled and
+             * handed to another Worker. Kept short deliberately: redelivery is
+             * how an interrupted execution resumes, and the dispatcher
+             * re-attaches to an in-flight agent job instead of dispatching a
+             * second one, so recovering quickly is safe.
+             */
+            lockDuration: 30_000,
+            /*
+             * Default is 1, which spends the execution's only recovery on the
+             * first restart — a rolling deploy that bounces this pod twice
+             * during an hour-long step would drop the run on the floor. Three
+             * covers an ordinary deploy while still bounding a job that stalls
+             * because of something about the job itself. Past that the
+             * TimeoutStuckExecutions sweep fails the execution with a reason.
+             */
+            maxStalledCount: 3,
+          },
         );
       }
     } catch (err) {

--- a/App/FeatureSet/Runbook/Services/RunRunbook.ts
+++ b/App/FeatureSet/Runbook/Services/RunRunbook.ts
@@ -114,6 +114,21 @@ export default class RunRunbook {
         return;
       }
 
+      /*
+       * Somebody else may have finished this execution while the previous step
+       * was in flight: a user cancelling it, or the stuck-execution sweep
+       * failing it after this Worker went quiet for too long. Neither can
+       * interrupt a step that is already running, but both mean nobody wants
+       * the rest of the runbook — and the array held here is now stale, so
+       * carrying on would write Cancelled steps back as Pending and keep
+       * dispatching scripts for a run the operator was told had stopped.
+       * Checked at the step boundary, which is the only place it is safe to
+       * stop.
+       */
+      if (await this.hasReachedTerminalState(execution._id!)) {
+        return;
+      }
+
       // Pending or Running — execute the step.
       stepExec.status = RunbookStepExecutionStatus.Running;
       stepExec.startedAt = new Date().toISOString();
@@ -246,6 +261,26 @@ export default class RunRunbook {
           errorMessage: `Unknown step type: ${String(step.type)}`,
         };
     }
+  }
+
+  private async hasReachedTerminalState(executionId: string): Promise<boolean> {
+    const current: RunbookExecution | null =
+      await RunbookExecutionService.findOneById({
+        id: new ObjectID(executionId),
+        select: { status: true },
+        props: { isRoot: true },
+      });
+
+    // A row that has vanished is as good as terminal — there is nothing to advance.
+    if (!current) {
+      return true;
+    }
+
+    return (
+      current.status === RunbookExecutionStatus.Completed ||
+      current.status === RunbookExecutionStatus.Failed ||
+      current.status === RunbookExecutionStatus.Cancelled
+    );
   }
 
   private async persistStepExecutions(

--- a/App/FeatureSet/Runbook/Services/StepExecutors.ts
+++ b/App/FeatureSet/Runbook/Services/StepExecutors.ts
@@ -12,7 +12,9 @@ import {
   resolveStepExecutionTimeoutInMs,
 } from "Common/Types/Runbook/RunbookStepTimeout";
 import ObjectID from "Common/Types/ObjectID";
-import RunbookAgentJobService from "Common/Server/Services/RunbookAgentJobService";
+import RunbookAgentJobService, {
+  isTerminalAgentJobStatus,
+} from "Common/Server/Services/RunbookAgentJobService";
 import RunbookAgentJobStatus from "Common/Types/Runbook/RunbookAgentJobStatus";
 import RunbookAgentJob from "Common/Models/DatabaseModels/RunbookAgentJob";
 import { RunbookStepExecutionState } from "Common/Types/Runbook/RunbookStepExecution";
@@ -49,6 +51,25 @@ export function truncate(s: string): string {
     Buffer.from(s, "utf8").slice(0, MAX_OUTPUT_BYTES).toString("utf8") +
     "\n... [output truncated]"
   );
+}
+
+// Translate a finished agent job row into the step result the runner records.
+function toStepResult(job: RunbookAgentJob): StepRunResult {
+  const output: string = truncate(job.output || "");
+
+  if (job.status === RunbookAgentJobStatus.Succeeded) {
+    return { success: true, output };
+  }
+
+  return {
+    success: false,
+    output,
+    errorMessage:
+      job.errorMessage ||
+      (typeof job.exitCode === "number"
+        ? `Exit code ${job.exitCode}`
+        : `Step ended with status ${job.status ?? "unknown"}`),
+  };
 }
 
 /*
@@ -92,39 +113,64 @@ async function dispatchToAgent(args: {
   }
 
   try {
-    const job: RunbookAgentJob = await RunbookAgentJobService.enqueue({
-      projectId: args.ctx.projectId,
-      runbookExecutionId: args.ctx.runbookExecutionId,
-      stepId: args.step.id,
-      stepType: args.stepType,
-      targetAgentId,
-      script: args.script,
-      timeoutInMs: args.timeoutInMs,
-      claimTimeoutInMs: args.claimTimeoutInMs,
-    });
+    /*
+     * A runbook execution occupies one BullMQ job for its whole run, so a
+     * Worker restart mid-step gets the execution redelivered and walks us back
+     * to this same step. Enqueueing again would hand the agent a second copy
+     * of the script — a database restore run twice. The row this step already
+     * produced is the source of truth: adopt it if it finished, wait on it if
+     * it did not.
+     */
+    const existingJob: RunbookAgentJob | null =
+      await RunbookAgentJobService.findLatestJobForStep({
+        runbookExecutionId: args.ctx.runbookExecutionId,
+        stepId: args.step.id,
+      });
+
+    if (existingJob && isTerminalAgentJobStatus(existingJob.status)) {
+      logger.info(
+        `Runbook step ${args.step.id} already has a finished agent job (${existingJob.status}); adopting its result instead of re-running it.`,
+      );
+      return toStepResult(existingJob);
+    }
+
+    let jobId: ObjectID;
+    /*
+     * Anchors the claim + execution window. Re-attaching keeps the original
+     * job's clock so a step cannot buy itself another full window on each
+     * redelivery; a fresh dispatch starts its window now.
+     */
+    let waitStartedAt: Date | undefined = undefined;
+
+    if (existingJob) {
+      logger.info(
+        `Runbook step ${args.step.id} already has an in-flight agent job (${existingJob.status}); re-attaching to it rather than dispatching a second one.`,
+      );
+      jobId = new ObjectID(existingJob._id!);
+      waitStartedAt = existingJob.createdAt;
+    } else {
+      const job: RunbookAgentJob = await RunbookAgentJobService.enqueue({
+        projectId: args.ctx.projectId,
+        runbookExecutionId: args.ctx.runbookExecutionId,
+        stepId: args.step.id,
+        stepType: args.stepType,
+        targetAgentId,
+        script: args.script,
+        timeoutInMs: args.timeoutInMs,
+        claimTimeoutInMs: args.claimTimeoutInMs,
+      });
+      jobId = new ObjectID(job._id!);
+    }
 
     const terminal: RunbookAgentJob =
       await RunbookAgentJobService.pollUntilTerminal({
-        jobId: new ObjectID(job._id!),
+        jobId,
         claimTimeoutInMs: args.claimTimeoutInMs,
         executionTimeoutInMs: args.timeoutInMs,
+        waitStartedAt,
       });
 
-    const output: string = truncate(terminal.output || "");
-
-    if (terminal.status === RunbookAgentJobStatus.Succeeded) {
-      return { success: true, output };
-    }
-
-    return {
-      success: false,
-      output,
-      errorMessage:
-        terminal.errorMessage ||
-        (typeof terminal.exitCode === "number"
-          ? `Exit code ${terminal.exitCode}`
-          : `Step ended with status ${terminal.status ?? "unknown"}`),
-    };
+    return toStepResult(terminal);
   } catch (err) {
     logger.error(`${args.stepType} step dispatch failed`);
     logger.error(err);

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -136,6 +136,13 @@ import "./Jobs/UserOnCallLog/ExecutePendingExecutions";
 import "./Jobs/UserOnCallLog/TimeoutStuckExecutions";
 import "./Jobs/Workflow/TimeoutJobs";
 
+/*
+ * Runbook executions live inside a single queue job, so a Worker that dies
+ * mid-run takes the execution's only keeper with it. This fails the ones that
+ * were never redelivered, so an execution can never hang in Running.
+ */
+import "./Jobs/Runbook/TimeoutStuckExecutions";
+
 // Probes
 import "./Jobs/Probe/SendOwnerAddedNotification";
 import "./Jobs/Probe/UpdateConnectionStatus";

--- a/App/FeatureSet/Workers/Jobs/Runbook/TimeoutStuckExecutions.ts
+++ b/App/FeatureSet/Workers/Jobs/Runbook/TimeoutStuckExecutions.ts
@@ -1,0 +1,155 @@
+import RunCron from "../../Utils/Cron";
+import OneUptimeDate from "Common/Types/Date";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import { EVERY_MINUTE } from "Common/Utils/CronTime";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import RunbookExecutionService from "Common/Server/Services/RunbookExecutionService";
+import RunbookAgentJobService from "Common/Server/Services/RunbookAgentJobService";
+import RunbookExecution from "Common/Models/DatabaseModels/RunbookExecution";
+import RunbookExecutionStatus from "Common/Types/Runbook/RunbookExecutionStatus";
+import RunbookStepExecutionStatus from "Common/Types/Runbook/RunbookStepExecutionStatus";
+import { RunbookStepExecutionState } from "Common/Types/Runbook/RunbookStepExecution";
+import {
+  getRunningExecutionDeadline,
+  STUCK_EXECUTION_GRACE_IN_MS,
+} from "Common/Types/Runbook/RunbookExecutionDeadline";
+import logger from "Common/Server/Utils/Logger";
+
+/*
+ * A runbook execution runs synchronously inside one queue job, so its only
+ * keeper is the Worker holding that job. Kill that Worker — a deploy, an OOM,
+ * a node eviction — and the execution is either redelivered (which the
+ * dispatcher now handles idempotently) or lost. Lost means a row that says
+ * Running forever: no step advances, no failure is recorded, and the person
+ * who ran the runbook during an incident watches a spinner that will never
+ * resolve.
+ *
+ * This sweep is the backstop. It fails executions that have outlived the
+ * window their own steps were configured for, so an execution always reaches a
+ * terminal state and always says why.
+ *
+ * Deliberately NOT swept:
+ *  - Scheduled executions. Those are queued but not yet picked up, and with 25
+ *    concurrent slots against steps that may now run for an hour each, a
+ *    healthy backlog can legitimately sit Scheduled for a long time. Failing
+ *    on age would kill runs that were about to start.
+ *  - WaitingForManualStep executions. Waiting on a human is intended to be
+ *    unbounded.
+ */
+
+// Bound the work per tick so one bad window cannot monopolise the Worker queue.
+const MAX_EXECUTIONS_PER_RUN: number = 100;
+
+RunCron(
+  "Runbook:TimeoutStuckExecutions",
+  { schedule: EVERY_MINUTE, runOnStartup: false },
+  async () => {
+    /*
+     * Cheap prefilter. An execution's updatedAt is stamped when its current
+     * step is marked Running, and the deadline is always at least that instant
+     * plus the grace margin — so nothing past its deadline can be excluded
+     * here. The exact per-execution deadline is computed below.
+     */
+    const candidates: Array<RunbookExecution> =
+      await RunbookExecutionService.findBy({
+        query: {
+          status: RunbookExecutionStatus.Running,
+          updatedAt: QueryHelper.lessThan(
+            new Date(
+              OneUptimeDate.getCurrentDate().getTime() -
+                STUCK_EXECUTION_GRACE_IN_MS,
+            ),
+          ),
+        },
+        select: {
+          _id: true,
+          projectId: true,
+          runbookNameSnapshot: true,
+          stepExecutions: true,
+          updatedAt: true,
+        },
+        limit: MAX_EXECUTIONS_PER_RUN,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+    if (candidates.length === 0) {
+      return;
+    }
+
+    const now: Date = OneUptimeDate.getCurrentDate();
+
+    for (const execution of candidates) {
+      try {
+        const stepExecutions: Array<RunbookStepExecutionState> =
+          (execution.stepExecutions as unknown as Array<RunbookStepExecutionState>) ||
+          [];
+
+        const deadline: Date = getRunningExecutionDeadline({
+          stepExecutions,
+          executionUpdatedAt: execution.updatedAt || now,
+        });
+
+        if (now <= deadline) {
+          // Still inside its own window — a Worker is plausibly still on it.
+          continue;
+        }
+
+        /*
+         * Fail the step that was in flight so the timeline names it, rather
+         * than leaving a Running step under a Failed execution.
+         */
+        const runningStep: RunbookStepExecutionState | undefined =
+          stepExecutions.find((stepExecution: RunbookStepExecutionState) => {
+            return stepExecution.status === RunbookStepExecutionStatus.Running;
+          });
+
+        const stepMessage: string =
+          "This step stopped being tracked because the server running it restarted or stopped responding. It may have partially run — check the target system before running this runbook again.";
+
+        if (runningStep) {
+          runningStep.status = RunbookStepExecutionStatus.Failed;
+          runningStep.completedAt = now.toISOString();
+          runningStep.errorMessage = stepMessage;
+        }
+
+        const failureReason: string = runningStep
+          ? `Step "${runningStep.step.title}" was interrupted: ${stepMessage}`
+          : "This runbook execution stopped making progress because the server running it restarted or stopped responding. Run the runbook again to retry it.";
+
+        await RunbookExecutionService.updateOneById({
+          id: execution.id!,
+          data: {
+            status: RunbookExecutionStatus.Failed,
+            completedAt: now,
+            failureReason,
+            stepExecutions: stepExecutions as unknown as JSONArray,
+          } as unknown as JSONObject,
+          props: { isRoot: true },
+        });
+
+        /*
+         * Release any agent job the execution left behind. Without this a
+         * Pending job stays claimable and an agent could start a script for an
+         * execution nobody is reading the result of any more.
+         */
+        await RunbookAgentJobService.cancelJobsForExecution({
+          runbookExecutionId: execution.id!,
+        });
+
+        logger.warn(
+          `Runbook execution ${execution.id?.toString()} ("${
+            execution.runbookNameSnapshot
+          }") was stuck in Running past its deadline (${deadline.toISOString()}) and has been failed.`,
+          { service: "workers" },
+        );
+      } catch (err) {
+        logger.error(
+          `Failed to reconcile stuck runbook execution ${execution.id?.toString()}:`,
+          { service: "workers" },
+        );
+        logger.error(err, { service: "workers" });
+      }
+    }
+  },
+);

--- a/App/Tests/Runbook/RunRunbook.test.ts
+++ b/App/Tests/Runbook/RunRunbook.test.ts
@@ -427,6 +427,81 @@ describe("RunRunbook state machine", () => {
     );
   });
 
+  test("a run that turns terminal mid-flight stops at the next step boundary", async () => {
+    /*
+     * Nothing can interrupt a step that is already running, so a cancel — or
+     * the stuck-execution sweep failing this run after the Worker went quiet —
+     * lands while step one is in flight. The step array held in memory is
+     * stale by then: carrying on would write the Cancelled steps back as
+     * Pending and keep dispatching scripts for a run the operator was told
+     * had stopped.
+     */
+    runBashStepMock.mockResolvedValue({ success: true, output: "first" });
+
+    const first: RunbookStepExecutionState = pending(
+      makeStep(RunbookStepType.Bash),
+    );
+    const second: RunbookStepExecutionState = pending(
+      makeStep(RunbookStepType.Bash),
+    );
+    const execution: RunbookExecution = makeExecution([first, second], {
+      status: RunbookExecutionStatus.Running,
+      startedAt: new Date(),
+    });
+
+    jest
+      .spyOn(RunbookExecutionService, "findOneById")
+      .mockResolvedValueOnce(execution)
+      .mockResolvedValueOnce(execution)
+      .mockResolvedValueOnce({
+        status: RunbookExecutionStatus.Cancelled,
+      } as unknown as RunbookExecution);
+    const updateSpy: jest.SpyInstance = jest
+      .spyOn(RunbookExecutionService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    await new RunRunbook().runExecution({
+      runbookExecutionId: new ObjectID("exec1"),
+    });
+
+    expect(runBashStepMock).toHaveBeenCalledTimes(1);
+    expect(second.status).toBe(RunbookStepExecutionStatus.Pending);
+    expect(lastStatusUpdate(updateSpy).status).not.toBe(
+      RunbookExecutionStatus.Completed,
+    );
+  });
+
+  test("an execution that vanishes mid-run stops rather than writing to a deleted row", async () => {
+    runBashStepMock.mockResolvedValue({ success: true, output: "first" });
+
+    const first: RunbookStepExecutionState = pending(
+      makeStep(RunbookStepType.Bash),
+    );
+    const second: RunbookStepExecutionState = pending(
+      makeStep(RunbookStepType.Bash),
+    );
+    const execution: RunbookExecution = makeExecution([first, second], {
+      status: RunbookExecutionStatus.Running,
+      startedAt: new Date(),
+    });
+
+    jest
+      .spyOn(RunbookExecutionService, "findOneById")
+      .mockResolvedValueOnce(execution)
+      .mockResolvedValueOnce(execution)
+      .mockResolvedValueOnce(null);
+    jest
+      .spyOn(RunbookExecutionService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    await new RunRunbook().runExecution({
+      runbookExecutionId: new ObjectID("exec1"),
+    });
+
+    expect(runBashStepMock).toHaveBeenCalledTimes(1);
+    expect(second.status).toBe(RunbookStepExecutionStatus.Pending);
+  });
+
   test("skipped steps count as done", async () => {
     const skipped: RunbookStepExecutionState = {
       step: makeStep(RunbookStepType.Manual),

--- a/App/Tests/Runbook/RunbookExecutionDeadline.test.ts
+++ b/App/Tests/Runbook/RunbookExecutionDeadline.test.ts
@@ -1,0 +1,284 @@
+import RunbookStepExecutionStatus from "Common/Types/Runbook/RunbookStepExecutionStatus";
+import RunbookStepType from "Common/Types/Runbook/RunbookStepType";
+import { RunbookStep } from "Common/Types/Runbook/RunbookStep";
+import { RunbookStepExecutionState } from "Common/Types/Runbook/RunbookStepExecution";
+import {
+  getRunningExecutionDeadline,
+  getStepMaxRuntimeInMs,
+  STUCK_EXECUTION_GRACE_IN_MS,
+  UNBOUNDED_STEP_ALLOWANCE_IN_MS,
+} from "Common/Types/Runbook/RunbookExecutionDeadline";
+import {
+  DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS,
+  DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+  MAX_AGENT_CLAIM_TIMEOUT_IN_MS,
+  MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+} from "Common/Types/Runbook/RunbookStepTimeout";
+import { describe, expect, test } from "@jest/globals";
+
+const STEP_STARTED_AT: string = "2026-07-30T10:00:00.000Z";
+const EXECUTION_UPDATED_AT: Date = new Date("2026-07-30T09:00:00.000Z");
+
+function makeStep(
+  type: RunbookStepType,
+  config: Record<string, unknown> = {},
+): RunbookStep {
+  return {
+    id: "step-1",
+    order: 1,
+    type,
+    title: "A step",
+    config: config as never,
+  };
+}
+
+function running(
+  step: RunbookStep,
+  startedAt?: string,
+): RunbookStepExecutionState {
+  const state: RunbookStepExecutionState = {
+    step,
+    status: RunbookStepExecutionStatus.Running,
+  };
+
+  if (startedAt) {
+    state.startedAt = startedAt;
+  }
+
+  return state;
+}
+
+describe("getStepMaxRuntimeInMs", () => {
+  test.each([RunbookStepType.Bash, RunbookStepType.JavaScript])(
+    "%s steps get the claim window plus the execution window",
+    (type: RunbookStepType) => {
+      /*
+       * An agent step spends the claim window waiting to be picked up and the
+       * execution window running. Charging it only the execution window would
+       * fail live runs that are still legitimately waiting for their agent.
+       */
+      expect(
+        getStepMaxRuntimeInMs(
+          makeStep(type, { timeoutInMs: 600_000, claimTimeoutInMs: 900_000 }),
+        ),
+      ).toBe(1_500_000);
+    },
+  );
+
+  test.each([RunbookStepType.Bash, RunbookStepType.JavaScript])(
+    "%s steps with unset timeouts get the documented defaults",
+    (type: RunbookStepType) => {
+      expect(getStepMaxRuntimeInMs(makeStep(type))).toBe(
+        DEFAULT_AGENT_CLAIM_TIMEOUT_IN_MS +
+          DEFAULT_STEP_EXECUTION_TIMEOUT_IN_MS,
+      );
+    },
+  );
+
+  test("an out-of-range timeout is clamped the same way execution clamps it", () => {
+    /*
+     * Step configs are untyped JSON at rest, so a stored value can sit outside
+     * the bounds. The sweep has to use the number the Worker will actually
+     * honour, not the one on disk.
+     */
+    expect(
+      getStepMaxRuntimeInMs(
+        makeStep(RunbookStepType.Bash, {
+          timeoutInMs: 24 * 60 * 60_000,
+          claimTimeoutInMs: 24 * 60 * 60_000,
+        }),
+      ),
+    ).toBe(MAX_AGENT_CLAIM_TIMEOUT_IN_MS + MAX_STEP_EXECUTION_TIMEOUT_IN_MS);
+  });
+
+  test("HTTP steps get only the execution window — there is no agent to wait for", () => {
+    expect(
+      getStepMaxRuntimeInMs(
+        makeStep(RunbookStepType.HttpRequest, { timeoutInMs: 45_000 }),
+      ),
+    ).toBe(45_000);
+  });
+
+  test("AI steps, whose runtime the author cannot bound, get the ceiling", () => {
+    expect(getStepMaxRuntimeInMs(makeStep(RunbookStepType.AI))).toBe(
+      UNBOUNDED_STEP_ALLOWANCE_IN_MS,
+    );
+  });
+
+  test("a Manual step found Running is a torn write, not a wait, so it gets no allowance", () => {
+    expect(getStepMaxRuntimeInMs(makeStep(RunbookStepType.Manual))).toBe(0);
+  });
+});
+
+describe("getRunningExecutionDeadline", () => {
+  test("the deadline is the running step's own window plus the grace margin", () => {
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [
+        running(
+          makeStep(RunbookStepType.Bash, {
+            timeoutInMs: 600_000,
+            claimTimeoutInMs: 900_000,
+          }),
+          STEP_STARTED_AT,
+        ),
+      ],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(deadline.getTime()).toBe(
+      new Date(STEP_STARTED_AT).getTime() +
+        1_500_000 +
+        STUCK_EXECUTION_GRACE_IN_MS,
+    );
+  });
+
+  test("an hour-long step is still inside its window forty minutes in", () => {
+    /*
+     * The regression this guards: one global threshold would kill the
+     * legitimate long restores the docs tell people to configure.
+     */
+    const startedAt: string = "2026-07-30T10:00:00.000Z";
+    const fortyMinutesIn: Date = new Date("2026-07-30T10:40:00.000Z");
+
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [
+        running(
+          makeStep(RunbookStepType.Bash, {
+            timeoutInMs: MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+            claimTimeoutInMs: 60_000,
+          }),
+          startedAt,
+        ),
+      ],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(fortyMinutesIn.getTime()).toBeLessThan(deadline.getTime());
+  });
+
+  test("a one-second step is past its deadline six minutes in, not an hour", () => {
+    const startedAt: string = "2026-07-30T10:00:00.000Z";
+    const sixMinutesIn: Date = new Date("2026-07-30T10:06:00.000Z");
+
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [
+        running(
+          makeStep(RunbookStepType.HttpRequest, { timeoutInMs: 1_000 }),
+          startedAt,
+        ),
+      ],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(sixMinutesIn.getTime()).toBeGreaterThan(deadline.getTime());
+  });
+
+  test("no Running step means nothing is executing — only the grace margin applies", () => {
+    /*
+     * The Worker died between steps. There is no work in flight to protect,
+     * so the execution should not sit there for the length of a step window.
+     */
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [
+        {
+          step: makeStep(RunbookStepType.Bash),
+          status: RunbookStepExecutionStatus.Completed,
+        },
+        {
+          step: makeStep(RunbookStepType.Bash),
+          status: RunbookStepExecutionStatus.Pending,
+        },
+      ],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(deadline.getTime()).toBe(
+      EXECUTION_UPDATED_AT.getTime() + STUCK_EXECUTION_GRACE_IN_MS,
+    );
+  });
+
+  test("an empty step list falls back to the execution's own timestamp", () => {
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(deadline.getTime()).toBe(
+      EXECUTION_UPDATED_AT.getTime() + STUCK_EXECUTION_GRACE_IN_MS,
+    );
+  });
+
+  test.each([undefined, "not a date"])(
+    "a Running step with an unusable startedAt (%s) still gets its full allowance",
+    (startedAt: string | undefined) => {
+      /*
+       * startedAt and updatedAt are written in the same statement, so falling
+       * back to updatedAt keeps the step's window intact rather than expiring
+       * it immediately.
+       */
+      const state: RunbookStepExecutionState = running(
+        makeStep(RunbookStepType.HttpRequest, { timeoutInMs: 45_000 }),
+      );
+      if (startedAt) {
+        state.startedAt = startedAt;
+      }
+
+      const deadline: Date = getRunningExecutionDeadline({
+        stepExecutions: [state],
+        executionUpdatedAt: EXECUTION_UPDATED_AT,
+      });
+
+      expect(deadline.getTime()).toBe(
+        EXECUTION_UPDATED_AT.getTime() + 45_000 + STUCK_EXECUTION_GRACE_IN_MS,
+      );
+    },
+  );
+
+  test("the first Running step is the one that decides — later steps have not started", () => {
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [
+        {
+          step: makeStep(RunbookStepType.Bash),
+          status: RunbookStepExecutionStatus.Completed,
+        },
+        running(
+          makeStep(RunbookStepType.HttpRequest, { timeoutInMs: 45_000 }),
+          STEP_STARTED_AT,
+        ),
+        {
+          step: makeStep(RunbookStepType.AI),
+          status: RunbookStepExecutionStatus.Pending,
+        },
+      ],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(deadline.getTime()).toBe(
+      new Date(STEP_STARTED_AT).getTime() +
+        45_000 +
+        STUCK_EXECUTION_GRACE_IN_MS,
+    );
+  });
+
+  test("the deadline always sits past the Worker's own claim + execution + 5s giveup", () => {
+    /*
+     * The Worker running the step times out at claim + execution + 5s and
+     * writes the failure itself. The sweep must never beat it to the punch, or
+     * two writers would race over the same execution.
+     */
+    const step: RunbookStep = makeStep(RunbookStepType.Bash, {
+      timeoutInMs: 600_000,
+      claimTimeoutInMs: 900_000,
+    });
+    const startedAtMs: number = new Date(STEP_STARTED_AT).getTime();
+
+    const deadline: Date = getRunningExecutionDeadline({
+      stepExecutions: [running(step, STEP_STARTED_AT)],
+      executionUpdatedAt: EXECUTION_UPDATED_AT,
+    });
+
+    expect(deadline.getTime()).toBeGreaterThan(
+      startedAtMs + getStepMaxRuntimeInMs(step) + 5_000,
+    );
+  });
+});

--- a/App/Tests/Runbook/StepExecutors.test.ts
+++ b/App/Tests/Runbook/StepExecutors.test.ts
@@ -215,6 +215,17 @@ describe("agent-dispatched steps (Bash / JavaScript)", () => {
     jest.spyOn(logger, "error").mockImplementation((): void => {
       return undefined;
     });
+    jest.spyOn(logger, "info").mockImplementation((): void => {
+      return undefined;
+    });
+    /*
+     * No job exists for the step yet — the ordinary first dispatch, and the
+     * baseline for every test in here. Redelivery, where a row already
+     * exists, has its own describe block below.
+     */
+    jest
+      .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+      .mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -414,9 +425,187 @@ describe("agent-dispatched steps (Bash / JavaScript)", () => {
   });
 });
 
+/*
+ * An execution occupies one queue job for its whole run, so a Worker that dies
+ * mid-step gets the execution redelivered and walks back to the same step —
+ * which is still persisted as Running. Dispatching again would hand the agent
+ * a second copy of the script; for the database restore the docs suggest as a
+ * long-running step, that is the restore running twice.
+ */
+describe("redelivery after a Worker restart", () => {
+  beforeEach(() => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+    jest.spyOn(logger, "info").mockImplementation((): void => {
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    RunbookAgentJobStatus.Pending,
+    RunbookAgentJobStatus.Claimed,
+    RunbookAgentJobStatus.Running,
+  ])(
+    "an in-flight job (%s) is re-attached to instead of dispatched again",
+    async (status: RunbookAgentJobStatus) => {
+      jest
+        .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+        .mockResolvedValue(
+          makeTerminalJob({ _id: "existing-job", status, output: undefined }),
+        );
+      const enqueueSpy: jest.SpyInstance = jest.spyOn(
+        RunbookAgentJobService,
+        "enqueue",
+      );
+      const pollSpy: jest.SpyInstance = jest
+        .spyOn(RunbookAgentJobService, "pollUntilTerminal")
+        .mockResolvedValue(
+          makeTerminalJob({ _id: "existing-job", output: "finished later" }),
+        );
+
+      const result: StepRunResult = await runBashStep(
+        makeBashStep(),
+        makeCtx(),
+      );
+
+      expect(enqueueSpy).not.toHaveBeenCalled();
+      expect(
+        (pollSpy.mock.calls[0]![0] as Record<string, unknown>)["jobId"],
+      ).toEqual(new ObjectID("existing-job"));
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("finished later");
+    },
+  );
+
+  test("re-attaching keeps the original job's clock rather than starting a fresh window", async () => {
+    /*
+     * Otherwise every redelivery would buy the step another full claim +
+     * execution window, and a step configured for an hour could occupy a
+     * Worker slot for several.
+     */
+    const createdAt: Date = new Date("2026-07-30T10:00:00.000Z");
+    jest
+      .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+      .mockResolvedValue(
+        makeTerminalJob({
+          _id: "existing-job",
+          status: RunbookAgentJobStatus.Running,
+          createdAt,
+        }),
+      );
+    const pollSpy: jest.SpyInstance = jest
+      .spyOn(RunbookAgentJobService, "pollUntilTerminal")
+      .mockResolvedValue(makeTerminalJob());
+
+    await runBashStep(makeBashStep(), makeCtx());
+
+    expect(
+      (pollSpy.mock.calls[0]![0] as Record<string, unknown>)["waitStartedAt"],
+    ).toBe(createdAt);
+  });
+
+  test.each([
+    RunbookAgentJobStatus.Succeeded,
+    RunbookAgentJobStatus.Failed,
+    RunbookAgentJobStatus.TimedOut,
+    RunbookAgentJobStatus.Cancelled,
+  ])(
+    "a job that already finished (%s) has its result adopted, not re-run",
+    async (status: RunbookAgentJobStatus) => {
+      jest
+        .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+        .mockResolvedValue(
+          makeTerminalJob({
+            status,
+            output: "ran once",
+            errorMessage:
+              status === RunbookAgentJobStatus.Succeeded
+                ? undefined
+                : "it went wrong",
+          }),
+        );
+      const enqueueSpy: jest.SpyInstance = jest.spyOn(
+        RunbookAgentJobService,
+        "enqueue",
+      );
+      const pollSpy: jest.SpyInstance = jest.spyOn(
+        RunbookAgentJobService,
+        "pollUntilTerminal",
+      );
+
+      const result: StepRunResult = await runBashStep(
+        makeBashStep(),
+        makeCtx(),
+      );
+
+      expect(enqueueSpy).not.toHaveBeenCalled();
+      expect(pollSpy).not.toHaveBeenCalled();
+      expect(result.output).toBe("ran once");
+      expect(result.success).toBe(status === RunbookAgentJobStatus.Succeeded);
+    },
+  );
+
+  test("the lookup is scoped to this execution and this step", async () => {
+    const findSpy: jest.SpyInstance = jest
+      .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+      .mockResolvedValue(null);
+    jest
+      .spyOn(RunbookAgentJobService, "enqueue")
+      .mockResolvedValue(makeTerminalJob());
+    jest
+      .spyOn(RunbookAgentJobService, "pollUntilTerminal")
+      .mockResolvedValue(makeTerminalJob());
+
+    await runBashStep(makeBashStep(), makeCtx());
+
+    const args: Record<string, unknown> = findSpy.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect((args["runbookExecutionId"] as ObjectID).toString()).toBe(
+      new ObjectID("exec1").toString(),
+    );
+    expect(args["stepId"]).toBe(makeBashStep().id);
+  });
+
+  test("JavaScript steps re-attach on the same terms as Bash", async () => {
+    jest
+      .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+      .mockResolvedValue(
+        makeTerminalJob({
+          _id: "existing-js-job",
+          status: RunbookAgentJobStatus.Claimed,
+        }),
+      );
+    const enqueueSpy: jest.SpyInstance = jest.spyOn(
+      RunbookAgentJobService,
+      "enqueue",
+    );
+    jest
+      .spyOn(RunbookAgentJobService, "pollUntilTerminal")
+      .mockResolvedValue(makeTerminalJob({ output: "js done" }));
+
+    const result: StepRunResult = await runJavaScriptStep(
+      makeJsStep(),
+      makeCtx(),
+    );
+
+    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(result.output).toBe("js done");
+  });
+});
+
 describe("per-step timeouts", () => {
   beforeEach(() => {
     jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+    jest.spyOn(logger, "info").mockImplementation((): void => {
       return undefined;
     });
   });
@@ -429,6 +618,15 @@ describe("per-step timeouts", () => {
     enqueueSpy: jest.SpyInstance;
     pollSpy: jest.SpyInstance;
   } {
+    /*
+     * Part of the stub rather than a beforeEach: one test below restores all
+     * mocks between iterations, so the "no prior job for this step" default
+     * has to be re-established alongside enqueue and poll.
+     */
+    jest
+      .spyOn(RunbookAgentJobService, "findLatestJobForStep")
+      .mockResolvedValue(null);
+
     return {
       enqueueSpy: jest
         .spyOn(RunbookAgentJobService, "enqueue")

--- a/App/Tests/Workers/Jobs/Runbook/TimeoutStuckExecutions.test.ts
+++ b/App/Tests/Workers/Jobs/Runbook/TimeoutStuckExecutions.test.ts
@@ -1,0 +1,303 @@
+import ObjectID from "Common/Types/ObjectID";
+import RunbookExecution from "Common/Models/DatabaseModels/RunbookExecution";
+import RunbookExecutionStatus from "Common/Types/Runbook/RunbookExecutionStatus";
+import RunbookStepExecutionStatus from "Common/Types/Runbook/RunbookStepExecutionStatus";
+import RunbookStepType from "Common/Types/Runbook/RunbookStepType";
+import { JSONArray } from "Common/Types/JSON";
+import { RunbookStep } from "Common/Types/Runbook/RunbookStep";
+import { RunbookStepExecutionState } from "Common/Types/Runbook/RunbookStepExecution";
+import { STUCK_EXECUTION_GRACE_IN_MS } from "Common/Types/Runbook/RunbookExecutionDeadline";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * A runbook execution runs inside one queue job, so a Worker that dies mid-run
+ * and never gets the job redelivered leaves the row Running with nobody
+ * advancing it — the person who ran the runbook during an incident watches a
+ * spinner forever. This suite drives the sweep that ends that state, and pins
+ * the thing that makes it safe: it must not touch an execution that is still
+ * inside the window its own steps were configured for.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to capture the handler (same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/RunbookExecutionService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/RunbookAgentJobService", () => {
+  return {
+    __esModule: true,
+    default: {
+      cancelJobsForExecution: jest.fn(),
+    },
+  };
+});
+
+// Imported AFTER the mocks above (jest hoists them) so the job registers into the recorder.
+import "../../../../FeatureSet/Workers/Jobs/Runbook/TimeoutStuckExecutions";
+import RunbookExecutionService from "Common/Server/Services/RunbookExecutionService";
+import RunbookAgentJobService from "Common/Server/Services/RunbookAgentJobService";
+
+const findBy: jest.Mock =
+  RunbookExecutionService.findBy as unknown as jest.Mock;
+const updateOneById: jest.Mock =
+  RunbookExecutionService.updateOneById as unknown as jest.Mock;
+const cancelJobsForExecution: jest.Mock =
+  RunbookAgentJobService.cancelJobsForExecution as unknown as jest.Mock;
+
+const JOB_NAME: string = "Runbook:TimeoutStuckExecutions";
+
+function runTick(): Promise<void> {
+  return mockCapturedJobs[JOB_NAME]!();
+}
+
+function makeStep(
+  type: RunbookStepType,
+  config: Record<string, unknown> = {},
+): RunbookStep {
+  return {
+    id: "step-1",
+    order: 1,
+    type,
+    title: "Restore the database",
+    config: config as never,
+  };
+}
+
+function minutesAgo(minutes: number): Date {
+  return new Date(Date.now() - minutes * 60_000);
+}
+
+function makeExecution(
+  stepExecutions: Array<RunbookStepExecutionState>,
+  updatedAt: Date,
+): RunbookExecution {
+  const execution: RunbookExecution = new RunbookExecution();
+  execution._id = "exec-1";
+  execution.projectId = new ObjectID("proj-1");
+  execution.runbookNameSnapshot = "Restore runbook";
+  execution.stepExecutions = stepExecutions as unknown as JSONArray;
+  execution.updatedAt = updatedAt;
+  return execution;
+}
+
+function lastUpdateData(): Record<string, unknown> {
+  const call: Array<unknown> = updateOneById.mock.calls[0]!;
+  return (call[0] as { data: Record<string, unknown> }).data;
+}
+
+describe("Runbook:TimeoutStuckExecutions", () => {
+  beforeEach(() => {
+    findBy.mockReset();
+    updateOneById.mockReset().mockResolvedValue(undefined);
+    cancelJobsForExecution.mockReset().mockResolvedValue(undefined);
+  });
+
+  test("only Running executions are swept", async () => {
+    /*
+     * Scheduled runs are queued but not yet picked up — with steps that may
+     * now run for an hour each, a healthy backlog legitimately sits Scheduled.
+     * WaitingForManualStep is an intended unbounded wait on a human.
+     */
+    findBy.mockResolvedValue([]);
+
+    await runTick();
+
+    const query: Record<string, unknown> = (
+      findBy.mock.calls[0]![0] as { query: Record<string, unknown> }
+    ).query;
+    expect(query["status"]).toBe(RunbookExecutionStatus.Running);
+  });
+
+  test("an execution still inside its step's window is left alone", async () => {
+    /*
+     * The regression that matters most: the docs tell people to raise the
+     * timeout for a database restore. Forty minutes into an hour-long step,
+     * a Worker is plausibly still on it.
+     */
+    findBy.mockResolvedValue([
+      makeExecution(
+        [
+          {
+            step: makeStep(RunbookStepType.Bash, {
+              timeoutInMs: 60 * 60_000,
+              claimTimeoutInMs: 60_000,
+            }),
+            status: RunbookStepExecutionStatus.Running,
+            startedAt: minutesAgo(40).toISOString(),
+          },
+        ],
+        minutesAgo(40),
+      ),
+    ]);
+
+    await runTick();
+
+    expect(updateOneById).not.toHaveBeenCalled();
+    expect(cancelJobsForExecution).not.toHaveBeenCalled();
+  });
+
+  test("an execution past its step's window is failed with a reason naming the step", async () => {
+    findBy.mockResolvedValue([
+      makeExecution(
+        [
+          {
+            step: makeStep(RunbookStepType.Bash, {
+              timeoutInMs: 60_000,
+              claimTimeoutInMs: 60_000,
+            }),
+            status: RunbookStepExecutionStatus.Running,
+            startedAt: minutesAgo(90).toISOString(),
+          },
+        ],
+        minutesAgo(90),
+      ),
+    ]);
+
+    await runTick();
+
+    const data: Record<string, unknown> = lastUpdateData();
+    expect(data["status"]).toBe(RunbookExecutionStatus.Failed);
+    expect(data["completedAt"]).toBeInstanceOf(Date);
+    expect(String(data["failureReason"])).toContain("Restore the database");
+    expect(String(data["failureReason"])).toContain("restarted");
+  });
+
+  test("the interrupted step is failed too, and warns that it may have partially run", async () => {
+    /*
+     * Leaving a Running step under a Failed execution would read as "still
+     * going" on the timeline. And the operator needs to know the script may
+     * have done half its work before the Worker vanished.
+     */
+    const stepExecutions: Array<RunbookStepExecutionState> = [
+      {
+        step: makeStep(RunbookStepType.Bash, { timeoutInMs: 60_000 }),
+        status: RunbookStepExecutionStatus.Running,
+        startedAt: minutesAgo(90).toISOString(),
+      },
+    ];
+    findBy.mockResolvedValue([makeExecution(stepExecutions, minutesAgo(90))]);
+
+    await runTick();
+
+    const persisted: Array<RunbookStepExecutionState> = lastUpdateData()[
+      "stepExecutions"
+    ] as unknown as Array<RunbookStepExecutionState>;
+
+    expect(persisted[0]!.status).toBe(RunbookStepExecutionStatus.Failed);
+    expect(persisted[0]!.completedAt).toBeTruthy();
+    expect(persisted[0]!.errorMessage).toContain("partially run");
+  });
+
+  test("outstanding agent jobs are cancelled so no agent starts work nobody is reading", async () => {
+    findBy.mockResolvedValue([
+      makeExecution(
+        [
+          {
+            step: makeStep(RunbookStepType.Bash, { timeoutInMs: 60_000 }),
+            status: RunbookStepExecutionStatus.Running,
+            startedAt: minutesAgo(90).toISOString(),
+          },
+        ],
+        minutesAgo(90),
+      ),
+    ]);
+
+    await runTick();
+
+    expect(cancelJobsForExecution).toHaveBeenCalledWith({
+      runbookExecutionId: new ObjectID("exec-1"),
+    });
+  });
+
+  test("an execution whose Worker died between steps is failed on the grace margin alone", async () => {
+    // No step is Running, so nothing is in flight and no allowance is owed.
+    findBy.mockResolvedValue([
+      makeExecution(
+        [
+          {
+            step: makeStep(RunbookStepType.Bash),
+            status: RunbookStepExecutionStatus.Completed,
+          },
+          {
+            step: makeStep(RunbookStepType.Bash),
+            status: RunbookStepExecutionStatus.Pending,
+          },
+        ],
+        new Date(Date.now() - STUCK_EXECUTION_GRACE_IN_MS - 60_000),
+      ),
+    ]);
+
+    await runTick();
+
+    const data: Record<string, unknown> = lastUpdateData();
+    expect(data["status"]).toBe(RunbookExecutionStatus.Failed);
+    expect(String(data["failureReason"])).toContain("stopped making progress");
+  });
+
+  test("one execution that blows up does not stop the rest of the sweep", async () => {
+    const stuck: Array<RunbookStepExecutionState> = [
+      {
+        step: makeStep(RunbookStepType.Bash, { timeoutInMs: 60_000 }),
+        status: RunbookStepExecutionStatus.Running,
+        startedAt: minutesAgo(90).toISOString(),
+      },
+    ];
+    const first: RunbookExecution = makeExecution(stuck, minutesAgo(90));
+    const second: RunbookExecution = makeExecution(stuck, minutesAgo(90));
+    second._id = "exec-2";
+    findBy.mockResolvedValue([first, second]);
+
+    updateOneById
+      .mockRejectedValueOnce(new Error("database went away"))
+      .mockResolvedValue(undefined);
+
+    await runTick();
+
+    expect(updateOneById).toHaveBeenCalledTimes(2);
+  });
+
+  test("a tick with nothing to do issues no writes", async () => {
+    findBy.mockResolvedValue([]);
+
+    await runTick();
+
+    expect(updateOneById).not.toHaveBeenCalled();
+    expect(cancelJobsForExecution).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Server/Services/RunbookAgentJobService.ts
+++ b/Common/Server/Services/RunbookAgentJobService.ts
@@ -4,6 +4,7 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import Model from "../../Models/DatabaseModels/RunbookAgentJob";
 import RunbookAgentJobStatus from "../../Types/Runbook/RunbookAgentJobStatus";
 import RunbookStepType from "../../Types/Runbook/RunbookStepType";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../Types/Date";
 import { JSONObject } from "../../Types/JSON";
 import PostgresAppInstance from "../Infrastructure/PostgresDatabase";
@@ -25,6 +26,24 @@ const DEFAULT_LEASE_MS: number = 30_000;
 const DEFAULT_CLAIM_TIMEOUT_MS: number = 2 * 60_000;
 
 const POLL_INTERVAL_MS: number = 500;
+
+/*
+ * A job in one of these states will never change again, so its row is a
+ * durable record of what the step did. Everything else is still in flight and
+ * can be waited on.
+ */
+const TERMINAL_STATUSES: Array<RunbookAgentJobStatus> = [
+  RunbookAgentJobStatus.Succeeded,
+  RunbookAgentJobStatus.Failed,
+  RunbookAgentJobStatus.TimedOut,
+  RunbookAgentJobStatus.Cancelled,
+];
+
+export function isTerminalAgentJobStatus(
+  status: RunbookAgentJobStatus | undefined,
+): boolean {
+  return Boolean(status && TERMINAL_STATUSES.includes(status));
+}
 
 /*
  * TypeORM's dataSource.query returns `[rows, rowCount]` for UPDATE/DELETE
@@ -93,6 +112,47 @@ export class Service extends DatabaseService<Model> {
     row.claimDeadlineAt = claimDeadlineAt;
 
     return this.create({ data: row, props: { isRoot: true } });
+  }
+
+  /*
+   * The job this (execution, step) pair already produced, if any.
+   *
+   * A runbook execution runs inside a single BullMQ job, so a Worker restart
+   * mid-step means the execution is re-delivered and RunRunbook walks back to
+   * the same step — which is still persisted as Running. Without this lookup
+   * the step would be dispatched a second time and the agent would run the
+   * script again. The dispatcher calls this first: a terminal row is the
+   * step's result, a live row is something to re-attach to.
+   *
+   * A step is dispatched at most once per execution, so the newest row is the
+   * only one there can be; ordering is belt-and-braces against a torn write
+   * from a previous release.
+   */
+  @CaptureSpan()
+  public async findLatestJobForStep(data: {
+    runbookExecutionId: ObjectID;
+    stepId: string;
+  }): Promise<Model | null> {
+    const jobs: Array<Model> = await this.findBy({
+      query: {
+        runbookExecutionId: data.runbookExecutionId,
+        stepId: data.stepId,
+      },
+      select: {
+        _id: true,
+        status: true,
+        output: true,
+        exitCode: true,
+        errorMessage: true,
+        createdAt: true,
+      },
+      sort: { createdAt: SortOrder.Descending },
+      limit: 1,
+      skip: 0,
+      props: { isRoot: true },
+    });
+
+    return jobs[0] || null;
   }
 
   /*
@@ -279,15 +339,21 @@ export class Service extends DatabaseService<Model> {
    * POLL_INTERVAL_MS until the job reaches a terminal status, or until the
    * combined claim + execution window is exhausted (in which case we mark
    * the job TimedOut ourselves and return it).
+   *
+   * waitStartedAt anchors that window. It defaults to now — right for a job
+   * this Worker just enqueued — but a Worker re-attaching to a job left behind
+   * by a restart passes the job's createdAt, so the step keeps the single
+   * window its author configured instead of earning a fresh one per redelivery.
    */
   @CaptureSpan()
   public async pollUntilTerminal(data: {
     jobId: ObjectID;
     claimTimeoutInMs: number;
     executionTimeoutInMs: number;
+    waitStartedAt?: Date | undefined;
   }): Promise<Model> {
     const overallDeadline: Date = OneUptimeDate.addRemoveSeconds(
-      OneUptimeDate.getCurrentDate(),
+      data.waitStartedAt || OneUptimeDate.getCurrentDate(),
       Math.ceil(
         (data.claimTimeoutInMs + data.executionTimeoutInMs + 5_000) / 1000,
       ),
@@ -318,12 +384,7 @@ export class Service extends DatabaseService<Model> {
         );
       }
 
-      if (
-        job.status === RunbookAgentJobStatus.Succeeded ||
-        job.status === RunbookAgentJobStatus.Failed ||
-        job.status === RunbookAgentJobStatus.TimedOut ||
-        job.status === RunbookAgentJobStatus.Cancelled
-      ) {
+      if (isTerminalAgentJobStatus(job.status)) {
         return job;
       }
 

--- a/Common/Types/Runbook/RunbookExecutionDeadline.ts
+++ b/Common/Types/Runbook/RunbookExecutionDeadline.ts
@@ -1,0 +1,129 @@
+/*
+ * When a runbook execution stops being anybody's responsibility.
+ *
+ * An execution runs inside a single queue job on one Worker. If that Worker
+ * dies mid-step and the job is never redelivered — Redis lost it, the stall
+ * budget ran out, the handler threw somewhere unrecoverable — the row stays
+ * Running with nobody advancing it. Nothing else in the system would ever
+ * change it, so the reconciler needs a defensible answer to "has this been
+ * abandoned?".
+ *
+ * The answer is derived from the step that is currently Running: it cannot
+ * legitimately outlive the claim + execution window its author configured, so
+ * anything past that window plus a grace margin is abandoned. Deriving it per
+ * execution (rather than picking one global timeout) matters now that a step
+ * may be configured for anything from one second to one hour — a single
+ * threshold would either kill live hour-long restores or leave a one-second
+ * step hanging for an hour.
+ */
+
+import {
+  BashStepConfig,
+  HttpRequestStepConfig,
+  JavaScriptStepConfig,
+  RunbookStep,
+} from "./RunbookStep";
+import { RunbookStepExecutionState } from "./RunbookStepExecution";
+import RunbookStepExecutionStatus from "./RunbookStepExecutionStatus";
+import RunbookStepType from "./RunbookStepType";
+import {
+  MAX_STEP_EXECUTION_TIMEOUT_IN_MS,
+  resolveAgentClaimTimeoutInMs,
+  resolveStepExecutionTimeoutInMs,
+} from "./RunbookStepTimeout";
+
+/*
+ * Margin on top of a step's own window before the execution is declared
+ * abandoned. The Worker running the step gives up at claim + execution + 5s
+ * and then writes the failure itself, so this only has to outlast that write —
+ * five minutes leaves room for a slow database or a Worker that is briefly
+ * paused, and keeps the reconciler from racing a run that is still healthy.
+ */
+export const STUCK_EXECUTION_GRACE_IN_MS: number = 5 * 60 * 1000;
+
+/*
+ * Allowance for a step type whose runtime the author cannot bound — today
+ * that is the AI step, which runs as long as the model provider takes. The
+ * longest configurable step window is the least surprising ceiling to borrow.
+ */
+export const UNBOUNDED_STEP_ALLOWANCE_IN_MS: number =
+  MAX_STEP_EXECUTION_TIMEOUT_IN_MS;
+
+/*
+ * The longest a single step can legitimately occupy its Worker. Agent steps
+ * spend the claim window waiting for an agent to pick the job up and the
+ * execution window actually running, so they get both.
+ */
+export function getStepMaxRuntimeInMs(step: RunbookStep): number {
+  switch (step.type) {
+    case RunbookStepType.Bash:
+    case RunbookStepType.JavaScript: {
+      const config: BashStepConfig | JavaScriptStepConfig = step.config as
+        | BashStepConfig
+        | JavaScriptStepConfig;
+      return (
+        resolveAgentClaimTimeoutInMs(config.claimTimeoutInMs) +
+        resolveStepExecutionTimeoutInMs(config.timeoutInMs)
+      );
+    }
+
+    case RunbookStepType.HttpRequest: {
+      const config: HttpRequestStepConfig =
+        step.config as HttpRequestStepConfig;
+      return resolveStepExecutionTimeoutInMs(config.timeoutInMs);
+    }
+
+    /*
+     * Manual steps park the execution as WaitingForManualStep rather than
+     * Running, so one found Running is a torn write, not a wait. It gets no
+     * allowance — the grace margin alone decides.
+     */
+    case RunbookStepType.Manual:
+      return 0;
+
+    default:
+      return UNBOUNDED_STEP_ALLOWANCE_IN_MS;
+  }
+}
+
+/*
+ * Deadline for an execution currently in the Running state.
+ *
+ * Anchored on the running step's own startedAt where possible. Two fallbacks
+ * use the execution's updatedAt instead:
+ *
+ *  - A step is Running but carries no usable startedAt. The state machine
+ *    stamps startedAt and persists in the same write, so updatedAt is the same
+ *    instant; the step still gets its full allowance.
+ *  - No step is Running at all. The Worker died between steps, so nothing is
+ *    executing and no allowance is owed — only the grace margin.
+ */
+export function getRunningExecutionDeadline(data: {
+  stepExecutions: Array<RunbookStepExecutionState>;
+  executionUpdatedAt: Date;
+}): Date {
+  const runningStep: RunbookStepExecutionState | undefined =
+    data.stepExecutions.find((stepExecution: RunbookStepExecutionState) => {
+      return stepExecution.status === RunbookStepExecutionStatus.Running;
+    });
+
+  if (!runningStep) {
+    return new Date(
+      data.executionUpdatedAt.getTime() + STUCK_EXECUTION_GRACE_IN_MS,
+    );
+  }
+
+  const startedAtMs: number = runningStep.startedAt
+    ? new Date(runningStep.startedAt).getTime()
+    : NaN;
+
+  const anchorMs: number = isFinite(startedAtMs)
+    ? startedAtMs
+    : data.executionUpdatedAt.getTime();
+
+  return new Date(
+    anchorMs +
+      getStepMaxRuntimeInMs(runningStep.step) +
+      STUCK_EXECUTION_GRACE_IN_MS,
+  );
+}


### PR DESCRIPTION
### Title of this pull request?

fix(runbook): make executions durable across a Worker restart

### Small Description?

A runbook execution runs synchronously inside a single BullMQ job, so the Worker holding that job is the execution's only keeper. Kill it — a deploy, an OOM, a node eviction — and there were two bad outcomes. #2923 made per-step timeouts configurable (1 second to 1 hour, for both claim and execution), which widened the exposure window per step from ~2.5 minutes to ~2 hours, and the docs actively encourage raising it for work that takes minutes.

**Re-delivered.** BullMQ's stalled-job handling hands the execution to another Worker. `RunRunbook` walks back to a step that is still persisted as `Running` and, because the loop treats `Running` exactly like `Pending`, dispatches it to the agent a second time. For the database restore the docs suggest a long timeout for, that is the restore running twice against the same database.

**Not re-delivered.** The row says `Running` forever. There was no reconciler, so nothing else in the system would ever change it — the person who ran the runbook during an incident watches a spinner that never resolves.

`App/FeatureSet/Docs/Content/en/runbooks/agents.md` already disclosed part of this ("design scripts to be safe to re-run"), but that is a caveat, not a fix, and it said nothing about the stuck case.

#### What changed

**1. Re-attach instead of re-dispatch** — `App/FeatureSet/Runbook/Services/StepExecutors.ts`

`dispatchToAgent` now consults the `RunbookAgentJob` row this `(execution, step)` pair already produced before enqueueing a new one:

- terminal row → adopt its result outright (no poll, no re-run)
- live row (`Pending`/`Claimed`/`Running`) → re-attach and poll *that* job
- no row → enqueue, exactly as before

A step therefore reaches an agent at most once per execution. The lookup is a new `RunbookAgentJobService.findLatestJobForStep`, scoped by the already-indexed `runbookExecutionId`.

Re-attaching passes the original job's `createdAt` as `pollUntilTerminal`'s new optional `waitStartedAt`, so the claim + execution window stays anchored to the first dispatch. Without it, every redelivery would buy the step another full window and a step configured for an hour could occupy a Worker slot for several.

**2. A reconciler for executions stuck in Running** — `App/FeatureSet/Workers/Jobs/Runbook/TimeoutStuckExecutions.ts`

Runs every minute. The deadline is derived per execution from the currently-`Running` step's own configured claim + execution timeouts, plus a 5-minute grace (`Common/Types/Runbook/RunbookExecutionDeadline.ts`). Deriving it per execution is the point: a single global threshold would either kill live hour-long restores or leave a one-second step hanging for an hour. Past the deadline it fails the execution *and* the interrupted step, with a message saying the step may have partially run and to check the target system, then cancels outstanding agent jobs so no agent starts work nobody is reading.

Deliberately **not** swept, and commented as such:
- `Scheduled` executions. With 25 concurrent slots against steps that may each run an hour, a healthy backlog legitimately sits `Scheduled` for a long time; failing on age would kill runs that were about to start.
- `WaitingForManualStep`. Waiting on a human is meant to be unbounded.

**3. Queue options** — `App/FeatureSet/Runbook/Index.ts`

`maxStalledCount: 3` is the one that matters. The default of 1 spends the execution's only recovery on the first restart, so a rolling deploy that bounces the pod twice during a long step drops the run on the floor.

`lockDuration` is set explicitly at BullMQ's default 30s rather than raised. The lock renews while the process is alive, so it is not a cap on job length — raising it only *delays* recovery after a Worker dies, and now that redelivery re-attaches rather than re-runs, recovering quickly is the safe outcome. It is set explicitly with a comment so nobody raises it later on the wrong theory.

#### One thing found on the way that was not in scope

**Cancelling an execution did not stop it.** `cancelExecution` wrote `Cancelled`, but a Worker mid-step held a stale `stepExecutions` array and wrote it back on completion — resurrecting the cancelled steps as `Pending` and the execution as `Running` — then carried on dispatching the rest of the runbook. The new sweep would have been undone by exactly the same race, so `RunRunbook` now re-checks for a terminal state at each step boundary and stops. This is pre-existing and unrelated to #2923; it is fixed here because the reconciler depends on it.

#### Reviewer notes

- No schema change. The reconciler reasons entirely off `stepExecutions` JSON plus `updatedAt`.
- One extra indexed point-read per agent step dispatch (the job lookup), and one per step boundary (the terminal-state check). Negligible against steps measured in seconds to minutes.
- `getRunningExecutionDeadline` is a pure function in `Common/Types/Runbook` precisely so the deadline maths is testable without a database.
- The behaviour change worth eyeballing: an agent step whose job row already finished no longer re-runs, it adopts. That is the intended fix, but it is the one place where a resumed execution now produces a different outcome than before.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verification run locally: 143 Runbook tests and the full `Tests/Workers` suite (186 tests) pass, `eslint` clean on every touched path, and the touched sources typecheck.

Two environment caveats, neither related to these changes: `Tests/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.test.ts` fails to load with `Cannot find module '@protobufjs/aspromise'` (a broken local `App/node_modules` install, same class of problem as its empty `@types/node` directory); and this was developed in a git worktree whose `node_modules` symlinks back to the main checkout, so `Common/*` resolves to the unmodified main tree — the suites above were run through a config mapping `Common/*` into the worktree. CI installs cleanly and is unaffected.

Test coverage added:
- re-attach across all three live job states, and adoption across all four terminal states
- the window anchoring (`waitStartedAt` is the original job's `createdAt`)
- the deadline maths, including "40 minutes into an hour-long step is still live" and "a one-second step is past its deadline at six minutes, not an hour"
- the sweep's behaviour: leaves live runs alone, names the step in the failure reason, marks the interrupted step failed, cancels agent jobs, and isolates a failure in one execution from the rest of the tick
- the terminal-state guard at the step boundary, for both a cancelled and a deleted execution

### Related Issue?

Follow-up to #2923. Found by an adversarial review of that PR and deliberately left out of scope there, since it is a pre-existing reliability gap rather than something #2923 introduced.
