### PR TITLE
feat(facets): add a date-range chip, and give the device list its Last Seen filter back

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceFacets.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceFacets.ts
@@ -1,5 +1,6 @@
 import { DEVICE_FRESH_WINDOW_MINUTES } from "./DeviceStatusUtil";
 import { FacetTileSelection } from "../ResourceOwners/FacetTileSelection";
+import { buildFacetDateRangeQuery } from "../ResourceOwners/FacetDateRange";
 import {
   FilterChipDropdownOption,
   FilterOperator,
@@ -39,6 +40,7 @@ export const DEVICE_STATUS_FACET_KEY: string = "deviceStatus";
 export const DEVICE_INTERFACES_FACET_KEY: string = "deviceInterfaces";
 export const DEVICE_SITE_FACET_KEY: string = "deviceSite";
 export const DEVICE_PROBE_FACET_KEY: string = "deviceProbe";
+export const DEVICE_LAST_SEEN_FACET_KEY: string = "deviceLastSeen";
 
 /*
  * The column each chip owns. A chip and the column-filter popup cannot both
@@ -57,6 +59,7 @@ export const DEVICE_FACET_QUERY_FIELDS: {
   interfaces: string;
   site: string;
   probe: string;
+  lastSeen: string;
 } = {
   status: "lastSeenAt",
   interfaces: "interfacesDown",
@@ -67,7 +70,25 @@ export const DEVICE_FACET_QUERY_FIELDS: {
    */
   site: "siteId",
   probe: "probeId",
+  /*
+   * Deliberately the same column as `status`. Status asks a fixed
+   * DEVICE_FRESH_WINDOW_MINUTES question of `lastSeenAt` and Last Seen asks an
+   * arbitrary-date one, and there is no single-field query that is both — so
+   * the two chips are declared mutually exclusive (see
+   * DEVICE_STATUS_LAST_SEEN_EXCLUSION) and activating either clears the other,
+   * rather than one silently overwriting the other in the merged query.
+   */
+  lastSeen: "lastSeenAt",
 };
+
+/*
+ * The two chips over `lastSeenAt`, named as a pair so the page cannot wire one
+ * side of the exclusion and forget the other.
+ */
+export const DEVICE_STATUS_LAST_SEEN_EXCLUSION: Array<string> = [
+  DEVICE_STATUS_FACET_KEY,
+  DEVICE_LAST_SEEN_FACET_KEY,
+];
 
 /**
  * The Status chip's values. Up / Down / Pending partition the fleet exactly:
@@ -260,6 +281,47 @@ export const DEVICE_INTERFACES_FACET_OPTIONS: Array<FilterChipDropdownOption> =
       sublabel: "No interface is down",
     },
   ];
+
+/**
+ * The Last Seen chip's operators.
+ *
+ * "is empty" and "is not empty" are left out on purpose: over `lastSeenAt` they
+ * are Pending and not-Pending, which the Status chip already offers in the
+ * words the rest of the page uses. Two chips spelling one thing two ways is how
+ * a user ends up believing they have applied two filters.
+ */
+export const DEVICE_LAST_SEEN_FACET_OPERATORS: Array<FilterOperator> = [
+  "is",
+  "before",
+  "after",
+  "between",
+];
+
+export type BuildDeviceLastSeenFacetQueryFunction = (
+  values: Array<string>,
+  operator: FilterOperator,
+) => unknown;
+
+/**
+ * The `lastSeenAt` constraint behind a Last Seen selection.
+ *
+ * The chip the Status one cannot be: an arbitrary date rather than the fixed
+ * freshness window, which is the only way to ask "which devices have not been
+ * polled since last Tuesday" or "which were polled between the 1st and the
+ * 5th".
+ *
+ * Day-granular, and identical to what the column-filter popup's date entry
+ * produced before the facet bar took the column over — so a question a user
+ * used to be able to ask of this list still returns the same rows.
+ */
+export const buildDeviceLastSeenFacetQuery: BuildDeviceLastSeenFacetQueryFunction =
+  (values: Array<string>, operator: FilterOperator): unknown => {
+    if (!DEVICE_LAST_SEEN_FACET_OPERATORS.includes(operator)) {
+      return undefined;
+    }
+
+    return buildFacetDateRangeQuery(values, operator);
+  };
 
 /**
  * "Devices assigned to no site at all" — the Site chip on its "is empty"

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetDateRange.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetDateRange.ts
@@ -1,0 +1,319 @@
+import { FilterOperator } from "./FilterChipDropdownTypes";
+import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import LessThan from "Common/Types/BaseDatabase/LessThan";
+import NotNull from "Common/Types/BaseDatabase/NotNull";
+import OneUptimeDate from "Common/Types/Date";
+
+/*
+ * What a date-range chip holds, and what the database is asked for it.
+ *
+ * The facet bar stores every chip's selection as `Array<string>` so the whole
+ * bar can go through one URL param and one saved view without a per-chip
+ * codec. A date range is two dates, so it is encoded as ONE string — the two
+ * instants joined by a slash — rather than two array entries:
+ *
+ *   is / before / after   →  ["2026-07-16T00:00:00.000Z"]
+ *   between               →  ["2026-07-01T00:00:00.000Z/2026-07-05T23:59:59.999Z"]
+ *
+ * One entry, because the shared selection plumbing treats an array as a *set*:
+ * `normalizeFacetValues` drops duplicates, so a two-entry "between the 1st and
+ * the 1st" would collapse to a single date and silently stop filtering, and the
+ * single-select clamp in `sanitizeFacetSelectionState` would truncate any range
+ * to its start. Keeping the pair inside one value sidesteps both, and costs
+ * nothing: ISO-8601 instants contain no slash, so the split is unambiguous.
+ *
+ * Deliberately free of React, like FacetSelectionState next to it, so the
+ * mapping from "what the chip says" to "what the database is asked" can be
+ * pinned in tests without a renderer.
+ */
+
+/** The separator between the two instants of a `between` selection. */
+export const FACET_DATE_RANGE_SEPARATOR: string = "/";
+
+export interface FacetDateRange {
+  start: Date | null;
+  end: Date | null;
+}
+
+export type ToFacetDateFunction = (
+  value: string | null | undefined,
+) => Date | null;
+
+/*
+ * A calendar date, optionally followed by a time.
+ *
+ * Everything this chip stores went through `Date.toISOString()`, and everything
+ * the shared date Input hands back went through `OneUptimeDate.toString()`,
+ * which is the same call — so anything not starting with YYYY-MM-DD is not
+ * something either of them wrote.
+ *
+ * The check is deliberately made BEFORE parsing rather than by testing the
+ * result: `OneUptimeDate.fromString` falls back to the browser's own lenient
+ * parser, which reads "0" as the year 2000. A junk value that silently becomes
+ * a filter for January 2000 is worse than one that is rejected, because the
+ * table then shows nothing and the chip explains it as a date the user never
+ * picked.
+ */
+const CALENDAR_DATE_PREFIX: RegExp = /^\d{4}-\d{2}-\d{2}(?:[T ]|$)/;
+
+/**
+ * A single instant from the stored form, or `null` when it is not one.
+ *
+ * Everything reaching here is user-editable — a URL a teammate pasted, a view
+ * saved by an older build, a date input mid-keystroke — so an unreadable value
+ * has to come back as "no date" rather than as something the query builder
+ * would happily turn into a filter.
+ */
+export const toFacetDate: ToFacetDateFunction = (
+  value: string | null | undefined,
+): Date | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed: string = value.trim();
+
+  if (!CALENDAR_DATE_PREFIX.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    const parsed: Date = OneUptimeDate.fromString(trimmed);
+
+    return isNaN(parsed.getTime()) ? null : parsed;
+  } catch {
+    return null;
+  }
+};
+
+export type ParseFacetDateRangeFunction = (
+  values: Array<string> | null | undefined,
+) => FacetDateRange;
+
+/**
+ * Decode a chip's stored selection back into the two instants it stands for.
+ *
+ * Only the first entry is read: the clamp in `sanitizeFacetSelectionState`
+ * already reduces a date facet to one value, and honouring extras here would
+ * mean the chip and the query disagreed about which of them counted.
+ */
+export const parseFacetDateRange: ParseFacetDateRangeFunction = (
+  values: Array<string> | null | undefined,
+): FacetDateRange => {
+  if (!Array.isArray(values) || values.length === 0) {
+    return { start: null, end: null };
+  }
+
+  const raw: string = typeof values[0] === "string" ? values[0] : "";
+  const parts: Array<string> = raw.split(FACET_DATE_RANGE_SEPARATOR);
+
+  return {
+    start: toFacetDate(parts[0]),
+    end: toFacetDate(parts[1]),
+  };
+};
+
+export type SerializeFacetDateRangeFunction = (
+  range: FacetDateRange,
+  operator: FilterOperator,
+) => Array<string>;
+
+/**
+ * Encode exactly what the popover's inputs currently hold — including a range
+ * with only one end filled in.
+ *
+ * A half-filled range has to survive the round trip, because the user is
+ * mid-way through entering it: the chip is a controlled component with no
+ * private copy of the dates, so anything this drops is a date that vanishes
+ * from under the cursor the moment the first of the two is picked.
+ *
+ * It is not, however, a filter yet — `isFacetDateRangeActive` says no and
+ * `buildFacetDateRangeQuery` returns undefined, so the column stays
+ * unconstrained and the chip stays unlit until both ends are in.
+ *
+ * The operator still decides how much is *kept*: switching from "between" back
+ * to "before" drops the end date rather than leaving it behind, where nothing
+ * on screen would show it and nothing in the query would use it.
+ */
+export const serializeFacetDateRange: SerializeFacetDateRangeFunction = (
+  range: FacetDateRange,
+  operator: FilterOperator,
+): Array<string> => {
+  if (operator === "is_empty" || operator === "is_not_empty") {
+    return [];
+  }
+
+  if (operator === "between") {
+    if (!range.start && !range.end) {
+      return [];
+    }
+
+    const start: string = range.start ? range.start.toISOString() : "";
+    const end: string = range.end ? range.end.toISOString() : "";
+
+    return [`${start}${FACET_DATE_RANGE_SEPARATOR}${end}`];
+  }
+
+  if (!range.start) {
+    return [];
+  }
+
+  return [range.start.toISOString()];
+};
+
+export type IsFacetDateRangeActiveFunction = (
+  values: Array<string> | null | undefined,
+  operator: FilterOperator,
+) => boolean;
+
+/**
+ * Does this selection narrow the list? Drives the chip's active styling and the
+ * bar's "n filters" count, and is read from the same encoding the query is
+ * built from — so a chip can never look lit over an unfiltered table.
+ */
+export const isFacetDateRangeActive: IsFacetDateRangeActiveFunction = (
+  values: Array<string> | null | undefined,
+  operator: FilterOperator,
+): boolean => {
+  if (operator === "is_empty" || operator === "is_not_empty") {
+    return true;
+  }
+
+  const range: FacetDateRange = parseFacetDateRange(values);
+
+  if (!range.start) {
+    return false;
+  }
+
+  return operator !== "between" || Boolean(range.end);
+};
+
+/** Stands in for an end of the range the user has not filled in yet. */
+export const FACET_DATE_PLACEHOLDER: string = "…";
+
+export type FormatFacetDateRangeFunction = (
+  values: Array<string> | null | undefined,
+  operator: FilterOperator,
+) => string;
+
+/**
+ * What the chip reads once a date is picked — "Jul 16, 2026", or
+ * "Jul 01, 2026 – Jul 05, 2026" for a range.
+ *
+ * Day precision, matching what the inputs let the user choose. Printing the
+ * midnight instant those dates really are would put a time on the chip that the
+ * popover has no way to change.
+ */
+export const formatFacetDateRange: FormatFacetDateRangeFunction = (
+  values: Array<string> | null | undefined,
+  operator: FilterOperator,
+): string => {
+  const range: FacetDateRange = parseFacetDateRange(values);
+
+  const asDay: (date: Date | null) => string = (date: Date | null): string => {
+    return date
+      ? OneUptimeDate.getDateAsLocalFormattedString(date, true)
+      : FACET_DATE_PLACEHOLDER;
+  };
+
+  if (operator === "between") {
+    return `${asDay(range.start)} – ${asDay(range.end)}`;
+  }
+
+  return asDay(range.start);
+};
+
+export interface BuildFacetDateRangeQueryOptions {
+  /**
+   * Treat the picked values as instants rather than as days. Defaults to
+   * false, which is what a `<input type="date">` produces and what every date
+   * column filter in the product has always meant by "is".
+   */
+  isDateTime?: boolean | undefined;
+}
+
+export type BuildFacetDateRangeQueryFunction = (
+  values: Array<string> | null | undefined,
+  operator: FilterOperator,
+  options?: BuildFacetDateRangeQueryOptions | undefined,
+) => unknown;
+
+/**
+ * The column constraint behind a date-range selection.
+ *
+ * Mirrors Common/UI/Components/Filters/DateFilter.tsx operator for operator,
+ * because this chip replaced that popup entry on the tables that grew a facet
+ * bar: the same picked dates have to keep returning the same rows, or a saved
+ * link stops meaning what it meant.
+ *
+ * That includes the day-granularity reading of "is" (the whole day, not the
+ * midnight instant) and the deliberately loose edges of "before" / "after",
+ * which compare against the picked instant as-is — so "after the 16th" includes
+ * the 16th, exactly as the popup has always behaved.
+ *
+ * `undefined` means "do not constrain this column": the honest answer to a
+ * half-filled range, and to a value this build cannot read at all.
+ */
+export const buildFacetDateRangeQuery: BuildFacetDateRangeQueryFunction = (
+  values: Array<string> | null | undefined,
+  operator: FilterOperator,
+  options?: BuildFacetDateRangeQueryOptions | undefined,
+): unknown => {
+  if (operator === "is_empty") {
+    return new IsNull();
+  }
+
+  if (operator === "is_not_empty") {
+    return new NotNull();
+  }
+
+  const isDateTime: boolean = Boolean(options?.isDateTime);
+  const range: FacetDateRange = parseFacetDateRange(values);
+
+  if (!range.start) {
+    return undefined;
+  }
+
+  switch (operator) {
+    case "is":
+      /*
+       * A day, not an instant. `EqualTo` on a timestamp column would only ever
+       * match a poll that landed on the exact millisecond the user picked, so
+       * "last seen on the 16th" would reliably return nothing.
+       */
+      return isDateTime
+        ? new InBetween<Date>(range.start, range.start)
+        : new InBetween<Date>(
+            OneUptimeDate.getStartOfDay(range.start),
+            OneUptimeDate.getEndOfDay(range.start),
+          );
+
+    case "before":
+      return new LessThan<Date>(range.start);
+
+    case "after":
+      return new GreaterThan<Date>(range.start);
+
+    case "between":
+      if (!range.end) {
+        return undefined;
+      }
+
+      return isDateTime
+        ? new InBetween<Date>(range.start, range.end)
+        : new InBetween<Date>(
+            OneUptimeDate.getStartOfDay(range.start),
+            OneUptimeDate.getEndOfDay(range.end),
+          );
+
+    default:
+      /*
+       * "is not" and anything a newer build might add. A date column has no
+       * single-field expression for "not on this day" that keeps NULLs honest,
+       * so the chip does not offer it and this refuses to invent one.
+       */
+      return undefined;
+  }
+};

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
@@ -1,4 +1,11 @@
-import { FilterOperator } from "./FilterChipDropdownTypes";
+import {
+  DATE_FACET_OPERATORS,
+  FILTER_OPERATOR_LABELS,
+  FacetKind,
+  FilterOperator,
+  OPTION_FACET_OPERATORS,
+} from "./FilterChipDropdownTypes";
+import { isFacetDateRangeActive } from "./FacetDateRange";
 import { JSONObject } from "Common/Types/JSON";
 
 /**
@@ -22,14 +29,22 @@ export type IsFilterOperatorFunction = (
   value: unknown,
 ) => value is FilterOperator;
 
+/**
+ * Derived from FILTER_OPERATOR_LABELS rather than restated, because this is the
+ * gate every operator arriving from a URL or a saved view passes through.
+ *
+ * Spelled out by hand, it silently fell behind the type when the date operators
+ * were added: TypeScript was happy, and a "between" in a shared link was thrown
+ * away and replaced with "is" — the same chip, a different filter, no error
+ * anywhere. Tying it to the label map means an operator the chip can print is
+ * an operator this accepts, by construction.
+ */
 export const isFilterOperator: IsFilterOperatorFunction = (
   value: unknown,
 ): value is FilterOperator => {
   return (
-    value === "is" ||
-    value === "is_not" ||
-    value === "is_empty" ||
-    value === "is_not_empty"
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(FILTER_OPERATOR_LABELS, value)
   );
 };
 
@@ -188,14 +203,72 @@ export interface FacetSelectionConstraint {
   key: string;
   isMultiSelect?: boolean | undefined;
   supportedOperators?: Array<FilterOperator> | undefined;
+  /** Defaults to "options" — the chip kind every facet was before dates. */
+  type?: FacetKind | undefined;
+  /** Facet keys this one cannot be active alongside. See buildFacetConflictMap. */
+  exclusiveWith?: Array<string> | undefined;
 }
 
-const DEFAULT_SUPPORTED_OPERATORS: Array<FilterOperator> = [
-  "is",
-  "is_not",
-  "is_empty",
-  "is_not_empty",
-];
+export type FacetConflictMap = { [facetKey: string]: Array<string> };
+
+export type BuildFacetConflictMapFunction = (
+  facets: Array<FacetSelectionConstraint>,
+) => FacetConflictMap;
+
+/**
+ * Which chips cannot be active at the same time, read from every facet's
+ * `exclusiveWith`.
+ *
+ * Two chips over the same column do not AND — the merged query is one object,
+ * so the later one overwrites the earlier, silently, while both stay lit and
+ * claim to apply. Naming the conflict makes an activating chip clear the other.
+ *
+ * Built symmetrically, so declaring it on one side is enough AND declaring it
+ * on one side only cannot half-work: a one-way map would clear the second chip
+ * when the first moved but not the reverse, leaving whichever the user reached
+ * for second to be the one silently overwritten — the exact bug the declaration
+ * exists to prevent.
+ */
+export const buildFacetConflictMap: BuildFacetConflictMapFunction = (
+  facets: Array<FacetSelectionConstraint>,
+): FacetConflictMap => {
+  const conflicts: { [facetKey: string]: Set<string> } = {};
+
+  const link: (from: string, to: string) => void = (
+    from: string,
+    to: string,
+  ): void => {
+    /*
+     * A facet excluded with itself would clear its own selection the instant it
+     * was made, and a blank key is something only a hand-written facet list
+     * produces — neither is a conflict anything can act on.
+     */
+    if (!from || !to || from === to) {
+      return;
+    }
+
+    if (!conflicts[from]) {
+      conflicts[from] = new Set<string>();
+    }
+
+    conflicts[from]!.add(to);
+  };
+
+  for (const facet of facets) {
+    for (const other of facet.exclusiveWith || []) {
+      link(facet.key, other);
+      link(other, facet.key);
+    }
+  }
+
+  const map: FacetConflictMap = {};
+
+  for (const key of Object.keys(conflicts)) {
+    map[key] = Array.from(conflicts[key]!);
+  }
+
+  return map;
+};
 
 export type SanitizeFacetSelectionStateFunction = (
   state: FacetSelectionState,
@@ -233,12 +306,20 @@ export const sanitizeFacetSelectionState: SanitizeFacetSelectionStateFunction =
     };
 
     for (const facet of facets) {
+      const isDateRange: boolean = facet.type === "dateRange";
       const operator: FilterOperator | undefined =
         sanitized.facetOperators[facet.key];
       const supported: Array<FilterOperator> =
         facet.supportedOperators && facet.supportedOperators.length > 0
           ? facet.supportedOperators
-          : DEFAULT_SUPPORTED_OPERATORS;
+          : isDateRange
+            ? DATE_FACET_OPERATORS
+            : OPTION_FACET_OPERATORS;
+
+      const resolvedOperator: FilterOperator =
+        operator !== undefined && !supported.includes(operator)
+          ? supported[0]!
+          : operator || "is";
 
       if (operator !== undefined && !supported.includes(operator)) {
         sanitized.facetOperators[facet.key] = supported[0]!;
@@ -251,21 +332,85 @@ export const sanitizeFacetSelectionState: SanitizeFacetSelectionStateFunction =
         // The chip shows only the first value, so only the first may filter.
         sanitized.facetSelections[facet.key] = [values[0]!];
       }
+
+      /*
+       * A date chip's value is dates, and its inputs can only show dates. A
+       * restored selection holding anything else — a hand-edited URL, a value
+       * a since-renamed build wrote — would leave the chip lit and its inputs
+       * blank, describing a filter the user cannot see or correct.
+       *
+       * Dropping it is what keeps those two in agreement: an unreadable range
+       * comes back as an empty chip over the full list, which is at least a
+       * state the bar can express.
+       */
+      if (isDateRange) {
+        const dateValues: Array<string> | undefined =
+          sanitized.facetSelections[facet.key];
+
+        if (
+          dateValues &&
+          dateValues.length > 0 &&
+          !isFacetDateRangeActive(dateValues, resolvedOperator)
+        ) {
+          sanitized.facetSelections[facet.key] = [];
+        }
+      }
     }
 
     return sanitized;
   };
 
+export type IsFacetActiveFunction = (
+  facet: FacetSelectionConstraint,
+  values: Array<string> | undefined,
+  operator: FilterOperator | undefined,
+) => boolean;
+
+/**
+ * Is this one chip narrowing the list?
+ *
+ * "Has a value" stopped being the whole answer once dates arrived: a date chip
+ * holds the half-filled range the user is still typing, which is a value but
+ * not yet a filter. Everything that counts active chips — the bar's badge, the
+ * table's "nothing matches the filters" copy, whether the selection is worth
+ * putting on the URL — has to agree with the query builder about which of those
+ * two a chip currently is, or the page claims a filter it is not applying.
+ */
+export const isFacetActive: IsFacetActiveFunction = (
+  facet: FacetSelectionConstraint,
+  values: Array<string> | undefined,
+  operator: FilterOperator | undefined,
+): boolean => {
+  const resolved: FilterOperator = resolveFacetOperator(operator);
+
+  if (facet.type === "dateRange") {
+    return isFacetDateRangeActive(values, resolved);
+  }
+
+  if (resolved === "is_empty" || resolved === "is_not_empty") {
+    return true;
+  }
+
+  return (values || []).length > 0;
+};
+
 export type IsFacetSelectionActiveFunction = (
   state: FacetSelectionState,
+  facets?: Array<FacetSelectionConstraint> | undefined,
 ) => boolean;
 
 /**
  * Does this state constrain anything? Used to decide whether the snapshot is
  * worth putting on the URL at all.
+ *
+ * `facets` is optional and only changes the answer for date chips, whose stored
+ * value can be a range the user has not finished entering. Without it, every
+ * facet is read the way option chips have always been read — which is what
+ * callers that predate date facets already expect.
  */
 export const isFacetSelectionActive: IsFacetSelectionActiveFunction = (
   state: FacetSelectionState,
+  facets?: Array<FacetSelectionConstraint> | undefined,
 ): boolean => {
   const operatorIsActive: (operator: FilterOperator) => boolean = (
     operator: FilterOperator,
@@ -282,14 +427,29 @@ export const isFacetSelectionActive: IsFacetSelectionActiveFunction = (
     return true;
   }
 
-  for (const key of Object.keys(state.facetSelections)) {
-    if ((state.facetSelections[key] || []).length > 0) {
-      return true;
-    }
-  }
+  const constraintFor: (key: string) => FacetSelectionConstraint = (
+    key: string,
+  ): FacetSelectionConstraint => {
+    return (
+      (facets || []).find((facet: FacetSelectionConstraint) => {
+        return facet.key === key;
+      }) || { key: key }
+    );
+  };
 
-  for (const key of Object.keys(state.facetOperators)) {
-    if (operatorIsActive(state.facetOperators[key] as FilterOperator)) {
+  const keys: Set<string> = new Set<string>([
+    ...Object.keys(state.facetSelections),
+    ...Object.keys(state.facetOperators),
+  ]);
+
+  for (const key of keys) {
+    if (
+      isFacetActive(
+        constraintFor(key),
+        state.facetSelections[key],
+        state.facetOperators[key],
+      )
+    ) {
       return true;
     }
   }

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDateRange.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDateRange.tsx
@@ -1,0 +1,288 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Input, { InputType } from "Common/UI/Components/Input/Input";
+import useComponentOutsideClick from "Common/UI/Types/UseComponentOutsideClick";
+import {
+  DATE_FACET_OPERATORS,
+  FILTER_OPERATOR_LABELS,
+  FilterOperator,
+  isValuelessOperator,
+} from "./FilterChipDropdownTypes";
+import {
+  FacetDateRange,
+  formatFacetDateRange,
+  isFacetDateRangeActive,
+  parseFacetDateRange,
+  serializeFacetDateRange,
+  toFacetDate,
+} from "./FacetDateRange";
+import {
+  FILTER_CHIP_ACTIVE_CLASSES,
+  FILTER_CHIP_BASE_CLASSES,
+  FILTER_CHIP_CLEAR_CLASSES,
+  FILTER_CHIP_INACTIVE_CLASSES,
+  FILTER_CHIP_OPERATOR_SELECT_CLASSES,
+  FILTER_CHIP_POPOVER_CLASSES,
+} from "./FilterChipStyles";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/*
+ * The facet bar's chip for a date column.
+ *
+ * Same shell as FilterChipDropdown — same pill, same operator row, same clear
+ * affordance — with date inputs where the option list would be. A date column
+ * has no option list to offer: every instant is its own value, so the questions
+ * a user actually has of one ("not polled since last Tuesday", "polled between
+ * the 1st and the 5th") can only be asked by typing a date.
+ *
+ * Fully controlled: the dates live in the facet selection the bar already
+ * persists, so a half-entered range survives a re-render and a completed one
+ * survives a shared link, with no second copy of the state to fall out of step.
+ */
+
+export interface ComponentProps {
+  label: string;
+  /**
+   * The facet's stored selection, in FacetDateRange's encoding. Empty when no
+   * date is picked.
+   */
+  values: Array<string>;
+  operator: FilterOperator;
+  /**
+   * Values and operator always travel together — changing the operator
+   * re-encodes the dates under it, so reporting them separately would leave a
+   * render in which the two disagree and the query is built from the mismatch.
+   */
+  onChange: (values: Array<string>, operator: FilterOperator) => void;
+  /** Defaults to DATE_FACET_OPERATORS. */
+  supportedOperators?: Array<FilterOperator> | undefined;
+  /** Icon shown on the chip while it has no selection. */
+  emptyIcon?: IconProp | undefined;
+  popoverWidthClassName?: string | undefined;
+}
+
+const FilterChipDateRange: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const { ref, isComponentVisible, setIsComponentVisible } =
+    useComponentOutsideClick(false);
+
+  const supportedOperators: Array<FilterOperator> =
+    props.supportedOperators && props.supportedOperators.length > 0
+      ? props.supportedOperators
+      : DATE_FACET_OPERATORS;
+
+  const operator: FilterOperator = props.operator || "is";
+  const valueless: boolean = isValuelessOperator(operator);
+  const isBetween: boolean = operator === "between";
+  const range: FacetDateRange = parseFacetDateRange(props.values);
+  const isChipActive: boolean = isFacetDateRangeActive(props.values, operator);
+
+  /*
+   * The chip says something as soon as an operator that needs no date is
+   * picked, and otherwise only once a date is in — so "is between" on its own
+   * reads as the unfinished thing it is rather than as an applied filter.
+   */
+  const hasAnyDate: boolean = Boolean(range.start || range.end);
+
+  type ApplyRangeFunction = (next: FacetDateRange) => void;
+
+  const applyRange: ApplyRangeFunction = (next: FacetDateRange): void => {
+    props.onChange(serializeFacetDateRange(next, operator), operator);
+  };
+
+  type ChangeOperatorFunction = (next: FilterOperator) => void;
+
+  const changeOperator: ChangeOperatorFunction = (
+    next: FilterOperator,
+  ): void => {
+    /*
+     * Re-encode under the new operator in the same gesture. Leaving the old
+     * encoding behind would keep an end date alive through a switch to
+     * "before", where the popover stops showing it but the stored selection
+     * still carries it into the next shared link.
+     */
+    props.onChange(serializeFacetDateRange(range, next), next);
+  };
+
+  const clearChipFully: () => void = (): void => {
+    // Back to the default operator too, so a cleared chip is fully cleared.
+    props.onChange([], "is");
+  };
+
+  const togglePopover: () => void = (): void => {
+    setIsComponentVisible(!isComponentVisible);
+  };
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={togglePopover}
+        className={`${FILTER_CHIP_BASE_CLASSES} ${
+          isChipActive
+            ? FILTER_CHIP_ACTIVE_CLASSES
+            : FILTER_CHIP_INACTIVE_CLASSES
+        }`}
+        aria-expanded={isComponentVisible}
+        aria-haspopup="dialog"
+      >
+        {isChipActive || hasAnyDate ? (
+          <>
+            {props.emptyIcon && (
+              <Icon
+                icon={props.emptyIcon}
+                className={`h-3.5 w-3.5 ${
+                  isChipActive ? "text-indigo-500" : "text-gray-400"
+                }`}
+              />
+            )}
+            <span className="whitespace-nowrap">
+              <span className={isChipActive ? "text-indigo-500/80" : ""}>
+                {props.label}
+              </span>
+              <span
+                className={`mx-1 ${
+                  isChipActive ? "text-indigo-300" : "text-gray-300"
+                }`}
+              >
+                ·
+              </span>
+              <span className="font-semibold">
+                {valueless
+                  ? FILTER_OPERATOR_LABELS[operator]
+                  : `${FILTER_OPERATOR_LABELS[operator]} ${formatFacetDateRange(
+                      props.values,
+                      operator,
+                    )}`}
+              </span>
+            </span>
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                clearChipFully();
+              }}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  clearChipFully();
+                }
+              }}
+              className={FILTER_CHIP_CLEAR_CLASSES}
+              aria-label={`Clear ${props.label} filter`}
+            >
+              <Icon icon={IconProp.Close} className="h-3 w-3" />
+            </span>
+          </>
+        ) : (
+          <>
+            {props.emptyIcon && (
+              <Icon
+                icon={props.emptyIcon}
+                className="h-3.5 w-3.5 text-gray-400"
+              />
+            )}
+            <span className="whitespace-nowrap">{props.label}</span>
+            <Icon
+              icon={IconProp.ChevronDown}
+              className="h-3 w-3 text-gray-400 transition-transform group-aria-expanded:rotate-180"
+            />
+          </>
+        )}
+      </button>
+
+      {isComponentVisible && (
+        <div
+          ref={ref}
+          className={`${FILTER_CHIP_POPOVER_CLASSES} ${
+            props.popoverWidthClassName || (isBetween ? "w-96" : "w-72")
+          }`}
+          role="dialog"
+        >
+          {supportedOperators.length > 1 && (
+            <div className="flex items-center gap-1.5 border-b border-gray-100 px-2 py-1.5 text-xs text-gray-500">
+              <span className="shrink-0">{props.label.toLowerCase()}</span>
+              <select
+                value={operator}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                  changeOperator(e.target.value as FilterOperator);
+                }}
+                className={FILTER_CHIP_OPERATOR_SELECT_CLASSES}
+                aria-label={`${props.label} operator`}
+              >
+                {supportedOperators.map((op: FilterOperator) => {
+                  return (
+                    <option key={op} value={op}>
+                      {FILTER_OPERATOR_LABELS[op]}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+          )}
+
+          {valueless ? (
+            <div className="px-3 py-4 text-center text-xs text-gray-500">
+              No date needed.
+            </div>
+          ) : (
+            <div className="p-2">
+              <div className={isBetween ? "flex gap-2" : ""}>
+                <div className="min-w-0 flex-1">
+                  {isBetween && (
+                    <label className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-gray-400">
+                      From
+                    </label>
+                  )}
+                  <Input
+                    /*
+                     * Re-keyed on the operator so switching between "between"
+                     * and the single-date operators remounts the field rather
+                     * than leaving the previous operator's value rendered in
+                     * it — the shared Input keeps its display string in state.
+                     */
+                    key={`start-${operator}`}
+                    type={InputType.DATE}
+                    value={range.start || ""}
+                    placeholder={isBetween ? "From" : "Pick a date"}
+                    outerDivClassName="relative rounded-md w-full"
+                    onChange={(changed: string) => {
+                      applyRange({ ...range, start: toFacetDate(changed) });
+                    }}
+                  />
+                </div>
+                {isBetween && (
+                  <div className="min-w-0 flex-1">
+                    <label className="mb-1 block text-[10px] font-semibold uppercase tracking-wider text-gray-400">
+                      To
+                    </label>
+                    <Input
+                      key={`end-${operator}`}
+                      type={InputType.DATE}
+                      value={range.end || ""}
+                      placeholder="To"
+                      outerDivClassName="relative rounded-md w-full"
+                      onChange={(changed: string) => {
+                        applyRange({ ...range, end: toFacetDate(changed) });
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
+              {isBetween && !isChipActive && hasAnyDate && (
+                <p className="mt-2 px-0.5 text-xs text-gray-400">
+                  Pick both dates to apply this filter.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FilterChipDateRange;

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdown.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdown.tsx
@@ -13,6 +13,14 @@ import {
   FilterOperator,
   FILTER_OPERATOR_LABELS,
 } from "./FilterChipDropdownTypes";
+import {
+  FILTER_CHIP_ACTIVE_CLASSES,
+  FILTER_CHIP_BASE_CLASSES,
+  FILTER_CHIP_CLEAR_CLASSES,
+  FILTER_CHIP_INACTIVE_CLASSES,
+  FILTER_CHIP_OPERATOR_SELECT_CLASSES,
+  FILTER_CHIP_POPOVER_CLASSES,
+} from "./FilterChipStyles";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -450,12 +458,9 @@ const FilterChipDropdown: FunctionComponent<ComponentProps> = (
     setIsComponentVisible(false);
   };
 
-  const chipBaseClasses: string =
-    "group inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-1";
-  const chipActiveClasses: string =
-    "border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm hover:border-indigo-300 hover:bg-indigo-100";
-  const chipInactiveClasses: string =
-    "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50";
+  const chipBaseClasses: string = FILTER_CHIP_BASE_CLASSES;
+  const chipActiveClasses: string = FILTER_CHIP_ACTIVE_CLASSES;
+  const chipInactiveClasses: string = FILTER_CHIP_INACTIVE_CLASSES;
 
   const clearChipFully: () => void = (): void => {
     if (isMulti) {
@@ -517,7 +522,7 @@ const FilterChipDropdown: FunctionComponent<ComponentProps> = (
                   clearChipFully();
                 }
               }}
-              className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full text-indigo-400 transition-colors hover:bg-indigo-200 hover:text-indigo-900 focus:outline-none"
+              className={FILTER_CHIP_CLEAR_CLASSES}
               aria-label={`Clear ${props.label} filter`}
             >
               <Icon icon={IconProp.Close} className="h-3 w-3" />
@@ -543,7 +548,7 @@ const FilterChipDropdown: FunctionComponent<ComponentProps> = (
       {isComponentVisible && (
         <div
           ref={ref}
-          className={`absolute left-0 top-full z-20 mt-2 ${props.popoverWidthClassName || "w-72"} origin-top-left overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xl ring-1 ring-black/5`}
+          className={`${FILTER_CHIP_POPOVER_CLASSES} ${props.popoverWidthClassName || "w-72"}`}
           role="dialog"
         >
           {supportedOperators.length > 1 && (
@@ -556,7 +561,7 @@ const FilterChipDropdown: FunctionComponent<ComponentProps> = (
                     props.onOperatorChange(e.target.value as FilterOperator);
                   }
                 }}
-                className="cursor-pointer rounded border border-gray-200 bg-white px-1.5 py-0.5 text-xs font-medium text-gray-700 hover:border-gray-300 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                className={FILTER_CHIP_OPERATOR_SELECT_CLASSES}
                 aria-label={`${props.label} operator`}
               >
                 {supportedOperators.map((op: FilterOperator) => {

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes.ts
@@ -15,6 +15,17 @@ import IconProp from "Common/Types/Icon/IconProp";
  * these names from "./FilterChipDropdown" keep working.
  */
 
+/**
+ * What kind of control a chip puts in its popover.
+ *
+ * - "options" — the option list every chip started as: search, pick, done.
+ * - "dateRange" — an operator plus one or two date inputs. A date column has no
+ *   option list to offer (every instant is a distinct value), so the question a
+ *   user actually has of one — "not polled since last Tuesday" — is only
+ *   expressible by typing a date.
+ */
+export type FacetKind = "options" | "dateRange";
+
 export interface FilterChipDropdownOption {
   value: string;
   label: string;
@@ -44,18 +55,79 @@ export interface FilterChipDropdownOption {
  * - "is" / "is_not" — match against the selected options
  * - "is_empty" / "is_not_empty" — match rows with no value / any value
  *   (no option selection required)
+ * - "before" / "after" / "between" — date-range chips only, and never offered
+ *   by an option-list chip: they compare against a date the user typed rather
+ *   than against anything in an option list.
  */
-export type FilterOperator = "is" | "is_not" | "is_empty" | "is_not_empty";
+export type FilterOperator =
+  | "is"
+  | "is_not"
+  | "is_empty"
+  | "is_not_empty"
+  | "before"
+  | "after"
+  | "between";
 
 export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
   is: "is",
   is_not: "is not",
   is_empty: "is empty",
   is_not_empty: "is not empty",
+  before: "is before",
+  after: "is after",
+  between: "is between",
 };
+
+/**
+ * The operators a date-range chip offers, in the order the popover lists them.
+ *
+ * Deliberately the same vocabulary the column-filter popup's date entry has
+ * always used (Common/UI/Components/Filters/DateFilter.tsx) — a user who has
+ * filtered a date column anywhere else in the product already knows what these
+ * four mean, and "is" meaning "on that day" rather than "at that instant" is
+ * part of what they know.
+ */
+export const DATE_FACET_OPERATORS: Array<FilterOperator> = [
+  "is",
+  "before",
+  "after",
+  "between",
+  "is_empty",
+  "is_not_empty",
+];
+
+/**
+ * Operators an *option-list* chip may offer. A date operator reaching one of
+ * those chips has no date to compare against, so it can only produce a filter
+ * the chip cannot describe — see sanitizeFacetSelectionState, which clamps it
+ * back rather than letting it through.
+ */
+export const OPTION_FACET_OPERATORS: Array<FilterOperator> = [
+  "is",
+  "is_not",
+  "is_empty",
+  "is_not_empty",
+];
 
 export const isValueOperator: (op: FilterOperator) => boolean = (
   op: FilterOperator,
 ): boolean => {
   return op === "is" || op === "is_not";
+};
+
+/**
+ * Does this operator carry no value at all? Both chip kinds hide their value
+ * input on these, and both write IsNull / NotNull for them.
+ */
+export const isValuelessOperator: (op: FilterOperator) => boolean = (
+  op: FilterOperator,
+): boolean => {
+  return op === "is_empty" || op === "is_not_empty";
+};
+
+/** Does this operator need two dates rather than one? */
+export const isRangeOperator: (op: FilterOperator) => boolean = (
+  op: FilterOperator,
+): boolean => {
+  return op === "between";
 };

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipStyles.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipStyles.ts
@@ -1,0 +1,26 @@
+/*
+ * The chip's look, in one place because there is now more than one kind of chip
+ * in the bar.
+ *
+ * A date chip that sat a shade off its neighbours would read as a different
+ * class of control rather than as the same control over a different column —
+ * and the bar's whole claim is that every filter on the list is one of these.
+ */
+
+export const FILTER_CHIP_BASE_CLASSES: string =
+  "group inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:ring-offset-1";
+
+export const FILTER_CHIP_ACTIVE_CLASSES: string =
+  "border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm hover:border-indigo-300 hover:bg-indigo-100";
+
+export const FILTER_CHIP_INACTIVE_CLASSES: string =
+  "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50";
+
+export const FILTER_CHIP_POPOVER_CLASSES: string =
+  "absolute left-0 top-full z-20 mt-2 origin-top-left overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xl ring-1 ring-black/5";
+
+export const FILTER_CHIP_CLEAR_CLASSES: string =
+  "ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full text-indigo-400 transition-colors hover:bg-indigo-200 hover:text-indigo-900 focus:outline-none";
+
+export const FILTER_CHIP_OPERATOR_SELECT_CLASSES: string =
+  "cursor-pointer rounded border border-gray-200 bg-white px-1.5 py-0.5 text-xs font-medium text-gray-700 hover:border-gray-300 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400";

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners.tsx
@@ -30,9 +30,15 @@ import FilterChipDropdown, {
   FilterChipDropdownOption,
   FilterOperator,
 } from "./FilterChipDropdown";
+import FilterChipDateRange from "./FilterChipDateRange";
+import { FacetKind, OPTION_FACET_OPERATORS } from "./FilterChipDropdownTypes";
+import { buildFacetDateRangeQuery } from "./FacetDateRange";
 import { ResourceOwnerEntry } from "./OwnerEntry";
 import {
+  FacetConflictMap,
   FacetSelectionState,
+  buildFacetConflictMap,
+  isFacetActive,
   normalizeFacetValues,
   parseFacetSelectionState,
   resolveFacetOperator,
@@ -60,6 +66,16 @@ const defaultFacetQueryValue: (
   }
   if (operator === "is_not_empty") {
     return new NotNull();
+  }
+  /*
+   * Date operators against an option list have no date to compare with — the
+   * values here are option ids. Only a hand-edited URL can pair the two, and
+   * sanitizeFacetSelectionState clamps that before it reaches here; refusing it
+   * again is what keeps "cannot express this" from becoming a filter on a
+   * string that happens to parse.
+   */
+  if (operator === "before" || operator === "after" || operator === "between") {
+    return undefined;
   }
   if (isMulti) {
     return operator === "is_not"
@@ -173,6 +189,16 @@ export interface ResourceFacet {
   key: string;
   /** Chip label (e.g. "Status", "Type"). */
   label: string;
+  /**
+   * What the chip's popover holds. Defaults to "options" — a searchable option
+   * list. Use "dateRange" for a date column, where there is no option list to
+   * offer and the useful questions ("not seen since last Tuesday", "between the
+   * 1st and the 5th") are only expressible by typing a date.
+   *
+   * A "dateRange" facet stores its selection in FacetDateRange's encoding and
+   * ignores `options` / `fetchOptions` / `loadOptions`.
+   */
+  type?: FacetKind | undefined;
   /** Icon shown on the empty chip. */
   icon?: IconProp | undefined;
   /** Allow selecting multiple values. Defaults to false. */
@@ -231,9 +257,23 @@ export interface ResourceFacet {
     | undefined;
   /**
    * Which operators this facet should expose in the chip dropdown.
-   * Defaults to ["is", "is_not", "is_empty", "is_not_empty"].
+   * Defaults to ["is", "is_not", "is_empty", "is_not_empty"], or to
+   * DATE_FACET_OPERATORS for a "dateRange" facet.
    */
   supportedOperators?: Array<FilterOperator> | undefined;
+  /**
+   * Other facet keys this chip cannot be active alongside, because they write
+   * the same column.
+   *
+   * `mergeFiltersIntoQuery` builds one object, so two chips over one field do
+   * not AND — the later one simply overwrites the earlier, silently, while both
+   * chips stay lit and claim to apply. Naming the conflict here makes activating
+   * either of them clear the other, so the bar always shows the filter the table
+   * is actually running.
+   *
+   * Declaring it on one side is enough; the hook reads it symmetrically.
+   */
+  exclusiveWith?: Array<string> | undefined;
   /**
    * For facets that filter across *multiple* relationship fields with OR
    * semantics (e.g. an "Affected Resources" chip spanning monitors / hosts /
@@ -1093,7 +1133,20 @@ const useResourceOwners: <TResource extends BaseModel>(
 
       const value: unknown = facet.toQueryValue
         ? facet.toQueryValue(selected, op)
-        : defaultFacetQueryValue(selected, op, Boolean(facet.isMultiSelect));
+        : facet.type === "dateRange"
+          ? buildFacetDateRangeQuery(selected, op)
+          : defaultFacetQueryValue(selected, op, Boolean(facet.isMultiSelect));
+
+      /*
+       * `undefined` is a query builder's way of saying "do not constrain this
+       * column" — a half-entered date range, or a value this build cannot read.
+       * Writing the key anyway would leave the field present-but-undefined in
+       * the request, which is a different statement from not filtering on it.
+       */
+      if (value === undefined) {
+        continue;
+      }
+
       (merged as unknown as Record<string, unknown>)[field] = value;
     }
 
@@ -1143,11 +1196,7 @@ const useResourceOwners: <TResource extends BaseModel>(
   };
 
   const anyExtraFacetActive: boolean = extraFacets.some((f: ResourceFacet) => {
-    const op: FilterOperator = facetOperators[f.key] || "is";
-    if (op === "is_empty" || op === "is_not_empty") {
-      return true;
-    }
-    return (facetSelections[f.key] || []).length > 0;
+    return isFacetActive(f, facetSelections[f.key], facetOperators[f.key]);
   });
 
   const ownerOperatorActive: boolean =
@@ -1162,6 +1211,79 @@ const useResourceOwners: <TResource extends BaseModel>(
 
   const hasActiveFilters: boolean = Boolean(
     ownerOperatorActive || labelOperatorActive || anyExtraFacetActive,
+  );
+
+  // Facet key → the keys it cannot be active alongside.
+  const facetConflicts: FacetConflictMap = useMemo((): FacetConflictMap => {
+    return buildFacetConflictMap(extraFacets);
+  }, [extraFacets]);
+
+  const facetByKey: { [facetKey: string]: ResourceFacet } = useMemo((): {
+    [facetKey: string]: ResourceFacet;
+  } => {
+    const map: { [facetKey: string]: ResourceFacet } = {};
+    for (const facet of extraFacets) {
+      map[facet.key] = facet;
+    }
+    return map;
+  }, [extraFacets]);
+
+  /**
+   * Set one facet's values and operator together, clearing anything it conflicts
+   * with.
+   *
+   * The single write path for every facet change — the chips, the summary tiles,
+   * and deep links all land here — so the conflict rule cannot be enforced in
+   * one of them and forgotten in another.
+   */
+  const applyFacetChange: (
+    facetKey: string,
+    values: Array<string>,
+    operator: FilterOperator,
+  ) => void = useCallback(
+    (
+      facetKey: string,
+      values: Array<string>,
+      operator: FilterOperator,
+    ): void => {
+      const conflicting: Array<string> = facetConflicts[facetKey] || [];
+      const facet: ResourceFacet = facetByKey[facetKey] || {
+        key: facetKey,
+        label: facetKey,
+      };
+      /*
+       * Only an active chip displaces another. Clearing a chip, or leaving it
+       * mid-range, must not wipe the one the user set before it.
+       */
+      const displaces: boolean =
+        conflicting.length > 0 && isFacetActive(facet, values, operator);
+
+      setFacetSelections((prev: { [k: string]: Array<string> }) => {
+        const next: { [k: string]: Array<string> } = {
+          ...prev,
+          [facetKey]: values,
+        };
+        if (displaces) {
+          for (const other of conflicting) {
+            next[other] = [];
+          }
+        }
+        return next;
+      });
+      setFacetOperators((prev: { [k: string]: FilterOperator }) => {
+        const next: { [k: string]: FilterOperator } = {
+          ...prev,
+          [facetKey]: operator,
+        };
+        if (displaces) {
+          for (const other of conflicting) {
+            next[other] = "is";
+          }
+        }
+        return next;
+      });
+    },
+    [facetConflicts, facetByKey],
   );
 
   const setFacetSelection: (
@@ -1184,22 +1306,25 @@ const useResourceOwners: <TResource extends BaseModel>(
        * query that ignores the values it just chose, with a chip that claims
        * otherwise.
        */
-      const nextValues: Array<string> = normalizeFacetValues(values);
       const nextOperator: FilterOperator = resolveFacetOperator(operator);
+      /*
+       * Date facets keep their two instants inside a single value, so the
+       * set-semantics of normalizeFacetValues (dedupe, drop blanks) would be
+       * meaningless at best. The range's own encoding is what validates it.
+       */
+      const nextValues: Array<string> =
+        facetByKey[facetKey]?.type === "dateRange"
+          ? values.slice(0, 1)
+          : normalizeFacetValues(values);
 
-      setFacetSelections((prev: { [k: string]: Array<string> }) => {
-        return { ...prev, [facetKey]: nextValues };
-      });
-      setFacetOperators((prev: { [k: string]: FilterOperator }) => {
-        return { ...prev, [facetKey]: nextOperator };
-      });
+      applyFacetChange(facetKey, nextValues, nextOperator);
 
       /*
        * Resolver-based facets recompute from the effect keyed on the selections
        * above, so nothing to do for them here.
        */
     },
-    [],
+    [applyFacetChange, facetByKey],
   );
 
   const clearAllFacets: () => void = useCallback((): void => {
@@ -1532,11 +1657,7 @@ const useResourceOwners: <TResource extends BaseModel>(
       (isOwnerActive ? 1 : 0) +
       (isLabelActive ? 1 : 0) +
       extraFacets.filter((f: ResourceFacet) => {
-        const op: FilterOperator = facetOperators[f.key] || "is";
-        if (op === "is_empty" || op === "is_not_empty") {
-          return true;
-        }
-        return (facetSelections[f.key] || []).length > 0;
+        return isFacetActive(f, facetSelections[f.key], facetOperators[f.key]);
       }).length;
 
     return (
@@ -1611,9 +1732,29 @@ const useResourceOwners: <TResource extends BaseModel>(
           />
         )}
         {extraFacets.map((facet: ResourceFacet) => {
+          const selected: Array<string> = facetSelections[facet.key] || [];
+
+          if (facet.type === "dateRange") {
+            return (
+              <FilterChipDateRange
+                key={facet.key}
+                label={facet.label}
+                emptyIcon={facet.icon}
+                values={selected}
+                operator={facetOperators[facet.key] || "is"}
+                supportedOperators={facet.supportedOperators}
+                onChange={(
+                  nextValues: Array<string>,
+                  nextOperator: FilterOperator,
+                ) => {
+                  applyFacetChange(facet.key, nextValues, nextOperator);
+                }}
+              />
+            );
+          }
+
           const opts: Array<FilterChipDropdownOption> =
             facet.options || facetDynamicOptions[facet.key] || [];
-          const selected: Array<string> = facetSelections[facet.key] || [];
           const value: string | Array<string> | null = facet.isMultiSelect
             ? selected
             : selected[0] || null;
@@ -1656,30 +1797,20 @@ const useResourceOwners: <TResource extends BaseModel>(
               searchPlaceholder={facet.searchPlaceholder}
               operator={facetOperators[facet.key] || "is"}
               onOperatorChange={(op: FilterOperator) => {
-                setFacetOperators((prev: { [k: string]: FilterOperator }) => {
-                  return { ...prev, [facet.key]: op };
-                });
+                applyFacetChange(facet.key, selected, op);
               }}
               supportedOperators={
-                facet.supportedOperators || [
-                  "is",
-                  "is_not",
-                  "is_empty",
-                  "is_not_empty",
-                ]
+                facet.supportedOperators || OPTION_FACET_OPERATORS
               }
               onChange={(next: string | Array<string> | null) => {
-                setFacetSelections((prev: { [k: string]: Array<string> }) => {
-                  const updated: { [k: string]: Array<string> } = { ...prev };
-                  if (next === null) {
-                    updated[facet.key] = [];
-                  } else if (Array.isArray(next)) {
-                    updated[facet.key] = next;
-                  } else {
-                    updated[facet.key] = [next];
-                  }
-                  return updated;
-                });
+                const nextValues: Array<string> =
+                  next === null ? [] : Array.isArray(next) ? next : [next];
+
+                applyFacetChange(
+                  facet.key,
+                  nextValues,
+                  facetOperators[facet.key] || "is",
+                );
               }}
             />
           );
@@ -1713,6 +1844,7 @@ const useResourceOwners: <TResource extends BaseModel>(
     labelOperator,
     facetOperators,
     clearAllFacets,
+    applyFacetChange,
   ]);
 
   const facetSaveState: JSONObject = useMemo((): JSONObject => {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
@@ -47,6 +47,8 @@ import {
   DEVICE_FACET_QUERY_FIELDS,
   DEVICE_INTERFACES_FACET_KEY,
   DEVICE_INTERFACES_FACET_OPTIONS,
+  DEVICE_LAST_SEEN_FACET_KEY,
+  DEVICE_LAST_SEEN_FACET_OPERATORS,
   DEVICE_PROBE_FACET_KEY,
   DEVICE_SITE_FACET_KEY,
   DEVICE_STATUS_FACET_KEY,
@@ -54,6 +56,7 @@ import {
   DeviceStatusCutoff,
   NETWORK_DEVICES_TABLE_ID,
   buildDeviceInterfacesFacetQuery,
+  buildDeviceLastSeenFacetQuery,
   buildDeviceStatusFacetQuery,
   isTimeBasedDeviceStatus,
 } from "../../Components/NetworkDevice/DeviceFacets";
@@ -117,6 +120,12 @@ const NetworkDevices: FunctionComponent<
          */
         supportedOperators: ["is"],
         options: DEVICE_STATUS_FACET_OPTIONS,
+        /*
+         * Both chips write `lastSeenAt`, and the merged query has room for one
+         * constraint per column — so picking either clears the other rather
+         * than one quietly overwriting the other while both stay lit.
+         */
+        exclusiveWith: [DEVICE_LAST_SEEN_FACET_KEY],
         toQueryValue: (
           values: Array<string>,
           operator: FilterOperator,
@@ -126,6 +135,26 @@ const NetworkDevices: FunctionComponent<
             operator,
             statusCutoff.current.getCutoffFor(values[0] || ""),
           );
+        },
+      },
+      {
+        key: DEVICE_LAST_SEEN_FACET_KEY,
+        queryField: DEVICE_FACET_QUERY_FIELDS.lastSeen,
+        label: "Last Seen",
+        icon: IconProp.Clock,
+        type: "dateRange",
+        /*
+         * The question the Status chip cannot express: an arbitrary date rather
+         * than the fixed 15-minute freshness window. "Not polled since last
+         * Tuesday" and "polled between the 1st and the 5th" live here.
+         */
+        supportedOperators: DEVICE_LAST_SEEN_FACET_OPERATORS,
+        exclusiveWith: [DEVICE_STATUS_FACET_KEY],
+        toQueryValue: (
+          values: Array<string>,
+          operator: FilterOperator,
+        ): unknown => {
+          return buildDeviceLastSeenFacetQuery(values, operator);
         },
       },
       {
@@ -394,11 +423,11 @@ const NetworkDevices: FunctionComponent<
         /*
          * Only what the chips cannot express — free text.
          *
-         * Status, Interfaces, Site, Probe and Labels have all moved to the facet
-         * bar, and their fields have to be gone from here: BaseModelTable spreads
-         * this popup's query OVER the page's, so a popup filter on a chip's field
-         * would replace the chip's constraint silently, while the chip and the lit
-         * tile above carried on claiming it applied.
+         * Status, Last Seen, Interfaces, Site, Probe and Labels have all moved to
+         * the facet bar, and their fields have to be gone from here:
+         * BaseModelTable spreads this popup's query OVER the page's, so a popup
+         * filter on a chip's field would replace the chip's constraint silently,
+         * while the chip and the lit tile above carried on claiming it applied.
          */
         filters={[
           {

--- a/App/Tests/Dashboard/DeviceFacets.test.ts
+++ b/App/Tests/Dashboard/DeviceFacets.test.ts
@@ -3,16 +3,20 @@ import {
   DEVICE_FACET_QUERY_FIELDS,
   DEVICE_INTERFACES_FACET_KEY,
   DEVICE_INTERFACES_FACET_OPTIONS,
+  DEVICE_LAST_SEEN_FACET_KEY,
+  DEVICE_LAST_SEEN_FACET_OPERATORS,
   DEVICE_PROBE_FACET_KEY,
   DEVICE_SITE_FACET_KEY,
   DEVICE_STATUS_FACET_KEY,
   DEVICE_STATUS_FACET_OPTIONS,
+  DEVICE_STATUS_LAST_SEEN_EXCLUSION,
   DeviceInterfacesFacetValue,
   DeviceStatusCutoff,
   DeviceStatusFacetValue,
   NETWORK_DEVICES_TABLE_ID,
   UNASSIGNED_DEVICES_FACET_SELECTION,
   buildDeviceInterfacesFacetQuery,
+  buildDeviceLastSeenFacetQuery,
   buildDeviceStatusFacetQuery,
   getDeviceFreshCutoff,
   isTimeBasedDeviceStatus,
@@ -23,12 +27,15 @@ import {
   FilterChipDropdownOption,
   FilterOperator,
 } from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes";
+import { serializeFacetDateRange } from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FacetDateRange";
 import EqualTo from "Common/Types/BaseDatabase/EqualTo";
 import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
 import IsNull from "Common/Types/BaseDatabase/IsNull";
 import LessThan from "Common/Types/BaseDatabase/LessThan";
 import CompareBase from "Common/Types/Database/CompareBase";
+import OneUptimeDate from "Common/Types/Date";
 
 /*
  * DeviceFacets is the contract between what a chip in the device list's facet
@@ -102,11 +109,37 @@ const ALL_FACET_KEYS: Array<string> = [
   DEVICE_INTERFACES_FACET_KEY,
   DEVICE_SITE_FACET_KEY,
   DEVICE_PROBE_FACET_KEY,
+  DEVICE_LAST_SEEN_FACET_KEY,
 ];
 
 const ALL_QUERY_FIELDS: Array<string> = Object.values(
   DEVICE_FACET_QUERY_FIELDS,
 );
+
+/*
+ * DEVICE_FACET_QUERY_FIELDS is keyed by the chip's role ("status"), not by its
+ * facet key ("deviceStatus"). This is the join between the two, so a test can
+ * ask "which chips write this column" rather than restating the answer.
+ */
+const FACET_KEY_BY_QUERY_FIELD_ROLE: Record<string, string> = {
+  status: DEVICE_STATUS_FACET_KEY,
+  interfaces: DEVICE_INTERFACES_FACET_KEY,
+  site: DEVICE_SITE_FACET_KEY,
+  probe: DEVICE_PROBE_FACET_KEY,
+  lastSeen: DEVICE_LAST_SEEN_FACET_KEY,
+};
+
+/*
+ * A day in the middle of the frozen "now"'s month, well clear of a month
+ * boundary so a start-of-day / end-of-day slip cannot land on a date that
+ * happens to read correctly.
+ */
+const PICKED_DAY: Date = new Date("2026-07-16T09:41:23.456Z");
+const PICKED_END_DAY: Date = new Date("2026-07-20T17:02:11.222Z");
+
+function lastSeenValues(start: Date | null, end: Date | null): Array<string> {
+  return serializeFacetDateRange({ start, end }, end ? "between" : "is");
+}
 
 /*
  * The values a hand-edited URL, a stale bookmark or a view saved by an older
@@ -168,6 +201,7 @@ describe("the facet keys", () => {
     expect(DEVICE_INTERFACES_FACET_KEY).toBe("deviceInterfaces");
     expect(DEVICE_SITE_FACET_KEY).toBe("deviceSite");
     expect(DEVICE_PROBE_FACET_KEY).toBe("deviceProbe");
+    expect(DEVICE_LAST_SEEN_FACET_KEY).toBe("deviceLastSeen");
   });
 
   test("are non-empty and distinct from one another", () => {
@@ -198,6 +232,7 @@ describe("DEVICE_FACET_QUERY_FIELDS", () => {
     expect(DEVICE_FACET_QUERY_FIELDS.interfaces).toBe("interfacesDown");
     expect(DEVICE_FACET_QUERY_FIELDS.site).toBe("siteId");
     expect(DEVICE_FACET_QUERY_FIELDS.probe).toBe("probeId");
+    expect(DEVICE_FACET_QUERY_FIELDS.lastSeen).toBe("lastSeenAt");
   });
 
   /*
@@ -215,14 +250,90 @@ describe("DEVICE_FACET_QUERY_FIELDS", () => {
     expect(DEVICE_FACET_QUERY_FIELDS.probe.endsWith("Id")).toBe(true);
   });
 
+  test("names a column for every chip", () => {
+    expect(ALL_QUERY_FIELDS).toHaveLength(ALL_FACET_KEYS.length);
+  });
+
   /*
    * The chips' constraints are merged into one query object, so two chips
    * writing the same column would have the later one silently replace the
    * earlier — one chip lit over a list it is not filtering.
+   *
+   * Status and Last Seen are the one deliberate exception: both ask about
+   * `lastSeenAt`, one against the fixed freshness window and one against a date
+   * the user picks, and no single-field query is both. They are declared
+   * mutually exclusive instead, so activating either clears the other and the
+   * merge never has two constraints to choose between.
    */
-  test("gives every chip a column of its own", () => {
-    expect(new Set(ALL_QUERY_FIELDS).size).toBe(ALL_QUERY_FIELDS.length);
-    expect(ALL_QUERY_FIELDS).toHaveLength(ALL_FACET_KEYS.length);
+  test("gives every chip a column of its own, except the pair that is declared exclusive", () => {
+    const duplicated: Array<string> = ALL_QUERY_FIELDS.filter(
+      (field: string, index: number) => {
+        return ALL_QUERY_FIELDS.indexOf(field) !== index;
+      },
+    );
+
+    expect(duplicated).toEqual([DEVICE_FACET_QUERY_FIELDS.status]);
+    expect(DEVICE_FACET_QUERY_FIELDS.lastSeen).toBe(
+      DEVICE_FACET_QUERY_FIELDS.status,
+    );
+  });
+
+  /*
+   * The exclusion is what makes a shared column safe, so it has to name exactly
+   * the chips that share one. Derived from the field map rather than restated,
+   * so a third chip pointed at `lastSeenAt` — or a second pair sharing some
+   * other column — fails here instead of silently overwriting at runtime.
+   */
+  test("every chip sharing a column is named in the exclusion", () => {
+    // The join has to cover the map, or a role could share a column unwatched.
+    expect(Object.keys(FACET_KEY_BY_QUERY_FIELD_ROLE).sort()).toEqual(
+      Object.keys(DEVICE_FACET_QUERY_FIELDS).sort(),
+    );
+
+    const facetKeysByColumn: Map<string, Array<string>> = new Map();
+
+    for (const [role, facetKey] of Object.entries(
+      FACET_KEY_BY_QUERY_FIELD_ROLE,
+    )) {
+      const column: string = (
+        DEVICE_FACET_QUERY_FIELDS as unknown as Record<string, string>
+      )[role]!;
+
+      facetKeysByColumn.set(column, [
+        ...(facetKeysByColumn.get(column) || []),
+        facetKey,
+      ]);
+    }
+
+    const sharedColumns: Array<Array<string>> = [
+      ...facetKeysByColumn.values(),
+    ].filter((facetKeys: Array<string>) => {
+      return facetKeys.length > 1;
+    });
+
+    expect(sharedColumns).toHaveLength(1);
+    expect([...sharedColumns[0]!].sort()).toEqual(
+      [...DEVICE_STATUS_LAST_SEEN_EXCLUSION].sort(),
+    );
+  });
+});
+
+describe("DEVICE_STATUS_LAST_SEEN_EXCLUSION", () => {
+  test("names the two chips that write lastSeenAt", () => {
+    expect(DEVICE_STATUS_LAST_SEEN_EXCLUSION).toEqual([
+      DEVICE_STATUS_FACET_KEY,
+      DEVICE_LAST_SEEN_FACET_KEY,
+    ]);
+  });
+
+  test("names real facet keys, and only those two", () => {
+    expect(DEVICE_STATUS_LAST_SEEN_EXCLUSION).toHaveLength(2);
+
+    for (const key of DEVICE_STATUS_LAST_SEEN_EXCLUSION) {
+      expect(ALL_FACET_KEYS).toContain(key);
+    }
+
+    expect(new Set(DEVICE_STATUS_LAST_SEEN_EXCLUSION).size).toBe(2);
   });
 });
 
@@ -435,13 +546,17 @@ describe("buildDeviceStatusFacetQuery", () => {
     );
 
     /*
-     * Derived from FILTER_OPERATOR_LABELS rather than hard-coded, so adding a
-     * fifth operator to the chip forces this list to be revisited instead of
+     * Derived from FILTER_OPERATOR_LABELS rather than hard-coded, so adding an
+     * operator to the vocabulary forces this list to be revisited instead of
      * quietly falling through to whichever branch happens to match.
+     *
+     * Seven: the four the option chips have always had, plus the three a date
+     * chip needs. Status offers only "is" and refuses every other one above —
+     * including the date operators, which have no date to compare against here.
      */
     test("covers every operator the chip can offer", () => {
-      expect(ALL_OPERATORS).toHaveLength(4);
-      expect(OPERATORS_OTHER_THAN_IS).toHaveLength(3);
+      expect(ALL_OPERATORS).toHaveLength(7);
+      expect(OPERATORS_OTHER_THAN_IS).toHaveLength(6);
       expect(OPERATORS_OTHER_THAN_IS).not.toContain("is");
     });
   });
@@ -606,6 +721,301 @@ describe("buildDeviceInterfacesFacetQuery", () => {
       expect(
         JSON.stringify(buildDeviceInterfacesFacetQuery([value], "is")),
       ).toBe(JSON.stringify(buildDeviceInterfacesFacetQuery([value], "is")));
+    }
+  });
+});
+
+describe("DEVICE_LAST_SEEN_FACET_OPERATORS", () => {
+  test("offers the four date operators the column-filter popup always did", () => {
+    expect(DEVICE_LAST_SEEN_FACET_OPERATORS).toEqual([
+      "is",
+      "before",
+      "after",
+      "between",
+    ]);
+  });
+
+  /*
+   * Over `lastSeenAt` these two ARE the Status chip's Pending and not-Pending.
+   * Offering them here would give the user two chips, in two vocabularies, for
+   * one question — and, because the two chips are mutually exclusive, picking
+   * the second would clear the first for no visible reason.
+   */
+  test("leaves the empty operators to the Status chip's Pending", () => {
+    expect(DEVICE_LAST_SEEN_FACET_OPERATORS).not.toContain("is_empty");
+    expect(DEVICE_LAST_SEEN_FACET_OPERATORS).not.toContain("is_not_empty");
+  });
+
+  /*
+   * "is not on this day" over a nullable timestamp silently drops never-polled
+   * devices — SQL fails them out of the comparison — while reading as though it
+   * included them. There is no single-field query that means what the words say.
+   */
+  test("does not offer is_not", () => {
+    expect(DEVICE_LAST_SEEN_FACET_OPERATORS).not.toContain("is_not");
+  });
+
+  test("every operator it offers is one the vocabulary knows", () => {
+    for (const operator of DEVICE_LAST_SEEN_FACET_OPERATORS) {
+      expect(ALL_OPERATORS).toContain(operator);
+    }
+  });
+});
+
+describe("buildDeviceLastSeenFacetQuery", () => {
+  /*
+   * This chip exists to ask the questions the Status chip cannot: "which
+   * devices have not been polled since last Tuesday", "which were polled
+   * between the 1st and the 5th". Both were answerable from the column-filter
+   * popup's date entry before the facet bar took `lastSeenAt` over, so the same
+   * picked dates have to keep returning the same rows — a link already pasted
+   * into a ticket does not get to change meaning.
+   */
+  describe("is", () => {
+    test("is the whole picked day, not the instant inside it", () => {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, null),
+        "is",
+      );
+
+      expect(query).toBeInstanceOf(InBetween);
+      expect((query as InBetween<Date>).startValue).toEqual(
+        OneUptimeDate.getStartOfDay(PICKED_DAY),
+      );
+      expect((query as InBetween<Date>).endValue).toEqual(
+        OneUptimeDate.getEndOfDay(PICKED_DAY),
+      );
+    });
+
+    /*
+     * `lastSeenAt` is a timestamp, so an equality against the picked midnight
+     * would match only a poll that landed on that exact millisecond — "last
+     * seen on the 16th" returning nothing, every time.
+     */
+    test("is a range rather than an equality", () => {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, null),
+        "is",
+      );
+
+      expect(query).not.toBeInstanceOf(EqualTo);
+      expect(operatorNameOf(query)).toBe("InBetween");
+    });
+  });
+
+  describe("before", () => {
+    test("is lastSeenAt < the picked date", () => {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, null),
+        "before",
+      );
+
+      expect(query).toBeInstanceOf(LessThan);
+      expect((query as CompareBase<Date>).value).toEqual(PICKED_DAY);
+    });
+
+    /*
+     * The question this chip was added for. A device polled long ago is
+     * "before", a device polled since is not, and a never-polled device matches
+     * neither — SQL drops NULLs from the comparison, exactly as the Status
+     * chip's Down does.
+     */
+    test("is a plain comparison, so never-polled devices do not match", () => {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, null),
+        "before",
+      );
+
+      expect(query).not.toBeInstanceOf(IsNull);
+      expect(operatorNameOf(query)).toBe("LessThan");
+    });
+  });
+
+  describe("after", () => {
+    test("is lastSeenAt > the picked date", () => {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, null),
+        "after",
+      );
+
+      expect(query).toBeInstanceOf(GreaterThan);
+      expect((query as CompareBase<Date>).value).toEqual(PICKED_DAY);
+    });
+  });
+
+  describe("between", () => {
+    test("spans from the start of the first day to the end of the last", () => {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, PICKED_END_DAY),
+        "between",
+      );
+
+      expect(query).toBeInstanceOf(InBetween);
+      expect((query as InBetween<Date>).startValue).toEqual(
+        OneUptimeDate.getStartOfDay(PICKED_DAY),
+      );
+      expect((query as InBetween<Date>).endValue).toEqual(
+        OneUptimeDate.getEndOfDay(PICKED_END_DAY),
+      );
+    });
+
+    /*
+     * Both ends inclusive. "Between the 1st and the 5th" that quietly excluded
+     * the 5th would be off by a day in the direction nobody checks.
+     */
+    test("includes both of the days the user named", () => {
+      const query: InBetween<Date> = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, PICKED_END_DAY),
+        "between",
+      ) as InBetween<Date>;
+
+      expect(query.startValue.getTime()).toBeLessThanOrEqual(
+        PICKED_DAY.getTime(),
+      );
+      expect(query.endValue.getTime()).toBeGreaterThanOrEqual(
+        PICKED_END_DAY.getTime(),
+      );
+    });
+
+    test("a single day is a range from its start to its end", () => {
+      const query: InBetween<Date> = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(PICKED_DAY, PICKED_DAY),
+        "between",
+      ) as InBetween<Date>;
+
+      expect(query.startValue).toEqual(OneUptimeDate.getStartOfDay(PICKED_DAY));
+      expect(query.endValue).toEqual(OneUptimeDate.getEndOfDay(PICKED_DAY));
+    });
+  });
+
+  describe("refuses anything it cannot express honestly", () => {
+    test("an empty selection does not constrain the column", () => {
+      expect(buildDeviceLastSeenFacetQuery([], "is")).toBeUndefined();
+      expect(buildDeviceLastSeenFacetQuery([], "before")).toBeUndefined();
+      expect(buildDeviceLastSeenFacetQuery([], "between")).toBeUndefined();
+    });
+
+    /*
+     * The user has picked one end of the range and is on their way to the
+     * other. Filtering on half of it would empty the table under their cursor.
+     */
+    test("a half-entered range does not constrain the column", () => {
+      expect(
+        buildDeviceLastSeenFacetQuery(
+          serializeFacetDateRange({ start: PICKED_DAY, end: null }, "between"),
+          "between",
+        ),
+      ).toBeUndefined();
+
+      expect(
+        buildDeviceLastSeenFacetQuery(
+          serializeFacetDateRange({ start: null, end: PICKED_DAY }, "between"),
+          "between",
+        ),
+      ).toBeUndefined();
+    });
+
+    test.each(JUNK_VALUES)(
+      "%s does not constrain the column",
+      (_label: string, raw: string) => {
+        for (const operator of DEVICE_LAST_SEEN_FACET_OPERATORS) {
+          expect(
+            buildDeviceLastSeenFacetQuery([raw], operator),
+          ).toBeUndefined();
+        }
+      },
+    );
+
+    /*
+     * The status values live on a different chip. A URL with the two facet keys
+     * swapped hands them here, and none of them is a date.
+     */
+    test.each(ALL_STATUS_VALUES)(
+      "the other chip's %s value does not constrain the column",
+      (value: DeviceStatusFacetValue) => {
+        expect(buildDeviceLastSeenFacetQuery([value], "is")).toBeUndefined();
+      },
+    );
+
+    /*
+     * The operators this chip does not offer. `is_empty` would be a second
+     * spelling of Pending, and `is_not` has no honest single-field form over a
+     * nullable timestamp — neither may sneak in through a hand-edited URL.
+     */
+    test.each(
+      ALL_OPERATORS.filter((operator: FilterOperator) => {
+        return !DEVICE_LAST_SEEN_FACET_OPERATORS.includes(operator);
+      }),
+    )(
+      "the %s operator it does not offer does not constrain the column",
+      (operator: FilterOperator) => {
+        expect(
+          buildDeviceLastSeenFacetQuery(
+            lastSeenValues(PICKED_DAY, null),
+            operator,
+          ),
+        ).toBeUndefined();
+      },
+    );
+  });
+
+  /*
+   * ModelTable decides whether to refetch by comparing the serialised query
+   * against the previous render's. Nothing here reads the clock — the dates
+   * come from the selection — so the same selection has to serialise
+   * identically or the table refetches forever.
+   */
+  test("serialises identically every time, with no clock in it", () => {
+    for (const operator of DEVICE_LAST_SEEN_FACET_OPERATORS) {
+      const values: Array<string> = lastSeenValues(
+        PICKED_DAY,
+        operator === "between" ? PICKED_END_DAY : null,
+      );
+
+      expect(
+        JSON.stringify(buildDeviceLastSeenFacetQuery(values, operator)),
+      ).toBe(JSON.stringify(buildDeviceLastSeenFacetQuery(values, operator)));
+    }
+  });
+
+  /*
+   * Why this chip has to exist alongside Status rather than instead of it.
+   *
+   * Status only ever produces an open-ended comparison against the freshness
+   * cutoff, or a null test. A bounded range — "polled between the 1st and the
+   * 5th", or "polled on the 16th" — is a shape it cannot make at any cutoff,
+   * which is exactly the question this chip was added to restore.
+   *
+   * The overlap runs the other way and is fine: "before" at the freshness
+   * cutoff IS Down. The two chips are mutually exclusive because they write one
+   * column, not because they can never agree.
+   */
+  test("expresses a bounded range, which the Status chip cannot", () => {
+    const statusShapes: Set<string> = new Set(
+      ALL_STATUS_VALUES.map((value: DeviceStatusFacetValue): string => {
+        return operatorNameOf(
+          buildDeviceStatusFacetQuery([value], "is", PICKED_DAY),
+        );
+      }),
+    );
+
+    expect([...statusShapes].sort()).toEqual([
+      "GreaterThanOrEqual",
+      "IsNull",
+      "LessThan",
+    ]);
+
+    for (const operator of ["is", "between"] as Array<FilterOperator>) {
+      const query: unknown = buildDeviceLastSeenFacetQuery(
+        lastSeenValues(
+          PICKED_DAY,
+          operator === "between" ? PICKED_END_DAY : null,
+        ),
+        operator,
+      );
+
+      expect(operatorNameOf(query)).toBe("InBetween");
+      expect(statusShapes).not.toContain(operatorNameOf(query));
     }
   });
 });

--- a/App/Tests/Dashboard/FacetDateRange.test.ts
+++ b/App/Tests/Dashboard/FacetDateRange.test.ts
@@ -1,0 +1,1073 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  FACET_DATE_PLACEHOLDER,
+  FACET_DATE_RANGE_SEPARATOR,
+  buildFacetDateRangeQuery,
+  formatFacetDateRange,
+  isFacetDateRangeActive,
+  parseFacetDateRange,
+  serializeFacetDateRange,
+  toFacetDate,
+} from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FacetDateRange";
+import {
+  DATE_FACET_OPERATORS,
+  FILTER_OPERATOR_LABELS,
+  FilterOperator,
+  OPTION_FACET_OPERATORS,
+} from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes";
+import {
+  FacetConflictMap,
+  FacetSelectionConstraint,
+  buildFacetConflictMap,
+  getEmptyFacetSelectionState,
+  isFacetActive,
+  sanitizeFacetSelectionState,
+} from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState";
+import EqualTo from "Common/Types/BaseDatabase/EqualTo";
+import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import LessThan from "Common/Types/BaseDatabase/LessThan";
+import NotNull from "Common/Types/BaseDatabase/NotNull";
+import CompareBase from "Common/Types/Database/CompareBase";
+import OneUptimeDate from "Common/Types/Date";
+
+/*
+ * FacetDateRange is what a date chip in the facet bar means.
+ *
+ * The chip is fully controlled — it keeps no private copy of the dates — so
+ * this module is simultaneously the codec the URL and saved views round-trip
+ * through, the rule for whether the chip counts as "filtering", and the mapping
+ * to the query. Those three have to agree: a chip that looks lit over a list it
+ * is not narrowing, or a link that comes back holding a different range than it
+ * left with, are both failures of this file rather than of the component.
+ */
+
+const START: Date = new Date("2026-07-16T09:41:23.456Z");
+const END: Date = new Date("2026-07-20T17:02:11.222Z");
+
+const ALL_OPERATORS: Array<FilterOperator> = Object.keys(
+  FILTER_OPERATOR_LABELS,
+) as Array<FilterOperator>;
+
+/*
+ * The values a hand-edited URL, a stale bookmark or a view saved by an older
+ * build can hand over. None of them is a date, and none may become a filter.
+ *
+ * "0" earns its place: the platform's own date parser reads it as the year
+ * 2000 through a lenient fallback, so a chip that trusted the parse would show
+ * an empty table and explain it with a date nobody picked.
+ */
+const JUNK_VALUES: Array<[string, string]> = [
+  ["an unknown word", "banana"],
+  ["the empty string", ""],
+  ["only whitespace", "   "],
+  ["a bare number", "0"],
+  ["another bare number", "1763251200000"],
+  ["a day with no year", "07-16"],
+  ["a US-style date", "07/16/2026"],
+  ["a spelled-out date", "July 16 2026"],
+  ["an Object.prototype member", "constructor"],
+  ["a prototype-pollution attempt", "__proto__"],
+  ["another prototype member", "toString"],
+  ["a JSON payload", '{"lastSeenAt":null}'],
+  ["a SQL fragment", "1' OR '1'='1"],
+  ["a bare separator", FACET_DATE_RANGE_SEPARATOR],
+  ["an option-chip value", "pending"],
+];
+
+/**
+ * The exact operator class a query fragment is — `instanceof` passes for a
+ * subclass too, and a subclass of a comparison is exactly what a regression
+ * here would look like.
+ */
+function operatorNameOf(query: unknown): string {
+  return (query as { constructor: { name: string } }).constructor.name;
+}
+
+const DATE_FACET: FacetSelectionConstraint = {
+  key: "lastSeen",
+  type: "dateRange",
+  isMultiSelect: false,
+  supportedOperators: DATE_FACET_OPERATORS,
+};
+
+const OPTION_FACET: FacetSelectionConstraint = {
+  key: "status",
+  isMultiSelect: false,
+  supportedOperators: OPTION_FACET_OPERATORS,
+};
+
+describe("the operator vocabulary", () => {
+  /*
+   * These strings are in saved views and shared URLs. Renaming one orphans
+   * every link already pasted into a ticket, so it has to break a test first.
+   */
+  test("carries the wire values that appear in URLs", () => {
+    expect(FILTER_OPERATOR_LABELS["before"]).toBe("is before");
+    expect(FILTER_OPERATOR_LABELS["after"]).toBe("is after");
+    expect(FILTER_OPERATOR_LABELS["between"]).toBe("is between");
+  });
+
+  test("every operator has a label the chip can print", () => {
+    for (const operator of ALL_OPERATORS) {
+      expect(FILTER_OPERATOR_LABELS[operator].length).toBeGreaterThan(0);
+    }
+  });
+
+  /*
+   * A date operator on an option chip has no date to compare against — the
+   * values there are option ids. Keeping the two lists disjoint on the date
+   * operators is what lets sanitizeFacetSelectionState clamp one back to the
+   * other without having to know which chip it is looking at.
+   */
+  test("the option chips are not offered the date operators", () => {
+    expect(OPTION_FACET_OPERATORS).not.toContain("before");
+    expect(OPTION_FACET_OPERATORS).not.toContain("after");
+    expect(OPTION_FACET_OPERATORS).not.toContain("between");
+  });
+
+  /*
+   * "is not on this day" over a nullable timestamp drops never-set rows —
+   * SQL fails NULL out of the comparison — while reading as though it kept
+   * them. There is no single-field query that means what those words say.
+   */
+  test("the date chips are not offered is_not", () => {
+    expect(DATE_FACET_OPERATORS).not.toContain("is_not");
+  });
+
+  test("both lists name only operators the vocabulary knows", () => {
+    for (const operator of [
+      ...DATE_FACET_OPERATORS,
+      ...OPTION_FACET_OPERATORS,
+    ]) {
+      expect(ALL_OPERATORS).toContain(operator);
+    }
+  });
+});
+
+describe("toFacetDate", () => {
+  test("reads an ISO instant, the form the chip stores", () => {
+    expect(toFacetDate(START.toISOString())).toEqual(START);
+  });
+
+  test("reads a bare calendar date, the form a date input produces", () => {
+    const parsed: Date | null = toFacetDate("2026-07-16");
+
+    expect(parsed).not.toBeNull();
+    expect(Number.isNaN(parsed!.getTime())).toBe(false);
+  });
+
+  test.each(JUNK_VALUES)("%s is not a date", (_label: string, raw: string) => {
+    expect(toFacetDate(raw)).toBeNull();
+  });
+
+  test("null and undefined are not dates", () => {
+    expect(toFacetDate(null)).toBeNull();
+    expect(toFacetDate(undefined)).toBeNull();
+  });
+
+  /*
+   * The specific failure this guards: the platform's date parser falls back to
+   * the browser's own, which reads "0" as the year 2000 rather than rejecting
+   * it. Anything that reaches the query builder has to have been a date first.
+   */
+  test("never returns an Invalid Date", () => {
+    for (const [, raw] of JUNK_VALUES) {
+      const parsed: Date | null = toFacetDate(raw);
+
+      expect(parsed === null || !Number.isNaN(parsed.getTime())).toBe(true);
+    }
+  });
+});
+
+describe("serializeFacetDateRange / parseFacetDateRange", () => {
+  /*
+   * The pair is a codec: whatever the popover holds has to survive a URL, a
+   * saved view and a Back navigation unchanged. A range that came back as a
+   * different range would filter the list differently from the link that was
+   * shared, with nothing on screen to say so.
+   */
+  test("round-trips a single date", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: null },
+      "is",
+    );
+
+    expect(parseFacetDateRange(values)).toEqual({ start: START, end: null });
+  });
+
+  test.each(["is", "before", "after"] as Array<FilterOperator>)(
+    "round-trips a single date under %s",
+    (operator: FilterOperator) => {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: null },
+        operator,
+      );
+
+      expect(parseFacetDateRange(values).start).toEqual(START);
+    },
+  );
+
+  test("round-trips a range", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: END },
+      "between",
+    );
+
+    expect(parseFacetDateRange(values)).toEqual({ start: START, end: END });
+  });
+
+  /*
+   * The two instants live inside ONE array entry. The shared selection
+   * plumbing treats a facet's values as a set — it dedupes them, and clamps a
+   * single-select facet to its first — so a two-entry range would come back
+   * from "between the 1st and the 1st" as a single date, and from any restore
+   * as its start alone.
+   */
+  test("keeps a range in a single value, whatever the two dates are", () => {
+    expect(
+      serializeFacetDateRange({ start: START, end: END }, "between"),
+    ).toHaveLength(1);
+    expect(
+      serializeFacetDateRange({ start: START, end: START }, "between"),
+    ).toHaveLength(1);
+  });
+
+  test("round-trips a range whose two ends are the same day", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: START },
+      "between",
+    );
+
+    expect(parseFacetDateRange(values)).toEqual({ start: START, end: START });
+  });
+
+  /*
+   * The user is mid-way through entering a range. Dropping the half they have
+   * typed would clear the input from under the cursor the moment they picked
+   * the first of the two dates.
+   */
+  test("keeps a half-entered range", () => {
+    expect(
+      parseFacetDateRange(
+        serializeFacetDateRange({ start: START, end: null }, "between"),
+      ),
+    ).toEqual({ start: START, end: null });
+
+    expect(
+      parseFacetDateRange(
+        serializeFacetDateRange({ start: null, end: END }, "between"),
+      ),
+    ).toEqual({ start: null, end: END });
+  });
+
+  /*
+   * Switching operators re-encodes. Left alone, an end date would outlive the
+   * switch to "before" — invisible in the popover, still riding along in the
+   * next link the user shares.
+   */
+  test("drops the end date when the operator stops taking one", () => {
+    for (const operator of ["is", "before", "after"] as Array<FilterOperator>) {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: END },
+        operator,
+      );
+
+      expect(parseFacetDateRange(values).end).toBeNull();
+      expect(values[0]).not.toContain(FACET_DATE_RANGE_SEPARATOR);
+    }
+  });
+
+  test("an operator that takes no date stores nothing", () => {
+    for (const operator of [
+      "is_empty",
+      "is_not_empty",
+    ] as Array<FilterOperator>) {
+      expect(
+        serializeFacetDateRange({ start: START, end: END }, operator),
+      ).toEqual([]);
+    }
+  });
+
+  test("an empty range stores nothing", () => {
+    for (const operator of DATE_FACET_OPERATORS) {
+      expect(
+        serializeFacetDateRange({ start: null, end: null }, operator),
+      ).toEqual([]);
+    }
+  });
+
+  describe("parsing what it did not write", () => {
+    test("no values is no range", () => {
+      expect(parseFacetDateRange([])).toEqual({ start: null, end: null });
+      expect(parseFacetDateRange(null)).toEqual({ start: null, end: null });
+      expect(parseFacetDateRange(undefined)).toEqual({
+        start: null,
+        end: null,
+      });
+    });
+
+    test.each(JUNK_VALUES)("%s is no range", (_label: string, raw: string) => {
+      expect(parseFacetDateRange([raw])).toEqual({ start: null, end: null });
+    });
+
+    test("junk on one side leaves the other side readable", () => {
+      expect(
+        parseFacetDateRange([
+          `${START.toISOString()}${FACET_DATE_RANGE_SEPARATOR}banana`,
+        ]),
+      ).toEqual({ start: START, end: null });
+    });
+
+    /*
+     * Only the first entry counts. The single-select clamp already reduces a
+     * date facet to one value, so honouring extras here would mean the chip and
+     * the query disagreed about which of them was the filter.
+     */
+    test("extra values are ignored", () => {
+      expect(
+        parseFacetDateRange([START.toISOString(), END.toISOString()]),
+      ).toEqual({ start: START, end: null });
+    });
+  });
+});
+
+describe("isFacetDateRangeActive", () => {
+  /*
+   * The chip's lit state, the bar's filter count and the table's "nothing
+   * matches the filters" copy all read this, and the query builder has to
+   * agree with it — a chip that claims a filter the table is not applying is
+   * the whole failure mode the facet bar exists to avoid.
+   */
+  test("a single date is a filter", () => {
+    for (const operator of ["is", "before", "after"] as Array<FilterOperator>) {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: null },
+        operator,
+      );
+
+      expect(isFacetDateRangeActive(values, operator)).toBe(true);
+      expect(buildFacetDateRangeQuery(values, operator)).toBeDefined();
+    }
+  });
+
+  test("a complete range is a filter", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: END },
+      "between",
+    );
+
+    expect(isFacetDateRangeActive(values, "between")).toBe(true);
+    expect(buildFacetDateRangeQuery(values, "between")).toBeDefined();
+  });
+
+  test("a half-entered range is not a filter yet", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: null },
+      "between",
+    );
+
+    expect(isFacetDateRangeActive(values, "between")).toBe(false);
+    expect(buildFacetDateRangeQuery(values, "between")).toBeUndefined();
+  });
+
+  test("no date is not a filter", () => {
+    for (const operator of [
+      "is",
+      "before",
+      "after",
+      "between",
+    ] as Array<FilterOperator>) {
+      expect(isFacetDateRangeActive([], operator)).toBe(false);
+    }
+  });
+
+  test("the empty operators are a filter without any date", () => {
+    expect(isFacetDateRangeActive([], "is_empty")).toBe(true);
+    expect(isFacetDateRangeActive([], "is_not_empty")).toBe(true);
+  });
+
+  /*
+   * The invariant the two have to keep between them: lit exactly when
+   * filtering. Checked across every operator and every shape of selection
+   * rather than case by case, so a new operator cannot land on one side only.
+   */
+  test("says yes exactly when a query is produced", () => {
+    const selections: Array<Array<string>> = [
+      [],
+      serializeFacetDateRange({ start: START, end: null }, "is"),
+      serializeFacetDateRange({ start: START, end: END }, "between"),
+      serializeFacetDateRange({ start: START, end: null }, "between"),
+      serializeFacetDateRange({ start: null, end: END }, "between"),
+      ["banana"],
+    ];
+
+    for (const operator of DATE_FACET_OPERATORS) {
+      for (const values of selections) {
+        expect(isFacetDateRangeActive(values, operator)).toBe(
+          buildFacetDateRangeQuery(values, operator) !== undefined,
+        );
+      }
+    }
+  });
+});
+
+describe("buildFacetDateRangeQuery", () => {
+  describe("is", () => {
+    /*
+     * A day, not an instant. These chips sit over timestamp columns, so an
+     * equality against the picked midnight would match only a row written on
+     * that exact millisecond — "on the 16th" reliably returning nothing.
+     */
+    test("is the whole picked day", () => {
+      const query: unknown = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: null }, "is"),
+        "is",
+      );
+
+      expect(query).toBeInstanceOf(InBetween);
+      expect((query as InBetween<Date>).startValue).toEqual(
+        OneUptimeDate.getStartOfDay(START),
+      );
+      expect((query as InBetween<Date>).endValue).toEqual(
+        OneUptimeDate.getEndOfDay(START),
+      );
+    });
+
+    test("is not an equality", () => {
+      const query: unknown = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: null }, "is"),
+        "is",
+      );
+
+      expect(query).not.toBeInstanceOf(EqualTo);
+      expect(operatorNameOf(query)).toBe("InBetween");
+    });
+
+    test("brackets the picked instant on both sides", () => {
+      const query: InBetween<Date> = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: null }, "is"),
+        "is",
+      ) as InBetween<Date>;
+
+      expect(query.startValue.getTime()).toBeLessThanOrEqual(START.getTime());
+      expect(query.endValue.getTime()).toBeGreaterThanOrEqual(START.getTime());
+    });
+  });
+
+  describe("before and after", () => {
+    test("before is a LessThan on the picked date", () => {
+      const query: unknown = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: null }, "before"),
+        "before",
+      );
+
+      expect(query).toBeInstanceOf(LessThan);
+      expect((query as CompareBase<Date>).value).toEqual(START);
+    });
+
+    test("after is a GreaterThan on the picked date", () => {
+      const query: unknown = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: null }, "after"),
+        "after",
+      );
+
+      expect(query).toBeInstanceOf(GreaterThan);
+      expect((query as CompareBase<Date>).value).toEqual(START);
+    });
+
+    /*
+     * Plain comparisons, so a NULL column matches neither — the same way the
+     * column-filter popup's date entry has always behaved, and the reason a
+     * date chip does not need to say anything about never-set rows.
+     */
+    test("neither is a null test", () => {
+      for (const operator of ["before", "after"] as Array<FilterOperator>) {
+        const query: unknown = buildFacetDateRangeQuery(
+          serializeFacetDateRange({ start: START, end: null }, operator),
+          operator,
+        );
+
+        expect(query).not.toBeInstanceOf(IsNull);
+        expect(query).not.toBeInstanceOf(NotNull);
+      }
+    });
+
+    test("the two are opposites, not the same fragment", () => {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: null },
+        "before",
+      );
+
+      expect(
+        JSON.stringify(buildFacetDateRangeQuery(values, "before")),
+      ).not.toBe(JSON.stringify(buildFacetDateRangeQuery(values, "after")));
+    });
+  });
+
+  describe("between", () => {
+    test("spans the start of the first day to the end of the last", () => {
+      const query: unknown = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: END }, "between"),
+        "between",
+      );
+
+      expect(query).toBeInstanceOf(InBetween);
+      expect((query as InBetween<Date>).startValue).toEqual(
+        OneUptimeDate.getStartOfDay(START),
+      );
+      expect((query as InBetween<Date>).endValue).toEqual(
+        OneUptimeDate.getEndOfDay(END),
+      );
+    });
+
+    /*
+     * Both ends inclusive. A range that quietly excluded the last day named
+     * would be off by one in the direction nobody checks.
+     */
+    test("includes both of the days the user named", () => {
+      const query: InBetween<Date> = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: END }, "between"),
+        "between",
+      ) as InBetween<Date>;
+
+      expect(query.startValue.getTime()).toBeLessThanOrEqual(START.getTime());
+      expect(query.endValue.getTime()).toBeGreaterThanOrEqual(END.getTime());
+    });
+
+    test("a single day is a range from its start to its end", () => {
+      const query: InBetween<Date> = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: START }, "between"),
+        "between",
+      ) as InBetween<Date>;
+
+      expect(query.startValue).toEqual(OneUptimeDate.getStartOfDay(START));
+      expect(query.endValue).toEqual(OneUptimeDate.getEndOfDay(START));
+    });
+
+    /*
+     * A backwards range is the user's to make — the inputs do not stop it —
+     * and it is honestly empty. What must not happen is a silent reordering
+     * into a range they did not ask for.
+     */
+    test("does not quietly reorder a backwards range", () => {
+      const query: InBetween<Date> = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: END, end: START }, "between"),
+        "between",
+      ) as InBetween<Date>;
+
+      expect(query.startValue.getTime()).toBeGreaterThan(
+        query.endValue.getTime(),
+      );
+    });
+  });
+
+  describe("the empty operators", () => {
+    test("is_empty asks the column for NULL", () => {
+      expect(buildFacetDateRangeQuery([], "is_empty")).toBeInstanceOf(IsNull);
+    });
+
+    test("is_not_empty asks the column for any value", () => {
+      expect(buildFacetDateRangeQuery([], "is_not_empty")).toBeInstanceOf(
+        NotNull,
+      );
+    });
+
+    /*
+     * They mean "has no value" regardless of what is stored, so a leftover
+     * range must not turn them into a date comparison.
+     */
+    test("ignore any range left behind by another operator", () => {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: END },
+        "between",
+      );
+
+      expect(buildFacetDateRangeQuery(values, "is_empty")).toBeInstanceOf(
+        IsNull,
+      );
+      expect(buildFacetDateRangeQuery(values, "is_not_empty")).toBeInstanceOf(
+        NotNull,
+      );
+    });
+  });
+
+  describe("isDateTime", () => {
+    /*
+     * The opt-in for a column the user picks an instant on rather than a day.
+     * Default is day granularity, because that is what a date input offers and
+     * what every date column filter in the product has always meant.
+     */
+    test("takes the picked instants as-is rather than widening to days", () => {
+      const query: InBetween<Date> = buildFacetDateRangeQuery(
+        serializeFacetDateRange({ start: START, end: END }, "between"),
+        "between",
+        { isDateTime: true },
+      ) as InBetween<Date>;
+
+      expect(query.startValue).toEqual(START);
+      expect(query.endValue).toEqual(END);
+    });
+
+    test("is not the default", () => {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: END },
+        "between",
+      );
+
+      expect(
+        JSON.stringify(buildFacetDateRangeQuery(values, "between")),
+      ).not.toBe(
+        JSON.stringify(
+          buildFacetDateRangeQuery(values, "between", { isDateTime: true }),
+        ),
+      );
+    });
+  });
+
+  describe("refuses anything it cannot express honestly", () => {
+    test.each(JUNK_VALUES)(
+      "%s does not constrain the column",
+      (_label: string, raw: string) => {
+        for (const operator of [
+          "is",
+          "before",
+          "after",
+          "between",
+        ] as Array<FilterOperator>) {
+          expect(buildFacetDateRangeQuery([raw], operator)).toBeUndefined();
+        }
+      },
+    );
+
+    test("an empty selection does not constrain the column", () => {
+      for (const operator of [
+        "is",
+        "before",
+        "after",
+        "between",
+      ] as Array<FilterOperator>) {
+        expect(buildFacetDateRangeQuery([], operator)).toBeUndefined();
+      }
+    });
+
+    test("a half-entered range does not constrain the column", () => {
+      expect(
+        buildFacetDateRangeQuery(
+          serializeFacetDateRange({ start: START, end: null }, "between"),
+          "between",
+        ),
+      ).toBeUndefined();
+
+      expect(
+        buildFacetDateRangeQuery(
+          serializeFacetDateRange({ start: null, end: END }, "between"),
+          "between",
+        ),
+      ).toBeUndefined();
+    });
+
+    /*
+     * The operator no date chip offers. Only a hand-edited URL can pair it
+     * with a date, and there is no honest single-field query for it — so it
+     * has to fall through to "do not constrain", not to a nearby branch.
+     */
+    test("is_not does not constrain the column", () => {
+      expect(
+        buildFacetDateRangeQuery(
+          serializeFacetDateRange({ start: START, end: null }, "is"),
+          "is_not",
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  /*
+   * ModelTable decides whether to refetch by comparing the serialised query
+   * against the previous render's. Nothing here reads the clock — every date
+   * comes from the selection — so the same selection must serialise
+   * identically, or the table refetches forever.
+   */
+  test("serialises identically every time, with no clock in it", () => {
+    for (const operator of DATE_FACET_OPERATORS) {
+      const values: Array<string> = serializeFacetDateRange(
+        { start: START, end: END },
+        operator,
+      );
+
+      expect(JSON.stringify(buildFacetDateRangeQuery(values, operator))).toBe(
+        JSON.stringify(buildFacetDateRangeQuery(values, operator)),
+      );
+    }
+  });
+
+  /*
+   * A GreaterThan serialising to the same JSON as a LessThan would mean the
+   * chip's operator switcher moved nothing. Every operator has to produce a
+   * distinguishable fragment.
+   */
+  test("no two operators produce the same constraint", () => {
+    const fragments: Array<string> = DATE_FACET_OPERATORS.map(
+      (operator: FilterOperator): string => {
+        return JSON.stringify(
+          buildFacetDateRangeQuery(
+            serializeFacetDateRange({ start: START, end: END }, operator),
+            operator,
+          ),
+        );
+      },
+    );
+
+    expect(new Set(fragments).size).toBe(fragments.length);
+  });
+});
+
+describe("formatFacetDateRange", () => {
+  test("prints a single date at day precision", () => {
+    const text: string = formatFacetDateRange(
+      serializeFacetDateRange({ start: START, end: null }, "is"),
+      "is",
+    );
+
+    expect(text).toBe(OneUptimeDate.getDateAsLocalFormattedString(START, true));
+  });
+
+  test("prints both ends of a range", () => {
+    const text: string = formatFacetDateRange(
+      serializeFacetDateRange({ start: START, end: END }, "between"),
+      "between",
+    );
+
+    expect(text).toContain(
+      OneUptimeDate.getDateAsLocalFormattedString(START, true),
+    );
+    expect(text).toContain(
+      OneUptimeDate.getDateAsLocalFormattedString(END, true),
+    );
+  });
+
+  /*
+   * A range the user is still filling in has to read as unfinished. Printing
+   * only the end they have entered would make it look like a single-date
+   * filter that the table is not, in fact, applying.
+   */
+  test("marks the end of a range that is not entered yet", () => {
+    const text: string = formatFacetDateRange(
+      serializeFacetDateRange({ start: START, end: null }, "between"),
+      "between",
+    );
+
+    expect(text).toContain(
+      OneUptimeDate.getDateAsLocalFormattedString(START, true),
+    );
+    expect(text).toContain(FACET_DATE_PLACEHOLDER);
+  });
+
+  /*
+   * The chip prints a time nowhere, because the popover offers no way to
+   * change one — a filter the user cannot see the whole of is a filter they
+   * cannot correct.
+   */
+  test("never prints a time", () => {
+    for (const operator of DATE_FACET_OPERATORS) {
+      const text: string = formatFacetDateRange(
+        serializeFacetDateRange({ start: START, end: END }, operator),
+        operator,
+      );
+
+      expect(text).not.toMatch(/\d{1,2}:\d{2}/);
+    }
+  });
+});
+
+describe("isFacetActive", () => {
+  /*
+   * The one question every "is this chip filtering" caller asks, answered per
+   * chip kind. An option chip is active as soon as it holds a value; a date
+   * chip is not active until its range is complete, because until then the
+   * query builder produces nothing.
+   */
+  test("an option chip is active as soon as it holds a value", () => {
+    expect(isFacetActive(OPTION_FACET, ["up"], "is")).toBe(true);
+    expect(isFacetActive(OPTION_FACET, [], "is")).toBe(false);
+  });
+
+  test("an option chip is active on the empty operators", () => {
+    expect(isFacetActive(OPTION_FACET, [], "is_empty")).toBe(true);
+    expect(isFacetActive(OPTION_FACET, [], "is_not_empty")).toBe(true);
+  });
+
+  test("a date chip is active once its range is complete", () => {
+    expect(
+      isFacetActive(
+        DATE_FACET,
+        serializeFacetDateRange({ start: START, end: END }, "between"),
+        "between",
+      ),
+    ).toBe(true);
+  });
+
+  test("a date chip is not active while its range is half-entered", () => {
+    expect(
+      isFacetActive(
+        DATE_FACET,
+        serializeFacetDateRange({ start: START, end: null }, "between"),
+        "between",
+      ),
+    ).toBe(false);
+  });
+
+  test("an unspecified operator reads as the default", () => {
+    expect(isFacetActive(OPTION_FACET, ["up"], undefined)).toBe(true);
+    expect(
+      isFacetActive(
+        DATE_FACET,
+        serializeFacetDateRange({ start: START, end: null }, "is"),
+        undefined,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("sanitizeFacetSelectionState, for a date chip", () => {
+  type StateWith = (
+    values: Array<string>,
+    operator: FilterOperator,
+  ) => ReturnType<typeof getEmptyFacetSelectionState>;
+
+  const stateWith: StateWith = (
+    values: Array<string>,
+    operator: FilterOperator,
+  ) => {
+    const state: ReturnType<typeof getEmptyFacetSelectionState> =
+      getEmptyFacetSelectionState();
+    state.facetSelections[DATE_FACET.key] = values;
+    state.facetOperators[DATE_FACET.key] = operator;
+    return state;
+  };
+
+  test("keeps a range it can read", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: END },
+      "between",
+    );
+
+    expect(
+      sanitizeFacetSelectionState(stateWith(values, "between"), [DATE_FACET])
+        .facetSelections[DATE_FACET.key],
+    ).toEqual(values);
+  });
+
+  /*
+   * A range the chip cannot render would leave it lit with blank inputs —
+   * claiming a filter the user can neither see nor correct. Coming back empty
+   * over the full list is at least a state the bar can express.
+   */
+  test.each(JUNK_VALUES)(
+    "drops %s rather than leaving the chip lit and blank",
+    (_label: string, raw: string) => {
+      expect(
+        sanitizeFacetSelectionState(stateWith([raw], "is"), [DATE_FACET])
+          .facetSelections[DATE_FACET.key],
+      ).toEqual([]);
+    },
+  );
+
+  test("drops a half-entered range restored from a link", () => {
+    expect(
+      sanitizeFacetSelectionState(
+        stateWith(
+          serializeFacetDateRange({ start: START, end: null }, "between"),
+          "between",
+        ),
+        [DATE_FACET],
+      ).facetSelections[DATE_FACET.key],
+    ).toEqual([]);
+  });
+
+  /*
+   * The chip renders no operator it was not given, so an operator it does not
+   * offer would be invisible AND unchangeable — the switcher would show
+   * something else while the query used this.
+   */
+  test("clamps an operator the chip does not offer", () => {
+    const sanitized: ReturnType<typeof getEmptyFacetSelectionState> =
+      sanitizeFacetSelectionState(
+        stateWith(
+          serializeFacetDateRange({ start: START, end: null }, "is"),
+          "is_not",
+        ),
+        [DATE_FACET],
+      );
+
+    expect(DATE_FACET_OPERATORS).toContain(
+      sanitized.facetOperators[DATE_FACET.key],
+    );
+    expect(sanitized.facetOperators[DATE_FACET.key]).not.toBe("is_not");
+  });
+
+  /*
+   * The mirror image: an option chip must not come back holding a date
+   * operator, which it has no date to satisfy.
+   */
+  test("clamps a date operator off an option chip", () => {
+    const state: ReturnType<typeof getEmptyFacetSelectionState> =
+      getEmptyFacetSelectionState();
+    state.facetSelections[OPTION_FACET.key] = ["up"];
+    state.facetOperators[OPTION_FACET.key] = "between";
+
+    const sanitized: ReturnType<typeof getEmptyFacetSelectionState> =
+      sanitizeFacetSelectionState(state, [OPTION_FACET]);
+
+    expect(sanitized.facetOperators[OPTION_FACET.key]).toBe("is");
+    // The user's value is kept — only the operator it cannot use is corrected.
+    expect(sanitized.facetSelections[OPTION_FACET.key]).toEqual(["up"]);
+  });
+
+  test("a date chip with nothing selected stays empty", () => {
+    expect(
+      sanitizeFacetSelectionState(stateWith([], "is"), [DATE_FACET])
+        .facetSelections[DATE_FACET.key],
+    ).toEqual([]);
+  });
+
+  /*
+   * A restored range and a freshly picked one have to produce the same query,
+   * or a shared link shows different rows than the session that made it.
+   */
+  test("a surviving range still builds the query it was saved as", () => {
+    const values: Array<string> = serializeFacetDateRange(
+      { start: START, end: END },
+      "between",
+    );
+
+    const restored: Array<string> = sanitizeFacetSelectionState(
+      stateWith(values, "between"),
+      [DATE_FACET],
+    ).facetSelections[DATE_FACET.key]!;
+
+    expect(JSON.stringify(buildFacetDateRangeQuery(restored, "between"))).toBe(
+      JSON.stringify(buildFacetDateRangeQuery(values, "between")),
+    );
+  });
+});
+
+describe("buildFacetConflictMap", () => {
+  /*
+   * Two chips over one column cannot both apply: the merged query is a single
+   * object, so the later one replaces the earlier outright while both stay lit
+   * and claim to apply. The map is what turns that into "activating either
+   * clears the other".
+   */
+  test("pairs the two chips a facet declares itself exclusive with", () => {
+    const map: FacetConflictMap = buildFacetConflictMap([
+      { key: "status", exclusiveWith: ["lastSeen"] },
+      { key: "lastSeen" },
+    ]);
+
+    expect(map["status"]).toEqual(["lastSeen"]);
+  });
+
+  /*
+   * The half-working failure this exists to rule out: declared on one side
+   * only, the map would clear the second chip when the first moved but not the
+   * reverse — so whichever the user reached for second would be the one
+   * silently overwritten, which is the whole bug.
+   */
+  test("is symmetric whichever side declares it", () => {
+    const declaredForward: FacetConflictMap = buildFacetConflictMap([
+      { key: "status", exclusiveWith: ["lastSeen"] },
+      { key: "lastSeen" },
+    ]);
+    const declaredBackward: FacetConflictMap = buildFacetConflictMap([
+      { key: "status" },
+      { key: "lastSeen", exclusiveWith: ["status"] },
+    ]);
+
+    expect(declaredForward).toEqual(declaredBackward);
+    expect(declaredForward["lastSeen"]).toEqual(["status"]);
+  });
+
+  test("declaring it on both sides is the same as declaring it on one", () => {
+    expect(
+      buildFacetConflictMap([
+        { key: "status", exclusiveWith: ["lastSeen"] },
+        { key: "lastSeen", exclusiveWith: ["status"] },
+      ]),
+    ).toEqual(
+      buildFacetConflictMap([
+        { key: "status", exclusiveWith: ["lastSeen"] },
+        { key: "lastSeen" },
+      ]),
+    );
+  });
+
+  test("a chip can conflict with more than one other", () => {
+    const map: FacetConflictMap = buildFacetConflictMap([
+      { key: "status", exclusiveWith: ["lastSeen", "firstSeen"] },
+      { key: "lastSeen" },
+      { key: "firstSeen" },
+    ]);
+
+    expect([...map["status"]!].sort()).toEqual(["firstSeen", "lastSeen"]);
+    expect(map["lastSeen"]).toEqual(["status"]);
+    expect(map["firstSeen"]).toEqual(["status"]);
+  });
+
+  test("chips that declare nothing are absent from the map", () => {
+    const map: FacetConflictMap = buildFacetConflictMap([
+      { key: "status", exclusiveWith: ["lastSeen"] },
+      { key: "lastSeen" },
+      { key: "site" },
+    ]);
+
+    expect(map["site"]).toBeUndefined();
+  });
+
+  test("no facets is no conflicts", () => {
+    expect(buildFacetConflictMap([])).toEqual({});
+  });
+
+  /*
+   * A chip excluded with itself would clear its own selection the instant the
+   * user made one — a chip that can never be set.
+   */
+  test("a facet cannot be exclusive with itself", () => {
+    expect(
+      buildFacetConflictMap([{ key: "status", exclusiveWith: ["status"] }]),
+    ).toEqual({});
+  });
+
+  /*
+   * A key nothing declares is a typo in a page's facet list. It costs nothing
+   * to carry — no chip answers to it — but it must not corrupt the real pair.
+   */
+  test("a key no facet claims does not disturb the rest", () => {
+    const map: FacetConflictMap = buildFacetConflictMap([
+      { key: "status", exclusiveWith: ["lastSeen", "typo"] },
+      { key: "lastSeen" },
+    ]);
+
+    expect(map["lastSeen"]).toEqual(["status"]);
+    expect([...map["status"]!].sort()).toEqual(["lastSeen", "typo"]);
+  });
+
+  test("a blank key is not a conflict", () => {
+    expect(
+      buildFacetConflictMap([
+        { key: "status", exclusiveWith: [""] },
+        { key: "", exclusiveWith: ["status"] },
+      ]),
+    ).toEqual({});
+  });
+
+  test("a repeated declaration does not repeat the entry", () => {
+    expect(
+      buildFacetConflictMap([
+        { key: "status", exclusiveWith: ["lastSeen", "lastSeen"] },
+        { key: "lastSeen", exclusiveWith: ["status"] },
+      ])["status"],
+    ).toEqual(["lastSeen"]);
+  });
+});

--- a/App/Tests/Dashboard/SummaryTileFilteringInvariants.test.ts
+++ b/App/Tests/Dashboard/SummaryTileFilteringInvariants.test.ts
@@ -790,32 +790,108 @@ describe("useResourceOwners exposes the chips a tile moves", () => {
    * the selection.
    */
   test("setFacetSelection writes the values and the operator together", () => {
-    expect(HOOK).toContain(
+    const body: string = HOOK.split("const setFacetSelection: (")[1]!.split(
+      "const clearAllFacets",
+    )[0]!;
+
+    expect(body).toContain(
       squash(
-        "const nextValues: Array<string> = normalizeFacetValues(values); const nextOperator: FilterOperator = resolveFacetOperator(operator);",
+        "const nextOperator: FilterOperator = resolveFacetOperator(operator);",
       ),
     );
-    expect(HOOK).toContain(
-      squash(
-        "setFacetSelections((prev: { [k: string]: Array<string> }) => { return { ...prev, [facetKey]: nextValues }; }); setFacetOperators((prev: { [k: string]: FilterOperator }) => { return { ...prev, [facetKey]: nextOperator }; });",
-      ),
+    /*
+     * One call carrying both. Two calls, one per piece, would leave a render in
+     * which the chip's values and its operator disagree — and that render is
+     * the one the merged query is built from.
+     */
+    expect(body).toContain(
+      squash("applyFacetChange(facetKey, nextValues, nextOperator);"),
     );
+    expect(body).not.toContain("setFacetSelections(");
+    expect(body).not.toContain("setFacetOperators(");
+  });
+
+  /*
+   * Every facet change goes through one function, so the rules below are
+   * enforced for the chips, the summary tiles and deep links alike rather than
+   * in whichever of them was written first.
+   */
+  test("the chips and the tiles write through the same function", () => {
+    for (const caller of [
+      // The tiles and deep links, via setFacetSelection.
+      squash("applyFacetChange(facetKey, nextValues, nextOperator);"),
+      // The date chip.
+      squash("applyFacetChange(facet.key, nextValues, nextOperator);"),
+      // The option chip's operator switcher and its option list.
+      squash("applyFacetChange(facet.key, selected, op);"),
+      squash(
+        'applyFacetChange( facet.key, nextValues, facetOperators[facet.key] || "is", );',
+      ),
+    ]) {
+      expect(HOOK).toContain(caller);
+    }
   });
 
   /*
    * Spreading the previous map is what makes chips layer: drilling into a
    * status must not throw away the site the user had already picked.
+   *
+   * The one exception is deliberate and declared. Two chips over the same
+   * column cannot both apply — the merged query has room for one constraint per
+   * field, so the later one silently replaces the earlier while both stay lit —
+   * so an activating chip clears the ones it names in `exclusiveWith`.
    */
-  test("it writes only its own facet's entry", () => {
-    const body: string = HOOK.split("const setFacetSelection: (")[1]!.split(
-      "const clearAllFacets",
+  test("it writes only its own facet's entry, and the ones declared exclusive with it", () => {
+    const body: string = HOOK.split("const applyFacetChange: (")[1]!.split(
+      "const setFacetSelection: (",
     )[0]!;
 
-    expect(body).toContain("{ ...prev, [facetKey]: nextValues }");
-    expect(body).toContain("{ ...prev, [facetKey]: nextOperator }");
+    expect(body).toContain("...prev,");
+    expect(body).toContain("[facetKey]: values,");
+    expect(body).toContain("[facetKey]: operator,");
+
     // Never a wholesale replacement — that would clear every other chip.
     expect(body).not.toContain("setFacetSelections({");
     expect(body).not.toContain("setFacetOperators({");
+
+    /*
+     * Other entries are touched only under `displaces`, and only for the keys
+     * the conflict map names — never for the whole selection.
+     */
+    expect(body).toContain("if (displaces) {");
+    expect(body).toContain("for (const other of conflicting) {");
+    expect(body).toContain("next[other] = [];");
+    expect(body).toContain('next[other] = "is";');
+  });
+
+  /*
+   * Clearing a chip, or leaving one mid-range, must not displace anything: the
+   * user backing out of one filter cannot silently discard another they set
+   * first.
+   */
+  test("only an active chip displaces the one it conflicts with", () => {
+    const body: string = HOOK.split("const applyFacetChange: (")[1]!.split(
+      "const setFacetSelection: (",
+    )[0]!;
+
+    expect(body).toContain(
+      squash(
+        "const displaces: boolean = conflicting.length > 0 && isFacetActive(facet, values, operator);",
+      ),
+    );
+  });
+
+  /*
+   * The conflict map is the shared, tested rule rather than something the hook
+   * works out inline — see FacetDateRange.test.ts for its behaviour. What has to
+   * hold here is that the hook uses it, over the facets the page passed.
+   */
+  test("the exclusion comes from the shared conflict map", () => {
+    expect(HOOK).toContain(
+      squash(
+        "const facetConflicts: FacetConflictMap = useMemo((): FacetConflictMap => { return buildFacetConflictMap(extraFacets); }, [extraFacets]);",
+      ),
+    );
   });
 
   /*


### PR DESCRIPTION
### Title of this pull request?

feat(facets): add a date-range chip, and give the device list its Last Seen filter back

### Small Description?

When the Status chip took ownership of `lastSeenAt` on the Network Devices table (#2932), the column-filter popup's **Last Seen At** entry had to go with it — `BaseModelTable` builds its request as `{...props.query, ...columnFilterQuery}`, so a popup filter on a chip's field replaces the chip's constraint *silently*, while the chip carries on claiming it applies.

That left the chip's three fixed buckets — Up / Down / Pending, against a 15-minute window — as the only thing the list could say about `lastSeenAt`. There was no longer any way to ask **"which devices haven't been polled since last Tuesday"** or **"which were polled between the 1st and the 5th"**.

Rather than reinstating the popup entry and making the two mutually exclusive, this adds a **date-range chip to the facet bar itself**, so the answer is a chip like every other filter on the list: visible, editable, shareable, and captured by a saved view.

#### The general part (benefits every faceted table)

- `ResourceFacet` gains `type: "dateRange"`. Its popover holds an operator plus one or two date inputs, producing `InBetween` / `GreaterThan` / `LessThan`.
- `FacetDateRange.ts` is the React-free contract — codec, activity rule, query builder — mirroring `Common/UI/Components/Filters/DateFilter.tsx` **operator for operator**, so the same picked dates keep returning the same rows. A link already pasted into a ticket does not get to change meaning.
- `FilterChipDateRange.tsx` shares the pill and popover styling with the existing chip via a new `FilterChipStyles.ts`, so a date chip reads as the same control over a different column rather than a different class of control.

#### Two design decisions worth a reviewer's attention

**A range is stored as ONE value** (`"<startISO>/<endISO>"`), not two array entries. The shared selection plumbing treats a facet's values as a *set*: `normalizeFacetValues` dedupes them and the single-select clamp truncates to the first. A two-entry "between the 1st and the 1st" would have collapsed to a single date and quietly stopped filtering; any restore would have kept only the start. ISO instants contain no slash, so the split is unambiguous.

**Two chips over one column.** Status and Last Seen both write `lastSeenAt`, and the merged query has room for one constraint per field — they do not AND, the later one just overwrites. `ResourceFacet.exclusiveWith` declares the conflict, and activating either chip clears the other, so the bar always shows the filter the table is actually running. `buildFacetConflictMap` reads it symmetrically: declaring it on one side is enough, **and** declaring it on one side only cannot half-work (a one-way map would clear the second chip when the first moved but not the reverse — leaving whichever the user reached for second to be the one silently overwritten, i.e. the exact bug the declaration exists to prevent).

The Last Seen chip offers `is` / `before` / `after` / `between` only. `is_empty` over `lastSeenAt` *is* Status = Pending in different words, and with the two chips mutually exclusive, picking it would clear Status for no visible reason. `is_not` has no honest single-field form over a nullable timestamp — SQL fails NULLs out of the comparison while the words suggest they're included.

A half-entered range is deliberately **not** a filter: unlit chip, unconstrained column, until both ends are in.

#### Two bugs found while testing

1. **`isFilterOperator` silently fell behind its own type.** It listed the four operators literally, so when the date operators were added TypeScript was happy — and a `between` arriving from a shared link was thrown away and replaced with `is`. Same chip, different filter, no error anywhere. Now derived from `FILTER_OPERATOR_LABELS`, so an operator the chip can print is one this accepts, by construction.
2. **`OneUptimeDate.fromString("0")` returns the year 2000**, via a lenient fallback to the browser's own parser. A junk facet value would have become a real filter and emptied the table under a date nobody picked. `toFacetDate` now requires a calendar date *before* it parses, rather than testing the result.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Verification run locally:**

- `App/Tests` — **2537 passed, 0 failed**. 13 suites fail to *load* on pre-existing environment issues unrelated to this change (uninstalled `@modelcontextprotocol/sdk`, a missing `@protobufjs/aspromise` transitive dep, and an `isolated-vm` native binary built against a different Node/V8).
- `tsc --noEmit` on `App/FeatureSet/Dashboard` — clean.
- `eslint` on every changed file — clean.

**Tests added:** `App/Tests/Dashboard/FacetDateRange.test.ts` (new, ~145 tests covering the codec round-trip, the activity rule, the query builder per operator, the conflict map, and the sanitizer) and ~40 added to `App/Tests/Dashboard/DeviceFacets.test.ts` for the Last Seen chip's contract.

**Tests changed, and why:** `DEVICE_FACET_QUERY_FIELDS` now deliberately maps two roles to one column, so "gives every chip a column of its own" became "…except the pair that is declared exclusive" — derived from the field map, so a *third* chip pointed at `lastSeenAt` still fails. Two source-text assertions in `SummaryTileFilteringInvariants.test.ts` moved with the refactor; the symmetry check there is now a real behavioural test against `buildFacetConflictMap` instead of a string match.

### Related Issue?

Follow-up to #2932, which introduced the facet bar and removed the Last Seen At popup filter.

### Screenshots (if appropriate):

None — the Dashboard needs the full stack (Postgres / Redis / ClickHouse / API) to run and the repo's only `launch.json` entry is the Home marketing site, so a local preview would not have exercised this. The page wiring is covered by the source-text invariant tests in `SummaryTileFilteringInvariants.test.ts`, which exist precisely because the App suite runs in a plain Node environment with no renderer.
