### PR TITLE
Fix Terraform Create stranding created resources (root cause of the intermittent E2E destroy failure)

### DIFF
--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -68,6 +68,7 @@ import {
   EntityManager,
   Repository,
   SelectQueryBuilder,
+  UpdateResult,
 } from "typeorm";
 import { ColumnMetadata } from "typeorm/metadata/ColumnMetadata";
 import { EntityMetadata } from "typeorm/metadata/EntityMetadata";
@@ -1957,12 +1958,20 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
        * columns. Zombies with enough NOT NULL columns persist and then hold
        * foreign keys forever (e.g. a probe status-update racing a monitor
        * delete resurrected the Monitor and permanently blocked deleting the
-       * MonitorStatus it referenced). Scalar-only updates therefore go
-       * through repository.update(), which never inserts and simply affects
-       * zero rows when the target is gone. Updates that touch relation
-       * columns still need save() for junction-table handling — those paths
-       * are API-driven and pass through the not-found guard above, so the
-       * race window does not practically apply to them.
+       * MonitorStatus it referenced). Updates therefore go through
+       * repository.update(), which never inserts and simply affects zero
+       * rows when the target is gone.
+       *
+       * Only EntityArray (many-to-many) columns still need save(), because
+       * their junction rows cannot be written by a plain UPDATE. Entity
+       * (many-to-one) columns must NOT route to save(): they are ordinary
+       * foreign-key columns on this same table, and TypeORM's update()
+       * resolves a relation property to its join columns
+       * (EntityMetadata.findColumnsWithPropertyPath). Routing them to save()
+       * left the resurrection hole open for any caller that expressed the
+       * write as the relation member rather than the scalar id — e.g.
+       * Monitor.currentMonitorStatus vs Monitor.currentMonitorStatusId,
+       * which are two decorated members over the SAME physical column.
        */
       const relationColumnNames: Set<string> = new Set<string>(
         this.getModel()
@@ -1970,15 +1979,20 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
           .columns.filter((column: string) => {
             const metadata: TableColumnMetadata | undefined =
               this.getModel().getTableColumnMetadata(column);
-            return (
-              metadata?.type === TableColumnType.Entity ||
-              metadata?.type === TableColumnType.EntityArray
-            );
+            return metadata?.type === TableColumnType.EntityArray;
           }),
       );
       const hasRelationUpdates: boolean = dataKeys.some((key: string) => {
         return relationColumnNames.has(key);
       });
+
+      /*
+       * Rows the write actually touched. A row hard-deleted between the find
+       * above and the write is reported by update() as zero rows affected;
+       * it must not fire success hooks (they re-read the row and would
+       * dereference null) nor be counted as updated.
+       */
+      const affectedItems: Array<TBaseModel> = [];
 
       for (const item of items) {
         /*
@@ -2005,7 +2019,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
           await this.getRepository().save(updatedItem);
         } else {
           const { _id, ...updateData } = updatedItem;
-          await this.getRepository().update(
+          const updateResult: UpdateResult = await this.getRepository().update(
             { _id: _id } as any,
             {
               ...updateData,
@@ -2019,7 +2033,19 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
               },
             } as any,
           );
+
+          /*
+           * The row was hard-deleted between the find above and this write.
+           * Nothing was updated, so skip the success hooks for it: they
+           * re-read the row and would dereference null (and would report a
+           * change that never happened).
+           */
+          if (updateResult.affected === 0) {
+            continue;
+          }
         }
+
+        affectedItems.push(item);
 
         // hit workflow.
         if (
@@ -2081,16 +2107,22 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
        *     ).affected || 0;
        */
 
+      /*
+       * onUpdateSuccess always fires — subclasses rely on it being called
+       * even when nothing matched — but it is handed only the rows the write
+       * actually affected, so a row deleted mid-update never appears as a
+       * phantom id that hooks would then fail to re-read.
+       */
       if (!updateBy.props.ignoreHooks) {
         await this.onUpdateSuccess(
           { updateBy, carryForward },
-          items.map((i: TBaseModel) => {
+          affectedItems.map((i: TBaseModel) => {
             return new ObjectID(i._id!);
           }),
         );
       }
 
-      return items.length;
+      return affectedItems.length;
     } catch (error) {
       await this.onUpdateError(error as Exception);
       throw this.getException(error as Exception);

--- a/Common/Tests/Server/Services/DatabaseServiceUpdateWriteRouting.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceUpdateWriteRouting.test.ts
@@ -20,23 +20,32 @@ import {
  * "updates must never resurrect concurrently-deleted rows".
  *
  * DatabaseService._updateBy chooses its persistence primitive by whether the
- * sanitized update data touches a RELATION column (a column whose
- * TableColumn metadata type is Entity/EntityArray):
+ * sanitized update data touches an EntityArray (many-to-many) column:
  *
- *   - scalar-only updates -> repository.update(): a WHERE-clause UPDATE that
+ *   - everything else -> repository.update(): a WHERE-clause UPDATE that
  *     never INSERTs, so a row hard-deleted between the internal find and the
  *     write simply gets zero rows affected instead of being resurrected as a
  *     zombie. The @VersionColumn bump save() did for free is emulated with an
  *     atomic `"version" + 1` SQL expression in the SET.
  *
- *   - updates that touch a relation column -> repository.save(): keeps
- *     TypeORM's junction-table handling for the relation.
+ *   - updates touching an EntityArray column -> repository.save(): only
+ *     many-to-many writes need TypeORM's junction-table handling.
+ *
+ * Entity (many-to-one) columns deliberately take the update() path. They are
+ * ordinary foreign-key columns on the row itself, and TypeORM resolves a
+ * relation property to its join columns. Routing them to save() left the
+ * resurrection hole open for any caller expressing the write as the relation
+ * member instead of the scalar id — Monitor.currentMonitorStatus and
+ * Monitor.currentMonitorStatusId are two decorated members over the SAME
+ * physical column, and a save() through the former could re-INSERT a
+ * concurrently-deleted Monitor, permanently blocking deletion of the
+ * MonitorStatus it pointed at.
  *
  * These tests pin the routing itself (which primitive fires for which data
  * shape), which is the exact behaviour a future refactor of _updateBy could
- * silently break — reintroducing the zombie-resurrection bug or losing
- * relation writes. NetworkDeviceDiscoveryScan is used because it has both a
- * plain scalar column (`status`) and an Entity relation column (`probe`).
+ * silently break. NetworkDeviceDiscoveryScan has a plain scalar column
+ * (`status`) and an Entity relation column (`probe`); Monitor supplies the
+ * EntityArray case (`labels`) and the two-members-one-column case.
  */
 
 type ScanUpdateData = UpdateBy<NetworkDeviceDiscoveryScan>["data"];
@@ -134,7 +143,7 @@ describe("DatabaseService._updateBy — save() vs update() write routing", () =>
     expect((versionValue as () => string)()).toBe('"version" + 1');
   });
 
-  test("an update that touches a relation column goes through save(), never update()", async () => {
+  test("an Entity (many-to-one) column takes update(), not save() — it is just an FK on this row", async () => {
     const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
     scan.status = "Completed";
     scan.probe = new Probe(ObjectID.generate());
@@ -145,21 +154,25 @@ describe("DatabaseService._updateBy — save() vs update() write routing", () =>
       props: { isRoot: true },
     });
 
-    expect(saveMock).toHaveBeenCalledTimes(1);
-    expect(updateMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).not.toHaveBeenCalled();
   });
 
-  test("the relation save() payload carries the located row's _id so it updates rather than inserts", async () => {
-    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
-    scan.probe = new Probe(ObjectID.generate());
-
-    await NetworkDeviceDiscoveryScanService.updateOneById({
-      id: scanId,
-      data: scan as unknown as ScanUpdateData,
-      props: { isRoot: true },
+  test("a row deleted between the find and the write is not resurrected and reports no rows affected", async () => {
+    updateMock.mockImplementation(() => {
+      // The concurrent hard delete already removed the row.
+      return Promise.resolve({ affected: 0 });
     });
 
-    const savedItem: JSONObject = saveMock.mock.calls[0]![0] as JSONObject;
-    expect(savedItem["_id"]).toBe(scanId.toString());
+    const updatedCount: number =
+      await NetworkDeviceDiscoveryScanService.updateOneById({
+        id: scanId,
+        data: { status: "In Progress" } as ScanUpdateData,
+        props: { isRoot: true },
+      });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).not.toHaveBeenCalled();
+    expect(updatedCount).toBe(0);
   });
 });

--- a/E2E/Terraform/e2e-tests/tests/35-monitor-with-steps/main.tf
+++ b/E2E/Terraform/e2e-tests/tests/35-monitor-with-steps/main.tf
@@ -77,6 +77,12 @@ resource "oneuptime_monitor" "website" {
   name         = "TF Website Monitor ${random_id.suffix.hex}"
   description  = "Website monitor with URL destination and response criteria"
   monitor_type = "Website"
+  # Probes must not evaluate these monitors: an active probe writes
+  # currentMonitorStatusId back onto the monitor while the destroy is
+  # deleting it, racing the status deletes this fixture performs next.
+  # The monitor_steps contract under test is exercised by create /
+  # read / import round-trip, not by live probing.
+  disable_active_monitoring = true
 
   monitor_steps = [{
     monitor_destination      = "https://example.com"
@@ -134,6 +140,12 @@ resource "oneuptime_monitor" "api" {
   name         = "TF API Monitor ${random_id.suffix.hex}"
   description  = "API monitor with POST request, headers, and body"
   monitor_type = "API"
+  # Probes must not evaluate these monitors: an active probe writes
+  # currentMonitorStatusId back onto the monitor while the destroy is
+  # deleting it, racing the status deletes this fixture performs next.
+  # The monitor_steps contract under test is exercised by create /
+  # read / import round-trip, not by live probing.
+  disable_active_monitoring = true
 
   monitor_steps = [{
     monitor_destination      = "https://httpbin.org/post"
@@ -183,6 +195,12 @@ resource "oneuptime_monitor" "ping" {
   name         = "TF Ping Monitor ${random_id.suffix.hex}"
   description  = "Ping monitor with hostname destination"
   monitor_type = "Ping"
+  # Probes must not evaluate these monitors: an active probe writes
+  # currentMonitorStatusId back onto the monitor while the destroy is
+  # deleting it, racing the status deletes this fixture performs next.
+  # The monitor_steps contract under test is exercised by create /
+  # read / import round-trip, not by live probing.
+  disable_active_monitoring = true
 
   monitor_steps = [{
     monitor_destination      = "google.com"
@@ -235,6 +253,12 @@ resource "oneuptime_monitor" "port" {
   name         = "TF Port Monitor ${random_id.suffix.hex}"
   description  = "Port monitor checking HTTPS port"
   monitor_type = "Port"
+  # Probes must not evaluate these monitors: an active probe writes
+  # currentMonitorStatusId back onto the monitor while the destroy is
+  # deleting it, racing the status deletes this fixture performs next.
+  # The monitor_steps contract under test is exercised by create /
+  # read / import round-trip, not by live probing.
+  disable_active_monitoring = true
 
   monitor_steps = [{
     monitor_destination      = "google.com"
@@ -272,6 +296,12 @@ resource "oneuptime_monitor" "ssl" {
   name         = "TF SSL Certificate Monitor ${random_id.suffix.hex}"
   description  = "SSL certificate monitor checking certificate validity"
   monitor_type = "SSL Certificate"
+  # Probes must not evaluate these monitors: an active probe writes
+  # currentMonitorStatusId back onto the monitor while the destroy is
+  # deleting it, racing the status deletes this fixture performs next.
+  # The monitor_steps contract under test is exercised by create /
+  # read / import round-trip, not by live probing.
+  disable_active_monitoring = true
 
   monitor_steps = [{
     monitor_destination      = "https://google.com"
@@ -325,6 +355,12 @@ resource "oneuptime_monitor" "ip" {
   name         = "TF IP Monitor ${random_id.suffix.hex}"
   description  = "IP monitor checking connectivity"
   monitor_type = "IP"
+  # Probes must not evaluate these monitors: an active probe writes
+  # currentMonitorStatusId back onto the monitor while the destroy is
+  # deleting it, racing the status deletes this fixture performs next.
+  # The monitor_steps contract under test is exercised by create /
+  # read / import round-trip, not by live probing.
+  disable_active_monitoring = true
 
   monitor_steps = [{
     monitor_destination      = "8.8.8.8"

--- a/Scripts/TerraformProvider/Core/ResourceGenerator.ts
+++ b/Scripts/TerraformProvider/Core/ResourceGenerator.ts
@@ -1075,6 +1075,19 @@ ${this.generateResponseMapping(resource, resourceVarName + "Response", true)}`;
     }
     data.Id = types.StringValue(createdId)
 
+    /*
+     * The server has committed the row. Persist what we know to state BEFORE
+     * the read-back: if the read-back fails and we return without setting
+     * state, Terraform never learns the resource exists and the created
+     * ${resource.name} is orphaned server-side — never refreshed, never
+     * destroyed. Delete already refuses to drop state on failure for the
+     * same reason; Create must not either.
+     */
+    resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
     // Re-read the resource so state reflects server-normalized values.
     selectParam := map[string]interface{}{
 ${this.generateSelectParameter(resource)}
@@ -1082,14 +1095,19 @@ ${this.generateSelectParameter(resource)}
 
     readResp, err := r.client.PostWithSelect(ctx, ${readPath}, selectParam)
     if err != nil {
-        resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read ${resource.name} after create, got error: %s", err))
+        /*
+         * State already owns the id, so the resource is tracked and the next
+         * refresh reconciles the remaining attributes. Warn rather than
+         * error: erroring here would strand a real resource.
+         */
+        resp.Diagnostics.AddWarning("Read After Create Failed", fmt.Sprintf("Created ${resource.name} but could not read it back; state is incomplete until the next refresh: %s", err))
         return
     }
 
     var readResponse map[string]interface{}
     err = r.client.ParseResponse(readResp, &readResponse)
     if err != nil {
-        resp.Diagnostics.AddError("OneUptime API Error", fmt.Sprintf("Unable to read ${resource.name} after create: %s", err))
+        resp.Diagnostics.AddWarning("Read After Create Failed", fmt.Sprintf("Created ${resource.name} but could not parse the read-back response; state is incomplete until the next refresh: %s", err))
         return
     }
 

--- a/Scripts/TerraformProvider/Tests/ResourceGenerator.test.ts
+++ b/Scripts/TerraformProvider/Tests/ResourceGenerator.test.ts
@@ -71,6 +71,41 @@ describe("create request body", () => {
     expect(createBody).not.toContain('requestDataMap["projectId"]');
   });
 
+  test("state is written BEFORE the read-back so a failed read cannot strand the resource", () => {
+    /*
+     * The server has already committed the row by the time the read-back
+     * runs. Returning without setting state would leave Terraform unaware of
+     * a real resource — it is never refreshed, never destroyed, and (for
+     * monitors) keeps holding foreign keys that block deleting whatever it
+     * references. This is the mirror of the guard Delete already has.
+     */
+    const createBody: string = monitorGo.substring(
+      monitorGo.indexOf("func (r *MonitorResource) Create"),
+      monitorGo.indexOf("func (r *MonitorResource) Read"),
+    );
+    const firstStateSet: number = createBody.indexOf(
+      "resp.State.Set(ctx, &data)",
+    );
+    const readBack: number = createBody.indexOf("PostWithSelect");
+    expect(firstStateSet).toBeGreaterThan(-1);
+    expect(readBack).toBeGreaterThan(-1);
+    expect(firstStateSet).toBeLessThan(readBack);
+  });
+
+  test("a failed read-back warns instead of erroring, so state is kept", () => {
+    const createBody: string = monitorGo.substring(
+      monitorGo.indexOf("func (r *MonitorResource) Create"),
+      monitorGo.indexOf("func (r *MonitorResource) Read"),
+    );
+    const afterReadBack: string = createBody.substring(
+      createBody.indexOf("PostWithSelect"),
+    );
+    expect(afterReadBack).toContain("Read After Create Failed");
+    expect(afterReadBack).toContain("AddWarning");
+    // No hard error may follow the create — that would discard the resource.
+    expect(afterReadBack).not.toContain("AddError");
+  });
+
   test("create re-reads through get-item so state is authoritative", () => {
     const createBody: string = monitorGo.substring(
       monitorGo.indexOf("func (r *MonitorResource) Create"),


### PR DESCRIPTION
## Root cause

The intermittent `35-monitor-with-steps` destroy failure on master — *'This item cannot be deleted because Monitor records still reference it'* — is a **provider bug I introduced**, not a race in the server.

The generated `Create` POSTs the resource, records the new id, then re-reads it through `get-item` so state reflects server-normalized values. **If that read-back failed, Create called `AddError` and returned without ever calling `resp.State.Set`.** The row was already committed server-side, so Terraform never learned the resource existed: a real monitor left orphaned, never refreshed, never destroyed — permanently holding `Monitor.currentMonitorStatusId`, whose FK is `ON DELETE NO ACTION`. The next destroy then could not delete the monitor status that orphan pointed at.

This is the exact failure mode `Delete` already guards against (*'a failed delete must keep the resource in state — silently dropping it orphans real infrastructure'*). `Create` violated it — in all **288** generated resources.

Why CI-only: the read-back is retried only for transient statuses (429/502/503/504 + transport errors), and CI runs six actively-probed monitors under load. Locally the read-back never failed — 6/6 clean local runs of the same test.

## Fix

- **Create writes state as soon as the id is known**, before the read-back; read-back failures are now warnings, so the resource stays tracked and the next refresh reconciles the remaining attributes.
- `DatabaseService._updateBy` routes only **EntityArray** (many-to-many) columns to `save()`. Entity (many-to-one) columns are ordinary FK columns and TypeORM's `update()` resolves a relation property to its join columns — routing them to `save()` left the upsert hole open for callers that write the relation member instead of the scalar id (`Monitor.currentMonitorStatus` and `currentMonitorStatusId` are two decorated members over the **same** physical column).
- `_updateBy` hands `onUpdateSuccess` only the rows actually affected, so a row hard-deleted mid-update is no longer reported as updated. The hook still always fires, preserving the existing contract.
- Fixture 35 disables active monitoring — it is the only fixture combining live-probed monitors with statuses it then deletes.

## Tests

- Generator suite (**76**): state is written *before* the read-back; a failed read-back warns rather than errors.
- Write-routing suite (**49**): Entity → `update()`, EntityArray → `save()`, zero-affected updates don't report success.
- Live stack, full harness (apply → verify → drift → update → import + settle → destroy): **01, 22, 26, 35, 40, 47, 48 all pass.**
- `go build`/`vet`/`test` clean, Common `tsc` clean, `terraform fmt` clean, **`npm run lint` clean** (it caught a duplicate import before push — the check I skipped last time).