### PR TITLE
feat(incidents): show the monitor summary that caused the incident / alert

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSummarySnapshotCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSummarySnapshotCard.tsx
@@ -1,0 +1,252 @@
+import OneUptimeDate from "Common/Types/Date";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+import { JSONObject } from "Common/Types/JSON";
+import MonitorSummarySnapshot, {
+  MonitorSummarySnapshotSource,
+} from "Common/Types/Monitor/MonitorSummarySnapshot";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+import Alert from "Common/Models/DatabaseModels/Alert";
+import Incident from "Common/Models/DatabaseModels/Incident";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Card from "Common/UI/Components/Card/Card";
+import InfoCard from "Common/UI/Components/InfoCard/InfoCard";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import MonitorSummarySnapshotUtil, {
+  MonitorSummaryInfoProps,
+} from "Common/Utils/Monitor/MonitorSummarySnapshotUtil";
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useState,
+} from "react";
+import SummaryInfo from "./SummaryView/SummaryInfo";
+
+/*
+ * The "Monitor Summary" card, as of the moment this incident / alert was
+ * opened.
+ *
+ * The monitor page shows the live version of this card. Until now an
+ * incident showed nothing at all, so "what did the monitor actually see?"
+ * had no answer on the page that raised the question - and no answer
+ * anywhere at all once the check aged out (MonitorLog's retention is one
+ * day by default, and MonitorProbe.lastMonitoringLog is overwritten by
+ * the next check). The snapshot is written to the incident / alert row at
+ * creation time so it outlives both.
+ *
+ * Renders nothing at all when there is no summary to show: manual
+ * monitors, incidents opened by hand, and pre-snapshot rows whose
+ * createdStateLog cannot be reconstructed.
+ */
+
+export interface ComponentProps {
+  // Exactly one of these.
+  incidentId?: ObjectID | undefined;
+  alertId?: ObjectID | undefined;
+}
+
+const MonitorSummarySnapshotCard: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [snapshot, setSnapshot] = useState<MonitorSummarySnapshot | null>(null);
+
+  const fetchSnapshot: PromiseVoidFunction = async (): Promise<void> => {
+    try {
+      const stored: {
+        monitorSummary?: JSONObject | undefined;
+        createdStateLog?: JSONObject | undefined;
+        createdAt?: Date | undefined;
+        monitor?: Monitor | undefined;
+      } | null = props.incidentId
+        ? await fetchFromIncident(props.incidentId)
+        : props.alertId
+          ? await fetchFromAlert(props.alertId)
+          : null;
+
+      if (!stored) {
+        setSnapshot(null);
+        return;
+      }
+
+      /*
+       * The stored capture is authoritative. It knows the monitor type it
+       * was taken for, so a monitor whose type was changed afterwards
+       * still renders the check that actually fired.
+       */
+      let resolved: MonitorSummarySnapshot | null =
+        MonitorSummarySnapshotUtil.deserialize(stored.monitorSummary);
+
+      if (!resolved) {
+        /*
+         * Incidents and alerts created before the snapshot column
+         * existed. createdStateLog holds the same evaluated payload,
+         * so the card is reconstructed from it plus the attached
+         * monitor's type - best effort, and blank if the monitor is
+         * gone or its type has since changed.
+         */
+        resolved = MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+          createdStateLog: stored.createdStateLog,
+          monitorType: stored.monitor?.monitorType as MonitorType | undefined,
+          monitorId: stored.monitor?._id?.toString(),
+          monitorName: stored.monitor?.name?.toString(),
+          capturedAt: stored.createdAt,
+        });
+      }
+
+      setSnapshot(
+        MonitorSummarySnapshotUtil.hasRenderableContent(resolved)
+          ? resolved
+          : null,
+      );
+    } catch (err) {
+      /*
+       * Not worth surfacing: the card just does not render. A viewer
+       * without read access to monitors gets a hard failure from the
+       * relation select rather than a hidden row, and the page's own
+       * detail cards already report anything that matters.
+       */
+      API.getFriendlyMessage(err);
+      setSnapshot(null);
+    }
+  };
+
+  useEffect(() => {
+    fetchSnapshot().catch(() => {
+      // handled inside fetchSnapshot
+    });
+  }, [props.incidentId?.toString(), props.alertId?.toString()]);
+
+  if (!snapshot) {
+    return <Fragment />;
+  }
+
+  const summaryInfoProps: MonitorSummaryInfoProps =
+    MonitorSummarySnapshotUtil.toSummaryInfoProps(snapshot);
+
+  const capturedAtText: string = snapshot.capturedAt
+    ? OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+        snapshot.capturedAt,
+      )
+    : "";
+
+  const description: string =
+    snapshot.source === MonitorSummarySnapshotSource.Legacy
+      ? "What the monitor reported when this was created, reconstructed from the stored evaluation."
+      : capturedAtText
+        ? `What the monitor reported at ${capturedAtText}, when this was created.`
+        : "What the monitor reported when this was created.";
+
+  return (
+    <Fragment>
+      <Card title="Monitor Summary" description={description}>
+        <div className="space-y-5">
+          {snapshot.telemetryMonitorSummary?.observedCount !== undefined && (
+            <div className="flex">
+              <InfoCard
+                className="w-full shadow-none border-2 border-gray-100"
+                title={
+                  snapshot.telemetryMonitorSummary.observedCountTitle ||
+                  "Observed"
+                }
+                value={snapshot.telemetryMonitorSummary.observedCount.toString()}
+              />
+            </div>
+          )}
+
+          <SummaryInfo {...summaryInfoProps} />
+
+          {snapshot.areScreenshotsOmitted && (
+            <div className="text-sm text-gray-500">
+              Screenshots from this check were not stored because the capture
+              was too large. They are on the monitor page while the check is
+              still retained.
+            </div>
+          )}
+
+          {snapshot.isResponseBodyTruncated && (
+            <div className="text-sm text-gray-500">
+              The response body shown above was truncated because the capture
+              was too large.
+            </div>
+          )}
+        </div>
+      </Card>
+    </Fragment>
+  );
+};
+
+type FetchStored = {
+  monitorSummary?: JSONObject | undefined;
+  createdStateLog?: JSONObject | undefined;
+  createdAt?: Date | undefined;
+  monitor?: Monitor | undefined;
+};
+
+async function fetchFromIncident(
+  incidentId: ObjectID,
+): Promise<FetchStored | null> {
+  const incident: Incident | null = await ModelAPI.getItem({
+    modelType: Incident,
+    id: incidentId,
+    select: {
+      monitorSummary: true,
+      createdStateLog: true,
+      createdAt: true,
+      /*
+       * Only used by the legacy reconstruction, which needs a monitor
+       * type from somewhere. `monitorType` and `name` both allow reads
+       * through a relation query; nothing deeper is selectable here.
+       */
+      monitors: {
+        _id: true,
+        name: true,
+        monitorType: true,
+      },
+    },
+  });
+
+  if (!incident) {
+    return null;
+  }
+
+  return {
+    monitorSummary: incident.monitorSummary as JSONObject | undefined,
+    createdStateLog: incident.createdStateLog as JSONObject | undefined,
+    createdAt: incident.createdAt,
+    // An incident can span several monitors; the summary belongs to the first.
+    monitor: incident.monitors?.[0],
+  };
+}
+
+async function fetchFromAlert(alertId: ObjectID): Promise<FetchStored | null> {
+  const alert: Alert | null = await ModelAPI.getItem({
+    modelType: Alert,
+    id: alertId,
+    select: {
+      monitorSummary: true,
+      createdStateLog: true,
+      createdAt: true,
+      monitor: {
+        _id: true,
+        name: true,
+        monitorType: true,
+      },
+    },
+  });
+
+  if (!alert) {
+    return null;
+  }
+
+  return {
+    monitorSummary: alert.monitorSummary as JSONObject | undefined,
+    createdStateLog: alert.createdStateLog as JSONObject | undefined,
+    createdAt: alert.createdAt,
+    monitor: alert.monitor,
+  };
+}
+
+export default MonitorSummarySnapshotCard;

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -64,6 +64,7 @@ import InvestigationPanel from "../../../Components/AI/InvestigationPanel";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
 import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
 import AlertAffectedResources from "./AffectedResources";
+import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard";
 import ExceptionInstanceTable from "../../../Components/Exceptions/ExceptionInstanceTable";
 import Query from "Common/Types/BaseDatabase/Query";
 import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
@@ -449,6 +450,8 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
                 }
               />
             )}
+
+          <MonitorSummarySnapshotCard alertId={modelId} />
 
           <AlertAffectedResources alertId={modelId} />
 

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -52,6 +52,7 @@ import IncidentFeedElement from "../../../Components/Incident/IncidentFeed";
 import InvestigationPanel from "../../../Components/AI/InvestigationPanel";
 import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
 import IncidentAffectedResources from "./AffectedResources";
+import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard";
 import IncidentMemberRoleAssignment from "../../../Components/Incident/IncidentMemberRoleAssignment";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
@@ -469,6 +470,8 @@ const IncidentView: FunctionComponent<
                 }
               />
             )}
+
+          <MonitorSummarySnapshotCard incidentId={modelId} />
 
           <IncidentAffectedResources incidentId={modelId} />
 

--- a/App/Tests/Dashboard/MonitorSummaryOnIncidentAndAlert.test.ts
+++ b/App/Tests/Dashboard/MonitorSummaryOnIncidentAndAlert.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * A monitor that trips opens an incident, and the incident page said
+ * nothing about what the monitor actually saw - the "Monitor Summary" card
+ * lived only on the monitor page, fed by live data that does not last
+ * (MonitorLog's ClickHouse TTL defaults to one day, and
+ * MonitorProbe.lastMonitoringLog is overwritten by the next check).
+ *
+ * The behaviour lives in Common and is tested there:
+ *   Common/Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts
+ *     - what gets captured, for all 31 monitor types
+ *   Common/Tests/Server/Utils/Monitor/MonitorSummaryPersistence.test.ts
+ *     - that it lands on the incident / alert row
+ *   Common/Tests/UI/Monitor/MonitorSummarySnapshotRender.test.tsx
+ *     - that a stored capture renders the right per-type view
+ *
+ * What none of those can reach is the Dashboard wiring: the App suite runs
+ * in plain Node with no renderer. So the wiring is pinned here by reading
+ * the sources, the way IncidentMetricSeriesScope.test.ts does. Sources are
+ * whitespace-squashed and comment-stripped first so a prettier re-wrap
+ * cannot turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    stripComments(
+      fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+    ),
+  );
+}
+
+const SUMMARY_CARD: string = readSource(
+  "Components",
+  "Monitor",
+  "MonitorSummarySnapshotCard.tsx",
+);
+
+const INCIDENT_VIEW: string = readSource(
+  "Pages",
+  "Incidents",
+  "View",
+  "Index.tsx",
+);
+
+const ALERT_VIEW: string = readSource("Pages", "Alerts", "View", "Index.tsx");
+
+describe("The Monitor Summary card is on both the incident and the alert page", () => {
+  test("the incident page renders it, scoped to that incident", () => {
+    expect(INCIDENT_VIEW).toContain(
+      "<MonitorSummarySnapshotCard incidentId={modelId} />",
+    );
+    expect(INCIDENT_VIEW).toContain(
+      'import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard"',
+    );
+  });
+
+  test("the alert page renders it, scoped to that alert", () => {
+    expect(ALERT_VIEW).toContain(
+      "<MonitorSummarySnapshotCard alertId={modelId} />",
+    );
+    expect(ALERT_VIEW).toContain(
+      'import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard"',
+    );
+  });
+});
+
+describe("The Monitor Summary card reads the stored capture", () => {
+  test("selects the stored snapshot column on both models", () => {
+    /*
+     * Without the column in the select, ModelAPI returns the row with
+     * monitorSummary undefined and the card silently renders nothing -
+     * exactly the bug it exists to fix.
+     */
+    const selects: Array<string> = SUMMARY_CARD.split("monitorSummary: true");
+
+    // Once for the Incident fetch, once for the Alert fetch.
+    expect(selects.length - 1).toBe(2);
+  });
+
+  test("falls back to createdStateLog for rows created before the column existed", () => {
+    expect(SUMMARY_CARD).toContain("createdStateLog: true");
+    expect(SUMMARY_CARD).toContain("fromLegacyCreatedStateLog");
+  });
+
+  test("asks the monitor for its type, which the legacy fallback needs and the page does not otherwise know", () => {
+    expect(SUMMARY_CARD).toContain("monitorType: true");
+  });
+
+  test("routes rendering through the shared per-monitor-type mapper rather than re-deriving it", () => {
+    expect(SUMMARY_CARD).toContain("MonitorSummarySnapshotUtil.deserialize");
+    expect(SUMMARY_CARD).toContain(
+      "MonitorSummarySnapshotUtil.toSummaryInfoProps",
+    );
+    expect(SUMMARY_CARD).toContain("<SummaryInfo {...summaryInfoProps} />");
+  });
+
+  test("renders nothing at all when there is no capture to show", () => {
+    /*
+     * Manual monitors and hand-declared incidents have no summary. An
+     * empty card on those pages is worse than no card.
+     */
+    expect(SUMMARY_CARD).toContain(
+      "MonitorSummarySnapshotUtil.hasRenderableContent",
+    );
+    expect(SUMMARY_CARD).toContain("if (!snapshot) { return <Fragment />; }");
+  });
+
+  test("degrades to nothing when the fetch fails instead of breaking the page", () => {
+    /*
+     * The card hand-rolls its own ModelAPI call, so it bypasses
+     * ModelDetail's permission filtering: a viewer without read access to
+     * monitors gets a hard failure from the relation select rather than a
+     * hidden row.
+     */
+    expect(SUMMARY_CARD).toContain("catch (err)");
+    expect(SUMMARY_CARD).toContain("setSnapshot(null)");
+  });
+});

--- a/Common/Models/DatabaseModels/Alert.ts
+++ b/Common/Models/DatabaseModels/Alert.ts
@@ -1824,6 +1824,35 @@ export default class Alert extends BaseModel {
     update: [],
   })
   @TableColumn({
+    type: TableColumnType.JSON,
+    required: false,
+    isDefaultValueColumn: false,
+    computed: true,
+    title: "Monitor Summary",
+    description:
+      "The monitor summary captured at the moment this alert was created - the same card the monitor page shows, frozen so it survives the monitor log being aged out.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public monitorSummary?: JSONObject = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.AlertAdmin,
+      Permission.AlertMember,
+      Permission.AlertViewer,
+      Permission.ReadAlert,
+    ],
+    update: [],
+  })
+  @TableColumn({
     manyToOneRelationColumn: "createdByProbeId",
     type: TableColumnType.Entity,
     modelType: Probe,

--- a/Common/Models/DatabaseModels/Incident.ts
+++ b/Common/Models/DatabaseModels/Incident.ts
@@ -2339,6 +2339,35 @@ export default class Incident extends BaseModel {
     update: [],
   })
   @TableColumn({
+    type: TableColumnType.JSON,
+    required: false,
+    isDefaultValueColumn: false,
+    computed: true,
+    title: "Monitor Summary",
+    description:
+      "The monitor summary captured at the moment this incident was created - the same card the monitor page shows, frozen so it survives the monitor log being aged out.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public monitorSummary?: JSONObject = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.IncidentAdmin,
+      Permission.IncidentMember,
+      Permission.IncidentViewer,
+      Permission.ReadProjectIncident,
+    ],
+    update: [],
+  })
+  @TableColumn({
     manyToOneRelationColumn: "createdByProbeId",
     type: TableColumnType.Entity,
     modelType: Probe,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785496223183-AddMonitorSummaryToIncidentAndAlert.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785496223183-AddMonitorSummaryToIncidentAndAlert.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMonitorSummaryToIncidentAndAlert1785496223183
+  implements MigrationInterface
+{
+  public name = "AddMonitorSummaryToIncidentAndAlert1785496223183";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "Incident" ADD "monitorSummary" jsonb`,
+    );
+    await queryRunner.query(`ALTER TABLE "Alert" ADD "monitorSummary" jsonb`);
+    await queryRunner.query(
+      `ALTER TABLE "OnCallDutyPolicyScheduleLayer" ALTER COLUMN "rotation" SET DEFAULT '{"_type":"Recurring","value":{"intervalType":"Day","intervalCount":{"_type":"PositiveNumber","value":1}}}'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "OnCallDutyPolicyScheduleLayer" ALTER COLUMN "restrictionTimes" SET DEFAULT '{"_type":"RestrictionTimes","value":{"restictionType":"None","dayRestrictionTimes":null,"weeklyRestrictionTimes":[]}}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "OnCallDutyPolicyScheduleLayer" ALTER COLUMN "restrictionTimes" SET DEFAULT '{"_type": "RestrictionTimes", "value": {"restictionType": "None", "dayRestrictionTimes": null, "weeklyRestrictionTimes": []}}'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "OnCallDutyPolicyScheduleLayer" ALTER COLUMN "rotation" SET DEFAULT '{"_type": "Recurring", "value": {"intervalType": "Day", "intervalCount": {"_type": "PositiveNumber", "value": 1}}}'`,
+    );
+    await queryRunner.query(`ALTER TABLE "Alert" DROP COLUMN "monitorSummary"`);
+    await queryRunner.query(
+      `ALTER TABLE "Incident" DROP COLUMN "monitorSummary"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -480,6 +480,7 @@ import { AddRecommendationDismissalTable1785397674289 } from "./1785397674289-Ad
 import { AddDroppedCountersToDropFilters1785405581596 } from "./1785405581596-AddDroppedCountersToDropFilters";
 import { AddSessionReplay1785417351021 } from "./1785417351021-AddSessionReplay";
 import { EnableSessionReplayByDefault1785491583874 } from "./1785491583874-EnableSessionReplayByDefault";
+import { AddMonitorSummaryToIncidentAndAlert1785496223183 } from "./1785496223183-AddMonitorSummaryToIncidentAndAlert";
 
 export default [
   InitialMigration,
@@ -964,4 +965,5 @@ export default [
   AddDroppedCountersToDropFilters1785405581596,
   AddSessionReplay1785417351021,
   EnableSessionReplayByDefault1785491583874,
+  AddMonitorSummaryToIncidentAndAlert1785496223183,
 ];

--- a/Common/Server/Utils/Monitor/MonitorAlert.ts
+++ b/Common/Server/Utils/Monitor/MonitorAlert.ts
@@ -39,6 +39,8 @@ import MonitorTemplateUtil from "./MonitorTemplateUtil";
 import { JSONObject } from "../../../Types/JSON";
 import OneUptimeDate from "../../../Types/Date";
 import MonitorEvaluationSummary from "../../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorSummarySnapshot from "../../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorSummarySnapshotUtil from "../../../Utils/Monitor/MonitorSummarySnapshotUtil";
 import { PerSeriesCriteriaMatch } from "../../../Types/Probe/ProbeApiIngestResponse";
 
 export default class MonitorAlert {
@@ -220,6 +222,13 @@ export default class MonitorAlert {
     rootCause: string;
     autoResolveCriteriaInstanceIdAlertIdsDictionary: Dictionary<Array<string>>;
     evaluationSummary?: MonitorEvaluationSummary | undefined;
+    /**
+     * The Monitor Summary as it stood at this evaluation, captured by
+     * MonitorSummaryCapture before this call. Stored on every alert
+     * created below so the alert page can render the same card the
+     * monitor page shows, long after the monitor log has aged out.
+     */
+    monitorSummary?: MonitorSummarySnapshot | null | undefined;
     props: {
       telemetryQuery?: TelemetryQuery | undefined;
     };
@@ -481,6 +490,17 @@ export default class MonitorAlert {
         alert.createdStateLog = JSON.parse(
           JSON.stringify(input.dataToProcess, null, 2),
         );
+
+        /*
+         * Same capture on every alert this evaluation opens - they all
+         * came from the one check.
+         */
+        const serializedMonitorSummary: JSONObject | null =
+          MonitorSummarySnapshotUtil.serialize(input.monitorSummary);
+
+        if (serializedMonitorSummary) {
+          alert.monitorSummary = serializedMonitorSummary;
+        }
 
         if (input.criteriaInstance.data?.id) {
           alert.createdCriteriaId = input.criteriaInstance.data.id.toString();

--- a/Common/Server/Utils/Monitor/MonitorIncident.ts
+++ b/Common/Server/Utils/Monitor/MonitorIncident.ts
@@ -47,6 +47,8 @@ import MonitorTemplateUtil from "./MonitorTemplateUtil";
 import { JSONObject } from "../../../Types/JSON";
 import OneUptimeDate from "../../../Types/Date";
 import MonitorEvaluationSummary from "../../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorSummarySnapshot from "../../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorSummarySnapshotUtil from "../../../Utils/Monitor/MonitorSummarySnapshotUtil";
 import { IncidentMemberRoleAssignment } from "../../../Types/Monitor/CriteriaIncident";
 import { PerSeriesCriteriaMatch } from "../../../Types/Probe/ProbeApiIngestResponse";
 import MonitorClusterContextUtil, {
@@ -261,6 +263,13 @@ export default class MonitorIncident {
       Array<string>
     >;
     evaluationSummary?: MonitorEvaluationSummary | undefined;
+    /**
+     * The Monitor Summary as it stood at this evaluation, captured by
+     * MonitorSummaryCapture before this call. Stored on every incident
+     * created below so the incident page can render the same card the
+     * monitor page shows, long after the monitor log has aged out.
+     */
+    monitorSummary?: MonitorSummarySnapshot | null | undefined;
     props: {
       telemetryQuery?: TelemetryQuery | undefined;
     };
@@ -588,6 +597,17 @@ export default class MonitorIncident {
         incident.createdStateLog = JSON.parse(
           JSON.stringify(input.dataToProcess, null, 2),
         );
+
+        /*
+         * Same capture on every incident this evaluation opens - they all
+         * came from the one check.
+         */
+        const serializedMonitorSummary: JSONObject | null =
+          MonitorSummarySnapshotUtil.serialize(input.monitorSummary);
+
+        if (serializedMonitorSummary) {
+          incident.monitorSummary = serializedMonitorSummary;
+        }
 
         /*
          * Guard against missing ids — these are optional reference fields and

--- a/Common/Server/Utils/Monitor/MonitorResource.ts
+++ b/Common/Server/Utils/Monitor/MonitorResource.ts
@@ -41,6 +41,8 @@ import ExceptionMonitorResponse from "../../../Types/Monitor/ExceptionMonitor/Ex
 import { TelemetryQuery } from "../../../Types/Telemetry/TelemetryQuery";
 import MonitorIncident from "./MonitorIncident";
 import MonitorAlert from "./MonitorAlert";
+import MonitorSummaryCapture from "./MonitorSummaryCapture";
+import MonitorSummarySnapshot from "../../../Types/Monitor/MonitorSummarySnapshot";
 import IncomingRequestIncidentGrouping from "./IncomingRequestIncidentGrouping";
 import MonitorMaintenanceSuppression from "./MonitorMaintenanceSuppression";
 import MonitorStatusTimelineUtil from "./MonitorStatusTimeline";
@@ -900,6 +902,21 @@ export default class MonitorResourceUtil {
             matchesPerSeries: response.perSeriesMatches,
           });
 
+        /*
+         * Freeze the Monitor Summary as it stands right now, before any
+         * incident or alert is created from it. Both creators store the
+         * same capture, so the incident page can show what the monitor
+         * saw long after MonitorLog's TTL (one day by default) has
+         * dropped the underlying log.
+         */
+        const monitorSummary: MonitorSummarySnapshot | null =
+          await MonitorSummaryCapture.capture({
+            monitor: monitor,
+            dataToProcess: dataToProcess,
+            evaluationSummary: evaluationSummary,
+            probeName: probeName,
+          });
+
         await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
           monitor: monitor,
           rootCause: response.rootCause,
@@ -907,6 +924,7 @@ export default class MonitorResourceUtil {
           autoResolveCriteriaInstanceIdIncidentIdsDictionary,
           criteriaInstance: matchedCriteriaInstance,
           evaluationSummary: evaluationSummary,
+          monitorSummary: monitorSummary,
           props: {
             telemetryQuery: telemetryQuery,
           },
@@ -930,6 +948,7 @@ export default class MonitorResourceUtil {
           autoResolveCriteriaInstanceIdAlertIdsDictionary,
           criteriaInstance: criteriaInstanceAlertMap[response.criteriaMetId!]!,
           evaluationSummary: evaluationSummary,
+          monitorSummary: monitorSummary,
           props: {
             telemetryQuery: telemetryQuery,
           },

--- a/Common/Server/Utils/Monitor/MonitorSummaryCapture.ts
+++ b/Common/Server/Utils/Monitor/MonitorSummaryCapture.ts
@@ -1,0 +1,104 @@
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import MonitorEvaluationSummary from "../../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorSummarySnapshot from "../../../Types/Monitor/MonitorSummarySnapshot";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
+import MonitorSummarySnapshotUtil, {
+  MonitorSummaryDataToProcess,
+} from "../../../Utils/Monitor/MonitorSummarySnapshotUtil";
+import ProbeService from "../../Services/ProbeService";
+import logger from "../Logger";
+import CaptureSpan from "../Telemetry/CaptureSpan";
+import DataToProcess from "./DataToProcess";
+
+/*
+ * Captures the "Monitor Summary" that an incident or alert is about to be
+ * created from, so the incident page can show what the monitor saw even
+ * after the evidence is gone.
+ *
+ * It has to be gone: MonitorLog rows are dropped by a ClickHouse TTL whose
+ * default is one day (MonitorLogUtil), and MonitorProbe.lastMonitoringLog
+ * is overwritten on the very next check. Without this the summary card on
+ * an incident older than a day would always be empty.
+ *
+ * The routing itself is the pure MonitorSummarySnapshotUtil; this wrapper
+ * exists only for the one thing that needs the database - turning a probe
+ * id into a probe name, which every probeable summary view renders.
+ */
+export default class MonitorSummaryCapture {
+  @CaptureSpan()
+  public static async capture(input: {
+    monitor: Monitor;
+    dataToProcess: DataToProcess;
+    evaluationSummary?: MonitorEvaluationSummary | undefined;
+    /*
+     * Already resolved by the caller for probeable monitors. Passed in so
+     * the common path costs no extra query.
+     */
+    probeName?: string | undefined;
+  }): Promise<MonitorSummarySnapshot | null> {
+    try {
+      if (!input.monitor.monitorType) {
+        return null;
+      }
+
+      const probeName: string | undefined =
+        input.probeName ||
+        (await this.resolveProbeName({
+          probeId: (input.dataToProcess as ProbeMonitorResponse | undefined)
+            ?.probeId,
+        }));
+
+      return MonitorSummarySnapshotUtil.buildSnapshot({
+        monitorType: input.monitor.monitorType,
+        dataToProcess: input.dataToProcess as MonitorSummaryDataToProcess,
+        monitorId: input.monitor.id?.toString(),
+        monitorName: input.monitor.name || undefined,
+        probeName: probeName,
+        evaluationSummary: input.evaluationSummary,
+        capturedAt: OneUptimeDate.getCurrentDate(),
+      });
+    } catch (err) {
+      /*
+       * A summary is evidence, not a precondition. This runs inside the
+       * probe / telemetry ingest workers, where a throw fails the whole
+       * job and retries forever - losing the incident itself, which is the
+       * thing that actually matters.
+       */
+      logger.error(
+        `${input.monitor.id?.toString()} - Could not capture the monitor summary for this evaluation. The incident / alert will be created without it.`,
+      );
+      logger.error(err);
+      return null;
+    }
+  }
+
+  /*
+   * Only reached for monitor types the caller does not pre-resolve a probe
+   * name for - Network Device is the one that matters, because it is not a
+   * "probeable" monitor (the device owns its polling schedule) yet its
+   * walk and trap results do arrive as a ProbeMonitorResponse with a
+   * probeId on them.
+   */
+  private static async resolveProbeName(input: {
+    probeId?: ObjectID | undefined;
+  }): Promise<string | undefined> {
+    if (!input.probeId) {
+      return undefined;
+    }
+
+    const probe: Probe | null = await ProbeService.findOneById({
+      id: new ObjectID(input.probeId.toString()),
+      select: {
+        name: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return probe?.name || undefined;
+  }
+}

--- a/Common/Tests/Server/Utils/Monitor/MonitorSummaryCapture.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorSummaryCapture.test.ts
@@ -1,0 +1,205 @@
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Probe from "../../../../Models/DatabaseModels/Probe";
+import ProbeService from "../../../../Server/Services/ProbeService";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import MonitorSummaryCapture from "../../../../Server/Utils/Monitor/MonitorSummaryCapture";
+import MonitorSummarySnapshot from "../../../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import ServerMonitorResponse from "../../../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * The one thing the pure snapshot builder cannot do for itself: turn the
+ * probe id on a check into the probe NAME, which every probeable summary
+ * view renders as its "Probe" card.
+ *
+ * MonitorResource already has that name in hand for probeable monitors and
+ * passes it down for free. Network Device monitors are the gap - they are
+ * deliberately NOT "probeable" (the device owns its polling schedule) yet
+ * their walks and traps still arrive as a ProbeMonitorResponse carrying a
+ * probeId, so without the lookup below their incidents would show
+ * "Probe: -".
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROBE_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+
+function monitor(monitorType: MonitorType): Monitor {
+  const model: Monitor = new Monitor();
+  model._id = MONITOR_ID.toString();
+  model.projectId = PROJECT_ID;
+  model.monitorType = monitorType;
+  model.name = "Core Switch";
+  return model;
+}
+
+function probeCheck(): DataToProcess {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    monitorStepId: new ObjectID("33333333-3333-4333-8333-333333333333"),
+    probeId: PROBE_ID,
+    failureCause: "Interface down",
+    monitoredAt: new Date("2026-07-31T10:00:00.000Z"),
+  } as unknown as DataToProcess;
+}
+
+function namedProbe(name: string): Probe {
+  const probe: Probe = new Probe();
+  probe._id = PROBE_ID.toString();
+  probe.name = name;
+  return probe;
+}
+
+describe("MonitorSummaryCapture.capture", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses the probe name the caller already resolved, without a database round trip", async () => {
+    jest.spyOn(ProbeService, "findOneById");
+
+    const snapshot: MonitorSummarySnapshot | null =
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.Website),
+        dataToProcess: probeCheck(),
+        probeName: "US West Probe",
+      });
+
+    expect(snapshot?.probeName).toBe("US West Probe");
+    expect(ProbeService.findOneById).not.toHaveBeenCalled();
+  });
+
+  it("looks the probe name up for a Network Device monitor, whose caller never resolves one", async () => {
+    jest
+      .spyOn(ProbeService, "findOneById")
+      .mockResolvedValue(namedProbe("Rack 3 Probe"));
+
+    const snapshot: MonitorSummarySnapshot | null =
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.NetworkDevice),
+        dataToProcess: probeCheck(),
+        probeName: undefined,
+      });
+
+    expect(snapshot?.probeName).toBe("Rack 3 Probe");
+    expect(snapshot?.probeId).toBe(PROBE_ID.toString());
+  });
+
+  it("captures without a probe name when the probe has been deleted", async () => {
+    jest.spyOn(ProbeService, "findOneById").mockResolvedValue(null);
+
+    const snapshot: MonitorSummarySnapshot | null =
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.NetworkDevice),
+        dataToProcess: probeCheck(),
+      });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.probeName).toBeUndefined();
+    expect(snapshot?.probeMonitorResponse).toBeDefined();
+  });
+
+  it("does not go looking for a probe on a check that has none", async () => {
+    jest.spyOn(ProbeService, "findOneById");
+
+    const serverResponse: ServerMonitorResponse = {
+      projectId: PROJECT_ID,
+      monitorId: MONITOR_ID,
+      hostname: "prod-db-01",
+      requestReceivedAt: new Date("2026-07-31T10:00:00.000Z"),
+      onlyCheckRequestReceivedAt: false,
+    } as unknown as ServerMonitorResponse;
+
+    const snapshot: MonitorSummarySnapshot | null =
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.Server),
+        dataToProcess: serverResponse,
+      });
+
+    expect(ProbeService.findOneById).not.toHaveBeenCalled();
+    expect(snapshot?.serverMonitorResponse?.hostname).toBe("prod-db-01");
+  });
+
+  it("stamps the monitor's own identity onto the capture", async () => {
+    const snapshot: MonitorSummarySnapshot | null =
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.Ping),
+        dataToProcess: probeCheck(),
+        probeName: "US West Probe",
+      });
+
+    expect(snapshot?.monitorId).toBe(MONITOR_ID.toString());
+    expect(snapshot?.monitorName).toBe("Core Switch");
+    expect(snapshot?.capturedAt).toBeDefined();
+  });
+
+  it("captures nothing for a manual monitor", async () => {
+    expect(
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.Manual),
+        dataToProcess: probeCheck(),
+      }),
+    ).toBeNull();
+  });
+
+  it("captures nothing for a monitor with no type rather than guessing one", async () => {
+    const typeless: Monitor = monitor(MonitorType.Website);
+    delete typeless.monitorType;
+
+    expect(
+      await MonitorSummaryCapture.capture({
+        monitor: typeless,
+        dataToProcess: probeCheck(),
+      }),
+    ).toBeNull();
+  });
+
+  it("swallows a failed lookup instead of failing the ingest job", async () => {
+    /*
+     * This runs inside the probe / telemetry queue workers, where a throw
+     * fails the whole job and retries forever - costing the incident
+     * itself, which matters far more than its evidence.
+     */
+    jest
+      .spyOn(ProbeService, "findOneById")
+      .mockRejectedValue(new Error("connection terminated unexpectedly"));
+
+    await expect(
+      MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.NetworkDevice),
+        dataToProcess: probeCheck(),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("prefers the evaluation summary handed in by the pipeline", async () => {
+    const snapshot: MonitorSummarySnapshot | null =
+      await MonitorSummaryCapture.capture({
+        monitor: monitor(MonitorType.Website),
+        dataToProcess: {
+          ...(probeCheck() as unknown as ProbeMonitorResponse),
+        } as unknown as DataToProcess,
+        probeName: "US West Probe",
+        evaluationSummary: {
+          evaluatedAt: new Date("2026-07-31T10:00:00.000Z"),
+          criteriaResults: [],
+          events: [
+            {
+              type: "criteria-met",
+              title: "Criteria met",
+            },
+          ],
+        },
+      });
+
+    expect(snapshot?.evaluationSummary?.events[0]?.title).toBe("Criteria met");
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/MonitorSummaryPersistence.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorSummaryPersistence.test.ts
@@ -1,0 +1,313 @@
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import AlertService from "../../../../Server/Services/AlertService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import NetworkDeviceOwnerUserService from "../../../../Server/Services/NetworkDeviceOwnerUserService";
+import MonitorAlert from "../../../../Server/Utils/Monitor/MonitorAlert";
+import MonitorClusterContextUtil from "../../../../Server/Utils/Monitor/MonitorClusterContext";
+import MonitorIncident from "../../../../Server/Utils/Monitor/MonitorIncident";
+import ProjectScopedReferenceValidator from "../../../../Server/Utils/Database/ProjectScopedReferenceValidator";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorSummarySnapshot, {
+  MonitorSummarySnapshotSource,
+  MonitorSummarySnapshotVersion,
+} from "../../../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import MonitorSummarySnapshotUtil from "../../../../Utils/Monitor/MonitorSummarySnapshotUtil";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * The point of the whole feature: the Monitor Summary has to land on the
+ * incident / alert ROW. Storing it anywhere else - or forgetting to store
+ * it on one of the two - leaves the page blank once MonitorLog's retention
+ * (one day by default) drops the underlying check.
+ *
+ * These drive the real creation paths with the surrounding services stubbed
+ * and assert on what was handed to IncidentService.create / AlertService.create.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SEVERITY_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const CAPTURED_AT: Date = new Date("2026-07-31T10:00:00.000Z");
+
+const SNAPSHOT: MonitorSummarySnapshot = {
+  version: MonitorSummarySnapshotVersion,
+  source: MonitorSummarySnapshotSource.Captured,
+  monitorType: MonitorType.Website,
+  monitorId: MONITOR_ID.toString(),
+  monitorName: "Production API",
+  probeName: "US West Probe",
+  capturedAt: CAPTURED_AT,
+  probeMonitorResponse: {
+    responseCode: 503,
+    failureCause: "Connection refused",
+  } as unknown as ProbeMonitorResponse,
+};
+
+function monitor(): Monitor {
+  const model: Monitor = new Monitor();
+  model._id = MONITOR_ID.toString();
+  model.projectId = PROJECT_ID;
+  model.monitorType = MonitorType.Website;
+  model.name = "Production API";
+  return model;
+}
+
+function criteriaInstance(input: {
+  createIncidents: boolean;
+  createAlerts: boolean;
+}): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+  instance.data!.id = "criteria-1";
+  instance.data!.name = "Is Offline";
+  instance.data!.createIncidents = input.createIncidents;
+  instance.data!.createAlerts = input.createAlerts;
+  instance.data!.incidents = [
+    {
+      id: "incident-template-1",
+      title: "API is down",
+      description: "The API stopped responding.",
+      incidentSeverityId: SEVERITY_ID,
+      autoResolveIncident: false,
+    },
+  ];
+  instance.data!.alerts = [
+    {
+      id: "alert-template-1",
+      title: "API is down",
+      description: "The API stopped responding.",
+      alertSeverityId: SEVERITY_ID,
+      autoResolveAlert: false,
+    },
+  ];
+  return instance;
+}
+
+const dataToProcess: ProbeMonitorResponse = {
+  projectId: PROJECT_ID,
+  monitorId: MONITOR_ID,
+  monitorStepId: new ObjectID("33333333-3333-4333-8333-333333333333"),
+  probeId: new ObjectID("44444444-4444-4444-8444-444444444444"),
+  failureCause: "Connection refused",
+  responseCode: 503,
+  monitoredAt: CAPTURED_AT,
+} as unknown as ProbeMonitorResponse;
+
+const NO_AUTO_RESOLVE: Dictionary<Array<string>> = {};
+
+describe("The monitor summary is stored on the incident / alert it created", () => {
+  let createdIncidents: Array<Incident> = [];
+  let createdAlerts: Array<Alert> = [];
+
+  beforeEach(() => {
+    createdIncidents = [];
+    createdAlerts = [];
+
+    // No incident / alert is already open for this monitor.
+    jest.spyOn(IncidentService, "findBy").mockResolvedValue([]);
+    jest.spyOn(AlertService, "findBy").mockResolvedValue([]);
+
+    // The criteria's severity belongs to this project, so no fallback lookup.
+    jest
+      .spyOn(ProjectScopedReferenceValidator, "isUsableInProject")
+      .mockResolvedValue(true);
+
+    jest
+      .spyOn(MonitorClusterContextUtil, "resolveClusterContextForMonitor")
+      .mockResolvedValue({
+        proxmoxClusterIds: [],
+        cephClusterIds: [],
+        dockerSwarmClusterIds: [],
+        iotFleetIds: [],
+      });
+
+    jest
+      .spyOn(NetworkDeviceOwnerUserService, "getDeviceOwnersForMonitor")
+      .mockResolvedValue({ ownerUserIds: [], ownerTeamIds: [] });
+
+    jest
+      .spyOn(IncidentService, "create")
+      .mockImplementation(async (createBy: unknown): Promise<Incident> => {
+        const incident: Incident = (createBy as { data: Incident }).data;
+        createdIncidents.push(incident);
+        incident._id = new ObjectID(
+          "66666666-6666-4666-8666-666666666666",
+        ).toString();
+        return incident;
+      });
+
+    jest
+      .spyOn(AlertService, "create")
+      .mockImplementation(async (createBy: unknown): Promise<Alert> => {
+        const alert: Alert = (createBy as { data: Alert }).data;
+        createdAlerts.push(alert);
+        alert._id = new ObjectID(
+          "77777777-7777-4777-8777-777777777777",
+        ).toString();
+        return alert;
+      });
+
+    jest.spyOn(IncidentService, "addOwners").mockResolvedValue(undefined);
+    jest.spyOn(AlertService, "addOwners").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("stores the captured summary on a created incident", async () => {
+    await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+      criteriaInstance: criteriaInstance({
+        createIncidents: true,
+        createAlerts: false,
+      }),
+      monitor: monitor(),
+      dataToProcess: dataToProcess,
+      rootCause: "Monitor is offline",
+      autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+      monitorSummary: SNAPSHOT,
+      props: {},
+    });
+
+    expect(createdIncidents).toHaveLength(1);
+
+    const stored: JSONObject | undefined = createdIncidents[0]!
+      .monitorSummary as JSONObject | undefined;
+
+    expect(stored).toBeDefined();
+
+    const readBack: MonitorSummarySnapshot | null =
+      MonitorSummarySnapshotUtil.deserialize(
+        JSON.parse(JSON.stringify(stored)) as JSONObject,
+      );
+
+    expect(readBack).not.toBeNull();
+    expect(readBack!.monitorType).toBe(MonitorType.Website);
+    expect(readBack!.probeName).toBe("US West Probe");
+    expect(readBack!.probeMonitorResponse?.responseCode).toBe(503);
+  });
+
+  it("stores the captured summary on a created alert", async () => {
+    await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+      criteriaInstance: criteriaInstance({
+        createIncidents: false,
+        createAlerts: true,
+      }),
+      monitor: monitor(),
+      dataToProcess: dataToProcess,
+      rootCause: "Monitor is offline",
+      autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+      monitorSummary: SNAPSHOT,
+      props: {},
+    });
+
+    expect(createdAlerts).toHaveLength(1);
+
+    const stored: JSONObject | undefined = createdAlerts[0]!.monitorSummary as
+      | JSONObject
+      | undefined;
+
+    expect(stored).toBeDefined();
+
+    const readBack: MonitorSummarySnapshot | null =
+      MonitorSummarySnapshotUtil.deserialize(
+        JSON.parse(JSON.stringify(stored)) as JSONObject,
+      );
+
+    expect(readBack).not.toBeNull();
+    expect(readBack!.monitorType).toBe(MonitorType.Website);
+    expect(readBack!.probeMonitorResponse?.failureCause).toBe(
+      "Connection refused",
+    );
+  });
+
+  it("still creates the incident when there is no summary to store", async () => {
+    /*
+     * A capture is evidence, not a precondition. MonitorSummaryCapture
+     * returns null for manual monitors and swallows its own failures, and
+     * neither may cost us the incident.
+     */
+    await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+      criteriaInstance: criteriaInstance({
+        createIncidents: true,
+        createAlerts: false,
+      }),
+      monitor: monitor(),
+      dataToProcess: dataToProcess,
+      rootCause: "Monitor is offline",
+      autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+      monitorSummary: null,
+      props: {},
+    });
+
+    expect(createdIncidents).toHaveLength(1);
+    expect(createdIncidents[0]!.monitorSummary).toBeUndefined();
+    // The raw state log is untouched by any of this.
+    expect(createdIncidents[0]!.createdStateLog).toBeDefined();
+  });
+
+  it("still creates the alert when there is no summary to store", async () => {
+    await MonitorAlert.criteriaMetCreateAlertsAndUpdateMonitorStatus({
+      criteriaInstance: criteriaInstance({
+        createIncidents: false,
+        createAlerts: true,
+      }),
+      monitor: monitor(),
+      dataToProcess: dataToProcess,
+      rootCause: "Monitor is offline",
+      autoResolveCriteriaInstanceIdAlertIdsDictionary: NO_AUTO_RESOLVE,
+      monitorSummary: undefined,
+      props: {},
+    });
+
+    expect(createdAlerts).toHaveLength(1);
+    expect(createdAlerts[0]!.monitorSummary).toBeUndefined();
+    expect(createdAlerts[0]!.createdStateLog).toBeDefined();
+  });
+
+  it("keeps the summary alongside the state log rather than replacing it", async () => {
+    /*
+     * createdStateLog is copied onward into the incident state timeline and
+     * the monitor status change log. The summary is additive - anything
+     * that quietly took its place would break those.
+     */
+    await MonitorIncident.criteriaMetCreateIncidentsAndUpdateMonitorStatus({
+      criteriaInstance: criteriaInstance({
+        createIncidents: true,
+        createAlerts: false,
+      }),
+      monitor: monitor(),
+      dataToProcess: dataToProcess,
+      rootCause: "Monitor is offline",
+      autoResolveCriteriaInstanceIdIncidentIdsDictionary: NO_AUTO_RESOLVE,
+      monitorSummary: SNAPSHOT,
+      props: {},
+    });
+
+    const incident: Incident = createdIncidents[0]!;
+
+    expect(incident.createdStateLog).toBeDefined();
+    expect((incident.createdStateLog as JSONObject)["responseCode"]).toBe(503);
+    expect(incident.monitorSummary).toBeDefined();
+    expect(incident.rootCause).toBe("Monitor is offline");
+  });
+});

--- a/Common/Tests/UI/Monitor/MonitorSummarySnapshotRender.test.tsx
+++ b/Common/Tests/UI/Monitor/MonitorSummarySnapshotRender.test.tsx
@@ -1,0 +1,248 @@
+/*
+ * The package entry, not the `/extend-expect` subpath the older tests use:
+ * the matchers are already registered by Tests/jest.setup.ts, and only this
+ * specifier resolves to the type augmentation that makes them visible to
+ * TypeScript.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "@jest/globals";
+import { JSONObject } from "../../../Types/JSON";
+import FilterCondition from "../../../Types/Filter/FilterCondition";
+import MonitorEvaluationSummary from "../../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorSummarySnapshot from "../../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import MonitorSummarySnapshotUtil, {
+  MonitorSummaryDataToProcess,
+  MonitorSummaryInfoProps,
+} from "../../../Utils/Monitor/MonitorSummarySnapshotUtil";
+/*
+ * The Dashboard resolves its own copy of react, which would give the
+ * component a different hook dispatcher than the one react-dom renders
+ * with. Pinned in Common's jest moduleNameMapper - see
+ * Tests/UI/Rum/ReplayStage.test.tsx for why the path-based version broke CI.
+ */
+import SummaryInfo from "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo";
+
+/*
+ * End to end for the read half of the feature: a snapshot that came out of
+ * the incident's jsonb column has to reach the same per-monitor-type view
+ * the monitor page renders, and actually put the check on screen.
+ *
+ * The pure mapping is covered in Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts.
+ * What that one cannot catch is the shape mismatch that renders nothing:
+ * SummaryInfo takes probeMonitorResponse*s* (plural, because a monitor can
+ * have several steps), so handing it the bare object silently produces an
+ * empty card - which is indistinguishable from "this monitor had no data",
+ * the exact bug this feature exists to fix.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MONITOR_STEP_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PROBE_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+
+const CAPTURED_AT: Date = new Date("2026-07-31T10:00:00.000Z");
+
+const EVALUATION_SUMMARY: MonitorEvaluationSummary = {
+  evaluatedAt: CAPTURED_AT,
+  criteriaResults: [
+    {
+      criteriaId: "criteria-1",
+      criteriaName: "Site Is Offline",
+      filterCondition: FilterCondition.Any,
+      met: true,
+      message: "Monitor is offline",
+      filters: [],
+    },
+  ],
+  events: [],
+};
+
+/*
+ * Build the snapshot the way the server does, push it through the jsonb
+ * round trip, and read it back the way the browser does - so the test
+ * exercises the real storage path rather than an in-memory object.
+ */
+function storeAndReadBack(input: {
+  monitorType: MonitorType;
+  dataToProcess?: MonitorSummaryDataToProcess | undefined;
+  probeName?: string | undefined;
+}): MonitorSummarySnapshot {
+  const snapshot: MonitorSummarySnapshot | null =
+    MonitorSummarySnapshotUtil.buildSnapshot({
+      monitorType: input.monitorType,
+      dataToProcess: input.dataToProcess,
+      monitorId: MONITOR_ID.toString(),
+      monitorName: "Production API",
+      probeName: input.probeName,
+      evaluationSummary: EVALUATION_SUMMARY,
+      capturedAt: CAPTURED_AT,
+    });
+
+  const stored: JSONObject = JSON.parse(
+    JSON.stringify(MonitorSummarySnapshotUtil.serialize(snapshot)),
+  ) as JSONObject;
+
+  return MonitorSummarySnapshotUtil.deserialize(stored)!;
+}
+
+function renderSnapshot(snapshot: MonitorSummarySnapshot): void {
+  const props: MonitorSummaryInfoProps =
+    MonitorSummarySnapshotUtil.toSummaryInfoProps(snapshot);
+
+  render(<SummaryInfo {...props} />);
+}
+
+describe("A stored monitor summary renders the check that caused the incident", () => {
+  it("renders a website check, including the probe that ran it", () => {
+    renderSnapshot(
+      storeAndReadBack({
+        monitorType: MonitorType.Website,
+        probeName: "US West Probe",
+        dataToProcess: {
+          projectId: PROJECT_ID,
+          monitorId: MONITOR_ID,
+          monitorStepId: MONITOR_STEP_ID,
+          probeId: PROBE_ID,
+          isOnline: false,
+          responseCode: 503,
+          responseTimeInMs: 1234,
+          failureCause: "Connection refused",
+          monitoredAt: CAPTURED_AT,
+        } as unknown as MonitorSummaryDataToProcess,
+      }),
+    );
+
+    expect(screen.getByText("503")).toBeInTheDocument();
+    /*
+     * The probe name is the whole reason MonitorSummaryCapture resolves it
+     * server-side - the old log only ever had the id, so this card would
+     * otherwise read "Probe: -".
+     */
+    expect(screen.getByText("US West Probe")).toBeInTheDocument();
+  });
+
+  it("renders a server check's hostname rather than an empty card", () => {
+    /*
+     * SummaryInfo has no guard for a Server monitor with no response - it
+     * renders an empty <div>. Routing the payload into serverMonitorResponse
+     * is what keeps this card populated.
+     */
+    renderSnapshot(
+      storeAndReadBack({
+        monitorType: MonitorType.Server,
+        dataToProcess: {
+          projectId: PROJECT_ID,
+          monitorId: MONITOR_ID,
+          hostname: "prod-db-01",
+          requestReceivedAt: CAPTURED_AT,
+          onlyCheckRequestReceivedAt: false,
+        } as unknown as MonitorSummaryDataToProcess,
+      }),
+    );
+
+    expect(screen.getByText("prod-db-01")).toBeInTheDocument();
+  });
+
+  it("renders an incoming request, including the check time the snapshot supplies", () => {
+    renderSnapshot(
+      storeAndReadBack({
+        monitorType: MonitorType.IncomingRequest,
+        dataToProcess: {
+          projectId: PROJECT_ID,
+          monitorId: MONITOR_ID,
+          requestMethod: "POST",
+          incomingRequestReceivedAt: CAPTURED_AT,
+          checkedAt: CAPTURED_AT,
+          requestBody: { status: "degraded" },
+        } as unknown as MonitorSummaryDataToProcess,
+      }),
+    );
+
+    expect(screen.getByText("POST")).toBeInTheDocument();
+    /*
+     * The live card fills this from the monitor's *current* heartbeat time.
+     * A frozen capture has no such thing, so toSummaryInfoProps substitutes
+     * the moment this very request was checked - without it the card loses
+     * a field on every incident.
+     */
+    expect(screen.getByText("Monitor Status Check At")).toBeInTheDocument();
+  });
+
+  it("renders an incoming email's subject and sender", () => {
+    renderSnapshot(
+      storeAndReadBack({
+        monitorType: MonitorType.IncomingEmail,
+        dataToProcess: {
+          projectId: PROJECT_ID,
+          monitorId: MONITOR_ID,
+          emailFrom: "alerts@example.com",
+          emailTo: "monitor@oneuptime.com",
+          emailSubject: "Backup failed",
+          emailBody: "The nightly backup did not complete.",
+          emailReceivedAt: CAPTURED_AT,
+          checkedAt: CAPTURED_AT,
+        } as unknown as MonitorSummaryDataToProcess,
+      }),
+    );
+
+    expect(screen.getByText("Backup failed")).toBeInTheDocument();
+    expect(screen.getByText("alerts@example.com")).toBeInTheDocument();
+  });
+
+  it("renders the criteria evaluation that decided to open the incident", () => {
+    /*
+     * For a telemetry monitor there is no per-probe check to show, so the
+     * evaluation log IS the summary - and it is the part that answers "why
+     * did this fire?".
+     */
+    renderSnapshot(
+      storeAndReadBack({
+        monitorType: MonitorType.Logs,
+        dataToProcess: {
+          projectId: PROJECT_ID,
+          monitorId: MONITOR_ID,
+          logCount: 412,
+        } as unknown as MonitorSummaryDataToProcess,
+      }),
+    );
+
+    expect(screen.getByText(/Site Is Offline/)).toBeInTheDocument();
+  });
+
+  it("does not tell the reader to wait a few minutes for data that is already here", () => {
+    /*
+     * SummaryInfo's empty state for a probeable monitor is "No summary
+     * available for the selected probe. Should be few minutes for summary
+     * to show up." On an incident from last quarter that is nonsense, and
+     * it is exactly what a bare (unwrapped) probe response produces.
+     */
+    renderSnapshot(
+      storeAndReadBack({
+        monitorType: MonitorType.Ping,
+        probeName: "US West Probe",
+        dataToProcess: {
+          projectId: PROJECT_ID,
+          monitorId: MONITOR_ID,
+          monitorStepId: MONITOR_STEP_ID,
+          probeId: PROBE_ID,
+          isOnline: false,
+          failureCause: "Host unreachable",
+          monitoredAt: CAPTURED_AT,
+        } as unknown as MonitorSummaryDataToProcess,
+      }),
+    );
+
+    expect(screen.queryByText(/few minutes for summary/)).toBeNull();
+    expect(screen.getByText("Host unreachable")).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts
@@ -1,0 +1,839 @@
+import { JSONObject } from "../../../Types/JSON";
+import OneUptimeDate from "../../../Types/Date";
+import MonitorEvaluationSummary from "../../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorSummarySnapshot, {
+  MonitorSummarySnapshotSource,
+  MonitorSummarySnapshotVersion,
+} from "../../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorType, {
+  MonitorTypeHelper,
+} from "../../../Types/Monitor/MonitorType";
+import FilterCondition from "../../../Types/Filter/FilterCondition";
+import ObjectID from "../../../Types/ObjectID";
+import MonitorSummarySnapshotUtil, {
+  MonitorSummaryDataToProcess,
+  MonitorSummaryInfoProps,
+  MonitorSummaryResponseBodyMaxLengthInChars,
+} from "../../../Utils/Monitor/MonitorSummarySnapshotUtil";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * When a monitor trips and opens an incident, the incident page showed
+ * nothing about what the monitor actually saw - the "Monitor Summary" card
+ * lived only on the monitor page, fed by live data. And that data does not
+ * last: MonitorLog rows are dropped by a ClickHouse TTL whose default is
+ * one day, and MonitorProbe.lastMonitoringLog is overwritten by the very
+ * next check. So an incident older than a day had no recoverable evidence
+ * at all.
+ *
+ * The fix freezes the summary onto the incident/alert row at creation.
+ * These tests pin the part that decides *what* gets frozen and how it is
+ * read back, for every monitor type - because the routing is by
+ * monitorType, and a type routed to the wrong slot renders an empty card
+ * that looks exactly like "this monitor had no data".
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MONITOR_STEP_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PROBE_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+
+const CAPTURED_AT: Date = OneUptimeDate.fromString("2026-07-31T10:00:00.000Z");
+
+const EVALUATION_SUMMARY: MonitorEvaluationSummary = {
+  evaluatedAt: CAPTURED_AT,
+  criteriaResults: [
+    {
+      criteriaId: "criteria-1",
+      criteriaName: "Is Offline",
+      filterCondition: FilterCondition.Any,
+      met: true,
+      message: "Monitor is offline",
+      filters: [],
+    },
+  ],
+  events: [
+    {
+      type: "criteria-met",
+      title: "Criteria met",
+      message: 'Criteria "Is Offline" was met.',
+      at: CAPTURED_AT,
+    },
+  ],
+};
+
+/*
+ * Which payload slot each monitor type has to land in. Written out by hand
+ * rather than derived from the helpers, so that a change to
+ * isTelemetryMonitor / isProbableMonitor has to be reflected here too -
+ * silently reclassifying a type is exactly the regression this guards.
+ */
+enum PayloadKind {
+  Probe = "Probe",
+  Server = "Server",
+  IncomingRequest = "IncomingRequest",
+  IncomingEmail = "IncomingEmail",
+  Telemetry = "Telemetry",
+  None = "None",
+}
+
+const EXPECTED_PAYLOAD_KIND: Record<MonitorType, PayloadKind> = {
+  [MonitorType.Manual]: PayloadKind.None,
+
+  [MonitorType.Website]: PayloadKind.Probe,
+  [MonitorType.API]: PayloadKind.Probe,
+  [MonitorType.Ping]: PayloadKind.Probe,
+  [MonitorType.IP]: PayloadKind.Probe,
+  [MonitorType.Port]: PayloadKind.Probe,
+  [MonitorType.SSLCertificate]: PayloadKind.Probe,
+  [MonitorType.SyntheticMonitor]: PayloadKind.Probe,
+  [MonitorType.CustomJavaScriptCode]: PayloadKind.Probe,
+  [MonitorType.DNS]: PayloadKind.Probe,
+  [MonitorType.DNSSEC]: PayloadKind.Probe,
+  [MonitorType.Domain]: PayloadKind.Probe,
+  [MonitorType.SQLQuery]: PayloadKind.Probe,
+  [MonitorType.ExternalStatusPage]: PayloadKind.Probe,
+  /*
+   * Not a "probeable" monitor - the device owns its polling schedule - but
+   * its walks and traps still arrive as a ProbeMonitorResponse, and
+   * SummaryInfo renders it with SnmpMonitorView.
+   */
+  [MonitorType.NetworkDevice]: PayloadKind.Probe,
+
+  [MonitorType.Server]: PayloadKind.Server,
+  [MonitorType.IncomingRequest]: PayloadKind.IncomingRequest,
+  [MonitorType.IncomingEmail]: PayloadKind.IncomingEmail,
+
+  [MonitorType.Logs]: PayloadKind.Telemetry,
+  [MonitorType.Metrics]: PayloadKind.Telemetry,
+  [MonitorType.Traces]: PayloadKind.Telemetry,
+  [MonitorType.Exceptions]: PayloadKind.Telemetry,
+  [MonitorType.Profiles]: PayloadKind.Telemetry,
+  [MonitorType.Kubernetes]: PayloadKind.Telemetry,
+  [MonitorType.Docker]: PayloadKind.Telemetry,
+  [MonitorType.Host]: PayloadKind.Telemetry,
+  [MonitorType.Podman]: PayloadKind.Telemetry,
+  [MonitorType.DockerSwarm]: PayloadKind.Telemetry,
+  [MonitorType.Proxmox]: PayloadKind.Telemetry,
+  [MonitorType.Ceph]: PayloadKind.Telemetry,
+  [MonitorType.IoTDevice]: PayloadKind.Telemetry,
+};
+
+const ALL_MONITOR_TYPES: Array<MonitorType> = Object.values(MonitorType);
+
+function probeResponse(
+  overrides?: Partial<Record<string, unknown>>,
+): MonitorSummaryDataToProcess {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    monitorStepId: MONITOR_STEP_ID,
+    probeId: PROBE_ID,
+    isOnline: false,
+    failureCause: "Connection refused",
+    responseTimeInMs: 1234,
+    responseCode: 503,
+    monitoredAt: CAPTURED_AT,
+    ...(overrides || {}),
+  } as unknown as MonitorSummaryDataToProcess;
+}
+
+function serverResponse(): MonitorSummaryDataToProcess {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    hostname: "prod-db-01",
+    requestReceivedAt: CAPTURED_AT,
+    onlyCheckRequestReceivedAt: false,
+    failureCause: "Disk usage above 90%",
+  } as unknown as MonitorSummaryDataToProcess;
+}
+
+function incomingRequest(): MonitorSummaryDataToProcess {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    incomingRequestReceivedAt: CAPTURED_AT,
+    checkedAt: CAPTURED_AT,
+    requestBody: { status: "degraded" },
+  } as unknown as MonitorSummaryDataToProcess;
+}
+
+function incomingEmail(): MonitorSummaryDataToProcess {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    emailFrom: "alerts@example.com",
+    emailTo: "monitor@oneuptime.com",
+    emailSubject: "Backup failed",
+    emailBody: "The nightly backup did not complete.",
+    emailReceivedAt: CAPTURED_AT,
+    checkedAt: CAPTURED_AT,
+  } as unknown as MonitorSummaryDataToProcess;
+}
+
+function telemetryResponse(
+  monitorType: MonitorType,
+): MonitorSummaryDataToProcess {
+  const base: JSONObject = {
+    projectId: PROJECT_ID as unknown as JSONObject,
+    monitorId: MONITOR_ID as unknown as JSONObject,
+  };
+
+  if (monitorType === MonitorType.Logs) {
+    return { ...base, logCount: 412 } as unknown as MonitorSummaryDataToProcess;
+  }
+  if (monitorType === MonitorType.Traces) {
+    return { ...base, spanCount: 7 } as unknown as MonitorSummaryDataToProcess;
+  }
+  if (monitorType === MonitorType.Exceptions) {
+    return {
+      ...base,
+      exceptionCount: 3,
+    } as unknown as MonitorSummaryDataToProcess;
+  }
+  if (monitorType === MonitorType.Profiles) {
+    return {
+      ...base,
+      profileCount: 11,
+    } as unknown as MonitorSummaryDataToProcess;
+  }
+
+  // Metrics and every infrastructure type built on it.
+  return {
+    ...base,
+    metricResult: [],
+    metricViewConfig: { queryConfigs: [], formulaConfigs: [] },
+  } as unknown as MonitorSummaryDataToProcess;
+}
+
+function payloadFor(
+  monitorType: MonitorType,
+): MonitorSummaryDataToProcess | undefined {
+  switch (EXPECTED_PAYLOAD_KIND[monitorType]) {
+    case PayloadKind.Probe:
+      return probeResponse();
+    case PayloadKind.Server:
+      return serverResponse();
+    case PayloadKind.IncomingRequest:
+      return incomingRequest();
+    case PayloadKind.IncomingEmail:
+      return incomingEmail();
+    case PayloadKind.Telemetry:
+      return telemetryResponse(monitorType);
+    default:
+      return undefined;
+  }
+}
+
+function build(
+  monitorType: MonitorType,
+  overrides?: {
+    dataToProcess?: MonitorSummaryDataToProcess | undefined;
+    probeName?: string | undefined;
+    evaluationSummary?: MonitorEvaluationSummary | undefined;
+    maxSizeInBytes?: number | undefined;
+  },
+): MonitorSummarySnapshot | null {
+  return MonitorSummarySnapshotUtil.buildSnapshot({
+    monitorType: monitorType,
+    dataToProcess:
+      overrides && "dataToProcess" in overrides
+        ? overrides.dataToProcess
+        : payloadFor(monitorType),
+    monitorId: MONITOR_ID.toString(),
+    monitorName: "Production API",
+    probeName: overrides?.probeName ?? "US West Probe",
+    evaluationSummary:
+      overrides && "evaluationSummary" in overrides
+        ? overrides.evaluationSummary
+        : EVALUATION_SUMMARY,
+    capturedAt: CAPTURED_AT,
+    maxSizeInBytes: overrides?.maxSizeInBytes,
+  });
+}
+
+describe("MonitorSummarySnapshotUtil - every monitor type is covered", () => {
+  it("has an expected payload slot declared for every MonitorType", () => {
+    /*
+     * A new monitor type added to the enum without a line in
+     * EXPECTED_PAYLOAD_KIND would otherwise silently store nothing and
+     * render a blank card on its incidents.
+     */
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      expect(EXPECTED_PAYLOAD_KIND[monitorType]).toBeDefined();
+    }
+
+    expect(Object.keys(EXPECTED_PAYLOAD_KIND).length).toBe(
+      ALL_MONITOR_TYPES.length,
+    );
+  });
+
+  it("agrees with MonitorTypeHelper about which types are telemetry", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      expect(MonitorTypeHelper.isTelemetryMonitor(monitorType)).toBe(
+        EXPECTED_PAYLOAD_KIND[monitorType] === PayloadKind.Telemetry,
+      );
+    }
+  });
+
+  it("routes every probeable type into probeMonitorResponse", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (!MonitorTypeHelper.isProbableMonitor(monitorType)) {
+        continue;
+      }
+
+      const snapshot: MonitorSummarySnapshot | null = build(monitorType);
+
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.probeMonitorResponse).toBeDefined();
+      expect(snapshot!.serverMonitorResponse).toBeUndefined();
+      expect(snapshot!.incomingMonitorRequest).toBeUndefined();
+      expect(snapshot!.incomingEmailMonitorRequest).toBeUndefined();
+      expect(snapshot!.telemetryMonitorSummary).toBeUndefined();
+    }
+  });
+
+  it("builds a renderable snapshot for every non-manual monitor type", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (monitorType === MonitorType.Manual) {
+        continue;
+      }
+
+      const snapshot: MonitorSummarySnapshot | null = build(monitorType);
+
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.monitorType).toBe(monitorType);
+      expect(MonitorSummarySnapshotUtil.hasRenderableContent(snapshot)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("puts each monitor type's payload in exactly the slot its summary view reads", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (monitorType === MonitorType.Manual) {
+        continue;
+      }
+
+      const snapshot: MonitorSummarySnapshot = build(monitorType)!;
+      const kind: PayloadKind = EXPECTED_PAYLOAD_KIND[monitorType];
+
+      expect(Boolean(snapshot.probeMonitorResponse)).toBe(
+        kind === PayloadKind.Probe,
+      );
+      expect(Boolean(snapshot.serverMonitorResponse)).toBe(
+        kind === PayloadKind.Server,
+      );
+      expect(Boolean(snapshot.incomingMonitorRequest)).toBe(
+        kind === PayloadKind.IncomingRequest,
+      );
+      expect(Boolean(snapshot.incomingEmailMonitorRequest)).toBe(
+        kind === PayloadKind.IncomingEmail,
+      );
+      expect(Boolean(snapshot.telemetryMonitorSummary)).toBe(
+        kind === PayloadKind.Telemetry,
+      );
+    }
+  });
+
+  it("survives a serialize / deserialize round trip for every monitor type", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (monitorType === MonitorType.Manual) {
+        continue;
+      }
+
+      const snapshot: MonitorSummarySnapshot = build(monitorType)!;
+
+      const stored: JSONObject | null =
+        MonitorSummarySnapshotUtil.serialize(snapshot);
+
+      expect(stored).not.toBeNull();
+
+      /*
+       * Through the jsonb column and back over the API - JSON.parse of the
+       * stringified form is what the browser actually receives.
+       */
+      const readBack: MonitorSummarySnapshot | null =
+        MonitorSummarySnapshotUtil.deserialize(
+          JSON.parse(JSON.stringify(stored)) as JSONObject,
+        );
+
+      expect(readBack).not.toBeNull();
+      expect(readBack!.monitorType).toBe(monitorType);
+      expect(readBack!.monitorName).toBe("Production API");
+      expect(
+        readBack!.evaluationSummary?.criteriaResults[0]?.criteriaName,
+      ).toBe("Is Offline");
+    }
+  });
+
+  it("produces SummaryInfo props the matching view can render, for every monitor type", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (monitorType === MonitorType.Manual) {
+        continue;
+      }
+
+      const snapshot: MonitorSummarySnapshot = build(monitorType)!;
+      const props: MonitorSummaryInfoProps =
+        MonitorSummarySnapshotUtil.toSummaryInfoProps(snapshot);
+
+      expect(props.monitorType).toBe(monitorType);
+      expect(props.evaluationSummary).toBeDefined();
+
+      const kind: PayloadKind = EXPECTED_PAYLOAD_KIND[monitorType];
+
+      if (kind === PayloadKind.Probe) {
+        /*
+         * SummaryInfo takes an ARRAY here because a monitor can have
+         * several steps. A snapshot is one check, so it must still be
+         * wrapped - handing the bare object over renders nothing.
+         */
+        expect(props.probeMonitorResponses).toHaveLength(1);
+        // Every probeable leaf view renders a "Probe" info card.
+        expect(props.probeName).toBe("US West Probe");
+      }
+
+      if (kind === PayloadKind.Server) {
+        expect(props.serverMonitorResponse).toBeDefined();
+      }
+
+      if (kind === PayloadKind.IncomingRequest) {
+        expect(props.incomingMonitorRequest).toBeDefined();
+        /*
+         * The live card shows the monitor's current heartbeat time; on a
+         * frozen capture the honest equivalent is when this request was
+         * checked.
+         */
+        expect(props.incomingRequestMonitorHeartbeatCheckedAt).toEqual(
+          CAPTURED_AT,
+        );
+      }
+
+      if (kind === PayloadKind.IncomingEmail) {
+        expect(props.incomingEmailMonitorRequest).toBeDefined();
+        expect(props.incomingEmailMonitorHeartbeatCheckedAt).toEqual(
+          CAPTURED_AT,
+        );
+      }
+
+      if (kind === PayloadKind.Telemetry) {
+        expect(props.telemetryMonitorSummary?.lastCheckedAt).toEqual(
+          CAPTURED_AT,
+        );
+        /*
+         * Never "next check at" - the capture is historical, and a future
+         * check time on a closed incident is a lie.
+         */
+        expect(props.telemetryMonitorSummary?.nextCheckAt).toBeUndefined();
+      }
+    }
+  });
+});
+
+describe("MonitorSummarySnapshotUtil.buildSnapshot", () => {
+  it("stores nothing for a manual monitor, which has no summary card at all", () => {
+    expect(build(MonitorType.Manual)).toBeNull();
+  });
+
+  it("stores nothing when there is neither a payload nor an evaluation to show", () => {
+    expect(
+      build(MonitorType.Website, {
+        dataToProcess: undefined,
+        evaluationSummary: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it("still stores the evaluation log when the payload is missing", () => {
+    /*
+     * "Why did this fire?" is answerable from the criteria evaluation
+     * alone, so a check with no usable response is still worth keeping.
+     */
+    const snapshot: MonitorSummarySnapshot | null = build(MonitorType.Website, {
+      dataToProcess: undefined,
+    });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.probeMonitorResponse).toBeUndefined();
+    expect(snapshot!.evaluationSummary).toBeDefined();
+  });
+
+  it("stamps the version and marks the snapshot as captured", () => {
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Ping)!;
+
+    expect(snapshot.version).toBe(MonitorSummarySnapshotVersion);
+    expect(snapshot.source).toBe(MonitorSummarySnapshotSource.Captured);
+    expect(snapshot.capturedAt).toEqual(CAPTURED_AT);
+    expect(snapshot.monitorId).toBe(MONITOR_ID.toString());
+  });
+
+  it("records the probe id off the check so the capture names its source", () => {
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.API)!;
+
+    expect(snapshot.probeId).toBe(PROBE_ID.toString());
+  });
+
+  it("falls back to the evaluation summary carried on the response itself", () => {
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.API, {
+      dataToProcess: probeResponse({
+        evaluationSummary: EVALUATION_SUMMARY,
+      }),
+      evaluationSummary: undefined,
+    })!;
+
+    expect(snapshot.evaluationSummary?.criteriaResults[0]?.criteriaName).toBe(
+      "Is Offline",
+    );
+  });
+
+  it("drops a payload whose shape does not match the monitor type rather than rendering it as a broken check", () => {
+    /*
+     * A cron re-evaluation or a monitor whose type changed can hand the
+     * wrong payload down. Stuffing a server response into the probe slot
+     * would reach WebsiteMonitorView, which reads fields that are not
+     * there.
+     */
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Website, {
+      dataToProcess: serverResponse(),
+    })!;
+
+    expect(snapshot.probeMonitorResponse).toBeUndefined();
+    // The evaluation log is still worth keeping.
+    expect(snapshot.evaluationSummary).toBeDefined();
+  });
+
+  it("keeps the observed count that tripped a telemetry monitor", () => {
+    const logs: MonitorSummarySnapshot = build(MonitorType.Logs)!;
+    expect(logs.telemetryMonitorSummary?.observedCount).toBe(412);
+    expect(logs.telemetryMonitorSummary?.observedCountTitle).toBe(
+      "Log Records",
+    );
+
+    const traces: MonitorSummarySnapshot = build(MonitorType.Traces)!;
+    expect(traces.telemetryMonitorSummary?.observedCount).toBe(7);
+    expect(traces.telemetryMonitorSummary?.observedCountTitle).toBe("Spans");
+
+    const exceptions: MonitorSummarySnapshot = build(MonitorType.Exceptions)!;
+    expect(exceptions.telemetryMonitorSummary?.observedCount).toBe(3);
+
+    const profiles: MonitorSummarySnapshot = build(MonitorType.Profiles)!;
+    expect(profiles.telemetryMonitorSummary?.observedCount).toBe(11);
+  });
+
+  it("leaves the observed count unset for metric monitors, which aggregate a series instead of counting rows", () => {
+    const metrics: MonitorSummarySnapshot = build(MonitorType.Metrics)!;
+
+    expect(metrics.telemetryMonitorSummary?.monitoredAt).toEqual(CAPTURED_AT);
+    expect(metrics.telemetryMonitorSummary?.observedCount).toBeUndefined();
+  });
+
+  it("captures a zero observed count rather than treating it as missing", () => {
+    /*
+     * "0 logs matched" is exactly what a log-absence criteria fires on, so
+     * a falsy-check here would blank the one number that explains it.
+     */
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Logs, {
+      dataToProcess: {
+        projectId: PROJECT_ID,
+        monitorId: MONITOR_ID,
+        logCount: 0,
+      } as unknown as MonitorSummaryDataToProcess,
+    })!;
+
+    expect(snapshot.telemetryMonitorSummary?.observedCount).toBe(0);
+  });
+});
+
+describe("MonitorSummarySnapshotUtil size budget", () => {
+  function screenshotResponse(
+    sizeInChars: number,
+  ): MonitorSummaryDataToProcess {
+    return probeResponse({
+      syntheticMonitorResponse: [
+        {
+          browserType: "Chromium",
+          screenSizeType: "Desktop",
+          result: undefined,
+          logMessages: [],
+          capturedMetrics: [],
+          executionTimeInMS: 900,
+          screenshots: {
+            "home-page": "A".repeat(sizeInChars),
+          },
+        },
+      ],
+    });
+  }
+
+  it("keeps synthetic screenshots when the capture fits", () => {
+    const snapshot: MonitorSummarySnapshot = build(
+      MonitorType.SyntheticMonitor,
+      {
+        dataToProcess: screenshotResponse(100),
+      },
+    )!;
+
+    expect(
+      snapshot.probeMonitorResponse?.syntheticMonitorResponse?.[0]?.screenshots,
+    ).toBeDefined();
+    expect(snapshot.areScreenshotsOmitted).toBeFalsy();
+  });
+
+  it("drops synthetic screenshots - and says so - rather than storing a multi-megabyte row", () => {
+    const snapshot: MonitorSummarySnapshot = build(
+      MonitorType.SyntheticMonitor,
+      {
+        dataToProcess: screenshotResponse(5000),
+        maxSizeInBytes: 2000,
+      },
+    )!;
+
+    expect(
+      snapshot.probeMonitorResponse?.syntheticMonitorResponse?.[0]?.screenshots,
+    ).toBeUndefined();
+    expect(snapshot.areScreenshotsOmitted).toBe(true);
+
+    // Everything else about the check has to survive the shed.
+    expect(
+      snapshot.probeMonitorResponse?.syntheticMonitorResponse?.[0]
+        ?.executionTimeInMS,
+    ).toBe(900);
+    expect(snapshot.evaluationSummary).toBeDefined();
+  });
+
+  it("truncates an oversized response body once there are no screenshots left to shed", () => {
+    const bodyLength: number = MonitorSummaryResponseBodyMaxLengthInChars + 500;
+
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Website, {
+      dataToProcess: probeResponse({
+        responseBody: "B".repeat(bodyLength),
+      }),
+      maxSizeInBytes: 2000,
+    })!;
+
+    expect(snapshot.isResponseBodyTruncated).toBe(true);
+    expect((snapshot.probeMonitorResponse?.responseBody as string).length).toBe(
+      MonitorSummaryResponseBodyMaxLengthInChars,
+    );
+    // The head is kept, because that is where an error page's message is.
+    expect(
+      (snapshot.probeMonitorResponse?.responseBody as string).startsWith("BBB"),
+    ).toBe(true);
+  });
+
+  it("leaves a response body that is already under the cap alone", () => {
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Website, {
+      dataToProcess: probeResponse({ responseBody: "Service Unavailable" }),
+      maxSizeInBytes: 10,
+    })!;
+
+    expect(snapshot.isResponseBodyTruncated).toBeFalsy();
+    expect(snapshot.probeMonitorResponse?.responseBody).toBe(
+      "Service Unavailable",
+    );
+  });
+
+  it("keeps an oversized capture rather than storing nothing when there is nothing safe to shed", () => {
+    const snapshot: MonitorSummarySnapshot | null = build(MonitorType.Ping, {
+      maxSizeInBytes: 1,
+    });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.probeMonitorResponse).toBeDefined();
+  });
+});
+
+describe("MonitorSummarySnapshotUtil.deserialize", () => {
+  it("returns null for a missing column, so the reader can fall back to the legacy log", () => {
+    expect(MonitorSummarySnapshotUtil.deserialize(undefined)).toBeNull();
+    expect(MonitorSummarySnapshotUtil.deserialize(null)).toBeNull();
+    expect(MonitorSummarySnapshotUtil.deserialize({})).toBeNull();
+  });
+
+  it("refuses a snapshot written by a future version instead of half-rendering it", () => {
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Ping)!;
+    const stored: JSONObject = MonitorSummarySnapshotUtil.serialize(snapshot)!;
+
+    stored["version"] = MonitorSummarySnapshotVersion + 1;
+
+    expect(MonitorSummarySnapshotUtil.deserialize(stored)).toBeNull();
+  });
+
+  it("restores dates as Dates, not as the strings jsonb hands back", () => {
+    const snapshot: MonitorSummarySnapshot = build(MonitorType.Website)!;
+    const stored: JSONObject = JSON.parse(
+      JSON.stringify(MonitorSummarySnapshotUtil.serialize(snapshot)),
+    ) as JSONObject;
+
+    const readBack: MonitorSummarySnapshot =
+      MonitorSummarySnapshotUtil.deserialize(stored)!;
+
+    expect(readBack.capturedAt instanceof Date).toBe(true);
+    expect(readBack.capturedAt!.getTime()).toBe(CAPTURED_AT.getTime());
+  });
+});
+
+describe("MonitorSummarySnapshotUtil.serialize", () => {
+  it("returns null for nothing to store, so the column is left NULL", () => {
+    expect(MonitorSummarySnapshotUtil.serialize(null)).toBeNull();
+    expect(MonitorSummarySnapshotUtil.serialize(undefined)).toBeNull();
+  });
+});
+
+describe("MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog", () => {
+  /*
+   * Incidents and alerts created before the snapshot column existed. Their
+   * createdStateLog holds the same evaluated payload, written with a plain
+   * JSON.stringify - so its dates are ISO strings and its ObjectIDs are
+   * flattened. Reconstructing from it is what stops every pre-existing
+   * incident from showing a blank card.
+   */
+  function legacyLog(payload: MonitorSummaryDataToProcess): JSONObject {
+    return JSON.parse(JSON.stringify(payload)) as JSONObject;
+  }
+
+  it("reconstructs a probe check from the stored state log", () => {
+    const snapshot: MonitorSummarySnapshot | null =
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: legacyLog(probeResponse()),
+        monitorType: MonitorType.Website,
+        monitorId: MONITOR_ID.toString(),
+        monitorName: "Production API",
+        capturedAt: CAPTURED_AT,
+      });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.probeMonitorResponse?.responseCode).toBe(503);
+    expect(snapshot!.source).toBe(MonitorSummarySnapshotSource.Legacy);
+  });
+
+  it("reconstructs every non-manual monitor type from its own state log", () => {
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (monitorType === MonitorType.Manual) {
+        continue;
+      }
+
+      const payload: MonitorSummaryDataToProcess | undefined =
+        payloadFor(monitorType);
+
+      const snapshot: MonitorSummarySnapshot | null =
+        MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+          createdStateLog: legacyLog(payload!),
+          monitorType: monitorType,
+          capturedAt: CAPTURED_AT,
+        });
+
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.monitorType).toBe(monitorType);
+      expect(snapshot!.source).toBe(MonitorSummarySnapshotSource.Legacy);
+    }
+  });
+
+  it("recovers the evaluation summary that the state log embedded", () => {
+    /*
+     * dataToProcess.evaluationSummary is the same object the pipeline
+     * mutates, so the old JSON.stringify dump already carries the criteria
+     * results - the reconstruction must not throw them away.
+     */
+    const snapshot: MonitorSummarySnapshot | null =
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: legacyLog(
+          probeResponse({ evaluationSummary: EVALUATION_SUMMARY }),
+        ),
+        monitorType: MonitorType.API,
+      });
+
+    expect(snapshot!.evaluationSummary?.criteriaResults[0]?.criteriaName).toBe(
+      "Is Offline",
+    );
+  });
+
+  it("gives up rather than guessing when the monitor type is unknown", () => {
+    /*
+     * The monitor was deleted, or the viewer cannot read it. Guessing a
+     * type would route the payload into the wrong view.
+     */
+    expect(
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: legacyLog(probeResponse()),
+        monitorType: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it("gives up when there is no state log to reconstruct from", () => {
+    expect(
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: undefined,
+        monitorType: MonitorType.Website,
+      }),
+    ).toBeNull();
+
+    expect(
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: null,
+        monitorType: MonitorType.Website,
+      }),
+    ).toBeNull();
+  });
+
+  it("has no probe name to recover, because the old log never carried one", () => {
+    const snapshot: MonitorSummarySnapshot | null =
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: legacyLog(probeResponse()),
+        monitorType: MonitorType.Ping,
+      });
+
+    expect(snapshot!.probeName).toBeUndefined();
+    // The probe id is on the response itself, so that much does survive.
+    expect(snapshot!.probeId).toBe(PROBE_ID.toString());
+  });
+
+  it("stores nothing for a manual monitor's state log", () => {
+    expect(
+      MonitorSummarySnapshotUtil.fromLegacyCreatedStateLog({
+        createdStateLog: legacyLog(probeResponse()),
+        monitorType: MonitorType.Manual,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("MonitorSummarySnapshotUtil.hasRenderableContent", () => {
+  it("is false for nothing at all", () => {
+    expect(MonitorSummarySnapshotUtil.hasRenderableContent(null)).toBe(false);
+    expect(MonitorSummarySnapshotUtil.hasRenderableContent(undefined)).toBe(
+      false,
+    );
+  });
+
+  it("is false for a snapshot that carries only its own type stamp", () => {
+    expect(
+      MonitorSummarySnapshotUtil.hasRenderableContent({
+        version: MonitorSummarySnapshotVersion,
+        source: MonitorSummarySnapshotSource.Captured,
+        monitorType: MonitorType.Website,
+        capturedAt: CAPTURED_AT,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when only the evaluation log survived", () => {
+    expect(
+      MonitorSummarySnapshotUtil.hasRenderableContent({
+        version: MonitorSummarySnapshotVersion,
+        source: MonitorSummarySnapshotSource.Captured,
+        monitorType: MonitorType.Website,
+        capturedAt: CAPTURED_AT,
+        evaluationSummary: EVALUATION_SUMMARY,
+      }),
+    ).toBe(true);
+  });
+});

--- a/Common/Types/Monitor/MonitorSummarySnapshot.ts
+++ b/Common/Types/Monitor/MonitorSummarySnapshot.ts
@@ -1,0 +1,88 @@
+import ProbeMonitorResponse from "../Probe/ProbeMonitorResponse";
+import IncomingEmailMonitorRequest from "./IncomingEmailMonitor/IncomingEmailMonitorRequest";
+import IncomingMonitorRequest from "./IncomingMonitor/IncomingMonitorRequest";
+import MonitorEvaluationSummary from "./MonitorEvaluationSummary";
+import MonitorType from "./MonitorType";
+import ServerMonitorResponse from "./ServerMonitor/ServerMonitorResponse";
+
+/*
+ * A frozen copy of the "Monitor Summary" card, taken at the moment a
+ * monitor's criteria opened an incident or an alert.
+ *
+ * The monitor page renders that card from live data - the probe's last
+ * monitoring log, the server agent's last push, the monitor's incoming
+ * request. All of that ages out (MonitorLog rows have a ClickHouse
+ * retention, MonitorProbe.lastMonitoringLog is overwritten on the next
+ * check), so an incident opened last quarter has no way to show what the
+ * monitor actually saw. Storing the snapshot on the incident/alert row is
+ * what makes "why did this fire?" answerable after the evidence is gone.
+ *
+ * Everything here must survive a JSON round-trip through a jsonb column,
+ * so it holds only plain data - no database models, no class instances
+ * beyond the ones JSONFunctions.serialize already knows how to encode.
+ */
+
+/*
+ * Telemetry monitors (logs / metrics / traces / exceptions / profiles and
+ * the infrastructure types built on them) have no per-probe check log to
+ * capture. What they do have is the moment of evaluation and the count
+ * the criteria was evaluated against, which is the useful half of the
+ * live card plus the number that actually tripped it.
+ */
+export interface MonitorSummaryTelemetrySnapshot {
+  monitoredAt?: Date | undefined;
+  // e.g. 412 log records, 3 spans, 7 exceptions. Undefined for metric monitors.
+  observedCount?: number | undefined;
+  // What observedCount counts: "Logs", "Spans", "Exceptions", "Profiles".
+  observedCountTitle?: string | undefined;
+}
+
+export enum MonitorSummarySnapshotSource {
+  // Captured at incident/alert creation by the monitor evaluation pipeline.
+  Captured = "Captured",
+  /*
+   * Reconstructed on read from the incident's createdStateLog, for rows
+   * created before the snapshot column existed. Best-effort: it has no
+   * probe name and no monitor name, because those were never in the log.
+   */
+  Legacy = "Legacy",
+}
+
+export const MonitorSummarySnapshotVersion: number = 1;
+
+export default interface MonitorSummarySnapshot {
+  /*
+   * Bumped when the shape changes incompatibly. Readers that do not
+   * understand a version render nothing rather than guessing.
+   */
+  version: number;
+  source: MonitorSummarySnapshotSource;
+  monitorType: MonitorType;
+  monitorId?: string | undefined;
+  monitorName?: string | undefined;
+  capturedAt?: Date | undefined;
+
+  // Which probe produced the check below. Probeable monitor types only.
+  probeId?: string | undefined;
+  probeName?: string | undefined;
+
+  // Exactly one of these is set, chosen by monitorType.
+  probeMonitorResponse?: ProbeMonitorResponse | undefined;
+  serverMonitorResponse?: ServerMonitorResponse | undefined;
+  incomingMonitorRequest?: IncomingMonitorRequest | undefined;
+  incomingEmailMonitorRequest?: IncomingEmailMonitorRequest | undefined;
+  telemetryMonitorSummary?: MonitorSummaryTelemetrySnapshot | undefined;
+
+  // The criteria evaluation that decided to open this incident / alert.
+  evaluationSummary?: MonitorEvaluationSummary | undefined;
+
+  /*
+   * Set when the synthetic-monitor screenshots were stripped to keep the
+   * stored row within MonitorSummarySnapshotUtil's size budget. The view
+   * says so rather than silently showing a check with no screenshots.
+   */
+  areScreenshotsOmitted?: boolean | undefined;
+
+  // Same idea for an oversized Website / API response body.
+  isResponseBodyTruncated?: boolean | undefined;
+}

--- a/Common/Utils/Monitor/MonitorSummarySnapshotUtil.ts
+++ b/Common/Utils/Monitor/MonitorSummarySnapshotUtil.ts
@@ -1,0 +1,593 @@
+import { JSONObject } from "../../Types/JSON";
+import JSONFunctions from "../../Types/JSONFunctions";
+import ExceptionMonitorResponse from "../../Types/Monitor/ExceptionMonitor/ExceptionMonitorResponse";
+import IncomingEmailMonitorRequest from "../../Types/Monitor/IncomingEmailMonitor/IncomingEmailMonitorRequest";
+import IncomingMonitorRequest from "../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
+import LogMonitorResponse from "../../Types/Monitor/LogMonitor/LogMonitorResponse";
+import MetricMonitorResponse from "../../Types/Monitor/MetricMonitor/MetricMonitorResponse";
+import MonitorEvaluationSummary from "../../Types/Monitor/MonitorEvaluationSummary";
+import MonitorSummarySnapshot, {
+  MonitorSummarySnapshotSource,
+  MonitorSummarySnapshotVersion,
+  MonitorSummaryTelemetrySnapshot,
+} from "../../Types/Monitor/MonitorSummarySnapshot";
+import MonitorType, {
+  MonitorTypeHelper,
+} from "../../Types/Monitor/MonitorType";
+import ProfileMonitorResponse from "../../Types/Monitor/ProfileMonitor/ProfileMonitorResponse";
+import ServerMonitorResponse from "../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
+import SyntheticMonitorResponse from "../../Types/Monitor/SyntheticMonitors/SyntheticMonitorResponse";
+import TraceMonitorResponse from "../../Types/Monitor/TraceMonitor/TraceMonitorResponse";
+import ProbeMonitorResponse from "../../Types/Probe/ProbeMonitorResponse";
+
+/*
+ * Builds and reads the frozen "Monitor Summary" stored on an incident or
+ * an alert (see Common/Types/Monitor/MonitorSummarySnapshot).
+ *
+ * Deliberately pure and free of database / React imports: the monitor
+ * evaluation pipeline calls buildSnapshot on the server, and the incident
+ * and alert pages call toSummaryInfoProps in the browser. Keeping the
+ * per-monitor-type routing in one tested place is what stops the two ends
+ * from disagreeing about where a Ping check lives in the payload.
+ */
+
+/*
+ * Mirrors Common/Server/Utils/Monitor/DataToProcess, which cannot be
+ * imported here - it is server-side and this module is bundled into the
+ * dashboard. Kept structurally identical so a mismatch is a compile error
+ * at the call site rather than a silent `any`.
+ */
+export type MonitorSummaryDataToProcess =
+  | ProbeMonitorResponse
+  | IncomingMonitorRequest
+  | IncomingEmailMonitorRequest
+  | ServerMonitorResponse
+  | LogMonitorResponse
+  | TraceMonitorResponse
+  | MetricMonitorResponse
+  | ExceptionMonitorResponse
+  | ProfileMonitorResponse;
+
+/*
+ * The props the dashboard's SummaryInfo component takes. Declared here
+ * (rather than imported from App) so the mapping can be unit-tested
+ * without pulling React in.
+ */
+export interface MonitorSummaryInfoProps {
+  monitorType: MonitorType;
+  probeName?: string | undefined;
+  probeMonitorResponses?: Array<ProbeMonitorResponse> | undefined;
+  incomingMonitorRequest?: IncomingMonitorRequest | undefined;
+  incomingRequestMonitorHeartbeatCheckedAt?: Date | undefined;
+  incomingEmailMonitorRequest?: IncomingEmailMonitorRequest | undefined;
+  incomingEmailMonitorHeartbeatCheckedAt?: Date | undefined;
+  serverMonitorResponse?: ServerMonitorResponse | undefined;
+  /*
+   * Structurally identical to App/.../SummaryView/Types/TelemetryMonitorSummary,
+   * which lives in App and so cannot be imported here.
+   */
+  telemetryMonitorSummary?:
+    | { lastCheckedAt?: Date | undefined; nextCheckAt?: Date | undefined }
+    | undefined;
+  evaluationSummary?: MonitorEvaluationSummary | undefined;
+}
+
+/*
+ * Synthetic monitors carry base64 screenshots, one per browser × screen
+ * size, and a single check can run to several megabytes. createdStateLog
+ * already stores them unbounded; this column will not. Past the budget we
+ * drop the screenshots (the largest thing by far) and flag it, so the row
+ * stays a sane size and the view can say why the images are missing.
+ */
+export const MonitorSummarySnapshotMaxSizeInBytes: number = 1024 * 1024;
+
+/*
+ * How much of an oversized response body to keep. The head is where an
+ * error page's title and message live, which is what a summary is for.
+ */
+export const MonitorSummaryResponseBodyMaxLengthInChars: number = 64 * 1024;
+
+export default class MonitorSummarySnapshotUtil {
+  /*
+   * Capture the summary for a monitor evaluation that just opened an
+   * incident or an alert. Returns null when there is nothing worth
+   * storing - a Manual monitor (which has no summary card at all) or an
+   * evaluation with no data and no criteria results behind it.
+   */
+  public static buildSnapshot(data: {
+    monitorType: MonitorType;
+    dataToProcess?: MonitorSummaryDataToProcess | undefined;
+    monitorId?: string | undefined;
+    monitorName?: string | undefined;
+    probeName?: string | undefined;
+    evaluationSummary?: MonitorEvaluationSummary | undefined;
+    capturedAt: Date;
+    maxSizeInBytes?: number | undefined;
+  }): MonitorSummarySnapshot | null {
+    if (!data.monitorType) {
+      return null;
+    }
+
+    /*
+     * Manual monitors never evaluate anything, and Summary.tsx renders
+     * nothing for them. Storing an empty shell would only put an empty
+     * card on the incident page.
+     */
+    if (MonitorTypeHelper.isManualMonitor(data.monitorType)) {
+      return null;
+    }
+
+    const snapshot: MonitorSummarySnapshot = {
+      version: MonitorSummarySnapshotVersion,
+      source: MonitorSummarySnapshotSource.Captured,
+      monitorType: data.monitorType,
+      capturedAt: data.capturedAt,
+    };
+
+    if (data.monitorId) {
+      snapshot.monitorId = data.monitorId;
+    }
+
+    if (data.monitorName) {
+      snapshot.monitorName = data.monitorName;
+    }
+
+    if (data.probeName) {
+      snapshot.probeName = data.probeName;
+    }
+
+    this.attachResponse({
+      snapshot,
+      monitorType: data.monitorType,
+      dataToProcess: data.dataToProcess,
+      capturedAt: data.capturedAt,
+    });
+
+    /*
+     * The criteria evaluation is the "why". Prefer the one handed in by
+     * the pipeline (it is the live object the incident was decided from)
+     * and fall back to the copy the response carries.
+     */
+    const evaluationSummary: MonitorEvaluationSummary | undefined =
+      data.evaluationSummary ||
+      (data.dataToProcess as ProbeMonitorResponse | undefined)
+        ?.evaluationSummary;
+
+    if (evaluationSummary) {
+      snapshot.evaluationSummary = evaluationSummary;
+    }
+
+    if (!this.hasAnyContent(snapshot)) {
+      return null;
+    }
+
+    return this.enforceSizeBudget({
+      snapshot,
+      maxSizeInBytes:
+        data.maxSizeInBytes ?? MonitorSummarySnapshotMaxSizeInBytes,
+    });
+  }
+
+  /*
+   * Route the evaluated payload into the one slot its monitor type reads
+   * from. monitorType is authoritative - it is the monitor's own column,
+   * not something inferred from the payload - but each branch still
+   * sanity-checks the shape so a mismatched payload (a cron re-evaluation
+   * handing a telemetry response to a probeable monitor, say) is dropped
+   * instead of rendering as a broken check.
+   */
+  private static attachResponse(data: {
+    snapshot: MonitorSummarySnapshot;
+    monitorType: MonitorType;
+    dataToProcess?: MonitorSummaryDataToProcess | undefined;
+    capturedAt: Date;
+  }): void {
+    const { snapshot, monitorType, dataToProcess } = data;
+
+    if (MonitorTypeHelper.isTelemetryMonitor(monitorType)) {
+      snapshot.telemetryMonitorSummary = this.buildTelemetrySummary({
+        monitorType,
+        dataToProcess,
+        capturedAt: data.capturedAt,
+      });
+      return;
+    }
+
+    if (monitorType === MonitorType.Server) {
+      if (this.isServerMonitorResponse(dataToProcess)) {
+        snapshot.serverMonitorResponse = dataToProcess as ServerMonitorResponse;
+      }
+      return;
+    }
+
+    if (monitorType === MonitorType.IncomingRequest) {
+      if (this.isIncomingMonitorRequest(dataToProcess)) {
+        snapshot.incomingMonitorRequest =
+          dataToProcess as IncomingMonitorRequest;
+      }
+      return;
+    }
+
+    if (monitorType === MonitorType.IncomingEmail) {
+      if (this.isIncomingEmailMonitorRequest(dataToProcess)) {
+        snapshot.incomingEmailMonitorRequest =
+          dataToProcess as IncomingEmailMonitorRequest;
+      }
+      return;
+    }
+
+    /*
+     * Everything else is served by a probe check: every probeable type,
+     * plus Network Device, whose SNMP walk and trap results arrive as a
+     * ProbeMonitorResponse even though the type is not "probeable" (its
+     * schedule belongs to the device, not to a MonitorProbe row).
+     */
+    if (this.isProbeMonitorResponse(dataToProcess)) {
+      const probeMonitorResponse: ProbeMonitorResponse =
+        dataToProcess as ProbeMonitorResponse;
+
+      snapshot.probeMonitorResponse = probeMonitorResponse;
+
+      if (probeMonitorResponse.probeId) {
+        snapshot.probeId = probeMonitorResponse.probeId.toString();
+      }
+    }
+  }
+
+  private static buildTelemetrySummary(data: {
+    monitorType: MonitorType;
+    dataToProcess?: MonitorSummaryDataToProcess | undefined;
+    capturedAt: Date;
+  }): MonitorSummaryTelemetrySnapshot {
+    const summary: MonitorSummaryTelemetrySnapshot = {
+      monitoredAt: data.capturedAt,
+    };
+
+    const payload: JSONObject = (data.dataToProcess || {}) as JSONObject;
+
+    /*
+     * The count the criteria was evaluated against. Metric monitors have
+     * no single count (they aggregate a series), so they get the
+     * evaluation log alone - which is where their numbers already live.
+     */
+    const counts: Array<{ key: string; title: string }> = [
+      { key: "logCount", title: "Log Records" },
+      { key: "spanCount", title: "Spans" },
+      { key: "exceptionCount", title: "Exceptions" },
+      { key: "profileCount", title: "Profiles" },
+    ];
+
+    for (const count of counts) {
+      if (typeof payload[count.key] === "number") {
+        summary.observedCount = payload[count.key] as number;
+        summary.observedCountTitle = count.title;
+        break;
+      }
+    }
+
+    return summary;
+  }
+
+  /*
+   * A snapshot with nothing but its own type stamp helps nobody - the
+   * card would render an empty "no summary available" box on an incident
+   * that plainly had a cause. Storing null instead lets the read path
+   * fall back to the legacy createdStateLog reconstruction.
+   */
+  private static hasAnyContent(snapshot: MonitorSummarySnapshot): boolean {
+    return Boolean(
+      snapshot.probeMonitorResponse ||
+        snapshot.serverMonitorResponse ||
+        snapshot.incomingMonitorRequest ||
+        snapshot.incomingEmailMonitorRequest ||
+        snapshot.telemetryMonitorSummary ||
+        snapshot.evaluationSummary,
+    );
+  }
+
+  /*
+   * Keep the stored jsonb bounded. Only synthetic / custom-code checks
+   * can realistically blow the budget, and only because of their base64
+   * screenshots, so that is the one thing we drop. Everything else - the
+   * script logs, the captured metrics, the evaluation log - is small and
+   * is exactly what someone reading an old incident needs.
+   */
+  private static enforceSizeBudget(data: {
+    snapshot: MonitorSummarySnapshot;
+    maxSizeInBytes: number;
+  }): MonitorSummarySnapshot {
+    const { snapshot, maxSizeInBytes } = data;
+
+    if (maxSizeInBytes <= 0) {
+      return snapshot;
+    }
+
+    if (this.getApproximateSizeInBytes(snapshot) <= maxSizeInBytes) {
+      return snapshot;
+    }
+
+    const syntheticResponses: Array<SyntheticMonitorResponse> | undefined =
+      snapshot.probeMonitorResponse?.syntheticMonitorResponse;
+
+    if (syntheticResponses && syntheticResponses.length > 0) {
+      snapshot.probeMonitorResponse = {
+        ...(snapshot.probeMonitorResponse as ProbeMonitorResponse),
+        syntheticMonitorResponse: syntheticResponses.map(
+          (response: SyntheticMonitorResponse): SyntheticMonitorResponse => {
+            const withoutScreenshots: SyntheticMonitorResponse = {
+              ...response,
+            };
+            delete withoutScreenshots.screenshots;
+            return withoutScreenshots;
+          },
+        ),
+      };
+
+      snapshot.areScreenshotsOmitted = true;
+
+      if (this.getApproximateSizeInBytes(snapshot) <= maxSizeInBytes) {
+        return snapshot;
+      }
+    }
+
+    /*
+     * Second largest payload after screenshots: the response body of a
+     * Website / API check against a big HTML page. Keep the head of it -
+     * that is where the error page's title and message are - and say it
+     * was cut.
+     */
+    const responseBody: string | JSONObject | undefined =
+      snapshot.probeMonitorResponse?.responseBody;
+
+    if (
+      typeof responseBody === "string" &&
+      responseBody.length > MonitorSummaryResponseBodyMaxLengthInChars
+    ) {
+      snapshot.probeMonitorResponse = {
+        ...(snapshot.probeMonitorResponse as ProbeMonitorResponse),
+        responseBody: responseBody.slice(
+          0,
+          MonitorSummaryResponseBodyMaxLengthInChars,
+        ),
+      };
+
+      snapshot.isResponseBodyTruncated = true;
+    }
+
+    /*
+     * Still over budget with nothing safe left to shed. Keep it: an
+     * oversized-but-complete summary is still better than none, and jsonb
+     * tolerates it.
+     */
+    return snapshot;
+  }
+
+  private static getApproximateSizeInBytes(
+    snapshot: MonitorSummarySnapshot,
+  ): number {
+    try {
+      return JSON.stringify(snapshot).length;
+    } catch {
+      /*
+       * A payload we cannot stringify cannot be stored either. Report it
+       * as infinitely large so the caller sheds what it can; the write
+       * itself is guarded by serialize() below.
+       */
+      return Number.MAX_SAFE_INTEGER;
+    }
+  }
+
+  /*
+   * Encode for the jsonb column. Dates and ObjectIDs inside the payload
+   * are wrapped by JSONFunctions so they come back as the same types on
+   * read, the way telemetryQuery already round-trips.
+   */
+  public static serialize(
+    snapshot: MonitorSummarySnapshot | null | undefined,
+  ): JSONObject | null {
+    if (!snapshot) {
+      return null;
+    }
+
+    return JSONFunctions.serialize(snapshot as unknown as JSONObject);
+  }
+
+  /*
+   * Read a stored snapshot back. Returns null for anything this build
+   * does not understand rather than rendering a half-decoded card.
+   */
+  public static deserialize(
+    stored: JSONObject | null | undefined,
+  ): MonitorSummarySnapshot | null {
+    if (!stored || typeof stored !== "object") {
+      return null;
+    }
+
+    const snapshot: MonitorSummarySnapshot = JSONFunctions.deserialize(
+      stored,
+    ) as unknown as MonitorSummarySnapshot;
+
+    if (!snapshot || !snapshot.monitorType) {
+      return null;
+    }
+
+    if (snapshot.version !== MonitorSummarySnapshotVersion) {
+      return null;
+    }
+
+    return snapshot;
+  }
+
+  /*
+   * Best-effort reconstruction for incidents and alerts created before
+   * this column existed. createdStateLog is the same evaluated payload,
+   * just untyped and without the monitor type - which the caller supplies
+   * from the monitor the incident is attached to.
+   *
+   * It cannot recover the probe name (never stored) and it is only as
+   * good as the monitor's type *today*, so a monitor whose type changed
+   * gets nothing useful. That is why new rows carry a real snapshot; this
+   * is purely so existing incidents are not blank.
+   */
+  public static fromLegacyCreatedStateLog(data: {
+    createdStateLog?: JSONObject | null | undefined;
+    monitorType?: MonitorType | undefined;
+    monitorId?: string | undefined;
+    monitorName?: string | undefined;
+    capturedAt?: Date | undefined;
+  }): MonitorSummarySnapshot | null {
+    if (!data.monitorType || !data.createdStateLog) {
+      return null;
+    }
+
+    if (typeof data.createdStateLog !== "object") {
+      return null;
+    }
+
+    /*
+     * createdStateLog was written with a plain JSON.stringify, so its
+     * dates are ISO strings and its ObjectIDs are already flattened.
+     * deserialize() restores whatever JSONFunctions can recognise and
+     * leaves the rest as-is, which the views render fine.
+     */
+    const dataToProcess: MonitorSummaryDataToProcess =
+      JSONFunctions.deserialize(
+        data.createdStateLog,
+      ) as unknown as MonitorSummaryDataToProcess;
+
+    const snapshot: MonitorSummarySnapshot | null = this.buildSnapshot({
+      monitorType: data.monitorType,
+      dataToProcess: dataToProcess,
+      monitorId: data.monitorId,
+      monitorName: data.monitorName,
+      capturedAt: data.capturedAt || new Date(),
+    });
+
+    if (!snapshot) {
+      return null;
+    }
+
+    snapshot.source = MonitorSummarySnapshotSource.Legacy;
+
+    return snapshot;
+  }
+
+  /*
+   * Map a snapshot onto the props the dashboard's SummaryInfo component
+   * already takes, so the incident and alert pages render the exact same
+   * per-monitor-type views as the monitor page. Every monitor type goes
+   * through here, telemetry included - one render path means a new leaf
+   * view added to SummaryInfo shows up on incidents for free.
+   */
+  public static toSummaryInfoProps(
+    snapshot: MonitorSummarySnapshot,
+  ): MonitorSummaryInfoProps {
+    const props: MonitorSummaryInfoProps = {
+      monitorType: snapshot.monitorType,
+    };
+
+    if (snapshot.probeName) {
+      props.probeName = snapshot.probeName;
+    }
+
+    if (snapshot.probeMonitorResponse) {
+      props.probeMonitorResponses = [snapshot.probeMonitorResponse];
+    }
+
+    if (snapshot.serverMonitorResponse) {
+      props.serverMonitorResponse = snapshot.serverMonitorResponse;
+    }
+
+    if (snapshot.incomingMonitorRequest) {
+      props.incomingMonitorRequest = snapshot.incomingMonitorRequest;
+      /*
+       * The live card shows the monitor's current heartbeat time. On a
+       * capture the equivalent is when this very request was checked.
+       */
+      props.incomingRequestMonitorHeartbeatCheckedAt =
+        snapshot.incomingMonitorRequest.checkedAt;
+    }
+
+    if (snapshot.incomingEmailMonitorRequest) {
+      props.incomingEmailMonitorRequest = snapshot.incomingEmailMonitorRequest;
+      props.incomingEmailMonitorHeartbeatCheckedAt =
+        snapshot.incomingEmailMonitorRequest.checkedAt;
+    }
+
+    if (snapshot.telemetryMonitorSummary) {
+      /*
+       * Only "monitored at". The live card's companion field is "next
+       * check at", which has no meaning on a frozen capture, and
+       * TelemetryMonitorView already renders "-" for a missing one.
+       */
+      props.telemetryMonitorSummary = {
+        lastCheckedAt: snapshot.telemetryMonitorSummary.monitoredAt,
+      };
+    }
+
+    if (snapshot.evaluationSummary) {
+      props.evaluationSummary = snapshot.evaluationSummary;
+    }
+
+    return props;
+  }
+
+  /*
+   * Does this snapshot have anything to put on screen? A capture whose
+   * payload was dropped (a shape mismatch, a monitor with no check data)
+   * still carries the evaluation log, which is worth showing on its own.
+   */
+  public static hasRenderableContent(
+    snapshot: MonitorSummarySnapshot | null | undefined,
+  ): boolean {
+    if (!snapshot) {
+      return false;
+    }
+
+    return this.hasAnyContent(snapshot);
+  }
+
+  private static isProbeMonitorResponse(
+    data: MonitorSummaryDataToProcess | undefined,
+  ): boolean {
+    if (!data || typeof data !== "object") {
+      return false;
+    }
+
+    /*
+     * monitorStepId is the field only a probe check has - every probe
+     * response is scoped to the monitor step it ran.
+     */
+    return Boolean((data as ProbeMonitorResponse).monitorStepId);
+  }
+
+  private static isServerMonitorResponse(
+    data: MonitorSummaryDataToProcess | undefined,
+  ): boolean {
+    if (!data || typeof data !== "object") {
+      return false;
+    }
+
+    return Boolean((data as ServerMonitorResponse).requestReceivedAt);
+  }
+
+  private static isIncomingMonitorRequest(
+    data: MonitorSummaryDataToProcess | undefined,
+  ): boolean {
+    if (!data || typeof data !== "object") {
+      return false;
+    }
+
+    return Boolean((data as IncomingMonitorRequest).incomingRequestReceivedAt);
+  }
+
+  private static isIncomingEmailMonitorRequest(
+    data: MonitorSummaryDataToProcess | undefined,
+  ): boolean {
+    if (!data || typeof data !== "object") {
+      return false;
+    }
+
+    return Boolean((data as IncomingEmailMonitorRequest).emailReceivedAt);
+  }
+}


### PR DESCRIPTION
## Problem

When a monitor trips (a Synthetic Monitor, say) it opens an incident or an alert — but the incident/alert page said nothing about **what the monitor actually saw**. The "Monitor Summary" card lived only on the monitor page.

Worse, that card is fed by live data which does not last:

- `MonitorLog` rows are dropped by a ClickHouse TTL that defaults to **one day** (`GlobalConfig.monitorLogRetentionInDays`).
- `MonitorProbe.lastMonitoringLog` is overwritten by the very next check.

So an incident older than a day had no recoverable evidence anywhere.

## What this does

Freezes the summary onto the incident / alert row at creation time, and renders it back on both pages through the **same per-monitor-type views the monitor page already uses** — so a leaf view added to `SummaryInfo` shows up on incidents for free.

Works for **all 31 monitor types**.

### Shared type + pure util — `Common`

- `Common/Types/Monitor/MonitorSummarySnapshot.ts` — a serializable capture: the monitor type, the check payload, the criteria evaluation, the probe that ran it, and when it was taken.
- `Common/Utils/Monitor/MonitorSummarySnapshotUtil.ts` — routes the evaluated payload into the one slot its monitor type reads from, and maps a stored snapshot back onto `SummaryInfo`'s props. Pure (no DB, no React) so the server pipeline and the dashboard share it and cannot disagree about where a Ping check lives.

### Capture — `Common/Server`

- `MonitorSummaryCapture` resolves the probe **name** that every probeable summary view renders. Free for probeable monitors (`MonitorResource` already has it in hand); one lookup for Network Device, which is deliberately not a "probeable" type yet still reports through a probe. It swallows its own failures — a capture is evidence, not a precondition, and this runs inside the probe/telemetry ingest workers where a throw fails the job and retries forever.
- Built once per evaluation in `MonitorResource` and handed to both `MonitorIncident` and `MonitorAlert`.

### Storage

- New `monitorSummary` jsonb column on `Incident` and `Alert`, written alongside the existing `createdStateLog` (which is untouched — it is still copied onward into the state timelines).
- Migration generated with `npm run generate-postgres-migration` and registered in `SchemaMigrations/Index.ts`.

### UI

- `MonitorSummarySnapshotCard` on both view pages, in the left column above Affected Resources.
- **Existing incidents are not blank**: when the column is absent it reconstructs the card from `createdStateLog` plus the attached monitor's type, and labels itself as reconstructed.
- Renders nothing at all when there is no summary (manual monitors, hand-declared incidents), and degrades to nothing rather than breaking the page if the fetch fails.

### Payload size

A synthetic check carries base64 screenshots and can run to megabytes. Past a 1 MB budget the capture sheds screenshots first, then truncates an oversized response body — both flagged so the card says why something is missing, rather than showing a check with silently absent screenshots.

## Tests — 56 new

| File | Covers |
|---|---|
| `Common/Tests/Utils/Monitor/MonitorSummarySnapshotUtil.test.ts` | Every one of the 31 monitor types through build → serialize → jsonb round trip → deserialize → props. Plus the size budget, version rejection, shape-mismatch defence, and the legacy `createdStateLog` reconstruction. Fails if a new `MonitorType` is added without being classified. |
| `Common/Tests/Server/Utils/Monitor/MonitorSummaryCapture.test.ts` | Probe-name resolution: reused for free when the caller has it, looked up for Network Device, absent when the probe is deleted, never queried for a check that has no probe — and a failed lookup never fails the ingest job. |
| `Common/Tests/Server/Utils/Monitor/MonitorSummaryPersistence.test.ts` | Drives the real creation paths and asserts the column actually lands on the created `Incident` **and** `Alert`, that a missing capture never costs the incident, and that `createdStateLog` is not displaced. |
| `Common/Tests/UI/Monitor/MonitorSummarySnapshotRender.test.tsx` | jsdom render: a snapshot that came out of the jsonb column reaches the right per-type view and puts the check on screen — including that it does not fall into `SummaryInfo`'s "wait a few minutes for data" empty state, which is what an unwrapped payload silently produces. |
| `App/Tests/Dashboard/MonitorSummaryOnIncidentAndAlert.test.ts` | The Dashboard wiring the App suite cannot render (it runs in plain Node): both pages mount the card, both selects request the column, the legacy fallback is present. |

## Verification

- `Common`: 613 monitor tests pass (37 suites), including the 56 new ones.
- `Common` and `App/FeatureSet/Dashboard` type-check clean (the Dashboard's only remaining error is the pre-existing `rrweb` one in `SessionReplayPlayer.tsx`).
- `npm run fix` / eslint clean on every touched file.
- Not verified by a live click-through in a running dashboard — the tests render the real components against real stored payloads instead.

## Notes

- No status-page exposure. `StatusPageAPI`'s incident selects stay `monitors: { _id: true }`; the card lives entirely inside the Dashboard bundle.