### PR TITLE
fix(status-page): make Add Multiple Monitors match the resource form

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/StatusPage/BulkAddStatusPageMonitors.ts
+++ b/App/FeatureSet/Dashboard/src/Components/StatusPage/BulkAddStatusPageMonitors.ts
@@ -1,6 +1,7 @@
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
 import ObjectID from "Common/Types/ObjectID";
+import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 
 export interface BulkAddStatusPageMonitorFailure {
@@ -13,6 +14,19 @@ export interface BulkAddStatusPageMonitorsResult {
   failed: Array<BulkAddStatusPageMonitorFailure>;
 }
 
+/**
+ * Options that are shared by every resource this bulk add creates. These are
+ * the same options the single resource form offers, minus display name and
+ * description which are copied from each monitor.
+ */
+export interface BulkAddStatusPageMonitorResourceOptions {
+  displayTooltip?: string | undefined;
+  showCurrentStatus?: boolean | undefined;
+  showUptimePercent?: boolean | undefined;
+  uptimePercentPrecision?: UptimePrecision | undefined;
+  showStatusHistoryChart?: boolean | undefined;
+}
+
 export interface BulkAddStatusPageMonitorsOptions {
   monitors: Array<Monitor>;
   projectId: ObjectID;
@@ -20,6 +34,7 @@ export interface BulkAddStatusPageMonitorsOptions {
   statusPageGroupId?: ObjectID | undefined;
   rowAxisValue?: string | undefined;
   columnAxisValue?: string | undefined;
+  resourceOptions?: BulkAddStatusPageMonitorResourceOptions | undefined;
   createResource?:
     | ((resource: StatusPageResource) => Promise<void>)
     | undefined;
@@ -97,6 +112,31 @@ export const bulkAddStatusPageMonitors: (
 
       if (options.columnAxisValue) {
         resource.columnAxisValue = options.columnAxisValue;
+      }
+
+      const resourceOptions: BulkAddStatusPageMonitorResourceOptions =
+        options.resourceOptions || {};
+
+      if (resourceOptions.displayTooltip) {
+        resource.displayTooltip = resourceOptions.displayTooltip;
+      }
+
+      if (resourceOptions.showCurrentStatus !== undefined) {
+        resource.showCurrentStatus = resourceOptions.showCurrentStatus;
+      }
+
+      if (resourceOptions.showUptimePercent !== undefined) {
+        resource.showUptimePercent = resourceOptions.showUptimePercent;
+      }
+
+      if (resourceOptions.uptimePercentPrecision) {
+        resource.uptimePercentPrecision =
+          resourceOptions.uptimePercentPrecision;
+      }
+
+      if (resourceOptions.showStatusHistoryChart !== undefined) {
+        resource.showStatusHistoryChart =
+          resourceOptions.showStatusHistoryChart;
       }
 
       await createResource(resource);

--- a/App/FeatureSet/Dashboard/src/Components/StatusPage/BulkAddStatusPageMonitorsModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/StatusPage/BulkAddStatusPageMonitorsModal.tsx
@@ -2,20 +2,28 @@ import bulkAddStatusPageMonitors, {
   BulkAddStatusPageMonitorFailure,
   BulkAddStatusPageMonitorsResult,
 } from "./BulkAddStatusPageMonitors";
+import { getStatusPageResourceAdvancedFields } from "./StatusPageResourceFormFields";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
-import API from "Common/UI/Utils/API/API";
-import { ButtonStyleType } from "Common/UI/Components/Button/Button";
-import Dropdown, {
-  DropdownOption,
-  DropdownValue,
-} from "Common/UI/Components/Dropdown/Dropdown";
-import ModelList from "Common/UI/Components/ModelList/ModelList";
-import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import ObjectID from "Common/Types/ObjectID";
+import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import ButtonType from "Common/UI/Components/Button/ButtonTypes";
+import BasicForm from "Common/UI/Components/Forms/BasicForm";
+import Field from "Common/UI/Components/Forms/Types/Field";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import { FormStep } from "Common/UI/Components/Forms/Types/FormStep";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import React, {
   FunctionComponent,
+  MutableRefObject,
   ReactElement,
-  useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -35,36 +43,207 @@ export interface ComponentProps {
   onComplete: (result: BulkAddStatusPageMonitorsResult) => void;
 }
 
+/**
+ * Mirrors the single resource form, except the monitor picker is multi-select
+ * and display name / description are not asked for - they are copied from each
+ * monitor. Every other option applies to all of the resources created here.
+ */
+export interface BulkAddStatusPageMonitorsFormValues {
+  monitors?: Array<ObjectID | string> | undefined;
+  rowAxisValue?: string | undefined;
+  columnAxisValue?: string | undefined;
+  displayTooltip?: string | undefined;
+  showCurrentStatus?: boolean | undefined;
+  showUptimePercent?: boolean | undefined;
+  uptimePercentPrecision?: UptimePrecision | undefined;
+  showStatusHistoryChart?: boolean | undefined;
+}
+
+const FORM_STEPS: Array<FormStep<BulkAddStatusPageMonitorsFormValues>> = [
+  {
+    title: "Monitor Details",
+    id: "monitor-details",
+  },
+  {
+    title: "Advanced",
+    id: "advanced",
+  },
+];
+
+type ToObjectIdsFunction = (value: unknown) => Array<ObjectID>;
+
+/*
+ * The multi-select dropdown hands back either raw values or dropdown options
+ * depending on whether the user picked from the list or the form normalized
+ * them on submit - accept both.
+ */
+const toObjectIds: ToObjectIdsFunction = (value: unknown): Array<ObjectID> => {
+  if (!value || !Array.isArray(value)) {
+    return [];
+  }
+
+  const ids: Array<ObjectID> = [];
+
+  for (const item of value) {
+    const rawValue: unknown =
+      item && typeof item === "object" && "value" in item
+        ? (item as { value: unknown }).value
+        : item;
+
+    if (rawValue instanceof ObjectID) {
+      ids.push(rawValue);
+    } else if (typeof rawValue === "string" && rawValue) {
+      ids.push(new ObjectID(rawValue));
+    }
+  }
+
+  return ids;
+};
+
 const BulkAddStatusPageMonitorsModal: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [selectedMonitors, setSelectedMonitors] = useState<Array<Monitor>>([]);
-  const [rowAxisValue, setRowAxisValue] = useState<string>("");
-  const [columnAxisValue, setColumnAxisValue] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const [result, setResult] = useState<BulkAddStatusPageMonitorsResult | null>(
     null,
   );
+  const [submitButtonText, setSubmitButtonText] =
+    useState<string>("Add Monitors");
 
-  const rowOptions: Array<DropdownOption> = useMemo(() => {
-    return (props.gridPlacement?.rowValues || []).map((value: string) => {
-      return { label: value, value };
+  const formRef: MutableRefObject<any> = useRef<any>(null);
+
+  const getFields: () => Array<
+    Field<BulkAddStatusPageMonitorsFormValues>
+  > = (): Array<Field<BulkAddStatusPageMonitorsFormValues>> => {
+    const fields: Array<Field<BulkAddStatusPageMonitorsFormValues>> = [
+      {
+        field: {
+          monitors: true,
+        },
+        title: "Monitors",
+        description:
+          "Select monitors that will be shown on the status page. The display name and description of each resource is copied from its monitor.",
+        fieldType: FormFieldSchemaType.MultiSelectDropdown,
+        dropdownModal: {
+          type: Monitor,
+          labelField: "name",
+          valueField: "_id",
+        },
+        required: true,
+        placeholder: "Select Monitors",
+        stepId: "monitor-details",
+      },
+    ];
+
+    if (props.gridPlacement) {
+      fields.push(
+        {
+          field: {
+            rowAxisValue: true,
+          },
+          title: `${props.gridPlacement.rowLabel} (Row)`,
+          description: "Row these resources belong to in the grid.",
+          fieldType: FormFieldSchemaType.Dropdown,
+          dropdownOptions: props.gridPlacement.rowValues.map(
+            (value: string) => {
+              return { label: value, value: value };
+            },
+          ),
+          required: true,
+          placeholder: `Select ${props.gridPlacement.rowLabel.toLowerCase()}`,
+          stepId: "monitor-details",
+        },
+        {
+          field: {
+            columnAxisValue: true,
+          },
+          title: `${props.gridPlacement.columnLabel} (Column)`,
+          description: "Column these resources belong to in the grid.",
+          fieldType: FormFieldSchemaType.Dropdown,
+          dropdownOptions: props.gridPlacement.columnValues.map(
+            (value: string) => {
+              return { label: value, value: value };
+            },
+          ),
+          required: true,
+          placeholder: `Select ${props.gridPlacement.columnLabel.toLowerCase()}`,
+          stepId: "monitor-details",
+        },
+      );
+    }
+
+    /*
+     * The advanced fields are declared against StatusPageResource because the
+     * single resource form uses them too. Their field keys are the same ones
+     * this form collects, so they render and validate identically here.
+     */
+    return [
+      ...fields,
+      ...(getStatusPageResourceAdvancedFields() as unknown as Array<
+        Field<BulkAddStatusPageMonitorsFormValues>
+      >),
+    ];
+  };
+
+  type FetchMonitorsFunction = (
+    monitorIds: Array<ObjectID>,
+  ) => Promise<Array<Monitor>>;
+
+  /*
+   * The form only carries monitor IDs, but each resource copies its display
+   * name and description from the monitor - so fetch those here.
+   */
+  const fetchMonitors: FetchMonitorsFunction = async (
+    monitorIds: Array<ObjectID>,
+  ): Promise<Array<Monitor>> => {
+    const listResult: ListResult<Monitor> = await ModelAPI.getList<Monitor>({
+      modelType: Monitor,
+      query: {
+        _id: new Includes(monitorIds),
+        projectId: props.projectId,
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      select: {
+        _id: true,
+        name: true,
+        description: true,
+      },
+      sort: {
+        name: SortOrder.Ascending,
+      },
+      requestOptions: {},
     });
-  }, [props.gridPlacement?.rowValues]);
 
-  const columnOptions: Array<DropdownOption> = useMemo(() => {
-    return (props.gridPlacement?.columnValues || []).map((value: string) => {
-      return { label: value, value };
-    });
-  }, [props.gridPlacement?.columnValues]);
+    // Create resources in the order the monitors were picked.
+    const monitorsById: Map<string, Monitor> = new Map<string, Monitor>();
 
-  const hasRequiredGridPlacement: boolean = props.gridPlacement
-    ? Boolean(rowAxisValue && columnAxisValue)
-    : true;
+    for (const monitor of listResult.data) {
+      if (monitor._id) {
+        monitorsById.set(monitor._id.toString(), monitor);
+      }
+    }
 
-  const onSubmit: () => Promise<void> = async (): Promise<void> => {
-    if (selectedMonitors.length === 0 || !hasRequiredGridPlacement) {
+    return monitorIds
+      .map((monitorId: ObjectID) => {
+        return monitorsById.get(monitorId.toString());
+      })
+      .filter((monitor: Monitor | undefined): monitor is Monitor => {
+        return Boolean(monitor);
+      });
+  };
+
+  type OnSubmitFunction = (
+    values: FormValues<BulkAddStatusPageMonitorsFormValues>,
+  ) => Promise<void>;
+
+  const onSubmit: OnSubmitFunction = async (
+    values: FormValues<BulkAddStatusPageMonitorsFormValues>,
+  ): Promise<void> => {
+    const monitorIds: Array<ObjectID> = toObjectIds(values.monitors);
+
+    if (monitorIds.length === 0) {
       return;
     }
 
@@ -72,14 +251,25 @@ const BulkAddStatusPageMonitorsModal: FunctionComponent<ComponentProps> = (
     setError("");
 
     try {
+      const monitors: Array<Monitor> = await fetchMonitors(monitorIds);
+
       const bulkResult: BulkAddStatusPageMonitorsResult =
         await bulkAddStatusPageMonitors({
-          monitors: selectedMonitors,
+          monitors: monitors,
           projectId: props.projectId,
           statusPageId: props.statusPageId,
           statusPageGroupId: props.statusPageGroupId,
-          rowAxisValue: rowAxisValue || undefined,
-          columnAxisValue: columnAxisValue || undefined,
+          rowAxisValue: (values.rowAxisValue as string) || undefined,
+          columnAxisValue: (values.columnAxisValue as string) || undefined,
+          resourceOptions: {
+            displayTooltip: (values.displayTooltip as string) || undefined,
+            showCurrentStatus: Boolean(values.showCurrentStatus),
+            showUptimePercent: Boolean(values.showUptimePercent),
+            uptimePercentPrecision: values.showUptimePercent
+              ? (values.uptimePercentPrecision as UptimePrecision)
+              : undefined,
+            showStatusHistoryChart: Boolean(values.showStatusHistoryChart),
+          },
         });
 
       setResult(bulkResult);
@@ -158,83 +348,35 @@ const BulkAddStatusPageMonitorsModal: FunctionComponent<ComponentProps> = (
   return (
     <Modal
       title="Add Multiple Monitors"
-      description="Select the monitors to add. Each status page display name and description will be copied from its monitor."
+      description="Add monitors to this status page. Each resource gets its display name and description from its monitor."
       modalWidth={ModalWidth.Medium}
-      submitButtonText={
-        selectedMonitors.length > 0
-          ? `Add ${selectedMonitors.length} Monitor${selectedMonitors.length === 1 ? "" : "s"}`
-          : "Add Monitors"
-      }
+      submitButtonText={submitButtonText}
+      submitButtonType={ButtonType.Submit}
       onClose={props.onClose}
       onSubmit={() => {
-        onSubmit().catch((err: Error) => {
-          setError(API.getFriendlyMessage(err));
-        });
+        formRef.current?.submitForm();
       }}
       isLoading={isLoading}
+      disableSubmitButton={isLoading}
       error={error}
-      disableSubmitButton={
-        selectedMonitors.length === 0 || !hasRequiredGridPlacement
-      }
     >
-      <div className="space-y-5">
-        {props.gridPlacement ? (
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                {props.gridPlacement.rowLabel} (Row)
-              </label>
-              <Dropdown
-                options={rowOptions}
-                placeholder={`Select ${props.gridPlacement.rowLabel.toLowerCase()}`}
-                ariaLabel={`${props.gridPlacement.rowLabel} row`}
-                onChange={(
-                  value: DropdownValue | Array<DropdownValue> | null,
-                ) => {
-                  setRowAxisValue((value as string) || "");
-                }}
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                {props.gridPlacement.columnLabel} (Column)
-              </label>
-              <Dropdown
-                options={columnOptions}
-                placeholder={`Select ${props.gridPlacement.columnLabel.toLowerCase()}`}
-                ariaLabel={`${props.gridPlacement.columnLabel} column`}
-                onChange={(
-                  value: DropdownValue | Array<DropdownValue> | null,
-                ) => {
-                  setColumnAxisValue((value as string) || "");
-                }}
-              />
-            </div>
-          </div>
-        ) : null}
-
-        <div>
-          <h4 className="text-sm font-medium text-gray-900">Monitors</h4>
-          <p className="mt-1 text-sm text-gray-500">
-            Choose one or more monitors. Click a selected monitor again to
-            remove it.
-          </p>
-          <ModelList<Monitor>
-            id="bulk-add-status-page-monitors"
-            modelType={Monitor}
-            query={{ projectId: props.projectId }}
-            titleField="name"
-            descriptionField="description"
-            selectMultiple={true}
-            isSearchEnabled={true}
-            select={{ _id: true, name: true, description: true }}
-            noItemsMessage="No monitors are available in this project."
-            onSelectChange={(monitors: Array<Monitor>) => {
-              setSelectedMonitors(monitors);
-            }}
-          />
-        </div>
-      </div>
+      <BasicForm
+        ref={formRef}
+        id="bulk-add-status-page-monitors"
+        name="Status Page > Add Multiple Monitors"
+        hideSubmitButton={true}
+        fields={getFields()}
+        steps={FORM_STEPS}
+        onIsLastFormStep={(isLastFormStep: boolean) => {
+          setSubmitButtonText(isLastFormStep ? "Add Monitors" : "Next");
+        }}
+        onSubmit={(values: FormValues<BulkAddStatusPageMonitorsFormValues>) => {
+          onSubmit(values).catch((err: Error) => {
+            setError(API.getFriendlyMessage(err));
+            setIsLoading(false);
+          });
+        }}
+      />
     </Modal>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Components/StatusPage/StatusPageResourceFormFields.ts
+++ b/App/FeatureSet/Dashboard/src/Components/StatusPage/StatusPageResourceFormFields.ts
@@ -1,0 +1,83 @@
+import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
+import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
+import { ModelField } from "Common/UI/Components/Forms/ModelForm";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import DropdownUtil from "Common/UI/Utils/Dropdown";
+
+/**
+ * Options that apply to a status page resource no matter how it was created -
+ * one at a time from the resource form, or in bulk from the "Add Multiple
+ * Monitors" modal. Both surfaces render these fields from here so they never
+ * drift apart.
+ */
+export const getStatusPageResourceAdvancedFields: () => Array<
+  ModelField<StatusPageResource>
+> = (): Array<ModelField<StatusPageResource>> => {
+  return [
+    {
+      field: {
+        displayTooltip: true,
+      },
+      title: "Tooltip ",
+      fieldType: FormFieldSchemaType.LongText,
+      required: false,
+      description:
+        "This will show up as tooltip beside the resource on your status page.",
+      placeholder: "Tooltip",
+      stepId: "advanced",
+    },
+    {
+      field: {
+        showCurrentStatus: true,
+      },
+      title: "Show Current Resource Status",
+      fieldType: FormFieldSchemaType.Toggle,
+      required: false,
+      defaultValue: true,
+      description:
+        "Current Resource Status will be shown beside this resource on your status page.",
+      stepId: "advanced",
+    },
+    {
+      field: {
+        showUptimePercent: true,
+      },
+      title: "Show Uptime %",
+      fieldType: FormFieldSchemaType.Toggle,
+      required: false,
+      defaultValue: false,
+      description:
+        "Show uptime percentage beside this resource on your status page. The number of days is configured in Status Page Settings.",
+      stepId: "advanced",
+    },
+    {
+      field: {
+        uptimePercentPrecision: true,
+      },
+      stepId: "advanced",
+      fieldType: FormFieldSchemaType.Dropdown,
+      dropdownOptions: DropdownUtil.getDropdownOptionsFromEnum(UptimePrecision),
+      showIf: (item: FormValues<StatusPageResource>): boolean => {
+        return Boolean(item.showUptimePercent);
+      },
+      title: "Select Uptime Precision",
+      defaultValue: UptimePrecision.ONE_DECIMAL,
+      required: true,
+    },
+    {
+      field: {
+        showStatusHistoryChart: true,
+      },
+      title: "Show Status History Chart",
+      fieldType: FormFieldSchemaType.Toggle,
+      required: false,
+      description:
+        "Show resource status history chart. The number of days is configured in Status Page Settings.",
+      defaultValue: true,
+      stepId: "advanced",
+    },
+  ];
+};
+
+export default getStatusPageResourceAdvancedFields;

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
@@ -2,6 +2,7 @@ import MonitorElement from "../../../Components/Monitor/Monitor";
 import MonitorGroupElement from "../../../Components/MonitorGroup/MonitorGroupElement";
 import BulkAddStatusPageMonitorsModal from "../../../Components/StatusPage/BulkAddStatusPageMonitorsModal";
 import GridResourceEditor from "../../../Components/StatusPage/GridResourceEditor";
+import { getStatusPageResourceAdvancedFields } from "../../../Components/StatusPage/StatusPageResourceFormFields";
 import PageComponentProps from "../../PageComponentProps";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
@@ -14,14 +15,12 @@ import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoade
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import { ModelField } from "Common/UI/Components/Forms/ModelForm";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
-import FormValues from "Common/UI/Components/Forms/Types/FormValues";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import Columns from "Common/UI/Components/ModelTable/Column";
 import Filter from "Common/UI/Components/ModelFilter/Filter";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import { GetReactElementFunction } from "Common/UI/Types/FunctionTypes";
 import API from "Common/UI/Utils/API/API";
-import DropdownUtil from "Common/UI/Utils/Dropdown";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import PermissionUtil from "Common/UI/Utils/Permission";
@@ -40,7 +39,6 @@ import React, {
   useEffect,
   useState,
 } from "react";
-import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
 import Link from "Common/UI/Components/Link/Link";
 import ProjectUtil from "Common/UI/Utils/Project";
@@ -221,68 +219,7 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
         "Describe this resource here",
       ),
     },
-    {
-      field: {
-        displayTooltip: true,
-      },
-      title: "Tooltip ",
-      fieldType: FormFieldSchemaType.LongText,
-      required: false,
-      description:
-        "This will show up as tooltip beside the resource on your status page.",
-      placeholder: "Tooltip",
-      stepId: "advanced",
-    },
-    {
-      field: {
-        showCurrentStatus: true,
-      },
-      title: "Show Current Resource Status",
-      fieldType: FormFieldSchemaType.Toggle,
-      required: false,
-      defaultValue: true,
-      description:
-        "Current Resource Status will be shown beside this resource on your status page.",
-      stepId: "advanced",
-    },
-    {
-      field: {
-        showUptimePercent: true,
-      },
-      title: "Show Uptime %",
-      fieldType: FormFieldSchemaType.Toggle,
-      required: false,
-      defaultValue: false,
-      description:
-        "Show uptime percentage beside this resource on your status page. The number of days is configured in Status Page Settings.",
-      stepId: "advanced",
-    },
-    {
-      field: {
-        uptimePercentPrecision: true,
-      },
-      stepId: "advanced",
-      fieldType: FormFieldSchemaType.Dropdown,
-      dropdownOptions: DropdownUtil.getDropdownOptionsFromEnum(UptimePrecision),
-      showIf: (item: FormValues<StatusPageResource>): boolean => {
-        return Boolean(item.showUptimePercent);
-      },
-      title: "Select Uptime Precision",
-      defaultValue: UptimePrecision.ONE_DECIMAL,
-      required: true,
-    },
-    {
-      field: {
-        showStatusHistoryChart: true,
-      },
-      title: "Show Status History Chart",
-      fieldType: FormFieldSchemaType.Toggle,
-      required: false,
-      description:
-        "Show resource status history chart. The number of days is configured in Status Page Settings.",
-      defaultValue: true,
-      stepId: "advanced",
-    },
+    ...getStatusPageResourceAdvancedFields(),
   ]);
 
   type GetModelTableFunction = (

--- a/Common/Tests/App/StatusPage/BulkAddStatusPageMonitors.test.ts
+++ b/Common/Tests/App/StatusPage/BulkAddStatusPageMonitors.test.ts
@@ -4,6 +4,7 @@ import bulkAddStatusPageMonitors, {
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
 import ObjectID from "../../../Types/ObjectID";
+import UptimePrecision from "../../../Types/StatusPage/UptimePrecision";
 import { describe, expect, jest, test } from "@jest/globals";
 
 const PROJECT_ID: ObjectID = new ObjectID(
@@ -133,6 +134,65 @@ describe("bulkAddStatusPageMonitors", () => {
         );
       }),
     ).toBe(true);
+  });
+
+  test("applies the shared resource options to every selected monitor", async () => {
+    const monitors: Array<Monitor> = [
+      makeMonitor("0198c8ec-2a1d-7f0c-9e75-384194160035", "US API"),
+      makeMonitor("0198c8ec-2a1d-7f0c-9e75-384194160036", "US Worker"),
+    ];
+    const created: Array<StatusPageResource> = [];
+
+    await bulkAddStatusPageMonitors({
+      monitors,
+      projectId: PROJECT_ID,
+      statusPageId: STATUS_PAGE_ID,
+      resourceOptions: {
+        displayTooltip: "Runs in US East",
+        showCurrentStatus: false,
+        showUptimePercent: true,
+        uptimePercentPrecision: UptimePrecision.TWO_DECIMAL,
+        showStatusHistoryChart: false,
+      },
+      createResource: async (resource: StatusPageResource): Promise<void> => {
+        created.push(resource);
+      },
+    });
+
+    expect(created).toHaveLength(2);
+
+    for (const resource of created) {
+      expect(resource).toMatchObject({
+        displayTooltip: "Runs in US East",
+        showCurrentStatus: false,
+        showUptimePercent: true,
+        uptimePercentPrecision: UptimePrecision.TWO_DECIMAL,
+        showStatusHistoryChart: false,
+      });
+    }
+  });
+
+  test("leaves resource options unset when the form did not collect them", async () => {
+    const monitor: Monitor = makeMonitor(
+      "0198c8ec-2a1d-7f0c-9e75-384194160037",
+      "US API",
+    );
+    let created: StatusPageResource | null = null;
+
+    await bulkAddStatusPageMonitors({
+      monitors: [monitor],
+      projectId: PROJECT_ID,
+      statusPageId: STATUS_PAGE_ID,
+      createResource: async (resource: StatusPageResource): Promise<void> => {
+        created = resource;
+      },
+    });
+
+    expect(created!.displayTooltip).toBeUndefined();
+    expect(created!.showCurrentStatus).toBeUndefined();
+    expect(created!.showUptimePercent).toBeUndefined();
+    expect(created!.uptimePercentPrecision).toBeUndefined();
+    expect(created!.showStatusHistoryChart).toBeUndefined();
   });
 
   test("deduplicates repeated monitor selections while retaining first-selection order", async () => {

--- a/Common/Tests/App/StatusPage/BulkAddStatusPageMonitorsModal.test.tsx
+++ b/Common/Tests/App/StatusPage/BulkAddStatusPageMonitorsModal.test.tsx
@@ -3,26 +3,29 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 
-jest.mock("Common/UI/Components/ModelList/ModelList", () => {
+const MONITOR_ONE_ID: string = "0198c8ec-2a1d-7f0c-9e75-384194161010";
+const MONITOR_TWO_ID: string = "0198c8ec-2a1d-7f0c-9e75-384194161011";
+
+jest.mock("Common/UI/Components/EntityDropdown/EntityDropdown", () => {
   return {
     __esModule: true,
     default: (props: {
-      modelType: new () => { name?: string };
-      onSelectChange?: (items: Array<{ name?: string }>) => void;
+      isMultiSelect?: boolean;
+      error?: string;
+      onChange?: (value: Array<string>) => void;
     }) => {
       return (
-        <button
-          type="button"
-          onClick={() => {
-            const first: { name?: string } = new props.modelType();
-            first.name = "Checkout API";
-            const second: { name?: string } = new props.modelType();
-            second.name = "Billing Worker";
-            props.onSelectChange?.([first, second]);
-          }}
-        >
-          Select two monitors
-        </button>
+        <div>
+          <button
+            type="button"
+            onClick={() => {
+              props.onChange?.([MONITOR_TWO_ID, MONITOR_ONE_ID]);
+            }}
+          >
+            {props.isMultiSelect ? "Select two monitors" : "Select one monitor"}
+          </button>
+          {props.error ? <p>{props.error}</p> : null}
+        </div>
       );
     },
   };
@@ -31,22 +34,35 @@ jest.mock("Common/UI/Components/ModelList/ModelList", () => {
 jest.mock("Common/UI/Components/Dropdown/Dropdown", () => {
   return {
     __esModule: true,
+    DROPDOWN_MENU_Z_INDEX: 1,
     default: (props: {
-      ariaLabel?: string;
+      placeholder?: string;
+      error?: string;
       options: Array<{ value: string }>;
       onChange?: (value: string) => void;
     }) => {
       return (
-        <button
-          type="button"
-          aria-label={props.ariaLabel}
-          onClick={() => {
-            props.onChange?.(props.options[0]!.value);
-          }}
-        >
-          Choose {props.ariaLabel}
-        </button>
+        <div>
+          <button
+            type="button"
+            onClick={() => {
+              props.onChange?.(props.options[0]!.value);
+            }}
+          >
+            Choose {props.placeholder}
+          </button>
+          {props.error ? <p>{props.error}</p> : null}
+        </div>
       );
+    },
+  };
+});
+
+jest.mock("Common/UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: jest.fn(),
     },
   };
 });
@@ -68,6 +84,7 @@ import bulkAddStatusPageMonitors, {
 import BulkAddStatusPageMonitorsModal from "../../../../App/FeatureSet/Dashboard/src/Components/StatusPage/BulkAddStatusPageMonitorsModal";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import ObjectID from "../../../Types/ObjectID";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
 
 const PROJECT_ID: ObjectID = new ObjectID(
   "0198c8ec-2a1d-7f0c-9e75-384194161001",
@@ -82,9 +99,79 @@ const mockBulkAdd: jest.MockedFunction<typeof bulkAddStatusPageMonitors> =
     typeof bulkAddStatusPageMonitors
   >;
 
+const mockGetList: jest.MockedFunction<any> =
+  ModelAPI.getList as unknown as jest.MockedFunction<any>;
+
+type MakeMonitorFunction = (
+  id: string,
+  name: string,
+  description: string,
+) => Monitor;
+
+const makeMonitor: MakeMonitorFunction = (
+  id: string,
+  name: string,
+  description: string,
+): Monitor => {
+  const monitor: Monitor = new Monitor();
+  monitor._id = id;
+  monitor.name = name;
+  monitor.description = description;
+  return monitor;
+};
+
+type RenderModalFunction = (
+  overrides?: Partial<
+    React.ComponentProps<typeof BulkAddStatusPageMonitorsModal>
+  >,
+) => ReturnType<typeof render>;
+
+const renderModal: RenderModalFunction = (
+  overrides: Partial<
+    React.ComponentProps<typeof BulkAddStatusPageMonitorsModal>
+  > = {},
+): ReturnType<typeof render> => {
+  return render(
+    <BulkAddStatusPageMonitorsModal
+      projectId={PROJECT_ID}
+      statusPageId={STATUS_PAGE_ID}
+      statusPageGroupId={GROUP_ID}
+      onClose={jest.fn()}
+      onComplete={jest.fn()}
+      {...overrides}
+    />,
+  );
+};
+
+type GoToLastStepFunction = (view: ReturnType<typeof render>) => Promise<void>;
+
+// The form has the same "Monitor Details" then "Advanced" steps as the single resource form.
+const goToLastStep: GoToLastStepFunction = async (
+  view: ReturnType<typeof render>,
+): Promise<void> => {
+  fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+  await waitFor(() => {
+    expect(view.getByTestId("modal-footer-submit-button")).toHaveTextContent(
+      "Add Monitors",
+    );
+  });
+};
+
 describe("BulkAddStatusPageMonitorsModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockGetList.mockImplementation(async (): Promise<any> => {
+      return {
+        data: [
+          makeMonitor(MONITOR_ONE_ID, "Checkout API", "Takes payments"),
+          makeMonitor(MONITOR_TWO_ID, "Billing Worker", "Sends invoices"),
+        ],
+        count: 2,
+      };
+    });
+
     mockBulkAdd.mockImplementation(
       async (
         options: BulkAddStatusPageMonitorsOptions,
@@ -94,40 +181,35 @@ describe("BulkAddStatusPageMonitorsModal", () => {
     );
   });
 
-  test("requires at least one monitor before enabling the bulk action", () => {
-    const view: ReturnType<typeof render> = render(
-      <BulkAddStatusPageMonitorsModal
-        projectId={PROJECT_ID}
-        statusPageId={STATUS_PAGE_ID}
-        statusPageGroupId={GROUP_ID}
-        onClose={jest.fn()}
-        onComplete={jest.fn()}
-      />,
-    );
+  test("asks for monitors and the resource options, but never a display name", () => {
+    const view: ReturnType<typeof render> = renderModal();
 
-    const submit: HTMLElement = view.getByTestId("modal-footer-submit-button");
-    expect(submit).toBeDisabled();
-
-    fireEvent.click(view.getByRole("button", { name: "Select two monitors" }));
-
-    expect(submit).not.toBeDisabled();
-    expect(submit).toHaveTextContent("Add 2 Monitors");
+    expect(view.getByText("Monitors")).toBeVisible();
+    expect(view.getByText("Monitor Details")).toBeVisible();
+    expect(view.getByText("Advanced")).toBeVisible();
+    expect(view.queryByText("Display Name")).not.toBeInTheDocument();
+    expect(view.queryByText("Description")).not.toBeInTheDocument();
   });
 
-  test("submits selected monitors to the requested status page group", async () => {
+  test("requires at least one monitor before the bulk add runs", async () => {
+    const view: ReturnType<typeof render> = renderModal();
+
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(view.getByText("Monitors is required.")).toBeVisible();
+    });
+
+    expect(mockBulkAdd).not.toHaveBeenCalled();
+  });
+
+  test("adds the selected monitors with the shared resource options", async () => {
     const onComplete: (result: BulkAddStatusPageMonitorsResult) => void =
       jest.fn((_result: BulkAddStatusPageMonitorsResult): void => {});
-    const view: ReturnType<typeof render> = render(
-      <BulkAddStatusPageMonitorsModal
-        projectId={PROJECT_ID}
-        statusPageId={STATUS_PAGE_ID}
-        statusPageGroupId={GROUP_ID}
-        onClose={jest.fn()}
-        onComplete={onComplete}
-      />,
-    );
+    const view: ReturnType<typeof render> = renderModal({ onComplete });
 
     fireEvent.click(view.getByRole("button", { name: "Select two monitors" }));
+    await goToLastStep(view);
     fireEvent.click(view.getByTestId("modal-footer-submit-button"));
 
     await waitFor(() => {
@@ -139,11 +221,21 @@ describe("BulkAddStatusPageMonitorsModal", () => {
     expect(options.projectId).toBe(PROJECT_ID);
     expect(options.statusPageId).toBe(STATUS_PAGE_ID);
     expect(options.statusPageGroupId).toBe(GROUP_ID);
+
+    // Monitors are added in the order they were picked, not the order they were fetched in.
     expect(
       options.monitors.map((monitor: Monitor) => {
         return monitor.name;
       }),
-    ).toEqual(["Checkout API", "Billing Worker"]);
+    ).toEqual(["Billing Worker", "Checkout API"]);
+
+    expect(options.resourceOptions).toEqual({
+      displayTooltip: undefined,
+      showCurrentStatus: true,
+      showUptimePercent: false,
+      uptimePercentPrecision: undefined,
+      showStatusHistoryChart: true,
+    });
 
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
@@ -152,32 +244,30 @@ describe("BulkAddStatusPageMonitorsModal", () => {
   });
 
   test("requires and submits a shared grid placement", async () => {
-    const view: ReturnType<typeof render> = render(
-      <BulkAddStatusPageMonitorsModal
-        projectId={PROJECT_ID}
-        statusPageId={STATUS_PAGE_ID}
-        statusPageGroupId={GROUP_ID}
-        gridPlacement={{
-          rowLabel: "Environment",
-          rowValues: ["Production", "Staging"],
-          columnLabel: "Region",
-          columnValues: ["US East", "EU West"],
-        }}
-        onClose={jest.fn()}
-        onComplete={jest.fn()}
-      />,
-    );
+    const view: ReturnType<typeof render> = renderModal({
+      gridPlacement: {
+        rowLabel: "Environment",
+        rowValues: ["Production", "Staging"],
+        columnLabel: "Region",
+        columnValues: ["US East", "EU West"],
+      },
+    });
 
     fireEvent.click(view.getByRole("button", { name: "Select two monitors" }));
-    const submit: HTMLElement = view.getByTestId("modal-footer-submit-button");
-    expect(submit).toBeDisabled();
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
 
-    fireEvent.click(view.getByRole("button", { name: "Environment row" }));
-    expect(submit).toBeDisabled();
+    await waitFor(() => {
+      expect(view.getByText("Environment (Row) is required.")).toBeVisible();
+    });
+    expect(view.getByText("Region (Column) is required.")).toBeVisible();
 
-    fireEvent.click(view.getByRole("button", { name: "Region column" }));
-    expect(submit).not.toBeDisabled();
-    fireEvent.click(submit);
+    fireEvent.click(
+      view.getByRole("button", { name: "Choose Select environment" }),
+    );
+    fireEvent.click(view.getByRole("button", { name: "Choose Select region" }));
+
+    await goToLastStep(view);
+    fireEvent.click(view.getByTestId("modal-footer-submit-button"));
 
     await waitFor(() => {
       expect(mockBulkAdd).toHaveBeenCalledTimes(1);
@@ -206,16 +296,10 @@ describe("BulkAddStatusPageMonitorsModal", () => {
       },
     );
     const onClose: () => void = jest.fn((): void => {});
-    const view: ReturnType<typeof render> = render(
-      <BulkAddStatusPageMonitorsModal
-        projectId={PROJECT_ID}
-        statusPageId={STATUS_PAGE_ID}
-        onClose={onClose}
-        onComplete={jest.fn()}
-      />,
-    );
+    const view: ReturnType<typeof render> = renderModal({ onClose });
 
     fireEvent.click(view.getByRole("button", { name: "Select two monitors" }));
+    await goToLastStep(view);
     fireEvent.click(view.getByTestId("modal-footer-submit-button"));
 
     await waitFor(() => {
@@ -224,8 +308,8 @@ describe("BulkAddStatusPageMonitorsModal", () => {
 
     expect(view.getByText("Added (1)")).toBeVisible();
     expect(view.getByText("Failed (1)")).toBeVisible();
-    expect(view.getByText("Checkout API")).toBeVisible();
-    expect(view.getByText(/Billing Worker:/)).toBeVisible();
+    expect(view.getByText("Billing Worker")).toBeVisible();
+    expect(view.getByText(/Checkout API:/)).toBeVisible();
     expect(view.getByText("Permission denied")).toBeVisible();
     expect(view.queryByText("Select two monitors")).not.toBeInTheDocument();
 


### PR DESCRIPTION
### Title of this pull request?

fix(status-page): make Add Multiple Monitors match the resource form

### Small Description?

The "Add Multiple Monitors" modal on Status Page > Resources was its own one-off UI: a checkbox list of monitors, with none of the options the single resource form offers.

It is now the same form as "Create Status Page Resource" — same two steps (Monitor Details, Advanced) — with two differences:

- The monitor picker is a **multi-select** entity dropdown instead of single-select (server-side search, chips, and the Labels tab for bulk-picking monitors by label).
- It does **not** ask for Display Name or Description. Each resource copies `displayName` from the monitor's name and `displayDescription` from the monitor's description.

Every other option stays and is applied to all monitors added in one go: Tooltip, Show Current Resource Status, Show Uptime % (+ Uptime Precision), Show Status History Chart, and the Row / Column dropdowns when the modal is opened from a grid group.

**Changes**

- `App/FeatureSet/Dashboard/src/Components/StatusPage/StatusPageResourceFormFields.ts` (new) — the advanced resource fields declared once. Both the single resource form and the bulk modal render from it, so the two forms can't drift apart.
- `BulkAddStatusPageMonitorsModal.tsx` — rewritten on top of `BasicForm`. The dropdown yields IDs only, so on submit it fetches name/description for the picked monitors and re-orders them back into selection order before creating.
- `BulkAddStatusPageMonitors.ts` — accepts `resourceOptions` and stamps them onto every created resource. Resources are still created sequentially, and the existing success/failure summary screen is unchanged.
- `Resources.tsx` — renders the advanced fields from the shared definition.

**Notes for reviewers**

- Selecting a monitor that was deleted between picking and submitting silently drops it from the batch; the summary then reports the smaller total.
- The advanced fields are typed against `StatusPageResource` (the single form needs that) and cast once in the bulk modal, whose form values use the same field keys.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verified locally: `tsc` clean on `App/FeatureSet/Dashboard` (only the pre-existing, unrelated `rrweb` error), eslint clean on the changed files, and 15/15 tests pass in `Common/Tests/App/StatusPage`. The modal tests were rewritten for the form flow (required-monitor validation, step navigation, resource options passed through, grid placement), plus two new tests covering `resourceOptions`.

Not verified in a browser: the dashboard needs the docker compose stack, which was not running in this environment.

### Related Issue?

N/A

### Screenshots (if appropriate):

N/A
