### PR TITLE
fix(i18n): translate the Clock widget catalog strings

### DIFF
--- a/App/FeatureSet/Dashboard/src/Locales/da.json
+++ b/App/FeatureSet/Dashboard/src/Locales/da.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Videresendte bytes",
   "Forwarded Packets": "Videresendte pakker",
   "Free-form Markdown text for headers and notes.": "Fri Markdown-tekst til overskrifter og noter.",
+  "Clock": "Ur",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Aktuel tid i en hvilken som helst tidszone — digital eller analog. Tilføj et ur pr. kontor, så du kan se, hvem der er vågen.",
   "Frequency": "Frekvens",
   "Friendly description for this config so you remember what this is about.": "Brugervenlig beskrivelse af denne konfiguration, så du husker, hvad den handler om.",
   "Friendly description for this Kubernetes cluster.": "Brugervenlig beskrivelse af denne Kubernetes-klynge.",

--- a/App/FeatureSet/Dashboard/src/Locales/de.json
+++ b/App/FeatureSet/Dashboard/src/Locales/de.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Weitergeleitete Bytes",
   "Forwarded Packets": "Weitergeleitete Pakete",
   "Free-form Markdown text for headers and notes.": "Freiformtext in Markdown für Überschriften und Notizen.",
+  "Clock": "Uhr",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Aktuelle Uhrzeit in jeder Zeitzone — digital oder analog. Fügen Sie eine Uhr pro Büro hinzu, damit Sie sehen, wer gerade wach ist.",
   "Frequency": "Häufigkeit",
   "Friendly description for this config so you remember what this is about.": "Aussagekräftige Beschreibung für diese Konfiguration, damit Sie sich erinnern, worum es geht.",
   "Friendly description for this Kubernetes cluster.": "Aussagekräftige Beschreibung für diesen Kubernetes-Cluster.",

--- a/App/FeatureSet/Dashboard/src/Locales/en.json
+++ b/App/FeatureSet/Dashboard/src/Locales/en.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Forwarded Bytes",
   "Forwarded Packets": "Forwarded Packets",
   "Free-form Markdown text for headers and notes.": "Free-form Markdown text for headers and notes.",
+  "Clock": "Clock",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.",
   "Frequency": "Frequency",
   "Friendly description for this config so you remember what this is about.": "Friendly description for this config so you remember what this is about.",
   "Friendly description for this Kubernetes cluster.": "Friendly description for this Kubernetes cluster.",

--- a/App/FeatureSet/Dashboard/src/Locales/es.json
+++ b/App/FeatureSet/Dashboard/src/Locales/es.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Bytes reenviados",
   "Forwarded Packets": "Paquetes reenviados",
   "Free-form Markdown text for headers and notes.": "Texto Markdown de formato libre para encabezados y notas.",
+  "Clock": "Reloj",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Hora actual en cualquier zona horaria — digital o analógico. Añade uno por oficina para ver quién está despierto.",
   "Frequency": "Frecuencia",
   "Friendly description for this config so you remember what this is about.": "Descripción descriptiva para esta configuración para que recuerde de qué se trata.",
   "Friendly description for this Kubernetes cluster.": "Descripción descriptiva para este clúster de Kubernetes.",

--- a/App/FeatureSet/Dashboard/src/Locales/fr.json
+++ b/App/FeatureSet/Dashboard/src/Locales/fr.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Octets transférés",
   "Forwarded Packets": "Paquets transférés",
   "Free-form Markdown text for headers and notes.": "Texte Markdown libre pour les en-têtes et les notes.",
+  "Clock": "Horloge",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Heure actuelle dans n'importe quel fuseau horaire — numérique ou analogique. Ajoutez-en une par bureau pour voir qui est réveillé.",
   "Frequency": "Fréquence",
   "Friendly description for this config so you remember what this is about.": "Description conviviale pour cette configuration afin que vous vous souveniez de quoi il s'agit.",
   "Friendly description for this Kubernetes cluster.": "Description conviviale pour ce cluster Kubernetes.",

--- a/App/FeatureSet/Dashboard/src/Locales/hi.json
+++ b/App/FeatureSet/Dashboard/src/Locales/hi.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "अग्रेषित बाइट्स",
   "Forwarded Packets": "अग्रेषित पैकेट",
   "Free-form Markdown text for headers and notes.": "हेडर और नोट्स के लिए स्वतंत्र-रूप Markdown टेक्स्ट।",
+  "Clock": "घड़ी",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "किसी भी टाइमज़ोन में मौजूदा समय — डिजिटल या एनालॉग। हर ऑफ़िस के लिए एक जोड़ें ताकि आप देख सकें कि कौन जाग रहा है।",
   "Frequency": "आवृत्ति",
   "Friendly description for this config so you remember what this is about.": "इस कॉन्फ़िग के लिए सुगम विवरण ताकि आप याद रख सकें कि यह किस बारे में है।",
   "Friendly description for this Kubernetes cluster.": "इस Kubernetes क्लस्टर के लिए सुगम विवरण।",

--- a/App/FeatureSet/Dashboard/src/Locales/it.json
+++ b/App/FeatureSet/Dashboard/src/Locales/it.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Byte inoltrati",
   "Forwarded Packets": "Pacchetti inoltrati",
   "Free-form Markdown text for headers and notes.": "Testo Markdown a forma libera per intestazioni e note.",
+  "Clock": "Orologio",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Ora corrente in qualsiasi fuso orario — digitale o analogico. Aggiungine uno per ufficio per vedere chi è sveglio.",
   "Frequency": "Frequenza",
   "Friendly description for this config so you remember what this is about.": "Descrizione descrittiva per questa configurazione, così da ricordare di cosa si tratta.",
   "Friendly description for this Kubernetes cluster.": "Descrizione descrittiva per questo cluster Kubernetes.",

--- a/App/FeatureSet/Dashboard/src/Locales/ja.json
+++ b/App/FeatureSet/Dashboard/src/Locales/ja.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "転送されたバイト数",
   "Forwarded Packets": "転送されたパケット",
   "Free-form Markdown text for headers and notes.": "ヘッダーとメモ用の自由形式のMarkdownテキスト。",
+  "Clock": "時計",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "任意のタイムゾーンの現在時刻 — デジタルまたはアナログ。オフィスごとに 1 つ追加すると、誰が起きているかがわかります。",
   "Frequency": "頻度",
   "Friendly description for this config so you remember what this is about.": "この設定が何に関するものか思い出せるよう、わかりやすい説明。",
   "Friendly description for this Kubernetes cluster.": "このKubernetesクラスターのわかりやすい説明。",

--- a/App/FeatureSet/Dashboard/src/Locales/ko.json
+++ b/App/FeatureSet/Dashboard/src/Locales/ko.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "전달된 바이트",
   "Forwarded Packets": "전달된 패킷",
   "Free-form Markdown text for headers and notes.": "헤더 및 메모를 위한 자유 형식 Markdown 텍스트입니다.",
+  "Clock": "시계",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "모든 시간대의 현재 시각입니다 — 디지털 또는 아날로그. 사무실마다 하나씩 추가하면 누가 깨어 있는지 확인할 수 있습니다.",
   "Frequency": "빈도",
   "Friendly description for this config so you remember what this is about.": "이 구성이 무엇에 관한 것인지 기억할 수 있도록 알기 쉬운 설명입니다.",
   "Friendly description for this Kubernetes cluster.": "이 Kubernetes 클러스터에 대한 알기 쉬운 설명입니다.",

--- a/App/FeatureSet/Dashboard/src/Locales/nl.json
+++ b/App/FeatureSet/Dashboard/src/Locales/nl.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Doorgestuurde bytes",
   "Forwarded Packets": "Doorgestuurde pakketten",
   "Free-form Markdown text for headers and notes.": "Markdown-tekst in vrije vorm voor kopteksten en notities.",
+  "Clock": "Klok",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Huidige tijd in elke tijdzone — digitaal of analoog. Voeg er één per kantoor toe zodat je kunt zien wie wakker is.",
   "Frequency": "Frequentie",
   "Friendly description for this config so you remember what this is about.": "Vriendelijke beschrijving voor deze configuratie zodat u weet waar dit over gaat.",
   "Friendly description for this Kubernetes cluster.": "Vriendelijke beschrijving voor dit Kubernetes-cluster.",

--- a/App/FeatureSet/Dashboard/src/Locales/no.json
+++ b/App/FeatureSet/Dashboard/src/Locales/no.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Videresendte byte",
   "Forwarded Packets": "Videresendte pakker",
   "Free-form Markdown text for headers and notes.": "Fritt formatert Markdown-tekst for overskrifter og notater.",
+  "Clock": "Klokke",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Gjeldende tid i en hvilken som helst tidssone — digital eller analog. Legg til én per kontor, så ser du hvem som er våken.",
   "Frequency": "Frekvens",
   "Friendly description for this config so you remember what this is about.": "Beskrivende tekst for denne konfigurasjonen slik at du husker hva det gjelder.",
   "Friendly description for this Kubernetes cluster.": "Beskrivende tekst for denne Kubernetes-klyngen.",

--- a/App/FeatureSet/Dashboard/src/Locales/pt.json
+++ b/App/FeatureSet/Dashboard/src/Locales/pt.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Bytes encaminhados",
   "Forwarded Packets": "Pacotes encaminhados",
   "Free-form Markdown text for headers and notes.": "Texto livre em Markdown para cabeçalhos e notas.",
+  "Clock": "Relógio",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Hora atual em qualquer fuso horário — digital ou analógico. Adicione um por escritório para ver quem está acordado.",
   "Frequency": "Frequência",
   "Friendly description for this config so you remember what this is about.": "Descrição amigável para esta configuração para que você lembre do que se trata.",
   "Friendly description for this Kubernetes cluster.": "Descrição amigável para este cluster Kubernetes.",

--- a/App/FeatureSet/Dashboard/src/Locales/ru.json
+++ b/App/FeatureSet/Dashboard/src/Locales/ru.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Переслано байтов",
   "Forwarded Packets": "Переслано пакетов",
   "Free-form Markdown text for headers and notes.": "Текст в свободной форме на Markdown для заголовков и заметок.",
+  "Clock": "Часы",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Текущее время в любом часовом поясе — цифровые или аналоговые. Добавьте отдельные часы для каждого офиса, чтобы видеть, кто уже проснулся.",
   "Frequency": "Частота",
   "Friendly description for this config so you remember what this is about.": "Понятное описание этой конфигурации, чтобы вы помнили, о чём она.",
   "Friendly description for this Kubernetes cluster.": "Понятное описание для этого кластера Kubernetes.",

--- a/App/FeatureSet/Dashboard/src/Locales/sv.json
+++ b/App/FeatureSet/Dashboard/src/Locales/sv.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "Vidarebefordrade byte",
   "Forwarded Packets": "Vidarebefordrade paket",
   "Free-form Markdown text for headers and notes.": "Fritextformaterad Markdown-text för rubriker och anteckningar.",
+  "Clock": "Klocka",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "Aktuell tid i valfri tidszon — digital eller analog. Lägg till en per kontor så att du kan se vem som är vaken.",
   "Frequency": "Frekvens",
   "Friendly description for this config so you remember what this is about.": "Beskrivande text för denna konfiguration så att du kommer ihåg vad den handlar om.",
   "Friendly description for this Kubernetes cluster.": "Beskrivande text för detta Kubernetes-kluster.",

--- a/App/FeatureSet/Dashboard/src/Locales/zh-CN.json
+++ b/App/FeatureSet/Dashboard/src/Locales/zh-CN.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "已转发字节数",
   "Forwarded Packets": "已转发数据包",
   "Free-form Markdown text for headers and notes.": "用于标题和备注的自由格式 Markdown 文本。",
+  "Clock": "时钟",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "任意时区的当前时间——数字或指针样式。为每个办公室添加一个，就能看到谁已经醒了。",
   "Frequency": "频率",
   "Friendly description for this config so you remember what this is about.": "此配置的友好描述，以便您记住它的用途。",
   "Friendly description for this Kubernetes cluster.": "此 Kubernetes 集群的友好描述。",

--- a/App/FeatureSet/Dashboard/src/Locales/zh-TW.json
+++ b/App/FeatureSet/Dashboard/src/Locales/zh-TW.json
@@ -2630,6 +2630,8 @@
   "Forwarded Bytes": "已轉送位元組",
   "Forwarded Packets": "已轉送封包",
   "Free-form Markdown text for headers and notes.": "用於標頭和備註的自由格式 Markdown 文字。",
+  "Clock": "時鐘",
+  "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.": "任何時區的目前時間 — 數位或指針式。為每個辦公室新增一個，即可看出誰醒著。",
   "Frequency": "頻率",
   "Friendly description for this config so you remember what this is about.": "此設定的易記描述,以便您記得這是關於什麼的。",
   "Friendly description for this Kubernetes cluster.": "此 Kubernetes 叢集的易記描述。",


### PR DESCRIPTION
## What

The Clock widget added in 016fdcd3ef registers a label and description in the Add Widget catalog, but neither string was ever added to the Dashboard locale files. `AddWidgetModal` wraps every catalog label and description in `translateString()`, and `Common/UI/Utils/Translation.tsx` is configured with `keySeparator: false, nsSeparator: false` — so the whole English string is the lookup key, and an absent key falls back to English. Both strings have been rendering untranslated for all 15 non-English locales.

This adds them as flat top-level keys to all 16 files in `App/FeatureSet/Dashboard/src/Locales/`:

- `"Clock"`
- `"Current time in any timezone — digital or analog. Add one per office so you can see who is awake."`

Each is inserted at the same position in every file — immediately after `"Free-form Markdown text for headers and notes."`, the description of the Text widget that directly precedes Clock in the same "Visualization" catalog category. The files are only loosely sorted, so this keeps the diff to a uniform +2 lines at the same line number in all 16.

## Translation notes

- **Register follows each locale's existing catalog entries** rather than a uniform default: formal address in de/fr/ru (`Fügen Sie`, `Ajoutez`, `Добавьте`), informal in es/it (`Añade`, `Aggiungine`) — matching how the sibling Table widget description is already phrased in each file.
- **"Timezone"** reuses each file's own existing translation of the term (`Zeitzone`, `Fuso orario`, `часовом поясе`, …).
- **Punctuation follows per-locale convention**: zh-CN uses `——` and full-width commas, zh-TW uses a spaced `—`, consistent with neighbouring entries.
- **`"Clock"` is translated natively everywhere** (`Uhr`, `Horloge`, `時計`, `Часы`), so nothing lands in the validator's "identical to English" bucket.
- **Russian `Часы` is plural-only**, so the adjectives agree in plural (`цифровые или аналоговые`) and "add one per office" became "add separate clocks for each office" — a literal "one" is ungrammatical there.

## Verification

`node Scripts/I18n/ValidateLocales.js` passes (exit 0).

That validator only checks locale-vs-en parity, so it would not catch a string missing from `en.json` too. The en side was confirmed separately by extracting both literals directly out of the `DashboardComponentType.Clock` entry in `AddWidgetModal.tsx` and checking them against `en.json` — both present, value identical to key, and the em dash verified as U+2014 in both source and key. A lookalike hyphen there would have silently broken the lookup while still passing the validator.

No locale was left with the description in English.

## Not included

`App/FeatureSet/Docs/Content/*/dashboards/widgets.md` still has no Clock section in any of the 16 locales. Left out deliberately: it's a separate kind of change (prose across 16 more files, with no validator covering it), and the gap is pre-existing across six other shipped widgets — SLO, Podman, Proxmox, Ceph, Docker Swarm, and Trace Table are all undocumented too. Worth doing as one sweep rather than singling out Clock.
