### PR TITLE
feat(status-page): bulk import resource groups from a CSV

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/StatusPage/ImportGroupsFromCsvModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/StatusPage/ImportGroupsFromCsvModal.tsx
@@ -1,0 +1,594 @@
+import {
+  ExistingStatusPageGroup,
+  ParsedStatusPageGroupRow,
+  STATUS_PAGE_GROUP_CSV_COLUMNS,
+  STATUS_PAGE_GROUP_CSV_EXAMPLE,
+  StatusPageGroupCsvError,
+  StatusPageGroupCsvParseResult,
+  parseStatusPageGroupCsv,
+} from "../../Utils/StatusPageGroupCsv";
+import {
+  CreateStatusPageGroupFunction,
+  StatusPageGroupCreateResult,
+  StatusPageGroupImportProgress,
+  StatusPageGroupImportRowResult,
+  StatusPageGroupImportSummary,
+  runStatusPageGroupImport,
+} from "../../Utils/StatusPageGroupImportRunner";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import { PromiseVoidFunction, VoidFunction } from "Common/Types/FunctionTypes";
+import ObjectID from "Common/Types/ObjectID";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import ProgressBar, {
+  ProgressBarSize,
+} from "Common/UI/Components/ProgressBar/ProgressBar";
+import TextArea from "Common/UI/Components/TextArea/TextArea";
+import { ToastType } from "Common/UI/Components/Toast/Toast";
+import { ShowToastNotification } from "Common/UI/Components/Toast/ToastInit";
+import API from "Common/UI/Utils/API/API";
+import downloadFile from "Common/UI/Utils/DownloadFile";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useRef,
+  useState,
+} from "react";
+
+/*
+ * Bulk CSV import for Status Page Groups, reached from the ⋯ menu on the
+ * Groups table — the same place every other table in the product hides its
+ * bulk actions.
+ *
+ * Parsing and dependency planning live in the react-free
+ * Utils/StatusPageGroupCsv module, and the sequential create loop in
+ * Utils/StatusPageGroupImportRunner; this component only wires them to a
+ * textarea, a file input, and the ModelAPI.
+ *
+ * Groups nest, so the file may name a parent it also creates. The groups
+ * already on the page are fetched at import time (not when the modal opens)
+ * so a group added from the table a moment ago is still a usable parent, and
+ * so their depths are current for the nesting-limit check.
+ */
+
+export interface ComponentProps {
+  statusPageId: ObjectID;
+  projectId: ObjectID;
+  onClose: () => void;
+  /*
+   * Fired once, after a run that created at least one group, so the table
+   * behind the modal can refetch while the modal stays open on its results.
+   */
+  onImportComplete: () => void;
+}
+
+const ImportGroupsFromCsvModal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [csvText, setCsvText] = useState<string>("");
+  const [parseResult, setParseResult] =
+    useState<StatusPageGroupCsvParseResult | null>(null);
+  const [isImporting, setIsImporting] = useState<boolean>(false);
+  const [hasImported, setHasImported] = useState<boolean>(false);
+  const [importedCount, setImportedCount] = useState<number>(0);
+  const [importTotal, setImportTotal] = useState<number>(0);
+  const [rowResults, setRowResults] = useState<
+    Array<StatusPageGroupImportRowResult>
+  >([]);
+  const [importError, setImportError] = useState<string>("");
+
+  const fileInputRef: React.MutableRefObject<HTMLInputElement | null> =
+    useRef<HTMLInputElement | null>(null);
+
+  type HandleFileChangeFunction = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+
+  const handleFileChange: HandleFileChangeFunction = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    const file: File | undefined = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const reader: FileReader = new FileReader();
+    reader.onload = () => {
+      const text: string = (reader.result as string) || "";
+      setCsvText(text);
+      setParseResult(parseStatusPageGroupCsv(text));
+      setRowResults([]);
+      setImportError("");
+      setHasImported(false);
+    };
+    reader.readAsText(file);
+    // Allow re-choosing the same file later.
+    event.target.value = "";
+  };
+
+  const previewCsv: VoidFunction = (): void => {
+    setParseResult(parseStatusPageGroupCsv(csvText));
+    setRowResults([]);
+    setImportError("");
+    setHasImported(false);
+  };
+
+  /*
+   * One group, one POST. The runner decides the order and hands over the
+   * parent's id; everything here is the mapping onto the model plus turning
+   * an API rejection into a message the results table can show.
+   *
+   * `order` is deliberately never written: StatusPageGroupService assigns the
+   * next one on create, so an imported group lands at the bottom of the page
+   * in file order instead of shuffling the groups that were already there.
+   */
+  const createGroup: CreateStatusPageGroupFunction = async (
+    row: ParsedStatusPageGroupRow,
+    parentStatusPageGroupId: string | undefined,
+  ): Promise<StatusPageGroupCreateResult> => {
+    try {
+      const group: StatusPageGroup = new StatusPageGroup();
+      group.projectId = props.projectId;
+      group.statusPageId = props.statusPageId;
+      group.name = row.name;
+
+      if (parentStatusPageGroupId) {
+        group.parentStatusPageGroupId = new ObjectID(parentStatusPageGroupId);
+      }
+
+      if (row.description !== "") {
+        group.description = row.description;
+      }
+
+      /*
+       * Blank cells are left off the model entirely rather than sent as a
+       * value — the column default is what the create form would have used,
+       * and an import must not decide a toggle the author never mentioned.
+       */
+      if (row.isExpandedByDefault !== undefined) {
+        group.isExpandedByDefault = row.isExpandedByDefault;
+      }
+
+      if (row.showCurrentStatus !== undefined) {
+        group.showCurrentStatus = row.showCurrentStatus;
+      }
+
+      if (row.showUptimePercent !== undefined) {
+        group.showUptimePercent = row.showUptimePercent;
+      }
+
+      if (row.uptimePercentPrecision !== undefined) {
+        group.uptimePercentPrecision = row.uptimePercentPrecision;
+      }
+
+      if (row.viewMode !== undefined) {
+        group.viewMode = row.viewMode;
+      }
+
+      if (row.viewMode === StatusPageGroupViewMode.Grid) {
+        if (row.rowAxisLabel !== "") {
+          group.rowAxisLabel = row.rowAxisLabel;
+        }
+        if (row.rowAxisValues !== "") {
+          group.rowAxisValues = row.rowAxisValues;
+        }
+        if (row.columnAxisLabel !== "") {
+          group.columnAxisLabel = row.columnAxisLabel;
+        }
+        if (row.columnAxisValues !== "") {
+          group.columnAxisValues = row.columnAxisValues;
+        }
+      }
+
+      const response: HTTPResponse<
+        JSONObject | JSONArray | StatusPageGroup | Array<StatusPageGroup>
+      > = await ModelAPI.create<StatusPageGroup>({
+        model: group,
+        modelType: StatusPageGroup,
+      });
+
+      const created: StatusPageGroup = response.data as StatusPageGroup;
+
+      return {
+        created: true,
+        statusPageGroupId: created._id?.toString() || created.id?.toString(),
+      };
+    } catch (err) {
+      return { created: false, errorMessage: API.getFriendlyMessage(err) };
+    }
+  };
+
+  const importGroups: PromiseVoidFunction = async (): Promise<void> => {
+    if (!parseResult || parseResult.rows.length === 0) {
+      return;
+    }
+
+    setIsImporting(true);
+    setImportError("");
+    setRowResults([]);
+    setImportedCount(0);
+
+    try {
+      /*
+       * The groups already on this status page: they can be parents of
+       * imported rows, rows that collide with them are skipped, and their
+       * depth decides whether a child would breach the nesting limit.
+       */
+      const existing: ListResult<StatusPageGroup> =
+        await ModelAPI.getList<StatusPageGroup>({
+          modelType: StatusPageGroup,
+          query: {
+            statusPageId: props.statusPageId,
+            projectId: props.projectId,
+          },
+          limit: LIMIT_PER_PROJECT,
+          skip: 0,
+          select: {
+            _id: true,
+            name: true,
+            parentStatusPageGroupId: true,
+          },
+          sort: {
+            order: SortOrder.Ascending,
+          },
+        });
+
+      const existingGroups: Array<ExistingStatusPageGroup> = existing.data
+        .filter((group: StatusPageGroup) => {
+          return Boolean(group._id && group.name);
+        })
+        .map((group: StatusPageGroup): ExistingStatusPageGroup => {
+          return {
+            id: group._id!.toString(),
+            name: group.name!,
+            depth: StatusPageGroupTreeUtil.getDepth({
+              statusPageGroup: group,
+              statusPageGroups: existing.data,
+            }),
+          };
+        });
+
+      const summary: StatusPageGroupImportSummary =
+        await runStatusPageGroupImport({
+          rows: parseResult.rows,
+          existingGroups: existingGroups,
+          createGroup: createGroup,
+          onProgress: (progress: StatusPageGroupImportProgress): void => {
+            setRowResults(progress.results);
+            setImportedCount(progress.createdCount);
+            setImportTotal(progress.totalToCreate);
+          },
+        });
+
+      setHasImported(true);
+
+      if (summary.createdCount > 0) {
+        ShowToastNotification({
+          title: "Groups Imported",
+          description: `${summary.createdCount} status page group${
+            summary.createdCount === 1 ? "" : "s"
+          } imported successfully.`,
+          type: ToastType.SUCCESS,
+        });
+
+        props.onImportComplete();
+      }
+
+      const notCreatedCount: number =
+        summary.failedCount + summary.skippedCount;
+
+      if (notCreatedCount > 0) {
+        ShowToastNotification({
+          title: "Some Groups Could Not Be Imported",
+          description: `${notCreatedCount} row${
+            notCreatedCount === 1 ? "" : "s"
+          } failed or were skipped.`,
+          type: ToastType.DANGER,
+        });
+      }
+    } catch (err) {
+      setImportError(API.getFriendlyMessage(err));
+    }
+
+    setIsImporting(false);
+  };
+
+  const rows: Array<ParsedStatusPageGroupRow> = parseResult?.rows || [];
+  const parseErrors: Array<StatusPageGroupCsvError> = parseResult?.errors || [];
+
+  const canImport: boolean = Boolean(
+    parseResult && rows.length > 0 && parseErrors.length === 0,
+  );
+
+  /*
+   * Once a run has finished the footer stops offering "Import" — re-pressing
+   * it would replay the whole file against a status page that now contains
+   * half of it. Editing the CSV or previewing again re-arms it.
+   */
+  const submitButtonText: string = hasImported
+    ? "Done"
+    : rows.length > 0
+      ? `Import ${rows.length} Group${rows.length === 1 ? "" : "s"}`
+      : "Import";
+
+  type DescribeOptionsFunction = (row: ParsedStatusPageGroupRow) => string;
+
+  /*
+   * Only what the row actually says. A blank cell is the model's default, and
+   * printing a guess at it here would tell the reader the file contains a
+   * decision it does not.
+   */
+  const describeOptions: DescribeOptionsFunction = (
+    row: ParsedStatusPageGroupRow,
+  ): string => {
+    const parts: Array<string> = [];
+
+    if (row.isExpandedByDefault !== undefined) {
+      parts.push(row.isExpandedByDefault ? "Expanded" : "Collapsed");
+    }
+    if (row.showCurrentStatus !== undefined) {
+      parts.push(row.showCurrentStatus ? "Status shown" : "Status hidden");
+    }
+    if (row.showUptimePercent !== undefined) {
+      parts.push(
+        row.showUptimePercent
+          ? `Uptime % (${row.uptimePercentPrecision})`
+          : "No uptime %",
+      );
+    }
+
+    return parts.join(", ");
+  };
+
+  return (
+    <Modal
+      title="Import Groups from CSV"
+      description="Bulk-create the groups on this status page from a CSV file."
+      modalWidth={ModalWidth.Large}
+      onClose={() => {
+        if (isImporting) {
+          return;
+        }
+        props.onClose();
+      }}
+      closeButtonText={hasImported ? "Close" : "Cancel"}
+      submitButtonText={submitButtonText}
+      isLoading={isImporting}
+      disableSubmitButton={isImporting || (!hasImported && !canImport)}
+      onSubmit={() => {
+        if (hasImported) {
+          props.onClose();
+          return;
+        }
+
+        importGroups().catch((err: Error) => {
+          setImportError(API.getFriendlyMessage(err));
+          setIsImporting(false);
+        });
+      }}
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-gray-500">
+          Columns: {STATUS_PAGE_GROUP_CSV_COLUMNS.join(", ")}. Only name is
+          required — leave any other column blank to keep the default. Rows
+          whose parentName is empty or already exists import first, then their
+          children, so parents and children can live in the same file. Rows with
+          an unresolvable parent are skipped and reported. The axis columns
+          apply only when viewMode is {StatusPageGroupViewMode.Grid}; wrap their
+          comma-separated lists in quotes.
+        </p>
+
+        <TextArea
+          id="status-page-group-import-csv"
+          value={csvText}
+          placeholder={STATUS_PAGE_GROUP_CSV_EXAMPLE}
+          onChange={(value: string) => {
+            setCsvText(value);
+            /*
+             * The import runs off parseResult, not off this text, so a parse
+             * the user has since edited away must not stay armed — otherwise
+             * fixing a typo here and hitting Import would create the pre-edit
+             * rows. Dropping it disables the button until they preview again.
+             */
+            setParseResult(null);
+            setRowResults([]);
+            setImportError("");
+            setHasImported(false);
+          }}
+          disableSpellCheck={true}
+        />
+
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv,text/plain"
+            className="hidden"
+            data-testid="status-page-group-import-file-input"
+            onChange={handleFileChange}
+          />
+          <Button
+            title="Choose CSV File"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            disabled={isImporting}
+            onClick={() => {
+              fileInputRef.current?.click();
+            }}
+          />
+          {/*
+           * The same example the textarea shows as its placeholder, as a file
+           * — a spreadsheet is where most of these files are actually built,
+           * and re-typing twelve column names into one by hand is how a
+           * header ends up misspelled.
+           */}
+          <Button
+            title="Download CSV Template"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            disabled={isImporting}
+            onClick={() => {
+              downloadFile({
+                content: `${STATUS_PAGE_GROUP_CSV_EXAMPLE}\n`,
+                filename: "status-page-groups-template.csv",
+                mimeType: "text/csv;charset=utf-8;",
+              });
+            }}
+          />
+          <Button
+            title="Preview Import"
+            buttonStyle={ButtonStyleType.NORMAL}
+            disabled={isImporting}
+            isLoading={false}
+            onClick={previewCsv}
+          />
+        </div>
+
+        {isImporting && importTotal > 0 && (
+          <ProgressBar
+            count={importedCount}
+            totalCount={importTotal}
+            suffix="groups"
+            size={ProgressBarSize.Small}
+          />
+        )}
+
+        {importError && <p className="text-sm text-red-700">{importError}</p>}
+
+        {parseErrors.length > 0 && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3">
+            <p className="mb-1 text-sm font-medium text-red-800">
+              Fix these problems before importing:
+            </p>
+            <ul className="list-disc space-y-0.5 pl-5">
+              {parseErrors.map(
+                (
+                  error: StatusPageGroupCsvError,
+                  index: number,
+                ): ReactElement => {
+                  return (
+                    <li key={index} className="text-sm text-red-700">
+                      {error.line > 0 ? `Line ${error.line}: ` : ""}
+                      {error.message}
+                    </li>
+                  );
+                },
+              )}
+            </ul>
+          </div>
+        )}
+
+        {parseResult &&
+          parseErrors.length === 0 &&
+          rows.length > 0 &&
+          rowResults.length === 0 && (
+            <div className="overflow-x-auto">
+              <p className="mb-2 text-sm text-gray-600">
+                {rows.length} group{rows.length === 1 ? "" : "s"} ready to
+                import.
+              </p>
+              <table className="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                  <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                    <th className="px-3 py-2">Line</th>
+                    <th className="px-3 py-2">Name</th>
+                    <th className="px-3 py-2">Parent</th>
+                    <th className="px-3 py-2">Description</th>
+                    <th className="px-3 py-2">View Mode</th>
+                    <th className="px-3 py-2">Options</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {rows.map((row: ParsedStatusPageGroupRow): ReactElement => {
+                    return (
+                      <tr key={row.line}>
+                        <td className="px-3 py-2 text-gray-500">{row.line}</td>
+                        <td className="px-3 py-2 font-medium text-gray-900">
+                          {row.name}
+                        </td>
+                        <td className="px-3 py-2 text-gray-600">
+                          {row.parentName || "Top level"}
+                        </td>
+                        <td className="px-3 py-2 text-gray-600">
+                          {row.description || "—"}
+                        </td>
+                        <td className="px-3 py-2 text-gray-600">
+                          {row.viewMode || "—"}
+                        </td>
+                        <td className="px-3 py-2 text-gray-600">
+                          {describeOptions(row) || "—"}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+        {rowResults.length > 0 && (
+          <div className="overflow-x-auto">
+            <p className="mb-2 text-sm font-medium text-gray-700">
+              Import results
+            </p>
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead>
+                <tr className="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                  <th className="px-3 py-2">Line</th>
+                  <th className="px-3 py-2">Name</th>
+                  <th className="px-3 py-2">Result</th>
+                  <th className="px-3 py-2">Details</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {rowResults.map(
+                  (
+                    result: StatusPageGroupImportRowResult,
+                    index: number,
+                  ): ReactElement => {
+                    return (
+                      <tr key={index}>
+                        <td className="px-3 py-2 text-gray-500">
+                          {result.line}
+                        </td>
+                        <td className="px-3 py-2 font-medium text-gray-900">
+                          {result.name}
+                        </td>
+                        <td className="px-3 py-2">
+                          {result.status === "created" && (
+                            <span className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
+                              Created
+                            </span>
+                          )}
+                          {result.status === "failed" && (
+                            <span className="inline-flex items-center rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">
+                              Failed
+                            </span>
+                          )}
+                          {result.status === "skipped" && (
+                            <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+                              Skipped
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2 text-gray-600">
+                          {result.message || "—"}
+                        </td>
+                      </tr>
+                    );
+                  },
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default ImportGroupsFromCsvModal;

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
@@ -12,19 +12,36 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
 import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
-import React, { Fragment, FunctionComponent, ReactElement } from "react";
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useState,
+} from "react";
 import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import { CardButtonSchema } from "Common/UI/Components/Card/Card";
+import IconProp from "Common/Types/Icon/IconProp";
 import DropdownUtil from "Common/UI/Utils/Dropdown";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ProjectUtil from "Common/UI/Utils/Project";
 import MarkdownUtil from "Common/UI/Utils/Markdown";
 import AxisValuesInput from "../../../Components/StatusPage/AxisValuesInput";
+import ImportGroupsFromCsvModal from "../../../Components/StatusPage/ImportGroupsFromCsvModal";
 
 const StatusPageDelete: FunctionComponent<PageComponentProps> = (
   props: PageComponentProps,
 ): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID(1);
+
+  const [showImportModal, setShowImportModal] = useState<boolean>(false);
+
+  /*
+   * Bumped when a CSV import creates groups, so the table refetches without a
+   * page reload while the modal is still open on its results.
+   */
+  const [refreshToggle, setRefreshToggle] = useState<string>("");
 
   /*
    * Groups nest, so the parent picker has to show where each candidate sits in
@@ -84,6 +101,7 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
     <Fragment>
       <ModelTable<StatusPageGroup>
         modelType={StatusPageGroup}
+        refreshToggle={refreshToggle}
         id="status-page-group"
         name="Status Page > Groups"
         userPreferencesKey="status-page-group-table"
@@ -115,6 +133,22 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
           title: "Resource Groups",
           description:
             "Here are different groups for your status page resources. Groups can be nested inside other groups, and each level shows the rolled up status and uptime of everything beneath it. Deleting a group also deletes its sub groups and the resources in them.",
+          buttons: [
+            /*
+             * OUTLINE, not NORMAL/PRIMARY: BaseModelTable promotes the first
+             * NORMAL/PRIMARY button to the header slot, and bulk import
+             * belongs in the ⋯ overflow next to the other table-wide actions
+             * — the same place every other bulk import in the product lives.
+             */
+            {
+              title: "Import from CSV",
+              buttonStyle: ButtonStyleType.OUTLINE,
+              icon: IconProp.Upload,
+              onClick: () => {
+                setShowImportModal(true);
+              },
+            } as CardButtonSchema,
+          ],
         }}
         noItemsMessage={"No status page group created for this status page."}
         formSteps={[
@@ -371,6 +405,23 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
           },
         ]}
       />
+
+      {showImportModal && (
+        <ImportGroupsFromCsvModal
+          statusPageId={modelId}
+          projectId={ProjectUtil.getCurrentProjectId()!}
+          onClose={() => {
+            setShowImportModal(false);
+          }}
+          onImportComplete={() => {
+            /*
+             * Fires while the modal is still open on its results, so the
+             * table behind it is already current when the user closes it.
+             */
+            setRefreshToggle(Date.now().toString());
+          }}
+        />
+      )}
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupCsv.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupCsv.ts
@@ -1,0 +1,699 @@
+import { VoidFunction } from "Common/Types/FunctionTypes";
+import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
+import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
+
+/*
+ * Pure CSV parsing + import planning for the Status Page > Groups bulk
+ * import. React-free on purpose: this module must never import RouteMap or
+ * Config (they touch window at module load), so it stays testable from the
+ * node-env jest suite in App/Tests/Dashboard.
+ *
+ * Expected CSV columns (header row required, any order, case-insensitive):
+ *   name,parentName,description,isExpandedByDefault,showCurrentStatus,
+ *   showUptimePercent,uptimePercentPrecision,viewMode,rowAxisLabel,
+ *   rowAxisValues,columnAxisLabel,columnAxisValues
+ *
+ * Only `name` is required. Every other column may be omitted from the header
+ * entirely or left blank on a row, in which case the model's own default
+ * applies — an import must never write a value the user did not ask for.
+ *
+ * Groups nest, so this file also owns the dependency ordering: a parent
+ * created by the same file is resolved before its children, and the nesting
+ * limit StatusPageGroupService enforces on write is checked here first so a
+ * too-deep row is reported in the preview instead of failing mid-run.
+ */
+
+/*
+ * How deep a group may be nested. Mirrors
+ * StatusPageGroupTreeUtil.MaxNestingDepth, which is what the server enforces
+ * on write — duplicated rather than imported because that module pulls in the
+ * StatusPageGroup entity (and with it typeorm) for a single number, and this
+ * module is deliberately dependency-free. StatusPageGroupCsv.test.ts pins the
+ * two together.
+ */
+export const MAX_GROUP_NESTING_DEPTH: number = 10;
+
+export interface ParsedStatusPageGroupRow {
+  // 1-based line number in the CSV where this row starts.
+  line: number;
+  name: string;
+  // Empty string for a top level group.
+  parentName: string;
+  description: string;
+  /*
+   * undefined means "the column was blank" — the create leaves the field off
+   * entirely so the model default (or the status page's own behaviour) wins.
+   */
+  isExpandedByDefault: boolean | undefined;
+  showCurrentStatus: boolean | undefined;
+  showUptimePercent: boolean | undefined;
+  uptimePercentPrecision: UptimePrecision | undefined;
+  viewMode: StatusPageGroupViewMode | undefined;
+  rowAxisLabel: string;
+  rowAxisValues: string;
+  columnAxisLabel: string;
+  columnAxisValues: string;
+}
+
+export interface StatusPageGroupCsvError {
+  // 1-based line the error belongs to; 0 for file-level errors.
+  line: number;
+  message: string;
+}
+
+export interface StatusPageGroupCsvParseResult {
+  rows: Array<ParsedStatusPageGroupRow>;
+  errors: Array<StatusPageGroupCsvError>;
+}
+
+export const STATUS_PAGE_GROUP_CSV_COLUMNS: Array<string> = [
+  "name",
+  "parentName",
+  "description",
+  "isExpandedByDefault",
+  "showCurrentStatus",
+  "showUptimePercent",
+  "uptimePercentPrecision",
+  "viewMode",
+  "rowAxisLabel",
+  "rowAxisValues",
+  "columnAxisLabel",
+  "columnAxisValues",
+];
+
+const REQUIRED_COLUMNS: Array<string> = ["name"];
+
+/*
+ * The file the modal offers as a downloadable template, and shows as the
+ * textarea's placeholder. It lives here rather than in the component so the
+ * parser's own suite can import it and prove that the example we hand people
+ * actually imports — a template that fails validation is worse than none.
+ *
+ * It deliberately exercises the three shapes an author has to get right: a
+ * top level group, a child naming its parent from the same file, and a grid
+ * whose axis lists are quoted because they contain commas.
+ */
+export const STATUS_PAGE_GROUP_CSV_EXAMPLE: string = [
+  STATUS_PAGE_GROUP_CSV_COLUMNS.join(","),
+  "Core Services,,The services everything else runs on,true,true,true,ONE_DECIMAL,List,,,,",
+  "API,Core Services,,true,true,false,,List,,,,",
+  '"Regional Availability",,,true,true,false,,Grid,Service,"Auth, API, Database",Region,"US-East, EU-West"',
+].join("\n");
+
+// The grid layout columns, which only mean anything when viewMode is Grid.
+const GRID_ONLY_COLUMNS: Array<string> = [
+  "rowAxisLabel",
+  "rowAxisValues",
+  "columnAxisLabel",
+  "columnAxisValues",
+];
+
+interface CsvRecord {
+  // 1-based line the record starts on (quoted fields may span lines).
+  line: number;
+  cells: Array<string>;
+}
+
+interface CsvLexResult {
+  records: Array<CsvRecord>;
+  errors: Array<StatusPageGroupCsvError>;
+}
+
+/*
+ * Character-level CSV lexer: quoted fields ("" escapes a quote), commas
+ * and newlines inside quotes, CRLF and LF record separators. Blank
+ * records are dropped.
+ */
+function lexCsv(text: string): CsvLexResult {
+  const records: Array<CsvRecord> = [];
+  const errors: Array<StatusPageGroupCsvError> = [];
+
+  let cells: Array<string> = [];
+  let current: string = "";
+  let inQuotes: boolean = false;
+  let cellHadQuotes: boolean = false;
+  let line: number = 1;
+  let recordStartLine: number = 1;
+
+  const endCell: VoidFunction = (): void => {
+    // Quoted cells keep their exact content; bare cells are trimmed.
+    cells.push(cellHadQuotes ? current : current.trim());
+    current = "";
+    cellHadQuotes = false;
+  };
+
+  const endRecord: VoidFunction = (): void => {
+    endCell();
+    const isBlank: boolean = cells.every((cell: string) => {
+      return cell === "";
+    });
+    if (!isBlank) {
+      records.push({ line: recordStartLine, cells: cells });
+    }
+    cells = [];
+  };
+
+  for (let i: number = 0; i < text.length; i++) {
+    const char: string = text[i]!;
+    const nextChar: string | undefined = text[i + 1];
+
+    if (inQuotes) {
+      if (char === '"' && nextChar === '"') {
+        current += '"';
+        i++;
+      } else if (char === '"') {
+        inQuotes = false;
+      } else {
+        if (char === "\n") {
+          line++;
+        }
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      cellHadQuotes = true;
+    } else if (char === ",") {
+      endCell();
+    } else if (char === "\r" && nextChar === "\n") {
+      // CRLF — consume both, one record separator.
+      i++;
+      line++;
+      endRecord();
+      recordStartLine = line;
+    } else if (char === "\n" || char === "\r") {
+      line++;
+      endRecord();
+      recordStartLine = line;
+    } else {
+      current += char;
+    }
+  }
+
+  if (inQuotes) {
+    errors.push({
+      line: recordStartLine,
+      message: "Unterminated quoted field — a closing quote is missing.",
+    });
+    return { records: records, errors: errors };
+  }
+
+  // Flush the trailing record (files often end without a newline).
+  endRecord();
+
+  return { records: records, errors: errors };
+}
+
+type HeaderIndex = Map<string, number>;
+
+function parseHeader(
+  record: CsvRecord,
+  errors: Array<StatusPageGroupCsvError>,
+): HeaderIndex | null {
+  const canonicalByLowercase: Map<string, string> = new Map<string, string>(
+    STATUS_PAGE_GROUP_CSV_COLUMNS.map((column: string) => {
+      return [column.toLowerCase(), column];
+    }),
+  );
+
+  const headerIndex: HeaderIndex = new Map<string, number>();
+  let hasErrors: boolean = false;
+
+  record.cells.forEach((cell: string, index: number) => {
+    const canonical: string | undefined = canonicalByLowercase.get(
+      cell.trim().toLowerCase(),
+    );
+    if (!canonical) {
+      errors.push({
+        line: record.line,
+        message: `Unknown column "${cell.trim()}" in header. Expected columns: ${STATUS_PAGE_GROUP_CSV_COLUMNS.join(
+          ", ",
+        )}.`,
+      });
+      hasErrors = true;
+      return;
+    }
+    if (headerIndex.has(canonical)) {
+      errors.push({
+        line: record.line,
+        message: `Duplicate column "${canonical}" in header.`,
+      });
+      hasErrors = true;
+      return;
+    }
+    headerIndex.set(canonical, index);
+  });
+
+  for (const required of REQUIRED_COLUMNS) {
+    if (!headerIndex.has(required)) {
+      errors.push({
+        line: record.line,
+        message: `Missing required column "${required}" in header.`,
+      });
+      hasErrors = true;
+    }
+  }
+
+  return hasErrors ? null : headerIndex;
+}
+
+function cellAt(
+  record: CsvRecord,
+  headerIndex: HeaderIndex,
+  column: string,
+): string {
+  const index: number | undefined = headerIndex.get(column);
+  if (index === undefined) {
+    return "";
+  }
+  // The lexer already trimmed bare cells; quoted cells keep their spacing.
+  return record.cells[index] || "";
+}
+
+interface BooleanParseResult {
+  value: boolean | undefined;
+  error: string | null;
+}
+
+const TRUE_WORDS: Array<string> = ["true", "yes", "y", "1"];
+const FALSE_WORDS: Array<string> = ["false", "no", "n", "0"];
+
+/*
+ * Spreadsheets export booleans in whatever the author typed, so all the
+ * spellings a human would reach for are accepted. Anything else is an error
+ * rather than a silent false — "off" quietly becoming "expanded" is exactly
+ * the kind of surprise a bulk import must not spring on somebody.
+ */
+function parseBoolean(raw: string, column: string): BooleanParseResult {
+  const value: string = raw.trim().toLowerCase();
+
+  if (value === "") {
+    return { value: undefined, error: null };
+  }
+  if (TRUE_WORDS.includes(value)) {
+    return { value: true, error: null };
+  }
+  if (FALSE_WORDS.includes(value)) {
+    return { value: false, error: null };
+  }
+
+  return {
+    value: undefined,
+    error: `${column} "${raw.trim()}" is not a true/false value. Use true or false (yes/no and 1/0 also work).`,
+  };
+}
+
+/*
+ * Enum cells are matched on letters and digits alone, so a project can write
+ * "One Decimal", "one-decimal", "ONE_DECIMAL" or the precision's own display
+ * value and mean the same thing.
+ */
+function normalizeEnumCell(raw: string): string {
+  return raw.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+interface EnumParseResult<TEnumValue> {
+  value: TEnumValue | undefined;
+  error: string | null;
+}
+
+function parseEnumCell<TEnumValue extends string>(data: {
+  raw: string;
+  column: string;
+  // The enum object itself — both its keys and its values are accepted.
+  enumObject: Record<string, TEnumValue>;
+}): EnumParseResult<TEnumValue> {
+  if (data.raw.trim() === "") {
+    return { value: undefined, error: null };
+  }
+
+  const byNormalized: Map<string, TEnumValue> = new Map<string, TEnumValue>();
+
+  for (const key of Object.keys(data.enumObject)) {
+    const value: TEnumValue = data.enumObject[key]!;
+    // Values win over keys where the two normalize to the same string.
+    byNormalized.set(normalizeEnumCell(key), value);
+    byNormalized.set(normalizeEnumCell(value), value);
+  }
+
+  const matched: TEnumValue | undefined = byNormalized.get(
+    normalizeEnumCell(data.raw),
+  );
+
+  if (matched === undefined) {
+    return {
+      value: undefined,
+      error: `Unknown ${data.column} "${data.raw.trim()}". Valid values: ${Object.keys(
+        data.enumObject,
+      ).join(", ")}.`,
+    };
+  }
+
+  return { value: matched, error: null };
+}
+
+/*
+ * Parse a Status Page Groups CSV. Rows that fail validation are reported and
+ * dropped; the rows around them still import, so one bad line never costs the
+ * whole file.
+ */
+export function parseStatusPageGroupCsv(
+  text: string,
+): StatusPageGroupCsvParseResult {
+  const errors: Array<StatusPageGroupCsvError> = [];
+  const rows: Array<ParsedStatusPageGroupRow> = [];
+
+  const { records, errors: lexErrors } = lexCsv(text);
+  errors.push(...lexErrors);
+  if (lexErrors.length > 0) {
+    return { rows: [], errors: errors };
+  }
+
+  if (records.length === 0) {
+    errors.push({ line: 0, message: "The CSV is empty." });
+    return { rows: [], errors: errors };
+  }
+
+  const headerRecord: CsvRecord = records[0]!;
+  const headerIndex: HeaderIndex | null = parseHeader(headerRecord, errors);
+  if (!headerIndex) {
+    return { rows: [], errors: errors };
+  }
+
+  const dataRecords: Array<CsvRecord> = records.slice(1);
+  if (dataRecords.length === 0) {
+    errors.push({
+      line: 0,
+      message: "The CSV has a header but no data rows.",
+    });
+    return { rows: [], errors: errors };
+  }
+
+  // name -> line of first use, for duplicate flagging.
+  const firstLineByName: Map<string, number> = new Map<string, number>();
+
+  for (const record of dataRecords) {
+    const rowErrors: Array<string> = [];
+
+    if (record.cells.length > headerRecord.cells.length) {
+      errors.push({
+        line: record.line,
+        message: `Row has ${record.cells.length} values but the header has ${headerRecord.cells.length} columns.`,
+      });
+      continue;
+    }
+
+    const name: string = cellAt(record, headerIndex, "name");
+    if (name === "") {
+      rowErrors.push("name is required.");
+    }
+
+    const parentName: string = cellAt(record, headerIndex, "parentName");
+    if (name !== "" && parentName === name) {
+      rowErrors.push("A group cannot be its own parent.");
+    }
+
+    const description: string = cellAt(record, headerIndex, "description");
+
+    const isExpandedByDefault: BooleanParseResult = parseBoolean(
+      cellAt(record, headerIndex, "isExpandedByDefault"),
+      "isExpandedByDefault",
+    );
+    const showCurrentStatus: BooleanParseResult = parseBoolean(
+      cellAt(record, headerIndex, "showCurrentStatus"),
+      "showCurrentStatus",
+    );
+    const showUptimePercent: BooleanParseResult = parseBoolean(
+      cellAt(record, headerIndex, "showUptimePercent"),
+      "showUptimePercent",
+    );
+
+    for (const result of [
+      isExpandedByDefault,
+      showCurrentStatus,
+      showUptimePercent,
+    ]) {
+      if (result.error) {
+        rowErrors.push(result.error);
+      }
+    }
+
+    const uptimePercentPrecision: EnumParseResult<UptimePrecision> =
+      parseEnumCell<UptimePrecision>({
+        raw: cellAt(record, headerIndex, "uptimePercentPrecision"),
+        column: "uptimePercentPrecision",
+        enumObject: UptimePrecision as unknown as Record<
+          string,
+          UptimePrecision
+        >,
+      });
+    if (uptimePercentPrecision.error) {
+      rowErrors.push(uptimePercentPrecision.error);
+    }
+
+    const viewMode: EnumParseResult<StatusPageGroupViewMode> =
+      parseEnumCell<StatusPageGroupViewMode>({
+        raw: cellAt(record, headerIndex, "viewMode"),
+        column: "viewMode",
+        enumObject: StatusPageGroupViewMode as unknown as Record<
+          string,
+          StatusPageGroupViewMode
+        >,
+      });
+    if (viewMode.error) {
+      rowErrors.push(viewMode.error);
+    }
+
+    const rowAxisLabel: string = cellAt(record, headerIndex, "rowAxisLabel");
+    const rowAxisValues: string = cellAt(record, headerIndex, "rowAxisValues");
+    const columnAxisLabel: string = cellAt(
+      record,
+      headerIndex,
+      "columnAxisLabel",
+    );
+    const columnAxisValues: string = cellAt(
+      record,
+      headerIndex,
+      "columnAxisValues",
+    );
+
+    /*
+     * The axis columns are only read when the group renders as a grid. A row
+     * that fills them in on a List group has said two contradictory things,
+     * and importing it would drop the axes on the floor without a word — so
+     * it is an error the author can see and fix in the preview.
+     */
+    if (!viewMode.error && viewMode.value !== StatusPageGroupViewMode.Grid) {
+      const suppliedGridColumns: Array<string> = GRID_ONLY_COLUMNS.filter(
+        (column: string) => {
+          return cellAt(record, headerIndex, column).trim() !== "";
+        },
+      );
+
+      if (suppliedGridColumns.length > 0) {
+        rowErrors.push(
+          `${suppliedGridColumns.join(
+            ", ",
+          )} only applies when viewMode is ${StatusPageGroupViewMode.Grid}.`,
+        );
+      }
+    }
+
+    if (name !== "") {
+      const firstLine: number | undefined = firstLineByName.get(name);
+      if (firstLine !== undefined) {
+        rowErrors.push(
+          `Duplicate group name "${name}" (first used on line ${firstLine}).`,
+        );
+      } else {
+        firstLineByName.set(name, record.line);
+      }
+    }
+
+    if (rowErrors.length > 0) {
+      for (const message of rowErrors) {
+        errors.push({ line: record.line, message: message });
+      }
+      continue;
+    }
+
+    rows.push({
+      line: record.line,
+      name: name,
+      parentName: parentName,
+      description: description,
+      isExpandedByDefault: isExpandedByDefault.value,
+      showCurrentStatus: showCurrentStatus.value,
+      showUptimePercent: showUptimePercent.value,
+      /*
+       * The create form makes the precision required the moment uptime is
+       * shown, and defaults it to one decimal. A CSV that asks for the
+       * percent without naming a precision means the same thing.
+       */
+      uptimePercentPrecision:
+        uptimePercentPrecision.value ??
+        (showUptimePercent.value === true
+          ? UptimePrecision.ONE_DECIMAL
+          : undefined),
+      viewMode: viewMode.value,
+      rowAxisLabel: rowAxisLabel,
+      rowAxisValues: rowAxisValues,
+      columnAxisLabel: columnAxisLabel,
+      columnAxisValues: columnAxisValues,
+    });
+  }
+
+  return { rows: rows, errors: errors };
+}
+
+/*
+ * A group that is already on this status page. Imported rows may name one as
+ * their parent, and a row whose name collides with one cannot be created —
+ * `name` is unique per status page.
+ */
+export interface ExistingStatusPageGroup {
+  id: string;
+  name: string;
+  // 0 for a top level group.
+  depth: number;
+}
+
+export interface SkippedStatusPageGroupRow {
+  row: ParsedStatusPageGroupRow;
+  reason: string;
+}
+
+export interface StatusPageGroupImportPlan {
+  /*
+   * Rows grouped into creation batches in dependency order: batch 0 is
+   * every row whose parent is empty or already exists, batch 1 the rows
+   * whose parent is created by batch 0, and so on.
+   */
+  batches: Array<Array<ParsedStatusPageGroupRow>>;
+  // Rows that can never be created, with a human-readable reason.
+  skipped: Array<SkippedStatusPageGroupRow>;
+}
+
+/*
+ * Order parsed rows for creation. Parent references resolve against the
+ * groups already on the status page plus the names created by earlier
+ * batches; anything left over (missing parent, or a dependency cycle) is
+ * skipped with a reason.
+ *
+ * Two other rows can never be created, and both are cheaper to catch here
+ * than to send and have rejected: a name that collides with a group already
+ * on the page, and a row that would sit deeper than the nesting limit
+ * StatusPageGroupService enforces.
+ */
+export function planStatusPageGroupImport(
+  rows: Array<ParsedStatusPageGroupRow>,
+  existingGroups: Array<ExistingStatusPageGroup>,
+): StatusPageGroupImportPlan {
+  const depthByName: Map<string, number> = new Map<string, number>();
+  for (const group of existingGroups) {
+    depthByName.set(group.name, group.depth);
+  }
+
+  const skipped: Array<SkippedStatusPageGroupRow> = [];
+  let pending: Array<ParsedStatusPageGroupRow> = [];
+
+  for (const row of rows) {
+    if (depthByName.has(row.name)) {
+      skipped.push({
+        row: row,
+        reason: `A group named "${row.name}" already exists on this status page.`,
+      });
+    } else {
+      pending.push(row);
+    }
+  }
+
+  const batches: Array<Array<ParsedStatusPageGroupRow>> = [];
+
+  while (pending.length > 0) {
+    const batch: Array<ParsedStatusPageGroupRow> = [];
+    const remaining: Array<ParsedStatusPageGroupRow> = [];
+    // Depths resolved this round, applied only once the round is decided.
+    const depthsFromBatch: Array<[string, number]> = [];
+
+    for (const row of pending) {
+      if (row.parentName === "") {
+        batch.push(row);
+        depthsFromBatch.push([row.name, 0]);
+        continue;
+      }
+
+      const parentDepth: number | undefined = depthByName.get(row.parentName);
+
+      if (parentDepth === undefined) {
+        remaining.push(row);
+        continue;
+      }
+
+      const depth: number = parentDepth + 1;
+
+      if (depth >= MAX_GROUP_NESTING_DEPTH) {
+        /*
+         * Skipped rather than batched, so its own children fall out as
+         * "parent was not found" rather than being sent and rejected one by
+         * one at the same depth.
+         */
+        skipped.push({
+          row: row,
+          reason: `Nesting "${row.name}" under "${row.parentName}" would be more than ${MAX_GROUP_NESTING_DEPTH} levels deep.`,
+        });
+        continue;
+      }
+
+      batch.push(row);
+      depthsFromBatch.push([row.name, depth]);
+    }
+
+    /*
+     * Before the progress check, and unconditionally: a row skipped inside
+     * this round is in neither list, and leaving it in `pending` would have
+     * the leftover pass report it a second time under a different reason.
+     */
+    pending = remaining;
+
+    if (batch.length === 0) {
+      /*
+       * No progress. Nothing new can become resolvable — a skip adds no
+       * names — so every row still pending is unreachable.
+       */
+      break;
+    }
+
+    for (const [name, depth] of depthsFromBatch) {
+      depthByName.set(name, depth);
+    }
+
+    batches.push(batch);
+  }
+
+  /*
+   * Whatever is left is unreachable. Its parent is either a row this file
+   * never got to create (too deep, or itself unreachable, or one half of a
+   * cycle) or a name that exists nowhere at all — and the two want different
+   * things from the reader, so they are told apart rather than lumped into
+   * one "not found".
+   */
+  const namesInFile: Set<string> = new Set<string>(
+    rows.map((row: ParsedStatusPageGroupRow) => {
+      return row.name;
+    }),
+  );
+
+  for (const row of pending) {
+    skipped.push({
+      row: row,
+      reason: namesInFile.has(row.parentName)
+        ? `Parent group "${row.parentName}" could not be created.`
+        : `Parent group "${row.parentName}" was not found in the file or on this status page.`,
+    });
+  }
+
+  return { batches: batches, skipped: skipped };
+}

--- a/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupImportRunner.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupImportRunner.ts
@@ -1,0 +1,223 @@
+import {
+  ExistingStatusPageGroup,
+  ParsedStatusPageGroupRow,
+  SkippedStatusPageGroupRow,
+  StatusPageGroupImportPlan,
+  planStatusPageGroupImport,
+} from "./StatusPageGroupCsv";
+
+/*
+ * The create-loop behind the Status Page > Groups CSV import, kept react-free
+ * and transport-free for the same reason StatusPageGroupCsv is: it must never
+ * import Common/UI/Config (it touches window at module load), so the node-env
+ * jest suite in App/Tests/Dashboard can drive the whole ordering / parent-
+ * resolution / partial-failure story without a renderer.
+ *
+ * The caller supplies `createGroup`, which is the only part that talks to the
+ * API. It reports its own outcome rather than throwing, so error phrasing
+ * (API.getFriendlyMessage) stays in the UI layer where it belongs.
+ */
+
+export type StatusPageGroupImportRowStatus = "created" | "failed" | "skipped";
+
+export interface StatusPageGroupImportRowResult {
+  // 1-based line in the CSV this result belongs to.
+  line: number;
+  name: string;
+  status: StatusPageGroupImportRowStatus;
+  // Empty for a created row; the reason otherwise.
+  message: string;
+}
+
+export interface StatusPageGroupImportProgress {
+  // Every result so far, in the order they were decided.
+  results: Array<StatusPageGroupImportRowResult>;
+  createdCount: number;
+  // Rows the plan intends to create — skipped rows are not counted.
+  totalToCreate: number;
+}
+
+export interface StatusPageGroupImportSummary
+  extends StatusPageGroupImportProgress {
+  failedCount: number;
+  skippedCount: number;
+}
+
+/*
+ * Outcome of creating one group. A failure is a value, not an exception, so
+ * one bad row never aborts the run and the message can be formatted by
+ * whoever owns the transport.
+ */
+export type StatusPageGroupCreateResult =
+  | { created: true; statusPageGroupId: string | undefined }
+  | { created: false; errorMessage: string };
+
+export type CreateStatusPageGroupFunction = (
+  row: ParsedStatusPageGroupRow,
+  // The id of the already-created parent, or undefined for a top level group.
+  parentStatusPageGroupId: string | undefined,
+) => Promise<StatusPageGroupCreateResult>;
+
+export interface RunStatusPageGroupImportOptions {
+  rows: Array<ParsedStatusPageGroupRow>;
+  /*
+   * Groups already on this status page. Read for parent resolution, for the
+   * "already exists" skip and for the nesting-depth check; never mutated —
+   * the run works on its own copies.
+   */
+  existingGroups: Array<ExistingStatusPageGroup>;
+  createGroup: CreateStatusPageGroupFunction;
+  // Called after the skip pass and after every attempted row.
+  onProgress?: ((progress: StatusPageGroupImportProgress) => void) | undefined;
+}
+
+function summarize(
+  results: Array<StatusPageGroupImportRowResult>,
+  totalToCreate: number,
+): StatusPageGroupImportSummary {
+  let createdCount: number = 0;
+  let failedCount: number = 0;
+  let skippedCount: number = 0;
+
+  for (const result of results) {
+    if (result.status === "created") {
+      createdCount++;
+    } else if (result.status === "failed") {
+      failedCount++;
+    } else {
+      skippedCount++;
+    }
+  }
+
+  return {
+    results: results,
+    createdCount: createdCount,
+    failedCount: failedCount,
+    skippedCount: skippedCount,
+    totalToCreate: totalToCreate,
+  };
+}
+
+/*
+ * Create every parsed row, parents before children.
+ *
+ * planStatusPageGroupImport groups the rows into dependency-ordered batches,
+ * so by the time a child is attempted its parent's id is already in the
+ * name->id map (either it was there to begin with, or an earlier batch created
+ * it). A row whose parent failed to create has no id to point at, so it is
+ * skipped rather than created as an accidental top level group — a group that
+ * silently jumps to the root of the status page is far worse than a reported
+ * skip.
+ */
+export async function runStatusPageGroupImport(
+  options: RunStatusPageGroupImportOptions,
+): Promise<StatusPageGroupImportSummary> {
+  const groupIdByName: Map<string, string> = new Map<string, string>();
+  for (const group of options.existingGroups) {
+    groupIdByName.set(group.name, group.id);
+  }
+
+  const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+    options.rows,
+    options.existingGroups,
+  );
+
+  const results: Array<StatusPageGroupImportRowResult> = [];
+
+  const totalToCreate: number = plan.batches.reduce(
+    (sum: number, batch: Array<ParsedStatusPageGroupRow>): number => {
+      return sum + batch.length;
+    },
+    0,
+  );
+
+  let createdCount: number = 0;
+
+  const reportProgress: () => void = (): void => {
+    options.onProgress?.({
+      // A copy per tick so a React consumer sees a new array identity.
+      results: [...results],
+      createdCount: createdCount,
+      totalToCreate: totalToCreate,
+    });
+  };
+
+  for (const skipped of plan.skipped as Array<SkippedStatusPageGroupRow>) {
+    results.push({
+      line: skipped.row.line,
+      name: skipped.row.name,
+      status: "skipped",
+      message: skipped.reason,
+    });
+  }
+
+  /*
+   * Report once before the first create so the caller can render the
+   * up-front skips and the total alongside a zeroed progress bar.
+   */
+  reportProgress();
+
+  for (const batch of plan.batches) {
+    for (const row of batch) {
+      let parentStatusPageGroupId: string | undefined = undefined;
+
+      if (row.parentName !== "") {
+        parentStatusPageGroupId = groupIdByName.get(row.parentName);
+
+        if (!parentStatusPageGroupId) {
+          results.push({
+            line: row.line,
+            name: row.name,
+            status: "skipped",
+            message: `Parent group "${row.parentName}" could not be created.`,
+          });
+          reportProgress();
+          continue;
+        }
+      }
+
+      let outcome: StatusPageGroupCreateResult;
+
+      try {
+        outcome = await options.createGroup(row, parentStatusPageGroupId);
+      } catch (err) {
+        /*
+         * createGroup is contracted to report failures as values, but a
+         * genuinely unexpected throw must still land on the row rather than
+         * abort every row after it.
+         */
+        outcome = {
+          created: false,
+          errorMessage:
+            err instanceof Error && err.message
+              ? err.message
+              : "Something went wrong while creating this group.",
+        };
+      }
+
+      if (outcome.created) {
+        if (outcome.statusPageGroupId) {
+          groupIdByName.set(row.name, outcome.statusPageGroupId);
+        }
+        createdCount++;
+        results.push({
+          line: row.line,
+          name: row.name,
+          status: "created",
+          message: "",
+        });
+      } else {
+        results.push({
+          line: row.line,
+          name: row.name,
+          status: "failed",
+          message: outcome.errorMessage,
+        });
+      }
+
+      reportProgress();
+    }
+  }
+
+  return summarize(results, totalToCreate);
+}

--- a/App/Tests/Dashboard/StatusPageGroupCsv.test.ts
+++ b/App/Tests/Dashboard/StatusPageGroupCsv.test.ts
@@ -1,0 +1,904 @@
+import { describe, expect, test } from "@jest/globals";
+import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
+import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
+import {
+  ExistingStatusPageGroup,
+  MAX_GROUP_NESTING_DEPTH,
+  ParsedStatusPageGroupRow,
+  STATUS_PAGE_GROUP_CSV_COLUMNS,
+  STATUS_PAGE_GROUP_CSV_EXAMPLE,
+  StatusPageGroupCsvError,
+  StatusPageGroupCsvParseResult,
+  StatusPageGroupImportPlan,
+  parseStatusPageGroupCsv,
+  planStatusPageGroupImport,
+} from "../../FeatureSet/Dashboard/src/Utils/StatusPageGroupCsv";
+
+/*
+ * Pins the pure CSV parser + import planner behind the Status Page > Groups
+ * bulk import: header validation, quoted-field support, boolean and enum
+ * cells, duplicate flagging, and the dependency-order batching that lets a
+ * parent in the same file be created before its children.
+ *
+ * Only `name` is required, which is the part most easily broken by accident:
+ * a blank cell has to stay blank all the way to the create, because writing
+ * a guessed default is how an import silently flips a toggle the author
+ * never mentioned.
+ */
+
+const FULL_HEADER: string = STATUS_PAGE_GROUP_CSV_COLUMNS.join(",");
+
+type MessagesFunction = (
+  result: StatusPageGroupCsvParseResult,
+) => Array<string>;
+
+const messages: MessagesFunction = (
+  result: StatusPageGroupCsvParseResult,
+): Array<string> => {
+  return result.errors.map((error: StatusPageGroupCsvError) => {
+    return error.message;
+  });
+};
+
+type MakeRowFunction = (
+  overrides: Partial<ParsedStatusPageGroupRow>,
+) => ParsedStatusPageGroupRow;
+
+const makeRow: MakeRowFunction = (
+  overrides: Partial<ParsedStatusPageGroupRow>,
+): ParsedStatusPageGroupRow => {
+  return {
+    line: 2,
+    name: "Group",
+    parentName: "",
+    description: "",
+    isExpandedByDefault: undefined,
+    showCurrentStatus: undefined,
+    showUptimePercent: undefined,
+    uptimePercentPrecision: undefined,
+    viewMode: undefined,
+    rowAxisLabel: "",
+    rowAxisValues: "",
+    columnAxisLabel: "",
+    columnAxisValues: "",
+    ...overrides,
+  };
+};
+
+type ExistingFunction = (
+  name: string,
+  depth: number,
+) => ExistingStatusPageGroup;
+
+const existing: ExistingFunction = (
+  name: string,
+  depth: number,
+): ExistingStatusPageGroup => {
+  return { id: `existing-${name}`, name: name, depth: depth };
+};
+
+describe("parseStatusPageGroupCsv — the file as a whole", () => {
+  test("empty file returns a file-level error and no rows", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv("");
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([{ line: 0, message: "The CSV is empty." }]);
+  });
+
+  test("whitespace-only file is treated as empty", () => {
+    const result: StatusPageGroupCsvParseResult =
+      parseStatusPageGroupCsv("\n\n   \n");
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([{ line: 0, message: "The CSV is empty." }]);
+  });
+
+  test("header-only file errors: no data rows", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      `${FULL_HEADER}\n`,
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toContain("no data rows");
+  });
+
+  test("file without a trailing newline still parses the last row", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name\nCore Services",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(1);
+  });
+
+  test("blank lines are skipped without shifting line numbers", () => {
+    const result: StatusPageGroupCsvParseResult =
+      parseStatusPageGroupCsv("name\n\nA\n\n\nB\n");
+    expect(result.errors).toEqual([]);
+    expect(
+      result.rows.map((row: ParsedStatusPageGroupRow) => {
+        return [row.name, row.line];
+      }),
+    ).toEqual([
+      ["A", 3],
+      ["B", 6],
+    ]);
+  });
+
+  test("CRLF line endings parse identically to LF", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,parentName\r\nA,\r\nB,A\r\n",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[1]!.parentName).toBe("A");
+    expect(result.rows[1]!.line).toBe(3);
+  });
+});
+
+describe("parseStatusPageGroupCsv — the header", () => {
+  test("name alone is a valid header", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name\nCore Services\n",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toEqual([makeRow({ line: 2, name: "Core Services" })]);
+  });
+
+  test("columns match case-insensitively and in any order", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "PARENTNAME,NAME,viewmode\n,Core Services,Grid\n",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.name).toBe("Core Services");
+    expect(result.rows[0]!.viewMode).toBe(StatusPageGroupViewMode.Grid);
+  });
+
+  test("missing the name column is a fatal error", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "parentName,description\nCore,Hello\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(messages(result)).toEqual([
+      'Missing required column "name" in header.',
+    ]);
+  });
+
+  test("unknown header column is a fatal error naming the column", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,parentGroup\nA,\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors[0]!.message).toContain('Unknown column "parentGroup"');
+    // The message has to list what the author could have written instead.
+    expect(result.errors[0]!.message).toContain("uptimePercentPrecision");
+  });
+
+  test("duplicate header column is a fatal error", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,description,name\nA,x,B\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(
+      result.errors.some((error: StatusPageGroupCsvError) => {
+        return error.message.includes('Duplicate column "name"');
+      }),
+    ).toBe(true);
+  });
+
+  test("missing trailing cells are padded as empty", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      `${FULL_HEADER}\nCore Services\n`,
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]).toEqual(makeRow({ line: 2, name: "Core Services" }));
+  });
+
+  test("row with more values than header columns is rejected", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,parentName\nA,,extra\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        line: 2,
+        message: "Row has 3 values but the header has 2 columns.",
+      },
+    ]);
+  });
+});
+
+describe("parseStatusPageGroupCsv — quoting", () => {
+  test("quoted fields keep commas", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      'name,description\n"Core, Shared","API, database, and auth"\n',
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.name).toBe("Core, Shared");
+    expect(result.rows[0]!.description).toBe("API, database, and auth");
+  });
+
+  /*
+   * The axis columns are themselves comma-separated lists, so quoting is not
+   * a nicety here — it is the only way to express more than one axis value.
+   */
+  test("a quoted axis list survives as one cell", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      'name,viewMode,rowAxisValues,columnAxisValues\nRegions,Grid,"Auth, API, Database","US-East, EU-West"\n',
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.rowAxisValues).toBe("Auth, API, Database");
+    expect(result.rows[0]!.columnAxisValues).toBe("US-East, EU-West");
+  });
+
+  test("escaped quotes inside quoted fields become literal quotes", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      'name\n"The ""Core"" Group"\n',
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.name).toBe('The "Core" Group');
+  });
+
+  test("newlines inside quoted fields stay inside the cell", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      'name,description\nA,"Line one\nLine two"\nB,\n',
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.description).toBe("Line one\nLine two");
+    // The row after a multi-line cell still reports its own start line.
+    expect(result.rows[1]!.line).toBe(4);
+  });
+
+  test("unterminated quote is a fatal error", () => {
+    const result: StatusPageGroupCsvParseResult =
+      parseStatusPageGroupCsv('name\n"Broken\n');
+    expect(result.rows).toEqual([]);
+    expect(result.errors[0]!.message).toContain("Unterminated quoted field");
+  });
+
+  test("cells are trimmed; quoted cells keep interior spacing", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      'name,description\n  A  ,"  spaced  "\n',
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.name).toBe("A");
+    expect(result.rows[0]!.description).toBe("  spaced  ");
+  });
+});
+
+describe("parseStatusPageGroupCsv — names and parents", () => {
+  test("empty name is a row error", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,description\n,Nameless\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([{ line: 2, message: "name is required." }]);
+  });
+
+  test("a group cannot be its own parent", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,parentName\nA,A\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([
+      { line: 2, message: "A group cannot be its own parent." },
+    ]);
+  });
+
+  test("duplicate names within the file flag the later row", () => {
+    const result: StatusPageGroupCsvParseResult =
+      parseStatusPageGroupCsv("name\nA\nB\nA\n");
+    expect(
+      result.rows.map((row: ParsedStatusPageGroupRow) => {
+        return row.name;
+      }),
+    ).toEqual(["A", "B"]);
+    expect(result.errors).toEqual([
+      {
+        line: 4,
+        message: 'Duplicate group name "A" (first used on line 2).',
+      },
+    ]);
+  });
+
+  test("a bad row does not poison surrounding good rows", () => {
+    const result: StatusPageGroupCsvParseResult =
+      parseStatusPageGroupCsv("name\nA\n\nB\n");
+    expect(result.rows).toHaveLength(2);
+
+    const withBadRow: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,parentName\nA,\n,orphan\nB,\n",
+    );
+    expect(
+      withBadRow.rows.map((row: ParsedStatusPageGroupRow) => {
+        return row.name;
+      }),
+    ).toEqual(["A", "B"]);
+    expect(withBadRow.errors).toHaveLength(1);
+    expect(withBadRow.errors[0]!.line).toBe(3);
+  });
+
+  test("every problem on one row is reported, not just the first", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,isExpandedByDefault,viewMode\nA,maybe,Tiles\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toHaveLength(2);
+    expect(messages(result)[0]).toContain("isExpandedByDefault");
+    expect(messages(result)[1]).toContain('Unknown viewMode "Tiles"');
+  });
+});
+
+describe("parseStatusPageGroupCsv — boolean columns", () => {
+  test.each([
+    ["true", true],
+    ["TRUE", true],
+    ["True", true],
+    ["yes", true],
+    ["Y", true],
+    ["1", true],
+    ["false", false],
+    ["FALSE", false],
+    ["no", false],
+    ["n", false],
+    ["0", false],
+  ])("%s reads as %s", (cell: string, expected: boolean) => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      `name,isExpandedByDefault\nA,${cell}\n`,
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.isExpandedByDefault).toBe(expected);
+  });
+
+  /*
+   * The whole point of leaving a cell blank is to get the model's default.
+   * A blank that read as `false` would collapse every imported group on a
+   * page whose author only filled in the name column.
+   */
+  test("a blank boolean stays undefined rather than becoming false", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,isExpandedByDefault,showCurrentStatus,showUptimePercent\nA,,,\n",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.isExpandedByDefault).toBeUndefined();
+    expect(result.rows[0]!.showCurrentStatus).toBeUndefined();
+    expect(result.rows[0]!.showUptimePercent).toBeUndefined();
+  });
+
+  test("an unrecognised boolean is an error, not a silent false", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,showCurrentStatus\nA,off\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toContain('showCurrentStatus "off"');
+    expect(result.errors[0]!.message).toContain("Use true or false");
+  });
+
+  test("each boolean column is validated on its own", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,isExpandedByDefault,showCurrentStatus,showUptimePercent\nA,true,nope,false\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toContain("showCurrentStatus");
+  });
+});
+
+describe("parseStatusPageGroupCsv — enum columns", () => {
+  test.each([
+    ["List", StatusPageGroupViewMode.List],
+    ["list", StatusPageGroupViewMode.List],
+    ["Grid", StatusPageGroupViewMode.Grid],
+    ["GRID", StatusPageGroupViewMode.Grid],
+  ])("viewMode %s reads as %s", (cell: string, expected: string) => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      `name,viewMode\nA,${cell}\n`,
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.viewMode).toBe(expected);
+  });
+
+  test("a blank viewMode stays undefined", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,viewMode\nA,\n",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.viewMode).toBeUndefined();
+  });
+
+  test("unknown viewMode is an error listing the valid values", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,viewMode\nA,Tiles\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors[0]!.message).toContain('Unknown viewMode "Tiles"');
+    expect(result.errors[0]!.message).toContain("Valid values: List, Grid.");
+  });
+
+  /*
+   * The precision enum's VALUES are display strings ("99.9% (One Decimal)")
+   * and its KEYS are the readable identifiers. A CSV author will reach for
+   * either, so both resolve — matched on letters and digits alone.
+   */
+  test.each([
+    ["ONE_DECIMAL", UptimePrecision.ONE_DECIMAL],
+    ["one_decimal", UptimePrecision.ONE_DECIMAL],
+    ["One Decimal", UptimePrecision.ONE_DECIMAL],
+    ["one-decimal", UptimePrecision.ONE_DECIMAL],
+    ["NO_DECIMAL", UptimePrecision.NO_DECIMAL],
+    ["TWO_DECIMAL", UptimePrecision.TWO_DECIMAL],
+    ["THREE_DECIMAL", UptimePrecision.THREE_DECIMAL],
+    ["99.99% (Two Decimal)", UptimePrecision.TWO_DECIMAL],
+  ])(
+    "uptimePercentPrecision %s reads as %s",
+    (cell: string, expected: string) => {
+      const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+        `name,showUptimePercent,uptimePercentPrecision\nA,true,"${cell}"\n`,
+      );
+      expect(result.errors).toEqual([]);
+      expect(result.rows[0]!.uptimePercentPrecision).toBe(expected);
+    },
+  );
+
+  test("unknown precision is an error listing the valid values", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,uptimePercentPrecision\nA,FOUR_DECIMAL\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors[0]!.message).toContain(
+      'Unknown uptimePercentPrecision "FOUR_DECIMAL"',
+    );
+    expect(result.errors[0]!.message).toContain("ONE_DECIMAL");
+  });
+
+  /*
+   * The create form makes the precision required the moment uptime is shown,
+   * defaulting it to one decimal. A CSV that asks for the percent and says
+   * nothing about precision has to mean the same thing, or the group renders
+   * a percentage with no precision behind it.
+   */
+  test("showUptimePercent without a precision defaults to one decimal", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,showUptimePercent\nA,true\n",
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.uptimePercentPrecision).toBe(
+      UptimePrecision.ONE_DECIMAL,
+    );
+  });
+
+  test("an explicit precision beats the default", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,showUptimePercent,uptimePercentPrecision\nA,true,THREE_DECIMAL\n",
+    );
+    expect(result.rows[0]!.uptimePercentPrecision).toBe(
+      UptimePrecision.THREE_DECIMAL,
+    );
+  });
+
+  test("no default is invented when uptime is not being shown", () => {
+    for (const cell of ["", "false"]) {
+      const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+        `name,showUptimePercent\nA,${cell}\n`,
+      );
+      expect(result.errors).toEqual([]);
+      expect(result.rows[0]!.uptimePercentPrecision).toBeUndefined();
+    }
+  });
+});
+
+describe("parseStatusPageGroupCsv — the grid axis columns", () => {
+  test("a Grid row keeps all four axis cells", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      'name,viewMode,rowAxisLabel,rowAxisValues,columnAxisLabel,columnAxisValues\nRegions,Grid,Service,"Auth, API",Region,"US-East, EU-West"\n',
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]).toEqual(
+      makeRow({
+        line: 2,
+        name: "Regions",
+        viewMode: StatusPageGroupViewMode.Grid,
+        rowAxisLabel: "Service",
+        rowAxisValues: "Auth, API",
+        columnAxisLabel: "Region",
+        columnAxisValues: "US-East, EU-West",
+      }),
+    );
+  });
+
+  /*
+   * Nothing reads the axis columns on a List group, so importing them would
+   * drop them on the floor without a word. Better to say so while the author
+   * is still looking at the preview.
+   */
+  test.each([
+    ["rowAxisLabel", "Service"],
+    ["rowAxisValues", "Auth"],
+    ["columnAxisLabel", "Region"],
+    ["columnAxisValues", "US-East"],
+  ])("%s on a List row is an error", (column: string, value: string) => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      `name,viewMode,${column}\nA,List,${value}\n`,
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toBe(
+      `${column} only applies when viewMode is Grid.`,
+    );
+  });
+
+  test("axis columns on a row with no viewMode at all are an error too", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,rowAxisLabel\nA,Service\n",
+    );
+    expect(result.rows).toEqual([]);
+    expect(result.errors[0]!.message).toBe(
+      "rowAxisLabel only applies when viewMode is Grid.",
+    );
+  });
+
+  test("all offending axis columns are named in one message", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,viewMode,rowAxisLabel,columnAxisLabel\nA,List,Service,Region\n",
+    );
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toBe(
+      "rowAxisLabel, columnAxisLabel only applies when viewMode is Grid.",
+    );
+  });
+
+  test("blank axis columns on a List row are fine", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      `${FULL_HEADER}\nA,,,,,,,List,,,,\n`,
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.rows[0]!.viewMode).toBe(StatusPageGroupViewMode.List);
+  });
+
+  /*
+   * An unparseable viewMode is already reported. Adding "and your axes are
+   * wrong too" on the same row would send the author chasing a second
+   * problem that does not exist.
+   */
+  test("a bad viewMode does not also produce an axis complaint", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      "name,viewMode,rowAxisLabel\nA,Tiles,Service\n",
+    );
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.message).toContain('Unknown viewMode "Tiles"');
+  });
+});
+
+describe("parseStatusPageGroupCsv — a fully populated file", () => {
+  test("every column round-trips onto the parsed row", () => {
+    const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+      [
+        FULL_HEADER,
+        "Core Services,,The core,true,true,true,TWO_DECIMAL,List,,,,",
+        'Regions,Core Services,"By region",false,false,false,,Grid,Service,"Auth, API",Region,"US-East, EU-West"',
+      ].join("\n"),
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toEqual([
+      makeRow({
+        line: 2,
+        name: "Core Services",
+        description: "The core",
+        isExpandedByDefault: true,
+        showCurrentStatus: true,
+        showUptimePercent: true,
+        uptimePercentPrecision: UptimePrecision.TWO_DECIMAL,
+        viewMode: StatusPageGroupViewMode.List,
+      }),
+      makeRow({
+        line: 3,
+        name: "Regions",
+        parentName: "Core Services",
+        description: "By region",
+        isExpandedByDefault: false,
+        showCurrentStatus: false,
+        showUptimePercent: false,
+        viewMode: StatusPageGroupViewMode.Grid,
+        rowAxisLabel: "Service",
+        rowAxisValues: "Auth, API",
+        columnAxisLabel: "Region",
+        columnAxisValues: "US-East, EU-West",
+      }),
+    ]);
+  });
+});
+
+/*
+ * The example is what the modal offers as a downloadable template and shows
+ * as its placeholder — the file most authors will start from. A template
+ * that does not survive its own parser is worse than no template at all, so
+ * it is run through the real thing here rather than eyeballed.
+ */
+describe("the example file the product hands out", () => {
+  const result: StatusPageGroupCsvParseResult = parseStatusPageGroupCsv(
+    STATUS_PAGE_GROUP_CSV_EXAMPLE,
+  );
+
+  test("parses without a single error", () => {
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(3);
+  });
+
+  test("its header is the canonical column list", () => {
+    expect(STATUS_PAGE_GROUP_CSV_EXAMPLE.split("\n")[0]).toBe(FULL_HEADER);
+  });
+
+  /*
+   * The three shapes an author has to get right. If the example stops
+   * demonstrating one of them it has stopped being a useful template.
+   */
+  test("it demonstrates a top level group, a nested child and a grid", () => {
+    expect(result.rows[0]!.parentName).toBe("");
+    expect(result.rows[1]!.parentName).toBe(result.rows[0]!.name);
+    expect(result.rows[2]!.viewMode).toBe(StatusPageGroupViewMode.Grid);
+    // Quoted, because an axis list is itself comma-separated.
+    expect(result.rows[2]!.rowAxisValues).toBe("Auth, API, Database");
+  });
+
+  test("and it imports as one clean batch order", () => {
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      result.rows,
+      [],
+    );
+    expect(plan.skipped).toEqual([]);
+    expect(
+      plan.batches.map((batch: Array<ParsedStatusPageGroupRow>) => {
+        return batch.map((row: ParsedStatusPageGroupRow) => {
+          return row.name;
+        });
+      }),
+    ).toEqual([["Core Services", "Regional Availability"], ["API"]]);
+  });
+});
+
+describe("planStatusPageGroupImport — ordering", () => {
+  test("empty input plans nothing", () => {
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport([], []);
+    expect(plan.batches).toEqual([]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  test("top level rows and rows with an existing parent land in batch 0", () => {
+    const root: ParsedStatusPageGroupRow = makeRow({ name: "Root" });
+    const child: ParsedStatusPageGroupRow = makeRow({
+      name: "Child",
+      parentName: "Existing",
+    });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [root, child],
+      [existing("Existing", 0)],
+    );
+
+    expect(plan.batches).toEqual([[root, child]]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  test("children created in the file follow their parents, batch by batch", () => {
+    const grandchild: ParsedStatusPageGroupRow = makeRow({
+      name: "C",
+      parentName: "B",
+    });
+    const child: ParsedStatusPageGroupRow = makeRow({
+      name: "B",
+      parentName: "A",
+    });
+    const root: ParsedStatusPageGroupRow = makeRow({ name: "A" });
+
+    // Deliberately out of order in the file.
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [grandchild, child, root],
+      [],
+    );
+
+    expect(plan.batches).toEqual([[root], [child], [grandchild]]);
+    expect(plan.skipped).toEqual([]);
+  });
+});
+
+describe("planStatusPageGroupImport — rows that can never be created", () => {
+  test("an unresolvable parent is skipped, and its descendants cascade", () => {
+    const orphan: ParsedStatusPageGroupRow = makeRow({
+      name: "Orphan",
+      parentName: "Ghost",
+    });
+    const childOfOrphan: ParsedStatusPageGroupRow = makeRow({
+      name: "Deeper",
+      parentName: "Orphan",
+    });
+    const ok: ParsedStatusPageGroupRow = makeRow({ name: "OK" });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [orphan, childOfOrphan, ok],
+      [],
+    );
+
+    expect(plan.batches).toEqual([[ok]]);
+    expect(plan.skipped).toHaveLength(2);
+    expect(plan.skipped[0]!.reason).toBe(
+      'Parent group "Ghost" was not found in the file or on this status page.',
+    );
+    /*
+     * The child's parent IS in the file — telling the reader it "was not
+     * found" would send them looking for a typo that is not there.
+     */
+    expect(plan.skipped[1]!.reason).toBe(
+      'Parent group "Orphan" could not be created.',
+    );
+  });
+
+  test("a dependency cycle is skipped instead of looping forever", () => {
+    const a: ParsedStatusPageGroupRow = makeRow({ name: "A", parentName: "B" });
+    const b: ParsedStatusPageGroupRow = makeRow({ name: "B", parentName: "A" });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [a, b],
+      [],
+    );
+
+    expect(plan.batches).toEqual([]);
+    expect(plan.skipped).toHaveLength(2);
+  });
+
+  test("a name already on the status page is skipped up front", () => {
+    const dupe: ParsedStatusPageGroupRow = makeRow({ name: "Core" });
+    const child: ParsedStatusPageGroupRow = makeRow({
+      name: "API",
+      parentName: "Core",
+    });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [dupe, child],
+      [existing("Core", 0)],
+    );
+
+    // The child still resolves — its parent is the group already on the page.
+    expect(plan.batches).toEqual([[child]]);
+    expect(plan.skipped).toHaveLength(1);
+    expect(plan.skipped[0]!.row).toBe(dupe);
+    expect(plan.skipped[0]!.reason).toBe(
+      'A group named "Core" already exists on this status page.',
+    );
+  });
+});
+
+describe("planStatusPageGroupImport — the nesting limit", () => {
+  /*
+   * The number is the server's, enforced in StatusPageGroupService via
+   * StatusPageGroupTreeUtil. Checking it here only helps if the two agree —
+   * a copy that drifts would report rows as too deep that the API accepts,
+   * or send rows it rejects.
+   */
+  test("the limit matches the one the server enforces", () => {
+    expect(MAX_GROUP_NESTING_DEPTH).toBe(
+      StatusPageGroupTreeUtil.MaxNestingDepth,
+    );
+  });
+
+  test("a child of the deepest legal parent is still planned", () => {
+    const child: ParsedStatusPageGroupRow = makeRow({
+      name: "Deep",
+      parentName: "Parent",
+    });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [child],
+      [existing("Parent", MAX_GROUP_NESTING_DEPTH - 2)],
+    );
+
+    expect(plan.batches).toEqual([[child]]);
+    expect(plan.skipped).toEqual([]);
+  });
+
+  test("one level deeper is skipped with a reason instead of being sent", () => {
+    const child: ParsedStatusPageGroupRow = makeRow({
+      name: "Too Deep",
+      parentName: "Parent",
+    });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [child],
+      [existing("Parent", MAX_GROUP_NESTING_DEPTH - 1)],
+    );
+
+    expect(plan.batches).toEqual([]);
+    expect(plan.skipped).toEqual([
+      {
+        row: child,
+        reason: `Nesting "Too Deep" under "Parent" would be more than ${MAX_GROUP_NESTING_DEPTH} levels deep.`,
+      },
+    ]);
+  });
+
+  test("depth accumulates through the chain the file itself builds", () => {
+    // Two more levels than the page has room for.
+    const rows: Array<ParsedStatusPageGroupRow> = [];
+    for (let level: number = 0; level < MAX_GROUP_NESTING_DEPTH + 2; level++) {
+      rows.push(
+        makeRow({
+          line: level + 2,
+          name: `Level ${level}`,
+          parentName: level === 0 ? "" : `Level ${level - 1}`,
+        }),
+      );
+    }
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(rows, []);
+
+    // Depths 0 .. MAX-1 are legal, one batch each.
+    expect(plan.batches).toHaveLength(MAX_GROUP_NESTING_DEPTH);
+    expect(plan.skipped).toHaveLength(2);
+    expect(plan.skipped[0]!.reason).toContain("levels deep");
+    // ...and the level below it falls out behind its uncreated parent.
+    expect(plan.skipped[1]!.reason).toBe(
+      `Parent group "Level ${MAX_GROUP_NESTING_DEPTH}" could not be created.`,
+    );
+  });
+
+  test("a too-deep row does not stop its siblings importing", () => {
+    const tooDeep: ParsedStatusPageGroupRow = makeRow({
+      name: "Too Deep",
+      parentName: "Deep Parent",
+    });
+    const sibling: ParsedStatusPageGroupRow = makeRow({
+      name: "Fine",
+      parentName: "Shallow Parent",
+    });
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(
+      [tooDeep, sibling],
+      [
+        existing("Deep Parent", MAX_GROUP_NESTING_DEPTH - 1),
+        existing("Shallow Parent", 0),
+      ],
+    );
+
+    expect(plan.batches).toEqual([[sibling]]);
+    expect(plan.skipped).toHaveLength(1);
+    expect(plan.skipped[0]!.row).toBe(tooDeep);
+  });
+});
+
+describe("planStatusPageGroupImport — the caller's inputs are inputs", () => {
+  test("the existing-groups list is not mutated", () => {
+    const existingGroups: Array<ExistingStatusPageGroup> = [
+      existing("Core", 0),
+    ];
+    const before: string = JSON.stringify(existingGroups);
+
+    planStatusPageGroupImport(
+      [makeRow({ name: "API", parentName: "Core" })],
+      existingGroups,
+    );
+
+    expect(JSON.stringify(existingGroups)).toBe(before);
+  });
+
+  test("every row lands in exactly one batch or the skip list", () => {
+    const rows: Array<ParsedStatusPageGroupRow> = [
+      makeRow({ line: 2, name: "Root" }),
+      makeRow({ line: 3, name: "Child", parentName: "Root" }),
+      makeRow({ line: 4, name: "Core" }),
+      makeRow({ line: 5, name: "Orphan", parentName: "Ghost" }),
+    ];
+
+    const plan: StatusPageGroupImportPlan = planStatusPageGroupImport(rows, [
+      existing("Core", 0),
+    ]);
+
+    const planned: number =
+      plan.batches.reduce(
+        (sum: number, batch: Array<ParsedStatusPageGroupRow>) => {
+          return sum + batch.length;
+        },
+        0,
+      ) + plan.skipped.length;
+
+    expect(planned).toBe(rows.length);
+  });
+});

--- a/App/Tests/Dashboard/StatusPageGroupImportPageInvariants.test.ts
+++ b/App/Tests/Dashboard/StatusPageGroupImportPageInvariants.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The import modal and the Groups page are React components, and the App
+ * suite runs in a plain Node environment with no renderer — so the defects
+ * pinned below, which all live in a prop or a conditional rather than in
+ * extractable logic, are pinned by reading the sources, the same way
+ * NetworkSitePageInvariants.test.ts pins the Network Sites import.
+ *
+ * Sources are whitespace-squashed first so prettier re-wrapping a line
+ * cannot turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+  );
+}
+
+/*
+ * The same source with its comments removed. Assertions about what the code
+ * DOES have to read the code, not the commentary — a comment naming the very
+ * thing a test asserts is absent would otherwise fail it.
+ */
+function readCode(...relativeParts: Array<string>): string {
+  const raw: string = fs.readFileSync(
+    path.join(DASHBOARD_SRC, ...relativeParts),
+    "utf8",
+  );
+  return squash(
+    raw.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " "),
+  );
+}
+
+const MODAL: Array<string> = [
+  "Components",
+  "StatusPage",
+  "ImportGroupsFromCsvModal.tsx",
+];
+const GROUPS_PAGE: Array<string> = [
+  "Pages",
+  "StatusPages",
+  "View",
+  "Groups.tsx",
+];
+
+describe("the Groups table owns the CSV import", () => {
+  const source: string = readSource(...GROUPS_PAGE);
+
+  test("the table offers an Import from CSV card button", () => {
+    expect(source).toContain(squash('title: "Import from CSV",'));
+    expect(source).toContain("setShowImportModal(true);");
+  });
+
+  /*
+   * BaseModelTable promotes the first NORMAL/PRIMARY-styled button to the
+   * header slot and hides the rest behind the ⋯ menu. An OUTLINE style is
+   * what keeps this one in the overflow, next to Refresh and Filter, instead
+   * of competing with "Create Status Page Group".
+   */
+  test("it is styled so it stays in the overflow menu", () => {
+    const buttonBlock: string = source
+      .split('title: "Import from CSV",')[1]!
+      .split("} as CardButtonSchema")[0]!;
+    expect(buttonBlock).toContain("buttonStyle: ButtonStyleType.OUTLINE,");
+    expect(buttonBlock).not.toContain("ButtonStyleType.NORMAL");
+    expect(buttonBlock).not.toContain("ButtonStyleType.PRIMARY");
+  });
+
+  test("the modal is rendered from the page", () => {
+    expect(source).toContain("<ImportGroupsFromCsvModal");
+    expect(source).toContain("setShowImportModal(false);");
+  });
+
+  /*
+   * A group belongs to one status page and one project, and the modal has no
+   * route of its own to read them from. Handing them down is what keeps an
+   * imported group on the page the user is actually looking at.
+   */
+  test("the modal is told which status page and project to import into", () => {
+    expect(source).toContain("statusPageId={modelId}");
+    expect(source).toContain("projectId={ProjectUtil.getCurrentProjectId()!}");
+  });
+
+  /*
+   * The import creates rows the table is already showing a page of. Without
+   * the toggle reaching it, the user closes the modal onto a table that does
+   * not contain what they just imported.
+   */
+  test("a completed import refreshes the table behind the modal", () => {
+    const completeBody: string = source
+      .split("onImportComplete={() => {")[1]!
+      .split("}}")[0]!;
+    expect(completeBody).toContain("setRefreshToggle(Date.now().toString());");
+    expect(source).toContain(
+      squash(
+        "<ModelTable<StatusPageGroup> modelType={StatusPageGroup} refreshToggle={refreshToggle}",
+      ),
+    );
+  });
+});
+
+describe("the import modal disarms a stale parse", () => {
+  const source: string = readSource(...MODAL);
+
+  /*
+   * importGroups() runs off parseResult, never off the textarea's current
+   * text. Editing the CSV after previewing would therefore import the
+   * pre-edit rows — a typo "fixed" in the box still persisted.
+   */
+  test("typing in the textarea drops the previous parse", () => {
+    const onChangeBody: string = source
+      .split("onChange={(value: string) => {")[1]!
+      .split("}}")[0]!;
+    expect(onChangeBody).toContain("setCsvText(value);");
+    expect(onChangeBody).toContain("setParseResult(null);");
+    expect(onChangeBody).toContain("setRowResults([]);");
+  });
+
+  test("the Import button is still gated on a live parse", () => {
+    expect(source).toContain(
+      squash(
+        "const canImport: boolean = Boolean( parseResult && rows.length > 0 && parseErrors.length === 0, );",
+      ),
+    );
+    expect(source).toContain("(!hasImported && !canImport)");
+  });
+
+  /*
+   * A second press of a still-armed Import would replay the whole file
+   * against a status page that already contains most of it — every created
+   * row coming back as a duplicate-name failure.
+   */
+  test("a finished run turns the submit button into Done", () => {
+    expect(source).toContain("setHasImported(true);");
+    expect(source).toContain(squash('hasImported ? "Done"'));
+    expect(source).toContain(
+      squash("if (hasImported) { props.onClose(); return; }"),
+    );
+  });
+
+  // Closing mid-run would leave the create loop writing into an unmounted tree.
+  test("the modal cannot be dismissed while the import is running", () => {
+    expect(source).toContain(
+      squash(
+        "onClose={() => { if (isImporting) { return; } props.onClose(); }}",
+      ),
+    );
+  });
+});
+
+/*
+ * StatusPageGroupCsv.test.ts proves STATUS_PAGE_GROUP_CSV_EXAMPLE parses
+ * cleanly. That guarantee is only worth something if the file the user is
+ * actually handed — and the placeholder they read — is that same constant,
+ * rather than a second copy that drifts from it.
+ */
+describe("the template the modal hands out is the tested example", () => {
+  const code: string = readCode(...MODAL);
+
+  test("the download and the placeholder both come from the shared constant", () => {
+    expect(code).toContain("placeholder={STATUS_PAGE_GROUP_CSV_EXAMPLE}");
+    expect(code).toContain(
+      squash(
+        'content: `${STATUS_PAGE_GROUP_CSV_EXAMPLE}\\n`, filename: "status-page-groups-template.csv",',
+      ),
+    );
+  });
+
+  test("the modal defines no example CSV of its own", () => {
+    expect(code).not.toContain("const EXAMPLE_CSV");
+  });
+});
+
+describe("the import modal reads the status page at import time", () => {
+  const code: string = readCode(...MODAL);
+
+  /*
+   * The existing groups are what parent references resolve against, what a
+   * duplicate name is checked against, and where the nesting depths come
+   * from. Fetching them when the modal MOUNTS would make a group the user
+   * created from the table a moment earlier invisible to the import — so the
+   * fetch belongs inside the run, and the modal must not carry a mount-time
+   * effect for it.
+   */
+  test("existing groups are fetched inside the import, not on mount", () => {
+    const importBody: string = code
+      .split("const importGroups: PromiseVoidFunction")[1]!
+      .split("const rows: Array<ParsedStatusPageGroupRow>")[0]!;
+    expect(importBody).toContain("ModelAPI.getList<StatusPageGroup>({");
+    expect(code).not.toContain("useEffect(");
+  });
+
+  /*
+   * Groups are unique per status page, not per project. A query that forgot
+   * the statusPageId would resolve parents from a different status page and
+   * refuse names that are free on this one.
+   */
+  test("the query is scoped to this status page and project", () => {
+    const query: string = code
+      .split("ModelAPI.getList<StatusPageGroup>({")[1]!
+      .split("});")[0]!;
+    expect(query).toContain("statusPageId: props.statusPageId,");
+    expect(query).toContain("projectId: props.projectId,");
+    // parentStatusPageGroupId is what the depth walk needs.
+    expect(query).toContain("parentStatusPageGroupId: true,");
+  });
+
+  test("depth comes from the shared group tree util", () => {
+    expect(code).toContain(
+      squash(
+        "depth: StatusPageGroupTreeUtil.getDepth({ statusPageGroup: group, statusPageGroups: existing.data, }),",
+      ),
+    );
+  });
+});
+
+describe("the import modal writes only what the file says", () => {
+  const code: string = readCode(...MODAL);
+
+  const createBody: string = code
+    .split("const createGroup: CreateStatusPageGroupFunction")[1]!
+    .split("const importGroups:")[0]!;
+
+  /*
+   * StatusPageGroupService assigns the next `order` on create and renumbers
+   * the siblings around it. Sending an order of our own would shuffle the
+   * groups that were already on the page.
+   */
+  test("order is never written", () => {
+    expect(createBody).not.toContain("group.order");
+  });
+
+  /*
+   * A blank cell means "use the default". Writing the parser's `undefined`
+   * as a value would send an explicit null and override the column default —
+   * which is how an import silently collapses every group on a page whose
+   * author only filled in the name column.
+   */
+  test.each([
+    ["isExpandedByDefault"],
+    ["showCurrentStatus"],
+    ["showUptimePercent"],
+    ["uptimePercentPrecision"],
+    ["viewMode"],
+  ])("%s is only written when the row supplies it", (field: string) => {
+    expect(createBody).toContain(
+      squash(
+        `if (row.${field} !== undefined) { group.${field} = row.${field}; }`,
+      ),
+    );
+  });
+
+  test("description is only written when it is not blank", () => {
+    expect(createBody).toContain(
+      squash(
+        'if (row.description !== "") { group.description = row.description; }',
+      ),
+    );
+  });
+
+  /*
+   * Nothing renders the axis columns on a List group. The parser already
+   * refuses a row that fills them in without Grid, and this is the second
+   * half of the same rule: even a Grid-shaped leftover cannot reach a group
+   * that is not a grid.
+   */
+  test("axis fields are written only for a Grid group", () => {
+    expect(createBody).toContain(
+      squash("if (row.viewMode === StatusPageGroupViewMode.Grid) {"),
+    );
+
+    const gridBlock: string = createBody
+      .split("if (row.viewMode === StatusPageGroupViewMode.Grid) {")[1]!
+      .split("const response:")[0]!;
+
+    for (const field of [
+      "rowAxisLabel",
+      "rowAxisValues",
+      "columnAxisLabel",
+      "columnAxisValues",
+    ]) {
+      expect(gridBlock).toContain(`group.${field} = row.${field};`);
+      // ...and nowhere else.
+      expect(createBody.split(`group.${field} =`).length - 1).toBe(1);
+    }
+  });
+
+  /*
+   * The parent id comes from the runner, which has already created the
+   * parent. Reading it off the row's parentName here instead would send a
+   * name where the API wants an id.
+   */
+  test("the parent is set from the id the runner resolved", () => {
+    expect(createBody).toContain(
+      squash(
+        "if (parentStatusPageGroupId) { group.parentStatusPageGroupId = new ObjectID(parentStatusPageGroupId); }",
+      ),
+    );
+    expect(createBody).not.toContain("row.parentName");
+  });
+});

--- a/App/Tests/Dashboard/StatusPageGroupImportRunner.test.ts
+++ b/App/Tests/Dashboard/StatusPageGroupImportRunner.test.ts
@@ -1,0 +1,778 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  ExistingStatusPageGroup,
+  MAX_GROUP_NESTING_DEPTH,
+  ParsedStatusPageGroupRow,
+} from "../../FeatureSet/Dashboard/src/Utils/StatusPageGroupCsv";
+import {
+  CreateStatusPageGroupFunction,
+  StatusPageGroupCreateResult,
+  StatusPageGroupImportProgress,
+  StatusPageGroupImportRowResult,
+  StatusPageGroupImportSummary,
+  runStatusPageGroupImport,
+} from "../../FeatureSet/Dashboard/src/Utils/StatusPageGroupImportRunner";
+
+/*
+ * Pins the create loop behind the Status Page > Groups CSV import (the ⋯ >
+ * Import from CSV action on the Groups table). The loop is the part that can
+ * quietly corrupt a status page: get the ordering wrong and a child is
+ * created before its parent exists, get the failure handling wrong and a
+ * child whose parent failed silently becomes a top level group on a customer-
+ * facing page.
+ *
+ * The runner never talks to the API — the caller hands it a `createGroup`, so
+ * every one of those paths is drivable here without a renderer or a network.
+ */
+
+interface CreateCall {
+  name: string;
+  parentStatusPageGroupId: string | undefined;
+}
+
+type MakeRowFunction = (
+  overrides: Partial<ParsedStatusPageGroupRow>,
+) => ParsedStatusPageGroupRow;
+
+const makeRow: MakeRowFunction = (
+  overrides: Partial<ParsedStatusPageGroupRow>,
+): ParsedStatusPageGroupRow => {
+  return {
+    line: 2,
+    name: "Group",
+    parentName: "",
+    description: "",
+    isExpandedByDefault: undefined,
+    showCurrentStatus: undefined,
+    showUptimePercent: undefined,
+    uptimePercentPrecision: undefined,
+    viewMode: undefined,
+    rowAxisLabel: "",
+    rowAxisValues: "",
+    columnAxisLabel: "",
+    columnAxisValues: "",
+    ...overrides,
+  };
+};
+
+type ExistingFunction = (
+  name: string,
+  depth?: number,
+) => ExistingStatusPageGroup;
+
+const existing: ExistingFunction = (
+  name: string,
+  depth: number = 0,
+): ExistingStatusPageGroup => {
+  return { id: `existing-${name}`, name: name, depth: depth };
+};
+
+/*
+ * A createGroup that succeeds for every row, minting a predictable id, and
+ * records what it was asked to create. The recorded calls are how the
+ * ordering and parent-resolution assertions are made.
+ */
+interface Recorder {
+  createGroup: CreateStatusPageGroupFunction;
+  calls: Array<CreateCall>;
+}
+
+type RecordingCreatorFunction = (
+  outcomeByName?: Record<string, StatusPageGroupCreateResult>,
+) => Recorder;
+
+const recordingCreator: RecordingCreatorFunction = (
+  outcomeByName: Record<string, StatusPageGroupCreateResult> = {},
+): Recorder => {
+  const calls: Array<CreateCall> = [];
+
+  return {
+    calls: calls,
+    createGroup: async (
+      row: ParsedStatusPageGroupRow,
+      parentStatusPageGroupId: string | undefined,
+    ): Promise<StatusPageGroupCreateResult> => {
+      calls.push({
+        name: row.name,
+        parentStatusPageGroupId: parentStatusPageGroupId,
+      });
+
+      const configured: StatusPageGroupCreateResult | undefined =
+        outcomeByName[row.name];
+      if (configured) {
+        return configured;
+      }
+
+      return { created: true, statusPageGroupId: `id-${row.name}` };
+    },
+  };
+};
+
+type NamesOfFunction = (
+  results: Array<StatusPageGroupImportRowResult>,
+  status: StatusPageGroupImportRowResult["status"],
+) => Array<string>;
+
+const namesOf: NamesOfFunction = (
+  results: Array<StatusPageGroupImportRowResult>,
+  status: StatusPageGroupImportRowResult["status"],
+): Array<string> => {
+  return results
+    .filter((result: StatusPageGroupImportRowResult) => {
+      return result.status === status;
+    })
+    .map((result: StatusPageGroupImportRowResult) => {
+      return result.name;
+    });
+};
+
+describe("runStatusPageGroupImport — nothing to do", () => {
+  test("an empty file creates nothing and reports zeros", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([]);
+    expect(summary).toEqual({
+      results: [],
+      createdCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
+      totalToCreate: 0,
+    });
+  });
+
+  test("progress is still reported once, so a caller can render the total", async () => {
+    const progress: Array<StatusPageGroupImportProgress> = [];
+
+    await runStatusPageGroupImport({
+      rows: [],
+      existingGroups: [],
+      createGroup: recordingCreator().createGroup,
+      onProgress: (tick: StatusPageGroupImportProgress) => {
+        progress.push(tick);
+      },
+    });
+
+    expect(progress).toEqual([
+      { results: [], createdCount: 0, totalToCreate: 0 },
+    ]);
+  });
+});
+
+describe("runStatusPageGroupImport — ordering", () => {
+  test("top level groups are created with no parent id", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "Edge" }),
+        ],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([
+      { name: "Core", parentStatusPageGroupId: undefined },
+      { name: "Edge", parentStatusPageGroupId: undefined },
+    ]);
+    expect(summary.createdCount).toBe(2);
+    expect(summary.totalToCreate).toBe(2);
+  });
+
+  test("a parent later in the file is still created before its child", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    await runStatusPageGroupImport({
+      // Child first — the file order is deliberately the wrong order.
+      rows: [
+        makeRow({ line: 2, name: "API", parentName: "Core" }),
+        makeRow({ line: 3, name: "Core" }),
+      ],
+      existingGroups: [],
+      createGroup: recorder.createGroup,
+    });
+
+    expect(recorder.calls).toEqual([
+      { name: "Core", parentStatusPageGroupId: undefined },
+      { name: "API", parentStatusPageGroupId: "id-Core" },
+    ]);
+  });
+
+  test("a three-level chain resolves each level against the one above it", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    await runStatusPageGroupImport({
+      rows: [
+        makeRow({ line: 2, name: "Auth DB", parentName: "API" }),
+        makeRow({ line: 3, name: "API", parentName: "Core" }),
+        makeRow({ line: 4, name: "Core" }),
+      ],
+      existingGroups: [],
+      createGroup: recorder.createGroup,
+    });
+
+    expect(recorder.calls).toEqual([
+      { name: "Core", parentStatusPageGroupId: undefined },
+      { name: "API", parentStatusPageGroupId: "id-Core" },
+      { name: "Auth DB", parentStatusPageGroupId: "id-API" },
+    ]);
+  });
+
+  test("a parent already on the status page is not re-created", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    await runStatusPageGroupImport({
+      rows: [makeRow({ line: 2, name: "API", parentName: "Core" })],
+      existingGroups: [existing("Core")],
+      createGroup: recorder.createGroup,
+    });
+
+    expect(recorder.calls).toEqual([
+      { name: "API", parentStatusPageGroupId: "existing-Core" },
+    ]);
+  });
+
+  /*
+   * StatusPageGroupService renumbers every sibling on each create, so two
+   * in-flight creates would race on `order` and leave the page in an order
+   * nobody asked for.
+   */
+  test("creates run one at a time, never concurrently", async () => {
+    let inFlight: number = 0;
+    let maxInFlight: number = 0;
+
+    const createGroup: CreateStatusPageGroupFunction = async (
+      row: ParsedStatusPageGroupRow,
+    ): Promise<StatusPageGroupCreateResult> => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 0);
+      });
+      inFlight--;
+      return { created: true, statusPageGroupId: `id-${row.name}` };
+    };
+
+    await runStatusPageGroupImport({
+      rows: [
+        makeRow({ line: 2, name: "A" }),
+        makeRow({ line: 3, name: "B" }),
+        makeRow({ line: 4, name: "C" }),
+      ],
+      existingGroups: [],
+      createGroup: createGroup,
+    });
+
+    expect(maxInFlight).toBe(1);
+  });
+});
+
+describe("runStatusPageGroupImport — rows that can never be created", () => {
+  test("a name already on the page is skipped before any request", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "Edge" }),
+        ],
+        existingGroups: [existing("Core")],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([
+      { name: "Edge", parentStatusPageGroupId: undefined },
+    ]);
+    expect(summary.skippedCount).toBe(1);
+    expect(summary.results[0]).toEqual({
+      line: 2,
+      name: "Core",
+      status: "skipped",
+      message: 'A group named "Core" already exists on this status page.',
+    });
+  });
+
+  test("an unresolvable parent is skipped and reported", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [makeRow({ line: 2, name: "Orphan", parentName: "Nowhere" })],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([]);
+    expect(summary.results).toEqual([
+      {
+        line: 2,
+        name: "Orphan",
+        status: "skipped",
+        message:
+          'Parent group "Nowhere" was not found in the file or on this status page.',
+      },
+    ]);
+    expect(summary.totalToCreate).toBe(0);
+  });
+
+  test("a parent cycle is skipped rather than looping forever", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "A", parentName: "B" }),
+          makeRow({ line: 3, name: "B", parentName: "A" }),
+        ],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([]);
+    expect(summary.skippedCount).toBe(2);
+    expect(summary.createdCount).toBe(0);
+  });
+
+  /*
+   * The server rejects a group nested past the limit, so sending it would
+   * cost a round trip and come back as an opaque failure. It is reported as
+   * a skip with the reason instead — and exactly once.
+   */
+  test("a row past the nesting limit is skipped without a request", async () => {
+    const recorder: Recorder = recordingCreator();
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [makeRow({ line: 2, name: "Too Deep", parentName: "Deep" })],
+        existingGroups: [existing("Deep", MAX_GROUP_NESTING_DEPTH - 1)],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([]);
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0]!.status).toBe("skipped");
+    expect(summary.results[0]!.message).toContain("levels deep");
+  });
+
+  test("skipped rows do not count toward the progress total", async () => {
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Orphan", parentName: "Nowhere" }),
+          makeRow({ line: 3, name: "Core" }),
+        ],
+        existingGroups: [],
+        createGroup: recordingCreator().createGroup,
+      });
+
+    expect(summary.totalToCreate).toBe(1);
+  });
+});
+
+describe("runStatusPageGroupImport — partial failure", () => {
+  test("a failed row is reported with its message and does not stop the run", async () => {
+    const recorder: Recorder = recordingCreator({
+      Edge: { created: false, errorMessage: "Name is not unique." },
+    });
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "Edge" }),
+          makeRow({ line: 4, name: "Partners" }),
+        ],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(namesOf(summary.results, "created")).toEqual(["Core", "Partners"]);
+    expect(summary.results[1]).toEqual({
+      line: 3,
+      name: "Edge",
+      status: "failed",
+      message: "Name is not unique.",
+    });
+    expect(summary).toMatchObject({
+      createdCount: 2,
+      failedCount: 1,
+      skippedCount: 0,
+      totalToCreate: 3,
+    });
+  });
+
+  /*
+   * The defect this guards: without the parent-id check the child would be
+   * created anyway, with no parentStatusPageGroupId — a sub group silently
+   * promoted to the top level of a public status page instead of a reported
+   * skip.
+   */
+  test("children of a failed parent are skipped, not created at the top level", async () => {
+    const recorder: Recorder = recordingCreator({
+      Core: { created: false, errorMessage: "Boom." },
+    });
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "API", parentName: "Core" }),
+        ],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(recorder.calls).toEqual([
+      { name: "Core", parentStatusPageGroupId: undefined },
+    ]);
+    expect(summary.results).toEqual([
+      { line: 2, name: "Core", status: "failed", message: "Boom." },
+      {
+        line: 3,
+        name: "API",
+        status: "skipped",
+        message: 'Parent group "Core" could not be created.',
+      },
+    ]);
+  });
+
+  test("a grandchild of a failed parent is skipped too", async () => {
+    const recorder: Recorder = recordingCreator({
+      Core: { created: false, errorMessage: "Boom." },
+    });
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "API", parentName: "Core" }),
+          makeRow({ line: 4, name: "Auth DB", parentName: "API" }),
+        ],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(namesOf(summary.results, "skipped")).toEqual(["API", "Auth DB"]);
+    expect(summary.createdCount).toBe(0);
+  });
+
+  /*
+   * A create that reports success but hands back no id leaves the child with
+   * nothing to point at. Treating that as "parent could not be created" is
+   * the same safe answer as an outright failure.
+   */
+  test("a create that returns no id still blocks its children", async () => {
+    const recorder: Recorder = recordingCreator({
+      Core: { created: true, statusPageGroupId: undefined },
+    });
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "API", parentName: "Core" }),
+        ],
+        existingGroups: [],
+        createGroup: recorder.createGroup,
+      });
+
+    expect(namesOf(summary.results, "created")).toEqual(["Core"]);
+    expect(summary.results[1]).toMatchObject({
+      name: "API",
+      status: "skipped",
+      message: 'Parent group "Core" could not be created.',
+    });
+  });
+
+  test("an unexpected throw lands on the row, not on the run", async () => {
+    const createGroup: CreateStatusPageGroupFunction = async (
+      row: ParsedStatusPageGroupRow,
+    ): Promise<StatusPageGroupCreateResult> => {
+      if (row.name === "Edge") {
+        throw new Error("Network is down.");
+      }
+      return { created: true, statusPageGroupId: `id-${row.name}` };
+    };
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "Core" }),
+          makeRow({ line: 3, name: "Edge" }),
+          makeRow({ line: 4, name: "Partners" }),
+        ],
+        existingGroups: [],
+        createGroup: createGroup,
+      });
+
+    expect(summary.results[1]).toEqual({
+      line: 3,
+      name: "Edge",
+      status: "failed",
+      message: "Network is down.",
+    });
+    expect(namesOf(summary.results, "created")).toEqual(["Core", "Partners"]);
+  });
+
+  test.each([
+    ["a bare string", "not an error object"],
+    ["an Error with an empty message", new Error("")],
+  ])("%s still reads as a failure", async (_label: string, thrown: unknown) => {
+    const createGroup: CreateStatusPageGroupFunction =
+      (): Promise<StatusPageGroupCreateResult> => {
+        throw thrown;
+      };
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [makeRow({ line: 2, name: "Core" })],
+        existingGroups: [],
+        createGroup: createGroup,
+      });
+
+    expect(summary.results).toEqual([
+      {
+        line: 2,
+        name: "Core",
+        status: "failed",
+        message: "Something went wrong while creating this group.",
+      },
+    ]);
+    expect(summary.failedCount).toBe(1);
+  });
+});
+
+describe("runStatusPageGroupImport — progress reporting", () => {
+  test("reports the up-front skips before the first create", async () => {
+    const progress: Array<StatusPageGroupImportProgress> = [];
+
+    await runStatusPageGroupImport({
+      rows: [
+        makeRow({ line: 2, name: "Core" }),
+        makeRow({ line: 3, name: "Edge" }),
+      ],
+      existingGroups: [existing("Core")],
+      createGroup: recordingCreator().createGroup,
+      onProgress: (tick: StatusPageGroupImportProgress) => {
+        progress.push(tick);
+      },
+    });
+
+    expect(progress[0]).toEqual({
+      results: [
+        {
+          line: 2,
+          name: "Core",
+          status: "skipped",
+          message: 'A group named "Core" already exists on this status page.',
+        },
+      ],
+      createdCount: 0,
+      totalToCreate: 1,
+    });
+  });
+
+  test("ticks once per attempted row, with a running created count", async () => {
+    const progress: Array<StatusPageGroupImportProgress> = [];
+
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 2, name: "A" }),
+          makeRow({ line: 3, name: "B" }),
+          makeRow({ line: 4, name: "C" }),
+        ],
+        existingGroups: [],
+        createGroup: recordingCreator().createGroup,
+        onProgress: (tick: StatusPageGroupImportProgress) => {
+          progress.push(tick);
+        },
+      });
+
+    // One up-front tick plus one per row.
+    expect(progress).toHaveLength(4);
+    expect(
+      progress.map((tick: StatusPageGroupImportProgress) => {
+        return tick.createdCount;
+      }),
+    ).toEqual([0, 1, 2, 3]);
+    expect(progress[progress.length - 1]!.results).toEqual(summary.results);
+  });
+
+  test("a skipped child ticks too, so the results table stays live", async () => {
+    const progress: Array<StatusPageGroupImportProgress> = [];
+
+    await runStatusPageGroupImport({
+      rows: [
+        makeRow({ line: 2, name: "Core" }),
+        makeRow({ line: 3, name: "API", parentName: "Core" }),
+      ],
+      existingGroups: [],
+      createGroup: recordingCreator({
+        Core: { created: false, errorMessage: "Boom." },
+      }).createGroup,
+      onProgress: (tick: StatusPageGroupImportProgress) => {
+        progress.push(tick);
+      },
+    });
+
+    expect(progress).toHaveLength(3);
+    expect(progress[2]!.results[1]!.status).toBe("skipped");
+  });
+
+  /*
+   * A React caller stores the tick's array straight into state, so reusing
+   * one array would leave the results table on a stale render.
+   */
+  test("each tick carries its own array", async () => {
+    const progress: Array<StatusPageGroupImportProgress> = [];
+
+    await runStatusPageGroupImport({
+      rows: [makeRow({ line: 2, name: "A" }), makeRow({ line: 3, name: "B" })],
+      existingGroups: [],
+      createGroup: recordingCreator().createGroup,
+      onProgress: (tick: StatusPageGroupImportProgress) => {
+        progress.push(tick);
+      },
+    });
+
+    expect(progress[1]!.results).not.toBe(progress[2]!.results);
+    // The earlier snapshot must not have grown after the fact.
+    expect(progress[1]!.results).toHaveLength(1);
+  });
+
+  test("progress is optional", async () => {
+    await expect(
+      runStatusPageGroupImport({
+        rows: [makeRow({ line: 2, name: "A" })],
+        existingGroups: [],
+        createGroup: recordingCreator().createGroup,
+      }),
+    ).resolves.toMatchObject({ createdCount: 1 });
+  });
+});
+
+describe("runStatusPageGroupImport — the caller's inputs are inputs", () => {
+  test("the existing-groups list is not mutated", async () => {
+    const existingGroups: Array<ExistingStatusPageGroup> = [existing("Core")];
+    const before: string = JSON.stringify(existingGroups);
+
+    await runStatusPageGroupImport({
+      rows: [makeRow({ line: 2, name: "API", parentName: "Core" })],
+      existingGroups: existingGroups,
+      createGroup: recordingCreator().createGroup,
+    });
+
+    expect(JSON.stringify(existingGroups)).toBe(before);
+  });
+
+  test("the parsed rows are not mutated", async () => {
+    const rows: Array<ParsedStatusPageGroupRow> = [
+      makeRow({ line: 2, name: "Core" }),
+      makeRow({ line: 3, name: "API", parentName: "Core" }),
+    ];
+    const before: string = JSON.stringify(rows);
+
+    await runStatusPageGroupImport({
+      rows: rows,
+      existingGroups: [],
+      createGroup: recordingCreator().createGroup,
+    });
+
+    expect(JSON.stringify(rows)).toBe(before);
+  });
+
+  /*
+   * Every field the parser produced has to reach createGroup untouched — the
+   * runner's job is ordering, not editing.
+   */
+  test("the row handed to createGroup is the parsed row itself", async () => {
+    const row: ParsedStatusPageGroupRow = makeRow({
+      line: 7,
+      name: "Regions",
+      description: "By region",
+      isExpandedByDefault: false,
+      showUptimePercent: true,
+      rowAxisValues: "Auth, API",
+    });
+
+    let seen: ParsedStatusPageGroupRow | null = null;
+
+    await runStatusPageGroupImport({
+      rows: [row],
+      existingGroups: [],
+      createGroup: async (
+        received: ParsedStatusPageGroupRow,
+      ): Promise<StatusPageGroupCreateResult> => {
+        seen = received;
+        return { created: true, statusPageGroupId: "id-Regions" };
+      },
+    });
+
+    expect(seen).toBe(row);
+  });
+});
+
+describe("runStatusPageGroupImport — the summary adds up", () => {
+  test("every row lands in exactly one bucket", async () => {
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          // created
+          makeRow({ line: 2, name: "Core" }),
+          // failed
+          makeRow({ line: 3, name: "Edge" }),
+          // skipped: parent failed
+          makeRow({ line: 4, name: "CDN", parentName: "Edge" }),
+          // skipped: already exists
+          makeRow({ line: 5, name: "Partners" }),
+          // skipped: parent is nowhere
+          makeRow({ line: 6, name: "Orphan", parentName: "Nowhere" }),
+        ],
+        existingGroups: [existing("Partners")],
+        createGroup: recordingCreator({
+          Edge: { created: false, errorMessage: "Boom." },
+        }).createGroup,
+      });
+
+    expect(summary.createdCount).toBe(1);
+    expect(summary.failedCount).toBe(1);
+    expect(summary.skippedCount).toBe(3);
+    expect(summary.results).toHaveLength(5);
+    expect(
+      summary.createdCount + summary.failedCount + summary.skippedCount,
+    ).toBe(summary.results.length);
+    // Only the rows the plan intended to create are in the progress total.
+    expect(summary.totalToCreate).toBe(3);
+  });
+
+  test("every result keeps the CSV line it came from", async () => {
+    const summary: StatusPageGroupImportSummary =
+      await runStatusPageGroupImport({
+        rows: [
+          makeRow({ line: 7, name: "API", parentName: "Core" }),
+          makeRow({ line: 9, name: "Core" }),
+        ],
+        existingGroups: [],
+        createGroup: recordingCreator().createGroup,
+      });
+
+    expect(
+      summary.results.map((result: StatusPageGroupImportRowResult) => {
+        return [result.name, result.line];
+      }),
+    ).toEqual([
+      ["Core", 9],
+      ["API", 7],
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Status page groups could only be created one at a time, through a three-step form. A page with a real hierarchy — a dozen products under half a dozen regions — is an afternoon of clicking, and the nesting has to be built top-down by hand because a parent has to exist before it can be picked.

This adds **Import from CSV** to the Groups table's ⋯ overflow menu, next to Refresh and Filter — the same place every other bulk import in the product lives.

Built along the lines of the Network Sites CSV import: a react-free parser + planner in `Utils`, a transport-free create loop, and a modal that wires them to a textarea, a file picker and the `ModelAPI`. It reuses the shared `Modal`, `TextArea`, `ProgressBar`, `Button` and `DownloadFile` pieces, and `StatusPageGroupTreeUtil` for depth.

## The file

Every field the create form has, and only `name` is required:

```
name,parentName,description,isExpandedByDefault,showCurrentStatus,showUptimePercent,uptimePercentPrecision,viewMode,rowAxisLabel,rowAxisValues,columnAxisLabel,columnAxisValues
Core Services,,The services everything else runs on,true,true,true,ONE_DECIMAL,List,,,,
API,Core Services,,true,true,false,,List,,,,
"Regional Availability",,,true,true,false,,Grid,Service,"Auth, API, Database",Region,"US-East, EU-West"
```

- **A blank cell is left off the create entirely**, so the column default still applies. An import must never decide a toggle the author did not mention.
- Booleans accept `true/false`, `yes/no`, `1/0`; anything else is an error rather than a silent `false`.
- Enums match on letters and digits alone, so `ONE_DECIMAL`, `one decimal` and `99.9% (One Decimal)` all resolve. `showUptimePercent` with no precision defaults to one decimal, mirroring the form.
- The four grid axis columns are an error on a non-`Grid` row — nothing reads them there, and importing them would drop them on the floor without a word.
- Full CSV quoting (embedded commas, `""` escapes, newlines inside cells, CRLF), which is what makes the comma-separated axis lists expressible at all.

## Nesting

Groups nest, so the planner orders rows into dependency batches — a parent defined *later* in the same file is created before its children. Rows that can never be created are reported instead of sent:

- a name already on the status page,
- an unresolvable parent, or a cycle,
- a row that would nest past the limit `StatusPageGroupService` enforces (checked in the preview, so it doesn't come back as an opaque API failure mid-run).

A child whose parent failed to create is **skipped, not created at the top level** — a sub group silently promoted to the root of a public status page is worse than a reported skip. Same for a create that succeeds but returns no id.

`order` is deliberately never written: the service assigns the next one, so an import lands at the bottom instead of shuffling groups that were already there.

## UI

Preview before importing (per-line errors with line numbers), a progress bar during the run, and a per-row created / failed / skipped results table with reasons. Editing the textarea disarms a stale parse; a finished run turns Import into Done; the modal can't be dismissed mid-run. The table behind it refreshes on completion.

The placeholder and the downloadable template are the same constant, and the parser's own suite imports it and proves it parses — a template that fails validation is worse than none.

## Tests

135 tests across three suites:

- `StatusPageGroupCsv.test.ts` (85) — lexing, header validation, quoting, boolean/enum cells, blank-stays-blank, the axis rule, duplicates, batching, the nesting limit (pinned equal to `StatusPageGroupTreeUtil.MaxNestingDepth`), and the shipped example.
- `StatusPageGroupImportRunner.test.ts` (29) — ordering, one-at-a-time creates, partial failure, cascading skips, progress ticks, input immutability.
- `StatusPageGroupImportPageInvariants.test.ts` (21) — the wiring that can only be broken in a prop: overflow-menu styling, the refresh toggle, the stale-parse disarm, the import-time (not mount-time) fetch scoped to this status page, and that `createGroup` writes no `order`, no guessed defaults, and no axis fields off a `Grid` group.

One real defect surfaced while writing these: a row skipped for depth stayed in the pending list and was reported a second time under a different reason. Fixed, with the test that caught it.

Verified: `jest Tests/Dashboard/StatusPageGroup` 135/135 passing, `tsc --noEmit` clean, `eslint --fix` clean.
