### PR TITLE
fix(incidents): scope the metric preview to the series that triggered the incident

### DIFF
--- a/App/FeatureSet/BrowserRecorder/package.json
+++ b/App/FeatureSet/BrowserRecorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneuptime/browser-recorder",
-  "version": "11.7.3",
+  "version": "11.7.4",
   "private": false,
   "description": "OneUptime session replay browser recorder. Shipped to third-party origins as an IIFE bundle.",
   "repository": {

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentRootCauseMetricChart.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentRootCauseMetricChart.tsx
@@ -13,6 +13,8 @@ import MonitorStep from "Common/Types/Monitor/MonitorStep";
 import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
 import MetricFormulaConfigData from "Common/Types/Metrics/MetricFormulaConfigData";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import { JSONObject } from "Common/Types/JSON";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
 import OneUptimeDate from "Common/Types/Date";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
@@ -44,12 +46,19 @@ const IncidentRootCauseMetricChart: FunctionComponent<ComponentProps> = (
   const [incidentDeclaredAt, setIncidentDeclaredAt] = useState<Date | null>(
     null,
   );
+  /*
+   * "host.name = prod-01" when this incident belongs to one series of a
+   * grouped metric monitor — surfaced in the card subtitle so it is
+   * obvious the chart is scoped rather than missing data.
+   */
+  const [seriesSummary, setSeriesSummary] = useState<string>("");
 
   useEffect(() => {
     const load: () => Promise<void> = async (): Promise<void> => {
       try {
         setLoading(true);
         setError("");
+        setSeriesSummary("");
 
         const incident: Incident | null = await ModelAPI.getItem({
           modelType: Incident,
@@ -57,6 +66,7 @@ const IncidentRootCauseMetricChart: FunctionComponent<ComponentProps> = (
           select: {
             createdAt: true,
             createdCriteriaId: true,
+            seriesLabels: true,
             monitors: {
               _id: true,
               monitorType: true,
@@ -108,6 +118,38 @@ const IncidentRootCauseMetricChart: FunctionComponent<ComponentProps> = (
           setLoading(false);
           return;
         }
+
+        /*
+         * A grouped metric monitor (group by host.name, pod, ...) evaluates
+         * one series per group and opens one incident per BREACHING group,
+         * but every one of those incidents stores the same monitor-wide
+         * query configs. Replaying them as-is charts every group, so the
+         * one series this incident is about is buried — or missing outright
+         * once the Top-N cap kicks in. The incident records its own series
+         * in `seriesLabels`, so push that back onto the query as an
+         * attribute filter.
+         */
+        const seriesLabels: JSONObject | undefined = incident.seriesLabels as
+          | JSONObject
+          | undefined;
+
+        /*
+         * Describe the narrowing that was actually applied, not the raw
+         * labels: a label the queries never grouped by narrows nothing, and
+         * announcing it would have the card vouch for a chart that still
+         * shows every series.
+         */
+        setSeriesSummary(
+          MetricSeriesScope.getAppliedSeriesLabelSummary({
+            queryConfigs: queryConfigs,
+            seriesLabels: seriesLabels,
+          }),
+        );
+
+        queryConfigs = MetricSeriesScope.scopeQueryConfigsToSeries({
+          queryConfigs: queryConfigs,
+          seriesLabels: seriesLabels,
+        });
 
         /*
          * Center the chart on the incident's creation time: 30 minutes
@@ -172,7 +214,15 @@ const IncidentRootCauseMetricChart: FunctionComponent<ComponentProps> = (
   return (
     <Card
       title="Metric at Incident Time"
-      description="Metric data from around when this incident was declared."
+      /*
+       * Say so when the chart is narrowed to one series of a grouped
+       * monitor, otherwise "where are my other hosts?" reads as a bug.
+       */
+      description={
+        seriesSummary
+          ? `Metric data from around when this incident was declared, scoped to the affected series (${seriesSummary}).`
+          : "Metric data from around when this incident was declared."
+      }
     >
       <MetricView
         data={metricViewData}

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -53,6 +53,7 @@ import AlertEpisodeElement from "../../../Components/AlertEpisode/AlertEpisode";
 import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
 import MetricView from "../../../Components/Metrics/MetricView";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
 import HeaderAlert, {
   HeaderAlertType,
 } from "Common/UI/Components/HeaderAlert/HeaderAlert";
@@ -79,6 +80,12 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
   const [error, setError] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  /*
+   * "host.name = prod-01" when a grouped metric monitor opened this alert
+   * for one series. Empty for whole-monitor alerts.
+   */
+  const [seriesSummary, setSeriesSummary] = useState<string>("");
 
   const [telemetryQuery, setTelemetryQuery] = useState<TelemetryQuery | null>(
     null,
@@ -137,6 +144,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         modelType: Alert,
         select: {
           telemetryQuery: true,
+          seriesLabels: true,
           isPrivate: true,
           title: true,
           alertNumber: true,
@@ -154,6 +162,39 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         telemetryQuery = JSONFunctions.deserialize(
           alert?.telemetryQuery as any,
         ) as any;
+      }
+
+      /*
+       * The stored telemetryQuery is the monitor's whole-evaluation view:
+       * a grouped metric monitor that breached on five hosts stamps the
+       * SAME query configs onto all five alerts. Narrow it to this alert's
+       * own series so the chart shows the host it is about instead of
+       * every host the monitor watches.
+       */
+      if (telemetryQuery?.metricViewData) {
+        /*
+         * Describe the narrowing that was actually applied, not the raw
+         * labels: a label the queries never grouped by narrows nothing, and
+         * announcing it would have the card vouch for a chart that still
+         * shows every series.
+         */
+        setSeriesSummary(
+          MetricSeriesScope.getAppliedSeriesLabelSummary({
+            queryConfigs: telemetryQuery.metricViewData.queryConfigs,
+            seriesLabels: alert?.seriesLabels as JSONObject | undefined,
+          }),
+        );
+
+        telemetryQuery = {
+          ...telemetryQuery,
+          metricViewData:
+            MetricSeriesScope.scopeMetricViewDataToSeries({
+              metricViewData: telemetryQuery.metricViewData,
+              seriesLabels: alert?.seriesLabels as JSONObject | undefined,
+            }) || null,
+        };
+      } else {
+        setSeriesSummary("");
       }
 
       if (alert?.alertSeverity) {
@@ -360,7 +401,11 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             telemetryQuery.metricViewData && (
               <Card
                 title={"Metrics"}
-                description={"Metrics for this alert."}
+                description={
+                  seriesSummary
+                    ? `Metrics for this alert, scoped to the affected series (${seriesSummary}).`
+                    : "Metrics for this alert."
+                }
                 rightElement={
                   telemetryQuery.metricViewData.startAndEndDate ? (
                     <HeaderAlert

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -42,6 +42,7 @@ import TraceTable from "../../../Components/Traces/TraceTable";
 import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
 import MetricView from "../../../Components/Metrics/MetricView";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
 import IconProp from "Common/Types/Icon/IconProp";
 import HeaderAlert, {
   HeaderAlertType,
@@ -88,6 +89,11 @@ const IncidentView: FunctionComponent<
   const [telemetryQuery, setTelemetryQuery] = useState<TelemetryQuery | null>(
     null,
   );
+  /*
+   * "host.name = prod-01" when a grouped metric monitor opened this
+   * incident for one series. Empty for whole-monitor incidents.
+   */
+  const [seriesSummary, setSeriesSummary] = useState<string>("");
   const [isPrivate, setIsPrivate] = useState<boolean>(false);
   const [eventNumber, setEventNumber] = useState<string | undefined>(undefined);
   const [incidentTitle, setIncidentTitle] = useState<string | undefined>(
@@ -143,6 +149,7 @@ const IncidentView: FunctionComponent<
         modelType: Incident,
         select: {
           telemetryQuery: true,
+          seriesLabels: true,
           isPrivate: true,
           title: true,
           incidentNumber: true,
@@ -160,6 +167,39 @@ const IncidentView: FunctionComponent<
         telemetryQuery = JSONFunctions.deserialize(
           incident?.telemetryQuery as any,
         ) as any;
+      }
+
+      /*
+       * The stored telemetryQuery is the monitor's whole-evaluation view:
+       * a grouped metric monitor that breached on five hosts stamps the
+       * SAME query configs onto all five incidents. Narrow it to this
+       * incident's own series so the chart shows the host it is about
+       * instead of every host the monitor watches.
+       */
+      if (telemetryQuery?.metricViewData) {
+        /*
+         * Describe the narrowing that was actually applied, not the raw
+         * labels: a label the queries never grouped by narrows nothing, and
+         * announcing it would have the card vouch for a chart that still
+         * shows every series.
+         */
+        setSeriesSummary(
+          MetricSeriesScope.getAppliedSeriesLabelSummary({
+            queryConfigs: telemetryQuery.metricViewData.queryConfigs,
+            seriesLabels: incident?.seriesLabels as JSONObject | undefined,
+          }),
+        );
+
+        telemetryQuery = {
+          ...telemetryQuery,
+          metricViewData:
+            MetricSeriesScope.scopeMetricViewDataToSeries({
+              metricViewData: telemetryQuery.metricViewData,
+              seriesLabels: incident?.seriesLabels as JSONObject | undefined,
+            }) || null,
+        };
+      } else {
+        setSeriesSummary("");
       }
 
       setIsPrivate(incident?.isPrivate === true);
@@ -381,7 +421,11 @@ const IncidentView: FunctionComponent<
             telemetryQuery.metricViewData && (
               <Card
                 title={"Metrics"}
-                description={"Metrics related to this incident."}
+                description={
+                  seriesSummary
+                    ? `Metrics related to this incident, scoped to the affected series (${seriesSummary}).`
+                    : "Metrics related to this incident."
+                }
                 rightElement={
                   telemetryQuery.metricViewData.startAndEndDate ? (
                     <HeaderAlert

--- a/App/Tests/Dashboard/IncidentMetricSeriesScope.test.ts
+++ b/App/Tests/Dashboard/IncidentMetricSeriesScope.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import Dictionary from "Common/Types/Dictionary";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
+import MetricViewData from "Common/Types/Metrics/MetricViewData";
+import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+
+/*
+ * A metric monitor grouped by an attribute (host.name, pod, device) opens
+ * ONE incident per breaching group, yet all of those incidents are stamped
+ * with the SAME monitor-wide query configs. Three surfaces replay those
+ * configs, and all three used to chart every group:
+ *
+ *   - the incident Root Cause page's "Metric at Incident Time" chart,
+ *     which reads the query configs off the monitor step;
+ *   - the incident overview's "Metrics" card, and
+ *   - the alert overview's "Metrics" card, both of which read them off the
+ *     stored telemetryQuery.
+ *
+ * The fix routes all three through MetricSeriesScope using the affected
+ * series recorded on the incident/alert. None of that is reachable from a
+ * unit test — the App suite runs in plain Node with no renderer — so the
+ * wiring is pinned by reading the sources, the way
+ * RecommendationPageWiring.test.ts pins the recommendation pages. Sources
+ * are whitespace-squashed first so a prettier re-wrap cannot turn a real
+ * regression check into a red herring.
+ *
+ * The second half of the file exercises the actual data pipeline (stored
+ * JSON -> deserialize -> narrow -> serialize for the aggregate request),
+ * which needs no renderer and would catch the narrowing silently falling
+ * off somewhere in the round trip.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    stripComments(
+      fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+    ),
+  );
+}
+
+const ROOT_CAUSE_CHART: string = readSource(
+  "Components",
+  "Incident",
+  "IncidentRootCauseMetricChart.tsx",
+);
+
+const INCIDENT_VIEW: string = readSource(
+  "Pages",
+  "Incidents",
+  "View",
+  "Index.tsx",
+);
+
+const ALERT_VIEW: string = readSource("Pages", "Alerts", "View", "Index.tsx");
+
+const MONITOR_METRIC_PREVIEW: string = readSource(
+  "Components",
+  "Monitor",
+  "MetricMonitor",
+  "MetricMonitorPreview.tsx",
+);
+
+/*
+ * Narrow a squashed source down to one getItem's `select` object so the
+ * assertions below pin THAT a column is requested without pinning where
+ * in the literal it sits — key order in a select is meaningless, and an
+ * unrelated field landing between two of them must not fail the build.
+ */
+function selectBlockAfter(source: string, marker: string): string {
+  const afterMarker: string | undefined = source.split(marker)[1];
+  return (afterMarker || "").split("});")[0] || "";
+}
+
+describe("incident Root Cause metric chart is scoped to the incident's series", () => {
+  test("imports MetricSeriesScope", () => {
+    expect(ROOT_CAUSE_CHART).toContain(
+      'import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";',
+    );
+  });
+
+  test("asks the API for the incident's series labels", () => {
+    /*
+     * ModelAPI only returns selected columns, so a dropped select here
+     * makes seriesLabels undefined and silently un-scopes the chart —
+     * exactly the bug, with no error anywhere.
+     */
+    expect(
+      selectBlockAfter(ROOT_CAUSE_CHART, "modelType: Incident, id:"),
+    ).toContain("seriesLabels: true,");
+  });
+
+  test("narrows the monitor step's query configs before charting them", () => {
+    /*
+     * The assignment is the load-bearing part: calling the util and
+     * dropping its result restores the bug in full while still
+     * mentioning the util.
+     */
+    expect(ROOT_CAUSE_CHART).toContain(
+      "queryConfigs = MetricSeriesScope.scopeQueryConfigsToSeries({",
+    );
+  });
+
+  test("describes only the narrowing it actually applied", () => {
+    /*
+     * getAppliedSeriesLabelSummary — not a summary of the raw labels,
+     * which would have the card vouch for an unscoped chart whenever the
+     * labels don't intersect the queries' group-bys.
+     */
+    expect(ROOT_CAUSE_CHART).toContain(
+      "MetricSeriesScope.getAppliedSeriesLabelSummary({",
+    );
+    expect(ROOT_CAUSE_CHART).toContain("scoped to the affected series");
+  });
+});
+
+describe("incident overview Metrics card is scoped to the incident's series", () => {
+  test("imports MetricSeriesScope", () => {
+    expect(INCIDENT_VIEW).toContain(
+      'import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";',
+    );
+  });
+
+  test("asks the API for the incident's series labels", () => {
+    expect(
+      selectBlockAfter(INCIDENT_VIEW, "modelType: Incident, select: {"),
+    ).toContain("seriesLabels: true,");
+  });
+
+  test("narrows the stored telemetryQuery before handing it to MetricView", () => {
+    expect(INCIDENT_VIEW).toContain(
+      "telemetryQuery = { ...telemetryQuery, metricViewData: MetricSeriesScope.scopeMetricViewDataToSeries({",
+    );
+  });
+
+  test("describes only the narrowing it actually applied", () => {
+    expect(INCIDENT_VIEW).toContain(
+      "MetricSeriesScope.getAppliedSeriesLabelSummary({",
+    );
+    expect(INCIDENT_VIEW).toContain("scoped to the affected series");
+  });
+});
+
+describe("alert overview Metrics card is scoped to the alert's series", () => {
+  test("imports MetricSeriesScope", () => {
+    expect(ALERT_VIEW).toContain(
+      'import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";',
+    );
+  });
+
+  test("asks the API for the alert's series labels", () => {
+    expect(
+      selectBlockAfter(ALERT_VIEW, "modelType: Alert, select: {"),
+    ).toContain("seriesLabels: true,");
+  });
+
+  test("narrows the stored telemetryQuery before handing it to MetricView", () => {
+    expect(ALERT_VIEW).toContain(
+      "telemetryQuery = { ...telemetryQuery, metricViewData: MetricSeriesScope.scopeMetricViewDataToSeries({",
+    );
+  });
+
+  test("describes only the narrowing it actually applied", () => {
+    expect(ALERT_VIEW).toContain(
+      "MetricSeriesScope.getAppliedSeriesLabelSummary({",
+    );
+    expect(ALERT_VIEW).toContain("scoped to the affected series");
+  });
+});
+
+describe("the monitor-level metrics preview stays unscoped", () => {
+  test("does not narrow to any single series", () => {
+    /*
+     * This one previews the monitor's own criteria, not one incident —
+     * showing every group is the entire point of it. Scoping it would
+     * hide the very series a user is checking their criteria against.
+     */
+    expect(MONITOR_METRIC_PREVIEW).not.toContain("MetricSeriesScope");
+    expect(MONITOR_METRIC_PREVIEW).not.toContain("seriesLabels");
+  });
+});
+
+/*
+ * The pipeline the incident/alert overview pages actually run: the
+ * telemetryQuery is stored as JSON on the row, deserialized on load,
+ * narrowed, and then the query's attributes are serialized again into the
+ * aggregate request. Operator instances (IsNull, used for an unset label)
+ * are the fragile part of that round trip.
+ */
+describe("the narrowing survives the stored-JSON round trip", () => {
+  function buildStoredTelemetryQuery(input: {
+    groupByAttributeKeys: Array<string>;
+  }): JSONObject {
+    const metricViewData: JSONObject = {
+      startAndEndDate: {
+        _type: "InBetween",
+        value: {
+          startValue: "2024-05-01T10:00:00.000Z",
+          endValue: "2024-05-01T11:00:00.000Z",
+        },
+      },
+      queryConfigs: [
+        {
+          id: "query-1",
+          metricAliasData: {
+            metricVariable: "a",
+            title: "",
+            description: "",
+            legend: "",
+            legendUnit: "",
+          },
+          metricQueryData: {
+            filterData: {
+              metricName: "system.cpu.utilization",
+              aggegationType: "Avg",
+            },
+            groupByAttributeKeys: input.groupByAttributeKeys,
+          },
+        },
+      ],
+      formulaConfigs: [],
+    };
+
+    return {
+      telemetryType: "Metric",
+      telemetryQuery: null,
+      metricViewData: metricViewData,
+    };
+  }
+
+  function getAttributes(
+    queryConfig: MetricQueryConfigData | undefined,
+  ): Dictionary<unknown> {
+    return (
+      queryConfig?.metricQueryData?.filterData as
+        | Dictionary<unknown>
+        | undefined
+    )?.["attributes"] as Dictionary<unknown> | undefined as Dictionary<unknown>;
+  }
+
+  test("a deserialized telemetryQuery narrows to the incident's host", () => {
+    const stored: JSONObject = buildStoredTelemetryQuery({
+      groupByAttributeKeys: ["resource.host.name"],
+    });
+
+    const deserialized: JSONObject = JSONFunctions.deserialize(stored);
+
+    const metricViewData: MetricViewData = deserialized[
+      "metricViewData"
+    ] as unknown as MetricViewData;
+
+    // Five hosts breached, five incidents, one shared query config.
+    expect(metricViewData.queryConfigs).toHaveLength(1);
+    expect(getAttributes(metricViewData.queryConfigs[0])).toBeUndefined();
+
+    const scoped: MetricViewData | null | undefined =
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: metricViewData,
+        seriesLabels: { "resource.host.name": "prod-01" },
+      });
+
+    expect(getAttributes(scoped?.queryConfigs[0])).toEqual({
+      "resource.host.name": "prod-01",
+    });
+    // The window the monitor evaluated over must come through untouched.
+    expect(scoped?.startAndEndDate).toBe(metricViewData.startAndEndDate);
+  });
+
+  test("an unset label round-trips through serialize/deserialize as IsNull", () => {
+    /*
+     * The aggregate request re-serializes the query, and the API
+     * rehydrates it. A plain "" would be dropped by the chart's filter
+     * sanitizer on the way out and quietly un-scope the chart, so the
+     * operator instance has to survive intact.
+     */
+    const stored: JSONObject = buildStoredTelemetryQuery({
+      groupByAttributeKeys: ["disk.device"],
+    });
+
+    const metricViewData: MetricViewData = JSONFunctions.deserialize(stored)[
+      "metricViewData"
+    ] as unknown as MetricViewData;
+
+    const scoped: MetricViewData | null | undefined =
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: metricViewData,
+        seriesLabels: { "disk.device": "" },
+      });
+
+    const attributes: Dictionary<unknown> = getAttributes(
+      scoped?.queryConfigs[0],
+    );
+
+    expect(attributes["disk.device"]).toBeInstanceOf(IsNull);
+
+    const serialized: JSONObject = JSONFunctions.serialize(
+      attributes as JSONObject,
+    );
+    expect(serialized).toEqual({
+      "disk.device": { _type: "IsNull", value: null },
+    });
+
+    const rehydrated: JSONObject = JSONFunctions.deserialize(serialized);
+    expect(rehydrated["disk.device"]).toBeInstanceOf(IsNull);
+  });
+
+  test("a whole-monitor incident (no series labels) charts everything, unchanged", () => {
+    const stored: JSONObject = buildStoredTelemetryQuery({
+      groupByAttributeKeys: [],
+    });
+
+    const metricViewData: MetricViewData = JSONFunctions.deserialize(stored)[
+      "metricViewData"
+    ] as unknown as MetricViewData;
+
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: metricViewData,
+        seriesLabels: undefined,
+      }),
+    ).toBe(metricViewData);
+
+    // ...and the card says nothing about being scoped.
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: metricViewData.queryConfigs,
+        seriesLabels: undefined,
+      }),
+    ).toBe("");
+  });
+
+  test("an incoming-request incident's labels never scope a metric query", () => {
+    /*
+     * Incoming-request monitors also write seriesLabels, keyed by a JSON
+     * payload field ("alertname", "instance"). Those are not metric
+     * attributes, and their names can collide with real ones — the
+     * per-query group-by intersection is what stops them from inventing a
+     * filter and charting an empty panel.
+     */
+    const stored: JSONObject = buildStoredTelemetryQuery({
+      groupByAttributeKeys: ["resource.host.name"],
+    });
+
+    const metricViewData: MetricViewData = JSONFunctions.deserialize(stored)[
+      "metricViewData"
+    ] as unknown as MetricViewData;
+
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: metricViewData,
+        seriesLabels: { alertname: "HighCPU" },
+      }),
+    ).toBe(metricViewData);
+
+    /*
+     * And — the half that matters for trust — the card must not announce
+     * "scoped to the affected series (alertname = HighCPU)" over a chart
+     * that still shows every host.
+     */
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: metricViewData.queryConfigs,
+        seriesLabels: { alertname: "HighCPU" },
+      }),
+    ).toBe("");
+  });
+
+  test("a label with no filterable form narrows nothing and claims nothing", () => {
+    /*
+     * SeriesResourceLabels reads array-valued labels off the same object,
+     * so a multi-valued group-by attribute is reachable here. An array has
+     * no faithful attribute-equality form, so the chart stays unscoped —
+     * and the subtitle has to stay silent about it.
+     */
+    const stored: JSONObject = buildStoredTelemetryQuery({
+      groupByAttributeKeys: ["tags"],
+    });
+
+    const metricViewData: MetricViewData = JSONFunctions.deserialize(stored)[
+      "metricViewData"
+    ] as unknown as MetricViewData;
+
+    const seriesLabels: JSONObject = {
+      tags: ["a", "b"],
+    } as unknown as JSONObject;
+
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: metricViewData,
+        seriesLabels: seriesLabels,
+      }),
+    ).toBe(metricViewData);
+
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: metricViewData.queryConfigs,
+        seriesLabels: seriesLabels,
+      }),
+    ).toBe("");
+  });
+});

--- a/Common/Tests/Utils/Metrics/MetricSeriesScope.test.ts
+++ b/Common/Tests/Utils/Metrics/MetricSeriesScope.test.ts
@@ -1,0 +1,1197 @@
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import Dictionary from "../../../Types/Dictionary";
+import { JSONObject } from "../../../Types/JSON";
+import MetricQueryConfigData from "../../../Types/Metrics/MetricQueryConfigData";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import {
+  DictionaryFilterOperator,
+  DictionaryFilterOperatorOption,
+  detectOperatorFromValue,
+  getOperatorOption,
+} from "../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import MetricSeriesScope, {
+  MetricSeriesFilterValue,
+} from "../../../Utils/Metrics/MetricSeriesScope";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * A metric monitor grouped by an attribute (host.name, pod, device) opens
+ * ONE incident per breaching group, but every one of those incidents
+ * stores the SAME monitor-wide query configs. Charting them verbatim shows
+ * every group — so an incident about prod-01 renders a wall of unrelated
+ * hosts, and once the Top-N cap trims the result the breaching host can be
+ * missing from its own incident page entirely.
+ *
+ * MetricSeriesScope narrows those configs back to the incident's own
+ * series using the labels recorded on the incident. These tests lock the
+ * three properties the fix depends on:
+ *
+ *   1. PER-QUERY intersection. The monitor worker groups every query by
+ *      the UNION of group-by keys across all queries, so seriesLabels
+ *      routinely carries keys a given query never grouped by. Filtering a
+ *      query on a dimension it did not group by would narrow the chart to
+ *      something the monitor never evaluated.
+ *   2. Faithful value translation. "" means "the attribute was absent on
+ *      this series" — that is the IsEmpty operator, not an equality
+ *      against the empty string (which the chart's filter sanitizer drops
+ *      on the floor, silently un-scoping the chart).
+ *   3. Identity preservation. React hosts call this on every load; handing
+ *      back a fresh-but-equal object where nothing changed would churn
+ *      state and refetch.
+ */
+
+interface QueryConfigFixture {
+  id?: string | undefined;
+  groupByAttributeKeys?: Array<string> | undefined;
+  attributes?: Dictionary<unknown> | undefined;
+  metricName?: string | undefined;
+  topN?: number | undefined;
+}
+
+function buildQueryConfig(
+  fixture: QueryConfigFixture = {},
+): MetricQueryConfigData {
+  return {
+    id: fixture.id || "query-id-1",
+    metricAliasData: {
+      metricVariable: "a",
+      title: "",
+      description: "",
+      legend: "",
+      legendUnit: "",
+    },
+    metricQueryData: {
+      filterData: {
+        metricName: fixture.metricName || "system.cpu.utilization",
+        aggegationType: "Avg",
+        ...(fixture.attributes ? { attributes: fixture.attributes } : {}),
+      },
+      ...(fixture.groupByAttributeKeys
+        ? { groupByAttributeKeys: fixture.groupByAttributeKeys }
+        : {}),
+      ...(fixture.topN === undefined ? {} : { topN: fixture.topN }),
+    },
+  } as unknown as MetricQueryConfigData;
+}
+
+function getAttributes(
+  queryConfig: MetricQueryConfigData | undefined,
+): Dictionary<unknown> {
+  return (
+    queryConfig?.metricQueryData?.filterData as Dictionary<unknown> | undefined
+  )?.["attributes"] as Dictionary<unknown> | undefined as Dictionary<unknown>;
+}
+
+describe("MetricSeriesScope.hasSeriesLabels", () => {
+  test("is false for undefined, null and the empty object", () => {
+    expect(MetricSeriesScope.hasSeriesLabels(undefined)).toBe(false);
+    expect(MetricSeriesScope.hasSeriesLabels(null)).toBe(false);
+    expect(MetricSeriesScope.hasSeriesLabels({})).toBe(false);
+  });
+
+  test("is true as soon as there is one label", () => {
+    expect(MetricSeriesScope.hasSeriesLabels({ "host.name": "prod-01" })).toBe(
+      true,
+    );
+    // Even an unset value still identifies a series.
+    expect(MetricSeriesScope.hasSeriesLabels({ "host.name": "" })).toBe(true);
+  });
+});
+
+describe("MetricSeriesScope.getSeriesFilterAttributesForQuery", () => {
+  test("returns nothing when the incident carries no series labels", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: undefined,
+      }),
+    ).toEqual({});
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: null,
+      }),
+    ).toEqual({});
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: {},
+      }),
+    ).toEqual({});
+  });
+
+  test("returns nothing for a missing query config", () => {
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig: undefined,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({});
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig: null,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({});
+  });
+
+  test("returns nothing when the query is not grouped at all", () => {
+    /*
+     * An ungrouped query already renders a single line — narrowing it
+     * would change what the monitor evaluated.
+     */
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({});
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({});
+  });
+
+  test("maps a grouped key to an exact-equality string filter", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({ "host.name": "prod-01" });
+  });
+
+  test("maps every grouped key when the series is multi-dimensional", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name", "service.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01", "service.name": "api" },
+      }),
+    ).toEqual({ "host.name": "prod-01", "service.name": "api" });
+  });
+
+  test("ignores label keys this query did not group by", () => {
+    /*
+     * The monitor worker groups EVERY query by the union of group-by keys
+     * across all queries, so seriesLabels carries keys a given query never
+     * asked for. Filtering on them would scope the chart to something the
+     * monitor never evaluated.
+     */
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: {
+          "host.name": "prod-01",
+          "k8s.pod.name": "checkout-abc",
+        },
+      }),
+    ).toEqual({ "host.name": "prod-01" });
+  });
+
+  test("ignores grouped keys the incident's series says nothing about", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name", "service.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({ "host.name": "prod-01" });
+  });
+
+  test("translates an empty label value into the IsEmpty operator", () => {
+    /*
+     * "" is what the series builder writes when the attribute is missing
+     * on the sample. An equality filter on "" is dropped by the chart's
+     * sanitizer, which would silently un-scope the chart; IsNull compiles
+     * to "key absent OR value empty", which is exactly the series.
+     */
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    const filters: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "" },
+      });
+
+    expect(Object.keys(filters)).toEqual(["host.name"]);
+    expect(filters["host.name"]).toBeInstanceOf(IsNull);
+  });
+
+  test("treats null and an explicitly-undefined label value as IsEmpty", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    const withNull: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": null } as unknown as JSONObject,
+      });
+    expect(withNull["host.name"]).toBeInstanceOf(IsNull);
+
+    const withUndefined: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": undefined } as unknown as JSONObject,
+      });
+    expect(withUndefined["host.name"]).toBeInstanceOf(IsNull);
+  });
+
+  test("skips whitespace-only values rather than pretending they are unset", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "   " },
+      }),
+    ).toEqual({});
+  });
+
+  test("preserves surrounding whitespace and case on real values", () => {
+    /*
+     * Attributes are matched byte-exactly against the analytics store, so
+     * trimming or lower-casing here would silently chart nothing.
+     */
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["host.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": " PROD-01 " },
+      }),
+    ).toEqual({ "host.name": " PROD-01 " });
+  });
+
+  test("stringifies numeric and boolean label values", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["http.status_code", "is.canary"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "http.status_code": 200, "is.canary": false },
+      }),
+    ).toEqual({ "http.status_code": "200", "is.canary": "false" });
+  });
+
+  test("keeps the zero value — it is a real label, not an empty one", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["pool_id"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { pool_id: 0 },
+      }),
+    ).toEqual({ pool_id: "0" });
+  });
+
+  test("skips non-finite numbers", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["weird"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { weird: Number.NaN },
+      }),
+    ).toEqual({});
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { weird: Number.POSITIVE_INFINITY },
+      }),
+    ).toEqual({});
+  });
+
+  test("skips array and object label values", () => {
+    /*
+     * Metric attributes are a Map(String, String); String([1,2]) or
+     * "[object Object]" would compile to a predicate matching nothing,
+     * which is worse than leaving the chart un-narrowed.
+     */
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["tags", "meta", "when"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: {
+          tags: ["a", "b"],
+          meta: { nested: true },
+          when: new Date("2024-01-01T00:00:00.000Z"),
+        } as unknown as JSONObject,
+      }),
+    ).toEqual({});
+  });
+
+  test("keeps dotted and resource-prefixed keys verbatim", () => {
+    /*
+     * The `resource.` prefix is applied at INGEST, so the group-by
+     * dropdown, the stored query config and seriesLabels all agree on the
+     * literal key. Adding or stripping it here would address a different
+     * map entry and match nothing.
+     */
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["resource.k8s.node.name", "container.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: {
+          "resource.k8s.node.name": "ip-10-0-1-7",
+          "container.name": "api.1.xyz",
+        },
+      }),
+    ).toEqual({
+      "resource.k8s.node.name": "ip-10-0-1-7",
+      "container.name": "api.1.xyz",
+    });
+  });
+
+  test("does not treat a bare key as the resource-prefixed one", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["resource.host.name"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({});
+  });
+
+  test("ignores blank group-by keys and collapses duplicates", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["", "host.name", "host.name"],
+    });
+
+    const filters: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01", "": "ignored" },
+      });
+
+    expect(filters).toEqual({ "host.name": "prod-01" });
+    expect(Object.keys(filters)).toHaveLength(1);
+  });
+
+  test("does not pick up inherited prototype keys as labels", () => {
+    const queryConfig: MetricQueryConfigData = buildQueryConfig({
+      groupByAttributeKeys: ["toString", "constructor"],
+    });
+
+    expect(
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("MetricSeriesScope.scopeQueryConfigsToSeries — identity", () => {
+  test("hands back the very same array when there are no series labels", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ];
+
+    expect(
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: undefined,
+      }),
+    ).toBe(queryConfigs);
+    expect(
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: {},
+      }),
+    ).toBe(queryConfigs);
+  });
+
+  test("hands back the very same array when nothing could be narrowed", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ];
+
+    expect(
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: { "k8s.pod.name": "checkout-abc" },
+      }),
+    ).toBe(queryConfigs);
+  });
+
+  test("tolerates a missing or empty query config list", () => {
+    expect(
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: undefined,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual([]);
+    expect(
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: null,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual([]);
+    expect(
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: [],
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("MetricSeriesScope.scopeQueryConfigsToSeries — narrowing", () => {
+  test("pushes the series onto the query's attribute filter", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ];
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(scoped).not.toBe(queryConfigs);
+    expect(getAttributes(scoped[0])).toEqual({ "host.name": "prod-01" });
+  });
+
+  test("keeps the group-by so the surviving series is still named", () => {
+    /*
+     * Dropping groupByAttributeKeys would collapse the legend to a bare
+     * metric name — the chart would be correct but would no longer say
+     * WHICH host it is showing.
+     */
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ];
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(scoped[0]?.metricQueryData.groupByAttributeKeys).toEqual([
+      "host.name",
+    ]);
+  });
+
+  test("merges with — and wins over — filters the monitor already carried", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({
+        groupByAttributeKeys: ["host.name"],
+        attributes: {
+          "deployment.environment": "production",
+          "host.name": "prod-99",
+        },
+      }),
+    ];
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(getAttributes(scoped[0])).toEqual({
+      "deployment.environment": "production",
+      "host.name": "prod-01",
+    });
+  });
+
+  test("never mutates the query configs it was handed", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({
+        groupByAttributeKeys: ["host.name"],
+        attributes: { "deployment.environment": "production" },
+      }),
+    ];
+    const snapshot: string = JSON.stringify(queryConfigs);
+
+    MetricSeriesScope.scopeQueryConfigsToSeries({
+      queryConfigs,
+      seriesLabels: { "host.name": "prod-01" },
+    });
+
+    expect(JSON.stringify(queryConfigs)).toBe(snapshot);
+    expect(getAttributes(queryConfigs[0])).toEqual({
+      "deployment.environment": "production",
+    });
+  });
+
+  test("narrows each query by its OWN group-by only", () => {
+    /*
+     * The realistic shape: the worker groups both queries by the union
+     * {host.name, k8s.pod.name}, so the incident carries both keys — but
+     * the chart splits each query by only the keys that query configured.
+     */
+    const hostQuery: MetricQueryConfigData = buildQueryConfig({
+      id: "host-query",
+      groupByAttributeKeys: ["host.name"],
+    });
+    const podQuery: MetricQueryConfigData = buildQueryConfig({
+      id: "pod-query",
+      groupByAttributeKeys: ["k8s.pod.name"],
+    });
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: [hostQuery, podQuery],
+        seriesLabels: {
+          "host.name": "prod-01",
+          "k8s.pod.name": "checkout-abc",
+        },
+      });
+
+    expect(getAttributes(scoped[0])).toEqual({ "host.name": "prod-01" });
+    expect(getAttributes(scoped[1])).toEqual({
+      "k8s.pod.name": "checkout-abc",
+    });
+  });
+
+  test("passes ungrouped queries through untouched, by identity", () => {
+    const groupedQuery: MetricQueryConfigData = buildQueryConfig({
+      id: "grouped",
+      groupByAttributeKeys: ["host.name"],
+    });
+    const ungroupedQuery: MetricQueryConfigData = buildQueryConfig({
+      id: "ungrouped",
+    });
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: [groupedQuery, ungroupedQuery],
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(scoped[0]).not.toBe(groupedQuery);
+    expect(scoped[1]).toBe(ungroupedQuery);
+  });
+
+  test("preserves everything else on the query config", () => {
+    const original: MetricQueryConfigData = buildQueryConfig({
+      id: "keep-me",
+      groupByAttributeKeys: ["host.name"],
+      topN: 25,
+    });
+    original.chartType = undefined;
+    original.color = "#6366f1";
+    original.transformAsRate = true;
+    original.getSeries = () => {
+      return { title: "custom" };
+    };
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: [original],
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    const result: MetricQueryConfigData | undefined = scoped[0];
+
+    expect(result?.id).toBe("keep-me");
+    expect(result?.color).toBe("#6366f1");
+    expect(result?.transformAsRate).toBe(true);
+    expect(result?.getSeries).toBe(original.getSeries);
+    expect(result?.metricAliasData?.metricVariable).toBe("a");
+    expect(result?.metricQueryData.topN).toBe(25);
+    expect(
+      (result?.metricQueryData.filterData as Dictionary<unknown>)["metricName"],
+    ).toBe("system.cpu.utilization");
+    expect(
+      (result?.metricQueryData.filterData as Dictionary<unknown>)[
+        "aggegationType"
+      ],
+    ).toBe("Avg");
+  });
+
+  test("creates the attributes bag when the query had no filters", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ];
+
+    expect(getAttributes(queryConfigs[0])).toBeUndefined();
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(getAttributes(scoped[0])).toEqual({ "host.name": "prod-01" });
+  });
+
+  test("survives a query config whose filterData is missing entirely", () => {
+    /*
+     * Query configs arrive from stored JSON (monitor steps, telemetryQuery
+     * on the incident) — a hand-edited or legacy shape must not throw and
+     * blank the whole page.
+     */
+    const malformed: MetricQueryConfigData = {
+      metricQueryData: {
+        groupByAttributeKeys: ["host.name"],
+      },
+    } as unknown as MetricQueryConfigData;
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: [malformed],
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(getAttributes(scoped[0])).toEqual({ "host.name": "prod-01" });
+  });
+
+  test("scopes a multi-key series across a multi-key query", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({
+        groupByAttributeKeys: ["resource.host.name", "disk.device"],
+      }),
+    ];
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: {
+          "resource.host.name": "prod-01",
+          "disk.device": "/dev/sda1",
+        },
+      });
+
+    expect(getAttributes(scoped[0])).toEqual({
+      "resource.host.name": "prod-01",
+      "disk.device": "/dev/sda1",
+    });
+  });
+
+  test("still narrows on the keys it can when one label is unusable", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({
+        groupByAttributeKeys: ["host.name", "tags"],
+      }),
+    ];
+
+    const scoped: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs,
+        seriesLabels: {
+          "host.name": "prod-01",
+          tags: ["a", "b"],
+        } as unknown as JSONObject,
+      });
+
+    expect(getAttributes(scoped[0])).toEqual({ "host.name": "prod-01" });
+  });
+});
+
+describe("MetricSeriesScope.scopeMetricViewDataToSeries", () => {
+  function buildMetricViewData(
+    queryConfigs: Array<MetricQueryConfigData>,
+  ): MetricViewData {
+    return {
+      startAndEndDate: null,
+      rangeToken: "Past 1 Hour",
+      queryConfigs: queryConfigs,
+      formulaConfigs: [
+        {
+          metricAliasData: {
+            metricVariable: "b",
+            title: "",
+            description: "",
+            legend: "",
+            legendUnit: "",
+          },
+          metricFormulaData: { metricFormula: "a * 2" },
+        },
+      ],
+    } as unknown as MetricViewData;
+  }
+
+  test("passes null and undefined straight through", () => {
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: null,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBeNull();
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData: undefined,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBeUndefined();
+  });
+
+  test("hands back the same object when nothing narrows", () => {
+    const metricViewData: MetricViewData = buildMetricViewData([
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ]);
+
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData,
+        seriesLabels: undefined,
+      }),
+    ).toBe(metricViewData);
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData,
+        seriesLabels: { "k8s.pod.name": "checkout-abc" },
+      }),
+    ).toBe(metricViewData);
+  });
+
+  test("narrows the query configs and keeps the rest of the view", () => {
+    const metricViewData: MetricViewData = buildMetricViewData([
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ]);
+
+    const scoped: MetricViewData | null | undefined =
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData,
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(scoped).not.toBe(metricViewData);
+    expect(getAttributes(scoped?.queryConfigs[0])).toEqual({
+      "host.name": "prod-01",
+    });
+    expect(scoped?.rangeToken).toBe("Past 1 Hour");
+    expect(scoped?.formulaConfigs).toBe(metricViewData.formulaConfigs);
+    expect(scoped?.startAndEndDate).toBeNull();
+  });
+
+  test("never mutates the view data it was handed", () => {
+    const metricViewData: MetricViewData = buildMetricViewData([
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ]);
+    const snapshot: string = JSON.stringify(metricViewData);
+
+    MetricSeriesScope.scopeMetricViewDataToSeries({
+      metricViewData,
+      seriesLabels: { "host.name": "prod-01" },
+    });
+
+    expect(JSON.stringify(metricViewData)).toBe(snapshot);
+  });
+
+  test("keeps identity — and the shape — when queryConfigs is missing", () => {
+    /*
+     * queryConfigs is non-optional on the type, but this arrives from
+     * stored JSON. Rewriting a missing list into [] would both break the
+     * identity contract on every load and change the shape the host reads.
+     */
+    const metricViewData: MetricViewData = {
+      startAndEndDate: null,
+      formulaConfigs: [],
+    } as unknown as MetricViewData;
+
+    const scoped: MetricViewData | null | undefined =
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData,
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    expect(scoped).toBe(metricViewData);
+    expect(scoped?.queryConfigs).toBeUndefined();
+  });
+
+  test("keeps identity when the query config list is empty", () => {
+    const metricViewData: MetricViewData = buildMetricViewData([]);
+
+    expect(
+      MetricSeriesScope.scopeMetricViewDataToSeries({
+        metricViewData,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBe(metricViewData);
+  });
+});
+
+/*
+ * The card subtitle ("scoped to the affected series (...)") is a claim
+ * about the chart below it. It therefore has to describe the narrowing
+ * that was APPLIED, never the raw labels — a summary that outruns the
+ * filter would have the UI vouch for a chart still showing every series,
+ * which is worse than the bug this class fixes. The final block below
+ * pins that as an invariant rather than case by case.
+ */
+describe("MetricSeriesScope.getAppliedSeriesLabelSummary", () => {
+  test("is empty when there is no series", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+    ];
+
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs,
+        seriesLabels: undefined,
+      }),
+    ).toBe("");
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs,
+        seriesLabels: null,
+      }),
+    ).toBe("");
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs,
+        seriesLabels: {},
+      }),
+    ).toBe("");
+  });
+
+  test("is empty when there are no query configs", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: undefined,
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBe("");
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [],
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBe("");
+  });
+
+  test("renders the one label that was applied", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+        ],
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBe("host.name = prod-01");
+  });
+
+  test("joins several applied labels in group-by order", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({
+            groupByAttributeKeys: ["host.name", "disk.device"],
+          }),
+        ],
+        seriesLabels: {
+          "disk.device": "/dev/sda1",
+          "host.name": "prod-01",
+        },
+      }),
+    ).toBe("host.name = prod-01, disk.device = /dev/sda1");
+  });
+
+  test("unions across queries without repeating a shared key", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({
+            id: "a",
+            groupByAttributeKeys: ["host.name"],
+          }),
+          buildQueryConfig({
+            id: "b",
+            groupByAttributeKeys: ["host.name", "k8s.pod.name"],
+          }),
+        ],
+        seriesLabels: {
+          "host.name": "prod-01",
+          "k8s.pod.name": "checkout-abc",
+        },
+      }),
+    ).toBe("host.name = prod-01, k8s.pod.name = checkout-abc");
+  });
+
+  test("renders an applied unset label as (unset), matching the chart legend", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+        ],
+        seriesLabels: { "host.name": "" },
+      }),
+    ).toBe("host.name = (unset)");
+    expect(MetricSeriesScope.UnsetLabelDisplayValue).toBe("(unset)");
+  });
+
+  test("stringifies applied numeric and boolean labels", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({
+            groupByAttributeKeys: ["http.status_code", "is.canary"],
+          }),
+        ],
+        seriesLabels: { "http.status_code": 500, "is.canary": false },
+      }),
+    ).toBe("http.status_code = 500, is.canary = false");
+  });
+
+  test("says nothing about labels the queries never grouped by", () => {
+    /*
+     * Incoming-request monitors write seriesLabels keyed by a payload
+     * field name. Those narrow nothing, so the card must not claim they
+     * did.
+     */
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({ groupByAttributeKeys: ["host.name"] }),
+        ],
+        seriesLabels: { alertname: "HighCPU" },
+      }),
+    ).toBe("");
+  });
+
+  test("says nothing about labels whose value cannot be filtered on", () => {
+    const queryConfigs: Array<MetricQueryConfigData> = [
+      buildQueryConfig({
+        groupByAttributeKeys: ["tags", "meta", "host.name"],
+      }),
+    ];
+
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs,
+        seriesLabels: {
+          tags: ["a", "b"],
+          meta: { nested: true },
+          "host.name": "   ",
+        } as unknown as JSONObject,
+      }),
+    ).toBe("");
+  });
+
+  test("reports only the part it could apply on a mixed series", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [
+          buildQueryConfig({
+            groupByAttributeKeys: ["host.name", "tags"],
+          }),
+        ],
+        seriesLabels: {
+          "host.name": "prod-01",
+          tags: ["a", "b"],
+        } as unknown as JSONObject,
+      }),
+    ).toBe("host.name = prod-01");
+  });
+
+  test("says nothing about an ungrouped query", () => {
+    expect(
+      MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs: [buildQueryConfig({})],
+        seriesLabels: { "host.name": "prod-01" },
+      }),
+    ).toBe("");
+  });
+});
+
+/*
+ * The invariant the card subtitle rests on, stated once and checked
+ * across a matrix of realistic inputs: the summary is non-empty EXACTLY
+ * when the query configs were actually narrowed. Any future value rule
+ * added to one side and not the other fails here.
+ */
+describe("MetricSeriesScope — the summary never outruns the narrowing", () => {
+  interface ScopeCase {
+    name: string;
+    groupByAttributeKeys: Array<string>;
+    seriesLabels: JSONObject | undefined;
+  }
+
+  const cases: Array<ScopeCase> = [
+    {
+      name: "no labels at all",
+      groupByAttributeKeys: ["host.name"],
+      seriesLabels: undefined,
+    },
+    {
+      name: "plain matching label",
+      groupByAttributeKeys: ["host.name"],
+      seriesLabels: { "host.name": "prod-01" },
+    },
+    {
+      name: "unset label",
+      groupByAttributeKeys: ["host.name"],
+      seriesLabels: { "host.name": "" },
+    },
+    {
+      name: "whitespace-only label",
+      groupByAttributeKeys: ["host.name"],
+      seriesLabels: { "host.name": "   " },
+    },
+    {
+      name: "array label",
+      groupByAttributeKeys: ["tags"],
+      seriesLabels: { tags: ["a", "b"] } as unknown as JSONObject,
+    },
+    {
+      name: "object label",
+      groupByAttributeKeys: ["meta"],
+      seriesLabels: { meta: { a: 1 } } as unknown as JSONObject,
+    },
+    {
+      name: "empty array label",
+      groupByAttributeKeys: ["tags"],
+      seriesLabels: { tags: [] } as unknown as JSONObject,
+    },
+    {
+      name: "non-finite numeric label",
+      groupByAttributeKeys: ["weird"],
+      seriesLabels: { weird: Number.NaN },
+    },
+    {
+      name: "zero label",
+      groupByAttributeKeys: ["pool_id"],
+      seriesLabels: { pool_id: 0 },
+    },
+    {
+      name: "label for a dimension the query never grouped by",
+      groupByAttributeKeys: ["host.name"],
+      seriesLabels: { alertname: "HighCPU" },
+    },
+    {
+      name: "ungrouped query",
+      groupByAttributeKeys: [],
+      seriesLabels: { "host.name": "prod-01" },
+    },
+    {
+      name: "one usable label among unusable ones",
+      groupByAttributeKeys: ["host.name", "tags"],
+      seriesLabels: {
+        "host.name": "prod-01",
+        tags: ["a", "b"],
+      } as unknown as JSONObject,
+    },
+  ];
+
+  for (const scopeCase of cases) {
+    test(`summary and narrowing agree — ${scopeCase.name}`, () => {
+      const queryConfigs: Array<MetricQueryConfigData> = [
+        buildQueryConfig({
+          groupByAttributeKeys: scopeCase.groupByAttributeKeys,
+        }),
+      ];
+
+      const scoped: Array<MetricQueryConfigData> =
+        MetricSeriesScope.scopeQueryConfigsToSeries({
+          queryConfigs,
+          seriesLabels: scopeCase.seriesLabels,
+        });
+
+      const didNarrow: boolean = scoped !== queryConfigs;
+
+      const summary: string = MetricSeriesScope.getAppliedSeriesLabelSummary({
+        queryConfigs,
+        seriesLabels: scopeCase.seriesLabels,
+      });
+
+      expect(summary !== "").toBe(didNarrow);
+    });
+  }
+});
+
+/*
+ * The narrowed filters only reach ClickHouse if they survive the chart's
+ * own filter sanitizer, which classifies each value through
+ * detectOperatorFromValue/getOperatorOption. These pin that contract from
+ * this side: a plain string must read as "equals" with a non-blank value,
+ * and IsNull must read as "is empty" — the one operator the sanitizer
+ * keeps despite having no value text.
+ */
+describe("MetricSeriesScope — the filters it emits survive the chart's sanitizer", () => {
+  test("a string label reads as an equals filter with a non-blank value", () => {
+    const filters: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig: buildQueryConfig({
+          groupByAttributeKeys: ["host.name"],
+        }),
+        seriesLabels: { "host.name": "prod-01" },
+      });
+
+    const detected: { operator: DictionaryFilterOperator; rawValue: string } =
+      detectOperatorFromValue(filters["host.name"]);
+
+    expect(detected.operator).toBe(DictionaryFilterOperator.EqualTo);
+    expect(detected.rawValue.trim()).not.toBe("");
+  });
+
+  test("an unset label reads as is-empty, which needs no value text", () => {
+    const filters: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig: buildQueryConfig({
+          groupByAttributeKeys: ["host.name"],
+        }),
+        seriesLabels: { "host.name": "" },
+      });
+
+    const detected: { operator: DictionaryFilterOperator; rawValue: string } =
+      detectOperatorFromValue(filters["host.name"]);
+    const option: DictionaryFilterOperatorOption = getOperatorOption(
+      detected.operator,
+    );
+
+    expect(detected.operator).toBe(DictionaryFilterOperator.IsEmpty);
+    /*
+     * hidesValueInput is precisely what stops the sanitizer from dropping
+     * an operator whose rawValue is blank. Without it this filter would be
+     * silently discarded and the chart would show every series again.
+     */
+    expect(option.hidesValueInput).toBe(true);
+  });
+
+  test("the emitted IsNull serializes to the shape the API rehydrates", () => {
+    const filters: Dictionary<MetricSeriesFilterValue> =
+      MetricSeriesScope.getSeriesFilterAttributesForQuery({
+        queryConfig: buildQueryConfig({
+          groupByAttributeKeys: ["host.name"],
+        }),
+        seriesLabels: { "host.name": "" },
+      });
+
+    expect(JSON.parse(JSON.stringify(filters))).toEqual({
+      "host.name": { _type: "IsNull", value: null },
+    });
+  });
+});

--- a/Common/Utils/Metrics/MetricSeriesScope.ts
+++ b/Common/Utils/Metrics/MetricSeriesScope.ts
@@ -1,0 +1,301 @@
+import IsNull from "../../Types/BaseDatabase/IsNull";
+import Dictionary from "../../Types/Dictionary";
+import { JSONObject, JSONValue } from "../../Types/JSON";
+import MetricQueryConfigData from "../../Types/Metrics/MetricQueryConfigData";
+import MetricQueryData from "../../Types/Metrics/MetricQueryData";
+import MetricViewData from "../../Types/Metrics/MetricViewData";
+
+/**
+ * The value we can put back on a metric query's attribute filter for one
+ * group-by key. A plain string is an exact equality filter; `IsNull` is
+ * the "is empty" operator, which the analytics layer compiles to
+ * "key absent OR value is the empty string" — exactly what an empty
+ * series label means.
+ */
+export type MetricSeriesFilterValue = string | IsNull;
+
+/**
+ * A metric monitor grouped by, say, `host.name` evaluates one series per
+ * host and opens ONE incident per breaching host — the affected series is
+ * recorded on the incident as `seriesLabels` (e.g. `{host.name: prod-01}`).
+ * The monitor's stored query configs, however, are shared by every series
+ * it produced: replaying them verbatim on the incident page charts EVERY
+ * host, so an incident about one host renders a wall of unrelated lines
+ * and (worse) the breaching host can be dropped entirely by the Top-N cap.
+ *
+ * This narrows those query configs back down to the one series the
+ * incident/alert is actually about, by pushing the series labels into the
+ * query's attribute filter. Grouping is deliberately left in place: with
+ * the filter applied it yields exactly one series, and the legend still
+ * names it ("host.name=prod-01") instead of collapsing to a bare metric
+ * name.
+ *
+ * Everything here is pure and identity-preserving — when there is nothing
+ * to narrow, the very same objects come back out, so React hosts can call
+ * it without churning state.
+ */
+export default class MetricSeriesScope {
+  // How an empty (unset) label value is rendered in human-facing summaries.
+  public static readonly UnsetLabelDisplayValue: string = "(unset)";
+
+  public static hasSeriesLabels(
+    seriesLabels: JSONObject | null | undefined,
+  ): boolean {
+    return Boolean(seriesLabels && Object.keys(seriesLabels).length > 0);
+  }
+
+  /**
+   * Turn one series-label value into something the metric attribute
+   * filter can express. Returns null when the value cannot be filtered
+   * on at all — the caller then leaves that key alone rather than
+   * emitting a predicate that would silently match nothing.
+   */
+  private static toFilterValue(
+    value: JSONValue | undefined,
+  ): MetricSeriesFilterValue | null {
+    if (value === undefined || value === null) {
+      return new IsNull();
+    }
+
+    if (typeof value === "string") {
+      /*
+       * "" is what the series builder writes when the attribute is
+       * missing on the sample, so the series really is "rows with no
+       * value for this key" — that is the IsEmpty operator, not an
+       * equality against the empty string (which the UI's filter
+       * sanitizer would drop on the floor anyway).
+       */
+      if (value === "") {
+        return new IsNull();
+      }
+
+      /*
+       * Whitespace-only is neither: an equality filter on it is dropped
+       * by the sanitizer, and treating it as "unset" would be a lie. Skip
+       * the key instead.
+       */
+      if (value.trim() === "") {
+        return null;
+      }
+
+      return value;
+    }
+
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? String(value) : null;
+    }
+
+    if (typeof value === "boolean") {
+      return String(value);
+    }
+
+    /*
+     * Arrays, nested objects and Dates have no faithful representation as
+     * a metric attribute equality filter (attributes are a
+     * Map(String, String) in the analytics store), so they are skipped.
+     */
+    return null;
+  }
+
+  /**
+   * The attribute filters that scope ONE query config to the given
+   * series.
+   *
+   * Only the keys this query actually groups by are considered. The
+   * monitor worker groups every query by the UNION of the group-by keys
+   * across all query configs (so per-series formulas line up), which
+   * means `seriesLabels` routinely carries keys a given query never asked
+   * for — filtering a query on a dimension it does not group by would
+   * narrow the chart to something the monitor never evaluated.
+   */
+  public static getSeriesFilterAttributesForQuery(input: {
+    queryConfig: MetricQueryConfigData | undefined | null;
+    seriesLabels: JSONObject | null | undefined;
+  }): Dictionary<MetricSeriesFilterValue> {
+    const filters: Dictionary<MetricSeriesFilterValue> = {};
+
+    const seriesLabels: JSONObject | null | undefined = input.seriesLabels;
+
+    if (
+      !input.queryConfig ||
+      !MetricSeriesScope.hasSeriesLabels(seriesLabels)
+    ) {
+      return filters;
+    }
+
+    const groupByAttributeKeys: Array<string> =
+      input.queryConfig.metricQueryData?.groupByAttributeKeys || [];
+
+    for (const key of groupByAttributeKeys) {
+      if (!key) {
+        continue;
+      }
+
+      // Key not on the incident's series — we know nothing, so filter nothing.
+      if (!Object.prototype.hasOwnProperty.call(seriesLabels, key)) {
+        continue;
+      }
+
+      const filterValue: MetricSeriesFilterValue | null =
+        MetricSeriesScope.toFilterValue(
+          (seriesLabels as JSONObject)[key] as JSONValue | undefined,
+        );
+
+      if (filterValue === null) {
+        continue;
+      }
+
+      filters[key] = filterValue;
+    }
+
+    return filters;
+  }
+
+  /**
+   * Narrow every query config to the incident's/alert's own series.
+   * Returns the input array unchanged (same reference) when there is
+   * nothing to narrow.
+   */
+  public static scopeQueryConfigsToSeries(input: {
+    queryConfigs: Array<MetricQueryConfigData> | undefined | null;
+    seriesLabels: JSONObject | null | undefined;
+  }): Array<MetricQueryConfigData> {
+    const queryConfigs: Array<MetricQueryConfigData> = input.queryConfigs || [];
+
+    if (!MetricSeriesScope.hasSeriesLabels(input.seriesLabels)) {
+      return queryConfigs;
+    }
+
+    let didNarrowAny: boolean = false;
+
+    const scopedQueryConfigs: Array<MetricQueryConfigData> = queryConfigs.map(
+      (queryConfig: MetricQueryConfigData) => {
+        const filters: Dictionary<MetricSeriesFilterValue> =
+          MetricSeriesScope.getSeriesFilterAttributesForQuery({
+            queryConfig: queryConfig,
+            seriesLabels: input.seriesLabels,
+          });
+
+        if (Object.keys(filters).length === 0) {
+          return queryConfig;
+        }
+
+        didNarrowAny = true;
+
+        const metricQueryData: MetricQueryData = queryConfig.metricQueryData;
+
+        const existingAttributes: Dictionary<unknown> =
+          ((metricQueryData?.filterData as Dictionary<unknown> | undefined)?.[
+            "attributes"
+          ] as Dictionary<unknown> | undefined) || {};
+
+        return {
+          ...queryConfig,
+          metricQueryData: {
+            ...metricQueryData,
+            filterData: {
+              ...(metricQueryData?.filterData || {}),
+              /*
+               * Series labels win over any filter the monitor already
+               * carried for the same key — they are strictly narrower,
+               * and they describe the series this incident is about.
+               */
+              attributes: {
+                ...existingAttributes,
+                ...filters,
+              },
+            },
+          },
+        } as MetricQueryConfigData;
+      },
+    );
+
+    return didNarrowAny ? scopedQueryConfigs : queryConfigs;
+  }
+
+  /**
+   * Convenience wrapper for the places that hold a whole MetricViewData
+   * (the incident/alert "Metrics" cards read one straight off the stored
+   * telemetryQuery). Identity-preserving like the array form.
+   */
+  public static scopeMetricViewDataToSeries<T extends MetricViewData>(input: {
+    metricViewData: T | null | undefined;
+    seriesLabels: JSONObject | null | undefined;
+  }): T | null | undefined {
+    const metricViewData: T | null | undefined = input.metricViewData;
+
+    if (!metricViewData || !metricViewData.queryConfigs) {
+      /*
+       * `queryConfigs` is non-optional on the type, but this data comes
+       * from stored JSON. Returning early keeps the identity contract and
+       * avoids quietly rewriting a missing list into an empty one.
+       */
+      return metricViewData;
+    }
+
+    const scopedQueryConfigs: Array<MetricQueryConfigData> =
+      MetricSeriesScope.scopeQueryConfigsToSeries({
+        queryConfigs: metricViewData.queryConfigs,
+        seriesLabels: input.seriesLabels,
+      });
+
+    if (scopedQueryConfigs === metricViewData.queryConfigs) {
+      return metricViewData;
+    }
+
+    return {
+      ...metricViewData,
+      queryConfigs: scopedQueryConfigs,
+    };
+  }
+
+  /**
+   * "host.name = prod-01, service.name = api" — a one-line description of
+   * the narrowing that was ACTUALLY applied to these query configs, for
+   * card subtitles.
+   *
+   * Deliberately derived from the filters rather than from the raw labels:
+   * a label the queries never grouped by, or one whose value has no
+   * faithful filter form (an array, a whitespace-only string), does not
+   * narrow anything. Summarising it anyway would have the card claim
+   * "scoped to the affected series" over a chart that still shows every
+   * series — a worse failure than the bug this class fixes.
+   *
+   * Returns "" when nothing was narrowed, which is exactly the condition
+   * for the card to say nothing.
+   */
+  public static getAppliedSeriesLabelSummary(input: {
+    queryConfigs: Array<MetricQueryConfigData> | undefined | null;
+    seriesLabels: JSONObject | null | undefined;
+  }): string {
+    const parts: Array<string> = [];
+    const seen: Set<string> = new Set<string>();
+
+    for (const queryConfig of input.queryConfigs || []) {
+      const filters: Dictionary<MetricSeriesFilterValue> =
+        MetricSeriesScope.getSeriesFilterAttributesForQuery({
+          queryConfig: queryConfig,
+          seriesLabels: input.seriesLabels,
+        });
+
+      for (const key of Object.keys(filters)) {
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+
+        const filterValue: MetricSeriesFilterValue | undefined = filters[key];
+
+        parts.push(
+          `${key} = ${
+            typeof filterValue === "string"
+              ? filterValue
+              : MetricSeriesScope.UnsetLabelDisplayValue
+          }`,
+        );
+      }
+    }
+
+    return parts.join(", ");
+  }
+}


### PR DESCRIPTION
## The bug

A metric monitor with group-by attributes (`metricQueryData.groupByAttributeKeys`, e.g. `host.name`) evaluates **one series per group** and opens **one incident per breaching group**. But every one of those incidents is stamped with the same monitor-wide query configs.

Replaying them verbatim charted **every** series. So an incident about `prod-01` rendered a wall of unrelated hosts — and once the Top-N cap trimmed the result, the breaching host could be missing from its own incident page entirely.

## The fix

The affected series is already recorded on the incident/alert as `seriesLabels` (e.g. `{"host.name": "prod-01"}`). New pure util `Common/Utils/Metrics/MetricSeriesScope.ts` pushes those labels back onto each query config's `metricQueryData.filterData.attributes`, so the chart resolves to the single series the event is about.

Applied at all three surfaces that replay a monitor's query configs for one event:

| Surface | File |
| --- | --- |
| Incident Root Cause → "Metric at Incident Time" | `App/FeatureSet/Dashboard/src/Components/Incident/IncidentRootCauseMetricChart.tsx` |
| Incident overview → "Metrics" card | `App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx` |
| Alert overview → "Metrics" card | `App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx` |

The alert card is the exact same bug next door — both read the same `telemetryQuery` that `MonitorResource` builds once per evaluation tick and stamps onto every entity created that tick.

Fixing this in the UI rather than at write time also repairs incidents and alerts that are **already stored**.

## Details that matter

- **Narrowing is per query config**, intersected with *that* query's own `groupByAttributeKeys`. The monitor worker groups every query by the *union* of group-by keys across all queries (so per-series formulas line up), so `seriesLabels` routinely carries keys a given query never grouped by. Filtering on those would scope the chart to something the monitor never evaluated — and would mis-scope incidents whose `seriesLabels` came from a non-metric source such as incoming-request grouping (`{alertname: "HighCPU"}`).
- **An empty label value means "the attribute was absent on this series"**, so it becomes the `IsEmpty` operator, not an equality against `""` — which the chart's filter sanitizer drops on the floor, silently un-scoping the chart.
- **Values with no faithful attribute-equality form** (arrays, objects, whitespace-only strings) are skipped rather than compiled into a predicate that matches nothing. Attributes are a `Map(String, String)` in ClickHouse.
- **Group-by is deliberately kept.** With the filter applied it yields exactly one series, and the legend still names it (`host.name=prod-01`) instead of collapsing to a bare metric name.
- **The card subtitle is derived from the narrowing that was actually applied**, never from the raw labels — so the UI can never claim "scoped to the affected series" over a chart that still shows all of them.
- **Pure and identity-preserving.** When nothing narrows, the same objects come back out, so the React hosts don't churn state or refetch.
- Keys are used **verbatim**, no `resource.` prefix munging — the prefix is applied at ingest, so the group-by dropdown, the stored query config and `seriesLabels` all agree on the literal ClickHouse map key.

The monitor-level "Metrics Preview" is untouched — showing every series is the point of it, and there's a test pinning that it stays unscoped.

## Tests

- `Common/Tests/Utils/Metrics/MetricSeriesScope.test.ts` — **67 tests**: per-query intersection, value translation (unset / whitespace / numeric / boolean / zero / non-finite / array / object), dotted and `resource.`-prefixed keys, filter merge precedence, non-mutation, identity preservation, plus a matrix invariant that the subtitle is non-empty *exactly* when the query configs were narrowed, and cross-module checks that the emitted filters survive the chart's filter sanitizer and the `IsNull` serialize/rehydrate round trip.
- `App/Tests/Dashboard/IncidentMetricSeriesScope.test.ts` — **18 tests**: page wiring for all three surfaces (source-text, in the style of `RecommendationPageWiring.test.ts`, reading a comment-stripped copy) plus the real stored-JSON → deserialize → narrow → serialize pipeline.

Both suites were **mutation-checked**. Each of these turns them red: commenting out the scoping call, discarding the narrowed result, dropping `seriesLabels` from a `select`, dropping the per-query intersection, emitting `""` instead of `IsEmpty`, breaking identity preservation, or summarizing raw labels instead of applied ones. Reordering keys in a `select` does **not** — that's a semantic no-op and must not fail the build.

Full runs: `Common/Tests/Utils/Metrics` 125/125, `App/Tests/Dashboard` 1754/1754. Lint clean; `tsc --noEmit` clean for Common and the Dashboard (only the pre-existing `rrweb` resolution error, which is present on `master` too).

## Note

The commit includes a one-line `App/FeatureSet/BrowserRecorder/package.json` version sync (11.7.3 → 11.7.4) added automatically by the repo's pre-commit hook — the last release bump had left that file behind.