### PR TITLE
feat(auto-remediation): outcome verification loop (Phase 2)

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AutoRemediation/AutoRemediationRulesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AutoRemediation/AutoRemediationRulesTable.tsx
@@ -287,6 +287,26 @@ const AutoRemediationRulesTable: FunctionComponent<ComponentProps> = (
           required: true,
           defaultValue: AutoRemediationExecutionMode.Suggest,
         },
+        {
+          field: { verificationWindowMinutes: true },
+          title: "Verification Window (Minutes)",
+          stepId: "remediation",
+          sectionTitle: "Verify the Outcome",
+          sectionDescription:
+            "A remediation is verified when the monitors return to an operational state within this window after the runbook starts. Verification never delays or suppresses on-call escalation.",
+          fieldType: FormFieldSchemaType.Number,
+          required: false,
+          placeholder: "15",
+        },
+        {
+          field: { autoResolveOnVerifiedRecovery: true },
+          title: "Auto-Resolve on Verified Recovery",
+          stepId: "remediation",
+          description:
+            "When verification confirms the monitors recovered, automatically resolve the incident/alert. Off by default.",
+          fieldType: FormFieldSchemaType.Toggle,
+          required: false,
+        },
       ]}
       showRefreshButton={true}
     />

--- a/App/FeatureSet/Dashboard/src/Components/AutoRemediation/RemediationSuggestionCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AutoRemediation/RemediationSuggestionCard.tsx
@@ -6,6 +6,7 @@ import ObjectID from "Common/Types/ObjectID";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import AutoRemediationSuggestion from "Common/Models/DatabaseModels/AutoRemediationSuggestion";
 import AutoRemediationSuggestionStatus from "Common/Types/AutoRemediation/AutoRemediationSuggestionStatus";
+import AutoRemediationVerificationStatus from "Common/Types/AutoRemediation/AutoRemediationVerificationStatus";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
@@ -94,6 +95,56 @@ function StatusPill({
   );
 }
 
+interface VerificationVisual {
+  label: string;
+  badge: string;
+  dot: string;
+}
+
+const VERIFICATION_VISUAL: Record<
+  AutoRemediationVerificationStatus,
+  VerificationVisual
+> = {
+  [AutoRemediationVerificationStatus.Pending]: {
+    label: "Verifying recovery\u2026",
+    badge: "bg-blue-50 text-blue-700 ring-blue-200",
+    dot: "bg-blue-500",
+  },
+  [AutoRemediationVerificationStatus.Verified]: {
+    label: "Verified fixed",
+    badge: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+    dot: "bg-emerald-500",
+  },
+  [AutoRemediationVerificationStatus.Failed]: {
+    label: "Verification failed",
+    badge: "bg-rose-50 text-rose-700 ring-rose-200",
+    dot: "bg-rose-500",
+  },
+  [AutoRemediationVerificationStatus.Skipped]: {
+    label: "Verification skipped",
+    badge: "bg-gray-100 text-gray-700 ring-gray-200",
+    dot: "bg-gray-400",
+  },
+};
+
+function VerificationPill({
+  status,
+}: {
+  status: AutoRemediationVerificationStatus;
+}): ReactElement {
+  const v: VerificationVisual =
+    VERIFICATION_VISUAL[status] ||
+    VERIFICATION_VISUAL[AutoRemediationVerificationStatus.Pending]!;
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset ${v.badge}`}
+    >
+      <span className={`inline-block w-1.5 h-1.5 rounded-full ${v.dot}`}></span>
+      {v.label}
+    </span>
+  );
+}
+
 const POLL_INTERVAL_MS: number = 15 * 1000;
 
 const RemediationSuggestionCard: FunctionComponent<ComponentProps> = (
@@ -142,6 +193,8 @@ const RemediationSuggestionCard: FunctionComponent<ComponentProps> = (
             rationaleMarkdown: true,
             runbookId: true,
             runbookExecutionId: true,
+            verificationStatus: true,
+            verificationNote: true,
             createdAt: true,
           },
           sort: {
@@ -166,7 +219,10 @@ const RemediationSuggestionCard: FunctionComponent<ComponentProps> = (
   // Poll while an AI plan is still in flight so the pick lands live.
   const hasPlanning: boolean = suggestions.some(
     (s: AutoRemediationSuggestion) => {
-      return s.status === AutoRemediationSuggestionStatus.Planning;
+      return (
+        s.status === AutoRemediationSuggestionStatus.Planning ||
+        s.verificationStatus === AutoRemediationVerificationStatus.Pending
+      );
     },
   );
 
@@ -277,8 +333,27 @@ const RemediationSuggestionCard: FunctionComponent<ComponentProps> = (
                       Rule: {suggestion.ruleNameSnapshot || "Unknown"}
                     </span>
                   </div>
-                  <StatusPill status={status} />
+                  <div className="flex items-center gap-2">
+                    <StatusPill status={status} />
+                    {suggestion.verificationStatus ? (
+                      <VerificationPill
+                        status={
+                          suggestion.verificationStatus as AutoRemediationVerificationStatus
+                        }
+                      />
+                    ) : (
+                      <></>
+                    )}
+                  </div>
                 </div>
+
+                {suggestion.verificationNote ? (
+                  <div className="mt-2 text-xs text-gray-500">
+                    {suggestion.verificationNote}
+                  </div>
+                ) : (
+                  <></>
+                )}
 
                 {suggestion.rationaleMarkdown ? (
                   <div className="mt-3">

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -157,6 +157,8 @@ import "./Jobs/AIChat/ProcessQueuedInvestigations";
 
 // Auto-remediation — settle Planning suggestions whose plan run died.
 import "./Jobs/AutoRemediation/SettleStrandedSuggestions";
+// Auto-remediation — verify started remediations actually restored service.
+import "./Jobs/AutoRemediation/VerifyRemediations";
 
 // AI Insights — preventive telemetry scan (deterministic, no LLM).
 import "./Jobs/AIInsight/ScanForInsights";

--- a/App/FeatureSet/Workers/Jobs/AutoRemediation/VerifyRemediations.ts
+++ b/App/FeatureSet/Workers/Jobs/AutoRemediation/VerifyRemediations.ts
@@ -1,0 +1,24 @@
+import RunCron from "../../Utils/Cron";
+import { EVERY_MINUTE } from "Common/Utils/CronTime";
+import RemediationVerifier from "Common/Server/Utils/AutoRemediation/RemediationVerifier";
+
+/**
+ * Closes the auto-remediation loop: a remediation is not done when the
+ * runbook exits — it is done when the subject's monitors recover within the
+ * verification window. This sweep verifies every started remediation
+ * (runbook failed/overran -> Failed; monitors recovered -> Verified, with
+ * optional system auto-resolve; window elapsed unhealthy -> Failed) and
+ * posts the outcome to the incident/alert feed. Escalation is never
+ * delayed or suppressed by verification. Conclusions are CAS-guarded, so
+ * concurrent Workers replicas settle each verification exactly once.
+ */
+RunCron(
+  "AutoRemediation:VerifyRemediations",
+  {
+    schedule: EVERY_MINUTE,
+    runOnStartup: false,
+  },
+  async () => {
+    await RemediationVerifier.verifyPendingRemediations();
+  },
+);

--- a/Common/Models/DatabaseModels/AutoRemediationRule.ts
+++ b/Common/Models/DatabaseModels/AutoRemediationRule.ts
@@ -695,6 +695,73 @@ export default class AutoRemediationRule extends BaseModel {
       Permission.Viewer,
       Permission.ReadAutoRemediationRule,
     ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditAutoRemediationRule,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Number,
+    title: "Verification Window (Minutes)",
+    description:
+      "How long after the runbook starts the subject's monitors get to recover before verification fails. Defaults to 15 minutes.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Number,
+  })
+  public verificationWindowMinutes?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateAutoRemediationRule,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadAutoRemediationRule,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditAutoRemediationRule,
+    ],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Boolean,
+    title: "Auto-Resolve on Verified Recovery",
+    description:
+      "When verification confirms the monitors recovered inside the window, automatically resolve the incident/alert. Off by default — the timeline note is posted either way.",
+    defaultValue: false,
+    isDefaultValueColumn: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    nullable: false,
+    default: false,
+  })
+  public autoResolveOnVerifiedRecovery?: boolean = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateAutoRemediationRule,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadAutoRemediationRule,
+    ],
     update: [],
   })
   @TableColumn({

--- a/Common/Models/DatabaseModels/AutoRemediationSuggestion.ts
+++ b/Common/Models/DatabaseModels/AutoRemediationSuggestion.ts
@@ -8,6 +8,7 @@ import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
 import Route from "../../Types/API/Route";
 import AutoRemediationExecutionMode from "../../Types/AutoRemediation/AutoRemediationExecutionMode";
 import AutoRemediationSuggestionStatus from "../../Types/AutoRemediation/AutoRemediationSuggestionStatus";
+import AutoRemediationVerificationStatus from "../../Types/AutoRemediation/AutoRemediationVerificationStatus";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
@@ -633,6 +634,142 @@ export default class AutoRemediationSuggestion extends BaseModel {
     nullable: true,
   })
   public dismissedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @Index()
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Verification Status",
+    description:
+      "Outcome verification after execution: Pending, Verified, Failed or Skipped. Empty until a runbook is started.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public verificationStatus?: AutoRemediationVerificationStatus = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Verification Deadline At",
+    description:
+      "When the verification window closes — the monitors must be operational by this time.",
+  })
+  @Column({
+    type: ColumnType.Date,
+    nullable: true,
+  })
+  public verificationDeadlineAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.Date,
+    required: false,
+    title: "Verification Completed At",
+    description: "When verification reached a terminal outcome.",
+  })
+  @Column({
+    type: ColumnType.Date,
+    nullable: true,
+  })
+  public verificationCompletedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.LongText,
+    title: "Verification Note",
+    description: "Why verification ended the way it did.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.LongText,
+    length: ColumnLength.LongText,
+  })
+  public verificationNote?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Number,
+    title: "Verification Window (Minutes)",
+    description:
+      "Snapshot of the rule's verification window when this suggestion was created.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Number,
+  })
+  public verificationWindowMinutes?: number = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Boolean,
+    title: "Auto-Resolve on Recovery",
+    description:
+      "Snapshot of the rule's auto-resolve-on-verified-recovery setting when this suggestion was created.",
+    defaultValue: false,
+    isDefaultValueColumn: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    nullable: false,
+    default: false,
+  })
+  public autoResolveOnRecovery?: boolean = undefined;
 
   @ColumnAccessControl({
     create: [],

--- a/Common/Server/API/AutoRemediationAPI.ts
+++ b/Common/Server/API/AutoRemediationAPI.ts
@@ -13,6 +13,8 @@ import OneUptimeDate from "../../Types/Date";
 import BadDataException from "../../Types/Exception/BadDataException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import AutoRemediationSuggestionStatus from "../../Types/AutoRemediation/AutoRemediationSuggestionStatus";
+import AutoRemediationVerificationStatus from "../../Types/AutoRemediation/AutoRemediationVerificationStatus";
+import { DEFAULT_VERIFICATION_WINDOW_MINUTES } from "../Services/AutoRemediationRuleEngineService";
 import Permission, {
   UserPermission,
   UserTenantAccessPermission,
@@ -138,6 +140,7 @@ async function loadSuggestionAsRoot(
         runbookId: true,
         runbookNameSnapshot: true,
         ruleNameSnapshot: true,
+        verificationWindowMinutes: true,
       },
       props: { isRoot: true },
     });
@@ -229,6 +232,14 @@ router.post(
             status: AutoRemediationSuggestionStatus.Approved,
             approvedByUserId: props.userId!.toString(),
             approvedAt: OneUptimeDate.getCurrentDate(),
+            // The runbook starts next — the outcome verifier watches for
+            // monitor recovery until this deadline.
+            verificationStatus: AutoRemediationVerificationStatus.Pending,
+            verificationDeadlineAt: OneUptimeDate.addRemoveMinutes(
+              OneUptimeDate.getCurrentDate(),
+              suggestion.verificationWindowMinutes ||
+                DEFAULT_VERIFICATION_WINDOW_MINUTES,
+            ),
           },
         });
 

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785768089408-AddRemediationVerification.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785768089408-AddRemediationVerification.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddRemediationVerification1785768089408
+  implements MigrationInterface
+{
+  name = "AddRemediationVerification1785768089408";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationRule" ADD "verificationWindowMinutes" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationRule" ADD "autoResolveOnVerifiedRecovery" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" ADD "verificationStatus" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" ADD "verificationDeadlineAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" ADD "verificationCompletedAt" TIMESTAMP WITH TIME ZONE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" ADD "verificationNote" character varying(500)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" ADD "verificationWindowMinutes" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" ADD "autoResolveOnRecovery" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c6aa9892fd13093b12e389082c" ON "AutoRemediationSuggestion" ("verificationStatus") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c6aa9892fd13093b12e389082c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" DROP COLUMN "autoResolveOnRecovery"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" DROP COLUMN "verificationWindowMinutes"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" DROP COLUMN "verificationNote"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" DROP COLUMN "verificationCompletedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" DROP COLUMN "verificationDeadlineAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationSuggestion" DROP COLUMN "verificationStatus"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationRule" DROP COLUMN "autoResolveOnVerifiedRecovery"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "AutoRemediationRule" DROP COLUMN "verificationWindowMinutes"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -484,6 +484,7 @@ import { AddMonitorSummaryToIncidentAndAlert1785496223183 } from "./178549622318
 import { AddSessionReplayReliabilityColumns1785516996695 } from "./1785516996695-AddSessionReplayReliabilityColumns";
 import { AddSessionReplayCorrelationColumns1785533806494 } from "./1785533806494-AddSessionReplayCorrelationColumns";
 import { AddAutoRemediation1785763818197 } from "./1785763818197-AddAutoRemediation";
+import { AddRemediationVerification1785768089408 } from "./1785768089408-AddRemediationVerification";
 
 export default [
   InitialMigration,
@@ -972,4 +973,5 @@ export default [
   AddSessionReplayReliabilityColumns1785516996695,
   AddSessionReplayCorrelationColumns1785533806494,
   AddAutoRemediation1785763818197,
+  AddRemediationVerification1785768089408,
 ];

--- a/Common/Server/Services/AutoRemediationRuleEngineService.ts
+++ b/Common/Server/Services/AutoRemediationRuleEngineService.ts
@@ -13,6 +13,7 @@ import AlertSeverity from "../../Models/DatabaseModels/AlertSeverity";
 import IncidentSeverity from "../../Models/DatabaseModels/IncidentSeverity";
 import AutoRemediationExecutionMode from "../../Types/AutoRemediation/AutoRemediationExecutionMode";
 import AutoRemediationSuggestionStatus from "../../Types/AutoRemediation/AutoRemediationSuggestionStatus";
+import AutoRemediationVerificationStatus from "../../Types/AutoRemediation/AutoRemediationVerificationStatus";
 import AutoRemediationTriggerEntity from "../../Types/AutoRemediation/AutoRemediationTriggerEntity";
 import { Indigo500 } from "../../Types/BrandColors";
 import OneUptimeDate from "../../Types/Date";
@@ -45,6 +46,14 @@ export const MAX_SUGGESTIONS_PER_SUBJECT: number = 3;
  *   being started in a tight flap loop.
  */
 export const MAX_AUTO_EXECUTIONS_PER_RULE_PER_HOUR: number = 3;
+
+/*
+ * How long the subject's monitors get to recover after a remediation
+ * runbook starts, when the rule does not set its own window. The verifier
+ * fails the remediation past this deadline — escalation continues as
+ * normal either way.
+ */
+export const DEFAULT_VERIFICATION_WINDOW_MINUTES: number = 15;
 
 type SubjectLinkage = {
   incidentId?: ObjectID | undefined;
@@ -127,6 +136,8 @@ class AutoRemediationRuleEngineServiceClass {
           name: true,
           executionMode: true,
           aiSelectsRunbook: true,
+          verificationWindowMinutes: true,
+          autoResolveOnVerifiedRecovery: true,
           titlePattern: true,
           descriptionPattern: true,
           monitors: { _id: true },
@@ -417,6 +428,11 @@ class AutoRemediationRuleEngineServiceClass {
     suggestion.ruleNameSnapshot = data.rule.name || "Auto Remediation Rule";
     suggestion.status = AutoRemediationSuggestionStatus.Planning;
     suggestion.executionMode = AutoRemediationExecutionMode.Suggest;
+    suggestion.verificationWindowMinutes =
+      data.rule.verificationWindowMinutes ||
+      DEFAULT_VERIFICATION_WINDOW_MINUTES;
+    suggestion.autoResolveOnRecovery =
+      data.rule.autoResolveOnVerifiedRecovery === true;
     if (data.linkage.incidentId) {
       suggestion.incidentId = data.linkage.incidentId;
     }
@@ -485,6 +501,11 @@ class AutoRemediationRuleEngineServiceClass {
     suggestion.runbookNameSnapshot = data.runbook.name || "Runbook";
     suggestion.status = AutoRemediationSuggestionStatus.Suggested;
     suggestion.executionMode = AutoRemediationExecutionMode.Suggest;
+    suggestion.verificationWindowMinutes =
+      data.rule.verificationWindowMinutes ||
+      DEFAULT_VERIFICATION_WINDOW_MINUTES;
+    suggestion.autoResolveOnRecovery =
+      data.rule.autoResolveOnVerifiedRecovery === true;
     suggestion.rationaleMarkdown = data.downgradedByCircuitBreaker
       ? "Proposed by a FullAuto rule that was downgraded to suggest-only by the hourly circuit breaker (too many recent auto-executions). Approve to start the runbook."
       : "Proposed by a matching auto-remediation rule. Approve to start the runbook.";
@@ -558,6 +579,18 @@ class AutoRemediationRuleEngineServiceClass {
     suggestion.status = AutoRemediationSuggestionStatus.AutoExecuted;
     suggestion.executionMode = AutoRemediationExecutionMode.FullAuto;
     suggestion.runbookExecutionId = execution.id!;
+    suggestion.verificationWindowMinutes =
+      data.rule.verificationWindowMinutes ||
+      DEFAULT_VERIFICATION_WINDOW_MINUTES;
+    suggestion.autoResolveOnRecovery =
+      data.rule.autoResolveOnVerifiedRecovery === true;
+    // The runbook is already running — verification starts now.
+    suggestion.verificationStatus = AutoRemediationVerificationStatus.Pending;
+    suggestion.verificationDeadlineAt = OneUptimeDate.addRemoveMinutes(
+      OneUptimeDate.getCurrentDate(),
+      data.rule.verificationWindowMinutes ||
+        DEFAULT_VERIFICATION_WINDOW_MINUTES,
+    );
     suggestion.rationaleMarkdown =
       "Automatically executed by a FullAuto auto-remediation rule.";
     if (data.linkage.incidentId) {

--- a/Common/Server/Services/AutoRemediationSuggestionService.ts
+++ b/Common/Server/Services/AutoRemediationSuggestionService.ts
@@ -1,4 +1,5 @@
 import AutoRemediationSuggestionStatus from "../../Types/AutoRemediation/AutoRemediationSuggestionStatus";
+import AutoRemediationVerificationStatus from "../../Types/AutoRemediation/AutoRemediationVerificationStatus";
 import ObjectID from "../../Types/ObjectID";
 import PositiveNumber from "../../Types/PositiveNumber";
 import CountBy from "../Types/Database/CountBy";
@@ -29,6 +30,15 @@ export interface SuggestionTransitionSet {
   approvedAt?: Date | undefined;
   dismissedByUserId?: string | undefined;
   dismissedAt?: Date | undefined;
+  verificationStatus?: AutoRemediationVerificationStatus | undefined;
+  verificationDeadlineAt?: Date | undefined;
+}
+
+// What the outcome verifier may set when a verification concludes.
+export interface VerificationTransitionSet {
+  verificationStatus: AutoRemediationVerificationStatus;
+  verificationCompletedAt?: Date | undefined;
+  verificationNote?: string | undefined;
 }
 
 export class Service extends DatabaseService<Model> {
@@ -123,6 +133,33 @@ export class Service extends DatabaseService<Model> {
       .set(data.set as QueryDeepPartialEntity<Model>)
       .where('"_id" = :id', { id: data.suggestionId.toString() })
       .andWhere('"status" = :fromStatus', { fromStatus: data.fromStatus })
+      .andWhere('"deletedAt" IS NULL');
+
+    const result: UpdateResult = await queryBuilder.execute();
+
+    return result.affected || 0;
+  }
+
+  /*
+   * The verification twin of attemptStatusTransition: one conditional
+   * UPDATE guarded on the expected current verificationStatus, so
+   * concurrent verifier sweeps (multiple Workers replicas) settle each
+   * verification exactly once.
+   */
+  @CaptureSpan()
+  public async attemptVerificationTransition(data: {
+    suggestionId: ObjectID;
+    fromVerificationStatus: AutoRemediationVerificationStatus;
+    set: VerificationTransitionSet;
+  }): Promise<number> {
+    const queryBuilder: UpdateQueryBuilder<Model> = this.getRepository()
+      .createQueryBuilder()
+      .update(Model)
+      .set(data.set as QueryDeepPartialEntity<Model>)
+      .where('"_id" = :id', { id: data.suggestionId.toString() })
+      .andWhere('"verificationStatus" = :fromVerificationStatus', {
+        fromVerificationStatus: data.fromVerificationStatus,
+      })
       .andWhere('"deletedAt" IS NULL');
 
     const result: UpdateResult = await queryBuilder.execute();

--- a/Common/Server/Utils/AutoRemediation/RemediationVerifier.ts
+++ b/Common/Server/Utils/AutoRemediation/RemediationVerifier.ts
@@ -1,0 +1,486 @@
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import AlertState from "../../../Models/DatabaseModels/AlertState";
+import AlertStateTimeline from "../../../Models/DatabaseModels/AlertStateTimeline";
+import AutoRemediationSuggestion from "../../../Models/DatabaseModels/AutoRemediationSuggestion";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentState from "../../../Models/DatabaseModels/IncidentState";
+import IncidentStateTimeline from "../../../Models/DatabaseModels/IncidentStateTimeline";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import RunbookExecution from "../../../Models/DatabaseModels/RunbookExecution";
+import { AlertFeedEventType } from "../../../Models/DatabaseModels/AlertFeed";
+import { IncidentFeedEventType } from "../../../Models/DatabaseModels/IncidentFeed";
+import AutoRemediationSuggestionStatus from "../../../Types/AutoRemediation/AutoRemediationSuggestionStatus";
+import AutoRemediationVerificationStatus from "../../../Types/AutoRemediation/AutoRemediationVerificationStatus";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import RunbookExecutionStatus from "../../../Types/Runbook/RunbookExecutionStatus";
+import { Green500, Red500 } from "../../../Types/BrandColors";
+import Color from "../../../Types/Color";
+import QueryHelper from "../../Types/Database/QueryHelper";
+import AlertFeedService from "../../Services/AlertFeedService";
+import AlertService from "../../Services/AlertService";
+import AlertStateService from "../../Services/AlertStateService";
+import AlertStateTimelineService from "../../Services/AlertStateTimelineService";
+import AutoRemediationSuggestionService from "../../Services/AutoRemediationSuggestionService";
+import IncidentFeedService from "../../Services/IncidentFeedService";
+import IncidentService from "../../Services/IncidentService";
+import IncidentStateService from "../../Services/IncidentStateService";
+import IncidentStateTimelineService from "../../Services/IncidentStateTimelineService";
+import MonitorService from "../../Services/MonitorService";
+import MonitorStatusService from "../../Services/MonitorStatusService";
+import RunbookExecutionService from "../../Services/RunbookExecutionService";
+import logger from "../Logger";
+import CaptureSpan from "../Telemetry/CaptureSpan";
+
+/*
+ * Auto-remediation — the outcome verifier.
+ *
+ * A remediation is not done when the runbook exits 0 — it is done when the
+ * subject's monitors are back to an operational state (or a human resolved
+ * the incident/alert) within the verification window. This every-minute
+ * sweep closes that loop for every Approved/AutoExecuted suggestion:
+ *
+ *   runbook failed/cancelled        -> verification Failed
+ *   runbook overran the window      -> verification Failed
+ *   monitors recovered in time      -> verification Verified
+ *                                      (+ optional system auto-resolve)
+ *   subject already resolved        -> verification Verified
+ *   window elapsed, still unhealthy -> verification Failed
+ *   nothing to verify against       -> verification Skipped
+ *
+ * Verification NEVER touches paging: escalation continues (or stops on
+ * ack/resolve) exactly as it always did. Every conclusion goes through a
+ * verification-status CAS, so concurrent Workers replicas settle each
+ * verification exactly once. The Verified/Failed columns are the
+ * measurement layer: per-rule verified-fixed rate is what earns (or
+ * revokes) FullAuto trust.
+ */
+
+type VerificationOutcome = {
+  status: AutoRemediationVerificationStatus;
+  note: string;
+  pingWorkspace: boolean;
+  displayColor: Color;
+  // Set only on Verified outcomes where the rule opted into auto-resolve.
+  shouldAutoResolve: boolean;
+};
+
+export default class RemediationVerifier {
+  @CaptureSpan()
+  public static async verifyPendingRemediations(): Promise<void> {
+    const pending: Array<AutoRemediationSuggestion> =
+      await AutoRemediationSuggestionService.findBy({
+        query: {
+          verificationStatus: AutoRemediationVerificationStatus.Pending,
+          /*
+           * Only executions-in-flight verify. A rolled-back approval
+           * (status back to Suggested) or a dismissal can leave a stale
+           * Pending marker behind — re-approving stamps a fresh one.
+           */
+          status: QueryHelper.any([
+            AutoRemediationSuggestionStatus.Approved,
+            AutoRemediationSuggestionStatus.AutoExecuted,
+          ]),
+        },
+        select: {
+          _id: true,
+          projectId: true,
+          incidentId: true,
+          alertId: true,
+          runbookExecutionId: true,
+          verificationDeadlineAt: true,
+          autoResolveOnRecovery: true,
+          ruleNameSnapshot: true,
+          runbookNameSnapshot: true,
+        },
+        limit: 100,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+    for (const suggestion of pending) {
+      try {
+        const outcome: VerificationOutcome | null =
+          await this.evaluate(suggestion);
+
+        if (!outcome) {
+          continue; // Still inside the window — check again next tick.
+        }
+
+        const transitioned: number =
+          await AutoRemediationSuggestionService.attemptVerificationTransition(
+            {
+              suggestionId: suggestion.id!,
+              fromVerificationStatus:
+                AutoRemediationVerificationStatus.Pending,
+              set: {
+                verificationStatus: outcome.status,
+                verificationCompletedAt: OneUptimeDate.getCurrentDate(),
+                verificationNote: outcome.note,
+              },
+            },
+          );
+
+        if (transitioned === 0) {
+          continue; // Another sweep settled it first.
+        }
+
+        if (outcome.shouldAutoResolve) {
+          await this.systemResolveSubject(suggestion);
+        }
+
+        if (outcome.status !== AutoRemediationVerificationStatus.Skipped) {
+          await this.postFeedItem({
+            suggestion,
+            outcome,
+          });
+        }
+      } catch (error) {
+        logger.error(
+          `RemediationVerifier: failed to verify suggestion ${suggestion.id?.toString()}: ${error}`,
+        );
+      }
+    }
+  }
+
+  /*
+   * Decide the verification outcome, or null while the window is still
+   * open and nothing has concluded yet.
+   */
+  private static async evaluate(
+    suggestion: AutoRemediationSuggestion,
+  ): Promise<VerificationOutcome | null> {
+    const runbookName: string = suggestion.runbookNameSnapshot || "Runbook";
+
+    if (!suggestion.runbookExecutionId) {
+      return {
+        status: AutoRemediationVerificationStatus.Skipped,
+        note: "No runbook execution was recorded for this suggestion.",
+        pingWorkspace: false,
+        displayColor: Red500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    const execution: RunbookExecution | null =
+      await RunbookExecutionService.findOneById({
+        id: suggestion.runbookExecutionId,
+        select: {
+          _id: true,
+          status: true,
+        },
+        props: { isRoot: true },
+      });
+
+    if (!execution) {
+      return {
+        status: AutoRemediationVerificationStatus.Skipped,
+        note: "The runbook execution no longer exists.",
+        pingWorkspace: false,
+        displayColor: Red500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    const deadlinePassed: boolean = suggestion.verificationDeadlineAt
+      ? suggestion.verificationDeadlineAt.getTime() <
+        OneUptimeDate.getCurrentDate().getTime()
+      : false;
+
+    if (execution.status === RunbookExecutionStatus.Failed) {
+      return {
+        status: AutoRemediationVerificationStatus.Failed,
+        note: `Runbook "${runbookName}" failed — remediation was not verified.`,
+        pingWorkspace: true,
+        displayColor: Red500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    if (execution.status === RunbookExecutionStatus.Cancelled) {
+      return {
+        status: AutoRemediationVerificationStatus.Failed,
+        note: `Runbook "${runbookName}" was cancelled — remediation was not verified.`,
+        pingWorkspace: false,
+        displayColor: Red500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    if (execution.status !== RunbookExecutionStatus.Completed) {
+      // Scheduled / Running / WaitingForManualStep.
+      if (deadlinePassed) {
+        return {
+          status: AutoRemediationVerificationStatus.Failed,
+          note: `Runbook "${runbookName}" did not complete within the verification window.`,
+          pingWorkspace: true,
+          displayColor: Red500,
+          shouldAutoResolve: false,
+        };
+      }
+      return null;
+    }
+
+    // The runbook completed — did the subject actually recover?
+    if (await this.isSubjectResolved(suggestion)) {
+      return {
+        status: AutoRemediationVerificationStatus.Verified,
+        note: `The ${suggestion.incidentId ? "incident" : "alert"} was resolved within the verification window.`,
+        pingWorkspace: false,
+        displayColor: Green500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    const monitorsOperational: boolean | null =
+      await this.areSubjectMonitorsOperational(suggestion);
+
+    if (monitorsOperational === null) {
+      return {
+        status: AutoRemediationVerificationStatus.Skipped,
+        note: "There are no monitors to verify recovery against.",
+        pingWorkspace: false,
+        displayColor: Green500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    if (monitorsOperational) {
+      return {
+        status: AutoRemediationVerificationStatus.Verified,
+        note: `Runbook "${runbookName}" completed and the monitor(s) returned to an operational state within the verification window.`,
+        pingWorkspace: true,
+        displayColor: Green500,
+        shouldAutoResolve: suggestion.autoResolveOnRecovery === true,
+      };
+    }
+
+    if (deadlinePassed) {
+      return {
+        status: AutoRemediationVerificationStatus.Failed,
+        note: `Runbook "${runbookName}" completed but the service did not recover within the verification window — escalation continues as normal.`,
+        pingWorkspace: true,
+        displayColor: Red500,
+        shouldAutoResolve: false,
+      };
+    }
+
+    return null;
+  }
+
+  private static async isSubjectResolved(
+    suggestion: AutoRemediationSuggestion,
+  ): Promise<boolean> {
+    if (suggestion.incidentId) {
+      const incident: Incident | null = await IncidentService.findOneById({
+        id: suggestion.incidentId,
+        select: { _id: true, currentIncidentStateId: true },
+        props: { isRoot: true },
+      });
+
+      if (!incident?.currentIncidentStateId) {
+        return false;
+      }
+
+      const state: IncidentState | null =
+        await IncidentStateService.findOneById({
+          id: incident.currentIncidentStateId,
+          select: { _id: true, isResolvedState: true },
+          props: { isRoot: true },
+        });
+
+      return state?.isResolvedState === true;
+    }
+
+    if (suggestion.alertId) {
+      const alert: Alert | null = await AlertService.findOneById({
+        id: suggestion.alertId,
+        select: { _id: true, currentAlertStateId: true },
+        props: { isRoot: true },
+      });
+
+      if (!alert?.currentAlertStateId) {
+        return false;
+      }
+
+      const state: AlertState | null = await AlertStateService.findOneById({
+        id: alert.currentAlertStateId,
+        select: { _id: true, isResolvedState: true },
+        props: { isRoot: true },
+      });
+
+      return state?.isResolvedState === true;
+    }
+
+    return false;
+  }
+
+  /*
+   * All of the subject's monitors must be in an operational state.
+   * Returns null when there are no monitors to check (manual incidents).
+   */
+  private static async areSubjectMonitorsOperational(
+    suggestion: AutoRemediationSuggestion,
+  ): Promise<boolean | null> {
+    const monitorIds: Array<ObjectID> = [];
+
+    if (suggestion.incidentId) {
+      const incident: Incident | null = await IncidentService.findOneById({
+        id: suggestion.incidentId,
+        select: { _id: true, monitors: { _id: true } },
+        props: { isRoot: true },
+      });
+
+      for (const monitor of incident?.monitors || []) {
+        if (monitor.id) {
+          monitorIds.push(monitor.id);
+        }
+      }
+    } else if (suggestion.alertId) {
+      const alert: Alert | null = await AlertService.findOneById({
+        id: suggestion.alertId,
+        select: { _id: true, monitorId: true },
+        props: { isRoot: true },
+      });
+
+      if (alert?.monitorId) {
+        monitorIds.push(alert.monitorId);
+      }
+    }
+
+    if (monitorIds.length === 0) {
+      return null;
+    }
+
+    for (const monitorId of monitorIds) {
+      const monitor: Monitor | null = await MonitorService.findOneById({
+        id: monitorId,
+        select: { _id: true, currentMonitorStatusId: true },
+        props: { isRoot: true },
+      });
+
+      if (!monitor?.currentMonitorStatusId) {
+        return false; // Unknown state counts as not recovered.
+      }
+
+      const status: MonitorStatus | null =
+        await MonitorStatusService.findOneById({
+          id: monitor.currentMonitorStatusId,
+          select: { _id: true, isOperationalState: true },
+          props: { isRoot: true },
+        });
+
+      if (status?.isOperationalState !== true) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /*
+   * System auto-resolve on verified recovery: write the resolved
+   * state-timeline row directly with no user, exactly like monitor-criteria
+   * auto-resolve does. The state-dedupe race (someone resolved concurrently)
+   * is treated as a no-op.
+   */
+  private static async systemResolveSubject(
+    suggestion: AutoRemediationSuggestion,
+  ): Promise<void> {
+    const rootCause: string = `Auto-resolved by auto-remediation: runbook "${suggestion.runbookNameSnapshot || "Runbook"}" (rule "${suggestion.ruleNameSnapshot || "Auto Remediation Rule"}") completed and the monitor(s) recovered within the verification window.`;
+
+    try {
+      if (suggestion.incidentId && suggestion.projectId) {
+        const resolvedStateId: ObjectID =
+          await IncidentStateTimelineService.getResolvedStateIdForProject(
+            suggestion.projectId,
+          );
+
+        const timeline: IncidentStateTimeline = new IncidentStateTimeline();
+        timeline.incidentId = suggestion.incidentId;
+        timeline.incidentStateId = resolvedStateId;
+        timeline.projectId = suggestion.projectId;
+        timeline.rootCause = rootCause;
+
+        await IncidentStateTimelineService.create({
+          data: timeline,
+          props: { isRoot: true },
+        });
+      } else if (suggestion.alertId && suggestion.projectId) {
+        const resolvedStateId: ObjectID =
+          await AlertStateTimelineService.getResolvedStateIdForProject(
+            suggestion.projectId,
+          );
+
+        const timeline: AlertStateTimeline = new AlertStateTimeline();
+        timeline.alertId = suggestion.alertId;
+        timeline.alertStateId = resolvedStateId;
+        timeline.projectId = suggestion.projectId;
+        timeline.rootCause = rootCause;
+
+        await AlertStateTimelineService.create({
+          data: timeline,
+          props: { isRoot: true },
+        });
+      }
+    } catch (err) {
+      if (
+        err instanceof BadDataException &&
+        (err.message === "Incident state cannot be same as previous state." ||
+          err.message === "Alert state cannot be same as previous state.")
+      ) {
+        // Someone resolved it concurrently — exactly the outcome we wanted.
+        logger.debug(
+          `RemediationVerifier: subject of suggestion ${suggestion.id?.toString()} already resolved; skipping duplicate resolve.`,
+        );
+      } else {
+        logger.error(
+          `RemediationVerifier: failed to auto-resolve subject of suggestion ${suggestion.id?.toString()}: ${err}`,
+        );
+      }
+    }
+  }
+
+  private static async postFeedItem(data: {
+    suggestion: AutoRemediationSuggestion;
+    outcome: VerificationOutcome;
+  }): Promise<void> {
+    const emoji: string =
+      data.outcome.status === AutoRemediationVerificationStatus.Verified
+        ? "✅"
+        : "⚠️";
+    const markdown: string = `${emoji} **Auto-remediation verification:** ${data.outcome.note}`;
+
+    try {
+      if (data.suggestion.incidentId && data.suggestion.projectId) {
+        await IncidentFeedService.createIncidentFeedItem({
+          incidentId: data.suggestion.incidentId,
+          projectId: data.suggestion.projectId,
+          incidentFeedEventType: IncidentFeedEventType.AutoRemediation,
+          displayColor: data.outcome.displayColor,
+          feedInfoInMarkdown: markdown,
+          workspaceNotification: {
+            sendWorkspaceNotification: data.outcome.pingWorkspace,
+          },
+        });
+      } else if (data.suggestion.alertId && data.suggestion.projectId) {
+        await AlertFeedService.createAlertFeedItem({
+          alertId: data.suggestion.alertId,
+          projectId: data.suggestion.projectId,
+          alertFeedEventType: AlertFeedEventType.AutoRemediation,
+          displayColor: data.outcome.displayColor,
+          feedInfoInMarkdown: markdown,
+          workspaceNotification: {
+            sendWorkspaceNotification: data.outcome.pingWorkspace,
+          },
+        });
+      }
+    } catch (error) {
+      logger.error(
+        `RemediationVerifier: failed to create feed item: ${error}`,
+      );
+    }
+  }
+}

--- a/Common/Tests/Server/Utils/AutoRemediation/RemediationVerifier.test.ts
+++ b/Common/Tests/Server/Utils/AutoRemediation/RemediationVerifier.test.ts
@@ -1,0 +1,341 @@
+import RemediationVerifier from "../../../../Server/Utils/AutoRemediation/RemediationVerifier";
+import AutoRemediationSuggestionService from "../../../../Server/Services/AutoRemediationSuggestionService";
+import AlertService from "../../../../Server/Services/AlertService";
+import IncidentFeedService from "../../../../Server/Services/IncidentFeedService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import IncidentStateService from "../../../../Server/Services/IncidentStateService";
+import IncidentStateTimelineService from "../../../../Server/Services/IncidentStateTimelineService";
+import MonitorService from "../../../../Server/Services/MonitorService";
+import MonitorStatusService from "../../../../Server/Services/MonitorStatusService";
+import RunbookExecutionService from "../../../../Server/Services/RunbookExecutionService";
+import AutoRemediationSuggestion from "../../../../Models/DatabaseModels/AutoRemediationSuggestion";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentState from "../../../../Models/DatabaseModels/IncidentState";
+import IncidentStateTimeline from "../../../../Models/DatabaseModels/IncidentStateTimeline";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
+import RunbookExecution from "../../../../Models/DatabaseModels/RunbookExecution";
+import AutoRemediationVerificationStatus from "../../../../Types/AutoRemediation/AutoRemediationVerificationStatus";
+import RunbookExecutionStatus from "../../../../Types/Runbook/RunbookExecutionStatus";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — the outcome verifier: a remediation is done when
+ * the subject's monitors recover within the window, not when the runbook
+ * exits. Runbook failure/overrun and non-recovery fail closed; recovery
+ * verifies (with optional system auto-resolve); every conclusion goes
+ * through the verification CAS; escalation is never touched.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SUGGESTION_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const EXECUTION_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const STATE_ID: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+
+const FUTURE: Date = new Date(Date.now() + 10 * 60 * 1000);
+const PAST: Date = new Date(Date.now() - 10 * 60 * 1000);
+
+function fakePending(
+  overrides: Partial<Record<string, unknown>> = {},
+): AutoRemediationSuggestion {
+  return {
+    id: SUGGESTION_ID,
+    _id: SUGGESTION_ID.toString(),
+    projectId: PROJECT_ID,
+    incidentId: INCIDENT_ID,
+    runbookExecutionId: EXECUTION_ID,
+    verificationDeadlineAt: FUTURE,
+    autoResolveOnRecovery: false,
+    ruleNameSnapshot: "Restart API pods",
+    runbookNameSnapshot: "Restart pods",
+    ...overrides,
+  } as unknown as AutoRemediationSuggestion;
+}
+
+function mockPendingList(suggestion: AutoRemediationSuggestion): void {
+  jest
+    .spyOn(AutoRemediationSuggestionService, "findBy")
+    .mockResolvedValue([suggestion]);
+}
+
+function mockExecution(status: RunbookExecutionStatus): void {
+  jest.spyOn(RunbookExecutionService, "findOneById").mockResolvedValue({
+    id: EXECUTION_ID,
+    status,
+  } as unknown as RunbookExecution);
+}
+
+function mockIncident(overrides: Partial<Record<string, unknown>> = {}): void {
+  jest.spyOn(IncidentService, "findOneById").mockResolvedValue({
+    id: INCIDENT_ID,
+    currentIncidentStateId: STATE_ID,
+    monitors: [{ id: MONITOR_ID }],
+    ...overrides,
+  } as unknown as Incident);
+}
+
+function mockIncidentState(isResolved: boolean): void {
+  jest.spyOn(IncidentStateService, "findOneById").mockResolvedValue({
+    id: STATE_ID,
+    isResolvedState: isResolved,
+  } as unknown as IncidentState);
+}
+
+function mockMonitorOperational(isOperational: boolean): void {
+  jest.spyOn(MonitorService, "findOneById").mockResolvedValue({
+    id: MONITOR_ID,
+    currentMonitorStatusId: STATE_ID,
+  } as unknown as Monitor);
+  jest.spyOn(MonitorStatusService, "findOneById").mockResolvedValue({
+    id: STATE_ID,
+    isOperationalState: isOperational,
+  } as unknown as MonitorStatus);
+}
+
+function mockCas(result: number): jest.SpyInstance {
+  return jest
+    .spyOn(AutoRemediationSuggestionService, "attemptVerificationTransition")
+    .mockResolvedValue(result as never);
+}
+
+function mockFeed(): jest.SpyInstance {
+  return jest
+    .spyOn(IncidentFeedService, "createIncidentFeedItem")
+    .mockResolvedValue(undefined as never);
+}
+
+describe("RemediationVerifier.verifyPendingRemediations", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("fails verification when the runbook execution failed", async () => {
+    mockPendingList(fakePending());
+    mockExecution(RunbookExecutionStatus.Failed);
+    const cas: jest.SpyInstance = mockCas(1);
+    mockFeed();
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        suggestionId: SUGGESTION_ID,
+        fromVerificationStatus: AutoRemediationVerificationStatus.Pending,
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Failed,
+        }),
+      }),
+    );
+  });
+
+  it("verifies when the runbook completed and the monitors recovered", async () => {
+    mockPendingList(fakePending());
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident();
+    mockIncidentState(false);
+    mockMonitorOperational(true);
+    const cas: jest.SpyInstance = mockCas(1);
+    const resolveTimeline: jest.SpyInstance = jest
+      .spyOn(IncidentStateTimelineService, "create")
+      .mockResolvedValue({} as unknown as IncidentStateTimeline);
+    mockFeed();
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Verified,
+        }),
+      }),
+    );
+    // autoResolveOnRecovery is false — no system resolve.
+    expect(resolveTimeline).not.toHaveBeenCalled();
+  });
+
+  it("system-resolves the incident on verified recovery when the rule opted in", async () => {
+    mockPendingList(fakePending({ autoResolveOnRecovery: true }));
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident();
+    mockIncidentState(false);
+    mockMonitorOperational(true);
+    mockCas(1);
+    mockFeed();
+    jest
+      .spyOn(IncidentStateTimelineService, "getResolvedStateIdForProject")
+      .mockResolvedValue(STATE_ID);
+    const resolveTimeline: jest.SpyInstance = jest
+      .spyOn(IncidentStateTimelineService, "create")
+      .mockResolvedValue({} as unknown as IncidentStateTimeline);
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(resolveTimeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          incidentId: INCIDENT_ID,
+          incidentStateId: STATE_ID,
+        }),
+        props: expect.objectContaining({ isRoot: true }),
+      }),
+    );
+  });
+
+  it("fails verification when the window elapsed and the monitors did not recover", async () => {
+    mockPendingList(fakePending({ verificationDeadlineAt: PAST }));
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident();
+    mockIncidentState(false);
+    mockMonitorOperational(false);
+    const cas: jest.SpyInstance = mockCas(1);
+    mockFeed();
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Failed,
+        }),
+      }),
+    );
+  });
+
+  it("keeps waiting while the window is open and the monitors are still unhealthy", async () => {
+    mockPendingList(fakePending());
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident();
+    mockIncidentState(false);
+    mockMonitorOperational(false);
+    const cas: jest.SpyInstance = mockCas(1);
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).not.toHaveBeenCalled();
+  });
+
+  it("fails verification when the runbook overran the window without completing", async () => {
+    mockPendingList(fakePending({ verificationDeadlineAt: PAST }));
+    mockExecution(RunbookExecutionStatus.Running);
+    const cas: jest.SpyInstance = mockCas(1);
+    mockFeed();
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Failed,
+        }),
+      }),
+    );
+  });
+
+  it("verifies without auto-resolve when the subject was already resolved", async () => {
+    mockPendingList(fakePending({ autoResolveOnRecovery: true }));
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident();
+    mockIncidentState(true);
+    const cas: jest.SpyInstance = mockCas(1);
+    const resolveTimeline: jest.SpyInstance = jest
+      .spyOn(IncidentStateTimelineService, "create")
+      .mockResolvedValue({} as unknown as IncidentStateTimeline);
+    mockFeed();
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Verified,
+        }),
+      }),
+    );
+    expect(resolveTimeline).not.toHaveBeenCalled();
+  });
+
+  it("skips verification for a subject with no monitors, quietly", async () => {
+    mockPendingList(fakePending());
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident({ monitors: [] });
+    mockIncidentState(false);
+    const cas: jest.SpyInstance = mockCas(1);
+    const feed: jest.SpyInstance = mockFeed();
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Skipped,
+        }),
+      }),
+    );
+    expect(feed).not.toHaveBeenCalled();
+  });
+
+  it("posts no feed item and never auto-resolves when the CAS loses the race", async () => {
+    mockPendingList(fakePending({ autoResolveOnRecovery: true }));
+    mockExecution(RunbookExecutionStatus.Completed);
+    mockIncident();
+    mockIncidentState(false);
+    mockMonitorOperational(true);
+    mockCas(0);
+    const feed: jest.SpyInstance = mockFeed();
+    const resolveTimeline: jest.SpyInstance = jest
+      .spyOn(IncidentStateTimelineService, "create")
+      .mockResolvedValue({} as unknown as IncidentStateTimeline);
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(feed).not.toHaveBeenCalled();
+    expect(resolveTimeline).not.toHaveBeenCalled();
+  });
+
+  it("verifies an alert through its single monitor", async () => {
+    mockPendingList(
+      fakePending({
+        incidentId: undefined,
+        alertId: new ObjectID("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+      }),
+    );
+    mockExecution(RunbookExecutionStatus.Completed);
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue({
+      id: new ObjectID("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+      currentAlertStateId: undefined,
+      monitorId: MONITOR_ID,
+    } as unknown as never);
+    mockMonitorOperational(true);
+    const cas: jest.SpyInstance = mockCas(1);
+    jest
+      .spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+        require("../../../../Server/Services/AlertFeedService").default,
+        "createAlertFeedItem",
+      )
+      .mockResolvedValue(undefined as never);
+
+    await RemediationVerifier.verifyPendingRemediations();
+
+    expect(cas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          verificationStatus: AutoRemediationVerificationStatus.Verified,
+        }),
+      }),
+    );
+  });
+});

--- a/Common/Types/AutoRemediation/AutoRemediationVerificationStatus.ts
+++ b/Common/Types/AutoRemediation/AutoRemediationVerificationStatus.ts
@@ -1,0 +1,21 @@
+/*
+ * Outcome verification for an executed remediation. A remediation is not
+ * done when the runbook exits — it is done when the subject's monitors are
+ * back to an operational state (or the incident/alert was resolved) within
+ * the verification window.
+ *
+ * Pending:  the runbook was started; the verifier is watching for recovery.
+ * Verified: the subject recovered (or was resolved) within the window.
+ * Failed:   the runbook failed, did not finish in time, or the service did
+ *           not recover within the window — escalation continues as normal.
+ * Skipped:  nothing to verify against (e.g. a manual incident with no
+ *           monitors).
+ */
+enum AutoRemediationVerificationStatus {
+  Pending = "Pending",
+  Verified = "Verified",
+  Failed = "Failed",
+  Skipped = "Skipped",
+}
+
+export default AutoRemediationVerificationStatus;


### PR DESCRIPTION
Follow-up to #2966 — this commit was pushed a few minutes **after** #2966 was merged, so it never made it onto master.

## What this adds

A remediation is not done when the runbook exits 0 — it is done when the subject's monitors are back to an operational state. An every-minute Workers sweep now closes that loop for every started remediation (one-click Approved or FullAuto AutoExecuted):

| Outcome | Result |
| --- | --- |
| Runbook failed or was cancelled | **Failed** (workspace ping) |
| Runbook overran the verification window | **Failed** (workspace ping) |
| Monitors operational within the window | **Verified** — plus optional system auto-resolve |
| Subject already resolved | **Verified** |
| Window elapsed, still unhealthy | **Failed** — escalation continues as normal |
| No monitors to verify against | **Skipped** (quiet) |

Verification **never touches paging**: escalation proceeds (or stops on ack/resolve) exactly as before.

## Per-rule knobs

`verificationWindowMinutes` (default 15) and `autoResolveOnVerifiedRecovery` (default off), both snapshotted onto each suggestion at creation so editing or deleting a rule never changes an in-flight verification. Auto-resolve writes the resolved state-timeline row with no user — the same system-resolve pattern monitor-criteria auto-resolve uses, so a concurrent human resolve is a harmless no-op.

## Why it matters beyond the loop

The Verified/Failed columns are the measurement layer: per-rule verified-fixed rate is what should eventually *earn* a rule its FullAuto mode ("19/20 verified — promote?"), which was the graduation story from the original design.

## Implementation notes

- Conclusions go through a `verificationStatus` CAS (`attemptVerificationTransition`), so concurrent Workers replicas settle each verification exactly once.
- The remediation card shows a live verification pill and polls until verification concludes.
- Migration generated + drift-checked.

## Testing

10 new verifier tests (runbook-failed, recovered, auto-resolve opt-in, window elapsed, still-waiting, overrun, already-resolved, no-monitors skip, CAS-lost race, alert path). 669 AI/remediation tests green; Common, App and Dashboard type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dohLzsG7E9dXxuoBDYuoV