### PR TITLE
fix(api): enforce ownership on user-incoming-call-number resend-verification-code (GHSA-wc96-jm46-37hh)

### DIFF
--- a/Common/Server/API/UserIncomingCallNumberAPI.ts
+++ b/Common/Server/API/UserIncomingCallNumberAPI.ts
@@ -116,6 +116,37 @@ export default class UserIncomingCallNumberAPI extends BaseAPI<
             );
           }
 
+          const item: UserIncomingCallNumber | null =
+            await this.service.findOneById({
+              id: req.body["itemId"],
+              props: {
+                isRoot: true,
+              },
+              select: {
+                userId: true,
+              },
+            });
+
+          if (!item) {
+            return Response.sendErrorResponse(
+              req,
+              res,
+              new BadDataException("Item not found"),
+            );
+          }
+
+          // Check user ID
+          if (
+            item.userId?.toString() !==
+            (req as OneUptimeRequest)?.userAuthorization?.userId?.toString()
+          ) {
+            return Response.sendErrorResponse(
+              req,
+              res,
+              new BadDataException("Invalid user ID"),
+            );
+          }
+
           await this.service.resendVerificationCode(req.body.itemId);
 
           return Response.sendEmptySuccessResponse(req, res);

--- a/Common/Tests/Server/API/UserIncomingCallNumberApi.test.ts
+++ b/Common/Tests/Server/API/UserIncomingCallNumberApi.test.ts
@@ -1,0 +1,429 @@
+import UserIncomingCallNumberAPI from "../../../Server/API/UserIncomingCallNumberAPI";
+import UserIncomingCallNumberService from "../../../Server/Services/UserIncomingCallNumberService";
+import {
+  NextFunction,
+  OneUptimeRequest,
+  OneUptimeResponse,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import { mockRouter } from "./Helpers";
+import { beforeAll, describe, expect, it } from "@jest/globals";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import JSONWebTokenData from "../../../Types/JsonWebTokenData";
+import ObjectID from "../../../Types/ObjectID";
+import UserIncomingCallNumber from "../../../Models/DatabaseModels/UserIncomingCallNumber";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendJsonObjectResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendErrorResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+  };
+});
+
+jest.mock("../../../Server/Services/UserIncomingCallNumberService");
+
+const VERIFY_ROUTE: string = "/user-incoming-call-number/verify";
+const RESEND_ROUTE: string =
+  "/user-incoming-call-number/resend-verification-code";
+
+const CALLER_USER_ID: string = "5f8d0d55b54764421b7156c1";
+const ATTACKER_USER_ID: string = "5f8d0d55b54764421b7156c2";
+const ITEM_ID: string = "5f8d0d55b54764421b7156d9";
+
+describe("UserIncomingCallNumberAPI", () => {
+  let mockRequest: OneUptimeRequest;
+  let mockResponse: OneUptimeResponse;
+  let nextFunction: NextFunction;
+
+  beforeAll(() => {
+    // Registers the routes on the mock router exactly once.
+    new UserIncomingCallNumberAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRequest = {} as OneUptimeRequest;
+    mockResponse = {
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as OneUptimeResponse;
+    nextFunction = jest.fn();
+
+    UserIncomingCallNumberService.findOneById = jest
+      .fn()
+      .mockResolvedValue(null);
+    UserIncomingCallNumberService.updateOneById = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    UserIncomingCallNumberService.resendVerificationCode = jest
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  type CallRouteFunction = (uri: string) => Promise<void>;
+
+  const callRoute: CallRouteFunction = async (uri: string): Promise<void> => {
+    await mockRouter
+      .match("post", uri)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+  };
+
+  type ItemFunction = (userId?: string) => UserIncomingCallNumber;
+
+  const itemOwnedBy: ItemFunction = (
+    userId?: string,
+  ): UserIncomingCallNumber => {
+    return {
+      _id: ITEM_ID,
+      id: new ObjectID(ITEM_ID),
+      userId: userId ? new ObjectID(userId) : undefined,
+    } as UserIncomingCallNumber;
+  };
+
+  type AuthenticateFunction = (userId?: string) => void;
+
+  const authenticateAs: AuthenticateFunction = (userId?: string): void => {
+    mockRequest.userAuthorization = {
+      userId: userId ? new ObjectID(userId) : undefined,
+    } as JSONWebTokenData;
+  };
+
+  describe("POST /user-incoming-call-number/resend-verification-code", () => {
+    /*
+     * GHSA-wc96-jm46-37hh — this route used to call resendVerificationCode()
+     * with any itemId the caller supplied, without checking that the item
+     * belonged to the caller. That let an authenticated user trigger
+     * verification-code SMS resends to another user's phone number (SMS spam
+     * to the victim, SMS balance drain on the project). It is the same class
+     * as CVE-2026-30959, which was fixed on the sibling channels only.
+     */
+    describe("ownership enforcement (GHSA-wc96-jm46-37hh regression)", () => {
+      it("should reject an itemId that belongs to another user", async () => {
+        mockRequest.body = { itemId: ITEM_ID };
+        authenticateAs(ATTACKER_USER_ID);
+        UserIncomingCallNumberService.findOneById = jest
+          .fn()
+          .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+        await callRoute(RESEND_ROUTE);
+
+        expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+          mockRequest,
+          mockResponse,
+          new BadDataException("Invalid user ID"),
+        );
+      });
+
+      it("should not send an SMS when the item belongs to another user", async () => {
+        mockRequest.body = { itemId: ITEM_ID };
+        authenticateAs(ATTACKER_USER_ID);
+        UserIncomingCallNumberService.findOneById = jest
+          .fn()
+          .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+        await callRoute(RESEND_ROUTE);
+
+        expect(
+          UserIncomingCallNumberService.resendVerificationCode,
+        ).not.toHaveBeenCalled();
+        expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+      });
+
+      it("should reject when the request carries no user authorization", async () => {
+        mockRequest.body = { itemId: ITEM_ID };
+        UserIncomingCallNumberService.findOneById = jest
+          .fn()
+          .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+        await callRoute(RESEND_ROUTE);
+
+        expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+          mockRequest,
+          mockResponse,
+          new BadDataException("Invalid user ID"),
+        );
+        expect(
+          UserIncomingCallNumberService.resendVerificationCode,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("should reject when the authorized user has no user ID", async () => {
+        mockRequest.body = { itemId: ITEM_ID };
+        authenticateAs(undefined);
+        UserIncomingCallNumberService.findOneById = jest
+          .fn()
+          .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+        await callRoute(RESEND_ROUTE);
+
+        expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+          mockRequest,
+          mockResponse,
+          new BadDataException("Invalid user ID"),
+        );
+        expect(
+          UserIncomingCallNumberService.resendVerificationCode,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("should look the item up by ID before resending", async () => {
+        mockRequest.body = { itemId: ITEM_ID };
+        authenticateAs(CALLER_USER_ID);
+        UserIncomingCallNumberService.findOneById = jest
+          .fn()
+          .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+        await callRoute(RESEND_ROUTE);
+
+        expect(UserIncomingCallNumberService.findOneById).toHaveBeenCalledWith({
+          id: ITEM_ID,
+          props: { isRoot: true },
+          select: { userId: true },
+        });
+      });
+
+      it("should compare owner IDs by value, not by object identity", async () => {
+        mockRequest.body = { itemId: ITEM_ID };
+        authenticateAs(CALLER_USER_ID);
+
+        // Distinct ObjectID instances that hold the same value.
+        UserIncomingCallNumberService.findOneById = jest
+          .fn()
+          .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+        await callRoute(RESEND_ROUTE);
+
+        expect(
+          UserIncomingCallNumberService.resendVerificationCode,
+        ).toHaveBeenCalledTimes(1);
+        expect(Response.sendErrorResponse).not.toHaveBeenCalled();
+      });
+    });
+
+    it("should handle required item ID", async () => {
+      mockRequest.body = {};
+
+      await callRoute(RESEND_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Invalid item ID"),
+      );
+      expect(
+        UserIncomingCallNumberService.resendVerificationCode,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should not look up an item when the item ID is missing", async () => {
+      mockRequest.body = {};
+      authenticateAs(CALLER_USER_ID);
+
+      await callRoute(RESEND_ROUTE);
+
+      expect(UserIncomingCallNumberService.findOneById).not.toHaveBeenCalled();
+    });
+
+    it("should handle item not found", async () => {
+      mockRequest.body = { itemId: ITEM_ID };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      await callRoute(RESEND_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Item not found"),
+      );
+      expect(
+        UserIncomingCallNumberService.resendVerificationCode,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should resend the verification code for the caller's own item", async () => {
+      mockRequest.body = { itemId: ITEM_ID };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest
+        .fn()
+        .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+
+      await callRoute(RESEND_ROUTE);
+
+      expect(
+        UserIncomingCallNumberService.resendVerificationCode,
+      ).toHaveBeenCalledWith(ITEM_ID);
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+      );
+    });
+
+    it("should forward service errors to the error handler", async () => {
+      const error: Error = new Error("Phone Number already verified");
+      mockRequest.body = { itemId: ITEM_ID };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest
+        .fn()
+        .mockResolvedValue(itemOwnedBy(CALLER_USER_ID));
+      UserIncomingCallNumberService.resendVerificationCode = jest
+        .fn()
+        .mockRejectedValue(error);
+
+      await callRoute(RESEND_ROUTE);
+
+      expect(nextFunction).toHaveBeenCalledWith(error);
+      expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    });
+
+    it("should forward lookup errors to the error handler", async () => {
+      const error: Error = new Error("db down");
+      mockRequest.body = { itemId: ITEM_ID };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest
+        .fn()
+        .mockRejectedValue(error);
+
+      await callRoute(RESEND_ROUTE);
+
+      expect(nextFunction).toHaveBeenCalledWith(error);
+      expect(
+        UserIncomingCallNumberService.resendVerificationCode,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should be guarded by the user authorization middleware", () => {
+      expect(mockRouter.match("post", RESEND_ROUTE).middleware).toBeDefined();
+    });
+  });
+
+  describe("POST /user-incoming-call-number/verify", () => {
+    it("should handle required item ID", async () => {
+      mockRequest.body = {};
+
+      await callRoute(VERIFY_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Invalid item ID"),
+      );
+    });
+
+    it("should handle required code", async () => {
+      mockRequest.body = { itemId: ITEM_ID };
+
+      await callRoute(VERIFY_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Invalid code"),
+      );
+    });
+
+    it("should handle item not found", async () => {
+      mockRequest.body = { itemId: ITEM_ID, code: "123456" };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest
+        .fn()
+        .mockResolvedValue(null);
+
+      await callRoute(VERIFY_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Item not found"),
+      );
+    });
+
+    it("should reject verifying an item that belongs to another user", async () => {
+      mockRequest.body = { itemId: ITEM_ID, code: "123456" };
+      authenticateAs(ATTACKER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest.fn().mockResolvedValue({
+        ...itemOwnedBy(CALLER_USER_ID),
+        verificationCode: "123456",
+      });
+
+      await callRoute(VERIFY_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Invalid user ID"),
+      );
+      expect(
+        UserIncomingCallNumberService.updateOneById,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should reject an incorrect verification code", async () => {
+      mockRequest.body = { itemId: ITEM_ID, code: "123456" };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest.fn().mockResolvedValue({
+        ...itemOwnedBy(CALLER_USER_ID),
+        verificationCode: "654321",
+      });
+
+      await callRoute(VERIFY_ROUTE);
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+        new BadDataException("Invalid code"),
+      );
+      expect(
+        UserIncomingCallNumberService.updateOneById,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("should mark the number verified on a correct code", async () => {
+      mockRequest.body = { itemId: ITEM_ID, code: "123456" };
+      authenticateAs(CALLER_USER_ID);
+      UserIncomingCallNumberService.findOneById = jest.fn().mockResolvedValue({
+        ...itemOwnedBy(CALLER_USER_ID),
+        verificationCode: "123456",
+      });
+
+      await callRoute(VERIFY_ROUTE);
+
+      expect(UserIncomingCallNumberService.updateOneById).toHaveBeenCalledWith({
+        id: new ObjectID(ITEM_ID),
+        props: { isRoot: true },
+        data: { isVerified: true },
+      });
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+      );
+    });
+
+    it("should be guarded by the user authorization middleware", () => {
+      expect(mockRouter.match("post", VERIFY_ROUTE).middleware).toBeDefined();
+    });
+  });
+});

--- a/Common/Tests/Server/API/UserSmsApi.test.ts
+++ b/Common/Tests/Server/API/UserSmsApi.test.ts
@@ -212,16 +212,78 @@ describe("UserSmsAPI", () => {
       expect(response).toHaveBeenCalledWith(mockRequest, mockResponse, error);
     });
 
+    it("should handle Item not found", async () => {
+      const error: BadDataException = new BadDataException("Item not found");
+      mockRequest.body = {
+        itemId: "item1",
+      };
+      mockRequest.userAuthorization = {
+        userId: new ObjectID("user123"),
+      } as JSONWebTokenData;
+
+      UserSmsService.findOneById = jest.fn().mockResolvedValue(null);
+      UserSmsService.resendVerificationCode = jest.fn().mockResolvedValue(null);
+
+      await mockRouter
+        .match("post", "/user-sms/resend-verification-code")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      const response: jest.SpyInstance = jest.spyOn(
+        Response,
+        "sendErrorResponse",
+      );
+      expect(response).toHaveBeenCalledWith(mockRequest, mockResponse, error);
+      expect(UserSmsService.resendVerificationCode).not.toHaveBeenCalled();
+    });
+
+    /*
+     * CVE-2026-30959 regression: the resend route must not send a verification
+     * code for an item that belongs to a different user.
+     */
+    it("should reject an itemId that belongs to another user", async () => {
+      const error: BadDataException = new BadDataException("Invalid user ID");
+      mockRequest.body = {
+        itemId: "item1",
+      };
+      mockRequest.userAuthorization = {
+        userId: new ObjectID("user123"),
+      } as JSONWebTokenData;
+
+      const item: UserSMS = {
+        _id: "123",
+        userId: new ObjectID("user321"),
+      } as UserSMS;
+
+      UserSmsService.findOneById = jest.fn().mockResolvedValue(item);
+      UserSmsService.resendVerificationCode = jest.fn().mockResolvedValue(null);
+
+      await mockRouter
+        .match("post", "/user-sms/resend-verification-code")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      const response: jest.SpyInstance = jest.spyOn(
+        Response,
+        "sendErrorResponse",
+      );
+      expect(response).toHaveBeenCalledWith(mockRequest, mockResponse, error);
+      expect(UserSmsService.resendVerificationCode).not.toHaveBeenCalled();
+    });
+
     it("should handle valid response resend", async () => {
       mockRequest.body = {
         itemId: "item1",
-        code: "123456",
       };
 
       mockRequest.userAuthorization = {
         userId: new ObjectID("user123"),
       } as JSONWebTokenData;
 
+      const item: UserSMS = {
+        _id: "123",
+        userId: new ObjectID("user123"),
+      } as UserSMS;
+
+      UserSmsService.findOneById = jest.fn().mockResolvedValue(item);
       UserSmsService.resendVerificationCode = jest
         .fn()
         .mockImplementation(() => {
@@ -229,8 +291,12 @@ describe("UserSmsAPI", () => {
         });
 
       await mockRouter
-        .match("post", "/user-sms/verify")
+        .match("post", "/user-sms/resend-verification-code")
         .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(UserSmsService.resendVerificationCode).toHaveBeenCalledWith(
+        "item1",
+      );
 
       const response: jest.SpyInstance = jest.spyOn(
         Response,


### PR DESCRIPTION
## Summary

Fixes the missing ownership check on `POST /user-incoming-call-number/resend-verification-code`, reported privately as **GHSA-wc96-jm46-37hh** (CWE-862, Missing Authorization, CVSS 3.1 / low).

The report is accurate. The handler in `Common/Server/API/UserIncomingCallNumberAPI.ts` validated only that `itemId` was present, then called `resendVerificationCode(itemId)` — which loads the row with `props: { isRoot: true }`, bypassing row-level access control, and sends an SMS to whatever phone number is on that row. Any authenticated user who knew another user's pending incoming-call-number id could trigger verification-code SMS resends to that user's phone.

This is the same class as CVE-2026-30959. The sweep that followed it (`ea57608ca6`) added ownership checks to `UserCallAPI`, `UserEmailAPI`, `UserSmsAPI` and `UserWhatsAppAPI`, but not to `UserIncomingCallNumberAPI`, which had shipped earlier and wasn't revisited.

**Impact is availability-only and limited**, as the reporter noted: `itemId` is a non-enumerable ObjectID so an attacker needs a known or leaked id, and the service rejects already-verified numbers, so only pending numbers are affected. No data is returned and nothing is modified beyond regenerating the code. The practical effect is SMS spam to the victim and SMS-balance drain on the project.

## The fix

`Common/Server/API/UserIncomingCallNumberAPI.ts` — load the item first and reject when it doesn't belong to the caller, before calling the service. This is a verbatim copy of the guard the five sibling resend routes already use, so the channels now behave identically:

```ts
const item: UserIncomingCallNumber | null = await this.service.findOneById({
  id: req.body["itemId"],
  props: { isRoot: true },
  select: { userId: true },
});

if (!item) { /* BadDataException("Item not found") */ }

// Check user ID
if (
  item.userId?.toString() !==
  (req as OneUptimeRequest)?.userAuthorization?.userId?.toString()
) {
  /* BadDataException("Invalid user ID") */
}
```

I deliberately matched the existing pattern rather than inventing a new one — the root cause here was one route drifting out of line with its siblings, so consistency is the thing that prevents the next miss.

## Sweep for the same bug class

I checked every API route that accepts an `itemId` from the request body and acts on it:

| File | Ownership check |
| --- | --- |
| `UserCallAPI.ts` | already present |
| `UserEmailAPI.ts` | already present |
| `UserSmsAPI.ts` | already present |
| `UserTelegramAPI.ts` | already present |
| `UserWhatsAppAPI.ts` | already present |
| `UserWebhookAPI.ts` | already present |
| `UserIncomingCallNumberAPI.ts` | **missing — fixed here** |

`UserIncomingCallNumberAPI` was the only gap.

## Tests

New — `Common/Tests/Server/API/UserIncomingCallNumberApi.test.ts` (20 tests), covering both routes on this API, which had no test file at all before.

Ownership enforcement on the resend route (the regression the advisory is about):
- rejects an `itemId` belonging to another user
- does not call `resendVerificationCode` and does not return success in that case, i.e. no SMS is sent
- rejects when the request carries no user authorization
- rejects when the authorized user has no user id
- looks the item up with the expected `isRoot` / `select` arguments before resending
- compares owner ids by value rather than object identity

Resend route, rest of the surface: missing `itemId`, item not found, no lookup when `itemId` is absent, happy path calls the service with the right id, service and lookup errors forward to `next(err)`, route is mounted behind the user-authorization middleware.

Verify route (regression cover for behavior that was already correct): missing `itemId`, missing code, item not found, another user's item, wrong code, happy path marks the number verified, middleware present.

**Negative control.** I reverted the fix and re-ran the suite to confirm these tests actually fail against the vulnerable code rather than passing vacuously. 7 failed / 13 passed, and the decisive one reproduces the advisory directly — the attacker's request reached the service with the victim's item id:

```
✕ should not send an SMS when the item belongs to another user

  expect(jest.fn()).not.toHaveBeenCalled()
  Expected number of calls: 0
  Received number of calls: 1
  1: "5f8d0d55b54764421b7156d9"
```

With the fix applied, all 20 pass.

Also fixed in `Common/Tests/Server/API/UserSmsApi.test.ts`: the existing "should handle valid response resend" test dispatched to `/user-sms/verify` instead of `/user-sms/resend-verification-code`, so the SMS resend route's ownership check — the original CVE-2026-30959 fix — had no regression coverage. Pointed it at the right route and added an ownership-rejection case and an item-not-found case alongside it.

## Test results

```
Test Suites: 2 passed, 2 total
Tests:       30 passed, 30 total
```

(`Common/Tests/Server/API/UserIncomingCallNumberApi.test.ts` and `Common/Tests/Server/API/UserSmsApi.test.ts`)

`npx eslint` clean on all three changed files.

## Note for a possible follow-up

All six resend routes share one latent edge: the guard compares `item.userId?.toString()` to `userAuthorization?.userId?.toString()`, so if *both* were `undefined` the comparison would pass. It isn't reachable today — `userId` is non-null on these models and `UserMiddleware.getUserMiddleware` guarantees the authorization object — so I left it alone rather than diverge this one route from the other five again. If you want it hardened, it should be done across all six in one change.
