### PR TITLE
Network map: markers can no longer hide each other

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoViewport.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoViewport.ts
@@ -65,14 +65,32 @@ const heightForWidth: (width: number) => number = (width: number): number => {
  * Zoom is expressed as magnification relative to the whole-world view, so
  * zoom 1 is the world and zoom 8 shows an eighth of its width.
  *
- * MAX_ZOOM is bounded by the geometry we ship, not by taste: the detail tier
- * is simplified to 0.04 viewBox units of error (see
- * Scripts/Geo/GenerateMapGeometry.js), which is about one screen pixel at
- * this zoom. Going deeper would magnify simplification artefacts into visible
- * corners on a coastline. The two constants are chosen together.
+ * MAX_ZOOM is a trade against the geometry we ship. The detail tier is
+ * simplified to 0.04 viewBox units of error (see
+ * Scripts/Geo/GenerateMapGeometry.js) — about one screen pixel at zoom 20,
+ * and a couple of pixels here. That softening is worth paying for, because
+ * the alternative is worse: sites in one metro area are a fraction of a
+ * pixel apart at zoom 20, so a reader who zooms in to tell two of them apart
+ * hits the stop with the two still on top of each other and no way further
+ * in. Country outlines are the BACKDROP; the markers are the subject, and
+ * this is the range in which a busy corner of an estate actually comes
+ * apart.
+ *
+ * Beyond that the collision layout is what guarantees markers stay legible
+ * (Geo/MarkerLayout.ts) — zoom separates them for real, and the layout holds
+ * the picture together until it does.
  */
 export const MIN_ZOOM: number = 1;
-export const MAX_ZOOM: number = 20;
+export const MAX_ZOOM: number = 64;
+
+/*
+ * The deepest the map will FRAME ITSELF, as opposed to the deepest a reader
+ * may zoom. An estate that sits in one town has a near-zero bounding box, and
+ * opening on a single street with no town around it tells nobody anything —
+ * the opening view has to carry enough context to be recognisable. Manual
+ * zoom goes all the way to MAX_ZOOM from there.
+ */
+export const FIT_MAX_ZOOM: number = 20;
 
 /*
  * Below this zoom the map draws the small overview outlines; at or above it
@@ -92,11 +110,14 @@ const FIT_PADDING_FRACTION: number = 0.18;
 /*
  * Minimum fitted width in viewBox units, before padding. A single site — or
  * several in one city — has a zero-size bounding box, which would otherwise
- * fit to infinite zoom. 48 units is the MAX_ZOOM frame, so the clamp below
- * would land there anyway; naming it here keeps the degenerate case from
- * depending on that coincidence.
+ * fit to infinite zoom.
+ *
+ * This is FIT_MAX_ZOOM's frame, not MAX_ZOOM's: how deep a reader may go and
+ * how deep the map opens are different questions, and tying them together
+ * meant that raising the manual limit silently dropped every one-town estate
+ * onto a street corner the moment the page loaded.
  */
-const MIN_FIT_WIDTH: number = WORLD_VIEWPORT.width / MAX_ZOOM;
+const MIN_FIT_WIDTH: number = WORLD_VIEWPORT.width / FIT_MAX_ZOOM;
 
 export interface ViewportPoint {
   x: number;

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/Geo/MarkerLayout.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/Geo/MarkerLayout.ts
@@ -1,0 +1,505 @@
+/*
+ * Pure, react-free collision layout for map markers: where each marker is
+ * DRAWN, given where it actually belongs.
+ *
+ * Kept out of the map component so the math can be imported (and unit-tested)
+ * in a plain Node/TypeScript environment — see GeoProjection.ts for why.
+ *
+ * WHY THIS EXISTS
+ *
+ * A real estate piles markers on top of each other. Two stores in the same
+ * retail park, a market whose centroid lands on its parent's, six regions
+ * whose derived positions all average out over the same city — every one of
+ * those draws N markers at one spot and shows ONE. The others are not merely
+ * hard to read: they are unreachable. No hover, no name, no click, and
+ * nothing on screen says they are there at all.
+ *
+ * Zoom alone cannot fix it. Markers are sized in screen units so they do not
+ * grow with the map, but two sites a hundred metres apart are still a
+ * fraction of a pixel apart at the deepest zoom this map supports — and two
+ * derived centroids that landed on the SAME coordinates never separate at
+ * any zoom, because there is no distance between them to magnify.
+ *
+ * So markers that would cover each other are pushed apart until they do not,
+ * and every marker that had to move is drawn with a thin line back to the
+ * exact spot it belongs to (SiteGeoMap draws the line; this decides the
+ * positions). Two rules keep that honest:
+ *
+ *   - the displacement is the SMALLEST one that clears the overlap. A marker
+ *     with room around it does not move at all — its drawn position is
+ *     exactly its projected one, to the bit.
+ *   - a marker is never pushed further than MAX_MARKER_DISPLACEMENT. Past
+ *     that the map would be telling a lie no leader line can undo.
+ *
+ * Deterministic and order-independent by construction: markers are relaxed in
+ * a canonical order (by key), markers that share a point exactly are seeded
+ * along golden-angle rays derived from that order, and there is no randomness
+ * and no clock access. The same markers at the same zoom always lay out the
+ * same way — which is what keeps the map from twitching every time the page's
+ * 60-second poll hands over a fresh array.
+ */
+
+// A marker to place. Position is viewBox units; radius is SCREEN units.
+export interface CollidableMarker {
+  // Stable identity: the placement comes back under this key.
+  key: string;
+  x: number;
+  y: number;
+  /*
+   * The radius that has to stay clear of every other marker's, in SCREEN
+   * units — the same units MapMarker.screenRadius is in. A marker drawn as
+   * a square passes the radius of the circle that contains it, so two
+   * squares cannot touch corner to corner.
+   */
+  radius: number;
+}
+
+export interface MarkerPlacement {
+  key: string;
+  // Where the marker is DRAWN, in viewBox units.
+  x: number;
+  y: number;
+  // Where it belongs, in viewBox units — what the leader line points at.
+  anchorX: number;
+  anchorY: number;
+  /*
+   * Whether this marker's anchor is worth drawing a line to: it has moved
+   * far enough that the spot it belongs to is no longer UNDER the marker.
+   *
+   * A marker nudged by less than its own radius still covers its true
+   * position, so a line and a dot there would be drawn entirely beneath the
+   * marker — ink nobody can see, and a legend entry explaining a line that
+   * is not on screen. It is a real displacement either way; it just does not
+   * need explaining.
+   */
+  needsLeaderLine: boolean;
+}
+
+/*
+ * Clear space left between two marker edges, in screen units. Markers that
+ * merely touch still read as one blob, and each one carries a soft halo a
+ * couple of pixels wide that would otherwise be swallowed.
+ */
+export const MARKER_CLEARANCE: number = 3;
+
+/*
+ * How far a marker may be pushed from where it belongs, in screen units.
+ * Roughly 90 minimum-size markers fit inside a disc this size, which covers
+ * every pile-up a level realistically has; a denser one keeps some overlap
+ * rather than scattering markers across a county they are not in.
+ */
+export const MAX_MARKER_DISPLACEMENT: number = 72;
+
+/*
+ * Below this (screen units) a marker has not visibly moved at all, so it
+ * gets no leader line whatever its size. Its position is still the resolved
+ * one — snapping it back would put the overlap back.
+ */
+export const MIN_VISIBLE_DISPLACEMENT: number = 1.5;
+
+/*
+ * Past this many markers the map is a texture rather than a set of things to
+ * click, and the relaxation would run on every wheel tick of a zoom. The
+ * layout steps aside rather than make a drag stutter for a picture where
+ * moving a marker by a few pixels changes nothing anybody can see.
+ */
+export const MAX_LAID_OUT_MARKERS: number = 2500;
+
+/*
+ * Relaxation budget. Settling is the normal exit — these bound the work when
+ * a pile-up is too dense to resolve inside MAX_MARKER_DISPLACEMENT and the
+ * passes would otherwise keep nibbling at it forever.
+ *
+ * The budget is spent per MARKER rather than per pass, because a pass costs
+ * what the map holds: a level with a dozen markers can afford to be relaxed
+ * until it is perfect, and a thousand-marker "all sites" view cannot — it is
+ * laid out again on every wheel tick of a zoom, and a map that stutters
+ * under a drag is a worse map than one with a couple of overlaps left in a
+ * crowd of a thousand.
+ */
+const MAX_RELAX_PASSES: number = 120;
+const MIN_RELAX_PASSES: number = 12;
+const RELAX_MARKER_VISITS: number = 24_000;
+
+// Total movement in one pass below which the layout counts as settled.
+const SETTLED_MOVEMENT: number = 0.01;
+
+/*
+ * Markers at EXACTLY the same point have no direction to be pushed apart in,
+ * so each is first nudged a hair along its own ray. The golden angle spreads
+ * consecutive rays as evenly as an angle can, and the index comes from the
+ * canonical key order, so the fan is the same on every render.
+ */
+const GOLDEN_ANGLE: number = Math.PI * (3 - Math.sqrt(5));
+const COINCIDENT_NUDGE: number = 0.01;
+
+// Distance below which two markers count as being at the same point.
+const COINCIDENT_EPSILON: number = 1e-9;
+
+const compareKeys: (a: string, b: string) => number = (
+  a: string,
+  b: string,
+): number => {
+  // Plain code-unit comparison — localeCompare depends on the runtime locale.
+  return a < b ? -1 : a > b ? 1 : 0;
+};
+
+/*
+ * Bucket id for a grid cell. A numeric hash rather than the obvious "x:y"
+ * string: the grid is rebuilt on every relaxation pass, and building
+ * thousands of throwaway strings per pass costs more than every distance
+ * check in the layout put together.
+ *
+ * Two different cells hashing the same is HARMLESS — a bucket is a set of
+ * candidates, and every candidate is distance-checked anyway. It can only
+ * ever add work, never hide a collision, because inserts and lookups run the
+ * same function over the same cell coordinates.
+ */
+const cellHash: (cellX: number, cellY: number) => number = (
+  cellX: number,
+  cellY: number,
+): number => {
+  return (Math.imul(cellX, 73_856_093) ^ Math.imul(cellY, 19_349_663)) | 0;
+};
+
+/*
+ * One marker mid-relaxation. Everything here is in SCREEN units: overlap is
+ * a screen-space question (that is the whole reason marker radii are screen
+ * units), so the math is done there and converted back once at the end.
+ */
+interface RelaxItem {
+  key: string;
+  anchorX: number;
+  anchorY: number;
+  x: number;
+  y: number;
+  radius: number;
+  /*
+   * How much of a shared push this marker absorbs. Heavier markers move
+   * less, so a region standing for 300 units keeps its position and the
+   * single store next to it steps aside — the reader's eye is on the big
+   * one, and it is the one whose position carries the most meaning.
+   */
+  mass: number;
+  // Its ray out of a coincident pile, from the canonical order.
+  seedAngle: number;
+}
+
+const isFiniteMarker: (marker: CollidableMarker) => boolean = (
+  marker: CollidableMarker,
+): boolean => {
+  return Number.isFinite(marker.x) && Number.isFinite(marker.y);
+};
+
+const safeRadius: (radius: number) => number = (radius: number): number => {
+  return Number.isFinite(radius) && radius > 0 ? radius : 0;
+};
+
+/**
+ * Push two overlapping markers apart, in place. Returns how far they moved
+ * in total, so the caller can tell when the layout has settled.
+ *
+ * The pair is separated to exactly the distance it needs and no further, and
+ * the two share the correction in inverse proportion to their mass.
+ */
+const separate: (a: RelaxItem, b: RelaxItem) => number = (
+  a: RelaxItem,
+  b: RelaxItem,
+): number => {
+  const required: number = a.radius + b.radius + MARKER_CLEARANCE;
+  let deltaX: number = b.x - a.x;
+  let deltaY: number = b.y - a.y;
+  let distance: number = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+  if (distance >= required) {
+    return 0;
+  }
+
+  if (distance < COINCIDENT_EPSILON) {
+    /*
+     * The same point to the bit. The seeding in the caller normally prevents
+     * this, so this is the safety net for a pair that a third marker has
+     * pushed onto each other — separate them along a direction built from
+     * both of their rays, which is the same on every render.
+     */
+    const angle: number = a.seedAngle + b.seedAngle + GOLDEN_ANGLE;
+    deltaX = Math.cos(angle) * COINCIDENT_NUDGE;
+    deltaY = Math.sin(angle) * COINCIDENT_NUDGE;
+    distance = COINCIDENT_NUDGE;
+  }
+
+  const overlap: number = required - distance;
+  const unitX: number = deltaX / distance;
+  const unitY: number = deltaY / distance;
+
+  const totalMass: number = a.mass + b.mass;
+  // Equal split when neither has any mass to speak of.
+  const shareOfA: number = totalMass > 0 ? b.mass / totalMass : 0.5;
+  const shareOfB: number = 1 - shareOfA;
+
+  a.x -= unitX * overlap * shareOfA;
+  a.y -= unitY * overlap * shareOfA;
+  b.x += unitX * overlap * shareOfB;
+  b.y += unitY * overlap * shareOfB;
+
+  return overlap;
+};
+
+/**
+ * Pull a marker back onto the disc of allowed displacement around its
+ * anchor. Returns how far it had to be pulled.
+ */
+const clampToAnchor: (item: RelaxItem) => number = (
+  item: RelaxItem,
+): number => {
+  const deltaX: number = item.x - item.anchorX;
+  const deltaY: number = item.y - item.anchorY;
+  const distance: number = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+  if (distance <= MAX_MARKER_DISPLACEMENT || distance === 0) {
+    return 0;
+  }
+  const scale: number = MAX_MARKER_DISPLACEMENT / distance;
+  item.x = item.anchorX + deltaX * scale;
+  item.y = item.anchorY + deltaY * scale;
+  return distance - MAX_MARKER_DISPLACEMENT;
+};
+
+/**
+ * One relaxation pass over every overlapping pair.
+ *
+ * Pairs are found through a uniform grid whose cell is the largest distance
+ * two markers can be required to keep — so two markers that are too close
+ * are always within one cell of each other, and checking the 3x3 block
+ * around a marker finds every pair it could be colliding with. That is what
+ * keeps a pass linear in the number of markers instead of quadratic: a
+ * thousand-marker map cannot afford a million distance checks on every wheel
+ * tick of a zoom.
+ *
+ * `reversed` flips the sweep direction. A pass carries a correction about
+ * one marker along a run of overlapping ones, so sweeping the same way every
+ * time makes a long row of markers unpack from one end at one marker per
+ * pass — which is how a perfectly resolvable row runs out of budget with an
+ * overlap still in it. Alternating the direction walks the correction back
+ * the other way and settles a row in a handful of passes.
+ */
+const relaxPass: (
+  items: Array<RelaxItem>,
+  cellSize: number,
+  reversed: boolean,
+) => number = (
+  items: Array<RelaxItem>,
+  cellSize: number,
+  reversed: boolean,
+): number => {
+  const buckets: Map<number, Array<number>> = new Map<number, Array<number>>();
+  for (let index: number = 0; index < items.length; index++) {
+    const item: RelaxItem = items[index]!;
+    const key: number = cellHash(
+      Math.floor(item.x / cellSize),
+      Math.floor(item.y / cellSize),
+    );
+    const bucket: Array<number> | undefined = buckets.get(key);
+    if (bucket) {
+      bucket.push(index);
+    } else {
+      buckets.set(key, [index]);
+    }
+  }
+
+  let movement: number = 0;
+
+  for (let step: number = 0; step < items.length; step++) {
+    const index: number = reversed ? items.length - 1 - step : step;
+    const item: RelaxItem = items[index]!;
+    const cellX: number = Math.floor(item.x / cellSize);
+    const cellY: number = Math.floor(item.y / cellSize);
+    for (let offsetX: number = -1; offsetX <= 1; offsetX++) {
+      for (let offsetY: number = -1; offsetY <= 1; offsetY++) {
+        const bucket: Array<number> | undefined = buckets.get(
+          cellHash(cellX + offsetX, cellY + offsetY),
+        );
+        if (!bucket) {
+          continue;
+        }
+        for (const other of bucket) {
+          // Each pair once, and never a marker against itself.
+          if (other <= index) {
+            continue;
+          }
+          movement += separate(item, items[other]!);
+        }
+      }
+    }
+  }
+
+  for (const item of items) {
+    movement += clampToAnchor(item);
+  }
+
+  return movement;
+};
+
+/**
+ * Decide where every marker is drawn so that none of them covers another.
+ *
+ * `zoom` is the map's magnification (see GeoViewport.zoomOfViewport): marker
+ * radii are screen units and positions are viewBox units, and the zoom is
+ * what relates the two. Zooming in therefore separates markers on its own,
+ * and the displacement quietly falls to zero — the layout only ever moves
+ * what genuinely overlaps at the zoom being drawn.
+ *
+ * Every marker gets exactly one placement, in the input's order, with its
+ * anchor set to where it actually belongs. Markers whose coordinates are not
+ * finite are passed straight through: they cannot collide with anything, and
+ * this is not the place that decides whether they are drawn.
+ */
+export const resolveMarkerCollisions: (
+  markers: Array<CollidableMarker>,
+  zoom: number,
+) => Array<MarkerPlacement> = (
+  markers: Array<CollidableMarker>,
+  zoom: number,
+): Array<MarkerPlacement> => {
+  const safeZoom: number = Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+
+  const identity: (marker: CollidableMarker) => MarkerPlacement = (
+    marker: CollidableMarker,
+  ): MarkerPlacement => {
+    return {
+      key: marker.key,
+      x: marker.x,
+      y: marker.y,
+      anchorX: marker.x,
+      anchorY: marker.y,
+      needsLeaderLine: false,
+    };
+  };
+
+  if (markers.length < 2 || markers.length > MAX_LAID_OUT_MARKERS) {
+    return markers.map(identity);
+  }
+
+  /*
+   * Canonical order, so the layout does not depend on paint order. Two
+   * renders that draw the same markers in a different sequence — a re-sort,
+   * a poll that reordered the payload — must produce the same picture.
+   */
+  const ordered: Array<CollidableMarker> = markers
+    .filter(isFiniteMarker)
+    .slice()
+    .sort((a: CollidableMarker, b: CollidableMarker): number => {
+      return compareKeys(a.key, b.key);
+    });
+
+  if (ordered.length < 2) {
+    return markers.map(identity);
+  }
+
+  const items: Array<RelaxItem> = ordered.map(
+    (marker: CollidableMarker, index: number): RelaxItem => {
+      const radius: number = safeRadius(marker.radius);
+      return {
+        key: marker.key,
+        anchorX: marker.x * safeZoom,
+        anchorY: marker.y * safeZoom,
+        x: marker.x * safeZoom,
+        y: marker.y * safeZoom,
+        radius: radius,
+        // Area, so weight tracks how much of the map a marker is claiming.
+        mass: radius * radius,
+        seedAngle: index * GOLDEN_ANGLE,
+      };
+    },
+  );
+
+  /*
+   * Markers sharing a point exactly have no direction to be separated in, so
+   * fan them out by a hair first. Only the markers that need it are touched
+   * — everything else must keep its projected position to the bit, or a map
+   * with nothing overlapping on it would still redraw every marker slightly
+   * off where the customer pinned it.
+   */
+  const atPoint: Map<string, Array<number>> = new Map<string, Array<number>>();
+  for (let index: number = 0; index < items.length; index++) {
+    const item: RelaxItem = items[index]!;
+    const key: string = `${item.x}:${item.y}`;
+    const bucket: Array<number> | undefined = atPoint.get(key);
+    if (bucket) {
+      bucket.push(index);
+    } else {
+      atPoint.set(key, [index]);
+    }
+  }
+  for (const bucket of atPoint.values()) {
+    if (bucket.length < 2) {
+      continue;
+    }
+    for (const index of bucket) {
+      const item: RelaxItem = items[index]!;
+      item.x += Math.cos(item.seedAngle) * COINCIDENT_NUDGE;
+      item.y += Math.sin(item.seedAngle) * COINCIDENT_NUDGE;
+    }
+  }
+
+  let maxRadius: number = 0;
+  for (const item of items) {
+    maxRadius = Math.max(maxRadius, item.radius);
+  }
+  /*
+   * The largest separation any pair can be required to keep. Anything closer
+   * than this is inside the 3x3 block the pass scans, so no collision can
+   * hide between cells.
+   */
+  const cellSize: number = Math.max(
+    2 * maxRadius + MARKER_CLEARANCE,
+    COINCIDENT_NUDGE,
+  );
+
+  const passes: number = Math.max(
+    MIN_RELAX_PASSES,
+    Math.min(MAX_RELAX_PASSES, Math.ceil(RELAX_MARKER_VISITS / items.length)),
+  );
+  for (let pass: number = 0; pass < passes; pass++) {
+    if (relaxPass(items, cellSize, pass % 2 === 1) <= SETTLED_MOVEMENT) {
+      break;
+    }
+  }
+
+  const placed: Map<string, RelaxItem> = new Map<string, RelaxItem>();
+  for (const item of items) {
+    placed.set(item.key, item);
+  }
+
+  return markers.map((marker: CollidableMarker): MarkerPlacement => {
+    const item: RelaxItem | undefined = placed.get(marker.key);
+    if (!item || !isFiniteMarker(marker)) {
+      return identity(marker);
+    }
+    const deltaX: number = item.x - item.anchorX;
+    const deltaY: number = item.y - item.anchorY;
+    const distance: number = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    /*
+     * Nothing moved: hand back the anchor itself rather than a value that
+     * has been through a multiply and a divide, so an untouched marker is
+     * bit-for-bit where it was projected.
+     */
+    if (distance === 0) {
+      return identity(marker);
+    }
+    return {
+      key: marker.key,
+      x: item.x / safeZoom,
+      y: item.y / safeZoom,
+      anchorX: marker.x,
+      anchorY: marker.y,
+      /*
+       * A line is only worth drawing once the spot this marker belongs to is
+       * out from under it. Nudged by less than its own radius, the marker is
+       * still sitting on its own coordinates and the line would be buried
+       * beneath it.
+       */
+      needsLeaderLine:
+        distance >= MIN_VISIBLE_DISPLACEMENT && distance > item.radius,
+    };
+  });
+};

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
@@ -27,16 +27,19 @@ import {
 } from "./Geo/GeoViewport";
 import {
   BuildPinsResult,
+  CONTAINER_SIDE_FACTOR,
   ClusterColorKey,
   MapMarker,
   LABEL_FONT_SIZE,
   LABEL_GAP,
   LabelPlacement,
+  PlacedMapMarker,
   buildMapMarkers,
   buildPins,
   GENERIC_SITE_TYPE_LABEL,
   clusterCellSize,
   describeMapCoverage,
+  layoutMapMarkers,
   mapPinFingerprint,
   pluralizeSiteType,
   resolveMarkerLabels,
@@ -476,14 +479,38 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   }, [props.sites, props.mode, cellSize]);
 
   /*
+   * Where each marker is DRAWN — which is not always where it is. Markers
+   * that would cover each other are pushed apart until they do not, and the
+   * ones that moved keep a line back to their real position (drawn below).
+   * Everything from here on works off the placed positions: the labels, the
+   * hover tooltip, the site picker and the focus ring all have to point at
+   * the marker the reader can actually see.
+   *
+   * Keyed on the zoom, like the labels: zooming genuinely separates markers
+   * so the displacement melts away as you go in, while panning must not
+   * re-lay-out anything — markers keep their relative distances as the frame
+   * moves, and a map that reshuffled under a drag would be unusable.
+   */
+  const placedMarkers: Array<PlacedMapMarker> = useMemo(() => {
+    return layoutMapMarkers(markers, zoom);
+  }, [markers, zoom]);
+
+  /*
    * Which names fit without landing on each other. Keyed on the zoom rather
    * than on the whole viewport: markers keep their relative distances as the
    * frame moves, so panning must not re-decide which names are shown — that
    * would make labels flicker in and out under the pointer.
    */
   const labelPlacements: Map<string, LabelPlacement> = useMemo(() => {
-    return resolveMarkerLabels(markers, zoom);
-  }, [markers, zoom]);
+    return resolveMarkerLabels(placedMarkers, zoom);
+  }, [placedMarkers, zoom]);
+
+  // Whether the legend has to explain the leader lines this frame.
+  const hasNudgedMarkers: boolean = placedMarkers.some(
+    (marker: PlacedMapMarker): boolean => {
+      return marker.needsLeaderLine;
+    },
+  );
 
   /*
    * Zoom changes which sites share a marker, so an open picker's list can go
@@ -909,14 +936,80 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
             </g>
 
             {/*
+             * Leader lines, under the markers they belong to.
+             *
+             * A marker that had to be moved off its real position keeps a
+             * thread back to it, ending in a dot on the exact spot. Without
+             * this the map would be quietly wrong — a store drawn twenty
+             * pixels from where it is, with nothing saying so. With it, the
+             * displacement is legible: the marker is the thing you click,
+             * the dot is the place it is.
+             *
+             * Drawn in the marker's own colour so a nudged outage still
+             * reads red at a glance, over a white under-stroke so the thread
+             * survives a coastline or a dark landmass — the same trick the
+             * name labels use.
+             */}
+            <g style={{ pointerEvents: "none" }}>
+              {placedMarkers
+                .filter((marker: PlacedMapMarker): boolean => {
+                  return marker.needsLeaderLine;
+                })
+                .map((marker: PlacedMapMarker): ReactElement => {
+                  const color: string = CLUSTER_COLORS[marker.colorKey];
+                  return (
+                    <g key={`leader-${marker.key}`} aria-hidden="true">
+                      <line
+                        x1={marker.anchorX}
+                        y1={marker.anchorY}
+                        x2={marker.x}
+                        y2={marker.y}
+                        stroke="var(--ou-surface-primary, #ffffff)"
+                        strokeWidth={3.5 / zoom}
+                        strokeOpacity={0.9}
+                        strokeLinecap="round"
+                      />
+                      <line
+                        x1={marker.anchorX}
+                        y1={marker.anchorY}
+                        x2={marker.x}
+                        y2={marker.y}
+                        stroke={color}
+                        strokeWidth={1.25 / zoom}
+                        strokeOpacity={0.9}
+                        strokeLinecap="round"
+                      />
+                      {/* The exact spot: a white pip so the dot reads on
+                       * land, and the marker's colour inside it. */}
+                      <circle
+                        cx={marker.anchorX}
+                        cy={marker.anchorY}
+                        r={2.25 / zoom}
+                        fill="var(--ou-surface-primary, #ffffff)"
+                      />
+                      <circle
+                        cx={marker.anchorX}
+                        cy={marker.anchorY}
+                        r={1.25 / zoom}
+                        fill={color}
+                      />
+                    </g>
+                  );
+                })}
+            </g>
+
+            {/*
              * The markers. A CONTAINER — a region, a market, "Corp" — is
              * drawn as a rounded square, the same shape as the cards it
              * opens into; a single site stays a round pin. The difference is
              * a shape, not a hue, so "this is a level you can go into"
              * survives both a color-blind reader and a grayscale print.
+             *
+             * Positions come from the collision layout above, so no marker
+             * is ever hidden under another one — see layoutMapMarkers.
              */}
             <g>
-              {markers.map((marker: MapMarker): ReactElement => {
+              {placedMarkers.map((marker: PlacedMapMarker): ReactElement => {
                 const color: string = CLUSTER_COLORS[marker.colorKey];
                 /*
                  * Sized on screen, then converted for this zoom: the marker
@@ -943,9 +1036,11 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                 /*
                  * A square of side 2r covers a good deal more ink than a
                  * circle of radius r, so containers are drawn slightly
-                 * tighter to keep the two shapes reading at one weight.
+                 * tighter to keep the two shapes reading at one weight. The
+                 * factor is shared with the label and collision geometry,
+                 * which both have to know the same square.
                  */
-                const side: number = radius * 1.78;
+                const side: number = radius * CONTAINER_SIDE_FACTOR;
                 const haloSide: number = side + ((hasCount ? 4 : 3) * 2) / zoom;
 
                 return (
@@ -1329,6 +1424,39 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
               Single site
             </li>
           </ul>
+        ) : (
+          <></>
+        )}
+
+        {/*
+         * What the threads mean. Shown only while the map is drawing some:
+         * a key for something that is not on screen is clutter, and on most
+         * levels nothing has to move at all.
+         */}
+        {hasNudgedMarkers ? (
+          <span
+            data-testid="site-geo-map-nudged-key"
+            className="flex items-center gap-1.5 text-xs text-gray-600"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 12"
+              className="h-3 w-6 flex-shrink-0"
+            >
+              <line
+                x1="3"
+                y1="9"
+                x2="16"
+                y2="4"
+                stroke={CLUSTER_COLORS["none"]}
+                strokeWidth="1.4"
+                strokeLinecap="round"
+              />
+              <circle cx="3" cy="9" r="1.8" fill={CLUSTER_COLORS["none"]} />
+              <circle cx="18" cy="4" r="4" fill={CLUSTER_COLORS["none"]} />
+            </svg>
+            Nudged apart — the line ends at the real spot
+          </span>
         ) : (
           <></>
         )}

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
@@ -5,6 +5,11 @@ import {
   GeoClusterPoint,
   clusterPoints,
 } from "./Geo/GeoClusterUtil";
+import {
+  CollidableMarker,
+  MarkerPlacement,
+  resolveMarkerCollisions,
+} from "./Geo/MarkerLayout";
 import { MapSiteView, SiteMapMode } from "./SiteHierarchyTypes";
 
 /*
@@ -560,6 +565,26 @@ export const groupedMarkerRadius: (
 };
 
 /*
+ * A container is drawn as a SQUARE rather than a disc — same shape as the
+ * card it opens into — and a square of side 2r covers a good deal more ink
+ * than a circle of radius r, so the side is pulled in to keep the two shapes
+ * reading at one weight.
+ *
+ * One constant, because three different pieces of geometry have to agree on
+ * it: the square SiteGeoMap draws, the box a label has to clear, and the
+ * circle the collision layout keeps clear around it.
+ */
+export const CONTAINER_SIDE_FACTOR: number = 1.78;
+
+/*
+ * The radius of the circle that CONTAINS that square — half its diagonal.
+ * Collision uses it so two containers cannot be pushed together corner to
+ * corner, which is the one direction a side-length comparison misses.
+ */
+export const CONTAINER_COLLISION_FACTOR: number =
+  (CONTAINER_SIDE_FACTOR / 2) * Math.SQRT2;
+
+/*
  * Past this many markers the name labels come off: they would overlap into
  * an unreadable mat, and the hover tooltip still names every one. Levels
  * with this many children are rare — it is the deep, unit-heavy levels that
@@ -617,8 +642,8 @@ export type LabelPlacement = "below" | "above";
 export const LABEL_PLACEMENTS: Array<LabelPlacement> = ["below", "above"];
 
 /*
- * A container is drawn as a square of side 1.78r, so its label clears the
- * corner rather than the circumscribed circle.
+ * A container is drawn as a square of side CONTAINER_SIDE_FACTOR * r, so its
+ * label clears the SIDE rather than the circumscribed circle.
  */
 const markerLabelRect: (
   marker: MapMarker,
@@ -636,7 +661,7 @@ const markerLabelRect: (
   const centerX: number = marker.x * zoom;
   const offset: number =
     (marker.isContainer
-      ? (marker.screenRadius * 1.78) / 2
+      ? (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2
       : marker.screenRadius) + LABEL_GAP;
   const centerY: number =
     marker.y * zoom + (placement === "above" ? -offset : offset);
@@ -654,7 +679,7 @@ const markerBodyRect: (marker: MapMarker, zoom: number) => LabelRect = (
   zoom: number,
 ): LabelRect => {
   const half: number = marker.isContainer
-    ? (marker.screenRadius * 1.78) / 2
+    ? (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2
     : marker.screenRadius;
   const centerX: number = marker.x * zoom;
   const centerY: number = marker.y * zoom;
@@ -927,4 +952,96 @@ export const buildMapMarkers: (input: BuildMarkersInput) => Array<MapMarker> = (
   });
 
   return markers;
+};
+
+/*
+ * ── Where a marker is DRAWN ────────────────────────────────────────────
+ *
+ * Paint order stopped being enough the moment two markers landed on the same
+ * point. The smaller one being painted last only helps while there is some
+ * of the bigger one left to see: a market whose centroid is its parent's, or
+ * six regions whose derived positions all average out over the same city,
+ * draw N markers in one place and show ONE. The rest cannot be hovered,
+ * named or clicked, and nothing on screen admits they exist.
+ *
+ * So markers are laid out before they are drawn: anything that would cover
+ * another is pushed off it by the smallest amount that clears the overlap,
+ * and keeps a line back to where it really is. See Geo/MarkerLayout.ts.
+ */
+
+// A marker plus where the map actually draws it.
+export interface PlacedMapMarker extends MapMarker {
+  // Where the marker belongs — the far end of its leader line.
+  anchorX: number;
+  anchorY: number;
+  /*
+   * Pushed clear of the spot it belongs to, rather than merely nudged within
+   * its own footprint. The map draws a leader line for exactly these, and
+   * says so in the legend.
+   */
+  needsLeaderLine: boolean;
+}
+
+/**
+ * The radius that has to stay clear around a marker, in screen units: its
+ * own radius, or — for a container — the radius of the circle that contains
+ * the square it is drawn as.
+ */
+export const collisionRadiusOfMarker: (marker: MapMarker) => number = (
+  marker: MapMarker,
+): number => {
+  const radius: number =
+    Number.isFinite(marker.screenRadius) && marker.screenRadius > 0
+      ? marker.screenRadius
+      : 0;
+  return marker.isContainer ? radius * CONTAINER_COLLISION_FACTOR : radius;
+};
+
+/**
+ * Place markers so that none of them covers another at this zoom.
+ *
+ * Returns the markers in PAINT order — the order they came in — each
+ * carrying the position it is drawn at, the position it belongs to, and
+ * whether the two differ enough to be worth a leader line. Markers with room
+ * around them come back untouched, so a map with nothing overlapping on it
+ * draws every marker exactly where the customer's coordinates put it.
+ */
+export const layoutMapMarkers: (
+  markers: Array<MapMarker>,
+  zoom: number,
+) => Array<PlacedMapMarker> = (
+  markers: Array<MapMarker>,
+  zoom: number,
+): Array<PlacedMapMarker> => {
+  const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+    markers.map((marker: MapMarker): CollidableMarker => {
+      return {
+        key: marker.key,
+        x: marker.x,
+        y: marker.y,
+        radius: collisionRadiusOfMarker(marker),
+      };
+    }),
+    zoom,
+  );
+
+  return markers.map((marker: MapMarker, index: number): PlacedMapMarker => {
+    const placement: MarkerPlacement | undefined = placements[index];
+    if (!placement) {
+      return {
+        ...marker,
+        anchorX: marker.x,
+        anchorY: marker.y,
+        needsLeaderLine: false,
+      };
+    }
+    return {
+      ...marker,
+      x: placement.x,
+      y: placement.y,
+      anchorX: placement.anchorX,
+      anchorY: placement.anchorY,
+      needsLeaderLine: placement.needsLeaderLine,
+    };
+  });
 };

--- a/App/Tests/Dashboard/GeoViewport.test.ts
+++ b/App/Tests/Dashboard/GeoViewport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import {
   DETAIL_GEOMETRY_MIN_ZOOM,
+  FIT_MAX_ZOOM,
   MAX_ZOOM,
   MIN_ZOOM,
   MapViewport,
@@ -315,6 +316,42 @@ describe("fitViewportToPoints", () => {
     expectDrawable(fitted);
     expect(zoomOfViewport(fitted)).toBeLessThanOrEqual(MAX_ZOOM);
     expect(containsPoint(fitted, point(480, 250))).toBe(true);
+  });
+
+  /*
+   * How deep a reader MAY zoom and how deep the map opens are different
+   * questions. Tying them together meant that raising the manual limit —
+   * so that sites in one metro area can actually be told apart, see
+   * MarkerLayout.test.ts — would silently drop every one-town estate onto a
+   * street corner with no town around it the moment the page loaded.
+   */
+  test("the opening frame never goes deeper than FIT_MAX_ZOOM", () => {
+    expect(FIT_MAX_ZOOM).toBeLessThanOrEqual(MAX_ZOOM);
+
+    const single: MapViewport = fitViewportToPoints([CITIES["nairobi"]!]);
+    expect(zoomOfViewport(single)).toBeLessThanOrEqual(FIT_MAX_ZOOM + 1e-9);
+
+    // Several sites in one town: the same degenerate case with more rows.
+    const oneTown: MapViewport = fitViewportToPoints([
+      city(51.51, -0.13),
+      city(51.512, -0.128),
+      city(51.509, -0.131),
+    ]);
+    expect(zoomOfViewport(oneTown)).toBeLessThanOrEqual(FIT_MAX_ZOOM + 1e-9);
+    expectDrawable(oneTown);
+  });
+
+  test("a reader can still zoom in deeper than the map ever frames itself", () => {
+    expect(MAX_ZOOM).toBeGreaterThan(FIT_MAX_ZOOM);
+
+    const fitted: MapViewport = fitViewportToPoints([CITIES["london"]!]);
+    let deeper: MapViewport = fitted;
+    for (let step: number = 0; step < 10; step++) {
+      deeper = zoomViewport(deeper, 2);
+    }
+    expect(zoomOfViewport(deeper)).toBeCloseTo(MAX_ZOOM, 9);
+    expect(zoomOfViewport(deeper)).toBeGreaterThan(zoomOfViewport(fitted));
+    expectDrawable(deeper);
   });
 
   test("a tall network is framed by its height, not squashed", () => {

--- a/App/Tests/Dashboard/GeometryAssets.test.ts
+++ b/App/Tests/Dashboard/GeometryAssets.test.ts
@@ -9,6 +9,7 @@ import {
   projectRobinson,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoProjection";
 import {
+  FIT_MAX_ZOOM,
   MAX_ZOOM,
   WORLD_VIEWPORT,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoViewport";
@@ -430,22 +431,40 @@ describe("asset budget", () => {
 });
 
 /*
- * The detail tier's simplification tolerance and the map's MAX_ZOOM are
- * chosen against each other (see Scripts/Geo/README.md). If somebody raises
- * MAX_ZOOM without regenerating finer geometry, the simplification starts
- * showing as visible corners on coastlines — so pin the relationship.
+ * The detail tier's simplification tolerance and the map's zoom limits are
+ * chosen against each other (see Scripts/Geo/README.md), and the two limits
+ * make different promises.
+ *
+ * FIT_MAX_ZOOM is the deepest frame the MAP ever picks for a reader — every
+ * opening view, and every "Fit to sites". At that scale one tolerance is
+ * about one screen pixel: outlines nobody asked to magnify are exact.
+ *
+ * MAX_ZOOM is how far a reader may then push it by hand, and it is deeper on
+ * purpose: sites in one metro area do not come apart at FIT_MAX_ZOOM (see
+ * MarkerLayout.test.ts), so the map has to keep going for zoom to be worth
+ * doing. Coastlines soften there. That is the trade, and it is BOUNDED —
+ * raising MAX_ZOOM past this means regenerating finer geometry, not quietly
+ * letting the outlines polygonize.
  */
-describe("detail resolution supports the deepest zoom", () => {
+describe("detail resolution supports the zooms the map offers", () => {
   const DETAIL_TOLERANCE_VIEWBOX_UNITS: number = 0.04;
+  // A map rendered at a typical dashboard width.
+  const RENDERED_WIDTH_PX: number = 1000;
 
-  test("one tolerance is about one screen pixel at MAX_ZOOM", () => {
-    // A map rendered at a typical dashboard width.
-    const renderedWidthPx: number = 1000;
-    const pixelsPerUnit: number =
-      renderedWidthPx / (WORLD_VIEWPORT.width / MAX_ZOOM);
-    expect(DETAIL_TOLERANCE_VIEWBOX_UNITS * pixelsPerUnit).toBeLessThanOrEqual(
-      1.5,
+  function toleranceInPixelsAt(zoom: number): number {
+    return (
+      DETAIL_TOLERANCE_VIEWBOX_UNITS *
+      (RENDERED_WIDTH_PX / (WORLD_VIEWPORT.width / zoom))
     );
+  }
+
+  test("one tolerance is about one screen pixel at the deepest frame the map picks", () => {
+    expect(toleranceInPixelsAt(FIT_MAX_ZOOM)).toBeLessThanOrEqual(1.5);
+  });
+
+  test("zooming in by hand goes deeper, and softens the outlines only so far", () => {
+    expect(MAX_ZOOM).toBeGreaterThan(FIT_MAX_ZOOM);
+    expect(toleranceInPixelsAt(MAX_ZOOM)).toBeLessThanOrEqual(3);
   });
 
   test("detail coordinates are quantized finer than the tolerance", () => {

--- a/App/Tests/Dashboard/MarkerLayout.test.ts
+++ b/App/Tests/Dashboard/MarkerLayout.test.ts
@@ -1,0 +1,817 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  CollidableMarker,
+  MARKER_CLEARANCE,
+  MAX_LAID_OUT_MARKERS,
+  MAX_MARKER_DISPLACEMENT,
+  MIN_VISIBLE_DISPLACEMENT,
+  MarkerPlacement,
+  resolveMarkerCollisions,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/MarkerLayout";
+import { projectRobinson } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoProjection";
+import {
+  FIT_MAX_ZOOM,
+  MAX_ZOOM,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoViewport";
+
+/*
+ * The Network Map draws one marker per thing, wherever that thing is — and a
+ * real estate puts several of them in the same place. Two stores in one
+ * retail park, a market whose centroid is its parent's, six regions whose
+ * derived positions all average out over the same city: every one of those
+ * used to draw N markers on one spot and show ONE. The rest were not merely
+ * cramped, they were GONE — no hover, no name, no click, and nothing on
+ * screen admitting they existed.
+ *
+ * This module is the fix, so this is where the promise has to be pinned:
+ *
+ *   - markers never cover each other, whatever the data does;
+ *   - a marker with room around it does not move AT ALL, so the map keeps
+ *     telling the truth about where things are;
+ *   - one that has to move never goes further than a leader line can
+ *     honestly explain, and reports that it moved;
+ *   - the same markers always lay out the same way, whatever order they
+ *     arrive in — a map that reshuffled itself on the 60-second poll would
+ *     be worse than one that overlaps.
+ */
+
+const DEFAULT_RADIUS: number = 7;
+
+function marker(
+  key: string,
+  x: number,
+  y: number,
+  radius: number = DEFAULT_RADIUS,
+): CollidableMarker {
+  return { key, x, y, radius };
+}
+
+// Markers all sitting on exactly the same point — the case that broke.
+function pileOf(
+  count: number,
+  radius: number = DEFAULT_RADIUS,
+): Array<CollidableMarker> {
+  const markers: Array<CollidableMarker> = [];
+  for (let index: number = 0; index < count; index++) {
+    markers.push(marker(`site-${index}`, 480, 250, radius));
+  }
+  return markers;
+}
+
+function byKey(
+  placements: Array<MarkerPlacement>,
+): Map<string, MarkerPlacement> {
+  const map: Map<string, MarkerPlacement> = new Map<string, MarkerPlacement>();
+  for (const placement of placements) {
+    map.set(placement.key, placement);
+  }
+  return map;
+}
+
+/*
+ * Overlap is a SCREEN question — that is the whole reason marker radii are
+ * screen units — so distances are compared there, at the zoom being drawn.
+ */
+function screenDistance(
+  a: MarkerPlacement,
+  b: MarkerPlacement,
+  zoom: number,
+): number {
+  return Math.hypot(a.x - b.x, a.y - b.y) * zoom;
+}
+
+function displacement(placement: MarkerPlacement, zoom: number): number {
+  return (
+    Math.hypot(
+      placement.x - placement.anchorX,
+      placement.y - placement.anchorY,
+    ) * zoom
+  );
+}
+
+/*
+ * Whether the layout had to move this marker at all — a different question
+ * from needsLeaderLine, which is about whether the move is worth EXPLAINING.
+ * A marker nudged by less than its own radius is still sitting on its own
+ * coordinates, and a line to a point underneath it would be invisible ink.
+ */
+function wasMoved(placement: MarkerPlacement): boolean {
+  return placement.x !== placement.anchorX || placement.y !== placement.anchorY;
+}
+
+function requiredDistance(a: CollidableMarker, b: CollidableMarker): number {
+  return a.radius + b.radius + MARKER_CLEARANCE;
+}
+
+/*
+ * The headline promise, checked over every pair rather than over a sample.
+ * The tolerance absorbs the hair of residual movement the relaxation stops
+ * at; it is far below one screen pixel.
+ *
+ * Every one of these helpers collects its complaints and asserts ONCE.
+ * These tests run over piles of hundreds of markers, and an expect() per
+ * marker turns a millisecond of layout into seconds of test harness.
+ */
+function overlappingPairs(
+  markers: Array<CollidableMarker>,
+  placements: Array<MarkerPlacement>,
+  zoom: number,
+): Array<string> {
+  const problems: Array<string> = [];
+  for (let i: number = 0; i < markers.length; i++) {
+    for (let j: number = i + 1; j < markers.length; j++) {
+      const distance: number = screenDistance(
+        placements[i]!,
+        placements[j]!,
+        zoom,
+      );
+      const required: number = requiredDistance(markers[i]!, markers[j]!);
+      if (distance < required - 0.05) {
+        problems.push(
+          `${markers[i]!.key} and ${markers[j]!.key} are ${distance.toFixed(
+            3,
+          )} apart on screen but need ${required.toFixed(3)}`,
+        );
+      }
+    }
+  }
+  return problems;
+}
+
+function expectNothingOverlaps(
+  markers: Array<CollidableMarker>,
+  placements: Array<MarkerPlacement>,
+  zoom: number,
+): void {
+  expect(overlappingPairs(markers, placements, zoom)).toEqual([]);
+}
+
+// Placements that fail a promise, named — so a failure says which and why.
+function offenders(
+  placements: Array<MarkerPlacement>,
+  isGood: (placement: MarkerPlacement) => boolean,
+  explain: (placement: MarkerPlacement) => string,
+): Array<string> {
+  const problems: Array<string> = [];
+  for (const placement of placements) {
+    if (!isGood(placement)) {
+      problems.push(`${placement.key}: ${explain(placement)}`);
+    }
+  }
+  return problems;
+}
+
+describe("resolveMarkerCollisions leaves markers alone when it can", () => {
+  test("markers with room around them are drawn exactly where they belong", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("a", 100, 100),
+      marker("b", 300, 300),
+      marker("c", 700, 120),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+
+    for (let index: number = 0; index < markers.length; index++) {
+      // Bit-for-bit, not merely close: an untouched marker must not drift.
+      expect(placements[index]!.x).toBe(markers[index]!.x);
+      expect(placements[index]!.y).toBe(markers[index]!.y);
+      expect(placements[index]!.needsLeaderLine).toBe(false);
+    }
+  });
+
+  test("a lone marker is never moved", () => {
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      [marker("only", 12.5, 88.25)],
+      4,
+    );
+    expect(placements).toEqual([
+      {
+        key: "only",
+        x: 12.5,
+        y: 88.25,
+        anchorX: 12.5,
+        anchorY: 88.25,
+        needsLeaderLine: false,
+      },
+    ]);
+  });
+
+  test("no markers, no placements", () => {
+    expect(resolveMarkerCollisions([], 1)).toEqual([]);
+  });
+
+  test("every marker gets exactly one placement, in the order it came in", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("zulu", 480, 250),
+      marker("alpha", 480, 250),
+      marker("mike", 481, 250),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+    expect(
+      placements.map((placement: MarkerPlacement): string => {
+        return placement.key;
+      }),
+    ).toEqual(["zulu", "alpha", "mike"]);
+  });
+});
+
+describe("resolveMarkerCollisions pulls a pile-up apart", () => {
+  test("two markers on the same point end up clear of each other", () => {
+    const markers: Array<CollidableMarker> = pileOf(2);
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+
+    expectNothingOverlaps(markers, placements, 1);
+    expect(screenDistance(placements[0]!, placements[1]!, 1)).toBeGreaterThan(
+      requiredDistance(markers[0]!, markers[1]!) - 0.05,
+    );
+    for (const placement of placements) {
+      expect(placement.needsLeaderLine).toBe(true);
+    }
+  });
+
+  test.each([3, 5, 8, 13, 30])(
+    "a pile of %i markers comes apart completely",
+    (count: number) => {
+      const markers: Array<CollidableMarker> = pileOf(count);
+      const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+        markers,
+        1,
+      );
+      expectNothingOverlaps(markers, placements, 1);
+    },
+  );
+
+  test("a pile-up keeps every anchor, so nothing loses its real position", () => {
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      pileOf(9),
+      1,
+    );
+    expect(
+      offenders(
+        placements,
+        (placement: MarkerPlacement): boolean => {
+          return placement.anchorX === 480 && placement.anchorY === 250;
+        },
+        (placement: MarkerPlacement): string => {
+          return `anchored at ${placement.anchorX},${placement.anchorY}`;
+        },
+      ),
+    ).toEqual([]);
+    // They moved, and they say so — that is what draws the leader lines.
+    expect(
+      offenders(
+        placements,
+        (placement: MarkerPlacement): boolean => {
+          return (
+            placement.needsLeaderLine &&
+            displacement(placement, 1) > MIN_VISIBLE_DISPLACEMENT
+          );
+        },
+        (placement: MarkerPlacement): string => {
+          return `moved ${displacement(placement, 1).toFixed(3)}, flagged ${
+            placement.needsLeaderLine
+          }`;
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  test("markers of different sizes still clear each other", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("huge", 480, 250, 22),
+      marker("mid", 480, 250, 14),
+      marker("small", 480, 250, 7),
+      marker("tiny", 480.5, 250.5, 7),
+    ];
+    expectNothingOverlaps(markers, resolveMarkerCollisions(markers, 1), 1);
+  });
+
+  /*
+   * A chain of markers each overlapping the next is the case a naive
+   * "nudge the pair apart" pass gets wrong: fixing one pair breaks the
+   * neighbouring one, and it has to keep going until the whole row is clear.
+   */
+  test("a chain of overlapping markers separates all the way down", () => {
+    const markers: Array<CollidableMarker> = [];
+    for (let index: number = 0; index < 12; index++) {
+      markers.push(marker(`chain-${index}`, 300 + index * 8, 250));
+    }
+    expectNothingOverlaps(markers, resolveMarkerCollisions(markers, 1), 1);
+  });
+
+  test("a busy map with piles, chains and loners resolves all of it", () => {
+    const markers: Array<CollidableMarker> = [
+      ...pileOf(6),
+      marker("chain-a", 300, 100),
+      marker("chain-b", 304, 100),
+      marker("chain-c", 308, 100),
+      marker("far-1", 100, 400, 22),
+      marker("far-2", 800, 60, 14),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+    expectNothingOverlaps(markers, placements, 1);
+
+    // The loners had room, so they did not move.
+    const placed: Map<string, MarkerPlacement> = byKey(placements);
+    expect(placed.get("far-1")!.needsLeaderLine).toBe(false);
+    expect(placed.get("far-1")!.x).toBe(100);
+    expect(placed.get("far-2")!.needsLeaderLine).toBe(false);
+    expect(placed.get("far-2")!.y).toBe(60);
+  });
+
+  /*
+   * The promise that makes displacement acceptable at all: the map never
+   * draws a marker away from the place it belongs without a line saying so.
+   * "Away from" means off its own footprint — a marker nudged within its own
+   * radius is still covering its coordinates, and a line to a point beneath
+   * it would be invisible.
+   */
+  test("nothing is drawn off its spot without a line to explain it", () => {
+    const markers: Array<CollidableMarker> = [
+      ...pileOf(7),
+      marker("pair-a", 300, 100, 18),
+      marker("pair-b", 316, 104, 18),
+      marker("row-a", 700, 400),
+      marker("row-b", 706, 400),
+      marker("row-c", 712, 400),
+      marker("alone", 120, 60, 22),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+
+    const unexplained: Array<string> = [];
+    for (let index: number = 0; index < markers.length; index++) {
+      const placement: MarkerPlacement = placements[index]!;
+      if (placement.needsLeaderLine) {
+        continue;
+      }
+      const moved: number = displacement(placement, 1);
+      if (moved > markers[index]!.radius) {
+        unexplained.push(`${placement.key} moved ${moved.toFixed(2)}`);
+      }
+    }
+    expect(unexplained).toEqual([]);
+  });
+});
+
+describe("resolveMarkerCollisions moves markers as little as possible", () => {
+  /*
+   * The displacement is a lie the leader line has to carry. A marker moved
+   * further than it needed to be is a lie told for no reason.
+   */
+  test("a pair that barely overlaps barely moves", () => {
+    const required: number = requiredDistance(
+      marker("a", 0, 0),
+      marker("b", 0, 0),
+    );
+    const markers: Array<CollidableMarker> = [
+      marker("a", 400, 250),
+      marker("b", 400 + required - 2, 250),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+
+    // They end up exactly clear, not flung apart.
+    expect(screenDistance(placements[0]!, placements[1]!, 1)).toBeCloseTo(
+      required,
+      3,
+    );
+    // Two pixels of overlap, shared: one screen unit each.
+    for (const placement of placements) {
+      expect(displacement(placement, 1)).toBeCloseTo(1, 3);
+    }
+  });
+
+  /*
+   * A sub-pixel nudge gets no leader line: a thread nobody can see, pointing
+   * at a marker that has not visibly moved, is noise. The POSITION is still
+   * the resolved one — snapping it back would put the overlap back.
+   */
+  test("a nudge too small to see draws no leader line", () => {
+    const required: number = requiredDistance(
+      marker("a", 0, 0),
+      marker("b", 0, 0),
+    );
+    const markers: Array<CollidableMarker> = [
+      marker("a", 400, 250),
+      marker("b", 400 + required - 1, 250),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+
+    for (const placement of placements) {
+      expect(displacement(placement, 1)).toBeCloseTo(0.5, 3);
+      expect(displacement(placement, 1)).toBeLessThan(MIN_VISIBLE_DISPLACEMENT);
+      expect(placement.needsLeaderLine).toBe(false);
+    }
+    // Moved anyway — the overlap is real even if the correction is invisible.
+    expect(placements[0]!.x).not.toBe(400);
+  });
+
+  /*
+   * Nor does a marker nudged by less than its own radius. It is still sitting
+   * on the spot it belongs to — the line and the dot would be drawn entirely
+   * underneath it, and the legend would be explaining ink that is not on
+   * screen. Big markers are exactly where this bites: two large regions in
+   * one city need a lot of separating before either one stops covering its
+   * own coordinates.
+   */
+  test("a marker still covering its own spot draws no leader line", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("big-a", 480, 250, 30),
+      // Overlapping enough to need a few units of correction, no more.
+      marker("big-b", 480 + 30 + 30 + MARKER_CLEARANCE - 8, 250, 30),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+
+    for (const placement of placements) {
+      expect(displacement(placement, 1)).toBeCloseTo(4, 3);
+      // Well past the "did it move at all" floor...
+      expect(displacement(placement, 1)).toBeGreaterThan(
+        MIN_VISIBLE_DISPLACEMENT,
+      );
+      // ...and still deep inside the marker's own footprint.
+      expect(placement.needsLeaderLine).toBe(false);
+      expect(wasMoved(placement)).toBe(true);
+    }
+  });
+
+  test("once the marker clears its own spot, the line appears", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("big-a", 480, 250, 30),
+      marker("big-b", 480, 250, 30),
+    ];
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+    for (const placement of placements) {
+      // Half the required separation each: 31.5, clear of a radius of 30.
+      expect(displacement(placement, 1)).toBeGreaterThan(30);
+      expect(placement.needsLeaderLine).toBe(true);
+    }
+  });
+
+  /*
+   * The big marker is the one carrying the most meaning — a region standing
+   * for three hundred units — and it is the one the eye is on. The single
+   * store next to it is what steps aside.
+   */
+  test("the bigger marker holds its ground and the small one moves", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("region", 480, 250, 22),
+      marker("store", 480, 250, 7),
+    ];
+    const placed: Map<string, MarkerPlacement> = byKey(
+      resolveMarkerCollisions(markers, 1),
+    );
+    expect(displacement(placed.get("region")!, 1)).toBeLessThan(
+      displacement(placed.get("store")!, 1),
+    );
+  });
+
+  test("nothing is ever pushed further than a leader line can explain", () => {
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      pileOf(120),
+      1,
+    );
+    expect(
+      offenders(
+        placements,
+        (placement: MarkerPlacement): boolean => {
+          return displacement(placement, 1) <= MAX_MARKER_DISPLACEMENT + 1e-6;
+        },
+        (placement: MarkerPlacement): string => {
+          return `moved ${displacement(placement, 1).toFixed(3)}`;
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  /*
+   * Past what fits, the map keeps some overlap rather than scattering
+   * markers across a county they are not in. It must still be a map, not a
+   * crash or an infinite loop.
+   */
+  test("a pile too dense to resolve still terminates and stays near home", () => {
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      pileOf(400),
+      1,
+    );
+    expect(placements).toHaveLength(400);
+    expect(
+      offenders(
+        placements,
+        (placement: MarkerPlacement): boolean => {
+          return (
+            Number.isFinite(placement.x) &&
+            Number.isFinite(placement.y) &&
+            displacement(placement, 1) <= MAX_MARKER_DISPLACEMENT + 1e-6
+          );
+        },
+        (placement: MarkerPlacement): string => {
+          return `at ${placement.x},${placement.y}`;
+        },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("resolveMarkerCollisions is the same every time", () => {
+  const markers: Array<CollidableMarker> = [
+    ...pileOf(7),
+    marker("near-a", 300, 100),
+    marker("near-b", 305, 103),
+    marker("lonely", 800, 400, 18),
+  ];
+
+  test("the same markers lay out identically twice", () => {
+    expect(resolveMarkerCollisions(markers, 1)).toEqual(
+      resolveMarkerCollisions(markers, 1),
+    );
+  });
+
+  /*
+   * Paint order is re-decided every render (biggest marker first, and the
+   * counts change as sites go down). If the layout depended on it, a site
+   * going offline would visibly shuffle the map.
+   */
+  test("the order the markers arrive in changes nothing", () => {
+    const reversed: Array<CollidableMarker> = [...markers].reverse();
+    const forward: Map<string, MarkerPlacement> = byKey(
+      resolveMarkerCollisions(markers, 1),
+    );
+    const backward: Map<string, MarkerPlacement> = byKey(
+      resolveMarkerCollisions(reversed, 1),
+    );
+
+    expect(backward.size).toBe(forward.size);
+    for (const [key, placement] of forward.entries()) {
+      expect(backward.get(key)).toEqual(placement);
+    }
+  });
+
+  test("a shuffled pile lays out the same way", () => {
+    const shuffled: Array<CollidableMarker> = [
+      markers[4]!,
+      markers[9]!,
+      markers[0]!,
+      markers[7]!,
+      markers[2]!,
+      markers[8]!,
+      markers[1]!,
+      markers[5]!,
+      markers[3]!,
+      markers[6]!,
+    ];
+    const straight: Map<string, MarkerPlacement> = byKey(
+      resolveMarkerCollisions(markers, 1),
+    );
+    for (const placement of resolveMarkerCollisions(shuffled, 1)) {
+      expect(placement).toEqual(straight.get(placement.key));
+    }
+  });
+});
+
+describe("resolveMarkerCollisions works in screen space, so zoom undoes it", () => {
+  /*
+   * This is the other half of the fix, and the reason the map's zoom limit
+   * was raised: zooming in genuinely separates markers, and when it does the
+   * layout stops moving them. Markers snap back to their true positions
+   * rather than staying nudged at every zoom.
+   */
+  test("two markers that need nudging zoomed out are untouched zoomed in", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("a", 400, 250),
+      marker("b", 402, 250),
+    ];
+
+    const wide: Array<MarkerPlacement> = resolveMarkerCollisions(markers, 1);
+    expect(wasMoved(wide[0]!)).toBe(true);
+    expect(wasMoved(wide[1]!)).toBe(true);
+
+    const close: Array<MarkerPlacement> = resolveMarkerCollisions(markers, 10);
+    expect(close[0]!.x).toBe(400);
+    expect(close[1]!.x).toBe(402);
+    expect(wasMoved(close[0]!)).toBe(false);
+    expect(close[0]!.needsLeaderLine).toBe(false);
+    expect(close[1]!.needsLeaderLine).toBe(false);
+  });
+
+  test("the displacement shrinks as the map zooms in", () => {
+    const markers: Array<CollidableMarker> = pileOf(4);
+    const spread: (zoom: number) => number = (zoom: number): number => {
+      const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+        markers,
+        zoom,
+      );
+      return Math.max(
+        ...placements.map((placement: MarkerPlacement): number => {
+          // In viewBox units: the same screen spread covers less world.
+          return Math.hypot(
+            placement.x - placement.anchorX,
+            placement.y - placement.anchorY,
+          );
+        }),
+      );
+    };
+    expect(spread(4)).toBeLessThan(spread(1));
+    expect(spread(16)).toBeLessThan(spread(4));
+  });
+
+  /*
+   * Sites in one metro area are the everyday version of this problem. At the
+   * map's old zoom limit two of them 20 km apart were still inside one
+   * marker's radius, so a reader who zoomed in to tell them apart hit the
+   * stop with the pair still stacked. The current limit resolves them for
+   * real — which is what the raise was for.
+   */
+  test("the deepest zoom separates sites the old limit could not", () => {
+    const [aX, aY]: [number, number] = projectRobinson(40, -100);
+    // ~20 km east, at that latitude.
+    const [bX, bY]: [number, number] = projectRobinson(40, -100 + 0.2345);
+    const markers: Array<CollidableMarker> = [
+      marker("store-a", aX, aY),
+      marker("store-b", bX, bY),
+    ];
+
+    const atOldLimit: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      FIT_MAX_ZOOM,
+    );
+    expect(wasMoved(atOldLimit[0]!)).toBe(true);
+    expect(wasMoved(atOldLimit[1]!)).toBe(true);
+
+    const atMaxZoom: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      MAX_ZOOM,
+    );
+    expect(wasMoved(atMaxZoom[0]!)).toBe(false);
+    expect(atMaxZoom[0]!.needsLeaderLine).toBe(false);
+    expect(atMaxZoom[0]!.x).toBe(aX);
+    expect(atMaxZoom[1]!.x).toBe(bX);
+  });
+});
+
+describe("resolveMarkerCollisions survives hostile input", () => {
+  test("a marker with no usable position is passed straight through", () => {
+    const markers: Array<CollidableMarker> = [
+      marker("nan", Number.NaN, 250),
+      marker("infinite", 480, Infinity),
+      marker("real-a", 480, 250),
+      marker("real-b", 480, 250),
+    ];
+    const placed: Map<string, MarkerPlacement> = byKey(
+      resolveMarkerCollisions(markers, 1),
+    );
+
+    expect(Number.isNaN(placed.get("nan")!.x)).toBe(true);
+    expect(placed.get("nan")!.needsLeaderLine).toBe(false);
+    expect(placed.get("infinite")!.y).toBe(Infinity);
+    expect(placed.get("infinite")!.needsLeaderLine).toBe(false);
+
+    // The real pair is still pulled apart around them.
+    expect(
+      screenDistance(placed.get("real-a")!, placed.get("real-b")!, 1),
+    ).toBeGreaterThan(2 * DEFAULT_RADIUS + MARKER_CLEARANCE - 0.05);
+  });
+
+  test("only one usable marker means nothing to resolve", () => {
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      [marker("nan", Number.NaN, Number.NaN), marker("real", 100, 100)],
+      1,
+    );
+    expect(placements[1]!.x).toBe(100);
+    expect(placements[1]!.needsLeaderLine).toBe(false);
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["zero", 0],
+    ["negative", -4],
+    ["infinite", Infinity],
+  ])(
+    "a %s zoom is treated as the whole world",
+    (_name: string, zoom: number) => {
+      const markers: Array<CollidableMarker> = pileOf(4);
+      expect(resolveMarkerCollisions(markers, zoom)).toEqual(
+        resolveMarkerCollisions(markers, 1),
+      );
+    },
+  );
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["negative", -7],
+    ["infinite", Infinity],
+  ])(
+    "a %s radius still gets the markers off each other",
+    (_name: string, radius: number) => {
+      const markers: Array<CollidableMarker> = pileOf(4, radius);
+      const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+        markers,
+        1,
+      );
+      const tooClose: Array<string> = [];
+      for (let i: number = 0; i < placements.length; i++) {
+        for (let j: number = i + 1; j < placements.length; j++) {
+          const distance: number = screenDistance(
+            placements[i]!,
+            placements[j]!,
+            1,
+          );
+          if (distance < MARKER_CLEARANCE - 0.05) {
+            tooClose.push(`${i}/${j}: ${distance.toFixed(3)}`);
+          }
+        }
+      }
+      expect(tooClose).toEqual([]);
+    },
+  );
+
+  test("a zero radius still leaves the clearance between markers", () => {
+    const markers: Array<CollidableMarker> = pileOf(3, 0);
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+    expectNothingOverlaps(markers, placements, 1);
+  });
+});
+
+describe("resolveMarkerCollisions stays out of the way of a huge map", () => {
+  /*
+   * Past a few thousand markers the map is a texture rather than a set of
+   * things to click, and the relaxation would run on every wheel tick of a
+   * zoom. Stepping aside is the honest failure: the picture is unchanged,
+   * and a drag does not stutter.
+   */
+  test("past the ceiling every marker is drawn exactly where it belongs", () => {
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      pileOf(MAX_LAID_OUT_MARKERS + 1),
+      1,
+    );
+    expect(placements).toHaveLength(MAX_LAID_OUT_MARKERS + 1);
+    expect(
+      offenders(
+        placements,
+        (placement: MarkerPlacement): boolean => {
+          return (
+            placement.x === 480 &&
+            placement.y === 250 &&
+            !placement.needsLeaderLine
+          );
+        },
+        (placement: MarkerPlacement): string => {
+          return `drawn at ${placement.x},${placement.y}`;
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  /*
+   * ...and right up to the ceiling it still does the work. A thousand
+   * markers is an ordinary "all sites" view of a large estate, and it has to
+   * lay out fast enough to run on every frame of a zoom — which is what the
+   * neighbourhood grid inside is for.
+   */
+  test("a thousand markers, some of them stacked, all come apart", () => {
+    const markers: Array<CollidableMarker> = [];
+    for (let index: number = 0; index < 1000; index++) {
+      const column: number = index % 40;
+      const row: number = Math.floor(index / 40);
+      markers.push(marker(`grid-${index}`, 20 + column * 23, 10 + row * 18));
+    }
+    // Five sites sharing one address, in the middle of all that.
+    for (let index: number = 0; index < 5; index++) {
+      markers.push(marker(`stacked-${index}`, 480, 250));
+    }
+
+    const placements: Array<MarkerPlacement> = resolveMarkerCollisions(
+      markers,
+      1,
+    );
+    expect(placements).toHaveLength(1005);
+    expectNothingOverlaps(markers, placements, 1);
+  });
+});

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -748,6 +748,80 @@ describe("SiteGeoMap", () => {
     );
     expect(source).toContain("event.preventDefault();");
   });
+
+  /*
+   * Markers used to be drawn straight at their projected positions, with
+   * paint order as the only defence against two of them landing on the same
+   * spot — which is no defence at all once they land on exactly the same
+   * spot. The map now lays them out first (Geo/MarkerLayout.ts, pinned by
+   * MarkerLayout.test.ts) and every marker is drawn from that result.
+   *
+   * A single `markers.map` left behind here would put one marker back under
+   * another with nothing on screen saying so, so these pin the wiring rather
+   * than the geometry.
+   */
+  test("markers are drawn from the collision layout, not from raw positions", () => {
+    expect(source).toContain(
+      squash(
+        "const placedMarkers: Array<PlacedMapMarker> = useMemo(() => { return layoutMapMarkers(markers, zoom); }, [markers, zoom]);",
+      ),
+    );
+    expect(source).toContain(
+      squash("{placedMarkers.map((marker: PlacedMapMarker): ReactElement =>"),
+    );
+    // Nothing draws off the un-laid-out list any more.
+    expect(source).not.toContain(squash("{markers.map((marker: MapMarker)"));
+  });
+
+  /*
+   * The names have to follow the marker a reader can SEE. Resolving them
+   * against the projected positions would drop labels for a collision that
+   * the layout has already resolved, and print the survivors in the wrong
+   * place.
+   */
+  test("labels are placed against the drawn positions", () => {
+    expect(source).toContain(
+      squash("return resolveMarkerLabels(placedMarkers, zoom); }, "),
+    );
+  });
+
+  /*
+   * A marker moved off its coordinates without saying so is a map that
+   * lies. The line back to the anchor is the whole reason the displacement
+   * is allowed at all.
+   */
+  test("a displaced marker keeps a leader line to where it really is", () => {
+    const leaders: string = source
+      .split('<g style={{ pointerEvents: "none" }}>')[1]!
+      .split("</g>")[0]!;
+    expect(leaders).toContain("return marker.needsLeaderLine;");
+    expect(leaders).toContain("x1={marker.anchorX}");
+    expect(leaders).toContain("y1={marker.anchorY}");
+    expect(leaders).toContain("x2={marker.x}");
+    expect(leaders).toContain("y2={marker.y}");
+  });
+
+  test("the leader lines are explained, and only when there are some", () => {
+    expect(source).toContain(
+      squash("const hasNudgedMarkers: boolean = placedMarkers.some("),
+    );
+    expect(source).toContain(squash("{hasNudgedMarkers ? ("));
+    expect(source).toContain('data-testid="site-geo-map-nudged-key"');
+  });
+
+  /*
+   * The square, the box a label has to clear and the circle the layout keeps
+   * clear around a container are three views of ONE shape. A second literal
+   * here is how they drift apart.
+   */
+  test("the container square is drawn from the shared factor", () => {
+    expect(source).toContain(
+      "const side: number = radius * CONTAINER_SIDE_FACTOR;",
+    );
+    expect(
+      readCode("Components", "NetworkSite", "SiteGeoMap.tsx"),
+    ).not.toContain("* 1.78");
+  });
 });
 
 /*

--- a/App/Tests/Dashboard/SiteMapViewModel.test.ts
+++ b/App/Tests/Dashboard/SiteMapViewModel.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "@jest/globals";
 import {
   BuildPinsResult,
   CLUSTER_CELL_SIZE,
+  CONTAINER_COLLISION_FACTOR,
+  CONTAINER_SIDE_FACTOR,
   ClusterColorKey,
   ClusterColorMember,
   GENERIC_SITE_TYPE_LABEL,
@@ -14,11 +16,13 @@ import {
   LabelPlacement,
   MapMarker,
   PinnableSite,
+  PlacedMapMarker,
   buildMapMarkers,
   buildPins,
   childTypeLabelFor,
   clusterCellSize,
   clusterRadius,
+  collisionRadiusOfMarker,
   colorKeyForTone,
   decideClusterColorKey,
   describeMapCoverage,
@@ -26,6 +30,7 @@ import {
   describeMarkerSite,
   formatUptimePercent,
   groupedMarkerRadius,
+  layoutMapMarkers,
   mapPinFingerprint,
   pluralizeSiteType,
   markerCountForSite,
@@ -34,6 +39,7 @@ import {
   truncateMarkerLabel,
   unitRollupTone,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel";
+import { MARKER_CLEARANCE } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/MarkerLayout";
 import { MapSiteView } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteHierarchyTypes";
 import {
   ROBINSON_VIEW_BOX_HEIGHT,
@@ -1571,5 +1577,364 @@ describe("buildMapMarkers sizes markers by what is under them", () => {
       ),
     );
     expect(radii.size).toBe(1);
+  });
+});
+
+/*
+ * Paint order stopped being enough the moment two markers landed on the same
+ * point. "The smaller one is painted last" only helps while there is some of
+ * the bigger one left to see — and a market whose centroid is its parent's,
+ * or six regions whose derived positions all average out over one city, draw
+ * N markers in one place and show ONE. The others cannot be hovered, named
+ * or clicked, and nothing on screen admits they are there.
+ *
+ * layoutMapMarkers is where that is fixed: it decides where each marker is
+ * DRAWN, and SiteGeoMap threads a line from the ones that moved back to
+ * where they really are. The geometry lives in Geo/MarkerLayout.ts (pinned
+ * by MarkerLayout.test.ts); what is pinned here is the part that knows what
+ * a MARKER is — how much room each shape needs, and that everything
+ * downstream follows the drawn position rather than the projected one.
+ */
+describe("collisionRadiusOfMarker", () => {
+  function marker(overrides: Partial<MapMarker> = {}): MapMarker {
+    return {
+      key: "m",
+      x: 100,
+      y: 100,
+      ids: ["m"],
+      count: 1,
+      screenRadius: 10,
+      colorKey: "ok",
+      isContainer: false,
+      isApproximate: false,
+      label: "",
+      tooltip: "",
+      ...overrides,
+    };
+  }
+
+  test("a single site needs exactly its own radius", () => {
+    expect(collisionRadiusOfMarker(marker())).toBe(10);
+  });
+
+  /*
+   * A container is a SQUARE. Keeping squares apart by their side length lets
+   * two of them meet corner to corner, which is the one direction that looks
+   * like a collision to a reader and like clearance to the math.
+   */
+  test("a container needs the circle that contains its square", () => {
+    expect(collisionRadiusOfMarker(marker({ isContainer: true }))).toBeCloseTo(
+      10 * CONTAINER_COLLISION_FACTOR,
+      9,
+    );
+    expect(CONTAINER_COLLISION_FACTOR).toBeGreaterThan(1);
+    // Which is exactly half the diagonal of the square that gets drawn.
+    expect(CONTAINER_COLLISION_FACTOR).toBeCloseTo(
+      (CONTAINER_SIDE_FACTOR / 2) * Math.SQRT2,
+      9,
+    );
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["negative", -4],
+    ["infinite", Infinity],
+    ["zero", 0],
+  ])(
+    "a %s radius asks for no room rather than a broken layout",
+    (_name: string, screenRadius: number) => {
+      expect(collisionRadiusOfMarker(marker({ screenRadius }))).toBe(0);
+      expect(
+        collisionRadiusOfMarker(marker({ screenRadius, isContainer: true })),
+      ).toBe(0);
+    },
+  );
+});
+
+describe("layoutMapMarkers", () => {
+  function marker(
+    key: string,
+    x: number,
+    y: number,
+    overrides: Partial<MapMarker> = {},
+  ): MapMarker {
+    return {
+      key: key,
+      x: x,
+      y: y,
+      ids: [key],
+      count: 4,
+      screenRadius: MIN_CLUSTER_RADIUS,
+      colorKey: "ok",
+      isContainer: true,
+      isApproximate: false,
+      label: key,
+      tooltip: `${key} tooltip`,
+      ...overrides,
+    };
+  }
+
+  // The square SiteGeoMap actually draws, in screen units.
+  function squareOf(
+    placed: PlacedMapMarker,
+    zoom: number,
+  ): {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+  } {
+    const half: number = (placed.screenRadius * CONTAINER_SIDE_FACTOR) / 2;
+    return {
+      left: placed.x * zoom - half,
+      right: placed.x * zoom + half,
+      top: placed.y * zoom - half,
+      bottom: placed.y * zoom + half,
+    };
+  }
+
+  test("markers come back in paint order, with everything else intact", () => {
+    const markers: Array<MapMarker> = [
+      marker("first", 100, 100, { count: 90 }),
+      marker("second", 400, 300, { count: 3, colorKey: "down" }),
+    ];
+    const placed: Array<PlacedMapMarker> = layoutMapMarkers(markers, 1);
+
+    expect(
+      placed.map((entry: PlacedMapMarker): string => {
+        return entry.key;
+      }),
+    ).toEqual(["first", "second"]);
+    expect(placed[0]!.count).toBe(90);
+    expect(placed[1]!.colorKey).toBe("down");
+    expect(placed[1]!.tooltip).toBe("second tooltip");
+    expect(placed[1]!.ids).toEqual(["second"]);
+  });
+
+  test("a map with room on it is drawn exactly where the coordinates say", () => {
+    const placed: Array<PlacedMapMarker> = layoutMapMarkers(
+      [marker("a", 100, 100), marker("b", 500, 300)],
+      1,
+    );
+    for (const entry of placed) {
+      expect(entry.x).toBe(entry.anchorX);
+      expect(entry.y).toBe(entry.anchorY);
+      expect(entry.needsLeaderLine).toBe(false);
+    }
+  });
+
+  test("an empty map lays out to nothing", () => {
+    expect(layoutMapMarkers([], 1)).toEqual([]);
+  });
+
+  /*
+   * The defect, end to end: two children of a level whose positions are the
+   * same point. Before, one of them was simply invisible.
+   */
+  test("two markers on one point are drawn clear of each other", () => {
+    const placed: Array<PlacedMapMarker> = layoutMapMarkers(
+      [marker("alpha", 480, 250), marker("beta", 480, 250)],
+      1,
+    );
+
+    const first: {
+      left: number;
+      right: number;
+      top: number;
+      bottom: number;
+    } = squareOf(placed[0]!, 1);
+    const second: {
+      left: number;
+      right: number;
+      top: number;
+      bottom: number;
+    } = squareOf(placed[1]!, 1);
+
+    const overlaps: boolean = !(
+      first.right <= second.left ||
+      first.left >= second.right ||
+      first.bottom <= second.top ||
+      first.top >= second.bottom
+    );
+    expect(overlaps).toBe(false);
+
+    // Both keep a line home to the spot they share.
+    for (const entry of placed) {
+      expect(entry.needsLeaderLine).toBe(true);
+      expect(entry.anchorX).toBe(480);
+      expect(entry.anchorY).toBe(250);
+    }
+  });
+
+  test("containers are given more room than single sites of the same size", () => {
+    const gap: (isContainer: boolean) => number = (
+      isContainer: boolean,
+    ): number => {
+      const placed: Array<PlacedMapMarker> = layoutMapMarkers(
+        [
+          marker("a", 480, 250, { isContainer }),
+          marker("b", 480, 250, { isContainer }),
+        ],
+        1,
+      );
+      return Math.hypot(
+        placed[0]!.x - placed[1]!.x,
+        placed[0]!.y - placed[1]!.y,
+      );
+    };
+    expect(gap(true)).toBeGreaterThan(gap(false));
+    expect(gap(false)).toBeCloseTo(
+      2 * MIN_CLUSTER_RADIUS + MARKER_CLEARANCE,
+      2,
+    );
+  });
+
+  /*
+   * The whole point of laying out before drawing: everything the reader
+   * touches — the name under the marker, the tooltip anchor, the site picker
+   * — follows the marker they can SEE, not the coordinate underneath it.
+   */
+  test("names come back once the markers they belong to are pulled apart", () => {
+    /*
+     * Short names, so what is being measured is the marker positions rather
+     * than how wide "Region 1000" is: a label reserves a box roughly its own
+     * length, and six long names cannot fit around one point however well
+     * the markers are spread.
+     */
+    const markers: Array<MapMarker> = ["A", "B", "C", "D", "E", "F"].map(
+      (name: string): MapMarker => {
+        return marker(name, 480, 250);
+      },
+    );
+
+    const stacked: number = resolveMarkerLabels(markers, 1).size;
+    const spread: number = resolveMarkerLabels(
+      layoutMapMarkers(markers, 1),
+      1,
+    ).size;
+
+    /*
+     * Stacked, every name but the two that fit above and below has to be
+     * dropped rather than printed on top of another one. Spread out, the
+     * map can say what each marker is again.
+     */
+    expect(stacked).toBeLessThan(markers.length);
+    expect(spread).toBeGreaterThan(stacked);
+  });
+
+  /*
+   * Straight off the real builder, not hand-made markers: five sites a
+   * customer pinned to the same coordinates.
+   */
+  test("a level whose children share one address draws all of them", () => {
+    const sites: Array<MapSiteView> = [0, 1, 2, 3, 4].map(
+      (index: number): MapSiteView => {
+        return mapSite({
+          id: `store-${index}`,
+          name: `Store ${index}`,
+          latitude: 41.88,
+          longitude: -87.63,
+          totalUnits: 10,
+          operationalUnits: 10,
+        });
+      },
+    );
+    const placed: Array<PlacedMapMarker> = layoutMapMarkers(
+      buildMapMarkers({ sites: sites, mode: "grouped", cellSize: 0 }),
+      1,
+    );
+
+    expect(placed).toHaveLength(5);
+    const tooClose: Array<string> = [];
+    for (let i: number = 0; i < placed.length; i++) {
+      for (let j: number = i + 1; j < placed.length; j++) {
+        const distance: number = Math.hypot(
+          placed[i]!.x - placed[j]!.x,
+          placed[i]!.y - placed[j]!.y,
+        );
+        const required: number =
+          collisionRadiusOfMarker(placed[i]!) +
+          collisionRadiusOfMarker(placed[j]!) +
+          MARKER_CLEARANCE;
+        if (distance < required - 0.05) {
+          tooClose.push(
+            `${placed[i]!.key}/${placed[j]!.key}: ${distance.toFixed(2)}`,
+          );
+        }
+      }
+    }
+    expect(tooClose).toEqual([]);
+
+    // Every one of them still knows the address it was pinned to.
+    for (const entry of placed) {
+      expect(entry.anchorX).toBeCloseTo(placed[0]!.anchorX, 9);
+      expect(entry.anchorY).toBeCloseTo(placed[0]!.anchorY, 9);
+    }
+
+    /*
+     * And none of them is drawn off that address without saying so. A pile
+     * this size usually settles as one marker still sitting on the spot with
+     * the rest fanned around it — the one in the middle needs no line,
+     * because it has not left.
+     */
+    const unexplained: Array<string> = placed
+      .filter((entry: PlacedMapMarker): boolean => {
+        const moved: number = Math.hypot(
+          entry.x - entry.anchorX,
+          entry.y - entry.anchorY,
+        );
+        return !entry.needsLeaderLine && moved > collisionRadiusOfMarker(entry);
+      })
+      .map((entry: PlacedMapMarker): string => {
+        return entry.key;
+      });
+    expect(unexplained).toEqual([]);
+    expect(
+      placed.filter((entry: PlacedMapMarker): boolean => {
+        return entry.needsLeaderLine;
+      }).length,
+    ).toBeGreaterThanOrEqual(placed.length - 1);
+  });
+
+  /*
+   * Clusters in "all" mode overlap too — the cluster grid buckets by
+   * proximity, and two neighbouring buckets can still draw discs that touch.
+   */
+  test("clustered markers are laid out as well as grouped ones", () => {
+    const sites: Array<MapSiteView> = [];
+    for (let index: number = 0; index < 8; index++) {
+      sites.push(
+        mapSite({
+          id: `site-${index}`,
+          latitude: 34.05 + index * 0.01,
+          longitude: -118.24,
+          isContainer: false,
+          isOperational: true,
+        }),
+      );
+    }
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: sites,
+      mode: "all",
+      cellSize: 0.2,
+    });
+    const placed: Array<PlacedMapMarker> = layoutMapMarkers(markers, 1);
+
+    expect(placed).toHaveLength(markers.length);
+    const tooClose: Array<string> = [];
+    for (let i: number = 0; i < placed.length; i++) {
+      for (let j: number = i + 1; j < placed.length; j++) {
+        const distance: number = Math.hypot(
+          placed[i]!.x - placed[j]!.x,
+          placed[i]!.y - placed[j]!.y,
+        );
+        const required: number =
+          placed[i]!.screenRadius + placed[j]!.screenRadius + MARKER_CLEARANCE;
+        if (distance < required - 0.05) {
+          tooClose.push(`${i}/${j}`);
+        }
+      }
+    }
+    expect(tooClose).toEqual([]);
   });
 });

--- a/Scripts/Geo/README.md
+++ b/Scripts/Geo/README.md
@@ -61,9 +61,21 @@ cd App && npx jest Tests/Dashboard/GeometryAssets Tests/Dashboard/GeoProjection
 | Overview | countries-110m | 1 | 0.05 px | 0.5 px² | ~84 KB |
 | Detail | countries-50m | 2 | 0.04 px | 0.05 px² | ~511 KB |
 
-The detail tier's 0.04 px tolerance is chosen against the map's `MAX_ZOOM`:
-at the deepest zoom the UI allows, 0.04 viewBox units is about one screen
-pixel. Moving either number means revisiting the other.
+The detail tier's 0.04 px tolerance is chosen against the map's zoom limits,
+which make two different promises (`Geo/GeoViewport.ts`):
+
+- `FIT_MAX_ZOOM` is the deepest frame the map ever picks for a reader — every
+  opening view and every "Fit to sites". At that scale 0.04 viewBox units is
+  about one screen pixel, so outlines nobody asked to magnify are exact.
+- `MAX_ZOOM` is how far a reader may then push it by hand, and it is
+  deliberately deeper: sites in one metro area only come apart well past
+  `FIT_MAX_ZOOM`, and separating them is what zoom is for on this map.
+  Coastlines soften there — about 2.7 px of simplification at the very
+  bottom.
+
+Raising `MAX_ZOOM` further means regenerating with a finer tolerance rather
+than letting the outlines polygonize;
+`App/Tests/Dashboard/GeometryAssets.test.ts` pins both ends of that trade.
 
 ## Invariants and edge cases
 


### PR DESCRIPTION
## The problem

Sites pile up in one place, and the map drew every marker at its exact projected position with paint order as the only defence. That is no defence once two markers land on the **same** point — two stores in one retail park, a market whose centroid is its parent's, six regions whose derived positions all average out over one city.

The map drew N markers there and showed **one**. The others were not merely cramped, they were gone: no hover, no name, no click, and nothing on screen admitting they existed.

## The fix

**Markers are laid out before they are drawn** (`Geo/MarkerLayout.ts`, new).

- Anything that would cover another marker is pushed off it by the **smallest** correction that clears the overlap.
- A marker whose true spot ends up out from under it keeps a thin **leader line** back to that spot, ending in a dot on it.
- A marker with room around it **does not move at all** — its drawn position is its projected one, to the bit. The map still tells the truth about where things are.

The layout is pure, deterministic and order-independent, so the page's 60-second poll can never make the map twitch: markers relax in canonical key order through a neighbourhood grid, coincident ones fan out along golden-angle rays, and heavier markers absorb less of each push — a region standing for 300 units holds its ground while the single store beside it steps aside. Nothing moves further than a leader line can honestly explain, and the work is bounded per marker (~3 ms for a typical level, ~30 ms for a thousand markers) so a busy view still lays out inside a frame of a zoom.

**Zoom is the other half.** It genuinely separates markers, and when it does the displacement dissolves on its own — but sites in one metro area were still stacked at the old `MAX_ZOOM` of 20, so a reader who zoomed in to tell two of them apart hit the stop with the pair still on top of each other. `MAX_ZOOM` is now **64** (~9 km resolvable, vs ~29 km before).

How deep the map *frames itself* is a different question from how deep a reader may push it, so that keeps its own limit (`FIT_MAX_ZOOM`, 20) — a one-town estate still opens with its town around it rather than on a street corner.

**One honest trade:** coastlines soften past zoom 20, because the detail geometry is simplified to 0.04 viewBox units (~2.7 px at the new bottom, vs ~0.75 px before). Country outlines are the backdrop; the markers are the subject. The trade is now stated and pinned at *both* ends — outlines must stay pixel-exact through `FIT_MAX_ZOOM`, and softening at `MAX_ZOOM` is capped, so raising it further means regenerating finer geometry rather than quietly letting coastlines polygonize (`GeometryAssets.test.ts`, `Scripts/Geo/README.md`).

Labels, the hover tooltip, the site picker and the focus ring all follow the drawn position, so a name is no longer dropped for a collision the layout has already resolved. The legend explains the leader lines only while some are on screen.

## Verified

Six regions sharing one set of coordinates, before → after:

- **Before:** one marker visible, five unreachable.
- **After:** all six laid out around the shared point, leader lines converging on it, every one hoverable and clickable — confirmed against the real `SiteGeoMap` component in a browser, including that zooming in dissolves the nudge and removes the legend key.

## Tests

**1831 Dashboard tests pass** (62 suites). New/extended:

- `App/Tests/Dashboard/MarkerLayout.test.ts` (new, 40 tests) — nothing overlaps for piles of 2/3/5/8/13/30, chains, and mixed busy maps; untouched markers keep their exact positions bit-for-bit; minimum-displacement (a 2 px overlap moves each marker 1 px, not more); the displacement cap; determinism and order-independence under shuffling; big markers move less than small ones; zoom dissolves displacement; a 20 km pair that needed nudging at the old limit is clean at the new one; hostile input (NaN/Infinity coordinates, radii, zooms); termination and correctness at 1000+ markers; graceful step-aside past the marker ceiling.
- `SiteMapViewModel.test.ts` — container collision radius (the circle containing the square, so two squares cannot meet corner to corner), paint order preserved, real `buildMapMarkers` output for five sites at one address, clustered "all sites" markers, and names coming back once markers are pulled apart.
- `GeoViewport.test.ts` — the opening frame never goes deeper than `FIT_MAX_ZOOM`; a reader can still zoom deeper than the map ever frames itself.
- `GeometryAssets.test.ts` — both ends of the outline/zoom trade.
- `NetworkSitePageInvariants.test.ts` — the component draws from the layout (no raw `markers.map` left), resolves labels against drawn positions, renders leader lines anchored to the true spot, and shares one container-square factor across the three places that need it.

`npx tsc --noEmit` clean in App and Dashboard; eslint clean.
