### PR TITLE
fix(identity): close SAML XML Signature Wrapping bypasses (#2949)

### DIFF
--- a/App/FeatureSet/Identity/API/GlobalSSO.ts
+++ b/App/FeatureSet/Identity/API/GlobalSSO.ts
@@ -1,5 +1,5 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
-import SSOUtil from "../Utils/SSO";
+import SSOUtil, { VerifiedSamlResponse } from "../Utils/SSO";
 import { DashboardRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
 import Protocol from "Common/Types/API/Protocol";
@@ -11,7 +11,6 @@ import Email from "Common/Types/Email";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import Exception from "Common/Types/Exception/Exception";
 import ServerException from "Common/Types/Exception/ServerException";
-import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import SsoProviderType from "Common/Types/SSO/SsoProviderType";
@@ -45,7 +44,6 @@ import GlobalSSO from "Common/Models/DatabaseModels/GlobalSso";
 import GlobalSSOProject from "Common/Models/DatabaseModels/GlobalSsoProject";
 import TeamMember from "Common/Models/DatabaseModels/TeamMember";
 import User from "Common/Models/DatabaseModels/User";
-import xml2js from "xml2js";
 import Name from "Common/Types/Name";
 
 const router: ExpressRouter = Express.getRouter();
@@ -241,8 +239,6 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
       "base64",
     ).toString();
 
-    const response: JSONObject = await xml2js.parseStringPromise(samlResponse);
-
     const globalSso: GlobalSSO | null = await GlobalSSOService.findOneBy({
       query: {
         _id: globalSsoId.toString(),
@@ -286,23 +282,20 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     let fullName: Name | null = null;
 
     try {
-      SSOUtil.isPayloadValid(response);
+      /*
+       * Verify the signature AND extract the identity from the SAME
+       * cryptographically verified assertion. This single call defends against
+       * XML Signature Wrapping - see SSOUtil.getSamlResponseFromXML and
+       * GitHub issue #2949.
+       */
+      const verifiedSaml: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+        samlResponse,
+        globalSso.publicCertificate,
+      );
 
-      if (
-        !SSOUtil.isSignatureValid(samlResponse, globalSso.publicCertificate)
-      ) {
-        return Response.sendErrorResponse(
-          req,
-          res,
-          new BadRequestException(
-            "Signature is not valid or Public Certificate configured with this SSO provider is not valid",
-          ),
-        );
-      }
-
-      issuerUrl = SSOUtil.getIssuer(response);
-      email = SSOUtil.getEmail(response);
-      fullName = SSOUtil.getUserFullName(response);
+      issuerUrl = verifiedSaml.issuerUrl;
+      email = verifiedSaml.email;
+      fullName = verifiedSaml.name;
     } catch (err: unknown) {
       if (err instanceof Exception) {
         return Response.sendErrorResponse(req, res, err);

--- a/App/FeatureSet/Identity/API/SSO.ts
+++ b/App/FeatureSet/Identity/API/SSO.ts
@@ -1,5 +1,5 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
-import SSOUtil from "../Utils/SSO";
+import SSOUtil, { VerifiedSamlResponse } from "../Utils/SSO";
 import { DashboardRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
 import Protocol from "Common/Types/API/Protocol";
@@ -11,7 +11,6 @@ import Email from "Common/Types/Email";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import Exception from "Common/Types/Exception/Exception";
 import ServerException from "Common/Types/Exception/ServerException";
-import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import DatabaseConfig from "Common/Server/DatabaseConfig";
@@ -45,7 +44,6 @@ import Project from "Common/Models/DatabaseModels/Project";
 import ProjectSSO from "Common/Models/DatabaseModels/ProjectSso";
 import TeamMember from "Common/Models/DatabaseModels/TeamMember";
 import User from "Common/Models/DatabaseModels/User";
-import xml2js from "xml2js";
 import Name from "Common/Types/Name";
 import SsoProviderType from "Common/Types/SSO/SsoProviderType";
 
@@ -329,8 +327,6 @@ const loginUserWithSso: LoginUserWithSsoFunction = async (
       "base64",
     ).toString();
 
-    const response: JSONObject = await xml2js.parseStringPromise(samlResponse);
-
     let issuerUrl: string = "";
     let email: Email | null = null;
     let fullName: Name | null = null;
@@ -407,23 +403,20 @@ const loginUserWithSso: LoginUserWithSsoFunction = async (
     }
 
     try {
-      SSOUtil.isPayloadValid(response);
+      /*
+       * Verify the signature AND extract the identity from the SAME
+       * cryptographically verified assertion. This single call defends against
+       * XML Signature Wrapping - see SSOUtil.getSamlResponseFromXML and
+       * GitHub issue #2949.
+       */
+      const verifiedSaml: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+        samlResponse,
+        projectSSO.publicCertificate,
+      );
 
-      if (
-        !SSOUtil.isSignatureValid(samlResponse, projectSSO.publicCertificate)
-      ) {
-        return Response.sendErrorResponse(
-          req,
-          res,
-          new BadRequestException(
-            "Signature is not valid or Public Certificate configured with this SSO provider is not valid",
-          ),
-        );
-      }
-
-      issuerUrl = SSOUtil.getIssuer(response);
-      email = SSOUtil.getEmail(response);
-      fullName = SSOUtil.getUserFullName(response);
+      issuerUrl = verifiedSaml.issuerUrl;
+      email = verifiedSaml.email;
+      fullName = verifiedSaml.name;
     } catch (err: unknown) {
       if (err instanceof Exception) {
         return Response.sendErrorResponse(req, res, err);

--- a/App/FeatureSet/Identity/API/StatusPageSSO.ts
+++ b/App/FeatureSet/Identity/API/StatusPageSSO.ts
@@ -1,11 +1,10 @@
-import SSOUtil from "../Utils/SSO";
+import SSOUtil, { VerifiedSamlResponse } from "../Utils/SSO";
 import URL from "Common/Types/API/URL";
 import Email from "Common/Types/Email";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import Exception from "Common/Types/Exception/Exception";
 import ServerException from "Common/Types/Exception/ServerException";
 import HashedString from "Common/Types/HashedString";
-import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import { Host, HttpProtocol } from "Common/Server/EnvironmentConfig";
 import StatusPagePrivateUserService from "Common/Server/Services/StatusPagePrivateUserService";
@@ -31,7 +30,6 @@ import logger, {
 import Response from "Common/Server/Utils/Response";
 import StatusPagePrivateUser from "Common/Models/DatabaseModels/StatusPagePrivateUser";
 import StatusPageSSO from "Common/Models/DatabaseModels/StatusPageSso";
-import xml2js from "xml2js";
 
 // Initialize Express router.
 const router: ExpressRouter = Express.getRouter();
@@ -136,9 +134,6 @@ router.post(
         "base64",
       ).toString();
 
-      const response: JSONObject =
-        await xml2js.parseStringPromise(samlResponse);
-
       let issuerUrl: string = "";
       let email: Email | null = null;
 
@@ -225,24 +220,20 @@ router.post(
       }
 
       try {
-        SSOUtil.isPayloadValid(response);
-
-        if (
-          !SSOUtil.isSignatureValid(
+        /*
+         * Verify the signature AND extract the identity from the SAME
+         * cryptographically verified assertion. This single call defends against
+         * XML Signature Wrapping - see SSOUtil.getSamlResponseFromXML and
+         * GitHub issue #2949.
+         */
+        const verifiedSaml: VerifiedSamlResponse =
+          SSOUtil.getSamlResponseFromXML(
             samlResponse,
             statusPageSSO.publicCertificate,
-          )
-        ) {
-          return Response.sendErrorResponse(
-            req,
-            res,
-            new BadRequestException("Signature is not valid"),
           );
-        }
 
-        issuerUrl = SSOUtil.getIssuer(response);
-
-        email = SSOUtil.getEmail(response);
+        issuerUrl = verifiedSaml.issuerUrl;
+        email = verifiedSaml.email;
       } catch (err: unknown) {
         if (err instanceof Exception) {
           return Response.sendErrorResponse(req, res, err);

--- a/App/FeatureSet/Identity/Utils/SSO.ts
+++ b/App/FeatureSet/Identity/Utils/SSO.ts
@@ -2,7 +2,6 @@ import URL from "Common/Types/API/URL";
 import OneUptimeDate from "Common/Types/Date";
 import Email from "Common/Types/Email";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
-import { JSONArray, JSONObject } from "Common/Types/JSON";
 import Text from "Common/Types/Text";
 import logger from "Common/Server/Utils/Logger";
 import xmlCrypto, { FileKeyInfo } from "xml-crypto";
@@ -10,11 +9,36 @@ import {
   DOMParser,
   Document as XmlDocument,
   Element as XmlElement,
+  Node as XmlNode,
 } from "@xmldom/xmldom";
 import zlib from "zlib";
 import Name from "Common/Types/Name";
 
+/*
+ * Result of successfully verifying and parsing a SAML Response.
+ * Every field is sourced exclusively from the single, cryptographically
+ * verified Assertion - never from an independently parsed tree.
+ */
+export interface VerifiedSamlResponse {
+  issuerUrl: string;
+  email: Email;
+  name: Name | null;
+}
+
 export default class SSOUtil {
+  // Namespaces used across the SAML documents we consume.
+  private static readonly XMLDSIG_NAMESPACE: string =
+    "http://www.w3.org/2000/09/xmldsig#";
+
+  private static readonly SAML_ASSERTION_NAMESPACES: Array<string> = [
+    "urn:oasis:names:tc:SAML:2.0:assertion",
+    "urn:oasis:names:tc:SAML:1.0:assertion",
+  ];
+
+  // Microsoft display name claim - the only "full name" claim we read today.
+  private static readonly MS_DISPLAY_NAME_CLAIM: string =
+    "http://schemas.microsoft.com/identity/claims/displayname";
+
   public static createSAMLRequestUrl(data: {
     acsUrl: URL;
     signOnUrl: URL;
@@ -37,202 +61,391 @@ export default class SSOUtil {
     );
   }
 
-  public static isPayloadValid(payload: JSONObject): void {
+  /*
+   * Verify the signature on a SAML Response and extract the identity from the
+   * SAME assertion that the signature actually covers.
+   *
+   * This is the single, safe entry point that every SAML login flow must use.
+   * It defends against XML Signature Wrapping (XSW): the historic implementation
+   * validated whichever <Signature> element appeared first and then extracted the
+   * identity from an independently parsed tree, so an attacker could hide a
+   * genuinely signed assertion (e.g. inside <Extensions>) while presenting a
+   * forged assertion for consumption. See GitHub issue #2949.
+   *
+   * The checks below make that impossible:
+   *   1. The document must be well-formed XML with no DOCTYPE / entity
+   *      declarations (blocks XXE and entity-expansion / parser-differential
+   *      tricks).
+   *   2. The document must contain EXACTLY ONE <Assertion> element anywhere in
+   *      the tree (blocks decoy / wrapped assertions - every XSW variant needs a
+   *      second assertion to hide behind).
+   *   3. A <Signature> must validate against the configured certificate AND its
+   *      reference must resolve to that one assertion (or an ancestor that
+   *      contains it). This binds "what was signed" to "what we read".
+   *   4. The identity-bearing nodes must not contain XML comments (blocks the
+   *      SAML comment-truncation class of attacks).
+   *
+   * Throws BadRequestException on any anomaly.
+   */
+  public static getSamlResponseFromXML(
+    samlResponse: string,
+    certificate: string,
+  ): VerifiedSamlResponse {
+    if (!certificate) {
+      throw new BadRequestException("Public Certificate not found");
+    }
+
+    const dom: XmlDocument = SSOUtil.parseXmlStrict(samlResponse);
+    const assertion: XmlElement = SSOUtil.getSingleAssertion(dom);
+
     if (
-      !payload["saml2p:Response"] &&
-      !payload["samlp:Response"] &&
-      !payload["samlp:Response"]
+      !SSOUtil.verifyAssertionSignature(
+        samlResponse,
+        certificate,
+        dom,
+        assertion,
+      )
     ) {
-      throw new BadRequestException("SAML Response not found.");
-    }
-
-    payload =
-      (payload["saml2p:Response"] as JSONObject) ||
-      (payload["samlp:Response"] as JSONObject) ||
-      (payload["samlp:Response"] as JSONObject) ||
-      (payload["Response"] as JSONObject);
-
-    const issuers: JSONArray =
-      (payload["saml2:Issuer"] as JSONArray) ||
-      (payload["saml:Issuer"] as JSONArray) ||
-      (payload["Issuer"] as JSONArray);
-
-    if (issuers.length === 0) {
-      throw new BadRequestException("Issuers not found");
-    }
-
-    const issuer: JSONObject | string | undefined = issuers[0];
-
-    if (typeof issuer === "string") {
-      return issuer;
-    }
-    if (!issuer) {
-      throw new BadRequestException("Issuer not found");
-    }
-
-    const issuerUrl: string = issuer["_"] as string;
-
-    if (!issuerUrl) {
-      throw new BadRequestException("Issuer URL not found in SAML response");
-    }
-
-    const samlAssertion: JSONArray =
-      (payload["saml2:Assertion"] as JSONArray) ||
-      (payload["saml:Assertion"] as JSONArray) ||
-      (payload["Assertion"] as JSONArray);
-
-    if (!samlAssertion || samlAssertion.length === 0) {
-      throw new BadRequestException("SAML Assertion not found");
-    }
-
-    if (samlAssertion.length !== 1) {
       throw new BadRequestException(
-        "Expected exactly one Assertion in SAML Response",
+        "Signature is not valid or Public Certificate configured with this SSO provider is not valid",
       );
     }
 
-    const samlSubject: JSONArray =
-      ((samlAssertion[0] as JSONObject)["saml2:Subject"] as JSONArray) ||
-      ((samlAssertion[0] as JSONObject)["saml:Subject"] as JSONArray) ||
-      ((samlAssertion[0] as JSONObject)["Subject"] as JSONArray);
-
-    if (!samlSubject || samlSubject.length === 0) {
-      throw new BadRequestException("SAML Subject not found");
-    }
-
-    const samlNameId: JSONArray =
-      ((samlSubject[0] as JSONObject)["saml2:NameID"] as JSONArray) ||
-      ((samlSubject[0] as JSONObject)["saml:NameID"] as JSONArray) ||
-      ((samlSubject[0] as JSONObject)["NameID"] as JSONArray);
-
-    if (!samlNameId || samlNameId.length === 0) {
-      throw new BadRequestException("SAML NAME ID not found");
-    }
-
-    const emailString: string = (samlNameId[0] as JSONObject)["_"] as string;
-
-    if (!emailString) {
-      if (!samlNameId || samlNameId.length === 0) {
-        throw new BadRequestException("SAML Email not found");
-      }
-    }
+    return {
+      issuerUrl: SSOUtil.getIssuerFromAssertion(assertion),
+      email: SSOUtil.getEmailFromAssertion(assertion),
+      name: SSOUtil.getNameFromAssertion(assertion),
+    };
   }
 
+  /*
+   * Boolean form of the verification above. Kept for callers/tests that only
+   * need to know whether the response carries a valid, wrapping-safe signature.
+   * Uses exactly the same strict pipeline as getSamlResponseFromXML.
+   */
   public static isSignatureValid(
-    samlPayload: string,
+    samlResponse: string,
     certificate: string,
   ): boolean {
     try {
-      const dom: XmlDocument = new DOMParser().parseFromString(
-        samlPayload,
-        "text/xml",
+      if (!certificate) {
+        return false;
+      }
+
+      const dom: XmlDocument = SSOUtil.parseXmlStrict(samlResponse);
+      const assertion: XmlElement = SSOUtil.getSingleAssertion(dom);
+
+      return SSOUtil.verifyAssertionSignature(
+        samlResponse,
+        certificate,
+        dom,
+        assertion,
       );
-      const signature: XmlElement | undefined = dom.getElementsByTagNameNS(
-        "http://www.w3.org/2000/09/xmldsig#",
-        "Signature",
-      )[0];
-      const sig: xmlCrypto.SignedXml = new xmlCrypto.SignedXml();
-
-      sig.keyInfoProvider = {
-        getKeyInfo: function (_key: any) {
-          return `<X509Data><X509Certificate>${certificate}</X509Certificate></X509Data>`;
-        },
-        getKey: function () {
-          return certificate;
-        } as any,
-      } as FileKeyInfo;
-
-      sig.loadSignature(signature!.toString());
-      const res: boolean = sig.checkSignature(samlPayload);
-
-      return res;
     } catch (err) {
       logger.error(err);
       return false;
     }
   }
 
-  public static getUserFullName(payload: JSONObject): Name | null {
-    if (!payload["saml2p:Response"] && !payload["samlp:Response"]) {
-      return null;
-    }
-
-    payload =
-      (payload["saml2p:Response"] as JSONObject) ||
-      (payload["samlp:Response"] as JSONObject) ||
-      (payload["Response"] as JSONObject);
-
-    const samlAssertion: JSONArray =
-      (payload["saml2:Assertion"] as JSONArray) ||
-      (payload["saml:Assertion"] as JSONArray) ||
-      (payload["Assertion"] as JSONArray);
-
-    if (!samlAssertion || samlAssertion.length === 0) {
-      return null;
-    }
-
-    if (samlAssertion.length !== 1) {
-      return null;
-    }
-
-    const samlAttributeStatement: JSONArray =
-      ((samlAssertion[0] as JSONObject)[
-        "saml2:AttributeStatement"
-      ] as JSONArray) ||
-      ((samlAssertion[0] as JSONObject)[
-        "saml:AttributeStatement"
-      ] as JSONArray) ||
-      ((samlAssertion[0] as JSONObject)["AttributeStatement"] as JSONArray);
-
-    if (!samlAttributeStatement || samlAttributeStatement.length === 0) {
-      return null;
-    }
-
-    const samlAttribute: JSONArray =
-      ((samlAttributeStatement[0] as JSONObject)[
-        "saml2:Attribute"
-      ] as JSONArray) ||
-      ((samlAttributeStatement[0] as JSONObject)[
-        "saml:Attribute"
-      ] as JSONArray) ||
-      ((samlAttributeStatement[0] as JSONObject)["Attribute"] as JSONArray);
-
-    if (!samlAttribute || samlAttribute.length === 0) {
-      return null;
+  /*
+   * Parse the SAML Response once, strictly. Rejects empty input, DOCTYPE / entity
+   * declarations, and any XML that is not well-formed.
+   */
+  private static parseXmlStrict(samlResponse: string): XmlDocument {
+    if (typeof samlResponse !== "string" || samlResponse.trim() === "") {
+      throw new BadRequestException("SAML Response is empty");
     }
 
     /*
-     * get displayName attribute.
-     *   {
-     *     "$": {
-     *         "Name": "http://schemas.microsoft.com/identity/claims/displayname"
-     *     },
-     *     "AttributeValue": [
-     *         "Nawaz Dhandala"
-     *     ]
-     * },
+     * A SAML Response has no legitimate need for a DOCTYPE or entity
+     * declarations. Rejecting them outright blocks XML External Entity (XXE)
+     * attacks, billion-laughs style entity expansion, and parser-differential
+     * tricks that rely on entity handling.
      */
+    const doctypeOrEntity: RegExp = /<!DOCTYPE|<!ENTITY/i;
+    if (doctypeOrEntity.test(samlResponse)) {
+      throw new BadRequestException(
+        "SAML Response must not contain a DOCTYPE or entity declarations",
+      );
+    }
 
-    for (let i: number = 0; i < samlAttribute.length; i++) {
-      const attribute: JSONObject = samlAttribute[i] as JSONObject;
-      if (
-        attribute["$"] &&
-        (attribute["$"] as JSONObject)["Name"]?.toString()
-      ) {
-        const name: string | undefined = (attribute["$"] as JSONObject)[
-          "Name"
-        ]?.toString();
+    let dom: XmlDocument;
+
+    try {
+      dom = new DOMParser({
+        onError: (level: "warning" | "error" | "fatalError"): void => {
+          if (level === "error" || level === "fatalError") {
+            throw new Error("Malformed XML in SAML Response");
+          }
+        },
+      }).parseFromString(samlResponse, "text/xml");
+    } catch {
+      throw new BadRequestException("SAML Response is not valid XML");
+    }
+
+    if (!dom || !dom.documentElement) {
+      throw new BadRequestException("SAML Response is not valid XML");
+    }
+
+    return dom;
+  }
+
+  /*
+   * Return the single Assertion element in the document, or throw. Counting
+   * assertions across the WHOLE document (any namespace, including a wrapped or
+   * nested one) is what defeats signature-wrapping: the attack fundamentally
+   * needs a second assertion to hide the genuine signature behind.
+   */
+  private static getSingleAssertion(dom: XmlDocument): XmlElement {
+    const assertions: Array<XmlElement> = SSOUtil.toElementArray(
+      dom.getElementsByTagNameNS("*", "Assertion"),
+    );
+
+    if (assertions.length === 0) {
+      throw new BadRequestException("SAML Assertion not found");
+    }
+
+    if (assertions.length !== 1) {
+      throw new BadRequestException(
+        "Expected exactly one Assertion in SAML Response",
+      );
+    }
+
+    const assertion: XmlElement = assertions[0]!;
+
+    if (
+      !SSOUtil.SAML_ASSERTION_NAMESPACES.includes(assertion.namespaceURI || "")
+    ) {
+      throw new BadRequestException("SAML Assertion has an invalid namespace");
+    }
+
+    return assertion;
+  }
+
+  /*
+   * Verify that some <Signature> in the document:
+   *   - validates cryptographically against the configured certificate, and
+   *   - covers the given assertion (its reference resolves to the assertion or
+   *     an ancestor element that contains it).
+   *
+   * Only if BOTH hold do we consider the assertion authentic.
+   */
+  private static verifyAssertionSignature(
+    samlResponse: string,
+    certificate: string,
+    dom: XmlDocument,
+    assertion: XmlElement,
+  ): boolean {
+    const signatures: Array<XmlElement> = SSOUtil.toElementArray(
+      dom.getElementsByTagNameNS(SSOUtil.XMLDSIG_NAMESPACE, "Signature"),
+    );
+
+    if (signatures.length === 0) {
+      return false;
+    }
+
+    for (const signature of signatures) {
+      try {
+        const sig: xmlCrypto.SignedXml = new xmlCrypto.SignedXml();
+
+        sig.keyInfoProvider = {
+          getKeyInfo: function (_key: unknown): string {
+            return `<X509Data><X509Certificate>${certificate}</X509Certificate></X509Data>`;
+          },
+          getKey: function (): string {
+            return certificate;
+          } as unknown as () => Buffer,
+        } as FileKeyInfo;
+
+        sig.loadSignature(signature.toString());
+
+        /*
+         * Before trusting this signature, confirm it actually covers the
+         * assertion we are going to read from. A signature over some unrelated
+         * element must never authenticate a forged assertion.
+         */
+        const references: Array<{ uri?: string | undefined }> =
+          (sig.references as Array<{ uri?: string | undefined }>) || [];
+
+        const coversAssertion: boolean = references.some(
+          (reference: { uri?: string | undefined }): boolean => {
+            return SSOUtil.referenceCoversAssertion(
+              dom,
+              assertion,
+              reference.uri,
+            );
+          },
+        );
+
+        if (!coversAssertion) {
+          continue;
+        }
+
+        // Cryptographically validate digests + signature value.
+        if (sig.checkSignature(samlResponse)) {
+          return true;
+        }
+      } catch (err) {
+        logger.error(err);
+        continue;
+      }
+    }
+
+    return false;
+  }
+
+  /*
+   * Does a signed Reference (identified by its URI) cover the assertion?
+   * A URI of "" signs the whole document. Otherwise it points at an element by
+   * ID; that element must be the assertion itself or an ancestor of it.
+   */
+  private static referenceCoversAssertion(
+    dom: XmlDocument,
+    assertion: XmlElement,
+    uri: string | undefined,
+  ): boolean {
+    if (!uri || uri === "") {
+      // Whole-document signature: the single assertion is necessarily covered.
+      return true;
+    }
+
+    const id: string = uri.charAt(0) === "#" ? uri.substring(1) : uri;
+
+    const targets: Array<XmlElement> = SSOUtil.resolveElementsById(dom, id);
+
+    // Ambiguous (>1) or dangling (0) references do not count as coverage.
+    if (targets.length !== 1) {
+      return false;
+    }
+
+    return SSOUtil.isAncestorOrSelf(targets[0]!, assertion);
+  }
+
+  // Find every element carrying an ID / Id / id attribute equal to `id`.
+  private static resolveElementsById(
+    dom: XmlDocument,
+    id: string,
+  ): Array<XmlElement> {
+    const all: Array<XmlElement> = SSOUtil.toElementArray(
+      dom.getElementsByTagName("*"),
+    );
+
+    const matches: Array<XmlElement> = [];
+
+    for (const element of all) {
+      for (const attributeName of ["ID", "Id", "id"]) {
         if (
-          name &&
-          name === "http://schemas.microsoft.com/identity/claims/displayname" &&
-          attribute["AttributeValue"] &&
-          Array.isArray(attribute["AttributeValue"]) &&
-          attribute["AttributeValue"].length > 0
+          element.getAttribute &&
+          element.getAttribute(attributeName) === id
         ) {
-          const fullName: Name = new Name(
-            attribute["AttributeValue"][0]!.toString() as string,
-          );
-          return fullName;
+          matches.push(element);
+          break;
+        }
+      }
+    }
+
+    return matches;
+  }
+
+  private static isAncestorOrSelf(
+    ancestor: XmlNode,
+    node: XmlNode | null,
+  ): boolean {
+    let current: XmlNode | null = node;
+
+    while (current) {
+      if (current === ancestor) {
+        return true;
+      }
+      current = current.parentNode;
+    }
+
+    return false;
+  }
+
+  private static getIssuerFromAssertion(assertion: XmlElement): string {
+    const issuerElement: XmlElement | null = SSOUtil.getDirectChildByLocalName(
+      assertion,
+      "Issuer",
+    );
+
+    if (!issuerElement) {
+      throw new BadRequestException("Issuer not found in SAML Assertion");
+    }
+
+    SSOUtil.assertNoComments(issuerElement);
+
+    const issuerUrl: string = SSOUtil.getTrimmedText(issuerElement);
+
+    if (!issuerUrl) {
+      throw new BadRequestException("Issuer URL not found in SAML response");
+    }
+
+    return issuerUrl;
+  }
+
+  private static getEmailFromAssertion(assertion: XmlElement): Email {
+    const subject: XmlElement | null = SSOUtil.getDirectChildByLocalName(
+      assertion,
+      "Subject",
+    );
+
+    if (!subject) {
+      throw new BadRequestException("SAML Subject not found");
+    }
+
+    const nameId: XmlElement | null = SSOUtil.getDirectChildByLocalName(
+      subject,
+      "NameID",
+    );
+
+    if (!nameId) {
+      throw new BadRequestException("SAML NAME ID not found");
+    }
+
+    /*
+     * Reject comments inside the NameID. Exclusive canonicalization strips
+     * comments before hashing, so a naive extractor that stopped at a comment
+     * could read a different value than the one that was signed
+     * (e.g. "victim@corp.com<!---->.attacker.com"). We read the full text and
+     * additionally refuse any comment here.
+     */
+    SSOUtil.assertNoComments(nameId);
+
+    const emailString: string = SSOUtil.getTrimmedText(nameId);
+
+    if (!emailString) {
+      throw new BadRequestException("SAML Email not found");
+    }
+
+    return new Email(emailString);
+  }
+
+  private static getNameFromAssertion(assertion: XmlElement): Name | null {
+    const attributeStatement: XmlElement | null =
+      SSOUtil.getDirectChildByLocalName(assertion, "AttributeStatement");
+
+    if (!attributeStatement) {
+      return null;
+    }
+
+    const attributes: Array<XmlElement> = SSOUtil.toElementArray(
+      attributeStatement.getElementsByTagNameNS("*", "Attribute"),
+    );
+
+    for (const attribute of attributes) {
+      const name: string | null = attribute.getAttribute("Name");
+
+      if (name === SSOUtil.MS_DISPLAY_NAME_CLAIM) {
+        const attributeValue: XmlElement | null =
+          SSOUtil.getDirectChildByLocalName(attribute, "AttributeValue");
+
+        if (attributeValue) {
+          SSOUtil.assertNoComments(attributeValue);
+          const fullName: string = SSOUtil.getTrimmedText(attributeValue);
+          if (fullName) {
+            return new Name(fullName);
+          }
         }
       }
     }
@@ -240,89 +453,71 @@ export default class SSOUtil {
     return null;
   }
 
-  public static getEmail(payload: JSONObject): Email {
-    if (!payload["saml2p:Response"] && !payload["samlp:Response"]) {
-      throw new BadRequestException("SAML Response not found.");
+  // ---- Small DOM helpers -------------------------------------------------
+
+  private static getDirectChildByLocalName(
+    parent: XmlElement,
+    localName: string,
+  ): XmlElement | null {
+    for (
+      let child: XmlNode | null = parent.firstChild;
+      child;
+      child = child.nextSibling
+    ) {
+      if (
+        child.nodeType === 1 &&
+        (child as XmlElement).localName === localName
+      ) {
+        return child as XmlElement;
+      }
     }
 
-    payload =
-      (payload["saml2p:Response"] as JSONObject) ||
-      (payload["samlp:Response"] as JSONObject) ||
-      (payload["Response"] as JSONObject);
-
-    const samlAssertion: JSONArray =
-      (payload["saml2:Assertion"] as JSONArray) ||
-      (payload["saml:Assertion"] as JSONArray) ||
-      (payload["Assertion"] as JSONArray);
-
-    if (!samlAssertion || samlAssertion.length === 0) {
-      throw new BadRequestException("SAML Assertion not found");
-    }
-
-    if (samlAssertion.length !== 1) {
-      throw new BadRequestException(
-        "Expected exactly one Assertion in SAML Response",
-      );
-    }
-
-    const samlSubject: JSONArray =
-      ((samlAssertion[0] as JSONObject)["saml2:Subject"] as JSONArray) ||
-      ((samlAssertion[0] as JSONObject)["saml:Subject"] as JSONArray) ||
-      ((samlAssertion[0] as JSONObject)["Subject"] as JSONArray);
-
-    if (!samlSubject || samlSubject.length === 0) {
-      throw new BadRequestException("SAML Subject not found");
-    }
-
-    const samlNameId: JSONArray =
-      ((samlSubject[0] as JSONObject)["saml2:NameID"] as JSONArray) ||
-      ((samlSubject[0] as JSONObject)["saml:NameID"] as JSONArray) ||
-      ((samlSubject[0] as JSONObject)["NameID"] as JSONArray);
-
-    if (!samlNameId || samlNameId.length === 0) {
-      throw new BadRequestException("SAML NAME ID not found");
-    }
-
-    const emailString: string = (samlNameId[0] as JSONObject)["_"] as string;
-
-    return new Email(emailString.trim());
+    return null;
   }
 
-  public static getIssuer(payload: JSONObject): string {
-    if (!payload["saml2p:Response"] && !payload["samlp:Response"]) {
-      throw new BadRequestException("SAML Response not found.");
+  private static getTrimmedText(element: XmlElement): string {
+    return (element.textContent || "").trim();
+  }
+
+  // Throw if the element subtree contains any XML comment node.
+  private static assertNoComments(element: XmlElement): void {
+    const stack: Array<XmlNode> = [element];
+
+    while (stack.length > 0) {
+      const node: XmlNode = stack.pop()!;
+
+      for (
+        let child: XmlNode | null = node.firstChild;
+        child;
+        child = child.nextSibling
+      ) {
+        // nodeType 8 === COMMENT_NODE
+        if (child.nodeType === 8) {
+          throw new BadRequestException(
+            "SAML Assertion must not contain XML comments",
+          );
+        }
+        stack.push(child);
+      }
+    }
+  }
+
+  private static toElementArray(collection: {
+    length: number;
+    item?: (index: number) => XmlNode | null;
+  }): Array<XmlElement> {
+    const elements: Array<XmlElement> = [];
+
+    for (let index: number = 0; index < collection.length; index++) {
+      const node: XmlNode | null = collection.item
+        ? collection.item(index)
+        : (collection as unknown as Array<XmlNode>)[index] || null;
+
+      if (node && node.nodeType === 1) {
+        elements.push(node as XmlElement);
+      }
     }
 
-    payload =
-      (payload["saml2p:Response"] as JSONObject) ||
-      (payload["samlp:Response"] as JSONObject) ||
-      (payload["Response"] as JSONObject);
-
-    const issuers: JSONArray =
-      (payload["saml2:Issuer"] as JSONArray) ||
-      (payload["saml:Issuer"] as JSONArray) ||
-      (payload["Issuer"] as JSONArray);
-
-    if (issuers.length === 0) {
-      throw new BadRequestException("Issuers not found");
-    }
-
-    const issuer: JSONObject | string | undefined = issuers[0];
-
-    if (typeof issuer === "string") {
-      return issuer;
-    }
-
-    if (!issuer) {
-      throw new BadRequestException("Issuer not found");
-    }
-
-    const issuerUrl: string = issuer["_"] as string;
-
-    if (!issuerUrl) {
-      throw new BadRequestException("Issuer URL not found in SAML response");
-    }
-
-    return issuerUrl.trim();
+    return elements;
   }
 }

--- a/App/Tests/Identity/SSO.test.ts
+++ b/App/Tests/Identity/SSO.test.ts
@@ -1,0 +1,434 @@
+import SSOUtil, {
+  VerifiedSamlResponse,
+} from "../../FeatureSet/Identity/Utils/SSO";
+import Email from "Common/Types/Email";
+import URL from "Common/Types/API/URL";
+import { describe, expect, test, beforeAll } from "@jest/globals";
+import crypto from "crypto";
+import { SignedXml } from "xml-crypto";
+
+/*
+ * Security regression tests for SAML XML Signature Wrapping (XSW).
+ *
+ * Background (GitHub issue #2949): the historic implementation validated the
+ * first <Signature> element it found and then extracted the identity from an
+ * independently parsed tree. An attacker could therefore hide a genuinely
+ * signed assertion (e.g. inside <Extensions>) while presenting a forged
+ * assertion for consumption - a full authentication bypass.
+ *
+ * These tests:
+ *   1. Prove the genuine ("happy path") SAML flow still works.
+ *   2. Prove every wrapping / tampering variant is rejected.
+ *
+ * Keys are generated at runtime (no secrets committed). xml-crypto verifies
+ * against a raw public key just as well as against an X.509 certificate, so the
+ * generated public key PEM stands in for the provider's `publicCertificate`.
+ */
+
+const XMLDSIG_ENVELOPED: string =
+  "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+const XMLDSIG_EXC_C14N: string = "http://www.w3.org/2001/10/xml-exc-c14n#";
+const XMLENC_SHA256: string = "http://www.w3.org/2001/04/xmlenc#sha256";
+const RSA_SHA256: string = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+
+const ISSUER: string = "https://idp.example.com/metadata";
+const DISPLAY_NAME_CLAIM: string =
+  "http://schemas.microsoft.com/identity/claims/displayname";
+
+interface KeyPair {
+  privateKey: string;
+  publicKey: string;
+}
+
+let idpKeys: KeyPair;
+let attackerKeys: KeyPair;
+
+function generateRsaKeyPair(): KeyPair {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { privateKey, publicKey };
+}
+
+beforeAll(() => {
+  idpKeys = generateRsaKeyPair();
+  attackerKeys = generateRsaKeyPair();
+});
+
+// ---- SAML document builders ------------------------------------------------
+
+interface AssertionOptions {
+  assertionId?: string;
+  email?: string;
+  issuer?: string;
+  displayName?: string | null;
+  nameId?: string; // raw NameID inner XML override (for comment tests)
+}
+
+function buildAssertion(options: AssertionOptions = {}): string {
+  const assertionId: string = options.assertionId ?? "_assertion_genuine";
+  const issuer: string = options.issuer ?? ISSUER;
+  const nameIdInner: string =
+    options.nameId ?? options.email ?? "alice@example.com";
+
+  const attributeStatement: string =
+    options.displayName === null
+      ? ""
+      : `<saml:AttributeStatement><saml:Attribute Name="${DISPLAY_NAME_CLAIM}"><saml:AttributeValue>${
+          options.displayName ?? "Alice Example"
+        }</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>`;
+
+  return `<saml:Assertion ID="${assertionId}" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${issuer}</saml:Issuer><saml:Subject><saml:NameID>${nameIdInner}</saml:NameID></saml:Subject>${attributeStatement}</saml:Assertion>`;
+}
+
+function buildResponse(
+  innerXml: string,
+  responseId: string = "_resp1",
+): string {
+  return `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${responseId}" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer>${innerXml}</samlp:Response>`;
+}
+
+// Sign the single element with the given local name, appending the Signature into it.
+function sign(xml: string, localName: string, privateKey: string): string {
+  const xpath: string = `//*[local-name(.)='${localName}']`;
+  const sig: SignedXml = new SignedXml();
+  sig.addReference(xpath, [XMLDSIG_ENVELOPED, XMLDSIG_EXC_C14N], XMLENC_SHA256);
+  sig.signatureAlgorithm = RSA_SHA256;
+  sig.signingKey = privateKey;
+  sig.keyInfoProvider = {
+    getKeyInfo: (): string => {
+      return "<X509Data></X509Data>";
+    },
+  } as unknown as SignedXml["keyInfoProvider"];
+  sig.computeSignature(xml, {
+    location: { reference: xpath, action: "append" },
+  });
+  return sig.getSignedXml();
+}
+
+// Extract the (signed) <saml:Assertion>...</saml:Assertion> block from a document.
+function extractAssertion(signedXml: string): string {
+  const start: number = signedXml.indexOf("<saml:Assertion");
+  const endMarker: string = "</saml:Assertion>";
+  const end: number = signedXml.indexOf(endMarker) + endMarker.length;
+  return signedXml.substring(start, end);
+}
+
+function toBase64(xml: string): string {
+  return Buffer.from(xml).toString("base64");
+}
+
+// A genuine, assertion-signed response for alice@example.com.
+function genuineAssertionSignedResponse(): string {
+  return sign(buildResponse(buildAssertion()), "Assertion", idpKeys.privateKey);
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * Happy path - the genuine flow must keep working.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - genuine SAML flow (must not break)", () => {
+  test("accepts a genuinely assertion-signed response and extracts identity", () => {
+    const xml: string = genuineAssertionSignedResponse();
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+    expect(result.issuerUrl).toBe(ISSUER);
+    expect(result.name?.toString()).toBe("Alice Example");
+  });
+
+  test("accepts a genuinely response-signed (whole Response) response", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion()),
+      "Response",
+      idpKeys.privateKey,
+    );
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+    expect(result.issuerUrl).toBe(ISSUER);
+  });
+
+  test("returns null name when no display-name claim is present", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion({ displayName: null })),
+      "Assertion",
+      idpKeys.privateKey,
+    );
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+    expect(result.name).toBeNull();
+  });
+
+  test("works when the base64 SAMLResponse is decoded first (end-to-end shape)", () => {
+    const xml: string = Buffer.from(
+      toBase64(genuineAssertionSignedResponse()),
+      "base64",
+    ).toString();
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Attack path - signature wrapping and tampering must be rejected.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - XML Signature Wrapping is rejected (issue #2949)", () => {
+  test("rejects a genuine assertion hidden in <Extensions> with a forged sibling assertion", () => {
+    const genuineSigned: string = genuineAssertionSignedResponse();
+    const genuineAssertion: string = extractAssertion(genuineSigned);
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_assertion_forged",
+      email: "attacker@evil.com",
+      displayName: "Attacker",
+    });
+
+    const attack: string = buildResponse(
+      `<samlp:Extensions>${genuineAssertion}</samlp:Extensions>${forgedAssertion}`,
+    );
+
+    // The signature over the hidden genuine assertion must NOT be accepted.
+    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
+
+    // And the identity must never be extracted (it must throw, not return attacker@evil.com).
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects a forged assertion that nests the genuine signed assertion inside it", () => {
+    const genuineSigned: string = genuineAssertionSignedResponse();
+    const genuineAssertion: string = extractAssertion(genuineSigned);
+
+    // Forged outer assertion whose Subject wraps the genuine signed assertion.
+    const attack: string = buildResponse(
+      `<saml:Assertion ID="_assertion_forged" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer><saml:Subject><saml:NameID>attacker@evil.com</saml:NameID></saml:Subject>${genuineAssertion}</saml:Assertion>`,
+    );
+
+    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects a forged lone assertion with a valid signature over an unrelated element", () => {
+    /*
+     * The attacker holds a genuine signature over a non-assertion element (a
+     * signed <Dummy>), and pairs it with a single forged assertion.
+     */
+    const signedDummyDoc: string = sign(
+      buildResponse(
+        `<samlp:Extensions><Dummy ID="_dummy1">trusted-but-irrelevant</Dummy></samlp:Extensions><saml:Assertion ID="_placeholder" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer><saml:Subject><saml:NameID>alice@example.com</saml:NameID></saml:Subject></saml:Assertion>`,
+      ),
+      "Dummy",
+      idpKeys.privateKey,
+    );
+
+    // Grab the genuinely signed <Dummy> element.
+    const dummyStart: number = signedDummyDoc.indexOf("<Dummy");
+    const dummyEnd: number =
+      signedDummyDoc.indexOf("</Dummy>") + "</Dummy>".length;
+    const signedDummy: string = signedDummyDoc.substring(dummyStart, dummyEnd);
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_assertion_forged",
+      email: "attacker@evil.com",
+    });
+
+    const attack: string = buildResponse(
+      `<samlp:Extensions>${signedDummy}</samlp:Extensions>${forgedAssertion}`,
+    );
+
+    // The signature over <Dummy> validates, but it does not cover the assertion.
+    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects two assertions sharing the same ID (issue PoC shape)", () => {
+    const genuineSigned: string = sign(
+      buildResponse(buildAssertion({ assertionId: "_dup" })),
+      "Assertion",
+      idpKeys.privateKey,
+    );
+    const genuineAssertion: string = extractAssertion(genuineSigned);
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_dup",
+      email: "attacker@evil.com",
+    });
+
+    const attack: string = buildResponse(
+      `<samlp:Extensions>${genuineAssertion}</samlp:Extensions>${forgedAssertion}`,
+    );
+
+    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
+    }).toThrow();
+  });
+});
+
+describe("SSOUtil - signature tampering and forgery is rejected", () => {
+  test("rejects a tampered NameID (digest mismatch)", () => {
+    const genuine: string = genuineAssertionSignedResponse();
+    const tampered: string = genuine.replace(
+      "alice@example.com",
+      "attacker@evil.com",
+    );
+
+    expect(SSOUtil.isSignatureValid(tampered, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(tampered, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects a response signed by a different (attacker) key", () => {
+    const attackerSigned: string = sign(
+      buildResponse(buildAssertion({ email: "attacker@evil.com" })),
+      "Assertion",
+      attackerKeys.privateKey,
+    );
+
+    // Verified against the genuine IdP certificate -> must fail.
+    expect(SSOUtil.isSignatureValid(attackerSigned, idpKeys.publicKey)).toBe(
+      false,
+    );
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(attackerSigned, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects an unsigned response", () => {
+    const unsigned: string = buildResponse(buildAssertion());
+
+    expect(SSOUtil.isSignatureValid(unsigned, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(unsigned, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects a NameID containing an XML comment (comment-truncation defense)", () => {
+    /*
+     * Signed WITH the comment present. Exclusive c14n excludes comments, so the
+     * signature is valid, but our extractor must refuse comments outright.
+     */
+    const xml: string = sign(
+      buildResponse(
+        buildAssertion({ nameId: "admin@corp.com<!-- -->.attacker.com" }),
+      ),
+      "Assertion",
+      idpKeys.privateKey,
+    );
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow("SAML Assertion must not contain XML comments");
+  });
+});
+
+describe("SSOUtil - malformed and abusive input is rejected", () => {
+  test("rejects a DOCTYPE / entity declaration (XXE guard)", () => {
+    const xml: string =
+      `<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe "bar">]>` +
+      genuineAssertionSignedResponse();
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects malformed XML", () => {
+    const xml: string = "<samlp:Response><saml:Assertion></samlp:Response>";
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects an empty SAML response", () => {
+    expect(SSOUtil.isSignatureValid("", idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML("", idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects a response with no assertion", () => {
+    const xml: string = sign(
+      `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_r" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer></samlp:Response>`,
+      "Response",
+      idpKeys.privateKey,
+    );
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow();
+  });
+
+  test("rejects when the certificate is missing", () => {
+    const xml: string = genuineAssertionSignedResponse();
+
+    expect(SSOUtil.isSignatureValid(xml, "")).toBe(false);
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, "");
+    }).toThrow("Public Certificate not found");
+  });
+});
+
+describe("SSOUtil - createSAMLRequestUrl", () => {
+  test("produces a SAMLRequest query parameter", () => {
+    const url: string = SSOUtil.createSAMLRequestUrl({
+      acsUrl: URL.fromString("https://app.example.com/acs"),
+      signOnUrl: URL.fromString("https://idp.example.com/sso"),
+      issuerUrl: URL.fromString("https://app.example.com/issuer"),
+    }).toString();
+
+    expect(url).toContain("SAMLRequest=");
+    expect(url).toContain("https://idp.example.com/sso");
+  });
+});
+
+// Sanity check that the Email type is what we assert against above.
+describe("SSOUtil - sanity", () => {
+  test("extracted email is a Common Email instance", () => {
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      genuineAssertionSignedResponse(),
+      idpKeys.publicKey,
+    );
+    expect(result.email).toBeInstanceOf(Email);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2949 — multiple SAML **XML Signature Wrapping (XSW)** bypasses in the custom SAML implementation. This is a full authentication bypass: an attacker who captures a single genuinely-signed assertion from the IdP can impersonate any user.

### Root cause

`SSOUtil` validated the signature and extracted the identity through **two independent paths**:

- `isSignatureValid()` parsed with `@xmldom/xmldom`, took the **first** `<Signature>` element (`getElementsByTagNameNS(...)[0]`), and validated whatever it referenced.
- `getIssuer()` / `getEmail()` / `getUserFullName()` read the identity from a **separate `xml2js` parse** of the document.

Because "what was signed" and "what was read" were selected independently, an attacker could hide a genuinely-signed assertion (e.g. inside `<samlp:Extensions>`) and place a **forged** assertion where `xml2js` reads. The signature check passed on the hidden genuine assertion while the identity came from the forged one. The `Assertion.length !== 1` guard didn't help — the hidden assertion isn't a direct child, so it wasn't counted.

I reproduced this end-to-end before fixing: `isSignatureValid` returned `true` while the extracted email was `attacker@evil.com`.

### Fix

All three consumers (`SSO`, `GlobalSSO`, `StatusPageSSO`) now route through a single hardened entry point, `SSOUtil.getSamlResponseFromXML`, which **verifies and extracts from the same cryptographically-verified assertion**:

1. **Parse once, strictly.** Reject `DOCTYPE`/entity declarations (XXE, entity-expansion, parser-differential guard) and any malformed XML.
2. **Require exactly one `<Assertion>`** in the entire document (any namespace, including nested/wrapped). Every XSW variant needs a second assertion to hide behind — this removes the hiding place.
3. **Bind signature to identity.** A `<Signature>` must validate against the configured certificate **and** its reference must resolve to that one assertion (or an ancestor `<Response>` that contains it). A valid signature over an unrelated element no longer authenticates a forged assertion.
4. **Reject XML comments** in the identity-bearing nodes (`NameID`, `Issuer`, display-name), defeating comment-truncation attacks.

Identity fields now come from the signed Assertion's own DOM subtree — the `xml2js` second-parse is gone. `xml-crypto`'s built-in duplicate-ID protection remains an additional layer.

> Note: the issuer is now read from the (signed) `<Assertion><Issuer>` (mandatory per SAML 2.0 core) instead of the response-level `<Issuer>`, so the value used for the config match is always inside the signed region.

### Tests

New suite `App/Tests/Identity/SSO.test.ts` (19 tests, keys generated at runtime — no secrets committed):

- **Genuine flow (must not break):** assertion-signed and whole-response-signed responses are accepted and identity extracted; display-name present/absent; base64 round-trip.
- **Wrapping rejected:** genuine assertion hidden in `<Extensions>` + forged sibling; genuine assertion nested inside forged assertion; forged lone assertion + valid signature over an unrelated element; duplicate-ID PoC shape.
- **Tampering/forgery rejected:** tampered `NameID` (digest mismatch); attacker-key signature; unsigned response.
- **Abuse rejected:** comment-in-`NameID`; `DOCTYPE`/entity; malformed XML; empty input; no assertion; missing certificate.

### Verification

- `App/Tests/Identity/SSO.test.ts` — 19/19 pass
- `tsc --noEmit` (App) — clean
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)