### PR TITLE
Session replay: wire up the dark capabilities — exception replay card, timeline signals, budgets, install diagnostics

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionExplorer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionExplorer.tsx
@@ -34,6 +34,7 @@ import OneUptimeDate from "Common/Types/Date";
 import User from "Common/UI/Utils/User";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import OccouranceTable from "./OccuranceTable";
+import ReplayCard from "../SessionReplay/ReplayCard";
 import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
@@ -1137,6 +1138,22 @@ const ExceptionExplorer: FunctionComponent<ComponentProps> = (
           {...(latestInstance?.parsedFrames
             ? { parsedFrames: latestInstance.parsedFrames }
             : {})}
+        />
+      )}
+
+      {/** Watch what the user saw - session replay recorded around this exception */}
+      {telemetryException.fingerprint && (
+        <ReplayCard
+          fingerprint={telemetryException.fingerprint}
+          {...(latestInstance?.time
+            ? { errorTimeUnixMs: new Date(latestInstance.time).getTime() }
+            : telemetryException.lastSeenAt
+              ? {
+                  errorTimeUnixMs: new Date(
+                    telemetryException.lastSeenAt,
+                  ).getTime(),
+                }
+              : {})}
         />
       )}
 

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/InstallationTestPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/InstallationTestPanel.tsx
@@ -1,0 +1,489 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import { APP_API_URL, HOST, HTTP_PROTOCOL } from "Common/UI/Config";
+import Protocol from "Common/Types/API/Protocol";
+import URL from "Common/Types/API/URL";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import { JSONObject } from "Common/Types/JSON";
+import OneUptimeDate from "Common/Types/Date";
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import RumApplication from "Common/Models/DatabaseModels/RumApplication";
+import ProjectUtil from "Common/UI/Utils/Project";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+
+/*
+ * "Test your installation" - the diagnostic the recorder cannot provide for
+ * itself.
+ *
+ * Every install failure mode the recorder has is SILENT in the customer's
+ * browser by design (a blocked script, a refused origin, a disabled app, an
+ * exhausted budget all fail without console noise on end users' pages), and
+ * the server cannot see a recorder that never loaded. So this panel answers
+ * the question from the server's side: is every switch on, when did the last
+ * chunk actually land, and how much budget is left - plus the exact CSP the
+ * customer's page must allow, since that is the one failure class only their
+ * own deployment can fix.
+ */
+
+const INGEST_STATUS_ROUTE: string =
+  "/telemetry/rum/session-replay/ingest-status";
+
+/*
+ * The identifier is interpolated into an HTML attribute the customer will
+ * copy-paste into their own page, and it originates from whatever
+ * service.name arrived on telemetry — attacker-writable with a scraped
+ * ingestion key. Anything outside this closed charset is not interpolated.
+ */
+const SAFE_APP_IDENTIFIER: RegExp = new RegExp("^[A-Za-z0-9._-]{1,100}$");
+
+interface IngestStatus {
+  isProjectAllowed: boolean;
+  isApplicationEnabled: boolean;
+  appIdentifier: string;
+  allowedOrigins: Array<string>;
+  samplePercentage: number;
+  captureTrigger: string;
+  lastChunkReceivedAt: string | null;
+  budgetExceededAt: string | null;
+  projectBytesUsedToday: number | null;
+  dailyByteLimit: number;
+  applicationBytesUsedThisMonth: number | null;
+  monthlyBudgetInGB: number | null;
+}
+
+function parseIngestStatus(data: JSONObject): IngestStatus {
+  const origins: Array<string> = Array.isArray(data["allowedOrigins"])
+    ? (data["allowedOrigins"] as Array<unknown>).map(
+        (entry: unknown): string => {
+          return String(entry);
+        },
+      )
+    : [];
+
+  const readNullableNumber: (key: string) => number | null = (
+    key: string,
+  ): number | null => {
+    const value: unknown = data[key];
+
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const parsed: number = Number(value);
+
+    return isFinite(parsed) ? parsed : null;
+  };
+
+  return {
+    isProjectAllowed: data["isProjectAllowed"] === true,
+    isApplicationEnabled: data["isApplicationEnabled"] === true,
+    appIdentifier: String(data["appIdentifier"] || ""),
+    allowedOrigins: origins,
+    samplePercentage: Number(data["samplePercentage"]) || 0,
+    captureTrigger: String(data["captureTrigger"] || ""),
+    lastChunkReceivedAt: data["lastChunkReceivedAt"]
+      ? String(data["lastChunkReceivedAt"])
+      : null,
+    budgetExceededAt: data["budgetExceededAt"]
+      ? String(data["budgetExceededAt"])
+      : null,
+    projectBytesUsedToday: readNullableNumber("projectBytesUsedToday"),
+    dailyByteLimit: Number(data["dailyByteLimit"]) || 0,
+    applicationBytesUsedThisMonth: readNullableNumber(
+      "applicationBytesUsedThisMonth",
+    ),
+    monthlyBudgetInGB: readNullableNumber("monthlyBudgetInGB"),
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  }
+
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${bytes} B`;
+}
+
+type CheckState = "pass" | "fail" | "warn" | "info";
+
+interface CheckRow {
+  state: CheckState;
+  title: string;
+  detail: string;
+}
+
+function CheckRowView(props: { row: CheckRow }): ReactElement {
+  const { row } = props;
+
+  const icon: IconProp =
+    row.state === "pass"
+      ? IconProp.CheckCircle
+      : row.state === "fail"
+        ? IconProp.CircleClose
+        : row.state === "warn"
+          ? IconProp.Alert
+          : IconProp.Info;
+
+  const iconColor: string =
+    row.state === "pass"
+      ? "text-emerald-600"
+      : row.state === "fail"
+        ? "text-rose-600"
+        : row.state === "warn"
+          ? "text-amber-600"
+          : "text-gray-400";
+
+  return (
+    <div className="flex items-start gap-3 py-2">
+      <Icon icon={icon} className={`mt-0.5 h-5 w-5 shrink-0 ${iconColor}`} />
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-gray-900">{row.title}</div>
+        <div className="text-xs text-gray-500">{row.detail}</div>
+      </div>
+    </div>
+  );
+}
+
+const InstallationTestPanel: FunctionComponent = (): ReactElement => {
+  const [applications, setApplications] = useState<Array<RumApplication>>([]);
+  const [selectedApplicationId, setSelectedApplicationId] =
+    useState<string>("");
+  const [status, setStatus] = useState<IngestStatus | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>("");
+
+  /*
+   * Same guard as ReplayCard: two status requests can race when the user
+   * switches applications mid-flight, and the LAST to resolve would win —
+   * rendering app A's checks and install snippet under app B's dropdown.
+   */
+  const loadGenerationRef: React.MutableRefObject<number> = useRef<number>(0);
+
+  const httpProtocol: string =
+    HTTP_PROTOCOL === Protocol.HTTPS ? "https" : "http";
+  const oneuptimeUrl: string = HOST
+    ? `${httpProtocol}://${HOST}`
+    : "<YOUR_ONEUPTIME_URL>";
+
+  const loadApplications: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      const result: ListResult<RumApplication> =
+        await ModelAPI.getList<RumApplication>({
+          modelType: RumApplication,
+          query: {
+            projectId: ProjectUtil.getCurrentProjectId()!,
+          },
+          select: {
+            _id: true,
+            name: true,
+            appIdentifier: true,
+          },
+          sort: {
+            name: SortOrder.Ascending,
+          },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+        });
+
+      setApplications(result.data);
+
+      if (result.data.length > 0 && result.data[0]?._id) {
+        setSelectedApplicationId(result.data[0]._id.toString());
+      } else {
+        setIsLoading(false);
+      }
+    }, []);
+
+  const loadStatus: (applicationId: string) => Promise<void> = useCallback(
+    async (applicationId: string): Promise<void> => {
+      loadGenerationRef.current += 1;
+      const generation: number = loadGenerationRef.current;
+
+      try {
+        setIsLoading(true);
+        setError("");
+
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.post({
+            url: URL.fromString(APP_API_URL.toString()).addRoute(
+              INGEST_STATUS_ROUTE,
+            ),
+            data: {
+              rumApplicationId: applicationId,
+            },
+            headers: {
+              ...ModelAPI.getCommonHeaders(),
+            },
+          });
+
+        if (generation !== loadGenerationRef.current) {
+          return;
+        }
+
+        if (response instanceof HTTPErrorResponse) {
+          throw response;
+        }
+
+        setStatus(parseIngestStatus(response.data));
+      } catch (err) {
+        if (generation === loadGenerationRef.current) {
+          setStatus(null);
+          setError(API.getFriendlyMessage(err as HTTPErrorResponse));
+        }
+      } finally {
+        if (generation === loadGenerationRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    loadApplications().catch((err: unknown) => {
+      setError(API.getFriendlyMessage(err as HTTPErrorResponse));
+      setIsLoading(false);
+    });
+  }, [loadApplications]);
+
+  useEffect(() => {
+    if (selectedApplicationId) {
+      void loadStatus(selectedApplicationId);
+    }
+  }, [selectedApplicationId, loadStatus]);
+
+  const dropdownOptions: Array<DropdownOption> = applications.map(
+    (application: RumApplication): DropdownOption => {
+      return {
+        label: application.name || application._id?.toString() || "Unnamed",
+        value: application._id?.toString() || "",
+      };
+    },
+  );
+
+  const rows: Array<CheckRow> = [];
+
+  if (status) {
+    rows.push({
+      state: status.isProjectAllowed ? "pass" : "fail",
+      title: status.isProjectAllowed
+        ? "Session replay is allowed for this project"
+        : "Session replay is switched off for this project",
+      detail: status.isProjectAllowed
+        ? "The project-level master switch is on."
+        : "Turn on the project-level switch above. While it is off, every chunk is refused at ingest.",
+    });
+
+    rows.push({
+      state: status.isApplicationEnabled ? "pass" : "fail",
+      title: status.isApplicationEnabled
+        ? "Recording is enabled for this application"
+        : "Recording is disabled for this application",
+      detail: status.isApplicationEnabled
+        ? "The per-application recording toggle is on."
+        : "Enable recording in the per-application policy table above.",
+    });
+
+    rows.push({
+      state: status.allowedOrigins.length > 0 ? "pass" : "fail",
+      title:
+        status.allowedOrigins.length > 0
+          ? `Origin allowlist has ${status.allowedOrigins.length} ${
+              status.allowedOrigins.length === 1 ? "entry" : "entries"
+            }`
+          : "Origin allowlist is empty — every chunk is refused",
+      detail:
+        status.allowedOrigins.length > 0
+          ? status.allowedOrigins.join(", ")
+          : "Add your site's origin (e.g. https://app.example.com) to the application's allowed origins. An empty allowlist refuses everything by design.",
+    });
+
+    const isErrorTriggered: boolean =
+      status.captureTrigger !== "Always" && status.samplePercentage === 0;
+
+    rows.push({
+      state: "info",
+      title: `Capture: ${status.captureTrigger || "OnErrorOrFrustration"}, ${
+        status.samplePercentage
+      }% sampled`,
+      detail: isErrorTriggered
+        ? "Recordings upload only when an error or frustration signal fires. A healthy visit produces no recording — that is expected, not a broken install."
+        : "Sampled sessions upload from their first event; the rest only on error or frustration.",
+    });
+
+    rows.push({
+      state: status.lastChunkReceivedAt ? "pass" : "warn",
+      title: status.lastChunkReceivedAt
+        ? `Last recording received ${OneUptimeDate.fromNow(
+            OneUptimeDate.fromString(status.lastChunkReceivedAt),
+          )}`
+        : "No recording has ever been received",
+      detail: status.lastChunkReceivedAt
+        ? "The end-to-end path works: a recorder on your site reached this instance and its chunk was accepted."
+        : "This is the definitive end-to-end signal. If every check above passes and this stays empty after an error on an instrumented page, the recorder is most likely blocked by your site's Content-Security-Policy (see below) or the snippet is not installed.",
+    });
+
+    if (status.budgetExceededAt) {
+      rows.push({
+        state: "warn",
+        title: `A byte budget was exhausted ${OneUptimeDate.fromNow(
+          OneUptimeDate.fromString(status.budgetExceededAt),
+        )}`,
+        detail:
+          "Live recorders were told to stand down when the budget ran out. Recordings resume when the window rolls over or the budget is raised.",
+      });
+    }
+
+    const dailyDetail: string =
+      status.projectBytesUsedToday === null
+        ? "Today's usage is unknown (the usage counter is unreachable)."
+        : `${formatBytes(status.projectBytesUsedToday)} of ${formatBytes(
+            status.dailyByteLimit,
+          )} used today across this project.`;
+
+    const monthlyDetail: string =
+      status.monthlyBudgetInGB && status.monthlyBudgetInGB > 0
+        ? status.applicationBytesUsedThisMonth === null
+          ? " This month's application usage is unknown."
+          : ` ${formatBytes(
+              status.applicationBytesUsedThisMonth,
+            )} of this application's ${status.monthlyBudgetInGB} GB monthly budget used.`
+        : " No monthly budget is set for this application.";
+
+    rows.push({
+      state: "info",
+      title: "Byte budgets",
+      detail: dailyDetail + monthlyDetail,
+    });
+  }
+
+  return (
+    <div className="mb-5 rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div className="flex flex-col gap-3 border-b border-gray-100 px-5 py-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">
+            Test your installation
+          </h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Every install failure is silent in your end users&apos; browsers by
+            design, and the server cannot see a recorder that never loaded. This
+            panel checks everything the server can know.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {dropdownOptions.length > 1 && (
+            <div className="w-56">
+              <Dropdown
+                options={dropdownOptions}
+                value={dropdownOptions.find((option: DropdownOption) => {
+                  return option.value === selectedApplicationId;
+                })}
+                onChange={(
+                  value: DropdownValue | Array<DropdownValue> | null,
+                ) => {
+                  if (typeof value === "string") {
+                    setSelectedApplicationId(value);
+                  }
+                }}
+              />
+            </div>
+          )}
+          <Button
+            title="Run again"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            onClick={() => {
+              if (selectedApplicationId) {
+                void loadStatus(selectedApplicationId);
+              }
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="px-5 py-4">
+        {isLoading && <ComponentLoader />}
+
+        {!isLoading && error && (
+          <div className="text-sm text-rose-600">{error}</div>
+        )}
+
+        {!isLoading && !error && applications.length === 0 && (
+          <div className="text-sm text-gray-500">
+            No RUM applications yet. Create one first, then test its
+            installation here.
+          </div>
+        )}
+
+        {!isLoading && !error && status && (
+          <div>
+            <div className="divide-y divide-gray-100">
+              {rows.map((row: CheckRow, index: number): ReactElement => {
+                return <CheckRowView key={index} row={row} />;
+              })}
+            </div>
+
+            <div className="mt-4 rounded-lg bg-gray-50 p-4">
+              <div className="text-xs font-semibold text-gray-700">
+                Install snippet
+              </div>
+              <pre className="mt-2 overflow-x-auto whitespace-pre rounded bg-gray-900 p-3 text-[11px] leading-relaxed text-gray-100">
+                {`<script
+  src="${oneuptimeUrl}/telemetry/session-replay/v1/recorder.js"
+  data-oneuptime-host="${oneuptimeUrl}"
+  data-oneuptime-token="YOUR_TELEMETRY_INGESTION_KEY"
+  data-oneuptime-app-identifier="${
+    SAFE_APP_IDENTIFIER.test(status.appIdentifier)
+      ? status.appIdentifier
+      : "YOUR_APP_IDENTIFIER"
+  }"
+  async
+></script>`}
+              </pre>
+
+              <div className="mt-3 text-xs font-semibold text-gray-700">
+                Content-Security-Policy your site must allow
+              </div>
+              <p className="mt-1 text-xs text-gray-500">
+                A page with <code>script-src &apos;self&apos;</code> cannot load
+                the recorder and <code>connect-src &apos;self&apos;</code>{" "}
+                blocks uploads — both fail silently. If your site sets a CSP,
+                include:
+              </p>
+              <pre className="mt-2 overflow-x-auto whitespace-pre rounded bg-gray-900 p-3 text-[11px] leading-relaxed text-gray-100">
+                {`script-src  ${oneuptimeUrl};
+connect-src ${oneuptimeUrl};`}
+              </pre>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InstallationTestPanel;

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/ReplayCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/ReplayCard.tsx
@@ -49,7 +49,12 @@ const FOR_EXCEPTION_ROUTE: string =
 const PRE_ROLL_SECONDS: number = 10;
 
 export interface ReplayCardProps {
-  /* The RUM application the session belongs to; also its primaryEntityId. */
+  /*
+   * Optional fallback only. The /for-exception endpoint scopes by the
+   * caller's accessible applications and every returned session names its
+   * own application, so callers like the exception explorer — where an
+   * exception is not scoped to a single RUM application — can omit this.
+   */
   rumApplicationId?: ObjectID | undefined;
   /* Exact session, when the caller already has one (an exception instance). */
   sessionId?: string | undefined;
@@ -60,10 +65,16 @@ export interface ReplayCardProps {
   className?: string | undefined;
 }
 
+interface ReplaySessionRow {
+  summary: SessionReplaySummary;
+  /* From the response row; each session names the application it lives in. */
+  rumApplicationId: string;
+}
+
 const ReplayCard: FunctionComponent<ReplayCardProps> = (
   props: ReplayCardProps,
 ): ReactElement => {
-  const [sessions, setSessions] = useState<Array<SessionReplaySummary>>([]);
+  const [sessions, setSessions] = useState<Array<ReplaySessionRow>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [hasFailed, setHasFailed] = useState<boolean>(false);
 
@@ -84,7 +95,7 @@ const ReplayCard: FunctionComponent<ReplayCardProps> = (
        * without one. A caller holding only a sessionId has nothing to ask,
        * so the card stays quiet instead of firing a guaranteed 400.
        */
-      if (!rumApplicationIdString || !fingerprint) {
+      if (!fingerprint) {
         setIsLoading(false);
         return;
       }
@@ -99,7 +110,6 @@ const ReplayCard: FunctionComponent<ReplayCardProps> = (
               FOR_EXCEPTION_ROUTE,
             ),
             data: {
-              rumApplicationId: rumApplicationIdString,
               ...(sessionId ? { sessionId: sessionId } : {}),
               fingerprint: fingerprint,
             },
@@ -118,7 +128,14 @@ const ReplayCard: FunctionComponent<ReplayCardProps> = (
 
         const rows: JSONArray = (response.data["sessions"] as JSONArray) || [];
 
-        setSessions(rows.map(parseSessionReplaySummary));
+        setSessions(
+          rows.map((row: JSONObject): ReplaySessionRow => {
+            return {
+              summary: parseSessionReplaySummary(row),
+              rumApplicationId: String(row["rumApplicationId"] || ""),
+            };
+          }),
+        );
       } catch {
         if (generation === loadGenerationRef.current) {
           /*
@@ -155,9 +172,17 @@ const ReplayCard: FunctionComponent<ReplayCardProps> = (
     );
   }
 
-  const primary: SessionReplaySummary | undefined = sessions[0];
+  const primaryRow: ReplaySessionRow | undefined = sessions[0];
+  const primary: SessionReplaySummary | undefined = primaryRow?.summary;
 
-  if (hasFailed || !primary || !rumApplicationId) {
+  /*
+   * The application the watch link points into: the one the session itself
+   * names, falling back to the caller's scope when the row somehow lacks it.
+   */
+  const watchApplicationId: string =
+    primaryRow?.rumApplicationId || rumApplicationIdString;
+
+  if (hasFailed || !primary || !watchApplicationId) {
     return <></>;
   }
 
@@ -186,7 +211,7 @@ const ReplayCard: FunctionComponent<ReplayCardProps> = (
   let watchRoute: Route = RouteUtil.populateRouteParams(
     RouteMap[PageMap.RUM_APPLICATION_VIEW_SESSION_REPLAY_VIEW] as Route,
     {
-      modelId: rumApplicationId,
+      modelId: new ObjectID(watchApplicationId),
       subModelId: primary.sessionId,
     },
   );

--- a/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayPlayer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/SessionReplay/SessionReplayPlayer.tsx
@@ -67,22 +67,13 @@ const HEARTBEAT_INTERVAL_MS: number = 15 * 1000;
 /*
  * Per-chunk manifest row.
  *
- * The signal counters are read defensively rather than required: the chunk
- * table carries them, but the manifest endpoint's SELECT
+ * The signal counters are projected by the manifest endpoint's SELECT
  * (Common/Server/Utils/SessionReplay/SessionReplayReadService.getManifest)
- * does not project them today, so they arrive as 0 and the frustration,
- * error and route lanes stay empty. Parsing them here means the lanes light
- * up the moment the projection is widened, with no client change.
+ * and feed the frustration, error and route lanes plus the "next error"
+ * jump. They are still read defensively (missing -> 0) so a manifest from
+ * an older server renders as an empty lane rather than a parse failure.
  */
-export interface SessionReplayManifestChunk
-  extends SessionReplayChunkManifestEntry {
-  errorCount: number;
-  rageClickCount: number;
-  deadClickCount: number;
-  errorClickCount: number;
-  refreshRageCount: number;
-  routeCount: number;
-}
+export type SessionReplayManifestChunk = SessionReplayChunkManifestEntry;
 
 export interface SessionReplayManifestTab {
   tabId: string;

--- a/App/FeatureSet/Dashboard/src/Pages/Rum/Settings/SessionReplay.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Rum/Settings/SessionReplay.tsx
@@ -21,6 +21,7 @@ import {
   SESSION_REPLAY_ALLOWED_RETENTION_DAYS,
 } from "Common/Types/Rum/SessionReplay";
 import Navigation from "Common/UI/Utils/Navigation";
+import InstallationTestPanel from "../../../Components/SessionReplay/InstallationTestPanel";
 
 /*
  * Privacy controls for session replay.
@@ -342,6 +343,13 @@ const RumSessionReplaySettings: FunctionComponent<
         ]}
         viewPageRoute={Navigation.getCurrentRoute()}
       />
+
+      {/*
+       * The diagnostic both the README and the customer docs point at.
+       * Placed after the policy tables because its failing checks refer the
+       * user back up to them.
+       */}
+      <InstallationTestPanel />
     </Fragment>
   );
 };

--- a/App/FeatureSet/Docs/Content/en/telemetry/session-replay.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/session-replay.md
@@ -110,9 +110,9 @@ const sessionId = window.OneUptimeReplay.getSessionId();
 // Add { "session.id": sessionId } to your span attributes or resource.
 ```
 
-If you are not using OpenTelemetry, you still get correlation for free: the recorder wraps `fetch` and `XMLHttpRequest`, injects a `traceparent` header, and stamps the session id on outgoing requests.
+If you are not using OpenTelemetry, trace correlation is limited: the recorder observes a `traceparent` header your page's own instrumentation already set on `fetch` or `XMLHttpRequest` requests, but it deliberately does **not** inject one itself — adding a header turns a simple cross-origin request into a preflighted one, and an API that does not allow `traceparent` would start failing because you installed a recorder. Without existing OpenTelemetry browser instrumentation, recordings still capture every request's method, URL, status and timing; they just cannot be linked to the backend trace of a failing request.
 
-Once correlated, an exception in the dashboard shows a **Watch what the user saw** card, and the player's network lane links each failing request to its backend span.
+Exceptions are correlated automatically: an exception in the dashboard shows a **Watch what the user saw** card when a recording exists for a session that hit that error, and the player's correlation panel lists the trace ids observed during the session.
 
 ## What is not recorded
 
@@ -131,7 +131,7 @@ These are surfaced on the player rather than silently blank, so you always know 
 
 Recordings are kept for **7 days** by default; 1, 14, 30 and 90 days are also available per application. Session metadata (error counts, frustration signals, device) can be kept longer than the recording itself, so trends survive after the video is gone.
 
-To satisfy a deletion request, use _Settings → Session Replay → Erasure Requests_. You can erase by session, by identified user, by date range, or for an entire application. Erasure removes the recording **and** the correlated logs, spans and exceptions for those sessions, and any recording still in flight when the request completes is dropped rather than written.
+To satisfy a deletion request, file an erasure request through the OneUptime API (the `/rum-session-erasure-request` resource; a dashboard surface for this is planned). You can erase by session, by identified user, by date range, or for an entire application. Erasure removes the recording **and** the correlated logs, spans and exceptions for those sessions, and any recording still in flight when the request completes is dropped rather than written.
 
 ## Who can watch a recording
 

--- a/App/FeatureSet/Telemetry/API/SessionReplayIngest.ts
+++ b/App/FeatureSet/Telemetry/API/SessionReplayIngest.ts
@@ -15,6 +15,7 @@ import SessionReplayGateCache, {
   SessionReplayGatePolicy,
 } from "Common/Server/Utils/SessionReplay/SessionReplayGateCache";
 import TelemetryIngestionKeyService from "Common/Server/Services/TelemetryIngestionKeyService";
+import RumApplicationService from "Common/Server/Services/RumApplicationService";
 import logger from "Common/Server/Utils/Logger";
 import StatusCode from "Common/Types/API/StatusCode";
 import ObjectID from "Common/Types/ObjectID";
@@ -146,6 +147,20 @@ const replayIngestMetricsMiddleware: ReplayMetricsMiddleware = (
       outcome,
     };
 
+    /*
+     * The gate's reason ("budget-exhausted", "not-sampled", ...) is a small
+     * closed vocabulary, so it is safe as a metric label - and it is the
+     * difference between an alertable "replay refused: budget" series and
+     * an undifferentiated refusal count nobody can act on.
+     */
+    const gateReason: unknown = res.locals
+      ? res.locals["replayGateReason"]
+      : undefined;
+
+    if (typeof gateReason === "string" && gateReason.length > 0) {
+      attributes["reason"] = gateReason;
+    }
+
     AppMetrics.getIngestCounter().add(1, attributes);
     AppMetrics.getIngestDuration().record(Number(elapsedNs) / 1e6, attributes);
   };
@@ -219,7 +234,17 @@ function sendChunkDirective(
   const payload: SessionReplayChunkResponse = {
     directive: decision.directive,
     configEpoch: decision.configEpoch,
+    reason: decision.reason,
   };
+
+  /*
+   * Stashed for the metrics middleware, which fires on response finish and
+   * has no other way to see WHY a request was refused. Without the label an
+   * operator cannot tell budget exhaustion from sampling on a dashboard.
+   */
+  if (res.locals) {
+    res.locals["replayGateReason"] = decision.reason;
+  }
 
   if (decision.retryAfterSeconds !== undefined) {
     payload.retryAfterSeconds = decision.retryAfterSeconds;
@@ -236,6 +261,11 @@ function sendChunkDirective(
       "x-oneuptime-replay-config-epoch",
       String(decision.configEpoch),
     );
+
+    if (decision.reason) {
+      res.setHeader("x-oneuptime-replay-reason", decision.reason);
+    }
+
     res.status(204).end();
     return;
   }
@@ -370,6 +400,24 @@ router.post(
           payloadBytes: body.length,
         });
 
+      /*
+       * Budget exhaustion is recorded on the application row (throttled,
+       * fire-and-forget) so the Dashboard can show WHY recordings stopped.
+       * Without this the customer's only signal is silence.
+       */
+      if (
+        decision.policy?.rumApplicationId &&
+        (decision.reason === "budget-exhausted" ||
+          decision.reason === "app-monthly-budget-exhausted")
+      ) {
+        RumApplicationService.markSessionReplayBudgetExceeded(
+          decision.policy.rumApplicationId,
+        ).catch((err: unknown) => {
+          logger.warn("Could not record replay budget exhaustion:");
+          logger.warn(err);
+        });
+      }
+
       switch (decision.outcome) {
         case SessionReplayGateOutcome.Stop:
           sendChunkDirective(req, res, 204, decision);
@@ -426,6 +474,20 @@ router.post(
           reason: "staging-failed",
         });
         return;
+      }
+
+      /*
+       * Recording health, written after the enqueue so "last chunk
+       * received" means "accepted", not merely "arrived". Throttled and
+       * fire-and-forget - it must never delay or fail the response.
+       */
+      if (decision.policy?.rumApplicationId) {
+        RumApplicationService.markSessionReplayChunkReceived(
+          decision.policy.rumApplicationId,
+        ).catch((err: unknown) => {
+          logger.warn("Could not record replay chunk receipt:");
+          logger.warn(err);
+        });
       }
 
       sendChunkDirective(req, res, 202, decision);

--- a/App/FeatureSet/Telemetry/Config.ts
+++ b/App/FeatureSet/Telemetry/Config.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY } from "Common/Types/Rum/SessionReplay";
+
 let concurrency: string | number = process.env["TELEMETRY_CONCURRENCY"] || 100;
 
 if (typeof concurrency === "string") {
@@ -132,7 +134,7 @@ export const SESSION_REPLAY_MAX_CHUNKS_PER_PROJECT_PER_MINUTE: number =
 export const SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY: number =
   parseBatchSize(
     "SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY",
-    1024 * 1024 * 1024,
+    DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY,
   );
 
 /*

--- a/App/FeatureSet/Telemetry/Services/SessionReplayIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/SessionReplayIngestService.ts
@@ -351,6 +351,50 @@ export default class SessionReplayIngestService {
       };
     }
 
+    /*
+     * The customer's own monthly ceiling on this application, distinct from
+     * the operator's instance-wide daily cap above. It is the one budget a
+     * customer can configure, so it must actually be enforced - a budget
+     * field that is stored and displayed but never consulted is worse than
+     * no field, because it promises a protection that does not exist.
+     */
+    if (policy.monthlyBudgetInGB !== null && policy.monthlyBudgetInGB > 0) {
+      const monthlyDecision: SessionReplayLimitDecision =
+        await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+          projectId: data.projectId,
+          rumApplicationId: policy.rumApplicationId,
+          bytes: data.payloadBytes,
+          budgetBytes: Math.floor(
+            policy.monthlyBudgetInGB * 1024 * 1024 * 1024,
+          ),
+        });
+
+      if (
+        monthlyDecision.outcome === SessionReplayLimitOutcome.BudgetExhausted
+      ) {
+        return {
+          outcome: SessionReplayGateOutcome.Stop,
+          directive: "stop",
+          configEpoch: policy.configEpoch,
+          reason: "app-monthly-budget-exhausted",
+          policy,
+        };
+      }
+
+      if (
+        monthlyDecision.outcome === SessionReplayLimitOutcome.CounterUnavailable
+      ) {
+        return {
+          outcome: SessionReplayGateOutcome.StorageUnavailable,
+          directive: "throttle",
+          configEpoch: policy.configEpoch,
+          retryAfterSeconds: 30,
+          reason: "budget-counter-unavailable",
+          policy,
+        };
+      }
+    }
+
     return {
       outcome: SessionReplayGateOutcome.Accepted,
       directive: "continue",

--- a/App/FeatureSet/Telemetry/Utils/SessionReplayRateLimiter.ts
+++ b/App/FeatureSet/Telemetry/Utils/SessionReplayRateLimiter.ts
@@ -1,4 +1,5 @@
 import Redis, { ClientType } from "Common/Server/Infrastructure/Redis";
+import SessionReplayUsage from "Common/Server/Utils/SessionReplay/SessionReplayUsage";
 import logger from "Common/Server/Utils/Logger";
 import ObjectID from "Common/Types/ObjectID";
 import {
@@ -34,7 +35,6 @@ import {
  */
 
 const CHUNK_RATE_KEY_PREFIX: string = "replay:rate:chunks:";
-const BYTE_BUDGET_KEY_PREFIX: string = "replay:rate:bytes:";
 
 /*
  * Two minutes, so the counter for a minute bucket outlives the bucket it
@@ -45,6 +45,14 @@ const CHUNK_RATE_TTL_SECONDS: number = 120;
 
 /* Two days, for the same boundary reason applied to a UTC day bucket. */
 const BYTE_BUDGET_TTL_SECONDS: number = 2 * 24 * 60 * 60;
+
+/*
+ * The monthly key is created by whichever chunk lands first in the month,
+ * possibly on day 1, and must survive to the end of a 31-day month plus the
+ * same boundary margin. 40 days is one small integer per application per
+ * month - the memory cost is nothing.
+ */
+const MONTHLY_BYTE_BUDGET_TTL_SECONDS: number = 40 * 24 * 60 * 60;
 
 export enum SessionReplayLimitOutcome {
   /* Within both limits. */
@@ -145,7 +153,9 @@ export default class SessionReplayRateLimiter {
       return { outcome: SessionReplayLimitOutcome.CounterUnavailable };
     }
 
-    const key: string = `${BYTE_BUDGET_KEY_PREFIX}${data.projectId.toString()}:${this.getUtcDayBucket()}`;
+    const key: string = SessionReplayUsage.getDailyProjectByteKey(
+      data.projectId,
+    );
 
     try {
       const total: number = await client.incrby(key, data.bytes);
@@ -169,45 +179,84 @@ export default class SessionReplayRateLimiter {
   }
 
   /*
-   * Bytes already consumed today. Read-only, used by the config endpoint so
-   * a Dashboard can surface "quota exhausted" as a state rather than
-   * leaving the customer to infer it from missing recordings.
+   * Consume `bytes` from one application's customer-configured MONTHLY
+   * budget. Same crossing-request semantics as the daily budget above, and
+   * the same fail-closed answer when the counter is unreachable.
+   *
+   * The instance-wide daily cap and this cap answer different questions:
+   * the daily cap protects the operator's ClickHouse from any single
+   * project, while this one enforces the spend ceiling the customer set on
+   * their own application - it is the only control a customer can actually
+   * turn.
    */
-  public static async getBytesUsedToday(
-    projectId: ObjectID,
-  ): Promise<number | null> {
+  public static async consumeApplicationMonthlyBudget(data: {
+    projectId: ObjectID;
+    rumApplicationId: ObjectID;
+    bytes: number;
+    budgetBytes: number;
+  }): Promise<SessionReplayLimitDecision> {
     const client: ClientType | null = Redis.getClient();
 
     if (!client || !Redis.isConnected()) {
-      return null;
+      return { outcome: SessionReplayLimitOutcome.CounterUnavailable };
     }
 
-    const key: string = `${BYTE_BUDGET_KEY_PREFIX}${projectId.toString()}:${this.getUtcDayBucket()}`;
+    const key: string = SessionReplayUsage.getMonthlyApplicationByteKey({
+      projectId: data.projectId,
+      rumApplicationId: data.rumApplicationId,
+    });
 
     try {
-      const value: string | null = await client.get(key);
+      const total: number = await client.incrby(key, data.bytes);
 
-      if (value === null) {
-        return 0;
+      if (total === data.bytes) {
+        await client.expire(key, MONTHLY_BYTE_BUDGET_TTL_SECONDS);
       }
 
-      const parsed: number = parseInt(value, 10);
+      if (total > data.budgetBytes) {
+        /*
+         * Refund the refused bytes. Unlike the daily counter (which resets
+         * in 24h), this counter is read back as "usage" by the Dashboard's
+         * ingest-status endpoint and accumulates for up to 31 days — every
+         * post-exhaustion upload attempt would otherwise inflate the
+         * displayed figure past both the budget and the bytes actually
+         * stored, and a mid-month budget raise would find its new headroom
+         * already eaten by chunks that were never accepted. Best-effort:
+         * losing one decrement to a Redis blip skews the display by one
+         * chunk, which is better than failing the refusal path.
+         */
+        try {
+          await client.decrby(key, data.bytes);
+        } catch (decrementErr) {
+          logger.warn(
+            `SessionReplayRateLimiter: could not refund refused bytes for application ${data.rumApplicationId.toString()}`,
+          );
+          logger.warn(decrementErr);
+        }
 
-      return isNaN(parsed) ? 0 : parsed;
+        return { outcome: SessionReplayLimitOutcome.BudgetExhausted };
+      }
+
+      return { outcome: SessionReplayLimitOutcome.Allowed };
     } catch (err) {
       logger.warn(
-        `SessionReplayRateLimiter: could not read the byte budget for project ${projectId.toString()}`,
+        `SessionReplayRateLimiter: monthly budget counter failed for application ${data.rumApplicationId.toString()}`,
       );
       logger.warn(err);
-      return null;
+      return { outcome: SessionReplayLimitOutcome.CounterUnavailable };
     }
   }
 
   /*
-   * UTC rather than local, so the budget window is the same for every pod
-   * regardless of container timezone.
+   * Bytes already consumed today. Read-only, used by the ingest-status
+   * endpoint so a Dashboard can surface "quota exhausted" as a state rather
+   * than leaving the customer to infer it from missing recordings. The
+   * actual read lives in Common (SessionReplayUsage) so the Dashboard API
+   * and this consumer can never disagree on the key.
    */
-  private static getUtcDayBucket(): string {
-    return new Date().toISOString().substring(0, 10);
+  public static async getBytesUsedToday(
+    projectId: ObjectID,
+  ): Promise<number | null> {
+    return SessionReplayUsage.getProjectBytesUsedToday(projectId);
   }
 }

--- a/App/Tests/Telemetry/SessionReplayIngestAPI.test.ts
+++ b/App/Tests/Telemetry/SessionReplayIngestAPI.test.ts
@@ -156,6 +156,16 @@ jest.mock("Common/Server/Services/TelemetryIngestionKeyService", () => {
   };
 });
 
+jest.mock("Common/Server/Services/RumApplicationService", () => {
+  return {
+    __esModule: true,
+    default: {
+      markSessionReplayChunkReceived: jest.fn(),
+      markSessionReplayBudgetExceeded: jest.fn(),
+    },
+  };
+});
+
 jest.mock(
   "../../FeatureSet/Telemetry/Services/SessionReplayIngestService",
   () => {
@@ -194,6 +204,7 @@ jest.mock(
 );
 
 import Response from "Common/Server/Utils/Response";
+import RumApplicationService from "Common/Server/Services/RumApplicationService";
 import SessionReplayIngestService, {
   SessionReplayGateOutcome,
 } from "../../FeatureSet/Telemetry/Services/SessionReplayIngestService";
@@ -210,8 +221,13 @@ const addJobMock: MockedFn =
   TelemetryQueueService.addSessionReplayIngestJob as unknown as MockedFn;
 const sendJsonMock: MockedFn =
   Response.sendJsonObjectResponse as unknown as MockedFn;
+const markChunkReceivedMock: MockedFn =
+  RumApplicationService.markSessionReplayChunkReceived as unknown as MockedFn;
+const markBudgetExceededMock: MockedFn =
+  RumApplicationService.markSessionReplayBudgetExceeded as unknown as MockedFn;
 
 const PROJECT_ID: ObjectID = ObjectID.generate();
+const RUM_APPLICATION_ID: ObjectID = ObjectID.generate();
 const APP_IDENTIFIER: string = "checkout-web";
 
 const CHUNK_ROUTE: string = "/session-replay/v1/chunk";
@@ -221,6 +237,8 @@ interface FakeResponse {
   headers: Record<string, string>;
   ended: boolean;
   body: unknown;
+  /* Express guarantees res.locals; the route stashes the gate reason on it. */
+  locals: Record<string, unknown>;
   setHeader: (name: string, value: string) => void;
   status: (code: number) => FakeResponse;
   end: () => void;
@@ -235,6 +253,7 @@ function buildResponse(): FakeResponse {
     headers: {},
     ended: false,
     body: undefined,
+    locals: {},
     headersSent: false,
     setHeader: (name: string, value: string): void => {
       res.headers[name] = value;
@@ -383,12 +402,14 @@ describe("POST /session-replay/v1/chunk", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     addJobMock.mockResolvedValue(undefined as never);
+    markChunkReceivedMock.mockResolvedValue(undefined as never);
+    markBudgetExceededMock.mockResolvedValue(undefined as never);
     gateMock.mockResolvedValue({
       outcome: SessionReplayGateOutcome.Accepted,
       directive: "continue",
       configEpoch: 99,
       reason: "accepted",
-      policy: { samplePercentage: 100 },
+      policy: { samplePercentage: 100, rumApplicationId: RUM_APPLICATION_ID },
     } as never);
   });
 
@@ -439,6 +460,7 @@ describe("POST /session-replay/v1/chunk", () => {
 
     expect(payload["directive"]).toBe("throttle");
     expect(payload["retryAfterSeconds"]).toBeDefined();
+    expect(payload["reason"]).toBe("staging-failed");
   });
 
   test("answers 204 with a stop directive when the gate says stop", async () => {
@@ -456,7 +478,42 @@ describe("POST /session-replay/v1/chunk", () => {
     /* 204 carries no body, so the directive rides in a header. */
     expect(res.headers["x-oneuptime-replay-directive"]).toBe("stop");
     expect(res.headers["x-oneuptime-replay-config-epoch"]).toBe("7");
+    /*
+     * The WHY rides alongside the directive. Without it, "stop" is
+     * indistinguishable silence: a customer cannot tell a disabled app from
+     * an exhausted budget from an unsampled session.
+     */
+    expect(res.headers["x-oneuptime-replay-reason"]).toBe("not-enabled");
     expect(addJobMock).not.toHaveBeenCalled();
+  });
+
+  test("records recording health on an accepted chunk, after the enqueue", async () => {
+    const { res } = await invokeChunkRoute({ body: buildBody() });
+
+    expect(getStatus(res)).toBe(202);
+    expect(markChunkReceivedMock).toHaveBeenCalledTimes(1);
+    expect(markChunkReceivedMock).toHaveBeenCalledWith(RUM_APPLICATION_ID);
+    expect(markBudgetExceededMock).not.toHaveBeenCalled();
+  });
+
+  test("records budget exhaustion on the application so the Dashboard can explain the silence", async () => {
+    gateMock.mockResolvedValue({
+      outcome: SessionReplayGateOutcome.Stop,
+      directive: "stop",
+      configEpoch: 7,
+      reason: "app-monthly-budget-exhausted",
+      policy: { samplePercentage: 100, rumApplicationId: RUM_APPLICATION_ID },
+    } as never);
+
+    const { res } = await invokeChunkRoute({ body: buildBody() });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.headers["x-oneuptime-replay-reason"]).toBe(
+      "app-monthly-budget-exhausted",
+    );
+    expect(markBudgetExceededMock).toHaveBeenCalledWith(RUM_APPLICATION_ID);
+    /* A refused chunk is not a received recording. */
+    expect(markChunkReceivedMock).not.toHaveBeenCalled();
   });
 
   /*
@@ -493,6 +550,10 @@ describe("POST /session-replay/v1/chunk", () => {
     const { res } = await invokeChunkRoute({ body: buildBody() });
 
     expect(getStatus(res)).toBe(403);
+    /* The WHY rides on every bodied refusal, not only the 204 header. */
+    const forbiddenPayload: JSONObject = sendJsonMock.mock
+      .calls[0]![2] as unknown as JSONObject;
+    expect(forbiddenPayload["reason"]).toBe("origin-not-allowed");
     expect(addJobMock).not.toHaveBeenCalled();
   });
 
@@ -509,6 +570,9 @@ describe("POST /session-replay/v1/chunk", () => {
 
     expect(getStatus(res)).toBe(429);
     expect(res.headers["Retry-After"]).toBe("23");
+    const throttledPayload: JSONObject = sendJsonMock.mock
+      .calls[0]![2] as unknown as JSONObject;
+    expect(throttledPayload["reason"]).toBe("rate-limited");
     expect(addJobMock).not.toHaveBeenCalled();
   });
 

--- a/App/Tests/Telemetry/SessionReplayIngestService.test.ts
+++ b/App/Tests/Telemetry/SessionReplayIngestService.test.ts
@@ -183,6 +183,7 @@ jest.mock("../../FeatureSet/Telemetry/Utils/SessionReplayRateLimiter", () => {
     default: {
       consumeChunkAllowance: jest.fn(),
       consumeByteBudget: jest.fn(),
+      consumeApplicationMonthlyBudget: jest.fn(),
       getBytesUsedToday: jest.fn(),
     },
     SessionReplayLimitOutcome: {
@@ -248,6 +249,8 @@ const consumeChunkAllowanceMock: MockedFn =
   SessionReplayRateLimiter.consumeChunkAllowance as unknown as MockedFn;
 const consumeByteBudgetMock: MockedFn =
   SessionReplayRateLimiter.consumeByteBudget as unknown as MockedFn;
+const consumeApplicationMonthlyBudgetMock: MockedFn =
+  SessionReplayRateLimiter.consumeApplicationMonthlyBudget as unknown as MockedFn;
 
 const PROJECT_ID: ObjectID = ObjectID.generate();
 const RUM_APPLICATION_ID: ObjectID = ObjectID.generate();
@@ -397,6 +400,9 @@ describe("SessionReplayIngestService.gateChunkRequest", () => {
     consumeByteBudgetMock.mockResolvedValue({
       outcome: SessionReplayLimitOutcome.Allowed,
     } as never);
+    consumeApplicationMonthlyBudgetMock.mockResolvedValue({
+      outcome: SessionReplayLimitOutcome.Allowed,
+    } as never);
   });
 
   const baseGateInput: {
@@ -528,6 +534,74 @@ describe("SessionReplayIngestService.gateChunkRequest", () => {
       await SessionReplayIngestService.gateChunkRequest(baseGateInput);
 
     expect(decision.outcome).toBe(SessionReplayGateOutcome.StorageUnavailable);
+  });
+
+  /*
+   * The application's customer-configured monthly budget, distinct from the
+   * operator's instance-wide daily cap. A budget field that is stored and
+   * displayed but never consulted promises a protection that does not
+   * exist, so these pin that it is actually enforced.
+   */
+  test("does not consult the monthly budget when none is configured", async () => {
+    const decision: SessionReplayGateDecision =
+      await SessionReplayIngestService.gateChunkRequest(baseGateInput);
+
+    expect(decision.outcome).toBe(SessionReplayGateOutcome.Accepted);
+    expect(consumeApplicationMonthlyBudgetMock).not.toHaveBeenCalled();
+  });
+
+  test("charges the monthly budget with the configured ceiling in bytes", async () => {
+    getPolicyMock.mockResolvedValue(
+      buildPolicy({ monthlyBudgetInGB: 2 }) as never,
+    );
+
+    const decision: SessionReplayGateDecision =
+      await SessionReplayIngestService.gateChunkRequest(baseGateInput);
+
+    expect(decision.outcome).toBe(SessionReplayGateOutcome.Accepted);
+    expect(consumeApplicationMonthlyBudgetMock).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      rumApplicationId: RUM_APPLICATION_ID,
+      bytes: baseGateInput.payloadBytes,
+      budgetBytes: 2 * 1024 * 1024 * 1024,
+    });
+  });
+
+  test("an exhausted monthly budget stops the recorder with its own reason", async () => {
+    getPolicyMock.mockResolvedValue(
+      buildPolicy({ monthlyBudgetInGB: 1 }) as never,
+    );
+    consumeApplicationMonthlyBudgetMock.mockResolvedValue({
+      outcome: SessionReplayLimitOutcome.BudgetExhausted,
+    } as never);
+
+    const decision: SessionReplayGateDecision =
+      await SessionReplayIngestService.gateChunkRequest(baseGateInput);
+
+    expect(decision.outcome).toBe(SessionReplayGateOutcome.Stop);
+    expect(decision.directive).toBe("stop");
+    /*
+     * A distinct reason from the instance-wide "budget-exhausted": the
+     * customer's remediation differs (raise your own budget vs contact the
+     * operator), so the two must be tellable apart in the response and on
+     * the refusal metric.
+     */
+    expect(decision.reason).toBe("app-monthly-budget-exhausted");
+  });
+
+  test("an unreachable monthly budget counter fails closed as retryable", async () => {
+    getPolicyMock.mockResolvedValue(
+      buildPolicy({ monthlyBudgetInGB: 1 }) as never,
+    );
+    consumeApplicationMonthlyBudgetMock.mockResolvedValue({
+      outcome: SessionReplayLimitOutcome.CounterUnavailable,
+    } as never);
+
+    const decision: SessionReplayGateDecision =
+      await SessionReplayIngestService.gateChunkRequest(baseGateInput);
+
+    expect(decision.outcome).toBe(SessionReplayGateOutcome.StorageUnavailable);
+    expect(decision.reason).toBe("budget-counter-unavailable");
   });
 });
 

--- a/App/Tests/Telemetry/SessionReplayInstanceSwitch.test.ts
+++ b/App/Tests/Telemetry/SessionReplayInstanceSwitch.test.ts
@@ -151,6 +151,7 @@ jest.mock("../../FeatureSet/Telemetry/Utils/SessionReplayRateLimiter", () => {
     default: {
       consumeChunkAllowance: jest.fn(),
       consumeByteBudget: jest.fn(),
+      consumeApplicationMonthlyBudget: jest.fn(),
       getBytesUsedToday: jest.fn(),
     },
     SessionReplayLimitOutcome: {

--- a/App/Tests/Telemetry/SessionReplayRateLimiterMonthly.test.ts
+++ b/App/Tests/Telemetry/SessionReplayRateLimiterMonthly.test.ts
@@ -1,0 +1,209 @@
+import ObjectID from "Common/Types/ObjectID";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The Redis arithmetic behind the customer-facing monthly budget. The gate
+ * tests mock the whole rate limiter, so without this file the INCRBY /
+ * check-after / refund-on-refusal semantics exist only behind mocks — the
+ * budget could be deleted from the limiter and every suite would stay
+ * green.
+ */
+
+jest.mock("Common/Server/Infrastructure/Redis", () => {
+  return {
+    __esModule: true,
+    default: {
+      getClient: jest.fn(),
+      isConnected: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+import Redis from "Common/Server/Infrastructure/Redis";
+import SessionReplayRateLimiter, {
+  SessionReplayLimitDecision,
+  SessionReplayLimitOutcome,
+} from "../../FeatureSet/Telemetry/Utils/SessionReplayRateLimiter";
+
+type MockedFn = ReturnType<typeof jest.fn>;
+
+const getClientMock: MockedFn = Redis.getClient as unknown as MockedFn;
+const isConnectedMock: MockedFn = Redis.isConnected as unknown as MockedFn;
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const RUM_APPLICATION_ID: ObjectID = ObjectID.generate();
+
+const ONE_GB: number = 1024 * 1024 * 1024;
+
+interface FakeRedisClient {
+  incrby: MockedFn;
+  decrby: MockedFn;
+  expire: MockedFn;
+  get: MockedFn;
+}
+
+function buildClient(): FakeRedisClient {
+  return {
+    incrby: jest.fn(),
+    decrby: jest.fn(),
+    expire: jest.fn(),
+    get: jest.fn(),
+  };
+}
+
+describe("SessionReplayRateLimiter.consumeApplicationMonthlyBudget", () => {
+  let client: FakeRedisClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = buildClient();
+    getClientMock.mockReturnValue(client);
+    isConnectedMock.mockReturnValue(true);
+    client.expire.mockResolvedValue(1 as never);
+    client.decrby.mockResolvedValue(0 as never);
+  });
+
+  test("the first chunk of the month creates the key with a TTL that outlives any month", async () => {
+    client.incrby.mockResolvedValue(7000 as never);
+
+    const decision: SessionReplayLimitDecision =
+      await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+        projectId: PROJECT_ID,
+        rumApplicationId: RUM_APPLICATION_ID,
+        bytes: 7000,
+        budgetBytes: ONE_GB,
+      });
+
+    expect(decision.outcome).toBe(SessionReplayLimitOutcome.Allowed);
+
+    /* Keyed per application per UTC month, from the SHARED key builder. */
+    const key: string = client.incrby.mock.calls[0]![0] as string;
+    expect(key).toContain("replay:rate:bytes-month:");
+    expect(key).toContain(PROJECT_ID.toString());
+    expect(key).toContain(RUM_APPLICATION_ID.toString());
+
+    expect(client.expire).toHaveBeenCalledTimes(1);
+    const ttl: number = client.expire.mock.calls[0]![1] as number;
+    /* A key created on day 1 must survive a 31-day month plus margin. */
+    expect(ttl).toBeGreaterThanOrEqual(32 * 24 * 60 * 60);
+  });
+
+  test("a subsequent chunk does not re-arm the TTL", async () => {
+    client.incrby.mockResolvedValue(14000 as never);
+
+    await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+      projectId: PROJECT_ID,
+      rumApplicationId: RUM_APPLICATION_ID,
+      bytes: 7000,
+      budgetBytes: ONE_GB,
+    });
+
+    expect(client.expire).not.toHaveBeenCalled();
+  });
+
+  test("the crossing chunk is still accepted; everything after is refused", async () => {
+    /*
+     * Deliberate check-after-increment: refusing mid-session leaves an
+     * unplayable fragment, and the overshoot is bounded by one request.
+     */
+    client.incrby.mockResolvedValue(ONE_GB as never);
+
+    const crossing: SessionReplayLimitDecision =
+      await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+        projectId: PROJECT_ID,
+        rumApplicationId: RUM_APPLICATION_ID,
+        bytes: 7000,
+        budgetBytes: ONE_GB,
+      });
+
+    expect(crossing.outcome).toBe(SessionReplayLimitOutcome.Allowed);
+
+    client.incrby.mockResolvedValue((ONE_GB + 7000) as never);
+
+    const over: SessionReplayLimitDecision =
+      await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+        projectId: PROJECT_ID,
+        rumApplicationId: RUM_APPLICATION_ID,
+        bytes: 7000,
+        budgetBytes: ONE_GB,
+      });
+
+    expect(over.outcome).toBe(SessionReplayLimitOutcome.BudgetExhausted);
+  });
+
+  test("refused bytes are refunded so the counter stays an honest usage figure", async () => {
+    client.incrby.mockResolvedValue((ONE_GB + 7000) as never);
+
+    await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+      projectId: PROJECT_ID,
+      rumApplicationId: RUM_APPLICATION_ID,
+      bytes: 7000,
+      budgetBytes: ONE_GB,
+    });
+
+    /*
+     * Unlike the daily counter (which resets in 24h), this one is read
+     * back as "usage" by the Dashboard for up to 31 days — without the
+     * refund, every post-exhaustion upload attempt inflates the figure
+     * past both the budget and the bytes actually stored, and a mid-month
+     * budget raise finds its headroom already eaten.
+     */
+    expect(client.decrby).toHaveBeenCalledTimes(1);
+    expect(client.decrby.mock.calls[0]![1]).toBe(7000);
+  });
+
+  test("a failed refund still refuses the chunk rather than throwing", async () => {
+    client.incrby.mockResolvedValue((ONE_GB + 7000) as never);
+    client.decrby.mockRejectedValue(new Error("redis blip") as never);
+
+    const decision: SessionReplayLimitDecision =
+      await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+        projectId: PROJECT_ID,
+        rumApplicationId: RUM_APPLICATION_ID,
+        bytes: 7000,
+        budgetBytes: ONE_GB,
+      });
+
+    expect(decision.outcome).toBe(SessionReplayLimitOutcome.BudgetExhausted);
+  });
+
+  test("fails CLOSED as retryable when Redis is unreachable", async () => {
+    isConnectedMock.mockReturnValue(false);
+
+    const decision: SessionReplayLimitDecision =
+      await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+        projectId: PROJECT_ID,
+        rumApplicationId: RUM_APPLICATION_ID,
+        bytes: 7000,
+        budgetBytes: ONE_GB,
+      });
+
+    expect(decision.outcome).toBe(SessionReplayLimitOutcome.CounterUnavailable);
+  });
+
+  test("fails CLOSED when the increment itself throws", async () => {
+    client.incrby.mockRejectedValue(new Error("redis down") as never);
+
+    const decision: SessionReplayLimitDecision =
+      await SessionReplayRateLimiter.consumeApplicationMonthlyBudget({
+        projectId: PROJECT_ID,
+        rumApplicationId: RUM_APPLICATION_ID,
+        bytes: 7000,
+        budgetBytes: ONE_GB,
+      });
+
+    expect(decision.outcome).toBe(SessionReplayLimitOutcome.CounterUnavailable);
+  });
+});

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -87,7 +87,7 @@ import { IsBillingEnabled, getAllEnvVars } from "../EnvironmentConfig";
 import RumSession from "../../Models/AnalyticsModels/RumSession";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
-import { JSONObject } from "../../Types/JSON";
+import { JSONArray, JSONObject } from "../../Types/JSON";
 import ResourceFacetResolver, {
   ResolvedFacetValue,
   ResourceFacetSpec,
@@ -95,6 +95,9 @@ import ResourceFacetResolver, {
 import Label from "../../Models/DatabaseModels/Label";
 import RumApplication from "../../Models/DatabaseModels/RumApplication";
 import RumApplicationService from "../Services/RumApplicationService";
+import Project from "../../Models/DatabaseModels/Project";
+import ProjectService from "../Services/ProjectService";
+import SessionReplayUsage from "../Utils/SessionReplay/SessionReplayUsage";
 import RumSessionReplayView from "../../Models/DatabaseModels/RumSessionReplayView";
 import RumSessionReplayViewService from "../Services/RumSessionReplayViewService";
 import SessionReplayReadService, {
@@ -109,6 +112,7 @@ import SessionReplayReadService, {
   SessionReplaySessionHeader,
 } from "../Utils/SessionReplay/SessionReplayReadService";
 import {
+  DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY,
   MAX_SESSION_REPLAY_CHUNKS_PER_READ,
   MAX_SESSION_REPLAY_READ_BYTES,
 } from "../../Types/Rum/SessionReplay";
@@ -3959,6 +3963,172 @@ router.post(
          * and a caller who hits it is looking at a possibly short answer.
          */
         isApplicationScopeTruncated: accessibleApplications.isTruncated,
+      });
+    } catch (err: unknown) {
+      next(err);
+    }
+  },
+);
+
+// --- Session Replay Ingest Status Endpoint ---
+
+/*
+ * Recording health for one application: is replay switched on at every
+ * level, when did the last chunk actually land, and how much of the byte
+ * budgets is spent. This is what lets the Dashboard answer "why are there
+ * no recordings?" and "am I about to hit my budget?" as states rather than
+ * leaving the customer to infer them from silence — the ingest gate's
+ * refusals are deliberately quiet toward end users' browsers, so this
+ * endpoint is the loud side of that trade.
+ *
+ * Reads settings metadata and Redis counters only; never touches recording
+ * payloads, so list-level access is the right bar.
+ *
+ * The application row is loaded with root props even though its columns
+ * carry their own read ACLs. That is deliberate and bounded: every column
+ * returned here (appIdentifier, the replay policy fields, the two health
+ * timestamps) is readable by a plain project Viewer under its declared
+ * ACL — the least-privileged read tier there is — while this route demands
+ * the STRICTER session-replay list permission and pins tenancy and label
+ * scope first. Nothing is disclosed that the caller's project peers cannot
+ * already read through the generic CRUD API. If a column with a narrower
+ * ACL (e.g. anything identity-adjacent) is ever added to this SELECT, it
+ * must get an explicit permission check, not a wider isRoot ride-along.
+ */
+router.post(
+  "/telemetry/rum/session-replay/ingest-status",
+  ...requireSessionReplayListAccess,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const databaseProps: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      if (!databaseProps?.tenantId) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("Invalid Project ID"),
+        );
+      }
+
+      assertSessionReplayPlan(databaseProps);
+
+      const projectId: ObjectID = databaseProps.tenantId;
+      const body: JSONObject = req.body as JSONObject;
+
+      const rumApplicationId: ObjectID = readObjectIdFromBody(
+        body,
+        "rumApplicationId",
+      );
+
+      await assertSessionReplayApplicationAccess({
+        projectId: projectId,
+        rumApplicationId: rumApplicationId,
+        databaseProps: databaseProps,
+        permissions: SESSION_REPLAY_LIST_PERMISSIONS,
+      });
+
+      const application: RumApplication | null =
+        await RumApplicationService.findOneBy({
+          query: {
+            _id: rumApplicationId.toString(),
+            projectId: projectId,
+          },
+          select: {
+            _id: true,
+            appIdentifier: true,
+            isSessionReplayEnabled: true,
+            sessionReplayAllowedOrigins: true,
+            sessionReplaySamplePercentage: true,
+            sessionReplayCaptureTrigger: true,
+            sessionReplayMonthlyBudgetInGB: true,
+            sessionReplayLastChunkReceivedAt: true,
+            sessionReplayBudgetExceededAt: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      if (!application) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("RUM application not found."),
+        );
+      }
+
+      const project: Project | null = await ProjectService.findOneBy({
+        query: {
+          _id: projectId.toString(),
+        },
+        select: {
+          isSessionReplayAllowed: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      const [projectBytesUsedToday, applicationBytesUsedThisMonth]: [
+        number | null,
+        number | null,
+      ] = await Promise.all([
+        SessionReplayUsage.getProjectBytesUsedToday(projectId),
+        SessionReplayUsage.getApplicationBytesUsedThisMonth({
+          projectId: projectId,
+          rumApplicationId: rumApplicationId,
+        }),
+      ]);
+
+      /*
+       * Same env var, same default, as the value the ingest gate enforces
+       * (App Telemetry Config). The default is a shared constant so the
+       * number shown here cannot drift from the number enforced there.
+       */
+      const dailyCapEnv: number = parseInt(
+        process.env["SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY"] || "",
+        10,
+      );
+
+      const dailyByteLimit: number =
+        !isNaN(dailyCapEnv) && dailyCapEnv > 0
+          ? dailyCapEnv
+          : DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY;
+
+      const applicationView: JSONObject = application as unknown as JSONObject;
+
+      return Response.sendJsonObjectResponse(req, res, {
+        isProjectAllowed: Boolean(
+          (project as unknown as JSONObject | null)?.["isSessionReplayAllowed"],
+        ),
+        isApplicationEnabled: Boolean(
+          applicationView["isSessionReplayEnabled"],
+        ),
+        appIdentifier: String(applicationView["appIdentifier"] || ""),
+        allowedOrigins: (applicationView["sessionReplayAllowedOrigins"] ||
+          []) as JSONArray,
+        samplePercentage: Number(
+          applicationView["sessionReplaySamplePercentage"] || 0,
+        ),
+        captureTrigger: String(
+          applicationView["sessionReplayCaptureTrigger"] || "",
+        ),
+        lastChunkReceivedAt:
+          (applicationView["sessionReplayLastChunkReceivedAt"] as string) ||
+          null,
+        budgetExceededAt:
+          (applicationView["sessionReplayBudgetExceededAt"] as string) || null,
+        /* null = counter unreachable; render as unknown, never as zero. */
+        projectBytesUsedToday: projectBytesUsedToday,
+        dailyByteLimit: dailyByteLimit,
+        applicationBytesUsedThisMonth: applicationBytesUsedThisMonth,
+        monthlyBudgetInGB:
+          (applicationView["sessionReplayMonthlyBudgetInGB"] as number) ?? null,
       });
     } catch (err: unknown) {
       next(err);

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -2173,6 +2173,14 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
   public async updateColumnsByIdWithoutHooks(input: {
     id: ObjectID;
     data: PartialEntity<TBaseModel>;
+    /*
+     * Leave `updatedAt` untouched. For passive bookkeeping writes (liveness
+     * timestamps, ingest health markers) where consumers key change
+     * detection off updatedAt - e.g. the session replay configEpoch - a
+     * refreshed updateDate would broadcast "configuration changed" on every
+     * heartbeat.
+     */
+    skipUpdateDateColumn?: boolean;
   }): Promise<void> {
     if (!input.id) {
       throw new BadDataException("id is required");
@@ -2222,7 +2230,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     }
 
     // The raw path has no entity machinery to touch updateDate — do it here.
-    if (metadata.updateDateColumn) {
+    if (metadata.updateDateColumn && !input.skipUpdateDateColumn) {
       setClauses.push(
         `"${metadata.updateDateColumn.databaseName}" = CURRENT_TIMESTAMP`,
       );

--- a/Common/Server/Services/RumApplicationService.ts
+++ b/Common/Server/Services/RumApplicationService.ts
@@ -20,6 +20,14 @@ const LAST_SEEN_THROTTLE_SECONDS: number = 60;
 const LABELS_APPLIED_CACHE_NAMESPACE: string = "rum-application-labels-applied";
 const LABELS_APPLIED_CACHE_TTL_SECONDS: number = 60;
 
+const REPLAY_CHUNK_RECEIVED_CACHE_NAMESPACE: string =
+  "rum-application-replay-chunk-received";
+const REPLAY_CHUNK_RECEIVED_THROTTLE_SECONDS: number = 60;
+
+const REPLAY_BUDGET_EXCEEDED_CACHE_NAMESPACE: string =
+  "rum-application-replay-budget-exceeded";
+const REPLAY_BUDGET_EXCEEDED_THROTTLE_SECONDS: number = 300;
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -333,6 +341,98 @@ export class Service extends DatabaseService<Model> {
       id: rumApplicationId,
       data: data,
     });
+  }
+
+  /*
+   * Session replay ingest health markers.
+   *
+   * Both write columns whose names start with "sessionReplay", which the
+   * onUpdateSuccess hook treats as a policy edit (cache clear + kill-key
+   * churn) - so they MUST go through the hook-free single-statement path,
+   * exactly like updateLastSeen. They also skip the updatedAt refresh:
+   * configEpoch is derived from updatedAt, and a passive health timestamp
+   * broadcasting "configuration changed" to every live recorder once a
+   * minute would be self-inflicted config-fetch load.
+   *
+   * Throttled through GlobalCache so 20k chunks/min becomes at most one
+   * Postgres write per application per window across the whole fleet.
+   * Failures are swallowed after a warn: this bookkeeping must never make
+   * an ingest request fail.
+   */
+  @CaptureSpan()
+  public async markSessionReplayChunkReceived(
+    rumApplicationId: ObjectID,
+  ): Promise<void> {
+    await this.writeReplayHealthColumn({
+      rumApplicationId: rumApplicationId,
+      cacheNamespace: REPLAY_CHUNK_RECEIVED_CACHE_NAMESPACE,
+      throttleSeconds: REPLAY_CHUNK_RECEIVED_THROTTLE_SECONDS,
+      column: "sessionReplayLastChunkReceivedAt",
+    });
+  }
+
+  @CaptureSpan()
+  public async markSessionReplayBudgetExceeded(
+    rumApplicationId: ObjectID,
+  ): Promise<void> {
+    await this.writeReplayHealthColumn({
+      rumApplicationId: rumApplicationId,
+      cacheNamespace: REPLAY_BUDGET_EXCEEDED_CACHE_NAMESPACE,
+      throttleSeconds: REPLAY_BUDGET_EXCEEDED_THROTTLE_SECONDS,
+      column: "sessionReplayBudgetExceededAt",
+    });
+  }
+
+  private async writeReplayHealthColumn(data: {
+    rumApplicationId: ObjectID;
+    cacheNamespace: string;
+    throttleSeconds: number;
+    column:
+      | "sessionReplayLastChunkReceivedAt"
+      | "sessionReplayBudgetExceededAt";
+  }): Promise<void> {
+    const cacheKey: string = data.rumApplicationId.toString();
+
+    try {
+      const cached: string | null = await GlobalCache.getString(
+        data.cacheNamespace,
+        cacheKey,
+      );
+
+      if (cached) {
+        return; // written recently, across all pods
+      }
+    } catch {
+      /*
+       * Cache unavailable - fail open and write anyway, same stance as
+       * updateLastSeen: a stale health column is worse than an occasional
+       * extra single-row UPDATE.
+       */
+    }
+
+    try {
+      await GlobalCache.setString(data.cacheNamespace, cacheKey, "1", {
+        expiresInSeconds: data.throttleSeconds,
+      });
+    } catch {
+      // Best-effort throttle write; proceed with the DB update regardless.
+    }
+
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: data.rumApplicationId,
+        data: {
+          [data.column]: OneUptimeDate.getCurrentDate(),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        skipUpdateDateColumn: true,
+      });
+    } catch (err) {
+      logger.warn(
+        `RumApplicationService: could not write ${data.column} for application ${cacheKey}`,
+      );
+      logger.warn(err);
+    }
   }
 
   @CaptureSpan()

--- a/Common/Server/Utils/CorsOptions.ts
+++ b/Common/Server/Utils/CorsOptions.ts
@@ -26,6 +26,7 @@ import type { CorsOptions as ExpressCorsOptions } from "cors";
 export const CORS_EXPOSED_HEADERS: Array<string> = [
   "x-oneuptime-replay-directive",
   "x-oneuptime-replay-config-epoch",
+  "x-oneuptime-replay-reason",
   "Retry-After",
 ];
 

--- a/Common/Server/Utils/SessionReplay/SessionReplayReadService.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayReadService.ts
@@ -257,6 +257,11 @@ export interface SessionReplayExceptionSession {
   durationMs: number;
   hasError: boolean;
   errorCount: number;
+  rageClickCount: number;
+  deadClickCount: number;
+  errorClickCount: number;
+  refreshRageCount: number;
+  maskingMode: string;
   triggerReason: string;
   entryUrl: string;
   browserName: string;
@@ -818,7 +823,13 @@ export default class SessionReplayReadService {
         chunkEndOffsetMs,
         eventCount,
         hasFullSnapshot,
-        toFloat64(payloadBytes) AS chunkPayloadBytes
+        toFloat64(payloadBytes) AS chunkPayloadBytes,
+        errorCount,
+        rageClickCount,
+        deadClickCount,
+        errorClickCount,
+        refreshRageCount,
+        routeCount
       FROM ${AnalyticsTableName.RumSessionChunk}
       WHERE projectId = ${{
         type: TableColumnType.ObjectID,
@@ -871,6 +882,12 @@ export default class SessionReplayReadService {
         eventCount: readNumber(row, "eventCount"),
         hasFullSnapshot: readBoolean(row, "hasFullSnapshot"),
         payloadBytes: readNumber(row, "chunkPayloadBytes"),
+        errorCount: readNumber(row, "errorCount"),
+        rageClickCount: readNumber(row, "rageClickCount"),
+        deadClickCount: readNumber(row, "deadClickCount"),
+        errorClickCount: readNumber(row, "errorClickCount"),
+        refreshRageCount: readNumber(row, "refreshRageCount"),
+        routeCount: readNumber(row, "routeCount"),
       };
 
       const existing: Array<SessionReplayChunkManifestEntry> | undefined =
@@ -1174,6 +1191,29 @@ export default class SessionReplayReadService {
       { alias: "aggDurationMs", expression: argMaxNumeric("durationMs") },
       { alias: "aggHasError", expression: argMaxColumn("hasError") },
       { alias: "aggErrorCount", expression: argMaxNumeric("errorCount") },
+      /*
+       * The frustration counters and masking mode feed the "Watch what the
+       * user saw" card: the signals line ("2 rage clicks before the error")
+       * and the up-front masking disclosure both come from here. Omitting
+       * them renders the card with empty signals and "unknown" masking.
+       */
+      {
+        alias: "aggRageClickCount",
+        expression: argMaxNumeric("rageClickCount"),
+      },
+      {
+        alias: "aggDeadClickCount",
+        expression: argMaxNumeric("deadClickCount"),
+      },
+      {
+        alias: "aggErrorClickCount",
+        expression: argMaxNumeric("errorClickCount"),
+      },
+      {
+        alias: "aggRefreshRageCount",
+        expression: argMaxNumeric("refreshRageCount"),
+      },
+      { alias: "aggMaskingMode", expression: argMaxColumn("maskingMode") },
       { alias: "aggTriggerReason", expression: argMaxColumn("triggerReason") },
       { alias: "aggEntryUrl", expression: argMaxColumn("entryUrl") },
       { alias: "aggBrowserName", expression: argMaxColumn("browserName") },
@@ -1265,6 +1305,11 @@ export default class SessionReplayReadService {
           durationMs: readNumber(row, "aggDurationMs"),
           hasError: readBoolean(row, "aggHasError"),
           errorCount: readNumber(row, "aggErrorCount"),
+          rageClickCount: readNumber(row, "aggRageClickCount"),
+          deadClickCount: readNumber(row, "aggDeadClickCount"),
+          errorClickCount: readNumber(row, "aggErrorClickCount"),
+          refreshRageCount: readNumber(row, "aggRefreshRageCount"),
+          maskingMode: readString(row, "aggMaskingMode"),
           triggerReason: readString(row, "aggTriggerReason"),
           entryUrl: readString(row, "aggEntryUrl"),
           browserName: readString(row, "aggBrowserName"),

--- a/Common/Server/Utils/SessionReplay/SessionReplayUsage.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayUsage.ts
@@ -1,0 +1,92 @@
+import Redis, { ClientType } from "../../Infrastructure/Redis";
+import logger from "../Logger";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Session replay byte-budget bookkeeping shared between the two sides that
+ * need it: the App-tier ingest gate CONSUMES these counters (INCRBY, in
+ * App/FeatureSet/Telemetry/Utils/SessionReplayRateLimiter.ts) and the
+ * Dashboard-facing TelemetryAPI READS them so a customer can see "you have
+ * used 800MB of today's budget" instead of inferring exhaustion from
+ * recordings that silently stop appearing.
+ *
+ * The key builders live here, in Common, precisely so those two callers
+ * cannot drift: the ingest gate charging one key while the dashboard reads
+ * another would report a healthy budget forever.
+ */
+
+const DAILY_PROJECT_BYTE_KEY_PREFIX: string = "replay:rate:bytes:";
+const MONTHLY_APP_BYTE_KEY_PREFIX: string = "replay:rate:bytes-month:";
+
+export default class SessionReplayUsage {
+  /*
+   * UTC rather than local, so the budget window is the same for every pod
+   * regardless of container timezone.
+   */
+  public static getUtcDayBucket(): string {
+    return new Date().toISOString().substring(0, 10);
+  }
+
+  /* "YYYY-MM", UTC, for the per-application monthly budget window. */
+  public static getUtcMonthBucket(): string {
+    return new Date().toISOString().substring(0, 7);
+  }
+
+  public static getDailyProjectByteKey(projectId: ObjectID): string {
+    return `${DAILY_PROJECT_BYTE_KEY_PREFIX}${projectId.toString()}:${this.getUtcDayBucket()}`;
+  }
+
+  public static getMonthlyApplicationByteKey(data: {
+    projectId: ObjectID;
+    rumApplicationId: ObjectID;
+  }): string {
+    return `${MONTHLY_APP_BYTE_KEY_PREFIX}${data.projectId.toString()}:${data.rumApplicationId.toString()}:${this.getUtcMonthBucket()}`;
+  }
+
+  /*
+   * Bytes consumed from the project's daily budget so far. Read-only.
+   *
+   * null means "unknown" (Redis unavailable), which callers must render as
+   * unknown rather than as zero: a dashboard telling a customer their usage
+   * is 0 while the gate is refusing chunks would be worse than no number.
+   */
+  public static async getProjectBytesUsedToday(
+    projectId: ObjectID,
+  ): Promise<number | null> {
+    return this.readCounter(this.getDailyProjectByteKey(projectId));
+  }
+
+  /* Bytes consumed from the application's monthly budget. Read-only. */
+  public static async getApplicationBytesUsedThisMonth(data: {
+    projectId: ObjectID;
+    rumApplicationId: ObjectID;
+  }): Promise<number | null> {
+    return this.readCounter(this.getMonthlyApplicationByteKey(data));
+  }
+
+  private static async readCounter(key: string): Promise<number | null> {
+    const client: ClientType | null = Redis.getClient();
+
+    if (!client || !Redis.isConnected()) {
+      return null;
+    }
+
+    try {
+      const value: string | null = await client.get(key);
+
+      if (value === null) {
+        return 0;
+      }
+
+      const parsed: number = parseInt(value, 10);
+
+      return isNaN(parsed) ? 0 : parsed;
+    } catch (err) {
+      logger.warn(
+        `SessionReplayUsage: could not read the byte counter at ${key}`,
+      );
+      logger.warn(err);
+      return null;
+    }
+  }
+}

--- a/Common/Tests/Server/API/SessionReplayAPI.test.ts
+++ b/Common/Tests/Server/API/SessionReplayAPI.test.ts
@@ -1,5 +1,7 @@
 import CommonAPI from "../../../Server/API/CommonAPI";
 import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import ProjectService from "../../../Server/Services/ProjectService";
+import Project from "../../../Models/DatabaseModels/Project";
 import RumApplicationService from "../../../Server/Services/RumApplicationService";
 import RumSessionReplayViewService from "../../../Server/Services/RumSessionReplayViewService";
 import RumSessionService from "../../../Server/Services/RumSessionService";
@@ -119,6 +121,8 @@ const CHUNKS_ROUTE: string = "/telemetry/rum/session-replay/chunks";
 const HEARTBEAT_ROUTE: string = "/telemetry/rum/session-replay/heartbeat";
 const FOR_EXCEPTION_ROUTE: string =
   "/telemetry/rum/session-replay/for-exception";
+const INGEST_STATUS_ROUTE: string =
+  "/telemetry/rum/session-replay/ingest-status";
 
 function findRoute(uri: string): RecordedRoute {
   const route: RecordedRoute | undefined = recordedRoutes.find(
@@ -522,13 +526,14 @@ describe("Session replay playback API", () => {
   }
 
   describe("guard shape", () => {
-    test("all five routes are registered and every one carries the three-middleware guard", () => {
+    test("all six routes are registered and every one carries the three-middleware guard", () => {
       for (const uri of [
         LIST_ROUTE,
         MANIFEST_ROUTE,
         CHUNKS_ROUTE,
         HEARTBEAT_ROUTE,
         FOR_EXCEPTION_ROUTE,
+        INGEST_STATUS_ROUTE,
       ]) {
         const route: RecordedRoute = findRoute(uri);
 
@@ -1250,6 +1255,12 @@ describe("Session replay playback API", () => {
             eventCount: 100,
             hasFullSnapshot: true,
             chunkPayloadBytes: 1024,
+            errorCount: 2,
+            rageClickCount: 1,
+            deadClickCount: 4,
+            errorClickCount: 6,
+            refreshRageCount: 5,
+            routeCount: 3,
           },
           {
             tabId: "tab-1",
@@ -1259,6 +1270,12 @@ describe("Session replay playback API", () => {
             eventCount: 100,
             hasFullSnapshot: false,
             chunkPayloadBytes: 1024,
+            errorCount: 0,
+            rageClickCount: 0,
+            deadClickCount: 0,
+            errorClickCount: 0,
+            refreshRageCount: 0,
+            routeCount: 0,
           },
         ]) as never,
       );
@@ -1274,6 +1291,23 @@ describe("Session replay playback API", () => {
       expect(statement.query).not.toContain("payload,");
       expect(statement.query).not.toMatch(/\bpayload\b(?!Bytes)/);
       expect(statement.query).toContain("LIMIT 1 BY tabId, chunkIndex");
+
+      /*
+       * The signal counters must be projected: the player's error,
+       * frustration and route timeline lanes and the "next error" jump are
+       * fed exclusively by these per-chunk columns. Dropping one from the
+       * SELECT silently blanks a lane — it parses as 0 client-side.
+       */
+      for (const counterColumn of [
+        "errorCount",
+        "rageClickCount",
+        "deadClickCount",
+        "errorClickCount",
+        "refreshRageCount",
+        "routeCount",
+      ]) {
+        expect(statement.query).toContain(counterColumn);
+      }
 
       expect(recordViewSpy).toHaveBeenCalledTimes(1);
       const auditArgs: JSONObject = recordViewSpy.mock
@@ -1297,6 +1331,23 @@ describe("Session replay playback API", () => {
       expect(tabs).toHaveLength(1);
       expect(tabs[0]!["chunkIndexes"]).toEqual([0, 3]);
       expect(tabs[0]!["fullSnapshotChunkIndexes"]).toEqual([0]);
+
+      /*
+       * Every counter gets a DISTINCT nonzero value, asserted individually:
+       * the client parses missing keys to 0, so a counter dropped from the
+       * SELECT (or two counters cross-wired in the row mapping) fails
+       * loudly here instead of silently blanking a timeline lane.
+       */
+      const manifestChunks: Array<JSONObject> = tabs[0]![
+        "chunks"
+      ] as unknown as Array<JSONObject>;
+      expect(manifestChunks[0]!["errorCount"]).toBe(2);
+      expect(manifestChunks[0]!["rageClickCount"]).toBe(1);
+      expect(manifestChunks[0]!["deadClickCount"]).toBe(4);
+      expect(manifestChunks[0]!["errorClickCount"]).toBe(6);
+      expect(manifestChunks[0]!["refreshRageCount"]).toBe(5);
+      expect(manifestChunks[0]!["routeCount"]).toBe(3);
+      expect(manifestChunks[1]!["errorCount"]).toBe(0);
 
       /*
        * The hole between chunk 0 and chunk 3 must be reported. Playback
@@ -1812,6 +1863,195 @@ describe("Session replay playback API", () => {
 
       expect(statement.query).not.toContain("rumApplicationId IN (");
       expect(findBySpy).not.toHaveBeenCalled();
+    });
+
+    test("projects the frustration counters and masking mode the replay card renders", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ProjectOwner],
+      });
+
+      mockProps(principal.databaseProps);
+
+      headerQuerySpy.mockResolvedValue(
+        fakeResultSet([
+          {
+            sessionId: "session-9",
+            applicationId: applicationAId.toString(),
+            aggStartTime: "2026-07-30 10:00:00.000",
+            aggEndTime: "2026-07-30 10:01:00.000",
+            aggDurationMs: 60000,
+            aggHasError: 1,
+            aggErrorCount: 2,
+            aggRageClickCount: 3,
+            aggDeadClickCount: 4,
+            aggErrorClickCount: 6,
+            aggRefreshRageCount: 5,
+            aggMaskingMode: "MaskAllText",
+            aggTriggerReason: "error",
+            aggEntryUrl: "https://shop.example.com/checkout",
+            aggBrowserName: "Chrome",
+            aggOsName: "macOS",
+            aggDeviceType: "desktop",
+            aggIsFinalized: 1,
+          },
+        ]) as never,
+      );
+
+      const result: CallResult = await callRoute({
+        uri: FOR_EXCEPTION_ROUTE,
+        request: principal.request,
+        body: { fingerprint: "fp-1" },
+      });
+
+      /*
+       * The card's signals line ("3 rage clicks before the error") and its
+       * up-front masking disclosure are fed exclusively by these aliases.
+       * The client parses a missing key to 0/"", so dropping one from the
+       * SELECT silently degrades the card — it must fail here instead.
+       */
+      const statement: Statement = headerQuerySpy.mock
+        .calls[0]![0] as Statement;
+
+      for (const alias of [
+        "aggRageClickCount",
+        "aggDeadClickCount",
+        "aggErrorClickCount",
+        "aggRefreshRageCount",
+        "aggMaskingMode",
+      ]) {
+        expect(statement.query).toContain(alias);
+      }
+
+      const sessions: Array<JSONObject> = result.jsonBody?.[
+        "sessions"
+      ] as unknown as Array<JSONObject>;
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!["rumApplicationId"]).toBe(applicationAId.toString());
+      expect(sessions[0]!["rageClickCount"]).toBe(3);
+      expect(sessions[0]!["deadClickCount"]).toBe(4);
+      expect(sessions[0]!["errorClickCount"]).toBe(6);
+      expect(sessions[0]!["refreshRageCount"]).toBe(5);
+      expect(sessions[0]!["maskingMode"]).toBe("MaskAllText");
+    });
+  });
+
+  describe("ingest-status", () => {
+    function mockConfiguredApplication(): void {
+      const application: RumApplication = new RumApplication();
+      application.id = applicationAId;
+      application.projectId = projectId;
+      application.labels = [];
+      application.appIdentifier = "checkout-web";
+      application.isSessionReplayEnabled = true;
+      application.sessionReplayAllowedOrigins = ["https://shop.example.com"];
+      application.sessionReplaySamplePercentage = 25;
+      application.sessionReplayMonthlyBudgetInGB = 2;
+
+      findOneBySpy.mockResolvedValue(application);
+      findBySpy.mockResolvedValue([application]);
+    }
+
+    function mockProject(isAllowed: boolean): void {
+      const project: Project = new Project();
+      project.id = projectId;
+      project.isSessionReplayAllowed = isAllowed;
+
+      jest.spyOn(ProjectService, "findOneBy").mockResolvedValue(project);
+    }
+
+    test("a label-scoped caller whose labels do not reach the application is refused before any disclosure", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ReadRumSessionReplay],
+        labelIds: [labelBId],
+      });
+
+      mockProps(principal.databaseProps);
+      mockApplication({ id: applicationAId, labelIds: [labelAId] });
+      mockProject(true);
+
+      const result: CallResult = await callRoute({
+        uri: INGEST_STATUS_ROUTE,
+        request: principal.request,
+        body: { rumApplicationId: applicationAId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(result.jsonBody).toBeUndefined();
+    });
+
+    test("an application outside this tenant is refused identically to a missing one", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ProjectOwner],
+      });
+
+      mockProps(principal.databaseProps);
+      findOneBySpy.mockResolvedValue(null);
+      mockProject(true);
+
+      const result: CallResult = await callRoute({
+        uri: INGEST_STATUS_ROUTE,
+        request: principal.request,
+        body: { rumApplicationId: applicationAId.toString() },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(result.jsonBody).toBeUndefined();
+    });
+
+    test("returns the switches, health timestamps and budget figures the panel renders", async () => {
+      const principal: {
+        request: JSONObject;
+        databaseProps: DatabaseCommonInteractionProps;
+      } = buildPrincipal({
+        projectId: projectId,
+        userId: userId,
+        permissions: [Permission.ProjectOwner],
+      });
+
+      mockProps(principal.databaseProps);
+      mockConfiguredApplication();
+      mockProject(true);
+
+      const result: CallResult = await callRoute({
+        uri: INGEST_STATUS_ROUTE,
+        request: principal.request,
+        body: { rumApplicationId: applicationAId.toString() },
+      });
+
+      const body: JSONObject = result.jsonBody as JSONObject;
+
+      expect(body["isProjectAllowed"]).toBe(true);
+      expect(body["isApplicationEnabled"]).toBe(true);
+      expect(body["appIdentifier"]).toBe("checkout-web");
+      expect(body["allowedOrigins"]).toEqual(["https://shop.example.com"]);
+      expect(body["samplePercentage"]).toBe(25);
+      expect(body["monthlyBudgetInGB"]).toBe(2);
+      expect(body["lastChunkReceivedAt"]).toBeNull();
+      expect(body["budgetExceededAt"]).toBeNull();
+      /*
+       * Jest runs without Redis, so the usage readers answer null —
+       * "unknown", which the panel must render as unknown, never as 0.
+       * The daily limit is config, not a counter, so it is always known.
+       */
+      expect(body["projectBytesUsedToday"]).toBeNull();
+      expect(body["applicationBytesUsedThisMonth"]).toBeNull();
+      expect(body["dailyByteLimit"]).toBeGreaterThan(0);
     });
   });
 });

--- a/Common/Tests/Server/Services/DatabaseServiceUpdateColumnsWithoutHooks.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceUpdateColumnsWithoutHooks.test.ts
@@ -1,0 +1,128 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import RumApplication from "../../../Models/DatabaseModels/RumApplication";
+import ObjectID from "../../../Types/ObjectID";
+import { getJestSpyOn } from "../../Spy";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Pins `updateColumnsByIdWithoutHooks`' updatedAt behaviour at the SQL
+ * level, because the two sides of it protect different consumers:
+ *
+ *  - By DEFAULT the raw path must refresh updatedAt, preserving the
+ *    behaviour of the normal update pipeline it replaces — anything
+ *    watching row freshness (the RUM "connected" pill via lastSeenAt
+ *    heartbeats) relies on it.
+ *  - With `skipUpdateDateColumn` it must NOT: the session replay
+ *    configEpoch is DERIVED from RumApplication.updatedAt
+ *    (SessionReplayGateCache.getConfigEpoch), so a passive health
+ *    heartbeat that refreshed updatedAt would broadcast "configuration
+ *    changed" to every live recorder once a minute.
+ *
+ * Inverting either branch is invisible to every other suite — the health
+ * markers are mocked at their call sites — so the generated SQL is pinned
+ * here directly.
+ */
+
+const APPLICATION_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+interface CapturedQuery {
+  sql: string;
+  params: Array<unknown>;
+}
+
+describe("DatabaseService.updateColumnsByIdWithoutHooks", () => {
+  let service: DatabaseService<RumApplication>;
+  let captured: Array<CapturedQuery>;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    captured = [];
+
+    service = new DatabaseService<RumApplication>(RumApplication);
+
+    const columns: Record<string, string> = {
+      sessionReplayLastChunkReceivedAt: "sessionReplayLastChunkReceivedAt",
+      sessionReplayBudgetExceededAt: "sessionReplayBudgetExceededAt",
+      lastSeenAt: "lastSeenAt",
+      _id: "_id",
+      updatedAt: "updatedAt",
+    };
+
+    getJestSpyOn(service, "getRepository").mockReturnValue({
+      metadata: {
+        tableName: "RumApplication",
+        findColumnWithPropertyName: (
+          propertyName: string,
+        ): { databaseName: string } | undefined => {
+          return columns[propertyName]
+            ? { databaseName: columns[propertyName]! }
+            : undefined;
+        },
+        updateDateColumn: { databaseName: "updatedAt" },
+        primaryColumns: [{ databaseName: "_id" }],
+      },
+      manager: {
+        connection: {
+          driver: {
+            preparePersistentValue: (value: unknown): unknown => {
+              return value;
+            },
+          },
+        },
+        query: async (
+          sql: string,
+          params: Array<unknown>,
+        ): Promise<Array<unknown>> => {
+          captured.push({ sql, params });
+          return [];
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+  });
+
+  it("refreshes updatedAt by default, preserving the normal pipeline's behaviour", async () => {
+    await service.updateColumnsByIdWithoutHooks({
+      id: APPLICATION_ID,
+      data: { lastSeenAt: new Date() },
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain(`"updatedAt" = CURRENT_TIMESTAMP`);
+  });
+
+  it("leaves updatedAt untouched when skipUpdateDateColumn is set", async () => {
+    await service.updateColumnsByIdWithoutHooks({
+      id: APPLICATION_ID,
+      data: { sessionReplayLastChunkReceivedAt: new Date() },
+      skipUpdateDateColumn: true,
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).not.toContain("updatedAt");
+  });
+
+  it("never bumps the optimistic-lock version column in either mode", async () => {
+    await service.updateColumnsByIdWithoutHooks({
+      id: APPLICATION_ID,
+      data: { sessionReplayBudgetExceededAt: new Date() },
+      skipUpdateDateColumn: true,
+    });
+
+    expect(captured[0]!.sql).not.toContain("version");
+  });
+
+  it("scopes the update to the one row by primary key", async () => {
+    await service.updateColumnsByIdWithoutHooks({
+      id: APPLICATION_ID,
+      data: { lastSeenAt: new Date() },
+    });
+
+    expect(captured[0]!.sql).toMatch(/WHERE "_id" = \$\d+$/);
+    expect(captured[0]!.params[captured[0]!.params.length - 1]).toBe(
+      APPLICATION_ID.toString(),
+    );
+  });
+});

--- a/Common/Tests/Server/Services/RumApplicationReplayHealth.test.ts
+++ b/Common/Tests/Server/Services/RumApplicationReplayHealth.test.ts
@@ -1,0 +1,114 @@
+import RumApplicationService from "../../../Server/Services/RumApplicationService";
+import GlobalCache from "../../../Server/Infrastructure/GlobalCache";
+import ObjectID from "../../../Types/ObjectID";
+import { getJestSpyOn } from "../../Spy";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * The session replay ingest health markers
+ * (markSessionReplayChunkReceived / markSessionReplayBudgetExceeded) carry
+ * MUST-level invariants their call sites cannot pin, because the chunk
+ * route's tests mock the whole service:
+ *
+ *  1. The write goes through updateColumnsByIdWithoutHooks. Both columns
+ *     start with "sessionReplay", which onUpdateSuccess treats as a POLICY
+ *     edit — a refactor to the normal update pipeline would clear the gate
+ *     cache and write kill keys on every accepted chunk, a self-inflicted
+ *     cache stampede on the hottest browser endpoint we have.
+ *  2. skipUpdateDateColumn is set: configEpoch is derived from updatedAt,
+ *     so refreshing it would broadcast "configuration changed" to every
+ *     live recorder once a throttle window.
+ *  3. The GlobalCache throttle turns 20k chunks/min into at most one
+ *     Postgres write per application per window — and fails OPEN, because
+ *     a stale health column is worse than an occasional extra UPDATE.
+ *  4. A failed write is swallowed after a warn: bookkeeping must never
+ *     fail an ingest request.
+ */
+
+const APPLICATION_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+describe("RumApplicationService session replay health markers", () => {
+  let updateSpy: jest.SpyInstance;
+  let cacheGetSpy: jest.SpyInstance;
+  let cacheSetSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    updateSpy = getJestSpyOn(
+      RumApplicationService,
+      "updateColumnsByIdWithoutHooks",
+    ).mockResolvedValue(undefined);
+
+    cacheGetSpy = getJestSpyOn(GlobalCache, "getString").mockResolvedValue(
+      null,
+    );
+    cacheSetSpy = getJestSpyOn(GlobalCache, "setString").mockResolvedValue(
+      undefined,
+    );
+  });
+
+  it("writes the last-chunk column through the hook-free path, without touching updatedAt", async () => {
+    await RumApplicationService.markSessionReplayChunkReceived(APPLICATION_ID);
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+
+    const call: {
+      id: ObjectID;
+      data: Record<string, unknown>;
+      skipUpdateDateColumn?: boolean;
+    } = updateSpy.mock.calls[0]![0] as never;
+
+    expect(call.id.toString()).toBe(APPLICATION_ID.toString());
+    expect(Object.keys(call.data)).toEqual([
+      "sessionReplayLastChunkReceivedAt",
+    ]);
+    expect(call.data["sessionReplayLastChunkReceivedAt"]).toBeInstanceOf(Date);
+    expect(call.skipUpdateDateColumn).toBe(true);
+  });
+
+  it("writes the budget-exceeded column the same way", async () => {
+    await RumApplicationService.markSessionReplayBudgetExceeded(APPLICATION_ID);
+
+    const call: {
+      data: Record<string, unknown>;
+      skipUpdateDateColumn?: boolean;
+    } = updateSpy.mock.calls[0]![0] as never;
+
+    expect(Object.keys(call.data)).toEqual(["sessionReplayBudgetExceededAt"]);
+    expect(call.skipUpdateDateColumn).toBe(true);
+  });
+
+  it("skips the write entirely inside the throttle window", async () => {
+    cacheGetSpy.mockResolvedValue("1");
+
+    await RumApplicationService.markSessionReplayChunkReceived(APPLICATION_ID);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(cacheSetSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails OPEN when the throttle cache is unavailable", async () => {
+    cacheGetSpy.mockRejectedValue(new Error("redis down"));
+    cacheSetSpy.mockRejectedValue(new Error("redis down"));
+
+    await RumApplicationService.markSessionReplayChunkReceived(APPLICATION_ID);
+
+    /*
+     * A cache error must never skip the DB write — the same stance
+     * updateLastSeen takes. Otherwise a Redis outage silently freezes the
+     * health column while chunks are still flowing.
+     */
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a failed write instead of throwing into the ingest path", async () => {
+    updateSpy.mockRejectedValue(new Error("postgres down"));
+
+    await expect(
+      RumApplicationService.markSessionReplayChunkReceived(APPLICATION_ID),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/Common/Tests/Server/Utils/CorsOptions.test.ts
+++ b/Common/Tests/Server/Utils/CorsOptions.test.ts
@@ -96,6 +96,12 @@ describe("CORS preflight and exposed headers", () => {
      */
     expect(exposed).toContain("x-oneuptime-replay-directive");
     expect(exposed).toContain("x-oneuptime-replay-config-epoch");
+    /*
+     * The WHY behind a stand-down. The 204 stop path has no body, so the
+     * reason exists only as this header — unexposed, it is unreadable by
+     * every cross-origin page and the reason channel is dead on arrival.
+     */
+    expect(exposed).toContain("x-oneuptime-replay-reason");
     expect(exposed).toContain("retry-after");
   });
 

--- a/Common/Tests/UI/Rum/ChunkLoader.test.ts
+++ b/Common/Tests/UI/Rum/ChunkLoader.test.ts
@@ -29,6 +29,12 @@ function makeEntry(
     eventCount: 10,
     hasFullSnapshot: options?.hasFullSnapshot ?? false,
     payloadBytes: options?.payloadBytes ?? 4096,
+    errorCount: 0,
+    rageClickCount: 0,
+    deadClickCount: 0,
+    errorClickCount: 0,
+    refreshRageCount: 0,
+    routeCount: 0,
   };
 }
 

--- a/Common/Tests/UI/Rum/ReplayStage.test.tsx
+++ b/Common/Tests/UI/Rum/ReplayStage.test.tsx
@@ -63,6 +63,12 @@ function makeEntry(
     eventCount: 2,
     hasFullSnapshot: options?.hasFullSnapshot ?? false,
     payloadBytes: 4096,
+    errorCount: 0,
+    rageClickCount: 0,
+    deadClickCount: 0,
+    errorClickCount: 0,
+    refreshRageCount: 0,
+    routeCount: 0,
   };
 }
 

--- a/Common/Tests/Utils/Rum/ChunkMath.test.ts
+++ b/Common/Tests/Utils/Rum/ChunkMath.test.ts
@@ -18,6 +18,12 @@ const makeEntry: (
     eventCount: 100,
     hasFullSnapshot: chunkIndex === 0,
     payloadBytes: 7000,
+    errorCount: 0,
+    rageClickCount: 0,
+    deadClickCount: 0,
+    errorClickCount: 0,
+    refreshRageCount: 0,
+    routeCount: 0,
     ...overrides,
   };
 };

--- a/Common/Types/Rum/SessionReplay.ts
+++ b/Common/Types/Rum/SessionReplay.ts
@@ -48,6 +48,16 @@ export const MAX_SESSION_REPLAY_CHUNKS_PER_READ: number = 8;
 export const MAX_SESSION_REPLAY_READ_BYTES: number = 8 * 1024 * 1024;
 
 /*
+ * Default for the instance-wide per-project daily byte budget. The live
+ * value is the SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY env var; this
+ * default is shared between the ingest gate (App Telemetry Config) and the
+ * Dashboard-facing ingest-status endpoint so the number the gate enforces
+ * and the number the customer is shown cannot drift.
+ */
+export const DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY: number =
+  1024 * 1024 * 1024;
+
+/*
  * Recorder flush triggers. A chunk closes on whichever comes first.
  * SESSION_REPLAY_CHECKOUT_INTERVAL_MS is also the worst-case seek
  * granularity, since seeking rewinds to the nearest full snapshot.
@@ -315,6 +325,14 @@ export interface SessionReplayChunkResponse {
   directive: SessionReplayDirective;
   configEpoch: number;
   retryAfterSeconds?: number;
+  /*
+   * WHY the directive says what it says ("budget-exhausted",
+   * "not-sampled", "rate-limited", ...). A recorder told to stop without a
+   * reason leaves the customer diagnosing silence; the reason string is a
+   * closed vocabulary, carries no user data, and lets the recorder log
+   * something a support ticket can quote.
+   */
+  reason?: string;
 }
 
 /*
@@ -329,6 +347,18 @@ export interface SessionReplayChunkManifestEntry {
   eventCount: number;
   hasFullSnapshot: boolean;
   payloadBytes: number;
+
+  /*
+   * Per-chunk signal counters. These feed the player's error, frustration
+   * and route timeline lanes and the "next error" jump — a lane drawn from
+   * counters the chunk row already carries, never inferred from payloads.
+   */
+  errorCount: number;
+  rageClickCount: number;
+  deadClickCount: number;
+  errorClickCount: number;
+  refreshRageCount: number;
+  routeCount: number;
 }
 
 /* A hole in the chunk sequence. Never crossed silently during playback. */


### PR DESCRIPTION
## Why

A multi-agent analysis of the session replay feature (6 deep-dives + adversarial verification, 70 confirmed findings) showed the biggest wins aren't new capture tech — they're **already-built capabilities that were never wired in**. This PR is Wave 1: light up what's dark. Small diffs, large product impact.

## What

### Exception → replay (the flagship entry point)
- **Mount `ReplayCard` ("Watch what the user saw") on the exception explorer.** The 272-line card and its `/for-exception` endpoint were fully built and fully authorized — but nothing imported them, so exception→replay navigation didn't exist. The card no longer requires a `rumApplicationId` prop (an exception isn't scoped to one application); each returned session names its own.
- `getSessionsForException` now projects the frustration counters + masking mode the card renders (they parsed to 0/"unknown" before).

### Player timeline lanes
- **`getManifest` now projects the six per-chunk signal counters.** The player already parsed them defensively, so the error/frustration/route lanes were permanently empty and "Next error" permanently disabled — the headline click-to-jump-to-error workflow never functioned. Server-side projection fix only; the lanes light up with no client change.

### Budgets & refusal visibility
- **`monthlyBudgetInGB` is now enforced** (it was loaded on every gate evaluation and never read) via a per-application monthly Redis counter. Refused bytes are refunded so the counter stays an honest usage figure for the full 31-day window.
- **Refusal reasons are now visible on every surface**: the chunk response JSON, the bodyless 204 stand-down via `x-oneuptime-replay-reason` (added to `CORS_EXPOSED_HEADERS` — without that the header is unreadable by any cross-origin page), and a `reason` label on the refusal metric so operators can alert on budget exhaustion vs sampling.
- **New `POST /telemetry/rum/session-replay/ingest-status`** returns switch states, health timestamps, and budget usage. Key builders live in a shared `SessionReplayUsage` module so the gate (which charges) and the dashboard (which reads) can never disagree on a Redis key.

### Recording health
- The two dead `RumApplication` columns (`sessionReplayLastChunkReceivedAt`, `sessionReplayBudgetExceededAt`) are now written from the chunk route — throttled via GlobalCache, **hook-free** (their `sessionReplay*` names would otherwise trigger the policy-invalidation hook on every accepted chunk), and **without refreshing `updatedAt`** (configEpoch derives from it) via a new `skipUpdateDateColumn` option on `updateColumnsByIdWithoutHooks`.

### Install diagnostics
- **New "Test your installation" panel** on RUM Settings → Session Replay — the panel the README and customer docs both already promised. Every recorder install failure (CSP, wrong origin, disabled app, exhausted budget) is silent in end users' browsers by design; the panel answers from the server side: every switch state, origin allowlist, last-chunk-received (the definitive end-to-end signal), budget usage, plus the exact install snippet and CSP directives with the instance host substituted.

### Docs corrections
- Removed the false claim that the recorder injects `traceparent` (it deliberately only reads one the page already set — injection would break customers' CORS; an opt-in origin-allowlist design is queued as follow-up work).
- The erasure-request instructions now point at the real API path instead of a UI that doesn't exist yet.

## Review

The diff was reviewed by a 4-lens adversarial workflow (correctness, security/privacy, convention regressions, test coverage), with every finding re-verified against the code before counting. All confirmed findings are fixed in this PR, notably: the CORS expose-header gap, monthly-counter usage inflation, a stale-response race in the panel, unsafe interpolation of the ingest-writable `appIdentifier` into the copy-paste snippet, and every test-coverage gap below.

One deliberate call, documented in code: `ingest-status` loads the application with root props; every column it returns is Viewer-readable under its own declared ACL (the least-privileged read tier), while the route demands the stricter replay-list permission — nothing is disclosed that the caller's project peers can't already read via the generic CRUD API.

## Tests

- `App` replay suites: **79 passing** (incl. new: health-marker calls on 202/refusal, reason on 204 header + every bodied refusal status, monthly-budget gate branches).
- New `SessionReplayRateLimiterMonthly` suite: Redis INCRBY/TTL/refund/fail-closed semantics against a fake client.
- `Common` replay suites: **48 + 104 passing** (incl. new: per-counter manifest projection with distinct values, for-exception counter projection, `ingest-status` auth + payload, CORS expose pin).
- New `RumApplicationReplayHealth` suite: hook-free path, `skipUpdateDateColumn`, throttle, fail-open, swallow-on-error.
- New `DatabaseServiceUpdateColumnsWithoutHooks` suite: `updatedAt` behavior pinned at the generated-SQL level.
- `Common` tsc ✅, Dashboard tsc ✅, Dashboard esbuild ✅, eslint ✅. (App tsc has pre-existing failures in unrelated files from missing optional deps in the local worktree — none in files this PR touches.)

## Out of scope (queued next waves)

Reliability fixes (early-error capture in the loader stub, "Script error." noise suppression, never-finalized-session sweep, erasure retry/alerting, pin materializer, transport retry-drain fix), the DevTools console/network panel, list filters, traceparent injection, AI summaries, mobile replay. **Stripe metered price creation remains manual** — `BillingService` still deliberately throws for `ProductType.SessionReplay` until the price ids exist.