### PR TITLE
Fix monitor timeline no-data states

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -755,7 +755,7 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
           startDate={OneUptimeDate.getSomeDaysAgo(90)}
           endDate={OneUptimeDate.getCurrentDate()}
           isLoading={isLoading}
-          defaultBarColor={Green}
+          defaultBarColor={Gray500}
           downtimeMonitorStatuses={downTimeMonitorStatues}
           incidents={timelineIncidents}
           onIncidentClick={(incidentId: string) => {

--- a/App/FeatureSet/Dashboard/src/Pages/MonitorGroup/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/MonitorGroup/View/Index.tsx
@@ -2,7 +2,7 @@ import LabelsElement from "Common/UI/Components/Label/Labels";
 import PageComponentProps from "../../PageComponentProps";
 import URL from "Common/Types/API/URL";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
-import { Green } from "Common/Types/BrandColors";
+import { Gray500, Green } from "Common/Types/BrandColors";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import OneUptimeDate from "Common/Types/Date";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
@@ -301,7 +301,7 @@ const MonitorGroupView: FunctionComponent<
           startDate={OneUptimeDate.getSomeDaysAgo(90)}
           endDate={OneUptimeDate.getCurrentDate()}
           isLoading={isLoading}
-          defaultBarColor={Green}
+          defaultBarColor={Gray500}
           downtimeMonitorStatuses={downTimeMonitorStatues}
         />
       </Card>

--- a/App/FeatureSet/Workers/DataMigrations/CloseOpenMonitorStatusTimelinesForDisabledMonitors.ts
+++ b/App/FeatureSet/Workers/DataMigrations/CloseOpenMonitorStatusTimelinesForDisabledMonitors.ts
@@ -1,0 +1,53 @@
+import DataMigrationBase from "./DataMigrationBase";
+import logger from "Common/Server/Utils/Logger";
+import MonitorActiveMonitoringTimelineReconciler, {
+  ActiveMonitoringTimelineRepairResult,
+} from "Common/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler";
+import ObjectID from "Common/Types/ObjectID";
+
+/**
+ * Establish a no-data boundary for monitors that were already directly
+ * disabled before pause/resume timeline handling was introduced.
+ *
+ * Monitor.updatedAt is the closest persisted boundary available for legacy
+ * rows, so the shared reconciler uses it while re-reading the live flag under
+ * the timeline mutex. This stops disabled monitors from accruing fabricated
+ * green uptime after deployment. Runtime hooks record exact boundaries for new
+ * transitions, and the startup/hourly reconciler covers writes from old pods
+ * that race this migration during a rolling deployment.
+ */
+export default class CloseOpenMonitorStatusTimelinesForDisabledMonitors extends DataMigrationBase {
+  public constructor() {
+    super("CloseOpenMonitorStatusTimelinesForDisabledMonitors");
+  }
+
+  public override async migrate(): Promise<void> {
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    logger.debug(
+      `CloseOpenMonitorStatusTimelinesForDisabledMonitors: examined ${result.monitorsExamined} mismatched monitor(s), paused ${result.paused}, resumed ${result.resumed}.`,
+    );
+
+    if (result.failedMonitorIds.length > 0) {
+      throw new Error(
+        `Failed to reconcile active-monitoring timelines for ${result.failedMonitorIds.length} monitor(s): ${result.failedMonitorIds
+          .map((monitorId: ObjectID) => {
+            return monitorId.toString();
+          })
+          .join(
+            ", ",
+          )}. Not marking this migration executed so it can be retried safely.`,
+      );
+    }
+  }
+
+  public override async rollback(): Promise<void> {
+    /*
+     * Reopening these rows would turn disabled time back into fabricated
+     * healthy/downtime history, and the original disable timestamp cannot be
+     * recovered. The forward repair is intentionally irreversible.
+     */
+    return;
+  }
+}

--- a/App/FeatureSet/Workers/DataMigrations/Index.ts
+++ b/App/FeatureSet/Workers/DataMigrations/Index.ts
@@ -100,6 +100,7 @@ import AddRightSizingColumnsToKubernetesCostAllocation from "./AddRightSizingCol
 import MoveNetworkDeviceMonitorCollectionToDevices from "./MoveNetworkDeviceMonitorCollectionToDevices";
 import BackfillNetworkSiteTypes from "./BackfillNetworkSiteTypes";
 import AddSessionIdToTelemetryTables from "./AddSessionIdToTelemetryTables";
+import CloseOpenMonitorStatusTimelinesForDisabledMonitors from "./CloseOpenMonitorStatusTimelinesForDisabledMonitors";
 
 // This is the order in which the migrations will be run. Add new migrations to the end of the array.
 
@@ -323,6 +324,13 @@ const DataMigrations: Array<DataMigrationBase> = [
    * because a throw here halts every migration after it.
    */
   new AddSessionIdToTelemetryTables(),
+  /*
+   * Directly disabled monitors used to retain an open Operational/Offline
+   * status row indefinitely. Close the latest row at deploy time so existing
+   * disabled monitors stop accruing fabricated status history; runtime hooks
+   * record exact pause/resume boundaries from this point onward.
+   */
+  new CloseOpenMonitorStatusTimelinesForDisabledMonitors(),
 ];
 
 export default DataMigrations;

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -25,6 +25,7 @@ import "./Jobs/SloOwners/SendOwnerAddedNotification";
 
 // Monitor Jobs.
 import "./Jobs/Monitor/KeepCurrentStateConsistent";
+import "./Jobs/Monitor/ReconcileActiveMonitoringTimeline";
 
 // Alert Owners
 import "./Jobs/AlertOwners/SendCreatedResourceNotification";

--- a/App/FeatureSet/Workers/Jobs/Monitor/ReconcileActiveMonitoringTimeline.ts
+++ b/App/FeatureSet/Workers/Jobs/Monitor/ReconcileActiveMonitoringTimeline.ts
@@ -1,0 +1,41 @@
+import MonitorActiveMonitoringTimelineReconciler, {
+  ActiveMonitoringTimelineRepairResult,
+} from "Common/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler";
+import logger from "Common/Server/Utils/Logger";
+import { EVERY_HOUR } from "Common/Utils/CronTime";
+import RunCron from "../../Utils/Cron";
+
+/*
+ * Worker jobs are stopped by Promise.race without cancelling their bodies.
+ * Bound the recurring safety sweep so a large rollout backlog cannot overrun
+ * and overlap the next invocation. Repaired rows disappear from the mismatch
+ * query, so later hourly runs naturally continue through the backlog. The
+ * one-time data migration deliberately remains unbounded.
+ */
+const MAXIMUM_RECONCILIATION_BATCHES_PER_RUN: number = 5;
+
+RunCron(
+  "Monitor:ReconcileActiveMonitoringTimeline",
+  { schedule: EVERY_HOUR, runOnStartup: true },
+  async () => {
+    try {
+      const result: ActiveMonitoringTimelineRepairResult =
+        await MonitorActiveMonitoringTimelineReconciler.repairMismatches({
+          maximumBatches: MAXIMUM_RECONCILIATION_BATCHES_PER_RUN,
+        });
+
+      if (result.monitorsExamined > 0) {
+        logger.warn(
+          `Monitor:ReconcileActiveMonitoringTimeline - repaired active-monitoring timeline drift for ${result.monitorsExamined - result.failedMonitorIds.length} monitor(s): paused ${result.paused}, resumed ${result.resumed}, failed ${result.failedMonitorIds.length}.`,
+        );
+      } else {
+        logger.debug(
+          "Monitor:ReconcileActiveMonitoringTimeline - no active-monitoring timeline drift found.",
+        );
+      }
+    } catch (error) {
+      logger.error("Error in Monitor:ReconcileActiveMonitoringTimeline job");
+      logger.error(error);
+    }
+  },
+);

--- a/App/Tests/Workers/DataMigrations/CloseOpenMonitorStatusTimelinesForDisabledMonitors.test.ts
+++ b/App/Tests/Workers/DataMigrations/CloseOpenMonitorStatusTimelinesForDisabledMonitors.test.ts
@@ -1,0 +1,169 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import logger from "Common/Server/Utils/Logger";
+import MonitorActiveMonitoringTimelineReconciler, {
+  ActiveMonitoringTimelineRepairResult,
+} from "Common/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler";
+import ObjectID from "Common/Types/ObjectID";
+import CloseOpenMonitorStatusTimelinesForDisabledMonitors from "../../../FeatureSet/Workers/DataMigrations/CloseOpenMonitorStatusTimelinesForDisabledMonitors";
+
+jest.mock(
+  "Common/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        repairMismatches: jest.fn(),
+      },
+    };
+  },
+);
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+const mockedReconciler: { repairMismatches: jest.Mock } =
+  MonitorActiveMonitoringTimelineReconciler as unknown as {
+    repairMismatches: jest.Mock;
+  };
+const mockedLogger: { debug: jest.Mock } = logger as unknown as {
+  debug: jest.Mock;
+};
+
+function repairResult(
+  overrides: Partial<ActiveMonitoringTimelineRepairResult> = {},
+): ActiveMonitoringTimelineRepairResult {
+  return {
+    failedMonitorIds: [],
+    monitorsExamined: 0,
+    paused: 0,
+    resumed: 0,
+    ...overrides,
+  };
+}
+
+describe("CloseOpenMonitorStatusTimelinesForDisabledMonitors", () => {
+  const migration: CloseOpenMonitorStatusTimelinesForDisabledMonitors =
+    new CloseOpenMonitorStatusTimelinesForDisabledMonitors();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReconciler.repairMismatches.mockResolvedValue(
+      repairResult() as never,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("delegates repair to the shared reconciler and logs successful counts", async () => {
+    mockedReconciler.repairMismatches.mockResolvedValue(
+      repairResult({
+        monitorsExamined: 7,
+        paused: 4,
+        resumed: 3,
+      }) as never,
+    );
+
+    await expect(migration.migrate()).resolves.toBeUndefined();
+
+    expect(mockedReconciler.repairMismatches).toHaveBeenCalledTimes(1);
+    expect(mockedReconciler.repairMismatches).toHaveBeenCalledWith();
+    expect(mockedLogger.debug).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.debug).toHaveBeenCalledWith(
+      "CloseOpenMonitorStatusTimelinesForDisabledMonitors: examined 7 mismatched monitor(s), paused 4, resumed 3.",
+    );
+  });
+
+  test("treats a no-op repair as a successful migration", async () => {
+    await expect(migration.migrate()).resolves.toBeUndefined();
+
+    expect(mockedReconciler.repairMismatches).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.debug).toHaveBeenCalledWith(
+      "CloseOpenMonitorStatusTimelinesForDisabledMonitors: examined 0 mismatched monitor(s), paused 0, resumed 0.",
+    );
+  });
+
+  test("throws with every failed monitor ID so the migration remains retryable", async () => {
+    const firstMonitorId: ObjectID = new ObjectID(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const secondMonitorId: ObjectID = new ObjectID(
+      "22222222-2222-4222-8222-222222222222",
+    );
+    mockedReconciler.repairMismatches.mockResolvedValueOnce(
+      repairResult({
+        failedMonitorIds: [firstMonitorId, secondMonitorId],
+        monitorsExamined: 5,
+        paused: 2,
+        resumed: 1,
+      }) as never,
+    );
+
+    await expect(migration.migrate()).rejects.toThrow(
+      `Failed to reconcile active-monitoring timelines for 2 monitor(s): ${firstMonitorId.toString()}, ${secondMonitorId.toString()}. Not marking this migration executed so it can be retried safely.`,
+    );
+
+    expect(mockedLogger.debug).toHaveBeenCalledWith(
+      "CloseOpenMonitorStatusTimelinesForDisabledMonitors: examined 5 mismatched monitor(s), paused 2, resumed 1.",
+    );
+  });
+
+  test("can be retried safely after a repair result reports failures", async () => {
+    const failedMonitorId: ObjectID = new ObjectID(
+      "33333333-3333-4333-8333-333333333333",
+    );
+    mockedReconciler.repairMismatches
+      .mockResolvedValueOnce(
+        repairResult({ failedMonitorIds: [failedMonitorId] }) as never,
+      )
+      .mockResolvedValueOnce(
+        repairResult({ monitorsExamined: 1, paused: 1 }) as never,
+      );
+
+    await expect(migration.migrate()).rejects.toThrow(
+      "Not marking this migration executed so it can be retried safely.",
+    );
+    await expect(migration.migrate()).resolves.toBeUndefined();
+
+    expect(mockedReconciler.repairMismatches).toHaveBeenCalledTimes(2);
+    expect(mockedLogger.debug).toHaveBeenNthCalledWith(
+      2,
+      "CloseOpenMonitorStatusTimelinesForDisabledMonitors: examined 1 mismatched monitor(s), paused 1, resumed 0.",
+    );
+  });
+
+  test("propagates a shared reconciler failure without logging completion", async () => {
+    const databaseFailure: Error = new Error("database unavailable");
+    mockedReconciler.repairMismatches.mockRejectedValue(
+      databaseFailure as never,
+    );
+
+    await expect(migration.migrate()).rejects.toBe(databaseFailure);
+
+    expect(mockedLogger.debug).not.toHaveBeenCalled();
+  });
+
+  test("rollback is intentionally a no-op", async () => {
+    await expect(migration.rollback()).resolves.toBeUndefined();
+
+    expect(mockedReconciler.repairMismatches).not.toHaveBeenCalled();
+    expect(mockedLogger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -29,6 +29,7 @@ import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCom
 import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import { PlanType } from "../../Types/Billing/SubscriptionPlan";
 import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
 import { JSONObject, JSONValue } from "../../Types/JSON";
 import MonitorType, {
@@ -61,6 +62,7 @@ import NotificationSettingEventType from "../../Types/NotificationSetting/Notifi
 import Query from "../Types/Database/Query";
 import DeleteBy from "../Types/Database/DeleteBy";
 import UpdateBy from "../Types/Database/UpdateBy";
+import UpdateOneBy from "../Types/Database/UpdateOneBy";
 import StatusPageResourceService from "./StatusPageResourceService";
 import Label from "../../Models/DatabaseModels/Label";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -85,6 +87,9 @@ import ExceptionMessages from "../../Types/Exception/ExceptionMessages";
 import Project from "../../Models/DatabaseModels/Project";
 import { createWhatsAppMessageFromTemplate } from "../Utils/WhatsAppTemplateUtil";
 import { WhatsAppMessagePayload } from "../../Types/WhatsApp/WhatsAppMessage";
+import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
+
+const ACTIVE_MONITORING_TRANSITION_LOCK_NAMESPACE: string = "Monitor.update";
 
 export interface MonitorDestinationInfo {
   monitorDestination: string;
@@ -92,9 +97,133 @@ export interface MonitorDestinationInfo {
   monitorType: string;
 }
 
+interface MonitorUpdateCarryForward {
+  activeMonitoringTimelineTransitionAt: Date;
+  activeMonitoringPreviousStateByMonitorId: Dictionary<MonitorActiveMonitoringPreviousState>;
+}
+
+interface MonitorActiveMonitoringPreviousState {
+  currentMonitorStatusId?: ObjectID | undefined;
+  projectId?: ObjectID | undefined;
+  stateUpdatedAt: Date;
+  wasDisabled: boolean;
+}
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * A monitor flag write and its timeline boundary are two database writes.
+   * Serialize the complete operation per monitor across pods so rapid disable -> enable
+   * requests cannot commit both flags first and then run their timeline hooks
+   * out of order (which would erase the no-data gap). This lock is deliberately
+   * separate from the per-monitor timeline-writer lock: onUpdateSuccess acquires
+   * that lock while these are held, whereas ordinary timeline creates never
+   * acquire the monitor-update transition locks.
+   *
+   * Candidate IDs are resolved first, sorted, and the update query is narrowed
+   * to exactly that snapshot. Sorted acquisition prevents bulk-update
+   * deadlocks; narrowing prevents a changing query from updating an unlocked
+   * row. Independent monitors and tenants remain fully parallel.
+   */
+  @CaptureSpan()
+  public override async updateOneBy(
+    updateOneBy: UpdateOneBy<Model>,
+  ): Promise<number> {
+    if (typeof updateOneBy.data.disableActiveMonitoring !== "boolean") {
+      return await super.updateOneBy(updateOneBy);
+    }
+
+    return await this.runWithActiveMonitoringTransitionLocks({
+      updateBy: { ...updateOneBy, limit: 1, skip: 0 },
+      operation: async (scopedUpdateBy: UpdateBy<Model>): Promise<number> => {
+        return await super.updateOneBy(scopedUpdateBy);
+      },
+    });
+  }
+
+  @CaptureSpan()
+  public override async updateBy(updateBy: UpdateBy<Model>): Promise<number> {
+    if (typeof updateBy.data.disableActiveMonitoring !== "boolean") {
+      return await super.updateBy(updateBy);
+    }
+
+    return await this.runWithActiveMonitoringTransitionLocks({
+      updateBy: updateBy,
+      operation: async (scopedUpdateBy: UpdateBy<Model>): Promise<number> => {
+        return await super.updateBy(scopedUpdateBy);
+      },
+    });
+  }
+
+  private async runWithActiveMonitoringTransitionLocks(data: {
+    updateBy: UpdateBy<Model>;
+    operation: (scopedUpdateBy: UpdateBy<Model>) => Promise<number>;
+  }): Promise<number> {
+    const monitorsToUpdate: Array<Model> = await this.findBy({
+      query: data.updateBy.query,
+      select: {
+        _id: true,
+      },
+      limit: data.updateBy.limit,
+      skip: data.updateBy.skip,
+      props: {
+        ...data.updateBy.props,
+        ignoreHooks: true,
+      },
+    });
+    const monitorIds: Array<ObjectID> = Array.from(
+      new Map<string, ObjectID>(
+        monitorsToUpdate
+          .filter((monitor: Model): boolean => {
+            return Boolean(monitor.id);
+          })
+          .map((monitor: Model): [string, ObjectID] => {
+            return [monitor.id!.toString(), monitor.id!];
+          }),
+      ).values(),
+    ).sort((first: ObjectID, second: ObjectID): number => {
+      return first.toString().localeCompare(second.toString());
+    });
+
+    if (monitorIds.length === 0) {
+      return 0;
+    }
+
+    const mutexes: Array<SemaphoreMutex> = [];
+
+    try {
+      for (const monitorId of monitorIds) {
+        mutexes.push(
+          await Semaphore.lock({
+            key: monitorId.toString(),
+            namespace: ACTIVE_MONITORING_TRANSITION_LOCK_NAMESPACE,
+          }),
+        );
+      }
+
+      const scopedUpdateBy: UpdateBy<Model> = {
+        ...data.updateBy,
+        query: {
+          ...data.updateBy.query,
+          _id: QueryHelper.any(monitorIds),
+        },
+        limit: monitorIds.length,
+        skip: 0,
+      };
+
+      return await data.operation(scopedUpdateBy);
+    } finally {
+      for (const mutex of mutexes.reverse()) {
+        try {
+          await Semaphore.release(mutex);
+        } catch (error) {
+          logger.error(error);
+        }
+      }
+    }
   }
 
   public getMonitorDestinationInfo(monitor: Model): MonitorDestinationInfo {
@@ -440,7 +569,55 @@ export class Service extends DatabaseService<Model> {
       }
     }
 
-    return { updateBy, carryForward: null };
+    let carryForward: MonitorUpdateCarryForward | null = null;
+
+    if (typeof updateBy.data.disableActiveMonitoring === "boolean") {
+      const transitionAt: Date = OneUptimeDate.getCurrentDate();
+      const monitorsBeforeUpdate: Array<Model> = await this.findBy({
+        query: updateBy.query,
+        select: {
+          _id: true,
+          projectId: true,
+          currentMonitorStatusId: true,
+          disableActiveMonitoring: true,
+          updatedAt: true,
+        },
+        limit: updateBy.limit,
+        skip: updateBy.skip,
+        props: {
+          ...updateBy.props,
+          ignoreHooks: true,
+        },
+      });
+      const previousStateByMonitorId: MonitorUpdateCarryForward["activeMonitoringPreviousStateByMonitorId"] =
+        {};
+
+      for (const monitor of monitorsBeforeUpdate) {
+        if (!monitor.id) {
+          continue;
+        }
+
+        previousStateByMonitorId[monitor.id.toString()] = {
+          currentMonitorStatusId: monitor.currentMonitorStatusId,
+          projectId: monitor.projectId,
+          /*
+           * On a same-value retry, updatedAt is the timestamp of the earlier
+           * flag commit whose timeline hook failed. Retaining it lets the retry
+           * repair the original boundary instead of starting the no-data gap at
+           * the later retry time.
+           */
+          stateUpdatedAt: monitor.updatedAt || transitionAt,
+          wasDisabled: monitor.disableActiveMonitoring === true,
+        };
+      }
+
+      carryForward = {
+        activeMonitoringTimelineTransitionAt: transitionAt,
+        activeMonitoringPreviousStateByMonitorId: previousStateByMonitorId,
+      };
+    }
+
+    return { updateBy, carryForward };
   }
 
   private async getProjectIdsForUpdateQuery(
@@ -475,6 +652,16 @@ export class Service extends DatabaseService<Model> {
     onUpdate: OnUpdate<Model>,
     updatedItemIds: ObjectID[],
   ): Promise<OnUpdate<Model>> {
+    const isEnablingWithExplicitStatusChange: boolean = Boolean(
+      onUpdate.updateBy.data.disableActiveMonitoring === false &&
+        onUpdate.updateBy.data.currentMonitorStatusId &&
+        onUpdate.updateBy.props.tenantId,
+    );
+
+    if (!isEnablingWithExplicitStatusChange) {
+      await this.updateActiveMonitoringTimeline(onUpdate, updatedItemIds);
+    }
+
     if (
       onUpdate.updateBy.data.currentMonitorStatusId &&
       onUpdate.updateBy.props.tenantId
@@ -490,6 +677,18 @@ export class Service extends DatabaseService<Model> {
           isRoot: true,
         },
       );
+    }
+
+    /*
+     * On a combined enable + explicit status update, let the ordinary status
+     * create run first so it retains its feed item and owner notification. The
+     * active-monitoring reconciliation then sees that open row and becomes an
+     * idempotent no-op. Disable + status updates keep the opposite order so the
+     * true disable boundary is persisted before the disabled status write is
+     * collapsed to zero duration.
+     */
+    if (isEnablingWithExplicitStatusChange) {
+      await this.updateActiveMonitoringTimeline(onUpdate, updatedItemIds);
     }
 
     if (updatedItemIds.length > 0) {
@@ -613,6 +812,87 @@ export class Service extends DatabaseService<Model> {
     }
 
     return onUpdate;
+  }
+
+  /**
+   * Direct monitor disablement is a pause in observation, not an Operational
+   * (or Offline) status that should be extended indefinitely. Persist the
+   * enabled/disabled boundary as a gap in MonitorStatusTimeline. Incident and
+   * scheduled-maintenance suppression flags are intentionally excluded: those
+   * flows can carry an explicitly declared status for their duration.
+   */
+  private async updateActiveMonitoringTimeline(
+    onUpdate: OnUpdate<Model>,
+    updatedItemIds: Array<ObjectID>,
+  ): Promise<void> {
+    if (typeof onUpdate.updateBy.data.disableActiveMonitoring !== "boolean") {
+      return;
+    }
+
+    const carryForward: MonitorUpdateCarryForward | null =
+      onUpdate.carryForward as MonitorUpdateCarryForward | null;
+    const transitionAt: Date | undefined =
+      carryForward?.activeMonitoringTimelineTransitionAt;
+    const isDisabled: boolean =
+      onUpdate.updateBy.data.disableActiveMonitoring === true;
+
+    if (!transitionAt) {
+      return;
+    }
+
+    /*
+     * DatabaseService supplies the exact IDs it actually updated after
+     * permission filtering, skip, and limit have been applied. Reconcile every
+     * one, including same-value writes: if a prior post-update hook failed after
+     * the monitor row committed, retrying `disabled = true` must repair the
+     * still-open interval instead of treating the request as a no-op.
+     *
+     * The reconciler reads the live monitor flag while holding the same mutex as
+     * status timeline writers. If a newer opposite state has already won, it
+     * reconstructs this committed transition and that live transition in order
+     * under the same lock. This also covers opposite writes from old pods that
+     * do not yet run the new hook during a rolling deployment.
+     */
+    for (const monitorId of updatedItemIds) {
+      const previousState: MonitorActiveMonitoringPreviousState | undefined =
+        carryForward?.activeMonitoringPreviousStateByMonitorId[
+          monitorId.toString()
+        ];
+
+      /*
+       * Re-establish the state that was committed before this update, using
+       * that row's persisted updatedAt. This is normally an idempotent no-op.
+       * It becomes the durable recovery path when the previous request saved
+       * the flag but its post-save timeline hook failed:
+       *
+       * - previously disabled: shorten the old interval at the original
+       *   disable commit before opening the new enabled interval;
+       * - previously enabled: recreate a missing enabled interval at the
+       *   original enable commit before closing it for the new disable.
+       */
+      if (previousState?.wasDisabled) {
+        await MonitorStatusTimelineService.pauseActiveMonitoring({
+          monitorId: monitorId,
+          pausedAt: previousState.stateUpdatedAt,
+        });
+      } else if (
+        previousState?.projectId &&
+        previousState.currentMonitorStatusId
+      ) {
+        await MonitorStatusTimelineService.resumeActiveMonitoring({
+          monitorId: monitorId,
+          projectId: previousState.projectId,
+          monitorStatusId: previousState.currentMonitorStatusId,
+          resumedAt: previousState.stateUpdatedAt,
+        });
+      }
+
+      await MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: monitorId,
+        expectedDisableActiveMonitoring: isDisabled,
+        reconciledAt: transitionAt,
+      });
+    }
   }
 
   public getEnabledMonitorQuery(): Query<Model> {
@@ -851,6 +1131,16 @@ ${createdItem.description?.trim() || "No description provided."}
       })
       .then(async () => {
         try {
+          /*
+           * A monitor created with direct active monitoring disabled has not
+           * produced monitoring data yet. Seeding an open Operational row here
+           * would paint its entire history green until it is enabled. The
+           * enable transition opens the first interval at that point instead.
+           */
+          if (createdItem.disableActiveMonitoring) {
+            return Promise.resolve();
+          }
+
           return await this.changeMonitorStatus(
             createdItem.projectId!,
             [createdItem.id!],

--- a/Common/Server/Services/MonitorStatusTimelineService.ts
+++ b/Common/Server/Services/MonitorStatusTimelineService.ts
@@ -14,6 +14,7 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import MonitorStatusTimeline from "../../Models/DatabaseModels/MonitorStatusTimeline";
+import Monitor from "../../Models/DatabaseModels/Monitor";
 import MonitorFeedService from "./MonitorFeedService";
 import { MonitorFeedEventType } from "../../Models/DatabaseModels/MonitorFeed";
 import MonitorStatus from "../../Models/DatabaseModels/MonitorStatus";
@@ -37,6 +38,13 @@ export const MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE: string =
  */
 export const MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE: string =
   "Could not acquire the monitor status timeline lock for this monitor.";
+
+export interface ActiveMonitoringTimelineReconciliationResult {
+  didPause: boolean;
+  didResume: boolean;
+  monitorWasFound: boolean;
+  stateMatchedExpectation: boolean;
+}
 
 export class Service extends DatabaseService<MonitorStatusTimeline> {
   public constructor() {
@@ -73,33 +81,26 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
       monitorId: createBy.data.monitorId?.toString(),
     } as LogAttributes;
 
-    let mutex: SemaphoreMutex | null = null;
-
-    try {
-      mutex = await Semaphore.lock({
-        key: createBy.data.monitorId.toString(),
-        namespace: "MonitorStatusTimeline.create",
-      });
-    } catch (e) {
-      /*
-       * Fail closed. This used to fall through and INSERT UNLOCKED, which let two
-       * concurrent writers resolve the same predecessor row, both pass the
-       * same-as-previous check, and both INSERT a status row milliseconds apart.
-       * Only the later row is ever closed (the next writer resolves its
-       * predecessor with ORDER BY startsAt DESC LIMIT 1), so the earlier row is
-       * orphaned with endsAt = NULL permanently and is read back as unbounded
-       * downtime. Refusing the write is strictly safer: the monitor keeps its
-       * current status and the next probe result for the same monitor
-       * re-evaluates the same criteria and recreates the status change.
-       */
-      logger.error(e, logAttributes);
-      throw new ServerException(MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE);
-    }
+    const mutex: SemaphoreMutex = await this.acquireMonitorTimelineMutex(
+      createBy.data.monitorId,
+      logAttributes,
+    );
 
     let createdItem: MonitorStatusTimeline;
 
     try {
       createdItem = await super.create(createBy);
+
+      /*
+       * A probe or detached initial-status write can already be in flight when
+       * active monitoring is disabled. Because it waits on this same mutex, it
+       * can otherwise run immediately after the disable boundary and reopen an
+       * unbounded green interval. Keep the status change (and the monitor's
+       * current status) but collapse its timeline row to zero duration when the
+       * live monitor flag is disabled. Zero-duration rows are intentionally
+       * ignored by the uptime graph.
+       */
+      await this.closeCreatedTimelineIfMonitorIsDisabled(createdItem);
     } finally {
       await this.releaseMutex(mutex, logAttributes);
     }
@@ -117,6 +118,488 @@ export class Service extends DatabaseService<MonitorStatusTimeline> {
     await this.createStatusChangeFeedItem(createdItem, createBy);
 
     return createdItem;
+  }
+
+  /**
+   * Make the latest timeline interval agree with the monitor's live direct
+   * active-monitoring flag. This is the transition primitive used by monitor
+   * updates and the one-time repair migration.
+   *
+   * The monitor row itself is intentionally read inside the timeline mutex.
+   * An expected-state mismatch represents two ordered commits: the caller's
+   * observed transition at reconciledAt, followed by the opposite live state at
+   * Monitor.updatedAt. Reconstruct both boundaries under this one mutex. This
+   * matters during rolling deploys because the opposite write may come from an
+   * old pod with no timeline hook. We also re-read after every write so a state
+   * change during the critical section is reconciled before releasing the lock.
+   */
+  @CaptureSpan()
+  public async reconcileActiveMonitoring(data: {
+    monitorId: ObjectID;
+    reconciledAt: Date;
+    expectedDisableActiveMonitoring?: boolean | undefined;
+  }): Promise<ActiveMonitoringTimelineReconciliationResult> {
+    const logAttributes: LogAttributes = {
+      monitorId: data.monitorId.toString(),
+    } as LogAttributes;
+    const mutex: SemaphoreMutex = await this.acquireMonitorTimelineMutex(
+      data.monitorId,
+      logAttributes,
+    );
+    const result: ActiveMonitoringTimelineReconciliationResult = {
+      didPause: false,
+      didResume: false,
+      monitorWasFound: false,
+      stateMatchedExpectation: true,
+    };
+
+    try {
+      let boundaryAt: Date = data.reconciledAt;
+
+      for (let attempt: number = 0; attempt < 3; attempt++) {
+        const monitor: Monitor | null = await MonitorService.findOneBy({
+          query: {
+            _id: data.monitorId.toString(),
+          },
+          select: {
+            _id: true,
+            projectId: true,
+            currentMonitorStatusId: true,
+            disableActiveMonitoring: true,
+            updatedAt: true,
+          },
+          props: {
+            isRoot: true,
+            ignoreHooks: true,
+          },
+        });
+
+        if (!monitor) {
+          return result;
+        }
+
+        result.monitorWasFound = true;
+        const isDisabled: boolean = monitor.disableActiveMonitoring === true;
+        const expectationMismatched: boolean = Boolean(
+          attempt === 0 &&
+            typeof data.expectedDisableActiveMonitoring === "boolean" &&
+            data.expectedDisableActiveMonitoring !== isDisabled,
+        );
+
+        if (expectationMismatched) {
+          result.stateMatchedExpectation = false;
+
+          if (data.expectedDisableActiveMonitoring === true) {
+            result.didPause =
+              (await this.pauseActiveMonitoringWhileLocked({
+                monitorId: data.monitorId,
+                pausedAt: data.reconciledAt,
+              })) || result.didPause;
+          } else if (monitor.projectId && monitor.currentMonitorStatusId) {
+            result.didResume = Boolean(
+              (await this.resumeActiveMonitoringWhileLocked({
+                monitorId: data.monitorId,
+                projectId: monitor.projectId,
+                monitorStatusId: monitor.currentMonitorStatusId,
+                resumedAt: data.reconciledAt,
+              })) || result.didResume,
+            );
+          }
+
+          const liveStateUpdatedAt: Date =
+            monitor.updatedAt || OneUptimeDate.getCurrentDate();
+          boundaryAt =
+            liveStateUpdatedAt.getTime() >= data.reconciledAt.getTime()
+              ? liveStateUpdatedAt
+              : data.reconciledAt;
+        } else if (attempt === 0 && monitor.updatedAt) {
+          /*
+           * For bulk writes, each monitor commits at a different time. Its
+           * persisted timestamp is a more accurate boundary than the single
+           * request timestamp captured before the first row was saved.
+           */
+          boundaryAt = monitor.updatedAt;
+        }
+
+        if (isDisabled) {
+          result.didPause =
+            (await this.pauseActiveMonitoringWhileLocked({
+              monitorId: data.monitorId,
+              pausedAt: boundaryAt,
+            })) || result.didPause;
+        } else if (monitor.projectId && monitor.currentMonitorStatusId) {
+          result.didResume = Boolean(
+            (await this.resumeActiveMonitoringWhileLocked({
+              monitorId: data.monitorId,
+              projectId: monitor.projectId,
+              monitorStatusId: monitor.currentMonitorStatusId,
+              resumedAt: boundaryAt,
+            })) || result.didResume,
+          );
+        }
+
+        const monitorAfterWrite: Monitor | null =
+          await MonitorService.findOneBy({
+            query: {
+              _id: data.monitorId.toString(),
+            },
+            select: {
+              _id: true,
+              disableActiveMonitoring: true,
+              updatedAt: true,
+            },
+            props: {
+              isRoot: true,
+              ignoreHooks: true,
+            },
+          });
+
+        if (
+          !monitorAfterWrite ||
+          (monitorAfterWrite.disableActiveMonitoring === true) === isDisabled
+        ) {
+          return result;
+        }
+
+        const latestStateUpdatedAt: Date =
+          monitorAfterWrite.updatedAt || OneUptimeDate.getCurrentDate();
+        boundaryAt =
+          latestStateUpdatedAt.getTime() >= boundaryAt.getTime()
+            ? latestStateUpdatedAt
+            : boundaryAt;
+      }
+
+      logger.warn(
+        `MonitorStatusTimeline: monitor ${data.monitorId.toString()} changed active-monitoring state repeatedly during reconciliation; its newest update hook will reconcile the final state.`,
+        logAttributes,
+      );
+      return result;
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  /**
+   * End the monitor's current status interval when direct active monitoring is
+   * disabled. The monitor keeps its currentMonitorStatusId; the closed interval
+   * creates an intentional no-data gap until active monitoring resumes.
+   */
+  @CaptureSpan()
+  public async pauseActiveMonitoring(data: {
+    monitorId: ObjectID;
+    pausedAt: Date;
+  }): Promise<boolean> {
+    const logAttributes: LogAttributes = {
+      monitorId: data.monitorId.toString(),
+    } as LogAttributes;
+    const mutex: SemaphoreMutex = await this.acquireMonitorTimelineMutex(
+      data.monitorId,
+      logAttributes,
+    );
+
+    try {
+      return await this.pauseActiveMonitoringWhileLocked(data);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  /**
+   * Start a fresh interval at the monitor's current status when direct active
+   * monitoring is re-enabled. This deliberately bypasses the ordinary status
+   * transition hooks: resuming the same status after a gap is not a status
+   * change and must not notify owners or write a misleading feed item.
+   */
+  @CaptureSpan()
+  public async resumeActiveMonitoring(data: {
+    monitorId: ObjectID;
+    projectId: ObjectID;
+    monitorStatusId: ObjectID;
+    resumedAt: Date;
+  }): Promise<MonitorStatusTimeline | null> {
+    const logAttributes: LogAttributes = {
+      projectId: data.projectId.toString(),
+      monitorId: data.monitorId.toString(),
+    } as LogAttributes;
+    const mutex: SemaphoreMutex = await this.acquireMonitorTimelineMutex(
+      data.monitorId,
+      logAttributes,
+    );
+
+    try {
+      return await this.resumeActiveMonitoringWhileLocked(data);
+    } finally {
+      await this.releaseMutex(mutex, logAttributes);
+    }
+  }
+
+  private async pauseActiveMonitoringWhileLocked(data: {
+    monitorId: ObjectID;
+    pausedAt: Date;
+  }): Promise<boolean> {
+    /*
+     * First repair the interval that covered the actual disable boundary. A
+     * late status create can run after the monitor flag commits but before this
+     * hook acquires the mutex: that create closes the formerly-open predecessor
+     * at its own later startsAt and then zero-closes itself. Looking only for an
+     * open row would find nothing and leave the time from disabledAt to that
+     * later startsAt painted green. This covering-interval query lets us shorten
+     * the predecessor back to the real boundary even when it is already closed.
+     */
+    const timelineAtBoundary: MonitorStatusTimeline | null =
+      await this.findOneBy({
+        query: {
+          monitorId: data.monitorId,
+          startsAt: QueryHelper.lessThanEqualTo(data.pausedAt),
+          endsAt: QueryHelper.greaterThanEqualToOrNull(data.pausedAt),
+        },
+        select: {
+          _id: true,
+          startsAt: true,
+          endsAt: true,
+        },
+        sort: {
+          startsAt: SortOrder.Descending,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const timelineStrictlyCoversBoundary: boolean = Boolean(
+      timelineAtBoundary &&
+        (!timelineAtBoundary.endsAt ||
+          timelineAtBoundary.endsAt.getTime() > data.pausedAt.getTime()),
+    );
+
+    let didPause: boolean = false;
+
+    if (
+      timelineAtBoundary?.id &&
+      timelineAtBoundary.startsAt &&
+      timelineStrictlyCoversBoundary
+    ) {
+      const updatedCount: number = await this.updateOneBy({
+        query: {
+          _id: timelineAtBoundary.id.toString(),
+          startsAt: QueryHelper.lessThanEqualTo(data.pausedAt),
+          endsAt: QueryHelper.greaterThanEqualToOrNull(data.pausedAt),
+        },
+        data: {
+          endsAt: data.pausedAt,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      didPause = updatedCount > 0;
+    }
+
+    /*
+     * Always look for a remaining open row, even after shortening the interval
+     * that covered the boundary. A late status write can have closed that
+     * predecessor and inserted a newer open row after pausedAt. Returning after
+     * the first repair would leave the newer row accruing fabricated uptime on
+     * a disabled monitor. Its startsAt can be ahead of pausedAt, so collapse it
+     * at its own start instead of producing a negative interval.
+     */
+    const latestOpenTimeline: MonitorStatusTimeline | null =
+      await this.findOneBy({
+        query: {
+          monitorId: data.monitorId,
+          endsAt: QueryHelper.isNull(),
+          startsAt: QueryHelper.greaterThanEqualTo(data.pausedAt),
+        },
+        select: {
+          _id: true,
+          startsAt: true,
+          endsAt: true,
+        },
+        sort: {
+          startsAt: SortOrder.Descending,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    if (
+      !latestOpenTimeline?.id ||
+      latestOpenTimeline.endsAt ||
+      !latestOpenTimeline.startsAt ||
+      latestOpenTimeline.startsAt.getTime() < data.pausedAt.getTime()
+    ) {
+      return didPause;
+    }
+
+    /*
+     * Probe/app clocks can be slightly ahead of the monitor-update clock, and
+     * an in-flight status write may have started after the captured transition
+     * timestamp. Leaving that row open recreates the bug indefinitely. Close at
+     * max(pausedAt, startsAt); the skew/late-write case becomes a harmless
+     * zero-duration row instead of an inverted interval.
+     */
+    const effectivePausedAt: Date =
+      data.pausedAt.getTime() >= latestOpenTimeline.startsAt.getTime()
+        ? data.pausedAt
+        : latestOpenTimeline.startsAt;
+    const updatedCount: number = await this.updateOneBy({
+      query: {
+        _id: latestOpenTimeline.id.toString(),
+        endsAt: QueryHelper.isNull(),
+        startsAt: QueryHelper.lessThanEqualTo(effectivePausedAt),
+      },
+      data: {
+        endsAt: effectivePausedAt,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return updatedCount > 0 || didPause;
+  }
+
+  private async resumeActiveMonitoringWhileLocked(data: {
+    monitorId: ObjectID;
+    projectId: ObjectID;
+    monitorStatusId: ObjectID;
+    resumedAt: Date;
+  }): Promise<MonitorStatusTimeline | null> {
+    const latestTimeline: MonitorStatusTimeline | null = await this.findOneBy({
+      query: {
+        monitorId: data.monitorId,
+        projectId: data.projectId,
+      },
+      select: {
+        _id: true,
+        startsAt: true,
+        endsAt: true,
+      },
+      sort: {
+        startsAt: SortOrder.Descending,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (latestTimeline && !latestTimeline.endsAt) {
+      return null;
+    }
+
+    let effectiveResumedAt: Date = data.resumedAt;
+
+    if (
+      latestTimeline?.startsAt &&
+      latestTimeline.startsAt.getTime() > effectiveResumedAt.getTime()
+    ) {
+      effectiveResumedAt = latestTimeline.startsAt;
+    }
+
+    if (
+      latestTimeline?.endsAt &&
+      latestTimeline.endsAt.getTime() > effectiveResumedAt.getTime()
+    ) {
+      effectiveResumedAt = latestTimeline.endsAt;
+    }
+
+    /*
+     * A late status write while disabled is collapsed to startsAt === endsAt.
+     * If enablement has the same timestamp, start one millisecond later so the
+     * new open row is unambiguously the latest row; equal startsAt values have
+     * no guaranteed database sort order.
+     */
+    if (
+      latestTimeline?.startsAt &&
+      effectiveResumedAt.getTime() === latestTimeline.startsAt.getTime()
+    ) {
+      effectiveResumedAt = new Date(effectiveResumedAt.getTime() + 1);
+    }
+
+    const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+    timeline.monitorId = data.monitorId;
+    timeline.projectId = data.projectId;
+    timeline.monitorStatusId = data.monitorStatusId;
+    timeline.startsAt = effectiveResumedAt;
+    timeline.isOwnerNotified = true;
+
+    return await super.create({
+      data: timeline,
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+  }
+
+  private async closeCreatedTimelineIfMonitorIsDisabled(
+    createdItem: MonitorStatusTimeline,
+  ): Promise<void> {
+    if (
+      !createdItem.id ||
+      !createdItem.monitorId ||
+      !createdItem.startsAt ||
+      createdItem.endsAt
+    ) {
+      return;
+    }
+
+    const monitor: Monitor | null = await MonitorService.findOneBy({
+      query: {
+        _id: createdItem.monitorId.toString(),
+      },
+      select: {
+        _id: true,
+        disableActiveMonitoring: true,
+      },
+      props: {
+        isRoot: true,
+        ignoreHooks: true,
+      },
+    });
+
+    if (monitor?.disableActiveMonitoring !== true) {
+      return;
+    }
+
+    const updatedCount: number = await this.updateOneBy({
+      query: {
+        _id: createdItem.id.toString(),
+        endsAt: QueryHelper.isNull(),
+      },
+      data: {
+        endsAt: createdItem.startsAt,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (updatedCount > 0) {
+      createdItem.endsAt = createdItem.startsAt;
+    }
+  }
+
+  private async acquireMonitorTimelineMutex(
+    monitorId: ObjectID,
+    logAttributes: LogAttributes,
+  ): Promise<SemaphoreMutex> {
+    try {
+      return await Semaphore.lock({
+        key: monitorId.toString(),
+        namespace: "MonitorStatusTimeline.create",
+      });
+    } catch (error) {
+      /*
+       * Fail closed. Performing a status create, pause, or resume without the
+       * shared per-monitor lock can leave overlapping open rows and turn an
+       * intentional no-data gap into fabricated uptime or downtime.
+       */
+      logger.error(error, logAttributes);
+      throw new ServerException(MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE);
+    }
   }
 
   @CaptureSpan()

--- a/Common/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler.ts
+++ b/Common/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler.ts
@@ -1,0 +1,166 @@
+import PostgresAppInstance, {
+  DatabaseSource,
+} from "../../Infrastructure/PostgresDatabase";
+import MonitorStatusTimelineService, {
+  ActiveMonitoringTimelineReconciliationResult,
+} from "../../Services/MonitorStatusTimelineService";
+import DatabaseNotConnectedException from "../../../Types/Exception/DatabaseNotConnectedException";
+import ObjectID from "../../../Types/ObjectID";
+import CaptureSpan from "../Telemetry/CaptureSpan";
+import logger from "../Logger";
+
+const RECONCILIATION_BATCH_SIZE: number = 100;
+
+interface ActiveMonitoringMismatchRow {
+  disableActiveMonitoring: boolean;
+  monitorId: string;
+  stateUpdatedAt: Date | string;
+}
+
+export interface ActiveMonitoringTimelineRepairResult {
+  failedMonitorIds: Array<ObjectID>;
+  monitorsExamined: number;
+  paused: number;
+  resumed: number;
+}
+
+export interface ActiveMonitoringTimelineRepairOptions {
+  maximumBatches?: number | undefined;
+}
+
+/**
+ * Repairs drift between Monitor.disableActiveMonitoring and the presence of an
+ * open MonitorStatusTimeline row.
+ *
+ * Runtime hooks are the primary write path. This reconciler is the durable
+ * rollout/failure safety net: data migrations overlap old pods, and monitor
+ * rows commit before post-update hooks. Running on every worker startup and
+ * hourly means a late old-version write or an exhausted transient retry cannot
+ * leave fabricated green history indefinitely.
+ */
+export default class MonitorActiveMonitoringTimelineReconciler {
+  @CaptureSpan()
+  public static async repairMismatches(
+    options: ActiveMonitoringTimelineRepairOptions = {},
+  ): Promise<ActiveMonitoringTimelineRepairResult> {
+    const dataSource: DatabaseSource = this.getDataSource();
+    const result: ActiveMonitoringTimelineRepairResult = {
+      failedMonitorIds: [],
+      monitorsExamined: 0,
+      paused: 0,
+      resumed: 0,
+    };
+    let cursor: string | null = null;
+    let batchesProcessed: number = 0;
+
+    while (true) {
+      if (
+        options.maximumBatches !== undefined &&
+        batchesProcessed >= options.maximumBatches
+      ) {
+        break;
+      }
+
+      /*
+       * Keyset pagination is stable when monitors are deleted or repaired while
+       * the scan runs. The mismatch predicate is intentionally cheap: disabled
+       * monitors must have no open row; enabled monitors must have one. The
+       * existing stale-open-row reconciler runs separately and handles the
+       * pathological multiple-open-row case.
+       */
+      const rows: Array<ActiveMonitoringMismatchRow> = await dataSource.query(
+        `
+          SELECT
+            m."_id" AS "monitorId",
+            m."disableActiveMonitoring" AS "disableActiveMonitoring",
+            m."updatedAt" AS "stateUpdatedAt"
+          FROM "Monitor" m
+          WHERE m."deletedAt" IS NULL
+            AND ($1::uuid IS NULL OR m."_id" > $1::uuid)
+            AND (
+              (
+                m."disableActiveMonitoring" = true
+                AND EXISTS (
+                  SELECT 1
+                  FROM "MonitorStatusTimeline" t
+                  WHERE t."monitorId" = m."_id"
+                    AND t."deletedAt" IS NULL
+                    AND t."endsAt" IS NULL
+                )
+              )
+              OR
+              (
+                m."disableActiveMonitoring" = false
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM "MonitorStatusTimeline" t
+                  WHERE t."monitorId" = m."_id"
+                    AND t."deletedAt" IS NULL
+                    AND t."endsAt" IS NULL
+                )
+              )
+            )
+          ORDER BY m."_id" ASC
+          LIMIT $2
+        `,
+        [cursor, RECONCILIATION_BATCH_SIZE.toString()],
+      );
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      batchesProcessed++;
+      cursor = rows[rows.length - 1]!.monitorId;
+
+      for (const row of rows) {
+        const monitorId: ObjectID = new ObjectID(row.monitorId);
+        result.monitorsExamined++;
+
+        try {
+          const reconciliation: ActiveMonitoringTimelineReconciliationResult =
+            await MonitorStatusTimelineService.reconcileActiveMonitoring({
+              monitorId: monitorId,
+              expectedDisableActiveMonitoring:
+                row.disableActiveMonitoring === true,
+              reconciledAt:
+                row.stateUpdatedAt instanceof Date
+                  ? row.stateUpdatedAt
+                  : new Date(row.stateUpdatedAt),
+            });
+
+          if (reconciliation.didPause) {
+            result.paused++;
+          }
+
+          if (reconciliation.didResume) {
+            result.resumed++;
+          }
+        } catch (error) {
+          result.failedMonitorIds.push(monitorId);
+          logger.error(
+            `MonitorActiveMonitoringTimelineReconciler: failed to reconcile monitor ${monitorId.toString()}.`,
+          );
+          logger.error(error);
+        }
+      }
+
+      if (rows.length < RECONCILIATION_BATCH_SIZE) {
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  private static getDataSource(): DatabaseSource {
+    const dataSource: DatabaseSource | null =
+      PostgresAppInstance.getDataSource();
+
+    if (!dataSource) {
+      throw new DatabaseNotConnectedException();
+    }
+
+    return dataSource;
+  }
+}

--- a/Common/Tests/Server/Services/MonitorActiveMonitoringTimeline.test.ts
+++ b/Common/Tests/Server/Services/MonitorActiveMonitoringTimeline.test.ts
@@ -1,0 +1,1787 @@
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Active-monitoring boundaries share the same per-monitor mutex as ordinary
+ * status writes. These tests replace database and semaphore I/O with spies so
+ * they can pin the race-sensitive contract directly:
+ *
+ * - pause/resume timestamps are clamped instead of producing inverted or
+ *   overlapping intervals,
+ * - reconciliation reads the live monitor state while holding the mutex and
+ *   rejects stale rapid-toggle hooks,
+ * - an in-flight ordinary status create cannot reopen a disabled interval,
+ * - same-value retries still repair a boundary, and only the IDs actually
+ *   updated by DatabaseService are reconciled, and
+ * - acquired locks are released on every database failure path.
+ */
+
+const lockMock: jest.Mock = jest.fn();
+const releaseMock: jest.Mock = jest.fn();
+
+jest.mock("../../../Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    default: {
+      lock: (...args: Array<unknown>) => {
+        return lockMock(...args);
+      },
+      release: (...args: Array<unknown>) => {
+        return releaseMock(...args);
+      },
+    },
+  };
+});
+
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import MonitorStatusTimelineService, {
+  ActiveMonitoringTimelineReconciliationResult,
+  MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE,
+} from "../../../Server/Services/MonitorStatusTimelineService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import FindOneBy from "../../../Server/Types/Database/FindOneBy";
+import { OnUpdate } from "../../../Server/Types/Database/Hooks";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import UpdateOneBy from "../../../Server/Types/Database/UpdateOneBy";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import OneUptimeDate from "../../../Types/Date";
+import ServerException from "../../../Types/Exception/ServerException";
+
+const MONITOR_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_MONITOR_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const STATUS_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const TIMELINE_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const OTHER_TIMELINE_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+
+const STARTED_AT: Date = new Date("2026-07-30T08:00:00.000Z");
+const CLOSED_AT: Date = new Date("2026-07-30T11:00:00.000Z");
+const PAUSED_AT: Date = new Date("2026-07-30T12:00:00.000Z");
+const FUTURE_START_AT: Date = new Date("2026-07-30T13:00:00.000Z");
+const RESUMED_AT: Date = new Date("2026-07-30T16:00:00.000Z");
+const FUTURE_END_AT: Date = new Date("2026-07-30T18:00:00.000Z");
+const TRANSITION_AT: Date = new Date("2026-07-31T09:30:00.000Z");
+const FLIPPED_AT: Date = new Date("2026-07-31T09:30:01.000Z");
+const PRIOR_STATE_AT: Date = new Date("2026-07-31T09:00:00.000Z");
+
+const fakeMutex: { id: string } = { id: "active-monitoring-mutex" };
+
+interface MakeTimelineOptions {
+  endsAt?: Date | null;
+  id?: ObjectID;
+  monitorId?: ObjectID;
+  omitId?: boolean;
+  omitMonitorId?: boolean;
+  omitStartsAt?: boolean;
+  startsAt?: Date;
+}
+
+const makeTimeline: (options?: MakeTimelineOptions) => MonitorStatusTimeline = (
+  options?: MakeTimelineOptions,
+): MonitorStatusTimeline => {
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline();
+
+  if (!options?.omitId) {
+    timeline.id = options?.id || TIMELINE_ID;
+  }
+  if (!options?.omitMonitorId) {
+    timeline.monitorId = options?.monitorId || MONITOR_ID;
+  }
+
+  timeline.projectId = PROJECT_ID;
+  timeline.monitorStatusId = STATUS_ID;
+
+  if (!options?.omitStartsAt) {
+    timeline.startsAt = options?.startsAt || STARTED_AT;
+  }
+
+  if (options?.endsAt instanceof Date) {
+    timeline.endsAt = options.endsAt;
+  } else if (options?.endsAt === null) {
+    Reflect.set(timeline, "endsAt", null);
+  }
+
+  return timeline;
+};
+
+interface MakeMonitorOptions {
+  disabled?: boolean;
+  monitorId?: ObjectID;
+  omitProjectId?: boolean;
+  omitStatusId?: boolean;
+  updatedAt?: Date;
+}
+
+const makeMonitor: (options?: MakeMonitorOptions) => Monitor = (
+  options?: MakeMonitorOptions,
+): Monitor => {
+  const monitor: Monitor = new Monitor();
+
+  monitor.id = options?.monitorId || MONITOR_ID;
+  if (!options?.omitProjectId) {
+    monitor.projectId = PROJECT_ID;
+  }
+  if (!options?.omitStatusId) {
+    monitor.currentMonitorStatusId = STATUS_ID;
+  }
+  monitor.disableActiveMonitoring = options?.disabled === true;
+  if (options?.updatedAt) {
+    monitor.updatedAt = options.updatedAt;
+  }
+
+  return monitor;
+};
+
+const makeMonitorUpdate: (
+  disableActiveMonitoring?: boolean,
+) => UpdateBy<Monitor> = (
+  disableActiveMonitoring?: boolean,
+): UpdateBy<Monitor> => {
+  const data: Monitor = new Monitor();
+
+  if (typeof disableActiveMonitoring === "boolean") {
+    data.disableActiveMonitoring = disableActiveMonitoring;
+  } else {
+    data.name = "Renamed monitor";
+  }
+
+  return {
+    query: {
+      _id: MONITOR_ID.toString(),
+    },
+    data: data,
+    limit: 1,
+    skip: 0,
+    props: {
+      tenantId: PROJECT_ID,
+      isRoot: true,
+    },
+  } as unknown as UpdateBy<Monitor>;
+};
+
+const makeMonitorUpdateOne: (
+  disableActiveMonitoring?: boolean,
+) => UpdateOneBy<Monitor> = (
+  disableActiveMonitoring?: boolean,
+): UpdateOneBy<Monitor> => {
+  const updateBy: UpdateBy<Monitor> = makeMonitorUpdate(
+    disableActiveMonitoring,
+  );
+
+  return {
+    query: updateBy.query,
+    data: updateBy.data,
+    props: updateBy.props,
+  };
+};
+
+interface MonitorPreviousActiveState {
+  currentMonitorStatusId?: ObjectID | undefined;
+  projectId?: ObjectID | undefined;
+  stateUpdatedAt: Date;
+  wasDisabled: boolean;
+}
+
+interface MonitorUpdateCarryForward {
+  activeMonitoringTimelineTransitionAt: Date;
+  activeMonitoringPreviousStateByMonitorId: Record<
+    string,
+    MonitorPreviousActiveState
+  >;
+}
+
+interface MonitorActiveMonitoringHookAccess {
+  onBeforeUpdate(updateBy: UpdateBy<Monitor>): Promise<OnUpdate<Monitor>>;
+  updateActiveMonitoringTimeline(
+    onUpdate: OnUpdate<Monitor>,
+    updatedItemIds: Array<ObjectID>,
+  ): Promise<void>;
+  onUpdateSuccess(
+    onUpdate: OnUpdate<Monitor>,
+    updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Monitor>>;
+}
+
+const monitorHookAccess: MonitorActiveMonitoringHookAccess =
+  MonitorService as unknown as MonitorActiveMonitoringHookAccess;
+
+const makeOnUpdate: (data: {
+  disableActiveMonitoring?: boolean;
+  previousStateByMonitorId?: Record<string, MonitorPreviousActiveState>;
+  transitionAt?: Date;
+}) => OnUpdate<Monitor> = (data: {
+  disableActiveMonitoring?: boolean;
+  previousStateByMonitorId?: Record<string, MonitorPreviousActiveState>;
+  transitionAt?: Date;
+}): OnUpdate<Monitor> => {
+  return {
+    updateBy: makeMonitorUpdate(data.disableActiveMonitoring),
+    carryForward: data.transitionAt
+      ? ({
+          activeMonitoringTimelineTransitionAt: data.transitionAt,
+          activeMonitoringPreviousStateByMonitorId:
+            data.previousStateByMonitorId || {},
+        } satisfies MonitorUpdateCarryForward)
+      : null,
+  };
+};
+
+const makeTimelineCreateBy: () => CreateBy<MonitorStatusTimeline> =
+  (): CreateBy<MonitorStatusTimeline> => {
+    const timeline: MonitorStatusTimeline = makeTimeline({
+      omitId: true,
+      startsAt: STARTED_AT,
+    });
+
+    return {
+      data: timeline,
+      props: {
+        isRoot: true,
+      },
+    };
+  };
+
+const expectSharedMutex: () => void = (): void => {
+  expect(lockMock).toHaveBeenCalledWith({
+    key: MONITOR_ID.toString(),
+    namespace: "MonitorStatusTimeline.create",
+  });
+};
+
+describe("MonitorStatusTimelineService pause and resume boundaries", () => {
+  let findTimelineSpy: jest.SpyInstance;
+  let updateTimelineSpy: jest.SpyInstance;
+  let superCreateSpy: jest.SpyInstance;
+  let createdTimeline: MonitorStatusTimeline;
+
+  beforeEach(() => {
+    lockMock.mockReset();
+    releaseMock.mockReset();
+    lockMock.mockResolvedValue(fakeMutex);
+    releaseMock.mockResolvedValue(undefined);
+
+    findTimelineSpy = jest
+      .spyOn(MonitorStatusTimelineService, "findOneBy")
+      .mockResolvedValue(null);
+    updateTimelineSpy = jest
+      .spyOn(MonitorStatusTimelineService, "updateOneBy")
+      .mockResolvedValue(1);
+    createdTimeline = makeTimeline({ startsAt: RESUMED_AT });
+    superCreateSpy = jest
+      .spyOn(DatabaseService.prototype, "create")
+      .mockResolvedValue(createdTimeline);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("pauses an open interval under the shared mutex", async () => {
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline())
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+
+    expectSharedMutex();
+    const findRequest: FindOneBy<MonitorStatusTimeline> = findTimelineSpy.mock
+      .calls[0]![0] as FindOneBy<MonitorStatusTimeline>;
+    expect(findRequest).toMatchObject({
+      query: { monitorId: MONITOR_ID },
+      select: { _id: true, startsAt: true, endsAt: true },
+      sort: { startsAt: SortOrder.Descending },
+      props: { isRoot: true },
+    });
+    expect(findRequest.query.startsAt).toBeDefined();
+    expect(findRequest.query.endsAt).toBeDefined();
+
+    const updateRequest: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    expect(updateRequest.query).toMatchObject({
+      _id: TIMELINE_ID.toString(),
+    });
+    expect(updateRequest.query.endsAt).toBeDefined();
+    expect(updateRequest.query.startsAt).toBeDefined();
+    expect(updateRequest.data).toEqual({ endsAt: PAUSED_AT });
+    expect(updateRequest.props).toEqual({ isRoot: true });
+    expect(lockMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      findTimelineSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(updateTimelineSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+    expect(findTimelineSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("shortens the boundary interval and closes a newer open row from a late status write", async () => {
+    const closedPredecessor: MonitorStatusTimeline = makeTimeline({
+      endsAt: FUTURE_START_AT,
+    });
+    const newerOpenTimeline: MonitorStatusTimeline = makeTimeline({
+      id: OTHER_TIMELINE_ID,
+      startsAt: FUTURE_START_AT,
+    });
+
+    findTimelineSpy
+      .mockResolvedValueOnce(closedPredecessor)
+      .mockResolvedValueOnce(newerOpenTimeline);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+
+    expect(findTimelineSpy).toHaveBeenCalledTimes(2);
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(2);
+
+    const boundaryUpdate: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    const lateOpenUpdate: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[1]![0] as UpdateOneBy<MonitorStatusTimeline>;
+
+    expect(boundaryUpdate.query).toMatchObject({
+      _id: TIMELINE_ID.toString(),
+    });
+    expect(boundaryUpdate.data).toEqual({ endsAt: PAUSED_AT });
+    expect(lateOpenUpdate.query).toMatchObject({
+      _id: OTHER_TIMELINE_ID.toString(),
+    });
+    expect(lateOpenUpdate.data).toEqual({ endsAt: FUTURE_START_AT });
+  });
+
+  it("clamps a future start to a zero-duration interval", async () => {
+    findTimelineSpy
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(makeTimeline({ startsAt: FUTURE_START_AT }));
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+
+    const updateRequest: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    expect(updateRequest.data).toEqual({ endsAt: FUTURE_START_AT });
+    expect(updateRequest.query.startsAt).toBeDefined();
+    expect(findTimelineSpy).toHaveBeenCalledTimes(2);
+    const boundaryRequest: FindOneBy<MonitorStatusTimeline> = findTimelineSpy
+      .mock.calls[0]![0] as FindOneBy<MonitorStatusTimeline>;
+    const openRequest: FindOneBy<MonitorStatusTimeline> = findTimelineSpy.mock
+      .calls[1]![0] as FindOneBy<MonitorStatusTimeline>;
+    expect(boundaryRequest.query.startsAt).toBeDefined();
+    expect(openRequest.query.startsAt).toBeDefined();
+    expect(openRequest.query.endsAt).toBeDefined();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("shortens a boundary interval that ends later in the same second", async () => {
+    const pausedAt: Date = new Date("2026-07-30T12:00:00.100Z");
+    const endsAt: Date = new Date("2026-07-30T12:00:00.500Z");
+
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline({ endsAt: endsAt }))
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: pausedAt,
+      }),
+    ).resolves.toBe(true);
+
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    const updateRequest: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    expect(updateRequest.data).toEqual({ endsAt: pausedAt });
+  });
+
+  it("treats an exact endsAt boundary as half-open and still closes a future open row", async () => {
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline({ endsAt: PAUSED_AT }))
+      .mockResolvedValueOnce(makeTimeline({ startsAt: FUTURE_START_AT }));
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+
+    expect(findTimelineSpy).toHaveBeenCalledTimes(2);
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    const updateRequest: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    expect(updateRequest.data).toEqual({ endsAt: FUTURE_START_AT });
+  });
+
+  it.each([
+    ["there is no timeline", null],
+    ["the latest interval has no id", makeTimeline({ omitId: true })],
+    ["the latest interval has no start", makeTimeline({ omitStartsAt: true })],
+  ])(
+    "does not write when %s",
+    async (_label: string, latest: MonitorStatusTimeline | null) => {
+      findTimelineSpy.mockResolvedValue(latest);
+
+      await expect(
+        MonitorStatusTimelineService.pauseActiveMonitoring({
+          monitorId: MONITOR_ID,
+          pausedAt: PAUSED_AT,
+        }),
+      ).resolves.toBe(false);
+
+      expect(updateTimelineSpy).not.toHaveBeenCalled();
+      expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+    },
+  );
+
+  it("returns false when no interval covers the boundary and no open row remains", async () => {
+    findTimelineSpy.mockResolvedValue(null);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(false);
+
+    expect(findTimelineSpy).toHaveBeenCalledTimes(2);
+    expect(updateTimelineSpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("shortens an already-closed predecessor when a late zero-duration row left no open interval", async () => {
+    const closedPredecessor: MonitorStatusTimeline = makeTimeline({
+      endsAt: FUTURE_START_AT,
+    });
+    const lateZeroDurationRow: MonitorStatusTimeline = makeTimeline({
+      startsAt: FUTURE_START_AT,
+      endsAt: FUTURE_START_AT,
+    });
+
+    expect(lateZeroDurationRow.startsAt).toEqual(lateZeroDurationRow.endsAt);
+    findTimelineSpy
+      .mockResolvedValueOnce(closedPredecessor)
+      // This row is closed, so the open-row fallback must never select it.
+      .mockResolvedValueOnce(lateZeroDurationRow);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+
+    expect(findTimelineSpy).toHaveBeenCalledTimes(2);
+    const boundaryRequest: FindOneBy<MonitorStatusTimeline> = findTimelineSpy
+      .mock.calls[0]![0] as FindOneBy<MonitorStatusTimeline>;
+    expect(boundaryRequest.query.startsAt).toBeDefined();
+    expect(boundaryRequest.query.endsAt).toBeDefined();
+    const updateRequest: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    expect(updateRequest.query).toMatchObject({
+      _id: TIMELINE_ID.toString(),
+    });
+    expect(updateRequest.query.startsAt).toBeDefined();
+    expect(updateRequest.query.endsAt).toBeDefined();
+    expect(updateRequest.data).toEqual({ endsAt: PAUSED_AT });
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("does not stretch an older orphan open row to the disable boundary", async () => {
+    const boundaryTimeline: MonitorStatusTimeline = makeTimeline({
+      startsAt: new Date("2026-07-30T10:00:00.000Z"),
+    });
+    const olderOrphan: MonitorStatusTimeline = makeTimeline({
+      id: OTHER_TIMELINE_ID,
+      startsAt: STARTED_AT,
+    });
+
+    findTimelineSpy
+      .mockResolvedValueOnce(boundaryTimeline)
+      // Defensive return: the real query excludes starts before pausedAt.
+      .mockResolvedValueOnce(olderOrphan);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    expect(updateTimelineSpy.mock.calls[0]![0]).toMatchObject({
+      query: { _id: TIMELINE_ID.toString() },
+      data: { endsAt: PAUSED_AT },
+    });
+    const openRequest: FindOneBy<MonitorStatusTimeline> = findTimelineSpy.mock
+      .calls[1]![0] as FindOneBy<MonitorStatusTimeline>;
+    expect(openRequest.query.startsAt).toBeDefined();
+  });
+
+  it("reports a lost compare-and-update race without leaving the lock held", async () => {
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline())
+      .mockResolvedValueOnce(null);
+    updateTimelineSpy.mockResolvedValue(0);
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(false);
+
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("resumes the current status directly after a closed gap", async () => {
+    findTimelineSpy.mockResolvedValue(makeTimeline({ endsAt: CLOSED_AT }));
+
+    await expect(
+      MonitorStatusTimelineService.resumeActiveMonitoring({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitorStatusId: STATUS_ID,
+        resumedAt: RESUMED_AT,
+      }),
+    ).resolves.toBe(createdTimeline);
+
+    expectSharedMutex();
+    const createRequest: CreateBy<MonitorStatusTimeline> = superCreateSpy.mock
+      .calls[0]![0] as CreateBy<MonitorStatusTimeline>;
+    expect(createRequest.data).toMatchObject({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      monitorStatusId: STATUS_ID,
+      startsAt: RESUMED_AT,
+      isOwnerNotified: true,
+    });
+    expect(createRequest.data.endsAt).toBeUndefined();
+    expect(createRequest.props).toEqual({ isRoot: true, ignoreHooks: true });
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(superCreateSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("creates the first observed interval when no predecessor exists", async () => {
+    findTimelineSpy.mockResolvedValue(null);
+
+    await expect(
+      MonitorStatusTimelineService.resumeActiveMonitoring({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitorStatusId: STATUS_ID,
+        resumedAt: RESUMED_AT,
+      }),
+    ).resolves.toBe(createdTimeline);
+
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("does not resume when the latest interval is already open", async () => {
+    findTimelineSpy.mockResolvedValue(makeTimeline());
+
+    await expect(
+      MonitorStatusTimelineService.resumeActiveMonitoring({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitorStatusId: STATUS_ID,
+        resumedAt: RESUMED_AT,
+      }),
+    ).resolves.toBeNull();
+
+    expect(superCreateSpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it.each([
+    {
+      label: "overlapping predecessor end",
+      startsAt: new Date("2026-07-30T15:00:00.000Z"),
+      endsAt: new Date("2026-07-30T17:00:00.000Z"),
+      expectedStart: new Date("2026-07-30T17:00:00.000Z"),
+    },
+    {
+      label: "future closed predecessor",
+      startsAt: new Date("2026-07-30T17:00:00.000Z"),
+      endsAt: FUTURE_END_AT,
+      expectedStart: FUTURE_END_AT,
+    },
+    {
+      label: "equal-start zero-duration predecessor",
+      startsAt: RESUMED_AT,
+      endsAt: RESUMED_AT,
+      expectedStart: new Date("2026-07-30T16:00:00.001Z"),
+    },
+  ])(
+    "clamps resume beyond $label",
+    async (data: { startsAt: Date; endsAt: Date; expectedStart: Date }) => {
+      findTimelineSpy.mockResolvedValue(
+        makeTimeline({ startsAt: data.startsAt, endsAt: data.endsAt }),
+      );
+
+      await MonitorStatusTimelineService.resumeActiveMonitoring({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitorStatusId: STATUS_ID,
+        resumedAt: RESUMED_AT,
+      });
+
+      const createRequest: CreateBy<MonitorStatusTimeline> = superCreateSpy.mock
+        .calls[0]![0] as CreateBy<MonitorStatusTimeline>;
+      expect(createRequest.data.startsAt).toEqual(data.expectedStart);
+      expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+    },
+  );
+
+  it("never moves a resume boundary backward within the same second", async () => {
+    const resumedAt: Date = new Date("2026-07-30T16:00:00.900Z");
+    findTimelineSpy.mockResolvedValue(
+      makeTimeline({
+        startsAt: new Date("2026-07-30T16:00:00.500Z"),
+        endsAt: new Date("2026-07-30T16:00:00.700Z"),
+      }),
+    );
+
+    await expect(
+      MonitorStatusTimelineService.resumeActiveMonitoring({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitorStatusId: STATUS_ID,
+        resumedAt: resumedAt,
+      }),
+    ).resolves.toBe(createdTimeline);
+
+    const createRequest: CreateBy<MonitorStatusTimeline> = superCreateSpy.mock
+      .calls[0]![0] as CreateBy<MonitorStatusTimeline>;
+    expect(createRequest.data.startsAt).toEqual(resumedAt);
+  });
+
+  it("fails closed when the mutex cannot be acquired", async () => {
+    lockMock.mockRejectedValue(new Error("redis unavailable"));
+
+    const request: Promise<boolean> =
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      });
+
+    await expect(request).rejects.toBeInstanceOf(ServerException);
+    await expect(request).rejects.toThrow(
+      MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE,
+    );
+    expect(findTimelineSpy).not.toHaveBeenCalled();
+    expect(updateTimelineSpy).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it("releases and propagates a pause read failure", async () => {
+    findTimelineSpy.mockRejectedValue(new Error("timeline read failed"));
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).rejects.toThrow("timeline read failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("releases and propagates a pause write failure", async () => {
+    findTimelineSpy.mockResolvedValue(makeTimeline());
+    updateTimelineSpy.mockRejectedValue(new Error("timeline update failed"));
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).rejects.toThrow("timeline update failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("releases and propagates a resume insert failure", async () => {
+    findTimelineSpy.mockResolvedValue(makeTimeline({ endsAt: CLOSED_AT }));
+    superCreateSpy.mockRejectedValue(new Error("timeline insert failed"));
+
+    await expect(
+      MonitorStatusTimelineService.resumeActiveMonitoring({
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+        monitorStatusId: STATUS_ID,
+        resumedAt: RESUMED_AT,
+      }),
+    ).rejects.toThrow("timeline insert failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("does not mask a successful write when releasing the mutex fails", async () => {
+    findTimelineSpy.mockResolvedValue(makeTimeline());
+    releaseMock.mockRejectedValue(new Error("release failed"));
+
+    await expect(
+      MonitorStatusTimelineService.pauseActiveMonitoring({
+        monitorId: MONITOR_ID,
+        pausedAt: PAUSED_AT,
+      }),
+    ).resolves.toBe(true);
+  });
+});
+
+describe("MonitorStatusTimelineService live-state reconciliation", () => {
+  let findMonitorSpy: jest.SpyInstance;
+  let findTimelineSpy: jest.SpyInstance;
+  let updateTimelineSpy: jest.SpyInstance;
+  let superCreateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    lockMock.mockReset();
+    releaseMock.mockReset();
+    lockMock.mockResolvedValue(fakeMutex);
+    releaseMock.mockResolvedValue(undefined);
+
+    findMonitorSpy = jest
+      .spyOn(MonitorService, "findOneBy")
+      .mockResolvedValue(null);
+    findTimelineSpy = jest
+      .spyOn(MonitorStatusTimelineService, "findOneBy")
+      .mockResolvedValue(null);
+    updateTimelineSpy = jest
+      .spyOn(MonitorStatusTimelineService, "updateOneBy")
+      .mockResolvedValue(1);
+    superCreateSpy = jest
+      .spyOn(DatabaseService.prototype, "create")
+      .mockResolvedValue(makeTimeline({ startsAt: FLIPPED_AT }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reads live disabled state under the shared lock and closes the interval", async () => {
+    findMonitorSpy.mockResolvedValue(makeMonitor({ disabled: true }));
+    findTimelineSpy.mockResolvedValue(makeTimeline());
+
+    const result: ActiveMonitoringTimelineReconciliationResult =
+      await MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: true,
+        reconciledAt: TRANSITION_AT,
+      });
+
+    expect(result).toEqual({
+      didPause: true,
+      didResume: false,
+      monitorWasFound: true,
+      stateMatchedExpectation: true,
+    });
+    expectSharedMutex();
+    expect(findMonitorSpy).toHaveBeenCalledTimes(2);
+    expect(findMonitorSpy.mock.calls[0]![0]).toEqual({
+      query: { _id: MONITOR_ID.toString() },
+      select: {
+        _id: true,
+        projectId: true,
+        currentMonitorStatusId: true,
+        disableActiveMonitoring: true,
+        updatedAt: true,
+      },
+      props: { isRoot: true, ignoreHooks: true },
+    });
+    expect(lockMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      findMonitorSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(findMonitorSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      findTimelineSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(updateTimelineSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      findMonitorSpy.mock.invocationCallOrder[1]!,
+    );
+    expect(findMonitorSpy.mock.invocationCallOrder[1]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("uses the monitor's persisted save time for each bulk-update boundary", async () => {
+    findMonitorSpy.mockResolvedValue(
+      makeMonitor({ disabled: true, updatedAt: FLIPPED_AT }),
+    );
+    findTimelineSpy.mockResolvedValue(makeTimeline());
+
+    await MonitorStatusTimelineService.reconcileActiveMonitoring({
+      monitorId: MONITOR_ID,
+      expectedDisableActiveMonitoring: true,
+      reconciledAt: TRANSITION_AT,
+    });
+
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    expect(updateTimelineSpy.mock.calls[0]![0].data).toEqual({
+      endsAt: FLIPPED_AT,
+    });
+  });
+
+  it("reconstructs an observed disable before a newer live enable from an old pod", async () => {
+    findMonitorSpy.mockResolvedValue(
+      makeMonitor({ disabled: false, updatedAt: FLIPPED_AT }),
+    );
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline())
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(makeTimeline({ endsAt: TRANSITION_AT }));
+
+    await expect(
+      MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: true,
+        reconciledAt: TRANSITION_AT,
+      }),
+    ).resolves.toEqual({
+      didPause: true,
+      didResume: true,
+      monitorWasFound: true,
+      stateMatchedExpectation: false,
+    });
+
+    expect(findMonitorSpy).toHaveBeenCalledTimes(2);
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    expect(updateTimelineSpy.mock.calls[0]![0].data).toEqual({
+      endsAt: TRANSITION_AT,
+    });
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+    const createRequest: CreateBy<MonitorStatusTimeline> = superCreateSpy.mock
+      .calls[0]![0] as CreateBy<MonitorStatusTimeline>;
+    expect(createRequest.data.startsAt).toEqual(FLIPPED_AT);
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("reconstructs an observed enable before a newer live disable from an old pod", async () => {
+    findMonitorSpy.mockResolvedValue(
+      makeMonitor({ disabled: true, updatedAt: FLIPPED_AT }),
+    );
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline({ endsAt: PRIOR_STATE_AT }))
+      .mockResolvedValueOnce(makeTimeline({ startsAt: TRANSITION_AT }))
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: false,
+        reconciledAt: TRANSITION_AT,
+      }),
+    ).resolves.toEqual({
+      didPause: true,
+      didResume: true,
+      monitorWasFound: true,
+      stateMatchedExpectation: false,
+    });
+
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+    const createRequest: CreateBy<MonitorStatusTimeline> = superCreateSpy.mock
+      .calls[0]![0] as CreateBy<MonitorStatusTimeline>;
+    expect(createRequest.data.startsAt).toEqual(TRANSITION_AT);
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    expect(updateTimelineSpy.mock.calls[0]![0].data).toEqual({
+      endsAt: FLIPPED_AT,
+    });
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("returns a no-monitor result without touching timeline storage", async () => {
+    findMonitorSpy.mockResolvedValue(null);
+
+    await expect(
+      MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        reconciledAt: TRANSITION_AT,
+      }),
+    ).resolves.toEqual({
+      didPause: false,
+      didResume: false,
+      monitorWasFound: false,
+      stateMatchedExpectation: true,
+    });
+
+    expect(findTimelineSpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("closes then resumes when live state flips during reconciliation", async () => {
+    findMonitorSpy
+      .mockResolvedValueOnce(makeMonitor({ disabled: true }))
+      .mockResolvedValueOnce(
+        makeMonitor({ disabled: false, updatedAt: FLIPPED_AT }),
+      )
+      .mockResolvedValueOnce(
+        makeMonitor({ disabled: false, updatedAt: FLIPPED_AT }),
+      )
+      .mockResolvedValueOnce(
+        makeMonitor({ disabled: false, updatedAt: FLIPPED_AT }),
+      );
+    findTimelineSpy
+      .mockResolvedValueOnce(makeTimeline())
+      .mockResolvedValueOnce(makeTimeline({ endsAt: TRANSITION_AT }));
+
+    const result: ActiveMonitoringTimelineReconciliationResult =
+      await MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: true,
+        reconciledAt: TRANSITION_AT,
+      });
+
+    expect(result).toEqual({
+      didPause: true,
+      didResume: true,
+      monitorWasFound: true,
+      stateMatchedExpectation: true,
+    });
+    expect(updateTimelineSpy).toHaveBeenCalledTimes(1);
+    expect(updateTimelineSpy.mock.calls[0]![0].data).toEqual({
+      endsAt: TRANSITION_AT,
+    });
+    expect(superCreateSpy).toHaveBeenCalledTimes(1);
+    const createRequest: CreateBy<MonitorStatusTimeline> = superCreateSpy.mock
+      .calls[0]![0] as CreateBy<MonitorStatusTimeline>;
+    expect(createRequest.data.startsAt).toEqual(FLIPPED_AT);
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    expect(superCreateSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("does not synthesize a resumed row when the live enabled monitor lacks status context", async () => {
+    findMonitorSpy.mockResolvedValue(
+      makeMonitor({ disabled: false, omitProjectId: true, omitStatusId: true }),
+    );
+
+    await expect(
+      MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: false,
+        reconciledAt: TRANSITION_AT,
+      }),
+    ).resolves.toMatchObject({ didPause: false, didResume: false });
+
+    expect(findTimelineSpy).not.toHaveBeenCalled();
+    expect(superCreateSpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("releases and propagates a live monitor read failure", async () => {
+    findMonitorSpy.mockRejectedValue(new Error("monitor read failed"));
+
+    await expect(
+      MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        reconciledAt: TRANSITION_AT,
+      }),
+    ).rejects.toThrow("monitor read failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("releases and propagates a reconciliation write failure", async () => {
+    findMonitorSpy.mockResolvedValue(makeMonitor({ disabled: true }));
+    findTimelineSpy.mockResolvedValue(makeTimeline());
+    updateTimelineSpy.mockRejectedValue(new Error("reconcile write failed"));
+
+    await expect(
+      MonitorStatusTimelineService.reconcileActiveMonitoring({
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: true,
+        reconciledAt: TRANSITION_AT,
+      }),
+    ).rejects.toThrow("reconcile write failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+});
+
+describe("ordinary timeline creates during active-monitoring transitions", () => {
+  let superCreateSpy: jest.SpyInstance;
+  let feedItemSpy: jest.SpyInstance;
+  let findMonitorSpy: jest.SpyInstance;
+  let updateTimelineSpy: jest.SpyInstance;
+  let createdTimeline: MonitorStatusTimeline;
+
+  beforeEach(() => {
+    lockMock.mockReset();
+    releaseMock.mockReset();
+    lockMock.mockResolvedValue(fakeMutex);
+    releaseMock.mockResolvedValue(undefined);
+
+    createdTimeline = makeTimeline({ startsAt: STARTED_AT });
+    superCreateSpy = jest
+      .spyOn(DatabaseService.prototype, "create")
+      .mockResolvedValue(createdTimeline);
+    feedItemSpy = jest
+      .spyOn(
+        MonitorStatusTimelineService as unknown as {
+          createStatusChangeFeedItem: () => Promise<void>;
+        },
+        "createStatusChangeFeedItem",
+      )
+      .mockResolvedValue(undefined);
+    findMonitorSpy = jest
+      .spyOn(MonitorService, "findOneBy")
+      .mockResolvedValue(makeMonitor({ disabled: false }));
+    updateTimelineSpy = jest
+      .spyOn(MonitorStatusTimelineService, "updateOneBy")
+      .mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("closes a newly created row at startsAt when the monitor is directly disabled", async () => {
+    findMonitorSpy.mockResolvedValue(makeMonitor({ disabled: true }));
+
+    const result: MonitorStatusTimeline =
+      await MonitorStatusTimelineService.create(makeTimelineCreateBy());
+
+    expect(result).toBe(createdTimeline);
+    expect(result.endsAt).toEqual(STARTED_AT);
+    expectSharedMutex();
+    expect(findMonitorSpy).toHaveBeenCalledWith({
+      query: { _id: MONITOR_ID.toString() },
+      select: { _id: true, disableActiveMonitoring: true },
+      props: { isRoot: true, ignoreHooks: true },
+    });
+    const updateRequest: UpdateOneBy<MonitorStatusTimeline> = updateTimelineSpy
+      .mock.calls[0]![0] as UpdateOneBy<MonitorStatusTimeline>;
+    expect(updateRequest.query).toMatchObject({ _id: TIMELINE_ID.toString() });
+    expect(updateRequest.query.endsAt).toBeDefined();
+    expect(updateRequest.data).toEqual({ endsAt: STARTED_AT });
+    expect(superCreateSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      findMonitorSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(updateTimelineSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+    expect(releaseMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      feedItemSpy.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("leaves a newly created row open when the monitor is enabled", async () => {
+    findMonitorSpy.mockResolvedValue(makeMonitor({ disabled: false }));
+
+    const result: MonitorStatusTimeline =
+      await MonitorStatusTimelineService.create(makeTimelineCreateBy());
+
+    expect(result.endsAt).toBeUndefined();
+    expect(updateTimelineSpy).not.toHaveBeenCalled();
+    expect(findMonitorSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+    expect(feedItemSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the row open when the monitor disappeared before the live check", async () => {
+    findMonitorSpy.mockResolvedValue(null);
+
+    await MonitorStatusTimelineService.create(makeTimelineCreateBy());
+
+    expect(updateTimelineSpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+    expect(feedItemSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mutate the returned row when the conditional close loses a race", async () => {
+    findMonitorSpy.mockResolvedValue(makeMonitor({ disabled: true }));
+    updateTimelineSpy.mockResolvedValue(0);
+
+    const result: MonitorStatusTimeline =
+      await MonitorStatusTimelineService.create(makeTimelineCreateBy());
+
+    expect(result.endsAt).toBeUndefined();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+
+  it("releases and propagates a disabled-state read failure", async () => {
+    findMonitorSpy.mockRejectedValue(new Error("monitor lookup failed"));
+
+    await expect(
+      MonitorStatusTimelineService.create(makeTimelineCreateBy()),
+    ).rejects.toThrow("monitor lookup failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+    expect(feedItemSpy).not.toHaveBeenCalled();
+  });
+
+  it("releases and propagates a disabled-row close failure", async () => {
+    findMonitorSpy.mockResolvedValue(makeMonitor({ disabled: true }));
+    updateTimelineSpy.mockRejectedValue(new Error("close failed"));
+
+    await expect(
+      MonitorStatusTimelineService.create(makeTimelineCreateBy()),
+    ).rejects.toThrow("close failed");
+
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+    expect(feedItemSpy).not.toHaveBeenCalled();
+  });
+
+  it("releases and propagates an ordinary create failure", async () => {
+    superCreateSpy.mockRejectedValue(new Error("insert failed"));
+
+    await expect(
+      MonitorStatusTimelineService.create(makeTimelineCreateBy()),
+    ).rejects.toThrow("insert failed");
+
+    expect(findMonitorSpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+    expect(feedItemSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before an ordinary create when locking fails", async () => {
+    lockMock.mockRejectedValue(new Error("redis unavailable"));
+
+    await expect(
+      MonitorStatusTimelineService.create(makeTimelineCreateBy()),
+    ).rejects.toThrow(MONITOR_STATUS_TIMELINE_LOCK_ERROR_MESSAGE);
+
+    expect(superCreateSpy).not.toHaveBeenCalled();
+    expect(findMonitorSpy).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("MonitorService direct active-monitoring update dispatch", () => {
+  let currentDateSpy: jest.SpyInstance;
+  let findBySpy: jest.SpyInstance;
+  let pauseSpy: jest.SpyInstance;
+  let reconcileSpy: jest.SpyInstance;
+  let resumeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    currentDateSpy = jest
+      .spyOn(OneUptimeDate, "getCurrentDate")
+      .mockReturnValue(TRANSITION_AT);
+    findBySpy = jest.spyOn(MonitorService, "findBy").mockResolvedValue([]);
+    pauseSpy = jest
+      .spyOn(MonitorStatusTimelineService, "pauseActiveMonitoring")
+      .mockResolvedValue(false);
+    resumeSpy = jest
+      .spyOn(MonitorStatusTimelineService, "resumeActiveMonitoring")
+      .mockResolvedValue(null);
+    reconcileSpy = jest
+      .spyOn(MonitorStatusTimelineService, "reconcileActiveMonitoring")
+      .mockResolvedValue({
+        didPause: false,
+        didResume: false,
+        monitorWasFound: true,
+        stateMatchedExpectation: true,
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("captures each scoped monitor's prior flag, status, project, and persisted timestamp", async () => {
+    const updateBy: UpdateBy<Monitor> = makeMonitorUpdate(true);
+    findBySpy.mockResolvedValue([
+      makeMonitor({ disabled: true, updatedAt: PRIOR_STATE_AT }),
+      makeMonitor({
+        disabled: false,
+        monitorId: OTHER_MONITOR_ID,
+        updatedAt: FLIPPED_AT,
+      }),
+    ]);
+
+    const result: OnUpdate<Monitor> =
+      await monitorHookAccess.onBeforeUpdate(updateBy);
+
+    expect(result).toEqual({
+      updateBy: updateBy,
+      carryForward: {
+        activeMonitoringTimelineTransitionAt: TRANSITION_AT,
+        activeMonitoringPreviousStateByMonitorId: {
+          [MONITOR_ID.toString()]: {
+            currentMonitorStatusId: STATUS_ID,
+            projectId: PROJECT_ID,
+            stateUpdatedAt: PRIOR_STATE_AT,
+            wasDisabled: true,
+          },
+          [OTHER_MONITOR_ID.toString()]: {
+            currentMonitorStatusId: STATUS_ID,
+            projectId: PROJECT_ID,
+            stateUpdatedAt: FLIPPED_AT,
+            wasDisabled: false,
+          },
+        },
+      },
+    });
+    expect(currentDateSpy).toHaveBeenCalledTimes(1);
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(findBySpy).toHaveBeenCalledWith({
+      query: updateBy.query,
+      select: {
+        _id: true,
+        projectId: true,
+        currentMonitorStatusId: true,
+        disableActiveMonitoring: true,
+        updatedAt: true,
+      },
+      limit: updateBy.limit,
+      skip: updateBy.skip,
+      props: {
+        ...updateBy.props,
+        ignoreHooks: true,
+      },
+    });
+  });
+
+  it("does not capture a boundary for an unrelated update", async () => {
+    const updateBy: UpdateBy<Monitor> = makeMonitorUpdate();
+
+    await expect(monitorHookAccess.onBeforeUpdate(updateBy)).resolves.toEqual({
+      updateBy: updateBy,
+      carryForward: null,
+    });
+
+    expect(currentDateSpy).not.toHaveBeenCalled();
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("repairs the original boundary before reconciling a same-value disabled retry", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({
+        disableActiveMonitoring: true,
+        previousStateByMonitorId: {
+          [MONITOR_ID.toString()]: {
+            currentMonitorStatusId: STATUS_ID,
+            projectId: PROJECT_ID,
+            stateUpdatedAt: PRIOR_STATE_AT,
+            wasDisabled: true,
+          },
+        },
+        transitionAt: TRANSITION_AT,
+      }),
+      [MONITOR_ID],
+    );
+
+    expect(pauseSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      pausedAt: PRIOR_STATE_AT,
+    });
+    expect(reconcileSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      expectedDisableActiveMonitoring: true,
+      reconciledAt: TRANSITION_AT,
+    });
+    expect(pauseSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      reconcileSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("recreates the prior interval before reconciling a same-value enabled retry", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({
+        disableActiveMonitoring: false,
+        previousStateByMonitorId: {
+          [MONITOR_ID.toString()]: {
+            currentMonitorStatusId: STATUS_ID,
+            projectId: PROJECT_ID,
+            stateUpdatedAt: PRIOR_STATE_AT,
+            wasDisabled: false,
+          },
+        },
+        transitionAt: TRANSITION_AT,
+      }),
+      [MONITOR_ID],
+    );
+
+    expect(resumeSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      monitorStatusId: STATUS_ID,
+      resumedAt: PRIOR_STATE_AT,
+    });
+    expect(reconcileSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      expectedDisableActiveMonitoring: false,
+      reconciledAt: TRANSITION_AT,
+    });
+    expect(resumeSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      reconcileSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(pauseSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconstructs the original gap when enable follows a disable whose hook failed", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({
+        disableActiveMonitoring: false,
+        previousStateByMonitorId: {
+          [MONITOR_ID.toString()]: {
+            currentMonitorStatusId: STATUS_ID,
+            projectId: PROJECT_ID,
+            stateUpdatedAt: PRIOR_STATE_AT,
+            wasDisabled: true,
+          },
+        },
+        transitionAt: TRANSITION_AT,
+      }),
+      [MONITOR_ID],
+    );
+
+    expect(pauseSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      pausedAt: PRIOR_STATE_AT,
+    });
+    expect(reconcileSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      expectedDisableActiveMonitoring: false,
+      reconciledAt: TRANSITION_AT,
+    });
+    expect(pauseSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      reconcileSpy.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("reconstructs the prior enabled interval when disable follows an enable whose hook failed", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({
+        disableActiveMonitoring: true,
+        previousStateByMonitorId: {
+          [MONITOR_ID.toString()]: {
+            currentMonitorStatusId: STATUS_ID,
+            projectId: PROJECT_ID,
+            stateUpdatedAt: PRIOR_STATE_AT,
+            wasDisabled: false,
+          },
+        },
+        transitionAt: TRANSITION_AT,
+      }),
+      [MONITOR_ID],
+    );
+
+    expect(resumeSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      monitorStatusId: STATUS_ID,
+      resumedAt: PRIOR_STATE_AT,
+    });
+    expect(reconcileSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      expectedDisableActiveMonitoring: true,
+      reconciledAt: TRANSITION_AT,
+    });
+    expect(resumeSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      reconcileSpy.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("uses exactly the updated IDs and never re-runs the pre-update query", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({
+        disableActiveMonitoring: true,
+        transitionAt: TRANSITION_AT,
+      }),
+      [OTHER_MONITOR_ID, MONITOR_ID],
+    );
+
+    expect(reconcileSpy).toHaveBeenCalledTimes(2);
+    expect(
+      reconcileSpy.mock.calls.map((call: Array<unknown>) => {
+        return call[0];
+      }),
+    ).toEqual([
+      {
+        monitorId: OTHER_MONITOR_ID,
+        expectedDisableActiveMonitoring: true,
+        reconciledAt: TRANSITION_AT,
+      },
+      {
+        monitorId: MONITOR_ID,
+        expectedDisableActiveMonitoring: true,
+        reconciledAt: TRANSITION_AT,
+      },
+    ]);
+    expect(pauseSpy).not.toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when DatabaseService reports no updated IDs", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({
+        disableActiveMonitoring: true,
+        transitionAt: TRANSITION_AT,
+      }),
+      [],
+    );
+
+    expect(reconcileSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without a captured transition boundary", async () => {
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      makeOnUpdate({ disableActiveMonitoring: true }),
+      [MONITOR_ID],
+    );
+
+    expect(reconcileSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores indirect incident suppression flag updates", async () => {
+    const updateBy: UpdateBy<Monitor> = makeMonitorUpdate();
+    updateBy.data.disableActiveMonitoringBecauseOfManualIncident = true;
+
+    await monitorHookAccess.updateActiveMonitoringTimeline(
+      {
+        updateBy: updateBy,
+        carryForward: {
+          activeMonitoringTimelineTransitionAt: TRANSITION_AT,
+          activeMonitoringPreviousStateByMonitorId: {},
+        },
+      },
+      [MONITOR_ID],
+    );
+
+    expect(reconcileSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates reconciliation failures so a committed boundary is not silently lost", async () => {
+    reconcileSpy.mockRejectedValue(new Error("reconciliation failed"));
+
+    await expect(
+      monitorHookAccess.updateActiveMonitoringTimeline(
+        makeOnUpdate({
+          disableActiveMonitoring: true,
+          transitionAt: TRANSITION_AT,
+        }),
+        [MONITOR_ID],
+      ),
+    ).rejects.toThrow("reconciliation failed");
+  });
+
+  it("stops before requested-state reconciliation when prior-state restoration fails", async () => {
+    pauseSpy.mockRejectedValue(new Error("prior boundary repair failed"));
+
+    await expect(
+      monitorHookAccess.updateActiveMonitoringTimeline(
+        makeOnUpdate({
+          disableActiveMonitoring: false,
+          previousStateByMonitorId: {
+            [MONITOR_ID.toString()]: {
+              currentMonitorStatusId: STATUS_ID,
+              projectId: PROJECT_ID,
+              stateUpdatedAt: PRIOR_STATE_AT,
+              wasDisabled: true,
+            },
+          },
+          transitionAt: TRANSITION_AT,
+        }),
+        [MONITOR_ID],
+      ),
+    ).rejects.toThrow("prior boundary repair failed");
+
+    expect(reconcileSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs an explicit status change before reconciliation when enabling", async () => {
+    const updateBy: UpdateBy<Monitor> = makeMonitorUpdate(false);
+    updateBy.data.currentMonitorStatusId = STATUS_ID;
+    const dispatchSpy: jest.SpyInstance = jest
+      .spyOn(monitorHookAccess, "updateActiveMonitoringTimeline")
+      .mockResolvedValue(undefined);
+    const changeStatusSpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "changeMonitorStatus")
+      .mockResolvedValue(undefined);
+    const onUpdate: OnUpdate<Monitor> = {
+      updateBy: updateBy,
+      carryForward: null,
+    };
+
+    await monitorHookAccess.onUpdateSuccess(onUpdate, []);
+
+    expect(changeStatusSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(changeStatusSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      dispatchSpy.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("reconciles disablement before applying a combined explicit status change", async () => {
+    const updateBy: UpdateBy<Monitor> = makeMonitorUpdate(true);
+    updateBy.data.currentMonitorStatusId = STATUS_ID;
+    const dispatchSpy: jest.SpyInstance = jest
+      .spyOn(monitorHookAccess, "updateActiveMonitoringTimeline")
+      .mockResolvedValue(undefined);
+    const changeStatusSpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "changeMonitorStatus")
+      .mockResolvedValue(undefined);
+    const onUpdate: OnUpdate<Monitor> = {
+      updateBy: updateBy,
+      carryForward: null,
+    };
+
+    await monitorHookAccess.onUpdateSuccess(onUpdate, []);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(changeStatusSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      changeStatusSpy.mock.invocationCallOrder[0]!,
+    );
+  });
+});
+
+describe("MonitorService active-monitoring transition write lock", () => {
+  const firstMonitorMutex: { id: string } = { id: "first-monitor-mutex" };
+  const secondMonitorMutex: { id: string } = { id: "second-monitor-mutex" };
+
+  let findBySpy: jest.SpyInstance;
+  let superUpdateBySpy: jest.SpyInstance;
+  let superUpdateOneBySpy: jest.SpyInstance;
+
+  const getNarrowedMonitorIds: (queryValue: unknown) => Array<string> = (
+    queryValue: unknown,
+  ): Array<string> => {
+    const parameters: Record<string, Array<string>> = (
+      queryValue as {
+        _objectLiteralParameters: Record<string, Array<string>>;
+      }
+    )._objectLiteralParameters;
+
+    return Object.values(parameters)[0] || [];
+  };
+
+  beforeEach(() => {
+    lockMock.mockReset();
+    releaseMock.mockReset();
+    lockMock.mockResolvedValue(fakeMutex);
+    releaseMock.mockResolvedValue(undefined);
+
+    findBySpy = jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([makeMonitor()]);
+    superUpdateBySpy = jest
+      .spyOn(DatabaseService.prototype, "updateBy")
+      .mockResolvedValue(2);
+    superUpdateOneBySpy = jest
+      .spyOn(DatabaseService.prototype, "updateOneBy")
+      .mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("prefetches exact IDs, locks them in sorted order, narrows the bulk query, and releases in reverse", async () => {
+    const updateBy: UpdateBy<Monitor> = makeMonitorUpdate(true);
+    updateBy.limit = 10;
+    findBySpy.mockResolvedValue([
+      makeMonitor({ monitorId: OTHER_MONITOR_ID }),
+      makeMonitor({ monitorId: MONITOR_ID }),
+      makeMonitor({ monitorId: OTHER_MONITOR_ID }),
+    ]);
+    lockMock
+      .mockReset()
+      .mockResolvedValueOnce(firstMonitorMutex)
+      .mockResolvedValueOnce(secondMonitorMutex);
+
+    await expect(MonitorService.updateBy(updateBy)).resolves.toBe(2);
+
+    expect(findBySpy).toHaveBeenCalledWith({
+      query: updateBy.query,
+      select: { _id: true },
+      limit: 10,
+      skip: 0,
+      props: { ...updateBy.props, ignoreHooks: true },
+    });
+    expect(lockMock.mock.calls).toEqual([
+      [
+        {
+          key: MONITOR_ID.toString(),
+          namespace: "Monitor.update",
+        },
+      ],
+      [
+        {
+          key: OTHER_MONITOR_ID.toString(),
+          namespace: "Monitor.update",
+        },
+      ],
+    ]);
+    expect(releaseMock.mock.calls).toEqual([
+      [secondMonitorMutex],
+      [firstMonitorMutex],
+    ]);
+
+    const scopedUpdateBy: UpdateBy<Monitor> = superUpdateBySpy.mock
+      .calls[0]![0] as UpdateBy<Monitor>;
+    expect(scopedUpdateBy.data).toBe(updateBy.data);
+    expect(scopedUpdateBy.props).toBe(updateBy.props);
+    expect(scopedUpdateBy.limit).toBe(2);
+    expect(scopedUpdateBy.skip).toBe(0);
+    expect(getNarrowedMonitorIds(scopedUpdateBy.query._id)).toEqual([
+      MONITOR_ID.toString(),
+      OTHER_MONITOR_ID.toString(),
+    ]);
+
+    expect(findBySpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      lockMock.mock.invocationCallOrder[0]!,
+    );
+    expect(lockMock.mock.invocationCallOrder[1]!).toBeLessThan(
+      superUpdateBySpy.mock.invocationCallOrder[0]!,
+    );
+    expect(superUpdateBySpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+    expect(superUpdateOneBySpy).not.toHaveBeenCalled();
+  });
+
+  it("prefetches and narrows a single-row flag write before taking its monitor lock", async () => {
+    const updateOneBy: UpdateOneBy<Monitor> = makeMonitorUpdateOne(false);
+
+    await expect(MonitorService.updateOneBy(updateOneBy)).resolves.toBe(1);
+
+    expect(findBySpy).toHaveBeenCalledWith({
+      query: updateOneBy.query,
+      select: { _id: true },
+      limit: 1,
+      skip: 0,
+      props: { ...updateOneBy.props, ignoreHooks: true },
+    });
+    expect(lockMock).toHaveBeenCalledWith({
+      key: MONITOR_ID.toString(),
+      namespace: "Monitor.update",
+    });
+    const scopedUpdateOneBy: UpdateBy<Monitor> = superUpdateOneBySpy.mock
+      .calls[0]![0] as UpdateBy<Monitor>;
+    expect(scopedUpdateOneBy.data).toBe(updateOneBy.data);
+    expect(scopedUpdateOneBy.limit).toBe(1);
+    expect(scopedUpdateOneBy.skip).toBe(0);
+    expect(getNarrowedMonitorIds(scopedUpdateOneBy.query._id)).toEqual([
+      MONITOR_ID.toString(),
+    ]);
+    expect(lockMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      superUpdateOneBySpy.mock.invocationCallOrder[0]!,
+    );
+    expect(superUpdateOneBySpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+    expect(superUpdateBySpy).not.toHaveBeenCalled();
+  });
+
+  it("returns zero without locking or writing when the prefetch finds no monitor", async () => {
+    findBySpy.mockResolvedValue([]);
+
+    await expect(
+      MonitorService.updateBy(makeMonitorUpdate(true)),
+    ).resolves.toBe(0);
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(lockMock).not.toHaveBeenCalled();
+    expect(superUpdateBySpy).not.toHaveBeenCalled();
+    expect(superUpdateOneBySpy).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it("releases every acquired monitor lock in reverse when the bulk write fails", async () => {
+    findBySpy.mockResolvedValue([
+      makeMonitor({ monitorId: OTHER_MONITOR_ID }),
+      makeMonitor({ monitorId: MONITOR_ID }),
+    ]);
+    lockMock
+      .mockReset()
+      .mockResolvedValueOnce(firstMonitorMutex)
+      .mockResolvedValueOnce(secondMonitorMutex);
+    superUpdateBySpy.mockRejectedValue(new Error("monitor update failed"));
+
+    await expect(
+      MonitorService.updateBy(makeMonitorUpdate(true)),
+    ).rejects.toThrow("monitor update failed");
+
+    expect(releaseMock.mock.calls).toEqual([
+      [secondMonitorMutex],
+      [firstMonitorMutex],
+    ]);
+    expect(superUpdateBySpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      releaseMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("releases a partial lock set and never writes when later acquisition fails", async () => {
+    findBySpy.mockResolvedValue([
+      makeMonitor({ monitorId: MONITOR_ID }),
+      makeMonitor({ monitorId: OTHER_MONITOR_ID }),
+    ]);
+    lockMock
+      .mockReset()
+      .mockResolvedValueOnce(firstMonitorMutex)
+      .mockRejectedValueOnce(new Error("transition lock unavailable"));
+
+    await expect(
+      MonitorService.updateBy(makeMonitorUpdate(true)),
+    ).rejects.toThrow("transition lock unavailable");
+
+    expect(superUpdateOneBySpy).not.toHaveBeenCalled();
+    expect(superUpdateBySpy).not.toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(firstMonitorMutex);
+  });
+
+  it("bypasses transition locking for unrelated bulk and single-row updates", async () => {
+    const unrelatedBulk: UpdateBy<Monitor> = makeMonitorUpdate();
+    const unrelatedSingle: UpdateOneBy<Monitor> = makeMonitorUpdateOne();
+
+    await expect(MonitorService.updateBy(unrelatedBulk)).resolves.toBe(2);
+    await expect(MonitorService.updateOneBy(unrelatedSingle)).resolves.toBe(1);
+
+    expect(superUpdateBySpy).toHaveBeenCalledWith(unrelatedBulk);
+    expect(superUpdateOneBySpy).toHaveBeenCalledWith(unrelatedSingle);
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(lockMock).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fail a committed monitor write when releasing the transition lock fails", async () => {
+    releaseMock.mockRejectedValue(new Error("transition release failed"));
+
+    await expect(
+      MonitorService.updateBy(makeMonitorUpdate(true)),
+    ).resolves.toBe(2);
+
+    expect(superUpdateBySpy).toHaveBeenCalledTimes(1);
+    expect(releaseMock).toHaveBeenCalledWith(fakeMutex);
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler.test.ts
@@ -1,0 +1,313 @@
+import DatabaseNotConnectedException from "../../../../Types/Exception/DatabaseNotConnectedException";
+import ObjectID from "../../../../Types/ObjectID";
+import PostgresAppInstance from "../../../../Server/Infrastructure/PostgresDatabase";
+import MonitorStatusTimelineService from "../../../../Server/Services/MonitorStatusTimelineService";
+import logger from "../../../../Server/Utils/Logger";
+import MonitorActiveMonitoringTimelineReconciler, {
+  ActiveMonitoringTimelineRepairResult,
+} from "../../../../Server/Utils/Monitor/MonitorActiveMonitoringTimelineReconciler";
+
+jest.mock("../../../../Server/Infrastructure/PostgresDatabase", () => {
+  return {
+    __esModule: true,
+    default: {
+      getDataSource: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/MonitorStatusTimelineService", () => {
+  return {
+    __esModule: true,
+    default: {
+      reconcileActiveMonitoring: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+const mockedPostgresAppInstance: { getDataSource: jest.Mock } =
+  PostgresAppInstance as unknown as { getDataSource: jest.Mock };
+const mockedMonitorStatusTimelineService: {
+  reconcileActiveMonitoring: jest.Mock;
+} = MonitorStatusTimelineService as unknown as {
+  reconcileActiveMonitoring: jest.Mock;
+};
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+const mockedDataSource: { query: jest.Mock } = {
+  query: jest.fn(),
+};
+
+const FIRST_MONITOR_ID: string = "11111111-1111-4111-8111-111111111111";
+const SECOND_MONITOR_ID: string = "22222222-2222-4222-8222-222222222222";
+const THIRD_MONITOR_ID: string = "33333333-3333-4333-8333-333333333333";
+
+function mismatchRow(
+  monitorId: string,
+  stateUpdatedAt: Date | string,
+  disableActiveMonitoring: boolean = false,
+): {
+  disableActiveMonitoring: boolean;
+  monitorId: string;
+  stateUpdatedAt: Date | string;
+} {
+  return {
+    disableActiveMonitoring,
+    monitorId,
+    stateUpdatedAt,
+  };
+}
+
+function generatedMonitorId(index: number): string {
+  return `00000000-0000-4000-8000-${index.toString().padStart(12, "0")}`;
+}
+
+describe("MonitorActiveMonitoringTimelineReconciler.repairMismatches", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPostgresAppInstance.getDataSource.mockReturnValue(
+      mockedDataSource as never,
+    );
+    mockedDataSource.query.mockResolvedValue([] as never);
+    mockedMonitorStatusTimelineService.reconcileActiveMonitoring.mockResolvedValue(
+      {
+        didPause: false,
+        didResume: false,
+        monitorWasFound: true,
+        stateMatchedExpectation: true,
+      } as never,
+    );
+  });
+
+  test("throws before querying when Postgres is unavailable", async () => {
+    mockedPostgresAppInstance.getDataSource.mockReturnValue(null);
+
+    await expect(
+      MonitorActiveMonitoringTimelineReconciler.repairMismatches(),
+    ).rejects.toBeInstanceOf(DatabaseNotConnectedException);
+
+    expect(mockedDataSource.query).not.toHaveBeenCalled();
+    expect(
+      mockedMonitorStatusTimelineService.reconcileActiveMonitoring,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("returns an empty result when no mismatched monitors exist", async () => {
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    expect(result).toEqual({
+      failedMonitorIds: [],
+      monitorsExamined: 0,
+      paused: 0,
+      resumed: 0,
+    });
+    expect(mockedDataSource.query).toHaveBeenCalledTimes(1);
+    expect(mockedDataSource.query.mock.calls[0]![1]).toEqual([null, "100"]);
+  });
+
+  test("queries both mismatch directions with soft-delete, open-row, and keyset guards", async () => {
+    await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    const sql: string = mockedDataSource.query.mock.calls[0]![0] as string;
+    const normalizedSql: string = sql.replace(/\s+/g, " ").trim();
+
+    expect(normalizedSql).toContain('m."deletedAt" IS NULL');
+    expect(normalizedSql).toContain(
+      'm."disableActiveMonitoring" AS "disableActiveMonitoring"',
+    );
+    expect(normalizedSql).toContain('($1::uuid IS NULL OR m."_id" > $1::uuid)');
+    expect(normalizedSql).toContain(
+      'm."disableActiveMonitoring" = true AND EXISTS',
+    );
+    expect(normalizedSql).toContain(
+      'm."disableActiveMonitoring" = false AND NOT EXISTS',
+    );
+    expect(normalizedSql).toContain('t."monitorId" = m."_id"');
+    expect(normalizedSql).toContain('t."deletedAt" IS NULL');
+    expect(normalizedSql).toContain('t."endsAt" IS NULL');
+    expect(normalizedSql).toContain('ORDER BY m."_id" ASC LIMIT $2');
+    expect(mockedDataSource.query.mock.calls[0]![1]).toEqual([null, "100"]);
+  });
+
+  test("advances the keyset cursor after a full batch", async () => {
+    const fullBatch: Array<{
+      disableActiveMonitoring: boolean;
+      monitorId: string;
+      stateUpdatedAt: string;
+    }> = Array.from({ length: 100 }, (_value: unknown, index: number) => {
+      return {
+        disableActiveMonitoring: false,
+        monitorId: generatedMonitorId(index + 1),
+        stateUpdatedAt: "2026-07-31T10:00:00.000Z",
+      };
+    });
+    const finalRow: {
+      disableActiveMonitoring: boolean;
+      monitorId: string;
+      stateUpdatedAt: string;
+    } = {
+      disableActiveMonitoring: true,
+      monitorId: generatedMonitorId(101),
+      stateUpdatedAt: "2026-07-31T10:01:00.000Z",
+    };
+
+    mockedDataSource.query
+      .mockResolvedValueOnce(fullBatch as never)
+      .mockResolvedValueOnce([finalRow] as never);
+
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    expect(mockedDataSource.query).toHaveBeenCalledTimes(2);
+    expect(mockedDataSource.query.mock.calls[0]![1]).toEqual([null, "100"]);
+    expect(mockedDataSource.query.mock.calls[1]![1]).toEqual([
+      generatedMonitorId(100),
+      "100",
+    ]);
+    expect(result.monitorsExamined).toBe(101);
+    expect(
+      mockedMonitorStatusTimelineService.reconcileActiveMonitoring,
+    ).toHaveBeenCalledTimes(101);
+  });
+
+  test("bounds recurring repair work to the configured number of batches", async () => {
+    const fullBatch: Array<{
+      disableActiveMonitoring: boolean;
+      monitorId: string;
+      stateUpdatedAt: string;
+    }> = Array.from({ length: 100 }, (_value: unknown, index: number) => {
+      return {
+        disableActiveMonitoring: false,
+        monitorId: generatedMonitorId(index + 1),
+        stateUpdatedAt: "2026-07-31T10:00:00.000Z",
+      };
+    });
+    mockedDataSource.query.mockResolvedValue(fullBatch as never);
+
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches({
+        maximumBatches: 1,
+      });
+
+    expect(mockedDataSource.query).toHaveBeenCalledTimes(1);
+    expect(result.monitorsExamined).toBe(100);
+    expect(
+      mockedMonitorStatusTimelineService.reconcileActiveMonitoring,
+    ).toHaveBeenCalledTimes(100);
+  });
+
+  test("terminates immediately after a short batch", async () => {
+    mockedDataSource.query.mockResolvedValueOnce([
+      mismatchRow(FIRST_MONITOR_ID, "2026-07-31T10:00:00.000Z"),
+      mismatchRow(SECOND_MONITOR_ID, "2026-07-31T10:01:00.000Z"),
+    ] as never);
+
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    expect(mockedDataSource.query).toHaveBeenCalledTimes(1);
+    expect(result.monitorsExamined).toBe(2);
+  });
+
+  test("counts pause and resume repairs independently", async () => {
+    mockedDataSource.query.mockResolvedValueOnce([
+      mismatchRow(FIRST_MONITOR_ID, "2026-07-31T10:00:00.000Z"),
+      mismatchRow(SECOND_MONITOR_ID, "2026-07-31T10:01:00.000Z"),
+      mismatchRow(THIRD_MONITOR_ID, "2026-07-31T10:02:00.000Z"),
+    ] as never);
+    mockedMonitorStatusTimelineService.reconcileActiveMonitoring
+      .mockResolvedValueOnce({ didPause: true, didResume: false } as never)
+      .mockResolvedValueOnce({ didPause: false, didResume: true } as never)
+      .mockResolvedValueOnce({ didPause: true, didResume: true } as never);
+
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    expect(result).toMatchObject({
+      monitorsExamined: 3,
+      paused: 2,
+      resumed: 2,
+    });
+  });
+
+  test("passes each persisted state snapshot so a later opposite write can be reconstructed", async () => {
+    const persistedDate: Date = new Date("2026-07-31T10:15:30.000Z");
+    const serializedPersistedDate: string = "2026-07-31T11:16:31.000Z";
+    mockedDataSource.query.mockResolvedValueOnce([
+      mismatchRow(FIRST_MONITOR_ID, persistedDate, true),
+      mismatchRow(SECOND_MONITOR_ID, serializedPersistedDate, false),
+    ] as never);
+
+    await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    expect(
+      mockedMonitorStatusTimelineService.reconcileActiveMonitoring,
+    ).toHaveBeenNthCalledWith(1, {
+      monitorId: new ObjectID(FIRST_MONITOR_ID),
+      expectedDisableActiveMonitoring: true,
+      reconciledAt: persistedDate,
+    });
+    expect(
+      mockedMonitorStatusTimelineService.reconcileActiveMonitoring,
+    ).toHaveBeenNthCalledWith(2, {
+      monitorId: new ObjectID(SECOND_MONITOR_ID),
+      expectedDisableActiveMonitoring: false,
+      reconciledAt: new Date(serializedPersistedDate),
+    });
+
+    const firstArgs: { reconciledAt: Date } = mockedMonitorStatusTimelineService
+      .reconcileActiveMonitoring.mock.calls[0]![0] as { reconciledAt: Date };
+    expect(firstArgs.reconciledAt).toBe(persistedDate);
+  });
+
+  test("isolates per-monitor failures, continues the batch, and collects failed IDs", async () => {
+    const firstFailure: Error = new Error("first reconciliation failed");
+    const thirdFailure: Error = new Error("third reconciliation failed");
+    mockedDataSource.query.mockResolvedValueOnce([
+      mismatchRow(FIRST_MONITOR_ID, "2026-07-31T10:00:00.000Z"),
+      mismatchRow(SECOND_MONITOR_ID, "2026-07-31T10:01:00.000Z"),
+      mismatchRow(THIRD_MONITOR_ID, "2026-07-31T10:02:00.000Z"),
+    ] as never);
+    mockedMonitorStatusTimelineService.reconcileActiveMonitoring
+      .mockRejectedValueOnce(firstFailure as never)
+      .mockResolvedValueOnce({ didPause: true, didResume: false } as never)
+      .mockRejectedValueOnce(thirdFailure as never);
+
+    const result: ActiveMonitoringTimelineRepairResult =
+      await MonitorActiveMonitoringTimelineReconciler.repairMismatches();
+
+    expect(
+      mockedMonitorStatusTimelineService.reconcileActiveMonitoring,
+    ).toHaveBeenCalledTimes(3);
+    expect(result.monitorsExamined).toBe(3);
+    expect(result.paused).toBe(1);
+    expect(result.resumed).toBe(0);
+    expect(
+      result.failedMonitorIds.map((monitorId: ObjectID) => {
+        return monitorId.toString();
+      }),
+    ).toEqual([FIRST_MONITOR_ID, THIRD_MONITOR_ID]);
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      `MonitorActiveMonitoringTimelineReconciler: failed to reconcile monitor ${FIRST_MONITOR_ID}.`,
+    );
+    expect(mockedLogger.error).toHaveBeenCalledWith(firstFailure);
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      `MonitorActiveMonitoringTimelineReconciler: failed to reconcile monitor ${THIRD_MONITOR_ID}.`,
+    );
+    expect(mockedLogger.error).toHaveBeenCalledWith(thirdFailure);
+  });
+});

--- a/Common/Tests/UI/Components/Graphs/DayUptimeGraph.test.tsx
+++ b/Common/Tests/UI/Components/Graphs/DayUptimeGraph.test.tsx
@@ -1,0 +1,559 @@
+/** @timezone UTC */
+
+import Color from "../../../../Types/Color";
+import { Gray500 } from "../../../../Types/BrandColors";
+import ObjectID from "../../../../Types/ObjectID";
+import UptimeBarTooltipIncident from "../../../../Types/Monitor/UptimeBarTooltipIncident";
+import DayUptimeGraph, {
+  BarChartRule,
+  ComponentProps,
+  DayUptimeData,
+  Event as UptimeEvent,
+  getDayUptimeData,
+} from "../../../../UI/Components/Graphs/DayUptimeGraph";
+import "@testing-library/jest-dom";
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  within,
+} from "@testing-library/react";
+import { describe, expect, jest, test } from "@jest/globals";
+import React, { ReactElement } from "react";
+
+/*
+ * The real tooltip portals its content and only reveals it after a delayed
+ * pointer interaction. Rendering the rich content beside its trigger keeps
+ * these tests focused on the day classification and the data passed to the
+ * tooltip, without coupling them to Tippy's timers and positioning internals.
+ */
+jest.mock("../../../../UI/Components/Tooltip/Tooltip", () => {
+  return {
+    __esModule: true,
+    default: ({
+      children,
+      richContent,
+    }: {
+      children: ReactElement;
+      richContent?: ReactElement | undefined;
+    }): ReactElement => {
+      return (
+        <div data-testid="day-uptime-tooltip">
+          {children}
+          <div data-testid="day-uptime-tooltip-content">{richContent}</div>
+        </div>
+      );
+    },
+  };
+});
+
+const OPERATIONAL_STATUS_ID: ObjectID = new ObjectID("operational-status");
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID("offline-status");
+const DEGRADED_STATUS_ID: ObjectID = new ObjectID("degraded-status");
+
+const OPERATIONAL_COLOR: Color = new Color("#22c55e");
+const OFFLINE_COLOR: Color = new Color("#ef4444");
+const DEGRADED_COLOR: Color = new Color("#f59e0b");
+const HIGH_PRIORITY_COLOR: Color = new Color("#7c3aed");
+const LOW_PRIORITY_COLOR: Color = new Color("#0ea5e9");
+
+interface EventOptions {
+  start: string;
+  end: string;
+  statusId?: ObjectID | undefined;
+  color?: Color | undefined;
+  label?: string | undefined;
+  priority?: number | undefined;
+}
+
+const event: (options: EventOptions) => UptimeEvent = (
+  options: EventOptions,
+): UptimeEvent => {
+  return {
+    startDate: new Date(options.start),
+    endDate: new Date(options.end),
+    eventStatusId: options.statusId || OPERATIONAL_STATUS_ID,
+    color: options.color || OPERATIONAL_COLOR,
+    label: options.label || "Operational",
+    priority: options.priority ?? 1,
+  };
+};
+
+const renderGraph: (overrides?: Partial<ComponentProps>) => RenderResult = (
+  overrides: Partial<ComponentProps> = {},
+): RenderResult => {
+  const props: ComponentProps = {
+    startDate: new Date("2025-01-01T00:00:00.000Z"),
+    endDate: new Date("2025-01-01T00:00:00.000Z"),
+    events: [],
+    defaultBarColor: Gray500,
+    downtimeEventStatusIds: [OFFLINE_STATUS_ID],
+    ...overrides,
+  };
+
+  return render(<DayUptimeGraph {...props} />);
+};
+
+const getBars: () => Array<HTMLElement> = (): Array<HTMLElement> => {
+  return screen.getAllByTestId("day-uptime-bar");
+};
+
+const expectBar: (
+  bar: HTMLElement,
+  expected: { date: string; hasData: boolean; color: Color },
+) => void = (
+  bar: HTMLElement,
+  expected: { date: string; hasData: boolean; color: Color },
+): void => {
+  expect(bar).toHaveAttribute(
+    "data-date",
+    new Date(expected.date).toISOString(),
+  );
+  expect(bar).toHaveAttribute(
+    "data-has-data",
+    expected.hasData ? "true" : "false",
+  );
+  expect(bar).toHaveStyle({
+    backgroundColor: expected.color.toString(),
+  });
+};
+
+const getTooltipForBar: (bar: HTMLElement) => HTMLElement = (
+  bar: HTMLElement,
+): HTMLElement => {
+  const tooltip: HTMLElement | null = bar.closest(
+    '[data-testid="day-uptime-tooltip"]',
+  );
+
+  if (!tooltip) {
+    throw new Error("Expected the uptime bar to be wrapped in a tooltip");
+  }
+
+  return tooltip;
+};
+
+describe("DayUptimeGraph", () => {
+  test("renders every day in an empty range as caller-colored no-data", () => {
+    renderGraph({
+      startDate: new Date("2025-01-01T00:00:00.000Z"),
+      endDate: new Date("2025-01-03T00:00:00.000Z"),
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expect(bars).toHaveLength(3);
+
+    ["2025-01-01", "2025-01-02", "2025-01-03"].forEach(
+      (date: string, index: number) => {
+        expectBar(bars[index]!, {
+          date: `${date}T00:00:00.000Z`,
+          hasData: false,
+          color: Gray500,
+        });
+
+        const tooltip: HTMLElement = getTooltipForBar(bars[index]!);
+        expect(
+          within(tooltip).getByText("No monitoring data for this day"),
+        ).toBeInTheDocument();
+        expect(within(tooltip).queryByText("Uptime")).not.toBeInTheDocument();
+      },
+    );
+  });
+
+  test("keeps the pre-creation part of the range gray", () => {
+    renderGraph({
+      startDate: new Date("2025-01-01T00:00:00.000Z"),
+      endDate: new Date("2025-01-03T00:00:00.000Z"),
+      events: [
+        event({
+          start: "2025-01-02T09:00:00.000Z",
+          end: "2025-01-04T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expectBar(bars[0]!, {
+      date: "2025-01-01T00:00:00.000Z",
+      hasData: false,
+      color: Gray500,
+    });
+    expectBar(bars[1]!, {
+      date: "2025-01-02T00:00:00.000Z",
+      hasData: true,
+      color: OPERATIONAL_COLOR,
+    });
+    expectBar(bars[2]!, {
+      date: "2025-01-03T00:00:00.000Z",
+      hasData: true,
+      color: OPERATIONAL_COLOR,
+    });
+  });
+
+  test("keeps a closed disabled gap between status histories gray", () => {
+    renderGraph({
+      startDate: new Date("2025-01-01T00:00:00.000Z"),
+      endDate: new Date("2025-01-03T00:00:00.000Z"),
+      events: [
+        event({
+          start: "2025-01-01T00:00:00.000Z",
+          end: "2025-01-02T00:00:00.000Z",
+        }),
+        event({
+          start: "2025-01-03T00:00:00.000Z",
+          end: "2025-01-04T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expect(
+      bars.map((bar: HTMLElement) => {
+        return bar.dataset["hasData"];
+      }),
+    ).toEqual(["true", "false", "true"]);
+    expect(bars[1]).toHaveStyle({
+      backgroundColor: Gray500.toString(),
+    });
+    expect(
+      within(getTooltipForBar(bars[1]!)).getByText(
+        "No monitoring data for this day",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("uses the recorded colors for operational and offline days", () => {
+    renderGraph({
+      startDate: new Date("2025-02-01T00:00:00.000Z"),
+      endDate: new Date("2025-02-02T00:00:00.000Z"),
+      events: [
+        event({
+          start: "2025-02-01T00:00:00.000Z",
+          end: "2025-02-02T00:00:00.000Z",
+        }),
+        event({
+          start: "2025-02-02T00:00:00.000Z",
+          end: "2025-02-03T00:00:00.000Z",
+          statusId: OFFLINE_STATUS_ID,
+          color: OFFLINE_COLOR,
+          label: "Offline",
+          priority: 10,
+        }),
+      ],
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expectBar(bars[0]!, {
+      date: "2025-02-01T00:00:00.000Z",
+      hasData: true,
+      color: OPERATIONAL_COLOR,
+    });
+    expectBar(bars[1]!, {
+      date: "2025-02-02T00:00:00.000Z",
+      hasData: true,
+      color: OFFLINE_COLOR,
+    });
+  });
+
+  test("chooses the color of the highest-priority overlapping status", () => {
+    renderGraph({
+      events: [
+        event({
+          start: "2025-01-01T01:00:00.000Z",
+          end: "2025-01-01T23:00:00.000Z",
+          statusId: OFFLINE_STATUS_ID,
+          color: HIGH_PRIORITY_COLOR,
+          label: "Critical",
+          priority: 20,
+        }),
+        event({
+          start: "2025-01-01T02:00:00.000Z",
+          end: "2025-01-01T22:00:00.000Z",
+          statusId: DEGRADED_STATUS_ID,
+          color: LOW_PRIORITY_COLOR,
+          label: "Lower priority",
+          priority: 2,
+        }),
+      ],
+    });
+
+    expectBar(getBars()[0]!, {
+      date: "2025-01-01T00:00:00.000Z",
+      hasData: true,
+      color: HIGH_PRIORITY_COLOR,
+    });
+  });
+
+  test("applies uptime rules to covered days but never recolors a no-data day", () => {
+    const rules: Array<BarChartRule> = [
+      {
+        uptimePercentGreaterThanOrEqualTo: 99,
+        barColor: OPERATIONAL_COLOR,
+      },
+      {
+        uptimePercentGreaterThanOrEqualTo: 75,
+        barColor: DEGRADED_COLOR,
+      },
+      {
+        uptimePercentGreaterThanOrEqualTo: 0,
+        barColor: OFFLINE_COLOR,
+      },
+    ];
+
+    renderGraph({
+      startDate: new Date("2025-03-01T00:00:00.000Z"),
+      endDate: new Date("2025-03-02T00:00:00.000Z"),
+      barColorRules: rules,
+      events: [
+        event({
+          start: "2025-03-01T00:00:00.000Z",
+          end: "2025-03-01T18:00:00.000Z",
+        }),
+        event({
+          start: "2025-03-01T18:00:00.000Z",
+          end: "2025-03-02T00:00:00.000Z",
+          statusId: OFFLINE_STATUS_ID,
+          color: OFFLINE_COLOR,
+          label: "Offline",
+          priority: 10,
+        }),
+      ],
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expectBar(bars[0]!, {
+      date: "2025-03-01T00:00:00.000Z",
+      hasData: true,
+      color: DEGRADED_COLOR,
+    });
+    expectBar(bars[1]!, {
+      date: "2025-03-02T00:00:00.000Z",
+      hasData: false,
+      color: Gray500,
+    });
+  });
+
+  test("treats a full-day event as a half-open interval at midnight", () => {
+    renderGraph({
+      startDate: new Date("2025-04-02T00:00:00.000Z"),
+      endDate: new Date("2025-04-03T00:00:00.000Z"),
+      events: [
+        event({
+          start: "2025-04-02T00:00:00.000Z",
+          end: "2025-04-03T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expect(
+      bars.map((bar: HTMLElement) => {
+        return bar.dataset["hasData"];
+      }),
+    ).toEqual(["true", "false"]);
+    expect(bars[1]).toHaveStyle({
+      backgroundColor: Gray500.toString(),
+    });
+  });
+
+  test("does not count events that only touch either midnight boundary", () => {
+    renderGraph({
+      startDate: new Date("2025-04-02T00:00:00.000Z"),
+      endDate: new Date("2025-04-02T00:00:00.000Z"),
+      events: [
+        event({
+          start: "2025-04-01T12:00:00.000Z",
+          end: "2025-04-02T00:00:00.000Z",
+          color: OFFLINE_COLOR,
+          label: "Ends at day start",
+        }),
+        event({
+          start: "2025-04-03T00:00:00.000Z",
+          end: "2025-04-03T12:00:00.000Z",
+          color: OFFLINE_COLOR,
+          label: "Starts at next day boundary",
+        }),
+      ],
+    });
+
+    expectBar(getBars()[0]!, {
+      date: "2025-04-02T00:00:00.000Z",
+      hasData: false,
+      color: Gray500,
+    });
+  });
+
+  test("treats a zero-duration status record as no data", () => {
+    renderGraph({
+      barColorRules: [
+        {
+          uptimePercentGreaterThanOrEqualTo: 0,
+          barColor: OFFLINE_COLOR,
+        },
+      ],
+      events: [
+        event({
+          start: "2025-01-01T12:00:00.000Z",
+          end: "2025-01-01T12:00:00.000Z",
+          statusId: OFFLINE_STATUS_ID,
+          color: OFFLINE_COLOR,
+          label: "Zero duration",
+          priority: 100,
+        }),
+      ],
+    });
+
+    const bar: HTMLElement = getBars()[0]!;
+    expectBar(bar, {
+      date: "2025-01-01T00:00:00.000Z",
+      hasData: false,
+      color: Gray500,
+    });
+    expect(
+      within(getTooltipForBar(bar)).getByText(
+        "No monitoring data for this day",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(getTooltipForBar(bar)).queryByText("Uptime"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("counts even a sub-second overlap when it has positive duration", () => {
+    renderGraph({
+      events: [
+        event({
+          start: "2025-01-01T00:00:00.000Z",
+          end: "2025-01-01T00:00:00.001Z",
+          color: DEGRADED_COLOR,
+        }),
+      ],
+    });
+
+    expectBar(getBars()[0]!, {
+      date: "2025-01-01T00:00:00.000Z",
+      hasData: true,
+      color: DEGRADED_COLOR,
+    });
+  });
+
+  test("clips event duration and the live-day boundary at millisecond precision", () => {
+    const dayData: DayUptimeData = getDayUptimeData({
+      date: new Date("2025-01-01T00:00:00.000Z"),
+      currentDate: new Date("2025-01-01T00:00:00.300Z"),
+      events: [
+        event({
+          start: "2025-01-01T00:00:00.200Z",
+          end: "2025-01-01T00:00:00.400Z",
+        }),
+      ],
+      defaultBarColor: Gray500,
+    });
+
+    expect(dayData.hasEvents).toBe(true);
+    expect(dayData.statusDurations).toHaveLength(1);
+    expect(dayData.statusDurations[0]!.seconds).toBeCloseTo(0.1, 10);
+  });
+
+  test("marks every day positively overlapped by a spanning event as data", () => {
+    renderGraph({
+      startDate: new Date("2025-05-01T00:00:00.000Z"),
+      endDate: new Date("2025-05-03T00:00:00.000Z"),
+      events: [
+        event({
+          start: "2025-04-30T23:00:00.000Z",
+          end: "2025-05-04T01:00:00.000Z",
+          color: DEGRADED_COLOR,
+        }),
+      ],
+    });
+
+    const bars: Array<HTMLElement> = getBars();
+    expect(bars).toHaveLength(3);
+    for (const bar of bars) {
+      expect(bar).toHaveAttribute("data-has-data", "true");
+      expect(bar).toHaveStyle({
+        backgroundColor: DEGRADED_COLOR.toString(),
+      });
+    }
+  });
+
+  test("keeps an incident-only day as no-data while allowing its bar to open incidents", () => {
+    const incident: UptimeBarTooltipIncident = {
+      id: "incident-1",
+      title: "Checkout outage",
+      declaredAt: new Date("2025-06-01T12:00:00.000Z"),
+      monitorIds: [],
+    };
+    const onBarClick: ReturnType<
+      typeof jest.fn<
+        (date: Date, incidents: Array<UptimeBarTooltipIncident>) => void
+      >
+    > =
+      jest.fn<
+        (date: Date, incidents: Array<UptimeBarTooltipIncident>) => void
+      >();
+
+    renderGraph({
+      startDate: new Date("2025-06-01T00:00:00.000Z"),
+      endDate: new Date("2025-06-01T00:00:00.000Z"),
+      incidents: [incident],
+      onBarClick,
+    });
+
+    const bar: HTMLElement = getBars()[0]!;
+    expectBar(bar, {
+      date: "2025-06-01T00:00:00.000Z",
+      hasData: false,
+      color: Gray500,
+    });
+    expect(bar).toHaveClass("cursor-pointer");
+
+    const tooltip: HTMLElement = getTooltipForBar(bar);
+    expect(
+      within(tooltip).getByText("No monitoring data for this day"),
+    ).toBeInTheDocument();
+    expect(within(tooltip).getByText("Checkout outage")).toBeInTheDocument();
+
+    fireEvent.click(bar);
+
+    expect(onBarClick).toHaveBeenCalledTimes(1);
+    expect(onBarClick.mock.calls[0]![0].toISOString()).toBe(
+      "2025-06-01T00:00:00.000Z",
+    );
+    expect(onBarClick.mock.calls[0]![1]).toEqual([incident]);
+  });
+
+  test("incident clicks do not bubble into the incident-only bar click", () => {
+    const incident: UptimeBarTooltipIncident = {
+      id: "incident-2",
+      title: "API latency incident",
+      declaredAt: new Date("2025-06-02T08:30:00.000Z"),
+      monitorIds: [],
+    };
+    const onBarClick: ReturnType<
+      typeof jest.fn<
+        (date: Date, incidents: Array<UptimeBarTooltipIncident>) => void
+      >
+    > =
+      jest.fn<
+        (date: Date, incidents: Array<UptimeBarTooltipIncident>) => void
+      >();
+    const onIncidentClick: ReturnType<
+      typeof jest.fn<(incidentId: string) => void>
+    > = jest.fn<(incidentId: string) => void>();
+
+    renderGraph({
+      startDate: new Date("2025-06-02T00:00:00.000Z"),
+      endDate: new Date("2025-06-02T00:00:00.000Z"),
+      incidents: [incident],
+      onBarClick,
+      onIncidentClick,
+    });
+
+    fireEvent.click(screen.getByText("API latency incident"));
+
+    expect(onIncidentClick).toHaveBeenCalledWith("incident-2");
+    expect(onBarClick).not.toHaveBeenCalled();
+  });
+});

--- a/Common/UI/Components/Graphs/DayUptimeGraph.tsx
+++ b/Common/UI/Components/Graphs/DayUptimeGraph.tsx
@@ -6,12 +6,7 @@ import OneUptimeDate from "../../../Types/Date";
 import Dictionary from "../../../Types/Dictionary";
 import ObjectID from "../../../Types/ObjectID";
 import UptimeBarTooltipIncident from "../../../Types/Monitor/UptimeBarTooltipIncident";
-import React, {
-  FunctionComponent,
-  ReactElement,
-  useEffect,
-  useState,
-} from "react";
+import React, { FunctionComponent, ReactElement } from "react";
 import UptimeEvent from "../../../Utils/Uptime/Event";
 
 export type Event = UptimeEvent;
@@ -36,19 +31,153 @@ export interface ComponentProps {
   onIncidentClick?: ((incidentId: string) => void) | undefined;
 }
 
+export interface DayUptimeData {
+  color: Color;
+  hasEvents: boolean;
+  uptimePercent: number;
+  statusDurations: Array<StatusDuration>;
+}
+
+/**
+ * Summarize the monitoring coverage that actually overlaps one local calendar
+ * day. Timeline rows are half-open intervals: an event ending exactly at
+ * midnight belongs to the preceding day, while one starting at midnight
+ * belongs to the new day. Only positive-duration coverage is data.
+ */
+export function getDayUptimeData(data: {
+  date: Date;
+  events: Array<Event>;
+  defaultBarColor: Color;
+  barColorRules?: Array<BarChartRule> | undefined;
+  downtimeEventStatusIds?: Array<ObjectID> | undefined;
+  currentDate?: Date | undefined;
+}): DayUptimeData {
+  const startOfDay: Date = OneUptimeDate.getStartOfDay(data.date);
+  const endOfDayExclusive: Date = OneUptimeDate.getSomeDaysAfterDate(
+    startOfDay,
+    1,
+  );
+  const currentDate: Date = data.currentDate || OneUptimeDate.getCurrentDate();
+  const coverageEnd: Date =
+    endOfDayExclusive.getTime() <= currentDate.getTime()
+      ? endOfDayExclusive
+      : currentDate;
+
+  const secondsOfEvent: Dictionary<number> = {};
+  const eventColors: Dictionary<Color> = {};
+  const eventLabels: Dictionary<string> = {};
+  let highestPriority: number = Number.NEGATIVE_INFINITY;
+  let color: Color = data.defaultBarColor || Green;
+
+  for (const event of data.events) {
+    /*
+     * Positive half-open overlap: [event.start, event.end) intersects
+     * [startOfDay, min(endOfDay, now)). This avoids both midnight attribution
+     * bugs and zero-duration rows being presented as monitoring data.
+     */
+    if (
+      event.startDate.getTime() >= coverageEnd.getTime() ||
+      event.endDate.getTime() <= startOfDay.getTime()
+    ) {
+      continue;
+    }
+
+    const eventStart: Date =
+      event.startDate.getTime() >= startOfDay.getTime()
+        ? event.startDate
+        : startOfDay;
+    const eventEnd: Date =
+      event.endDate.getTime() <= coverageEnd.getTime()
+        ? event.endDate
+        : coverageEnd;
+    const seconds: number = OneUptimeDate.getSecondsBetweenDates(
+      eventStart,
+      eventEnd,
+    );
+
+    if (seconds <= 0) {
+      continue;
+    }
+
+    const eventStatusId: string = event.eventStatusId.toString();
+    secondsOfEvent[eventStatusId] =
+      (secondsOfEvent[eventStatusId] || 0) + seconds;
+    eventLabels[eventStatusId] = event.label;
+    eventColors[eventStatusId] = event.color;
+
+    if (highestPriority <= event.priority) {
+      highestPriority = event.priority;
+
+      if (!data.barColorRules || data.barColorRules.length === 0) {
+        color = event.color;
+      }
+    }
+  }
+
+  const downtimeStatusIds: Array<string> = (
+    data.downtimeEventStatusIds || []
+  ).map((id: ObjectID) => {
+    return id.toString();
+  });
+
+  let totalDowntimeInSeconds: number = 0;
+  let totalUptimeInSeconds: number = 0;
+  const statusDurations: Array<StatusDuration> = [];
+
+  for (const eventStatusId in secondsOfEvent) {
+    const seconds: number = secondsOfEvent[eventStatusId] || 0;
+    const isDowntime: boolean = downtimeStatusIds.includes(eventStatusId);
+
+    if (isDowntime) {
+      totalDowntimeInSeconds += seconds;
+    } else {
+      totalUptimeInSeconds += seconds;
+    }
+
+    statusDurations.push({
+      label: eventLabels[eventStatusId] || "Unknown",
+      seconds: seconds,
+      color: eventColors[eventStatusId] || data.defaultBarColor || Green,
+      isDowntime: isDowntime,
+    });
+  }
+
+  const totalObservedSeconds: number =
+    totalUptimeInSeconds + totalDowntimeInSeconds;
+  const hasEvents: boolean = totalObservedSeconds > 0;
+  const uptimePercent: number = hasEvents
+    ? (totalUptimeInSeconds / totalObservedSeconds) * 100
+    : 0;
+
+  /*
+   * A no-data day must keep the caller's explicit no-data color. In
+   * particular, a 0-second day must not flow through a 100%-uptime color rule
+   * and become green.
+   */
+  if (hasEvents) {
+    for (const rule of data.barColorRules || []) {
+      if (uptimePercent >= rule.uptimePercentGreaterThanOrEqualTo) {
+        color = rule.barColor;
+        break;
+      }
+    }
+  }
+
+  return {
+    color: color,
+    hasEvents: hasEvents,
+    uptimePercent: uptimePercent,
+    statusDurations: statusDurations,
+  };
+}
+
 const DayUptimeGraph: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [days, setDays] = useState<number>(0);
-
-  useEffect(() => {
-    setDays(
-      OneUptimeDate.getNumberOfDaysBetweenDatesInclusive(
-        props.startDate,
-        props.endDate,
-      ),
-    );
-  }, [props.startDate, props.endDate]);
+  const days: number = OneUptimeDate.getNumberOfDaysBetweenDatesInclusive(
+    props.startDate,
+    props.endDate,
+  );
 
   type GetIncidentsForDayFunction = (
     startOfDay: Date,
@@ -57,14 +186,17 @@ const DayUptimeGraph: FunctionComponent<ComponentProps> = (
 
   const getIncidentsForDay: GetIncidentsForDayFunction = (
     startOfDay: Date,
-    endOfDay: Date,
+    endOfDayExclusive: Date,
   ): Array<UptimeBarTooltipIncident> => {
     if (!props.incidents || props.incidents.length === 0) {
       return [];
     }
 
     return props.incidents.filter((incident: UptimeBarTooltipIncident) => {
-      return OneUptimeDate.isBetween(incident.declaredAt, startOfDay, endOfDay);
+      return (
+        incident.declaredAt.getTime() >= startOfDay.getTime() &&
+        incident.declaredAt.getTime() < endOfDayExclusive.getTime()
+      );
     });
   };
 
@@ -73,167 +205,34 @@ const DayUptimeGraph: FunctionComponent<ComponentProps> = (
   const getUptimeBar: GetUptimeBarFunction = (
     dayNumber: number,
   ): ReactElement => {
-    let color: Color = props.defaultBarColor || Green;
-
     const todaysDay: Date = OneUptimeDate.getSomeDaysAfterDate(
       props.startDate,
       dayNumber,
     );
 
     const startOfTheDay: Date = OneUptimeDate.getStartOfDay(todaysDay);
-    const endOfTheDay: Date = OneUptimeDate.getEndOfDay(todaysDay);
-
-    const todaysEvents: Array<Event> = props.events.filter((event: Event) => {
-      let doesEventBelongsToToday: boolean = false;
-
-      /// if the event starts or end today.
-      if (
-        OneUptimeDate.isBetween(event.startDate, startOfTheDay, endOfTheDay)
-      ) {
-        doesEventBelongsToToday = true;
-      }
-
-      if (OneUptimeDate.isBetween(event.endDate, startOfTheDay, endOfTheDay)) {
-        doesEventBelongsToToday = true;
-      }
-
-      // if the event is outside start or end day but overlaps the day completely.
-
-      if (
-        OneUptimeDate.isBetween(startOfTheDay, event.startDate, endOfTheDay) &&
-        OneUptimeDate.isBetween(endOfTheDay, startOfTheDay, event.endDate)
-      ) {
-        doesEventBelongsToToday = true;
-      }
-
-      return doesEventBelongsToToday;
+    const endOfTheDayExclusive: Date = OneUptimeDate.getSomeDaysAfterDate(
+      startOfTheDay,
+      1,
+    );
+    const dayData: DayUptimeData = getDayUptimeData({
+      date: todaysDay,
+      events: props.events,
+      defaultBarColor: props.defaultBarColor,
+      barColorRules: props.barColorRules,
+      downtimeEventStatusIds: props.downtimeEventStatusIds,
     });
-
-    const secondsOfEvent: Dictionary<number> = {};
-    const eventColors: Dictionary<Color> = {};
-
-    let currentPriority: number = 1;
-
-    const eventLabels: Dictionary<string> = {};
-
-    for (const event of todaysEvents) {
-      const startDate: Date = OneUptimeDate.getGreaterDate(
-        event.startDate,
-        startOfTheDay,
-      );
-
-      const endDate: Date = OneUptimeDate.getLesserDate(
-        event.endDate,
-        OneUptimeDate.getLesserDate(
-          OneUptimeDate.getCurrentDate(),
-          endOfTheDay,
-        ),
-      );
-
-      const seconds: number = OneUptimeDate.getSecondsBetweenDates(
-        startDate,
-        endDate,
-      );
-
-      if (!secondsOfEvent[event.eventStatusId.toString()]) {
-        secondsOfEvent[event.eventStatusId.toString()] = 0;
-      }
-
-      secondsOfEvent[event.eventStatusId.toString()]! += seconds;
-
-      eventLabels[event.eventStatusId.toString()] = event.label;
-      eventColors[event.eventStatusId.toString()] = event.color;
-
-      // set bar color.
-      if (currentPriority <= event.priority) {
-        currentPriority = event.priority;
-
-        // if there are no rules then use the color of the event.
-
-        if (!props.barColorRules || props.barColorRules.length === 0) {
-          color = event.color;
-        }
-      }
-    }
-
-    let hasEvents: boolean = false;
-
-    let totalDowntimeInSeconds: number = 0;
-
-    let totalUptimeInSeconds: number = 0;
-
-    const downtimeStatusIds: Array<string> = (
-      props.downtimeEventStatusIds || []
-    ).map((id: ObjectID) => {
-      return id.toString();
-    });
-
-    for (const key in secondsOfEvent) {
-      hasEvents = true;
-
-      const eventStatusId: string = key;
-
-      const isDowntimeEvent: boolean =
-        downtimeStatusIds.includes(eventStatusId);
-
-      if (isDowntimeEvent) {
-        const secondsOfDowntime: number = secondsOfEvent[key] || 0;
-        totalDowntimeInSeconds += secondsOfDowntime;
-      } else {
-        totalUptimeInSeconds += secondsOfEvent[key] || 0;
-      }
-    }
-
-    // now check bar rules and finalize the color of the bar
-
-    const uptimePercentForTheDay: number =
-      totalUptimeInSeconds + totalDowntimeInSeconds > 0
-        ? (totalUptimeInSeconds /
-            (totalDowntimeInSeconds + totalUptimeInSeconds)) *
-          100
-        : 100;
-
-    for (const rules of props.barColorRules || []) {
-      if (uptimePercentForTheDay >= rules.uptimePercentGreaterThanOrEqualTo) {
-        color = rules.barColor;
-        break;
-      }
-    }
-
-    if (todaysEvents.length === 1 && !hasEvents) {
-      hasEvents = true;
-    }
-
-    if (todaysEvents.length === 1) {
-      hasEvents = true;
-    }
-
-    if (todaysEvents.length === 0) {
-      hasEvents = false;
-      color = props.defaultBarColor || Green;
-    }
 
     // Get incidents for this day
     const dayIncidents: Array<UptimeBarTooltipIncident> = getIncidentsForDay(
       startOfTheDay,
-      endOfTheDay,
+      endOfTheDayExclusive,
     );
 
     let className: string = "h-20 w-20";
 
     if (props.height) {
       className = "w-20 h-" + props.height;
-    }
-
-    // Build status durations for tooltip
-    const statusDurations: Array<StatusDuration> = [];
-    for (const key in secondsOfEvent) {
-      statusDurations.push({
-        label: eventLabels[key] || "Unknown",
-        seconds: secondsOfEvent[key] || 0,
-        color: eventColors[key] || props.defaultBarColor || Green,
-        isDowntime: downtimeStatusIds.includes(key),
-      });
     }
 
     const hasDayIncidents: boolean = dayIncidents.length > 0;
@@ -245,18 +244,22 @@ const DayUptimeGraph: FunctionComponent<ComponentProps> = (
         richContent={
           <UptimeBarTooltip
             date={todaysDay}
-            uptimePercent={uptimePercentForTheDay}
-            hasEvents={hasEvents}
-            statusDurations={statusDurations}
+            uptimePercent={dayData.uptimePercent}
+            hasEvents={dayData.hasEvents}
+            statusDurations={dayData.statusDurations}
             incidents={dayIncidents}
             onIncidentClick={props.onIncidentClick}
           />
         }
       >
         <div
+          data-testid="day-uptime-bar"
+          data-date={startOfTheDay.toISOString()}
+          data-has-data={dayData.hasEvents.toString()}
+          data-uptime-percent={dayData.uptimePercent.toString()}
           className={`${className}${isClickable ? " cursor-pointer hover:opacity-80" : ""}`}
           style={{
-            backgroundColor: color.toString(),
+            backgroundColor: dayData.color.toString(),
           }}
           onClick={
             isClickable


### PR DESCRIPTION
## Summary
- render days with no monitoring coverage as neutral gray instead of healthy green, using half-open millisecond-precise day boundaries
- persist no-data gaps when monitors are directly disabled and safely resume their current status when re-enabled
- serialize bulk/single monitor transitions and recover failed hooks, late status writes, rapid toggles, and rolling-deploy writes from older pods
- repair existing timeline drift with a restartable data migration plus a bounded startup/hourly safety reconciler

## Root cause
The Dashboard passed healthy green as its empty-day fallback, while disabling a monitor left the latest status timeline row open. Open rows are extended to the present, so disabled or otherwise unobserved time appeared healthy.

## Testing
- `npm run fix`
- `cd Common && npm run compile`
- `cd App && npm run compile`
- `cd App/FeatureSet/Dashboard && npm run compile`
- 91 new regression tests covering day classification, half-open and exact-ms boundaries, pause/resume lifecycle, per-monitor locking, retries, failure recovery, old-pod races, late status writes, orphan protection, migration repair, pagination, and bounded recurring reconciliation
- 120 relevant checks passed (114 Common + 6 App)

Fixes #576