### PR TITLE
Allow creating empty resource inventories

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Ceph/Clusters.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Ceph/Clusters.tsx
@@ -234,17 +234,6 @@ const CephClusters: FunctionComponent<
     return <ErrorMessage message={error} />;
   }
 
-  if (clusterCount === 0) {
-    return (
-      <Fragment>
-        <CephDocumentationCard
-          title="Getting Started with Ceph Monitoring"
-          description="No Ceph clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<CephCluster>
@@ -257,6 +246,12 @@ const CephClusters: FunctionComponent<
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<CephCluster>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(item: CephCluster): Promise<CephCluster> => {
+          setClusterCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -504,6 +499,12 @@ const CephClusters: FunctionComponent<
           );
         }}
       />
+      {clusterCount === 0 && (
+        <CephDocumentationCard
+          title="Getting Started with Ceph Monitoring"
+          description="No Ceph clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Cloud/CloudResources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Cloud/CloudResources.tsx
@@ -56,18 +56,6 @@ const CloudResources: FunctionComponent<
     return <PageLoader isVisible={true} />;
   }
 
-  if (count === 0) {
-    return (
-      <Fragment>
-        <ResourceDocumentationCard
-          title="Getting Started with Cloud Environments"
-          description="No cloud environments connected yet. Point your OpenTelemetry Collector at OneUptime with a cloud resource detector using the guide below — managed compute appears here automatically once the first telemetry arrives."
-          buildMarkdown={getCloudDocMarkdown}
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<CloudResource>
@@ -77,9 +65,15 @@ const CloudResources: FunctionComponent<
         query={{
           isArchived: false,
         }}
+        onCreateSuccess={(item: CloudResource): Promise<CloudResource> => {
+          setCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
+        }}
         isDeleteable={false}
         isEditable={false}
-        isCreateable={false}
+        isCreateable={true}
         isViewable={true}
         bulkActions={{
           buttons: [...archiveBulkActions],
@@ -293,6 +287,13 @@ const CloudResources: FunctionComponent<
           );
         }}
       />
+      {count === 0 && (
+        <ResourceDocumentationCard
+          title="Getting Started with Cloud Environments"
+          description="No cloud environments connected yet. Point your OpenTelemetry Collector at OneUptime with a cloud resource detector using the guide below — managed compute appears here automatically once the first telemetry arrives."
+          buildMarkdown={getCloudDocMarkdown}
+        />
+      )}
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Pages/Docker/Hosts.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Docker/Hosts.tsx
@@ -119,17 +119,6 @@ const DockerHosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return <ErrorMessage message={error} />;
   }
 
-  if (hostCount === 0) {
-    return (
-      <Fragment>
-        <DockerDocumentationCard
-          title="Getting Started with Docker Monitoring"
-          description="No Docker hosts connected yet. Install the agent using the guide below and your host will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<DockerHost>
@@ -142,6 +131,12 @@ const DockerHosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<DockerHost>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(item: DockerHost): Promise<DockerHost> => {
+          setHostCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -320,6 +315,12 @@ const DockerHosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
           );
         }}
       />
+      {hostCount === 0 && (
+        <DockerDocumentationCard
+          title="Getting Started with Docker Monitoring"
+          description="No Docker hosts connected yet. Install the agent using the guide below and your host will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/DockerSwarm/Clusters.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/DockerSwarm/Clusters.tsx
@@ -160,17 +160,6 @@ const DockerSwarmClusters: FunctionComponent<
     return <ErrorMessage message={error} />;
   }
 
-  if (clusterCount === 0) {
-    return (
-      <Fragment>
-        <DockerSwarmDocumentationCard
-          title="Getting Started with Docker Swarm Monitoring"
-          description="No Docker Swarm clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<DockerSwarmCluster>
@@ -183,6 +172,14 @@ const DockerSwarmClusters: FunctionComponent<
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<DockerSwarmCluster>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(
+          item: DockerSwarmCluster,
+        ): Promise<DockerSwarmCluster> => {
+          setClusterCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -419,6 +416,12 @@ const DockerSwarmClusters: FunctionComponent<
           );
         }}
       />
+      {clusterCount === 0 && (
+        <DockerSwarmDocumentationCard
+          title="Getting Started with Docker Swarm Monitoring"
+          description="No Docker Swarm clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Host/Hosts.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Host/Hosts.tsx
@@ -289,17 +289,6 @@ const Hosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return <ErrorMessage message={error} />;
   }
 
-  if (hostCount === 0) {
-    return (
-      <Fragment>
-        <HostDocumentationCard
-          title="Getting Started with Host Monitoring"
-          description="No hosts connected yet. Wire up an OpenTelemetry Collector with the hostmetrics receiver using the guide below — your host will appear here automatically once the first metric batch arrives."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<Host>
@@ -315,6 +304,12 @@ const Hosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<Host>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(item: Host): Promise<Host> => {
+          setHostCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -613,6 +608,12 @@ const Hosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
           );
         }}
       />
+      {hostCount === 0 && (
+        <HostDocumentationCard
+          title="Getting Started with Host Monitoring"
+          description="No hosts connected yet. Wire up an OpenTelemetry Collector with the hostmetrics receiver using the guide below — your host will appear here automatically once the first metric batch arrives."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/IoT/Fleets.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/IoT/Fleets.tsx
@@ -158,17 +158,6 @@ const IoTFleets: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return <ErrorMessage message={error} />;
   }
 
-  if (fleetCount === 0) {
-    return (
-      <Fragment>
-        <IoTDocumentationCard
-          title="Getting Started with IoT Monitoring"
-          description="No IoT fleets connected yet. Install the agent using the guide below and your fleet will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<IoTFleet>
@@ -181,6 +170,12 @@ const IoTFleets: FunctionComponent<PageComponentProps> = (): ReactElement => {
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<IoTFleet>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(item: IoTFleet): Promise<IoTFleet> => {
+          setFleetCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -373,6 +368,12 @@ const IoTFleets: FunctionComponent<PageComponentProps> = (): ReactElement => {
           );
         }}
       />
+      {fleetCount === 0 && (
+        <IoTDocumentationCard
+          title="Getting Started with IoT Monitoring"
+          description="No IoT fleets connected yet. Install the agent using the guide below and your fleet will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Clusters.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Clusters.tsx
@@ -121,18 +121,6 @@ const KubernetesClusters: FunctionComponent<
     return <ErrorMessage message={error} />;
   }
 
-  if (clusterCount === 0) {
-    return (
-      <Fragment>
-        <KubernetesDocumentationCard
-          clusterName="my-cluster"
-          title="Getting Started with Kubernetes Monitoring"
-          description="No Kubernetes clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<KubernetesCluster>
@@ -145,6 +133,14 @@ const KubernetesClusters: FunctionComponent<
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<KubernetesCluster>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(
+          item: KubernetesCluster,
+        ): Promise<KubernetesCluster> => {
+          setClusterCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -323,6 +319,13 @@ const KubernetesClusters: FunctionComponent<
           );
         }}
       />
+      {clusterCount === 0 && (
+        <KubernetesDocumentationCard
+          clusterName="my-cluster"
+          title="Getting Started with Kubernetes Monitoring"
+          description="No Kubernetes clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Podman/Hosts.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Podman/Hosts.tsx
@@ -119,17 +119,6 @@ const PodmanHosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
     return <ErrorMessage message={error} />;
   }
 
-  if (hostCount === 0) {
-    return (
-      <Fragment>
-        <PodmanDocumentationCard
-          title="Getting Started with Podman Monitoring"
-          description="No Podman hosts connected yet. Install the agent using the guide below and your host will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<PodmanHost>
@@ -142,6 +131,12 @@ const PodmanHosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<PodmanHost>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(item: PodmanHost): Promise<PodmanHost> => {
+          setHostCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -320,6 +315,12 @@ const PodmanHosts: FunctionComponent<PageComponentProps> = (): ReactElement => {
           );
         }}
       />
+      {hostCount === 0 && (
+        <PodmanDocumentationCard
+          title="Getting Started with Podman Monitoring"
+          description="No Podman hosts connected yet. Install the agent using the guide below and your host will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Proxmox/Clusters.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Proxmox/Clusters.tsx
@@ -160,17 +160,6 @@ const ProxmoxClusters: FunctionComponent<
     return <ErrorMessage message={error} />;
   }
 
-  if (clusterCount === 0) {
-    return (
-      <Fragment>
-        <ProxmoxDocumentationCard
-          title="Getting Started with Proxmox Monitoring"
-          description="No Proxmox clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<ProxmoxCluster>
@@ -183,6 +172,12 @@ const ProxmoxClusters: FunctionComponent<
         query={mergeFiltersIntoQuery({ isArchived: false })}
         onFetchSuccess={(data: Array<ProxmoxCluster>) => {
           onResourcesFetched(data);
+        }}
+        onCreateSuccess={(item: ProxmoxCluster): Promise<ProxmoxCluster> => {
+          setClusterCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -360,6 +355,12 @@ const ProxmoxClusters: FunctionComponent<
           );
         }}
       />
+      {clusterCount === 0 && (
+        <ProxmoxDocumentationCard
+          title="Getting Started with Proxmox Monitoring"
+          description="No Proxmox clusters connected yet. Install the agent using the guide below and your cluster will appear here automatically."
+        />
+      )}
       {labelBulkActionModals}
       {ownerBulkActionModals}
     </Fragment>

--- a/App/FeatureSet/Dashboard/src/Pages/Rum/RumApplications.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Rum/RumApplications.tsx
@@ -56,18 +56,6 @@ const RumApplications: FunctionComponent<
     return <PageLoader isVisible={true} />;
   }
 
-  if (count === 0) {
-    return (
-      <Fragment>
-        <ResourceDocumentationCard
-          title="Getting Started with Real User Monitoring"
-          description="No RUM applications connected yet. Instrument your browser or mobile app with OpenTelemetry using the guide below — it appears here automatically once the first telemetry arrives."
-          buildMarkdown={getRumDocMarkdown}
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<RumApplication>
@@ -76,6 +64,12 @@ const RumApplications: FunctionComponent<
         userPreferencesKey="rum-applications-table"
         query={{
           isArchived: false,
+        }}
+        onCreateSuccess={(item: RumApplication): Promise<RumApplication> => {
+          setCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -279,6 +273,13 @@ const RumApplications: FunctionComponent<
           );
         }}
       />
+      {count === 0 && (
+        <ResourceDocumentationCard
+          title="Getting Started with Real User Monitoring"
+          description="No RUM applications connected yet. Instrument your browser or mobile app with OpenTelemetry using the guide below — it appears here automatically once the first telemetry arrives."
+          buildMarkdown={getRumDocMarkdown}
+        />
+      )}
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Pages/Serverless/ServerlessFunctions.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Serverless/ServerlessFunctions.tsx
@@ -56,18 +56,6 @@ const ServerlessFunctions: FunctionComponent<
     return <PageLoader isVisible={true} />;
   }
 
-  if (count === 0) {
-    return (
-      <Fragment>
-        <ResourceDocumentationCard
-          title="Getting Started with Serverless Functions"
-          description="No serverless functions connected yet. Instrument a function with OpenTelemetry using the guide below — it appears here automatically once the first telemetry arrives."
-          buildMarkdown={getServerlessDocMarkdown}
-        />
-      </Fragment>
-    );
-  }
-
   return (
     <Fragment>
       <ModelTable<ServerlessFunction>
@@ -76,6 +64,14 @@ const ServerlessFunctions: FunctionComponent<
         userPreferencesKey="serverless-functions-table"
         query={{
           isArchived: false,
+        }}
+        onCreateSuccess={(
+          item: ServerlessFunction,
+        ): Promise<ServerlessFunction> => {
+          setCount((currentCount: number | null): number => {
+            return (currentCount || 0) + 1;
+          });
+          return Promise.resolve(item);
         }}
         isDeleteable={false}
         isEditable={false}
@@ -288,6 +284,13 @@ const ServerlessFunctions: FunctionComponent<
           );
         }}
       />
+      {count === 0 && (
+        <ResourceDocumentationCard
+          title="Getting Started with Serverless Functions"
+          description="No serverless functions connected yet. Instrument a function with OpenTelemetry using the guide below — it appears here automatically once the first telemetry arrives."
+          buildMarkdown={getServerlessDocMarkdown}
+        />
+      )}
     </Fragment>
   );
 };

--- a/App/Tests/Dashboard/EmptyResourceInventoryPages.test.ts
+++ b/App/Tests/Dashboard/EmptyResourceInventoryPages.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Resource inventory pages used to return their setup documentation instead
+ * of their ModelTable when the initial count was zero. That made the table's
+ * Create button unreachable, so the only way to get the first resource was to
+ * send telemetry and let auto-discovery create it.
+ *
+ * The App test suite runs in a plain Node environment without a React renderer.
+ * These tests therefore pin the JSX wiring directly, following the same source
+ * invariant pattern as MonitorProbeSelectionPages.test.ts and
+ * NetworkSitePageInvariants.test.ts. Whitespace is squashed so Prettier can
+ * reflow props without making the tests brittle.
+ */
+
+const DASHBOARD_PAGES: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+);
+
+interface ResourceInventoryPageCase {
+  readonly label: string;
+  readonly relativePath: string;
+  readonly modelType: string;
+  readonly countState: string;
+  readonly countSetter: string;
+  readonly documentationCard: string;
+}
+
+const RESOURCE_INVENTORY_PAGES: ReadonlyArray<ResourceInventoryPageCase> = [
+  {
+    label: "RUM applications",
+    relativePath: "Rum/RumApplications.tsx",
+    modelType: "RumApplication",
+    countState: "count",
+    countSetter: "setCount",
+    documentationCard: "ResourceDocumentationCard",
+  },
+  {
+    label: "Kubernetes clusters",
+    relativePath: "Kubernetes/Clusters.tsx",
+    modelType: "KubernetesCluster",
+    countState: "clusterCount",
+    countSetter: "setClusterCount",
+    documentationCard: "KubernetesDocumentationCard",
+  },
+  {
+    label: "Docker hosts",
+    relativePath: "Docker/Hosts.tsx",
+    modelType: "DockerHost",
+    countState: "hostCount",
+    countSetter: "setHostCount",
+    documentationCard: "DockerDocumentationCard",
+  },
+  {
+    label: "Podman hosts",
+    relativePath: "Podman/Hosts.tsx",
+    modelType: "PodmanHost",
+    countState: "hostCount",
+    countSetter: "setHostCount",
+    documentationCard: "PodmanDocumentationCard",
+  },
+  {
+    label: "Docker Swarm clusters",
+    relativePath: "DockerSwarm/Clusters.tsx",
+    modelType: "DockerSwarmCluster",
+    countState: "clusterCount",
+    countSetter: "setClusterCount",
+    documentationCard: "DockerSwarmDocumentationCard",
+  },
+  {
+    label: "Proxmox clusters",
+    relativePath: "Proxmox/Clusters.tsx",
+    modelType: "ProxmoxCluster",
+    countState: "clusterCount",
+    countSetter: "setClusterCount",
+    documentationCard: "ProxmoxDocumentationCard",
+  },
+  {
+    label: "Ceph clusters",
+    relativePath: "Ceph/Clusters.tsx",
+    modelType: "CephCluster",
+    countState: "clusterCount",
+    countSetter: "setClusterCount",
+    documentationCard: "CephDocumentationCard",
+  },
+  {
+    label: "hosts",
+    relativePath: "Host/Hosts.tsx",
+    modelType: "Host",
+    countState: "hostCount",
+    countSetter: "setHostCount",
+    documentationCard: "HostDocumentationCard",
+  },
+  {
+    label: "IoT fleets",
+    relativePath: "IoT/Fleets.tsx",
+    modelType: "IoTFleet",
+    countState: "fleetCount",
+    countSetter: "setFleetCount",
+    documentationCard: "IoTDocumentationCard",
+  },
+  {
+    label: "cloud resources",
+    relativePath: "Cloud/CloudResources.tsx",
+    modelType: "CloudResource",
+    countState: "count",
+    countSetter: "setCount",
+    documentationCard: "ResourceDocumentationCard",
+  },
+  {
+    label: "serverless functions",
+    relativePath: "Serverless/ServerlessFunctions.tsx",
+    modelType: "ServerlessFunction",
+    countState: "count",
+    countSetter: "setCount",
+    documentationCard: "ResourceDocumentationCard",
+  },
+];
+
+function squash(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+function readRawSource(resourceCase: ResourceInventoryPageCase): string {
+  return fs.readFileSync(
+    path.join(DASHBOARD_PAGES, resourceCase.relativePath),
+    "utf8",
+  );
+}
+
+function readSource(resourceCase: ResourceInventoryPageCase): string {
+  return squash(readRawSource(resourceCase));
+}
+
+function readCode(resourceCase: ResourceInventoryPageCase): string {
+  return squash(stripComments(readRawSource(resourceCase)));
+}
+
+function getAllTsxFiles(directory: string): Array<string> {
+  const files: Array<string> = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...getAllTsxFiles(absolutePath));
+    } else if (entry.name.endsWith(".tsx")) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+function toPosixRelativePath(absolutePath: string): string {
+  return path.relative(DASHBOARD_PAGES, absolutePath).split(path.sep).join("/");
+}
+
+describe("empty resource inventory page catalog", () => {
+  test("covers every page that combines a model table with setup documentation", () => {
+    const discoveredPages: Array<string> = getAllTsxFiles(DASHBOARD_PAGES)
+      .filter((absolutePath: string): boolean => {
+        const source: string = fs.readFileSync(absolutePath, "utf8");
+
+        return (
+          source.includes("<ModelTable<") &&
+          source.match(/<[A-Za-z]+DocumentationCard\b/) !== null
+        );
+      })
+      .map(toPosixRelativePath)
+      .sort();
+
+    const testedPages: Array<string> = RESOURCE_INVENTORY_PAGES.map(
+      (resourceCase: ResourceInventoryPageCase): string => {
+        return resourceCase.relativePath;
+      },
+    ).sort();
+
+    expect(RESOURCE_INVENTORY_PAGES).toHaveLength(11);
+    expect(discoveredPages).toEqual(testedPages);
+  });
+
+  test("does not accidentally list the same inventory twice", () => {
+    const paths: Array<string> = RESOURCE_INVENTORY_PAGES.map(
+      (resourceCase: ResourceInventoryPageCase): string => {
+        return resourceCase.relativePath;
+      },
+    );
+
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});
+
+describe.each(RESOURCE_INVENTORY_PAGES)(
+  "$label empty state",
+  (resourceCase: ResourceInventoryPageCase) => {
+    const source: string = readSource(resourceCase);
+    const code: string = readCode(resourceCase);
+    const modelTable: string = `<ModelTable<${resourceCase.modelType}>`;
+    const zeroState: string = `{${resourceCase.countState} === 0 && (`;
+    const documentationCard: string = `<${resourceCase.documentationCard}`;
+
+    test("keeps the inventory table mounted when the count is zero", () => {
+      expect(source).toContain(modelTable);
+      expect(code).not.toMatch(
+        new RegExp(
+          `if\\s*\\(\\s*${resourceCase.countState}\\s*===\\s*0\\s*\\)\\s*\\{\\s*return\\s*\\(`,
+        ),
+      );
+    });
+
+    test("keeps manual creation available", () => {
+      const tableStart: number = source.indexOf(modelTable);
+      const tableEnd: number = source.indexOf("/>", tableStart);
+
+      expect(tableStart).toBeGreaterThan(-1);
+      expect(source.slice(tableStart, tableEnd)).toContain(
+        "isCreateable={true}",
+      );
+    });
+
+    test("renders setup documentation only for a zero count", () => {
+      expect(source).toContain(zeroState);
+      expect(
+        source.indexOf(documentationCard, source.indexOf(zeroState)),
+      ).toBeGreaterThan(source.indexOf(zeroState));
+    });
+
+    test("places the empty table above the documentation", () => {
+      const tableStart: number = source.indexOf(modelTable);
+      const zeroStateStart: number = source.indexOf(zeroState);
+      const documentationStart: number = source.indexOf(
+        documentationCard,
+        zeroStateStart,
+      );
+
+      expect(tableStart).toBeGreaterThan(-1);
+      expect(zeroStateStart).toBeGreaterThan(tableStart);
+      expect(documentationStart).toBeGreaterThan(zeroStateStart);
+    });
+
+    test("hides the guide immediately after the first manual creation", () => {
+      const createSuccessStart: number = source.indexOf("onCreateSuccess={");
+      const createSuccessEnd: number = source.indexOf(
+        "isDeleteable=",
+        createSuccessStart,
+      );
+      const createSuccessSource: string = source.slice(
+        createSuccessStart,
+        createSuccessEnd,
+      );
+
+      expect(createSuccessStart).toBeGreaterThan(-1);
+      expect(createSuccessSource).toContain(`${resourceCase.countSetter}(`);
+      expect(createSuccessSource).toContain("return (currentCount || 0) + 1;");
+      expect(createSuccessSource).toContain("return Promise.resolve(item);");
+    });
+
+    test("retains the loading and error gates before mounting the table", () => {
+      const tableStart: number = source.indexOf(modelTable);
+
+      expect(source.indexOf("<PageLoader")).toBeGreaterThan(-1);
+      expect(source.indexOf("<PageLoader")).toBeLessThan(tableStart);
+      expect(source.indexOf("<ErrorMessage")).toBeGreaterThan(-1);
+      expect(source.indexOf("<ErrorMessage")).toBeLessThan(tableStart);
+    });
+  },
+);


### PR DESCRIPTION
## What changed

- Always render the createable inventory table above setup documentation when a resource count is zero.
- Apply the empty-state behavior consistently to RUM applications, Kubernetes clusters, Docker hosts, Podman hosts, Docker Swarm clusters, Proxmox clusters, Ceph clusters, hosts, IoT fleets, cloud resources, and serverless functions.
- Enable manual creation for cloud resources, which was the remaining inventory in this group with creation disabled.
- Hide setup documentation immediately after the first manual resource is created.
- Add a catalog-driven regression suite that verifies all inventory/documentation pages keep creation available, order the table before the guide, retain loading and error gates, and cannot be omitted from the test matrix unnoticed.

## Why

These pages previously returned setup documentation instead of their `ModelTable` when the initial count was zero. That also removed the table's Create action, forcing users to send telemetry before they could create their first resource. The inventory now remains usable while the existing setup guide is preserved below it.

## Validation

- `npm run fix` from the repository root
- `npm run compile` in `App`
- `npm run compile` in `App/FeatureSet/Dashboard`
- Full Dashboard test suite: 66 suites and 2,018 tests passed
- Focused post-rebase regression suite: 68 tests passed
- Rebased onto the latest `origin/master`; final worktree is clean
