### PR TITLE
feat(dashboard): add a Clock widget

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 import DashboardTextComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardTextComponent";
+import DashboardClockComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardClockComponent";
 import DashboardChartComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardChartComponent";
 import DashboardValueComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardValueComponent";
 import DashboardTableComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardTableComponent";
@@ -48,6 +49,7 @@ import DashboardBaseComponent from "Common/Types/Dashboard/DashboardComponents/D
 import DashboardChartComponent from "./DashboardChartComponent";
 import DashboardValueComponent from "./DashboardValueComponent";
 import DashboardTextComponent from "./DashboardTextComponent";
+import DashboardClockComponent from "./DashboardClockComponent";
 import DashboardTableComponent from "./DashboardTableComponent";
 import DashboardGaugeComponent from "./DashboardGaugeComponent";
 import DashboardSloComponent from "./DashboardSloComponent";
@@ -643,6 +645,14 @@ const DashboardBaseComponentElement: FunctionComponent<ComponentProps> = (
             isEditMode={props.isEditMode}
             isSelected={props.isSelected}
             component={component as DashboardTextComponentType}
+          />
+        )}
+        {component.componentType === DashboardComponentType.Clock && (
+          <DashboardClockComponent
+            {...props}
+            isEditMode={props.isEditMode}
+            isSelected={props.isSelected}
+            component={component as DashboardClockComponentType}
           />
         )}
         {component.componentType === DashboardComponentType.Chart && (

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardClockComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardClockComponent.tsx
@@ -1,0 +1,411 @@
+import React, { FunctionComponent, ReactElement, useMemo } from "react";
+import DashboardClockComponentType, {
+  ClockWidgetFace,
+} from "Common/Types/Dashboard/DashboardComponents/DashboardClockComponent";
+import { DashboardBaseComponentProps } from "./DashboardBaseComponent";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import {
+  ClockHandAngles,
+  ClockWidgetDisplay,
+  CLOCK_SECONDARY_FONT_SCALE,
+  getClockAnalogDialSizeInPx,
+  getClockDigitalFontSizeInPx,
+  getClockGmtOffsetText,
+  getClockHandAngles,
+  getClockWidgetDisplay,
+  isDaytimeAtClock,
+  resolveClockFace,
+} from "Common/Utils/Dashboard/ClockWidgetFormat";
+import useClockTick from "Common/UI/Utils/UseClockTick";
+
+export interface ComponentProps extends DashboardBaseComponentProps {
+  component: DashboardClockComponentType;
+}
+
+/*
+ * The dial is drawn in its own 100x100 coordinate space and scaled by the
+ * SVG viewBox, so every number below is a percentage of the dial and the
+ * face stays proportional at any tile size.
+ */
+const DIAL_CENTER: number = 50;
+const DIAL_RADIUS: number = 47;
+
+interface DialTick {
+  key: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  isHour: boolean;
+}
+
+type GetDialTicksFunction = () => Array<DialTick>;
+
+/*
+ * 60 marks: a longer, heavier one every five minutes. Built once at module
+ * load — the geometry never changes, only the hands on top of it do.
+ */
+const getDialTicks: GetDialTicksFunction = (): Array<DialTick> => {
+  const ticks: Array<DialTick> = [];
+
+  for (let minute: number = 0; minute < 60; minute++) {
+    const isHour: boolean = minute % 5 === 0;
+    const angleInRadians: number = (minute * 6 * Math.PI) / 180;
+    const sin: number = Math.sin(angleInRadians);
+    const cos: number = Math.cos(angleInRadians);
+
+    const outerRadius: number = DIAL_RADIUS - 3;
+    const innerRadius: number = outerRadius - (isHour ? 7 : 3);
+
+    ticks.push({
+      key: `tick-${minute}`,
+      x1: DIAL_CENTER + innerRadius * sin,
+      y1: DIAL_CENTER - innerRadius * cos,
+      x2: DIAL_CENTER + outerRadius * sin,
+      y2: DIAL_CENTER - outerRadius * cos,
+      isHour: isHour,
+    });
+  }
+
+  return ticks;
+};
+
+const DIAL_TICKS: Array<DialTick> = getDialTicks();
+
+interface ClockHandProps {
+  angleInDegrees: number;
+  length: number;
+  width: number;
+  color: string;
+  /** How far the hand's tail extends past the centre pin. */
+  tail: number;
+}
+
+const ClockHand: FunctionComponent<ClockHandProps> = (
+  props: ClockHandProps,
+): ReactElement => {
+  return (
+    <line
+      x1={DIAL_CENTER}
+      y1={DIAL_CENTER + props.tail}
+      x2={DIAL_CENTER}
+      y2={DIAL_CENTER - props.length}
+      stroke={props.color}
+      strokeWidth={props.width}
+      strokeLinecap="round"
+      transform={`rotate(${props.angleInDegrees} ${DIAL_CENTER} ${DIAL_CENTER})`}
+    />
+  );
+};
+
+interface AnalogFaceProps {
+  sizeInPx: number;
+  angles: ClockHandAngles;
+  showSeconds: boolean;
+}
+
+const AnalogFace: FunctionComponent<AnalogFaceProps> = (
+  props: AnalogFaceProps,
+): ReactElement => {
+  return (
+    <svg
+      width={props.sizeInPx}
+      height={props.sizeInPx}
+      viewBox="0 0 100 100"
+      role="presentation"
+    >
+      <circle
+        cx={DIAL_CENTER}
+        cy={DIAL_CENTER}
+        r={DIAL_RADIUS}
+        fill="var(--ou-surface-primary, #ffffff)"
+        stroke="var(--ou-border-subtle, #e5e7eb)"
+        strokeWidth={1.5}
+      />
+
+      {DIAL_TICKS.map((tick: DialTick) => {
+        return (
+          <line
+            key={tick.key}
+            x1={tick.x1}
+            y1={tick.y1}
+            x2={tick.x2}
+            y2={tick.y2}
+            stroke={
+              tick.isHour
+                ? "var(--ou-text-muted, #64748b)"
+                : "var(--ou-border-subtle, #e5e7eb)"
+            }
+            strokeWidth={tick.isHour ? 2 : 1}
+            strokeLinecap="round"
+          />
+        );
+      })}
+
+      <ClockHand
+        angleInDegrees={props.angles.hourAngleInDegrees}
+        length={26}
+        width={5}
+        tail={7}
+        color="var(--ou-text-primary, #111827)"
+      />
+      <ClockHand
+        angleInDegrees={props.angles.minuteAngleInDegrees}
+        length={38}
+        width={3.5}
+        tail={9}
+        color="var(--ou-text-primary, #111827)"
+      />
+
+      {props.showSeconds && (
+        <ClockHand
+          angleInDegrees={props.angles.secondAngleInDegrees}
+          length={41}
+          width={1.5}
+          tail={11}
+          color="#ef4444"
+        />
+      )}
+
+      <circle
+        cx={DIAL_CENTER}
+        cy={DIAL_CENTER}
+        r={3}
+        fill="var(--ou-text-primary, #111827)"
+      />
+      {props.showSeconds && (
+        <circle cx={DIAL_CENTER} cy={DIAL_CENTER} r={1.5} fill="#ef4444" />
+      )}
+    </svg>
+  );
+};
+
+/*
+ * A sun or a moon, sized to the caption row. The whole reason to pin another
+ * team's timezone to a wall dashboard is to know at a glance whether paging
+ * them right now means waking someone up, so the glyph carries real meaning
+ * rather than decoration.
+ */
+const DayNightGlyph: FunctionComponent<{ isDaytime: boolean }> = (props: {
+  isDaytime: boolean;
+}): ReactElement => {
+  if (props.isDaytime) {
+    return (
+      <svg
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#f59e0b"
+        strokeWidth="2"
+        strokeLinecap="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#6366f1"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+    </svg>
+  );
+};
+
+const DashboardClockComponentElement: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const showSeconds: boolean = Boolean(props.component.arguments.showSeconds);
+
+  /*
+   * Drift-free and resynced when the tab comes back to the foreground — see
+   * useClockTick for why a plain setInterval is not good enough here.
+   */
+  const now: Date = useClockTick(showSeconds);
+
+  const display: ClockWidgetDisplay = useMemo(() => {
+    return getClockWidgetDisplay({
+      date: now,
+      timezone: props.component.arguments.timezone,
+      label: props.component.arguments.label,
+      hourFormat: props.component.arguments.hourFormat,
+      showSeconds: showSeconds,
+      showDate: props.component.arguments.showDate,
+      showTimezoneAbbreviation:
+        props.component.arguments.showTimezoneAbbreviation,
+    });
+  }, [
+    now,
+    showSeconds,
+    props.component.arguments.timezone,
+    props.component.arguments.label,
+    props.component.arguments.hourFormat,
+    props.component.arguments.showDate,
+    props.component.arguments.showTimezoneAbbreviation,
+  ]);
+
+  const isDaytime: boolean = isDaytimeAtClock({
+    date: now,
+    timezone: display.timezone,
+  });
+
+  const isAnalog: boolean =
+    resolveClockFace(props.component.arguments.clockFace) ===
+    ClockWidgetFace.Analog;
+
+  const captionRow: ReactElement = (
+    <div className="flex items-center justify-center gap-1 max-w-full">
+      <DayNightGlyph isDaytime={isDaytime} />
+      <span
+        className="text-[11px] font-medium text-gray-400 uppercase tracking-wider truncate"
+        title={`${display.label} — ${display.timezone} (${getClockGmtOffsetText(
+          {
+            date: now,
+            timezone: display.timezone,
+          },
+        )})`}
+      >
+        {display.label}
+      </span>
+    </div>
+  );
+
+  const secondaryRows: ReactElement = (
+    <>
+      {display.dateText ? (
+        <div className="text-[11px] text-gray-400 text-center truncate max-w-full">
+          {display.dateText}
+        </div>
+      ) : (
+        <></>
+      )}
+      {display.zoneAbbreviation ? (
+        <div className="text-[11px] text-gray-400 text-center tabular-nums truncate max-w-full">
+          {display.zoneAbbreviation}
+        </div>
+      ) : (
+        <></>
+      )}
+      {display.isFallbackTimezone ? (
+        <div className="text-[10px] text-amber-500 text-center truncate max-w-full">
+          Unknown timezone — showing yours
+        </div>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+
+  if (isAnalog) {
+    const dialSizeInPx: number = getClockAnalogDialSizeInPx({
+      widthInPx: props.dashboardComponentWidthInPx,
+      heightInPx: props.dashboardComponentHeightInPx,
+      display: display,
+      isEditMode: props.isEditMode,
+    });
+
+    const angles: ClockHandAngles = getClockHandAngles({
+      date: now,
+      timezone: display.timezone,
+    });
+
+    return (
+      <div className="w-full h-full flex flex-col items-center justify-center gap-1 overflow-hidden">
+        {captionRow}
+        <AnalogFace
+          sizeInPx={dialSizeInPx}
+          angles={angles}
+          showSeconds={showSeconds}
+        />
+        {secondaryRows}
+      </div>
+    );
+  }
+
+  const timeFontPx: number = getClockDigitalFontSizeInPx({
+    widthInPx: props.dashboardComponentWidthInPx,
+    heightInPx: props.dashboardComponentHeightInPx,
+    display: display,
+    isEditMode: props.isEditMode,
+  });
+
+  const secondaryFontPx: number = timeFontPx * CLOCK_SECONDARY_FONT_SCALE;
+
+  return (
+    <div className="w-full h-full flex flex-col items-center justify-center gap-1 overflow-hidden">
+      {captionRow}
+
+      <div
+        className="flex items-baseline justify-center font-bold text-gray-900 tabular-nums whitespace-nowrap"
+        style={{
+          fontSize: `${timeFontPx}px`,
+          lineHeight: 1.05,
+          letterSpacing: "-0.03em",
+        }}
+      >
+        <span>{display.time}</span>
+        {display.seconds ? (
+          <span
+            className="text-gray-400 font-medium"
+            style={{ fontSize: `${secondaryFontPx}px` }}
+          >
+            :{display.seconds}
+          </span>
+        ) : (
+          <></>
+        )}
+        {display.meridiem ? (
+          <span
+            className="text-gray-400 font-medium tracking-normal"
+            style={{
+              fontSize: `${secondaryFontPx}px`,
+              marginLeft: "0.25em",
+            }}
+          >
+            {display.meridiem}
+          </span>
+        ) : (
+          <></>
+        )}
+      </div>
+
+      {secondaryRows}
+    </div>
+  );
+};
+
+function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
+  /*
+   * refreshTick is deliberately NOT compared: the clock keeps its own time
+   * and re-renders on its own tick, so a dashboard-wide refresh has nothing
+   * to tell it.
+   */
+  if (
+    prev.componentId.toString() !== next.componentId.toString() ||
+    prev.isEditMode !== next.isEditMode ||
+    prev.isSelected !== next.isSelected ||
+    prev.dashboardComponentWidthInPx !== next.dashboardComponentWidthInPx ||
+    prev.dashboardComponentHeightInPx !== next.dashboardComponentHeightInPx
+  ) {
+    return false;
+  }
+
+  return JSONFunctions.deepEqual(
+    prev.component.arguments,
+    next.component.arguments,
+  );
+}
+
+export default React.memo(DashboardClockComponentElement, arePropsEqual);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
@@ -20,6 +20,7 @@ import DashboardBaseComponent from "Common/Types/Dashboard/DashboardComponents/D
 import DashboardChartComponentUtil from "Common/Utils/Dashboard/Components/DashboardChartComponent";
 import DashboardValueComponentUtil from "Common/Utils/Dashboard/Components/DashboardValueComponent";
 import DashboardTextComponentUtil from "Common/Utils/Dashboard/Components/DashboardTextComponent";
+import DashboardClockComponentUtil from "Common/Utils/Dashboard/Components/DashboardClockComponent";
 import DashboardTableComponentUtil from "Common/Utils/Dashboard/Components/DashboardTableComponent";
 import DashboardGaugeComponentUtil from "Common/Utils/Dashboard/Components/DashboardGaugeComponent";
 import DashboardLogStreamComponentUtil from "Common/Utils/Dashboard/Components/DashboardLogStreamComponent";
@@ -534,6 +535,10 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
 
           if (componentType === DashboardComponentType.Text) {
             newComponent = DashboardTextComponentUtil.getDefaultComponent();
+          }
+
+          if (componentType === DashboardComponentType.Clock) {
+            newComponent = DashboardClockComponentUtil.getDefaultComponent();
           }
 
           if (componentType === DashboardComponentType.Table) {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/AddWidgetModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/AddWidgetModal.tsx
@@ -59,6 +59,13 @@ const WIDGET_CATALOG: ReadonlyArray<CatalogCategory> = [
         icon: IconProp.Text,
         description: "Free-form Markdown text for headers and notes.",
       },
+      {
+        type: DashboardComponentType.Clock,
+        label: "Clock",
+        icon: IconProp.Clock,
+        description:
+          "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.",
+      },
     ],
   },
   {

--- a/Common/Tests/UI/Utils/Timezone.test.ts
+++ b/Common/Tests/UI/Utils/Timezone.test.ts
@@ -1,0 +1,86 @@
+/** @timezone UTC */
+
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+import OneUptimeDate, { Moment } from "../../../Types/Date";
+import Timezone from "../../../Types/Timezone";
+import TimezoneUtil from "../../../UI/Utils/Timezone";
+
+describe("TimezoneUtil", () => {
+  describe("getTimezoneDropdownOptions", () => {
+    it("offers a substantial list rather than an empty one", () => {
+      expect(TimezoneUtil.getTimezoneDropdownOptions().length).toBeGreaterThan(
+        100,
+      );
+    });
+
+    it("offers only zones moment can actually resolve to a wall clock", () => {
+      /*
+       * These options feed the on-call rotation engine, SLO windows and the
+       * user's own profile — a zone that cannot be resolved silently
+       * mis-schedules people, so none may be offered.
+       */
+      for (const option of TimezoneUtil.getTimezoneDropdownOptions()) {
+        expect(Moment.tz.zone(String(option.value))).toBeTruthy();
+      }
+    });
+
+    it("drops US/Pacific-New, which the tzdb removed in 2020", () => {
+      const values: Array<string> =
+        TimezoneUtil.getTimezoneDropdownOptions().map(
+          (option: DropdownOption): string => {
+            return String(option.value);
+          },
+        );
+
+      expect(Object.values(Timezone) as Array<string>).toContain(
+        "US/Pacific-New",
+      );
+      expect(values).not.toContain("US/Pacific-New");
+    });
+
+    it("keeps every zone the tzdb still knows about", () => {
+      const values: Array<string> =
+        TimezoneUtil.getTimezoneDropdownOptions().map(
+          (option: DropdownOption): string => {
+            return String(option.value);
+          },
+        );
+
+      const resolvable: Array<string> = (
+        Object.values(Timezone) as Array<string>
+      ).filter((timezone: string): boolean => {
+        return Boolean(Moment.tz.zone(timezone));
+      });
+
+      expect(values.sort()).toEqual(resolvable.sort());
+    });
+
+    it("never emits an empty value", () => {
+      for (const option of TimezoneUtil.getTimezoneDropdownOptions()) {
+        expect(String(option.value).length).toBeGreaterThan(0);
+      }
+    });
+
+    it("labels every option with its GMT offset and zone name", () => {
+      for (const option of TimezoneUtil.getTimezoneDropdownOptions()) {
+        expect(String(option.label)).toMatch(/^GMT[+-]\d/);
+        expect(String(option.label)).toContain(String(option.value));
+      }
+    });
+
+    it("orders the list west to east by GMT offset", () => {
+      const offsets: Array<number> =
+        TimezoneUtil.getTimezoneDropdownOptions().map(
+          (option: DropdownOption): number => {
+            return OneUptimeDate.getGmtOffsetByTimezone(
+              String(option.value) as Timezone,
+            );
+          },
+        );
+
+      for (let index: number = 1; index < offsets.length; index++) {
+        expect(offsets[index]!).toBeGreaterThanOrEqual(offsets[index - 1]!);
+      }
+    });
+  });
+});

--- a/Common/Tests/UI/Utils/UseClockTick.test.tsx
+++ b/Common/Tests/UI/Utils/UseClockTick.test.tsx
@@ -1,0 +1,276 @@
+/** @timezone UTC */
+
+import React, { FunctionComponent, ReactElement } from "react";
+import { act, render, screen } from "@testing-library/react";
+import useClockTick from "../../../UI/Utils/UseClockTick";
+
+const START: Date = new Date("2026-08-03T18:07:09.500Z");
+
+/*
+ * A probe that renders whatever the hook hands back, so the assertions read
+ * the value through a real component lifecycle (mount, re-render, unmount)
+ * rather than poking at the hook in isolation.
+ */
+const ClockProbe: FunctionComponent<{ showSeconds: boolean }> = (props: {
+  showSeconds: boolean;
+}): ReactElement => {
+  const now: Date = useClockTick(props.showSeconds);
+
+  return <div data-testid="now">{now.toISOString()}</div>;
+};
+
+function renderedTime(): string {
+  return screen.getByTestId("now").textContent || "";
+}
+
+/** Move both the clock and the timer queue forward together. */
+function advance(milliseconds: number): void {
+  act(() => {
+    jest.advanceTimersByTime(milliseconds);
+  });
+}
+
+/** Fire the event the browser sends when a tab comes back to the foreground. */
+function becomeVisible(): void {
+  act(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+function becomeHidden(): void {
+  act(() => {
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+describe("useClockTick", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: START });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
+  });
+
+  it("reports the current time on the very first render", () => {
+    render(<ClockProbe showSeconds={true} />);
+
+    expect(renderedTime()).toBe(START.toISOString());
+  });
+
+  describe("second cadence", () => {
+    it("does not advance before the next second boundary", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      advance(499);
+
+      expect(renderedTime()).toBe(START.toISOString());
+    });
+
+    it("advances exactly on the next second boundary", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      advance(500);
+
+      expect(renderedTime()).toBe("2026-08-03T18:07:10.000Z");
+    });
+
+    it("keeps ticking once a second after the first alignment", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      advance(500);
+      advance(1000);
+
+      expect(renderedTime()).toBe("2026-08-03T18:07:11.000Z");
+
+      advance(1000);
+
+      expect(renderedTime()).toBe("2026-08-03T18:07:12.000Z");
+    });
+
+    it("stays aligned to the second rather than drifting off it", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      advance(500);
+
+      for (let tick: number = 0; tick < 30; tick++) {
+        advance(1000);
+      }
+
+      // 30 aligned ticks after 18:07:10 — no accumulated drift.
+      expect(renderedTime()).toBe("2026-08-03T18:07:40.000Z");
+    });
+  });
+
+  describe("minute cadence", () => {
+    it("does not advance part-way through the minute", () => {
+      render(<ClockProbe showSeconds={false} />);
+
+      advance(50499);
+
+      expect(renderedTime()).toBe(START.toISOString());
+    });
+
+    it("advances exactly on the next minute boundary", () => {
+      render(<ClockProbe showSeconds={false} />);
+
+      advance(50500);
+
+      expect(renderedTime()).toBe("2026-08-03T18:08:00.000Z");
+    });
+
+    it("keeps ticking once a minute after the first alignment", () => {
+      render(<ClockProbe showSeconds={false} />);
+
+      advance(50500);
+      advance(60000);
+
+      expect(renderedTime()).toBe("2026-08-03T18:09:00.000Z");
+    });
+
+    it("does not schedule a second-by-second wake-up it does not need", () => {
+      render(<ClockProbe showSeconds={false} />);
+
+      advance(1000);
+      advance(1000);
+
+      expect(renderedTime()).toBe(START.toISOString());
+    });
+  });
+
+  describe("when the tab comes back to the foreground", () => {
+    it("catches up immediately instead of waiting for the throttled timer", () => {
+      render(<ClockProbe showSeconds={false} />);
+
+      /*
+       * Reproduces what a real background tab does: the wall clock moves on
+       * but the throttled timer never fires, so the rendered time goes stale.
+       */
+      becomeHidden();
+      act(() => {
+        jest.setSystemTime(new Date("2026-08-03T18:42:31.000Z"));
+      });
+
+      expect(renderedTime()).toBe(START.toISOString());
+
+      becomeVisible();
+
+      expect(renderedTime()).toBe("2026-08-03T18:42:31.000Z");
+    });
+
+    it("re-aligns the following tick to the new boundary", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      becomeHidden();
+      act(() => {
+        jest.setSystemTime(new Date("2026-08-03T18:42:31.250Z"));
+      });
+      becomeVisible();
+
+      advance(749);
+
+      expect(renderedTime()).toBe("2026-08-03T18:42:31.250Z");
+
+      advance(1);
+
+      expect(renderedTime()).toBe("2026-08-03T18:42:32.000Z");
+    });
+
+    it("ignores the event while the tab is still hidden", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      act(() => {
+        jest.setSystemTime(new Date("2026-08-03T18:42:31.000Z"));
+      });
+      becomeHidden();
+
+      expect(renderedTime()).toBe(START.toISOString());
+    });
+
+    it("does not leave a second timer running after a resync", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      becomeVisible();
+      becomeVisible();
+      becomeVisible();
+
+      /*
+       * Three resyncs must leave exactly one pending timer. A leaked one
+       * would fire alongside it and double-schedule from then on.
+       */
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("stops ticking once the widget is removed from the dashboard", () => {
+      const view: ReturnType<typeof render> = render(
+        <ClockProbe showSeconds={true} />,
+      );
+
+      view.unmount();
+
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it("stops listening for visibility changes once unmounted", () => {
+      const removeSpy: jest.SpyInstance = jest.spyOn(
+        document,
+        "removeEventListener",
+      );
+
+      const view: ReturnType<typeof render> = render(
+        <ClockProbe showSeconds={true} />,
+      );
+
+      view.unmount();
+
+      expect(removeSpy).toHaveBeenCalledWith(
+        "visibilitychange",
+        expect.any(Function),
+      );
+    });
+
+    it("runs exactly one timer per mounted clock", () => {
+      render(<ClockProbe showSeconds={true} />);
+
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe("when the cadence changes", () => {
+    it("switches to the second boundary after seconds are turned on", () => {
+      const view: ReturnType<typeof render> = render(
+        <ClockProbe showSeconds={false} />,
+      );
+
+      view.rerender(<ClockProbe showSeconds={true} />);
+
+      advance(500);
+
+      expect(renderedTime()).toBe("2026-08-03T18:07:10.000Z");
+    });
+
+    it("does not leave the old cadence's timer behind", () => {
+      const view: ReturnType<typeof render> = render(
+        <ClockProbe showSeconds={false} />,
+      );
+
+      view.rerender(<ClockProbe showSeconds={true} />);
+
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+});

--- a/Common/Tests/Utils/Dashboard/ClockWidgetFormat.test.ts
+++ b/Common/Tests/Utils/Dashboard/ClockWidgetFormat.test.ts
@@ -1,0 +1,1374 @@
+/** @timezone UTC */
+
+import {
+  ClockWidgetFace,
+  ClockWidgetHourFormat,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardClockComponent";
+import OneUptimeDate from "../../../Types/Date";
+import Timezone from "../../../Types/Timezone";
+import {
+  ClockContentBox,
+  ClockHandAngles,
+  ClockWidgetDisplay,
+  CLOCK_SECONDARY_FONT_SCALE,
+  getCityFromTimezone,
+  getClockAnalogDialSizeInPx,
+  getClockCaptionLineCount,
+  getClockContentBox,
+  getClockDigitalFontSizeInPx,
+  getClockGmtOffsetText,
+  getClockHandAngles,
+  getClockLabel,
+  getClockTimeWidthInFontUnits,
+  getClockWidgetDisplay,
+  getMillisecondsUntilNextClockTick,
+  isClockTimezoneFallback,
+  isDaytimeAtClock,
+  isSupportedClockTimezone,
+  resolveClockFace,
+  resolveClockTimezone,
+  resolveUse12HourFormat,
+} from "../../../Utils/Dashboard/ClockWidgetFormat";
+
+/*
+ * A Monday afternoon in UTC, deliberately picked so the same instant lands on
+ * three different calendar behaviours: still Monday in the Americas, late
+ * Monday night in India, and already Tuesday in Sydney.
+ */
+const INSTANT: Date = new Date("2026-08-03T18:07:09.500Z");
+
+/** The minimum/maximum the digital font sizer is allowed to return. */
+const MIN_FONT_SIZE_IN_PX: number = 14;
+const MAX_FONT_SIZE_IN_PX: number = 64;
+const MIN_DIAL_SIZE_IN_PX: number = 48;
+
+/** Mirrors the sizer's own reserved space, so the tests can predict it. */
+const SECONDARY_LINE_HEIGHT_IN_PX: number = 16;
+const HORIZONTAL_PADDING_IN_PX: number = 8;
+const VERTICAL_PADDING_IN_PX: number = 4;
+
+/*
+ * The padding DashboardBaseComponent puts around every widget. The canvas
+ * hands the widget its OUTER tile size, so the sizers have to subtract this
+ * before doing anything else.
+ */
+const CHROME_HORIZONTAL_IN_PX: number = 24;
+const CHROME_VERTICAL_IN_PX: number = 24;
+const CHROME_VERTICAL_EDIT_MODE_IN_PX: number = 40;
+
+/** The renderer's `gap-1` and the time row's line-height. */
+const ROW_GAP_IN_PX: number = 4;
+const TIME_LINE_HEIGHT_RATIO: number = 1.05;
+
+/**
+ * The height the widget actually occupies at a given font size — the same
+ * stack the renderer builds. Used to assert it fits rather than restating
+ * the sizer's own arithmetic back at it.
+ */
+function renderedStackHeightInPx(
+  display: ClockWidgetDisplay,
+  fontSizeInPx: number,
+): number {
+  const captionLines: number = getClockCaptionLineCount(display);
+
+  return (
+    fontSizeInPx * TIME_LINE_HEIGHT_RATIO +
+    captionLines * (SECONDARY_LINE_HEIGHT_IN_PX + ROW_GAP_IN_PX)
+  );
+}
+
+function makeDisplay(
+  overrides: Partial<ClockWidgetDisplay> = {},
+): ClockWidgetDisplay {
+  return {
+    label: "London",
+    time: "18:07",
+    seconds: null,
+    meridiem: null,
+    dateText: "Mon, Aug 3",
+    zoneAbbreviation: "UTC",
+    timezone: "UTC",
+    isFallbackTimezone: false,
+    ...overrides,
+  };
+}
+
+describe("ClockWidgetFormat", () => {
+  afterEach(() => {
+    // setUserTimezone is process-wide static state — never leak it between tests.
+    OneUptimeDate.setUserTimezone(null);
+    jest.restoreAllMocks();
+  });
+
+  describe("isSupportedClockTimezone", () => {
+    it("accepts the IANA names the timezone dropdown offers", () => {
+      expect(isSupportedClockTimezone("America/New_York")).toBe(true);
+      expect(isSupportedClockTimezone("Asia/Kolkata")).toBe(true);
+      expect(isSupportedClockTimezone("UTC")).toBe(true);
+      expect(isSupportedClockTimezone("Australia/Sydney")).toBe(true);
+    });
+
+    it("accepts a name with stray whitespace around it", () => {
+      expect(isSupportedClockTimezone("  Europe/London  ")).toBe(true);
+    });
+
+    it("rejects an empty or whitespace-only value", () => {
+      expect(isSupportedClockTimezone("")).toBe(false);
+      expect(isSupportedClockTimezone("   ")).toBe(false);
+    });
+
+    it("rejects null and undefined", () => {
+      expect(isSupportedClockTimezone(null)).toBe(false);
+      expect(isSupportedClockTimezone(undefined)).toBe(false);
+    });
+
+    it("rejects a zone that does not exist, rather than trusting the config", () => {
+      expect(isSupportedClockTimezone("Mars/Olympus_Mons")).toBe(false);
+      expect(isSupportedClockTimezone("America/Not_A_City")).toBe(false);
+    });
+
+    it("rejects a non-string smuggled in by a hand-edited config", () => {
+      expect(isSupportedClockTimezone(42 as unknown as string)).toBe(false);
+      expect(isSupportedClockTimezone({} as unknown as string)).toBe(false);
+    });
+  });
+
+  describe("resolveClockTimezone", () => {
+    it("uses the configured zone when it is one moment knows", () => {
+      expect(resolveClockTimezone("Asia/Tokyo")).toBe("Asia/Tokyo");
+    });
+
+    it("trims the configured zone so a padded value still resolves", () => {
+      expect(resolveClockTimezone("  Asia/Tokyo  ")).toBe("Asia/Tokyo");
+    });
+
+    it("falls back to the viewer's own zone when nothing is configured", () => {
+      OneUptimeDate.setUserTimezone(Timezone.AmericaNew_York);
+
+      expect(resolveClockTimezone("")).toBe(
+        Timezone.AmericaNew_York.toString(),
+      );
+      expect(resolveClockTimezone(undefined)).toBe(
+        Timezone.AmericaNew_York.toString(),
+      );
+    });
+
+    it("falls back rather than throwing when the saved zone no longer exists", () => {
+      OneUptimeDate.setUserTimezone(Timezone.AmericaNew_York);
+
+      expect(resolveClockTimezone("Mars/Olympus_Mons")).toBe(
+        Timezone.AmericaNew_York.toString(),
+      );
+    });
+  });
+
+  describe("isClockTimezoneFallback", () => {
+    it("does not flag a blank zone, which is how you ask for the viewer's own", () => {
+      expect(isClockTimezoneFallback("")).toBe(false);
+      expect(isClockTimezoneFallback("   ")).toBe(false);
+      expect(isClockTimezoneFallback(undefined)).toBe(false);
+      expect(isClockTimezoneFallback(null)).toBe(false);
+    });
+
+    it("does not flag a zone that resolves", () => {
+      expect(isClockTimezoneFallback("Europe/Berlin")).toBe(false);
+    });
+
+    it("flags a zone that was configured but cannot be resolved", () => {
+      expect(isClockTimezoneFallback("Mars/Olympus_Mons")).toBe(true);
+    });
+  });
+
+  describe("getCityFromTimezone", () => {
+    it("takes the city out of a two-part IANA name", () => {
+      expect(getCityFromTimezone("America/New_York")).toBe("New York");
+      expect(getCityFromTimezone("Europe/London")).toBe("London");
+    });
+
+    it("takes the city out of a three-part name", () => {
+      expect(getCityFromTimezone("America/Argentina/Buenos_Aires")).toBe(
+        "Buenos Aires",
+      );
+      expect(getCityFromTimezone("America/Indiana/Indianapolis")).toBe(
+        "Indianapolis",
+      );
+    });
+
+    it("replaces every underscore, not just the first", () => {
+      expect(getCityFromTimezone("America/Port_of_Spain")).toBe(
+        "Port of Spain",
+      );
+    });
+
+    it("leaves a single-segment zone alone", () => {
+      expect(getCityFromTimezone("UTC")).toBe("UTC");
+      expect(getCityFromTimezone("GMT")).toBe("GMT");
+    });
+
+    it("keeps the offset readable for an Etc zone", () => {
+      expect(getCityFromTimezone("Etc/GMT+5")).toBe("GMT+5");
+    });
+
+    it("ignores empty segments from a stray trailing slash", () => {
+      expect(getCityFromTimezone("Europe/Paris/")).toBe("Paris");
+    });
+  });
+
+  describe("getClockLabel", () => {
+    it("prefers the label the author wrote", () => {
+      expect(
+        getClockLabel({ label: "Sydney Office", timezone: "Australia/Sydney" }),
+      ).toBe("Sydney Office");
+    });
+
+    it("trims the author's label", () => {
+      expect(
+        getClockLabel({ label: "  NOC  ", timezone: "Australia/Sydney" }),
+      ).toBe("NOC");
+    });
+
+    it("falls back to the city when no label was written", () => {
+      expect(getClockLabel({ timezone: "Australia/Sydney" })).toBe("Sydney");
+      expect(getClockLabel({ label: "", timezone: "Asia/Kolkata" })).toBe(
+        "Kolkata",
+      );
+    });
+
+    it("falls back when the label is only whitespace", () => {
+      expect(getClockLabel({ label: "   ", timezone: "Europe/Lisbon" })).toBe(
+        "Lisbon",
+      );
+    });
+  });
+
+  describe("resolveUse12HourFormat", () => {
+    it("honours an explicit 12-hour choice", () => {
+      expect(resolveUse12HourFormat(ClockWidgetHourFormat.TwelveHour)).toBe(
+        true,
+      );
+    });
+
+    it("honours an explicit 24-hour choice", () => {
+      expect(resolveUse12HourFormat(ClockWidgetHourFormat.TwentyFourHour)).toBe(
+        false,
+      );
+    });
+
+    it("defers to the viewer's locale on Auto", () => {
+      const spy: jest.SpyInstance = jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(true);
+
+      expect(resolveUse12HourFormat(ClockWidgetHourFormat.Auto)).toBe(true);
+
+      spy.mockReturnValue(false);
+
+      expect(resolveUse12HourFormat(ClockWidgetHourFormat.Auto)).toBe(false);
+    });
+
+    it("defers to the viewer's locale for a config saved before this setting existed", () => {
+      const spy: jest.SpyInstance = jest
+        .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+        .mockReturnValue(true);
+
+      expect(resolveUse12HourFormat(undefined)).toBe(true);
+      expect(resolveUse12HourFormat(null)).toBe(true);
+      expect(
+        resolveUse12HourFormat("Whatever" as unknown as ClockWidgetHourFormat),
+      ).toBe(true);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe("getClockWidgetDisplay", () => {
+    it("reads the instant in the configured zone, not the viewer's", () => {
+      OneUptimeDate.setUserTimezone(Timezone.UTC);
+
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: INSTANT,
+        timezone: "America/New_York",
+        hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+      });
+
+      expect(display.time).toBe("14:07");
+      expect(display.timezone).toBe("America/New_York");
+    });
+
+    it("renders 24-hour time with a zero-padded hour", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: new Date("2026-08-03T06:05:00.000Z"),
+          timezone: "UTC",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        }).time,
+      ).toBe("06:05");
+    });
+
+    it("renders 12-hour time without padding the hour, plus a meridiem", () => {
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: INSTANT,
+        timezone: "America/New_York",
+        hourFormat: ClockWidgetHourFormat.TwelveHour,
+      });
+
+      expect(display.time).toBe("2:07");
+      expect(display.meridiem).toBe("PM");
+    });
+
+    it("has no meridiem at all in 24-hour mode", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: INSTANT,
+          timezone: "UTC",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        }).meridiem,
+      ).toBeNull();
+    });
+
+    it("shows midnight as 12 AM rather than 0 AM", () => {
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: new Date("2026-08-03T00:00:00.000Z"),
+        timezone: "UTC",
+        hourFormat: ClockWidgetHourFormat.TwelveHour,
+      });
+
+      expect(display.time).toBe("12:00");
+      expect(display.meridiem).toBe("AM");
+    });
+
+    it("shows noon as 12 PM rather than 0 PM", () => {
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: new Date("2026-08-03T12:00:00.000Z"),
+        timezone: "UTC",
+        hourFormat: ClockWidgetHourFormat.TwelveHour,
+      });
+
+      expect(display.time).toBe("12:00");
+      expect(display.meridiem).toBe("PM");
+    });
+
+    it("shows midnight as 00:00 in 24-hour mode", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: new Date("2026-08-03T00:00:00.000Z"),
+          timezone: "UTC",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        }).time,
+      ).toBe("00:00");
+    });
+
+    it("handles a half-hour zone offset", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: INSTANT,
+          timezone: "Asia/Kolkata",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        }).time,
+      ).toBe("23:37");
+    });
+
+    it("handles a quarter-hour zone offset", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: INSTANT,
+          timezone: "Asia/Kathmandu",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        }).time,
+      ).toBe("23:52");
+    });
+
+    it("handles a zone that is already on the next calendar day", () => {
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: INSTANT,
+        timezone: "Australia/Sydney",
+        hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        showDate: true,
+      });
+
+      expect(display.time).toBe("04:07");
+      expect(display.dateText).toBe("Tue, Aug 4");
+    });
+
+    it("omits the seconds unless the widget asked for them", () => {
+      expect(
+        getClockWidgetDisplay({ date: INSTANT, timezone: "UTC" }).seconds,
+      ).toBeNull();
+    });
+
+    it("zero-pads the seconds so the digits never reflow", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: new Date("2026-08-03T18:07:09.500Z"),
+          timezone: "UTC",
+          showSeconds: true,
+        }).seconds,
+      ).toBe("09");
+    });
+
+    it("never carries the seconds inside the time string", () => {
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: INSTANT,
+        timezone: "UTC",
+        hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+        showSeconds: true,
+      });
+
+      expect(display.time).toBe("18:07");
+      expect(display.seconds).toBe("09");
+    });
+
+    it("omits the date and the zone abbreviation unless asked for them", () => {
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: INSTANT,
+        timezone: "UTC",
+      });
+
+      expect(display.dateText).toBeNull();
+      expect(display.zoneAbbreviation).toBeNull();
+    });
+
+    it("renders the date with the weekday, so a day-ahead zone is obvious", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: INSTANT,
+          timezone: "UTC",
+          showDate: true,
+        }).dateText,
+      ).toBe("Mon, Aug 3");
+    });
+
+    it("labels the clock from the zone when no label was configured", () => {
+      expect(
+        getClockWidgetDisplay({ date: INSTANT, timezone: "Asia/Kolkata" })
+          .label,
+      ).toBe("Kolkata");
+    });
+
+    it("keeps the author's label when there is one", () => {
+      expect(
+        getClockWidgetDisplay({
+          date: INSTANT,
+          timezone: "Asia/Kolkata",
+          label: "Bangalore Team",
+        }).label,
+      ).toBe("Bangalore Team");
+    });
+
+    it("falls back to the viewer's zone and flags it when the saved zone is gone", () => {
+      OneUptimeDate.setUserTimezone(Timezone.UTC);
+
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: INSTANT,
+        timezone: "Mars/Olympus_Mons",
+        hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+      });
+
+      expect(display.timezone).toBe(Timezone.UTC.toString());
+      expect(display.time).toBe("18:07");
+      expect(display.isFallbackTimezone).toBe(true);
+    });
+
+    it("does not flag a fallback when the author simply left the zone blank", () => {
+      OneUptimeDate.setUserTimezone(Timezone.UTC);
+
+      expect(
+        getClockWidgetDisplay({ date: INSTANT, timezone: "" })
+          .isFallbackTimezone,
+      ).toBe(false);
+    });
+
+    describe("zone abbreviation", () => {
+      it("reports the standard-time abbreviation in winter", () => {
+        expect(
+          getClockWidgetDisplay({
+            date: new Date("2026-01-15T12:00:00.000Z"),
+            timezone: "America/New_York",
+            showTimezoneAbbreviation: true,
+          }).zoneAbbreviation,
+        ).toBe("EST");
+      });
+
+      it("reports the daylight-time abbreviation in summer", () => {
+        expect(
+          getClockWidgetDisplay({
+            date: INSTANT,
+            timezone: "America/New_York",
+            showTimezoneAbbreviation: true,
+          }).zoneAbbreviation,
+        ).toBe("EDT");
+      });
+
+      it("prefixes GMT for a zone whose abbreviation is a bare offset", () => {
+        expect(
+          getClockWidgetDisplay({
+            date: INSTANT,
+            timezone: "Asia/Kathmandu",
+            showTimezoneAbbreviation: true,
+          }).zoneAbbreviation,
+        ).toBe("GMT+0545");
+      });
+    });
+
+    describe("across a daylight-saving transition", () => {
+      it("jumps from 1:59 to 3:00 when the clocks spring forward", () => {
+        const before: ClockWidgetDisplay = getClockWidgetDisplay({
+          date: new Date("2026-03-08T06:59:00.000Z"),
+          timezone: "America/New_York",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+          showTimezoneAbbreviation: true,
+        });
+        const after: ClockWidgetDisplay = getClockWidgetDisplay({
+          date: new Date("2026-03-08T07:00:00.000Z"),
+          timezone: "America/New_York",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+          showTimezoneAbbreviation: true,
+        });
+
+        expect(before.time).toBe("01:59");
+        expect(before.zoneAbbreviation).toBe("EST");
+        expect(after.time).toBe("03:00");
+        expect(after.zoneAbbreviation).toBe("EDT");
+      });
+
+      it("shows 1:00 twice with different zones when the clocks fall back", () => {
+        const firstOnePm: ClockWidgetDisplay = getClockWidgetDisplay({
+          date: new Date("2026-11-01T05:00:00.000Z"),
+          timezone: "America/New_York",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+          showTimezoneAbbreviation: true,
+        });
+        const secondOnePm: ClockWidgetDisplay = getClockWidgetDisplay({
+          date: new Date("2026-11-01T06:00:00.000Z"),
+          timezone: "America/New_York",
+          hourFormat: ClockWidgetHourFormat.TwentyFourHour,
+          showTimezoneAbbreviation: true,
+        });
+
+        expect(firstOnePm.time).toBe("01:00");
+        expect(secondOnePm.time).toBe("01:00");
+        expect(firstOnePm.zoneAbbreviation).toBe("EDT");
+        expect(secondOnePm.zoneAbbreviation).toBe("EST");
+      });
+    });
+  });
+
+  describe("getClockGmtOffsetText", () => {
+    it("reports a whole-hour offset without minutes", () => {
+      expect(
+        getClockGmtOffsetText({ date: INSTANT, timezone: "America/New_York" }),
+      ).toBe("GMT-4");
+    });
+
+    it("reports a half-hour offset", () => {
+      expect(
+        getClockGmtOffsetText({ date: INSTANT, timezone: "Asia/Kolkata" }),
+      ).toBe("GMT+5:30");
+    });
+
+    it("reports a quarter-hour offset", () => {
+      expect(
+        getClockGmtOffsetText({ date: INSTANT, timezone: "Asia/Kathmandu" }),
+      ).toBe("GMT+5:45");
+    });
+
+    it("reports UTC as a zero offset", () => {
+      expect(getClockGmtOffsetText({ date: INSTANT, timezone: "UTC" })).toBe(
+        "GMT+0",
+      );
+    });
+
+    it("uses the offset in force at that instant, not the one in force today", () => {
+      const winter: string = getClockGmtOffsetText({
+        date: new Date("2026-01-15T12:00:00.000Z"),
+        timezone: "America/New_York",
+      });
+      const summer: string = getClockGmtOffsetText({
+        date: INSTANT,
+        timezone: "America/New_York",
+      });
+
+      expect(winter).toBe("GMT-5");
+      expect(summer).toBe("GMT-4");
+    });
+  });
+
+  describe("getClockHandAngles", () => {
+    function anglesAt(isoString: string): ClockHandAngles {
+      return getClockHandAngles({
+        date: new Date(isoString),
+        timezone: "UTC",
+      });
+    }
+
+    it("points every hand straight up at midnight", () => {
+      const angles: ClockHandAngles = anglesAt("2026-08-03T00:00:00.000Z");
+
+      expect(angles.hourAngleInDegrees).toBeCloseTo(0);
+      expect(angles.minuteAngleInDegrees).toBeCloseTo(0);
+      expect(angles.secondAngleInDegrees).toBeCloseTo(0);
+    });
+
+    it("puts the hour hand at a right angle at 3 o'clock", () => {
+      expect(
+        anglesAt("2026-08-03T03:00:00.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(90);
+    });
+
+    it("puts the hour hand straight down at 6 o'clock", () => {
+      expect(
+        anglesAt("2026-08-03T06:00:00.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(180);
+    });
+
+    it("puts the hour hand at three quarters at 9 o'clock", () => {
+      expect(
+        anglesAt("2026-08-03T09:00:00.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(270);
+    });
+
+    it("wraps a 12-hour dial back to the top at noon", () => {
+      expect(
+        anglesAt("2026-08-03T12:00:00.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(0);
+    });
+
+    it("treats the afternoon as its morning equivalent on a 12-hour dial", () => {
+      expect(
+        anglesAt("2026-08-03T15:00:00.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(90);
+      expect(
+        anglesAt("2026-08-03T21:00:00.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(270);
+    });
+
+    it("carries the hour hand half-way between the hours at half past", () => {
+      const angles: ClockHandAngles = anglesAt("2026-08-03T01:30:00.000Z");
+
+      expect(angles.hourAngleInDegrees).toBeCloseTo(45);
+      expect(angles.minuteAngleInDegrees).toBeCloseTo(180);
+    });
+
+    it("creeps the minute hand forward with the seconds", () => {
+      const angles: ClockHandAngles = anglesAt("2026-08-03T00:00:30.000Z");
+
+      expect(angles.minuteAngleInDegrees).toBeCloseTo(3);
+      expect(angles.secondAngleInDegrees).toBeCloseTo(180);
+    });
+
+    it("creeps the hour hand forward with the seconds too", () => {
+      expect(
+        anglesAt("2026-08-03T00:00:30.000Z").hourAngleInDegrees,
+      ).toBeCloseTo(0.25);
+    });
+
+    it("moves the second hand six degrees per second", () => {
+      expect(
+        anglesAt("2026-08-03T00:00:01.000Z").secondAngleInDegrees,
+      ).toBeCloseTo(6);
+      expect(
+        anglesAt("2026-08-03T00:00:59.000Z").secondAngleInDegrees,
+      ).toBeCloseTo(354);
+    });
+
+    it("ignores sub-second time so the second hand ticks rather than sweeps", () => {
+      expect(
+        anglesAt("2026-08-03T00:00:01.900Z").secondAngleInDegrees,
+      ).toBeCloseTo(6);
+    });
+
+    it("keeps every hand inside a single turn at any instant of the day", () => {
+      for (let hour: number = 0; hour < 24; hour++) {
+        const angles: ClockHandAngles = anglesAt(
+          `2026-08-03T${String(hour).padStart(2, "0")}:59:59.000Z`,
+        );
+
+        for (const angle of [
+          angles.hourAngleInDegrees,
+          angles.minuteAngleInDegrees,
+          angles.secondAngleInDegrees,
+        ]) {
+          expect(angle).toBeGreaterThanOrEqual(0);
+          expect(angle).toBeLessThan(360);
+        }
+      }
+    });
+
+    it("reads the hands in the configured zone, not the viewer's", () => {
+      const utc: ClockHandAngles = getClockHandAngles({
+        date: INSTANT,
+        timezone: "UTC",
+      });
+      const kolkata: ClockHandAngles = getClockHandAngles({
+        date: INSTANT,
+        timezone: "Asia/Kolkata",
+      });
+
+      // 18:07 UTC is 23:37 in Kolkata — a different dial position entirely.
+      expect(utc.hourAngleInDegrees).not.toBeCloseTo(
+        kolkata.hourAngleInDegrees,
+      );
+      expect(kolkata.minuteAngleInDegrees).toBeCloseTo((37 + 9 / 60) * 6);
+    });
+
+    it("offsets the hour hand by the half hour on a half-hour zone", () => {
+      const angles: ClockHandAngles = getClockHandAngles({
+        date: new Date("2026-08-03T06:30:00.000Z"),
+        timezone: "Asia/Kolkata",
+      });
+
+      // 06:30 UTC is 12:00 in Kolkata — straight up.
+      expect(angles.hourAngleInDegrees).toBeCloseTo(0);
+      expect(angles.minuteAngleInDegrees).toBeCloseTo(0);
+    });
+  });
+
+  describe("getMillisecondsUntilNextClockTick", () => {
+    it("waits only the remainder of the current second when showing seconds", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("2026-08-03T18:07:09.500Z"),
+          showSeconds: true,
+        }),
+      ).toBe(500);
+    });
+
+    it("waits a single millisecond at the very end of a second", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("2026-08-03T18:07:09.999Z"),
+          showSeconds: true,
+        }),
+      ).toBe(1);
+    });
+
+    it("waits a whole second when landing exactly on a second boundary", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("2026-08-03T18:07:09.000Z"),
+          showSeconds: true,
+        }),
+      ).toBe(1000);
+    });
+
+    it("waits for the next minute boundary when seconds are hidden", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("2026-08-03T18:07:09.500Z"),
+          showSeconds: false,
+        }),
+      ).toBe(50500);
+    });
+
+    it("waits a whole minute when landing exactly on a minute boundary", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("2026-08-03T18:07:00.000Z"),
+          showSeconds: false,
+        }),
+      ).toBe(60000);
+    });
+
+    it("treats an absent showSeconds as minute cadence", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("2026-08-03T18:07:09.500Z"),
+        }),
+      ).toBe(50500);
+    });
+
+    it("stays positive for an instant before 1970, where the remainder is negative", () => {
+      const delay: number = getMillisecondsUntilNextClockTick({
+        date: new Date("1969-07-20T20:17:40.500Z"),
+        showSeconds: true,
+      });
+
+      expect(delay).toBe(500);
+    });
+
+    it("never returns zero, so the caller can never schedule a spinning timer", () => {
+      for (let ms: number = 0; ms < 1000; ms += 37) {
+        const delay: number = getMillisecondsUntilNextClockTick({
+          date: new Date(Date.UTC(2026, 7, 3, 18, 7, 9, ms)),
+          showSeconds: true,
+        });
+
+        expect(delay).toBeGreaterThan(0);
+        expect(delay).toBeLessThanOrEqual(1000);
+      }
+    });
+
+    it("keeps the minute cadence inside one minute for every second of it", () => {
+      for (let second: number = 0; second < 60; second++) {
+        const delay: number = getMillisecondsUntilNextClockTick({
+          date: new Date(Date.UTC(2026, 7, 3, 18, 7, second, 250)),
+          showSeconds: false,
+        });
+
+        expect(delay).toBeGreaterThan(0);
+        expect(delay).toBeLessThanOrEqual(60000);
+      }
+    });
+
+    it("falls back to a full period for an Invalid Date instead of a NaN delay", () => {
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("not a date"),
+          showSeconds: true,
+        }),
+      ).toBe(1000);
+      expect(
+        getMillisecondsUntilNextClockTick({
+          date: new Date("not a date"),
+          showSeconds: false,
+        }),
+      ).toBe(60000);
+    });
+
+    it("lands exactly on the boundary when the delay is applied", () => {
+      const start: Date = new Date("2026-08-03T18:07:09.123Z");
+      const delay: number = getMillisecondsUntilNextClockTick({
+        date: start,
+        showSeconds: true,
+      });
+
+      expect(new Date(start.getTime() + delay).toISOString()).toBe(
+        "2026-08-03T18:07:10.000Z",
+      );
+    });
+  });
+
+  describe("isDaytimeAtClock", () => {
+    it("calls 06:00 the start of the day", () => {
+      expect(
+        isDaytimeAtClock({
+          date: new Date("2026-08-03T06:00:00.000Z"),
+          timezone: "UTC",
+        }),
+      ).toBe(true);
+    });
+
+    it("still calls 05:59 night", () => {
+      expect(
+        isDaytimeAtClock({
+          date: new Date("2026-08-03T05:59:59.000Z"),
+          timezone: "UTC",
+        }),
+      ).toBe(false);
+    });
+
+    it("still calls 17:59 day", () => {
+      expect(
+        isDaytimeAtClock({
+          date: new Date("2026-08-03T17:59:59.000Z"),
+          timezone: "UTC",
+        }),
+      ).toBe(true);
+    });
+
+    it("calls 18:00 the start of the night", () => {
+      expect(
+        isDaytimeAtClock({
+          date: new Date("2026-08-03T18:00:00.000Z"),
+          timezone: "UTC",
+        }),
+      ).toBe(false);
+    });
+
+    it("answers differently for two zones at the same instant", () => {
+      // 18:07 UTC: afternoon in New York, the small hours in Sydney.
+      expect(
+        isDaytimeAtClock({ date: INSTANT, timezone: "America/New_York" }),
+      ).toBe(true);
+      expect(
+        isDaytimeAtClock({ date: INSTANT, timezone: "Australia/Sydney" }),
+      ).toBe(false);
+    });
+
+    it("falls back to the viewer's zone for an unusable one", () => {
+      OneUptimeDate.setUserTimezone(Timezone.UTC);
+
+      expect(
+        isDaytimeAtClock({ date: INSTANT, timezone: "Mars/Olympus_Mons" }),
+      ).toBe(false);
+    });
+  });
+
+  describe("resolveClockFace", () => {
+    it("keeps an explicit analog choice", () => {
+      expect(resolveClockFace(ClockWidgetFace.Analog)).toBe(
+        ClockWidgetFace.Analog,
+      );
+    });
+
+    it("keeps an explicit digital choice", () => {
+      expect(resolveClockFace(ClockWidgetFace.Digital)).toBe(
+        ClockWidgetFace.Digital,
+      );
+    });
+
+    it("defaults to digital for a config that predates the setting", () => {
+      expect(resolveClockFace(undefined)).toBe(ClockWidgetFace.Digital);
+      expect(resolveClockFace(null)).toBe(ClockWidgetFace.Digital);
+    });
+
+    it("defaults to digital rather than rendering nothing for a junk value", () => {
+      expect(resolveClockFace("Sundial" as unknown as ClockWidgetFace)).toBe(
+        ClockWidgetFace.Digital,
+      );
+    });
+  });
+
+  describe("getClockTimeWidthInFontUnits", () => {
+    it("charges full width for the digits themselves", () => {
+      expect(
+        getClockTimeWidthInFontUnits(makeDisplay({ time: "18:07" })),
+      ).toBeCloseTo(5 * 0.62);
+    });
+
+    it("charges a longer time string more", () => {
+      expect(
+        getClockTimeWidthInFontUnits(makeDisplay({ time: "9:07" })),
+      ).toBeLessThan(
+        getClockTimeWidthInFontUnits(makeDisplay({ time: "18:07" })),
+      );
+    });
+
+    it("charges seconds and the meridiem at the reduced size", () => {
+      const bare: number = getClockTimeWidthInFontUnits(
+        makeDisplay({ seconds: null, meridiem: null }),
+      );
+      const withSeconds: number = getClockTimeWidthInFontUnits(
+        makeDisplay({ seconds: "09", meridiem: null }),
+      );
+
+      // ":" + "09" = 3 characters, charged at the secondary scale.
+      expect(withSeconds - bare).toBeCloseTo(
+        3 * CLOCK_SECONDARY_FONT_SCALE * 0.62,
+      );
+    });
+
+    it("charges for both the seconds and the meridiem when both are shown", () => {
+      const bare: number = getClockTimeWidthInFontUnits(
+        makeDisplay({ seconds: null, meridiem: null }),
+      );
+      const both: number = getClockTimeWidthInFontUnits(
+        makeDisplay({ seconds: "09", meridiem: "PM" }),
+      );
+
+      expect(both).toBeGreaterThan(bare);
+    });
+  });
+
+  describe("getClockDigitalFontSizeInPx", () => {
+    it("fills a generous tile up to the maximum size", () => {
+      expect(
+        getClockDigitalFontSizeInPx({
+          widthInPx: 400,
+          heightInPx: 400,
+          display: makeDisplay(),
+        }),
+      ).toBe(MAX_FONT_SIZE_IN_PX);
+    });
+
+    it("never exceeds the maximum however large the tile is", () => {
+      expect(
+        getClockDigitalFontSizeInPx({
+          widthInPx: 4000,
+          heightInPx: 4000,
+          display: makeDisplay(),
+        }),
+      ).toBe(MAX_FONT_SIZE_IN_PX);
+    });
+
+    it("never drops below the readable minimum however small the tile is", () => {
+      expect(
+        getClockDigitalFontSizeInPx({
+          widthInPx: 10,
+          heightInPx: 10,
+          display: makeDisplay(),
+        }),
+      ).toBe(MIN_FONT_SIZE_IN_PX);
+    });
+
+    it("survives a zero-sized tile during the first layout pass", () => {
+      expect(
+        getClockDigitalFontSizeInPx({
+          widthInPx: 0,
+          heightInPx: 0,
+          display: makeDisplay(),
+        }),
+      ).toBe(MIN_FONT_SIZE_IN_PX);
+    });
+
+    it("shrinks the digits when the tile gets narrower", () => {
+      const wide: number = getClockDigitalFontSizeInPx({
+        widthInPx: 240,
+        heightInPx: 240,
+        display: makeDisplay(),
+      });
+      const narrow: number = getClockDigitalFontSizeInPx({
+        widthInPx: 120,
+        heightInPx: 240,
+        display: makeDisplay(),
+      });
+
+      expect(narrow).toBeLessThan(wide);
+    });
+
+    it("shrinks the digits when the tile gets shorter", () => {
+      const tall: number = getClockDigitalFontSizeInPx({
+        widthInPx: 400,
+        heightInPx: 120,
+        display: makeDisplay(),
+      });
+      const short: number = getClockDigitalFontSizeInPx({
+        widthInPx: 400,
+        heightInPx: 70,
+        display: makeDisplay(),
+      });
+
+      expect(short).toBeLessThan(tall);
+    });
+
+    it("leaves less room for the digits as more caption lines are switched on", () => {
+      /*
+       * Height 110 keeps all three variants strictly between the 14px floor
+       * and the 64px ceiling, so the caption lines are what actually decides
+       * the size. Outside that band a clamp would make the comparison pass
+       * vacuously.
+       */
+      const bare: number = getClockDigitalFontSizeInPx({
+        widthInPx: 400,
+        heightInPx: 110,
+        display: makeDisplay({ dateText: null, zoneAbbreviation: null }),
+      });
+      const withDate: number = getClockDigitalFontSizeInPx({
+        widthInPx: 400,
+        heightInPx: 110,
+        display: makeDisplay({ zoneAbbreviation: null }),
+      });
+      const withBoth: number = getClockDigitalFontSizeInPx({
+        widthInPx: 400,
+        heightInPx: 110,
+        display: makeDisplay(),
+      });
+
+      expect(bare).toBeLessThan(MAX_FONT_SIZE_IN_PX);
+      expect(withBoth).toBeGreaterThan(MIN_FONT_SIZE_IN_PX);
+
+      /*
+       * Each caption costs its own line plus the gap above it, and the time
+       * row is line-height taller than its font size — so the font gives up
+       * (line + gap) / lineHeight per caption.
+       */
+      const stepInPx: number =
+        (SECONDARY_LINE_HEIGHT_IN_PX + ROW_GAP_IN_PX) / TIME_LINE_HEIGHT_RATIO;
+
+      expect(withDate).toBeCloseTo(bare - stepInPx);
+      expect(withBoth).toBeCloseTo(withDate - stepInPx);
+    });
+
+    it("shrinks the digits once seconds are added to a width-bound tile", () => {
+      const withoutSeconds: number = getClockDigitalFontSizeInPx({
+        widthInPx: 150,
+        heightInPx: 400,
+        display: makeDisplay({ seconds: null }),
+      });
+      const withSeconds: number = getClockDigitalFontSizeInPx({
+        widthInPx: 150,
+        heightInPx: 400,
+        display: makeDisplay({ seconds: "09" }),
+      });
+
+      expect(withSeconds).toBeLessThan(withoutSeconds);
+    });
+
+    it("keeps the rendered time inside the tile width whenever it is not clamped", () => {
+      const displays: Array<ClockWidgetDisplay> = [
+        makeDisplay(),
+        makeDisplay({ seconds: "09" }),
+        makeDisplay({ time: "11:52", seconds: "09", meridiem: "PM" }),
+        makeDisplay({ time: "9:07", meridiem: "AM" }),
+      ];
+
+      for (const display of displays) {
+        for (const widthInPx of [120, 180, 240, 320, 480]) {
+          const fontSizeInPx: number = getClockDigitalFontSizeInPx({
+            widthInPx: widthInPx,
+            heightInPx: 400,
+            display: display,
+          });
+
+          if (fontSizeInPx <= MIN_FONT_SIZE_IN_PX) {
+            // Legibility wins over fitting; the renderer truncates instead.
+            continue;
+          }
+
+          const renderedWidthInPx: number =
+            fontSizeInPx * getClockTimeWidthInFontUnits(display);
+
+          expect(renderedWidthInPx).toBeLessThanOrEqual(
+            widthInPx - CHROME_HORIZONTAL_IN_PX - HORIZONTAL_PADDING_IN_PX,
+          );
+        }
+      }
+    });
+
+    it("keeps the digits inside the height left over by the caption lines", () => {
+      const display: ClockWidgetDisplay = makeDisplay();
+      const heightInPx: number = 160;
+
+      const fontSizeInPx: number = getClockDigitalFontSizeInPx({
+        widthInPx: 4000,
+        heightInPx: heightInPx,
+        display: display,
+      });
+
+      expect(
+        renderedStackHeightInPx(display, fontSizeInPx),
+      ).toBeLessThanOrEqual(heightInPx - CHROME_VERTICAL_IN_PX);
+    });
+
+    /*
+     * The invariant that matters: whatever the tile size, the stack the
+     * renderer builds has to fit the padded content box, or the tile's
+     * overflow-hidden silently eats the bottom line. The MIN clamp is the one
+     * documented exception — below that we keep the digits legible and let
+     * the caller truncate instead.
+     */
+    it("never builds a stack taller than the content box it has to fit", () => {
+      const displays: Array<ClockWidgetDisplay> = [
+        makeDisplay(),
+        makeDisplay({ dateText: null }),
+        makeDisplay({ dateText: null, zoneAbbreviation: null }),
+        makeDisplay({ seconds: "09", meridiem: "PM" }),
+        makeDisplay({ isFallbackTimezone: true }),
+        makeDisplay({
+          seconds: "09",
+          meridiem: "PM",
+          isFallbackTimezone: true,
+        }),
+      ];
+
+      for (const display of displays) {
+        for (const heightInPx of [60, 80, 100, 140, 200, 260, 360, 520]) {
+          for (const isEditMode of [false, true]) {
+            const fontSizeInPx: number = getClockDigitalFontSizeInPx({
+              widthInPx: 540,
+              heightInPx: heightInPx,
+              display: display,
+              isEditMode: isEditMode,
+            });
+
+            if (fontSizeInPx <= MIN_FONT_SIZE_IN_PX) {
+              continue;
+            }
+
+            const contentHeightInPx: number =
+              heightInPx -
+              (isEditMode
+                ? CHROME_VERTICAL_EDIT_MODE_IN_PX
+                : CHROME_VERTICAL_IN_PX);
+
+            expect(
+              renderedStackHeightInPx(display, fontSizeInPx),
+            ).toBeLessThanOrEqual(contentHeightInPx);
+          }
+        }
+      }
+    });
+
+    /*
+     * The canvas reports the OUTER tile size while the widget draws inside
+     * DashboardBaseComponent's padding. Sizing against the outer box pushed
+     * the last caption line past the tile's overflow-hidden edge — most
+     * visible on a short, wide strip.
+     */
+    it("sizes against the padded content box, not the outer tile", () => {
+      const display: ClockWidgetDisplay = makeDisplay();
+      // 130 keeps the result off both clamps so the arithmetic is observable.
+      const heightInPx: number = 130;
+
+      const outerSized: number = getClockDigitalFontSizeInPx({
+        widthInPx: 4000,
+        heightInPx: heightInPx,
+        display: display,
+      });
+      const asIfNoChrome: number = getClockDigitalFontSizeInPx({
+        widthInPx: 4000,
+        heightInPx: heightInPx + CHROME_VERTICAL_IN_PX,
+        display: display,
+      });
+
+      // The chrome costs exactly its own height, no more and no less.
+      expect(asIfNoChrome).toBeGreaterThan(outerSized);
+      expect(renderedStackHeightInPx(display, outerSized)).toBeLessThanOrEqual(
+        heightInPx - CHROME_VERTICAL_IN_PX,
+      );
+    });
+
+    it("gives up more height in edit mode, where the drag handle sits", () => {
+      const display: ClockWidgetDisplay = makeDisplay();
+
+      const viewing: number = getClockDigitalFontSizeInPx({
+        widthInPx: 4000,
+        heightInPx: 130,
+        display: display,
+      });
+      const editing: number = getClockDigitalFontSizeInPx({
+        widthInPx: 4000,
+        heightInPx: 130,
+        display: display,
+        isEditMode: true,
+      });
+
+      expect(viewing).toBeLessThan(MAX_FONT_SIZE_IN_PX);
+      expect(viewing - editing).toBeCloseTo(
+        (CHROME_VERTICAL_EDIT_MODE_IN_PX - CHROME_VERTICAL_IN_PX) /
+          TIME_LINE_HEIGHT_RATIO,
+      );
+    });
+
+    it("fits everything a 6x1 strip has to show without clipping a line", () => {
+      /*
+       * The regression this guards: a 540x80 strip showing label + time +
+       * zone had its zone line clipped, because the digits were sized as if
+       * the full 80px were available and as if the time row were exactly its
+       * font size tall.
+       */
+      const display: ClockWidgetDisplay = makeDisplay({ dateText: null });
+
+      const fontSizeInPx: number = getClockDigitalFontSizeInPx({
+        widthInPx: 540,
+        heightInPx: 80,
+        display: display,
+      });
+
+      expect(
+        renderedStackHeightInPx(display, fontSizeInPx),
+      ).toBeLessThanOrEqual(80 - CHROME_VERTICAL_IN_PX);
+    });
+  });
+
+  describe("getClockContentBox", () => {
+    it("subtracts the widget chrome from the outer tile", () => {
+      expect(getClockContentBox({ widthInPx: 300, heightInPx: 200 })).toEqual({
+        widthInPx: 300 - CHROME_HORIZONTAL_IN_PX,
+        heightInPx: 200 - CHROME_VERTICAL_IN_PX,
+      });
+    });
+
+    it("subtracts the taller chrome in edit mode, where the drag handle sits", () => {
+      expect(
+        getClockContentBox({
+          widthInPx: 300,
+          heightInPx: 200,
+          isEditMode: true,
+        }),
+      ).toEqual({
+        widthInPx: 300 - CHROME_HORIZONTAL_IN_PX,
+        heightInPx: 200 - CHROME_VERTICAL_EDIT_MODE_IN_PX,
+      });
+    });
+
+    it("never reports a negative box for a tile smaller than its own chrome", () => {
+      const box: ClockContentBox = getClockContentBox({
+        widthInPx: 4,
+        heightInPx: 4,
+        isEditMode: true,
+      });
+
+      expect(box.widthInPx).toBe(0);
+      expect(box.heightInPx).toBe(0);
+    });
+
+    it("survives a zero-sized tile during the first layout pass", () => {
+      expect(getClockContentBox({ widthInPx: 0, heightInPx: 0 })).toEqual({
+        widthInPx: 0,
+        heightInPx: 0,
+      });
+    });
+  });
+
+  describe("getClockAnalogDialSizeInPx", () => {
+    it("fits the dial to the shorter side of the tile", () => {
+      expect(
+        getClockAnalogDialSizeInPx({
+          widthInPx: 400,
+          heightInPx: 200,
+          display: makeDisplay({ dateText: null, zoneAbbreviation: null }),
+        }),
+      ).toBe(
+        200 -
+          CHROME_VERTICAL_IN_PX -
+          (SECONDARY_LINE_HEIGHT_IN_PX + ROW_GAP_IN_PX) -
+          VERTICAL_PADDING_IN_PX,
+      );
+    });
+
+    it("is bound by the width on a wide-but-short tile's narrow sibling", () => {
+      expect(
+        getClockAnalogDialSizeInPx({
+          widthInPx: 120,
+          heightInPx: 400,
+          display: makeDisplay({ dateText: null, zoneAbbreviation: null }),
+        }),
+      ).toBe(120 - CHROME_HORIZONTAL_IN_PX - HORIZONTAL_PADDING_IN_PX);
+    });
+
+    it("shrinks the dial in edit mode, where the drag handle takes the top", () => {
+      const viewing: number = getClockAnalogDialSizeInPx({
+        widthInPx: 400,
+        heightInPx: 300,
+        display: makeDisplay(),
+      });
+      const editing: number = getClockAnalogDialSizeInPx({
+        widthInPx: 400,
+        heightInPx: 300,
+        display: makeDisplay(),
+        isEditMode: true,
+      });
+
+      expect(viewing - editing).toBe(
+        CHROME_VERTICAL_EDIT_MODE_IN_PX - CHROME_VERTICAL_IN_PX,
+      );
+    });
+
+    it("gives back the height taken by each caption line", () => {
+      const bare: number = getClockAnalogDialSizeInPx({
+        widthInPx: 400,
+        heightInPx: 300,
+        display: makeDisplay({ dateText: null, zoneAbbreviation: null }),
+      });
+      const withBoth: number = getClockAnalogDialSizeInPx({
+        widthInPx: 400,
+        heightInPx: 300,
+        display: makeDisplay(),
+      });
+
+      expect(bare - withBoth).toBe(
+        2 * (SECONDARY_LINE_HEIGHT_IN_PX + ROW_GAP_IN_PX),
+      );
+    });
+
+    it("never collapses below a legible dial on a tiny tile", () => {
+      expect(
+        getClockAnalogDialSizeInPx({
+          widthInPx: 20,
+          heightInPx: 20,
+          display: makeDisplay(),
+        }),
+      ).toBe(MIN_DIAL_SIZE_IN_PX);
+    });
+
+    it("survives a zero-sized tile during the first layout pass", () => {
+      expect(
+        getClockAnalogDialSizeInPx({
+          widthInPx: 0,
+          heightInPx: 0,
+          display: makeDisplay(),
+        }),
+      ).toBe(MIN_DIAL_SIZE_IN_PX);
+    });
+  });
+});

--- a/Common/Tests/Utils/Dashboard/DashboardClockComponent.test.ts
+++ b/Common/Tests/Utils/Dashboard/DashboardClockComponent.test.ts
@@ -1,0 +1,362 @@
+/** @timezone UTC */
+
+import {
+  ComponentArgument,
+  ComponentInputType,
+} from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
+import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import DashboardClockComponent, {
+  ClockWidgetFace,
+  ClockWidgetHourFormat,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardClockComponent";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import { ObjectType } from "../../../Types/JSON";
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+import DashboardClockComponentUtil from "../../../Utils/Dashboard/Components/DashboardClockComponent";
+import DashboardComponentsUtil from "../../../Utils/Dashboard/Components/Index";
+import {
+  ClockWidgetDisplay,
+  getClockWidgetDisplay,
+  isSupportedClockTimezone,
+} from "../../../Utils/Dashboard/ClockWidgetFormat";
+
+type ArgumentIds = keyof DashboardClockComponent["arguments"];
+
+function getArguments(): Array<ComponentArgument<DashboardClockComponent>> {
+  return DashboardClockComponentUtil.getComponentConfigArguments();
+}
+
+function getArgumentById(
+  id: ArgumentIds,
+): ComponentArgument<DashboardClockComponent> {
+  const found: ComponentArgument<DashboardClockComponent> | undefined =
+    getArguments().find((arg: ComponentArgument<DashboardClockComponent>) => {
+      return arg.id === id;
+    });
+
+  if (!found) {
+    throw new Error(`No Clock widget argument declared with id "${id}"`);
+  }
+
+  return found;
+}
+
+describe("DashboardClockComponentUtil", () => {
+  describe("getDefaultComponent", () => {
+    it("declares its componentType as Clock so the renderer dispatch matches", () => {
+      expect(
+        DashboardClockComponentUtil.getDefaultComponent().componentType,
+      ).toBe(DashboardComponentType.Clock);
+    });
+
+    it("marks itself as a dashboard component so it survives config serialization", () => {
+      expect(DashboardClockComponentUtil.getDefaultComponent()._type).toBe(
+        ObjectType.DashboardComponent,
+      );
+    });
+
+    it("defaults to a 3x3 tile placed at the canvas origin", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(component.widthInDashboardUnits).toBe(3);
+      expect(component.heightInDashboardUnits).toBe(3);
+      expect(component.topInDashboardUnits).toBe(0);
+      expect(component.leftInDashboardUnits).toBe(0);
+    });
+
+    it("declares a minimum no larger than its default size", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(component.minWidthInDashboardUnits).toBeLessThanOrEqual(
+        component.widthInDashboardUnits,
+      );
+      expect(component.minHeightInDashboardUnits).toBeLessThanOrEqual(
+        component.heightInDashboardUnits,
+      );
+    });
+
+    it("can be squeezed down to a single-row strip for a header of clocks", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(component.minHeightInDashboardUnits).toBe(1);
+      expect(component.minWidthInDashboardUnits).toBe(2);
+    });
+
+    it("fits within the dashboard's 12-unit width", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(component.widthInDashboardUnits).toBeLessThanOrEqual(12);
+    });
+
+    it("leaves the timezone blank so a freshly dropped clock shows the viewer's own time", () => {
+      expect(
+        DashboardClockComponentUtil.getDefaultComponent().arguments.timezone,
+      ).toBe("");
+    });
+
+    it("defaults to a digital face on the viewer's own time format", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(component.arguments.clockFace).toBe(ClockWidgetFace.Digital);
+      expect(component.arguments.hourFormat).toBe(ClockWidgetHourFormat.Auto);
+    });
+
+    it("shows the date and zone but not seconds by default", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(component.arguments.showDate).toBe(true);
+      expect(component.arguments.showTimezoneAbbreviation).toBe(true);
+      expect(component.arguments.showSeconds).toBe(false);
+    });
+
+    it("gives every new clock its own component id", () => {
+      const first: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+      const second: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      expect(first.componentId.toString()).not.toBe(
+        second.componentId.toString(),
+      );
+    });
+
+    it("renders a real time straight out of the box, before any configuration", () => {
+      const component: DashboardClockComponent =
+        DashboardClockComponentUtil.getDefaultComponent();
+
+      const display: ClockWidgetDisplay = getClockWidgetDisplay({
+        date: new Date("2026-08-03T18:07:09.500Z"),
+        timezone: component.arguments.timezone,
+        label: component.arguments.label,
+        hourFormat: component.arguments.hourFormat,
+        showSeconds: component.arguments.showSeconds,
+        showDate: component.arguments.showDate,
+        showTimezoneAbbreviation: component.arguments.showTimezoneAbbreviation,
+      });
+
+      expect(display.time).toMatch(/^\d{1,2}:\d{2}$/);
+      expect(display.label.length).toBeGreaterThan(0);
+      expect(display.dateText).not.toBeNull();
+      expect(display.zoneAbbreviation).not.toBeNull();
+      expect(display.seconds).toBeNull();
+      // A blank zone is a deliberate "use the viewer's", not a broken config.
+      expect(display.isFallbackTimezone).toBe(false);
+    });
+  });
+
+  describe("getComponentConfigArguments", () => {
+    it("exposes exactly the arguments the widget interface declares", () => {
+      const ids: Array<unknown> = getArguments().map(
+        (arg: ComponentArgument<DashboardClockComponent>): unknown => {
+          return arg.id;
+        },
+      );
+
+      expect(ids.sort()).toEqual(
+        [
+          "clockFace",
+          "hourFormat",
+          "label",
+          "showDate",
+          "showSeconds",
+          "showTimezoneAbbreviation",
+          "timezone",
+        ].sort(),
+      );
+    });
+
+    it("gives every argument a name and a description for the settings form", () => {
+      for (const arg of getArguments()) {
+        expect(arg.name.length).toBeGreaterThan(0);
+        expect(arg.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("puts every argument in a section so none float above the form", () => {
+      for (const arg of getArguments()) {
+        expect(arg.section).toBeDefined();
+        expect(arg.section?.name.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("orders the timezone section ahead of the display options", () => {
+      const timezoneOrder: number =
+        getArgumentById("timezone").section?.order ?? 0;
+      const clockFaceOrder: number =
+        getArgumentById("clockFace").section?.order ?? 0;
+
+      expect(timezoneOrder).toBeLessThan(clockFaceOrder);
+    });
+
+    it("requires nothing, because an unconfigured clock is already useful", () => {
+      for (const arg of getArguments()) {
+        expect(arg.required).toBe(false);
+      }
+    });
+
+    it("gives every dropdown a non-empty option list", () => {
+      const dropdowns: Array<ComponentArgument<DashboardClockComponent>> =
+        getArguments().filter(
+          (arg: ComponentArgument<DashboardClockComponent>): boolean => {
+            return arg.type === ComponentInputType.Dropdown;
+          },
+        );
+
+      expect(dropdowns.length).toBeGreaterThan(0);
+
+      for (const arg of dropdowns) {
+        expect(arg.dropdownOptions?.length).toBeGreaterThan(0);
+      }
+    });
+
+    describe("timezone argument", () => {
+      it("is a dropdown rather than free text, so no one can type an invalid zone", () => {
+        expect(getArgumentById("timezone").type).toBe(
+          ComponentInputType.Dropdown,
+        );
+      });
+
+      it("offers the whole IANA catalogue", () => {
+        expect(
+          getArgumentById("timezone").dropdownOptions?.length,
+        ).toBeGreaterThan(100);
+      });
+
+      it("offers only zones the widget can actually resolve", () => {
+        const options: Array<DropdownOption> =
+          getArgumentById("timezone").dropdownOptions || [];
+
+        for (const option of options) {
+          expect(isSupportedClockTimezone(String(option.value))).toBe(true);
+        }
+      });
+
+      it("labels each zone with its GMT offset so the list is scannable", () => {
+        const options: Array<DropdownOption> =
+          getArgumentById("timezone").dropdownOptions || [];
+
+        for (const option of options) {
+          expect(String(option.label)).toMatch(/^GMT[+-]/);
+        }
+      });
+
+      it("tells the author that leaving it blank means the viewer's zone", () => {
+        expect(getArgumentById("timezone").placeholder).toBe(
+          "Viewer's timezone",
+        );
+      });
+
+      it("builds the option list once and reuses it, so typing in the form stays fast", () => {
+        /*
+         * ArgumentsForm re-derives the arguments on every render — i.e. on
+         * every keystroke — and this list costs a ~556-entry sort with two
+         * moment.tz() calls per comparison. Same array identity proves the
+         * module-level cache is doing its job.
+         */
+        expect(getArgumentById("timezone").dropdownOptions).toBe(
+          getArgumentById("timezone").dropdownOptions,
+        );
+      });
+    });
+
+    describe("clockFace argument", () => {
+      it("offers exactly the faces the renderer knows how to draw", () => {
+        const values: Array<unknown> = (
+          getArgumentById("clockFace").dropdownOptions || []
+        ).map((option: DropdownOption): unknown => {
+          return option.value;
+        });
+
+        expect(values).toEqual(
+          Object.values(ClockWidgetFace) as Array<unknown>,
+        );
+      });
+    });
+
+    describe("hourFormat argument", () => {
+      it("offers exactly the formats the resolver handles", () => {
+        const values: Array<unknown> = (
+          getArgumentById("hourFormat").dropdownOptions || []
+        ).map((option: DropdownOption): unknown => {
+          return option.value;
+        });
+
+        expect(values).toEqual(
+          Object.values(ClockWidgetHourFormat) as Array<unknown>,
+        );
+      });
+
+      it("leads with Auto, which is also the default", () => {
+        expect(getArgumentById("hourFormat").dropdownOptions?.[0]?.value).toBe(
+          ClockWidgetHourFormat.Auto,
+        );
+      });
+    });
+
+    describe("toggles", () => {
+      it("renders each show/hide option as a boolean toggle", () => {
+        for (const id of [
+          "showSeconds",
+          "showDate",
+          "showTimezoneAbbreviation",
+        ] as Array<ArgumentIds>) {
+          expect(getArgumentById(id).type).toBe(ComponentInputType.Boolean);
+        }
+      });
+
+      it("renders the label as plain text", () => {
+        expect(getArgumentById("label").type).toBe(ComponentInputType.Text);
+      });
+    });
+  });
+
+  /*
+   * The registry is the seam between the widget and the settings form: a
+   * widget that is not wired in throws BadDataException the moment its
+   * settings panel opens.
+   */
+  describe("registration in DashboardComponentsUtil", () => {
+    it("resolves DashboardComponentType.Clock instead of throwing for an unknown type", () => {
+      expect(() => {
+        return DashboardComponentsUtil.getComponentSettingsArguments(
+          DashboardComponentType.Clock,
+        );
+      }).not.toThrow();
+    });
+
+    it("returns the Clock widget's own arguments for DashboardComponentType.Clock", () => {
+      const fromRegistry: Array<ComponentArgument<DashboardBaseComponent>> =
+        DashboardComponentsUtil.getComponentSettingsArguments(
+          DashboardComponentType.Clock,
+        );
+
+      expect(
+        fromRegistry.map(
+          (arg: ComponentArgument<DashboardBaseComponent>): unknown => {
+            return arg.id;
+          },
+        ),
+      ).toEqual(
+        getArguments().map(
+          (arg: ComponentArgument<DashboardClockComponent>): unknown => {
+            return arg.id;
+          },
+        ),
+      );
+    });
+
+    it("still throws for a component type that is not registered", () => {
+      expect(() => {
+        return DashboardComponentsUtil.getComponentSettingsArguments(
+          "NotARealWidget" as DashboardComponentType,
+        );
+      }).toThrow();
+    });
+  });
+});

--- a/Common/Types/Dashboard/DashboardComponentType.ts
+++ b/Common/Types/Dashboard/DashboardComponentType.ts
@@ -2,6 +2,7 @@ enum DashboardComponentType {
   Chart = `Chart`,
   Value = `Value`,
   Text = `Text`,
+  Clock = `Clock`,
   Table = `Table`,
   Gauge = `Gauge`,
   LogStream = `LogStream`,

--- a/Common/Types/Dashboard/DashboardComponents/DashboardClockComponent.ts
+++ b/Common/Types/Dashboard/DashboardComponents/DashboardClockComponent.ts
@@ -1,0 +1,45 @@
+import ObjectID from "../../ObjectID";
+import DashboardComponentType from "../DashboardComponentType";
+import BaseComponent from "./DashboardBaseComponent";
+
+/** How the time is drawn — digits, or a drawn clock face. */
+export enum ClockWidgetFace {
+  Digital = "Digital",
+  Analog = "Analog",
+}
+
+/**
+ * 12h vs 24h. `Auto` follows whatever the viewer's browser locale implies
+ * (OneUptimeDate.getUserPrefers12HourFormat), so a dashboard shared between a
+ * US and a European team reads naturally for both without either of them
+ * having to re-configure the widget.
+ */
+export enum ClockWidgetHourFormat {
+  Auto = "Auto",
+  TwelveHour = "12 Hour",
+  TwentyFourHour = "24 Hour",
+}
+
+export default interface DashboardClockComponent extends BaseComponent {
+  componentType: DashboardComponentType.Clock;
+  componentId: ObjectID;
+  arguments: {
+    /*
+     * IANA zone name (e.g. "America/New_York"), matching the values in the
+     * Timezone enum. Empty means "the zone the viewer is reading this in",
+     * which is what a single clock on a personal dashboard should do.
+     */
+    timezone?: string | undefined;
+    /*
+     * Caption under the time. Empty falls back to the city in the IANA name
+     * ("Asia/Kolkata" -> "Kolkata"), so an unconfigured clock is still
+     * labelled.
+     */
+    label?: string | undefined;
+    clockFace?: ClockWidgetFace | undefined;
+    hourFormat?: ClockWidgetHourFormat | undefined;
+    showSeconds?: boolean | undefined;
+    showDate?: boolean | undefined;
+    showTimezoneAbbreviation?: boolean | undefined;
+  };
+}

--- a/Common/UI/Utils/Timezone.ts
+++ b/Common/UI/Utils/Timezone.ts
@@ -1,10 +1,26 @@
 import Timezone from "../../Types/Timezone";
 import { DropdownOption } from "../Components/Dropdown/Dropdown";
-import OneUptimeDate from "../../Types/Date";
+import OneUptimeDate, { Moment } from "../../Types/Date";
 
 export default class TimezoneUtil {
   public static getTimezoneDropdownOptions(): DropdownOption[] {
-    let timezoneOptions: Array<string> = Object.keys(Timezone);
+    /*
+     * The Timezone enum outlives the tzdb, so it can still list a zone the
+     * bundled moment-timezone has since dropped ("US/Pacific-New", removed in
+     * tzdata 2020b). Offering one is a trap: every consumer of the choice —
+     * the on-call rotation engine, the SLO windows, this user's own profile —
+     * then holds a zone that cannot be resolved to a wall clock. Filter them
+     * out at the source rather than leave each caller to discover it.
+     */
+    let timezoneOptions: Array<string> = Object.keys(Timezone).filter(
+      (key: string): boolean => {
+        const timezone: Timezone = Timezone[key as keyof typeof Timezone];
+
+        return (
+          Boolean(timezone) && Boolean(Moment.tz.zone(timezone.toString()))
+        );
+      },
+    );
 
     // order timezone by GMT offset.
 

--- a/Common/UI/Utils/UseClockTick.ts
+++ b/Common/UI/Utils/UseClockTick.ts
@@ -1,0 +1,78 @@
+import { getMillisecondsUntilNextClockTick } from "../../Utils/Dashboard/ClockWidgetFormat";
+import { useEffect, useState } from "react";
+
+/**
+ * The current time, re-read once a second (or once a minute) and kept honest.
+ *
+ * Two things go wrong with the obvious `setInterval(1000)` version, and both
+ * are handled here rather than in the widget that renders the digits:
+ *
+ * 1. Drift. An interval accumulates every scheduling delay, so a clock left
+ *    open all day slides behind the real one and eventually skips a second
+ *    outright. Re-arming a timeout to the next real boundary after each tick
+ *    keeps the displayed second in step however late a callback runs.
+ *
+ * 2. Background tabs. Browsers throttle timers hard in a tab that is not
+ *    visible — to once a minute or less, and effectively not at all in a tab
+ *    that has stopped compositing. A dashboard left on a second monitor and
+ *    come back to would otherwise show a time minutes out of date until its
+ *    next throttled tick, which is the one moment a clock must not lie. The
+ *    visibilitychange listener re-reads the time and re-arms the moment the
+ *    tab comes back.
+ *
+ * @param showSeconds - tick every second when true, every minute when false.
+ */
+export type UseClockTickFunction = (showSeconds: boolean) => Date;
+
+const useClockTick: UseClockTickFunction = (showSeconds: boolean): Date => {
+  const [now, setNow] = useState<Date>(() => {
+    return new Date();
+  });
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const clearPendingTick: () => void = (): void => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+
+    const scheduleNextTick: () => void = (): void => {
+      const current: Date = new Date();
+
+      setNow(current);
+
+      timeoutId = setTimeout(
+        scheduleNextTick,
+        getMillisecondsUntilNextClockTick({
+          date: current,
+          showSeconds: showSeconds,
+        }),
+      );
+    };
+
+    const resyncOnVisible: () => void = (): void => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      // Drop the throttled timer and restart from the real current time.
+      clearPendingTick();
+      scheduleNextTick();
+    };
+
+    scheduleNextTick();
+    document.addEventListener("visibilitychange", resyncOnVisible);
+
+    return () => {
+      clearPendingTick();
+      document.removeEventListener("visibilitychange", resyncOnVisible);
+    };
+  }, [showSeconds]);
+
+  return now;
+};
+
+export default useClockTick;

--- a/Common/Utils/Dashboard/ClockWidgetFormat.ts
+++ b/Common/Utils/Dashboard/ClockWidgetFormat.ts
@@ -1,0 +1,604 @@
+import {
+  ClockWidgetFace,
+  ClockWidgetHourFormat,
+} from "../../Types/Dashboard/DashboardComponents/DashboardClockComponent";
+import OneUptimeDate, { Moment } from "../../Types/Date";
+import Timezone from "../../Types/Timezone";
+import type { Moment as MomentType } from "moment-timezone";
+
+/**
+ * Every derivation the dashboard Clock widget needs to turn "now" into what
+ * it draws — the digit strings, the caption, the analog hand angles, and how
+ * long to sleep before the next repaint.
+ *
+ * It all lives here rather than in the React renderer because the interesting
+ * cases are all clock arithmetic and none of them need a DOM: half-hour and
+ * quarter-hour zone offsets, DST jumps, midnight/noon in 12-hour form, a
+ * timezone that no longer exists, and hand angles that have to stay smooth
+ * across the top of the hour.
+ */
+
+/** Degrees swept per second (and per minute) — a full turn over 60 steps. */
+const DEGREES_PER_SECOND: number = 6;
+
+/** Degrees swept per hour on a 12-hour dial. */
+const DEGREES_PER_HOUR: number = 30;
+
+const MILLISECONDS_PER_SECOND: number = 1000;
+const MILLISECONDS_PER_MINUTE: number = 60 * MILLISECONDS_PER_SECOND;
+
+/** Local hour at which the widget starts calling it daytime (inclusive). */
+const DAY_STARTS_AT_HOUR: number = 6;
+
+/** Local hour at which the widget stops calling it daytime (exclusive). */
+const DAY_ENDS_AT_HOUR: number = 18;
+
+/**
+ * True when moment-timezone knows the zone. A dashboard config outlives the
+ * tzdb release it was written against, so a zone can be renamed or dropped
+ * (and a hand-edited config can hold anything at all) — every entry point
+ * below has to survive that rather than render "Invalid date".
+ */
+export type IsSupportedClockTimezoneFunction = (
+  timezone: string | undefined | null,
+) => boolean;
+
+export const isSupportedClockTimezone: IsSupportedClockTimezoneFunction = (
+  timezone: string | undefined | null,
+): boolean => {
+  if (typeof timezone !== "string") {
+    return false;
+  }
+
+  const trimmed: string = timezone.trim();
+
+  if (!trimmed) {
+    return false;
+  }
+
+  return Boolean(Moment.tz.zone(trimmed));
+};
+
+/**
+ * The zone the clock should actually be read in: the configured one when it
+ * is usable, otherwise the viewer's own. Falling back (rather than erroring)
+ * keeps an unconfigured, freshly-dropped widget showing a real time.
+ */
+export type ResolveClockTimezoneFunction = (
+  timezone: string | undefined | null,
+) => string;
+
+export const resolveClockTimezone: ResolveClockTimezoneFunction = (
+  timezone: string | undefined | null,
+): string => {
+  if (isSupportedClockTimezone(timezone)) {
+    return (timezone as string).trim();
+  }
+
+  return OneUptimeDate.getCurrentTimezone().toString();
+};
+
+/**
+ * The city out of an IANA name — "America/New_York" -> "New York",
+ * "America/Argentina/Buenos_Aires" -> "Buenos Aires", "UTC" -> "UTC".
+ * Used as the caption when the author did not write one, because
+ * "America/Argentina/Buenos_Aires" does not fit in a 3-unit tile.
+ */
+export type GetCityFromTimezoneFunction = (timezone: string) => string;
+
+export const getCityFromTimezone: GetCityFromTimezoneFunction = (
+  timezone: string,
+): string => {
+  const segments: Array<string> = timezone
+    .split("/")
+    .map((segment: string): string => {
+      return segment.trim();
+    })
+    .filter((segment: string): boolean => {
+      return segment.length > 0;
+    });
+
+  const lastSegment: string | undefined = segments[segments.length - 1];
+
+  if (!lastSegment) {
+    return timezone.trim();
+  }
+
+  return lastSegment.replace(/_/g, " ");
+};
+
+/**
+ * The caption under the time: the author's label if they wrote one, else the
+ * city of the zone being shown. Never the raw IANA path.
+ */
+export type GetClockLabelFunction = (data: {
+  label?: string | undefined;
+  timezone: string;
+}) => string;
+
+export const getClockLabel: GetClockLabelFunction = (data: {
+  label?: string | undefined;
+  timezone: string;
+}): string => {
+  const trimmedLabel: string = (data.label || "").trim();
+
+  if (trimmedLabel) {
+    return trimmedLabel;
+  }
+
+  return getCityFromTimezone(data.timezone);
+};
+
+/**
+ * Resolve the 12/24-hour choice. `Auto` (and anything unrecognised, which is
+ * what an older saved config holds) defers to the viewer's browser locale.
+ */
+export type ResolveUse12HourFormatFunction = (
+  hourFormat: ClockWidgetHourFormat | undefined | null,
+) => boolean;
+
+export const resolveUse12HourFormat: ResolveUse12HourFormatFunction = (
+  hourFormat: ClockWidgetHourFormat | undefined | null,
+): boolean => {
+  if (hourFormat === ClockWidgetHourFormat.TwelveHour) {
+    return true;
+  }
+
+  if (hourFormat === ClockWidgetHourFormat.TwentyFourHour) {
+    return false;
+  }
+
+  return OneUptimeDate.getUserPrefers12HourFormat();
+};
+
+export interface ClockWidgetDisplay {
+  /** Caption under the time. */
+  label: string;
+  /** "9:05" (12h) or "21:05" (24h) — never carries seconds. */
+  time: string;
+  /** "07", or null when the widget is configured without seconds. */
+  seconds: string | null;
+  /** "AM" / "PM" in 12-hour mode, null in 24-hour mode. */
+  meridiem: string | null;
+  /** "Mon, Aug 3", or null when the date is switched off. */
+  dateText: string | null;
+  /** DST-aware "EDT" / "GMT+05:30", or null when switched off. */
+  zoneAbbreviation: string | null;
+  /** The zone the strings above were resolved in. */
+  timezone: string;
+  /**
+   * True only when the author DID configure a zone and it turned out to be
+   * unusable, so the renderer can say so. Leaving the zone blank is the
+   * documented way to ask for the viewer's own zone and is not flagged.
+   */
+  isFallbackTimezone: boolean;
+}
+
+/**
+ * Did a configured zone get silently swapped for the viewer's own? True only
+ * when something was actually configured — an empty value means "use the
+ * viewer's zone", which is a choice rather than a failure.
+ */
+export type IsClockTimezoneFallbackFunction = (
+  timezone: string | undefined | null,
+) => boolean;
+
+export const isClockTimezoneFallback: IsClockTimezoneFallbackFunction = (
+  timezone: string | undefined | null,
+): boolean => {
+  if (typeof timezone !== "string" || !timezone.trim()) {
+    return false;
+  }
+
+  return !isSupportedClockTimezone(timezone);
+};
+
+/**
+ * Everything the digital face draws, for one instant.
+ *
+ * Seconds and meridiem come back separately from the time so the renderer can
+ * set them in a smaller type beside the big digits without re-parsing a
+ * formatted string.
+ */
+export type GetClockWidgetDisplayFunction = (data: {
+  date: Date;
+  timezone?: string | undefined;
+  label?: string | undefined;
+  hourFormat?: ClockWidgetHourFormat | undefined;
+  showSeconds?: boolean | undefined;
+  showDate?: boolean | undefined;
+  showTimezoneAbbreviation?: boolean | undefined;
+}) => ClockWidgetDisplay;
+
+export const getClockWidgetDisplay: GetClockWidgetDisplayFunction = (data: {
+  date: Date;
+  timezone?: string | undefined;
+  label?: string | undefined;
+  hourFormat?: ClockWidgetHourFormat | undefined;
+  showSeconds?: boolean | undefined;
+  showDate?: boolean | undefined;
+  showTimezoneAbbreviation?: boolean | undefined;
+}): ClockWidgetDisplay => {
+  const isFallbackTimezone: boolean = isClockTimezoneFallback(data.timezone);
+  const timezone: string = resolveClockTimezone(data.timezone);
+  const use12HourFormat: boolean = resolveUse12HourFormat(data.hourFormat);
+
+  const zoned: MomentType = Moment(data.date).tz(timezone);
+
+  return {
+    label: getClockLabel({ label: data.label, timezone: timezone }),
+    time: zoned.format(use12HourFormat ? "h:mm" : "HH:mm"),
+    seconds: data.showSeconds ? zoned.format("ss") : null,
+    meridiem: use12HourFormat ? zoned.format("A") : null,
+    dateText: data.showDate ? zoned.format("ddd, MMM D") : null,
+    zoneAbbreviation: data.showTimezoneAbbreviation
+      ? OneUptimeDate.getZoneAbbrByTimezone(timezone as Timezone, data.date)
+      : null,
+    timezone: timezone,
+    isFallbackTimezone: isFallbackTimezone,
+  };
+};
+
+/**
+ * "GMT+5:30" for the instant given — computed at `date` rather than at "now"
+ * so a clock rendered either side of a DST boundary reports the offset that
+ * actually applies to the time on its face.
+ */
+export type GetClockGmtOffsetTextFunction = (data: {
+  date: Date;
+  timezone: string;
+}) => string;
+
+export const getClockGmtOffsetText: GetClockGmtOffsetTextFunction = (data: {
+  date: Date;
+  timezone: string;
+}): string => {
+  const timezone: string = resolveClockTimezone(data.timezone);
+  const offsetInMinutes: number = Moment(data.date).tz(timezone).utcOffset();
+
+  return OneUptimeDate.getGmtOffsetFriendlyString(offsetInMinutes);
+};
+
+export interface ClockHandAngles {
+  /** Degrees clockwise from 12 o'clock. */
+  hourAngleInDegrees: number;
+  minuteAngleInDegrees: number;
+  secondAngleInDegrees: number;
+}
+
+/**
+ * Where the three hands point, in degrees clockwise from 12.
+ *
+ * The hour and minute hands carry the fraction of the smaller unit (the hour
+ * hand sits half-way between 3 and 4 at 3:30) — a dial whose hour hand jumps
+ * only on the hour reads as broken. The second hand ticks whole seconds,
+ * which is both what a real clock does and all the resolution the widget's
+ * once-a-second repaint can show.
+ */
+export type GetClockHandAnglesFunction = (data: {
+  date: Date;
+  timezone?: string | undefined;
+}) => ClockHandAngles;
+
+export const getClockHandAngles: GetClockHandAnglesFunction = (data: {
+  date: Date;
+  timezone?: string | undefined;
+}): ClockHandAngles => {
+  const timezone: string = resolveClockTimezone(data.timezone);
+  const zoned: MomentType = Moment(data.date).tz(timezone);
+
+  const seconds: number = zoned.seconds();
+  const minutes: number = zoned.minutes();
+  const hours: number = zoned.hours() % 12;
+
+  return {
+    hourAngleInDegrees:
+      (hours + minutes / 60 + seconds / 3600) * DEGREES_PER_HOUR,
+    minuteAngleInDegrees: (minutes + seconds / 60) * DEGREES_PER_SECOND,
+    secondAngleInDegrees: seconds * DEGREES_PER_SECOND,
+  };
+};
+
+/**
+ * How long to wait before repainting, aligned to the next second (or minute)
+ * boundary rather than a flat 1000ms.
+ *
+ * A plain setInterval(1000) accumulates every scheduling delay, so a clock
+ * left open drifts visibly and eventually skips a second outright. Re-arming
+ * to the boundary each tick keeps the displayed second in step with the real
+ * one no matter how late a given callback runs.
+ *
+ * Zone offsets are all whole minutes, so the sub-minute remainder is the same
+ * in every timezone and the instant alone answers this.
+ */
+export type GetMillisecondsUntilNextClockTickFunction = (data: {
+  date: Date;
+  showSeconds?: boolean | undefined;
+}) => number;
+
+export const getMillisecondsUntilNextClockTick: GetMillisecondsUntilNextClockTickFunction =
+  (data: { date: Date; showSeconds?: boolean | undefined }): number => {
+    const period: number = data.showSeconds
+      ? MILLISECONDS_PER_SECOND
+      : MILLISECONDS_PER_MINUTE;
+
+    const timeInMs: number = data.date.getTime();
+
+    if (!isFinite(timeInMs)) {
+      // An Invalid Date must not turn into a NaN (i.e. immediate) timeout.
+      return period;
+    }
+
+    /*
+     * `%` keeps the sign of the dividend, and pre-1970 instants are negative
+     * — normalise so the remainder is always the distance *past* the last
+     * boundary.
+     */
+    const sinceLastBoundary: number = ((timeInMs % period) + period) % period;
+    const untilNextBoundary: number = period - sinceLastBoundary;
+
+    /*
+     * Exactly on a boundary the remainder is 0 and this yields a full period,
+     * which is correct: the next boundary is one period away. The result is
+     * therefore always in 1..period and never 0, so the caller can never
+     * schedule a zero-delay timer that spins.
+     */
+    return untilNextBoundary;
+  };
+
+/**
+ * Whether it is daytime where the clock is pointed (06:00–17:59 local).
+ *
+ * The renderer uses this for the sun/moon glyph, which is the whole point of
+ * putting another team's zone on a wall dashboard: you want to see at a
+ * glance whether paging Sydney right now means waking someone up.
+ */
+export type IsDaytimeAtClockFunction = (data: {
+  date: Date;
+  timezone?: string | undefined;
+}) => boolean;
+
+export const isDaytimeAtClock: IsDaytimeAtClockFunction = (data: {
+  date: Date;
+  timezone?: string | undefined;
+}): boolean => {
+  const timezone: string = resolveClockTimezone(data.timezone);
+  const hour: number = Moment(data.date).tz(timezone).hours();
+
+  return hour >= DAY_STARTS_AT_HOUR && hour < DAY_ENDS_AT_HOUR;
+};
+
+/**
+ * Seconds and the AM/PM marker are drawn at this fraction of the main time
+ * size, so they read as annotations rather than competing with the digits.
+ * The width estimate below has to know it too.
+ */
+export const CLOCK_SECONDARY_FONT_SCALE: number = 0.45;
+
+/** Advance width of one tabular-numeral, as a fraction of the font size. */
+const TABULAR_DIGIT_WIDTH_RATIO: number = 0.62;
+
+/** Vertical space one secondary line (label / date / zone) occupies. */
+const SECONDARY_LINE_HEIGHT_IN_PX: number = 16;
+
+/** The `gap-1` the renderer puts between every stacked row. */
+const CLOCK_ROW_GAP_IN_PX: number = 4;
+
+/** line-height on the time row, so its box is taller than the font size. */
+const CLOCK_TIME_LINE_HEIGHT_RATIO: number = 1.05;
+
+/**
+ * Padding the widget chrome puts between the tile edge and the widget's own
+ * content box. Mirrors DashboardBaseComponent, which wraps every widget in
+ * `padding: 12px`, widened to `28px 12px 12px 12px` in edit mode to leave room
+ * for the drag handle it overlays on the top of the tile.
+ *
+ * The canvas hands each widget its OUTER tile size, so a sizer that does not
+ * subtract this overflows the content box — most visibly on a short tile,
+ * where the last caption line gets clipped by the tile's overflow-hidden.
+ */
+const CLOCK_CHROME_HORIZONTAL_IN_PX: number = 24;
+const CLOCK_CHROME_VERTICAL_IN_PX: number = 24;
+const CLOCK_CHROME_VERTICAL_EDIT_MODE_IN_PX: number = 40;
+
+/** Breathing room kept inside the content box so nothing sits flush. */
+const CLOCK_HORIZONTAL_PADDING_IN_PX: number = 8;
+const CLOCK_VERTICAL_PADDING_IN_PX: number = 4;
+
+const MIN_CLOCK_FONT_SIZE_IN_PX: number = 14;
+const MAX_CLOCK_FONT_SIZE_IN_PX: number = 64;
+const MIN_ANALOG_DIAL_SIZE_IN_PX: number = 48;
+
+export interface ClockContentBox {
+  widthInPx: number;
+  heightInPx: number;
+}
+
+/**
+ * How many single-line rows sit alongside the clock face: the label, plus
+ * whichever of the date, the zone and the unknown-zone warning are showing.
+ *
+ * The warning row counts too — it is the case where the widget has the MOST
+ * to fit, so leaving it out of the budget clips exactly the message the user
+ * needs to read.
+ */
+export type GetClockCaptionLineCountFunction = (
+  display: ClockWidgetDisplay,
+) => number;
+
+export const getClockCaptionLineCount: GetClockCaptionLineCountFunction = (
+  display: ClockWidgetDisplay,
+): number => {
+  return (
+    1 +
+    (display.dateText ? 1 : 0) +
+    (display.zoneAbbreviation ? 1 : 0) +
+    (display.isFallbackTimezone ? 1 : 0)
+  );
+};
+
+/**
+ * Height the caption rows claim, including the flex gap above each of them.
+ * The face itself is the row they are stacked around, so the gap count equals
+ * the caption count.
+ */
+type GetCaptionStackHeightFunction = (captionLineCount: number) => number;
+
+const getCaptionStackHeightInPx: GetCaptionStackHeightFunction = (
+  captionLineCount: number,
+): number => {
+  return captionLineCount * (SECONDARY_LINE_HEIGHT_IN_PX + CLOCK_ROW_GAP_IN_PX);
+};
+
+/**
+ * Turn the OUTER tile size the dashboard canvas reports into the box the
+ * widget actually gets to draw in, by subtracting the padding the widget
+ * chrome adds around it.
+ *
+ * Edit mode is not cosmetic here: the drag handle takes another 16px off the
+ * top, so a clock that only just fits while viewing would have its bottom
+ * caption clipped the moment the dashboard is edited.
+ */
+export type GetClockContentBoxFunction = (data: {
+  widthInPx: number;
+  heightInPx: number;
+  isEditMode?: boolean | undefined;
+}) => ClockContentBox;
+
+export const getClockContentBox: GetClockContentBoxFunction = (data: {
+  widthInPx: number;
+  heightInPx: number;
+  isEditMode?: boolean | undefined;
+}): ClockContentBox => {
+  const verticalChrome: number = data.isEditMode
+    ? CLOCK_CHROME_VERTICAL_EDIT_MODE_IN_PX
+    : CLOCK_CHROME_VERTICAL_IN_PX;
+
+  return {
+    widthInPx: Math.max(data.widthInPx - CLOCK_CHROME_HORIZONTAL_IN_PX, 0),
+    heightInPx: Math.max(data.heightInPx - verticalChrome, 0),
+  };
+};
+
+/**
+ * How wide the time reads, in multiples of the main font size — the digits at
+ * full size plus the seconds and meridiem at their reduced size. Used to size
+ * the digits to the tile instead of letting a long "12:34:56 PM" overflow a
+ * narrow one.
+ */
+export type GetClockTimeWidthInFontUnitsFunction = (
+  display: ClockWidgetDisplay,
+) => number;
+
+export const getClockTimeWidthInFontUnits: GetClockTimeWidthInFontUnitsFunction =
+  (display: ClockWidgetDisplay): number => {
+    // ":" + "ss", and " " + "AM", each drawn at the secondary size.
+    const secondsChars: number = display.seconds
+      ? (display.seconds.length + 1) * CLOCK_SECONDARY_FONT_SCALE
+      : 0;
+    const meridiemChars: number = display.meridiem
+      ? (display.meridiem.length + 1) * CLOCK_SECONDARY_FONT_SCALE
+      : 0;
+
+    return (
+      (display.time.length + secondsChars + meridiemChars) *
+      TABULAR_DIGIT_WIDTH_RATIO
+    );
+  };
+
+/**
+ * The font size for the digital face: as large as the tile allows, bounded by
+ * BOTH the height left over after the caption lines and the width the digits
+ * need. Clamped so a 1-unit-tall tile still shows readable digits and a huge
+ * tile does not turn the time into a billboard.
+ */
+export type GetClockDigitalFontSizeInPxFunction = (data: {
+  widthInPx: number;
+  heightInPx: number;
+  display: ClockWidgetDisplay;
+  isEditMode?: boolean | undefined;
+}) => number;
+
+export const getClockDigitalFontSizeInPx: GetClockDigitalFontSizeInPxFunction =
+  (data: {
+    widthInPx: number;
+    heightInPx: number;
+    display: ClockWidgetDisplay;
+    isEditMode?: boolean | undefined;
+  }): number => {
+    const contentBox: ClockContentBox = getClockContentBox(data);
+
+    /*
+     * Divide by the line-height ratio rather than treating the font size as
+     * the row height: at `line-height: 1.05` the time row's box is taller
+     * than its font size, and that difference is enough to push the last
+     * caption past the tile's overflow-hidden edge on a short strip.
+     */
+    const heightBudget: number = Math.max(
+      (contentBox.heightInPx -
+        getCaptionStackHeightInPx(getClockCaptionLineCount(data.display)) -
+        CLOCK_VERTICAL_PADDING_IN_PX) /
+        CLOCK_TIME_LINE_HEIGHT_RATIO,
+      MIN_CLOCK_FONT_SIZE_IN_PX,
+    );
+
+    const widthBudget: number = Math.max(
+      contentBox.widthInPx - CLOCK_HORIZONTAL_PADDING_IN_PX,
+      MIN_CLOCK_FONT_SIZE_IN_PX,
+    );
+
+    const widthLimited: number =
+      widthBudget / getClockTimeWidthInFontUnits(data.display);
+
+    return Math.max(
+      Math.min(heightBudget, widthLimited, MAX_CLOCK_FONT_SIZE_IN_PX),
+      MIN_CLOCK_FONT_SIZE_IN_PX,
+    );
+  };
+
+/**
+ * Diameter of the analog dial: the largest circle that fits once the caption
+ * lines below it have taken their share of the height.
+ */
+export type GetClockAnalogDialSizeInPxFunction = (data: {
+  widthInPx: number;
+  heightInPx: number;
+  display: ClockWidgetDisplay;
+  isEditMode?: boolean | undefined;
+}) => number;
+
+export const getClockAnalogDialSizeInPx: GetClockAnalogDialSizeInPxFunction =
+  (data: {
+    widthInPx: number;
+    heightInPx: number;
+    display: ClockWidgetDisplay;
+    isEditMode?: boolean | undefined;
+  }): number => {
+    const contentBox: ClockContentBox = getClockContentBox(data);
+
+    const availableHeight: number =
+      contentBox.heightInPx -
+      getCaptionStackHeightInPx(getClockCaptionLineCount(data.display)) -
+      CLOCK_VERTICAL_PADDING_IN_PX;
+
+    const availableWidth: number =
+      contentBox.widthInPx - CLOCK_HORIZONTAL_PADDING_IN_PX;
+
+    return Math.max(
+      Math.min(availableWidth, availableHeight),
+      MIN_ANALOG_DIAL_SIZE_IN_PX,
+    );
+  };
+
+/** Normalise a possibly-absent saved value to a face the renderer handles. */
+export type ResolveClockFaceFunction = (
+  clockFace: ClockWidgetFace | undefined | null,
+) => ClockWidgetFace;
+
+export const resolveClockFace: ResolveClockFaceFunction = (
+  clockFace: ClockWidgetFace | undefined | null,
+): ClockWidgetFace => {
+  return clockFace === ClockWidgetFace.Analog
+    ? ClockWidgetFace.Analog
+    : ClockWidgetFace.Digital;
+};

--- a/Common/Utils/Dashboard/Components/DashboardClockComponent.ts
+++ b/Common/Utils/Dashboard/Components/DashboardClockComponent.ts
@@ -1,0 +1,181 @@
+import {
+  ComponentArgument,
+  ComponentArgumentSection,
+  ComponentInputType,
+} from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
+import DashboardClockComponent, {
+  ClockWidgetFace,
+  ClockWidgetHourFormat,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardClockComponent";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import { ObjectType } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+import TimezoneUtil from "../../../UI/Utils/Timezone";
+import DashboardBaseComponentUtil from "./DashboardBaseComponent";
+
+const ClockSection: ComponentArgumentSection = {
+  name: "Clock",
+  description: "Which timezone this clock shows",
+  order: 1,
+};
+
+const DisplaySection: ComponentArgumentSection = {
+  name: "Display Options",
+  description: "Face, time format, and what to show alongside the time",
+  order: 2,
+  defaultCollapsed: true,
+};
+
+/*
+ * Built once and reused. ArgumentsForm calls getComponentSettingsArguments on
+ * every render — i.e. on every keystroke in the settings panel — and building
+ * this list sorts ~400 zones with two moment.tz() calls per comparison, which
+ * is more than enough to make typing in the panel feel laggy. The catalogue of
+ * zones does not change while the tab is open.
+ */
+let cachedTimezoneOptions: Array<DropdownOption> | null = null;
+
+type GetTimezoneOptionsFunction = () => Array<DropdownOption>;
+
+const getTimezoneOptions: GetTimezoneOptionsFunction =
+  (): Array<DropdownOption> => {
+    if (!cachedTimezoneOptions) {
+      cachedTimezoneOptions = TimezoneUtil.getTimezoneDropdownOptions();
+    }
+
+    return cachedTimezoneOptions;
+  };
+
+export default class DashboardClockComponentUtil extends DashboardBaseComponentUtil {
+  public static override getDefaultComponent(): DashboardClockComponent {
+    return {
+      _type: ObjectType.DashboardComponent,
+      componentType: DashboardComponentType.Clock,
+      /*
+       * Same footprint as the Gauge and SLO tiles, so a row of clocks lines
+       * up with the other single-value widgets. 3x3 is also the smallest
+       * square that fits a legible analog face plus its caption.
+       */
+      widthInDashboardUnits: 3,
+      heightInDashboardUnits: 3,
+      topInDashboardUnits: 0,
+      leftInDashboardUnits: 0,
+      componentId: ObjectID.generate(),
+      minHeightInDashboardUnits: 1,
+      minWidthInDashboardUnits: 2,
+      arguments: {
+        /*
+         * Empty timezone means "wherever the viewer is". A clock dropped on
+         * a dashboard is immediately correct and useful before it is
+         * configured at all, which is not true if we guessed a city.
+         */
+        timezone: "",
+        label: "",
+        clockFace: ClockWidgetFace.Digital,
+        hourFormat: ClockWidgetHourFormat.Auto,
+        showSeconds: false,
+        showDate: true,
+        showTimezoneAbbreviation: true,
+      },
+    };
+  }
+
+  public static override getComponentConfigArguments(): Array<
+    ComponentArgument<DashboardClockComponent>
+  > {
+    const componentArguments: Array<
+      ComponentArgument<DashboardClockComponent>
+    > = [];
+
+    componentArguments.push({
+      name: "Timezone",
+      description:
+        "The timezone this clock reads in. Leave empty to use the timezone of whoever is viewing the dashboard.",
+      required: false,
+      type: ComponentInputType.Dropdown,
+      id: "timezone",
+      placeholder: "Viewer's timezone",
+      section: ClockSection,
+      /*
+       * The full IANA list, ordered by GMT offset and labelled
+       * "GMT+5:30 Asia/Kolkata" — the same options and ordering the user
+       * already picks their timezone from in User Settings.
+       */
+      dropdownOptions: getTimezoneOptions(),
+    });
+
+    componentArguments.push({
+      name: "Label",
+      description:
+        "Caption under the time. Defaults to the city in the timezone, so use this for a team or office name instead.",
+      required: false,
+      type: ComponentInputType.Text,
+      id: "label",
+      placeholder: "Sydney Office",
+      section: ClockSection,
+    });
+
+    componentArguments.push({
+      name: "Clock Face",
+      description: "Digital digits, or a drawn analog dial",
+      required: false,
+      type: ComponentInputType.Dropdown,
+      id: "clockFace",
+      placeholder: "Digital",
+      section: DisplaySection,
+      dropdownOptions: [
+        { label: "Digital", value: ClockWidgetFace.Digital },
+        { label: "Analog", value: ClockWidgetFace.Analog },
+      ],
+    });
+
+    componentArguments.push({
+      name: "Time Format",
+      description:
+        "Auto follows the viewer's own locale, so one dashboard reads naturally for teams in different countries.",
+      required: false,
+      type: ComponentInputType.Dropdown,
+      id: "hourFormat",
+      placeholder: "Auto",
+      section: DisplaySection,
+      dropdownOptions: [
+        { label: "Auto (viewer's locale)", value: ClockWidgetHourFormat.Auto },
+        { label: "12 Hour", value: ClockWidgetHourFormat.TwelveHour },
+        { label: "24 Hour", value: ClockWidgetHourFormat.TwentyFourHour },
+      ],
+    });
+
+    componentArguments.push({
+      name: "Show Seconds",
+      description:
+        "Tick every second instead of every minute. Off by default — a wall dashboard rarely needs it.",
+      required: false,
+      type: ComponentInputType.Boolean,
+      id: "showSeconds",
+      section: DisplaySection,
+    });
+
+    componentArguments.push({
+      name: "Show Date",
+      description:
+        "Show the day and date under the time — worth keeping on when the zone is a day ahead or behind.",
+      required: false,
+      type: ComponentInputType.Boolean,
+      id: "showDate",
+      section: DisplaySection,
+    });
+
+    componentArguments.push({
+      name: "Show Timezone",
+      description:
+        "Show the zone abbreviation (EDT, GMT+05:30) so the time is never ambiguous.",
+      required: false,
+      type: ComponentInputType.Boolean,
+      id: "showTimezoneAbbreviation",
+      section: DisplaySection,
+    });
+
+    return componentArguments;
+  }
+}

--- a/Common/Utils/Dashboard/Components/Index.ts
+++ b/Common/Utils/Dashboard/Components/Index.ts
@@ -6,6 +6,7 @@ import DashboardAlertListComponentUtil from "./DashboardAlertListComponent";
 import DashboardCephOsdListComponentUtil from "./DashboardCephOsdListComponent";
 import DashboardCephPoolListComponentUtil from "./DashboardCephPoolListComponent";
 import DashboardChartComponentUtil from "./DashboardChartComponent";
+import DashboardClockComponentUtil from "./DashboardClockComponent";
 import DashboardDockerContainerListComponentUtil from "./DashboardDockerContainerListComponent";
 import DashboardDockerHostListComponentUtil from "./DashboardDockerHostListComponent";
 import DashboardDockerImageListComponentUtil from "./DashboardDockerImageListComponent";
@@ -54,6 +55,12 @@ export default class DashboardComponentsUtil {
 
     if (dashboardComponentType === DashboardComponentType.Text) {
       return DashboardTextComponentUtil.getComponentConfigArguments() as Array<
+        ComponentArgument<DashboardBaseComponent>
+      >;
+    }
+
+    if (dashboardComponentType === DashboardComponentType.Clock) {
+      return DashboardClockComponentUtil.getComponentConfigArguments() as Array<
         ComponentArgument<DashboardBaseComponent>
       >;
     }


### PR DESCRIPTION
Adds a **Clock** widget to dashboards — the current time in any timezone, digital or analog.

The use case is a NOC wall or a shared team dashboard: drop one clock per office and you can see at a glance whether paging Sydney right now means waking someone up. That's what the sun/moon glyph next to each label is for.

## Configuration

| Setting | Notes |
|---|---|
| **Timezone** | Full IANA list. Blank means "whoever is viewing the dashboard", so a clock is correct the moment it is dropped. |
| **Label** | Caption under the time. Defaults to the city in the zone name (`Asia/Kolkata` → "Kolkata"), so use it for a team or office name. |
| **Clock Face** | Digital digits, or a drawn analog dial. |
| **Time Format** | Auto / 12h / 24h. Auto follows the viewer's own locale, so one shared dashboard reads naturally for teams in different countries. |
| **Show Seconds / Date / Timezone** | Toggles. Seconds off by default — a wall dashboard rarely needs them, and it halves the repaint rate. |

Works on public dashboards automatically (the canvas is shared) and needs no data fetching.

## Design notes

**All the logic is outside the JSX.** `Common/Utils/Dashboard/ClockWidgetFormat.ts` holds every derivation — digit strings, caption, hand angles, tick scheduling, type sizing — so the interesting cases are unit-testable without a DOM.

**The tick is a re-armed timeout, not a `setInterval`.** An interval accumulates every scheduling delay, so a clock left open all day drifts and eventually skips a second. It also resyncs on `visibilitychange`, because browsers throttle timers in background tabs hard — coming back to a stale clock is the one failure a clock cannot have. Extracted as `Common/UI/Utils/UseClockTick.ts` so that behaviour has its own tests.

**Type is sized against the padded content box.** The canvas hands widgets their *outer* tile size while the content sits inside `DashboardBaseComponent`'s padding (and 16px more in edit mode, for the drag handle). Sizing against the outer box clipped the bottom caption on short tiles; caught in a browser preview and now covered by a "never builds a stack taller than the content box" invariant across tile sizes, caption combinations and both modes.

## Drive-by fix

`TimezoneUtil.getTimezoneDropdownOptions()` was offering `US/Pacific-New`, which the tzdb removed in 2020b and `moment` cannot resolve. Picking it yields a zone that silently produces no valid wall clock — and this dropdown also feeds **on-call rotations, SLO windows, status-page subscribers and user profiles**, not just this widget. Unresolvable zones are now filtered at the source. Called out separately because it touches shared code beyond the widget.

## Tests

240 passing across 8 suites (includes the pre-existing dashboard suites — no regressions).

- `ClockWidgetFormat.test.ts` (119) — half-hour (`+05:30`) and quarter-hour (`+05:45`, `+12:45`) offsets; both DST directions in `America/New_York` (1:59→3:00 forward, 1:00 twice back, with EST/EDT switching); midnight as 12 AM and noon as 12 PM; a zone that no longer exists falling back without being mistaken for a blank one; hand angles at each quadrant, on a 12-hour wrap, and creeping with the seconds; tick alignment including pre-1970 instants, exact boundaries and an `Invalid Date`; and the sizing invariants.
- `UseClockTick.test.tsx` (18) — cadence, drift-free alignment over 30 ticks, catch-up on tab focus, no leaked timers on resync/unmount/cadence change.
- `DashboardClockComponent.test.ts` (17) — defaults, argument declarations, dropdown options matching their enums, and registry wiring.
- `Timezone.test.ts` (7) — the dropdown fix.

## Verification

Typecheck and lint clean in both `Common` and `App`. The real component was bundled and rendered in a browser across 12 tile sizes and configurations to check the visuals and confirm zero overflow on every tile.

<img width="1600" alt="Clock widget — digital and analog faces at several tile sizes" src="https://github.com/user-attachments/assets/placeholder" />