### PR TITLE
feat(network-map): add a search box that finds a site anywhere in the hierarchy

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkSiteHierarchy.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkSiteHierarchy.ts
@@ -112,6 +112,14 @@ const NETWORK_SITE_TYPE_SELECT: Select<NetworkSiteType> = {
  */
 type MapMode = "grouped" | "all";
 
+/*
+ * How many search hits /network-site/search answers with. Deliberately far
+ * below LIMIT_PER_PROJECT: this feeds a dropdown somebody reads, and a
+ * franchise estate matching "unit" on ten thousand rows is a request to type
+ * more, not a list to scroll. The response says when the cap was hit.
+ */
+const SEARCH_RESULT_LIMIT: number = 50;
+
 type StatusMap = Map<string, StatusInfo>;
 
 function toStatusMap(statuses: Array<MonitorStatus>): StatusMap {
@@ -1028,6 +1036,177 @@ export default class NetworkSiteHierarchyAPI {
             isTruncated:
               childRows.length >= LIMIT_PER_PROJECT ||
               subtreeRows.length >= LIMIT_PER_PROJECT,
+          } as unknown as JSONObject);
+        } catch (err) {
+          return next(err);
+        }
+      },
+    );
+
+    /*
+     * Find a site by name ANYWHERE in the project.
+     *
+     * The map is a drill-down, and that is exactly what makes it hard to
+     * search: a store four levels under a region is reachable only by
+     * opening every level above it, and "which market is Unit 104822 in" is
+     * precisely the question you have when you cannot do that. A filter over
+     * the level in view cannot answer it — the answer is not on that level.
+     *
+     * So each hit carries the PATH to it. That is what tells two similarly
+     * named stores apart before the click, and it answers "where is this"
+     * without drilling at all.
+     *
+     * Reads are permission-scoped through the standard props helper like
+     * every other query in this file, so a user only ever finds sites they
+     * are allowed to read — including in the ancestor lookup that builds the
+     * paths, where an unreadable ancestor simply drops out of the string.
+     */
+    router.post(
+      "/network-site/search",
+      UserMiddleware.getUserMiddleware,
+      async (
+        req: ExpressRequest,
+        res: ExpressResponse,
+        next: NextFunction,
+      ): Promise<void> => {
+        try {
+          const props: DatabaseCommonInteractionProps =
+            await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+          if (!props.tenantId) {
+            throw new BadDataException("Project not found in request");
+          }
+          const projectId: ObjectID = props.tenantId;
+
+          const body: JSONObject = (req.body || {}) as JSONObject;
+          const searchText: string =
+            NetworkSiteHierarchyUtil.normalizeSearchText(body["searchText"]);
+
+          /*
+           * An empty box is not an error, and it is emphatically not a query
+           * for every site in the project — it is simply no results.
+           */
+          if (!searchText) {
+            return Response.sendJsonObjectResponse(req, res, {
+              results: [],
+              isTruncated: false,
+            } as unknown as JSONObject);
+          }
+
+          const matchedSites: Array<NetworkSite> =
+            await NetworkSiteService.findBy({
+              query: {
+                projectId: projectId,
+                name: QueryHelper.search(searchText),
+              },
+              select: {
+                _id: true,
+                name: true,
+                siteType: true,
+                networkSiteType: NETWORK_SITE_TYPE_SELECT,
+                materializedPath: true,
+                currentMonitorStatusId: true,
+              },
+              sort: {
+                name: SortOrder.Ascending,
+              },
+              limit: SEARCH_RESULT_LIMIT,
+              skip: 0,
+              props: props,
+            });
+
+          const matches: Array<{ site: NetworkSite; id: string }> = matchedSites
+            .filter((site: NetworkSite) => {
+              return Boolean(site._id);
+            })
+            .map((site: NetworkSite): { site: NetworkSite; id: string } => {
+              return { site: site, id: site._id!.toString() };
+            });
+
+          const nameById: Map<string, string> = new Map<string, string>();
+          for (const match of matches) {
+            if (match.site.name) {
+              nameById.set(match.id, match.site.name);
+            }
+          }
+
+          const statusIds: Set<string> = new Set<string>();
+          for (const match of matches) {
+            if (match.site.currentMonitorStatusId) {
+              statusIds.add(match.site.currentMonitorStatusId.toString());
+            }
+          }
+
+          /*
+           * One extra query resolves the ancestors of the WHOLE result set —
+           * the ids are collected up front precisely so this does not become
+           * a path walk per hit.
+           */
+          const ancestorIds: Array<string> =
+            NetworkSiteHierarchyUtil.collectAncestorIds(
+              matches.map((match: { site: NetworkSite; id: string }) => {
+                return {
+                  id: match.id,
+                  materializedPath: match.site.materializedPath,
+                };
+              }),
+              new Set<string>(nameById.keys()),
+            );
+
+          const [ancestorRows, statusById]: [Array<NetworkSite>, StatusMap] =
+            await Promise.all([
+              ancestorIds.length > 0
+                ? NetworkSiteService.findBy({
+                    query: {
+                      projectId: projectId,
+                      _id: QueryHelper.any(ancestorIds),
+                    },
+                    select: {
+                      _id: true,
+                      name: true,
+                    },
+                    limit: LIMIT_PER_PROJECT,
+                    skip: 0,
+                    props: props,
+                  })
+                : Promise.resolve([]),
+              fetchStatusesByIds(projectId, Array.from(statusIds), props),
+            ]);
+
+          for (const ancestor of ancestorRows) {
+            if (ancestor._id && ancestor.name) {
+              nameById.set(ancestor._id.toString(), ancestor.name);
+            }
+          }
+
+          const results: Array<JSONObject> = matches.map(
+            (match: { site: NetworkSite; id: string }): JSONObject => {
+              const status: StatusInfo | undefined = match.site
+                .currentMonitorStatusId
+                ? statusById.get(match.site.currentMonitorStatusId.toString())
+                : undefined;
+              return {
+                id: match.id,
+                name: match.site.name || "Unnamed site",
+                ...getSiteTypeInfo(match.site),
+                path: NetworkSiteHierarchyUtil.buildParentBreadcrumbString(
+                  match.site.materializedPath,
+                  match.id,
+                  nameById,
+                ),
+                currentMonitorStatus: status,
+              } as unknown as JSONObject;
+            },
+          );
+
+          return Response.sendJsonObjectResponse(req, res, {
+            results: results,
+            /*
+             * Hitting the cap means there are more matches than are being
+             * shown, so the box can tell the user to keep typing rather than
+             * let them read a partial list as the whole answer.
+             */
+            isTruncated: matchedSites.length >= SEARCH_RESULT_LIMIT,
           } as unknown as JSONObject);
         } catch (err) {
           return next(err);

--- a/App/FeatureSet/BaseAPI/Utils/NetworkSiteHierarchyUtil.ts
+++ b/App/FeatureSet/BaseAPI/Utils/NetworkSiteHierarchyUtil.ts
@@ -67,6 +67,20 @@ export const DEFAULT_UPTIME_WINDOW_DAYS: number = 30;
 export const MAX_UPTIME_WINDOW_DAYS: number = 90;
 export const MIN_UPTIME_WINDOW_DAYS: number = 1;
 
+/*
+ * Longest search text /network-site/search will act on. A site's name is a
+ * ShortText column, so nothing longer than this could match a row anyway —
+ * the cap is there to keep an unbounded caller-supplied string out of the
+ * ILIKE pattern the query builds from it.
+ */
+export const MAX_SEARCH_TEXT_LENGTH: number = 200;
+
+// A row the search endpoint has to print the path to.
+export interface SearchPathRow {
+  id: string;
+  materializedPath?: string | undefined;
+}
+
 export default class NetworkSiteHierarchyUtil {
   /*
    * Normalizes the caller-supplied uptime window: default 30 days, clamped
@@ -147,6 +161,48 @@ export default class NetworkSiteHierarchyUtil {
       isUnitLevel: site.isUnitLevel,
     });
     return breadcrumb;
+  }
+
+  /*
+   * Normalizes the caller-supplied search text. A non-string, or a string
+   * that is blank once trimmed, reads as NO SEARCH — which the endpoint
+   * answers with an empty result rather than with the whole project: an
+   * empty box must not be the query that returns everything.
+   *
+   * The length cap is applied after trimming (see MAX_SEARCH_TEXT_LENGTH).
+   */
+  public static normalizeSearchText(value: unknown): string {
+    if (typeof value !== "string") {
+      return "";
+    }
+    return value.trim().slice(0, MAX_SEARCH_TEXT_LENGTH);
+  }
+
+  /*
+   * Every ancestor id the given rows reference, deduplicated, minus the ones
+   * the caller already holds rows for.
+   *
+   * A search answers with matches from anywhere in the hierarchy, and each
+   * one has to print the path to it — so the names of their ancestors have
+   * to be resolved. Collecting the ids first is what keeps that to ONE extra
+   * query for the whole result set instead of one walk per hit.
+   */
+  public static collectAncestorIds(
+    rows: Array<SearchPathRow>,
+    knownIds: Set<string>,
+  ): Array<string> {
+    const ancestorIds: Set<string> = new Set<string>();
+    for (const row of rows) {
+      for (const ancestorId of NetworkSiteHierarchyUtil.parseAncestorIds(
+        row.materializedPath,
+        row.id,
+      )) {
+        if (!knownIds.has(ancestorId)) {
+          ancestorIds.add(ancestorId);
+        }
+      }
+    }
+    return Array.from(ancestorIds);
   }
 
   // ' / '-joined ancestor names for the map view, root-first.

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/NetworkMapDrillState.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/NetworkMapDrillState.ts
@@ -16,9 +16,17 @@ import Navigation from "Common/UI/Utils/Navigation";
  */
 export interface NetworkMapDrillState {
   siteId: string | null;
+  /*
+   * What the search box is narrowing the map to. It rides along with the
+   * drill position for the same reason the drill position is in the URL at
+   * all: what is on screen should survive a copy-paste and a back button.
+   * Absent reads as "" — no filter — never as a filter matching nothing.
+   */
+  searchText: string;
 }
 
 export const NETWORK_MAP_SITE_PARAM: string = "site";
+export const NETWORK_MAP_SEARCH_PARAM: string = "siteSearch";
 
 /*
  * The map used to offer a "United States / World" toggle, mirrored into this
@@ -32,6 +40,7 @@ export const LEGACY_NETWORK_MAP_REGION_PARAM: string = "mapRegion";
 export function readDrillStateFromUrl(): NetworkMapDrillState {
   return {
     siteId: Navigation.getQueryStringByName(NETWORK_MAP_SITE_PARAM),
+    searchText: Navigation.getQueryStringByName(NETWORK_MAP_SEARCH_PARAM) || "",
   };
 }
 

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteContainerGraph.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteContainerGraph.tsx
@@ -220,6 +220,13 @@ export interface ComponentProps {
   links: Array<SiteLinkView>;
   childrenTruncated: boolean;
   descendantCountsTruncated: boolean;
+  /*
+   * What the page's search box narrowed `sites` down to, if anything. The
+   * graph filters nothing itself — it is handed the survivors — but an empty
+   * result has to read as "nothing matches" rather than as "this site has no
+   * children", which is a different and much more alarming statement.
+   */
+  searchText?: string | undefined;
   onSiteClick: (siteId: string) => void;
 }
 
@@ -432,23 +439,37 @@ const SiteContainerGraph: FunctionComponent<ComponentProps> = (
   }, [hasNodes]);
 
   if (props.sites.length === 0) {
+    const searchText: string = (props.searchText || "").trim();
     return (
       /*
        * EmptyState ships 13rem of vertical padding for a full-page
        * placeholder; inside this page's card that reads as a hole.
        */
       <div className="-my-28">
-        <EmptyState
-          id="site-container-empty"
-          icon={IconProp.SquareStack}
-          title="No child sites here yet"
-          description={
-            <span className="mx-auto block max-w-md">
-              Sites added under this one (and network devices assigned to them)
-              will appear here as a map.
-            </span>
-          }
-        />
+        {searchText ? (
+          <EmptyState
+            id="site-container-no-search-match"
+            icon={IconProp.Search}
+            title="No child sites match your search"
+            description={
+              <span className="mx-auto block max-w-md">
+                {`Nothing under this site matches “${searchText}”. Clear the search to see all of its children again.`}
+              </span>
+            }
+          />
+        ) : (
+          <EmptyState
+            id="site-container-empty"
+            icon={IconProp.SquareStack}
+            title="No child sites here yet"
+            description={
+              <span className="mx-auto block max-w-md">
+                Sites added under this one (and network devices assigned to
+                them) will appear here as a map.
+              </span>
+            }
+          />
+        )}
       </div>
     );
   }

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
@@ -289,6 +289,13 @@ export interface ComponentProps {
    * never invents vocabulary the customer has not used.
    */
   childTypeLabel: string;
+  /*
+   * What the page's search box is narrowing `sites` to, if anything. The map
+   * does no filtering of its own — it is handed the survivors — but it has to
+   * know a filter is on, or an empty result reads as "you have no sites"
+   * rather than as "nothing matches what you typed".
+   */
+  searchText?: string | undefined;
   onSiteClick: (siteId: string) => void;
 }
 
@@ -758,6 +765,29 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   if (markers.length === 0) {
     const hasSites: boolean = props.sites.length > 0;
     const unplacedCount: number = props.unplacedSites.length;
+    const searchText: string = (props.searchText || "").trim();
+    /*
+     * A search that matched nothing is not the same emptiness as a project
+     * with no coordinates on it, and telling somebody to go add latitudes
+     * when the real answer is "that name is not here" sends them off to fix
+     * something that is not broken.
+     */
+    if (searchText && !hasSites) {
+      return (
+        <div className="w-full rounded-lg border border-gray-200 bg-white shadow-sm">
+          <EmptyState
+            id="site-geo-map-no-search-match"
+            icon={IconProp.Search}
+            title="No sites here match your search"
+            description={
+              <span className="mx-auto block max-w-md">
+                {`Nothing at this level matches “${searchText}”. The results under the search box look through your whole network, not just this level.`}
+              </span>
+            }
+          />
+        </div>
+      );
+    }
     return (
       <div className="w-full rounded-lg border border-gray-200 bg-white shadow-sm">
         <EmptyState

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes.ts
@@ -138,6 +138,28 @@ export interface SiteMapResponse {
   isTruncated: boolean;
 }
 
+/*
+ * One hit of /network-site/search — a site matched by name from anywhere in
+ * the project, not just the level in view. `path` is what makes the hit
+ * usable: two stores called "Michigan Ave" are told apart by the markets
+ * above them, and it answers "where is this" without drilling.
+ */
+export interface SiteSearchResultView {
+  id: string;
+  name: string;
+  siteType: string;
+  isUnitLevel: boolean;
+  /** ' / '-joined ancestor names, root-first. Empty for a root site. */
+  path: string;
+  currentMonitorStatus: SiteStatusInfo | undefined;
+}
+
+export interface SiteSearchResponse {
+  results: Array<SiteSearchResultView>;
+  // The server capped the result set — there are more matches than these.
+  isTruncated: boolean;
+}
+
 const asString: (value: unknown, fallback: string) => string = (
   value: unknown,
   fallback: string,
@@ -286,6 +308,54 @@ export const parseSiteChildrenResponse: (
     links: links,
     childrenTruncated: data?.["childrenTruncated"] === true,
     descendantCountsTruncated: data?.["descendantCountsTruncated"] === true,
+  };
+};
+
+const parseSearchResultRow: (value: unknown) => SiteSearchResultView | null = (
+  value: unknown,
+): SiteSearchResultView | null => {
+  const row: JSONObject = (value || {}) as JSONObject;
+  const id: string = asString(row["id"], "");
+  if (!id) {
+    return null;
+  }
+  return {
+    id: id,
+    name: asString(row["name"], "Unnamed site"),
+    siteType: asString(row["siteType"], "Other"),
+    isUnitLevel: row["isUnitLevel"] === true,
+    /*
+     * A root site has no ancestors, so an absent path is the normal case
+     * here rather than a defect — it narrows to "" and the row simply
+     * prints no path line.
+     */
+    path: asString(row["path"], ""),
+    currentMonitorStatus: parseStatusInfo(row["currentMonitorStatus"]),
+  };
+};
+
+/**
+ * Narrow an untyped /network-site/search payload. Rows without an id are
+ * dropped; everything else falls back the same way the other parsers here
+ * do, so a partially broken server costs the user a label rather than the
+ * whole search box.
+ */
+export const parseSiteSearchResponse: (
+  data: JSONObject | undefined,
+) => SiteSearchResponse = (
+  data: JSONObject | undefined,
+): SiteSearchResponse => {
+  return {
+    results: asRows(data?.["results"])
+      .map(parseSearchResultRow)
+      .filter(
+        (
+          result: SiteSearchResultView | null,
+        ): result is SiteSearchResultView => {
+          return result !== null;
+        },
+      ),
+    isTruncated: data?.["isTruncated"] === true,
   };
 };
 

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSearchBox.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSearchBox.tsx
@@ -1,0 +1,453 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import URL from "Common/Types/API/URL";
+import IconProp from "Common/Types/Icon/IconProp";
+import { JSONObject } from "Common/Types/JSON";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Input from "Common/UI/Components/Input/Input";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import { APP_API_URL } from "Common/UI/Config";
+import {
+  SiteSearchResponse,
+  SiteSearchResultView,
+  parseSiteSearchResponse,
+} from "./SiteHierarchyTypes";
+import {
+  MIN_SITE_SEARCH_CHARS,
+  isRemoteSearchable,
+  normalizeSiteSearchText,
+} from "./SiteSearchUtil";
+import { pluralizeSiteType } from "./SiteMapViewModel";
+
+/*
+ * The Network Map's search box.
+ *
+ * It answers two different questions with one control, because they are the
+ * same question asked from different distances:
+ *
+ *   "narrow what I am looking at" — handled by the PAGE, which applies the
+ *     same text to the markers, the cards and the WAN links of the level in
+ *     view. That is instant and local, so it happens on every keystroke.
+ *
+ *   "where is Unit 104822" — handled here, against /network-site/search,
+ *     because the answer is somewhere the page is not: the map holds one
+ *     level and the site is four levels down. Each hit prints the path to
+ *     it, and picking one drills straight there.
+ *
+ * The second is why this box exists at all. A drill-down map without it can
+ * only be searched by someone who already knows which region to open, which
+ * is the one thing they are trying to find out.
+ */
+
+// Per-keystroke requests would be one round trip per character typed.
+const SEARCH_DEBOUNCE_MS: number = 250;
+
+/*
+ * The input's own classes, not the shared default: the box carries a search
+ * glyph on the left and a clear button on the right, and both need room that
+ * the default padding does not leave.
+ */
+const INPUT_CLASS: string =
+  "block w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-9 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm";
+
+const NO_STATUS_COLOR: string = "#9ca3af"; // gray-400
+
+export interface ComponentProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Drill to a site the reader picked out of the results. */
+  onSelectSite: (siteId: string) => void;
+  /*
+   * How the level in view narrowed under this text. Shown as a quiet count
+   * so a search that hides most of the map says so, rather than leaving the
+   * reader to wonder where their sites went.
+   */
+  localMatchCount: number;
+  localTotalCount: number;
+  /*
+   * What the children of this level are called, in the customer's own words
+   * ("Regions", "Markets"). The box must not invent vocabulary either.
+   */
+  childTypeLabel: string;
+}
+
+const SiteSearchBox: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [results, setResults] = useState<Array<SiteSearchResultView>>([]);
+  const [isTruncated, setIsTruncated] = useState<boolean>(false);
+  const [isSearching, setIsSearching] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+  /*
+   * The text the results on screen actually answer. Without it the "no
+   * matches" line would appear the instant somebody types, over the results
+   * of the previous query, before the new request has even left.
+   */
+  const [answeredText, setAnsweredText] = useState<string>("");
+
+  const normalized: string = normalizeSiteSearchText(props.value);
+  const canSearchRemotely: boolean = isRemoteSearchable(normalized);
+
+  /*
+   * Cancel-stale: every request takes a sequence number and only the latest
+   * may write state, so a slow response for "kan" can never land on top of
+   * the results for "kansas city".
+   */
+  const requestSeq: React.MutableRefObject<number> = useRef<number>(0);
+  const isMounted: React.MutableRefObject<boolean> = useRef<boolean>(true);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  const runSearch: (searchText: string) => Promise<void> = useCallback(
+    async (searchText: string): Promise<void> => {
+      const seq: number = ++requestSeq.current;
+      try {
+        const url: URL = URL.fromString(APP_API_URL.toString()).addRoute(
+          "/network-site/search",
+        );
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.post<JSONObject>({
+            url: url,
+            data: { searchText: searchText },
+            headers: { ...ModelAPI.getCommonHeaders() },
+          });
+
+        if (response instanceof HTTPErrorResponse) {
+          throw response;
+        }
+
+        if (!isMounted.current || seq !== requestSeq.current) {
+          return;
+        }
+
+        const parsed: SiteSearchResponse = parseSiteSearchResponse(
+          response.data,
+        );
+        setResults(parsed.results);
+        setIsTruncated(parsed.isTruncated);
+        setError("");
+      } catch (err) {
+        if (!isMounted.current || seq !== requestSeq.current) {
+          return;
+        }
+        setResults([]);
+        setIsTruncated(false);
+        setError(API.getFriendlyMessage(err));
+      }
+      if (isMounted.current && seq === requestSeq.current) {
+        setIsSearching(false);
+        setAnsweredText(searchText);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    setActiveIndex(-1);
+
+    if (!canSearchRemotely) {
+      /*
+       * Below the threshold there is nothing to show — and the sequence
+       * number is bumped so a request already in flight for a longer string
+       * cannot arrive and repopulate the list after it was cleared.
+       */
+      requestSeq.current++;
+      setResults([]);
+      setIsTruncated(false);
+      setIsSearching(false);
+      setError("");
+      setAnsweredText("");
+      return undefined;
+    }
+
+    setIsSearching(true);
+    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+      runSearch(normalized).catch(() => {
+        // runSearch handles its own failures; this keeps the promise quiet.
+      });
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [normalized, canSearchRemotely, runSearch]);
+
+  const selectResult: (result: SiteSearchResultView) => void = (
+    result: SiteSearchResultView,
+  ): void => {
+    /*
+     * Clear the box on the way through. The text was a question ("where is
+     * 104822"), and it has been answered by going there — leaving it behind
+     * would also leave the destination level filtered by it, which is very
+     * rarely what somebody wants after arriving.
+     */
+    props.onChange("");
+    setIsFocused(false);
+    props.onSelectSite(result.id);
+  };
+
+  const onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ): void => {
+    if (event.key === "Escape") {
+      setIsFocused(false);
+      return;
+    }
+    if (results.length === 0) {
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setIsFocused(true);
+      setActiveIndex((previous: number): number => {
+        return previous + 1 >= results.length ? 0 : previous + 1;
+      });
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((previous: number): number => {
+        return previous <= 0 ? results.length - 1 : previous - 1;
+      });
+      return;
+    }
+    if (event.key === "Enter") {
+      /*
+       * Enter only commits an entry the reader has actually moved onto.
+       * Firing the first hit on a bare Enter would drill somewhere they
+       * never looked at, which is the worst outcome this control can have.
+       */
+      const active: SiteSearchResultView | undefined = results[activeIndex];
+      if (active) {
+        event.preventDefault();
+        selectResult(active);
+      }
+    }
+  };
+
+  const isNarrowed: boolean =
+    Boolean(normalized) && props.localMatchCount < props.localTotalCount;
+
+  const showResultsPanel: boolean = isFocused && canSearchRemotely;
+  const hasAnsweredCurrentText: boolean = answeredText === normalized;
+
+  return (
+    <div className="relative w-full" onKeyDown={onKeyDown}>
+      <div className="relative">
+        <div className="pointer-events-none absolute inset-y-0 left-0 z-10 flex items-center pl-3">
+          <Icon className="h-4 w-4 text-gray-400" icon={IconProp.Search} />
+        </div>
+        <Input
+          dataTestId="network-map-search"
+          placeholder="Search sites by name — anywhere in your network"
+          value={props.value}
+          className={INPUT_CLASS}
+          outerDivClassName="relative w-full rounded-md shadow-sm"
+          disableSpellCheck={true}
+          autoComplete="off"
+          onChange={(value: string) => {
+            /*
+             * Typing re-opens the panel. Picking a result closes it while
+             * leaving focus in the box (see selectResult), so without this
+             * the next search would run with nowhere to show its answers.
+             */
+            setIsFocused(true);
+            props.onChange(value);
+          }}
+          onFocus={() => {
+            setIsFocused(true);
+          }}
+          /*
+           * Closing on blur is enough, and it is exact: the panel swallows
+           * mousedown, so clicking a result never blurs the input, and the
+           * only thing that does is the reader going somewhere else.
+           */
+          onBlur={() => {
+            setIsFocused(false);
+          }}
+        />
+        {props.value ? (
+          <button
+            type="button"
+            data-testid="network-map-search-clear"
+            aria-label="Clear search"
+            className="absolute inset-y-0 right-0 z-10 flex items-center pr-3 text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:text-indigo-600"
+            onClick={() => {
+              props.onChange("");
+            }}
+          >
+            <Icon className="h-4 w-4" icon={IconProp.Close} />
+          </button>
+        ) : (
+          <></>
+        )}
+      </div>
+
+      {/*
+       * The local half's feedback: how far this text narrowed the level in
+       * view. It sits outside the dropdown because it stays true whether or
+       * not the reader is looking at the hierarchy-wide results.
+       */}
+      {/*
+       * The live region is always mounted, empty when there is nothing to
+       * say. A region that appears at the same moment as its first message
+       * is unreliably announced — screen readers watch regions that were
+       * already there.
+       */}
+      <div aria-live="polite">
+        {isNarrowed ? (
+          <p
+            className="mt-1 text-xs text-gray-500"
+            data-testid="network-map-search-local-count"
+          >
+            {/*
+             * pluralizeSiteType, not "+ s": the label is a per-project type
+             * name the customer wrote, and naive pluralization prints
+             * "Facilitys" and "Branchs" on a real estate's map.
+             */}
+            {`Showing ${props.localMatchCount} of ${props.localTotalCount} ${(props.localTotalCount ===
+            1
+              ? props.childTypeLabel
+              : pluralizeSiteType(props.childTypeLabel)
+            ).toLowerCase()} at this level`}
+          </p>
+        ) : (
+          <></>
+        )}
+      </div>
+
+      {showResultsPanel ? (
+        /*
+         * mousedown is where a blur would be triggered from, so swallowing
+         * it here is what lets a click on a result land at all — without it
+         * the panel unmounts under the pointer before the click fires.
+         */
+        <div
+          className="absolute left-0 right-0 top-full z-30 mt-1 max-h-80 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+          onMouseDown={(event: React.MouseEvent<HTMLDivElement>) => {
+            event.preventDefault();
+          }}
+        >
+          <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400">
+            Anywhere in your network
+          </p>
+
+          {error ? (
+            <p className="px-3 py-2 text-xs text-red-600">{error}</p>
+          ) : (
+            <></>
+          )}
+
+          {!error && isSearching && !hasAnsweredCurrentText ? (
+            <p className="px-3 py-2 text-xs text-gray-500">Searching…</p>
+          ) : (
+            <></>
+          )}
+
+          {!error && hasAnsweredCurrentText && results.length === 0 ? (
+            <p
+              className="px-3 py-2 text-xs text-gray-500"
+              data-testid="network-map-search-no-results"
+            >
+              No sites match that name.
+            </p>
+          ) : (
+            <></>
+          )}
+
+          <div role="listbox" aria-label="Site search results">
+            {results.map(
+              (result: SiteSearchResultView, index: number): ReactElement => {
+                const isActive: boolean = index === activeIndex;
+                return (
+                  <div
+                    key={result.id}
+                    role="option"
+                    tabIndex={-1}
+                    aria-selected={isActive}
+                    data-testid={`network-map-search-result-${result.id}`}
+                    className={`cursor-pointer px-3 py-2 ${
+                      isActive ? "bg-indigo-50" : "hover:bg-gray-50"
+                    }`}
+                    onMouseEnter={() => {
+                      setActiveIndex(index);
+                    }}
+                    onClick={() => {
+                      selectResult(result);
+                    }}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        {result.currentMonitorStatus ? (
+                          <span
+                            className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                            title={result.currentMonitorStatus.name}
+                            style={{
+                              backgroundColor:
+                                result.currentMonitorStatus.color ||
+                                NO_STATUS_COLOR,
+                            }}
+                          />
+                        ) : (
+                          /*
+                           * Hollow ring: "no data" is a different shape, not
+                           * merely a grayer color. Same rule as SiteCard.
+                           */
+                          <span
+                            className="h-1.5 w-1.5 flex-shrink-0 rounded-full border border-gray-400"
+                            title="Not reporting"
+                          />
+                        )}
+                        <span className="truncate text-sm font-medium text-gray-900">
+                          {result.name}
+                        </span>
+                      </span>
+                      <span className="flex-shrink-0 text-[10px] font-semibold uppercase tracking-wider text-gray-400">
+                        {result.siteType}
+                      </span>
+                    </div>
+                    {result.path ? (
+                      <div className="mt-0.5 truncate pl-3 text-[11px] leading-4 text-gray-500">
+                        {result.path}
+                      </div>
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                );
+              },
+            )}
+          </div>
+
+          {isTruncated ? (
+            <p className="border-t border-gray-100 px-3 py-2 text-[11px] text-gray-500">
+              More sites match than are shown — keep typing to narrow it down.
+            </p>
+          ) : (
+            <></>
+          )}
+        </div>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+};
+
+export { MIN_SITE_SEARCH_CHARS };
+export default SiteSearchBox;

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSearchUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteSearchUtil.ts
@@ -1,0 +1,164 @@
+/*
+ * Pure, react-free matching for the Network Map's search box.
+ *
+ * The box does two things at once, and this file is the local half: as you
+ * type, the level in view narrows — the same predicate applied to the map's
+ * markers, the site cards and the WAN links, so all three halves of the page
+ * agree about what you are looking at. (The other half, finding a site
+ * ANYWHERE in the hierarchy, cannot be done on the client: the map only ever
+ * holds one level, so it goes to /network-site/search.)
+ *
+ * Kept out of the components so it can be imported (and unit-tested) in a
+ * plain Node/TypeScript environment — see Geo/GeoProjection.ts for why.
+ */
+
+/*
+ * Below this many characters the box does not ask the server for anything.
+ * One character matches most of a franchise estate, so the round trip would
+ * buy a list nobody can use — the local narrowing still runs from the first
+ * keystroke, because that is free.
+ */
+export const MIN_SITE_SEARCH_CHARS: number = 2;
+
+// What the local filter reads off a row. Every site DTO on the page has both.
+export interface SearchableSite {
+  name: string;
+  siteType: string;
+}
+
+// What the local filter reads off a WAN link row.
+export interface SearchableLink {
+  name: string;
+  fromSiteId?: string | undefined;
+  toSiteId?: string | undefined;
+}
+
+/**
+ * Fold raw input into the form every function here expects: trimmed and
+ * lower-cased. Pass the result around rather than re-deriving it per row.
+ */
+export const normalizeSiteSearchText: (
+  value: string | null | undefined,
+) => string = (value: string | null | undefined): string => {
+  return (value || "").trim().toLowerCase();
+};
+
+/**
+ * Whether this text is worth a round trip to /network-site/search.
+ */
+export const isRemoteSearchable: (normalized: string) => boolean = (
+  normalized: string,
+): boolean => {
+  return normalized.length >= MIN_SITE_SEARCH_CHARS;
+};
+
+/*
+ * Every whitespace-separated token has to appear somewhere in the row.
+ *
+ * A single token behaves exactly like a substring test, so nothing that used
+ * to match stops matching. What it adds is the way people actually name and
+ * then recall these things: a site called "Unit 104822 — Michigan Ave" is
+ * found by "michigan 104822" and by "104822 michigan", neither of which is a
+ * substring of anything.
+ */
+const tokenize: (normalized: string) => Array<string> = (
+  normalized: string,
+): Array<string> => {
+  return normalized.split(/\s+/).filter((token: string): boolean => {
+    return token.length > 0;
+  });
+};
+
+/**
+ * Does this site match? An empty search matches everything — the box being
+ * empty is not a filter.
+ *
+ * The site TYPE is part of the haystack on purpose: "market" is a perfectly
+ * reasonable thing to type at a level that mixes markets and stores, and the
+ * type name is the customer's own word for it.
+ */
+export const siteMatchesSearch: (
+  site: SearchableSite,
+  normalized: string,
+) => boolean = (site: SearchableSite, normalized: string): boolean => {
+  if (!normalized) {
+    return true;
+  }
+  const haystack: string = `${site.name || ""} ${site.siteType || ""}`
+    .trim()
+    .toLowerCase();
+  return tokenize(normalized).every((token: string): boolean => {
+    return haystack.includes(token);
+  });
+};
+
+/**
+ * The rows that survive the search.
+ *
+ * An empty search returns the INPUT ARRAY ITSELF, not a copy: the graph and
+ * the map both key expensive memos (grid layout, projection, cluster
+ * bucketing) off this array's identity, and handing them a fresh array on
+ * every keystroke-free render would relayout the level for nothing.
+ */
+export const filterSitesBySearch: <T extends SearchableSite>(
+  sites: Array<T>,
+  normalized: string,
+) => Array<T> = <T extends SearchableSite>(
+  sites: Array<T>,
+  normalized: string,
+): Array<T> => {
+  if (!normalized) {
+    return sites;
+  }
+  return sites.filter((site: T): boolean => {
+    return siteMatchesSearch(site, normalized);
+  });
+};
+
+/**
+ * The links that survive the search: the ones whose own name matches, plus
+ * the ones that touch a site still on screen.
+ *
+ * Touching ONE surviving site is enough. A search for "kansas city" is a
+ * question about Kansas City, and the WAN links out of it are a large part
+ * of the answer — dropping every one of them because the far end is in
+ * Denver would answer a question nobody asked.
+ */
+export const filterLinksBySearch: <T extends SearchableLink>(
+  links: Array<T>,
+  normalized: string,
+  visibleSiteIds: Set<string>,
+) => Array<T> = <T extends SearchableLink>(
+  links: Array<T>,
+  normalized: string,
+  visibleSiteIds: Set<string>,
+): Array<T> => {
+  if (!normalized) {
+    return links;
+  }
+  const tokens: Array<string> = tokenize(normalized);
+  return links.filter((link: T): boolean => {
+    const name: string = (link.name || "").toLowerCase();
+    const nameMatches: boolean = tokens.every((token: string): boolean => {
+      return name.includes(token);
+    });
+    return (
+      nameMatches ||
+      (Boolean(link.fromSiteId) && visibleSiteIds.has(link.fromSiteId!)) ||
+      (Boolean(link.toSiteId) && visibleSiteIds.has(link.toSiteId!))
+    );
+  });
+};
+
+/**
+ * The ids of a filtered site list, for the link filter above.
+ */
+export const siteIdSet: (sites: Array<{ id: string }>) => Set<string> = (
+  sites: Array<{ id: string }>,
+): Set<string> => {
+  return new Set<string>(
+    sites.map((site: { id: string }): string => {
+      return site.id;
+    }),
+  );
+};

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/NetworkMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/NetworkMap.tsx
@@ -5,9 +5,17 @@ import SiteContainerGraph from "../../Components/NetworkSite/SiteContainerGraph"
 import SiteGeoMap from "../../Components/NetworkSite/SiteGeoMap";
 import {
   LEGACY_NETWORK_MAP_REGION_PARAM,
+  NETWORK_MAP_SEARCH_PARAM,
   NetworkMapDrillState,
   readDrillStateFromUrl,
 } from "../../Components/NetworkSite/NetworkMapDrillState";
+import SiteSearchBox from "../../Components/NetworkSite/SiteSearchBox";
+import {
+  filterLinksBySearch,
+  filterSitesBySearch,
+  normalizeSiteSearchText,
+  siteIdSet,
+} from "../../Components/NetworkSite/SiteSearchUtil";
 import {
   MapSiteView,
   MapUnplacedSiteView,
@@ -142,6 +150,16 @@ const NetworkSiteMap: FunctionComponent<
   const [error, setError] = useState<string>("");
 
   /*
+   * What the search box holds. Seeded from the URL like the drill position
+   * is, and mirrored back to it, so a filtered map is a link somebody can
+   * send. It narrows the level in view locally; finding a site ELSEWHERE in
+   * the hierarchy is the search box's own job (see SiteSearchBox).
+   */
+  const [searchText, setSearchTextState] = useState<string>((): string => {
+    return readDrillStateFromUrl().searchText;
+  });
+
+  /*
    * How the map groups what it draws. Deliberately NOT in the URL: the
    * drill state is the shareable part of this page (see
    * NetworkMapDrillState), and whether one viewer prefers to see regions or
@@ -196,6 +214,16 @@ const NetworkSiteMap: FunctionComponent<
       }
     };
   }, []);
+
+  /*
+   * React state is the source of truth; the URL is a mirror, written through
+   * the same debounced queue the drill position uses (Safari rate-limits
+   * replaceState, and this one is written per keystroke).
+   */
+  const setSearchText: (value: string) => void = (value: string): void => {
+    setSearchTextState(value);
+    queueQueryStringUpdate({ [NETWORK_MAP_SEARCH_PARAM]: value || null });
+  };
 
   const location: Location = useLocation();
 
@@ -415,7 +443,12 @@ const NetworkSiteMap: FunctionComponent<
     setIsLoading(true);
     setError("");
     setCurrentSiteId(siteId);
-    queueQueryStringUpdate({ site: siteId });
+    // Text that narrowed THIS level would hide most of the next one.
+    setSearchTextState("");
+    queueQueryStringUpdate({
+      site: siteId,
+      [NETWORK_MAP_SEARCH_PARAM]: null,
+    });
   };
 
   /*
@@ -441,6 +474,12 @@ const NetworkSiteMap: FunctionComponent<
   useEffect(() => {
     const drillState: NetworkMapDrillState = readDrillStateFromUrl();
     changeSite(drillState.siteId);
+    /*
+     * After changeSite, never before: a real drill clears the search, and
+     * seeding it first would hand that clear something to throw away. The URL
+     * is the authority on both halves of what is on screen.
+     */
+    setSearchTextState(drillState.searchText);
     /*
      * Links from before the map dropped its "United States / World" toggle
      * still carry that parameter. Nothing reads it any more, so clear it
@@ -513,12 +552,54 @@ const NetworkSiteMap: FunctionComponent<
    * children are all Regions still says "regions" while some of them are
    * missing from the map for want of coordinates.
    */
-  const levelSites: Array<SiteChildView> = childrenData?.children || [];
-  const levelLinks: Array<SiteLinkView> = childrenData?.links || [];
-  const pinnedSites: Array<MapSiteView> = mapData?.sites || [];
-  const unplacedSites: Array<MapUnplacedSiteView> =
-    mapData?.unplacedSites || [];
-  const childTypeLabel: string = childTypeLabelFor(levelSites);
+  const allLevelSites: Array<SiteChildView> = childrenData?.children || [];
+  const allLevelLinks: Array<SiteLinkView> = childrenData?.links || [];
+  const allPinnedSites: Array<MapSiteView> = mapData?.sites || [];
+  /*
+   * From the UNFILTERED list on purpose. The label names what the children of
+   * this level ARE — searching for one region does not turn a level of
+   * Regions into a level of something else, and a label that changed under a
+   * filter would rewrite the map's legend and its counts as you type.
+   */
+  const childTypeLabel: string = childTypeLabelFor(allLevelSites);
+
+  /*
+   * The search narrows the whole level at once — the markers, the cards or
+   * graph, the unplaced list and the WAN links all through the same
+   * predicate, so the halves of this page cannot disagree about what is being
+   * looked at. An empty box is not a filter: every helper here hands back the
+   * input array untouched, which also keeps the map's projection and the
+   * graph's grid layout off the work queue on every unrelated re-render.
+   */
+  const normalizedSearch: string = normalizeSiteSearchText(searchText);
+  const levelSites: Array<SiteChildView> = filterSitesBySearch(
+    allLevelSites,
+    normalizedSearch,
+  );
+  const pinnedSites: Array<MapSiteView> = filterSitesBySearch(
+    allPinnedSites,
+    normalizedSearch,
+  );
+  const unplacedSites: Array<MapUnplacedSiteView> = filterSitesBySearch(
+    mapData?.unplacedSites || [],
+    normalizedSearch,
+  );
+  const levelLinks: Array<SiteLinkView> = filterLinksBySearch(
+    allLevelLinks,
+    normalizedSearch,
+    siteIdSet(levelSites),
+  );
+
+  const searchBox: ReactElement = (
+    <SiteSearchBox
+      value={searchText}
+      onChange={setSearchText}
+      onSelectSite={changeSite}
+      localMatchCount={levelSites.length}
+      localTotalCount={allLevelSites.length}
+      childTypeLabel={childTypeLabel}
+    />
+  );
 
   const geoMap: ReactElement = (
     <SiteGeoMap
@@ -528,6 +609,7 @@ const NetworkSiteMap: FunctionComponent<
       onModeChange={setMapMode}
       unplacedSites={unplacedSites}
       childTypeLabel={childTypeLabel}
+      searchText={searchText}
       onSiteClick={changeSite}
     />
   );
@@ -548,6 +630,13 @@ const NetworkSiteMap: FunctionComponent<
           buttons={[refreshButton]}
         >
           {/*
+           * Above the map, not beside it: the box narrows the map AND the
+           * graph under it, so it has to read as belonging to both rather
+           * than as a control on either one.
+           */}
+          <div className="mb-4 sm:max-w-md">{searchBox}</div>
+
+          {/*
            * The map comes first at every level, and it is the SAME map:
            * drilling re-frames it onto this site's children instead of
            * swapping it out for a diagram. The graph below it is the other
@@ -559,7 +648,11 @@ const NetworkSiteMap: FunctionComponent<
           <MapSection
             title="Sites"
             count={levelSites.length}
-            hint="Click a site to drill in; a unit opens its device topology."
+            hint={
+              normalizedSearch
+                ? "Matching sites at this level. Click one to drill in."
+                : "Click a site to drill in; a unit opens its device topology."
+            }
           >
             <SiteContainerGraph
               sites={levelSites}
@@ -568,6 +661,7 @@ const NetworkSiteMap: FunctionComponent<
               descendantCountsTruncated={Boolean(
                 childrenData?.descendantCountsTruncated,
               )}
+              searchText={searchText}
               onSiteClick={changeSite}
             />
           </MapSection>
@@ -580,7 +674,13 @@ const NetworkSiteMap: FunctionComponent<
   const rootSites: Array<SiteChildView> = levelSites;
   const rootLinks: Array<SiteLinkView> = levelLinks;
 
-  if (rootSites.length === 0 && pinnedSites.length === 0) {
+  /*
+   * "No network sites yet" is a claim about the PROJECT, so it is decided on
+   * the unfiltered lists. A search that matches nothing must not tell a
+   * customer with a thousand stores that they have never created one — that
+   * case is the map's own "nothing matches" state, further down.
+   */
+  if (allLevelSites.length === 0 && allPinnedSites.length === 0) {
     return (
       <Card title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
         {/* EmptyState ships 13rem of vertical padding for a full-page
@@ -624,6 +724,8 @@ const NetworkSiteMap: FunctionComponent<
        * sites are, and zoom/pan live on the map itself where the geography
        * is — see Components/NetworkSite/Geo/GeoViewport.ts.
        */}
+      <div className="mb-4 sm:max-w-md">{searchBox}</div>
+
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-xs text-gray-500">
           Drag to pan, scroll to zoom, or use the controls on the map.
@@ -652,7 +754,11 @@ const NetworkSiteMap: FunctionComponent<
         <MapSection
           title="Sites"
           count={rootSites.length}
-          hint="Click a site to drill into its markets and units."
+          hint={
+            normalizedSearch
+              ? "Matching top-level sites. Click one to drill in."
+              : "Click a site to drill into its markets and units."
+          }
         >
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {rootSites.map((site: SiteChildView): ReactElement => {

--- a/App/Tests/BaseAPI/NetworkSiteHierarchyUtil.test.ts
+++ b/App/Tests/BaseAPI/NetworkSiteHierarchyUtil.test.ts
@@ -3,6 +3,7 @@ import NetworkSiteHierarchyUtil, {
   BreadcrumbEntry,
   ChildAggregate,
   DEFAULT_UPTIME_WINDOW_DAYS,
+  MAX_SEARCH_TEXT_LENGTH,
   MAX_UPTIME_WINDOW_DAYS,
   MIN_UPTIME_WINDOW_DAYS,
   SiteLinkRow,
@@ -577,5 +578,102 @@ describe("filterLinksBetweenChildren", () => {
         new Set<string>(),
       ),
     ).toEqual([]);
+  });
+});
+
+/*
+ * The two helpers behind /network-site/search.
+ *
+ * The endpoint exists because the map is a drill-down: a store four levels
+ * under a region cannot be found by filtering the level in view, since it is
+ * not on that level. So the search reaches across the whole project — and
+ * every hit has to print the path to it, which is what collectAncestorIds
+ * makes affordable (one extra query for the whole result set, not a path walk
+ * per hit).
+ */
+describe("normalizeSearchText", () => {
+  test("trims, and keeps the reader's own casing for the ILIKE to fold", () => {
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText("  Kansas City ")).toBe(
+      "Kansas City",
+    );
+  });
+
+  /*
+   * The load-bearing case. An empty box must not be the query that matches
+   * every site in the project, so it normalizes to "" and the endpoint
+   * answers with no results rather than with everything.
+   */
+  test("blank and non-string inputs read as NO search", () => {
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText("")).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText("    ")).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText("\t\n")).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText(undefined)).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText(null)).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText(42)).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText({})).toBe("");
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText(["kansas"])).toBe("");
+  });
+
+  test("caps the length, after trimming", () => {
+    const long: string = `   ${"a".repeat(MAX_SEARCH_TEXT_LENGTH + 50)}   `;
+    expect(NetworkSiteHierarchyUtil.normalizeSearchText(long)).toHaveLength(
+      MAX_SEARCH_TEXT_LENGTH,
+    );
+  });
+});
+
+describe("collectAncestorIds", () => {
+  test("collects every ancestor referenced, deduplicated", () => {
+    expect(
+      NetworkSiteHierarchyUtil.collectAncestorIds(
+        [
+          { id: "u1", materializedPath: "/east/acme/chicago/" },
+          { id: "u2", materializedPath: "/east/acme/chicago/" },
+          { id: "u3", materializedPath: "/west/pdx/" },
+        ],
+        new Set<string>(),
+      ).sort(),
+    ).toEqual(["acme", "chicago", "east", "pdx", "west"]);
+  });
+
+  /*
+   * Rows the caller already holds are excluded — their names came back with
+   * the search itself, so re-fetching them would be a second query for data
+   * already in hand.
+   */
+  test("skips ids the caller already has rows for", () => {
+    expect(
+      NetworkSiteHierarchyUtil.collectAncestorIds(
+        [{ id: "u1", materializedPath: "/east/acme/" }],
+        new Set<string>(["east"]),
+      ),
+    ).toEqual(["acme"]);
+  });
+
+  // A root site has no ancestors, and a pathless row must not throw.
+  test("root and pathless rows contribute nothing", () => {
+    expect(
+      NetworkSiteHierarchyUtil.collectAncestorIds(
+        [
+          { id: "r1", materializedPath: "/" },
+          { id: "r2", materializedPath: "" },
+          { id: "r3" },
+        ],
+        new Set<string>(),
+      ),
+    ).toEqual([]);
+  });
+
+  /*
+   * Some writers append a site's own id to its materialized path. Fetching a
+   * site as its own ancestor would print it twice in its own path.
+   */
+  test("a row's own id is never collected as its ancestor", () => {
+    expect(
+      NetworkSiteHierarchyUtil.collectAncestorIds(
+        [{ id: "u1", materializedPath: "/east/acme/u1/" }],
+        new Set<string>(),
+      ).sort(),
+    ).toEqual(["acme", "east"]);
   });
 });

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -540,6 +540,7 @@ describe("Network Map sidebar entry escapes a drilled view", () => {
 
     expect(drillStateModule.readDrillStateFromUrl()).toEqual({
       siteId: null,
+      searchText: "",
     });
   });
 
@@ -549,7 +550,27 @@ describe("Network Map sidebar entry escapes a drilled view", () => {
 
     expect(drillStateModule.readDrillStateFromUrl()).toEqual({
       siteId: DRILLED_SITE_ID,
+      searchText: "",
     });
+  });
+
+  /*
+   * The search box's text rides in the URL alongside the drill position, so a
+   * narrowed map is a link somebody can send. An absent parameter has to read
+   * as "" — no filter — and never as a filter that matches nothing, which
+   * would open a map with everything hidden.
+   */
+  test("a shared link carries the search text, and its absence is no filter", () => {
+    standAt(`?site=${DRILLED_SITE_ID}&siteSearch=kansas%20city`);
+
+    expect(drillStateModule.readDrillStateFromUrl()).toEqual({
+      siteId: DRILLED_SITE_ID,
+      searchText: "kansas city",
+    });
+
+    standAt(`?site=${DRILLED_SITE_ID}`);
+
+    expect(drillStateModule.readDrillStateFromUrl().searchText).toBe("");
   });
 
   /*
@@ -562,15 +583,123 @@ describe("Network Map sidebar entry escapes a drilled view", () => {
 
     expect(drillStateModule.readDrillStateFromUrl()).toEqual({
       siteId: DRILLED_SITE_ID,
+      searchText: "",
     });
   });
 
+  /*
+   * An exact whitelist, not a "does not contain mapRegion" check: the point is
+   * that a geography key cannot come back under ANY name, so every field the
+   * drill state carries has to be named here deliberately.
+   */
   test("the drill state no longer carries any geography", () => {
     standAt(DRILLED_SEARCH);
 
     expect(Object.keys(drillStateModule.readDrillStateFromUrl())).toEqual([
       "siteId",
+      "searchText",
     ]);
+  });
+});
+
+/*
+ * The Network Map's search box narrows the level in view AND finds sites
+ * anywhere in the hierarchy. The wiring below is the whole of the first half,
+ * and every assertion here corresponds to a way of getting it subtly wrong
+ * that produces a page which still renders and still looks plausible.
+ */
+describe("the Network Map search narrows the whole level at once", () => {
+  const PAGE: string = readCode("Pages", "NetworkSite", "NetworkMap.tsx");
+
+  /*
+   * The map, the cards/graph and the WAN links must be fed from the SAME
+   * predicate. Filtering the cards but not the markers is the exact defect
+   * the grouped-marker rewrite existed to end — two halves of one page
+   * describing two different networks — reintroduced through a search box.
+   */
+  test("markers, sites, unplaced sites and links all go through the filter", () => {
+    expect(PAGE).toContain(
+      squash("const pinnedSites: Array<MapSiteView> = filterSitesBySearch("),
+    );
+    expect(PAGE).toContain(
+      squash("const levelSites: Array<SiteChildView> = filterSitesBySearch("),
+    );
+    expect(PAGE).toContain(
+      squash(
+        "const unplacedSites: Array<MapUnplacedSiteView> = filterSitesBySearch(",
+      ),
+    );
+    expect(PAGE).toContain(
+      squash("const levelLinks: Array<SiteLinkView> = filterLinksBySearch("),
+    );
+    // The link filter has to see the SURVIVING sites, not the raw list.
+    expect(PAGE).toContain(squash("siteIdSet(levelSites),"));
+  });
+
+  /*
+   * The type label names what the children of this level ARE. Deriving it
+   * from the filtered list makes searching for one region rewrite the map's
+   * legend, its mode switch and its coverage count as you type — a level of
+   * Regions becomes a level of "sites" the moment two types both match.
+   */
+  test("the child type label is derived from the unfiltered level", () => {
+    expect(PAGE).toContain(squash("childTypeLabelFor(allLevelSites)"));
+    expect(PAGE).not.toContain(squash("childTypeLabelFor(levelSites)"));
+  });
+
+  /*
+   * "No network sites yet" is a claim about the PROJECT. Deciding it on the
+   * filtered lists tells a customer with a thousand stores that they have
+   * never created one, and offers them a "create your first network site"
+   * button, because they typed a name that does not match anything.
+   */
+  test("the empty state is decided on the unfiltered lists", () => {
+    expect(PAGE).toContain(
+      squash("if (allLevelSites.length === 0 && allPinnedSites.length === 0)"),
+    );
+  });
+
+  /*
+   * Both levels that draw a map get the box — the root and the container. The
+   * unit level deliberately does not: its device topology carries its own
+   * search over devices, and a second box above it would be two search fields
+   * on one screen searching different things.
+   */
+  test("the box renders at the root and at a container level, not on a unit", () => {
+    expect(PAGE).toContain(squash("const searchBox: ReactElement = ("));
+    expect(PAGE.split("{searchBox}").length - 1).toBeGreaterThanOrEqual(2);
+    // The unit branch returns before searchBox is ever built.
+    expect(PAGE.indexOf("<NetworkTopologyLiveView")).toBeLessThan(
+      PAGE.indexOf("const searchBox: ReactElement = ("),
+    );
+  });
+
+  /*
+   * Both empty states have to know a filter is on. Without it, a search that
+   * matches nothing at this level reads as "you have no sites here" and sends
+   * the reader off to add coordinates to fix something that is not broken.
+   */
+  test("the map and the graph are told what the search text is", () => {
+    expect(PAGE).toContain(squash("searchText={searchText}"));
+    expect(readCode("Components", "NetworkSite", "SiteGeoMap.tsx")).toContain(
+      "site-geo-map-no-search-match",
+    );
+    expect(
+      readCode("Components", "NetworkSite", "SiteContainerGraph.tsx"),
+    ).toContain("site-container-no-search-match");
+  });
+
+  /*
+   * Drilling ends the search. Text that narrowed THIS level would hide most
+   * of the next one, and the reader would arrive at a level that looks empty
+   * for a reason sitting in a box they have stopped looking at.
+   */
+  test("drilling clears the search, in state and in the URL", () => {
+    const body: string = PAGE.split(
+      "const changeSite: (siteId: string | null) => void = (",
+    )[1]!.split("};")[0]!;
+    expect(body).toContain(squash('setSearchTextState("");'));
+    expect(body).toContain(squash("[NETWORK_MAP_SEARCH_PARAM]: null,"));
   });
 });
 

--- a/App/Tests/Dashboard/SiteHierarchyTypes.test.ts
+++ b/App/Tests/Dashboard/SiteHierarchyTypes.test.ts
@@ -3,8 +3,11 @@ import { JSONObject } from "Common/Types/JSON";
 import {
   SiteChildrenResponse,
   SiteMapResponse,
+  SiteSearchResponse,
+  SiteSearchResultView,
   parseSiteChildrenResponse,
   parseSiteMapResponse,
+  parseSiteSearchResponse,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes";
 
 /*
@@ -500,5 +503,120 @@ describe("parseSiteMapResponse", () => {
       { id: "r7", name: "Region 2100", siteType: "Region", isUnitLevel: false },
       { id: "u9", name: "Unnamed site", siteType: "Other", isUnitLevel: true },
     ]);
+  });
+});
+
+/*
+ * The search payload gets the same defensive treatment as the other two: a
+ * partially broken (or older) server must cost the reader a label, never the
+ * whole search box.
+ *
+ * `path` earns its own attention. It is the only thing that tells two stores
+ * called "Michigan Ave" apart before the click, and a root site legitimately
+ * has none — so an absent path is the NORMAL case here and has to narrow to
+ * "" rather than to a hole in the row.
+ */
+describe("parseSiteSearchResponse", () => {
+  test("undefined/empty/malformed payloads narrow to an empty response", () => {
+    const expected: SiteSearchResponse = { results: [], isTruncated: false };
+    expect(parseSiteSearchResponse(undefined)).toEqual(expected);
+    expect(parseSiteSearchResponse({})).toEqual(expected);
+    expect(
+      parseSiteSearchResponse({
+        results: "nope",
+        isTruncated: "yes",
+      } as unknown as JSONObject),
+    ).toEqual(expected);
+  });
+
+  test("a well-formed payload narrows faithfully", () => {
+    const parsed: SiteSearchResponse = parseSiteSearchResponse({
+      results: [
+        {
+          id: "u1",
+          name: "Unit 104822 — Michigan Ave",
+          siteType: "Store",
+          isUnitLevel: true,
+          path: "East / Acme Franchising / Chicago North",
+          currentMonitorStatus: {
+            id: "s1",
+            name: "Operational",
+            color: "#4ade80",
+            priority: 1,
+            isOperationalState: true,
+          },
+        },
+      ],
+      isTruncated: true,
+    } as unknown as JSONObject);
+
+    expect(parsed.isTruncated).toBe(true);
+    expect(parsed.results).toEqual([
+      {
+        id: "u1",
+        name: "Unit 104822 — Michigan Ave",
+        siteType: "Store",
+        isUnitLevel: true,
+        path: "East / Acme Franchising / Chicago North",
+        currentMonitorStatus: {
+          id: "s1",
+          name: "Operational",
+          color: "#4ade80",
+          priority: 1,
+          isOperationalState: true,
+        },
+      },
+    ]);
+  });
+
+  test("rows without an id are dropped; the rest fall back safely", () => {
+    const parsed: SiteSearchResponse = parseSiteSearchResponse({
+      results: [{ name: "no id at all", siteType: "Region" }, { id: "r1" }],
+    } as unknown as JSONObject);
+
+    expect(parsed.results).toEqual([
+      {
+        id: "r1",
+        name: "Unnamed site",
+        siteType: "Other",
+        // Never inferred from a name — an unflagged row is a container.
+        isUnitLevel: false,
+        path: "",
+        currentMonitorStatus: undefined,
+      },
+    ]);
+  });
+
+  /*
+   * A root site has no ancestors. Its path is legitimately absent, and a
+   * non-string one is corrupt — both narrow to "" so the row simply prints no
+   * path line instead of "undefined" under the site's name.
+   */
+  test("a missing or non-string path narrows to no path", () => {
+    expect(
+      parseSiteSearchResponse({ results: [{ id: "r1", name: "East" }] })
+        .results[0]!.path,
+    ).toBe("");
+    expect(
+      parseSiteSearchResponse({
+        results: [{ id: "r1", name: "East", path: 42 }],
+      } as unknown as JSONObject).results[0]!.path,
+    ).toBe("");
+  });
+
+  // isUnitLevel decides whether drilling opens a device topology or a level.
+  test("isUnitLevel is strictly boolean", () => {
+    const parsed: SiteSearchResponse = parseSiteSearchResponse({
+      results: [
+        { id: "a", isUnitLevel: true },
+        { id: "b", isUnitLevel: "true" },
+        { id: "c", isUnitLevel: 1 },
+      ],
+    } as unknown as JSONObject);
+    expect(
+      parsed.results.map((row: SiteSearchResultView): boolean => {
+        return row.isUnitLevel;
+      }),
+    ).toEqual([true, false, false]);
   });
 });

--- a/App/Tests/Dashboard/SiteSearchUtil.test.ts
+++ b/App/Tests/Dashboard/SiteSearchUtil.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  MIN_SITE_SEARCH_CHARS,
+  SearchableLink,
+  SearchableSite,
+  filterLinksBySearch,
+  filterSitesBySearch,
+  isRemoteSearchable,
+  normalizeSiteSearchText,
+  siteIdSet,
+  siteMatchesSearch,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteSearchUtil";
+
+/*
+ * The local half of the Network Map's search: the predicate that narrows the
+ * level in view. The map's markers, its site cards and its WAN links are all
+ * filtered through these functions, so anything that is true here is true of
+ * all three at once — that agreement is the point.
+ *
+ * The identity checks below are not micro-optimisation trivia: the geo map
+ * and the container graph both key expensive memos (projection, cluster
+ * bucketing, grid layout) off the array they are handed, so an empty search
+ * returning a fresh array would relayout the whole level on every unrelated
+ * re-render of the page.
+ */
+
+const site: (name: string, siteType: string) => SearchableSite = (
+  name: string,
+  siteType: string,
+): SearchableSite => {
+  return { name, siteType };
+};
+
+describe("normalizeSiteSearchText", () => {
+  test("trims and lower-cases", () => {
+    expect(normalizeSiteSearchText("  Kansas City  ")).toBe("kansas city");
+  });
+
+  test("null, undefined and blank all read as no search", () => {
+    expect(normalizeSiteSearchText(null)).toBe("");
+    expect(normalizeSiteSearchText(undefined)).toBe("");
+    expect(normalizeSiteSearchText("   ")).toBe("");
+  });
+});
+
+describe("isRemoteSearchable", () => {
+  test("one character is not worth a round trip", () => {
+    expect(isRemoteSearchable("")).toBe(false);
+    expect(isRemoteSearchable("u")).toBe(false);
+  });
+
+  test("the threshold itself is searchable", () => {
+    expect(MIN_SITE_SEARCH_CHARS).toBe(2);
+    expect(isRemoteSearchable("un")).toBe(true);
+    expect(isRemoteSearchable("unit 104822")).toBe(true);
+  });
+});
+
+describe("siteMatchesSearch", () => {
+  test("an empty search is not a filter — it matches everything", () => {
+    expect(siteMatchesSearch(site("Kansas City", "Market"), "")).toBe(true);
+  });
+
+  test("matches a substring of the name, case-insensitively", () => {
+    expect(siteMatchesSearch(site("Kansas City", "Market"), "sas ci")).toBe(
+      true,
+    );
+    expect(siteMatchesSearch(site("Kansas City", "Market"), "denver")).toBe(
+      false,
+    );
+  });
+
+  /*
+   * Site types are the customer's own words for their levels, and "market" is
+   * a perfectly reasonable thing to type at a level that mixes them with
+   * stores.
+   */
+  test("matches the site type as well as the name", () => {
+    expect(siteMatchesSearch(site("Kansas City", "Market"), "market")).toBe(
+      true,
+    );
+  });
+
+  /*
+   * The whole reason for tokenizing. Nobody recalls a name in the exact order
+   * it was written, and neither of these is a substring of anything.
+   */
+  test("every token must appear, in any order", () => {
+    const unit: SearchableSite = site("Unit 104822 — Michigan Ave", "Unit");
+    expect(siteMatchesSearch(unit, "michigan 104822")).toBe(true);
+    expect(siteMatchesSearch(unit, "104822 michigan")).toBe(true);
+    // ALL tokens, not any: a stray word must still exclude the row.
+    expect(siteMatchesSearch(unit, "michigan denver")).toBe(false);
+  });
+
+  test("a single token behaves exactly like a substring test", () => {
+    expect(siteMatchesSearch(site("Unit 104822", "Unit"), "104822")).toBe(true);
+    expect(siteMatchesSearch(site("Unit 104822", "Unit"), "104823")).toBe(
+      false,
+    );
+  });
+
+  test("runs of whitespace between tokens are not empty tokens", () => {
+    expect(
+      siteMatchesSearch(site("Kansas City", "Market"), "kansas    city"),
+    ).toBe(true);
+  });
+});
+
+describe("filterSitesBySearch", () => {
+  const sites: Array<SearchableSite & { id: string }> = [
+    { id: "a", ...site("Kansas City Market", "Market") },
+    { id: "b", ...site("Denver Market", "Market") },
+    { id: "c", ...site("Unit 104822 — Michigan Ave", "Unit") },
+  ];
+
+  test("keeps only the rows that match", () => {
+    expect(
+      filterSitesBySearch(sites, "market").map(
+        (row: { id: string }): string => {
+          return row.id;
+        },
+      ),
+    ).toEqual(["a", "b"]);
+  });
+
+  /*
+   * Identity, not just equality: the map and the graph memoize off this
+   * array, and a copy on every render would relayout the level for nothing.
+   */
+  test("an empty search hands back the very same array", () => {
+    expect(filterSitesBySearch(sites, "")).toBe(sites);
+  });
+
+  test("a search matching nothing yields an empty list, not everything", () => {
+    expect(filterSitesBySearch(sites, "tokyo")).toEqual([]);
+  });
+});
+
+describe("filterLinksBySearch", () => {
+  const links: Array<SearchableLink & { id: string }> = [
+    {
+      id: "kc-den",
+      name: "KC ↔ Denver backbone",
+      fromSiteId: "a",
+      toSiteId: "b",
+    },
+    {
+      id: "den-sea",
+      name: "Denver ↔ Seattle",
+      fromSiteId: "b",
+      toSiteId: "d",
+    },
+    {
+      id: "orphan",
+      name: "Spare circuit",
+      fromSiteId: undefined,
+      toSiteId: undefined,
+    },
+  ];
+
+  test("an empty search hands back the very same array", () => {
+    expect(filterLinksBySearch(links, "", new Set<string>())).toBe(links);
+  });
+
+  /*
+   * ONE surviving endpoint is enough. A search for Kansas City is a question
+   * about Kansas City, and its WAN links are most of the answer — dropping
+   * them because the far end is in Denver answers a question nobody asked.
+   */
+  test("keeps a link that touches a single surviving site", () => {
+    expect(
+      filterLinksBySearch(links, "kansas", new Set<string>(["a"])).map(
+        (link: { id: string }): string => {
+          return link.id;
+        },
+      ),
+    ).toEqual(["kc-den"]);
+  });
+
+  test("keeps a link whose own name matches even when neither end survives", () => {
+    expect(
+      filterLinksBySearch(links, "spare circuit", new Set<string>()).map(
+        (link: { id: string }): string => {
+          return link.id;
+        },
+      ),
+    ).toEqual(["orphan"]);
+  });
+
+  test("drops a link that neither matches nor touches anything visible", () => {
+    expect(
+      filterLinksBySearch(links, "kansas", new Set<string>(["z"])),
+    ).toEqual([]);
+  });
+
+  // A missing endpoint id must never be read as "matches the visible set".
+  test("an endpoint-less link is not kept by an empty visible set", () => {
+    expect(filterLinksBySearch(links, "kansas", new Set<string>([""]))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("siteIdSet", () => {
+  test("collects the ids of the filtered rows", () => {
+    expect(siteIdSet([{ id: "a" }, { id: "b" }])).toEqual(
+      new Set<string>(["a", "b"]),
+    );
+  });
+});


### PR DESCRIPTION
## The gap

The Network Map had no search box. Every other map in the product has one — Service Map, Infrastructure and the Network device topology all ship a search field — and the Network Map is the one that needs it most.

It is a **drill-down**: a store four levels under a region is reachable only by opening every level above it. "Which market is Unit 104822 in?" is exactly the question you have when you cannot do that, and a filter over the level in view cannot answer it, because the answer is not on that level.

## What this adds

One box that does two things at once:

**Locally — it narrows the level in view.** The same predicate is applied to the map's markers, the site cards / container graph, the unplaced list and the WAN links, so the halves of the page cannot disagree about what is being looked at. The map re-frames itself onto the survivors, so typing a name flies the map to it.

**Remotely — it searches the whole project**, through a new `POST /network-site/search`. Each hit prints the **path** to it, so two stores called "Michigan Ave" are told apart before the click, and "where is this?" is answered without drilling at all. Picking one drills straight there.

Matching is by name and site type, tokenized: `michigan 104822` and `104822 michigan` both find "Unit 104822 — Michigan Ave", neither of which is a substring of anything. A single token behaves exactly like the substring test the sibling maps use, so nothing that used to match stops matching.

## Details worth reviewing

- **Permissions.** The endpoint is scoped through the same props helper as its siblings — including the ancestor lookup, where an unreadable ancestor drops out of the path string rather than leaking a name.
- **Query cost.** Ancestor ids for the whole result set are collected up front, so paths cost *one* extra query rather than a path walk per hit. Results cap at 50; the response reports when the cap was hit.
- **An empty box is never the query that returns the project** — it normalizes to `""` and the endpoint answers with no results.
- **The child type label comes from the unfiltered level.** Deriving it from the filtered list would rewrite the map's legend, mode switch and coverage count as you type.
- **"No network sites yet" stays a claim about the project**, decided on the unfiltered lists. Both the map and the container graph now know when a filter is on, so a search matching nothing says so — instead of telling a customer with a thousand stores to go add coordinates.
- **Drilling clears the search** — text that narrowed *this* level would hide most of the next one.
- **The text rides in the URL** beside the drill position, so a narrowed map is a link somebody can send.
- **The unit level deliberately gets no box**: its device topology already carries its own search, over devices. Two search fields on one screen searching different things is worse than one.

## Tests

- `SiteSearchUtil.test.ts` — matching, tokenization, and the link filter (including that an empty search returns the *same array*, which is what keeps the map's projection and the graph's grid layout off the work queue).
- `SiteHierarchyTypes.test.ts` — the new parser's defensive narrowing, with `path` and `isUnitLevel` given their own attention.
- `NetworkSiteHierarchyUtil.test.ts` — the two new server helpers, including that a blank search reads as *no* search.
- `NetworkSitePageInvariants.test.ts` — source invariants pinning the page wiring, this repo's convention for React pages. Each new invariant was **verified to fail when broken** (mutation-checked), not just to pass.

`App` suite: 65 suites / 1876 tests green. `tsc --noEmit` clean, eslint clean.

## Not verified in a browser

Docker was not running locally, so I could not exercise this against a live dashboard. Everything above is typecheck-, lint- and test-verified; the interaction behaviour (dropdown, keyboard nav, blur handling) is reasoned through and commented but has not been clicked.