### PR TITLE
Fix zombie-row resurrection: updates racing hard deletes blocked status deletion forever

### DIFF
--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1950,6 +1950,36 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
           })
         : [];
 
+      /*
+       * save() has upsert semantics: if the located row is hard-deleted by a
+       * concurrent request between the _findBy above and the write below,
+       * save() INSERTs a resurrected "zombie" row carrying only the update's
+       * columns. Zombies with enough NOT NULL columns persist and then hold
+       * foreign keys forever (e.g. a probe status-update racing a monitor
+       * delete resurrected the Monitor and permanently blocked deleting the
+       * MonitorStatus it referenced). Scalar-only updates therefore go
+       * through repository.update(), which never inserts and simply affects
+       * zero rows when the target is gone. Updates that touch relation
+       * columns still need save() for junction-table handling — those paths
+       * are API-driven and pass through the not-found guard above, so the
+       * race window does not practically apply to them.
+       */
+      const relationColumnNames: Set<string> = new Set<string>(
+        this.getModel()
+          .getTableColumns()
+          .columns.filter((column: string) => {
+            const metadata: TableColumnMetadata | undefined = this.getModel()
+              .getTableColumnMetadata(column);
+            return (
+              metadata?.type === TableColumnType.Entity ||
+              metadata?.type === TableColumnType.EntityArray
+            );
+          }),
+      );
+      const hasRelationUpdates: boolean = dataKeys.some((key: string) => {
+        return relationColumnNames.has(key);
+      });
+
       for (const item of items) {
         /*
          * _id must be set AFTER the spread: update data can carry an
@@ -1971,7 +2001,22 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
           projectId: updateBy.props.tenantId?.toString(),
         } as LogAttributes);
 
-        await this.getRepository().save(updatedItem);
+        if (hasRelationUpdates) {
+          await this.getRepository().save(updatedItem);
+        } else {
+          const { _id, ...updateData } = updatedItem;
+          await this.getRepository().update({ _id: _id } as any, {
+            ...updateData,
+            /*
+             * save() bumps the @VersionColumn automatically; update() does
+             * not, so emulate it to keep the audit counter behaviour
+             * identical.
+             */
+            version: () => {
+              return '"version" + 1';
+            },
+          } as any);
+        }
 
         // hit workflow.
         if (


### PR DESCRIPTION
## The intermittent `35-monitor-with-steps` destroy failure on master

The E2E run on the latest master commit failed destroying `oneuptime_monitor_status.operational` with **'Monitor records still reference it'** — after every monitor had already been confirmed destroyed. Sequential API repro shows clean deletes work, so a live Monitor row had to appear *after* the deletions.

### Root cause

TypeORM `save()` has upsert semantics. `_updateBy` locates rows with `_findBy`, then writes with `save()`; when a concurrent request hard-deletes the row in that window, `save()` **INSERTs a resurrected zombie** carrying only the update's columns. A probe status-evaluation racing Terraform's monitor destroy resurrected the Monitor row — whose `currentMonitorStatusId` foreign key then blocked deleting the referenced MonitorStatus **permanently** (no retry can fix a committed zombie). Same mechanism as the rearrange-priority 500 fixed in #2954, one level deeper.

### Fix

Scalar-only updates now go through `repository.update()`, which never inserts — a vanished target simply affects zero rows. The `@VersionColumn` bump that `save()` performed is emulated with an atomic `"version" + 1` SQL increment. Updates touching relation columns keep `save()` for junction-table handling; those paths are API-driven and pass the existing not-found guard, so the race window doesn't practically apply to them.

### Verification (live local stack)

- Scalar update bumps `version` identically to `save()` (checked in Postgres: 1 → 2).
- Relation updates intact: E2E 22 grows a monitor's label set through `update.tf`.
- E2E 01-label, 22-monitor-crud, 35-monitor-with-steps all pass with the patch live (full harness: apply → verify → drift → update → import + settle → destroy).
- Common `tsc` clean; lint clean.