### PR TITLE
fix(sso): block SAML signature bypass via signed error response (#2981)

### DIFF
--- a/App/FeatureSet/Identity/API/GlobalSSO.ts
+++ b/App/FeatureSet/Identity/API/GlobalSSO.ts
@@ -286,7 +286,7 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
        * Verify the signature AND extract the identity from the SAME
        * cryptographically verified assertion. This single call defends against
        * XML Signature Wrapping - see SSOUtil.getSamlResponseFromXML and
-       * GitHub issue #2949.
+       * GitHub issues #2949 and #2981.
        */
       const verifiedSaml: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
         samlResponse,

--- a/App/FeatureSet/Identity/API/SSO.ts
+++ b/App/FeatureSet/Identity/API/SSO.ts
@@ -407,7 +407,7 @@ const loginUserWithSso: LoginUserWithSsoFunction = async (
        * Verify the signature AND extract the identity from the SAME
        * cryptographically verified assertion. This single call defends against
        * XML Signature Wrapping - see SSOUtil.getSamlResponseFromXML and
-       * GitHub issue #2949.
+       * GitHub issues #2949 and #2981.
        */
       const verifiedSaml: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
         samlResponse,

--- a/App/FeatureSet/Identity/API/StatusPageSSO.ts
+++ b/App/FeatureSet/Identity/API/StatusPageSSO.ts
@@ -224,7 +224,7 @@ router.post(
          * Verify the signature AND extract the identity from the SAME
          * cryptographically verified assertion. This single call defends against
          * XML Signature Wrapping - see SSOUtil.getSamlResponseFromXML and
-         * GitHub issue #2949.
+         * GitHub issues #2949 and #2981.
          */
         const verifiedSaml: VerifiedSamlResponse =
           SSOUtil.getSamlResponseFromXML(

--- a/App/FeatureSet/Identity/Utils/SSO.ts
+++ b/App/FeatureSet/Identity/Utils/SSO.ts
@@ -30,9 +30,26 @@ export default class SSOUtil {
   private static readonly XMLDSIG_NAMESPACE: string =
     "http://www.w3.org/2000/09/xmldsig#";
 
+  private static readonly SAML_PROTOCOL_NAMESPACE: string =
+    "urn:oasis:names:tc:SAML:2.0:protocol";
+
   private static readonly SAML_ASSERTION_NAMESPACES: Array<string> = [
     "urn:oasis:names:tc:SAML:2.0:assertion",
     "urn:oasis:names:tc:SAML:1.0:assertion",
+  ];
+
+  /*
+   * The only top-level <StatusCode> value that means "the user authenticated".
+   * SAML 2.0 Core, section 3.2.2.2.
+   */
+  private static readonly SAML_STATUS_SUCCESS: string =
+    "urn:oasis:names:tc:SAML:2.0:status:Success";
+
+  // xml-crypto resolves same-document references against these attribute names.
+  private static readonly ID_ATTRIBUTE_LOCAL_NAMES: Array<string> = [
+    "ID",
+    "Id",
+    "id",
   ];
 
   // Microsoft display name claim - the only "full name" claim we read today.
@@ -66,23 +83,56 @@ export default class SSOUtil {
    * SAME assertion that the signature actually covers.
    *
    * This is the single, safe entry point that every SAML login flow must use.
-   * It defends against XML Signature Wrapping (XSW): the historic implementation
-   * validated whichever <Signature> element appeared first and then extracted the
-   * identity from an independently parsed tree, so an attacker could hide a
-   * genuinely signed assertion (e.g. inside <Extensions>) while presenting a
-   * forged assertion for consumption. See GitHub issue #2949.
+   * It defends against XML Signature Wrapping (XSW) - the family of attacks
+   * where a genuinely signed element and the element we actually read are not
+   * the same element.
    *
-   * The checks below make that impossible:
-   *   1. The document must be well-formed XML with no DOCTYPE / entity
-   *      declarations (blocks XXE and entity-expansion / parser-differential
-   *      tricks).
-   *   2. The document must contain EXACTLY ONE <Assertion> element anywhere in
-   *      the tree (blocks decoy / wrapped assertions - every XSW variant needs a
-   *      second assertion to hide behind).
-   *   3. A <Signature> must validate against the configured certificate AND its
-   *      reference must resolve to that one assertion (or an ancestor that
-   *      contains it). This binds "what was signed" to "what we read".
-   *   4. The identity-bearing nodes must not contain XML comments (blocks the
+   * Two reported bypasses shaped this code:
+   *
+   *   - GitHub issue #2949: the original implementation validated whichever
+   *     <Signature> appeared first and then extracted the identity from an
+   *     independently parsed tree, so a genuinely signed assertion could be
+   *     hidden (e.g. inside <Extensions>) while a forged sibling assertion was
+   *     consumed.
+   *
+   *   - GitHub issue #2981: counting assertions is not sufficient. The
+   *     enveloped-signature transform removes the whole <Signature> subtree
+   *     from the digest, so ANY element parked inside a <Signature> is
+   *     unauthenticated even though the signature validates. An attacker who
+   *     replays a genuinely signed *error* Response (which legitimately carries
+   *     no assertion) can park a forged assertion inside a <Signature> and it
+   *     becomes the document's one and only assertion. xml-crypto makes this
+   *     easier still: its enveloped-signature transform strips every
+   *     <Signature> whose <SignatureValue> text matches the one being verified,
+   *     so a decoy <Signature> that merely repeats the genuine
+   *     <SignatureValue> is removed from the digest too.
+   *
+   * The defence is to stop reasoning about "is this signed?" in isolation and
+   * instead pin the document to the shape SAML actually defines, so that the
+   * element we read cannot be anywhere except inside the signed payload:
+   *
+   *   1. Well-formed XML with no DOCTYPE / entity declarations (blocks XXE,
+   *      entity expansion and parser-differential tricks).
+   *   2. The root MUST be <samlp:Response> (SAML 2.0 protocol namespace).
+   *   3. No encrypted elements - we cannot decrypt them, and silently reading
+   *      around them would mean reading unauthenticated data.
+   *   4. EXACTLY ONE <Assertion> in the whole document, and it MUST be a direct
+   *      child of the root <Response>. Per SAML 2.0 Core (ResponseType) that is
+   *      the only place an assertion may legitimately appear, and it makes
+   *      every "hide the real one / smuggle a fake one" placement impossible.
+   *   5. Every <ds:Signature> MUST be a direct child of the root <Response> or
+   *      of the Assertion (SAML 2.0 Core: StatusResponseType and AssertionType
+   *      each allow at most one), no two signatures may share a parent, no two
+   *      may share a <SignatureValue>, and no signature may carry a payload
+   *      (<ds:Object> or SAML content) inside it.
+   *   6. A <Signature> must validate against the configured certificate AND at
+   *      least one of its verified references must resolve to exactly one
+   *      element which is the Assertion itself or the root <Response>.
+   *   7. The <Status> must be a top-level Success. SAML 2.0 Profiles 4.1.4.2:
+   *      an identity provider returning an error "MUST NOT include any
+   *      assertions in the <Response> message", so an assertion delivered
+   *      alongside an error status is by definition not one the IdP issued.
+   *   8. The identity-bearing nodes must not contain XML comments (blocks the
    *      SAML comment-truncation class of attacks).
    *
    * Throws BadRequestException on any anomaly.
@@ -91,25 +141,10 @@ export default class SSOUtil {
     samlResponse: string,
     certificate: string,
   ): VerifiedSamlResponse {
-    if (!certificate) {
-      throw new BadRequestException("Public Certificate not found");
-    }
-
-    const dom: XmlDocument = SSOUtil.parseXmlStrict(samlResponse);
-    const assertion: XmlElement = SSOUtil.getSingleAssertion(dom);
-
-    if (
-      !SSOUtil.verifyAssertionSignature(
-        samlResponse,
-        certificate,
-        dom,
-        assertion,
-      )
-    ) {
-      throw new BadRequestException(
-        "Signature is not valid or Public Certificate configured with this SSO provider is not valid",
-      );
-    }
+    const assertion: XmlElement = SSOUtil.verifyAndGetAssertion(
+      samlResponse,
+      certificate,
+    );
 
     return {
       issuerUrl: SSOUtil.getIssuerFromAssertion(assertion),
@@ -128,23 +163,52 @@ export default class SSOUtil {
     certificate: string,
   ): boolean {
     try {
-      if (!certificate) {
-        return false;
-      }
-
-      const dom: XmlDocument = SSOUtil.parseXmlStrict(samlResponse);
-      const assertion: XmlElement = SSOUtil.getSingleAssertion(dom);
-
-      return SSOUtil.verifyAssertionSignature(
-        samlResponse,
-        certificate,
-        dom,
-        assertion,
-      );
+      SSOUtil.verifyAndGetAssertion(samlResponse, certificate);
+      return true;
     } catch (err) {
       logger.error(err);
       return false;
     }
+  }
+
+  /*
+   * The single verification pipeline. Returns the one assertion that the
+   * signature provably covers, or throws.
+   */
+  private static verifyAndGetAssertion(
+    samlResponse: string,
+    certificate: string,
+  ): XmlElement {
+    if (!certificate) {
+      throw new BadRequestException("Public Certificate not found");
+    }
+
+    const dom: XmlDocument = SSOUtil.parseXmlStrict(samlResponse);
+    const response: XmlElement = SSOUtil.getResponseElement(dom);
+
+    SSOUtil.assertNoEncryptedElements(dom);
+
+    const assertion: XmlElement = SSOUtil.getSingleAssertion(dom, response);
+
+    SSOUtil.assertSignaturesAreWellPlaced(dom, response, assertion);
+
+    if (
+      !SSOUtil.verifyAssertionSignature(
+        samlResponse,
+        certificate,
+        dom,
+        response,
+        assertion,
+      )
+    ) {
+      throw new BadRequestException(
+        "Signature is not valid or Public Certificate configured with this SSO provider is not valid",
+      );
+    }
+
+    SSOUtil.assertStatusIsSuccess(dom, response);
+
+    return assertion;
   }
 
   /*
@@ -191,12 +255,65 @@ export default class SSOUtil {
   }
 
   /*
-   * Return the single Assertion element in the document, or throw. Counting
-   * assertions across the WHOLE document (any namespace, including a wrapped or
-   * nested one) is what defeats signature-wrapping: the attack fundamentally
-   * needs a second assertion to hide the genuine signature behind.
+   * The document element must be a SAML 2.0 protocol <Response>. Anchoring on
+   * the root - rather than searching the tree for something Response-shaped -
+   * is what lets every later check talk about "direct child of the Response".
    */
-  private static getSingleAssertion(dom: XmlDocument): XmlElement {
+  private static getResponseElement(dom: XmlDocument): XmlElement {
+    const root: XmlElement | null = dom.documentElement;
+
+    if (
+      !root ||
+      root.localName !== "Response" ||
+      root.namespaceURI !== SSOUtil.SAML_PROTOCOL_NAMESPACE
+    ) {
+      throw new BadRequestException(
+        "SAML Response must be a samlp:Response element in the urn:oasis:names:tc:SAML:2.0:protocol namespace",
+      );
+    }
+
+    return root;
+  }
+
+  /*
+   * We do not support encrypted assertions / identifiers / attributes. If one
+   * is present we must fail loudly: quietly reading whatever plaintext sits
+   * next to it would mean reading data the IdP never intended us to consume.
+   */
+  private static assertNoEncryptedElements(dom: XmlDocument): void {
+    const encryptedLocalNames: Array<string> = [
+      "EncryptedAssertion",
+      "EncryptedID",
+      "EncryptedAttribute",
+    ];
+
+    for (const localName of encryptedLocalNames) {
+      const found: Array<XmlElement> = SSOUtil.toElementArray(
+        dom.getElementsByTagNameNS("*", localName),
+      );
+
+      if (found.length > 0) {
+        throw new BadRequestException(
+          "Encrypted SAML Responses are not supported. Please configure this SSO provider to send an unencrypted, signed assertion.",
+        );
+      }
+    }
+  }
+
+  /*
+   * Return the single Assertion element in the document, or throw.
+   *
+   * Counting assertions across the WHOLE document (any namespace, including a
+   * wrapped or nested one) removes the decoy every XSW variant needs. Requiring
+   * that the assertion is a DIRECT CHILD of the root <Response> - the only
+   * position SAML 2.0 Core's ResponseType allows - removes every hiding place,
+   * including the <ds:Object> of a <Signature>, whose whole subtree is stripped
+   * out of the digest by the enveloped-signature transform (issue #2981).
+   */
+  private static getSingleAssertion(
+    dom: XmlDocument,
+    response: XmlElement,
+  ): XmlElement {
     const assertions: Array<XmlElement> = SSOUtil.toElementArray(
       dom.getElementsByTagNameNS("*", "Assertion"),
     );
@@ -219,14 +336,140 @@ export default class SSOUtil {
       throw new BadRequestException("SAML Assertion has an invalid namespace");
     }
 
+    if (assertion.parentNode !== response) {
+      throw new BadRequestException(
+        "SAML Assertion must be a direct child of the SAML Response",
+      );
+    }
+
     return assertion;
+  }
+
+  /*
+   * Constrain where signatures may live and what they may carry.
+   *
+   * SAML 2.0 Core allows at most one <ds:Signature>, as a direct child, on
+   * StatusResponseType (the <Response>) and on AssertionType (the
+   * <Assertion>). Anything else is either an attack or a document we have no
+   * business trusting. Two extra rules close the specific tricks from #2981:
+   *
+   *   - No two signatures may repeat the same <SignatureValue>. xml-crypto's
+   *     enveloped-signature transform deletes EVERY signature whose
+   *     <SignatureValue> matches the one under verification, so a decoy that
+   *     copies the genuine value is silently removed from the digest.
+   *
+   *   - A <Signature> may not carry a payload. Its subtree is excluded from
+   *     the digest of the reference that envelopes it, so a <ds:Object> (or any
+   *     smuggled SAML element) inside it is unauthenticated by construction.
+   */
+  private static assertSignaturesAreWellPlaced(
+    dom: XmlDocument,
+    response: XmlElement,
+    assertion: XmlElement,
+  ): void {
+    const signatures: Array<XmlElement> = SSOUtil.toElementArray(
+      dom.getElementsByTagNameNS(SSOUtil.XMLDSIG_NAMESPACE, "Signature"),
+    );
+
+    let responseSignatureSeen: boolean = false;
+    let assertionSignatureSeen: boolean = false;
+    const signatureValuesSeen: Set<string> = new Set<string>();
+
+    for (const signature of signatures) {
+      const parent: XmlNode | null = signature.parentNode;
+
+      if (parent === response) {
+        if (responseSignatureSeen) {
+          throw new BadRequestException(
+            "SAML Response must not contain more than one Signature",
+          );
+        }
+        responseSignatureSeen = true;
+      } else if (parent === assertion) {
+        if (assertionSignatureSeen) {
+          throw new BadRequestException(
+            "SAML Assertion must not contain more than one Signature",
+          );
+        }
+        assertionSignatureSeen = true;
+      } else {
+        throw new BadRequestException(
+          "An XML Signature in a SAML Response must be a direct child of the Response or of the Assertion",
+        );
+      }
+
+      SSOUtil.assertSignatureCarriesNoPayload(signature);
+
+      const signatureValue: string = SSOUtil.getSignatureValueText(signature);
+
+      if (signatureValuesSeen.has(signatureValue)) {
+        throw new BadRequestException(
+          "SAML Response must not contain two Signatures with the same SignatureValue",
+        );
+      }
+
+      signatureValuesSeen.add(signatureValue);
+    }
+  }
+
+  /*
+   * Nothing that we (or anyone) would read may live inside a <Signature>: the
+   * enveloped-signature transform removes the entire <Signature> subtree before
+   * the digest is computed, so its contents are never authenticated.
+   */
+  private static assertSignatureCarriesNoPayload(signature: XmlElement): void {
+    const descendants: Array<XmlElement> = SSOUtil.toElementArray(
+      signature.getElementsByTagName("*"),
+    );
+
+    for (const element of descendants) {
+      const namespaceUri: string = element.namespaceURI || "";
+
+      if (
+        namespaceUri === SSOUtil.XMLDSIG_NAMESPACE &&
+        element.localName === "Object"
+      ) {
+        throw new BadRequestException(
+          "XML Signature Object elements are not allowed in a SAML Response",
+        );
+      }
+
+      if (
+        namespaceUri === SSOUtil.SAML_PROTOCOL_NAMESPACE ||
+        SSOUtil.SAML_ASSERTION_NAMESPACES.includes(namespaceUri) ||
+        element.localName === "Assertion"
+      ) {
+        throw new BadRequestException(
+          "SAML elements are not allowed inside an XML Signature",
+        );
+      }
+    }
+  }
+
+  private static getSignatureValueText(signature: XmlElement): string {
+    const signatureValues: Array<XmlElement> = SSOUtil.toElementArray(
+      signature.getElementsByTagNameNS(
+        SSOUtil.XMLDSIG_NAMESPACE,
+        "SignatureValue",
+      ),
+    );
+
+    if (signatureValues.length === 0) {
+      return "";
+    }
+
+    return SSOUtil.getTrimmedText(signatureValues[0]!);
   }
 
   /*
    * Verify that some <Signature> in the document:
    *   - validates cryptographically against the configured certificate, and
-   *   - covers the given assertion (its reference resolves to the assertion or
-   *     an ancestor element that contains it).
+   *   - has a verified reference that resolves to exactly one element, and that
+   *     element is the Assertion itself or the root <Response>.
+   *
+   * The references are read back AFTER checkSignature() because xml-crypto
+   * rebuilds them from the canonicalized <SignedInfo> it just verified - the
+   * ones parsed by loadSignature() are still unauthenticated at that point.
    *
    * Only if BOTH hold do we consider the assertion authentic.
    */
@@ -234,6 +477,7 @@ export default class SSOUtil {
     samlResponse: string,
     certificate: string,
     dom: XmlDocument,
+    response: XmlElement,
     assertion: XmlElement,
   ): boolean {
     const signatures: Array<XmlElement> = SSOUtil.toElementArray(
@@ -259,9 +503,14 @@ export default class SSOUtil {
 
         sig.loadSignature(signature.toString());
 
+        // Cryptographically validate digests + signature value.
+        if (!sig.checkSignature(samlResponse)) {
+          continue;
+        }
+
         /*
-         * Before trusting this signature, confirm it actually covers the
-         * assertion we are going to read from. A signature over some unrelated
+         * The signature is genuine. Now confirm it actually covers the
+         * assertion we are going to read from - a signature over some unrelated
          * element must never authenticate a forged assertion.
          */
         const references: Array<{ uri?: string | undefined }> =
@@ -271,18 +520,14 @@ export default class SSOUtil {
           (reference: { uri?: string | undefined }): boolean => {
             return SSOUtil.referenceCoversAssertion(
               dom,
+              response,
               assertion,
               reference.uri,
             );
           },
         );
 
-        if (!coversAssertion) {
-          continue;
-        }
-
-        // Cryptographically validate digests + signature value.
-        if (sig.checkSignature(samlResponse)) {
+        if (coversAssertion) {
           return true;
         }
       } catch (err) {
@@ -296,11 +541,16 @@ export default class SSOUtil {
 
   /*
    * Does a signed Reference (identified by its URI) cover the assertion?
-   * A URI of "" signs the whole document. Otherwise it points at an element by
-   * ID; that element must be the assertion itself or an ancestor of it.
+   *
+   * A URI of "" signs the whole document, whose root is the <Response> that the
+   * assertion is a direct child of. Otherwise it points at an element by ID and
+   * that element must be the Assertion itself or the root <Response>; those are
+   * the only two elements SAML lets a signature apply to, and both contain the
+   * assertion in the digested payload.
    */
   private static referenceCoversAssertion(
     dom: XmlDocument,
+    response: XmlElement,
     assertion: XmlElement,
     uri: string | undefined,
   ): boolean {
@@ -318,10 +568,17 @@ export default class SSOUtil {
       return false;
     }
 
-    return SSOUtil.isAncestorOrSelf(targets[0]!, assertion);
+    const target: XmlElement = targets[0]!;
+
+    return target === assertion || target === response;
   }
 
-  // Find every element carrying an ID / Id / id attribute equal to `id`.
+  /*
+   * Find every element carrying an ID / Id / id attribute equal to `id`.
+   * Matching on the attribute's LOCAL name mirrors how xml-crypto resolves
+   * same-document references, so we can never disagree with it about which
+   * element a reference points at.
+   */
   private static resolveElementsById(
     dom: XmlDocument,
     id: string,
@@ -333,10 +590,30 @@ export default class SSOUtil {
     const matches: Array<XmlElement> = [];
 
     for (const element of all) {
-      for (const attributeName of ["ID", "Id", "id"]) {
+      const attributes: XmlElement["attributes"] | null = element.attributes;
+
+      if (!attributes) {
+        continue;
+      }
+
+      for (let index: number = 0; index < attributes.length; index++) {
+        const attribute: { localName?: string; name?: string; value?: string } =
+          attributes[index] as unknown as {
+            localName?: string;
+            name?: string;
+            value?: string;
+          };
+
+        if (!attribute) {
+          continue;
+        }
+
+        const attributeLocalName: string =
+          attribute.localName || attribute.name || "";
+
         if (
-          element.getAttribute &&
-          element.getAttribute(attributeName) === id
+          SSOUtil.ID_ATTRIBUTE_LOCAL_NAMES.includes(attributeLocalName) &&
+          attribute.value === id
         ) {
           matches.push(element);
           break;
@@ -347,20 +624,72 @@ export default class SSOUtil {
     return matches;
   }
 
-  private static isAncestorOrSelf(
-    ancestor: XmlNode,
-    node: XmlNode | null,
-  ): boolean {
-    let current: XmlNode | null = node;
+  /*
+   * SAML 2.0 Profiles 4.1.4.2: an identity provider that wants to return an
+   * error "MUST NOT include any assertions in the <Response> message". So a
+   * non-Success status can never legitimately accompany an assertion, and a
+   * replayed error Response can never be turned into a login.
+   */
+  private static assertStatusIsSuccess(
+    dom: XmlDocument,
+    response: XmlElement,
+  ): void {
+    const statuses: Array<XmlElement> = SSOUtil.toElementArray(
+      dom.getElementsByTagNameNS(SSOUtil.SAML_PROTOCOL_NAMESPACE, "Status"),
+    );
 
-    while (current) {
-      if (current === ancestor) {
-        return true;
-      }
-      current = current.parentNode;
+    if (statuses.length !== 1) {
+      throw new BadRequestException(
+        "Expected exactly one Status element in SAML Response",
+      );
     }
 
-    return false;
+    const status: XmlElement = statuses[0]!;
+
+    if (status.parentNode !== response) {
+      throw new BadRequestException(
+        "SAML Status must be a direct child of the SAML Response",
+      );
+    }
+
+    const statusCodes: Array<XmlElement> = SSOUtil.getDirectChildrenByLocalName(
+      status,
+      "StatusCode",
+    ).filter((element: XmlElement): boolean => {
+      return element.namespaceURI === SSOUtil.SAML_PROTOCOL_NAMESPACE;
+    });
+
+    if (statusCodes.length !== 1) {
+      throw new BadRequestException(
+        "Expected exactly one StatusCode element in SAML Status",
+      );
+    }
+
+    const statusCode: string = statusCodes[0]!.getAttribute("Value") || "";
+
+    if (statusCode !== SSOUtil.SAML_STATUS_SUCCESS) {
+      throw new BadRequestException(
+        `SAML Response was not successful${SSOUtil.describeStatusCode(
+          statusCode,
+        )}`,
+      );
+    }
+  }
+
+  /*
+   * The status code is attacker-controllable (we have verified a signature, but
+   * not that the signer intended this document). Only echo it back when it
+   * looks like a SAML status URI so it cannot be used to inject junk into
+   * error pages or logs.
+   */
+  private static describeStatusCode(statusCode: string): string {
+    const safeStatusCode: RegExp = /^[A-Za-z0-9:._/-]{1,200}$/;
+
+    if (!statusCode || !safeStatusCode.test(statusCode)) {
+      return "";
+    }
+
+    return `. Status: ${statusCode}`;
   }
 
   private static getIssuerFromAssertion(assertion: XmlElement): string {
@@ -459,6 +788,15 @@ export default class SSOUtil {
     parent: XmlElement,
     localName: string,
   ): XmlElement | null {
+    return SSOUtil.getDirectChildrenByLocalName(parent, localName)[0] || null;
+  }
+
+  private static getDirectChildrenByLocalName(
+    parent: XmlElement,
+    localName: string,
+  ): Array<XmlElement> {
+    const children: Array<XmlElement> = [];
+
     for (
       let child: XmlNode | null = parent.firstChild;
       child;
@@ -468,11 +806,11 @@ export default class SSOUtil {
         child.nodeType === 1 &&
         (child as XmlElement).localName === localName
       ) {
-        return child as XmlElement;
+        children.push(child as XmlElement);
       }
     }
 
-    return null;
+    return children;
   }
 
   private static getTrimmedText(element: XmlElement): string {

--- a/App/Tests/Identity/SSO.test.ts
+++ b/App/Tests/Identity/SSO.test.ts
@@ -10,15 +10,28 @@ import { SignedXml } from "xml-crypto";
 /*
  * Security regression tests for SAML XML Signature Wrapping (XSW).
  *
- * Background (GitHub issue #2949): the historic implementation validated the
- * first <Signature> element it found and then extracted the identity from an
- * independently parsed tree. An attacker could therefore hide a genuinely
- * signed assertion (e.g. inside <Extensions>) while presenting a forged
- * assertion for consumption - a full authentication bypass.
+ * Two publicly reported bypasses are covered here:
+ *
+ *   - GitHub issue #2949: the original implementation validated the first
+ *     <Signature> element it found and then extracted the identity from an
+ *     independently parsed tree. An attacker could hide a genuinely signed
+ *     assertion (e.g. inside <Extensions>) while presenting a forged assertion
+ *     for consumption - a full authentication bypass.
+ *
+ *   - GitHub issue #2981: "exactly one <Assertion>" is not enough. The
+ *     enveloped-signature transform strips the whole <Signature> subtree out of
+ *     the digest, so an assertion parked inside a <Signature> is completely
+ *     unauthenticated while still being the document's only assertion. Replay a
+ *     genuinely signed *error* Response (which legitimately carries no
+ *     assertion), park a forged assertion inside a signature, and you are
+ *     logged in as anybody. xml-crypto widens this: its enveloped-signature
+ *     transform removes EVERY <Signature> whose <SignatureValue> text matches
+ *     the one being verified, so a decoy signature that simply repeats the
+ *     genuine <SignatureValue> also disappears from the digest.
  *
  * These tests:
- *   1. Prove the genuine ("happy path") SAML flow still works.
- *   2. Prove every wrapping / tampering variant is rejected.
+ *   1. Prove the genuine ("happy path") SAML flows still work.
+ *   2. Prove every wrapping / smuggling / tampering variant is rejected.
  *
  * Keys are generated at runtime (no secrets committed). xml-crypto verifies
  * against a raw public key just as well as against an X.509 certificate, so the
@@ -34,6 +47,12 @@ const RSA_SHA256: string = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
 const ISSUER: string = "https://idp.example.com/metadata";
 const DISPLAY_NAME_CLAIM: string =
   "http://schemas.microsoft.com/identity/claims/displayname";
+
+const STATUS_SUCCESS: string = "urn:oasis:names:tc:SAML:2.0:status:Success";
+const STATUS_REQUESTER: string = "urn:oasis:names:tc:SAML:2.0:status:Requester";
+const STATUS_RESPONDER: string = "urn:oasis:names:tc:SAML:2.0:status:Responder";
+const STATUS_AUTHN_FAILED: string =
+  "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed";
 
 interface KeyPair {
   privateKey: string;
@@ -57,7 +76,11 @@ beforeAll(() => {
   attackerKeys = generateRsaKeyPair();
 });
 
-// ---- SAML document builders ------------------------------------------------
+/*
+ * ---------------------------------------------------------------------------
+ * SAML document builders
+ * ---------------------------------------------------------------------------
+ */
 
 interface AssertionOptions {
   assertionId?: string;
@@ -65,6 +88,7 @@ interface AssertionOptions {
   issuer?: string;
   displayName?: string | null;
   nameId?: string; // raw NameID inner XML override (for comment tests)
+  extraInner?: string; // extra XML appended inside the assertion
 }
 
 function buildAssertion(options: AssertionOptions = {}): string {
@@ -80,54 +104,186 @@ function buildAssertion(options: AssertionOptions = {}): string {
           options.displayName ?? "Alice Example"
         }</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>`;
 
-  return `<saml:Assertion ID="${assertionId}" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${issuer}</saml:Issuer><saml:Subject><saml:NameID>${nameIdInner}</saml:NameID></saml:Subject>${attributeStatement}</saml:Assertion>`;
+  return `<saml:Assertion ID="${assertionId}" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${issuer}</saml:Issuer><saml:Subject><saml:NameID>${nameIdInner}</saml:NameID></saml:Subject>${attributeStatement}${
+    options.extraInner ?? ""
+  }</saml:Assertion>`;
+}
+
+interface ResponseOptions {
+  responseId?: string;
+  statusCode?: string;
+  statusXml?: string; // full <samlp:Status> override ("" removes it entirely)
+  extensions?: string;
+  beforeStatus?: string;
+}
+
+function buildStatus(statusCode: string = STATUS_SUCCESS): string {
+  return `<samlp:Status><samlp:StatusCode Value="${statusCode}"/></samlp:Status>`;
 }
 
 function buildResponse(
   innerXml: string,
-  responseId: string = "_resp1",
+  options: ResponseOptions = {},
 ): string {
-  return `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${responseId}" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer>${innerXml}</samlp:Response>`;
+  const responseId: string = options.responseId ?? "_resp1";
+  const status: string =
+    options.statusXml ?? buildStatus(options.statusCode ?? STATUS_SUCCESS);
+
+  return `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ID="${responseId}" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer>${
+    options.extensions ?? ""
+  }${options.beforeStatus ?? ""}${status}${innerXml}</samlp:Response>`;
 }
 
-// Sign the single element with the given local name, appending the Signature into it.
-function sign(xml: string, localName: string, privateKey: string): string {
-  const xpath: string = `//*[local-name(.)='${localName}']`;
+interface SignOptions {
+  // XPath of the element whose content is digested.
+  referenceXPath: string;
+  privateKey?: string | undefined;
+  // Where the <Signature> element itself is inserted. Defaults to the reference.
+  location?: {
+    reference: string;
+    action: "append" | "prepend" | "before" | "after";
+  };
+  emptyUri?: boolean;
+}
+
+function signXml(xml: string, options: SignOptions): string {
   const sig: SignedXml = new SignedXml();
-  sig.addReference(xpath, [XMLDSIG_ENVELOPED, XMLDSIG_EXC_C14N], XMLENC_SHA256);
+
+  sig.addReference(
+    options.referenceXPath,
+    [XMLDSIG_ENVELOPED, XMLDSIG_EXC_C14N],
+    XMLENC_SHA256,
+    undefined as unknown as string,
+    undefined as unknown as string,
+    undefined as unknown as string,
+    options.emptyUri === true,
+  );
+
   sig.signatureAlgorithm = RSA_SHA256;
-  sig.signingKey = privateKey;
+  sig.signingKey = options.privateKey ?? idpKeys.privateKey;
   sig.keyInfoProvider = {
     getKeyInfo: (): string => {
       return "<X509Data></X509Data>";
     },
   } as unknown as SignedXml["keyInfoProvider"];
+
   sig.computeSignature(xml, {
-    location: { reference: xpath, action: "append" },
+    location: options.location ?? {
+      reference: options.referenceXPath,
+      action: "append",
+    },
   });
+
   return sig.getSignedXml();
 }
 
-// Extract the (signed) <saml:Assertion>...</saml:Assertion> block from a document.
+// Sign the single element with the given local name, appending the Signature into it.
+function sign(xml: string, localName: string, privateKey?: string): string {
+  const referenceXPath: string = `//*[local-name(.)='${localName}']`;
+  return signXml(xml, { referenceXPath, privateKey });
+}
+
+// Extract `<tag ...>...</tag>` (first occurrence) from a document.
+function extractElement(xml: string, tag: string): string {
+  const start: number = xml.indexOf(`<${tag}`);
+  const endMarker: string = `</${tag}>`;
+  const end: number = xml.indexOf(endMarker) + endMarker.length;
+
+  if (start < 0 || end < endMarker.length) {
+    throw new Error(`Could not extract <${tag}> from document`);
+  }
+
+  return xml.substring(start, end);
+}
+
 function extractAssertion(signedXml: string): string {
-  const start: number = signedXml.indexOf("<saml:Assertion");
-  const endMarker: string = "</saml:Assertion>";
-  const end: number = signedXml.indexOf(endMarker) + endMarker.length;
-  return signedXml.substring(start, end);
+  return extractElement(signedXml, "saml:Assertion");
+}
+
+// The <Signature> that `signXml` produced (it is emitted without a prefix).
+function extractSignature(signedXml: string): string {
+  return extractElement(signedXml, "Signature");
+}
+
+function extractSignatureValue(signatureXml: string): string {
+  const match: RegExpMatchArray | null = signatureXml.match(
+    /<SignatureValue>([\s\S]*?)<\/SignatureValue>/,
+  );
+
+  if (!match || !match[1]) {
+    throw new Error("Could not extract <SignatureValue>");
+  }
+
+  return match[1];
 }
 
 function toBase64(xml: string): string {
   return Buffer.from(xml).toString("base64");
 }
 
+/*
+ * Attack documents are built by surgery on genuine ones. If a search string
+ * stops matching (xmldom re-serializes what xml-crypto produces, so e.g.
+ * `<X509Data></X509Data>` comes back as `<X509Data/>`) the "attack" silently
+ * becomes a copy of the genuine document and the test passes for the wrong
+ * reason. Fail loudly instead.
+ */
+function replaceOnce(
+  xml: string,
+  search: string | RegExp,
+  replacement: string,
+): string {
+  const replaced: string = xml.replace(search, replacement);
+
+  if (replaced === xml) {
+    throw new Error(
+      `Test setup error: ${String(search)} did not match the document`,
+    );
+  }
+
+  return replaced;
+}
+
 // A genuine, assertion-signed response for alice@example.com.
 function genuineAssertionSignedResponse(): string {
-  return sign(buildResponse(buildAssertion()), "Assertion", idpKeys.privateKey);
+  return sign(buildResponse(buildAssertion()), "Assertion");
+}
+
+// A genuine, response-signed (whole Response) response for alice@example.com.
+function genuineResponseSignedResponse(): string {
+  return sign(buildResponse(buildAssertion()), "Response");
+}
+
+/*
+ * A GENUINE, IdP-signed error Response. Per SAML 2.0 Profiles 4.1.4.2 an error
+ * response carries no assertion at all - which is precisely what makes it
+ * useful to an attacker looking for a signature to graft onto.
+ */
+function genuineSignedErrorResponse(
+  statusCode: string = STATUS_REQUESTER,
+): string {
+  return sign(buildResponse("", { statusCode }), "Response");
+}
+
+// Assert that both entry points reject a document.
+function expectRejected(xml: string, messageFragment?: string): void {
+  expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
+
+  if (messageFragment) {
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow(messageFragment);
+    return;
+  }
+
+  expect(() => {
+    return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+  }).toThrow();
 }
 
 /*
  * ---------------------------------------------------------------------------
- * Happy path - the genuine flow must keep working.
+ * Happy path - the genuine flows must keep working.
  * ---------------------------------------------------------------------------
  */
 
@@ -148,11 +304,7 @@ describe("SSOUtil - genuine SAML flow (must not break)", () => {
   });
 
   test("accepts a genuinely response-signed (whole Response) response", () => {
-    const xml: string = sign(
-      buildResponse(buildAssertion()),
-      "Response",
-      idpKeys.privateKey,
-    );
+    const xml: string = genuineResponseSignedResponse();
 
     expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
 
@@ -165,11 +317,98 @@ describe("SSOUtil - genuine SAML flow (must not break)", () => {
     expect(result.issuerUrl).toBe(ISSUER);
   });
 
+  test("accepts a response signed at BOTH the Response and Assertion level", () => {
+    const assertionSigned: string = sign(
+      buildResponse(buildAssertion()),
+      "Assertion",
+    );
+    const bothSigned: string = signXml(assertionSigned, {
+      referenceXPath: "//*[local-name(.)='Response']",
+      location: {
+        reference: "//*[local-name(.)='Response']",
+        action: "append",
+      },
+    });
+
+    expect(SSOUtil.isSignatureValid(bothSigned, idpKeys.publicKey)).toBe(true);
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      bothSigned,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
+
+  test("accepts a Response signature placed right after <Issuer> (real IdP layout)", () => {
+    const xml: string = signXml(buildResponse(buildAssertion()), {
+      referenceXPath: "//*[local-name(.)='Response']",
+      location: {
+        reference: "//*[local-name(.)='Issuer']",
+        action: "after",
+      },
+    });
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
+
+  test('accepts a whole-document signature (Reference URI="")', () => {
+    const xml: string = signXml(buildResponse(buildAssertion()), {
+      referenceXPath: "//*[local-name(.)='Response']",
+      emptyUri: true,
+    });
+
+    expect(xml).toContain('URI=""');
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
+
+  test("accepts a Status carrying a second-level StatusCode, StatusMessage and StatusDetail", () => {
+    const statusXml: string = `<samlp:Status><samlp:StatusCode Value="${STATUS_SUCCESS}"><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:PartialLogout"/></samlp:StatusCode><samlp:StatusMessage>All good</samlp:StatusMessage><samlp:StatusDetail/></samlp:Status>`;
+
+    const xml: string = sign(
+      buildResponse(buildAssertion(), { statusXml }),
+      "Assertion",
+    );
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
+
+  test("accepts a Response carrying <samlp:Extensions>", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), {
+        extensions: `<samlp:Extensions><vendor:Thing xmlns:vendor="https://vendor.example.com/ns">hello</vendor:Thing></samlp:Extensions>`,
+      }),
+      "Assertion",
+    );
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
+
   test("returns null name when no display-name claim is present", () => {
     const xml: string = sign(
       buildResponse(buildAssertion({ displayName: null })),
       "Assertion",
-      idpKeys.privateKey,
     );
 
     const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
@@ -197,7 +436,229 @@ describe("SSOUtil - genuine SAML flow (must not break)", () => {
 
 /*
  * ---------------------------------------------------------------------------
- * Attack path - signature wrapping and tampering must be rejected.
+ * Issue #2981 - a signed error Response must never become a login.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - signed error Response cannot smuggle an assertion (issue #2981)", () => {
+  /*
+   * The exact proof of concept from the report: a genuine signed error Response
+   * plus a decoy <Signature> that repeats the genuine <SignatureValue>. Both
+   * signature subtrees are stripped by the enveloped-signature transform, so
+   * the digest still matches while the decoy's <Object> carries a forged
+   * assertion that is the document's ONLY assertion.
+   */
+  test("rejects the reported PoC: decoy Signature repeating the genuine SignatureValue", () => {
+    const genuineSigned: string = genuineSignedErrorResponse();
+    const genuineSignature: string = extractSignature(genuineSigned);
+    const signatureValue: string = extractSignatureValue(genuineSignature);
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_assertion_forged",
+      email: "attacker@evil.com",
+    });
+
+    const decoy: string = `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignatureValue>${signatureValue}</SignatureValue><Object>${forgedAssertion}</Object></Signature>`;
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</samlp:Response>",
+      `${decoy}</samlp:Response>`,
+    );
+
+    expectRejected(attack);
+
+    // And under no circumstances may the attacker's identity come back.
+    let extracted: string = "";
+    try {
+      extracted = SSOUtil.getSamlResponseFromXML(
+        attack,
+        idpKeys.publicKey,
+      ).email.toString();
+    } catch {
+      extracted = "";
+    }
+    expect(extracted).not.toBe("attacker@evil.com");
+  });
+
+  /*
+   * The same idea without any decoy at all: append the forged assertion inside
+   * the GENUINE signature's own <Object>. The enveloped-signature transform
+   * removes that whole subtree from the digest, so the signature still
+   * validates - and there is exactly one <Signature> with a unique
+   * <SignatureValue>, so "no duplicate signature values" alone would not help.
+   */
+  test("rejects a forged assertion appended inside the genuine Signature's <Object>", () => {
+    const genuineSigned: string = genuineSignedErrorResponse();
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_assertion_forged",
+      email: "attacker@evil.com",
+    });
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</Signature>",
+      `<Object>${forgedAssertion}</Object></Signature>`,
+    );
+
+    expectRejected(
+      attack,
+      "SAML Assertion must be a direct child of the SAML Response",
+    );
+  });
+
+  test("rejects a forged assertion hidden inside the genuine Signature's <KeyInfo>", () => {
+    const genuineSigned: string = genuineSignedErrorResponse();
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_assertion_forged",
+      email: "attacker@evil.com",
+    });
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "<X509Data/>",
+      `<X509Data/>${forgedAssertion}`,
+    );
+
+    expectRejected(
+      attack,
+      "SAML Assertion must be a direct child of the SAML Response",
+    );
+  });
+
+  test("rejects a forged assertion simply appended to a signed error Response", () => {
+    const genuineSigned: string = genuineSignedErrorResponse();
+
+    const forgedAssertion: string = buildAssertion({
+      assertionId: "_assertion_forged",
+      email: "attacker@evil.com",
+    });
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</samlp:Response>",
+      `${forgedAssertion}</samlp:Response>`,
+    );
+
+    // Digest mismatch: the assertion is inside the signed payload this time.
+    expectRejected(attack);
+  });
+
+  test("rejects a decoy Signature bolted onto a genuine SUCCESS response", () => {
+    const genuineSigned: string = genuineResponseSignedResponse();
+    const genuineSignature: string = extractSignature(genuineSigned);
+    const signatureValue: string = extractSignatureValue(genuineSignature);
+
+    const decoy: string = `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignatureValue>${signatureValue}</SignatureValue><Object>anything</Object></Signature>`;
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</samlp:Response>",
+      `${decoy}</samlp:Response>`,
+    );
+
+    expectRejected(attack);
+  });
+
+  test.each([STATUS_REQUESTER, STATUS_RESPONDER, STATUS_AUTHN_FAILED])(
+    "rejects a genuinely signed assertion delivered with a non-Success status (%s)",
+    (statusCode: string) => {
+      const xml: string = sign(
+        buildResponse(buildAssertion(), { statusCode }),
+        "Assertion",
+      );
+
+      expectRejected(xml, "SAML Response was not successful");
+    },
+  );
+
+  test("rejects a Response with no <Status> element at all", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), { statusXml: "" }),
+      "Assertion",
+    );
+
+    expectRejected(xml, "Expected exactly one Status element in SAML Response");
+  });
+
+  test("rejects a Response carrying two <Status> elements", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), {
+        beforeStatus: buildStatus(STATUS_REQUESTER),
+      }),
+      "Assertion",
+    );
+
+    expectRejected(xml, "Expected exactly one Status element in SAML Response");
+  });
+
+  test("rejects a <Status> that is not a direct child of the Response", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), {
+        statusXml: `<samlp:Extensions>${buildStatus()}</samlp:Extensions>`,
+      }),
+      "Assertion",
+    );
+
+    expectRejected(
+      xml,
+      "SAML Status must be a direct child of the SAML Response",
+    );
+  });
+
+  test("rejects a <Status> with two top-level <StatusCode> children", () => {
+    const statusXml: string = `<samlp:Status><samlp:StatusCode Value="${STATUS_REQUESTER}"/><samlp:StatusCode Value="${STATUS_SUCCESS}"/></samlp:Status>`;
+
+    const xml: string = sign(
+      buildResponse(buildAssertion(), { statusXml }),
+      "Assertion",
+    );
+
+    expectRejected(
+      xml,
+      "Expected exactly one StatusCode element in SAML Status",
+    );
+  });
+
+  test("rejects a <Status> with no <StatusCode>", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), {
+        statusXml: `<samlp:Status><samlp:StatusMessage>nope</samlp:StatusMessage></samlp:Status>`,
+      }),
+      "Assertion",
+    );
+
+    expectRejected(
+      xml,
+      "Expected exactly one StatusCode element in SAML Status",
+    );
+  });
+
+  test("does not echo an unsafe status code back into the error message", () => {
+    const statusXml: string = `<samlp:Status><samlp:StatusCode Value="&lt;script&gt;alert(1)&lt;/script&gt;"/></samlp:Status>`;
+
+    const xml: string = sign(
+      buildResponse(buildAssertion(), { statusXml }),
+      "Assertion",
+    );
+
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow("SAML Response was not successful");
+
+    try {
+      SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    } catch (err) {
+      expect((err as Error).message).not.toContain("script");
+    }
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Issue #2949 - classic signature wrapping must stay rejected.
  * ---------------------------------------------------------------------------
  */
 
@@ -212,52 +673,63 @@ describe("SSOUtil - XML Signature Wrapping is rejected (issue #2949)", () => {
       displayName: "Attacker",
     });
 
-    const attack: string = buildResponse(
-      `<samlp:Extensions>${genuineAssertion}</samlp:Extensions>${forgedAssertion}`,
-    );
+    const attack: string = buildResponse(forgedAssertion, {
+      extensions: `<samlp:Extensions>${genuineAssertion}</samlp:Extensions>`,
+    });
 
-    // The signature over the hidden genuine assertion must NOT be accepted.
-    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
-
-    // And the identity must never be extracted (it must throw, not return attacker@evil.com).
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected(attack);
   });
 
   test("rejects a forged assertion that nests the genuine signed assertion inside it", () => {
     const genuineSigned: string = genuineAssertionSignedResponse();
     const genuineAssertion: string = extractAssertion(genuineSigned);
 
-    // Forged outer assertion whose Subject wraps the genuine signed assertion.
     const attack: string = buildResponse(
-      `<saml:Assertion ID="_assertion_forged" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer><saml:Subject><saml:NameID>attacker@evil.com</saml:NameID></saml:Subject>${genuineAssertion}</saml:Assertion>`,
+      buildAssertion({
+        assertionId: "_assertion_forged",
+        email: "attacker@evil.com",
+        extraInner: genuineAssertion,
+      }),
     );
 
-    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected(attack);
+  });
+
+  test("rejects a genuine signed assertion hidden inside a forged assertion's <Advice>", () => {
+    const genuineSigned: string = genuineAssertionSignedResponse();
+    const genuineAssertion: string = extractAssertion(genuineSigned);
+
+    const attack: string = buildResponse(
+      buildAssertion({
+        assertionId: "_assertion_forged",
+        email: "attacker@evil.com",
+        extraInner: `<saml:Advice>${genuineAssertion}</saml:Advice>`,
+      }),
+    );
+
+    expectRejected(attack, "Expected exactly one Assertion in SAML Response");
   });
 
   test("rejects a forged lone assertion with a valid signature over an unrelated element", () => {
     /*
-     * The attacker holds a genuine signature over a non-assertion element (a
-     * signed <Dummy>), and pairs it with a single forged assertion.
+     * The signature lives exactly where SAML allows it (a direct child of the
+     * Response) and validates cryptographically - but its Reference digests an
+     * unrelated <Dummy> element, not the assertion. Only the reference-coverage
+     * check stands between this document and an authentication bypass.
      */
-    const signedDummyDoc: string = sign(
-      buildResponse(
-        `<samlp:Extensions><Dummy ID="_dummy1">trusted-but-irrelevant</Dummy></samlp:Extensions><saml:Assertion ID="_placeholder" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer><saml:Subject><saml:NameID>alice@example.com</saml:NameID></saml:Subject></saml:Assertion>`,
-      ),
-      "Dummy",
-      idpKeys.privateKey,
+    const signedDummyDoc: string = signXml(
+      buildResponse(`<Dummy ID="_dummy1">trusted-but-irrelevant</Dummy>`),
+      {
+        referenceXPath: "//*[local-name(.)='Dummy']",
+        location: {
+          reference: "//*[local-name(.)='Response']",
+          action: "append",
+        },
+      },
     );
 
-    // Grab the genuinely signed <Dummy> element.
-    const dummyStart: number = signedDummyDoc.indexOf("<Dummy");
-    const dummyEnd: number =
-      signedDummyDoc.indexOf("</Dummy>") + "</Dummy>".length;
-    const signedDummy: string = signedDummyDoc.substring(dummyStart, dummyEnd);
+    const signedDummy: string = extractElement(signedDummyDoc, "Dummy");
+    const genuineSignature: string = extractSignature(signedDummyDoc);
 
     const forgedAssertion: string = buildAssertion({
       assertionId: "_assertion_forged",
@@ -265,21 +737,16 @@ describe("SSOUtil - XML Signature Wrapping is rejected (issue #2949)", () => {
     });
 
     const attack: string = buildResponse(
-      `<samlp:Extensions>${signedDummy}</samlp:Extensions>${forgedAssertion}`,
+      `${signedDummy}${forgedAssertion}${genuineSignature}`,
     );
 
-    // The signature over <Dummy> validates, but it does not cover the assertion.
-    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected(attack);
   });
 
   test("rejects two assertions sharing the same ID (issue PoC shape)", () => {
     const genuineSigned: string = sign(
       buildResponse(buildAssertion({ assertionId: "_dup" })),
       "Assertion",
-      idpKeys.privateKey,
     );
     const genuineAssertion: string = extractAssertion(genuineSigned);
 
@@ -288,29 +755,258 @@ describe("SSOUtil - XML Signature Wrapping is rejected (issue #2949)", () => {
       email: "attacker@evil.com",
     });
 
-    const attack: string = buildResponse(
-      `<samlp:Extensions>${genuineAssertion}</samlp:Extensions>${forgedAssertion}`,
+    const attack: string = buildResponse(forgedAssertion, {
+      extensions: `<samlp:Extensions>${genuineAssertion}</samlp:Extensions>`,
+    });
+
+    expectRejected(attack);
+  });
+
+  test("rejects a forged assertion whose ID collides with the signed Response ID", () => {
+    const genuineSigned: string = genuineResponseSignedResponse();
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      'ID="_assertion_genuine"',
+      'ID="_resp1"',
     );
 
-    expect(SSOUtil.isSignatureValid(attack, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(attack, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected(attack);
   });
 });
+
+/*
+ * ---------------------------------------------------------------------------
+ * Structural rules: where assertions and signatures may live.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - assertion placement rules", () => {
+  test("rejects an assertion that is not a direct child of the Response", () => {
+    const xml: string = sign(
+      buildResponse("", {
+        extensions: `<samlp:Extensions>${buildAssertion()}</samlp:Extensions>`,
+      }),
+      "Assertion",
+    );
+
+    expectRejected(
+      xml,
+      "SAML Assertion must be a direct child of the SAML Response",
+    );
+  });
+
+  test("rejects a document with two assertions", () => {
+    const xml: string = buildResponse(
+      `${buildAssertion()}${buildAssertion({ assertionId: "_second" })}`,
+    );
+
+    expectRejected(xml, "Expected exactly one Assertion in SAML Response");
+  });
+
+  test("rejects an assertion in an unexpected namespace", () => {
+    const xml: string = buildResponse(
+      `<Assertion xmlns="https://evil.example.com/ns" ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><Issuer>${ISSUER}</Issuer><Subject><NameID>attacker@evil.com</NameID></Subject></Assertion>`,
+    );
+
+    expectRejected(xml, "SAML Assertion has an invalid namespace");
+  });
+
+  test("rejects an <EncryptedAssertion> we cannot decrypt", () => {
+    const xml: string = buildResponse(
+      `<saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">ciphertext</xenc:EncryptedData></saml:EncryptedAssertion>${buildAssertion(
+        { email: "attacker@evil.com" },
+      )}`,
+    );
+
+    expectRejected(xml, "Encrypted SAML Responses are not supported");
+  });
+
+  test("rejects an <EncryptedID> inside the Subject", () => {
+    const xml: string = sign(
+      buildResponse(
+        buildAssertion({
+          extraInner: `<saml:EncryptedID>ciphertext</saml:EncryptedID>`,
+        }),
+      ),
+      "Assertion",
+    );
+
+    expectRejected(xml, "Encrypted SAML Responses are not supported");
+  });
+});
+
+describe("SSOUtil - signature placement rules", () => {
+  test("rejects a Signature that is not a direct child of the Response or Assertion", () => {
+    const genuineSigned: string = genuineAssertionSignedResponse();
+    const genuineSignature: string = extractSignature(genuineSigned);
+
+    const attack: string = buildResponse(buildAssertion(), {
+      extensions: `<samlp:Extensions>${genuineSignature}</samlp:Extensions>`,
+    });
+
+    expectRejected(
+      attack,
+      "must be a direct child of the Response or of the Assertion",
+    );
+  });
+
+  test("rejects two Signatures under the same Response", () => {
+    const genuineSigned: string = genuineResponseSignedResponse();
+    const genuineSignature: string = extractSignature(genuineSigned);
+
+    // Second signature carries a DIFFERENT value, so only the placement rule bites.
+    const otherSignature: string = replaceOnce(
+      genuineSignature,
+      /<SignatureValue>[\s\S]*?<\/SignatureValue>/,
+      "<SignatureValue>ZGlmZmVyZW50</SignatureValue>",
+    );
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</samlp:Response>",
+      `${otherSignature}</samlp:Response>`,
+    );
+
+    expectRejected(
+      attack,
+      "SAML Response must not contain more than one Signature",
+    );
+  });
+
+  test("rejects two Signatures under the same Assertion", () => {
+    const genuineSigned: string = genuineAssertionSignedResponse();
+    const genuineSignature: string = extractSignature(genuineSigned);
+
+    const otherSignature: string = replaceOnce(
+      genuineSignature,
+      /<SignatureValue>[\s\S]*?<\/SignatureValue>/,
+      "<SignatureValue>ZGlmZmVyZW50</SignatureValue>",
+    );
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</saml:Assertion>",
+      `${otherSignature}</saml:Assertion>`,
+    );
+
+    expectRejected(
+      attack,
+      "SAML Assertion must not contain more than one Signature",
+    );
+  });
+
+  test("rejects two Signatures sharing one SignatureValue", () => {
+    const genuineSigned: string = genuineResponseSignedResponse();
+    const genuineSignature: string = extractSignature(genuineSigned);
+    const signatureValue: string = extractSignatureValue(genuineSignature);
+
+    /*
+     * One under the Assertion, one under the Response - placement is fine,
+     * but they repeat the same SignatureValue.
+     */
+    const twin: string = `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignatureValue>${signatureValue}</SignatureValue></Signature>`;
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</saml:Assertion>",
+      `${twin}</saml:Assertion>`,
+    );
+
+    expectRejected(
+      attack,
+      "must not contain two Signatures with the same SignatureValue",
+    );
+  });
+
+  test("rejects a <ds:Object> inside a Signature even with harmless content", () => {
+    const genuineSigned: string = genuineResponseSignedResponse();
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "</Signature>",
+      "<Object>harmless</Object></Signature>",
+    );
+
+    expectRejected(attack, "Object elements are not allowed");
+  });
+
+  test("rejects SAML elements smuggled inside a Signature", () => {
+    const genuineSigned: string = genuineResponseSignedResponse();
+
+    const attack: string = replaceOnce(
+      genuineSigned,
+      "<X509Data/>",
+      `<X509Data/>${buildStatus(STATUS_REQUESTER)}`,
+    );
+
+    expectRejected(
+      attack,
+      "SAML elements are not allowed inside an XML Signature",
+    );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Root element rules.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - the document root must be a samlp:Response", () => {
+  test("rejects a bare signed <Assertion> as the document root", () => {
+    const signedResponse: string = genuineAssertionSignedResponse();
+    const bareAssertion: string = replaceOnce(
+      extractAssertion(signedResponse),
+      "<saml:Assertion ",
+      '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ',
+    );
+
+    expectRejected(bareAssertion, "must be a samlp:Response element");
+  });
+
+  test("rejects a Response in the wrong namespace", () => {
+    const xml: string = replaceOnce(
+      genuineAssertionSignedResponse(),
+      "urn:oasis:names:tc:SAML:2.0:protocol",
+      "urn:oasis:names:tc:SAML:1.0:protocol",
+    );
+
+    expectRejected(xml, "must be a samlp:Response element");
+  });
+
+  test("rejects a non-SAML root element wrapping a genuine Response", () => {
+    const genuineSigned: string = genuineAssertionSignedResponse();
+
+    const xml: string = `<Wrapper>${genuineSigned}</Wrapper>`;
+
+    expectRejected(xml, "must be a samlp:Response element");
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Tampering and forgery.
+ * ---------------------------------------------------------------------------
+ */
 
 describe("SSOUtil - signature tampering and forgery is rejected", () => {
   test("rejects a tampered NameID (digest mismatch)", () => {
     const genuine: string = genuineAssertionSignedResponse();
-    const tampered: string = genuine.replace(
+    const tampered: string = replaceOnce(
+      genuine,
       "alice@example.com",
       "attacker@evil.com",
     );
 
-    expect(SSOUtil.isSignatureValid(tampered, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(tampered, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected(tampered);
+  });
+
+  test("rejects a tampered display name (digest mismatch)", () => {
+    const genuine: string = genuineAssertionSignedResponse();
+    const tampered: string = replaceOnce(genuine, "Alice Example", "Attacker");
+
+    expectRejected(tampered);
   });
 
   test("rejects a response signed by a different (attacker) key", () => {
@@ -320,22 +1016,41 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
       attackerKeys.privateKey,
     );
 
-    // Verified against the genuine IdP certificate -> must fail.
-    expect(SSOUtil.isSignatureValid(attackerSigned, idpKeys.publicKey)).toBe(
-      false,
+    expectRejected(attackerSigned);
+  });
+
+  test("rejects a response where the attacker re-signed a forged assertion but kept the genuine Response signature", () => {
+    const genuineResponseSigned: string = genuineResponseSignedResponse();
+    const genuineSignature: string = extractSignature(genuineResponseSigned);
+
+    const attackerSignedAssertion: string = extractAssertion(
+      sign(
+        buildResponse(buildAssertion({ email: "attacker@evil.com" })),
+        "Assertion",
+        attackerKeys.privateKey,
+      ),
     );
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(attackerSigned, idpKeys.publicKey);
-    }).toThrow();
+
+    const attack: string = buildResponse(
+      `${attackerSignedAssertion}${genuineSignature}`,
+    );
+
+    expectRejected(attack);
   });
 
   test("rejects an unsigned response", () => {
-    const unsigned: string = buildResponse(buildAssertion());
+    expectRejected(buildResponse(buildAssertion()));
+  });
 
-    expect(SSOUtil.isSignatureValid(unsigned, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(unsigned, idpKeys.publicKey);
-    }).toThrow();
+  test("rejects a stripped signature (SignatureValue emptied)", () => {
+    const genuine: string = genuineAssertionSignedResponse();
+    const stripped: string = replaceOnce(
+      genuine,
+      /<SignatureValue>[\s\S]*?<\/SignatureValue>/,
+      "<SignatureValue></SignatureValue>",
+    );
+
+    expectRejected(stripped);
   });
 
   test("rejects a NameID containing an XML comment (comment-truncation defense)", () => {
@@ -348,7 +1063,6 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
         buildAssertion({ nameId: "admin@corp.com<!-- -->.attacker.com" }),
       ),
       "Assertion",
-      idpKeys.privateKey,
     );
 
     expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
@@ -356,7 +1070,39 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
       return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
     }).toThrow("SAML Assertion must not contain XML comments");
   });
+
+  test("rejects an Issuer containing an XML comment", () => {
+    const xml: string = sign(
+      buildResponse(
+        buildAssertion({
+          issuer: "https://idp.example.com<!-- -->.attacker.com/metadata",
+        }),
+      ),
+      "Assertion",
+    );
+
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow("SAML Assertion must not contain XML comments");
+  });
+
+  test("rejects a display name containing an XML comment", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion({ displayName: "Alice<!-- -->Attacker" })),
+      "Assertion",
+    );
+
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow("SAML Assertion must not contain XML comments");
+  });
 });
+
+/*
+ * ---------------------------------------------------------------------------
+ * Malformed and abusive input.
+ * ---------------------------------------------------------------------------
+ */
 
 describe("SSOUtil - malformed and abusive input is rejected", () => {
   test("rejects a DOCTYPE / entity declaration (XXE guard)", () => {
@@ -364,39 +1110,73 @@ describe("SSOUtil - malformed and abusive input is rejected", () => {
       `<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe "bar">]>` +
       genuineAssertionSignedResponse();
 
-    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected(
+      xml,
+      "SAML Response must not contain a DOCTYPE or entity declarations",
+    );
   });
 
   test("rejects malformed XML", () => {
-    const xml: string = "<samlp:Response><saml:Assertion></samlp:Response>";
-
-    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
-    }).toThrow();
+    expectRejected("<samlp:Response><saml:Assertion></samlp:Response>");
   });
 
   test("rejects an empty SAML response", () => {
     expect(SSOUtil.isSignatureValid("", idpKeys.publicKey)).toBe(false);
     expect(() => {
       return SSOUtil.getSamlResponseFromXML("", idpKeys.publicKey);
-    }).toThrow();
+    }).toThrow("SAML Response is empty");
   });
 
-  test("rejects a response with no assertion", () => {
+  test("rejects a whitespace-only SAML response", () => {
+    expect(SSOUtil.isSignatureValid("   \n  ", idpKeys.publicKey)).toBe(false);
+  });
+
+  test("rejects a signed Response with no assertion at all", () => {
+    expectRejected(genuineSignedErrorResponse(), "SAML Assertion not found");
+  });
+
+  test("rejects a signed success Response with no assertion", () => {
+    expectRejected(
+      sign(buildResponse(""), "Response"),
+      "SAML Assertion not found",
+    );
+  });
+
+  test("rejects an assertion with no Subject/NameID", () => {
     const xml: string = sign(
-      `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_r" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer></samlp:Response>`,
-      "Response",
-      idpKeys.privateKey,
+      buildResponse(
+        `<saml:Assertion ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer></saml:Assertion>`,
+      ),
+      "Assertion",
     );
 
-    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
     expect(() => {
       return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
-    }).toThrow();
+    }).toThrow("SAML Subject not found");
+  });
+
+  test("rejects an assertion with an empty NameID", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion({ nameId: "" })),
+      "Assertion",
+    );
+
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow("SAML Email not found");
+  });
+
+  test("rejects an assertion with no Issuer", () => {
+    const xml: string = sign(
+      buildResponse(
+        `<saml:Assertion ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Subject><saml:NameID>alice@example.com</saml:NameID></saml:Subject></saml:Assertion>`,
+      ),
+      "Assertion",
+    );
+
+    expect(() => {
+      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+    }).toThrow("Issuer not found in SAML Assertion");
   });
 
   test("rejects when the certificate is missing", () => {
@@ -407,7 +1187,19 @@ describe("SSOUtil - malformed and abusive input is rejected", () => {
       return SSOUtil.getSamlResponseFromXML(xml, "");
     }).toThrow("Public Certificate not found");
   });
+
+  test("rejects a response verified against a different certificate", () => {
+    const xml: string = genuineAssertionSignedResponse();
+
+    expect(SSOUtil.isSignatureValid(xml, attackerKeys.publicKey)).toBe(false);
+  });
 });
+
+/*
+ * ---------------------------------------------------------------------------
+ * Request generation.
+ * ---------------------------------------------------------------------------
+ */
 
 describe("SSOUtil - createSAMLRequestUrl", () => {
   test("produces a SAMLRequest query parameter", () => {


### PR DESCRIPTION
Fixes #2981.

## The report is correct — reproduced end to end

I built the PoC from the issue against `master` before changing anything. `SSOUtil.isSignatureValid()` returned `true` and `getSamlResponseFromXML()` returned `attacker@evil.com`, using nothing but a genuine IdP-signed **error** response.

## Why it worked

The XML-DSig enveloped-signature transform removes the whole `<Signature>` subtree before the digest is computed. Anything parked inside a `<Signature>` is therefore **unauthenticated by construction**, even though the signature validates.

Two facts combine into a full auth bypass:

1. Per [SAML 2.0 Profiles §4.1.4.2](https://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf), an IdP returning an error "MUST NOT include any assertions in the `<Response>` message". So a signed error response is a genuine signature over a document with **zero** assertions — exactly the raw material an attacker needs. Keycloak, PingFederate and ADFS all emit these.
2. The `#2949` fix asserted "exactly one `<Assertion>` in the document". Park a forged assertion inside a `<Signature>` and it becomes the document's *one and only* assertion. The check passes; the reference (`#_resp`) resolves to the `Response`, which is an ancestor of the forged assertion, so the old coverage check passed too.

`xml-crypto` (3.2.1, current) widens it further. Its enveloped-signature transform removes **every** `<Signature>` whose `<SignatureValue>` text matches the one being verified, rather than only the one containing the transform:

```js
// node_modules/xml-crypto/lib/enveloped-signature.js
if (expectedSignatureValue === signatureValue) {
  nodeSignature.parentNode.removeChild(nodeSignature);
}
```

That is what makes the decoy signature in the report work — it just repeats the genuine `<SignatureValue>` and the whole decoy subtree, forged assertion included, vanishes from the digest.

Worth noting: the decoy is not even required. Appending `<Object><saml:Assertion>…</saml:Assertion></Object>` to the **genuine** signature has the same effect, with one signature and a unique `SignatureValue`. Both variants are covered by tests.

## The fix

Rather than chase individual wrapping tricks, `App/FeatureSet/Identity/Utils/SSO.ts` now pins the document to the shape SAML 2.0 actually defines, so the element we read cannot live anywhere except inside the signed payload. Each rule below is a schema requirement, not an attack-specific patch:

| Rule | Basis |
|---|---|
| Root must be `samlp:Response` (SAML 2.0 protocol NS) | anchors every "direct child of" rule below |
| Encrypted elements rejected outright | we cannot decrypt them; reading around them means reading unauthenticated data |
| The single `<Assertion>` must be a **direct child** of the Response | Core `ResponseType` — removes every hiding place, including `<ds:Object>` |
| Every `<ds:Signature>` must be a direct child of the Response or the Assertion, max one each | Core `StatusResponseType` / `AssertionType` |
| No two signatures may share a `<SignatureValue>` | closes the decoy-signature stripping trick |
| No signature may carry a `<ds:Object>` or SAML content | a signature's own subtree is never in its digest |
| A verified reference must resolve to exactly one element that is the Assertion or the root Response | was previously *any* ancestor |
| References read back **after** `checkSignature()` | the ones from `loadSignature()` are still unauthenticated |
| Top-level `<Status>` must be `…:status:Success` | Profiles §4.1.4.3; an error status can never legitimately accompany an assertion |

## Tests

`App/Tests/Identity/SSO.test.ts` — 65 cases, all passing:

- **Genuine flows still work**: assertion-signed, response-signed, both-signed, `Reference URI=""`, signature placed after `<Issuer>` (real IdP layout), `<samlp:Extensions>`, second-level `StatusCode`/`StatusMessage`/`StatusDetail`, base64 round-trip.
- **#2981**: the reported PoC verbatim; forged assertion inside the genuine signature's `<Object>`; inside its `<KeyInfo>`; decoy bolted onto a success response; every non-Success status; missing/duplicated/misplaced/malformed `Status`.
- **#2949 regression**: assertion hidden in `<Extensions>`, nested inside a forged assertion, hidden in `<Advice>`, duplicate assertion IDs, ID collision with the signed Response, and a valid signature over an unrelated element.
- **Structure**: assertion/signature placement, `EncryptedAssertion`/`EncryptedID`, wrong namespaces, non-`samlp:Response` roots.
- **Tampering**: modified NameID and display name, attacker-key signatures, unsigned, stripped `SignatureValue`, comment truncation in NameID / Issuer / display name.

Attack documents are built by surgery on genuine signed ones, so a `replaceOnce()` helper throws if a search string ever stops matching — otherwise an "attack" silently degrades into a copy of the genuine document and the test passes for the wrong reason. That actually caught two vacuous tests during development (xmldom re-serializes `<X509Data></X509Data>` as `<X509Data/>`).

## Verification

- `npx jest Tests/Identity/SSO.test.ts` — 65/65 pass; the PoC fails on `master` and is rejected here.
- `npx tsc --noEmit` in `App` — clean.
- `npx eslint` on all changed files — clean.

## Known gaps, deliberately out of scope

Flagging these rather than silently widening the PR — happy to open follow-ups:

- **No `Conditions` validation.** `NotBefore` / `NotOnOrAfter` / `AudienceRestriction` are not checked, so a captured assertion stays valid indefinitely and an assertion minted for a different SP would be accepted. Profiles §4.1.4.3 requires these.
- **No replay protection.** Profiles §4.1.4.5 requires the SP to track used assertion `ID`s.
- **`xml-crypto` is on 3.x.** v6 fixes the enveloped-signature transform and exposes `getSignedReferences()`, which would let us assert directly against the bytes that were signed. The fix here is deliberately independent of library internals, so it holds either way, but the upgrade is worth doing.

Thanks to the reporter for the clear write-up — the decoy-signature detail is what made this quick to reproduce.
