### PR TITLE
ci: supersede in-flight runs per branch/PR with concurrency groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,11 @@
 #
 name: "CodeQL"
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/common-jobs.yaml
+++ b/.github/workflows/common-jobs.yaml
@@ -1,5 +1,10 @@
 name: Common Jobs
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: 
   push:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,5 +1,10 @@
 name: Compile
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: 
   push:

--- a/.github/workflows/openapi-spec-generation.yml
+++ b/.github/workflows/openapi-spec-generation.yml
@@ -1,5 +1,10 @@
 name: OpenAPI Spec Generation
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: 
   push:

--- a/.github/workflows/terraform-provider-e2e.yml
+++ b/.github/workflows/terraform-provider-e2e.yml
@@ -1,5 +1,11 @@
 name: Terraform Provider E2E Tests
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
 permissions:
   contents: read
 

--- a/.github/workflows/terraform-provider-generation.yml
+++ b/.github/workflows/terraform-provider-generation.yml
@@ -1,5 +1,10 @@
 name: Terraform Provider Generation
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test.ai-agent.yaml
+++ b/.github/workflows/test.ai-agent.yaml
@@ -1,5 +1,10 @@
 name: AIAgent Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test.app.yaml
+++ b/.github/workflows/test.app.yaml
@@ -1,5 +1,10 @@
 name: App Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test.cli.yaml
+++ b/.github/workflows/test.cli.yaml
@@ -1,5 +1,10 @@
 name: CLI Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test.common.yaml
+++ b/.github/workflows/test.common.yaml
@@ -1,5 +1,10 @@
 name: Common Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: 
   push:

--- a/.github/workflows/test.mobile-app.yaml
+++ b/.github/workflows/test.mobile-app.yaml
@@ -1,5 +1,10 @@
 name: MobileApp Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test.probe.yaml
+++ b/.github/workflows/test.probe.yaml
@@ -1,5 +1,10 @@
 name: Probe Test
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: 
   push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,10 @@
 name: Tests
 
+# Supersede in-flight runs for the same branch/PR: only the newest commit needs CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: 
   push:


### PR DESCRIPTION
### Title of this pull request?

ci: supersede in-flight runs per branch/PR with concurrency groups

### Small Description?

Every CI workflow ran unbounded — each push to a branch queued a fresh set of jobs while the previous commit's jobs were still running. On a busy day that leaves hundreds of queued runs for commits nobody cares about anymore, starving the runner pool so CI for `master` HEAD and for the commits actually under review sits behind dead work. When I looked at the queue today, **115 of 141 active non-master runs belonged to branches whose PRs were already merged.**

This adds a per-workflow, per-branch/PR concurrency group with `cancel-in-progress` to the 14 CI workflows, so a new commit cancels the superseded run instead of queueing behind it:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

Workflows changed: `build.yml`, `codeql-analysis.yml`, `common-jobs.yaml`, `compile.yml`, `openapi-spec-generation.yml`, `terraform-provider-e2e.yml`, `terraform-provider-generation.yml`, and all seven `test.*` files.

**Deliberately left without a cancelling group:**

| Workflow | Why |
| --- | --- |
| `release.yml` | Publishes release images — cancelling mid-publish can leave a partial push to the registries. |
| `npm-audit-fix.yml` | Nightly cron that opens PRs; there is no "superseded" commit to cancel for. |
| `test-release.yaml` | Already has its own `test-release` group. |

### Reviewer notes

- The group key is scoped by `github.workflow`, so workflows never cancel each other — only same-workflow runs on the same branch/PR.
- `github.event.pull_request.number || github.ref` keeps `pull_request` runs keyed by PR number and `push` runs keyed by ref. A merge into `master` therefore cancels the previous `master` push run, which is the intended behaviour here.
- Cancelling a superseded run does not affect required checks: the run that reports status is the one for the newest commit, which is the commit being merged.
- All 17 workflow files were verified to still parse as valid YAML.
- **Known limitation, not addressed here:** these workflows trigger on both `pull_request` and unrestricted `push`, so every branch produces two full run sets (a single PR shows ~24 queued jobs instead of ~12). Those two events run on different refs and so land in different concurrency groups by design — concurrency cannot dedupe them. Narrowing `push:` to `branches: [master]` would halve CI load outright, but that is a behavioural change to when CI fires, so I left it for a separate discussion.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission? (YAML parse-checked all 17 workflow files)
- [ ] Did you write tests where appropriate? (n/a — CI configuration only)

### Related Issue?

None.

### Screenshots (if appropriate):

n/a — CI configuration only.