### PR TITLE
Carry the status page group hierarchy into the emailed uptime report

### DIFF
--- a/App/FeatureSet/Dashboard/src/Utils/SubscriberNotificationTemplateDefaults.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/SubscriberNotificationTemplateDefaults.ts
@@ -805,24 +805,34 @@ const reportDefaults: EventDefaults = {
       </td>
     </tr>
   </table>
-  <h3 style="color: #1a1a2e; font-size: 16px; font-weight: 700; margin: 0 0 12px 0;">Per-resource breakdown</h3>
+  <h3 style="color: #1a1a2e; font-size: 16px; font-weight: 700; margin: 0 0 12px 0;">{{#if report.hasGroups}}Breakdown by group{{else}}Per-resource breakdown{{/if}}</h3>
   <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse: separate; border-spacing: 0; border: 1px solid #e2e8f0; border-radius: 12px; overflow: hidden; margin: 0 0 24px 0;">
     <thead>
       <tr>
-        <th align="left" style="background-color: #1a1a2e; color: #ffffff; padding: 12px 14px; font-size: 11px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;">Resource</th>
+        <th align="left" style="background-color: #1a1a2e; color: #ffffff; padding: 12px 14px; font-size: 11px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;">{{#if report.hasGroups}}Group / Resource{{else}}Resource{{/if}}</th>
         <th align="right" style="background-color: #1a1a2e; color: #ffffff; padding: 12px 14px; font-size: 11px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;">Uptime</th>
         <th align="right" style="background-color: #1a1a2e; color: #ffffff; padding: 12px 14px; font-size: 11px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;">Downtime</th>
         <th align="right" style="background-color: #1a1a2e; color: #ffffff; padding: 12px 14px; font-size: 11px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;">Incidents</th>
       </tr>
     </thead>
     <tbody>
-      {{#each report.resources}}
+      {{!-- report.rows is the status page's group hierarchy flattened into render order, so any depth of nesting renders without recursion. Loop over report.resources instead for a flat list. --}}
+      {{#each report.rows}}
+      {{#if this.isGroup}}
+      <tr style="background-color: #e8ecf5;">
+        <td align="left" style="padding: 12px 14px; border-top: 1px solid #d6dcea; font-size: 14px; color: #1a1a2e; font-weight: 700;"><div style="margin-left: {{this.indentInPixels}}px;">{{this.name}}</div></td>
+        <td align="right" style="padding: 12px 14px; border-top: 1px solid #d6dcea; font-size: 14px; color: #1a1a2e; font-weight: 700;">{{this.uptimePercentAsString}}</td>
+        <td align="right" style="padding: 12px 14px; border-top: 1px solid #d6dcea; font-size: 14px; color: #1a1a2e; font-weight: 600;">{{this.downtimeInHoursAndMinutes}}</td>
+        <td align="right" style="padding: 12px 14px; border-top: 1px solid #d6dcea; font-size: 14px; color: #1a1a2e; font-weight: 700;">{{this.totalIncidentCount}}</td>
+      </tr>
+      {{else}}
       <tr>
-        <td align="left" style="padding: 12px 14px; border-top: 1px solid #e5e8f0; font-size: 14px; color: #374151; font-weight: 500;">{{this.resourceName}}</td>
+        <td align="left" style="padding: 12px 14px; border-top: 1px solid #e5e8f0; font-size: 14px; color: #374151; font-weight: 500;"><div style="margin-left: {{this.indentInPixels}}px;">{{this.name}}</div></td>
         <td align="right" style="padding: 12px 14px; border-top: 1px solid #e5e8f0; font-size: 14px; color: #1e293b; font-weight: 600;">{{this.uptimePercentAsString}}</td>
         <td align="right" style="padding: 12px 14px; border-top: 1px solid #e5e8f0; font-size: 14px; color: #374151;">{{this.downtimeInHoursAndMinutes}}</td>
         <td align="right" style="padding: 12px 14px; border-top: 1px solid #e5e8f0; font-size: 14px; color: #1e293b; font-weight: 600;">{{this.totalIncidentCount}}</td>
       </tr>
+      {{/if}}
       {{/each}}
     </tbody>
   </table>

--- a/App/FeatureSet/Dashboard/src/Utils/SubscriberNotificationTemplateVariables.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/SubscriberNotificationTemplateVariables.ts
@@ -146,7 +146,11 @@ ${commonVariablesRows}`;
 | \`{{report.totalDowntimeInHoursAndMinutes}}\` | Total downtime in the period |
 | \`{{report.totalIncidents}}\` | Total number of incidents in the period |
 | \`{{report.totalResources}}\` | Number of resources on the status page |
-| \`{{report.resources}}\` | Array of per-resource breakdown rows (loop over this) |
+| \`{{report.resources}}\` | Array of per-resource breakdown rows, flat (loop over this) |
+| \`{{report.hasGroups}}\` | \`true\` when the status page organises its resources into groups |
+| \`{{report.rows}}\` | The group hierarchy flattened into render order — group rows and resource rows interleaved (loop over this) |
+| \`{{report.groups}}\` | The group hierarchy as a nested tree (top level groups) |
+| \`{{report.ungroupedResources}}\` | Resources that are not in any group |
 
 **Per-resource fields** (available inside \`{{#each report.resources}}\`):
 
@@ -156,13 +160,34 @@ ${commonVariablesRows}`;
 | \`{{this.uptimePercentAsString}}\` | Uptime for the resource (e.g. "99.9%") |
 | \`{{this.downtimeInHoursAndMinutes}}\` | Downtime for the resource |
 | \`{{this.totalIncidentCount}}\` | Number of incidents for the resource |
+| \`{{this.groupName}}\` | Group the resource sits in (empty when ungrouped) |
+| \`{{this.groupPath}}\` | Full group path, e.g. "Region 001 / Market 001 / Unit 0660" |
+
+**Row fields** (available inside \`{{#each report.rows}}\`) — use these to reproduce the status page's nested group hierarchy without recursion:
+
+| Variable | Description |
+|----------|-------------|
+| \`{{this.isGroup}}\` | \`true\` for a group header row, \`false\` for a resource row |
+| \`{{this.name}}\` | Group name or resource name |
+| \`{{this.depth}}\` | Nesting level — 0 for a top level group |
+| \`{{this.indentInPixels}}\` | Indent to render the row with (16px per level) |
+| \`{{this.uptimePercentAsString}}\` | Uptime — rolled up over the whole subtree on a group row |
+| \`{{this.downtimeInHoursAndMinutes}}\` | Downtime for the row |
+| \`{{this.totalIncidentCount}}\` | Incidents for the row |
+| \`{{this.totalResources}}\` | Resources a group rolls up (0 on a resource row) |
+
+**Group fields** (available inside \`{{#each report.groups}}\`): \`{{this.groupName}}\`, \`{{this.groupPath}}\`, \`{{this.depth}}\`, \`{{this.uptimePercentAsString}}\`, \`{{this.downtimeInHoursAndMinutes}}\`, \`{{this.totalIncidentCount}}\`, \`{{this.totalResources}}\`, \`{{this.resources}}\` (the group's own resources) and \`{{this.subGroups}}\` (groups nested under it).
 
 **Example — loop and conditional:**
 
 \`\`\`handlebars
 {{#if report.totalResources}}
-  {{#each report.resources}}
-    {{this.resourceName}}: {{this.uptimePercentAsString}} uptime
+  {{#each report.rows}}
+    {{#if this.isGroup}}
+[group] {{this.name}}: {{this.uptimePercentAsString}} uptime
+    {{else}}
+{{this.name}}: {{this.uptimePercentAsString}} uptime
+    {{/if}}
   {{/each}}
 {{else}}
   No resources to report this period.

--- a/App/FeatureSet/Notification/Templates/StatusPageSubscriberReport.hbs
+++ b/App/FeatureSet/Notification/Templates/StatusPageSubscriberReport.hbs
@@ -71,9 +71,19 @@
 </table>
 <!-- /Supporting Stats Strip -->
 
+{{#if report.hasGroups}}
+{{> TitleBlock title="Breakdown by group"}}
+{{else}}
 {{> TitleBlock title="Per-resource breakdown"}}
+{{/if}}
 
-<!-- Per-resource Table -->
+<!--
+  Breakdown table. `report.rows` is the status page's group hierarchy already
+  flattened into render order - ungrouped resources first, then each group
+  followed by its own resources and then its sub groups - so this renders any
+  depth of nesting without recursion, which email clients handle poorly.
+  Group rows carry the uptime rolled up over everything beneath them.
+-->
 <table class="st-Copy st-Width st-Width--mobile" border="0" cellpadding="0" cellspacing="0" width="600" style="min-width: 600px;">
   <tbody>
     <tr>
@@ -82,20 +92,33 @@
         <table border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:separate;border-spacing:0;border:1px solid #e2e8f0;border-radius:12px;overflow:hidden;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Ubuntu,sans-serif;">
           <thead>
             <tr>
-              <th align="left" bgcolor="#1a1a2e" style="background-color:#1a1a2e;color:#ffffff;padding:12px 14px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;text-align:left;">Resource</th>
+              <th align="left" bgcolor="#1a1a2e" style="background-color:#1a1a2e;color:#ffffff;padding:12px 14px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;text-align:left;">{{#if report.hasGroups}}Group / Resource{{else}}Resource{{/if}}</th>
               <th align="right" bgcolor="#1a1a2e" style="background-color:#1a1a2e;color:#ffffff;padding:12px 14px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;text-align:right;">Uptime</th>
               <th align="right" bgcolor="#1a1a2e" style="background-color:#1a1a2e;color:#ffffff;padding:12px 14px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;text-align:right;">Downtime</th>
               <th align="right" bgcolor="#1a1a2e" style="background-color:#1a1a2e;color:#ffffff;padding:12px 14px;font-size:11px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;text-align:right;">Incidents</th>
             </tr>
           </thead>
           <tbody>
-            {{#each report.resources}}
-            <tr bgcolor="{{#if @odd}}#f0f3f9{{else}}#ffffff{{/if}}" style="background-color:{{#if @odd}}#f0f3f9{{else}}#ffffff{{/if}};">
-              <td align="left" style="padding:12px 14px;border-top:1px solid #e5e8f0;font-size:14px;color:#374151;font-weight:500;">{{this.resourceName}}</td>
+            {{#each report.rows}}
+            {{#if this.isGroup}}
+            <tr bgcolor="#e8ecf5" style="background-color:#e8ecf5;">
+              <td align="left" style="padding:12px 14px;border-top:1px solid #d6dcea;font-size:14px;color:#1a1a2e;font-weight:700;">
+                <div style="margin-left:{{this.indentInPixels}}px;">{{this.name}}<span style="font-size:11px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.4px;"> &middot; {{this.totalResources}} resources</span></div>
+              </td>
+              <td align="right" style="padding:12px 14px;border-top:1px solid #d6dcea;font-size:14px;color:#1a1a2e;font-weight:700;text-align:right;">{{this.uptimePercentAsString}}</td>
+              <td align="right" style="padding:12px 14px;border-top:1px solid #d6dcea;font-size:14px;color:#1a1a2e;font-weight:600;text-align:right;">{{this.downtimeInHoursAndMinutes}}</td>
+              <td align="right" style="padding:12px 14px;border-top:1px solid #d6dcea;font-size:14px;color:#1a1a2e;font-weight:700;text-align:right;">{{this.totalIncidentCount}}</td>
+            </tr>
+            {{else}}
+            <tr bgcolor="#ffffff" style="background-color:#ffffff;">
+              <td align="left" style="padding:12px 14px;border-top:1px solid #e5e8f0;font-size:14px;color:#374151;font-weight:500;">
+                <div style="margin-left:{{this.indentInPixels}}px;">{{this.name}}</div>
+              </td>
               <td align="right" style="padding:12px 14px;border-top:1px solid #e5e8f0;font-size:14px;color:#1e293b;font-weight:600;text-align:right;">{{this.uptimePercentAsString}}</td>
               <td align="right" style="padding:12px 14px;border-top:1px solid #e5e8f0;font-size:14px;color:#374151;text-align:right;">{{this.downtimeInHoursAndMinutes}}</td>
               <td align="right" style="padding:12px 14px;border-top:1px solid #e5e8f0;font-size:14px;color:#1e293b;font-weight:600;text-align:right;">{{this.totalIncidentCount}}</td>
             </tr>
+            {{/if}}
             {{/each}}
           </tbody>
         </table>
@@ -107,7 +130,7 @@
     </tr>
   </tbody>
 </table>
-<!-- /Per-resource Table -->
+<!-- /Breakdown Table -->
 {{/ifCond}}
 
 {{#ifCond hasResources "false"}}

--- a/App/Tests/Notification/StatusPageSubscriberReportTemplate.test.ts
+++ b/App/Tests/Notification/StatusPageSubscriberReportTemplate.test.ts
@@ -1,0 +1,482 @@
+/*
+ * The rendered "Uptime Report" email for a status page.
+ *
+ * StatusPageService builds the report; this is the other half - what a
+ * subscriber actually receives. The bug these tests pin: the email dumped every
+ * monitor into one flat "Per-resource breakdown" table, so a reader could not
+ * tell which Region / Market / Unit a monitor belonged to and never saw the
+ * rolled up availability the live status page shows at every level. Most
+ * recipients of this email have no OneUptime login, so the email is all they get.
+ *
+ * Both the built-in template (StatusPageSubscriberReport.hbs) and the default
+ * body offered to customers who author their own report template are rendered
+ * here, through real Handlebars, from a report built by the real tree util.
+ */
+
+import Handlebars from "handlebars";
+import fs from "fs";
+import Path from "path";
+import StatusPageReportTreeUtil, {
+  StatusPageReportResourceEntry,
+  StatusPageReportStructure,
+} from "Common/Utils/StatusPage/Report";
+import ObjectID from "Common/Types/ObjectID";
+import Dictionary from "Common/Types/Dictionary";
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
+import {
+  StatusPageReport,
+  StatusPageReportGroupMetrics,
+} from "Common/Types/StatusPage/StatusPageReport";
+import { getDefaultSubscriberNotificationTemplate } from "../../FeatureSet/Dashboard/src/Utils/SubscriberNotificationTemplateDefaults";
+import StatusPageSubscriberNotificationEventType from "Common/Types/StatusPage/StatusPageSubscriberNotificationEventType";
+import StatusPageSubscriberNotificationMethod from "Common/Types/StatusPage/StatusPageSubscriberNotificationMethod";
+import { beforeAll, describe, expect, test } from "@jest/globals";
+
+const TEMPLATES_DIR: string = Path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Notification",
+  "Templates",
+);
+
+const HANDLEBARS_UTIL_PATH: string = Path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Notification",
+  "Utils",
+  "Handlebars.ts",
+);
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MARKET_ONE: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const UNIT_0660: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+  group.order = 1;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  return group;
+}
+
+function makeEntry(data: {
+  resourceName: string;
+  groupId?: ObjectID | undefined;
+  uptimePercent?: number | undefined;
+}): StatusPageReportResourceEntry {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource.displayName = data.resourceName;
+
+  if (data.groupId) {
+    resource.statusPageGroupId = data.groupId;
+  }
+
+  const uptimePercent: number =
+    data.uptimePercent === undefined ? 100 : data.uptimePercent;
+
+  return {
+    statusPageResource: resource,
+    reportItem: {
+      resourceName: data.resourceName,
+      totalIncidentCount: 1,
+      uptimePercent: uptimePercent,
+      uptimePercentAsString: `${uptimePercent}%`,
+      downtimeInHoursAndMinutes: "0 minutes",
+    },
+  };
+}
+
+function buildReport(data: {
+  entries: Array<StatusPageReportResourceEntry>;
+  statusPageGroups: Array<StatusPageGroup>;
+  groupMetricsByGroupId?: Dictionary<StatusPageReportGroupMetrics> | undefined;
+}): StatusPageReport {
+  const structure: StatusPageReportStructure = StatusPageReportTreeUtil.build({
+    entries: data.entries,
+    statusPageGroups: data.statusPageGroups,
+    groupMetricsByGroupId: data.groupMetricsByGroupId || {},
+  });
+
+  return {
+    reportDates: "14 days (01 Jul 2026 - 14 Jul 2026)",
+    totalResources: structure.resources.length,
+    totalIncidents: 3,
+    averageUptimePercent: "97.85%",
+    totalDowntimeInHoursAndMinutes: "2 days, 0 minutes",
+    resources: structure.resources,
+    groups: structure.groups,
+    ungroupedResources: structure.resourcesWithoutGroup,
+    rows: structure.rows,
+    hasGroups: structure.groups.length > 0,
+  };
+}
+
+/*
+ * The hierarchy from the bug report:
+ *
+ *   Corporate Unit's
+ *     Region 001
+ *       Market 001
+ *         Unit 0660
+ *           Router
+ *           Switch 01
+ *   (ungrouped) WBHQ website
+ */
+function nestedGroups(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+    makeGroup({ id: REGION_ONE, name: "Region 001", parentId: CORPORATE }),
+    makeGroup({ id: MARKET_ONE, name: "Market 001", parentId: REGION_ONE }),
+    makeGroup({ id: UNIT_0660, name: "Unit 0660", parentId: MARKET_ONE }),
+  ];
+}
+
+function nestedEntries(): Array<StatusPageReportResourceEntry> {
+  return [
+    makeEntry({
+      resourceName: "Router",
+      groupId: UNIT_0660,
+      uptimePercent: 85.71,
+    }),
+    makeEntry({ resourceName: "WBHQ website" }),
+    makeEntry({ resourceName: "Switch 01", groupId: UNIT_0660 }),
+  ];
+}
+
+function nestedMetrics(): Dictionary<StatusPageReportGroupMetrics> {
+  const rolledUp: StatusPageReportGroupMetrics = {
+    uptimePercent: 92.85,
+    uptimePercentAsString: "92.85%",
+    downtimeInHoursAndMinutes: "2 days, 0 minutes",
+    totalIncidentCount: 2,
+  };
+
+  return {
+    [CORPORATE.toString()]: rolledUp,
+    [REGION_ONE.toString()]: rolledUp,
+    [MARKET_ONE.toString()]: rolledUp,
+    [UNIT_0660.toString()]: rolledUp,
+  };
+}
+
+/*
+ * The names of the rows the breakdown table renders, in document order. Every
+ * row's name sits in a `<div style="margin-left: ...">` inside the first cell,
+ * which is also where the indent lives.
+ */
+function renderedRows(html: string): Array<{ name: string; indent: number }> {
+  const rows: Array<{ name: string; indent: number }> = [];
+  const pattern: RegExp = /<div style="margin-left: ?(\d+)px;">([^<]*)/g;
+
+  let match: RegExpExecArray | null = pattern.exec(html);
+
+  while (match) {
+    rows.push({
+      indent: Number(match[1]),
+      name: match[2]!.trim(),
+    });
+
+    match = pattern.exec(html);
+  }
+
+  return rows;
+}
+
+function renderReportTemplate(vars: Record<string, unknown>): string {
+  const templateSource: string = fs.readFileSync(
+    Path.resolve(TEMPLATES_DIR, "StatusPageSubscriberReport.hbs"),
+    { encoding: "utf8" },
+  );
+
+  return Handlebars.compile(templateSource)(vars);
+}
+
+beforeAll(() => {
+  /*
+   * Mirrors what FeatureSet/Notification/Utils/Handlebars.ts does at runtime:
+   * every file in Templates/Partials becomes a partial, plus the small helper
+   * set the templates use. Registered here (rather than importing that module)
+   * so the test does not depend on the process working directory - the module
+   * resolves the partials directory from process.cwd(). The
+   * "registers every helper" test below keeps the two in step.
+   */
+  const partialsDir: string = Path.resolve(TEMPLATES_DIR, "Partials");
+
+  for (const filename of fs.readdirSync(partialsDir)) {
+    const matches: RegExpMatchArray | null = filename.match(/^(.*)\.hbs$/);
+
+    if (!matches) {
+      continue;
+    }
+
+    Handlebars.registerPartial(
+      matches[1]!,
+      fs.readFileSync(Path.resolve(partialsDir, filename), {
+        encoding: "utf8",
+      }),
+    );
+  }
+
+  Handlebars.registerHelper(
+    "ifCond",
+    function (v1: any, v2: any, options: any) {
+      // @ts-expect-error - Handlebars uses dynamic this context for template helpers
+      return v1 === v2 ? options.fn(this) : options.inverse(this);
+    },
+  );
+
+  Handlebars.registerHelper(
+    "ifNotCond",
+    function (v1: any, v2: any, options: any) {
+      // @ts-expect-error - Handlebars uses dynamic this context for template helpers
+      return v1 !== v2 ? options.fn(this) : options.inverse(this);
+    },
+  );
+
+  Handlebars.registerHelper("concat", (v1: any, v2: any) => {
+    return v1 + v2;
+  });
+});
+
+describe("StatusPageSubscriberReport.hbs", () => {
+  describe("a status page with nested groups", () => {
+    let html: string = "";
+
+    beforeAll(() => {
+      html = renderReportTemplate({
+        statusPageName: "WBHQ Status Page",
+        hasResources: "true",
+        statusPageUrl: "https://status.example.com",
+        detailsUrl: "https://status.example.com",
+        report: buildReport({
+          entries: nestedEntries(),
+          statusPageGroups: nestedGroups(),
+          groupMetricsByGroupId: nestedMetrics(),
+        }),
+      });
+    });
+
+    test("renders every level of the hierarchy, in the order the live page shows it", () => {
+      expect(
+        renderedRows(html).map(
+          (row: { name: string; indent: number }): string => {
+            return row.name;
+          },
+        ),
+      ).toEqual([
+        "WBHQ website",
+        "Corporate Unit&#x27;s",
+        "Region 001",
+        "Market 001",
+        "Unit 0660",
+        "Router",
+        "Switch 01",
+      ]);
+    });
+
+    test("indents each level so the nesting is readable", () => {
+      const indentByName: Dictionary<number> = {};
+
+      for (const row of renderedRows(html)) {
+        indentByName[row.name] = row.indent;
+      }
+
+      expect(indentByName["WBHQ website"]).toBe(0);
+      expect(indentByName["Corporate Unit&#x27;s"]).toBe(0);
+      expect(indentByName["Region 001"]).toBe(16);
+      expect(indentByName["Market 001"]).toBe(32);
+      expect(indentByName["Unit 0660"]).toBe(48);
+      expect(indentByName["Router"]).toBe(64);
+      expect(indentByName["Switch 01"]).toBe(64);
+    });
+
+    test("shows the uptime rolled up over each group", () => {
+      /*
+       * Every group in this fixture rolls up the same two resources, so the
+       * rolled up figure appears once per group row.
+       */
+      expect(html.split("92.85%")).toHaveLength(5);
+      // and the resources still report their own numbers.
+      expect(html).toContain("85.71%");
+    });
+
+    test("tells the reader how many resources each group covers", () => {
+      expect(html).toContain("2 resources");
+    });
+
+    test("titles the table as a group breakdown", () => {
+      expect(html).toContain("Breakdown by group");
+      expect(html).toContain("Group / Resource");
+      expect(html).not.toContain("Per-resource breakdown");
+    });
+
+    test("escapes group and resource names", () => {
+      const injected: string = renderReportTemplate({
+        statusPageName: "WBHQ Status Page",
+        hasResources: "true",
+        report: buildReport({
+          entries: [
+            makeEntry({
+              resourceName: "<script>alert(1)</script>",
+              groupId: CORPORATE,
+            }),
+          ],
+          statusPageGroups: [
+            makeGroup({ id: CORPORATE, name: "<img src=x onerror=1>" }),
+          ],
+        }),
+      });
+
+      expect(injected).not.toContain("<script>alert(1)</script>");
+      expect(injected).not.toContain("<img src=x onerror=1>");
+      expect(injected).toContain("&lt;script&gt;");
+      expect(injected).toContain("&lt;img src");
+    });
+  });
+
+  describe("a status page with no groups", () => {
+    let html: string = "";
+
+    beforeAll(() => {
+      html = renderReportTemplate({
+        statusPageName: "WBHQ Status Page",
+        hasResources: "true",
+        report: buildReport({
+          entries: [
+            makeEntry({ resourceName: "Router", uptimePercent: 85.71 }),
+            makeEntry({ resourceName: "WBHQ website" }),
+          ],
+          statusPageGroups: [],
+        }),
+      });
+    });
+
+    test("falls back to the flat per-resource table", () => {
+      expect(html).toContain("Per-resource breakdown");
+      expect(html).not.toContain("Breakdown by group");
+      expect(html).not.toContain("Group / Resource");
+    });
+
+    test("lists every resource, unindented", () => {
+      expect(renderedRows(html)).toEqual([
+        { name: "Router", indent: 0 },
+        { name: "WBHQ website", indent: 0 },
+      ]);
+    });
+  });
+
+  describe("a status page with no resources", () => {
+    test("says there is nothing to report instead of rendering an empty table", () => {
+      const html: string = renderReportTemplate({
+        statusPageName: "WBHQ Status Page",
+        hasResources: "false",
+        report: buildReport({ entries: [], statusPageGroups: [] }),
+      });
+
+      expect(html).toContain(
+        "No resources have been added to this status page",
+      );
+      expect(renderedRows(html)).toEqual([]);
+    });
+  });
+
+  test("only uses helpers the notification Handlebars util registers", () => {
+    const templateSource: string = fs.readFileSync(
+      Path.resolve(TEMPLATES_DIR, "StatusPageSubscriberReport.hbs"),
+      { encoding: "utf8" },
+    );
+
+    const utilSource: string = fs.readFileSync(HANDLEBARS_UTIL_PATH, {
+      encoding: "utf8",
+    });
+
+    for (const helper of ["ifCond", "ifNotCond", "concat"]) {
+      if (!templateSource.includes(helper)) {
+        continue;
+      }
+
+      expect(utilSource).toContain(`registerHelper("${helper}"`);
+    }
+  });
+});
+
+describe("the default report template offered to customers", () => {
+  function renderDefaultBody(report: StatusPageReport): string {
+    const body: string =
+      getDefaultSubscriberNotificationTemplate(
+        StatusPageSubscriberNotificationEventType.SubscriberReport,
+        StatusPageSubscriberNotificationMethod.Email,
+      )?.body || "";
+
+    expect(body).not.toBe("");
+
+    return Handlebars.compile(body)({
+      statusPageName: "WBHQ Status Page",
+      detailsUrl: "https://status.example.com",
+      report: report,
+    });
+  }
+
+  test("renders the same nested hierarchy", () => {
+    const html: string = renderDefaultBody(
+      buildReport({
+        entries: nestedEntries(),
+        statusPageGroups: nestedGroups(),
+        groupMetricsByGroupId: nestedMetrics(),
+      }),
+    );
+
+    expect(
+      renderedRows(html).map(
+        (row: { name: string; indent: number }): string => {
+          return row.name;
+        },
+      ),
+    ).toEqual([
+      "WBHQ website",
+      "Corporate Unit&#x27;s",
+      "Region 001",
+      "Market 001",
+      "Unit 0660",
+      "Router",
+      "Switch 01",
+    ]);
+
+    expect(html).toContain("Breakdown by group");
+  });
+
+  test("falls back to a flat table when the page has no groups", () => {
+    const html: string = renderDefaultBody(
+      buildReport({
+        entries: [makeEntry({ resourceName: "Router" })],
+        statusPageGroups: [],
+      }),
+    );
+
+    expect(html).toContain("Per-resource breakdown");
+    expect(renderedRows(html)).toEqual([{ name: "Router", indent: 0 }]);
+  });
+});

--- a/Common/Server/Services/StatusPageService.ts
+++ b/Common/Server/Services/StatusPageService.ts
@@ -75,23 +75,27 @@ import {
   MASTER_PASSWORD_COOKIE_IDENTIFIER,
   MASTER_PASSWORD_REQUIRED_MESSAGE,
 } from "../../Types/StatusPage/MasterPassword";
+import StatusPageGroup from "../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupService from "./StatusPageGroupService";
+import StatusPageGroupTreeUtil from "../../Utils/StatusPage/GroupTree";
+import StatusPageReportTreeUtil, {
+  StatusPageReportResourceEntry,
+  StatusPageReportStructure,
+} from "../../Utils/StatusPage/Report";
+import {
+  StatusPageReport,
+  StatusPageReportGroup,
+  StatusPageReportGroupMetrics,
+  StatusPageReportItem,
+  StatusPageReportRow,
+} from "../../Types/StatusPage/StatusPageReport";
 
-export interface StatusPageReportItem {
-  resourceName: string;
-  totalIncidentCount: number;
-  uptimePercent: number;
-  uptimePercentAsString: string;
-  downtimeInHoursAndMinutes: string;
-}
-
-export interface StatusPageReport {
-  reportDates: string; // start date and end date in string. e.g. "01 July 2021 - 14 July 2021"
-  totalResources: number;
-  totalIncidents: number;
-  averageUptimePercent: string;
-  totalDowntimeInHoursAndMinutes: string;
-  resources: Array<StatusPageReportItem>;
-}
+export {
+  StatusPageReport,
+  StatusPageReportGroup,
+  StatusPageReportItem,
+  StatusPageReportRow,
+};
 
 export class Service extends DatabaseService<StatusPage> {
   /*
@@ -1262,6 +1266,10 @@ export class Service extends DatabaseService<StatusPage> {
         averageUptimePercent: "0%",
         totalDowntimeInHoursAndMinutes: "0",
         resources: [],
+        groups: [],
+        ungroupedResources: [],
+        rows: [],
+        hasGroups: false,
       };
     }
 
@@ -1284,7 +1292,13 @@ export class Service extends DatabaseService<StatusPage> {
         endDate: endDate,
       });
 
-    const reportItems: Array<StatusPageReportItem> = [];
+    const entries: Array<StatusPageReportResourceEntry> = [];
+
+    /*
+     * Kept alongside `entries` so a group can roll up the monitors of every
+     * resource beneath it without expanding monitor groups a second time.
+     */
+    const monitorIdsByResourceIndex: Array<Array<ObjectID>> = [];
 
     for (const resource of statusPageResources) {
       // for each of these resource, calculate uptime percent.
@@ -1324,27 +1338,30 @@ export class Service extends DatabaseService<StatusPage> {
         reportWindow,
       );
 
-      const reportItem: StatusPageReportItem = {
-        resourceName: resource.displayName || "",
-        totalIncidentCount: await this.getIncidentCountByMonitorIds({
-          monitorIds: monitorIdsForThisResource,
-          historyDays: data.historyDays,
-        }),
-        uptimePercent: uptimePercent,
-        uptimePercentAsString: `${uptimePercent}%`,
-        downtimeInHoursAndMinutes:
-          OneUptimeDate.convertMinutesToDaysHoursAndMinutes(
-            Math.ceil(downtime.totalDowntimeInSeconds / 60),
-          ),
-      };
+      entries.push({
+        statusPageResource: resource,
+        reportItem: {
+          resourceName: resource.displayName || "",
+          totalIncidentCount: await this.getIncidentCountByMonitorIds({
+            monitorIds: monitorIdsForThisResource,
+            historyDays: data.historyDays,
+          }),
+          uptimePercent: uptimePercent,
+          uptimePercentAsString: `${uptimePercent}%`,
+          downtimeInHoursAndMinutes:
+            OneUptimeDate.convertMinutesToDaysHoursAndMinutes(
+              Math.ceil(downtime.totalDowntimeInSeconds / 60),
+            ),
+        },
+      });
 
-      reportItems.push(reportItem);
+      monitorIdsByResourceIndex.push(monitorIdsForThisResource);
     }
 
     const avgUptimePercent: number =
-      reportItems.reduce((acc: number, item: StatusPageReportItem) => {
-        return acc + item.uptimePercent;
-      }, 0) / reportItems.length;
+      entries.reduce((acc: number, entry: StatusPageReportResourceEntry) => {
+        return acc + entry.reportItem.uptimePercent;
+      }, 0) / entries.length;
 
     const avgUptimePercentString: string = avgUptimePercent.toFixed(2) + "%";
 
@@ -1357,17 +1374,204 @@ export class Service extends DatabaseService<StatusPage> {
       reportWindow,
     );
 
+    /*
+     * The status page arranges its resources into a tree of groups and shows a
+     * rolled up number at every level. Recipients of this email usually have no
+     * login, so the report has to carry that hierarchy too - see
+     * StatusPageReportTreeUtil.
+     */
+    const statusPageGroups: Array<StatusPageGroup> =
+      await this.getStatusPageGroups({
+        statusPageId: data.statusPageId,
+      });
+
+    const groupMetricsByGroupId: Dictionary<StatusPageReportGroupMetrics> =
+      await this.getReportGroupMetrics({
+        statusPageGroups: statusPageGroups,
+        entries: entries,
+        monitorIdsByResourceIndex: monitorIdsByResourceIndex,
+        timeline: timeline,
+        downtimeMonitorStatuses: statusPage.downtimeMonitorStatuses || [],
+        reportWindow: reportWindow,
+        historyDays: data.historyDays,
+      });
+
+    const structure: StatusPageReportStructure = StatusPageReportTreeUtil.build(
+      {
+        entries: entries,
+        statusPageGroups: statusPageGroups,
+        groupMetricsByGroupId: groupMetricsByGroupId,
+      },
+    );
+
     return {
       reportDates: startAndEndDate,
       totalResources: statusPageResources.length,
       totalIncidents: incidentCount,
       averageUptimePercent: avgUptimePercentString,
-      resources: reportItems,
+      resources: structure.resources,
+      groups: structure.groups,
+      ungroupedResources: structure.resourcesWithoutGroup,
+      rows: structure.rows,
+      hasGroups: structure.groups.length > 0,
       totalDowntimeInHoursAndMinutes:
         OneUptimeDate.convertMinutesToDaysHoursAndMinutes(
           Math.ceil(totalDowntimeInSeconds.totalDowntimeInSeconds / 60),
         ),
     };
+  }
+
+  /*
+   * Uptime, downtime and incidents for each group, measured over the group and
+   * every group nested under it - the same set of resources the live status page
+   * rolls a group's number over.
+   */
+  @CaptureSpan()
+  public async getReportGroupMetrics(data: {
+    statusPageGroups: Array<StatusPageGroup>;
+    entries: Array<StatusPageReportResourceEntry>;
+    monitorIdsByResourceIndex: Array<Array<ObjectID>>;
+    timeline: Array<MonitorStatusTimeline>;
+    downtimeMonitorStatuses: Array<MonitorStatus>;
+    reportWindow: UptimeWindow;
+    historyDays: number;
+  }): Promise<Dictionary<StatusPageReportGroupMetrics>> {
+    const groupMetricsByGroupId: Dictionary<StatusPageReportGroupMetrics> = {};
+    const incidentCountByMonitorSet: Dictionary<number> = {};
+
+    for (const group of data.statusPageGroups) {
+      const groupId: string | undefined = group._id?.toString();
+
+      if (!groupId) {
+        continue;
+      }
+
+      const groupIdsInSubtree: Set<string> = new Set<string>(
+        StatusPageGroupTreeUtil.getGroupAndDescendants({
+          statusPageGroup: group,
+          statusPageGroups: data.statusPageGroups,
+        }).map((groupInSubtree: StatusPageGroup) => {
+          return groupInSubtree._id?.toString() || "";
+        }),
+      );
+
+      const uptimePercentsInSubtree: Array<number> = [];
+      const monitorIdsInSubtree: Dictionary<ObjectID> = {};
+
+      data.entries.forEach(
+        (entry: StatusPageReportResourceEntry, index: number) => {
+          const resourceGroupId: string | undefined =
+            entry.statusPageResource.statusPageGroupId?.toString();
+
+          if (!resourceGroupId || !groupIdsInSubtree.has(resourceGroupId)) {
+            return;
+          }
+
+          uptimePercentsInSubtree.push(entry.reportItem.uptimePercent);
+
+          for (const monitorId of data.monitorIdsByResourceIndex[index] || []) {
+            // de-duplicated: the same monitor can back more than one resource.
+            monitorIdsInSubtree[monitorId.toString()] = monitorId;
+          }
+        },
+      );
+
+      const monitorIds: Array<ObjectID> = Object.values(monitorIdsInSubtree);
+
+      const timelineForThisGroup: Array<MonitorStatusTimeline> =
+        data.timeline.filter((item: MonitorStatusTimeline) => {
+          return Boolean(
+            item.monitorId && monitorIdsInSubtree[item.monitorId.toString()],
+          );
+        });
+
+      const downtime: {
+        totalDowntimeInSeconds: number;
+        totalSecondsInTimePeriod: number;
+      } = UptimeUtil.getTotalDowntimeInSeconds(
+        timelineForThisGroup,
+        data.downtimeMonitorStatuses,
+        data.reportWindow,
+      );
+
+      /*
+       * Averaging the resources' percentages (rather than recomputing from the
+       * merged timeline) is what the live page does, so a group in the email
+       * shows the number a reader can compare against the page.
+       */
+      const uptimePercent: number =
+        uptimePercentsInSubtree.length > 0
+          ? UptimeUtil.calculateAvgUptimePercentage({
+              uptimePercentages: uptimePercentsInSubtree,
+              precision:
+                group.uptimePercentPrecision || UptimePrecision.TWO_DECIMAL,
+            })
+          : 0;
+
+      /*
+       * A chain like Corporate -> Region -> Market -> Unit rolls up the exact
+       * same monitors at every level, so the incident count is cached by the
+       * monitor set rather than issuing one identical query per level.
+       */
+      const monitorSetKey: string = monitorIds
+        .map((monitorId: ObjectID) => {
+          return monitorId.toString();
+        })
+        .sort()
+        .join(",");
+
+      let totalIncidentCount: number | undefined =
+        incidentCountByMonitorSet[monitorSetKey];
+
+      if (totalIncidentCount === undefined) {
+        totalIncidentCount =
+          monitorIds.length > 0
+            ? await this.getIncidentCountByMonitorIds({
+                monitorIds: monitorIds,
+                historyDays: data.historyDays,
+              })
+            : 0;
+
+        incidentCountByMonitorSet[monitorSetKey] = totalIncidentCount;
+      }
+
+      groupMetricsByGroupId[groupId] = {
+        uptimePercent: uptimePercent,
+        uptimePercentAsString: `${uptimePercent}%`,
+        downtimeInHoursAndMinutes:
+          OneUptimeDate.convertMinutesToDaysHoursAndMinutes(
+            Math.ceil(downtime.totalDowntimeInSeconds / 60),
+          ),
+        totalIncidentCount: totalIncidentCount,
+      };
+    }
+
+    return groupMetricsByGroupId;
+  }
+
+  @CaptureSpan()
+  public async getStatusPageGroups(data: {
+    statusPageId: ObjectID;
+  }): Promise<Array<StatusPageGroup>> {
+    return await StatusPageGroupService.findBy({
+      query: {
+        statusPageId: data.statusPageId,
+      },
+      select: {
+        name: true,
+        order: true,
+        parentStatusPageGroupId: true,
+        uptimePercentPrecision: true,
+      },
+      sort: {
+        order: SortOrder.Ascending,
+      },
+      skip: 0,
+      limit: LIMIT_PER_PROJECT,
+      props: {
+        isRoot: true,
+      },
+    });
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/StatusPageSubscriberNotificationTemplateService.ts
+++ b/Common/Server/Services/StatusPageSubscriberNotificationTemplateService.ts
@@ -277,7 +277,26 @@ export class Service extends DatabaseService<Model> {
           {
             name: "report.resources",
             description:
-              "Array of per-resource rows (resourceName, uptimePercentAsString, downtimeInHoursAndMinutes, totalIncidentCount) to loop over with {{#each}}",
+              "Array of per-resource rows (resourceName, uptimePercentAsString, downtimeInHoursAndMinutes, totalIncidentCount, groupName, groupPath) to loop over with {{#each}}",
+          },
+          {
+            name: "report.hasGroups",
+            description:
+              "true when the status page organises its resources into groups",
+          },
+          {
+            name: "report.rows",
+            description:
+              "The status page's group hierarchy flattened into render order (isGroup, name, depth, indentInPixels, uptimePercentAsString, downtimeInHoursAndMinutes, totalIncidentCount, totalResources) to loop over with {{#each}}",
+          },
+          {
+            name: "report.groups",
+            description:
+              "The group hierarchy as a nested tree (groupName, groupPath, depth, uptimePercentAsString, downtimeInHoursAndMinutes, totalIncidentCount, totalResources, resources, subGroups)",
+          },
+          {
+            name: "report.ungroupedResources",
+            description: "Per-resource rows for resources that are in no group",
           },
         ];
 

--- a/Common/Tests/Server/Services/StatusPageSubscriberReport.test.ts
+++ b/Common/Tests/Server/Services/StatusPageSubscriberReport.test.ts
@@ -1,0 +1,555 @@
+/*
+ * The scheduled "Uptime Report" email for a status page.
+ *
+ * The report used to be a flat per-monitor table. Status pages arrange their
+ * resources into a tree of groups (Corporate Unit's -> Region -> Market -> Unit)
+ * and show a rolled up availability at every level, and the people this email is
+ * addressed to usually have no OneUptime login - so a flat list of monitor names
+ * left them with no way to tell which region or unit a monitor belonged to, and
+ * no rolled up number at all.
+ *
+ * These tests build the report end to end (every database read spied - no
+ * database is touched) and pin:
+ *   - the nested group structure and the render order it flattens to,
+ *   - the numbers rolled up onto each group,
+ *   - the flat `resources` array custom templates written before groups still
+ *     loop over,
+ *   - and the empty-status-page case.
+ */
+
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import StatusPageGroupService from "../../../Server/Services/StatusPageGroupService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import MonitorStatus from "../../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../../Models/DatabaseModels/MonitorStatusTimeline";
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import { Green, Red } from "../../../Types/BrandColors";
+import {
+  StatusPageReport,
+  StatusPageReportGroup,
+  StatusPageReportItem,
+  StatusPageReportRow,
+} from "../../../Types/StatusPage/StatusPageReport";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MARKET_ONE: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const UNIT_0660: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+const ROUTER_MONITOR: ObjectID = new ObjectID(
+  "aa000000-0000-4000-8000-000000000001",
+);
+const SWITCH_MONITOR: ObjectID = new ObjectID(
+  "aa000000-0000-4000-8000-000000000002",
+);
+const WEBSITE_MONITOR: ObjectID = new ObjectID(
+  "aa000000-0000-4000-8000-000000000003",
+);
+
+const HISTORY_DAYS: number = 14;
+
+const OPERATIONAL: MonitorStatus = new MonitorStatus();
+OPERATIONAL.id = new ObjectID("bb000000-0000-4000-8000-000000000001");
+OPERATIONAL.name = "Operational";
+OPERATIONAL.priority = 1;
+OPERATIONAL.color = Green;
+
+const OFFLINE: MonitorStatus = new MonitorStatus();
+OFFLINE.id = new ObjectID("bb000000-0000-4000-8000-000000000002");
+OFFLINE.name = "Offline";
+OFFLINE.priority = 2;
+OFFLINE.color = Red;
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+  group.order = data.order === undefined ? 1 : data.order;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  return group;
+}
+
+function makeResource(data: {
+  displayName: string;
+  monitorId: ObjectID;
+  groupId?: ObjectID | undefined;
+  order: number;
+}): StatusPageResource {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource.displayName = data.displayName;
+  resource.monitorId = data.monitorId;
+  resource.order = data.order;
+
+  if (data.groupId) {
+    resource.statusPageGroupId = data.groupId;
+  }
+
+  return resource;
+}
+
+function makeTimelineItem(data: {
+  monitorId: ObjectID;
+  monitorStatus: MonitorStatus;
+  startsAt: Date;
+  endsAt?: Date | undefined;
+}): MonitorStatusTimeline {
+  const item: MonitorStatusTimeline = new MonitorStatusTimeline();
+  item.monitorId = data.monitorId;
+  item.monitorStatus = data.monitorStatus;
+  item.startsAt = data.startsAt;
+
+  if (data.endsAt) {
+    item.endsAt = data.endsAt;
+  }
+
+  return item;
+}
+
+/*
+ * Router is offline for exactly two days inside a fourteen day window; every
+ * other monitor is operational for the whole window. Two days out of fourteen is
+ * 85.71% uptime after the report's two decimal rounding, which makes the rolled
+ * up averages above it predictable.
+ */
+function makeTimeline(): Array<MonitorStatusTimeline> {
+  const windowStart: Date = OneUptimeDate.getSomeDaysAgo(HISTORY_DAYS);
+  const outageStart: Date = OneUptimeDate.getSomeDaysAgo(7);
+  const outageEnd: Date = OneUptimeDate.getSomeDaysAgo(5);
+
+  return [
+    makeTimelineItem({
+      monitorId: ROUTER_MONITOR,
+      monitorStatus: OPERATIONAL,
+      startsAt: windowStart,
+      endsAt: outageStart,
+    }),
+    makeTimelineItem({
+      monitorId: ROUTER_MONITOR,
+      monitorStatus: OFFLINE,
+      startsAt: outageStart,
+      endsAt: outageEnd,
+    }),
+    makeTimelineItem({
+      monitorId: ROUTER_MONITOR,
+      monitorStatus: OPERATIONAL,
+      startsAt: outageEnd,
+    }),
+    makeTimelineItem({
+      monitorId: SWITCH_MONITOR,
+      monitorStatus: OPERATIONAL,
+      startsAt: windowStart,
+    }),
+    makeTimelineItem({
+      monitorId: WEBSITE_MONITOR,
+      monitorStatus: OPERATIONAL,
+      startsAt: windowStart,
+    }),
+  ];
+}
+
+/*
+ * Corporate Unit's
+ *   Region 001
+ *     Market 001
+ *       Unit 0660
+ *         Router
+ *         Switch 01
+ * (ungrouped) WBHQ website
+ */
+function nestedGroups(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+    makeGroup({ id: REGION_ONE, name: "Region 001", parentId: CORPORATE }),
+    makeGroup({ id: MARKET_ONE, name: "Market 001", parentId: REGION_ONE }),
+    makeGroup({ id: UNIT_0660, name: "Unit 0660", parentId: MARKET_ONE }),
+  ];
+}
+
+function nestedResources(): Array<StatusPageResource> {
+  return [
+    makeResource({
+      displayName: "Router",
+      monitorId: ROUTER_MONITOR,
+      groupId: UNIT_0660,
+      order: 1,
+    }),
+    makeResource({
+      displayName: "WBHQ website",
+      monitorId: WEBSITE_MONITOR,
+      order: 2,
+    }),
+    makeResource({
+      displayName: "Switch 01",
+      monitorId: SWITCH_MONITOR,
+      groupId: UNIT_0660,
+      order: 3,
+    }),
+  ];
+}
+
+/*
+ * Wires up every read getReportByStatusPage makes. Incident counts come back as
+ * "one incident per monitor asked about", which makes it visible whether a group
+ * asked about its whole subtree.
+ */
+function mockReads(data: {
+  statusPageResources: Array<StatusPageResource>;
+  statusPageGroups: Array<StatusPageGroup>;
+  timeline: Array<MonitorStatusTimeline>;
+}): void {
+  const statusPage: StatusPage = new StatusPage();
+  statusPage.downtimeMonitorStatuses = [OFFLINE];
+
+  jest
+    .spyOn(StatusPageService, "findOneById")
+    .mockResolvedValue(statusPage as never);
+
+  jest
+    .spyOn(StatusPageService, "getStatusPageResources")
+    .mockResolvedValue(data.statusPageResources as never);
+
+  jest
+    .spyOn(StatusPageGroupService, "findBy")
+    .mockResolvedValue(data.statusPageGroups as never);
+
+  jest
+    .spyOn(StatusPageService, "getMonitorStatusTimelineForStatusPage")
+    .mockResolvedValue(data.timeline as never);
+
+  jest
+    .spyOn(IncidentService, "countBy")
+    .mockImplementation(async (findBy: any) => {
+      const monitorIds: Array<ObjectID> = (findBy?.query?.monitors ||
+        []) as Array<ObjectID>;
+      return new PositiveNumber(monitorIds.length) as never;
+    });
+}
+
+function rowNames(rows: Array<StatusPageReportRow>): Array<string> {
+  return rows.map((row: StatusPageReportRow) => {
+    return row.name;
+  });
+}
+
+describe("StatusPageService.getReportByStatusPage", () => {
+  beforeEach(() => {
+    mockReads({
+      statusPageResources: nestedResources(),
+      statusPageGroups: nestedGroups(),
+      timeline: makeTimeline(),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("the nested group hierarchy", () => {
+    test("reports the status page's groups instead of a flat list of monitors", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      expect(report.hasGroups).toBe(true);
+      expect(report.groups).toHaveLength(1);
+      expect(report.groups[0]!.groupName).toBe("Corporate Unit's");
+      expect(report.groups[0]!.subGroups[0]!.groupName).toBe("Region 001");
+      expect(report.groups[0]!.subGroups[0]!.subGroups[0]!.groupName).toBe(
+        "Market 001",
+      );
+      expect(
+        report.groups[0]!.subGroups[0]!.subGroups[0]!.subGroups[0]!.groupName,
+      ).toBe("Unit 0660");
+    });
+
+    test("flattens the hierarchy into the order the live page renders it", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      expect(rowNames(report.rows)).toEqual([
+        "WBHQ website",
+        "Corporate Unit's",
+        "Region 001",
+        "Market 001",
+        "Unit 0660",
+        "Router",
+        "Switch 01",
+      ]);
+    });
+
+    test("puts the monitors under the group they belong to", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      const unit: StatusPageReportGroup =
+        report.groups[0]!.subGroups[0]!.subGroups[0]!.subGroups[0]!;
+
+      expect(
+        unit.resources.map((resource: StatusPageReportItem) => {
+          return resource.resourceName;
+        }),
+      ).toEqual(["Router", "Switch 01"]);
+
+      expect(
+        report.ungroupedResources.map((resource: StatusPageReportItem) => {
+          return resource.resourceName;
+        }),
+      ).toEqual(["WBHQ website"]);
+    });
+
+    test("tells every resource its full group path", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      const pathByName: Dictionary<string> = {};
+
+      for (const resource of report.resources) {
+        pathByName[resource.resourceName] = resource.groupPath;
+      }
+
+      expect(pathByName["Router"]).toBe(
+        "Corporate Unit's / Region 001 / Market 001 / Unit 0660",
+      );
+      expect(pathByName["Switch 01"]).toBe(
+        "Corporate Unit's / Region 001 / Market 001 / Unit 0660",
+      );
+      expect(pathByName["WBHQ website"]).toBe("");
+    });
+  });
+
+  describe("rolled up numbers", () => {
+    test("reports each resource's own uptime", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      const uptimeByName: Dictionary<string> = {};
+
+      for (const resource of report.resources) {
+        uptimeByName[resource.resourceName] = resource.uptimePercentAsString;
+      }
+
+      // two days offline out of a fourteen day window.
+      expect(uptimeByName["Router"]).toBe("85.71%");
+      expect(uptimeByName["Switch 01"]).toBe("100%");
+      expect(uptimeByName["WBHQ website"]).toBe("100%");
+    });
+
+    test("averages the subtree onto every level of the hierarchy", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      const corporate: StatusPageReportGroup = report.groups[0]!;
+      const unit: StatusPageReportGroup =
+        corporate.subGroups[0]!.subGroups[0]!.subGroups[0]!;
+
+      // (85.71 + 100) / 2, rounded the way the report rounds.
+      expect(unit.uptimePercentAsString).toBe("92.85%");
+      // every level above the unit rolls up the same two resources.
+      expect(corporate.uptimePercentAsString).toBe("92.85%");
+      expect(corporate.subGroups[0]!.uptimePercentAsString).toBe("92.85%");
+    });
+
+    test("counts a group's downtime over every monitor beneath it", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      const corporate: StatusPageReportGroup = report.groups[0]!;
+
+      expect(corporate.downtimeInHoursAndMinutes).toContain("2 days");
+      expect(report.totalDowntimeInHoursAndMinutes).toContain("2 days");
+    });
+
+    test("counts a group's incidents over every monitor beneath it", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      const corporate: StatusPageReportGroup = report.groups[0]!;
+
+      /*
+       * The stub returns one incident per monitor queried, so this is the size
+       * of the monitor set the group asked about: Router and Switch 01.
+       */
+      expect(corporate.totalIncidentCount).toBe(2);
+      expect(corporate.totalResources).toBe(2);
+    });
+
+    test("asks the database once for a chain of levels that covers the same monitors", async () => {
+      const countBy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        IncidentService,
+        "countBy",
+      ) as ReturnType<typeof jest.spyOn>;
+
+      countBy.mockClear();
+
+      await StatusPageService.getReportByStatusPage({
+        statusPageId: STATUS_PAGE_ID,
+        historyDays: HISTORY_DAYS,
+      });
+
+      /*
+       * One for the page total, one per resource, and ONE for all four levels
+       * of the hierarchy - Corporate / Region / Market / Unit all roll up the
+       * same two monitors, so they must not issue four identical queries.
+       */
+      expect(countBy).toHaveBeenCalledTimes(5);
+    });
+
+    test("keeps reporting page level totals", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      expect(report.totalResources).toBe(3);
+      // (85.71 + 100 + 100) / 3
+      expect(report.averageUptimePercent).toBe("95.24%");
+      expect(report.reportDates).toContain("14 days");
+    });
+  });
+
+  describe("backwards compatibility", () => {
+    test("still exposes the flat resource list custom templates loop over", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      expect(
+        report.resources.map((resource: StatusPageReportItem) => {
+          return resource.resourceName;
+        }),
+      ).toEqual(["Router", "WBHQ website", "Switch 01"]);
+
+      for (const resource of report.resources) {
+        expect(typeof resource.uptimePercentAsString).toBe("string");
+        expect(typeof resource.downtimeInHoursAndMinutes).toBe("string");
+        expect(typeof resource.totalIncidentCount).toBe("number");
+      }
+    });
+  });
+
+  describe("a status page without groups", () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      mockReads({
+        statusPageResources: [
+          makeResource({
+            displayName: "Router",
+            monitorId: ROUTER_MONITOR,
+            order: 1,
+          }),
+          makeResource({
+            displayName: "WBHQ website",
+            monitorId: WEBSITE_MONITOR,
+            order: 2,
+          }),
+        ],
+        statusPageGroups: [],
+        timeline: makeTimeline(),
+      });
+    });
+
+    test("reports a flat list and says so", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      expect(report.hasGroups).toBe(false);
+      expect(report.groups).toEqual([]);
+      expect(rowNames(report.rows)).toEqual(["Router", "WBHQ website"]);
+      expect(
+        report.rows.every((row: StatusPageReportRow) => {
+          return !row.isGroup && row.indentInPixels === 0;
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("a status page with no resources", () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+      mockReads({
+        statusPageResources: [],
+        statusPageGroups: nestedGroups(),
+        timeline: [],
+      });
+    });
+
+    test("reports nothing rather than throwing", async () => {
+      const report: StatusPageReport =
+        await StatusPageService.getReportByStatusPage({
+          statusPageId: STATUS_PAGE_ID,
+          historyDays: HISTORY_DAYS,
+        });
+
+      expect(report.totalResources).toBe(0);
+      expect(report.resources).toEqual([]);
+      expect(report.groups).toEqual([]);
+      expect(report.rows).toEqual([]);
+      expect(report.ungroupedResources).toEqual([]);
+      expect(report.hasGroups).toBe(false);
+    });
+  });
+});

--- a/Common/Tests/Utils/StatusPage/Report.test.ts
+++ b/Common/Tests/Utils/StatusPage/Report.test.ts
@@ -1,0 +1,708 @@
+import StatusPageReportTreeUtil, {
+  StatusPageReportResourceEntry,
+  StatusPageReportStructure,
+} from "../../../Utils/StatusPage/Report";
+import ObjectID from "../../../Types/ObjectID";
+import Dictionary from "../../../Types/Dictionary";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import {
+  StatusPageReportGroup,
+  StatusPageReportGroupMetrics,
+  StatusPageReportItem,
+  StatusPageReportRow,
+} from "../../../Types/StatusPage/StatusPageReport";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Contract under test - the emailed uptime report has to carry the same group
+ * hierarchy the live status page renders.
+ *
+ * Recipients of the report (vendors, leadership, external stakeholders) usually
+ * have no OneUptime login, so the email is the whole product for them. A flat
+ * list of monitor names is unusable for anyone running several regions or
+ * units: it says nothing about which unit a monitor belongs to, and it drops
+ * the rolled up availability every level of the page shows.
+ *
+ * So this pins:
+ *   - render order matches the page: ungrouped resources first, then each group
+ *     followed by its own resources and then its sub groups,
+ *   - depth / indent survive any nesting level,
+ *   - every resource row carries the group and full group path it sits under,
+ *   - a group's totalResources covers its whole subtree,
+ *   - and no shape of bad data (a resource pointing at a group that is not on
+ *     the page, a group in a cycle, a group with no metrics) may silently drop
+ *     a row from the report.
+ */
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MARKET_ONE: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const UNIT_0660: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const REGION_TWO: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const NOT_ON_PAGE: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  if (data.order !== undefined) {
+    group.order = data.order;
+  }
+
+  return group;
+}
+
+function makeEntry(data: {
+  resourceName: string;
+  groupId?: ObjectID | undefined;
+  uptimePercent?: number | undefined;
+  downtimeInHoursAndMinutes?: string | undefined;
+  totalIncidentCount?: number | undefined;
+}): StatusPageReportResourceEntry {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource.displayName = data.resourceName;
+
+  if (data.groupId) {
+    resource.statusPageGroupId = data.groupId;
+  }
+
+  const uptimePercent: number =
+    data.uptimePercent === undefined ? 100 : data.uptimePercent;
+
+  return {
+    statusPageResource: resource,
+    reportItem: {
+      resourceName: data.resourceName,
+      totalIncidentCount: data.totalIncidentCount || 0,
+      uptimePercent: uptimePercent,
+      uptimePercentAsString: `${uptimePercent}%`,
+      downtimeInHoursAndMinutes: data.downtimeInHoursAndMinutes || "0",
+    },
+  };
+}
+
+function makeMetrics(data: {
+  uptimePercent: number;
+  downtimeInHoursAndMinutes?: string | undefined;
+  totalIncidentCount?: number | undefined;
+}): StatusPageReportGroupMetrics {
+  return {
+    uptimePercent: data.uptimePercent,
+    uptimePercentAsString: `${data.uptimePercent}%`,
+    downtimeInHoursAndMinutes: data.downtimeInHoursAndMinutes || "0",
+    totalIncidentCount: data.totalIncidentCount || 0,
+  };
+}
+
+/*
+ * The hierarchy from the bug report:
+ *
+ *   Corporate Unit's
+ *     Region 001
+ *       Market 001
+ *         Unit 0660
+ *           Router
+ *           Switch 01
+ *   (ungrouped) WBHQ website
+ */
+function makeNestedGroups(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate Unit's", order: 1 }),
+    makeGroup({
+      id: REGION_ONE,
+      name: "Region 001",
+      parentId: CORPORATE,
+      order: 1,
+    }),
+    makeGroup({
+      id: MARKET_ONE,
+      name: "Market 001",
+      parentId: REGION_ONE,
+      order: 1,
+    }),
+    makeGroup({
+      id: UNIT_0660,
+      name: "Unit 0660",
+      parentId: MARKET_ONE,
+      order: 1,
+    }),
+  ];
+}
+
+function makeNestedEntries(): Array<StatusPageReportResourceEntry> {
+  return [
+    makeEntry({ resourceName: "Router", groupId: UNIT_0660 }),
+    makeEntry({ resourceName: "WBHQ website" }),
+    makeEntry({ resourceName: "Switch 01", groupId: UNIT_0660 }),
+  ];
+}
+
+function rowNames(rows: Array<StatusPageReportRow>): Array<string> {
+  return rows.map((row: StatusPageReportRow) => {
+    return row.name;
+  });
+}
+
+describe("StatusPageReportTreeUtil", () => {
+  describe("a status page with no groups", () => {
+    test("reports every resource flat, with no group rows", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [
+            makeEntry({ resourceName: "Router" }),
+            makeEntry({ resourceName: "WBHQ website" }),
+          ],
+          statusPageGroups: [],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(structure.groups).toEqual([]);
+      expect(rowNames(structure.rows)).toEqual(["Router", "WBHQ website"]);
+      expect(
+        structure.rows.every((row: StatusPageReportRow) => {
+          return row.isGroup === false && row.depth === 0;
+        }),
+      ).toBe(true);
+      expect(structure.resourcesWithoutGroup).toHaveLength(2);
+    });
+
+    test("leaves groupName and groupPath empty on every resource", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [makeEntry({ resourceName: "Router" })],
+          statusPageGroups: [],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(structure.resources[0]!.groupName).toBe("");
+      expect(structure.resources[0]!.groupPath).toBe("");
+    });
+  });
+
+  describe("the nested hierarchy from the bug report", () => {
+    test("renders ungrouped resources first, then the group tree top down", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual([
+        "WBHQ website",
+        "Corporate Unit's",
+        "Region 001",
+        "Market 001",
+        "Unit 0660",
+        "Router",
+        "Switch 01",
+      ]);
+    });
+
+    test("marks group rows as groups and resource rows as resources", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const isGroupByName: Dictionary<boolean> = {};
+
+      for (const row of structure.rows) {
+        isGroupByName[row.name] = row.isGroup;
+      }
+
+      expect(isGroupByName["Corporate Unit's"]).toBe(true);
+      expect(isGroupByName["Unit 0660"]).toBe(true);
+      expect(isGroupByName["Router"]).toBe(false);
+      expect(isGroupByName["WBHQ website"]).toBe(false);
+    });
+
+    test("nests four levels deep without losing a level", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const depthByName: Dictionary<number> = {};
+
+      for (const row of structure.rows) {
+        depthByName[row.name] = row.depth;
+      }
+
+      expect(depthByName["WBHQ website"]).toBe(0);
+      expect(depthByName["Corporate Unit's"]).toBe(0);
+      expect(depthByName["Region 001"]).toBe(1);
+      expect(depthByName["Market 001"]).toBe(2);
+      expect(depthByName["Unit 0660"]).toBe(3);
+      // resources sit one level below the group they are attached to.
+      expect(depthByName["Router"]).toBe(4);
+      expect(depthByName["Switch 01"]).toBe(4);
+    });
+
+    test("indents each level by a fixed step so a template needs no arithmetic", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      for (const row of structure.rows) {
+        expect(row.indentInPixels).toBe(
+          row.depth * StatusPageReportTreeUtil.IndentInPixelsPerDepth,
+        );
+      }
+    });
+
+    test("tells each resource which group it belongs to, and the full path to it", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const router: StatusPageReportItem = structure.resources.find(
+        (resource: StatusPageReportItem) => {
+          return resource.resourceName === "Router";
+        },
+      )!;
+
+      expect(router.groupName).toBe("Unit 0660");
+      expect(router.groupPath).toBe(
+        "Corporate Unit's / Region 001 / Market 001 / Unit 0660",
+      );
+
+      const website: StatusPageReportItem = structure.resources.find(
+        (resource: StatusPageReportItem) => {
+          return resource.resourceName === "WBHQ website";
+        },
+      )!;
+
+      expect(website.groupName).toBe("");
+      expect(website.groupPath).toBe("");
+    });
+
+    test("keeps the flat resource list, in the order the resources were supplied", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      /*
+       * Templates written before groups existed loop over report.resources, so
+       * this list stays flat and in page order.
+       */
+      expect(
+        structure.resources.map((resource: StatusPageReportItem) => {
+          return resource.resourceName;
+        }),
+      ).toEqual(["Router", "WBHQ website", "Switch 01"]);
+    });
+
+    test("rolls the resource count up through every level of the subtree", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const corporate: StatusPageReportGroup = structure.groups[0]!;
+      const region: StatusPageReportGroup = corporate.subGroups[0]!;
+      const market: StatusPageReportGroup = region.subGroups[0]!;
+      const unit: StatusPageReportGroup = market.subGroups[0]!;
+
+      expect(corporate.totalResources).toBe(2);
+      expect(region.totalResources).toBe(2);
+      expect(market.totalResources).toBe(2);
+      expect(unit.totalResources).toBe(2);
+
+      // only the unit holds the resources directly.
+      expect(corporate.resources).toEqual([]);
+      expect(
+        unit.resources.map((resource: StatusPageReportItem) => {
+          return resource.resourceName;
+        }),
+      ).toEqual(["Router", "Switch 01"]);
+    });
+
+    test("gives every group its own path", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const corporate: StatusPageReportGroup = structure.groups[0]!;
+
+      expect(corporate.groupPath).toBe("Corporate Unit's");
+      expect(corporate.subGroups[0]!.groupPath).toBe(
+        "Corporate Unit's / Region 001",
+      );
+      expect(corporate.subGroups[0]!.subGroups[0]!.groupPath).toBe(
+        "Corporate Unit's / Region 001 / Market 001",
+      );
+    });
+  });
+
+  describe("rolled up numbers on group rows", () => {
+    test("uses the metrics supplied for each group", () => {
+      const groupMetricsByGroupId: Dictionary<StatusPageReportGroupMetrics> = {
+        [CORPORATE.toString()]: makeMetrics({
+          uptimePercent: 99.1,
+          downtimeInHoursAndMinutes: "3 hours",
+          totalIncidentCount: 4,
+        }),
+        [UNIT_0660.toString()]: makeMetrics({
+          uptimePercent: 98.5,
+          downtimeInHoursAndMinutes: "5 hours",
+          totalIncidentCount: 2,
+        }),
+      };
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: groupMetricsByGroupId,
+        });
+
+      const corporate: StatusPageReportGroup = structure.groups[0]!;
+
+      expect(corporate.uptimePercentAsString).toBe("99.1%");
+      expect(corporate.downtimeInHoursAndMinutes).toBe("3 hours");
+      expect(corporate.totalIncidentCount).toBe(4);
+
+      const unitRow: StatusPageReportRow = structure.rows.find(
+        (row: StatusPageReportRow) => {
+          return row.name === "Unit 0660";
+        },
+      )!;
+
+      expect(unitRow.uptimePercentAsString).toBe("98.5%");
+      expect(unitRow.downtimeInHoursAndMinutes).toBe("5 hours");
+      expect(unitRow.totalIncidentCount).toBe(2);
+      expect(unitRow.totalResources).toBe(2);
+    });
+
+    test("still renders a group whose metrics are missing, as zeroes", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: makeNestedEntries(),
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const corporate: StatusPageReportGroup = structure.groups[0]!;
+
+      expect(corporate.uptimePercent).toBe(0);
+      expect(corporate.uptimePercentAsString).toBe("0%");
+      expect(corporate.downtimeInHoursAndMinutes).toBe("0");
+      expect(corporate.totalIncidentCount).toBe(0);
+      // the level is still on the report - a missing number beats a missing level.
+      expect(rowNames(structure.rows)).toContain("Corporate Unit's");
+    });
+
+    test("carries the resource's own numbers onto its row", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [
+            makeEntry({
+              resourceName: "Router",
+              groupId: UNIT_0660,
+              uptimePercent: 97.25,
+              downtimeInHoursAndMinutes: "9 hours 30 minutes",
+              totalIncidentCount: 3,
+            }),
+          ],
+          statusPageGroups: makeNestedGroups(),
+          groupMetricsByGroupId: {},
+        });
+
+      const routerRow: StatusPageReportRow = structure.rows.find(
+        (row: StatusPageReportRow) => {
+          return row.name === "Router";
+        },
+      )!;
+
+      expect(routerRow.uptimePercentAsString).toBe("97.25%");
+      expect(routerRow.downtimeInHoursAndMinutes).toBe("9 hours 30 minutes");
+      expect(routerRow.totalIncidentCount).toBe(3);
+      // totalResources is a group concept only.
+      expect(routerRow.totalResources).toBe(0);
+    });
+  });
+
+  describe("sibling ordering", () => {
+    test("renders sibling groups in their configured order", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: REGION_TWO, name: "Region 002", order: 2 }),
+        makeGroup({ id: CORPORATE, name: "Region 001", order: 1 }),
+      ];
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [],
+          statusPageGroups: groups,
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual(["Region 001", "Region 002"]);
+    });
+
+    test("keeps a group's own resources in the order they were supplied", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [
+            makeEntry({ resourceName: "Switch 01", groupId: CORPORATE }),
+            makeEntry({ resourceName: "Router", groupId: CORPORATE }),
+          ],
+          statusPageGroups: [
+            makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+          ],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual([
+        "Corporate Unit's",
+        "Switch 01",
+        "Router",
+      ]);
+    });
+
+    test("puts a group's own resources above its sub groups", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 001",
+          parentId: CORPORATE,
+        }),
+      ];
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [
+            makeEntry({
+              resourceName: "Region 001 router",
+              groupId: REGION_ONE,
+            }),
+            makeEntry({ resourceName: "Head office link", groupId: CORPORATE }),
+          ],
+          statusPageGroups: groups,
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual([
+        "Corporate Unit's",
+        "Head office link",
+        "Region 001",
+        "Region 001 router",
+      ]);
+    });
+  });
+
+  describe("groups without resources", () => {
+    test("keeps an empty group on the report", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [],
+          statusPageGroups: [
+            makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+          ],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual(["Corporate Unit's"]);
+      expect(structure.groups[0]!.totalResources).toBe(0);
+      expect(structure.groups[0]!.resources).toEqual([]);
+    });
+  });
+
+  describe("data that does not fit the tree", () => {
+    test("renders a resource pointing at a group that is not on the page as ungrouped", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [
+            makeEntry({ resourceName: "Orphan", groupId: NOT_ON_PAGE }),
+            makeEntry({ resourceName: "Router", groupId: CORPORATE }),
+          ],
+          statusPageGroups: [
+            makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+          ],
+          groupMetricsByGroupId: {},
+        });
+
+      // ungrouped resources render first, so the orphan is visible, not dropped.
+      expect(rowNames(structure.rows)).toEqual([
+        "Orphan",
+        "Corporate Unit's",
+        "Router",
+      ]);
+      expect(structure.resourcesWithoutGroup).toHaveLength(1);
+      expect(structure.resources).toHaveLength(2);
+      expect(structure.resources[0]!.groupName).toBe("");
+    });
+
+    test("treats a group that is its own parent as a top level group", () => {
+      const selfParented: StatusPageGroup = makeGroup({
+        id: CORPORATE,
+        name: "Corporate Unit's",
+        parentId: CORPORATE,
+      });
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [makeEntry({ resourceName: "Router", groupId: CORPORATE })],
+          statusPageGroups: [selfParented],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual(["Corporate Unit's", "Router"]);
+      expect(structure.groups[0]!.depth).toBe(0);
+      expect(structure.groups[0]!.groupPath).toBe("Corporate Unit's");
+    });
+
+    test("promotes a group whose parent is missing rather than hiding it", () => {
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [makeEntry({ resourceName: "Router", groupId: REGION_ONE })],
+          statusPageGroups: [
+            makeGroup({
+              id: REGION_ONE,
+              name: "Region 001",
+              parentId: NOT_ON_PAGE,
+            }),
+          ],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toEqual(["Region 001", "Router"]);
+      expect(structure.groups[0]!.depth).toBe(0);
+      // the missing ancestor is simply not part of the path.
+      expect(structure.resources[0]!.groupPath).toBe("Region 001");
+    });
+
+    test("still reports every group in a parent cycle, and terminates", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: REGION_ONE, name: "Region 001", parentId: MARKET_ONE }),
+        makeGroup({ id: MARKET_ONE, name: "Market 001", parentId: REGION_ONE }),
+      ];
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [
+            makeEntry({ resourceName: "Router", groupId: REGION_ONE }),
+            makeEntry({ resourceName: "Switch 01", groupId: MARKET_ONE }),
+          ],
+          statusPageGroups: groups,
+          groupMetricsByGroupId: {},
+        });
+
+      expect(rowNames(structure.rows)).toContain("Region 001");
+      expect(rowNames(structure.rows)).toContain("Market 001");
+      expect(rowNames(structure.rows)).toContain("Router");
+      expect(rowNames(structure.rows)).toContain("Switch 01");
+    });
+
+    test("tolerates a group with no name", () => {
+      const unnamed: StatusPageGroup = new StatusPageGroup();
+      unnamed._id = CORPORATE.toString();
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [makeEntry({ resourceName: "Router", groupId: CORPORATE })],
+          statusPageGroups: [unnamed],
+          groupMetricsByGroupId: {},
+        });
+
+      expect(structure.groups[0]!.groupName).toBe("");
+      expect(rowNames(structure.rows)).toEqual(["", "Router"]);
+    });
+
+    test("ignores a group row that has no id", () => {
+      const withoutId: StatusPageGroup = new StatusPageGroup();
+      withoutId.name = "Ghost";
+
+      const structure: StatusPageReportStructure =
+        StatusPageReportTreeUtil.build({
+          entries: [makeEntry({ resourceName: "Router" })],
+          statusPageGroups: [withoutId],
+          groupMetricsByGroupId: {},
+        });
+
+      // it cannot own resources, and the resource is still reported.
+      expect(rowNames(structure.rows)).toContain("Router");
+    });
+  });
+
+  describe("getPathByGroupId", () => {
+    test("builds a top down path for every group", () => {
+      const pathByGroupId: Dictionary<string> =
+        StatusPageReportTreeUtil.getPathByGroupId({
+          statusPageGroups: makeNestedGroups(),
+        });
+
+      expect(pathByGroupId[CORPORATE.toString()]).toBe("Corporate Unit's");
+      expect(pathByGroupId[UNIT_0660.toString()]).toBe(
+        "Corporate Unit's / Region 001 / Market 001 / Unit 0660",
+      );
+    });
+
+    test("skips unnamed groups in the middle of a path", () => {
+      const unnamedRegion: StatusPageGroup = makeGroup({
+        id: REGION_ONE,
+        name: "",
+        parentId: CORPORATE,
+      });
+
+      const pathByGroupId: Dictionary<string> =
+        StatusPageReportTreeUtil.getPathByGroupId({
+          statusPageGroups: [
+            makeGroup({ id: CORPORATE, name: "Corporate Unit's" }),
+            unnamedRegion,
+            makeGroup({
+              id: MARKET_ONE,
+              name: "Market 001",
+              parentId: REGION_ONE,
+            }),
+          ],
+        });
+
+      expect(pathByGroupId[MARKET_ONE.toString()]).toBe(
+        "Corporate Unit's / Market 001",
+      );
+    });
+  });
+});

--- a/Common/Types/StatusPage/StatusPageReport.ts
+++ b/Common/Types/StatusPage/StatusPageReport.ts
@@ -1,0 +1,99 @@
+/*
+ * The shape of the scheduled "Uptime Report" email for a status page.
+ *
+ * A status page organises its resources into a tree of groups (Corporate Unit ->
+ * Region -> Market -> Unit), and every level of that tree shows a rolled up
+ * availability on the live page. Recipients of this email frequently have no
+ * login, so the report has to carry the same hierarchy - a flat list of monitor
+ * names says nothing about which region or unit a monitor belongs to.
+ *
+ * Three views of the same numbers are exposed, because the built-in email
+ * template and customer authored templates need different things:
+ *
+ *   - `resources`  - every resource, flat. The original shape, kept so templates
+ *                    written before groups existed keep rendering. Each row now
+ *                    also carries the group it belongs to.
+ *   - `groups`     - the nested tree, for templates that can recurse.
+ *   - `rows`       - the tree flattened into render order with a `depth` on each
+ *                    row. Email HTML cannot recurse comfortably, so the built-in
+ *                    template walks this.
+ */
+
+export interface StatusPageReportItem {
+  resourceName: string;
+  totalIncidentCount: number;
+  uptimePercent: number;
+  uptimePercentAsString: string;
+  downtimeInHoursAndMinutes: string;
+  /*
+   * The group this resource is attached to directly. Empty string when the
+   * resource is not in any group (it renders above the groups on the live page).
+   */
+  groupName: string;
+  /*
+   * Every group from the top of the tree down to this resource's own group,
+   * joined with " / " - e.g. "Region 001 / Market 001 / Unit 0660". Empty string
+   * when the resource is not in any group.
+   */
+  groupPath: string;
+}
+
+/*
+ * Numbers rolled up over a group and everything nested under it - the same set
+ * of resources the live status page rolls a group's uptime over.
+ */
+export interface StatusPageReportGroupMetrics {
+  uptimePercent: number;
+  uptimePercentAsString: string;
+  downtimeInHoursAndMinutes: string;
+  totalIncidentCount: number;
+}
+
+export interface StatusPageReportGroup extends StatusPageReportGroupMetrics {
+  groupName: string;
+  // Ancestors and this group joined with " / ".
+  groupPath: string;
+  // 0 for a top level group, 1 for its children, and so on.
+  depth: number;
+  // Resources in this group AND in every group nested under it.
+  totalResources: number;
+  // Resources attached to this group directly, in status page order.
+  resources: Array<StatusPageReportItem>;
+  subGroups: Array<StatusPageReportGroup>;
+}
+
+/*
+ * One line of the report, in the order the live status page renders it:
+ * ungrouped resources first, then each group followed by its own resources and
+ * then its sub groups.
+ */
+export interface StatusPageReportRow {
+  isGroup: boolean;
+  name: string;
+  depth: number;
+  // Precomputed so an email template does not have to do arithmetic in Handlebars.
+  indentInPixels: number;
+  uptimePercentAsString: string;
+  downtimeInHoursAndMinutes: string;
+  totalIncidentCount: number;
+  /*
+   * Only meaningful on a group row: how many resources the group rolls up.
+   * Always 0 on a resource row.
+   */
+  totalResources: number;
+}
+
+export interface StatusPageReport {
+  reportDates: string; // start date and end date in string. e.g. "01 July 2021 - 14 July 2021"
+  totalResources: number;
+  totalIncidents: number;
+  averageUptimePercent: string;
+  totalDowntimeInHoursAndMinutes: string;
+  resources: Array<StatusPageReportItem>;
+  groups: Array<StatusPageReportGroup>;
+  // Resources that are not in any group, in status page order.
+  ungroupedResources: Array<StatusPageReportItem>;
+  rows: Array<StatusPageReportRow>;
+  // Whether this status page organises its resources into groups at all.
+  hasGroups: boolean;
+}

--- a/Common/Utils/StatusPage/Report.ts
+++ b/Common/Utils/StatusPage/Report.ts
@@ -1,0 +1,304 @@
+import StatusPageGroup from "../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "../../Models/DatabaseModels/StatusPageResource";
+import Dictionary from "../../Types/Dictionary";
+import {
+  StatusPageReportGroup,
+  StatusPageReportGroupMetrics,
+  StatusPageReportItem,
+  StatusPageReportRow,
+} from "../../Types/StatusPage/StatusPageReport";
+import StatusPageGroupTreeUtil, { StatusPageGroupTreeNode } from "./GroupTree";
+
+/*
+ * One resource on the status page paired with the numbers already computed for
+ * it. Kept as a pair (rather than keyed by id) because the report is built from
+ * the same array the resources were fetched in, and a resource row is not
+ * guaranteed to have been selected with its `_id`.
+ */
+export interface StatusPageReportResourceEntry {
+  statusPageResource: StatusPageResource;
+  reportItem: Omit<StatusPageReportItem, "groupName" | "groupPath">;
+}
+
+export interface StatusPageReportStructure {
+  // Every resource, flat, in the order it was supplied.
+  resources: Array<StatusPageReportItem>;
+  // The group tree, top level groups first.
+  groups: Array<StatusPageReportGroup>;
+  resourcesWithoutGroup: Array<StatusPageReportItem>;
+  // The tree flattened into render order.
+  rows: Array<StatusPageReportRow>;
+}
+
+/*
+ * Turns the flat per-resource numbers of an uptime report into the same nested
+ * shape the live status page renders: ungrouped resources first, then each top
+ * level group with its own resources and then its sub groups, at any depth.
+ *
+ * Deliberately pure and synchronous. Anything that needs the database (rolled up
+ * incident counts, downtime over a group's monitors) is computed by the caller
+ * and handed in through `groupMetricsByGroupId`, which keeps the tree walk here
+ * testable on its own and keeps the number of queries in the caller's hands.
+ */
+export default class StatusPageReportTreeUtil {
+  // How far one level of nesting indents a row in the emailed report.
+  public static readonly IndentInPixelsPerDepth: number = 16;
+
+  public static readonly GroupPathSeparator: string = " / ";
+
+  public static build(data: {
+    entries: Array<StatusPageReportResourceEntry>;
+    statusPageGroups: Array<StatusPageGroup>;
+    /*
+     * Rolled up numbers per group id, covering the group and every group nested
+     * under it. A group with no entry here reports zeroes rather than
+     * disappearing - a level missing from the report is worse than a level with
+     * an empty number.
+     */
+    groupMetricsByGroupId: Dictionary<StatusPageReportGroupMetrics>;
+  }): StatusPageReportStructure {
+    const groupsById: Dictionary<StatusPageGroup> = {};
+
+    for (const group of data.statusPageGroups) {
+      const groupId: string | undefined = group._id?.toString();
+
+      if (groupId) {
+        groupsById[groupId] = group;
+      }
+    }
+
+    const pathByGroupId: Dictionary<string> = this.getPathByGroupId({
+      statusPageGroups: data.statusPageGroups,
+    });
+
+    const resources: Array<StatusPageReportItem> = data.entries.map(
+      (entry: StatusPageReportResourceEntry) => {
+        const groupId: string | undefined =
+          entry.statusPageResource.statusPageGroupId?.toString();
+
+        const group: StatusPageGroup | undefined = groupId
+          ? groupsById[groupId]
+          : undefined;
+
+        return {
+          ...entry.reportItem,
+          groupName: group?.name || "",
+          groupPath: (groupId && pathByGroupId[groupId]) || "",
+        };
+      },
+    );
+
+    /*
+     * Resources are keyed back to their group by index, so this has to stay in
+     * step with `data.entries` above.
+     */
+    const resourcesByGroupId: Dictionary<Array<StatusPageReportItem>> = {};
+    const resourcesWithoutGroup: Array<StatusPageReportItem> = [];
+
+    data.entries.forEach(
+      (entry: StatusPageReportResourceEntry, index: number) => {
+        const reportItem: StatusPageReportItem = resources[index]!;
+
+        const groupId: string | undefined =
+          entry.statusPageResource.statusPageGroupId?.toString();
+
+        /*
+         * A resource pointing at a group that is not on this page has nowhere to
+         * nest, so it renders at the top like any other ungrouped resource
+         * instead of falling out of the report.
+         */
+        if (!groupId || !groupsById[groupId]) {
+          resourcesWithoutGroup.push(reportItem);
+          return;
+        }
+
+        resourcesByGroupId[groupId] = resourcesByGroupId[groupId] || [];
+        resourcesByGroupId[groupId]!.push(reportItem);
+      },
+    );
+
+    /*
+     * buildTree rather than getRootGroups: a parent pointer written straight to
+     * the database can put a group in a cycle, and a cycle has no root. buildTree
+     * promotes those groups to the top level so they still appear.
+     */
+    const tree: Array<StatusPageGroupTreeNode> =
+      StatusPageGroupTreeUtil.buildTree({
+        statusPageGroups: data.statusPageGroups,
+      });
+
+    const groups: Array<StatusPageReportGroup> = tree.map(
+      (node: StatusPageGroupTreeNode) => {
+        return this.buildGroup({
+          node: node,
+          resourcesByGroupId: resourcesByGroupId,
+          groupMetricsByGroupId: data.groupMetricsByGroupId,
+          pathByGroupId: pathByGroupId,
+        });
+      },
+    );
+
+    return {
+      resources: resources,
+      groups: groups,
+      resourcesWithoutGroup: resourcesWithoutGroup,
+      rows: this.getRows({
+        groups: groups,
+        resourcesWithoutGroup: resourcesWithoutGroup,
+      }),
+    };
+  }
+
+  /*
+   * "Region 001 / Market 001 / Unit 0660" for every group, so a resource row can
+   * say where it sits without the reader having to reconstruct the tree.
+   */
+  public static getPathByGroupId(data: {
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Dictionary<string> {
+    const pathByGroupId: Dictionary<string> = {};
+
+    for (const group of data.statusPageGroups) {
+      const groupId: string | undefined = group._id?.toString();
+
+      if (!groupId) {
+        continue;
+      }
+
+      const ancestors: Array<StatusPageGroup> =
+        StatusPageGroupTreeUtil.getAncestorGroups({
+          statusPageGroup: group,
+          statusPageGroups: data.statusPageGroups,
+        });
+
+      const names: Array<string> = [...ancestors]
+        .reverse()
+        .concat([group])
+        .map((groupInPath: StatusPageGroup) => {
+          return groupInPath.name || "";
+        })
+        .filter((name: string) => {
+          return Boolean(name);
+        });
+
+      pathByGroupId[groupId] = names.join(this.GroupPathSeparator);
+    }
+
+    return pathByGroupId;
+  }
+
+  private static buildGroup(data: {
+    node: StatusPageGroupTreeNode;
+    resourcesByGroupId: Dictionary<Array<StatusPageReportItem>>;
+    groupMetricsByGroupId: Dictionary<StatusPageReportGroupMetrics>;
+    pathByGroupId: Dictionary<string>;
+  }): StatusPageReportGroup {
+    const groupId: string = data.node.group._id?.toString() || "";
+
+    const subGroups: Array<StatusPageReportGroup> = data.node.children.map(
+      (child: StatusPageGroupTreeNode) => {
+        return this.buildGroup({
+          node: child,
+          resourcesByGroupId: data.resourcesByGroupId,
+          groupMetricsByGroupId: data.groupMetricsByGroupId,
+          pathByGroupId: data.pathByGroupId,
+        });
+      },
+    );
+
+    const ownResources: Array<StatusPageReportItem> =
+      data.resourcesByGroupId[groupId] || [];
+
+    const metrics: StatusPageReportGroupMetrics = data.groupMetricsByGroupId[
+      groupId
+    ] || {
+      uptimePercent: 0,
+      uptimePercentAsString: "0%",
+      downtimeInHoursAndMinutes: "0",
+      totalIncidentCount: 0,
+    };
+
+    const totalResources: number = subGroups.reduce(
+      (count: number, subGroup: StatusPageReportGroup) => {
+        return count + subGroup.totalResources;
+      },
+      ownResources.length,
+    );
+
+    return {
+      groupName: data.node.group.name || "",
+      groupPath: data.pathByGroupId[groupId] || data.node.group.name || "",
+      depth: data.node.depth,
+      totalResources: totalResources,
+      resources: ownResources,
+      subGroups: subGroups,
+      uptimePercent: metrics.uptimePercent,
+      uptimePercentAsString: metrics.uptimePercentAsString,
+      downtimeInHoursAndMinutes: metrics.downtimeInHoursAndMinutes,
+      totalIncidentCount: metrics.totalIncidentCount,
+    };
+  }
+
+  /*
+   * Render order, matching the live page: resources with no group first, then
+   * each group followed by its own resources and then its sub groups.
+   */
+  public static getRows(data: {
+    groups: Array<StatusPageReportGroup>;
+    resourcesWithoutGroup: Array<StatusPageReportItem>;
+  }): Array<StatusPageReportRow> {
+    const rows: Array<StatusPageReportRow> = [];
+
+    for (const resource of data.resourcesWithoutGroup) {
+      rows.push(this.toResourceRow({ resource: resource, depth: 0 }));
+    }
+
+    const walk: (groups: Array<StatusPageReportGroup>) => void = (
+      groups: Array<StatusPageReportGroup>,
+    ): void => {
+      for (const group of groups) {
+        rows.push({
+          isGroup: true,
+          name: group.groupName,
+          depth: group.depth,
+          indentInPixels: group.depth * this.IndentInPixelsPerDepth,
+          uptimePercentAsString: group.uptimePercentAsString,
+          downtimeInHoursAndMinutes: group.downtimeInHoursAndMinutes,
+          totalIncidentCount: group.totalIncidentCount,
+          totalResources: group.totalResources,
+        });
+
+        for (const resource of group.resources) {
+          rows.push(
+            this.toResourceRow({
+              resource: resource,
+              depth: group.depth + 1,
+            }),
+          );
+        }
+
+        walk(group.subGroups);
+      }
+    };
+
+    walk(data.groups);
+
+    return rows;
+  }
+
+  private static toResourceRow(data: {
+    resource: StatusPageReportItem;
+    depth: number;
+  }): StatusPageReportRow {
+    return {
+      isGroup: false,
+      name: data.resource.resourceName,
+      depth: data.depth,
+      indentInPixels: data.depth * this.IndentInPixelsPerDepth,
+      uptimePercentAsString: data.resource.uptimePercentAsString,
+      downtimeInHoursAndMinutes: data.resource.downtimeInHoursAndMinutes,
+      totalIncidentCount: data.resource.totalIncidentCount,
+      totalResources: 0,
+    };
+  }
+}


### PR DESCRIPTION
Fixes #2973.

## The problem

A status page arranges its resources into a tree of groups (`Corporate Unit's` → `Region 001` → `Market 001` → `Unit 0660`) and shows a rolled up availability at every level. The scheduled **Uptime Report** email dropped that entirely and rendered one flat "Per-resource breakdown" table — `Router`, `WBHQ website`, `Switch 01` with no group context.

Most recipients of this email (vendors, leadership, external stakeholders) have no OneUptime login, so the email is all they get. A flat list of monitor names says nothing about which region or unit a monitor belongs to, and shows no rolled up number at any level.

Confirmed in the code: `StatusPageService.getReportByStatusPage` never read `StatusPageGroup` at all, and `StatusPageSubscriberReport.hbs` looped over one flat `report.resources` array.

## The fix

The report now carries the hierarchy the live page renders.

- **`Common/Utils/StatusPage/Report.ts`** (new, pure and synchronous) turns the per-resource numbers into the same shape the live page renders: ungrouped resources first, then each group followed by its own resources and then its sub groups, at any depth. It reuses the existing `StatusPageGroupTreeUtil`, so it inherits that util's handling of bad data — a group in a cycle, a self-parent, or a missing parent is promoted rather than dropped.
- **`StatusPageService`** rolls uptime, downtime and incidents up over each group's whole subtree. Uptime averages the subtree's resources, which is exactly what `StatusPageResourceUptimeUtil.calculateAvgUptimePercentOfStatusPageGroup` does on the live page, so the two numbers can be compared side by side.
- **`StatusPageSubscriberReport.hbs`** walks `report.rows` — the tree flattened into render order with a `depth` on each row — so any nesting level renders without recursion, which email clients handle poorly. Group rows are visually distinct and show the rolled up uptime, downtime, incidents, and how many resources they cover.

### Report shape

`report` gains `groups` (nested tree), `ungroupedResources`, `rows` (flattened render order) and `hasGroups`; every resource row gains `groupName` and `groupPath` (`"Corporate Unit's / Region 001 / Market 001 / Unit 0660"`).

The existing flat `resources` array is unchanged in shape and order, so **report templates written before this keep rendering**. The template variable docs shown in the dashboard and the default customer-authored report body are updated to cover the new variables.

### Incidental

A chain of levels that rolls up the same monitors (`Corporate` → `Region` → `Market` → `Unit` over the same two monitors) now shares one incident count query instead of issuing four identical ones.

## Tests

50 new tests across three suites, all passing:

- `Common/Tests/Utils/StatusPage/Report.test.ts` (25) — render order, depth/indent at four levels, group paths, subtree resource counts, sibling ordering, own-resources-before-sub-groups, empty groups, and the bad-data shapes (resource pointing at a group not on the page, self-parent, missing parent, parent cycle, unnamed group, group with no id).
- `Common/Tests/Server/Services/StatusPageSubscriberReport.test.ts` (13) — the report built end to end with every database read spied: the nested structure, the rolled up uptime/downtime/incident numbers, page level totals, the flat `resources` back-compat array, a page with no groups, a page with no resources, and the shared incident query.
- `App/Tests/Notification/StatusPageSubscriberReportTemplate.test.ts` (12) — the real `.hbs` and the default customer template rendered through real Handlebars with the real partials: every level present in the right order, indentation per level, rolled up uptime on group rows, the flat fallback when a page has no groups, the empty-page message, and HTML escaping of group and resource names.

Also verified: `tsc --noEmit` clean for both `Common` and `App`, `eslint` clean, and the full existing `StatusPage` test suites still pass (286 in Common, 250 in App).