### PR TITLE
Add colors to custom field dropdown options

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Settings/Base/CustomFieldsPageBase.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/Base/CustomFieldsPageBase.tsx
@@ -125,7 +125,7 @@ const CustomFieldsPageBase: (
             },
             title: "Dropdown Options",
             description:
-              "Add the options that should appear in the dropdown when this field is edited.",
+              "Add the options that should appear in the dropdown and optionally choose a color for each value.",
             fieldType: FormFieldSchemaType.CustomComponent,
             required: (item: FormValues<CustomFieldsBaseModels>) => {
               return isDropdownType((item as any).customFieldType);

--- a/App/FeatureSet/Dashboard/src/Pages/Users/CustomFields.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Users/CustomFields.tsx
@@ -1,12 +1,24 @@
 import PageComponentProps from "../PageComponentProps";
 import CustomFieldType from "Common/Types/CustomField/CustomFieldType";
+import DropdownOptionsInput from "Common/UI/Components/CustomFields/DropdownOptionsInput";
+import { CustomElementProps } from "Common/UI/Components/Forms/Types/Field";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import TeamMemberCustomField from "Common/Models/DatabaseModels/TeamMemberCustomField";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
 import ProjectUtil from "Common/UI/Utils/Project";
+
+const isDropdownType: (value: unknown) => boolean = (
+  value: unknown,
+): boolean => {
+  return (
+    value === CustomFieldType.Dropdown ||
+    value === CustomFieldType.MultiSelectDropdown
+  );
+};
 
 const TeamMemberCustomFields: FunctionComponent<PageComponentProps> = (
   _props: PageComponentProps,
@@ -74,6 +86,42 @@ const TeamMemberCustomFields: FunctionComponent<PageComponentProps> = (
                 };
               },
             ),
+          },
+          {
+            field: {
+              dropdownOptions: true,
+            },
+            title: "Dropdown Options",
+            description:
+              "Add the options that should appear in the dropdown and optionally choose a color for each value.",
+            fieldType: FormFieldSchemaType.CustomComponent,
+            required: (item: FormValues<TeamMemberCustomField>) => {
+              return isDropdownType(item.customFieldType);
+            },
+            showIf: (item: FormValues<TeamMemberCustomField>) => {
+              return isDropdownType(item.customFieldType);
+            },
+            getCustomElement: (
+              _values: FormValues<TeamMemberCustomField>,
+              customElementProps: CustomElementProps,
+            ) => {
+              return (
+                <DropdownOptionsInput
+                  initialValue={
+                    typeof customElementProps.initialValue === "string"
+                      ? customElementProps.initialValue
+                      : ""
+                  }
+                  error={customElementProps.error}
+                  onChange={(value: string) => {
+                    customElementProps.onChange?.(value);
+                  }}
+                  onBlur={() => {
+                    customElementProps.onBlur?.();
+                  }}
+                />
+              );
+            },
           },
         ]}
         showRefreshButton={true}

--- a/Common/Models/DatabaseModels/AlertCustomField.ts
+++ b/Common/Models/DatabaseModels/AlertCustomField.ts
@@ -276,7 +276,7 @@ export default class AlertCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Models/DatabaseModels/IncidentCustomField.ts
+++ b/Common/Models/DatabaseModels/IncidentCustomField.ts
@@ -276,7 +276,7 @@ export default class IncidentCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Models/DatabaseModels/MonitorCustomField.ts
+++ b/Common/Models/DatabaseModels/MonitorCustomField.ts
@@ -276,7 +276,7 @@ export default class MonitorCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Models/DatabaseModels/OnCallDutyPolicyCustomField.ts
+++ b/Common/Models/DatabaseModels/OnCallDutyPolicyCustomField.ts
@@ -271,7 +271,7 @@ export default class OnCallDutyPolicyCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Models/DatabaseModels/ScheduledMaintenanceCustomField.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenanceCustomField.ts
@@ -276,7 +276,7 @@ export default class ScheduledMaintenanceCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Models/DatabaseModels/StatusPageCustomField.ts
+++ b/Common/Models/DatabaseModels/StatusPageCustomField.ts
@@ -271,7 +271,7 @@ export default class StatusPageCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Models/DatabaseModels/TeamCustomField.ts
+++ b/Common/Models/DatabaseModels/TeamCustomField.ts
@@ -275,7 +275,7 @@ export default class TeamCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Engineering\nSales\nSupport",
   })
   @Column({

--- a/Common/Models/DatabaseModels/TeamMemberCustomField.ts
+++ b/Common/Models/DatabaseModels/TeamMemberCustomField.ts
@@ -275,7 +275,7 @@ export default class TeamMemberCustomField extends BaseModel {
     type: TableColumnType.LongText,
     title: "Dropdown Options",
     description:
-      "Options for the dropdown field, one per line. Only used when Custom Field Type is Dropdown.",
+      "Options and optional colors for dropdown fields. Plain one-per-line values remain supported.",
     example: "Option 1\nOption 2\nOption 3",
   })
   @Column({

--- a/Common/Tests/Types/CustomField/CustomFieldDropdownOption.test.ts
+++ b/Common/Tests/Types/CustomField/CustomFieldDropdownOption.test.ts
@@ -1,0 +1,227 @@
+import {
+  CustomFieldDropdownOption,
+  getCustomFieldDropdownOption,
+  normalizeCustomFieldDropdownOptionColor,
+  parseCustomFieldDropdownOptions,
+  serializeCustomFieldDropdownOptions,
+} from "../../../Types/CustomField/CustomFieldDropdownOption";
+import { describe, expect, test } from "@jest/globals";
+
+describe("CustomFieldDropdownOption color normalization", () => {
+  test("accepts a six-digit hex color", () => {
+    expect(normalizeCustomFieldDropdownOptionColor("#12abEF")).toEqual(
+      "#12abef",
+    );
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(normalizeCustomFieldDropdownOptionColor("  #22C55E  ")).toEqual(
+      "#22c55e",
+    );
+  });
+
+  test.each(["fff", "#fff", "22c55e", "#22c55g", "red", "", "   "])(
+    "rejects an unsupported color value: %s",
+    (value: string) => {
+      expect(normalizeCustomFieldDropdownOptionColor(value)).toBeUndefined();
+    },
+  );
+
+  test("rejects non-string colors", () => {
+    expect(normalizeCustomFieldDropdownOptionColor(null)).toBeUndefined();
+    expect(normalizeCustomFieldDropdownOptionColor(123)).toBeUndefined();
+    expect(normalizeCustomFieldDropdownOptionColor({})).toBeUndefined();
+  });
+});
+
+describe("CustomFieldDropdownOption parsing", () => {
+  test("parses the legacy one-value-per-line format", () => {
+    expect(parseCustomFieldDropdownOptions("Low\nMedium\nHigh")).toEqual([
+      { value: "Low" },
+      { value: "Medium" },
+      { value: "High" },
+    ]);
+  });
+
+  test("trims values and drops blank legacy lines", () => {
+    expect(
+      parseCustomFieldDropdownOptions("  Low  \n\n  \n\tHigh\t\n"),
+    ).toEqual([{ value: "Low" }, { value: "High" }]);
+  });
+
+  test("keeps punctuation in legacy values", () => {
+    expect(
+      parseCustomFieldDropdownOptions("Needs review, urgent\n[Internal]"),
+    ).toEqual([{ value: "Needs review, urgent" }, { value: "[Internal]" }]);
+  });
+
+  test("parses colored structured options", () => {
+    expect(
+      parseCustomFieldDropdownOptions(
+        '[{"value":"Low","color":"#22c55e"},{"value":"High","color":"#ef4444"}]',
+      ),
+    ).toEqual([
+      { value: "Low", color: "#22c55e" },
+      { value: "High", color: "#ef4444" },
+    ]);
+  });
+
+  test("preserves a legacy option that looks like a JSON array", () => {
+    expect(parseCustomFieldDropdownOptions('["Low","High"]')).toEqual([
+      { value: '["Low","High"]' },
+    ]);
+  });
+
+  test("accepts label as a compatibility alias for value", () => {
+    expect(
+      parseCustomFieldDropdownOptions('[{"label":"High","color":"#EF4444"}]'),
+    ).toEqual([{ value: "High", color: "#ef4444" }]);
+  });
+
+  test("trims structured values and normalizes colors", () => {
+    expect(
+      parseCustomFieldDropdownOptions(
+        '[{"value":"  High  ","color":"  #EF4444  "}]',
+      ),
+    ).toEqual([{ value: "High", color: "#ef4444" }]);
+  });
+
+  test("keeps an option but drops its invalid color", () => {
+    expect(
+      parseCustomFieldDropdownOptions(
+        '[{"value":"High","color":"javascript:alert(1)"}]',
+      ),
+    ).toEqual([{ value: "High" }]);
+  });
+
+  test("drops malformed structured entries without dropping valid neighbors", () => {
+    expect(
+      parseCustomFieldDropdownOptions(
+        '[null,42,{},[],{"value":""},{"value":"Low"},{"label":"High","color":"invalid"}]',
+      ),
+    ).toEqual([{ value: "Low" }, { value: "High" }]);
+  });
+
+  test("preserves duplicate values because existing definitions may contain them", () => {
+    expect(parseCustomFieldDropdownOptions("Low\nLow")).toEqual([
+      { value: "Low" },
+      { value: "Low" },
+    ]);
+  });
+
+  test("falls back to legacy parsing for malformed JSON", () => {
+    expect(parseCustomFieldDropdownOptions("[Needs review")).toEqual([
+      { value: "[Needs review" },
+    ]);
+  });
+
+  test("returns an empty array for empty and non-string input", () => {
+    expect(parseCustomFieldDropdownOptions("")).toEqual([]);
+    expect(parseCustomFieldDropdownOptions("  \n\t ")).toEqual([]);
+    expect(parseCustomFieldDropdownOptions(undefined)).toEqual([]);
+    expect(parseCustomFieldDropdownOptions(null)).toEqual([]);
+    expect(parseCustomFieldDropdownOptions(42)).toEqual([]);
+    expect(parseCustomFieldDropdownOptions({ value: "High" })).toEqual([]);
+  });
+});
+
+describe("CustomFieldDropdownOption serialization", () => {
+  test("keeps the compact legacy format when no option has a color", () => {
+    expect(
+      serializeCustomFieldDropdownOptions([
+        { value: "Low" },
+        { value: "High" },
+      ]),
+    ).toEqual("Low\nHigh");
+  });
+
+  test("uses structured storage when any option has a color", () => {
+    expect(
+      serializeCustomFieldDropdownOptions([
+        { value: "Low", color: "#22c55e" },
+        { value: "High" },
+      ]),
+    ).toEqual('[{"value":"Low","color":"#22c55e"},{"value":"High"}]');
+  });
+
+  test("trims values, normalizes colors, and drops empty options", () => {
+    expect(
+      serializeCustomFieldDropdownOptions([
+        { value: "  Low  ", color: "  #22C55E  " },
+        { value: "   ", color: "#ef4444" },
+        { value: "High", color: "not-a-color" },
+      ]),
+    ).toEqual('[{"value":"Low","color":"#22c55e"},{"value":"High"}]');
+  });
+
+  test("returns to legacy storage after the last color is cleared", () => {
+    expect(
+      serializeCustomFieldDropdownOptions([
+        { value: "Low", color: undefined },
+        { value: "High" },
+      ]),
+    ).toEqual("Low\nHigh");
+  });
+
+  test("returns an empty string when there are no valid options", () => {
+    expect(serializeCustomFieldDropdownOptions([])).toEqual("");
+    expect(serializeCustomFieldDropdownOptions([{ value: "  " }])).toEqual("");
+  });
+
+  test("does not mutate the caller's options", () => {
+    const options: Array<CustomFieldDropdownOption> = [
+      { value: "  Low  ", color: "#22C55E" },
+    ];
+
+    serializeCustomFieldDropdownOptions(options);
+
+    expect(options).toEqual([{ value: "  Low  ", color: "#22C55E" }]);
+  });
+
+  test("round-trips colored values including punctuation", () => {
+    const options: Array<CustomFieldDropdownOption> = [
+      { value: "Needs review, urgent", color: "#f97316" },
+      { value: "[Internal]", color: "#64748b" },
+    ];
+
+    expect(
+      parseCustomFieldDropdownOptions(
+        serializeCustomFieldDropdownOptions(options),
+      ),
+    ).toEqual(options);
+  });
+});
+
+describe("CustomFieldDropdownOption lookup", () => {
+  const serializedOptions: string =
+    '[{"value":"Low","color":"#22c55e"},{"value":"High","color":"#ef4444"}]';
+
+  test("returns the exact matching option", () => {
+    expect(getCustomFieldDropdownOption(serializedOptions, "High")).toEqual({
+      value: "High",
+      color: "#ef4444",
+    });
+  });
+
+  test("stringifies primitive saved values for matching", () => {
+    expect(getCustomFieldDropdownOption("1\n2", 2)).toEqual({ value: "2" });
+  });
+
+  test("does not use a case-insensitive match", () => {
+    expect(
+      getCustomFieldDropdownOption(serializedOptions, "high"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for missing, null, and unknown values", () => {
+    expect(
+      getCustomFieldDropdownOption(serializedOptions, "Critical"),
+    ).toBeUndefined();
+    expect(
+      getCustomFieldDropdownOption(serializedOptions, null),
+    ).toBeUndefined();
+    expect(
+      getCustomFieldDropdownOption(serializedOptions, undefined),
+    ).toBeUndefined();
+  });
+});

--- a/Common/Tests/UI/Components/CustomFields/DropdownOptionsInput.test.tsx
+++ b/Common/Tests/UI/Components/CustomFields/DropdownOptionsInput.test.tsx
@@ -1,0 +1,228 @@
+import DropdownOptionsInput from "../../../../UI/Components/CustomFields/DropdownOptionsInput";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+type JestMock = ReturnType<typeof jest.fn>;
+
+jest.mock("../../../../UI/Components/Forms/Fields/ColorPicker", () => {
+  interface MockColorPickerProps {
+    dataTestId?: string | undefined;
+    value?: string | undefined;
+    initialValue?: { toString: () => string } | undefined;
+    onChange: (value: { toString: () => string } | null) => void;
+    onBlur?: (() => void) | undefined;
+  }
+
+  const MockColorPicker: React.FunctionComponent<MockColorPickerProps> = (
+    props: MockColorPickerProps,
+  ): React.ReactElement => {
+    return (
+      <input
+        data-testid={props.dataTestId}
+        value={props.value || props.initialValue?.toString() || ""}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          const value: string = event.target.value;
+          props.onChange(
+            value
+              ? {
+                  toString: () => {
+                    return value;
+                  },
+                }
+              : null,
+          );
+        }}
+        onBlur={() => {
+          props.onBlur?.();
+        }}
+      />
+    );
+  };
+
+  return {
+    __esModule: true,
+    default: MockColorPicker,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const getInputValue: (testId: string) => string = (testId: string): string => {
+  return (screen.getByTestId(testId) as HTMLInputElement).value;
+};
+
+describe("DropdownOptionsInput", () => {
+  test("renders legacy options with an empty color control for each value", async () => {
+    const onChange: JestMock = jest.fn();
+
+    render(
+      <DropdownOptionsInput initialValue={"Low\nHigh"} onChange={onChange} />,
+    );
+
+    await waitFor(() => {
+      expect(getInputValue("dropdown-option-value-0")).toEqual("Low");
+      expect(getInputValue("dropdown-option-value-1")).toEqual("High");
+    });
+    expect(getInputValue("dropdown-option-color-0")).toEqual("");
+    expect(getInputValue("dropdown-option-color-1")).toEqual("");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("renders saved colors from structured options", async () => {
+    render(
+      <DropdownOptionsInput
+        initialValue={
+          '[{"value":"Low","color":"#22c55e"},{"value":"High","color":"#ef4444"}]'
+        }
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getInputValue("dropdown-option-color-0")).toEqual("#22c55e");
+      expect(getInputValue("dropdown-option-color-1")).toEqual("#ef4444");
+    });
+  });
+
+  test("keeps newline storage when only a value changes", async () => {
+    const onChange: JestMock = jest.fn();
+    render(
+      <DropdownOptionsInput initialValue={"Low\nHigh"} onChange={onChange} />,
+    );
+
+    fireEvent.change(screen.getByTestId("dropdown-option-value-1"), {
+      target: { value: "Critical" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith("Low\nCritical");
+    });
+  });
+
+  test("serializes the values and colors when a color is selected", async () => {
+    const onChange: JestMock = jest.fn();
+    render(
+      <DropdownOptionsInput initialValue={"Low\nHigh"} onChange={onChange} />,
+    );
+
+    fireEvent.change(screen.getByTestId("dropdown-option-color-1"), {
+      target: { value: "#ef4444" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        '[{"value":"Low"},{"value":"High","color":"#ef4444"}]',
+      );
+    });
+  });
+
+  test("returns to newline storage when the final color is cleared", async () => {
+    const onChange: JestMock = jest.fn();
+    render(
+      <DropdownOptionsInput
+        initialValue={'[{"value":"Low"},{"value":"High","color":"#ef4444"}]'}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("dropdown-option-color-1"), {
+      target: { value: "" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith("Low\nHigh");
+    });
+  });
+
+  test("adds a value and preserves its selected color", async () => {
+    const onChange: JestMock = jest.fn();
+    render(<DropdownOptionsInput initialValue="Low" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Option" }));
+    fireEvent.change(screen.getByTestId("dropdown-option-value-1"), {
+      target: { value: "High" },
+    });
+    fireEvent.change(screen.getByTestId("dropdown-option-color-1"), {
+      target: { value: "#ef4444" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        '[{"value":"Low"},{"value":"High","color":"#ef4444"}]',
+      );
+    });
+  });
+
+  test("removing an option keeps the remaining option's color paired with its value", async () => {
+    const onChange: JestMock = jest.fn();
+    render(
+      <DropdownOptionsInput
+        initialValue={
+          '[{"value":"Low","color":"#22c55e"},{"value":"High","color":"#ef4444"}]'
+        }
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]!);
+
+    await waitFor(() => {
+      expect(getInputValue("dropdown-option-value-0")).toEqual("High");
+      expect(getInputValue("dropdown-option-color-0")).toEqual("#ef4444");
+      expect(onChange).toHaveBeenLastCalledWith(
+        '[{"value":"High","color":"#ef4444"}]',
+      );
+    });
+  });
+
+  test("removing the last option leaves one editable blank row and clears the value", async () => {
+    const onChange: JestMock = jest.fn();
+    render(<DropdownOptionsInput initialValue="Low" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(getInputValue("dropdown-option-value-0")).toEqual("");
+      expect(onChange).toHaveBeenLastCalledWith("");
+    });
+    expect(screen.getAllByRole("button", { name: "Remove" })).toHaveLength(1);
+  });
+
+  test("does not store a color for a blank option", async () => {
+    const onChange: JestMock = jest.fn();
+    render(<DropdownOptionsInput onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId("dropdown-option-color-0"), {
+      target: { value: "#ef4444" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  test("forwards blur events and displays validation errors", () => {
+    const onBlur: JestMock = jest.fn();
+    render(
+      <DropdownOptionsInput
+        initialValue="Low"
+        onBlur={onBlur}
+        error="Add at least one option"
+      />,
+    );
+
+    fireEvent.blur(screen.getByTestId("dropdown-option-value-0"));
+    fireEvent.blur(screen.getByTestId("dropdown-option-color-0"));
+
+    expect(onBlur).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("Add at least one option")).not.toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Detail/DropdownColors.test.tsx
+++ b/Common/Tests/UI/Components/Detail/DropdownColors.test.tsx
@@ -1,0 +1,128 @@
+import Detail from "../../../../UI/Components/Detail/Detail";
+import Field from "../../../../UI/Components/Detail/Field";
+import { DropdownOption } from "../../../../UI/Components/Dropdown/Dropdown";
+import FieldType from "../../../../UI/Components/Types/FieldType";
+import Color from "../../../../Types/Color";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+interface DetailItem {
+  selection: string | Array<string>;
+}
+
+const options: Array<DropdownOption> = [
+  {
+    label: "Low",
+    value: "Low",
+    color: new Color("#22c55e"),
+  },
+  {
+    label: "High",
+    value: "High",
+    color: new Color("#ef4444"),
+  },
+];
+
+const renderDetail: (
+  value: string | Array<string>,
+  fieldType: FieldType,
+) => HTMLElement = (
+  value: string | Array<string>,
+  fieldType: FieldType,
+): HTMLElement => {
+  const fields: Array<Field<DetailItem>> = [
+    {
+      key: "selection",
+      title: "Selection",
+      fieldType,
+      dropdownOptions: options,
+      placeholder: "No selection",
+    },
+  ];
+  const { container } = render(
+    <Detail<DetailItem>
+      item={{ selection: value }}
+      fields={fields}
+      showDetailsInNumberOfColumns={1}
+    />,
+  );
+
+  return container;
+};
+
+const requireElement: (
+  element: HTMLElement | null | undefined,
+) => HTMLElement = (element: HTMLElement | null | undefined): HTMLElement => {
+  if (!element) {
+    throw new Error("Expected dropdown value badge to be rendered");
+  }
+
+  return element;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Detail dropdown colors", () => {
+  test("renders a single-select value with its option color", () => {
+    const container: HTMLElement = renderDetail("High", FieldType.Dropdown);
+    const badge: HTMLElement | null = container.querySelector(
+      '[data-dropdown-value-badge="true"]',
+    );
+
+    expect(requireElement(badge).textContent).toContain("High");
+    expect(requireElement(badge).style.backgroundColor).toEqual(
+      "rgb(239, 68, 68)",
+    );
+  });
+
+  test("renders each multi-select value with its own option color", () => {
+    const container: HTMLElement = renderDetail(
+      ["Low", "High"],
+      FieldType.MultiSelectDropdown,
+    );
+    const badges: Array<HTMLElement> = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-dropdown-value-badge="true"]',
+      ),
+    );
+
+    expect(badges).toHaveLength(2);
+    expect(requireElement(badges[0]).textContent).toContain("Low");
+    expect(requireElement(badges[0]).style.backgroundColor).toEqual(
+      "rgb(34, 197, 94)",
+    );
+    expect(requireElement(badges[1]).textContent).toContain("High");
+    expect(requireElement(badges[1]).style.backgroundColor).toEqual(
+      "rgb(239, 68, 68)",
+    );
+  });
+
+  test("uses the legacy uncolored badge for an unmatched multi-select value", () => {
+    const container: HTMLElement = renderDetail(
+      ["Low", "Legacy"],
+      FieldType.MultiSelectDropdown,
+    );
+    const badges: Array<HTMLElement> = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-dropdown-value-badge="true"]',
+      ),
+    );
+
+    expect(requireElement(badges[1]).textContent).toContain("Legacy");
+    expect(requireElement(badges[1]).classList.contains("bg-indigo-50")).toBe(
+      true,
+    );
+  });
+
+  test("continues to show the placeholder for an unknown single-select value", () => {
+    const container: HTMLElement = renderDetail("Legacy", FieldType.Dropdown);
+
+    expect(container.textContent).toContain("No selection");
+    expect(
+      container.querySelector('[data-dropdown-value-badge="true"]'),
+    ).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Dropdown/DropdownValueBadge.test.tsx
+++ b/Common/Tests/UI/Components/Dropdown/DropdownValueBadge.test.tsx
@@ -1,0 +1,60 @@
+import DropdownValueBadge from "../../../../UI/Components/Dropdown/DropdownValueBadge";
+import Color from "../../../../Types/Color";
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DropdownValueBadge", () => {
+  test("keeps the existing indigo appearance when no color is configured", () => {
+    render(<DropdownValueBadge label="High" />);
+
+    const badge: HTMLElement = screen.getByText("High");
+    expect(badge.classList.contains("bg-indigo-50")).toBe(true);
+    expect(badge.classList.contains("text-indigo-700")).toBe(true);
+    expect(badge.getAttribute("data-dropdown-value-color")).toBeNull();
+  });
+
+  test("uses a configured Color as the badge background and border", () => {
+    render(
+      <DropdownValueBadge label="Critical" color={new Color("#dc2626")} />,
+    );
+
+    const badge: HTMLElement = screen.getByText("Critical");
+    expect(badge.style.backgroundColor).toEqual("rgb(220, 38, 38)");
+    expect(badge.style.borderColor).toEqual("#dc2626");
+    expect(badge.getAttribute("data-dropdown-value-color")).toEqual("#dc2626");
+  });
+
+  test("also accepts a serialized color string", () => {
+    render(<DropdownValueBadge label="Warning" color="#f97316" />);
+
+    expect(screen.getByText("Warning").style.backgroundColor).toEqual(
+      "rgb(249, 115, 22)",
+    );
+  });
+
+  test("uses light text on a dark background", () => {
+    render(<DropdownValueBadge label="Dark" color="#1e293b" />);
+
+    expect(screen.getByText("Dark").style.color).toEqual("rgb(249, 250, 251)");
+  });
+
+  test("uses dark text on a light background", () => {
+    render(<DropdownValueBadge label="Light" color="#fef08a" />);
+
+    expect(screen.getByText("Light").style.color).toEqual("rgb(17, 24, 39)");
+  });
+
+  test("falls back safely when given an invalid color", () => {
+    render(<DropdownValueBadge label="Invalid" color="not-a-color" />);
+
+    const badge: HTMLElement = screen.getByText("Invalid");
+    expect(badge.classList.contains("bg-indigo-50")).toBe(true);
+    expect(badge.classList.contains("text-indigo-700")).toBe(true);
+    expect(badge.getAttribute("data-dropdown-value-color")).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Forms/ColorPicker.test.tsx
+++ b/Common/Tests/UI/Components/Forms/ColorPicker.test.tsx
@@ -1,0 +1,48 @@
+import ColorPicker from "../../../../UI/Components/Forms/Fields/ColorPicker";
+import Color from "../../../../Types/Color";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+type JestMock = ReturnType<typeof jest.fn>;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ColorPicker", () => {
+  test("clearing a selected color leaves the control empty", async () => {
+    const onChange: JestMock = jest.fn();
+    const { container } = render(
+      <ColorPicker
+        placeholder="No color"
+        dataTestId="color-value"
+        initialValue={new Color("#ef4444")}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("color-value") as HTMLInputElement).value,
+      ).toEqual("#ef4444");
+    });
+
+    const clearIcon: SVGSVGElement | null = container.querySelector("svg");
+    expect(clearIcon).not.toBeNull();
+    fireEvent.click(clearIcon!);
+
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("color-value") as HTMLInputElement).value,
+      ).toEqual("");
+      expect(onChange).toHaveBeenLastCalledWith(null);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/CustomFieldColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/CustomFieldColumns.test.tsx
@@ -45,6 +45,13 @@ const dropdownDefinition: CustomFieldDefinition = {
   dropdownOptions: "Low\nHigh",
 };
 
+const coloredDropdownDefinition: CustomFieldDefinition = {
+  name: "Severity",
+  customFieldType: CustomFieldType.Dropdown,
+  dropdownOptions:
+    '[{"value":"Low","color":"#22c55e"},{"value":"High","color":"#ef4444"}]',
+};
+
 const multiSelectDefinition: CustomFieldDefinition = {
   name: "Teams",
   customFieldType: CustomFieldType.MultiSelectDropdown,
@@ -90,6 +97,16 @@ const getPlaceholder: GetPlaceholderFunction = (
   container: HTMLElement,
 ): Element | null => {
   return container.querySelector("span.text-gray-400");
+};
+
+const requireElement: (
+  element: HTMLElement | null | undefined,
+) => HTMLElement = (element: HTMLElement | null | undefined): HTMLElement => {
+  if (!element) {
+    throw new Error("Expected custom field value badge to be rendered");
+  }
+
+  return element;
 };
 
 type ColumnAtFunction = (
@@ -164,19 +181,25 @@ describe("CustomFieldColumns.parseDropdownOptions", () => {
      * inside an option label.
      */
     expect(parseDropdownOptions("Low\nMedium\nHigh")).toEqual([
-      "Low",
-      "Medium",
-      "High",
+      { value: "Low" },
+      { value: "Medium" },
+      { value: "High" },
     ]);
   });
 
   test("trims each option", () => {
-    expect(parseDropdownOptions("  Low  \n\tHigh\t")).toEqual(["Low", "High"]);
+    expect(parseDropdownOptions("  Low  \n\tHigh\t")).toEqual([
+      { value: "Low" },
+      { value: "High" },
+    ]);
   });
 
   test("drops blank and whitespace-only lines", () => {
     // A trailing newline in the textarea must not become an empty option.
-    expect(parseDropdownOptions("Low\n\n   \nHigh\n")).toEqual(["Low", "High"]);
+    expect(parseDropdownOptions("Low\n\n   \nHigh\n")).toEqual([
+      { value: "Low" },
+      { value: "High" },
+    ]);
   });
 
   test("returns an empty list for a blob that is only whitespace", () => {
@@ -184,7 +207,18 @@ describe("CustomFieldColumns.parseDropdownOptions", () => {
   });
 
   test("returns the single option when the blob has no newline at all", () => {
-    expect(parseDropdownOptions("Low")).toEqual(["Low"]);
+    expect(parseDropdownOptions("Low")).toEqual([{ value: "Low" }]);
+  });
+
+  test("parses colors from the structured representation", () => {
+    expect(
+      parseDropdownOptions(
+        '[{"value":"Low","color":"#22c55e"},{"value":"High","color":"#ef4444"}]',
+      ),
+    ).toEqual([
+      { value: "Low", color: "#22c55e" },
+      { value: "High", color: "#ef4444" },
+    ]);
   });
 
   test("returns an empty list for empty, null, undefined and non-string input", () => {
@@ -874,6 +908,64 @@ describe("CustomFieldColumns.renderCustomFieldValue", () => {
     expect(getBadgeLabels(container)).toEqual(["High"]);
   });
 
+  test("renders a dropdown value with its configured color", () => {
+    const container: HTMLElement = renderValue({
+      value: "High",
+      definition: coloredDropdownDefinition,
+    });
+    const badgeElement: HTMLElement | null = container.querySelector(
+      '[data-dropdown-value-badge="true"]',
+    );
+
+    expect(badgeElement).not.toBeNull();
+    expect(requireElement(badgeElement).textContent).toContain("High");
+    expect(requireElement(badgeElement).style.backgroundColor).toEqual(
+      "rgb(239, 68, 68)",
+    );
+    expect(requireElement(badgeElement).style.borderColor).toEqual("#ef4444");
+    expect(
+      requireElement(badgeElement).getAttribute("data-dropdown-value-color"),
+    ).toEqual("#ef4444");
+    expect(requireElement(badgeElement).style.color).toEqual(
+      "rgb(249, 250, 251)",
+    );
+  });
+
+  test("uses dark text on a light dropdown color", () => {
+    const container: HTMLElement = renderValue({
+      value: "Low",
+      definition: {
+        ...coloredDropdownDefinition,
+        dropdownOptions: '[{"value":"Low","color":"#fef08a"}]',
+      },
+    });
+
+    expect(
+      requireElement(
+        container.querySelector<HTMLElement>(
+          '[data-dropdown-value-badge="true"]',
+        ),
+      ).style.color,
+    ).toEqual("rgb(17, 24, 39)");
+  });
+
+  test("falls back to the uncolored badge for a saved value no longer in the options", () => {
+    const container: HTMLElement = renderValue({
+      value: "Critical",
+      definition: coloredDropdownDefinition,
+    });
+    const badgeElement: HTMLElement | null = container.querySelector(
+      '[data-dropdown-value-badge="true"]',
+    );
+
+    expect(
+      requireElement(badgeElement).classList.contains("bg-indigo-50"),
+    ).toBe(true);
+    expect(
+      requireElement(badgeElement).getAttribute("data-dropdown-value-color"),
+    ).toBeNull();
+  });
+
   test("renders one badge per multi-select value", () => {
     /*
      * One badge each rather than a single comma-joined badge: the table reads
@@ -885,6 +977,33 @@ describe("CustomFieldColumns.renderCustomFieldValue", () => {
     });
 
     expect(getBadgeLabels(container)).toEqual(["Infra", "Apps"]);
+  });
+
+  test("applies each configured color to the matching multi-select value", () => {
+    const container: HTMLElement = renderValue({
+      value: ["Infra", "Apps", "Legacy"],
+      definition: {
+        ...multiSelectDefinition,
+        dropdownOptions:
+          '[{"value":"Infra","color":"#0ea5e9"},{"value":"Apps","color":"#a855f7"}]',
+      },
+    });
+    const badges: Array<HTMLElement> = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-dropdown-value-badge="true"]',
+      ),
+    );
+
+    expect(badges).toHaveLength(3);
+    expect(requireElement(badges[0]).style.backgroundColor).toEqual(
+      "rgb(14, 165, 233)",
+    );
+    expect(requireElement(badges[1]).style.backgroundColor).toEqual(
+      "rgb(168, 85, 247)",
+    );
+    expect(requireElement(badges[2]).classList.contains("bg-indigo-50")).toBe(
+      true,
+    );
   });
 
   test("renders a bare string on a multi-select field as one badge", () => {

--- a/Common/Types/CustomField/CustomFieldDropdownOption.ts
+++ b/Common/Types/CustomField/CustomFieldDropdownOption.ts
@@ -1,0 +1,190 @@
+export interface CustomFieldDropdownOption {
+  value: string;
+  color?: string | undefined;
+}
+
+const HEX_COLOR_REGEX: RegExp = /^#[0-9a-f]{6}$/i;
+
+export type NormalizeCustomFieldDropdownOptionColorFunction = (
+  value: unknown,
+) => string | undefined;
+
+export const normalizeCustomFieldDropdownOptionColor: NormalizeCustomFieldDropdownOptionColorFunction =
+  (value: unknown): string | undefined => {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+
+    const color: string = value.trim().toLowerCase();
+
+    return HEX_COLOR_REGEX.test(color) ? color : undefined;
+  };
+
+const normalizeOption: (
+  value: unknown,
+) => CustomFieldDropdownOption | undefined = (
+  value: unknown,
+): CustomFieldDropdownOption | undefined => {
+  if (typeof value === "string") {
+    const optionValue: string = value.trim();
+
+    return optionValue ? { value: optionValue } : undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const optionValue: unknown =
+    (value as Record<string, unknown>)["value"] ??
+    (value as Record<string, unknown>)["label"];
+
+  if (typeof optionValue !== "string" || !optionValue.trim()) {
+    return undefined;
+  }
+
+  const option: CustomFieldDropdownOption = {
+    value: optionValue.trim(),
+  };
+  const color: string | undefined = normalizeCustomFieldDropdownOptionColor(
+    (value as Record<string, unknown>)["color"],
+  );
+
+  if (color) {
+    option.color = color;
+  }
+
+  return option;
+};
+
+const isStructuredOptions: (value: unknown) => value is Array<unknown> = (
+  value: unknown,
+): value is Array<unknown> => {
+  return (
+    Array.isArray(value) &&
+    value.some((option: unknown) => {
+      return Boolean(
+        option &&
+          typeof option === "object" &&
+          !Array.isArray(option) &&
+          Object.prototype.hasOwnProperty.call(option, "color"),
+      );
+    })
+  );
+};
+
+export type ParseCustomFieldDropdownOptionsFunction = (
+  value: unknown,
+) => Array<CustomFieldDropdownOption>;
+
+/*
+ * Dropdown options used to be stored as one value per line. Colored options
+ * use a compact JSON array, while this parser deliberately keeps accepting
+ * the original newline format so existing custom fields need no migration.
+ */
+export const parseCustomFieldDropdownOptions: ParseCustomFieldDropdownOptionsFunction =
+  (value: unknown): Array<CustomFieldDropdownOption> => {
+    if (typeof value !== "string" || !value.trim()) {
+      return [];
+    }
+
+    const serialized: string = value.trim();
+
+    if (serialized.startsWith("[")) {
+      try {
+        const parsed: unknown = JSON.parse(serialized);
+
+        if (isStructuredOptions(parsed)) {
+          return parsed
+            .map((option: unknown) => {
+              return normalizeOption(option);
+            })
+            .filter(
+              (
+                option: CustomFieldDropdownOption | undefined,
+              ): option is CustomFieldDropdownOption => {
+                return Boolean(option);
+              },
+            );
+        }
+      } catch {
+        /*
+         * Fall through to the legacy format. A value may legitimately start
+         * with "[", and malformed data must remain editable instead of vanish.
+         */
+      }
+    }
+
+    return serialized
+      .split("\n")
+      .map((line: string) => {
+        return normalizeOption(line);
+      })
+      .filter(
+        (
+          option: CustomFieldDropdownOption | undefined,
+        ): option is CustomFieldDropdownOption => {
+          return Boolean(option);
+        },
+      );
+  };
+
+export type SerializeCustomFieldDropdownOptionsFunction = (
+  options: Array<CustomFieldDropdownOption>,
+) => string;
+
+export const serializeCustomFieldDropdownOptions: SerializeCustomFieldDropdownOptionsFunction =
+  (options: Array<CustomFieldDropdownOption>): string => {
+    const normalizedOptions: Array<CustomFieldDropdownOption> = (options || [])
+      .map((option: CustomFieldDropdownOption) => {
+        return normalizeOption(option);
+      })
+      .filter(
+        (
+          option: CustomFieldDropdownOption | undefined,
+        ): option is CustomFieldDropdownOption => {
+          return Boolean(option);
+        },
+      );
+
+    if (normalizedOptions.length === 0) {
+      return "";
+    }
+
+    if (
+      normalizedOptions.every((option: CustomFieldDropdownOption) => {
+        return !option.color;
+      })
+    ) {
+      return normalizedOptions
+        .map((option: CustomFieldDropdownOption) => {
+          return option.value;
+        })
+        .join("\n");
+    }
+
+    return JSON.stringify(normalizedOptions);
+  };
+
+export type GetCustomFieldDropdownOptionFunction = (
+  serializedOptions: unknown,
+  value: unknown,
+) => CustomFieldDropdownOption | undefined;
+
+export const getCustomFieldDropdownOption: GetCustomFieldDropdownOptionFunction =
+  (
+    serializedOptions: unknown,
+    value: unknown,
+  ): CustomFieldDropdownOption | undefined => {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+
+    const optionValue: string = String(value);
+
+    return parseCustomFieldDropdownOptions(serializedOptions).find(
+      (option: CustomFieldDropdownOption) => {
+        return option.value === optionValue;
+      },
+    );
+  };

--- a/Common/UI/Components/CustomFields/CustomFieldsDetail.tsx
+++ b/Common/UI/Components/CustomFields/CustomFieldsDetail.tsx
@@ -11,6 +11,11 @@ import BaseModel, {
   DatabaseBaseModelType,
 } from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import CustomFieldType from "../../../Types/CustomField/CustomFieldType";
+import {
+  CustomFieldDropdownOption,
+  parseCustomFieldDropdownOptions,
+} from "../../../Types/CustomField/CustomFieldDropdownOption";
+import Color from "../../../Types/Color";
 import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
 import { PromiseVoidFunction } from "../../../Types/FunctionTypes";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -22,20 +27,20 @@ import useAsyncEffect from "use-async-effect";
 const parseDropdownOptions: (value: unknown) => Array<DropdownOption> = (
   value: unknown,
 ): Array<DropdownOption> => {
-  if (typeof value !== "string" || !value) {
-    return [];
-  }
-  return value
-    .split("\n")
-    .map((line: string) => {
-      return line.trim();
-    })
-    .filter((line: string) => {
-      return line.length > 0;
-    })
-    .map((line: string) => {
-      return { label: line, value: line };
-    });
+  return parseCustomFieldDropdownOptions(value).map(
+    (option: CustomFieldDropdownOption): DropdownOption => {
+      const dropdownOption: DropdownOption = {
+        label: option.value,
+        value: option.value,
+      };
+
+      if (option.color) {
+        dropdownOption.color = Color.fromString(option.color);
+      }
+
+      return dropdownOption;
+    },
+  );
 };
 
 export interface ComponentProps {

--- a/Common/UI/Components/CustomFields/DropdownOptionsInput.tsx
+++ b/Common/UI/Components/CustomFields/DropdownOptionsInput.tsx
@@ -1,5 +1,12 @@
 import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
+import ColorPicker from "../Forms/Fields/ColorPicker";
 import Input, { InputType } from "../Input/Input";
+import Color from "../../../Types/Color";
+import {
+  CustomFieldDropdownOption,
+  parseCustomFieldDropdownOptions,
+  serializeCustomFieldDropdownOptions,
+} from "../../../Types/CustomField/CustomFieldDropdownOption";
 import IconProp from "../../../Types/Icon/IconProp";
 import React, {
   FunctionComponent,
@@ -18,49 +25,51 @@ export interface ComponentProps {
   onBlur?: (() => void) | undefined;
 }
 
-const parseValue: (value: string | undefined) => Array<string> = (
-  value: string | undefined,
-): Array<string> => {
-  if (!value) {
-    return [];
-  }
-  return value
-    .split("\n")
-    .map((line: string) => {
-      return line.trim();
-    })
-    .filter((line: string) => {
-      return line.length > 0;
-    });
-};
-
-const serializeValue: (options: Array<string>) => string = (
-  options: Array<string>,
-): string => {
-  return options
-    .map((option: string) => {
-      return option.trim();
-    })
-    .filter((option: string) => {
-      return option.length > 0;
-    })
-    .join("\n");
-};
+interface EditableDropdownOption extends CustomFieldDropdownOption {
+  id: number;
+}
 
 const DropdownOptionsInput: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [options, setOptions] = useState<Array<string>>(() => {
-    const parsed: Array<string> = parseValue(props.initialValue);
-    return parsed.length > 0 ? parsed : [""];
+  const nextIdRef: MutableRefObject<number> = useRef<number>(0);
+
+  const createEditableOption: (
+    option?: CustomFieldDropdownOption,
+  ) => EditableDropdownOption = (
+    option?: CustomFieldDropdownOption,
+  ): EditableDropdownOption => {
+    const editableOption: EditableDropdownOption = {
+      id: nextIdRef.current,
+      value: option?.value || "",
+    };
+    nextIdRef.current += 1;
+
+    if (option?.color) {
+      editableOption.color = option.color;
+    }
+
+    return editableOption;
+  };
+
+  const [options, setOptions] = useState<Array<EditableDropdownOption>>(() => {
+    const parsed: Array<CustomFieldDropdownOption> =
+      parseCustomFieldDropdownOptions(props.initialValue);
+    return parsed.length > 0
+      ? parsed.map((option: CustomFieldDropdownOption) => {
+          return createEditableOption(option);
+        })
+      : [createEditableOption()];
   });
 
   const lastEmittedRef: MutableRefObject<string> = useRef<string>(
-    serializeValue(parseValue(props.initialValue)),
+    serializeCustomFieldDropdownOptions(
+      parseCustomFieldDropdownOptions(props.initialValue),
+    ),
   );
 
   useEffect(() => {
-    const serialized: string = serializeValue(options);
+    const serialized: string = serializeCustomFieldDropdownOptions(options);
     if (serialized !== lastEmittedRef.current) {
       lastEmittedRef.current = serialized;
       if (props.onChange) {
@@ -69,47 +78,102 @@ const DropdownOptionsInput: FunctionComponent<ComponentProps> = (
     }
   }, [options]);
 
-  type UpdateAtFn = (index: number, value: string) => void;
-  const updateAt: UpdateAtFn = (index: number, value: string): void => {
-    setOptions((prev: Array<string>) => {
-      const next: Array<string> = [...prev];
-      next[index] = value;
+  type UpdateAtFunction = (
+    id: number,
+    update: Partial<CustomFieldDropdownOption>,
+  ) => void;
+  const updateAt: UpdateAtFunction = (
+    id: number,
+    update: Partial<CustomFieldDropdownOption>,
+  ): void => {
+    setOptions((previousOptions: Array<EditableDropdownOption>) => {
+      return previousOptions.map((option: EditableDropdownOption) => {
+        if (option.id !== id) {
+          return option;
+        }
+
+        return {
+          ...option,
+          ...update,
+        };
+      });
+    });
+  };
+
+  type UpdateColorAtFunction = (id: number, color: Color | null) => void;
+  const updateColorAt: UpdateColorAtFunction = (
+    id: number,
+    color: Color | null,
+  ): void => {
+    setOptions((previousOptions: Array<EditableDropdownOption>) => {
+      const next: Array<EditableDropdownOption> = previousOptions.map(
+        (option: EditableDropdownOption) => {
+          if (option.id !== id) {
+            return option;
+          }
+
+          const updatedOption: EditableDropdownOption = {
+            id: option.id,
+            value: option.value,
+          };
+
+          if (color) {
+            updatedOption.color = color.toString();
+          }
+
+          return updatedOption;
+        },
+      );
+
       return next;
     });
   };
 
-  type RemoveAtFn = (index: number) => void;
-  const removeAt: RemoveAtFn = (index: number): void => {
-    setOptions((prev: Array<string>) => {
-      const next: Array<string> = prev.filter((_: string, i: number) => {
-        return i !== index;
-      });
-      return next.length > 0 ? next : [""];
+  type RemoveAtFn = (id: number) => void;
+  const removeAt: RemoveAtFn = (id: number): void => {
+    setOptions((previousOptions: Array<EditableDropdownOption>) => {
+      const next: Array<EditableDropdownOption> = previousOptions.filter(
+        (option: EditableDropdownOption) => {
+          return option.id !== id;
+        },
+      );
+      return next.length > 0 ? next : [createEditableOption()];
     });
   };
 
   type AddOptionFn = () => void;
   const addOption: AddOptionFn = (): void => {
-    setOptions((prev: Array<string>) => {
-      return [...prev, ""];
+    setOptions((previousOptions: Array<EditableDropdownOption>) => {
+      return [...previousOptions, createEditableOption()];
     });
   };
 
   return (
     <div>
-      <div className="space-y-2">
-        {options.map((value: string, index: number) => {
+      <div className="space-y-3">
+        {options.map((option: EditableDropdownOption, index: number) => {
           return (
-            <div key={index} className="flex items-center gap-2">
+            <div
+              key={option.id}
+              className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 sm:grid-cols-[auto_minmax(0,1fr)_minmax(9rem,12rem)_auto]"
+            >
               <div className="flex h-7 w-7 items-center justify-center rounded-md bg-gray-100 text-xs font-medium text-gray-500">
                 {index + 1}
               </div>
-              <div className="flex-1">
+              <div className="min-w-0">
+                <span
+                  id={`dropdown-option-value-${option.id}-label`}
+                  className="sr-only"
+                >
+                  Dropdown option {index + 1}
+                </span>
                 <Input
-                  value={value}
+                  value={option.value}
+                  dataTestId={`dropdown-option-value-${index}`}
+                  ariaLabelledby={`dropdown-option-value-${option.id}-label`}
                   placeholder={props.placeholder || `Option ${index + 1}`}
                   onChange={(newValue: string) => {
-                    updateAt(index, newValue);
+                    updateAt(option.id, { value: newValue });
                   }}
                   onBlur={() => {
                     if (props.onBlur) {
@@ -119,12 +183,38 @@ const DropdownOptionsInput: FunctionComponent<ComponentProps> = (
                   type={InputType.TEXT}
                 />
               </div>
+              <div className="col-span-2 col-start-2 row-start-2 sm:col-span-1 sm:col-start-3 sm:row-start-1">
+                <span
+                  id={`dropdown-option-color-${option.id}-label`}
+                  className="sr-only"
+                >
+                  Color for {option.value || `option ${index + 1}`}
+                </span>
+                <ColorPicker
+                  dataTestId={`dropdown-option-color-${index}`}
+                  ariaLabelledby={`dropdown-option-color-${option.id}-label`}
+                  placeholder="No color"
+                  value={option.color}
+                  initialValue={
+                    option.color ? Color.fromString(option.color) : undefined
+                  }
+                  onChange={(color: Color | null) => {
+                    updateColorAt(option.id, color);
+                  }}
+                  onBlur={() => {
+                    if (props.onBlur) {
+                      props.onBlur();
+                    }
+                  }}
+                />
+              </div>
               <Button
                 title="Remove"
+                className="col-start-3 row-start-1 sm:col-start-4"
                 buttonStyle={ButtonStyleType.ICON}
                 icon={IconProp.Trash}
                 onClick={() => {
-                  removeAt(index);
+                  removeAt(option.id);
                 }}
               />
             </div>

--- a/Common/UI/Components/Detail/Detail.tsx
+++ b/Common/UI/Components/Detail/Detail.tsx
@@ -6,6 +6,7 @@ import ColorViewer from "../ColorViewer/ColorViewer";
 import CopyableButton from "../CopyableButton/CopyableButton";
 import DictionaryOfStringsViewer from "../Dictionary/DictionaryOfStingsViewer";
 import { DropdownOption, DropdownOptionGroup } from "../Dropdown/Dropdown";
+import DropdownValueBadge from "../Dropdown/DropdownValueBadge";
 import HiddenText from "../HiddenText/HiddenText";
 import MarkdownViewer from "../Markdown.tsx/LazyMarkdownViewer";
 import ObjectIDView from "../ObjectID/ObjectIDView";
@@ -113,16 +114,10 @@ const Detail: DetailFunction = <T extends GenericObject>(
     }
 
     return (
-      <span className="inline-flex items-center gap-x-1.5 px-2 py-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium ring-1 ring-inset ring-indigo-700/10">
-        <svg
-          className="h-1.5 w-1.5 fill-indigo-500"
-          viewBox="0 0 6 6"
-          aria-hidden="true"
-        >
-          <circle cx={3} cy={3} r={3} />
-        </svg>
-        {selectedOption.label as string}
-      </span>
+      <DropdownValueBadge
+        label={selectedOption.label as string}
+        color={selectedOption.color}
+      />
     );
   };
 
@@ -171,19 +166,11 @@ const Detail: DetailFunction = <T extends GenericObject>(
               ? (matched.label as string)
               : String(value);
             return (
-              <span
+              <DropdownValueBadge
                 key={`${String(value)}-${index}`}
-                className="inline-flex items-center gap-x-1.5 px-2 py-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium ring-1 ring-inset ring-indigo-700/10"
-              >
-                <svg
-                  className="h-1.5 w-1.5 fill-indigo-500"
-                  viewBox="0 0 6 6"
-                  aria-hidden="true"
-                >
-                  <circle cx={3} cy={3} r={3} />
-                </svg>
-                {label}
-              </span>
+                label={label}
+                color={matched?.color}
+              />
             );
           },
         )}

--- a/Common/UI/Components/Dropdown/DropdownValueBadge.tsx
+++ b/Common/UI/Components/Dropdown/DropdownValueBadge.tsx
@@ -1,0 +1,61 @@
+import Color from "../../../Types/Color";
+import React, { CSSProperties, FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  label: string;
+  color?: Color | string | undefined;
+}
+
+const getColor: (color: Color | string | undefined) => Color | undefined = (
+  color: Color | string | undefined,
+): Color | undefined => {
+  if (!color) {
+    return undefined;
+  }
+
+  const normalizedColor: Color =
+    color instanceof Color ? color : Color.fromString(color);
+
+  try {
+    Color.colorToRgb(normalizedColor);
+    return normalizedColor;
+  } catch {
+    return undefined;
+  }
+};
+
+const DropdownValueBadge: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const color: Color | undefined = getColor(props.color);
+  const style: CSSProperties | undefined = color
+    ? {
+        backgroundColor: color.toString(),
+        borderColor: color.toString(),
+        color: Color.shouldUseDarkText(color) ? "#111827" : "#f9fafb",
+      }
+    : undefined;
+
+  return (
+    <span
+      data-dropdown-value-badge="true"
+      data-dropdown-value-color={color?.toString()}
+      className={`inline-flex items-center gap-x-1.5 rounded-md px-2 py-1 text-xs font-medium ${
+        color
+          ? "border border-solid"
+          : "bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-700/10"
+      }`}
+      style={style}
+    >
+      <span
+        aria-hidden="true"
+        className={`h-1.5 w-1.5 rounded-full ${
+          color ? "bg-current" : "bg-indigo-500"
+        }`}
+      ></span>
+      {props.label}
+    </span>
+  );
+};
+
+export default DropdownValueBadge;

--- a/Common/UI/Components/Forms/Fields/ColorPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/ColorPicker.tsx
@@ -97,7 +97,7 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
             icon={IconProp.Close}
             className="text-gray-400 h-5 w-5 cursor-pointer hover:text-gray-600"
             onClick={() => {
-              setColor("#FFFFFF");
+              setColor("");
               if (props.onChange) {
                 props.onChange(null);
               }

--- a/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
+++ b/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
@@ -1,9 +1,14 @@
 import Column from "./Column";
 import Columns from "./Columns";
 import FieldType from "../Types/FieldType";
+import DropdownValueBadge from "../Dropdown/DropdownValueBadge";
 import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import CustomFieldType from "../../../Types/CustomField/CustomFieldType";
+import {
+  CustomFieldDropdownOption,
+  parseCustomFieldDropdownOptions,
+} from "../../../Types/CustomField/CustomFieldDropdownOption";
 import { JSONObject } from "../../../Types/JSON";
 import React, { ReactElement } from "react";
 
@@ -51,27 +56,17 @@ export const CustomFieldsColumnKey: string = "customFields";
 
 export type ParseDropdownOptionsFunction = (
   value: string | undefined | null,
-) => Array<string>;
+) => Array<CustomFieldDropdownOption>;
 
 /*
- * Dropdown options are stored as one option per line, the same format the
- * settings page writes.
+ * Kept as an exported wrapper for callers and tests that historically used
+ * this module's parser. The shared parser understands both legacy newline
+ * values and the colored JSON representation.
  */
 export const parseDropdownOptions: ParseDropdownOptionsFunction = (
   value: string | undefined | null,
-): Array<string> => {
-  if (typeof value !== "string" || !value) {
-    return [];
-  }
-
-  return value
-    .split("\n")
-    .map((line: string) => {
-      return line.trim();
-    })
-    .filter((line: string) => {
-      return line.length > 0;
-    });
+): Array<CustomFieldDropdownOption> => {
+  return parseCustomFieldDropdownOptions(value);
 };
 
 export type GetCustomFieldDefinitionsFunction = (
@@ -151,26 +146,19 @@ export const getCustomFieldValue: GetCustomFieldValueFunction = (
   return (customFields as JSONObject)[name];
 };
 
-type BadgeFunction = (data: { label: string; key: string }) => ReactElement;
+type BadgeFunction = (data: {
+  label: string;
+  key: string;
+  color?: string | undefined;
+}) => ReactElement;
 
 const badge: BadgeFunction = (data: {
   label: string;
   key: string;
+  color?: string | undefined;
 }): ReactElement => {
   return (
-    <span
-      key={data.key}
-      className="inline-flex items-center gap-x-1.5 px-2 py-1 rounded-md bg-indigo-50 text-indigo-700 text-xs font-medium ring-1 ring-inset ring-indigo-700/10"
-    >
-      <svg
-        className="h-1.5 w-1.5 fill-indigo-500"
-        viewBox="0 0 6 6"
-        aria-hidden="true"
-      >
-        <circle cx={3} cy={3} r={3} />
-      </svg>
-      {data.label}
-    </span>
+    <DropdownValueBadge key={data.key} label={data.label} color={data.color} />
   );
 };
 
@@ -235,17 +223,38 @@ export const renderCustomFieldValue: RenderCustomFieldValueFunction = (data: {
       return empty;
     }
 
+    const configuredOptions: Array<CustomFieldDropdownOption> =
+      parseDropdownOptions(definition.dropdownOptions);
+
     return (
       <div className="flex flex-wrap gap-1.5">
         {labels.map((label: string, index: number) => {
-          return badge({ label, key: `${label}-${index}` });
+          const option: CustomFieldDropdownOption | undefined =
+            configuredOptions.find(
+              (configuredOption: CustomFieldDropdownOption) => {
+                return configuredOption.value === label;
+              },
+            );
+
+          return badge({
+            label,
+            key: `${label}-${index}`,
+            color: option?.color,
+          });
         })}
       </div>
     );
   }
 
   if (definition.customFieldType === CustomFieldType.Dropdown) {
-    return badge({ label: String(value), key: String(value) });
+    const label: string = String(value);
+    const option: CustomFieldDropdownOption | undefined = parseDropdownOptions(
+      definition.dropdownOptions,
+    ).find((configuredOption: CustomFieldDropdownOption) => {
+      return configuredOption.value === label;
+    });
+
+    return badge({ label, key: label, color: option?.color });
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION
## What changed

- Add an optional color picker beside each single- and multi-select custom-field dropdown option.
- Render saved colors consistently in custom-field detail views and generated model-table columns, with automatic readable foreground contrast.
- Add dropdown option editing to the team-member custom-field settings page as well.
- Keep legacy one-option-per-line definitions unchanged when no colors are configured; colored definitions use a structured representation parsed through one shared compatibility layer.
- Make clearing a color truly return the color picker to its empty state.

## Why

Custom-field dropdown values could not carry the same visual meaning as other colored values in OneUptime. This adds that capability through the existing dropdown color model while retaining old definitions and saved custom-field values.

## Compatibility and impact

- No database migration is required.
- Existing newline-based options remain readable and continue to be written in their original format until a color is selected.
- Clearing the final color returns the definition to newline storage.
- Unknown or removed saved values retain the existing uncolored badge fallback.
- Malformed or invalid color data is ignored safely, and legacy values that happen to resemble JSON remain intact.

## Validation

- 6 focused Jest suites: 134 tests passed.
- `npm run compile` in `Common`: passed.
- `npm run compile` in `App`: passed.
- ESLint with fixes over every changed TypeScript/TSX file: passed.
- `git diff --check`: passed.
