### PR TITLE
Show incident, alert, and maintenance durations

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
@@ -65,6 +65,8 @@ import ObjectID from "Common/Types/ObjectID";
 import AlertStateTimeline from "Common/Models/DatabaseModels/AlertStateTimeline";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
+import LiveDuration from "../EventView/LiveDuration";
+import useEventTimelineEndDates from "../EventView/useEventTimelineEndDates";
 
 export interface ComponentProps {
   query?: Query<Alert> | undefined;
@@ -87,6 +89,27 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
     useState<boolean>(false);
   const [bulkActionProps, setBulkActionProps] =
     useState<BulkActionOnClickProps<Alert> | null>(null);
+  const [visibleAlerts, setVisibleAlerts] = useState<Array<Alert>>([]);
+
+  const resolvedAlertIds: Array<string> = visibleAlerts
+    .filter((alert: Alert) => {
+      return Boolean(alert.currentAlertState?.isResolvedState);
+    })
+    .map((alert: Alert) => {
+      return alert.id?.toString() || "";
+    })
+    .filter((alertId: string) => {
+      return Boolean(alertId);
+    });
+
+  const {
+    endDateByEventId: resolvedAtByAlertId,
+    isLoading: isLoadingAlertDurations,
+  } = useEventTimelineEndDates<AlertStateTimeline>({
+    eventIds: resolvedAlertIds,
+    eventIdField: "alertId",
+    timelineModelType: AlertStateTimeline,
+  });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
     useBulkLabelActions<Alert>({ modelType: Alert });
@@ -532,6 +555,7 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
         onFacetStateRestored={restoreFacetState}
         query={mergeFiltersIntoQuery(props.query)}
         onFetchSuccess={(data: Array<Alert>) => {
+          setVisibleAlerts(data);
           onResourcesFetched(data);
         }}
         isEditable={false}
@@ -678,6 +702,7 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
               currentAlertState: {
                 name: true,
                 color: true,
+                isResolvedState: true,
               },
             },
             title: "State",
@@ -790,6 +815,38 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
             title: "Created",
             type: FieldType.DateTime,
             hideOnMobile: true,
+          },
+          {
+            field: {
+              createdAt: true,
+            },
+            title: "Duration",
+            type: FieldType.Element,
+            disableSort: true,
+            disableCsvExport: true,
+            getElement: (item: Alert): ReactElement => {
+              const alertId: string = item.id?.toString() || "";
+              const isResolved: boolean = Boolean(
+                item.currentAlertState?.isResolvedState,
+              );
+              const resolvedAt: Date | undefined = alertId
+                ? resolvedAtByAlertId[alertId]
+                : undefined;
+
+              if (
+                !item.createdAt ||
+                (isResolved && (isLoadingAlertDurations || !resolvedAt))
+              ) {
+                return <>-</>;
+              }
+
+              return (
+                <LiveDuration
+                  startDate={item.createdAt}
+                  endDate={isResolved ? resolvedAt : undefined}
+                />
+              );
+            },
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Components/Alert/ChangeState.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/ChangeState.tsx
@@ -37,6 +37,7 @@ export interface ComponentProps {
   onActionComplete: () => void;
   eventNumber?: string | undefined;
   title?: string | undefined;
+  eventStartsAt?: Date | undefined;
   severity?: { name: string; color: Color } | undefined;
   isPrivate?: boolean | undefined;
 }
@@ -279,7 +280,8 @@ const ChangeAlertState: FunctionComponent<ComponentProps> = (
       return actions;
     };
 
-  const durationStartsAt: Date | undefined = alertStateTimelines[0]?.startsAt;
+  const durationStartsAt: Date | undefined =
+    props.eventStartsAt || alertStateTimelines[0]?.startsAt;
 
   let durationPrefix: string = "Ongoing for";
   let durationEndsAt: Date | undefined = undefined;

--- a/App/FeatureSet/Dashboard/src/Components/EventView/LiveDuration.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/LiveDuration.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { getEventDurationText } from "../../Utils/EventDuration";
 
 export interface ComponentProps {
   startDate: Date;
@@ -32,14 +33,7 @@ const LiveDuration: FunctionComponent<ComponentProps> = (
 
   const endDate: Date = props.endDate || now;
 
-  const minutes: number = Math.abs(
-    OneUptimeDate.getDifferenceInMinutes(endDate, props.startDate),
-  );
-
-  const text: string =
-    minutes < 1
-      ? "less than a minute"
-      : OneUptimeDate.convertMinutesToDaysHoursAndMinutes(minutes);
+  const text: string = getEventDurationText(props.startDate, endDate);
 
   return <span>{text}</span>;
 };

--- a/App/FeatureSet/Dashboard/src/Components/EventView/useEventTimelineEndDates.ts
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/useEventTimelineEndDates.ts
@@ -1,0 +1,132 @@
+import Includes from "Common/Types/BaseDatabase/Includes";
+import Query from "Common/Types/BaseDatabase/Query";
+import Select from "Common/Types/BaseDatabase/Select";
+import Sort from "Common/Types/BaseDatabase/Sort";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import DatabaseBaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import { useEffect, useMemo, useState } from "react";
+import {
+  EventTimelineDate,
+  getLatestTimelineDateByEventId,
+} from "../../Utils/EventDuration";
+
+type TimelineModel = DatabaseBaseModel & {
+  startsAt?: Date | undefined;
+};
+
+export interface UseEventTimelineEndDatesProps<
+  TTimeline extends TimelineModel,
+> {
+  eventIds: Array<string>;
+  eventIdField: keyof TTimeline;
+  timelineModelType: { new (): TTimeline };
+}
+
+export interface UseEventTimelineEndDatesResult {
+  endDateByEventId: Record<string, Date>;
+  isLoading: boolean;
+}
+
+/**
+ * Fetch the final state-change date for the resolved events on the current
+ * table page. Keeping this batched avoids an N+1 request for every table row.
+ */
+export default function useEventTimelineEndDates<
+  TTimeline extends TimelineModel,
+>(
+  props: UseEventTimelineEndDatesProps<TTimeline>,
+): UseEventTimelineEndDatesResult {
+  const eventIdsKey: string = useMemo(() => {
+    return Array.from(new Set(props.eventIds)).sort().join(",");
+  }, [props.eventIds]);
+
+  const [endDateByEventId, setEndDateByEventId] = useState<
+    Record<string, Date>
+  >({});
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    const eventIds: Array<string> = eventIdsKey ? eventIdsKey.split(",") : [];
+
+    if (eventIds.length === 0) {
+      setEndDateByEventId({});
+      setIsLoading(false);
+      return () => {};
+    }
+
+    let isCancelled: boolean = false;
+
+    const fetchEndDates: () => Promise<void> = async (): Promise<void> => {
+      setIsLoading(true);
+
+      try {
+        const query: Query<TTimeline> = {
+          [props.eventIdField]: new Includes(eventIds),
+        } as unknown as Query<TTimeline>;
+        const select: Select<TTimeline> = {
+          [props.eventIdField]: true,
+          startsAt: true,
+        } as Select<TTimeline>;
+
+        const result: ListResult<TTimeline> = await ModelAPI.getList<TTimeline>(
+          {
+            modelType: props.timelineModelType,
+            query: query,
+            limit: LIMIT_PER_PROJECT,
+            skip: 0,
+            select: select,
+            sort: {
+              startsAt: SortOrder.Descending,
+            } as Sort<TTimeline>,
+          },
+        );
+
+        const timelineDates: Array<EventTimelineDate> = [];
+
+        for (const timeline of result.data) {
+          const eventId: unknown = timeline[props.eventIdField];
+
+          if (!eventId) {
+            continue;
+          }
+
+          timelineDates.push({
+            eventId: eventId.toString(),
+            ...(timeline.startsAt ? { startsAt: timeline.startsAt } : {}),
+          });
+        }
+
+        if (!isCancelled) {
+          setEndDateByEventId(getLatestTimelineDateByEventId(timelineDates));
+        }
+      } catch {
+        if (!isCancelled) {
+          // The primary table remains usable if duration enrichment fails.
+          setEndDateByEventId({});
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchEndDates().catch(() => {
+      if (!isCancelled) {
+        setEndDateByEventId({});
+        setIsLoading(false);
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [eventIdsKey, props.eventIdField, props.timelineModelType]);
+
+  return {
+    endDateByEventId,
+    isLoading,
+  };
+}

--- a/App/FeatureSet/Dashboard/src/Components/Incident/ChangeState.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/ChangeState.tsx
@@ -36,6 +36,7 @@ export interface ComponentProps {
   onActionComplete: () => void;
   eventNumber?: string | undefined;
   title?: string | undefined;
+  eventStartsAt?: Date | undefined;
   severity?: { name: string; color: Color } | undefined;
   isPrivate?: boolean | undefined;
 }
@@ -260,7 +261,7 @@ const ChangeIncidentState: FunctionComponent<ComponentProps> = (
   }
 
   const durationStartsAt: Date | undefined =
-    incidentStateTimelines[0]?.startsAt;
+    props.eventStartsAt || incidentStateTimelines[0]?.startsAt;
 
   let durationEndsAt: Date | undefined = undefined;
   let durationPrefix: string = "Ongoing for";

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
@@ -65,6 +65,8 @@ import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import IncidentStateTimeline from "Common/Models/DatabaseModels/IncidentStateTimeline";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
+import LiveDuration from "../EventView/LiveDuration";
+import useEventTimelineEndDates from "../EventView/useEventTimelineEndDates";
 
 export interface ComponentProps {
   query?: Query<Incident> | undefined;
@@ -90,6 +92,27 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
     useState<boolean>(false);
   const [bulkActionProps, setBulkActionProps] =
     useState<BulkActionOnClickProps<Incident> | null>(null);
+  const [visibleIncidents, setVisibleIncidents] = useState<Array<Incident>>([]);
+
+  const resolvedIncidentIds: Array<string> = visibleIncidents
+    .filter((incident: Incident) => {
+      return Boolean(incident.currentIncidentState?.isResolvedState);
+    })
+    .map((incident: Incident) => {
+      return incident.id?.toString() || "";
+    })
+    .filter((incidentId: string) => {
+      return Boolean(incidentId);
+    });
+
+  const {
+    endDateByEventId: resolvedAtByIncidentId,
+    isLoading: isLoadingIncidentDurations,
+  } = useEventTimelineEndDates<IncidentStateTimeline>({
+    eventIds: resolvedIncidentIds,
+    eventIdField: "incidentId",
+    timelineModelType: IncidentStateTimeline,
+  });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
     useBulkLabelActions<Incident>({ modelType: Incident });
@@ -501,6 +524,7 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
         onFacetStateRestored={restoreFacetState}
         query={mergeFiltersIntoQuery(props.query)}
         onFetchSuccess={(data: Array<Incident>) => {
+          setVisibleIncidents(data);
           onResourcesFetched(data);
         }}
         isEditable={false}
@@ -650,6 +674,7 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
               currentIncidentState: {
                 name: true,
                 color: true,
+                isResolvedState: true,
               },
             },
             title: "State",
@@ -756,6 +781,38 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
             title: "Declared",
             type: FieldType.DateTime,
             hideOnMobile: true,
+          },
+          {
+            field: {
+              declaredAt: true,
+            },
+            title: "Duration",
+            type: FieldType.Element,
+            disableSort: true,
+            disableCsvExport: true,
+            getElement: (item: Incident): ReactElement => {
+              const incidentId: string = item.id?.toString() || "";
+              const isResolved: boolean = Boolean(
+                item.currentIncidentState?.isResolvedState,
+              );
+              const resolvedAt: Date | undefined = incidentId
+                ? resolvedAtByIncidentId[incidentId]
+                : undefined;
+
+              if (
+                !item.declaredAt ||
+                (isResolved && (isLoadingIncidentDurations || !resolvedAt))
+              ) {
+                return <>-</>;
+              }
+
+              return (
+                <LiveDuration
+                  startDate={item.declaredAt}
+                  endDate={isResolved ? resolvedAt : undefined}
+                />
+              );
+            },
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
@@ -65,6 +65,7 @@ import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import ScheduledMaintenanceStateTimeline from "Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
+import LiveDuration from "../EventView/LiveDuration";
 
 export interface ComponentProps {
   query?: Query<ScheduledMaintenance> | undefined;
@@ -722,6 +723,25 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
             title: "Starts At",
             type: FieldType.DateTime,
             hideOnMobile: true,
+          },
+          {
+            field: {
+              startsAt: true,
+              endsAt: true,
+            },
+            title: "Duration",
+            type: FieldType.Element,
+            disableSort: true,
+            disableCsvExport: true,
+            getElement: (item: ScheduledMaintenance): ReactElement => {
+              if (!item.startsAt || !item.endsAt) {
+                return <>-</>;
+              }
+
+              return (
+                <LiveDuration startDate={item.startsAt} endDate={item.endsAt} />
+              );
+            },
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -71,6 +71,8 @@ import Query from "Common/Types/BaseDatabase/Query";
 import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
 import Span from "Common/Models/AnalyticsModels/Span";
 import Log from "Common/Models/AnalyticsModels/Log";
+import LiveDuration from "../../../Components/EventView/LiveDuration";
+import { getEventEndDateForCurrentState } from "../../../Utils/EventDuration";
 
 const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID();
@@ -99,6 +101,9 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [isPrivate, setIsPrivate] = useState<boolean>(false);
   const [eventNumber, setEventNumber] = useState<string | undefined>(undefined);
   const [alertTitle, setAlertTitle] = useState<string | undefined>(undefined);
+  const [alertStartedAt, setAlertStartedAt] = useState<Date | undefined>(
+    undefined,
+  );
 
   const fetchData: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -149,6 +154,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
           seriesLabels: true,
           isPrivate: true,
           title: true,
+          createdAt: true,
           alertNumber: true,
           alertNumberWithPrefix: true,
           alertSeverity: {
@@ -211,6 +217,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
       setIsPrivate(alert?.isPrivate || false);
 
       setAlertTitle(alert?.title || undefined);
+      setAlertStartedAt(alert?.createdAt || undefined);
 
       setEventNumber(
         alert?.alertNumberWithPrefix ||
@@ -297,7 +304,8 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   type getTimeFunction = () => string;
 
   const getTimeToAcknowledge: getTimeFunction = (): string => {
-    const alertStartTime: Date = alertStateTimeline[0]?.startsAt || new Date();
+    const alertStartTime: Date =
+      alertStartedAt || alertStateTimeline[0]?.startsAt || new Date();
 
     const acknowledgeTime: Date | undefined = getLastTimelineDateForState(
       getAcknowledgeState()?._id?.toString(),
@@ -326,7 +334,8 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   };
 
   const getTimeToResolve: getTimeFunction = (): string => {
-    const alertStartTime: Date = alertStateTimeline[0]?.startsAt || new Date();
+    const alertStartTime: Date =
+      alertStartedAt || alertStateTimeline[0]?.startsAt || new Date();
 
     const resolveTime: Date | undefined = getFirstTimelineDateForState(
       getResolvedState()?._id?.toString(),
@@ -343,6 +352,18 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
     );
   };
 
+  const durationStartDate: Date | undefined =
+    alertStartedAt || alertStateTimeline[0]?.startsAt;
+  const durationEndDate: Date | undefined = getEventEndDateForCurrentState(
+    alertStateTimeline.map((timeline: AlertStateTimeline) => {
+      return {
+        stateId: timeline.alertStateId?.toString(),
+        startsAt: timeline.startsAt,
+      };
+    }),
+    getResolvedState()?._id?.toString(),
+  );
+
   return (
     <Fragment>
       <div className="mb-5">
@@ -350,6 +371,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
           alertId={modelId}
           eventNumber={eventNumber}
           title={alertTitle}
+          eventStartsAt={durationStartDate}
           severity={severity}
           isPrivate={isPrivate}
           onActionComplete={async () => {
@@ -360,7 +382,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
       <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
         <div className="min-w-0 xl:col-span-2">
-          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
             <EventStatTile
               label={`${getAcknowledgeState()?.name || "Acknowledged"} in`}
               icon={IconProp.Check}
@@ -370,6 +392,20 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
               label={`${getResolvedState()?.name || "Resolved"} in`}
               icon={IconProp.CheckCircle}
               value={getTimeToResolve()}
+            />
+            <EventStatTile
+              label="Duration"
+              icon={IconProp.Clock}
+              value={
+                durationStartDate ? (
+                  <LiveDuration
+                    startDate={durationStartDate}
+                    endDate={durationEndDate}
+                  />
+                ) : (
+                  "-"
+                )
+              }
             />
           </div>
 

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -74,6 +74,8 @@ import Query from "Common/Types/BaseDatabase/Query";
 import Span from "Common/Models/AnalyticsModels/Span";
 import Log from "Common/Models/AnalyticsModels/Log";
 import ExceptionInstance from "Common/Models/AnalyticsModels/ExceptionInstance";
+import LiveDuration from "../../../Components/EventView/LiveDuration";
+import { getEventEndDateForCurrentState } from "../../../Utils/EventDuration";
 
 const IncidentView: FunctionComponent<
   PageComponentProps
@@ -99,6 +101,9 @@ const IncidentView: FunctionComponent<
   const [isPrivate, setIsPrivate] = useState<boolean>(false);
   const [eventNumber, setEventNumber] = useState<string | undefined>(undefined);
   const [incidentTitle, setIncidentTitle] = useState<string | undefined>(
+    undefined,
+  );
+  const [incidentStartedAt, setIncidentStartedAt] = useState<Date | undefined>(
     undefined,
   );
   const [severity, setSeverity] = useState<
@@ -154,6 +159,7 @@ const IncidentView: FunctionComponent<
           seriesLabels: true,
           isPrivate: true,
           title: true,
+          declaredAt: true,
           incidentNumber: true,
           incidentNumberWithPrefix: true,
           incidentSeverity: {
@@ -207,6 +213,7 @@ const IncidentView: FunctionComponent<
       setIsPrivate(incident?.isPrivate === true);
 
       setIncidentTitle(incident?.title || undefined);
+      setIncidentStartedAt(incident?.declaredAt || undefined);
 
       setEventNumber(
         incident?.incidentNumberWithPrefix ||
@@ -299,7 +306,7 @@ const IncidentView: FunctionComponent<
 
   const getTimeToAcknowledge: getTimeFunction = (): string => {
     const incidentStartTime: Date =
-      incidentStateTimeline[0]?.startsAt || new Date();
+      incidentStartedAt || incidentStateTimeline[0]?.startsAt || new Date();
 
     // last matching acknowledge entry (search a copy in reverse; do not mutate state).
     const acknowledgeTime: Date | undefined = [...incidentStateTimeline]
@@ -341,7 +348,7 @@ const IncidentView: FunctionComponent<
 
   const getTimeToResolve: getTimeFunction = (): string => {
     const incidentStartTime: Date =
-      incidentStateTimeline[0]?.startsAt || new Date();
+      incidentStartedAt || incidentStateTimeline[0]?.startsAt || new Date();
 
     const resolveTime: Date | undefined = incidentStateTimeline.find(
       (timeline: IncidentStateTimeline) => {
@@ -363,6 +370,18 @@ const IncidentView: FunctionComponent<
     );
   };
 
+  const durationStartDate: Date | undefined =
+    incidentStartedAt || incidentStateTimeline[0]?.startsAt;
+  const durationEndDate: Date | undefined = getEventEndDateForCurrentState(
+    incidentStateTimeline.map((timeline: IncidentStateTimeline) => {
+      return {
+        stateId: timeline.incidentStateId?.toString(),
+        startsAt: timeline.startsAt,
+      };
+    }),
+    getResolvedState()?._id?.toString(),
+  );
+
   return (
     <Fragment>
       <div className="mb-5">
@@ -370,6 +389,7 @@ const IncidentView: FunctionComponent<
           incidentId={modelId}
           eventNumber={eventNumber}
           title={incidentTitle}
+          eventStartsAt={durationStartDate}
           severity={severity}
           isPrivate={isPrivate}
           onActionComplete={async () => {
@@ -380,7 +400,7 @@ const IncidentView: FunctionComponent<
 
       <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
         <div className="min-w-0 xl:col-span-2">
-          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
             <EventStatTile
               label={`${getAcknowledgeState()?.name || "Acknowledged"} in`}
               icon={IconProp.Check}
@@ -390,6 +410,20 @@ const IncidentView: FunctionComponent<
               label={`${getResolvedState()?.name || "Resolved"} in`}
               icon={IconProp.CheckCircle}
               value={getTimeToResolve()}
+            />
+            <EventStatTile
+              label="Duration"
+              icon={IconProp.Clock}
+              value={
+                durationStartDate ? (
+                  <LiveDuration
+                    startDate={durationStartDate}
+                    endDate={durationEndDate}
+                  />
+                ) : (
+                  "-"
+                )
+              }
             />
           </div>
 

--- a/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/ScheduledMaintenanceEvents/View/Index.tsx
@@ -150,7 +150,7 @@ const ScheduledMaintenanceView: FunctionComponent<
                 icon={IconProp.Clock}
               />
               <EventStatTile
-                label="Window"
+                label="Duration"
                 value={
                   <LiveDuration
                     startDate={eventStartsAt}

--- a/App/FeatureSet/Dashboard/src/Utils/EventDuration.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/EventDuration.ts
@@ -1,0 +1,92 @@
+import OneUptimeDate from "Common/Types/Date";
+
+export interface EventTimelineDate {
+  eventId: string;
+  startsAt?: Date | undefined;
+}
+
+export interface EventStateTimelineDate {
+  stateId?: string | undefined;
+  startsAt?: Date | undefined;
+}
+
+/**
+ * Format an event duration consistently anywhere it is shown in Dashboard.
+ * The caller supplies `endDate` for completed events and the current time for
+ * live events, which keeps this helper deterministic and straightforward to
+ * test.
+ */
+export function getEventDurationText(startDate: Date, endDate: Date): string {
+  const minutes: number = OneUptimeDate.getDifferenceInMinutes(
+    endDate,
+    startDate,
+  );
+
+  if (minutes < 1) {
+    return "less than a minute";
+  }
+
+  return OneUptimeDate.convertMinutesToDaysHoursAndMinutes(minutes);
+}
+
+/**
+ * Build the completion-date lookup used by event tables. Timelines can arrive
+ * in any order, so always retain the latest dated entry for each event.
+ */
+export function getLatestTimelineDateByEventId(
+  timelines: Array<EventTimelineDate>,
+): Record<string, Date> {
+  const latestDateByEventId: Record<string, Date> = {};
+
+  for (const timeline of timelines) {
+    if (!timeline.eventId || !timeline.startsAt) {
+      continue;
+    }
+
+    const currentLatestDate: Date | undefined =
+      latestDateByEventId[timeline.eventId];
+
+    if (
+      !currentLatestDate ||
+      timeline.startsAt.getTime() > currentLatestDate.getTime()
+    ) {
+      latestDateByEventId[timeline.eventId] = timeline.startsAt;
+    }
+  }
+
+  return latestDateByEventId;
+}
+
+/**
+ * Return an event's completion date only when its latest state is resolved.
+ * An event that was resolved and subsequently reopened must keep counting.
+ */
+export function getEventEndDateForCurrentState(
+  timelines: Array<EventStateTimelineDate>,
+  resolvedStateId: string | undefined,
+): Date | undefined {
+  if (!resolvedStateId) {
+    return undefined;
+  }
+
+  let latestTimeline: EventStateTimelineDate | undefined = undefined;
+
+  for (const timeline of timelines) {
+    if (!timeline.startsAt) {
+      continue;
+    }
+
+    if (
+      !latestTimeline?.startsAt ||
+      timeline.startsAt.getTime() >= latestTimeline.startsAt.getTime()
+    ) {
+      latestTimeline = timeline;
+    }
+  }
+
+  if (latestTimeline?.stateId !== resolvedStateId) {
+    return undefined;
+  }
+
+  return latestTimeline.startsAt;
+}

--- a/App/Tests/Dashboard/EventDuration.test.ts
+++ b/App/Tests/Dashboard/EventDuration.test.ts
@@ -1,0 +1,287 @@
+import fs from "fs";
+import path from "path";
+import {
+  EventTimelineDate,
+  getEventEndDateForCurrentState,
+  getEventDurationText,
+  getLatestTimelineDateByEventId,
+} from "../../FeatureSet/Dashboard/src/Utils/EventDuration";
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function readSource(...relativeParts: Array<string>): string {
+  return fs
+    .readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8")
+    .replace(/\s+/g, " ");
+}
+
+describe("getEventDurationText", () => {
+  const startDate: Date = new Date("2026-08-01T00:00:00.000Z");
+
+  test.each([
+    [0, "less than a minute"],
+    [59, "less than a minute"],
+    [60, "1 minutes"],
+    [59 * 60, "59 minutes"],
+    [60 * 60, "1 hours, 0 minutes"],
+    [61 * 60, "1 hours, 1 minutes"],
+    [24 * 60 * 60, "1 days, 0 minutes"],
+    [25 * 60 * 60 + 2 * 60, "1 days, 1 hours, 2 minutes"],
+  ])("formats a %i-second duration as %s", (seconds: number, text: string) => {
+    const endDate: Date = new Date(startDate.getTime() + seconds * 1000);
+
+    expect(getEventDurationText(startDate, endDate)).toBe(text);
+  });
+
+  it("handles countdown dates in the same human-readable form", () => {
+    const earlierDate: Date = new Date(startDate.getTime() - 90 * 60 * 1000);
+
+    expect(getEventDurationText(startDate, earlierDate)).toBe(
+      "1 hours, 30 minutes",
+    );
+  });
+
+  it("does not round a partial minute up", () => {
+    const endDate: Date = new Date(startDate.getTime() + 119 * 1000);
+
+    expect(getEventDurationText(startDate, endDate)).toBe("1 minutes");
+  });
+});
+
+describe("getLatestTimelineDateByEventId", () => {
+  const firstDate: Date = new Date("2026-08-01T01:00:00.000Z");
+  const secondDate: Date = new Date("2026-08-01T02:00:00.000Z");
+  const thirdDate: Date = new Date("2026-08-01T03:00:00.000Z");
+
+  it("returns an empty lookup for no timelines", () => {
+    expect(getLatestTimelineDateByEventId([])).toEqual({});
+  });
+
+  it("maps a single event to its state-change date", () => {
+    expect(
+      getLatestTimelineDateByEventId([
+        { eventId: "incident-1", startsAt: firstDate },
+      ]),
+    ).toEqual({ "incident-1": firstDate });
+  });
+
+  it("retains independent dates for different events", () => {
+    expect(
+      getLatestTimelineDateByEventId([
+        { eventId: "incident-1", startsAt: firstDate },
+        { eventId: "incident-2", startsAt: secondDate },
+      ]),
+    ).toEqual({
+      "incident-1": firstDate,
+      "incident-2": secondDate,
+    });
+  });
+
+  it("uses the latest date when timelines are ascending", () => {
+    expect(
+      getLatestTimelineDateByEventId([
+        { eventId: "alert-1", startsAt: firstDate },
+        { eventId: "alert-1", startsAt: thirdDate },
+      ])["alert-1"],
+    ).toBe(thirdDate);
+  });
+
+  it("uses the latest date when timelines are descending", () => {
+    expect(
+      getLatestTimelineDateByEventId([
+        { eventId: "alert-1", startsAt: thirdDate },
+        { eventId: "alert-1", startsAt: firstDate },
+      ])["alert-1"],
+    ).toBe(thirdDate);
+  });
+
+  it("uses the latest date when timelines are unsorted", () => {
+    expect(
+      getLatestTimelineDateByEventId([
+        { eventId: "alert-1", startsAt: secondDate },
+        { eventId: "alert-1", startsAt: thirdDate },
+        { eventId: "alert-1", startsAt: firstDate },
+      ])["alert-1"],
+    ).toBe(thirdDate);
+  });
+
+  it("ignores a timeline without a date", () => {
+    const timelines: Array<EventTimelineDate> = [
+      { eventId: "incident-1" },
+      { eventId: "incident-1", startsAt: secondDate },
+    ];
+
+    expect(getLatestTimelineDateByEventId(timelines)).toEqual({
+      "incident-1": secondDate,
+    });
+  });
+
+  it("ignores a timeline without an event id", () => {
+    expect(
+      getLatestTimelineDateByEventId([{ eventId: "", startsAt: thirdDate }]),
+    ).toEqual({});
+  });
+
+  it("does not let an older invalid entry erase a valid completion date", () => {
+    expect(
+      getLatestTimelineDateByEventId([
+        { eventId: "incident-1", startsAt: thirdDate },
+        { eventId: "incident-1" },
+        { eventId: "incident-1", startsAt: firstDate },
+      ])["incident-1"],
+    ).toBe(thirdDate);
+  });
+});
+
+describe("getEventEndDateForCurrentState", () => {
+  const openDate: Date = new Date("2026-08-01T01:00:00.000Z");
+  const resolvedDate: Date = new Date("2026-08-01T02:00:00.000Z");
+  const reopenedDate: Date = new Date("2026-08-01T03:00:00.000Z");
+
+  it("returns the latest date when the current state is resolved", () => {
+    expect(
+      getEventEndDateForCurrentState(
+        [
+          { stateId: "open", startsAt: openDate },
+          { stateId: "resolved", startsAt: resolvedDate },
+        ],
+        "resolved",
+      ),
+    ).toBe(resolvedDate);
+  });
+
+  it("keeps a reopened event live", () => {
+    expect(
+      getEventEndDateForCurrentState(
+        [
+          { stateId: "open", startsAt: openDate },
+          { stateId: "resolved", startsAt: resolvedDate },
+          { stateId: "open", startsAt: reopenedDate },
+        ],
+        "resolved",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("finds the current state when timelines are unsorted", () => {
+    expect(
+      getEventEndDateForCurrentState(
+        [
+          { stateId: "resolved", startsAt: resolvedDate },
+          { stateId: "open", startsAt: openDate },
+        ],
+        "resolved",
+      ),
+    ).toBe(resolvedDate);
+  });
+
+  it("ignores timelines without dates", () => {
+    expect(
+      getEventEndDateForCurrentState(
+        [{ stateId: "open", startsAt: openDate }, { stateId: "resolved" }],
+        "resolved",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns no end date without a resolved state", () => {
+    expect(
+      getEventEndDateForCurrentState(
+        [{ stateId: "resolved", startsAt: resolvedDate }],
+        undefined,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("duration display wiring", () => {
+  const incidentTable: string = readSource(
+    "Components",
+    "Incident",
+    "IncidentsTable.tsx",
+  );
+  const alertTable: string = readSource(
+    "Components",
+    "Alert",
+    "AlertsTable.tsx",
+  );
+  const maintenanceTable: string = readSource(
+    "Components",
+    "ScheduledMaintenance",
+    "ScheduledMaintenanceTable.tsx",
+  );
+  const incidentView: string = readSource(
+    "Pages",
+    "Incidents",
+    "View",
+    "Index.tsx",
+  );
+  const alertView: string = readSource("Pages", "Alerts", "View", "Index.tsx");
+  const maintenanceView: string = readSource(
+    "Pages",
+    "ScheduledMaintenanceEvents",
+    "View",
+    "Index.tsx",
+  );
+
+  it("shows incident duration and requests resolved-state metadata", () => {
+    expect(incidentTable).toContain('title: "Duration"');
+    expect(incidentTable).toContain("isResolvedState: true");
+    expect(incidentTable).toContain(
+      "useEventTimelineEndDates<IncidentStateTimeline>",
+    );
+  });
+
+  it("shows alert duration and requests resolved-state metadata", () => {
+    expect(alertTable).toContain('title: "Duration"');
+    expect(alertTable).toContain("isResolvedState: true");
+    expect(alertTable).toContain(
+      "useEventTimelineEndDates<AlertStateTimeline>",
+    );
+  });
+
+  it("uses one batched timeline lookup instead of a request per row", () => {
+    const durationHook: string = readSource(
+      "Components",
+      "EventView",
+      "useEventTimelineEndDates.ts",
+    );
+
+    expect(durationHook).toContain("new Includes(eventIds)");
+    expect(durationHook).toContain("ModelAPI.getList<TTimeline>");
+    expect(durationHook).not.toContain("ModelAPI.getItem");
+  });
+
+  it("shows the scheduled maintenance window duration in the table", () => {
+    expect(maintenanceTable).toContain('title: "Duration"');
+    expect(maintenanceTable).toContain("startDate={item.startsAt}");
+    expect(maintenanceTable).toContain("endDate={item.endsAt}");
+  });
+
+  it("uses the declared incident time on the detail page", () => {
+    expect(incidentView).toContain("declaredAt: true");
+    expect(incidentView).toContain("eventStartsAt={durationStartDate}");
+    expect(incidentView).toContain("getEventEndDateForCurrentState");
+    expect(incidentView).toContain('label="Duration"');
+  });
+
+  it("uses the alert creation time on the detail page", () => {
+    expect(alertView).toContain("createdAt: true");
+    expect(alertView).toContain("eventStartsAt={durationStartDate}");
+    expect(alertView).toContain("getEventEndDateForCurrentState");
+    expect(alertView).toContain('label="Duration"');
+  });
+
+  it("labels the scheduled maintenance view statistic as duration", () => {
+    expect(maintenanceView).toContain('label="Duration"');
+    expect(maintenanceView).toContain("startDate={eventStartsAt}");
+    expect(maintenanceView).toContain("endDate={eventEndsAt}");
+  });
+});


### PR DESCRIPTION
## What changed

- add duration columns to incident, alert, and scheduled maintenance tables
- show explicit duration statistics on incident and alert overview pages, and label the scheduled maintenance window statistic as Duration
- keep active events updating live while freezing resolved events at their latest resolution transition
- use one batched timeline request per visible table page for resolved incident and alert end times
- anchor incident and alert durations to their declared/created timestamps
- handle reopened events by resuming the live duration instead of freezing at an earlier resolution

## Why

These resources exposed their start/end timestamps but did not consistently present a human-readable duration in list and detail views. Incident and alert tables also lacked a completion timestamp on the row model, so resolved durations require timeline enrichment.

## Impact

Users can compare elapsed time directly across incident, alert, and scheduled maintenance lists and see the same duration on the corresponding overview pages. Active values refresh every 30 seconds. Resolved values remain stable. The resolved-row enrichment is batched to avoid N+1 API calls.

## Verification

- `npm run fix`
- focused ESLint pass for all changed files
- `App/Tests/Dashboard/EventDuration.test.ts`: 31 tests passed
- `npm run compile` in `App`
- `npm run compile` in `App/FeatureSet/Dashboard`
- rebased cleanly onto the latest `origin/master` and reran focused lint, tests, and both compilers