### PR TITLE
fix(network): make site assignment and label rules actually reach devices

### DIFF
--- a/App/FeatureSet/BrowserRecorder/package.json
+++ b/App/FeatureSet/BrowserRecorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneuptime/browser-recorder",
-  "version": "11.7.3",
+  "version": "11.7.4",
   "private": false,
   "description": "OneUptime session replay browser recorder. Shipped to third-party origins as an IIFE bundle.",
   "repository": {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LabelRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LabelRules.tsx
@@ -21,7 +21,7 @@ Network Device Label Rules attach labels to a network device automatically when 
 A rule matches a network device only when **all** specified criteria pass. Empty criteria are skipped.
 
 - **Network Device Labels** (prerequisite) — any-of
-- **Name / Description Pattern** — case-insensitive regex
+- **Name / Description Pattern** — case-insensitive regex, or a \`*\` wildcard pattern like \`*0664*\` (the same syntax Network Site assignment rules use). Whichever you write, the pattern has to match for the rule to fire.
 
 ### Action
 
@@ -138,10 +138,10 @@ const NetworkDeviceLabelRulesPage: FunctionComponent<
           stepId: "match-criteria",
           sectionTitle: "Match by Pattern",
           sectionDescription:
-            "Case-insensitive regex matched against the network device name and description.",
+            "Case-insensitive regex — or a '*' wildcard pattern such as *0664* — matched against the network device name and description.",
           fieldType: FormFieldSchemaType.Text,
           required: false,
-          placeholder: "core-switch-.*",
+          placeholder: "core-switch-.* or *0664*",
         },
         {
           field: { networkDeviceDescriptionPattern: true },

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/OwnerRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/OwnerRules.tsx
@@ -24,7 +24,7 @@ Network Device Owner Rules add owner users and teams to a network device automat
 A rule matches a network device only when **all** specified criteria pass. Empty criteria are skipped.
 
 - **Network Device Labels** — any-of (M2M)
-- **Name / Description Pattern** — case-insensitive regex
+- **Name / Description Pattern** — case-insensitive regex, or a \`*\` wildcard pattern like \`*0664*\` (the same syntax Network Site assignment rules use).
 
 ### Action
 
@@ -151,10 +151,10 @@ const NetworkDeviceOwnerRulesPage: FunctionComponent<
           stepId: "match-criteria",
           sectionTitle: "Match by Pattern",
           sectionDescription:
-            "Case-insensitive regex matched against the network device name and description.",
+            "Case-insensitive regex — or a '*' wildcard pattern such as *0664* — matched against the network device name and description.",
           fieldType: FormFieldSchemaType.Text,
           required: false,
-          placeholder: "core-switch-.*",
+          placeholder: "core-switch-.* or *0664*",
         },
         {
           field: { networkDeviceDescriptionPattern: true },

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/AssignmentRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/AssignmentRules.tsx
@@ -27,7 +27,7 @@ const NetworkSiteAssignmentRules: FunctionComponent<
         cardProps={{
           title: "Assignment Rules",
           description:
-            "Automatically assign discovered devices and endpoints to a site by subnet CIDR or hostname pattern. The higher priority number wins; ties are broken by the older rule. Rules apply to NEW or CHANGED devices only — existing devices are never retroactively reassigned.",
+            "Automatically assign discovered devices to a site by subnet CIDR or hostname pattern. The higher priority number wins; ties are broken by the older rule. Rules are evaluated when a device is created, when its hostname / name / SNMP system name changes, and on the next poll of any device that has no site yet. A device you assigned to a site by hand is never moved unless its identity changes.",
         }}
         noItemsMessage="No assignment rules yet. Add one to route newly discovered devices into the right site automatically."
         filters={[
@@ -93,7 +93,7 @@ const NetworkSiteAssignmentRules: FunctionComponent<
             },
             title: "Hostname Pattern",
             description:
-              "Devices with a hostname matching this wildcard pattern match.",
+              "Wildcard pattern ('*' matches any run of characters, case-insensitive). It is matched against the device's hostname, its SNMP system name and its display name — a match on any of them assigns the device. Example: *0664* matches UN0664LANSWI03.",
             fieldType: FormFieldSchemaType.Text,
             required: false,
             placeholder: "unit-1042-*",

--- a/Common/Models/DatabaseModels/NetworkDeviceLabelRule.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceLabelRule.ts
@@ -311,7 +311,7 @@ export default class NetworkDeviceLabelRule extends BaseModel {
     type: TableColumnType.LongText,
     title: "Network Device Name Pattern",
     description:
-      "Regex (case-insensitive) matched against the network device name. Leave empty to match any name.",
+      "Regex or * wildcard pattern (case-insensitive) matched against the network device name. Leave empty to match any name.",
   })
   @Column({
     type: ColumnType.LongText,
@@ -344,7 +344,7 @@ export default class NetworkDeviceLabelRule extends BaseModel {
     type: TableColumnType.LongText,
     title: "Network Device Description Pattern",
     description:
-      "Regex (case-insensitive) matched against the network device description. Leave empty to match any description.",
+      "Regex or * wildcard pattern (case-insensitive) matched against the network device description. Leave empty to match any description.",
   })
   @Column({
     type: ColumnType.LongText,

--- a/Common/Models/DatabaseModels/NetworkDeviceOwnerRule.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceOwnerRule.ts
@@ -347,7 +347,7 @@ export default class NetworkDeviceOwnerRule extends BaseModel {
     type: TableColumnType.LongText,
     title: "Network Device Name Pattern",
     description:
-      "Regex (case-insensitive) matched against the network device name. Leave empty to match any name.",
+      "Regex or * wildcard pattern (case-insensitive) matched against the network device name. Leave empty to match any name.",
   })
   @Column({
     type: ColumnType.LongText,
@@ -380,7 +380,7 @@ export default class NetworkDeviceOwnerRule extends BaseModel {
     type: TableColumnType.LongText,
     title: "Network Device Description Pattern",
     description:
-      "Regex (case-insensitive) matched against the network device description. Leave empty to match any description.",
+      "Regex or * wildcard pattern (case-insensitive) matched against the network device description. Leave empty to match any description.",
   })
   @Column({
     type: ColumnType.LongText,

--- a/Common/Models/DatabaseModels/NetworkSiteAssignmentRule.ts
+++ b/Common/Models/DatabaseModels/NetworkSiteAssignmentRule.ts
@@ -319,7 +319,7 @@ export default class NetworkSiteAssignmentRule extends BaseModel {
     canReadOnRelationQuery: true,
     title: "Hostname Pattern",
     description:
-      "Devices with a hostname matching this wildcard pattern are assigned to the site",
+      "Devices whose hostname, SNMP system name or display name matches this wildcard pattern are assigned to the site",
     example: "unit-1042-*",
   })
   @Column({

--- a/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
@@ -4,6 +4,7 @@ import NetworkDeviceLabelRule from "../../Models/DatabaseModels/NetworkDeviceLab
 import NetworkDeviceLabelRuleService from "./NetworkDeviceLabelRuleService";
 import NetworkDeviceService from "./NetworkDeviceService";
 import ObjectID from "../../Types/ObjectID";
+import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 
@@ -159,24 +160,18 @@ class NetworkDeviceLabelRuleEngineServiceClass {
 
     if (
       rule.networkDeviceNamePattern &&
-      (!networkDevice.name ||
-        !this.testRegex(
-          rule.networkDeviceNamePattern,
-          networkDevice.name,
-          rule,
-        ))
+      !this.testPattern(rule.networkDeviceNamePattern, networkDevice.name, rule)
     ) {
       return false;
     }
 
     if (
       rule.networkDeviceDescriptionPattern &&
-      (!networkDevice.description ||
-        !this.testRegex(
-          rule.networkDeviceDescriptionPattern,
-          networkDevice.description,
-          rule,
-        ))
+      !this.testPattern(
+        rule.networkDeviceDescriptionPattern,
+        networkDevice.description,
+        rule,
+      )
     ) {
       return false;
     }
@@ -184,20 +179,24 @@ class NetworkDeviceLabelRuleEngineServiceClass {
     return true;
   }
 
-  private testRegex(
+  /*
+   * Patterns are regexes, with a '*' wildcard fallback so the glob syntax the
+   * neighbouring site assignment rules use does not silently match nothing.
+   * See Common/Utils/Rules/RulePatternMatchUtil.
+   */
+  private testPattern(
     pattern: string,
-    value: string,
+    value: string | undefined,
     rule: NetworkDeviceLabelRule,
   ): boolean {
-    try {
-      const regex: RegExp = new RegExp(pattern, "i");
-      return regex.test(value);
-    } catch {
+    if (!RulePatternMatchUtil.isSupportedPattern(pattern)) {
       logger.warn(
-        `Invalid regex in network device label rule ${rule.id}: ${pattern}`,
+        `Invalid pattern in network device label rule ${rule.id}: ${pattern}. It is neither a valid regular expression nor a wildcard pattern, so it will never match.`,
       );
       return false;
     }
+
+    return RulePatternMatchUtil.matches(value, pattern);
   }
 }
 

--- a/Common/Server/Services/NetworkDeviceLabelRuleService.ts
+++ b/Common/Server/Services/NetworkDeviceLabelRuleService.ts
@@ -1,6 +1,11 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/NetworkDeviceLabelRule";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import NetworkDeviceRulePatternValidator from "../Utils/NetworkDevice/RulePatternValidator";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -8,6 +13,40 @@ export class Service extends DatabaseService<Model> {
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("createdAt", 3 * 365);
     }
+  }
+
+  /*
+   * A pattern that is neither a valid regex nor a wildcard can only ever
+   * match nothing, and the rule engine has no way to say so - it just quietly
+   * stops labelling. Reject it while the user is still looking at the form.
+   * See Common/Utils/Rules/RulePatternMatchUtil for the accepted syntaxes.
+   */
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    NetworkDeviceRulePatternValidator.validate({
+      namePattern: createBy.data.networkDeviceNamePattern,
+      descriptionPattern: createBy.data.networkDeviceDescriptionPattern,
+    });
+
+    return { createBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    NetworkDeviceRulePatternValidator.validate({
+      namePattern: (updateBy.data as any)["networkDeviceNamePattern"] as
+        | string
+        | undefined,
+      descriptionPattern: (updateBy.data as any)[
+        "networkDeviceDescriptionPattern"
+      ] as string | undefined,
+    });
+
+    return { updateBy, carryForward: null };
   }
 }
 

--- a/Common/Server/Services/NetworkDeviceOwnerRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceOwnerRuleEngineService.ts
@@ -8,6 +8,7 @@ import NetworkDeviceOwnerUserService from "./NetworkDeviceOwnerUserService";
 import NetworkDeviceOwnerTeamService from "./NetworkDeviceOwnerTeamService";
 import NetworkDeviceService from "./NetworkDeviceService";
 import ObjectID from "../../Types/ObjectID";
+import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
 
@@ -177,24 +178,18 @@ class NetworkDeviceOwnerRuleEngineServiceClass {
 
     if (
       rule.networkDeviceNamePattern &&
-      (!networkDevice.name ||
-        !this.testRegex(
-          rule.networkDeviceNamePattern,
-          networkDevice.name,
-          rule,
-        ))
+      !this.testPattern(rule.networkDeviceNamePattern, networkDevice.name, rule)
     ) {
       return false;
     }
 
     if (
       rule.networkDeviceDescriptionPattern &&
-      (!networkDevice.description ||
-        !this.testRegex(
-          rule.networkDeviceDescriptionPattern,
-          networkDevice.description,
-          rule,
-        ))
+      !this.testPattern(
+        rule.networkDeviceDescriptionPattern,
+        networkDevice.description,
+        rule,
+      )
     ) {
       return false;
     }
@@ -202,20 +197,24 @@ class NetworkDeviceOwnerRuleEngineServiceClass {
     return true;
   }
 
-  private testRegex(
+  /*
+   * Patterns are regexes, with a '*' wildcard fallback so the glob syntax the
+   * neighbouring site assignment rules use does not silently match nothing.
+   * See Common/Utils/Rules/RulePatternMatchUtil.
+   */
+  private testPattern(
     pattern: string,
-    value: string,
+    value: string | undefined,
     rule: NetworkDeviceOwnerRule,
   ): boolean {
-    try {
-      const regex: RegExp = new RegExp(pattern, "i");
-      return regex.test(value);
-    } catch {
+    if (!RulePatternMatchUtil.isSupportedPattern(pattern)) {
       logger.warn(
-        `Invalid regex in network device owner rule ${rule.id}: ${pattern}`,
+        `Invalid pattern in network device owner rule ${rule.id}: ${pattern}. It is neither a valid regular expression nor a wildcard pattern, so it will never match.`,
       );
       return false;
     }
+
+    return RulePatternMatchUtil.matches(value, pattern);
   }
 }
 

--- a/Common/Server/Services/NetworkDeviceOwnerRuleService.ts
+++ b/Common/Server/Services/NetworkDeviceOwnerRuleService.ts
@@ -1,6 +1,11 @@
 import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/NetworkDeviceOwnerRule";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import NetworkDeviceRulePatternValidator from "../Utils/NetworkDevice/RulePatternValidator";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -8,6 +13,38 @@ export class Service extends DatabaseService<Model> {
     if (IsBillingEnabled) {
       this.hardDeleteItemsOlderThanInDays("createdAt", 3 * 365);
     }
+  }
+
+  /*
+   * Same contract as NetworkDeviceLabelRuleService: a pattern that can never
+   * match is caught at write time rather than silently never adding owners.
+   */
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    NetworkDeviceRulePatternValidator.validate({
+      namePattern: createBy.data.networkDeviceNamePattern,
+      descriptionPattern: createBy.data.networkDeviceDescriptionPattern,
+    });
+
+    return { createBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    NetworkDeviceRulePatternValidator.validate({
+      namePattern: (updateBy.data as any)["networkDeviceNamePattern"] as
+        | string
+        | undefined,
+      descriptionPattern: (updateBy.data as any)[
+        "networkDeviceDescriptionPattern"
+      ] as string | undefined,
+    });
+
+    return { updateBy, carryForward: null };
   }
 }
 

--- a/Common/Server/Services/NetworkDeviceService.ts
+++ b/Common/Server/Services/NetworkDeviceService.ts
@@ -18,7 +18,55 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import CidrMatchUtil from "../../Utils/NetworkSite/CidrMatchUtil";
+import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import { EntityManager } from "typeorm";
+
+/*
+ * Columns a NetworkSiteAssignmentRule's hostname pattern is matched against.
+ * A write to any of them can change which rule wins for the device, so
+ * onUpdateSuccess re-evaluates the rules. `sysName` matters most in practice:
+ * a discovery import stores the responding IP in `hostname` and only the SNMP
+ * walk fills `sysName` in later, so a device's real identity usually lands
+ * AFTER creation.
+ */
+const SITE_RULE_IDENTITY_COLUMNS: Array<string> = [
+  "hostname",
+  "name",
+  "sysName",
+];
+
+/*
+ * Both spellings of "the device's site" in a write payload - see
+ * RelationIdUtil for why a hook has to watch for both.
+ */
+const SITE_KEYS: Array<string> = ["siteId", "site"];
+
+/*
+ * Null, undefined and "  Core-SW " all mean the same thing to a
+ * case-insensitive wildcard match, so compare identity values normalised -
+ * otherwise a no-op rewrite of sysName on every SNMP walk would look like a
+ * change and re-run the rules for the whole fleet every polling cycle.
+ */
+function normalizeIdentityValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value).trim().toLowerCase();
+}
+
+// True when the payload sets the device's site, under either spelling.
+function isSiteWrite(dataKeys: Array<string>): boolean {
+  return RelationIdUtil.isWritten(dataKeys, SITE_KEYS);
+}
+
+/*
+ * The site a payload moves the device to, or null when it clears the site (or
+ * carries no resolvable id).
+ */
+function readSiteIdFromData(data: Record<string, unknown>): ObjectID | null {
+  return RelationIdUtil.read(data, SITE_KEYS);
+}
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -88,9 +136,18 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeCreate(
     createBy: CreateBy<Model>,
   ): Promise<OnCreate<Model>> {
-    if (createBy.data.siteId) {
+    /*
+     * Read both spellings: the dashboard posts the `site` relation, not the
+     * `siteId` column, so guarding only `siteId` let a UI-created device
+     * point at another project's site.
+     */
+    const siteId: ObjectID | null = readSiteIdFromData(
+      createBy.data as unknown as Record<string, unknown>,
+    );
+
+    if (siteId) {
       await this.assertSiteBelongsToProject({
-        siteId: createBy.data.siteId,
+        siteId: siteId,
         projectId: createBy.data.projectId,
       });
     }
@@ -124,9 +181,16 @@ export class Service extends DatabaseService<Model> {
           );
         })
         .then(async () => {
-          if (createdItem.siteId) {
+          /*
+           * `site` (relation) or `siteId` (column) - a device created from
+           * the dashboard carries only the former.
+           */
+          const createdSiteId: ObjectID | null =
+            createdItem.siteId || createdItem.site?.id || null;
+
+          if (createdSiteId) {
             await NetworkSiteService.recomputeRollupForSiteAndAncestors(
-              createdItem.siteId,
+              createdSiteId,
             );
           } else {
             await this.applySiteAssignmentRulesToDevice(createdItem.id!);
@@ -146,9 +210,11 @@ export class Service extends DatabaseService<Model> {
   }
 
   /*
-   * Capture the previous site of every matched device when an update
-   * touches siteId, so onUpdateSuccess can refresh the OLD site's rollup
-   * as well as the new one.
+   * Capture the previous state of every matched device when an update
+   * touches siteId (so onUpdateSuccess can refresh the OLD site's rollup as
+   * well as the new one) or touches one of the columns site assignment rules
+   * match on (so onUpdateSuccess can tell a real rename from the identical
+   * sysName the SNMP walk rewrites on every poll).
    */
   @CaptureSpan()
   protected override async onBeforeUpdate(
@@ -156,7 +222,14 @@ export class Service extends DatabaseService<Model> {
   ): Promise<OnUpdate<Model>> {
     const dataKeys: Array<string> = Object.keys(updateBy.data || {});
 
-    if (!dataKeys.includes("siteId")) {
+    const isSiteChange: boolean = isSiteWrite(dataKeys);
+    const isIdentityChange: boolean = SITE_RULE_IDENTITY_COLUMNS.some(
+      (column: string) => {
+        return dataKeys.includes(column);
+      },
+    );
+
+    if (!isSiteChange && !isIdentityChange) {
       return { updateBy, carryForward: null };
     }
 
@@ -166,6 +239,9 @@ export class Service extends DatabaseService<Model> {
         _id: true,
         projectId: true,
         siteId: true,
+        hostname: true,
+        name: true,
+        sysName: true,
       },
       limit: LIMIT_MAX,
       skip: 0,
@@ -174,10 +250,11 @@ export class Service extends DatabaseService<Model> {
       },
     });
 
-    const newSiteIdValue: unknown = (updateBy.data as any)["siteId"];
+    const newSiteId: ObjectID | null = readSiteIdFromData(
+      updateBy.data as unknown as Record<string, unknown>,
+    );
 
-    if (newSiteIdValue) {
-      const newSiteId: ObjectID = new ObjectID(newSiteIdValue.toString());
+    if (newSiteId) {
       const checkedProjectIds: Set<string> = new Set();
 
       for (const previousDevice of previousDevices) {
@@ -216,7 +293,7 @@ export class Service extends DatabaseService<Model> {
     try {
       const dataKeys: Array<string> = Object.keys(onUpdate.updateBy.data || {});
 
-      if (dataKeys.includes("siteId")) {
+      if (isSiteWrite(dataKeys)) {
         // Manual or rule-driven site change: refresh old + new site chains.
         const affectedSiteIds: Map<string, ObjectID> = new Map();
 
@@ -250,23 +327,55 @@ export class Service extends DatabaseService<Model> {
           }
         }
 
-        const newSiteIdValue: unknown = (onUpdate.updateBy.data as any)[
-          "siteId"
-        ];
-        if (newSiteIdValue && updatedItemIds.length > 0) {
-          const newSiteId: ObjectID = new ObjectID(newSiteIdValue.toString());
+        const newSiteId: ObjectID | null = readSiteIdFromData(
+          onUpdate.updateBy.data as unknown as Record<string, unknown>,
+        );
+        if (newSiteId && updatedItemIds.length > 0) {
           affectedSiteIds.set(newSiteId.toString(), newSiteId);
         }
 
         for (const siteId of affectedSiteIds.values()) {
           await NetworkSiteService.recomputeRollupForSiteAndAncestors(siteId);
         }
-      } else if (dataKeys.includes("hostname")) {
+      } else if (
+        SITE_RULE_IDENTITY_COLUMNS.some((column: string) => {
+          return dataKeys.includes(column);
+        })
+      ) {
         /*
-         * The device's address changed, so subnet/hostname rules may now
-         * resolve differently — re-evaluate each updated device.
+         * The device's address or name changed, so subnet/hostname rules may
+         * now resolve differently — re-evaluate each updated device whose
+         * identity actually moved (or that has no site yet).
          */
+        const previousDevicesById: Map<string, Model> = new Map();
+
+        const previousDevices: Array<Model> =
+          (onUpdate.carryForward?.previousDevices as Array<Model>) || [];
+
+        for (const previousDevice of previousDevices) {
+          if (previousDevice.id) {
+            previousDevicesById.set(
+              previousDevice.id.toString(),
+              previousDevice,
+            );
+          }
+        }
+
         for (const deviceId of updatedItemIds) {
+          const previousDevice: Model | undefined = previousDevicesById.get(
+            deviceId.toString(),
+          );
+
+          if (
+            previousDevice &&
+            !this.shouldReapplySiteAssignmentRules(
+              previousDevice,
+              onUpdate.updateBy.data as Record<string, unknown>,
+            )
+          ) {
+            continue;
+          }
+
           await this.applySiteAssignmentRulesToDevice(deviceId);
         }
       }
@@ -277,6 +386,43 @@ export class Service extends DatabaseService<Model> {
     }
 
     return onUpdate;
+  }
+
+  /*
+   * True when an update that touched an identity column is worth re-running
+   * the assignment rules for.
+   *
+   * A device with no site is always re-evaluated: rules are usually written
+   * (or corrected) after the devices were imported, and the SNMP walk is the
+   * only thing that ever touches such a device again — without this, a
+   * matching rule would never reach it. Assigning a site to a device that has
+   * none cannot undo a human's choice.
+   *
+   * A device that already sits in a site is only re-evaluated when its
+   * identity really changed, so the sysName the walk rewrites verbatim every
+   * polling cycle does not keep dragging a manually placed device back to
+   * whatever a rule prefers.
+   */
+  private shouldReapplySiteAssignmentRules(
+    previousDevice: Model,
+    data: Record<string, unknown>,
+  ): boolean {
+    if (!previousDevice.siteId) {
+      return true;
+    }
+
+    const dataKeys: Array<string> = Object.keys(data || {});
+
+    return SITE_RULE_IDENTITY_COLUMNS.some((column: string) => {
+      if (!dataKeys.includes(column)) {
+        return false;
+      }
+
+      return (
+        normalizeIdentityValue(data[column]) !==
+        normalizeIdentityValue((previousDevice as any)[column])
+      );
+    });
   }
 
   /*
@@ -297,6 +443,7 @@ export class Service extends DatabaseService<Model> {
         siteId: true,
         hostname: true,
         sysName: true,
+        name: true,
       },
       props: {
         isRoot: true,
@@ -333,7 +480,10 @@ export class Service extends DatabaseService<Model> {
 
     /*
      * The device's hostname column stores an IP address or a DNS name; pass
-     * it as both — ipInCidr safely rejects non-IP strings.
+     * it as both — ipInCidr safely rejects non-IP strings. `name` is passed
+     * too because a discovery import puts the responding IP in `hostname`
+     * and the device's real identity in `name`, so a hostname pattern that
+     * only ever saw `hostname` could not match anything a user recognises.
      */
     const winner: NetworkSiteAssignmentRule | null = CidrMatchUtil.pickRule(
       rules,
@@ -341,6 +491,7 @@ export class Service extends DatabaseService<Model> {
         ip: device.hostname,
         hostname: device.hostname,
         sysName: device.sysName,
+        name: device.name,
       },
     );
 

--- a/Common/Server/Services/NetworkSiteAssignmentRuleService.ts
+++ b/Common/Server/Services/NetworkSiteAssignmentRuleService.ts
@@ -1,16 +1,71 @@
 import DatabaseService from "./DatabaseService";
+import NetworkSiteService from "./NetworkSiteService";
 import Model from "../../Models/DatabaseModels/NetworkSiteAssignmentRule";
+import NetworkSite from "../../Models/DatabaseModels/NetworkSite";
 import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import CreateBy from "../Types/Database/CreateBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
+import ObjectID from "../../Types/ObjectID";
 import CidrMatchUtil from "../../Utils/NetworkSite/CidrMatchUtil";
+import RelationIdUtil from "../Utils/Database/RelationIdUtil";
+
+/*
+ * The dashboard posts the `site` relation while server-side callers write the
+ * `siteId` column; read whichever is present. See RelationIdUtil.
+ */
+const SITE_KEYS: Array<string> = ["siteId", "site"];
+
+function readSiteId(data: Record<string, unknown>): ObjectID | null {
+  return RelationIdUtil.read(data, SITE_KEYS);
+}
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * The FK behind siteId only requires the NetworkSite row to exist, not that
+   * it belongs to the rule's project. A rule pointing at a foreign site is
+   * both a cross-tenant read (the rules table renders `site.name`) and a rule
+   * that can never assign anything - NetworkDeviceService's own tenancy guard
+   * rejects the resulting device update. Fail at write time instead, where
+   * the user can see it.
+   */
+  private async assertSiteBelongsToProject(data: {
+    siteId: ObjectID;
+    projectId: ObjectID | undefined;
+  }): Promise<void> {
+    if (!data.projectId) {
+      return;
+    }
+
+    const site: NetworkSite | null = await NetworkSiteService.findOneById({
+      id: data.siteId,
+      select: {
+        _id: true,
+        projectId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!site) {
+      throw new BadDataException("Network site not found.");
+    }
+
+    if (
+      site.projectId &&
+      site.projectId.toString() !== data.projectId.toString()
+    ) {
+      throw new BadDataException(
+        "Network site must belong to the same project.",
+      );
+    }
   }
 
   /*
@@ -26,6 +81,17 @@ export class Service extends DatabaseService<Model> {
       hostnamePattern: createBy.data.hostnamePattern,
     });
 
+    const siteId: ObjectID | null = readSiteId(
+      createBy.data as unknown as Record<string, unknown>,
+    );
+
+    if (siteId) {
+      await this.assertSiteBelongsToProject({
+        siteId: siteId,
+        projectId: createBy.data.projectId,
+      });
+    }
+
     return { createBy, carryForward: null };
   }
 
@@ -35,10 +101,14 @@ export class Service extends DatabaseService<Model> {
   ): Promise<OnUpdate<Model>> {
     const dataKeys: Array<string> = Object.keys(updateBy.data || {});
 
-    if (
-      !dataKeys.includes("subnetCidr") &&
-      !dataKeys.includes("hostnamePattern")
-    ) {
+    const isCriteriaChange: boolean =
+      dataKeys.includes("subnetCidr") || dataKeys.includes("hostnamePattern");
+
+    const newSiteId: ObjectID | null = readSiteId(
+      updateBy.data as unknown as Record<string, unknown>,
+    );
+
+    if (!isCriteriaChange && !newSiteId) {
       return { updateBy, carryForward: null };
     }
 
@@ -50,6 +120,7 @@ export class Service extends DatabaseService<Model> {
       query: updateBy.query,
       select: {
         _id: true,
+        projectId: true,
         subnetCidr: true,
         hostnamePattern: true,
       },
@@ -61,14 +132,23 @@ export class Service extends DatabaseService<Model> {
     });
 
     for (const existingRule of existingRules) {
-      this.validateCriteria({
-        subnetCidr: dataKeys.includes("subnetCidr")
-          ? ((updateBy.data as any)["subnetCidr"] as string | null)
-          : existingRule.subnetCidr,
-        hostnamePattern: dataKeys.includes("hostnamePattern")
-          ? ((updateBy.data as any)["hostnamePattern"] as string | null)
-          : existingRule.hostnamePattern,
-      });
+      if (isCriteriaChange) {
+        this.validateCriteria({
+          subnetCidr: dataKeys.includes("subnetCidr")
+            ? ((updateBy.data as any)["subnetCidr"] as string | null)
+            : existingRule.subnetCidr,
+          hostnamePattern: dataKeys.includes("hostnamePattern")
+            ? ((updateBy.data as any)["hostnamePattern"] as string | null)
+            : existingRule.hostnamePattern,
+        });
+      }
+
+      if (newSiteId) {
+        await this.assertSiteBelongsToProject({
+          siteId: newSiteId,
+          projectId: existingRule.projectId,
+        });
+      }
     }
 
     return { updateBy, carryForward: null };

--- a/Common/Server/Services/NetworkSiteService.ts
+++ b/Common/Server/Services/NetworkSiteService.ts
@@ -34,11 +34,21 @@ import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import Text from "../../Types/Text";
 import { Raw } from "typeorm";
+import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import MaterializedPathUtil from "../../Utils/NetworkSite/MaterializedPathUtil";
 import SiteStatusRollupUtil, {
   DeviceHealthState,
   RollupStatusOption,
 } from "../../Utils/NetworkSite/SiteStatusRollupUtil";
+
+/*
+ * Both spellings of "this site's parent" in a write payload: the dashboard's
+ * site form posts the `parentSite` relation while server-side callers write
+ * the `parentSiteId` column. Watching only the column let a re-parent done
+ * from the UI skip cycle detection, the same-project guard and the subtree
+ * path rebase entirely. See RelationIdUtil.
+ */
+const PARENT_SITE_KEYS: Array<string> = ["parentSiteId", "parentSite"];
 
 /*
  * Carried from onBeforeUpdate to onUpdateSuccess when an update touches
@@ -152,9 +162,18 @@ export class Service extends DatabaseService<Model> {
   ): Promise<OnCreate<Model>> {
     let parentPath: string | null = null;
 
-    if (createBy.data.parentSiteId) {
+    /*
+     * Both spellings: the dashboard's site form posts the `parentSite`
+     * relation, not the `parentSiteId` column. See RelationIdUtil.
+     */
+    const parentSiteId: ObjectID | null = RelationIdUtil.read(
+      createBy.data as unknown as Record<string, unknown>,
+      PARENT_SITE_KEYS,
+    );
+
+    if (parentSiteId) {
       const parent: Model | null = await this.findOneById({
-        id: createBy.data.parentSiteId,
+        id: parentSiteId,
         select: {
           _id: true,
           projectId: true,
@@ -178,9 +197,7 @@ export class Service extends DatabaseService<Model> {
         );
       }
 
-      parentPath = await this.getMaterializedPathForSite(
-        createBy.data.parentSiteId,
-      );
+      parentPath = await this.getMaterializedPathForSite(parentSiteId);
     }
 
     return {
@@ -228,14 +245,14 @@ export class Service extends DatabaseService<Model> {
   ): Promise<OnUpdate<Model>> {
     const dataKeys: Array<string> = Object.keys(updateBy.data || {});
 
-    if (!dataKeys.includes("parentSiteId")) {
+    if (!RelationIdUtil.isWritten(dataKeys, PARENT_SITE_KEYS)) {
       return { updateBy, carryForward: null };
     }
 
-    const newParentIdValue: unknown = (updateBy.data as any)["parentSiteId"];
-    const newParentId: ObjectID | null = newParentIdValue
-      ? new ObjectID(newParentIdValue.toString())
-      : null;
+    const newParentId: ObjectID | null = RelationIdUtil.read(
+      updateBy.data as unknown as Record<string, unknown>,
+      PARENT_SITE_KEYS,
+    );
 
     const previousItems: Array<Model> = await this.findBy({
       query: this.scopeQueryToCallerTenant(updateBy.query, updateBy.props),

--- a/Common/Server/Utils/Database/RelationIdUtil.ts
+++ b/Common/Server/Utils/Database/RelationIdUtil.ts
@@ -1,0 +1,68 @@
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * A many-to-one reference reaches a service hook under TWO different keys.
+ *
+ * The dashboard's forms post the RELATION object - `{ site: { _id: "..." } }`
+ * - because DatabaseBaseModel.toJSONObject serialises the entity column it
+ * was given (Common/Models/DatabaseModels/DatabaseBaseModel/
+ * DatabaseBaseModel.ts) and BaseAPI passes that body through to the service
+ * verbatim. Server-side callers, by contrast, write the FK column
+ * (`{ siteId: ... }`). onBeforeUpdate/onUpdateSuccess run BEFORE TypeORM
+ * resolves one into the other, so a hook that inspects only one spelling
+ * silently ignores every write made through the other - which is how a site
+ * picked in the UI could skip its tenancy check and its rollup refresh
+ * (OneUptime/oneuptime#2940).
+ *
+ * Give these helpers both spellings, FK column first.
+ */
+export default class RelationIdUtil {
+  // True when the payload writes the reference under any of `keys`.
+  public static isWritten(
+    dataKeys: Array<string>,
+    keys: Array<string>,
+  ): boolean {
+    return keys.some((key: string) => {
+      return dataKeys.includes(key);
+    });
+  }
+
+  /*
+   * The id the payload points the reference at, or null when it clears the
+   * reference (or carries nothing resolvable). Accepts an ObjectID, a plain
+   * id string, or a serialised relation carrying `_id` / `id`.
+   */
+  public static read(
+    data: Record<string, unknown> | undefined | null,
+    keys: Array<string>,
+  ): ObjectID | null {
+    for (const key of keys) {
+      const value: unknown = (data || {})[key];
+
+      if (!value) {
+        continue;
+      }
+
+      if (value instanceof ObjectID) {
+        return value;
+      }
+
+      if (typeof value === "string") {
+        return new ObjectID(value);
+      }
+
+      const relation: { _id?: unknown; id?: unknown } = value as {
+        _id?: unknown;
+        id?: unknown;
+      };
+
+      const relationId: unknown = relation._id || relation.id;
+
+      if (relationId) {
+        return new ObjectID(relationId.toString());
+      }
+    }
+
+    return null;
+  }
+}

--- a/Common/Server/Utils/NetworkDevice/RulePatternValidator.ts
+++ b/Common/Server/Utils/NetworkDevice/RulePatternValidator.ts
@@ -1,0 +1,44 @@
+import BadDataException from "../../../Types/Exception/BadDataException";
+import RulePatternMatchUtil from "../../../Utils/Rules/RulePatternMatchUtil";
+
+/*
+ * Write-time validation for the name / description patterns on network device
+ * label and owner rules.
+ *
+ * The rule engines accept a case-insensitive regex or a '*' wildcard glob.
+ * Anything else - `switch-(01`, `[unclosed` - compiles to nothing and matches
+ * nothing, and the engine can only log about it long after the user left the
+ * form. Reject it at the write instead (OneUptime/oneuptime#2940).
+ */
+export default class NetworkDeviceRulePatternValidator {
+  public static validate(data: {
+    namePattern?: string | null | undefined;
+    descriptionPattern?: string | null | undefined;
+  }): void {
+    NetworkDeviceRulePatternValidator.validateOne(
+      "Network Device Name Pattern",
+      data.namePattern,
+    );
+    NetworkDeviceRulePatternValidator.validateOne(
+      "Network Device Description Pattern",
+      data.descriptionPattern,
+    );
+  }
+
+  private static validateOne(
+    title: string,
+    pattern: string | null | undefined,
+  ): void {
+    if (!pattern) {
+      return;
+    }
+
+    if (RulePatternMatchUtil.isSupportedPattern(pattern)) {
+      return;
+    }
+
+    throw new BadDataException(
+      `${title} "${pattern}" is not a valid regular expression, and contains no '*' wildcard to fall back on, so it would never match a network device. Use a regex such as core-switch-.* or a wildcard such as *0664*.`,
+    );
+  }
+}

--- a/Common/Tests/Server/Services/NetworkDeviceRuleEngines.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceRuleEngines.test.ts
@@ -1,0 +1,726 @@
+import NetworkDeviceLabelRuleEngineService from "../../../Server/Services/NetworkDeviceLabelRuleEngineService";
+import NetworkDeviceLabelRuleService from "../../../Server/Services/NetworkDeviceLabelRuleService";
+import NetworkDeviceOwnerRuleEngineService from "../../../Server/Services/NetworkDeviceOwnerRuleEngineService";
+import NetworkDeviceOwnerRuleService from "../../../Server/Services/NetworkDeviceOwnerRuleService";
+import NetworkDeviceOwnerTeamService from "../../../Server/Services/NetworkDeviceOwnerTeamService";
+import NetworkDeviceOwnerUserService from "../../../Server/Services/NetworkDeviceOwnerUserService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import Label from "../../../Models/DatabaseModels/Label";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceLabelRule from "../../../Models/DatabaseModels/NetworkDeviceLabelRule";
+import NetworkDeviceOwnerRule from "../../../Models/DatabaseModels/NetworkDeviceOwnerRule";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { describe, expect, it, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - the network device label and owner rule engines, and
+ * the write-time validation in front of them.
+ *
+ * The pattern criteria are documented as case-insensitive regexes, but the
+ * assignment rules right next to them in Network > Automation take '*'
+ * wildcard globs. A rule written with the glob syntax - `*0664*` - used to
+ * throw inside `new RegExp`, get swallowed, and silently label nothing
+ * (OneUptime/oneuptime#2940). Both engines now accept either syntax, and a
+ * pattern that can satisfy neither is rejected at the write.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const DEVICE_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const LABEL_A_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const LABEL_B_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PREREQUISITE_LABEL_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const USER_ID: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+const TEAM_ID: ObjectID = new ObjectID("66666666-6666-4666-8666-666666666666");
+
+function fakeLabel(id: ObjectID): Label {
+  return { id: id, _id: id.toString() } as unknown as Label;
+}
+
+// The device as onCreateSuccess hands it to an engine: ids only.
+function ruleTarget(): NetworkDevice {
+  return {
+    id: DEVICE_ID,
+    _id: DEVICE_ID.toString(),
+    projectId: PROJECT_ID,
+  } as unknown as NetworkDevice;
+}
+
+/*
+ * The row the engine re-reads for the match. A discovery-imported device
+ * carries the SNMP identity in `name` and the responding IP in `hostname`.
+ */
+function fakeDeviceDetails(overrides: Record<string, unknown>): NetworkDevice {
+  return {
+    id: DEVICE_ID,
+    _id: DEVICE_ID.toString(),
+    projectId: PROJECT_ID,
+    name: "UN0664LANSWI03",
+    ...overrides,
+  } as unknown as NetworkDevice;
+}
+
+function fakeLabelRule(data: Record<string, unknown>): NetworkDeviceLabelRule {
+  return {
+    id: new ObjectID("77777777-7777-4777-8777-777777777777"),
+    labelsToAdd: [fakeLabel(LABEL_A_ID)],
+    ...data,
+  } as unknown as NetworkDeviceLabelRule;
+}
+
+function fakeOwnerRule(data: Record<string, unknown>): NetworkDeviceOwnerRule {
+  return {
+    id: new ObjectID("88888888-8888-4888-8888-888888888888"),
+    ownerUsers: [{ id: USER_ID } as unknown as Label],
+    ownerTeams: [],
+    ...data,
+  } as unknown as NetworkDeviceOwnerRule;
+}
+
+/*
+ * The label engine attaches through the relation query builder rather than a
+ * model write, so the assertion surface is the `.add(ids)` call at the end of
+ * that chain.
+ */
+function mockLabelAttach(): jest.Mock {
+  const addSpy: jest.Mock = jest.fn().mockResolvedValue(undefined);
+
+  jest.spyOn(NetworkDeviceService, "getRepository").mockReturnValue({
+    createQueryBuilder: (): any => {
+      return {
+        relation: (): any => {
+          return {
+            of: (): any => {
+              return { add: addSpy };
+            },
+          };
+        },
+      };
+    },
+  } as any);
+
+  return addSpy;
+}
+
+describe("NetworkDeviceLabelRuleEngineService - wildcard patterns", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The reported bug, end to end: an enabled rule with the glob the user
+   * typed, against the device the dashboard showed them.
+   */
+  it("attaches labels for the *0664* pattern from issue #2940", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    expect(addSpy.mock.calls[0]![0]).toEqual([LABEL_A_ID.toString()]);
+  });
+
+  it("does not attach labels to a device the pattern does not match", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(
+        fakeDeviceDetails({ name: "UN0661LANSWI03", labels: [] }),
+      );
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("still honours a plain regex pattern", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "un0664.*swi03" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches a wildcard description pattern", async () => {
+    jest.spyOn(NetworkDeviceLabelRuleService, "findBy").mockResolvedValue([
+      fakeLabelRule({
+        networkDeviceDescriptionPattern: "*IOS-XE*",
+      }),
+    ]);
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(
+      fakeDeviceDetails({
+        description: "Cisco IOS-XE Software, Catalyst L3 Switch",
+        labels: [],
+      }),
+    );
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires every configured pattern to match", async () => {
+    jest.spyOn(NetworkDeviceLabelRuleService, "findBy").mockResolvedValue([
+      fakeLabelRule({
+        networkDeviceNamePattern: "*0664*",
+        networkDeviceDescriptionPattern: "*IOS-XE*",
+      }),
+    ]);
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(
+      fakeDeviceDetails({
+        description: "Juniper JUNOS",
+        labels: [],
+      }),
+    );
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("cannot match a pattern against a device with no name", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ name: undefined, labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A pattern that is neither a regex nor a glob cannot match anything. It
+   * must not match everything either, and it must not throw out of the
+   * engine.
+   */
+  it("never matches - and never throws on - an unparseable pattern", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "switch-(01" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await expect(
+      NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+        ruleTarget(),
+      ),
+    ).resolves.toBeUndefined();
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a whitespace-only pattern as no criterion at all", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([fakeLabelRule({ networkDeviceNamePattern: "   " })]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("NetworkDeviceLabelRuleEngineService - rule selection and attach", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("only ever evaluates enabled rules from the device's project", async () => {
+    const rulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([]);
+    const deviceSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "findOneById",
+    );
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    const query: any = rulesSpy.mock.calls[0]![0].query;
+    expect(query.isEnabled).toBe(true);
+    expect(query.projectId.toString()).toBe(PROJECT_ID.toString());
+    // No rules means no reason to re-read the device.
+    expect(deviceSpy).not.toHaveBeenCalled();
+  });
+
+  it("unions the labels of every matching rule", async () => {
+    jest.spyOn(NetworkDeviceLabelRuleService, "findBy").mockResolvedValue([
+      fakeLabelRule({
+        networkDeviceNamePattern: "*0664*",
+        labelsToAdd: [fakeLabel(LABEL_A_ID)],
+      }),
+      fakeLabelRule({
+        networkDeviceNamePattern: "*LANSWI*",
+        labelsToAdd: [fakeLabel(LABEL_B_ID)],
+      }),
+      fakeLabelRule({
+        networkDeviceNamePattern: "*NOMATCH*",
+        labelsToAdd: [fakeLabel(PREREQUISITE_LABEL_ID)],
+      }),
+    ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy.mock.calls[0]![0].sort()).toEqual(
+      [LABEL_A_ID.toString(), LABEL_B_ID.toString()].sort(),
+    );
+  });
+
+  it("skips labels the device already carries", async () => {
+    jest.spyOn(NetworkDeviceLabelRuleService, "findBy").mockResolvedValue([
+      fakeLabelRule({
+        networkDeviceNamePattern: "*0664*",
+        labelsToAdd: [fakeLabel(LABEL_A_ID), fakeLabel(LABEL_B_ID)],
+      }),
+    ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(
+        fakeDeviceDetails({ labels: [fakeLabel(LABEL_A_ID)] }),
+      );
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy.mock.calls[0]![0]).toEqual([LABEL_B_ID.toString()]);
+  });
+
+  it("writes nothing when every matched label is already attached", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(
+        fakeDeviceDetails({ labels: [fakeLabel(LABEL_A_ID)] }),
+      );
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("honours the 'device already has one of these labels' prerequisite", async () => {
+    jest.spyOn(NetworkDeviceLabelRuleService, "findBy").mockResolvedValue([
+      fakeLabelRule({
+        networkDeviceLabels: [fakeLabel(PREREQUISITE_LABEL_ID)],
+        networkDeviceNamePattern: "*0664*",
+      }),
+    ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it("fires once the prerequisite label is present", async () => {
+    jest.spyOn(NetworkDeviceLabelRuleService, "findBy").mockResolvedValue([
+      fakeLabelRule({
+        networkDeviceLabels: [fakeLabel(PREREQUISITE_LABEL_ID)],
+        networkDeviceNamePattern: "*0664*",
+      }),
+    ]);
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(
+      fakeDeviceDetails({
+        labels: [fakeLabel(PREREQUISITE_LABEL_ID)],
+      }),
+    );
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * The owner engine runs next in the same chain and matches on labels, so
+   * the labels this engine just attached have to be visible on the in-memory
+   * device it was handed.
+   */
+  it("syncs the attached labels onto the passed device", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    mockLabelAttach();
+
+    const device: NetworkDevice = ruleTarget();
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(device);
+
+    expect(
+      (device.labels || []).map((label: Label) => {
+        return label.id?.toString();
+      }),
+    ).toEqual([LABEL_A_ID.toString()]);
+  });
+
+  it("does nothing for a device with no id or no project", async () => {
+    const rulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceLabelRuleService,
+      "findBy",
+    );
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice({
+      projectId: PROJECT_ID,
+    } as unknown as NetworkDevice);
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice({
+      id: DEVICE_ID,
+    } as unknown as NetworkDevice);
+
+    expect(rulesSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the device row has gone", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockResolvedValue([
+        fakeLabelRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(null);
+    const addSpy: jest.Mock = mockLabelAttach();
+
+    await NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  // A labelling failure must never break the device create it rides on.
+  it("swallows a lookup failure instead of propagating it", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleService, "findBy")
+      .mockRejectedValue(new Error("database is down"));
+
+    await expect(
+      NetworkDeviceLabelRuleEngineService.applyRulesToNetworkDevice(
+        ruleTarget(),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("NetworkDeviceOwnerRuleEngineService - wildcard patterns", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("adds owners for a *0664* pattern", async () => {
+    jest
+      .spyOn(NetworkDeviceOwnerRuleService, "findBy")
+      .mockResolvedValue([
+        fakeOwnerRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const createUserSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceOwnerUserService, "create")
+      .mockResolvedValue(undefined as never);
+
+    await NetworkDeviceOwnerRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(createUserSpy).toHaveBeenCalledTimes(1);
+    expect(createUserSpy.mock.calls[0]![0].data.userId.toString()).toBe(
+      USER_ID.toString(),
+    );
+  });
+
+  it("adds owner teams too", async () => {
+    jest.spyOn(NetworkDeviceOwnerRuleService, "findBy").mockResolvedValue([
+      fakeOwnerRule({
+        networkDeviceNamePattern: "*0664*",
+        ownerUsers: [],
+        ownerTeams: [{ id: TEAM_ID } as unknown as Label],
+      }),
+    ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const createTeamSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceOwnerTeamService, "create")
+      .mockResolvedValue(undefined as never);
+
+    await NetworkDeviceOwnerRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(createTeamSpy).toHaveBeenCalledTimes(1);
+    expect(createTeamSpy.mock.calls[0]![0].data.teamId.toString()).toBe(
+      TEAM_ID.toString(),
+    );
+  });
+
+  it("marks silently-added owners as already notified", async () => {
+    jest.spyOn(NetworkDeviceOwnerRuleService, "findBy").mockResolvedValue([
+      fakeOwnerRule({
+        networkDeviceNamePattern: "*0664*",
+        notifyOwners: false,
+      }),
+    ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const createUserSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceOwnerUserService, "create")
+      .mockResolvedValue(undefined as never);
+
+    await NetworkDeviceOwnerRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(createUserSpy.mock.calls[0]![0].data.isOwnerNotified).toBe(true);
+  });
+
+  it("does not add owners when the pattern does not match", async () => {
+    jest
+      .spyOn(NetworkDeviceOwnerRuleService, "findBy")
+      .mockResolvedValue([
+        fakeOwnerRule({ networkDeviceNamePattern: "*0664*" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(
+        fakeDeviceDetails({ name: "UN0661LANSWI03", labels: [] }),
+      );
+    const createUserSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceOwnerUserService,
+      "create",
+    );
+
+    await NetworkDeviceOwnerRuleEngineService.applyRulesToNetworkDevice(
+      ruleTarget(),
+    );
+
+    expect(createUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("never matches - and never throws on - an unparseable pattern", async () => {
+    jest
+      .spyOn(NetworkDeviceOwnerRuleService, "findBy")
+      .mockResolvedValue([
+        fakeOwnerRule({ networkDeviceNamePattern: "switch-(01" }),
+      ]);
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDeviceDetails({ labels: [] }));
+    const createUserSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceOwnerUserService,
+      "create",
+    );
+
+    await expect(
+      NetworkDeviceOwnerRuleEngineService.applyRulesToNetworkDevice(
+        ruleTarget(),
+      ),
+    ).resolves.toBeUndefined();
+    expect(createUserSpy).not.toHaveBeenCalled();
+  });
+
+  it("swallows a lookup failure instead of propagating it", async () => {
+    jest
+      .spyOn(NetworkDeviceOwnerRuleService, "findBy")
+      .mockRejectedValue(new Error("database is down"));
+
+    await expect(
+      NetworkDeviceOwnerRuleEngineService.applyRulesToNetworkDevice(
+        ruleTarget(),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+/*
+ * Write-time validation. The engines are forgiving, but a pattern neither
+ * reading can rescue is a typo that would fail silently forever - so it is
+ * refused where the user can still see the form.
+ */
+describe("Network device rule pattern validation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function labelRuleCreate(
+    data: Record<string, unknown>,
+  ): CreateBy<NetworkDeviceLabelRule> {
+    return {
+      data: data,
+      props: { tenantId: PROJECT_ID },
+    } as unknown as CreateBy<NetworkDeviceLabelRule>;
+  }
+
+  it("accepts a wildcard name pattern", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeCreate(
+        labelRuleCreate({ networkDeviceNamePattern: "*0664*" }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("accepts a regex name pattern", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeCreate(
+        labelRuleCreate({ networkDeviceNamePattern: "core-switch-.*" }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("accepts a rule with no pattern at all", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeCreate(
+        labelRuleCreate({ name: "Tag everything" }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects a name pattern that can never match", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeCreate(
+        labelRuleCreate({ networkDeviceNamePattern: "switch-(01" }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a description pattern that can never match", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeCreate(
+        labelRuleCreate({ networkDeviceDescriptionPattern: "[unclosed" }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("names the offending field in the error", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeCreate(
+        labelRuleCreate({ networkDeviceNamePattern: "switch-(01" }),
+      ),
+    ).rejects.toThrow(/Network Device Name Pattern/);
+  });
+
+  it("rejects a bad pattern on update as well as on create", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeUpdate({
+        query: {},
+        data: { networkDeviceNamePattern: "+bad" },
+        props: { tenantId: PROJECT_ID },
+      } as unknown as UpdateBy<NetworkDeviceLabelRule>),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("lets an unrelated update through", async () => {
+    await expect(
+      (NetworkDeviceLabelRuleService as any).onBeforeUpdate({
+        query: {},
+        data: { isEnabled: false },
+        props: { tenantId: PROJECT_ID },
+      } as unknown as UpdateBy<NetworkDeviceLabelRule>),
+    ).resolves.toBeDefined();
+  });
+
+  it("applies the same validation to owner rules", async () => {
+    await expect(
+      (NetworkDeviceOwnerRuleService as any).onBeforeCreate({
+        data: { networkDeviceNamePattern: "switch-(01" },
+        props: { tenantId: PROJECT_ID },
+      } as unknown as CreateBy<NetworkDeviceOwnerRule>),
+    ).rejects.toThrow(BadDataException);
+
+    await expect(
+      (NetworkDeviceOwnerRuleService as any).onBeforeCreate({
+        data: { networkDeviceNamePattern: "*0664*" },
+        props: { tenantId: PROJECT_ID },
+      } as unknown as CreateBy<NetworkDeviceOwnerRule>),
+    ).resolves.toBeDefined();
+  });
+});

--- a/Common/Tests/Server/Services/NetworkDeviceSiteAssignment.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceSiteAssignment.test.ts
@@ -1,3 +1,5 @@
+import NetworkDeviceLabelRuleEngineService from "../../../Server/Services/NetworkDeviceLabelRuleEngineService";
+import NetworkDeviceOwnerRuleEngineService from "../../../Server/Services/NetworkDeviceOwnerRuleEngineService";
 import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
 import NetworkSiteAssignmentRuleService from "../../../Server/Services/NetworkSiteAssignmentRuleService";
 import NetworkSiteService from "../../../Server/Services/NetworkSiteService";
@@ -14,11 +16,17 @@ import { describe, expect, it, afterEach } from "@jest/globals";
  * Contract under test - the device side of site auto-assignment:
  *
  *   - applySiteAssignmentRulesToDevice picks the highest-priority matching
- *     rule against the device's hostname (which may be an IP) / sysName and
- *     assigns via updateOneById so the update hooks refresh rollups,
- *   - onUpdateSuccess recomputes BOTH the old and the new site chain when
- *     siteId changes, re-evaluates rules when hostname changes, and never
- *     lets a rollup failure escape (device updates must not break).
+ *     rule against the device's hostname (which may be an IP), SNMP sysName
+ *     and display name, and assigns via updateOneById so the update hooks
+ *     refresh rollups,
+ *   - onUpdateSuccess recomputes BOTH the old and the new site chain when the
+ *     site changes - under either the `siteId` column or the `site` relation
+ *     the dashboard actually posts,
+ *   - onUpdateSuccess re-evaluates the rules when an identity column
+ *     (hostname / name / sysName) really changes value, or when the device
+ *     has no site yet, and NOT when the SNMP walk rewrites the same sysName
+ *     on a device someone placed by hand,
+ *   - and never lets a rollup failure escape (device updates must not break).
  */
 
 const PROJECT_ID: ObjectID = new ObjectID(
@@ -180,6 +188,116 @@ describe("NetworkDeviceService.applySiteAssignmentRulesToDevice", () => {
 
     expect(rulesSpy).not.toHaveBeenCalled();
   });
+
+  /*
+   * Verbatim reproduction of OneUptime/oneuptime#2940: the devices were
+   * imported from a discovery scan, so `hostname` is the responding IP and
+   * the string the user recognises ("UN0664LANSWI03") lives in `name`. The
+   * rule they wrote is `*0664*` at priority 1.
+   */
+  it("assigns a discovery-imported device whose NAME matches the pattern", async () => {
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(
+      fakeDevice({
+        hostname: "10.242.170.222",
+        name: "UN0664LANSWI03",
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([
+        fakeRule({ siteId: SITE_A_ID, hostnamePattern: "*0664*", priority: 1 }),
+      ]);
+    const updateSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    await NetworkDeviceService.applySiteAssignmentRulesToDevice(DEVICE_ID);
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy.mock.calls[0]![0].data.siteId.toString()).toBe(
+      SITE_A_ID.toString(),
+    );
+  });
+
+  it("does not assign a device whose name does not match the pattern", async () => {
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(
+      fakeDevice({
+        hostname: "10.242.167.10",
+        name: "UN0661LANSWI03",
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([
+        fakeRule({ siteId: SITE_A_ID, hostnamePattern: "*0664*", priority: 1 }),
+      ]);
+    const updateSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "updateOneById",
+    );
+
+    await NetworkDeviceService.applySiteAssignmentRulesToDevice(DEVICE_ID);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  // The name is useless to the matcher if the read never fetches it.
+  it("selects every column the matcher reads", async () => {
+    const findOneByIdSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDevice({ hostname: "10.0.5.9" }));
+    jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([]);
+
+    await NetworkDeviceService.applySiteAssignmentRulesToDevice(DEVICE_ID);
+
+    const select: any = findOneByIdSpy.mock.calls[0]![0].select;
+    expect(select.name).toBe(true);
+    expect(select.hostname).toBe(true);
+    expect(select.sysName).toBe(true);
+    expect(select.siteId).toBe(true);
+    expect(select.projectId).toBe(true);
+  });
+
+  it("scopes the rule lookup to the device's own project", async () => {
+    jest
+      .spyOn(NetworkDeviceService, "findOneById")
+      .mockResolvedValue(fakeDevice({ hostname: "10.0.5.9" }));
+    const rulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([]);
+
+    await NetworkDeviceService.applySiteAssignmentRulesToDevice(DEVICE_ID);
+
+    expect(rulesSpy.mock.calls[0]![0].query.projectId.toString()).toBe(
+      PROJECT_ID.toString(),
+    );
+  });
+
+  it("prefers the sysName match when hostname is an IP", async () => {
+    jest.spyOn(NetworkDeviceService, "findOneById").mockResolvedValue(
+      fakeDevice({
+        hostname: "10.242.170.222",
+        name: "10.242.170.222",
+        sysName: "UN0664LANSWI03",
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([
+        fakeRule({ siteId: SITE_B_ID, hostnamePattern: "*0664*" }),
+      ]);
+    const updateSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    await NetworkDeviceService.applySiteAssignmentRulesToDevice(DEVICE_ID);
+
+    expect(updateSpy.mock.calls[0]![0].data.siteId.toString()).toBe(
+      SITE_B_ID.toString(),
+    );
+  });
 });
 
 describe("NetworkDeviceService.onUpdateSuccess (site maintenance)", () => {
@@ -275,7 +393,220 @@ describe("NetworkDeviceService.onUpdateSuccess (site maintenance)", () => {
     );
   });
 
-  it("does nothing for updates that touch neither siteId nor hostname", async () => {
+  /*
+   * The SNMP walk is what finally gives a discovery-imported device its
+   * identity: at import time sysName is empty, and NetworkInventoryUtil
+   * writes it on the first successful poll. Before this, nothing re-ran the
+   * rules for that write, so the device stayed site-less forever
+   * (OneUptime/oneuptime#2940).
+   */
+  it("re-evaluates assignment rules when the SNMP walk first writes sysName", async () => {
+    const applyRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { sysName: "UN0664LANSWI03", lastSeenAt: new Date() },
+        previousDevices: [fakeDevice({ siteId: SITE_A_ID })],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-evaluates assignment rules when the device is renamed", async () => {
+    const applyRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { name: "UN0664LANSWI03" },
+        previousDevices: [fakeDevice({ siteId: SITE_A_ID, name: "sw-01" })],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * The walk rewrites the SAME sysName every polling cycle. Re-running the
+   * rules on each of those would drag a device someone deliberately placed in
+   * another site back to whatever a rule prefers, every few minutes.
+   */
+  it("does NOT re-evaluate when the walk rewrites an unchanged sysName on a placed device", async () => {
+    const applyRulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "applySiteAssignmentRulesToDevice",
+    );
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { sysName: "UN0664LANSWI03", lastSeenAt: new Date() },
+        previousDevices: [
+          fakeDevice({ siteId: SITE_A_ID, sysName: "UN0664LANSWI03" }),
+        ],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a case-only or whitespace-only rewrite as unchanged", async () => {
+    const applyRulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "applySiteAssignmentRulesToDevice",
+    );
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { sysName: "  un0664lanswi03 " },
+        previousDevices: [
+          fakeDevice({ siteId: SITE_A_ID, sysName: "UN0664LANSWI03" }),
+        ],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The self-healing half: a device with no site cannot have its site
+   * "clobbered", so an unchanged identity write is still worth a rule pass.
+   * This is what eventually assigns devices that were imported before the
+   * rule existed - on their next poll.
+   */
+  it("DOES re-evaluate an unchanged identity write when the device has no site", async () => {
+    const applyRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { sysName: "UN0664LANSWI03" },
+        previousDevices: [fakeDevice({ sysName: "UN0664LANSWI03" })],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-evaluates when no previous snapshot is available for a device", async () => {
+    const applyRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { sysName: "UN0664LANSWI03" },
+        previousDevices: [],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-evaluates only the devices whose identity actually moved", async () => {
+    const OTHER_DEVICE_ID: ObjectID = new ObjectID(
+      "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    );
+
+    const applyRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      {
+        updateBy: {
+          query: {},
+          data: { sysName: "renamed-switch" },
+          props: { isRoot: true },
+        } as unknown as UpdateBy<NetworkDevice>,
+        carryForward: {
+          previousDevices: [
+            fakeDevice({ siteId: SITE_A_ID, sysName: "renamed-switch" }),
+            {
+              id: OTHER_DEVICE_ID,
+              _id: OTHER_DEVICE_ID.toString(),
+              projectId: PROJECT_ID,
+              siteId: SITE_A_ID,
+              sysName: "old-name",
+            } as unknown as NetworkDevice,
+          ],
+        },
+      },
+      [DEVICE_ID, OTHER_DEVICE_ID],
+    );
+
+    expect(applyRulesSpy).toHaveBeenCalledTimes(1);
+    expect(applyRulesSpy.mock.calls[0]![0].toString()).toBe(
+      OTHER_DEVICE_ID.toString(),
+    );
+  });
+
+  /*
+   * The dashboard's device form posts the `site` RELATION plus every other
+   * field on the form (name, hostname, ...). Reading only `siteId` meant a
+   * site picked by hand refreshed no rollups AND fell through to the rule
+   * re-evaluation branch, which promptly overwrote the user's choice.
+   */
+  it("treats the dashboard's `site` relation key as a site change", async () => {
+    const rollupSpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+      .mockResolvedValue(undefined as never);
+    const applyRulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "applySiteAssignmentRulesToDevice",
+    );
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: {
+          name: "Core Switch",
+          hostname: "10.242.170.222",
+          site: { _id: SITE_B_ID.toString() },
+        },
+        previousDevices: [fakeDevice({ siteId: SITE_A_ID })],
+      }),
+      [DEVICE_ID],
+    );
+
+    const rollupIds: Array<string> = rollupSpy.mock.calls.map(
+      (call: Array<any>) => {
+        return call[0].toString();
+      },
+    );
+    expect(rollupIds.sort()).toEqual(
+      [SITE_A_ID.toString(), SITE_B_ID.toString()].sort(),
+    );
+    expect(applyRulesSpy).not.toHaveBeenCalled();
+  });
+
+  it("recomputes the old site when the `site` relation is cleared", async () => {
+    const rollupSpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onUpdateSuccess(
+      makeOnUpdate({
+        data: { site: null },
+        previousDevices: [fakeDevice({ siteId: SITE_A_ID })],
+      }),
+      [DEVICE_ID],
+    );
+
+    expect(rollupSpy).toHaveBeenCalledTimes(1);
+    expect(rollupSpy.mock.calls[0]![0].toString()).toBe(SITE_A_ID.toString());
+  });
+
+  it("does nothing for updates that touch neither the site nor an identity column", async () => {
     const rollupSpy: jest.SpyInstance = jest.spyOn(
       NetworkSiteService,
       "recomputeRollupForSiteAndAncestors",
@@ -286,7 +617,7 @@ describe("NetworkDeviceService.onUpdateSuccess (site maintenance)", () => {
     );
 
     await (NetworkDeviceService as any).onUpdateSuccess(
-      makeOnUpdate({ data: { name: "renamed" } }),
+      makeOnUpdate({ data: { pollingIntervalInMinutes: 10 } }),
       [DEVICE_ID],
     );
 
@@ -339,7 +670,7 @@ describe("NetworkDeviceService.onBeforeUpdate (previous-site capture)", () => {
     expect(result.carryForward.previousDevices).toHaveLength(1);
   });
 
-  it("skips the fetch for updates that do not touch siteId", async () => {
+  it("skips the fetch for updates that touch neither the site nor an identity column", async () => {
     const findBySpy: jest.SpyInstance = jest.spyOn(
       NetworkDeviceService,
       "findBy",
@@ -349,12 +680,75 @@ describe("NetworkDeviceService.onBeforeUpdate (previous-site capture)", () => {
       NetworkDeviceService as any
     ).onBeforeUpdate({
       query: { _id: DEVICE_ID.toString() },
-      data: { name: "renamed" },
+      data: { pollingIntervalInMinutes: 10 },
       props: { isRoot: true },
     } as unknown as UpdateBy<NetworkDevice>);
 
     expect(findBySpy).not.toHaveBeenCalled();
     expect(result.carryForward).toBeNull();
+  });
+
+  it("captures previous devices when an identity column is updated", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockResolvedValue([
+        fakeDevice({ siteId: SITE_A_ID, sysName: "old-name" }),
+      ]);
+
+    const result: OnUpdate<NetworkDevice> = await (
+      NetworkDeviceService as any
+    ).onBeforeUpdate({
+      query: { _id: DEVICE_ID.toString() },
+      data: { sysName: "UN0664LANSWI03" },
+      props: { isRoot: true },
+    } as unknown as UpdateBy<NetworkDevice>);
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(result.carryForward.previousDevices).toHaveLength(1);
+  });
+
+  /*
+   * onUpdateSuccess compares the previous identity values against the
+   * payload, so the snapshot has to carry them.
+   */
+  it("selects the identity columns onUpdateSuccess needs to compare", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockResolvedValue([]);
+
+    await (NetworkDeviceService as any).onBeforeUpdate({
+      query: { _id: DEVICE_ID.toString() },
+      data: { name: "renamed" },
+      props: { isRoot: true },
+    } as unknown as UpdateBy<NetworkDevice>);
+
+    const select: any = findBySpy.mock.calls[0]![0].select;
+    expect(select.name).toBe(true);
+    expect(select.hostname).toBe(true);
+    expect(select.sysName).toBe(true);
+    expect(select.siteId).toBe(true);
+  });
+
+  it("captures previous devices for the dashboard's `site` relation key", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockResolvedValue([fakeDevice({ siteId: SITE_A_ID })]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue({
+      id: SITE_B_ID,
+      _id: SITE_B_ID.toString(),
+      projectId: PROJECT_ID,
+    } as unknown as NetworkSite);
+
+    const result: OnUpdate<NetworkDevice> = await (
+      NetworkDeviceService as any
+    ).onBeforeUpdate({
+      query: { _id: DEVICE_ID.toString() },
+      data: { site: { _id: SITE_B_ID.toString() } },
+      props: { isRoot: true },
+    } as unknown as UpdateBy<NetworkDevice>);
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(result.carryForward.previousDevices).toHaveLength(1);
   });
 });
 
@@ -426,6 +820,39 @@ describe("NetworkDeviceService site tenancy guard", () => {
     expect(result.carryForward).toBeNull();
   });
 
+  it("onBeforeCreate rejects a foreign site given as the `site` relation", async () => {
+    jest
+      .spyOn(NetworkSiteService, "findOneById")
+      .mockResolvedValue(fakeSite(OTHER_PROJECT_ID));
+
+    await expect(
+      (NetworkDeviceService as any).onBeforeCreate({
+        data: {
+          projectId: PROJECT_ID,
+          site: { _id: SITE_B_ID.toString() },
+        },
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("onBeforeUpdate rejects a foreign site given as the `site` relation", async () => {
+    jest
+      .spyOn(NetworkDeviceService, "findBy")
+      .mockResolvedValue([fakeDevice({ siteId: SITE_A_ID })]);
+    jest
+      .spyOn(NetworkSiteService, "findOneById")
+      .mockResolvedValue(fakeSite(OTHER_PROJECT_ID));
+
+    await expect(
+      (NetworkDeviceService as any).onBeforeUpdate({
+        query: { _id: DEVICE_ID.toString() },
+        data: { site: { _id: SITE_B_ID.toString() } },
+        props: { tenantId: PROJECT_ID },
+      } as unknown as UpdateBy<NetworkDevice>),
+    ).rejects.toThrow(BadDataException);
+  });
+
   it("onBeforeUpdate rejects moving a device into another project's site", async () => {
     jest
       .spyOn(NetworkDeviceService, "findBy")
@@ -480,5 +907,139 @@ describe("NetworkDeviceService site tenancy guard", () => {
     );
 
     expect(rollupSpy).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * The create-side chain: label rules, then owner rules, then either a rollup
+ * refresh (the device was created straight into a site) or a rule pass. It is
+ * detached from the create response on purpose - a rule failure must never
+ * fail the device write - so the tests drain the microtask queue.
+ */
+describe("NetworkDeviceService.onCreateSuccess (rule chain)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function flushDetachedChain(): Promise<void> {
+    await new Promise((resolve: (value: unknown) => void) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  it("applies label rules, owner rules and site assignment to a new device", async () => {
+    const labelSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceLabelRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    const ownerSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceOwnerRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    const applyRulesSpy: jest.SpyInstance = jest
+      .spyOn(NetworkDeviceService, "applySiteAssignmentRulesToDevice")
+      .mockResolvedValue(undefined as never);
+
+    await (NetworkDeviceService as any).onCreateSuccess(
+      { createBy: { data: {}, props: {} }, carryForward: null },
+      fakeDevice({ hostname: "10.242.170.222", name: "UN0664LANSWI03" }),
+    );
+    await flushDetachedChain();
+
+    expect(labelSpy).toHaveBeenCalledTimes(1);
+    expect(ownerSpy).toHaveBeenCalledTimes(1);
+    expect(applyRulesSpy).toHaveBeenCalledTimes(1);
+    expect(applyRulesSpy.mock.calls[0]![0].toString()).toBe(
+      DEVICE_ID.toString(),
+    );
+  });
+
+  it("refreshes the rollup instead when the device was created into a site", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(NetworkDeviceOwnerRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    const rollupSpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+      .mockResolvedValue(undefined as never);
+    const applyRulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "applySiteAssignmentRulesToDevice",
+    );
+
+    await (NetworkDeviceService as any).onCreateSuccess(
+      { createBy: { data: {}, props: {} }, carryForward: null },
+      fakeDevice({ siteId: SITE_A_ID }),
+    );
+    await flushDetachedChain();
+
+    expect(rollupSpy).toHaveBeenCalledTimes(1);
+    expect(rollupSpy.mock.calls[0]![0].toString()).toBe(SITE_A_ID.toString());
+    expect(applyRulesSpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * A device created from the dashboard carries the `site` relation and no
+   * `siteId`; reading only the column made the chain run the assignment rules
+   * over a device the user had just placed by hand.
+   */
+  it("recognises a site given as the `site` relation on the created device", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(NetworkDeviceOwnerRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+    const rollupSpy: jest.SpyInstance = jest
+      .spyOn(NetworkSiteService, "recomputeRollupForSiteAndAncestors")
+      .mockResolvedValue(undefined as never);
+    const applyRulesSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceService,
+      "applySiteAssignmentRulesToDevice",
+    );
+
+    await (NetworkDeviceService as any).onCreateSuccess(
+      { createBy: { data: {}, props: {} }, carryForward: null },
+      fakeDevice({ site: { id: SITE_A_ID } }),
+    );
+    await flushDetachedChain();
+
+    expect(rollupSpy).toHaveBeenCalledTimes(1);
+    expect(rollupSpy.mock.calls[0]![0].toString()).toBe(SITE_A_ID.toString());
+    expect(applyRulesSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the created device and never throws when a rule engine fails", async () => {
+    jest
+      .spyOn(NetworkDeviceLabelRuleEngineService, "applyRulesToNetworkDevice")
+      .mockRejectedValue(new Error("label engine exploded"));
+    jest
+      .spyOn(NetworkDeviceOwnerRuleEngineService, "applyRulesToNetworkDevice")
+      .mockResolvedValue(undefined as never);
+
+    const created: NetworkDevice = await (
+      NetworkDeviceService as any
+    ).onCreateSuccess(
+      { createBy: { data: {}, props: {} }, carryForward: null },
+      fakeDevice({ hostname: "10.0.0.1" }),
+    );
+    await flushDetachedChain();
+
+    expect(created.id!.toString()).toBe(DEVICE_ID.toString());
+  });
+
+  it("does nothing for a device with no project", async () => {
+    const labelSpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceLabelRuleEngineService,
+      "applyRulesToNetworkDevice",
+    );
+
+    await (NetworkDeviceService as any).onCreateSuccess(
+      { createBy: { data: {}, props: {} }, carryForward: null },
+      { id: DEVICE_ID, _id: DEVICE_ID.toString() } as unknown as NetworkDevice,
+    );
+    await flushDetachedChain();
+
+    expect(labelSpy).not.toHaveBeenCalled();
   });
 });

--- a/Common/Tests/Server/Services/NetworkSiteAssignmentRuleService.test.ts
+++ b/Common/Tests/Server/Services/NetworkSiteAssignmentRuleService.test.ts
@@ -1,4 +1,6 @@
 import NetworkSiteAssignmentRuleService from "../../../Server/Services/NetworkSiteAssignmentRuleService";
+import NetworkSiteService from "../../../Server/Services/NetworkSiteService";
+import NetworkSite from "../../../Models/DatabaseModels/NetworkSite";
 import NetworkSiteAssignmentRule from "../../../Models/DatabaseModels/NetworkSiteAssignmentRule";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
@@ -11,12 +13,29 @@ import { describe, expect, it, afterEach } from "@jest/globals";
  * one usable criterion (subnetCidr or hostnamePattern), and a provided CIDR
  * must be well-formed - on create AND on any update, including updates that
  * clear one criterion while the other only exists on the stored row.
+ *
+ * Plus the site the rule points at must belong to the rule's own project,
+ * under either spelling of the reference: the dashboard's form posts the
+ * `site` relation, not the `siteId` column. A rule aimed at a foreign site
+ * renders that site's name in the rules table and can never assign anything,
+ * because NetworkDeviceService rejects the device update it would drive.
  */
 
 const PROJECT_ID: ObjectID = new ObjectID(
   "22222222-2222-4222-8222-222222222222",
 );
 const SITE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+function mockSiteInProject(projectId: ObjectID): jest.SpyInstance {
+  return jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue({
+    id: SITE_ID,
+    _id: SITE_ID.toString(),
+    projectId: projectId,
+  } as unknown as NetworkSite);
+}
 
 function makeCreateBy(data: {
   subnetCidr?: string | undefined;
@@ -72,6 +91,8 @@ describe("NetworkSiteAssignmentRuleService.onBeforeCreate", () => {
   });
 
   it("accepts a CIDR-only rule", async () => {
+    mockSiteInProject(PROJECT_ID);
+
     await expect(
       (NetworkSiteAssignmentRuleService as any).onBeforeCreate(
         makeCreateBy({ subnetCidr: "10.0.0.0/24" }),
@@ -80,11 +101,53 @@ describe("NetworkSiteAssignmentRuleService.onBeforeCreate", () => {
   });
 
   it("accepts a hostname-pattern-only rule", async () => {
+    mockSiteInProject(PROJECT_ID);
+
     await expect(
       (NetworkSiteAssignmentRuleService as any).onBeforeCreate(
         makeCreateBy({ hostnamePattern: "unit-*" }),
       ),
     ).resolves.toBeDefined();
+  });
+
+  it("rejects a rule that points at another project's site", async () => {
+    mockSiteInProject(OTHER_PROJECT_ID);
+
+    await expect(
+      (NetworkSiteAssignmentRuleService as any).onBeforeCreate(
+        makeCreateBy({ hostnamePattern: "unit-*" }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a rule whose site does not resolve to a row", async () => {
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(null);
+
+    await expect(
+      (NetworkSiteAssignmentRuleService as any).onBeforeCreate(
+        makeCreateBy({ hostnamePattern: "unit-*" }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  /*
+   * The dashboard posts `{ site: { _id } }`; a guard that reads only `siteId`
+   * would wave this straight through.
+   */
+  it("checks the site given as the dashboard's `site` relation", async () => {
+    mockSiteInProject(OTHER_PROJECT_ID);
+
+    const rule: NetworkSiteAssignmentRule = new NetworkSiteAssignmentRule();
+    rule.projectId = PROJECT_ID;
+    rule.hostnamePattern = "unit-*";
+    (rule as any).site = { _id: SITE_ID.toString() };
+
+    await expect(
+      (NetworkSiteAssignmentRuleService as any).onBeforeCreate({
+        data: rule,
+        props: { isRoot: true },
+      }),
+    ).rejects.toThrow(BadDataException);
   });
 });
 
@@ -168,7 +231,7 @@ describe("NetworkSiteAssignmentRuleService.onBeforeUpdate", () => {
     ).resolves.toBeDefined();
   });
 
-  it("skips validation entirely when neither criterion is touched", async () => {
+  it("skips validation entirely when neither criterion nor site is touched", async () => {
     const findBySpy: jest.SpyInstance = jest.spyOn(
       NetworkSiteAssignmentRuleService,
       "findBy",
@@ -181,5 +244,35 @@ describe("NetworkSiteAssignmentRuleService.onBeforeUpdate", () => {
     ).resolves.toBeDefined();
 
     expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects re-pointing a rule at another project's site", async () => {
+    jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([
+        { projectId: PROJECT_ID } as unknown as NetworkSiteAssignmentRule,
+      ]);
+    mockSiteInProject(OTHER_PROJECT_ID);
+
+    await expect(
+      (NetworkSiteAssignmentRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ site: { _id: SITE_ID.toString() } }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("accepts re-pointing a rule at a site in its own project", async () => {
+    jest
+      .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+      .mockResolvedValue([
+        { projectId: PROJECT_ID } as unknown as NetworkSiteAssignmentRule,
+      ]);
+    mockSiteInProject(PROJECT_ID);
+
+    await expect(
+      (NetworkSiteAssignmentRuleService as any).onBeforeUpdate(
+        makeUpdateBy({ siteId: SITE_ID }),
+      ),
+    ).resolves.toBeDefined();
   });
 });

--- a/Common/Tests/Server/Services/NetworkSiteService.test.ts
+++ b/Common/Tests/Server/Services/NetworkSiteService.test.ts
@@ -505,6 +505,71 @@ describe("NetworkSiteService.onBeforeUpdate (cycle rejection)", () => {
     expect(findOneByIdSpy).not.toHaveBeenCalled();
   });
 
+  /*
+   * The dashboard's site form posts the `parentSite` RELATION, not the
+   * `parentSiteId` column. A hook that watched only the column let a
+   * re-parent done from the UI skip cycle detection, the same-project guard
+   * and the subtree path rebase entirely - see RelationIdUtil.
+   */
+  it("rejects a cycle introduced through the `parentSite` relation key", async () => {
+    const childId: ObjectID = new ObjectID(
+      "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    );
+
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValue([
+        fakeSite({ materializedPath: `/${SITE_ID.toString()}/` }),
+      ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: childId,
+        _id: childId.toString(),
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${SITE_ID.toString()}/${childId.toString()}/`);
+
+    await expect(
+      (NetworkSiteService as any).onBeforeUpdate({
+        query: { _id: SITE_ID.toString() },
+        data: { parentSite: { _id: childId.toString() } },
+        props: { isRoot: true },
+      } as unknown as UpdateBy<NetworkSite>),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("carries a legal move made through the `parentSite` relation key", async () => {
+    jest
+      .spyOn(NetworkSiteService, "findBy")
+      .mockResolvedValue([
+        fakeSite({ materializedPath: `/${SITE_ID.toString()}/` }),
+      ]);
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+      }),
+    );
+    jest
+      .spyOn(NetworkSiteService, "getMaterializedPathForSite")
+      .mockResolvedValue(`/${PARENT_SITE_ID.toString()}/`);
+
+    const result: any = await (NetworkSiteService as any).onBeforeUpdate({
+      query: { _id: SITE_ID.toString() },
+      data: { parentSite: { _id: PARENT_SITE_ID.toString() } },
+      props: { isRoot: true },
+    } as unknown as UpdateBy<NetworkSite>);
+
+    expect(result.carryForward.newParentId.toString()).toBe(
+      PARENT_SITE_ID.toString(),
+    );
+    expect(result.carryForward.newParentPath).toBe(
+      `/${PARENT_SITE_ID.toString()}/`,
+    );
+  });
+
   it("does nothing when the update does not touch parentSiteId", async () => {
     const findBySpy: jest.SpyInstance = jest.spyOn(
       NetworkSiteService,
@@ -631,6 +696,26 @@ describe("NetworkSiteService.onBeforeCreate (cross-project parent guard)", () =>
         data: {
           projectId: PROJECT_ID,
           parentSiteId: PARENT_SITE_ID,
+        },
+        props: { tenantId: PROJECT_ID },
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a foreign parent given as the `parentSite` relation", async () => {
+    jest.spyOn(NetworkSiteService, "findOneById").mockResolvedValue(
+      fakeSite({
+        id: PARENT_SITE_ID,
+        _id: PARENT_SITE_ID.toString(),
+        projectId: OTHER_PROJECT_ID,
+      }),
+    );
+
+    await expect(
+      (NetworkSiteService as any).onBeforeCreate({
+        data: {
+          projectId: PROJECT_ID,
+          parentSite: { _id: PARENT_SITE_ID.toString() },
         },
         props: { tenantId: PROJECT_ID },
       }),

--- a/Common/Tests/Server/Utils/Database/RelationIdUtil.test.ts
+++ b/Common/Tests/Server/Utils/Database/RelationIdUtil.test.ts
@@ -1,0 +1,120 @@
+import RelationIdUtil from "../../../../Server/Utils/Database/RelationIdUtil";
+import ObjectID from "../../../../Types/ObjectID";
+
+/*
+ * Contract under test: a many-to-one reference reaches a service hook under
+ * two spellings - the FK column (`siteId`, written by server-side callers)
+ * and the serialised relation (`site`, which is what the dashboard's forms
+ * post). Hooks that watched only one of them silently ignored every write
+ * made through the other (OneUptime/oneuptime#2940).
+ */
+
+const SITE_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const OTHER_SITE_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const SITE_KEYS: Array<string> = ["siteId", "site"];
+
+describe("RelationIdUtil.isWritten", () => {
+  it("sees the FK column", () => {
+    expect(RelationIdUtil.isWritten(["siteId", "name"], SITE_KEYS)).toBe(true);
+  });
+
+  it("sees the relation key", () => {
+    expect(RelationIdUtil.isWritten(["site", "name"], SITE_KEYS)).toBe(true);
+  });
+
+  it("sees a key even when its value clears the reference", () => {
+    expect(RelationIdUtil.isWritten(["site"], SITE_KEYS)).toBe(true);
+  });
+
+  it("ignores payloads that touch neither", () => {
+    expect(
+      RelationIdUtil.isWritten(["name", "hostname", "sysName"], SITE_KEYS),
+    ).toBe(false);
+    expect(RelationIdUtil.isWritten([], SITE_KEYS)).toBe(false);
+  });
+
+  it("does not match a similarly named key", () => {
+    expect(RelationIdUtil.isWritten(["parentSiteId"], SITE_KEYS)).toBe(false);
+  });
+});
+
+describe("RelationIdUtil.read", () => {
+  it("reads an ObjectID from the FK column", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { siteId: SITE_ID },
+      SITE_KEYS,
+    );
+    expect(id?.toString()).toBe(SITE_ID.toString());
+  });
+
+  it("reads a plain id string from the FK column", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { siteId: SITE_ID.toString() },
+      SITE_KEYS,
+    );
+    expect(id?.toString()).toBe(SITE_ID.toString());
+  });
+
+  it("reads _id out of a serialised relation", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { site: { _id: SITE_ID.toString(), name: "WB Unit 0664" } },
+      SITE_KEYS,
+    );
+    expect(id?.toString()).toBe(SITE_ID.toString());
+  });
+
+  it("reads id out of a hydrated relation", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { site: { id: SITE_ID } },
+      SITE_KEYS,
+    );
+    expect(id?.toString()).toBe(SITE_ID.toString());
+  });
+
+  it("prefers the FK column when a payload carries both", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { siteId: SITE_ID, site: { _id: OTHER_SITE_ID.toString() } },
+      SITE_KEYS,
+    );
+    expect(id?.toString()).toBe(SITE_ID.toString());
+  });
+
+  it("falls through an empty FK column to the relation", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { siteId: null, site: { _id: OTHER_SITE_ID.toString() } },
+      SITE_KEYS,
+    );
+    expect(id?.toString()).toBe(OTHER_SITE_ID.toString());
+  });
+
+  it("returns null when the reference is being cleared", () => {
+    expect(RelationIdUtil.read({ siteId: null }, SITE_KEYS)).toBeNull();
+    expect(RelationIdUtil.read({ site: null }, SITE_KEYS)).toBeNull();
+    expect(RelationIdUtil.read({ siteId: "" }, SITE_KEYS)).toBeNull();
+  });
+
+  it("returns null for a relation object with no id in it", () => {
+    expect(
+      RelationIdUtil.read({ site: { name: "WB Unit 0664" } }, SITE_KEYS),
+    ).toBeNull();
+    expect(RelationIdUtil.read({ site: {} }, SITE_KEYS)).toBeNull();
+  });
+
+  it("returns null when the payload does not mention the reference", () => {
+    expect(RelationIdUtil.read({ name: "Core Switch" }, SITE_KEYS)).toBeNull();
+    expect(RelationIdUtil.read({}, SITE_KEYS)).toBeNull();
+    expect(RelationIdUtil.read(null, SITE_KEYS)).toBeNull();
+    expect(RelationIdUtil.read(undefined, SITE_KEYS)).toBeNull();
+  });
+
+  it("works for any reference, not just sites", () => {
+    const id: ObjectID | null = RelationIdUtil.read(
+      { parentSite: { _id: SITE_ID.toString() } },
+      ["parentSiteId", "parentSite"],
+    );
+    expect(id?.toString()).toBe(SITE_ID.toString());
+  });
+});

--- a/Common/Tests/Utils/NetworkSite/CidrMatchUtil.test.ts
+++ b/Common/Tests/Utils/NetworkSite/CidrMatchUtil.test.ts
@@ -304,6 +304,75 @@ describe("CidrMatchUtil.ruleMatches", () => {
     ).toBe(false);
   });
 
+  /*
+   * A device imported from a discovery scan carries the responding IP in
+   * `hostname` and its SNMP identity in `name`; `sysName` stays empty until
+   * the first walk. Matching only hostname/sysName meant the pattern a user
+   * wrote against what the device list SHOWS could never match
+   * (OneUptime/oneuptime#2940).
+   */
+  it("matches a hostname-pattern rule against the device name", () => {
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { hostnamePattern: "*0664*" },
+        { ip: "10.242.170.222", hostname: "10.242.170.222" },
+      ),
+    ).toBe(false);
+
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { hostnamePattern: "*0664*" },
+        {
+          ip: "10.242.170.222",
+          hostname: "10.242.170.222",
+          name: "UN0664LANSWI03",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("matches on any one of hostname, sysName or name", () => {
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { hostnamePattern: "unit-*" },
+        { hostname: "unit-1", name: "Core Switch", sysName: "sw1" },
+      ),
+    ).toBe(true);
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { hostnamePattern: "unit-*" },
+        { hostname: "10.0.0.5", name: "Core Switch", sysName: "unit-1-core" },
+      ),
+    ).toBe(true);
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { hostnamePattern: "unit-*" },
+        { hostname: "10.0.0.5", name: "unit-1-core", sysName: "sw1" },
+      ),
+    ).toBe(true);
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { hostnamePattern: "unit-*" },
+        { hostname: "10.0.0.5", name: "Core Switch", sysName: "sw1" },
+      ),
+    ).toBe(false);
+  });
+
+  it("still requires the CIDR to match when a name matches the pattern", () => {
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { subnetCidr: "10.0.0.0/8", hostnamePattern: "*0664*" },
+        { ip: "192.168.1.4", name: "UN0664LANSWI03" },
+      ),
+    ).toBe(false);
+    expect(
+      CidrMatchUtil.ruleMatches(
+        { subnetCidr: "10.0.0.0/8", hostnamePattern: "*0664*" },
+        { ip: "10.242.170.222", name: "UN0664LANSWI03" },
+      ),
+    ).toBe(true);
+  });
+
   it("requires BOTH criteria to match when both are set", () => {
     const rule: AssignmentRuleCandidate = {
       subnetCidr: "10.0.0.0/8",

--- a/Common/Tests/Utils/Rules/RulePatternMatchUtil.test.ts
+++ b/Common/Tests/Utils/Rules/RulePatternMatchUtil.test.ts
@@ -1,0 +1,274 @@
+import RulePatternMatchUtil from "../../../Utils/Rules/RulePatternMatchUtil";
+
+/*
+ * Contract under test - the pattern language automation rules (label rules,
+ * owner rules) accept:
+ *
+ *   - a case-insensitive, UNANCHORED regular expression (the documented and
+ *     historical behaviour), and
+ *   - a '*' wildcard glob, which must match the WHOLE value, as a fallback
+ *     for patterns the regex engine rejects or does not match.
+ *
+ * The glob fallback exists because the sibling Network Site assignment rules
+ * take globs, so `*0664*` is what users actually type - and `new
+ * RegExp("*0664*")` throws, which the engines used to swallow into "matches
+ * nothing, forever" (OneUptime/oneuptime#2940).
+ */
+
+describe("RulePatternMatchUtil.matches - regex behaviour (unchanged)", () => {
+  it("matches an unanchored regex anywhere in the value", () => {
+    expect(RulePatternMatchUtil.matches("core-switch-01", "switch")).toBe(true);
+    expect(
+      RulePatternMatchUtil.matches("core-switch-01", "core-switch-.*"),
+    ).toBe(true);
+    expect(RulePatternMatchUtil.matches("core-switch-01", "^core")).toBe(true);
+    expect(RulePatternMatchUtil.matches("core-switch-01", "01$")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(RulePatternMatchUtil.matches("CORE-SWITCH-01", "core-switch")).toBe(
+      true,
+    );
+    expect(RulePatternMatchUtil.matches("core-switch-01", "CORE-SWITCH")).toBe(
+      true,
+    );
+  });
+
+  it("supports regex alternation and character classes", () => {
+    expect(
+      RulePatternMatchUtil.matches(
+        "production edge router",
+        "production|critical",
+      ),
+    ).toBe(true);
+    expect(
+      RulePatternMatchUtil.matches(
+        "critical edge router",
+        "production|critical",
+      ),
+    ).toBe(true);
+    expect(
+      RulePatternMatchUtil.matches(
+        "staging edge router",
+        "production|critical",
+      ),
+    ).toBe(false);
+    expect(RulePatternMatchUtil.matches("sw-07", "sw-0[0-9]")).toBe(true);
+    expect(RulePatternMatchUtil.matches("sw-7a", "sw-0[0-9]")).toBe(false);
+  });
+
+  it("returns false when a valid regex simply does not match", () => {
+    expect(RulePatternMatchUtil.matches("core-switch-01", "^edge")).toBe(false);
+    expect(RulePatternMatchUtil.matches("core-switch-01", "firewall")).toBe(
+      false,
+    );
+  });
+});
+
+describe("RulePatternMatchUtil.matches - wildcard fallback", () => {
+  /*
+   * The exact reproduction from the issue: a rule authored with the site
+   * assignment rules' glob syntax against a device discovered by SNMP.
+   */
+  it("matches the *0664* pattern from issue #2940 against UN0664LANSWI03", () => {
+    expect(RulePatternMatchUtil.matches("UN0664LANSWI03", "*0664*")).toBe(true);
+    expect(RulePatternMatchUtil.matches("UN0664OUTWAP06", "*0664*")).toBe(true);
+    expect(RulePatternMatchUtil.matches("UN0661LANSWI03", "*0664*")).toBe(
+      false,
+    );
+  });
+
+  it("proves the fallback is needed - the pattern is not a valid regex", () => {
+    expect(RulePatternMatchUtil.isValidRegex("*0664*")).toBe(false);
+  });
+
+  it("matches a glob against the whole value", () => {
+    expect(RulePatternMatchUtil.matches("unit-1042-sw1", "unit-*")).toBe(true);
+    expect(RulePatternMatchUtil.matches("unit-1042-sw1", "*-sw1")).toBe(true);
+    expect(RulePatternMatchUtil.matches("unit-1042-sw1", "unit-*-sw1")).toBe(
+      true,
+    );
+    expect(RulePatternMatchUtil.matches("edge-1042-sw1", "unit-*")).toBe(false);
+  });
+
+  /*
+   * Regex first, so a pattern that happens to compile keeps the regex's
+   * unanchored reading even when the author meant a glob: `unit-*` compiles
+   * to "unit" + zero-or-more "-", which is found inside "my-unit-1042-sw1".
+   * That is deliberately the OLD behaviour - matching must only ever widen,
+   * never narrow, or fixing this bug would break rules that already work.
+   */
+  it("keeps the unanchored regex reading for a glob that also compiles", () => {
+    expect(RulePatternMatchUtil.isValidRegex("unit-*")).toBe(true);
+    expect(RulePatternMatchUtil.matches("my-unit-1042-sw1", "unit-*")).toBe(
+      true,
+    );
+  });
+
+  it("treats a bare * as match-everything", () => {
+    expect(RulePatternMatchUtil.matches("anything at all", "*")).toBe(true);
+    expect(RulePatternMatchUtil.matches("10.242.170.222", "*")).toBe(true);
+  });
+
+  it("is case-insensitive in the glob path too", () => {
+    expect(RulePatternMatchUtil.matches("un0664lanswi03", "*0664*")).toBe(true);
+    expect(RulePatternMatchUtil.matches("UN0664LANSWI03", "*LANSWI*")).toBe(
+      true,
+    );
+    expect(RulePatternMatchUtil.matches("UN0664LANSWI03", "*lanswi*")).toBe(
+      true,
+    );
+  });
+
+  it("falls back to the glob only when the regex attempt fails to match", () => {
+    /*
+     * `UN*SWI03` compiles ("U" followed by zero or more "N"), and as a regex
+     * it does not match - the glob reading does. Both are tried, so the user
+     * gets the reading they meant.
+     */
+    expect(RulePatternMatchUtil.isValidRegex("UN*SWI03")).toBe(true);
+    expect(new RegExp("UN*SWI03", "i").test("UN0664LANSWI03")).toBe(false);
+    expect(RulePatternMatchUtil.matches("UN0664LANSWI03", "UN*SWI03")).toBe(
+      true,
+    );
+  });
+
+  it("keeps regex semantics when the regex matches and the glob would not", () => {
+    // `.*0664.*` is a regex match; as a glob the literal dots would not match.
+    expect(RulePatternMatchUtil.matches("UN0664LANSWI03", ".*0664.*")).toBe(
+      true,
+    );
+  });
+});
+
+describe("RulePatternMatchUtil.matches - unsupported and empty patterns", () => {
+  it("never matches a pattern that is neither a regex nor a glob", () => {
+    expect(RulePatternMatchUtil.matches("switch-01", "switch-(01")).toBe(false);
+    expect(RulePatternMatchUtil.matches("switch-01", "[unclosed")).toBe(false);
+  });
+
+  it("does not throw on an unparseable pattern", () => {
+    expect(() => {
+      return RulePatternMatchUtil.matches("switch-01", "switch-(01");
+    }).not.toThrow();
+  });
+
+  it("treats an empty or whitespace-only pattern as 'no criterion'", () => {
+    expect(RulePatternMatchUtil.matches("switch-01", "")).toBe(true);
+    expect(RulePatternMatchUtil.matches("switch-01", "   ")).toBe(true);
+    expect(RulePatternMatchUtil.matches("switch-01", null)).toBe(true);
+    expect(RulePatternMatchUtil.matches("switch-01", undefined)).toBe(true);
+  });
+
+  it("never matches a missing value against a configured pattern", () => {
+    expect(RulePatternMatchUtil.matches(undefined, "*0664*")).toBe(false);
+    expect(RulePatternMatchUtil.matches(null, "*0664*")).toBe(false);
+    expect(RulePatternMatchUtil.matches("", "*0664*")).toBe(false);
+    expect(RulePatternMatchUtil.matches("", "*")).toBe(false);
+  });
+
+  it("trims surrounding whitespace on the pattern", () => {
+    // Untrimmed, the glob would demand the literal spaces and match nothing.
+    expect(RulePatternMatchUtil.matches("UN0664LANSWI03", "  *0664*  ")).toBe(
+      true,
+    );
+    expect(RulePatternMatchUtil.matches("core-switch-01", "  switch  ")).toBe(
+      true,
+    );
+    expect(RulePatternMatchUtil.matches("core-switch-01", " switch 01 ")).toBe(
+      false,
+    );
+  });
+
+  it("survives non-string inputs without throwing", () => {
+    expect(
+      RulePatternMatchUtil.matches(
+        42 as unknown as string,
+        "*0664*" as unknown as string,
+      ),
+    ).toBe(false);
+    expect(
+      RulePatternMatchUtil.matches("switch", 42 as unknown as string),
+    ).toBe(true);
+  });
+});
+
+describe("RulePatternMatchUtil.isValidRegex", () => {
+  it("accepts real regular expressions", () => {
+    expect(RulePatternMatchUtil.isValidRegex("core-switch-.*")).toBe(true);
+    expect(RulePatternMatchUtil.isValidRegex("production|critical")).toBe(true);
+    expect(RulePatternMatchUtil.isValidRegex("^sw-[0-9]{2}$")).toBe(true);
+    expect(RulePatternMatchUtil.isValidRegex("")).toBe(true);
+  });
+
+  it("rejects patterns the engine cannot compile", () => {
+    expect(RulePatternMatchUtil.isValidRegex("*0664*")).toBe(false);
+    expect(RulePatternMatchUtil.isValidRegex("+bad")).toBe(false);
+    expect(RulePatternMatchUtil.isValidRegex("(unclosed")).toBe(false);
+    expect(RulePatternMatchUtil.isValidRegex("[unclosed")).toBe(false);
+    expect(RulePatternMatchUtil.isValidRegex("a{2,1}")).toBe(false);
+  });
+
+  it("rejects non-strings", () => {
+    expect(RulePatternMatchUtil.isValidRegex(null as unknown as string)).toBe(
+      false,
+    );
+    expect(
+      RulePatternMatchUtil.isValidRegex(undefined as unknown as string),
+    ).toBe(false);
+  });
+});
+
+describe("RulePatternMatchUtil.isSupportedPattern", () => {
+  it("supports valid regexes", () => {
+    expect(RulePatternMatchUtil.isSupportedPattern("core-switch-.*")).toBe(
+      true,
+    );
+    expect(RulePatternMatchUtil.isSupportedPattern("production|critical")).toBe(
+      true,
+    );
+  });
+
+  it("supports wildcard globs that are not valid regexes", () => {
+    expect(RulePatternMatchUtil.isSupportedPattern("*0664*")).toBe(true);
+    expect(RulePatternMatchUtil.isSupportedPattern("*")).toBe(true);
+    expect(RulePatternMatchUtil.isSupportedPattern("*(*")).toBe(true);
+  });
+
+  it("treats an empty pattern as supported - it is simply not a criterion", () => {
+    expect(RulePatternMatchUtil.isSupportedPattern("")).toBe(true);
+    expect(RulePatternMatchUtil.isSupportedPattern("   ")).toBe(true);
+  });
+
+  it("rejects patterns that can never match anything", () => {
+    expect(RulePatternMatchUtil.isSupportedPattern("switch-(01")).toBe(false);
+    expect(RulePatternMatchUtil.isSupportedPattern("[unclosed")).toBe(false);
+    expect(RulePatternMatchUtil.isSupportedPattern("+bad")).toBe(false);
+  });
+});
+
+describe("RulePatternMatchUtil.matches - performance", () => {
+  /*
+   * The glob path is the one a user-authored `*a*a*a...` lands on. It is
+   * O(value x pattern) by construction (CidrMatchUtil.hostnameMatchesWildcard),
+   * so a hostile-looking rule cannot wedge the event loop the way the
+   * equivalent regex would.
+   */
+  it("rejects a pathological wildcard pattern quickly", () => {
+    const pattern: string = `${"*a".repeat(12)}*b`;
+    const value: string = "a".repeat(60);
+
+    const startedAt: number = Date.now();
+    expect(RulePatternMatchUtil.matches(value, pattern)).toBe(false);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+
+  it("accepts a pathological wildcard pattern quickly when it does match", () => {
+    const pattern: string = `${"*a".repeat(12)}*b`;
+    const value: string = `${"a".repeat(60)}b`;
+
+    const startedAt: number = Date.now();
+    expect(RulePatternMatchUtil.matches(value, pattern)).toBe(true);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+});

--- a/Common/Utils/NetworkSite/CidrMatchUtil.ts
+++ b/Common/Utils/NetworkSite/CidrMatchUtil.ts
@@ -13,11 +13,19 @@ export interface AssignmentRuleCandidate {
   createdAt?: Date | null | undefined;
 }
 
-// The device attributes a rule is evaluated against.
+/*
+ * The device attributes a rule is evaluated against. A hostname pattern is
+ * tried against every name-ish attribute because "the hostname" means
+ * different things depending on how the device got here: a discovery import
+ * stores the responding IP in `hostname` and the SNMP sysName in `name`, so a
+ * pattern like `*0664*` would never see the string the user is looking at in
+ * the device list if we only tried `hostname`.
+ */
 export interface RuleMatchTarget {
   ip?: string | null | undefined;
   hostname?: string | null | undefined;
   sysName?: string | null | undefined;
+  name?: string | null | undefined;
 }
 
 export class CidrMatchUtil {
@@ -176,8 +184,9 @@ export class CidrMatchUtil {
 
   /*
    * True when the rule's populated criteria all match the target. A CIDR
-   * criterion matches the target's ip; a hostname pattern matches either the
-   * hostname or the SNMP sysName. A rule with no criteria never matches.
+   * criterion matches the target's ip; a hostname pattern matches the
+   * hostname, the SNMP sysName, or the device's display name — see
+   * RuleMatchTarget. A rule with no criteria never matches.
    */
   public static ruleMatches(
     rule: AssignmentRuleCandidate,
@@ -201,21 +210,25 @@ export class CidrMatchUtil {
     }
 
     if (hasPattern) {
-      const matchesHostname: boolean = Boolean(
-        target.hostname &&
-          CidrMatchUtil.hostnameMatchesWildcard(
-            target.hostname,
-            rule.hostnamePattern!,
-          ),
+      const candidates: Array<string | null | undefined> = [
+        target.hostname,
+        target.sysName,
+        target.name,
+      ];
+
+      const matchesAnyName: boolean = candidates.some(
+        (candidate: string | null | undefined) => {
+          return Boolean(
+            candidate &&
+              CidrMatchUtil.hostnameMatchesWildcard(
+                candidate,
+                rule.hostnamePattern!,
+              ),
+          );
+        },
       );
-      const matchesSysName: boolean = Boolean(
-        target.sysName &&
-          CidrMatchUtil.hostnameMatchesWildcard(
-            target.sysName,
-            rule.hostnamePattern!,
-          ),
-      );
-      if (!matchesHostname && !matchesSysName) {
+
+      if (!matchesAnyName) {
         return false;
       }
     }

--- a/Common/Utils/Rules/RulePatternMatchUtil.ts
+++ b/Common/Utils/Rules/RulePatternMatchUtil.ts
@@ -1,0 +1,103 @@
+/*
+ * Matching for the free-text "pattern" criteria on automation rules (label
+ * rules, owner rules).
+ *
+ * These fields are documented as case-insensitive regular expressions, but
+ * the sibling Network Site assignment rules take '*' wildcard globs and the
+ * two features sit next to each other under Network > Automation. A user who
+ * typed `*0664*` into a label rule got silence: `new RegExp("*0664*")` throws
+ * "Nothing to repeat", the rule engine swallowed the SyntaxError, and the
+ * rule matched nothing forever (OneUptime/oneuptime#2940).
+ *
+ * So the pattern is tried as a regex first - existing rules keep their exact
+ * semantics - and a pattern containing '*' additionally gets a wildcard glob
+ * attempt. Matching is therefore a superset of the old behaviour: nothing
+ * that used to match stops matching.
+ *
+ * Pure and dependency-free (no logger, no models) so rule decisions stay
+ * unit-testable.
+ */
+
+import CidrMatchUtil from "../NetworkSite/CidrMatchUtil";
+
+export class RulePatternMatchUtil {
+  /*
+   * True when `value` satisfies `pattern`. An empty/missing pattern is "no
+   * criterion configured" and matches everything - callers that treat an
+   * empty criterion as skippable get the same answer either way. A missing
+   * value never matches a configured pattern.
+   */
+  public static matches(
+    value: string | null | undefined,
+    pattern: string | null | undefined,
+  ): boolean {
+    if (typeof pattern !== "string" || pattern.trim().length === 0) {
+      return true;
+    }
+
+    if (typeof value !== "string" || value.length === 0) {
+      return false;
+    }
+
+    const trimmedPattern: string = pattern.trim();
+
+    if (RulePatternMatchUtil.matchesRegex(value, trimmedPattern)) {
+      return true;
+    }
+
+    /*
+     * Glob fallback only for patterns that actually carry a wildcard. Without
+     * a '*' a glob is just a case-insensitive whole-string equality test,
+     * which the (unanchored) regex attempt above already covers.
+     */
+    if (trimmedPattern.includes("*")) {
+      return CidrMatchUtil.hostnameMatchesWildcard(value, trimmedPattern);
+    }
+
+    return false;
+  }
+
+  // True when `pattern` compiles as a JavaScript regular expression.
+  public static isValidRegex(pattern: string): boolean {
+    if (typeof pattern !== "string") {
+      return false;
+    }
+
+    try {
+      const regex: RegExp = new RegExp(pattern, "i");
+      return regex instanceof RegExp;
+    } catch {
+      return false;
+    }
+  }
+
+  /*
+   * A pattern this matcher can do something sensible with: either a valid
+   * regex, or a glob. Anything else (`switch-(01`, `[unclosed`) is a typo
+   * that can only ever match nothing - worth telling the user about instead
+   * of failing silently.
+   */
+  public static isSupportedPattern(pattern: string): boolean {
+    if (typeof pattern !== "string" || pattern.trim().length === 0) {
+      return true;
+    }
+
+    const trimmedPattern: string = pattern.trim();
+
+    return (
+      RulePatternMatchUtil.isValidRegex(trimmedPattern) ||
+      trimmedPattern.includes("*")
+    );
+  }
+
+  private static matchesRegex(value: string, pattern: string): boolean {
+    try {
+      const regex: RegExp = new RegExp(pattern, "i");
+      return regex.test(value);
+    } catch {
+      return false;
+    }
+  }
+}
+
+export default RulePatternMatchUtil;


### PR DESCRIPTION
Fixes #2940.

## What was wrong

The reporter created a Site Assignment Rule (`*0664*` → "WB Unit 0664") and a Label Rule (`*0664*`) **before** running a discovery scan, imported the matching devices, and got an empty Site column and no labels. Three independent defects were involved — each on its own is enough to produce that.

### 1. Site assignment rules never looked at the name the user matches on

A discovery import writes the **responding IP** into `hostname` and the **SNMP identity** into `name`, and cannot set `sysName` at all (the column forbids create — only the SNMP walk fills it in):

```
name     = "UN0664LANSWI03"     <- the string in the Name column
hostname = "10.242.170.222"     <- the string in the Hostname column
sysName  = (empty until the first walk)
```

`CidrMatchUtil.ruleMatches` only tried `hostname` and `sysName`, so `*0664*` was compared against `10.242.170.222` and never matched. `RuleMatchTarget` now carries `name`, `ruleMatches` tries all three, and `applySiteAssignmentRulesToDevice` selects and passes it.

### 2. Nothing re-evaluated the rules once the walk finally wrote `sysName`

`onUpdateSuccess` re-ran the rules on exactly one condition — the payload containing `hostname` — and the SNMP walk's enrichment write (`NetworkInventoryUtil.updateFromWalk`) never contains `hostname`. So even after the device gained the identity a rule could match, nothing looked again.

The trigger now covers `hostname` / `name` / `sysName`, with two guards that matter:

- it fires only when the value **actually changed** (compared against a previous-state snapshot captured in `onBeforeUpdate`, normalised for case/whitespace). Without this, the walk rewriting the same `sysName` every polling cycle would drag a hand-placed device back to whatever a rule prefers, every few minutes;
- **except** when the device has no site at all, where a rule pass cannot undo anyone's choice. That is the self-healing path: devices imported before their rule existed get assigned on their next poll, instead of needing a delete-and-reimport.

### 3. Label / owner rule patterns silently died on wildcard syntax

`new RegExp("*0664*")` throws `SyntaxError: Nothing to repeat`. The engines caught it, logged a warning nobody sees, and returned "no match" — forever, with a green **Enabled** pill and no API error. Indistinguishable from a legitimate non-match.

`*` is not a user mistake here: the Site Assignment Rules screen right next to it is glob-based and documents `unit-1042-*`. So `Common/Utils/Rules/RulePatternMatchUtil` now tries the pattern **as a regex first** — every existing rule keeps its exact semantics — and additionally as a `*` wildcard when the regex either fails to compile or does not match. Matching only ever widens; nothing that used to match stops matching.

A pattern that is neither a valid regex nor a glob (`switch-(01`, `[unclosed`) can only ever match nothing, so it is now rejected at write time with a message naming the field, instead of being persisted and failing silently.

## Found while tracing the above

Hooks keyed on the `siteId` / `parentSiteId` **FK columns** never fired for writes made from the dashboard, because `ModelForm` → `DatabaseBaseModel.toJSONObject` posts the **relation** (`{ site: { _id } }`) and hooks run before TypeORM resolves one into the other. That silently skipped:

- the cross-project site guard on device create/update,
- the rollup refresh when a user picks a site by hand (site health went stale),
- and on `NetworkSite`, **cycle detection**, the same-project parent guard and the subtree materialized-path rebase when re-parenting a site from the UI.

`Common/Server/Utils/Database/RelationIdUtil` normalises both spellings and the hooks read through it. This is in scope because widening the rule trigger without it would have let the rule engine overwrite a site the user had just picked. `NetworkSiteAssignmentRule` also gains the same-project site guard `NetworkDevice` already had — a rule aimed at a foreign site renders that site's name in the rules table and can never assign anything.

## Behaviour change worth reviewing

The Assignment Rules card used to say *"Rules apply to NEW or CHANGED devices only — existing devices are never retroactively reassigned."* It now says rules are evaluated on create, on identity change, **and on the next poll of any device that has no site yet**, and that a device assigned by hand is never moved unless its identity changes. Point 2 above is that change; it is what makes the reporter's already-imported devices recover without manual work.

## Tests

~100 new cases, all green (`3142 passed` across `Common/Tests/{Server/Services,Models,Utils}`; the one failing suite is the pre-existing `isolated-vm` native-module load failure on this machine, reproducible on `master`).

- `Common/Tests/Utils/Rules/RulePatternMatchUtil.test.ts` (new, 27) — regex semantics preserved, glob fallback, the exact `*0664*` / `UN0664LANSWI03` reproduction, unsupported patterns, empty/whitespace/non-string inputs, and that the glob path stays linear on a `*a*a*a…` pattern.
- `Common/Tests/Server/Services/NetworkDeviceRuleEngines.test.ts` (new, 33) — **the first tests any `*LabelRuleEngineService` in this repo has had.** Both network device engines: wildcard and regex patterns, description patterns, the label prerequisite, label dedupe, in-memory label sync for the owner engine that runs next, error swallowing, plus the write-time pattern validation.
- `Common/Tests/Server/Utils/Database/RelationIdUtil.test.ts` (new, 15).
- `NetworkDeviceSiteAssignment.test.ts` (+21) — the discovery-import reproduction, the walk-writes-sysName case, the unchanged-sysName-does-not-clobber case, the no-site self-heal, the `site` relation key, and the previously untested `onCreateSuccess` chain.
- `CidrMatchUtil.test.ts` (+3), `NetworkSiteAssignmentRuleService.test.ts` (+5), `NetworkSiteService.test.ts` (+3).

Two existing assertions changed on purpose: `{ name: "renamed" }` used to be the example of an update that triggers nothing, and now correctly re-evaluates. They were re-pointed at a genuinely inert column.

`App/FeatureSet/BrowserRecorder/package.json` moved 11.7.3 → 11.7.4 — the repo's own pre-commit version-sync hook did that, not this change.

## Not fixed here, flagged for a follow-up

- Label and owner rules still fire on **create only**, never on rename. That is the deliberate convention across all 26 label rule engines, so it is left alone — but it means a label rule authored after a device exists still needs the device to be re-created.
- The same `new RegExp(userPattern, "i")` shape is duplicated in 61 rule-engine services. Only the two network device engines are switched to the shared util here; the rest are untouched, since reinterpreting `*` as a glob elsewhere could widen matching for other tenants' existing rules.
- Assignment rules are still never applied to network **endpoints**, despite the card previously promising "devices and endpoints". The copy has been corrected to say devices; the feature gap remains.
