### PR TITLE
fix(sso): block SAML value rewriting via XML processing instructions (#2988)

### DIFF
--- a/App/FeatureSet/Identity/Utils/SSO.ts
+++ b/App/FeatureSet/Identity/Utils/SSO.ts
@@ -4,7 +4,7 @@ import Email from "Common/Types/Email";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import Text from "Common/Types/Text";
 import logger from "Common/Server/Utils/Logger";
-import xmlCrypto, { FileKeyInfo } from "xml-crypto";
+import { Reference, SignedXml } from "xml-crypto";
 import {
   DOMParser,
   Document as XmlDocument,
@@ -159,6 +159,16 @@ export default class SSOUtil {
    *      comments (blocks the SAML comment-truncation class of attacks), no
    *      processing instructions, no child elements. Whatever we read is then
    *      exactly the character data the canonicalizer digested.
+   *   9. The identity itself is read from the CANONICAL BYTES the signature was
+   *      verified over (xml-crypto's `signedReference`), not from a second
+   *      independent parse of the original document. Rules 1-8 establish that
+   *      there is exactly one assertion, in the one position SAML allows, under
+   *      a signature that covers it; rule 9 decides where the characters come
+   *      from. That is what makes a disagreement between our parse and
+   *      xml-crypto's canonicalizer stop being an authentication bug: the
+   *      processing-instruction trick of #2988 is one instance of that
+   *      disagreement, and xml-crypto still renders any node carrying a `data`
+   *      property as plain text in 6.x.
    *
    * Throws BadRequestException on any anomaly.
    */
@@ -203,8 +213,9 @@ export default class SSOUtil {
   }
 
   /*
-   * The single verification pipeline. Returns the one assertion that the
-   * signature provably covers, or throws.
+   * The single verification pipeline. Returns the assertion that the signature
+   * provably covers - parsed out of the canonical bytes the signature was
+   * actually verified over - or throws.
    */
   private static verifyAndGetAssertion(
     samlResponse: string,
@@ -223,15 +234,17 @@ export default class SSOUtil {
 
     SSOUtil.assertSignaturesAreWellPlaced(dom, response, assertion);
 
-    if (
-      !SSOUtil.verifyAssertionSignature(
-        samlResponse,
-        certificate,
-        dom,
-        response,
-        assertion,
-      )
-    ) {
+    SSOUtil.assertIdentityValuesArePlainText(assertion);
+
+    const signedReferenceXml: string | null = SSOUtil.verifyAssertionSignature(
+      samlResponse,
+      certificate,
+      dom,
+      response,
+      assertion,
+    );
+
+    if (signedReferenceXml === null) {
       throw new BadRequestException(
         "Signature is not valid or Public Certificate configured with this SSO provider is not valid",
       );
@@ -239,7 +252,7 @@ export default class SSOUtil {
 
     SSOUtil.assertStatusIsSuccess(dom, response);
 
-    return assertion;
+    return SSOUtil.getAssertionFromSignedBytes(signedReferenceXml, assertion);
   }
 
   /*
@@ -554,11 +567,14 @@ export default class SSOUtil {
    *   - has a verified reference that resolves to exactly one element, and that
    *     element is the Assertion itself or the root <Response>.
    *
-   * The references are read back AFTER checkSignature() because xml-crypto
-   * rebuilds them from the canonicalized <SignedInfo> it just verified - the
-   * ones parsed by loadSignature() are still unauthenticated at that point.
+   * Returns the CANONICAL BYTES of that reference - the exact string xml-crypto
+   * digested and the signature was verified over - or null.
    *
-   * Only if BOTH hold do we consider the assertion authentic.
+   * The references are read back AFTER checkSignature() because xml-crypto
+   * rebuilds them from the canonicalized <SignedInfo> it just verified; the
+   * ones parsed by loadSignature() are still unauthenticated at that point. For
+   * the same reason `signedReference` is only populated once every digest AND
+   * the signature value have checked out - xml-crypto clears it otherwise.
    */
   private static verifyAssertionSignature(
     samlResponse: string,
@@ -566,27 +582,41 @@ export default class SSOUtil {
     dom: XmlDocument,
     response: XmlElement,
     assertion: XmlElement,
-  ): boolean {
+  ): string | null {
     const signatures: Array<XmlElement> = SSOUtil.toElementArray(
       dom.getElementsByTagNameNS(SSOUtil.XMLDSIG_NAMESPACE, "Signature"),
     );
 
     if (signatures.length === 0) {
-      return false;
+      return null;
     }
 
     for (const signature of signatures) {
       try {
-        const sig: xmlCrypto.SignedXml = new xmlCrypto.SignedXml();
+        const sig: SignedXml = new SignedXml({
+          publicCert: certificate,
 
-        sig.keyInfoProvider = {
-          getKeyInfo: function (_key: unknown): string {
-            return `<X509Data><X509Certificate>${certificate}</X509Certificate></X509Data>`;
+          /*
+           * Pin the verification key to the certificate configured on this SSO
+           * provider.
+           *
+           * xml-crypto resolves its key as
+           *   getCertFromKeyInfo(keyInfo) || publicCert || privateKey
+           * where `keyInfo` is the <KeyInfo> carried INSIDE the document being
+           * verified - i.e. supplied by whoever sent it. xml-crypto ships
+           * SignedXml.getCertFromKeyInfo, which reads the certificate straight
+           * out of that element; enabling it would mean accepting a response
+           * signed by any key whose certificate the sender chose to staple on.
+           *
+           * The constructor currently defaults this to a no-op, so we are not
+           * fixing a live bug here. But that is a library default silently
+           * deciding an authentication question, so say it explicitly rather
+           * than inherit it.
+           */
+          getCertFromKeyInfo: (): null => {
+            return null;
           },
-          getKey: function (): string {
-            return certificate;
-          } as unknown as () => Buffer,
-        } as FileKeyInfo;
+        });
 
         sig.loadSignature(signature.toString());
 
@@ -600,22 +630,24 @@ export default class SSOUtil {
          * assertion we are going to read from - a signature over some unrelated
          * element must never authenticate a forged assertion.
          */
-        const references: Array<{ uri?: string | undefined }> =
-          (sig.references as Array<{ uri?: string | undefined }>) || [];
-
-        const coversAssertion: boolean = references.some(
-          (reference: { uri?: string | undefined }): boolean => {
-            return SSOUtil.referenceCoversAssertion(
+        for (const reference of sig.getReferences()) {
+          if (
+            !SSOUtil.referenceCoversAssertion(
               dom,
               response,
               assertion,
               reference.uri,
-            );
-          },
-        );
+            )
+          ) {
+            continue;
+          }
 
-        if (coversAssertion) {
-          return true;
+          const signedReferenceXml: string | undefined =
+            SSOUtil.getSignedReferenceXml(reference);
+
+          if (signedReferenceXml) {
+            return signedReferenceXml;
+          }
         }
       } catch (err) {
         logger.error(err);
@@ -623,7 +655,187 @@ export default class SSOUtil {
       }
     }
 
-    return false;
+    return null;
+  }
+
+  /*
+   * The canonical bytes xml-crypto digested for this reference, or undefined.
+   *
+   * xml-crypto populates `signedReference` only after every reference digest
+   * and the signature value have been verified, and clears it on any failure,
+   * so a non-empty value here is exactly "the bytes this signature vouches
+   * for".
+   */
+  private static getSignedReferenceXml(
+    reference: Reference,
+  ): string | undefined {
+    const signedReferenceXml: string | undefined = reference.signedReference;
+
+    if (typeof signedReferenceXml !== "string" || signedReferenceXml === "") {
+      return undefined;
+    }
+
+    return signedReferenceXml;
+  }
+
+  /*
+   * Re-read the assertion out of the canonical bytes that were signed.
+   *
+   * This is the structural answer to issue #2988 rather than a patch for one
+   * instance of it. Reading identity from a second, independent parse of the
+   * ORIGINAL document means every disagreement between that parse and
+   * xml-crypto's canonicalizer becomes an authentication bug - the processing
+   * instruction trick being one example, and xml-crypto's canonicalizer still
+   * renders any node with a `data` property as plain text in 6.x. Reading it
+   * from the canonical bytes instead means the string we act on is by
+   * construction the string that was digested and signed.
+   *
+   * The document-level rules still run on the original document: they are what
+   * establish that there is exactly one assertion, in the one position SAML
+   * allows, under a signature that covers it. This step only decides WHERE the
+   * characters come from.
+   *
+   * `expected` is the assertion located in the original document; the canonical
+   * copy must be the same assertion, not a different one that happened to be
+   * inside the signed subtree.
+   */
+  private static getAssertionFromSignedBytes(
+    signedReferenceXml: string,
+    expected: XmlElement,
+  ): XmlElement {
+    const signedDom: XmlDocument = SSOUtil.parseXmlStrict(signedReferenceXml);
+
+    /*
+     * A reference covers either the Assertion itself or the whole Response, so
+     * the canonical bytes are rooted at one or the other. Either way there must
+     * be exactly one assertion in them.
+     */
+    const assertions: Array<XmlElement> = SSOUtil.toElementArray(
+      signedDom.getElementsByTagNameNS("*", "Assertion"),
+    );
+
+    if (assertions.length !== 1) {
+      throw new BadRequestException(
+        "Expected exactly one Assertion in the signed SAML content",
+      );
+    }
+
+    const assertion: XmlElement = assertions[0]!;
+
+    if (
+      !SSOUtil.SAML_ASSERTION_NAMESPACES.includes(assertion.namespaceURI || "")
+    ) {
+      throw new BadRequestException("SAML Assertion has an invalid namespace");
+    }
+
+    /*
+     * When the signature covers the Response, the assertion must still sit
+     * directly under it - the same rule the original document had to satisfy.
+     */
+    const signedRoot: XmlElement | null = signedDom.documentElement;
+
+    if (assertion !== signedRoot && assertion.parentNode !== signedRoot) {
+      throw new BadRequestException(
+        "SAML Assertion must be a direct child of the SAML Response",
+      );
+    }
+
+    /*
+     * Pin the canonical assertion to the one the document-level checks were
+     * made about. Without this, a signature covering a Response that contained
+     * some other assertion could hand us an identity those checks never saw.
+     */
+    const expectedId: string = SSOUtil.getIdAttribute(expected);
+    const signedId: string = SSOUtil.getIdAttribute(assertion);
+
+    if (expectedId !== signedId) {
+      throw new BadRequestException(
+        "The signed SAML Assertion is not the Assertion in the SAML Response",
+      );
+    }
+
+    return assertion;
+  }
+
+  /*
+   * Apply the plain-text rule to the identity values in the ORIGINAL document,
+   * not only to the signed copy we read from.
+   *
+   * Since identity now comes from the canonical signed bytes, markup in the
+   * original can no longer change what we act on: exclusive canonicalization
+   * has already dropped comments and collapsed processing instructions into
+   * text by the time we read. We refuse the document anyway. No identity
+   * provider puts markup inside a NameID; every instance of it in the wild has
+   * been an attempt to make two readers of the same document disagree, and
+   * failing closed keeps the guarantee even if the extraction point moves
+   * again.
+   *
+   * Only the values we actually consume are checked, so this adds no rejection
+   * surface beyond what getIssuerFromAssertion / getEmailFromAssertion /
+   * getNameFromAssertion already read.
+   */
+  private static assertIdentityValuesArePlainText(assertion: XmlElement): void {
+    const issuer: XmlElement | null = SSOUtil.getDirectChildByLocalName(
+      assertion,
+      "Issuer",
+    );
+
+    if (issuer) {
+      SSOUtil.assertPlainTextOnly(issuer);
+    }
+
+    const subject: XmlElement | null = SSOUtil.getDirectChildByLocalName(
+      assertion,
+      "Subject",
+    );
+
+    if (subject) {
+      const nameId: XmlElement | null = SSOUtil.getDirectChildByLocalName(
+        subject,
+        "NameID",
+      );
+
+      if (nameId) {
+        SSOUtil.assertPlainTextOnly(nameId);
+      }
+    }
+
+    const attributeStatement: XmlElement | null =
+      SSOUtil.getDirectChildByLocalName(assertion, "AttributeStatement");
+
+    if (!attributeStatement) {
+      return;
+    }
+
+    const attributes: Array<XmlElement> = SSOUtil.toElementArray(
+      attributeStatement.getElementsByTagNameNS("*", "Attribute"),
+    );
+
+    for (const attribute of attributes) {
+      if (attribute.getAttribute("Name") !== SSOUtil.MS_DISPLAY_NAME_CLAIM) {
+        continue;
+      }
+
+      const attributeValue: XmlElement | null =
+        SSOUtil.getDirectChildByLocalName(attribute, "AttributeValue");
+
+      if (attributeValue) {
+        SSOUtil.assertPlainTextOnly(attributeValue);
+      }
+    }
+  }
+
+  // The value of this element's ID / Id / id attribute, or "".
+  private static getIdAttribute(element: XmlElement): string {
+    for (const localName of SSOUtil.ID_ATTRIBUTE_LOCAL_NAMES) {
+      const value: string | null = element.getAttribute(localName);
+
+      if (value) {
+        return value;
+      }
+    }
+
+    return "";
   }
 
   /*

--- a/App/FeatureSet/Identity/Utils/SSO.ts
+++ b/App/FeatureSet/Identity/Utils/SSO.ts
@@ -56,6 +56,16 @@ export default class SSOUtil {
   private static readonly MS_DISPLAY_NAME_CLAIM: string =
     "http://schemas.microsoft.com/identity/claims/displayname";
 
+  /*
+   * DOM node types we test for. xmldom exposes these as Node constants, but
+   * spelling them out keeps the checks readable next to the nodeType they
+   * compare against.
+   */
+  private static readonly ELEMENT_NODE: number = 1;
+  private static readonly PROCESSING_INSTRUCTION_NODE: number = 7;
+  private static readonly COMMENT_NODE: number = 8;
+  private static readonly DOCUMENT_NODE: number = 9;
+
   public static createSAMLRequestUrl(data: {
     acsUrl: URL;
     signOnUrl: URL;
@@ -87,7 +97,7 @@ export default class SSOUtil {
    * where a genuinely signed element and the element we actually read are not
    * the same element.
    *
-   * Two reported bypasses shaped this code:
+   * Three reported bypasses shaped this code:
    *
    *   - GitHub issue #2949: the original implementation validated whichever
    *     <Signature> appeared first and then extracted the identity from an
@@ -107,12 +117,25 @@ export default class SSOUtil {
    *     so a decoy <Signature> that merely repeats the genuine
    *     <SignatureValue> is removed from the digest too.
    *
+   *   - GitHub issue #2988: even a signature that provably covers the element
+   *     we read is not enough if the bytes that were digested and the bytes we
+   *     read are not the same bytes. xml-crypto canonicalizes every node that
+   *     exposes a `data` property by emitting that data as plain text, so a
+   *     processing instruction `<?p not-an-?>` is digested as the characters
+   *     `not-an-` rather than as `<?p not-an-?>`. The DOM, correctly, leaves
+   *     processing instructions out of `textContent` entirely. So
+   *     `<NameID><?p not-an-?>admin@example.com</NameID>` digests exactly like
+   *     the genuine `<NameID>not-an-admin@example.com</NameID>` while we read
+   *     it as `admin@example.com`.
+   *
    * The defence is to stop reasoning about "is this signed?" in isolation and
    * instead pin the document to the shape SAML actually defines, so that the
    * element we read cannot be anywhere except inside the signed payload:
    *
    *   1. Well-formed XML with no DOCTYPE / entity declarations (blocks XXE,
-   *      entity expansion and parser-differential tricks).
+   *      entity expansion and parser-differential tricks) and no processing
+   *      instructions anywhere in the document apart from the XML declaration
+   *      (blocks the canonicalization/`textContent` desynchronization above).
    *   2. The root MUST be <samlp:Response> (SAML 2.0 protocol namespace).
    *   3. No encrypted elements - we cannot decrypt them, and silently reading
    *      around them would mean reading unauthenticated data.
@@ -132,8 +155,10 @@ export default class SSOUtil {
    *      an identity provider returning an error "MUST NOT include any
    *      assertions in the <Response> message", so an assertion delivered
    *      alongside an error status is by definition not one the IdP issued.
-   *   8. The identity-bearing nodes must not contain XML comments (blocks the
-   *      SAML comment-truncation class of attacks).
+   *   8. The identity-bearing nodes must hold plain text and nothing else - no
+   *      comments (blocks the SAML comment-truncation class of attacks), no
+   *      processing instructions, no child elements. Whatever we read is then
+   *      exactly the character data the canonicalizer digested.
    *
    * Throws BadRequestException on any anomaly.
    */
@@ -156,14 +181,20 @@ export default class SSOUtil {
   /*
    * Boolean form of the verification above. Kept for callers/tests that only
    * need to know whether the response carries a valid, wrapping-safe signature.
-   * Uses exactly the same strict pipeline as getSamlResponseFromXML.
+   *
+   * It runs getSamlResponseFromXML itself rather than a subset of it. Anything
+   * less would let this return true for a document the real entry point
+   * refuses - the rules that reject a NameID containing a comment, a processing
+   * instruction or a child element live in the extraction step, and a caller
+   * gating on "is this SAML response valid?" must not be told yes about a
+   * document whose identity we would then refuse to read.
    */
   public static isSignatureValid(
     samlResponse: string,
     certificate: string,
   ): boolean {
     try {
-      SSOUtil.verifyAndGetAssertion(samlResponse, certificate);
+      SSOUtil.getSamlResponseFromXML(samlResponse, certificate);
       return true;
     } catch (err) {
       logger.error(err);
@@ -251,7 +282,63 @@ export default class SSOUtil {
       throw new BadRequestException("SAML Response is not valid XML");
     }
 
+    SSOUtil.assertNoProcessingInstructions(dom);
+
     return dom;
+  }
+
+  /*
+   * Reject XML processing instructions (issue #2988).
+   *
+   * xml-crypto's canonicalizer emits any node that exposes a `data` property as
+   * plain text, so a processing instruction is digested as its data rather than
+   * as `<?target data?>`. The DOM, per spec, omits processing instructions from
+   * `textContent` entirely. The digest and the value we read therefore describe
+   * different strings, and an attacker can wrap any leading part of a signed
+   * value in a processing instruction to delete it from what we read while the
+   * digest stays byte-for-byte identical:
+   *
+   *   <saml:NameID>not-an-admin@example.com</saml:NameID>       (signed)
+   *   <saml:NameID><?p not-an-?>admin@example.com</saml:NameID> (forged)
+   *
+   * Both digest as "not-an-admin@example.com"; the second reads as
+   * "admin@example.com".
+   *
+   * A SAML Response has no legitimate use for a processing instruction, so we
+   * reject every one of them rather than trying to reason about which ones land
+   * somewhere harmless. The XML declaration is the sole exception: xmldom
+   * surfaces it as a processing instruction node with target "xml" parented on
+   * the Document (never inside the document element), it is not part of any
+   * canonicalized subtree, and real identity providers emit it.
+   */
+  private static assertNoProcessingInstructions(dom: XmlDocument): void {
+    const stack: Array<XmlNode> = [dom as unknown as XmlNode];
+
+    while (stack.length > 0) {
+      const node: XmlNode = stack.pop()!;
+
+      for (
+        let child: XmlNode | null = node.firstChild;
+        child;
+        child = child.nextSibling
+      ) {
+        if (child.nodeType === SSOUtil.PROCESSING_INSTRUCTION_NODE) {
+          const parentNodeType: number | undefined = child.parentNode?.nodeType;
+
+          const isXmlDeclaration: boolean =
+            parentNodeType === SSOUtil.DOCUMENT_NODE &&
+            (child as unknown as { target?: string }).target === "xml";
+
+          if (!isXmlDeclaration) {
+            throw new BadRequestException(
+              "SAML Response must not contain XML processing instructions",
+            );
+          }
+        }
+
+        stack.push(child);
+      }
+    }
   }
 
   /*
@@ -702,7 +789,7 @@ export default class SSOUtil {
       throw new BadRequestException("Issuer not found in SAML Assertion");
     }
 
-    SSOUtil.assertNoComments(issuerElement);
+    SSOUtil.assertPlainTextOnly(issuerElement);
 
     const issuerUrl: string = SSOUtil.getTrimmedText(issuerElement);
 
@@ -733,13 +820,10 @@ export default class SSOUtil {
     }
 
     /*
-     * Reject comments inside the NameID. Exclusive canonicalization strips
-     * comments before hashing, so a naive extractor that stopped at a comment
-     * could read a different value than the one that was signed
-     * (e.g. "victim@corp.com<!---->.attacker.com"). We read the full text and
-     * additionally refuse any comment here.
+     * The NameID is the identity itself, so it is the value an attacker most
+     * wants to desynchronize from the digest. See assertPlainTextOnly.
      */
-    SSOUtil.assertNoComments(nameId);
+    SSOUtil.assertPlainTextOnly(nameId);
 
     const emailString: string = SSOUtil.getTrimmedText(nameId);
 
@@ -770,7 +854,7 @@ export default class SSOUtil {
           SSOUtil.getDirectChildByLocalName(attribute, "AttributeValue");
 
         if (attributeValue) {
-          SSOUtil.assertNoComments(attributeValue);
+          SSOUtil.assertPlainTextOnly(attributeValue);
           const fullName: string = SSOUtil.getTrimmedText(attributeValue);
           if (fullName) {
             return new Name(fullName);
@@ -817,25 +901,49 @@ export default class SSOUtil {
     return (element.textContent || "").trim();
   }
 
-  // Throw if the element subtree contains any XML comment node.
-  private static assertNoComments(element: XmlElement): void {
-    const stack: Array<XmlNode> = [element];
+  /*
+   * An identity-bearing element must hold character data and nothing else.
+   *
+   * This keeps the string we read identical to the string the canonicalizer
+   * digested. Three node kinds would break that equality:
+   *
+   *   - Comments. Exclusive canonicalization strips them before hashing, so an
+   *     extractor that stopped at one could read a different value than was
+   *     signed (e.g. "victim@corp.com<!---->.attacker.com").
+   *
+   *   - Processing instructions. xml-crypto digests their data as plain text
+   *     while the DOM leaves them out of `textContent` (issue #2988). The
+   *     parser already refuses these across the whole document; refusing them
+   *     here too keeps the guarantee attached to the values we consume rather
+   *     than to a check somewhere upstream.
+   *
+   *   - Child elements. `textContent` flattens their markup away while
+   *     canonicalization digests it, so the two views of the value diverge.
+   *     No SAML element we read from is allowed mixed content anyway: NameID
+   *     and Issuer are both NameIDType, whose content model is a plain string.
+   */
+  private static assertPlainTextOnly(element: XmlElement): void {
+    for (
+      let child: XmlNode | null = element.firstChild;
+      child;
+      child = child.nextSibling
+    ) {
+      if (child.nodeType === SSOUtil.COMMENT_NODE) {
+        throw new BadRequestException(
+          "SAML Assertion must not contain XML comments",
+        );
+      }
 
-    while (stack.length > 0) {
-      const node: XmlNode = stack.pop()!;
+      if (child.nodeType === SSOUtil.PROCESSING_INSTRUCTION_NODE) {
+        throw new BadRequestException(
+          "SAML Response must not contain XML processing instructions",
+        );
+      }
 
-      for (
-        let child: XmlNode | null = node.firstChild;
-        child;
-        child = child.nextSibling
-      ) {
-        // nodeType 8 === COMMENT_NODE
-        if (child.nodeType === 8) {
-          throw new BadRequestException(
-            "SAML Assertion must not contain XML comments",
-          );
-        }
-        stack.push(child);
+      if (child.nodeType === SSOUtil.ELEMENT_NODE) {
+        throw new BadRequestException(
+          "SAML Assertion identity values must not contain nested elements",
+        );
       }
     }
   }

--- a/App/FeatureSet/Identity/Utils/SSO.ts
+++ b/App/FeatureSet/Identity/Utils/SSO.ts
@@ -62,6 +62,7 @@ export default class SSOUtil {
    * compare against.
    */
   private static readonly ELEMENT_NODE: number = 1;
+  private static readonly TEXT_NODE: number = 3;
   private static readonly PROCESSING_INSTRUCTION_NODE: number = 7;
   private static readonly COMMENT_NODE: number = 8;
   private static readonly DOCUMENT_NODE: number = 9;
@@ -546,19 +547,72 @@ export default class SSOUtil {
     }
   }
 
+  /*
+   * The <SignatureValue> text used for the duplicate check above.
+   *
+   * This has to agree with how xml-crypto reads the same element, or the check
+   * compares a different string than the one that decides which signatures get
+   * stripped from the digest. xml-crypto selects it with
+   *
+   *   xpath.select1(".//*[local-name(.)='SignatureValue']/text()", signature)
+   *
+   * (enveloped-signature.js, signed-xml.js), which differs from a namespaced
+   * `textContent` read in two ways an attacker can use:
+   *
+   *   - The selection is namespace-AGNOSTIC. A decoy that puts a foreign
+   *     <foo:SignatureValue xmlns:foo="urn:x"> first is what xml-crypto reads
+   *     and strips on, while a namespaced lookup never sees it.
+   *
+   *   - select1 returns the FIRST TEXT NODE, not the concatenated text. A
+   *     comment or CDATA section splits the value, so xml-crypto reads
+   *     "ABC" where `textContent` reads "ABCZ".
+   *
+   * Either way a decoy signature can repeat the genuine <SignatureValue> as far
+   * as xml-crypto is concerned - and so be deleted from the digest, taking
+   * whatever it carries out of the signed bytes with it - while looking
+   * distinct to us. Rather than reimplement xml-crypto's selection and have to
+   * track it, refuse anything ambiguous.
+   */
   private static getSignatureValueText(signature: XmlElement): string {
     const signatureValues: Array<XmlElement> = SSOUtil.toElementArray(
-      signature.getElementsByTagNameNS(
-        SSOUtil.XMLDSIG_NAMESPACE,
-        "SignatureValue",
-      ),
+      signature.getElementsByTagNameNS("*", "SignatureValue"),
     );
 
     if (signatureValues.length === 0) {
       return "";
     }
 
-    return SSOUtil.getTrimmedText(signatureValues[0]!);
+    if (signatureValues.length > 1) {
+      throw new BadRequestException(
+        "An XML Signature must not contain more than one SignatureValue",
+      );
+    }
+
+    const signatureValue: XmlElement = signatureValues[0]!;
+
+    if (signatureValue.namespaceURI !== SSOUtil.XMLDSIG_NAMESPACE) {
+      throw new BadRequestException(
+        "SignatureValue must be in the XML Signature namespace",
+      );
+    }
+
+    /*
+     * A single run of character data, or nothing. Base64 wrapped across lines
+     * is still one text node, so the identity providers that pretty-print their
+     * signatures are unaffected.
+     */
+    const firstChild: XmlNode | null = signatureValue.firstChild;
+
+    if (
+      firstChild &&
+      (firstChild.nodeType !== SSOUtil.TEXT_NODE || firstChild.nextSibling)
+    ) {
+      throw new BadRequestException(
+        "SignatureValue must contain a single run of text",
+      );
+    }
+
+    return SSOUtil.getTrimmedText(signatureValue);
   }
 
   /*

--- a/App/Tests/Identity/SSO.test.ts
+++ b/App/Tests/Identity/SSO.test.ts
@@ -92,6 +92,133 @@ beforeAll(() => {
 
 /*
  * ---------------------------------------------------------------------------
+ * Minimal self-signed X.509 certificate builder.
+ *
+ * xml-crypto 6 can resolve its verification key from the <KeyInfo> carried in
+ * the document under verification, which is a full authentication bypass if it
+ * is left enabled. Testing that faithfully needs a REAL certificate whose key
+ * actually signed the document - a garbage blob would be rejected by the crypto
+ * layer and the test would pass for the wrong reason.
+ *
+ * Node cannot generate certificates and the repo has no certificate library, so
+ * this emits a minimal X.509 v1 certificate directly. Nothing validates its
+ * contents; it only has to parse and carry the public key.
+ * ---------------------------------------------------------------------------
+ */
+
+function derLength(length: number): Buffer {
+  if (length < 0x80) {
+    return Buffer.from([length]);
+  }
+
+  const bytes: Array<number> = [];
+  let remaining: number = length;
+
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining = remaining >> 8;
+  }
+
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+function der(tag: number, contents: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from([tag]),
+    derLength(contents.length),
+    contents,
+  ]);
+}
+
+function derSequence(...parts: Array<Buffer>): Buffer {
+  return der(0x30, Buffer.concat(parts));
+}
+
+// sha256WithRSAEncryption (1.2.840.113549.1.1.11), with the required NULL params.
+function sha256RsaAlgorithmIdentifier(): Buffer {
+  return derSequence(
+    der(
+      0x06,
+      Buffer.from([0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b]),
+    ),
+    der(0x05, Buffer.alloc(0)),
+  );
+}
+
+// A Name holding a single commonName (2.5.4.3) attribute.
+function derName(commonName: string): Buffer {
+  return derSequence(
+    der(
+      0x31,
+      derSequence(
+        der(0x06, Buffer.from([0x55, 0x04, 0x03])),
+        der(0x0c, Buffer.from(commonName, "utf8")),
+      ),
+    ),
+  );
+}
+
+function selfSignedCertificateBase64(
+  keys: KeyPair,
+  commonName: string,
+): string {
+  const spki: Buffer = crypto
+    .createPublicKey(keys.publicKey)
+    .export({ type: "spki", format: "der" });
+
+  const validity: Buffer = derSequence(
+    der(0x17, Buffer.from("240101000000Z", "ascii")),
+    der(0x17, Buffer.from("340101000000Z", "ascii")),
+  );
+
+  const tbsCertificate: Buffer = derSequence(
+    der(0x02, Buffer.from([0x01])), // serialNumber
+    sha256RsaAlgorithmIdentifier(),
+    derName(commonName), // issuer == subject: self-signed
+    validity,
+    derName(commonName),
+    spki,
+  );
+
+  const signature: Buffer = crypto.sign(
+    "sha256",
+    tbsCertificate,
+    keys.privateKey,
+  );
+
+  const certificate: Buffer = derSequence(
+    tbsCertificate,
+    sha256RsaAlgorithmIdentifier(),
+    der(0x03, Buffer.concat([Buffer.from([0x00]), signature])), // BIT STRING
+  );
+
+  return certificate.toString("base64");
+}
+
+/*
+ * Verify a document using the certificate the document itself carries, by
+ * opting in to xml-crypto's own SignedXml.getCertFromKeyInfo.
+ *
+ * This is the negative control for the KeyInfo tests: it proves the attack
+ * document is internally self-consistent, so the rejection that follows is
+ * attributable to SSOUtil insisting on the configured certificate rather than
+ * to a malformed one. It also documents the footgun - this is a supported
+ * xml-crypto configuration, one constructor option away.
+ */
+function signatureVerifiesAgainstEmbeddedCertificate(xml: string): boolean {
+  try {
+    const sig: SignedXml = new SignedXml({
+      getCertFromKeyInfo: SignedXml.getCertFromKeyInfo,
+    });
+    sig.loadSignature(extractSignature(xml));
+    return sig.checkSignature(xml);
+  } catch {
+    return false;
+  }
+}
+
+/*
+ * ---------------------------------------------------------------------------
  * SAML document builders
  * ---------------------------------------------------------------------------
  */
@@ -158,28 +285,26 @@ interface SignOptions {
     action: "append" | "prepend" | "before" | "after";
   };
   emptyUri?: boolean;
+  // Raw <KeyInfo> content override (for the embedded-certificate tests).
+  keyInfoContent?: string;
 }
 
 function signXml(xml: string, options: SignOptions): string {
-  const sig: SignedXml = new SignedXml();
-
-  sig.addReference(
-    options.referenceXPath,
-    [XMLDSIG_ENVELOPED, XMLDSIG_EXC_C14N],
-    XMLENC_SHA256,
-    undefined as unknown as string,
-    undefined as unknown as string,
-    undefined as unknown as string,
-    options.emptyUri === true,
-  );
-
-  sig.signatureAlgorithm = RSA_SHA256;
-  sig.signingKey = options.privateKey ?? idpKeys.privateKey;
-  sig.keyInfoProvider = {
-    getKeyInfo: (): string => {
-      return "<X509Data></X509Data>";
+  const sig: SignedXml = new SignedXml({
+    privateKey: options.privateKey ?? idpKeys.privateKey,
+    signatureAlgorithm: RSA_SHA256,
+    canonicalizationAlgorithm: XMLDSIG_EXC_C14N,
+    getKeyInfoContent: (): string => {
+      return options.keyInfoContent ?? "<X509Data></X509Data>";
     },
-  } as unknown as SignedXml["keyInfoProvider"];
+  });
+
+  sig.addReference({
+    xpath: options.referenceXPath,
+    transforms: [XMLDSIG_ENVELOPED, XMLDSIG_EXC_C14N],
+    digestAlgorithm: XMLENC_SHA256,
+    isEmptyUri: options.emptyUri === true,
+  });
 
   sig.computeSignature(xml, {
     location: options.location ?? {
@@ -290,20 +415,26 @@ function genuineSignedErrorResponse(
  * DOM reports, and not merely because the signature happened to break.
  */
 function signatureIsCryptographicallyValid(xml: string): boolean {
-  const sig: SignedXml = new SignedXml();
-
-  sig.keyInfoProvider = {
-    getKeyInfo: (): string => {
-      return "<X509Data></X509Data>";
+  const sig: SignedXml = new SignedXml({
+    publicCert: idpKeys.publicKey,
+    // Same rule SSOUtil enforces: the document's own KeyInfo yields no key.
+    getCertFromKeyInfo: (): null => {
+      return null;
     },
-    getKey: (): string => {
-      return idpKeys.publicKey;
-    },
-  } as unknown as SignedXml["keyInfoProvider"];
+  });
 
-  sig.loadSignature(extractSignature(xml));
+  try {
+    sig.loadSignature(extractSignature(xml));
 
-  return sig.checkSignature(xml);
+    /*
+     * xml-crypto 6 throws (rather than returning false) when the signature
+     * value itself does not verify, and returns false when a digest does not.
+     * Both mean the same thing here.
+     */
+    return sig.checkSignature(xml);
+  } catch {
+    return false;
+  }
 }
 
 /*
@@ -1094,6 +1225,113 @@ describe("SSOUtil - processing instructions are rejected anywhere in the documen
 
 /*
  * ---------------------------------------------------------------------------
+ * Identity is read from the canonical bytes that were signed.
+ *
+ * SSOUtil no longer extracts identity from a second, independent parse of the
+ * original document. It takes xml-crypto's `signedReference` - the exact
+ * canonical string the digest was computed over and the signature verified
+ * against - and reads from that. This is what stops a disagreement between our
+ * parse and xml-crypto's canonicalizer from being an authentication bug in the
+ * first place, rather than patching one instance of it (#2988).
+ *
+ * That makes the canonical fragment a new failure surface: it is a standalone
+ * document, so it has to carry the namespace declarations the assertion
+ * inherited from its ancestors, whatever prefixes the identity provider chose.
+ * These tests exercise the shapes real providers actually send.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - identity comes from the signed canonical bytes", () => {
+  function expectIdentity(xml: string): void {
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      xml,
+      idpKeys.publicKey,
+    );
+
+    expect(result.email.toString()).toBe("alice@example.com");
+    expect(result.issuerUrl).toBe(ISSUER);
+  }
+
+  test("namespaces inherited from the Response survive canonicalization", () => {
+    /*
+     * The default shape: xmlns:saml is declared on the Response, used on the
+     * Assertion, and must be rendered into the canonical Assertion fragment.
+     */
+    expectIdentity(genuineAssertionSignedResponse());
+  });
+
+  test("works when SAML uses a default namespace instead of a prefix", () => {
+    const assertion: string = `<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><Issuer>${ISSUER}</Issuer><Subject><NameID>alice@example.com</NameID></Subject></Assertion>`;
+
+    expectIdentity(sign(buildResponse(assertion), "Assertion"));
+  });
+
+  test("works with an unusual namespace prefix", () => {
+    const assertion: string = `<a:Assertion xmlns:a="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><a:Issuer>${ISSUER}</a:Issuer><a:Subject><a:NameID>alice@example.com</a:NameID></a:Subject></a:Assertion>`;
+
+    expectIdentity(sign(buildResponse(assertion), "Assertion"));
+  });
+
+  test("works when the signature covers the whole Response", () => {
+    /*
+     * Here the canonical bytes are the entire Response and the assertion has to
+     * be found inside them.
+     */
+    expectIdentity(genuineResponseSignedResponse());
+  });
+
+  test('works for a whole-document signature (Reference URI="")', () => {
+    expectIdentity(
+      signXml(buildResponse(buildAssertion()), {
+        referenceXPath: "//*[local-name(.)='Response']",
+        emptyUri: true,
+      }),
+    );
+  });
+
+  test("reads a NameID delivered as CDATA", () => {
+    expectIdentity(
+      sign(
+        buildResponse(
+          buildAssertion({ nameId: "<![CDATA[alice@example.com]]>" }),
+        ),
+        "Assertion",
+      ),
+    );
+  });
+
+  test("reads a NameID written with character references", () => {
+    expectIdentity(
+      sign(
+        buildResponse(buildAssertion({ nameId: "&#97;lice@example.com" })),
+        "Assertion",
+      ),
+    );
+  });
+
+  test("trims the XML whitespace a pretty-printing provider adds", () => {
+    expectIdentity(
+      sign(
+        buildResponse(
+          buildAssertion({ nameId: "\n        alice@example.com\n      " }),
+        ),
+        "Assertion",
+      ),
+    );
+  });
+
+  test("still extracts the display name through the canonical bytes", () => {
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      genuineAssertionSignedResponse(),
+      idpKeys.publicKey,
+    );
+
+    expect(result.name?.toString()).toBe("Alice Example");
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
  * Issue #2949 - classic signature wrapping must stay rejected.
  * ---------------------------------------------------------------------------
  */
@@ -1678,6 +1916,105 @@ describe("SSOUtil - malformed and abusive input is rejected", () => {
     const xml: string = genuineAssertionSignedResponse();
 
     expect(SSOUtil.isSignatureValid(xml, attackerKeys.publicKey)).toBe(false);
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * The verification key must come from configuration, never from the document.
+ *
+ * xml-crypto 6 resolves its key as
+ *   getCertFromKeyInfo(this.keyInfo) || this.publicCert || this.privateKey
+ * where `keyInfo` is the <KeyInfo> of the document being verified - written by
+ * whoever sent it. xml-crypto ships SignedXml.getCertFromKeyInfo, which reads
+ * the certificate straight out of that element. Turn it on and anyone can sign
+ * a response with a key they generated, staple the matching certificate to it,
+ * and be logged in as anybody.
+ *
+ * The constructor defaults this to a no-op, so this is a footgun rather than a
+ * live bug - but it is one constructor option away, and SSOUtil pins it shut
+ * explicitly instead of relying on that default. These tests lock that in.
+ *
+ * Each test carries a negative control: it first proves the attack document
+ * really is self-consistent (xml-crypto accepts it when told to trust the
+ * embedded certificate), so the rejection that follows is attributable to
+ * SSOUtil refusing the document's own key, not to a malformed certificate.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - the verification key never comes from the document", () => {
+  function attackerSignedWithEmbeddedCert(assertionXml?: string): string {
+    return signXml(
+      buildResponse(
+        assertionXml ?? buildAssertion({ email: "admin@example.com" }),
+      ),
+      {
+        referenceXPath: "//*[local-name(.)='Assertion']",
+        privateKey: attackerKeys.privateKey,
+        keyInfoContent: `<X509Data><X509Certificate>${selfSignedCertificateBase64(
+          attackerKeys,
+          "attacker.example.net",
+        )}</X509Certificate></X509Data>`,
+      },
+    );
+  }
+
+  test("the attack document is genuinely self-consistent (negative control)", () => {
+    /*
+     * If this ever stops holding, every test below would pass vacuously - the
+     * document would be rejected for being malformed rather than for carrying
+     * its own key.
+     */
+    expect(
+      signatureVerifiesAgainstEmbeddedCertificate(
+        attackerSignedWithEmbeddedCert(),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects a response signed by the attacker with their certificate in KeyInfo", () => {
+    expectRejected(attackerSignedWithEmbeddedCert());
+  });
+
+  test("rejects it at the Response level too", () => {
+    const xml: string = signXml(buildResponse(buildAssertion()), {
+      referenceXPath: "//*[local-name(.)='Response']",
+      privateKey: attackerKeys.privateKey,
+      keyInfoContent: `<X509Data><X509Certificate>${selfSignedCertificateBase64(
+        attackerKeys,
+        "attacker.example.net",
+      )}</X509Certificate></X509Data>`,
+    });
+
+    expect(signatureVerifiesAgainstEmbeddedCertificate(xml)).toBe(true);
+    expectRejected(xml);
+  });
+
+  test("still rejects when the attacker also names the real issuer", () => {
+    const xml: string = attackerSignedWithEmbeddedCert(
+      buildAssertion({ email: "admin@example.com", issuer: ISSUER }),
+    );
+
+    expect(signatureVerifiesAgainstEmbeddedCertificate(xml)).toBe(true);
+    expectRejected(xml);
+  });
+
+  test("a genuine response is still accepted when KeyInfo carries a certificate", () => {
+    /*
+     * Real identity providers do send their certificate in KeyInfo. Ignoring it
+     * must not mean rejecting it.
+     */
+    const xml: string = signXml(buildResponse(buildAssertion()), {
+      referenceXPath: "//*[local-name(.)='Assertion']",
+      keyInfoContent: `<X509Data><X509Certificate>${selfSignedCertificateBase64(
+        idpKeys,
+        "idp.example.com",
+      )}</X509Certificate></X509Data>`,
+    });
+
+    expect(
+      SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey).email.toString(),
+    ).toBe("alice@example.com");
   });
 });
 

--- a/App/Tests/Identity/SSO.test.ts
+++ b/App/Tests/Identity/SSO.test.ts
@@ -6,11 +6,16 @@ import URL from "Common/Types/API/URL";
 import { describe, expect, test, beforeAll } from "@jest/globals";
 import crypto from "crypto";
 import { SignedXml } from "xml-crypto";
+import {
+  DOMParser,
+  Element as XmlElement,
+  Node as XmlNode,
+} from "@xmldom/xmldom";
 
 /*
  * Security regression tests for SAML XML Signature Wrapping (XSW).
  *
- * Two publicly reported bypasses are covered here:
+ * Three publicly reported bypasses are covered here:
  *
  *   - GitHub issue #2949: the original implementation validated the first
  *     <Signature> element it found and then extracted the identity from an
@@ -28,6 +33,15 @@ import { SignedXml } from "xml-crypto";
  *     transform removes EVERY <Signature> whose <SignatureValue> text matches
  *     the one being verified, so a decoy signature that simply repeats the
  *     genuine <SignatureValue> also disappears from the digest.
+ *
+ *   - GitHub issue #2988: a signature that provably covers the element we read
+ *     still is not enough, because the bytes that were digested and the bytes
+ *     the DOM reports need not be the same bytes. xml-crypto canonicalizes any
+ *     node exposing a `data` property by emitting that data as plain text, so a
+ *     processing instruction `<?p not-an-?>` is digested as `not-an-` while
+ *     `textContent` omits it entirely. An attacker can therefore hide any
+ *     substring of a genuinely signed value inside a processing instruction and
+ *     the digest does not move.
  *
  * These tests:
  *   1. Prove the genuine ("happy path") SAML flows still work.
@@ -265,6 +279,58 @@ function genuineSignedErrorResponse(
   return sign(buildResponse("", { statusCode }), "Response");
 }
 
+/*
+ * Verify a document's <Signature> with xml-crypto alone, bypassing every
+ * structural rule SSOUtil layers on top of it.
+ *
+ * The #2988 attack documents are built so that this returns TRUE: the digest is
+ * byte-for-byte the digest of the genuine response. Asserting it in the tests
+ * is what makes them meaningful - it proves the document is rejected because
+ * SSOUtil refuses to read a value whose canonical form differs from what the
+ * DOM reports, and not merely because the signature happened to break.
+ */
+function signatureIsCryptographicallyValid(xml: string): boolean {
+  const sig: SignedXml = new SignedXml();
+
+  sig.keyInfoProvider = {
+    getKeyInfo: (): string => {
+      return "<X509Data></X509Data>";
+    },
+    getKey: (): string => {
+      return idpKeys.publicKey;
+    },
+  } as unknown as SignedXml["keyInfoProvider"];
+
+  sig.loadSignature(extractSignature(xml));
+
+  return sig.checkSignature(xml);
+}
+
+/*
+ * The value a textContent-based extractor (i.e. SSOUtil) sees for the first
+ * element with this local name. Used to show, in the test itself, that the DOM
+ * and the digest disagree.
+ */
+function domTextOf(xml: string, localName: string): string {
+  const element: XmlNode | null = new DOMParser()
+    .parseFromString(xml, "text/xml")
+    .getElementsByTagNameNS("*", localName)
+    .item(0);
+
+  return ((element as XmlElement | null)?.textContent || "").trim();
+}
+
+/*
+ * Hide `text` inside a processing instruction.
+ *
+ * xml-crypto digests the instruction's data as if it were character data, so
+ * `hidden("not-an-") + "admin@example.com"` canonicalizes exactly like
+ * "not-an-admin@example.com" while the DOM reports only "admin@example.com".
+ */
+function hidden(text: string): string {
+  return `<?p ${text}?>`;
+}
+
 // Assert that both entry points reject a document.
 function expectRejected(xml: string, messageFragment?: string): void {
   expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(false);
@@ -418,6 +484,67 @@ describe("SSOUtil - genuine SAML flow (must not break)", () => {
 
     expect(result.email.toString()).toBe("alice@example.com");
     expect(result.name).toBeNull();
+  });
+
+  /*
+   * xmldom surfaces the XML declaration as a processing instruction node, and
+   * essentially every identity provider emits one. It is the single processing
+   * instruction the parser is allowed to keep (issue #2988), so each spelling
+   * has to keep working.
+   */
+  test.each([
+    ['<?xml version="1.0" encoding="UTF-8"?>', "double-quoted, with encoding"],
+    ['<?xml version="1.0"?>', "no encoding"],
+    [
+      "<?xml version='1.0' encoding='utf-8' standalone='no'?>",
+      "single-quoted, standalone",
+    ],
+  ])(
+    "accepts a response introduced by an XML declaration (%s)",
+    (declaration: string) => {
+      const xml: string = declaration + genuineAssertionSignedResponse();
+
+      expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
+      expect(
+        SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey).email.toString(),
+      ).toBe("alice@example.com");
+    },
+  );
+
+  test("accepts an XML declaration that was present when the document was signed", () => {
+    const xml: string = sign(
+      `<?xml version="1.0" encoding="UTF-8"?>${buildResponse(buildAssertion())}`,
+      "Assertion",
+    );
+
+    expect(xml.startsWith("<?xml ")).toBe(true);
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
+  });
+
+  test("accepts a Response-signed document introduced by an XML declaration", () => {
+    const xml: string =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      genuineResponseSignedResponse();
+
+    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
+  });
+
+  test("accepts a display-name AttributeValue carrying xsi:type", () => {
+    /*
+     * Identity values must be plain text (issue #2988), but an xsi:type is an
+     * ATTRIBUTE, not a child element - Okta, Entra and ADFS all send it.
+     */
+    const attributeStatement: string = `<saml:AttributeStatement><saml:Attribute Name="${DISPLAY_NAME_CLAIM}"><saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">Alice Example</saml:AttributeValue></saml:Attribute></saml:AttributeStatement>`;
+
+    const assertion: string = `<saml:Assertion ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer><saml:Subject><saml:NameID>alice@example.com</saml:NameID></saml:Subject>${attributeStatement}</saml:Assertion>`;
+
+    const result: VerifiedSamlResponse = SSOUtil.getSamlResponseFromXML(
+      sign(buildResponse(assertion), "Assertion"),
+      idpKeys.publicKey,
+    );
+
+    expect(result.name?.toString()).toBe("Alice Example");
+    expect(result.email.toString()).toBe("alice@example.com");
   });
 
   test("works when the base64 SAMLResponse is decoded first (end-to-end shape)", () => {
@@ -652,6 +779,315 @@ describe("SSOUtil - signed error Response cannot smuggle an assertion (issue #29
       SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
     } catch (err) {
       expect((err as Error).message).not.toContain("script");
+    }
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Issue #2988 - a processing instruction must not be able to rewrite a signed
+ * value.
+ *
+ * Every attack below starts from a GENUINE, correctly signed IdP response and
+ * edits it. Each one asserts three things in order:
+ *
+ *   1. the edited document's signature still verifies under xml-crypto, i.e.
+ *      the attacker did not have to touch the digest at all;
+ *   2. a textContent-based read of the edited document now yields a different
+ *      identity than the one that was signed;
+ *   3. SSOUtil rejects it.
+ *
+ * Drop the fix and (1) and (2) still hold - only (3) fails, and the result is a
+ * full authentication bypass.
+ * ---------------------------------------------------------------------------
+ */
+
+const PI_REJECTED: string =
+  "SAML Response must not contain XML processing instructions";
+
+describe("SSOUtil - processing instructions cannot rewrite signed values (issue #2988)", () => {
+  test("rejects the reported PoC: a processing instruction hiding part of the NameID", () => {
+    // A genuine response for an ordinary, unprivileged user.
+    const genuine: string = sign(
+      buildResponse(buildAssertion({ nameId: "not-an-admin@example.com" })),
+      "Assertion",
+    );
+
+    expect(
+      SSOUtil.getSamlResponseFromXML(
+        genuine,
+        idpKeys.publicKey,
+      ).email.toString(),
+    ).toBe("not-an-admin@example.com");
+
+    // The attacker hides the "not-an-" prefix inside a processing instruction.
+    const attack: string = replaceOnce(
+      genuine,
+      ">not-an-admin@example.com<",
+      `>${hidden("not-an-")}admin@example.com<`,
+    );
+
+    // The digest never moved: xml-crypto still accepts the signature.
+    expect(signatureIsCryptographicallyValid(attack)).toBe(true);
+
+    // But the DOM now reports a completely different user.
+    expect(domTextOf(attack, "NameID")).toBe("admin@example.com");
+
+    expectRejected(attack, PI_REJECTED);
+  });
+
+  test("rejects the same rewrite under a Response-level signature", () => {
+    const genuine: string = sign(
+      buildResponse(buildAssertion({ nameId: "not-an-admin@example.com" })),
+      "Response",
+    );
+
+    const attack: string = replaceOnce(
+      genuine,
+      ">not-an-admin@example.com<",
+      `>${hidden("not-an-")}admin@example.com<`,
+    );
+
+    expect(signatureIsCryptographicallyValid(attack)).toBe(true);
+    expect(domTextOf(attack, "NameID")).toBe("admin@example.com");
+
+    expectRejected(attack, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction that truncates the tail of the NameID", () => {
+    /*
+     * The mirror image of the reported shape: the signed value carries a suffix
+     * the attacker wants gone, so the domain the email appears to belong to
+     * changes instead of the local part.
+     */
+    const genuine: string = sign(
+      buildResponse(
+        buildAssertion({ nameId: "admin@example.com.attacker.net" }),
+      ),
+      "Assertion",
+    );
+
+    const attack: string = replaceOnce(
+      genuine,
+      ">admin@example.com.attacker.net<",
+      `>admin@example.com${hidden(".attacker.net")}<`,
+    );
+
+    expect(signatureIsCryptographicallyValid(attack)).toBe(true);
+    expect(domTextOf(attack, "NameID")).toBe("admin@example.com");
+
+    expectRejected(attack, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction that rewrites the Issuer", () => {
+    /*
+     * On a multi-tenant IdP the attacker legitimately holds a signed response
+     * for their own tenant path and deletes the tenant segment from what we
+     * read, so the assertion appears to come from the tenant-less issuer.
+     */
+    const genuine: string = sign(
+      buildResponse(
+        buildAssertion({
+          issuer: "https://idp.example.com/attacker/metadata",
+        }),
+      ),
+      "Assertion",
+    );
+
+    const attack: string = replaceOnce(
+      genuine,
+      ">https://idp.example.com/attacker/metadata<",
+      `>https://idp.example.com/${hidden("attacker/")}metadata<`,
+    );
+
+    expect(signatureIsCryptographicallyValid(attack)).toBe(true);
+    expect(domTextOf(attack, "Issuer")).toBe(
+      "https://idp.example.com/metadata",
+    );
+
+    expectRejected(attack, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction that rewrites the display name", () => {
+    const genuine: string = sign(
+      buildResponse(buildAssertion({ displayName: "Mallory Alice Example" })),
+      "Assertion",
+    );
+
+    const attack: string = replaceOnce(
+      genuine,
+      ">Mallory Alice Example<",
+      `>${hidden("Mallory ")}Alice Example<`,
+    );
+
+    expect(signatureIsCryptographicallyValid(attack)).toBe(true);
+    expect(domTextOf(attack, "AttributeValue")).toBe("Alice Example");
+
+    expectRejected(attack, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction between two text runs of the NameID", () => {
+    const genuine: string = sign(
+      buildResponse(buildAssertion({ nameId: "ad-DROP-min@example.com" })),
+      "Assertion",
+    );
+
+    const attack: string = replaceOnce(
+      genuine,
+      ">ad-DROP-min@example.com<",
+      `>ad${hidden("-DROP-")}min@example.com<`,
+    );
+
+    expect(signatureIsCryptographicallyValid(attack)).toBe(true);
+    expect(domTextOf(attack, "NameID")).toBe("admin@example.com");
+
+    expectRejected(attack, PI_REJECTED);
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Issue #2988 - processing instructions are refused wherever they sit.
+ *
+ * The rewrite above only needs a processing instruction inside an identity
+ * value, but there is no position in a SAML Response where one is legitimate,
+ * and leaving any of them parseable leaves the next variant of the trick
+ * available. These documents are SIGNED WITH the instruction already in place,
+ * so the signature is genuinely valid and only the structural rule rejects them.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("SSOUtil - processing instructions are rejected anywhere in the document (issue #2988)", () => {
+  test("rejects a processing instruction that is a direct child of the Response", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), { beforeStatus: hidden("junk") }),
+      "Response",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction inside <samlp:Extensions>", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), {
+        extensions: `<samlp:Extensions>${hidden("junk")}</samlp:Extensions>`,
+      }),
+      "Response",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction inside <samlp:Status>", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion(), {
+        statusXml: `<samlp:Status>${hidden(
+          "junk",
+        )}<samlp:StatusCode Value="${STATUS_SUCCESS}"/></samlp:Status>`,
+      }),
+      "Response",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction inside the Assertion but outside any identity value", () => {
+    const xml: string = sign(
+      buildResponse(buildAssertion({ extraInner: hidden("junk") })),
+      "Assertion",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction inside the <Subject>", () => {
+    const assertion: string = `<saml:Assertion ID="_a" Version="2.0" IssueInstant="2024-01-01T00:00:00Z"><saml:Issuer>${ISSUER}</saml:Issuer><saml:Subject>${hidden(
+      "junk",
+    )}<saml:NameID>alice@example.com</saml:NameID></saml:Subject></saml:Assertion>`;
+
+    const xml: string = sign(buildResponse(assertion), "Assertion");
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction smuggled inside the <Signature> subtree", () => {
+    /*
+     * The enveloped-signature transform strips the whole <Signature> out of the
+     * digest, so this instruction is free: the signature stays valid no matter
+     * what is parked here.
+     */
+    const xml: string = replaceOnce(
+      genuineAssertionSignedResponse(),
+      "<X509Data/>",
+      `<X509Data>${hidden("junk")}</X509Data>`,
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction in the prolog", () => {
+    const xml: string = `<?xml-stylesheet href="evil.xsl"?>${genuineAssertionSignedResponse()}`;
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction after the root element", () => {
+    const xml: string = `${genuineAssertionSignedResponse()}${hidden("junk")}`;
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a prolog processing instruction that follows a valid XML declaration", () => {
+    const xml: string = `<?xml version="1.0" encoding="UTF-8"?>${hidden(
+      "junk",
+    )}${genuineAssertionSignedResponse()}`;
+
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction carrying no data at all", () => {
+    const xml: string = replaceOnce(
+      genuineAssertionSignedResponse(),
+      ">alice@example.com<",
+      "><?p?>alice@example.com<",
+    );
+
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects a processing instruction whose data is only whitespace", () => {
+    const xml: string = replaceOnce(
+      genuineAssertionSignedResponse(),
+      ">alice@example.com<",
+      "><?p ?>alice@example.com<",
+    );
+
+    expectRejected(xml, PI_REJECTED);
+  });
+
+  test("rejects the reserved 'xml' target used inside the document element", () => {
+    /*
+     * The XML declaration is allowed through as the one legitimate processing
+     * instruction, so make sure its target cannot be reused inside the tree to
+     * borrow that exemption. "xml" is a reserved target, so this does not even
+     * parse - which is a fine way to be rejected, as long as it is rejected.
+     */
+    for (const target of ["xml", "XML", "xMl"]) {
+      const xml: string = replaceOnce(
+        genuineAssertionSignedResponse(),
+        ">alice@example.com<",
+        `><?${target} junk?>alice@example.com<`,
+      );
+
+      expectRejected(xml);
     }
   });
 });
@@ -1053,10 +1489,13 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
     expectRejected(stripped);
   });
 
+  const COMMENT_REJECTED: string =
+    "SAML Assertion must not contain XML comments";
+
   test("rejects a NameID containing an XML comment (comment-truncation defense)", () => {
     /*
      * Signed WITH the comment present. Exclusive c14n excludes comments, so the
-     * signature is valid, but our extractor must refuse comments outright.
+     * signature is genuinely valid, but our extractor must refuse them outright.
      */
     const xml: string = sign(
       buildResponse(
@@ -1065,10 +1504,8 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
       "Assertion",
     );
 
-    expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(true);
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
-    }).toThrow("SAML Assertion must not contain XML comments");
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, COMMENT_REJECTED);
   });
 
   test("rejects an Issuer containing an XML comment", () => {
@@ -1081,9 +1518,8 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
       "Assertion",
     );
 
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
-    }).toThrow("SAML Assertion must not contain XML comments");
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, COMMENT_REJECTED);
   });
 
   test("rejects a display name containing an XML comment", () => {
@@ -1092,9 +1528,59 @@ describe("SSOUtil - signature tampering and forgery is rejected", () => {
       "Assertion",
     );
 
-    expect(() => {
-      return SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
-    }).toThrow("SAML Assertion must not contain XML comments");
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, COMMENT_REJECTED);
+  });
+
+  /*
+   * Child elements are the third way the digested bytes and `textContent` can
+   * describe different strings: canonicalization digests the markup,
+   * `textContent` flattens it away. The signature over these documents is
+   * genuine - only the plain-text rule rejects them.
+   */
+  const NESTED_REJECTED: string =
+    "SAML Assertion identity values must not contain nested elements";
+
+  test("rejects a NameID containing a nested element", () => {
+    const xml: string = sign(
+      buildResponse(
+        buildAssertion({
+          nameId: "admin@corp.com<saml:Wrap>.attacker.com</saml:Wrap>",
+        }),
+      ),
+      "Assertion",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, NESTED_REJECTED);
+  });
+
+  test("rejects an Issuer containing a nested element", () => {
+    const xml: string = sign(
+      buildResponse(
+        buildAssertion({
+          issuer: `${ISSUER}<saml:Wrap>.attacker.com</saml:Wrap>`,
+        }),
+      ),
+      "Assertion",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, NESTED_REJECTED);
+  });
+
+  test("rejects a display name containing a nested element", () => {
+    const xml: string = sign(
+      buildResponse(
+        buildAssertion({
+          displayName: "Alice<saml:Wrap>Attacker</saml:Wrap>",
+        }),
+      ),
+      "Assertion",
+    );
+
+    expect(signatureIsCryptographicallyValid(xml)).toBe(true);
+    expectRejected(xml, NESTED_REJECTED);
   });
 });
 
@@ -1222,5 +1708,53 @@ describe("SSOUtil - sanity", () => {
       idpKeys.publicKey,
     );
     expect(result.email).toBeInstanceOf(Email);
+  });
+
+  /*
+   * The two public entry points must never disagree. isSignatureValid()
+   * returning true for a document getSamlResponseFromXML() refuses would hand
+   * any caller that gates on it exactly the bypass this file exists to prevent.
+   */
+  test("isSignatureValid agrees with getSamlResponseFromXML on every document above", () => {
+    const documents: Array<string> = [
+      genuineAssertionSignedResponse(),
+      genuineResponseSignedResponse(),
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+        genuineAssertionSignedResponse(),
+      genuineSignedErrorResponse(),
+      sign(
+        buildResponse(
+          buildAssertion({ nameId: "admin@corp.com<!-- -->.attacker.com" }),
+        ),
+        "Assertion",
+      ),
+      sign(
+        buildResponse(
+          buildAssertion({
+            nameId: "admin@corp.com<saml:Wrap>.attacker.com</saml:Wrap>",
+          }),
+        ),
+        "Assertion",
+      ),
+      replaceOnce(
+        genuineAssertionSignedResponse(),
+        ">alice@example.com<",
+        `>${hidden("alice@")}example.com<`,
+      ),
+      "",
+      "<not-xml",
+    ];
+
+    for (const xml of documents) {
+      let extracted: boolean = true;
+
+      try {
+        SSOUtil.getSamlResponseFromXML(xml, idpKeys.publicKey);
+      } catch {
+        extracted = false;
+      }
+
+      expect(SSOUtil.isSignatureValid(xml, idpKeys.publicKey)).toBe(extracted);
+    }
   });
 });

--- a/App/Tests/Identity/SSO.test.ts
+++ b/App/Tests/Identity/SSO.test.ts
@@ -55,6 +55,7 @@ import {
 const XMLDSIG_ENVELOPED: string =
   "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
 const XMLDSIG_EXC_C14N: string = "http://www.w3.org/2001/10/xml-exc-c14n#";
+const XMLDSIG_NAMESPACE: string = "http://www.w3.org/2000/09/xmldsig#";
 const XMLENC_SHA256: string = "http://www.w3.org/2001/04/xmlenc#sha256";
 const RSA_SHA256: string = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
 
@@ -1591,6 +1592,92 @@ describe("SSOUtil - signature placement rules", () => {
       attack,
       "must not contain two Signatures with the same SignatureValue",
     );
+  });
+
+  /*
+   * The duplicate-SignatureValue rule only works if we read <SignatureValue>
+   * the way xml-crypto does. It selects with
+   *   xpath.select1(".//*[local-name(.)='SignatureValue']/text()", signature)
+   * which is namespace-agnostic and returns only the FIRST TEXT NODE. Any
+   * decoy that looks distinct to a namespaced textContent read but identical to
+   * that selection gets stripped out of the digest by the enveloped-signature
+   * transform while evading the rule (issue #2981's defence).
+   */
+  describe("the SignatureValue we compare is the one xml-crypto acts on", () => {
+    function withDecoySignature(decoyInner: string): string {
+      const genuine: string = genuineResponseSignedResponse();
+      const signatureValue: string = extractSignatureValue(
+        extractSignature(genuine),
+      );
+
+      return replaceOnce(
+        genuine,
+        "</saml:Assertion>",
+        `<Signature xmlns="${XMLDSIG_NAMESPACE}">${decoyInner.replace(
+          /\{SV\}/g,
+          signatureValue,
+        )}</Signature></saml:Assertion>`,
+      );
+    }
+
+    test("rejects a decoy whose SignatureValue is split by a comment", () => {
+      expectRejected(
+        withDecoySignature(
+          "<SignatureValue>{SV}<!--split-->Z</SignatureValue>",
+        ),
+      );
+    });
+
+    test("rejects a decoy whose SignatureValue is split by a CDATA section", () => {
+      expectRejected(
+        withDecoySignature(
+          "<SignatureValue>{SV}<![CDATA[Z]]></SignatureValue>",
+        ),
+      );
+    });
+
+    test("rejects a decoy that hides the repeat in a foreign namespace", () => {
+      expectRejected(
+        withDecoySignature(
+          '<foo:SignatureValue xmlns:foo="urn:x">{SV}</foo:SignatureValue><SignatureValue>DIFFERENT</SignatureValue>',
+        ),
+      );
+    });
+
+    test("rejects a Signature carrying two SignatureValue elements", () => {
+      expectRejected(
+        withDecoySignature(
+          "<SignatureValue>{SV}</SignatureValue><SignatureValue>DIFFERENT</SignatureValue>",
+        ),
+      );
+    });
+
+    test("accepts a SignatureValue whose base64 is wrapped across lines", () => {
+      /*
+       * ADFS and Shibboleth pretty-print the signature. Wrapping is still a
+       * single text node, and xml-crypto strips the newlines itself, so this
+       * must keep working.
+       */
+      const genuine: string = genuineAssertionSignedResponse();
+      const signatureValue: string = extractSignatureValue(
+        extractSignature(genuine),
+      );
+
+      const wrapped: string = replaceOnce(
+        genuine,
+        `<SignatureValue>${signatureValue}</SignatureValue>`,
+        `<SignatureValue>\n${(signatureValue.match(/.{1,64}/g) || []).join(
+          "\n",
+        )}\n</SignatureValue>`,
+      );
+
+      expect(
+        SSOUtil.getSamlResponseFromXML(
+          wrapped,
+          idpKeys.publicKey,
+        ).email.toString(),
+      ).toBe("alice@example.com");
+    });
   });
 
   test("rejects a <ds:Object> inside a Signature even with harmless content", () => {

--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -24,7 +24,7 @@
         "ts-node": "^10.9.1",
         "twilio": "^4.20.0",
         "ws": "^8.21.0",
-        "xml-crypto": "^3.2.0"
+        "xml-crypto": "^6.1.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.11",
@@ -1561,6 +1561,15 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
+    },
+    "node_modules/@xmldom/is-dom-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
@@ -6508,16 +6517,17 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.2.1.tgz",
-      "integrity": "sha512-0GUNbPtQt+PLMsC5HoZRONX+K6NBJEqpXe/lsvrFj0EqfpGPpVfJKGE7a5jCg8s2+Wkrf/2U1G41kIH+zC9eyQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
+      "integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "xpath": "0.0.32"
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "xpath": "^0.0.33"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/xml-crypto/node_modules/@xmldom/xmldom": {
@@ -6530,9 +6540,10 @@
       }
     },
     "node_modules/xpath": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
       }

--- a/App/package.json
+++ b/App/package.json
@@ -56,7 +56,7 @@
     "ts-node": "^10.9.1",
     "twilio": "^4.20.0",
     "ws": "^8.21.0",
-    "xml-crypto": "^3.2.0"
+    "xml-crypto": "^6.1.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
Fixes #2988.

## The report is accurate

Reproduced end to end against `master`. Taking a genuine, correctly signed response for `not-an-admin@example.com` and inserting a processing instruction:

```diff
-      <saml:NameID>not-an-admin@example.com</saml:NameID>
+      <saml:NameID><?p not-an-?>admin@example.com</saml:NameID>
```

`SSOUtil.isSignatureValid()` returns `true` and `getSamlResponseFromXML()` returns `admin@example.com`. Works against both assertion-level and response-level signatures. Full authentication bypass.

## Why it works

`xml-crypto`'s canonicalizer (`lib/exclusive-canonicalization.js`) renders any node exposing a `data` property as bare escaped text:

```js
if (node.nodeType === 8) { return this.renderComment(node); }
if (node.data)          { return utils.encodeSpecialCharactersInText(node.data); }
```

So `<?p not-an-?>` is digested as the characters `not-an-`, not as a processing instruction. The DOM, correctly per spec, omits processing instructions from `Element.textContent`.

The verifier computes the digest through xml-crypto but reads identity through the DOM, so the two describe different strings. Both documents above digest as `not-an-admin@example.com`; only the second *reads* as `admin@example.com`. The attacker never has to touch the signature.

This is the same shape as #2949 and #2981 — the element we read and the bytes that were signed are not the same thing — but at the character level rather than the element level.

## Changes

**`App/FeatureSet/Identity/Utils/SSO.ts`**

1. `parseXmlStrict` now rejects every processing instruction in the document, alongside the existing DOCTYPE/entity rule. A SAML Response has no legitimate use for one, so this refuses them outright rather than reasoning about which positions are harmless.

   The XML declaration is the sole exception: xmldom surfaces it as a processing-instruction node with target `xml` parented on the `Document`, it sits outside every canonicalized subtree, and real identity providers emit it. Verified that `<?xml version="1.0" encoding="UTF-8"?>` and its variants still work, both prepended and signed in place.

2. `assertNoComments` becomes `assertPlainTextOnly`, applied to `Issuer`, `NameID` and the display-name `AttributeValue`. Those must now be character data only — no comments, no processing instructions, no child elements — so the string read is the string the canonicalizer digested. (Child elements were the third way the two views could diverge: `textContent` flattens markup away, canonicalization digests it.)

   `xsi:type="xs:string"` is an *attribute*, not a child element, so the Okta/Entra/ADFS shape still passes — covered by a test.

3. `isSignatureValid` now runs `getSamlResponseFromXML` rather than a subset of it. It previously answered `true` for documents the real entry point refuses (the comment rule already lived in the extraction step, and the new rules widened that gap). It has no production callers — all three SSO routes already use `getSamlResponseFromXML` — and a test now asserts the two entry points agree on every document in the suite.

## Tests

`App/Tests/Identity/SSO.test.ts`, 93 passing (30 new).

Every attack test starts from a genuine signed response, edits it, and then asserts three things in order:

1. `xml-crypto` **still accepts the signature** — the attacker did not have to touch the digest;
2. a `textContent` read of the edited document now yields a **different identity**;
3. `SSOUtil` rejects it.

Drop the fix and (1) and (2) still hold — only (3) fails. That is what makes these regression tests rather than "it threw for some reason" tests.

Covered:

- the reported PoC, under both assertion-level and response-level signatures
- prefix, suffix and mid-value rewrites of `NameID`
- rewrites of `Issuer` and of the display-name claim
- processing instructions in every position: direct child of `Response`, inside `Extensions`, `Status`, `Subject`, the `Assertion` body, inside the `<Signature>` subtree (free for the attacker — the enveloped transform strips it from the digest anyway), in the prolog, and after the root element
- processing instructions with empty or whitespace-only data
- the reserved `xml` target reused inside the document element
- nested elements in each identity value
- XML-declaration acceptance in three spellings, plus a response-signed variant and an `xsi:type` variant, so the fix cannot silently break real identity providers

`npx tsc --noEmit` and eslint are clean.

## The report's deeper point

The report also noted that values are parsed from the original document rather than from `getSignedReferences()`. That is the architectural root cause, and it is addressed by the follow-up commits below.

---

## Follow-up commits: the dependency upgrade, and what it turned up

The section above described the minimal fix. Two further commits act on the follow-up it identified.

### `deps(app): upgrade xml-crypto to 6.1.2 and read identity from signed bytes`

`xml-crypto` `^3.2.0` → `^6.1.2`. `@xmldom/xmldom` is already on the latest 0.9.10 and is unchanged.

The point of the upgrade is `getSignedReferences()`. Identity is now read from the reference's `signedReference` — the canonical string xml-crypto digested and verified the signature against — instead of from a second, independent parse of the original document. That second parse is the structural reason #2988 existed at all, and it is why the next canonicalization quirk would have been the next bypass. xml-crypto populates `signedReference` only after every digest and the signature value check out, and clears it otherwise.

Two things worth being precise about:

- **The upgrade does not fix #2988.** The canonicalizer still renders any node exposing a `data` property as plain text in 6.1.2 (`exclusive-canonicalization.js:143`), so the processing-instruction bug is unfixed upstream. The structural rejection in the first commit remains the primary defence; the upgrade is what makes defence in depth possible.
- **It does not collapse the two-parser split either.** xml-crypto 6.1.2 still pins `@xmldom/xmldom ^0.8.10` internally, so App and xml-crypto continue to parse the same bytes with different parser versions. Reading identity from the canonical bytes is what stops that mattering for the values we act on.

v6 has no compatible API surface with v3, so the call site changed: `new SignedXml({ publicCert, getCertFromKeyInfo })` replaces the `keyInfoProvider` object, `addReference()` takes an options object, and verified references come from `getReferences()`. `getCertFromKeyInfo` is pinned to a no-op — xml-crypto resolves its key as `getCertFromKeyInfo(keyInfo) || publicCert || privateKey`, where `keyInfo` comes from the document under verification. The constructor already defaults this to a no-op, so this is **not** a live bug, but it is a library default deciding an authentication question and it is one constructor option away from accepting any certificate the sender staples on.

One behaviour change: reading from canonical bytes would on its own make comment truncation harmless, since canonicalization drops comments. Those documents stay rejected anyway — `assertIdentityValuesArePlainText` now applies the plain-text rule to the original document as well. No identity provider puts markup in a `NameID`, and failing closed keeps the guarantee if the extraction point ever moves again.

### `fix(sso): compare the SignatureValue xml-crypto actually acts on`

Found by adversarially auditing the migration. The duplicate-`SignatureValue` rule added for #2981 did not do what its comment claimed. It read the value with a namespaced `getElementsByTagNameNS` plus `textContent`, while xml-crypto selects the same element with `xpath.select1(".//*[local-name(.)='SignatureValue']/text()", signature)`. That differs in two ways, and either lets a decoy repeat the genuine `SignatureValue` as far as xml-crypto is concerned — so the enveloped transform deletes the decoy from the digest — while looking distinct to us:

- the selection is namespace-**agnostic**, so a decoy leading with `<foo:SignatureValue xmlns:foo="urn:x">GENUINE</foo:SignatureValue>` is what xml-crypto reads and strips on;
- `select1` returns the **first text node**, so a comment or CDATA section splits the value: xml-crypto reads `ABC` where `textContent` reads `ABCZ`.

`getSignatureValueText` now refuses anything ambiguous rather than reimplementing xml-crypto's selection and having to track it.

**This was not exploitable.** Identity comes from `signedReference`, and the decoy is excluded from those bytes by the same operation that strips it from the digest, so the identity returned was always the genuine one. What was broken is a documented control, and it is the last line of defence if extraction ever moves back to the original document.

## Verification

- 112 tests in `App/Tests/Identity/SSO.test.ts`; full App suite 4556 passing across 168 suites.
- `npx tsc --noEmit` and eslint clean.
- The new `SignatureValue` tests were checked against a reverted fix: exactly the three evasion cases fail without it, and the line-wrapped base64 case (ADFS/Shibboleth) passes either way — so they are not vacuous and that shape did not regress.
- A five-lens adversarial audit of the migrated verifier found **no** confirmed bypass: identity matches what the signature vouches for, the key always comes from configuration, the #2949/#2981/#2988 attacks stay blocked, and no legitimate identity-provider shape regressed.

## Known gaps, deliberately not addressed here

Both are real desynchronizations between signed bytes and bytes acted on, both were confirmed mechanically, and neither has a demonstrated attacker path:

1. `getTrimmedText()` uses JavaScript `trim()`, which strips digest-covered characters that are not XML whitespace (NBSP, BOM, U+3000, vertical tab). Over-determined by `Common/Types/Email`'s own `trim()`.
2. App's xmldom 0.9.10 rewrites a literal U+2029 to `\n` while xml-crypto's bundled 0.8.13 preserves it. An attacker cannot introduce the character — doing so breaks the digest — and the digest-preserving substitution (`&#xA;`) produces no divergence.

Fixing either properly means a character-rejection policy on identity values, which risks breaking logins for legitimate non-ASCII display names, and (1) touches a type used across the product. That is a scope call worth making separately.
