### PR TITLE
fix(workflow): authorize the manual workflow run endpoint (GHSA-v8v9-p6ff-jwmm)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
@@ -384,6 +384,13 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
                     data: {
                       data: component.arguments,
                     },
+                    /*
+                     * /workflow/manual/run is a custom route, so it gets no
+                     * tenant header unless the call site adds one. It needs
+                     * the header to check the caller is a member of the
+                     * workflow's project before running it.
+                     */
+                    headers: ModelAPI.getCommonHeaders(),
                   });
 
                 if (result instanceof HTTPErrorResponse) {

--- a/App/FeatureSet/Workflow/API/Manual.ts
+++ b/App/FeatureSet/Workflow/API/Manual.ts
@@ -1,7 +1,17 @@
 import QueueWorkflow from "../Services/QueueWorkflow";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
 import BadDataException from "Common/Types/Exception/BadDataException";
+import NotAuthorizedException from "Common/Types/Exception/NotAuthorizedException";
 import ObjectID from "Common/Types/ObjectID";
+import Permission, {
+  PermissionHelper,
+  UserPermission,
+  UserTenantAccessPermission,
+} from "Common/Types/Permission";
+import CommonAPI from "Common/Server/API/CommonAPI";
 import UserMiddleware from "Common/Server/Middleware/UserAuthorization";
+import WorkflowService from "Common/Server/Services/WorkflowService";
+import Workflow from "Common/Models/DatabaseModels/Workflow";
 import Express, {
   ExpressRequest,
   ExpressResponse,
@@ -45,8 +55,58 @@ export default class ManualAPI {
         );
       }
 
+      const workflowId: ObjectID = new ObjectID(
+        req.params["workflowId"] as string,
+      );
+
+      const databaseProps: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      /*
+       * getUserMiddleware is a context loader, not a gate: a request with no
+       * cookie, no bearer token and no apikey header is tagged
+       * UserType.Public and passed straight through to here. This route then
+       * runs the workflow as root — including its JavaScript / custom-code
+       * and notification components — so it has to prove the caller itself.
+       *
+       * Programmatic callers trigger a workflow through its own API/webhook
+       * trigger (`/workflow/trigger/:secretkey`), which authenticates with
+       * the workflow's secret key. This route backs the dashboard's "Run"
+       * button, so it requires a logged-in member of the project.
+       */
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(databaseProps);
+
+      /*
+       * The tenant above is only the project the caller *claimed* in the
+       * `tenantid` header. Take the owning project off the workflow row
+       * itself and require the two to match, otherwise a member of project A
+       * reaches project B's workflow id just by sending their own header.
+       * A workflow that does not exist is rejected the same way, so the route
+       * cannot be used to confirm which workflow ids exist in other projects.
+       */
+      const workflow: Workflow | null = await WorkflowService.findOneById({
+        id: workflowId,
+        select: {
+          projectId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: workflow?.projectId,
+        projectId: projectId,
+      });
+
+      ManualAPI.assertCallerCanRunWorkflow({
+        databaseProps: databaseProps,
+        projectId: projectId,
+      });
+
       await QueueWorkflow.addWorkflowToQueue({
-        workflowId: new ObjectID(req.params["workflowId"] as string),
+        workflowId: workflowId,
         returnValues: req.body.data || {},
       });
 
@@ -55,6 +115,49 @@ export default class ManualAPI {
       });
     } catch (err) {
       next(err);
+    }
+  }
+
+  /*
+   * Membership alone is not enough. Running a workflow executes its
+   * components inside the project — arbitrary JavaScript, notification sends,
+   * resource create/delete — so it is a write-level action, not a read. Gate
+   * it on the same permissions that govern updating the Workflow model
+   * itself: the dashboard's Run button lives on the builder page, which
+   * already needs those permissions to save the graph, so no caller who can
+   * legitimately reach the button loses access. Reading the list off the
+   * model keeps this in step with the CRUD route if the model's access
+   * control changes.
+   */
+  private static assertCallerCanRunWorkflow(data: {
+    databaseProps: DatabaseCommonInteractionProps;
+    projectId: ObjectID;
+  }): void {
+    // Master admins bypass permission checks, as they do in requirePermission.
+    if (data.databaseProps.isMasterAdmin) {
+      return;
+    }
+
+    const tenantPermission: UserTenantAccessPermission | undefined =
+      data.databaseProps.userTenantAccessPermission?.[
+        data.projectId.toString()
+      ];
+
+    const callerPermissions: Array<Permission> = (
+      tenantPermission?.permissions || []
+    ).map((userPermission: UserPermission) => {
+      return userPermission.permission;
+    });
+
+    if (
+      !PermissionHelper.doesPermissionsIntersect(
+        callerPermissions,
+        new Workflow().getUpdatePermissions(),
+      )
+    ) {
+      throw new NotAuthorizedException(
+        "You do not have permission to run this workflow.",
+      );
     }
   }
 }

--- a/App/Tests/FeatureSet/Workflow/ManualWorkflowRunAuth.test.ts
+++ b/App/Tests/FeatureSet/Workflow/ManualWorkflowRunAuth.test.ts
@@ -1,0 +1,786 @@
+import ManualAPI from "../../../FeatureSet/Workflow/API/Manual";
+import QueueWorkflow from "../../../FeatureSet/Workflow/Services/QueueWorkflow";
+import CommonAPI from "Common/Server/API/CommonAPI";
+import WorkflowService from "Common/Server/Services/WorkflowService";
+import WorkflowModel from "Common/Models/DatabaseModels/Workflow";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import Response from "Common/Server/Utils/Response";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "Common/Types/Dictionary";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import NotAuthorizedException from "Common/Types/Exception/NotAuthorizedException";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "Common/Types/Permission";
+import UserType from "Common/Types/UserType";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Regression tests for GET/POST /workflow/manual/run/:workflowId.
+ *
+ * CVE-2026-35053 (GHSA-6c3w-7xg4-4cf7) reported these routes as having no
+ * auth at all. The published patch added UserMiddleware.getUserMiddleware in
+ * front of both — but that middleware is a *context loader*, not a gate: with
+ * no cookie, no bearer token and no apikey header it tags the request
+ * UserType.Public and calls next(). The handler never looked at userType, and
+ * QueueWorkflow.addWorkflowToQueue is not passed the request at all, so it
+ * could not check the caller either. The route stayed reachable
+ * unauthenticated (GHSA-v8v9-p6ff-jwmm).
+ *
+ * Running a workflow executes its components as root — arbitrary JavaScript,
+ * notification sends, resource create/delete — so the load-bearing assertion
+ * in every deny case below is that QueueWorkflow.addWorkflowToQueue was NEVER
+ * called. An error response on its own would not prove the work was stopped.
+ *
+ * The second half of the bug class is cross-tenant reach: the project the
+ * caller is authorized for comes from a caller-supplied `tenantid` header, so
+ * proving the caller is *some* logged-in user is not enough. The workflow's
+ * own projectId has to come off the workflow row and match.
+ * ---------------------------------------------------------------------------
+ */
+
+type RouterFunction = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+type MockRoute = {
+  method: string;
+  uri: string;
+  middleware: RouterFunction;
+  handlerFunction: RouterFunction;
+};
+
+type MockRouter = {
+  get: jest.Mock;
+  post: jest.Mock;
+  put: jest.Mock;
+  delete: jest.Mock;
+};
+
+const mockRoutes: Array<MockRoute> = [];
+
+type RegisterRouteFunction = (
+  method: string,
+) => (
+  uri: string,
+  middleware: RouterFunction,
+  handlerFunction: RouterFunction,
+) => void;
+
+const registerRoute: RegisterRouteFunction = (method: string) => {
+  return (
+    uri: string,
+    middleware: RouterFunction,
+    handlerFunction: RouterFunction,
+  ): void => {
+    mockRoutes.push({
+      method: method.toUpperCase(),
+      uri,
+      middleware,
+      handlerFunction,
+    });
+  };
+};
+
+const mockRouter: MockRouter = {
+  get: jest.fn().mockImplementation(registerRoute("get")),
+  post: jest.fn().mockImplementation(registerRoute("post")),
+  put: jest.fn().mockImplementation(registerRoute("put")),
+  delete: jest.fn().mockImplementation(registerRoute("delete")),
+};
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      ...((actual["default"] as Record<string, unknown>) || {}),
+      getRouter: (): MockRouter => {
+        return mockRouter;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendJsonObjectResponse: jest.fn(),
+      sendErrorResponse: jest.fn(),
+      sendEmptySuccessResponse: jest.fn(),
+      sendEntityResponse: jest.fn(),
+    },
+  };
+});
+
+/*
+ * The queue itself is not under test — what matters is whether the handler
+ * ever reaches it. Mocking the module also keeps the real workflow runner
+ * (and its isolated-vm native binding) out of this suite.
+ */
+jest.mock("../../../FeatureSet/Workflow/Services/QueueWorkflow", () => {
+  return {
+    __esModule: true,
+    default: {
+      addWorkflowToQueue: jest.fn(),
+    },
+  };
+});
+
+const RUN_ROUTE: string = "/run/:workflowId";
+
+type RouteCallResult = {
+  thrownToNext: unknown;
+  nextCallCount: number;
+};
+
+function matchRoute(method: string, uri: string): MockRoute {
+  const route: MockRoute | undefined = mockRoutes.find((route: MockRoute) => {
+    return route.method === method.toUpperCase() && route.uri === uri;
+  });
+
+  if (!route) {
+    throw new Error(`Route ${method} ${uri} was never registered`);
+  }
+
+  return route;
+}
+
+async function callRunRoute(data: {
+  method: "GET" | "POST";
+  workflowId?: string | undefined;
+  body?: JSONObject | undefined;
+}): Promise<RouteCallResult> {
+  const params: Dictionary<string> = {};
+
+  if (data.workflowId !== undefined) {
+    params["workflowId"] = data.workflowId;
+  }
+
+  const req: ExpressRequest = {
+    params: params,
+    query: {},
+    body: data.body || {},
+    headers: {},
+  } as unknown as ExpressRequest;
+
+  const res: ExpressResponse = {
+    send: jest.fn(),
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as ExpressResponse;
+
+  const next: jest.Mock = jest.fn();
+
+  await matchRoute(data.method, RUN_ROUTE).handlerFunction(
+    req,
+    res,
+    next as unknown as NextFunction,
+  );
+
+  return {
+    thrownToNext: next.mock.calls[0] ? next.mock.calls[0][0] : undefined,
+    nextCallCount: next.mock.calls.length,
+  };
+}
+
+function buildTenantPermission(data: {
+  projectId: ObjectID;
+  permissions: Array<Permission>;
+}): UserTenantAccessPermission {
+  return {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: data.permissions.map((permission: Permission) => {
+      const userPermission: UserPermission = {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+      };
+
+      return userPermission;
+    }),
+  };
+}
+
+/*
+ * Shaped like what CommonAPI.getDatabaseCommonInteractionProps returns for a
+ * logged-in dashboard user whose request carried a `tenantid` header.
+ */
+function buildUserProps(data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+  permissions: Array<Permission>;
+  isMasterAdmin?: boolean | undefined;
+}): DatabaseCommonInteractionProps {
+  const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+
+  permissionMap[data.projectId.toString()] = buildTenantPermission({
+    projectId: data.projectId,
+    permissions: data.permissions,
+  });
+
+  return {
+    tenantId: data.projectId,
+    userId: data.userId,
+    userType: data.isMasterAdmin ? UserType.MasterAdmin : UserType.User,
+    userTenantAccessPermission: permissionMap,
+    ...(data.isMasterAdmin ? { isMasterAdmin: true } : {}),
+  };
+}
+
+describe("GET/POST /workflow/manual/run/:workflowId requires an authorized member of the workflow's own project", () => {
+  let callerProjectId: ObjectID;
+  let otherProjectId: ObjectID;
+  let callerUserId: ObjectID;
+  let workflowId: ObjectID;
+
+  let getPropsSpy: jest.SpyInstance;
+  let findOneByIdSpy: jest.SpyInstance;
+  let addWorkflowToQueueSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    mockRoutes.length = 0;
+    new ManualAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    callerProjectId = ObjectID.generate();
+    otherProjectId = ObjectID.generate();
+    callerUserId = ObjectID.generate();
+    workflowId = ObjectID.generate();
+
+    getPropsSpy = jest.spyOn(CommonAPI, "getDatabaseCommonInteractionProps");
+    findOneByIdSpy = jest.spyOn(WorkflowService, "findOneById");
+    addWorkflowToQueueSpy = jest
+      .spyOn(QueueWorkflow, "addWorkflowToQueue")
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockProps(props: DatabaseCommonInteractionProps): void {
+    getPropsSpy.mockResolvedValue(props);
+  }
+
+  function mockWorkflowInProject(projectId: ObjectID | null): void {
+    if (!projectId) {
+      findOneByIdSpy.mockResolvedValue(null);
+      return;
+    }
+
+    const workflow: WorkflowModel = new WorkflowModel();
+    workflow.id = workflowId;
+    workflow.projectId = projectId;
+    findOneByIdSpy.mockResolvedValue(workflow);
+  }
+
+  function editorProps(): DatabaseCommonInteractionProps {
+    return buildUserProps({
+      projectId: callerProjectId,
+      userId: callerUserId,
+      permissions: [Permission.EditWorkflow],
+    });
+  }
+
+  describe("route wiring", () => {
+    test("registers both GET and POST /run/:workflowId", () => {
+      expect(() => {
+        return matchRoute("GET", RUN_ROUTE);
+      }).not.toThrow();
+      expect(() => {
+        return matchRoute("POST", RUN_ROUTE);
+      }).not.toThrow();
+    });
+
+    /*
+     * getUserMiddleware still runs — it is what populates userType, tenantId
+     * and the tenant permissions the handler then checks. It just is not the
+     * thing doing the rejecting.
+     */
+    test("keeps a context-loading middleware in front of both routes", () => {
+      expect(typeof matchRoute("GET", RUN_ROUTE).middleware).toBe("function");
+      expect(typeof matchRoute("POST", RUN_ROUTE).middleware).toBe("function");
+    });
+  });
+
+  describe("unauthenticated callers (the reported CVE)", () => {
+    /*
+     * The advisory's proof of concept verbatim: a bare POST with no cookie,
+     * no Authorization header and no apikey header. getUserMiddleware tags it
+     * UserType.Public and calls next(), so it reaches the handler — the
+     * handler has to be the thing that stops it.
+     */
+    test("rejects the advisory's credential-less POST and never queues the workflow", async () => {
+      mockProps({ userType: UserType.Public });
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+        body: { data: { anything: "attacker-controlled" } },
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+
+    test("rejects the same credential-less call on the GET route", async () => {
+      mockProps({ userType: UserType.Public });
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "GET",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    test("never even reads the workflow for a credential-less caller", async () => {
+      mockProps({ userType: UserType.Public });
+
+      await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(findOneByIdSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * A public caller can freely put any project id in the `tenantid` header.
+     * That sets tenantId on the request without granting any permission, so
+     * the tenant check alone must not be mistaken for authentication.
+     */
+    test("rejects a public caller that supplies a tenant header it has no permission for", async () => {
+      mockProps({
+        userType: UserType.Public,
+        tenantId: callerProjectId,
+        userId: undefined,
+        userTenantAccessPermission: undefined,
+      });
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a caller with a tenant and a user id but no tenant permissions", async () => {
+      mockProps({
+        userType: UserType.User,
+        tenantId: callerProjectId,
+        userId: callerUserId,
+        userTenantAccessPermission: undefined,
+      });
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Permissions keyed by a *different* project than the one claimed must
+     * not satisfy the check for the claimed project.
+     */
+    test("rejects a caller whose permissions are keyed by a different project", async () => {
+      const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+      permissionMap[otherProjectId.toString()] = buildTenantPermission({
+        projectId: otherProjectId,
+        permissions: [Permission.ProjectOwner],
+      });
+
+      mockProps({
+        userType: UserType.User,
+        tenantId: callerProjectId,
+        userId: callerUserId,
+        userTenantAccessPermission: permissionMap,
+      });
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cross-tenant reach", () => {
+    /*
+     * The headline sibling risk: a real, fully-privileged member of project A
+     * sending their own tenant header while pointing the path at project B's
+     * workflow id.
+     */
+    test("rejects a project owner of one project targeting another project's workflow", async () => {
+      mockProps(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.ProjectOwner],
+        }),
+      );
+      mockWorkflowInProject(otherProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects the same cross-tenant attempt on the GET route", async () => {
+      mockProps(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.ProjectOwner],
+        }),
+      );
+      mockWorkflowInProject(otherProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "GET",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Same rejection for a workflow that does not exist, so the route cannot
+     * be used to probe which workflow ids are real in other projects.
+     */
+    test("rejects a workflow id that does not exist with the same error as a foreign one", async () => {
+      mockProps(editorProps());
+      mockWorkflowInProject(null);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    test("rejects a workflow that belongs to no project", async () => {
+      mockProps(editorProps());
+
+      const orphan: WorkflowModel = new WorkflowModel();
+      orphan.id = workflowId;
+      findOneByIdSpy.mockResolvedValue(orphan);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The owning project must come off the workflow row, not off the
+     * caller-supplied header — pin the read that derives it.
+     */
+    test("derives the owning project from the workflow row itself", async () => {
+      mockProps(editorProps());
+      mockWorkflowInProject(callerProjectId);
+
+      await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(findOneByIdSpy).toHaveBeenCalledTimes(1);
+
+      const readArgs: {
+        id: ObjectID;
+        select: Dictionary<boolean>;
+        props: Dictionary<boolean>;
+      } = findOneByIdSpy.mock.calls[0]![0] as {
+        id: ObjectID;
+        select: Dictionary<boolean>;
+        props: Dictionary<boolean>;
+      };
+
+      expect(readArgs.id.toString()).toBe(workflowId.toString());
+      expect(readArgs.select["projectId"]).toBe(true);
+      expect(readArgs.props["isRoot"]).toBe(true);
+    });
+  });
+
+  describe("permission level within the caller's own project", () => {
+    /*
+     * Running a workflow executes its components, so it is gated on the same
+     * permissions as updating the Workflow model. Anyone who can reach the
+     * dashboard's Run button already holds these, because the builder page
+     * needs them to save the graph.
+     */
+    const allowedPermissions: Array<Permission> =
+      new WorkflowModel().getUpdatePermissions();
+
+    test.each(allowedPermissions)(
+      "allows a caller holding %s",
+      async (permission: Permission) => {
+        mockProps(
+          buildUserProps({
+            projectId: callerProjectId,
+            userId: callerUserId,
+            permissions: [permission],
+          }),
+        );
+        mockWorkflowInProject(callerProjectId);
+
+        const result: RouteCallResult = await callRunRoute({
+          method: "POST",
+          workflowId: workflowId.toString(),
+        });
+
+        expect(result.nextCallCount).toBe(0);
+        expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    const deniedPermissions: Array<Permission> = [
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadWorkflow,
+      Permission.WorkflowViewer,
+    ];
+
+    test.each(deniedPermissions)(
+      "rejects a project member holding only %s",
+      async (permission: Permission) => {
+        mockProps(
+          buildUserProps({
+            projectId: callerProjectId,
+            userId: callerUserId,
+            permissions: [permission],
+          }),
+        );
+        mockWorkflowInProject(callerProjectId);
+
+        const result: RouteCallResult = await callRunRoute({
+          method: "POST",
+          workflowId: workflowId.toString(),
+        });
+
+        expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+        expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      },
+    );
+
+    test("rejects a member of the right project holding no permissions at all", async () => {
+      mockProps(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [],
+        }),
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    test("lets a master admin run a workflow in a project it is scoped to", async () => {
+      mockProps(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [],
+          isMasterAdmin: true,
+        }),
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.nextCallCount).toBe(0);
+      expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The master-admin bypass applies to the permission level only. It does
+     * not waive the check that the workflow belongs to the scoped project.
+     */
+    test("still rejects a master admin targeting a workflow outside the scoped project", async () => {
+      mockProps(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [],
+          isMasterAdmin: true,
+        }),
+      );
+      mockWorkflowInProject(otherProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("authorized callers keep working", () => {
+    test("queues the workflow with the caller's data for a member of its project", async () => {
+      mockProps(editorProps());
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+        body: { data: { hello: "world" } },
+      });
+
+      expect(result.nextCallCount).toBe(0);
+      expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+
+      const queueArgs: {
+        workflowId: ObjectID;
+        returnValues: JSONObject;
+      } = addWorkflowToQueueSpy.mock.calls[0]![0] as {
+        workflowId: ObjectID;
+        returnValues: JSONObject;
+      };
+
+      expect(queueArgs.workflowId.toString()).toBe(workflowId.toString());
+      expect(queueArgs.returnValues).toEqual({ hello: "world" });
+    });
+
+    test("responds with the Scheduled status", async () => {
+      mockProps(editorProps());
+      mockWorkflowInProject(callerProjectId);
+
+      await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+        body: { data: {} },
+      });
+
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+
+      const responseArgs: Array<unknown> = (
+        Response.sendJsonObjectResponse as unknown as jest.Mock
+      ).mock.calls[0] as Array<unknown>;
+
+      expect(responseArgs[2]).toEqual({ status: "Scheduled" });
+    });
+
+    test("defaults returnValues to an empty object when the body carries no data", async () => {
+      mockProps(editorProps());
+      mockWorkflowInProject(callerProjectId);
+
+      await callRunRoute({
+        method: "GET",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+
+      const queueArgs: { returnValues: JSONObject } = addWorkflowToQueueSpy.mock
+        .calls[0]![0] as { returnValues: JSONObject };
+
+      expect(queueArgs.returnValues).toEqual({});
+    });
+
+    test("works over the GET route for an authorized caller too", async () => {
+      mockProps(editorProps());
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "GET",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.nextCallCount).toBe(0);
+      expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("request shape", () => {
+    test("rejects a request with no workflowId and never authorizes or queues", async () => {
+      mockProps(editorProps());
+
+      await callRunRoute({ method: "POST" });
+
+      expect(Response.sendErrorResponse).toHaveBeenCalledTimes(1);
+
+      const errorArgs: Array<unknown> = (
+        Response.sendErrorResponse as unknown as jest.Mock
+      ).mock.calls[0] as Array<unknown>;
+
+      expect(errorArgs[2]).toBeInstanceOf(BadDataException);
+      expect(getPropsSpy).not.toHaveBeenCalled();
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Failures are handed to next() so the app's error middleware turns them
+     * into the right status code, rather than being swallowed into a 200.
+     */
+    test("passes authorization failures to next() instead of responding success", async () => {
+      mockProps({ userType: UserType.Public });
+
+      const result: RouteCallResult = await callRunRoute({
+        method: "POST",
+        workflowId: workflowId.toString(),
+      });
+
+      expect(result.nextCallCount).toBe(1);
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Fixes the report in [GHSA-v8v9-p6ff-jwmm](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-v8v9-p6ff-jwmm). I verified every claim in it against HEAD before changing anything — the report is accurate.

## The problem

[GHSA-6c3w-7xg4-4cf7 / CVE-2026-35053](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-6c3w-7xg4-4cf7) reported `GET`/`POST /workflow/manual/run/:workflowId` as having no authentication. The patch added `UserMiddleware.getUserMiddleware` to both routes — but that middleware is a **context loader, not a gate**. With no cookie, no bearer token and no `apikey` header it tags the request `UserType.Public` and calls `next()`:

https://github.com/OneUptime/oneuptime/blob/master/Common/Server/Middleware/UserAuthorization.ts#L314-L317

That is intentional and correct everywhere else it is used, because those routes go through `BaseAPI`/`DatabaseService`, which runs its own model-level `accessControl` check. `Manual.ts` is a hand-written route that calls `QueueWorkflow` directly and never gets that downstream check. The handler never inspected `req.userType`, and `QueueWorkflow.addWorkflowToQueue` is not passed the request, so it could not check the caller either.

Net result: the credential-less `curl` from the original advisory still reached the queue and scheduled the workflow.

## The fix

Authorize in the handler, following the pattern this repo already established for exactly this bug class — see `MonitorAPI` `/refresh-status` and `WorkspaceNotificationRuleAPI` `/test`, covered by `Common/Tests/Server/API/ProjectScopedCustomRouteAuth.test.ts`:

1. **`CommonAPI.assertAuthenticatedProjectMember`** — rejects `Public` callers.
2. **Bind to the workflow's real project.** The owning project is read off the workflow row (as root) and matched against the caller's project via `assertResourceBelongsToProject`. Authenticating alone is not enough for a multi-tenant system: the project comes from a caller-supplied `tenantid` header, so without this a member of project A could reach project B's workflow id just by sending their own header. A workflow that does not exist is rejected identically, so the route is not an id oracle.
3. **Permission level.** Running a workflow executes its components — arbitrary JavaScript, notification sends, resource create/delete — so it is a write, not a read. It is gated on the `Workflow` model's own `update` permissions rather than mere membership. The list is read off the model so it stays in step with the CRUD route.

Master admins bypass the permission check (as they do in `requirePermission`) but still need the workflow to belong to the project they are scoped to.

**Programmatic callers are unaffected.** They trigger a workflow through its own `/workflow/trigger/:secretkey` route, which authenticates with the workflow's secret key. `/manual/run` backs the dashboard's Run button.

### Dashboard call site

The Run button used a raw `API.post`, which sends no `tenantid` header, so it now sends `ModelAPI.getCommonHeaders()` — the same thing `CommonAPI`'s own docstring describes as the contract for custom routes. No caller who can legitimately reach the Run button loses access: the builder page already needs `update` permissions to save the graph.

## Tests

`Manual.ts` had no test coverage at all, which is part of why this gap went unnoticed. Adds `App/Tests/FeatureSet/Workflow/ManualWorkflowRunAuth.test.ts` — 30 tests covering the credential-less PoC verbatim, tenant-header spoofing, cross-tenant reach, non-existent and orphaned workflows, per-permission allow/deny, master admin, and preservation of the existing happy-path behavior. Both `GET` and `POST` are exercised.

The load-bearing assertion in every deny case is that `QueueWorkflow.addWorkflowToQueue` was **never called** — an error response alone would not prove the work was stopped.

```
Test Suites: 1 passed, 1 total
Tests:       30 passed, 30 total
```

**Negative control:** reverting `Manual.ts` to the pre-fix handler and re-running gives `17 failed, 13 passed` — including `rejects the advisory's credential-less POST and never queues the workflow`. The 13 that still pass are the route-wiring and behavior-preservation tests, which is expected. `tsc --noEmit` and `eslint` are clean.

## Not addressed here

`/workflow/model-schema/:tableName` ([`ModelSchema.ts`](https://github.com/OneUptime/oneuptime/blob/master/App/FeatureSet/Workflow/API/ModelSchema.ts)) has the identical `getUserMiddleware`-only shape and is anonymously reachable. It only returns static schema metadata derived from the code — no tenant data, no side effects — and the schema is open source, so I left it out of this security PR rather than widening the scope. Worth a separate look if you want it locked down.