### PR TITLE
Regroup the Add Widget picker by what widgets show

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/AddWidgetModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/AddWidgetModal.tsx
@@ -2,6 +2,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
@@ -9,350 +10,17 @@ import Icon from "Common/UI/Components/Icon/Icon";
 import useTranslateValue from "Common/UI/Utils/Translation";
 import IconProp from "Common/Types/Icon/IconProp";
 import DashboardComponentType from "Common/Types/Dashboard/DashboardComponentType";
-
-interface CatalogItem {
-  type: DashboardComponentType;
-  label: string;
-  icon: IconProp;
-  description: string;
-}
-
-interface CatalogCategory {
-  name: string;
-  description: string;
-  items: Array<CatalogItem>;
-}
-
-const WIDGET_CATALOG: ReadonlyArray<CatalogCategory> = [
-  {
-    name: "Visualization",
-    description: "Charts, values, tables, and other generic visualizations.",
-    items: [
-      {
-        type: DashboardComponentType.Chart,
-        label: "Chart",
-        icon: IconProp.ChartBar,
-        description: "Time-series chart from a metrics query.",
-      },
-      {
-        type: DashboardComponentType.Value,
-        label: "Value",
-        icon: IconProp.Hashtag,
-        description: "Single big-number stat, ideal for KPIs.",
-      },
-      {
-        type: DashboardComponentType.Gauge,
-        label: "Gauge",
-        icon: IconProp.Gauge,
-        description: "Radial gauge for a percent or threshold.",
-      },
-      {
-        type: DashboardComponentType.Table,
-        label: "Table",
-        icon: IconProp.TableCells,
-        description:
-          "Tabular metric values — set a Group By (e.g. host.name) for one row per entity, or none for time-bucketed rows. Add formulas for derived columns like availability %.",
-      },
-      {
-        type: DashboardComponentType.Text,
-        label: "Text",
-        icon: IconProp.Text,
-        description: "Free-form Markdown text for headers and notes.",
-      },
-      {
-        type: DashboardComponentType.Clock,
-        label: "Clock",
-        icon: IconProp.Clock,
-        description:
-          "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.",
-      },
-      {
-        type: DashboardComponentType.Html,
-        label: "HTML",
-        icon: IconProp.Code,
-        description:
-          "Your own HTML, CSS, and JavaScript, rendered in a sandbox.",
-      },
-    ],
-  },
-  {
-    name: "Telemetry",
-    description: "Live streams from your logs and traces.",
-    items: [
-      {
-        type: DashboardComponentType.LogStream,
-        label: "Log Stream",
-        icon: IconProp.Logs,
-        description: "Tail recent log records matching a filter.",
-      },
-      {
-        type: DashboardComponentType.LogChart,
-        label: "Log Chart",
-        icon: IconProp.ChartBar,
-        description:
-          "Log volume over time by severity, with bar, line, or area visualization and friendly attribute filters.",
-      },
-      {
-        type: DashboardComponentType.TraceList,
-        label: "Trace List",
-        icon: IconProp.Waterfall,
-        description: "Most recent traces for a service or operation.",
-      },
-      {
-        type: DashboardComponentType.TraceChart,
-        label: "Trace Chart",
-        icon: IconProp.ChartBar,
-        description:
-          "Span counts or response-time percentiles over time, optionally split by an attribute (e.g. per tenant).",
-      },
-      {
-        type: DashboardComponentType.TraceTable,
-        label: "Trace Table",
-        icon: IconProp.TableCells,
-        description:
-          "Top dimensions by request count — requests, median, avg, min, and max response time per span name, status, or attribute.",
-      },
-    ],
-  },
-  {
-    name: "Alerts & Status",
-    description: "OneUptime incidents, alerts, and monitor status.",
-    items: [
-      {
-        type: DashboardComponentType.IncidentList,
-        label: "Incident List",
-        icon: IconProp.Alert,
-        description: "Filtered list of incidents with state and severity.",
-      },
-      {
-        type: DashboardComponentType.AlertList,
-        label: "Alert List",
-        icon: IconProp.Bell,
-        description: "Recent alerts with state and severity.",
-      },
-      {
-        type: DashboardComponentType.MonitorList,
-        label: "Monitor List",
-        icon: IconProp.AltGlobe,
-        description: "Monitors with current operational status.",
-      },
-      {
-        type: DashboardComponentType.Slo,
-        label: "SLO",
-        icon: IconProp.Percent,
-        description:
-          "SLI, error budget remaining, or burn rate for one SLO — as a big number or a trend chart.",
-      },
-    ],
-  },
-  {
-    name: "Hosts",
-    description:
-      "Hosts auto-discovered from the host.name OTel resource attribute.",
-    items: [
-      {
-        type: DashboardComponentType.HostList,
-        label: "Hosts",
-        icon: IconProp.Server,
-        description:
-          "Hosts with connection status, OS, CPU/memory, and last-seen.",
-      },
-    ],
-  },
-  {
-    name: "Kubernetes",
-    description:
-      "Live inventory from any connected Kubernetes cluster — populated by the OneUptime Kubernetes Agent.",
-    items: [
-      {
-        type: DashboardComponentType.KubernetesPodList,
-        label: "Pods",
-        icon: IconProp.Cube,
-        description: "Pods with phase, namespace, and cluster.",
-      },
-      {
-        type: DashboardComponentType.KubernetesNodeList,
-        label: "Nodes",
-        icon: IconProp.Server,
-        description: "Nodes with readiness and pressure conditions.",
-      },
-      {
-        type: DashboardComponentType.KubernetesNamespaceList,
-        label: "Namespaces",
-        icon: IconProp.Folder,
-        description: "All namespaces across selected clusters.",
-      },
-      {
-        type: DashboardComponentType.KubernetesDeploymentList,
-        label: "Deployments",
-        icon: IconProp.ServerStack,
-        description: "Deployments in selected clusters or namespaces.",
-      },
-      {
-        type: DashboardComponentType.KubernetesStatefulSetList,
-        label: "StatefulSets",
-        icon: IconProp.ServerStack,
-        description: "StatefulSets in selected clusters or namespaces.",
-      },
-      {
-        type: DashboardComponentType.KubernetesDaemonSetList,
-        label: "DaemonSets",
-        icon: IconProp.ServerStack,
-        description: "DaemonSets in selected clusters or namespaces.",
-      },
-      {
-        type: DashboardComponentType.KubernetesJobList,
-        label: "Jobs",
-        icon: IconProp.Clock,
-        description: "Jobs in selected clusters or namespaces.",
-      },
-      {
-        type: DashboardComponentType.KubernetesCronJobList,
-        label: "CronJobs",
-        icon: IconProp.Clock,
-        description: "CronJobs in selected clusters or namespaces.",
-      },
-    ],
-  },
-  {
-    name: "Docker",
-    description:
-      "Live inventory from any connected Docker host — populated by the OneUptime Docker Agent.",
-    items: [
-      {
-        type: DashboardComponentType.DockerHostList,
-        label: "Hosts",
-        icon: IconProp.Server,
-        description:
-          "Docker hosts with connection status and container counts.",
-      },
-      {
-        type: DashboardComponentType.DockerContainerList,
-        label: "Containers",
-        icon: IconProp.Cube,
-        description: "Containers with state, image, and CPU/memory.",
-      },
-      {
-        type: DashboardComponentType.DockerImageList,
-        label: "Images",
-        icon: IconProp.Cube,
-        description: "Images present on selected hosts.",
-      },
-      {
-        type: DashboardComponentType.DockerNetworkList,
-        label: "Networks",
-        icon: IconProp.Globe,
-        description: "Networks defined on selected hosts.",
-      },
-      {
-        type: DashboardComponentType.DockerVolumeList,
-        label: "Volumes",
-        icon: IconProp.Database,
-        description: "Volumes defined on selected hosts.",
-      },
-    ],
-  },
-  {
-    name: "Podman",
-    description:
-      "Live inventory from any connected Podman host — populated by the OneUptime Podman Agent.",
-    items: [
-      {
-        type: DashboardComponentType.PodmanHostList,
-        label: "Hosts",
-        icon: IconProp.Server,
-        description:
-          "Podman hosts with connection status and container counts.",
-      },
-      {
-        type: DashboardComponentType.PodmanContainerList,
-        label: "Containers",
-        icon: IconProp.Cube,
-        description: "Containers with state, image, and CPU/memory.",
-      },
-      {
-        type: DashboardComponentType.PodmanImageList,
-        label: "Images",
-        icon: IconProp.Cube,
-        description: "Images present on selected hosts.",
-      },
-      {
-        type: DashboardComponentType.PodmanNetworkList,
-        label: "Networks",
-        icon: IconProp.Globe,
-        description: "Networks defined on selected hosts.",
-      },
-      {
-        type: DashboardComponentType.PodmanVolumeList,
-        label: "Volumes",
-        icon: IconProp.Database,
-        description: "Volumes defined on selected hosts.",
-      },
-    ],
-  },
-  {
-    name: "Proxmox",
-    description:
-      "Live inventory from any connected Proxmox VE cluster — populated by the OneUptime Proxmox Agent.",
-    items: [
-      {
-        type: DashboardComponentType.ProxmoxNodeList,
-        label: "Nodes",
-        icon: IconProp.ServerStack,
-        description: "PVE nodes with online status and CPU/memory.",
-      },
-      {
-        type: DashboardComponentType.ProxmoxGuestList,
-        label: "Guests",
-        icon: IconProp.Cube,
-        description:
-          "QEMU VMs and LXC containers with run state, HA state, and node.",
-      },
-    ],
-  },
-  {
-    name: "Docker Swarm",
-    description:
-      "Live inventory from any connected Docker Swarm cluster — populated by the OneUptime Docker Swarm Agent.",
-    items: [
-      {
-        type: DashboardComponentType.DockerSwarmNodeList,
-        label: "Nodes",
-        icon: IconProp.ServerStack,
-        description:
-          "Swarm nodes with manager/worker role, ready state, and CPU/memory.",
-      },
-      {
-        type: DashboardComponentType.DockerSwarmServiceList,
-        label: "Services",
-        icon: IconProp.Cube,
-        description:
-          "Replicated and global services with replicas, image, and converge state.",
-      },
-    ],
-  },
-  {
-    name: "Ceph",
-    description:
-      "Live inventory from any connected Ceph cluster — populated by the OneUptime Ceph Agent.",
-    items: [
-      {
-        type: DashboardComponentType.CephOsdList,
-        label: "OSDs",
-        icon: IconProp.SquareStack,
-        description:
-          "The OSD wall — a honeycomb of OSDs colored by up/in state.",
-      },
-      {
-        type: DashboardComponentType.CephPoolList,
-        label: "Pools",
-        icon: IconProp.Database,
-        description:
-          "Pools with stored bytes, capacity-used bars, and object counts.",
-      },
-    ],
-  },
-];
+import {
+  WIDGET_CATALOG,
+  WidgetCatalogCategory,
+  WidgetCatalogItem,
+  WidgetCategoryGroupSection,
+  countWidgets,
+  findCategoryByName,
+  getFirstWidget,
+  groupWidgetCategories,
+  searchWidgetCatalog,
+} from "./WidgetCatalog";
 
 export interface ComponentProps {
   onAddComponentClick: (type: DashboardComponentType) => void;
@@ -364,36 +32,132 @@ const AddWidgetModal: FunctionComponent<ComponentProps> = (
 ): ReactElement => {
   const { translateString } = useTranslateValue();
   const [searchTerm, setSearchTerm] = useState<string>("");
-  const trimmedSearch: string = searchTerm.trim().toLowerCase();
+  const [selectedCategoryName, setSelectedCategoryName] = useState<
+    string | null
+  >(null);
+  const searchInputRef: React.RefObject<HTMLInputElement> =
+    useRef<HTMLInputElement>(null);
 
-  const filteredCatalog: ReadonlyArray<CatalogCategory> = useMemo(() => {
-    if (!trimmedSearch) {
-      return WIDGET_CATALOG;
-    }
-    const out: Array<CatalogCategory> = [];
-    for (const category of WIDGET_CATALOG) {
-      const items: Array<CatalogItem> = category.items.filter(
-        (item: CatalogItem) => {
-          return (
-            item.label.toLowerCase().includes(trimmedSearch) ||
-            item.description.toLowerCase().includes(trimmedSearch) ||
-            category.name.toLowerCase().includes(trimmedSearch)
-          );
-        },
-      );
-      if (items.length > 0) {
-        out.push({ ...category, items });
-      }
-    }
-    return out;
-  }, [trimmedSearch]);
+  const isSearching: boolean = searchTerm.trim().length > 0;
 
-  const totalMatches: number = filteredCatalog.reduce(
-    (acc: number, c: CatalogCategory) => {
-      return acc + c.items.length;
-    },
-    0,
+  // Everything the current search matches. Drives both panes.
+  const matchingCatalog: Array<WidgetCatalogCategory> = useMemo(() => {
+    return searchWidgetCatalog(searchTerm, WIDGET_CATALOG);
+  }, [searchTerm]);
+
+  const totalMatches: number = countWidgets(matchingCatalog);
+
+  /*
+   * A search can filter away the category the rail has selected. Rather than
+   * showing an empty pane next to a list of live results, fall back to showing
+   * every match — the rail selection is picked back up as soon as the search
+   * matches it again.
+   */
+  const selectedCategory: WidgetCatalogCategory | null = findCategoryByName(
+    matchingCatalog,
+    selectedCategoryName,
   );
+
+  const visibleCategories: Array<WidgetCatalogCategory> = selectedCategory
+    ? [selectedCategory]
+    : matchingCatalog;
+
+  const railSections: Array<WidgetCategoryGroupSection> = useMemo(() => {
+    return groupWidgetCategories(matchingCatalog);
+  }, [matchingCatalog]);
+
+  type AddWidgetFunction = (type: DashboardComponentType) => void;
+
+  const addWidget: AddWidgetFunction = (type: DashboardComponentType): void => {
+    props.onAddComponentClick(type);
+    props.onClose();
+  };
+
+  type SearchKeyDownFunction = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => void;
+
+  /*
+   * Command-palette behaviour: type a few characters, hit Enter, get the top
+   * match. Only while searching, so Enter can never add a widget by accident
+   * on an untouched picker.
+   */
+  const onSearchKeyDown: SearchKeyDownFunction = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (event.key !== "Enter" || !isSearching) {
+      return;
+    }
+
+    const firstWidget: WidgetCatalogItem | null =
+      getFirstWidget(visibleCategories);
+
+    if (!firstWidget) {
+      return;
+    }
+
+    event.preventDefault();
+    addWidget(firstWidget.type);
+  };
+
+  type ClearSearchFunction = () => void;
+
+  const clearSearch: ClearSearchFunction = (): void => {
+    setSearchTerm("");
+    searchInputRef.current?.focus();
+  };
+
+  type RenderRailButtonFunction = (options: {
+    key: string;
+    label: string;
+    icon: IconProp;
+    count: number;
+    isSelected: boolean;
+    onClick: () => void;
+    testId: string;
+  }) => ReactElement;
+
+  const renderRailButton: RenderRailButtonFunction = (options: {
+    key: string;
+    label: string;
+    icon: IconProp;
+    count: number;
+    isSelected: boolean;
+    onClick: () => void;
+    testId: string;
+  }): ReactElement => {
+    return (
+      <button
+        key={options.key}
+        type="button"
+        data-testid={options.testId}
+        aria-pressed={options.isSelected}
+        onClick={options.onClick}
+        className={`flex shrink-0 items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors focus:outline-none focus:ring-1 focus:ring-indigo-300 md:w-full ${
+          options.isSelected
+            ? "bg-indigo-50 font-medium text-indigo-700"
+            : "text-gray-600 hover:bg-gray-100"
+        }`}
+      >
+        <Icon
+          icon={options.icon}
+          className={`h-4 w-4 shrink-0 ${
+            options.isSelected ? "text-indigo-500" : "text-gray-400"
+          }`}
+        />
+        <span className="flex-1 truncate">
+          {translateString(options.label)}
+        </span>
+        <span
+          className={`ml-1 shrink-0 text-xs tabular-nums ${
+            options.isSelected ? "text-indigo-400" : "text-gray-400"
+          }`}
+        >
+          {options.count}
+        </span>
+      </button>
+    );
+  };
 
   return (
     <Modal
@@ -410,73 +174,172 @@ const AddWidgetModal: FunctionComponent<ComponentProps> = (
             <Icon icon={IconProp.Search} className="h-4 w-4 text-gray-400" />
           </div>
           <input
+            ref={searchInputRef}
             type="text"
             value={searchTerm}
+            aria-label="Search widgets"
+            data-testid="add-widget-search"
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               setSearchTerm(e.target.value);
             }}
-            placeholder="Search widgets..."
-            className="block w-full rounded-md border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-700 placeholder-gray-400 focus:border-indigo-300 focus:outline-none focus:ring-1 focus:ring-indigo-300"
+            onKeyDown={onSearchKeyDown}
+            placeholder="Search widgets by name, e.g. chart, logs, pods..."
+            className="block w-full rounded-md border border-gray-200 bg-white py-2 pl-9 pr-9 text-sm text-gray-700 placeholder-gray-400 focus:border-indigo-300 focus:outline-none focus:ring-1 focus:ring-indigo-300"
             autoFocus={true}
           />
+          {isSearching && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              data-testid="add-widget-search-clear"
+              onClick={clearSearch}
+              className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600 focus:outline-none"
+            >
+              <Icon icon={IconProp.Close} className="h-4 w-4" />
+            </button>
+          )}
         </div>
 
-        {/* Empty search state */}
-        {totalMatches === 0 && (
-          <div className="py-12 flex flex-col items-center justify-center text-center text-gray-400">
-            <div className="w-10 h-10 rounded-full bg-gray-50 flex items-center justify-center mb-2">
-              <Icon icon={IconProp.Search} className="h-5 w-5 text-gray-300" />
-            </div>
-            <p className="text-sm">
-              No widgets match &ldquo;{searchTerm}&rdquo;.
-            </p>
-          </div>
-        )}
+        <div className="flex flex-col gap-4 md:flex-row md:gap-5">
+          {/* Category rail. Horizontal chips on small screens, a vertical
+              list with group headings from md up. Hidden entirely when a
+              search matched nothing — there is nothing to navigate to. */}
+          <nav
+            aria-label="Widget categories"
+            className={`shrink-0 flex-row gap-1 overflow-x-auto pb-1 md:max-h-[60vh] md:w-52 md:flex-col md:overflow-x-visible md:overflow-y-auto md:pb-0 md:pr-1 ${
+              totalMatches === 0 ? "hidden" : "flex"
+            }`}
+          >
+            {renderRailButton({
+              key: "all",
+              testId: "widget-category-all",
+              label: "All widgets",
+              icon: IconProp.Squares,
+              count: totalMatches,
+              isSelected: selectedCategory === null,
+              onClick: () => {
+                setSelectedCategoryName(null);
+              },
+            })}
 
-        {/* Categorized grid — single scroll container so the modal
-            footer (close button) is always reachable. */}
-        <div className="max-h-[60vh] overflow-y-auto pr-1 -mr-1 space-y-6">
-          {filteredCatalog.map((category: CatalogCategory) => {
-            return (
-              <div key={category.name}>
-                <div className="mb-2">
-                  <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                    {translateString(category.name)}
-                  </h4>
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    {translateString(category.description)}
-                  </p>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                  {category.items.map((item: CatalogItem) => {
-                    return (
-                      <button
-                        key={item.type}
-                        type="button"
-                        onClick={() => {
-                          props.onAddComponentClick(item.type);
-                          props.onClose();
-                        }}
-                        className="group flex items-start gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-indigo-300 hover:bg-indigo-50/30 focus:outline-none focus:ring-1 focus:ring-indigo-300"
-                      >
-                        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-gray-50 text-gray-500 group-hover:bg-indigo-50 group-hover:text-indigo-500 transition-colors">
-                          <Icon icon={item.icon} className="h-4 w-4" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <div className="text-sm font-medium text-gray-800 truncate">
-                            {translateString(item.label)}
-                          </div>
-                          <div className="text-xs text-gray-500 mt-0.5 line-clamp-2">
-                            {translateString(item.description)}
-                          </div>
-                        </div>
-                      </button>
-                    );
+            {railSections.map((section: WidgetCategoryGroupSection) => {
+              return (
+                <div key={section.group} className="contents md:block">
+                  <h5 className="mt-4 hidden px-2.5 pb-1 text-[11px] font-semibold uppercase tracking-wider text-gray-400 md:block">
+                    {translateString(section.group)}
+                  </h5>
+                  {section.categories.map((category: WidgetCatalogCategory) => {
+                    return renderRailButton({
+                      key: category.name,
+                      testId: `widget-category-${category.name}`,
+                      label: category.name,
+                      icon: category.icon,
+                      count: category.items.length,
+                      isSelected: selectedCategoryName === category.name,
+                      onClick: () => {
+                        setSelectedCategoryName(category.name);
+                      },
+                    });
                   })}
                 </div>
+              );
+            })}
+          </nav>
+
+          {/* Widget grid — its own scroll container so the modal footer
+              (close button) is always reachable. */}
+          <div className="min-w-0 flex-1 space-y-6 overflow-y-auto md:max-h-[60vh] md:pr-1">
+            {isSearching && totalMatches > 0 && (
+              <p
+                aria-live="polite"
+                data-testid="add-widget-result-count"
+                className="text-xs text-gray-400"
+              >
+                {totalMatches}{" "}
+                {totalMatches === 1 ? "widget matches" : "widgets match"}
+                &nbsp;&ldquo;{searchTerm.trim()}&rdquo;. Press Enter to add the
+                first one.
+              </p>
+            )}
+
+            {totalMatches === 0 && (
+              <div
+                data-testid="add-widget-empty"
+                className="flex flex-col items-center justify-center py-12 text-center text-gray-400"
+              >
+                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-gray-50">
+                  <Icon
+                    icon={IconProp.Search}
+                    className="h-5 w-5 text-gray-300"
+                  />
+                </div>
+                <p className="text-sm">
+                  No widgets match &ldquo;{searchTerm.trim()}&rdquo;.
+                </p>
+                <button
+                  type="button"
+                  data-testid="add-widget-empty-clear"
+                  onClick={clearSearch}
+                  className="mt-3 rounded-md px-2 py-1 text-sm font-medium text-indigo-600 hover:bg-indigo-50 focus:outline-none focus:ring-1 focus:ring-indigo-300"
+                >
+                  Clear search
+                </button>
               </div>
-            );
-          })}
+            )}
+
+            {visibleCategories.map((category: WidgetCatalogCategory) => {
+              return (
+                <section key={category.name}>
+                  <div className="mb-2 flex items-start gap-2">
+                    <Icon
+                      icon={category.icon}
+                      className="mt-0.5 h-4 w-4 shrink-0 text-gray-400"
+                    />
+                    <div className="min-w-0">
+                      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                        {translateString(category.name)}
+                      </h4>
+                      <p className="mt-0.5 text-xs text-gray-400">
+                        {translateString(category.description)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {category.items.map((item: WidgetCatalogItem) => {
+                      return (
+                        <button
+                          key={item.type}
+                          type="button"
+                          data-testid={`widget-card-${item.type}`}
+                          title={translateString(item.description)}
+                          onClick={() => {
+                            addWidget(item.type);
+                          }}
+                          className="group relative flex items-start gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-indigo-300 hover:bg-indigo-50/30 focus:outline-none focus:ring-1 focus:ring-indigo-300"
+                        >
+                          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-gray-50 text-gray-500 transition-colors group-hover:bg-indigo-50 group-hover:text-indigo-500">
+                            <Icon icon={item.icon} className="h-4 w-4" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-medium text-gray-800">
+                              {translateString(item.label)}
+                            </div>
+                            <div className="mt-0.5 line-clamp-2 text-xs text-gray-500">
+                              {translateString(item.description)}
+                            </div>
+                          </div>
+                          <Icon
+                            icon={IconProp.Add}
+                            className="mt-0.5 h-4 w-4 shrink-0 text-indigo-400 opacity-0 transition-opacity group-hover:opacity-100"
+                          />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
         </div>
       </div>
     </Modal>

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts
@@ -1,0 +1,646 @@
+import DashboardComponentType from "Common/Types/Dashboard/DashboardComponentType";
+import IconProp from "Common/Types/Icon/IconProp";
+
+/*
+ * The widget picker groups every dashboard widget twice: into a narrow
+ * category (what the widget shows) and into a broader group (why you would
+ * reach for that category). The group is what the picker renders as a section
+ * heading in its left rail, so a project with a dozen integrations still has a
+ * short, scannable list to navigate.
+ */
+export enum WidgetCategoryGroup {
+  General = "General",
+  Observability = "Observability",
+  Infrastructure = "Infrastructure",
+}
+
+export const WIDGET_CATEGORY_GROUP_ORDER: ReadonlyArray<WidgetCategoryGroup> = [
+  WidgetCategoryGroup.General,
+  WidgetCategoryGroup.Observability,
+  WidgetCategoryGroup.Infrastructure,
+];
+
+export interface WidgetCatalogItem {
+  type: DashboardComponentType;
+  label: string;
+  icon: IconProp;
+  description: string;
+  /*
+   * Extra search terms that are not in the label or description. These let
+   * someone find the SLO widget by typing "error budget", or the HTML widget
+   * by typing "iframe", without stuffing the visible copy with synonyms.
+   */
+  keywords: ReadonlyArray<string>;
+}
+
+export interface WidgetCatalogCategory {
+  name: string;
+  group: WidgetCategoryGroup;
+  description: string;
+  icon: IconProp;
+  items: ReadonlyArray<WidgetCatalogItem>;
+}
+
+export const WIDGET_CATALOG: ReadonlyArray<WidgetCatalogCategory> = [
+  {
+    name: "Essentials",
+    group: WidgetCategoryGroup.General,
+    icon: IconProp.Sparkles,
+    description:
+      "Layout and presentation widgets that do not need a data source.",
+    items: [
+      {
+        type: DashboardComponentType.Text,
+        label: "Text",
+        icon: IconProp.Text,
+        description: "Free-form Markdown text for headers and notes.",
+        keywords: ["markdown", "note", "heading", "title", "label", "comment"],
+      },
+      {
+        type: DashboardComponentType.Clock,
+        label: "Clock",
+        icon: IconProp.Clock,
+        description:
+          "Current time in any timezone — digital or analog. Add one per office so you can see who is awake.",
+        keywords: ["time", "timezone", "world", "analog", "digital", "utc"],
+      },
+      {
+        type: DashboardComponentType.Html,
+        label: "HTML",
+        icon: IconProp.Code,
+        description:
+          "Your own HTML, CSS, and JavaScript, rendered in a sandbox.",
+        keywords: ["embed", "iframe", "custom", "css", "javascript", "script"],
+      },
+    ],
+  },
+  {
+    name: "Metrics",
+    group: WidgetCategoryGroup.General,
+    icon: IconProp.ChartBar,
+    description: "Charts, numbers, and tables built from a metrics query.",
+    items: [
+      {
+        type: DashboardComponentType.Chart,
+        label: "Chart",
+        icon: IconProp.ChartBar,
+        description: "Time-series chart from a metrics query.",
+        keywords: ["graph", "line", "area", "bar", "timeseries", "metric"],
+      },
+      {
+        type: DashboardComponentType.Value,
+        label: "Value",
+        icon: IconProp.Hashtag,
+        description: "Single big-number stat, ideal for KPIs.",
+        keywords: ["number", "stat", "kpi", "single", "counter", "metric"],
+      },
+      {
+        type: DashboardComponentType.Gauge,
+        label: "Gauge",
+        icon: IconProp.Gauge,
+        description: "Radial gauge for a percent or threshold.",
+        keywords: ["dial", "radial", "percent", "threshold", "meter", "metric"],
+      },
+      {
+        type: DashboardComponentType.Table,
+        label: "Table",
+        icon: IconProp.TableCells,
+        description:
+          "Tabular metric values — set a Group By (e.g. host.name) for one row per entity, or none for time-bucketed rows. Add formulas for derived columns like availability %.",
+        keywords: ["grid", "rows", "columns", "group by", "formula", "metric"],
+      },
+    ],
+  },
+  {
+    name: "Logs",
+    group: WidgetCategoryGroup.Observability,
+    icon: IconProp.Logs,
+    description: "Live and aggregated views of your log records.",
+    items: [
+      {
+        type: DashboardComponentType.LogStream,
+        label: "Log Stream",
+        icon: IconProp.Logs,
+        description: "Tail recent log records matching a filter.",
+        keywords: ["tail", "live", "records", "severity", "search"],
+      },
+      {
+        type: DashboardComponentType.LogChart,
+        label: "Log Chart",
+        icon: IconProp.ChartBar,
+        description:
+          "Log volume over time by severity, with bar, line, or area visualization and friendly attribute filters.",
+        keywords: ["volume", "histogram", "severity", "error rate", "count"],
+      },
+    ],
+  },
+  {
+    name: "Traces",
+    group: WidgetCategoryGroup.Observability,
+    icon: IconProp.Waterfall,
+    description: "Distributed traces, spans, and response-time breakdowns.",
+    items: [
+      {
+        type: DashboardComponentType.TraceList,
+        label: "Trace List",
+        icon: IconProp.Waterfall,
+        description: "Most recent traces for a service or operation.",
+        keywords: ["span", "request", "service", "operation", "apm"],
+      },
+      {
+        type: DashboardComponentType.TraceChart,
+        label: "Trace Chart",
+        icon: IconProp.ChartBar,
+        description:
+          "Span counts or response-time percentiles over time, optionally split by an attribute (e.g. per tenant).",
+        keywords: [
+          "latency",
+          "percentile",
+          "p95",
+          "p99",
+          "throughput",
+          "duration",
+        ],
+      },
+      {
+        type: DashboardComponentType.TraceTable,
+        label: "Trace Table",
+        icon: IconProp.TableCells,
+        description:
+          "Top dimensions by request count — requests, median, avg, min, and max response time per span name, status, or attribute.",
+        keywords: ["top", "slowest", "endpoint", "latency", "dimension"],
+      },
+    ],
+  },
+  {
+    name: "Incidents",
+    group: WidgetCategoryGroup.Observability,
+    icon: IconProp.Alert,
+    description: "Incidents raised for your services, with state and severity.",
+    items: [
+      {
+        type: DashboardComponentType.IncidentList,
+        label: "Incident List",
+        icon: IconProp.Alert,
+        description: "Filtered list of incidents with state and severity.",
+        keywords: ["outage", "postmortem", "severity", "on call", "downtime"],
+      },
+    ],
+  },
+  {
+    name: "Alerts",
+    group: WidgetCategoryGroup.Observability,
+    icon: IconProp.Bell,
+    description: "Alerts your monitors and telemetry rules have fired.",
+    items: [
+      {
+        type: DashboardComponentType.AlertList,
+        label: "Alert List",
+        icon: IconProp.Bell,
+        description: "Recent alerts with state and severity.",
+        keywords: ["notification", "trigger", "severity", "paging", "warning"],
+      },
+    ],
+  },
+  {
+    name: "Monitors",
+    group: WidgetCategoryGroup.Observability,
+    icon: IconProp.AltGlobe,
+    description: "Uptime and current status of everything you monitor.",
+    items: [
+      {
+        type: DashboardComponentType.MonitorList,
+        label: "Monitor List",
+        icon: IconProp.AltGlobe,
+        description: "Monitors with current operational status.",
+        keywords: [
+          "uptime",
+          "probe",
+          "ping",
+          "status",
+          "health",
+          "availability",
+        ],
+      },
+    ],
+  },
+  {
+    name: "SLOs",
+    group: WidgetCategoryGroup.Observability,
+    icon: IconProp.Percent,
+    description: "Service level objectives, error budgets, and burn rate.",
+    items: [
+      {
+        type: DashboardComponentType.Slo,
+        label: "SLO",
+        icon: IconProp.Percent,
+        description:
+          "SLI, error budget remaining, or burn rate for one SLO — as a big number or a trend chart.",
+        keywords: [
+          "sli",
+          "service level",
+          "error budget",
+          "burn rate",
+          "reliability",
+        ],
+      },
+    ],
+  },
+  {
+    name: "Hosts",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.Server,
+    description:
+      "Hosts auto-discovered from the host.name OTel resource attribute.",
+    items: [
+      {
+        type: DashboardComponentType.HostList,
+        label: "Hosts",
+        icon: IconProp.Server,
+        description:
+          "Hosts with connection status, OS, CPU/memory, and last-seen.",
+        keywords: ["server", "machine", "vm", "cpu", "memory", "agent"],
+      },
+    ],
+  },
+  {
+    name: "Kubernetes",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.SquareStack3D,
+    description:
+      "Live inventory from any connected Kubernetes cluster — populated by the OneUptime Kubernetes Agent.",
+    items: [
+      {
+        type: DashboardComponentType.KubernetesPodList,
+        label: "Pods",
+        icon: IconProp.Cube,
+        description: "Pods with phase, namespace, and cluster.",
+        keywords: ["k8s", "kubernetes", "pod", "workload", "container"],
+      },
+      {
+        type: DashboardComponentType.KubernetesNodeList,
+        label: "Nodes",
+        icon: IconProp.Server,
+        description: "Nodes with readiness and pressure conditions.",
+        keywords: ["k8s", "kubernetes", "node", "kubelet", "capacity"],
+      },
+      {
+        type: DashboardComponentType.KubernetesNamespaceList,
+        label: "Namespaces",
+        icon: IconProp.Folder,
+        description: "All namespaces across selected clusters.",
+        keywords: ["k8s", "kubernetes", "namespace", "tenant"],
+      },
+      {
+        type: DashboardComponentType.KubernetesDeploymentList,
+        label: "Deployments",
+        icon: IconProp.ServerStack,
+        description: "Deployments in selected clusters or namespaces.",
+        keywords: ["k8s", "kubernetes", "deployment", "replicaset", "rollout"],
+      },
+      {
+        type: DashboardComponentType.KubernetesStatefulSetList,
+        label: "StatefulSets",
+        icon: IconProp.ServerStack,
+        description: "StatefulSets in selected clusters or namespaces.",
+        keywords: ["k8s", "kubernetes", "statefulset", "stateful", "database"],
+      },
+      {
+        type: DashboardComponentType.KubernetesDaemonSetList,
+        label: "DaemonSets",
+        icon: IconProp.ServerStack,
+        description: "DaemonSets in selected clusters or namespaces.",
+        keywords: ["k8s", "kubernetes", "daemonset", "agent", "node"],
+      },
+      {
+        type: DashboardComponentType.KubernetesJobList,
+        label: "Jobs",
+        icon: IconProp.Clock,
+        description: "Jobs in selected clusters or namespaces.",
+        keywords: ["k8s", "kubernetes", "job", "batch", "task"],
+      },
+      {
+        type: DashboardComponentType.KubernetesCronJobList,
+        label: "CronJobs",
+        icon: IconProp.Clock,
+        description: "CronJobs in selected clusters or namespaces.",
+        keywords: ["k8s", "kubernetes", "cronjob", "schedule", "batch"],
+      },
+    ],
+  },
+  {
+    name: "Docker",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.Cube,
+    description:
+      "Live inventory from any connected Docker host — populated by the OneUptime Docker Agent.",
+    items: [
+      {
+        type: DashboardComponentType.DockerHostList,
+        label: "Hosts",
+        icon: IconProp.Server,
+        description:
+          "Docker hosts with connection status and container counts.",
+        keywords: ["docker", "daemon", "engine", "host"],
+      },
+      {
+        type: DashboardComponentType.DockerContainerList,
+        label: "Containers",
+        icon: IconProp.Cube,
+        description: "Containers with state, image, and CPU/memory.",
+        keywords: ["docker", "container", "running", "exited", "cpu"],
+      },
+      {
+        type: DashboardComponentType.DockerImageList,
+        label: "Images",
+        icon: IconProp.Cube,
+        description: "Images present on selected hosts.",
+        keywords: ["docker", "image", "tag", "registry", "layer"],
+      },
+      {
+        type: DashboardComponentType.DockerNetworkList,
+        label: "Networks",
+        icon: IconProp.Globe,
+        description: "Networks defined on selected hosts.",
+        keywords: ["docker", "network", "bridge", "overlay"],
+      },
+      {
+        type: DashboardComponentType.DockerVolumeList,
+        label: "Volumes",
+        icon: IconProp.Database,
+        description: "Volumes defined on selected hosts.",
+        keywords: ["docker", "volume", "storage", "mount"],
+      },
+    ],
+  },
+  {
+    name: "Docker Swarm",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.ServerStack,
+    description:
+      "Live inventory from any connected Docker Swarm cluster — populated by the OneUptime Docker Swarm Agent.",
+    items: [
+      {
+        type: DashboardComponentType.DockerSwarmNodeList,
+        label: "Nodes",
+        icon: IconProp.ServerStack,
+        description:
+          "Swarm nodes with manager/worker role, ready state, and CPU/memory.",
+        keywords: ["swarm", "docker", "manager", "worker", "node"],
+      },
+      {
+        type: DashboardComponentType.DockerSwarmServiceList,
+        label: "Services",
+        icon: IconProp.Cube,
+        description:
+          "Replicated and global services with replicas, image, and converge state.",
+        keywords: ["swarm", "docker", "service", "replica", "global"],
+      },
+    ],
+  },
+  {
+    name: "Podman",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.TransparentCube,
+    description:
+      "Live inventory from any connected Podman host — populated by the OneUptime Podman Agent.",
+    items: [
+      {
+        type: DashboardComponentType.PodmanHostList,
+        label: "Hosts",
+        icon: IconProp.Server,
+        description:
+          "Podman hosts with connection status and container counts.",
+        keywords: ["podman", "rootless", "host", "daemonless"],
+      },
+      {
+        type: DashboardComponentType.PodmanContainerList,
+        label: "Containers",
+        icon: IconProp.Cube,
+        description: "Containers with state, image, and CPU/memory.",
+        keywords: ["podman", "container", "running", "exited", "cpu"],
+      },
+      {
+        type: DashboardComponentType.PodmanImageList,
+        label: "Images",
+        icon: IconProp.Cube,
+        description: "Images present on selected hosts.",
+        keywords: ["podman", "image", "tag", "registry", "layer"],
+      },
+      {
+        type: DashboardComponentType.PodmanNetworkList,
+        label: "Networks",
+        icon: IconProp.Globe,
+        description: "Networks defined on selected hosts.",
+        keywords: ["podman", "network", "bridge", "cni"],
+      },
+      {
+        type: DashboardComponentType.PodmanVolumeList,
+        label: "Volumes",
+        icon: IconProp.Database,
+        description: "Volumes defined on selected hosts.",
+        keywords: ["podman", "volume", "storage", "mount"],
+      },
+    ],
+  },
+  {
+    name: "Proxmox",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.SquareStack,
+    description:
+      "Live inventory from any connected Proxmox VE cluster — populated by the OneUptime Proxmox Agent.",
+    items: [
+      {
+        type: DashboardComponentType.ProxmoxNodeList,
+        label: "Nodes",
+        icon: IconProp.ServerStack,
+        description: "PVE nodes with online status and CPU/memory.",
+        keywords: ["proxmox", "pve", "node", "hypervisor", "cluster"],
+      },
+      {
+        type: DashboardComponentType.ProxmoxGuestList,
+        label: "Guests",
+        icon: IconProp.Cube,
+        description:
+          "QEMU VMs and LXC containers with run state, HA state, and node.",
+        keywords: ["proxmox", "qemu", "lxc", "vm", "guest", "virtual machine"],
+      },
+    ],
+  },
+  {
+    name: "Ceph",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.Database,
+    description:
+      "Live inventory from any connected Ceph cluster — populated by the OneUptime Ceph Agent.",
+    items: [
+      {
+        type: DashboardComponentType.CephOsdList,
+        label: "OSDs",
+        icon: IconProp.SquareStack,
+        description:
+          "The OSD wall — a honeycomb of OSDs colored by up/in state.",
+        keywords: ["ceph", "osd", "disk", "storage", "up", "in"],
+      },
+      {
+        type: DashboardComponentType.CephPoolList,
+        label: "Pools",
+        icon: IconProp.Database,
+        description:
+          "Pools with stored bytes, capacity-used bars, and object counts.",
+        keywords: ["ceph", "pool", "capacity", "storage", "objects"],
+      },
+    ],
+  },
+];
+
+export interface WidgetCategoryGroupSection {
+  group: WidgetCategoryGroup;
+  categories: ReadonlyArray<WidgetCatalogCategory>;
+}
+
+/**
+ * Buckets categories by their group, preserving WIDGET_CATEGORY_GROUP_ORDER and
+ * dropping groups that have no categories left (which happens once a search has
+ * filtered the catalog down).
+ */
+export function groupWidgetCategories(
+  categories: ReadonlyArray<WidgetCatalogCategory>,
+): Array<WidgetCategoryGroupSection> {
+  const sections: Array<WidgetCategoryGroupSection> = [];
+
+  for (const group of WIDGET_CATEGORY_GROUP_ORDER) {
+    const categoriesInGroup: Array<WidgetCatalogCategory> = categories.filter(
+      (category: WidgetCatalogCategory) => {
+        return category.group === group;
+      },
+    );
+
+    if (categoriesInGroup.length > 0) {
+      sections.push({ group: group, categories: categoriesInGroup });
+    }
+  }
+
+  return sections;
+}
+
+/**
+ * Everything a single widget can be matched against, lower-cased once so the
+ * search does not rebuild it per keystroke token.
+ */
+function getSearchHaystack(
+  category: WidgetCatalogCategory,
+  item: WidgetCatalogItem,
+): string {
+  return [
+    item.label,
+    item.description,
+    ...item.keywords,
+    category.name,
+    category.description,
+    category.group,
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+/**
+ * Splits the raw search box value into lower-cased tokens. Every token has to
+ * match for a widget to be kept, so "docker volume" finds the Docker Volumes
+ * widget even though no single field contains that exact phrase.
+ */
+export function tokenizeSearchTerm(searchTerm: string): Array<string> {
+  return searchTerm
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token: string) => {
+      return token.length > 0;
+    });
+}
+
+/**
+ * Filters the catalog down to the widgets matching every search token. Returns
+ * the catalog untouched for an empty search, and drops categories that end up
+ * with no matching widgets.
+ */
+export function searchWidgetCatalog(
+  searchTerm: string,
+  catalog: ReadonlyArray<WidgetCatalogCategory> = WIDGET_CATALOG,
+): Array<WidgetCatalogCategory> {
+  const tokens: Array<string> = tokenizeSearchTerm(searchTerm);
+
+  if (tokens.length === 0) {
+    return [...catalog];
+  }
+
+  const matches: Array<WidgetCatalogCategory> = [];
+
+  for (const category of catalog) {
+    const items: Array<WidgetCatalogItem> = category.items.filter(
+      (item: WidgetCatalogItem) => {
+        const haystack: string = getSearchHaystack(category, item);
+
+        return tokens.every((token: string) => {
+          return haystack.includes(token);
+        });
+      },
+    );
+
+    if (items.length > 0) {
+      matches.push({ ...category, items: items });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Total number of widgets across the given categories — used for the result
+ * count and to decide whether to show the empty state.
+ */
+export function countWidgets(
+  categories: ReadonlyArray<WidgetCatalogCategory>,
+): number {
+  return categories.reduce((total: number, category: WidgetCatalogCategory) => {
+    return total + category.items.length;
+  }, 0);
+}
+
+/**
+ * First widget in the given categories, in catalog order. The picker adds this
+ * one when the search box is submitted with Enter.
+ */
+export function getFirstWidget(
+  categories: ReadonlyArray<WidgetCatalogCategory>,
+): WidgetCatalogItem | null {
+  for (const category of categories) {
+    const first: WidgetCatalogItem | undefined = category.items[0];
+
+    if (first) {
+      return first;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Looks a category up by name. Returns null when the name is not in the given
+ * list, which is how the picker detects that its selected category has been
+ * filtered away by the current search.
+ */
+export function findCategoryByName(
+  categories: ReadonlyArray<WidgetCatalogCategory>,
+  name: string | null,
+): WidgetCatalogCategory | null {
+  if (!name) {
+    return null;
+  }
+
+  return (
+    categories.find((category: WidgetCatalogCategory) => {
+      return category.name === name;
+    }) || null
+  );
+}

--- a/Common/Tests/App/Dashboard/AddWidgetModal.test.tsx
+++ b/Common/Tests/App/Dashboard/AddWidgetModal.test.tsx
@@ -1,0 +1,557 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, test } from "@jest/globals";
+import AddWidgetModal from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/AddWidgetModal";
+import {
+  WIDGET_CATALOG,
+  WidgetCatalogCategory,
+  WidgetCatalogItem,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+
+/**
+ * What the picker reported back to the dashboard: the widget types it asked to
+ * add, in order, and how many times it asked to be closed.
+ */
+interface ModalCalls {
+  added: Array<DashboardComponentType>;
+  closed: number;
+}
+
+type RenderModalFunction = () => ModalCalls;
+
+const renderModal: RenderModalFunction = (): ModalCalls => {
+  const calls: ModalCalls = { added: [], closed: 0 };
+
+  render(
+    <AddWidgetModal
+      onAddComponentClick={(type: DashboardComponentType) => {
+        calls.added.push(type);
+      }}
+      onClose={() => {
+        calls.closed = calls.closed + 1;
+      }}
+    />,
+  );
+
+  return calls;
+};
+
+type GetSearchInputFunction = () => HTMLInputElement;
+
+const getSearchInput: GetSearchInputFunction = (): HTMLInputElement => {
+  return screen.getByTestId("add-widget-search") as HTMLInputElement;
+};
+
+type TypeSearchFunction = (value: string) => void;
+
+const typeSearch: TypeSearchFunction = (value: string): void => {
+  fireEvent.change(getSearchInput(), { target: { value: value } });
+};
+
+type GetVisibleWidgetTypesFunction = () => Array<string>;
+
+/**
+ * Widget types of every card currently rendered in the grid, in DOM order.
+ */
+const getVisibleWidgetTypes: GetVisibleWidgetTypesFunction =
+  (): Array<string> => {
+    return screen
+      .queryAllByTestId(/^widget-card-/)
+      .map((element: HTMLElement) => {
+        return (element.getAttribute("data-testid") || "").replace(
+          "widget-card-",
+          "",
+        );
+      });
+  };
+
+type GetRailCategoryNamesFunction = () => Array<string>;
+
+const getRailCategoryNames: GetRailCategoryNamesFunction =
+  (): Array<string> => {
+    return screen
+      .queryAllByTestId(/^widget-category-/)
+      .map((element: HTMLElement) => {
+        return (element.getAttribute("data-testid") || "").replace(
+          "widget-category-",
+          "",
+        );
+      })
+      .filter((name: string) => {
+        return name !== "all";
+      });
+  };
+
+const ALL_COMPONENT_TYPES: Array<DashboardComponentType> = Object.values(
+  DashboardComponentType,
+);
+
+type GetCategoryFunction = (name: string) => WidgetCatalogCategory;
+
+const getCategory: GetCategoryFunction = (
+  name: string,
+): WidgetCatalogCategory => {
+  const category: WidgetCatalogCategory | undefined = WIDGET_CATALOG.find(
+    (candidate: WidgetCatalogCategory) => {
+      return candidate.name === name;
+    },
+  );
+
+  if (!category) {
+    throw new Error(`Category "${name}" is missing from the widget catalog.`);
+  }
+
+  return category;
+};
+
+type GetTypesInFunction = (name: string) => Array<string>;
+
+const getTypesIn: GetTypesInFunction = (name: string): Array<string> => {
+  return getCategory(name).items.map((item: WidgetCatalogItem) => {
+    return item.type.toString();
+  });
+};
+
+describe("AddWidgetModal", () => {
+  describe("default view", () => {
+    test("renders the picker heading and search box", () => {
+      renderModal();
+
+      expect(screen.getByText("Add Widget")).toBeInTheDocument();
+      expect(
+        screen.getByText("Pick a widget to add to your dashboard."),
+      ).toBeInTheDocument();
+      expect(getSearchInput()).toBeInTheDocument();
+    });
+
+    test("renders a card for every widget in the catalog", () => {
+      renderModal();
+
+      expect(getVisibleWidgetTypes()).toHaveLength(ALL_COMPONENT_TYPES.length);
+
+      for (const type of ALL_COMPONENT_TYPES) {
+        expect(screen.getByTestId(`widget-card-${type}`)).toBeInTheDocument();
+      }
+    });
+
+    test("leads with Essentials — Text, Clock, and HTML", () => {
+      renderModal();
+
+      expect(getVisibleWidgetTypes().slice(0, 3)).toEqual([
+        DashboardComponentType.Text,
+        DashboardComponentType.Clock,
+        DashboardComponentType.Html,
+      ]);
+    });
+
+    test("lists every catalog category in the rail, in catalog order", () => {
+      renderModal();
+
+      expect(getRailCategoryNames()).toEqual(
+        WIDGET_CATALOG.map((category: WidgetCatalogCategory) => {
+          return category.name;
+        }),
+      );
+    });
+
+    test("renders the rail group headings", () => {
+      renderModal();
+
+      expect(screen.getByText("General")).toBeInTheDocument();
+      expect(screen.getByText("Observability")).toBeInTheDocument();
+      expect(screen.getByText("Infrastructure")).toBeInTheDocument();
+    });
+
+    test("shows the widget count next to each rail category", () => {
+      renderModal();
+
+      expect(screen.getByTestId("widget-category-Essentials").textContent).toBe(
+        "Essentials3",
+      );
+      expect(screen.getByTestId("widget-category-Metrics").textContent).toBe(
+        "Metrics4",
+      );
+      expect(screen.getByTestId("widget-category-Kubernetes").textContent).toBe(
+        "Kubernetes8",
+      );
+    });
+
+    test("selects All widgets by default and shows the catalog total", () => {
+      renderModal();
+
+      const allButton: HTMLElement = screen.getByTestId("widget-category-all");
+
+      expect(allButton).toHaveAttribute("aria-pressed", "true");
+      expect(allButton.textContent).toBe(
+        `All widgets${ALL_COMPONENT_TYPES.length}`,
+      );
+      expect(screen.getByTestId("widget-category-Metrics")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    test("shows neither a result count nor the empty state before searching", () => {
+      renderModal();
+
+      expect(
+        screen.queryByTestId("add-widget-result-count"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("add-widget-empty")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("add-widget-search-clear"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("category rail", () => {
+    test("narrows the grid to the selected category", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Metrics"));
+
+      expect(getVisibleWidgetTypes()).toEqual(getTypesIn("Metrics"));
+      expect(
+        screen.queryByTestId(`widget-card-${DashboardComponentType.Text}`),
+      ).not.toBeInTheDocument();
+    });
+
+    test("moves the pressed state onto the selected category", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Logs"));
+
+      expect(screen.getByTestId("widget-category-Logs")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByTestId("widget-category-all")).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    test("restores the full catalog when All widgets is clicked", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Logs"));
+      expect(getVisibleWidgetTypes()).toEqual(getTypesIn("Logs"));
+
+      fireEvent.click(screen.getByTestId("widget-category-all"));
+
+      expect(getVisibleWidgetTypes()).toHaveLength(ALL_COMPONENT_TYPES.length);
+      expect(screen.getByTestId("widget-category-all")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    test("keeps identically-labelled widgets in different categories apart", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Docker"));
+      expect(getVisibleWidgetTypes()).toEqual(getTypesIn("Docker"));
+
+      fireEvent.click(screen.getByTestId("widget-category-Podman"));
+      expect(getVisibleWidgetTypes()).toEqual(getTypesIn("Podman"));
+    });
+
+    test("keeps every rail category reachable while a category is selected", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Ceph"));
+
+      expect(getRailCategoryNames()).toHaveLength(WIDGET_CATALOG.length);
+    });
+  });
+
+  describe("adding a widget", () => {
+    test("reports the clicked widget type and closes the picker", () => {
+      const calls: ModalCalls = renderModal();
+
+      fireEvent.click(
+        screen.getByTestId(`widget-card-${DashboardComponentType.Gauge}`),
+      );
+
+      expect(calls.added).toEqual([DashboardComponentType.Gauge]);
+      expect(calls.closed).toBe(1);
+    });
+
+    test("adds the right widget when two categories share a label", () => {
+      const calls: ModalCalls = renderModal();
+
+      fireEvent.click(
+        screen.getByTestId(
+          `widget-card-${DashboardComponentType.PodmanVolumeList}`,
+        ),
+      );
+
+      expect(calls.added).toEqual([DashboardComponentType.PodmanVolumeList]);
+    });
+
+    test("adds a widget found through search", () => {
+      const calls: ModalCalls = renderModal();
+
+      typeSearch("cronjob");
+      fireEvent.click(
+        screen.getByTestId(
+          `widget-card-${DashboardComponentType.KubernetesCronJobList}`,
+        ),
+      );
+
+      expect(calls.added).toEqual([
+        DashboardComponentType.KubernetesCronJobList,
+      ]);
+      expect(calls.closed).toBe(1);
+    });
+
+    test("does not add anything when the picker is only opened", () => {
+      const calls: ModalCalls = renderModal();
+
+      expect(calls.added).toEqual([]);
+      expect(calls.closed).toBe(0);
+    });
+  });
+
+  describe("search", () => {
+    test("narrows the grid to matching widgets", () => {
+      renderModal();
+
+      typeSearch("gauge");
+
+      expect(getVisibleWidgetTypes()).toEqual([DashboardComponentType.Gauge]);
+    });
+
+    test("announces how many widgets matched", () => {
+      renderModal();
+
+      typeSearch("gauge");
+
+      expect(screen.getByTestId("add-widget-result-count")).toHaveTextContent(
+        "1 widget matches",
+      );
+
+      typeSearch("docker");
+
+      expect(screen.getByTestId("add-widget-result-count")).toHaveTextContent(
+        `${
+          getTypesIn("Docker").length + getTypesIn("Docker Swarm").length
+        } widgets match`,
+      );
+    });
+
+    test("is case insensitive", () => {
+      renderModal();
+
+      typeSearch("GAUGE");
+
+      expect(getVisibleWidgetTypes()).toEqual([DashboardComponentType.Gauge]);
+    });
+
+    test("finds widgets by keywords that are not shown on the card", () => {
+      renderModal();
+
+      typeSearch("error budget");
+
+      expect(getVisibleWidgetTypes()).toEqual([DashboardComponentType.Slo]);
+    });
+
+    test("narrows further with each additional word", () => {
+      renderModal();
+
+      // "volume" also hits the Log Chart card, which is about log volume.
+      typeSearch("volume");
+      expect(getVisibleWidgetTypes()).toEqual([
+        DashboardComponentType.LogChart,
+        DashboardComponentType.DockerVolumeList,
+        DashboardComponentType.PodmanVolumeList,
+      ]);
+
+      typeSearch("podman volume");
+      expect(getVisibleWidgetTypes()).toEqual([
+        DashboardComponentType.PodmanVolumeList,
+      ]);
+    });
+
+    test("matches a whole category by name", () => {
+      renderModal();
+
+      typeSearch("kubernetes");
+
+      expect(getVisibleWidgetTypes()).toEqual(getTypesIn("Kubernetes"));
+    });
+
+    test("hides rail categories that have no matches and re-counts the rest", () => {
+      renderModal();
+
+      typeSearch("kubernetes");
+
+      expect(getRailCategoryNames()).toEqual(["Kubernetes"]);
+      expect(screen.getByTestId("widget-category-all").textContent).toBe(
+        `All widgets${getTypesIn("Kubernetes").length}`,
+      );
+    });
+
+    test("re-counts a rail category down to its matching widgets", () => {
+      renderModal();
+
+      typeSearch("gauge");
+
+      expect(screen.getByTestId("widget-category-Metrics").textContent).toBe(
+        "Metrics1",
+      );
+    });
+
+    test("shows the empty state when nothing matches", () => {
+      renderModal();
+
+      typeSearch("zzzzz-not-a-widget");
+
+      expect(screen.getByTestId("add-widget-empty")).toBeInTheDocument();
+      expect(
+        screen.getByText(/No widgets match .*zzzzz-not-a-widget/),
+      ).toBeInTheDocument();
+      expect(getVisibleWidgetTypes()).toEqual([]);
+      expect(
+        screen.queryByTestId("add-widget-result-count"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("restores the catalog from the empty state's Clear search button", () => {
+      renderModal();
+
+      typeSearch("zzzzz-not-a-widget");
+      fireEvent.click(screen.getByTestId("add-widget-empty-clear"));
+
+      expect(getSearchInput().value).toBe("");
+      expect(getVisibleWidgetTypes()).toHaveLength(ALL_COMPONENT_TYPES.length);
+      expect(screen.queryByTestId("add-widget-empty")).not.toBeInTheDocument();
+    });
+
+    test("restores the catalog from the inline clear button", () => {
+      renderModal();
+
+      typeSearch("gauge");
+      fireEvent.click(screen.getByTestId("add-widget-search-clear"));
+
+      expect(getSearchInput().value).toBe("");
+      expect(getVisibleWidgetTypes()).toHaveLength(ALL_COMPONENT_TYPES.length);
+      expect(
+        screen.queryByTestId("add-widget-search-clear"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("treats a whitespace-only search as no search", () => {
+      renderModal();
+
+      typeSearch("   ");
+
+      expect(getVisibleWidgetTypes()).toHaveLength(ALL_COMPONENT_TYPES.length);
+      expect(
+        screen.queryByTestId("add-widget-result-count"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("keeps the category filter when the selection still has matches", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Docker"));
+      typeSearch("registry");
+
+      expect(getVisibleWidgetTypes()).toEqual([
+        DashboardComponentType.DockerImageList,
+      ]);
+    });
+
+    test("falls back to every match when the selected category is filtered away", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Metrics"));
+      typeSearch("kubernetes");
+
+      expect(getVisibleWidgetTypes()).toEqual(getTypesIn("Kubernetes"));
+      expect(screen.getByTestId("widget-category-all")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    test("picks the selected category back up once it matches again", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Metrics"));
+      typeSearch("kubernetes");
+      typeSearch("gauge");
+
+      expect(getVisibleWidgetTypes()).toEqual([DashboardComponentType.Gauge]);
+      expect(screen.getByTestId("widget-category-Metrics")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+  });
+
+  describe("keyboard", () => {
+    test("adds the top match when Enter is pressed while searching", () => {
+      const calls: ModalCalls = renderModal();
+
+      typeSearch("trace");
+      fireEvent.keyDown(getSearchInput(), { key: "Enter" });
+
+      expect(calls.added).toEqual([DashboardComponentType.TraceList]);
+      expect(calls.closed).toBe(1);
+    });
+
+    test("respects the selected category when Enter is pressed", () => {
+      const calls: ModalCalls = renderModal();
+
+      fireEvent.click(screen.getByTestId("widget-category-Podman"));
+      typeSearch("volume");
+      fireEvent.keyDown(getSearchInput(), { key: "Enter" });
+
+      expect(calls.added).toEqual([DashboardComponentType.PodmanVolumeList]);
+    });
+
+    test("does nothing when Enter is pressed with an empty search", () => {
+      const calls: ModalCalls = renderModal();
+
+      fireEvent.keyDown(getSearchInput(), { key: "Enter" });
+
+      expect(calls.added).toEqual([]);
+      expect(calls.closed).toBe(0);
+    });
+
+    test("does nothing when Enter is pressed with no matches", () => {
+      const calls: ModalCalls = renderModal();
+
+      typeSearch("zzzzz-not-a-widget");
+      fireEvent.keyDown(getSearchInput(), { key: "Enter" });
+
+      expect(calls.added).toEqual([]);
+      expect(calls.closed).toBe(0);
+    });
+
+    test("ignores other keys", () => {
+      const calls: ModalCalls = renderModal();
+
+      typeSearch("trace");
+      fireEvent.keyDown(getSearchInput(), { key: "a" });
+
+      expect(calls.added).toEqual([]);
+      expect(calls.closed).toBe(0);
+    });
+  });
+
+  describe("closing", () => {
+    test("closes from the Cancel button without adding a widget", () => {
+      const calls: ModalCalls = renderModal();
+
+      fireEvent.click(screen.getByTestId("modal-footer-close-button"));
+
+      expect(calls.closed).toBe(1);
+      expect(calls.added).toEqual([]);
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/WidgetCatalog.test.ts
+++ b/Common/Tests/App/Dashboard/WidgetCatalog.test.ts
@@ -1,0 +1,479 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  WIDGET_CATALOG,
+  WIDGET_CATEGORY_GROUP_ORDER,
+  WidgetCatalogCategory,
+  WidgetCatalogItem,
+  WidgetCategoryGroup,
+  WidgetCategoryGroupSection,
+  countWidgets,
+  findCategoryByName,
+  getFirstWidget,
+  groupWidgetCategories,
+  searchWidgetCatalog,
+  tokenizeSearchTerm,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+
+type GetCategoryFunction = (name: string) => WidgetCatalogCategory;
+
+const getCategory: GetCategoryFunction = (
+  name: string,
+): WidgetCatalogCategory => {
+  const category: WidgetCatalogCategory | undefined = WIDGET_CATALOG.find(
+    (candidate: WidgetCatalogCategory) => {
+      return candidate.name === name;
+    },
+  );
+
+  if (!category) {
+    throw new Error(`Category "${name}" is missing from the widget catalog.`);
+  }
+
+  return category;
+};
+
+type GetTypesInFunction = (name: string) => Array<DashboardComponentType>;
+
+const getTypesIn: GetTypesInFunction = (
+  name: string,
+): Array<DashboardComponentType> => {
+  return getCategory(name).items.map((item: WidgetCatalogItem) => {
+    return item.type;
+  });
+};
+
+type GetAllItemsFunction = (
+  categories: ReadonlyArray<WidgetCatalogCategory>,
+) => Array<WidgetCatalogItem>;
+
+const getAllItems: GetAllItemsFunction = (
+  categories: ReadonlyArray<WidgetCatalogCategory>,
+): Array<WidgetCatalogItem> => {
+  return categories.flatMap((category: WidgetCatalogCategory) => {
+    return [...category.items];
+  });
+};
+
+type GetMatchedTypesFunction = (searchTerm: string) => Array<string>;
+
+const getMatchedTypes: GetMatchedTypesFunction = (
+  searchTerm: string,
+): Array<string> => {
+  return getAllItems(searchWidgetCatalog(searchTerm)).map(
+    (item: WidgetCatalogItem) => {
+      return item.type.toString();
+    },
+  );
+};
+
+const ALL_COMPONENT_TYPES: Array<DashboardComponentType> = Object.values(
+  DashboardComponentType,
+);
+
+describe("WidgetCatalog", () => {
+  describe("catalog integrity", () => {
+    test("covers every DashboardComponentType exactly once", () => {
+      const catalogTypes: Array<DashboardComponentType> = getAllItems(
+        WIDGET_CATALOG,
+      ).map((item: WidgetCatalogItem) => {
+        return item.type;
+      });
+
+      expect([...catalogTypes].sort()).toEqual([...ALL_COMPONENT_TYPES].sort());
+      expect(catalogTypes).toHaveLength(ALL_COMPONENT_TYPES.length);
+      expect(new Set(catalogTypes).size).toBe(catalogTypes.length);
+    });
+
+    test("has unique category names", () => {
+      const names: Array<string> = WIDGET_CATALOG.map(
+        (category: WidgetCatalogCategory) => {
+          return category.name;
+        },
+      );
+
+      expect(new Set(names).size).toBe(names.length);
+    });
+
+    test("puts every category in a known group", () => {
+      for (const category of WIDGET_CATALOG) {
+        expect(WIDGET_CATEGORY_GROUP_ORDER).toContain(category.group);
+      }
+    });
+
+    test("gives every category a non-empty description and at least one widget", () => {
+      for (const category of WIDGET_CATALOG) {
+        expect(category.name.trim().length).toBeGreaterThan(0);
+        expect(category.description.trim().length).toBeGreaterThan(0);
+        expect(category.items.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("gives every widget a non-empty label and description", () => {
+      for (const item of getAllItems(WIDGET_CATALOG)) {
+        expect(item.label.trim().length).toBeGreaterThan(0);
+        expect(item.description.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    test("gives every widget lower-cased, de-duplicated search keywords", () => {
+      for (const item of getAllItems(WIDGET_CATALOG)) {
+        expect(item.keywords.length).toBeGreaterThan(0);
+        expect(new Set(item.keywords).size).toBe(item.keywords.length);
+
+        for (const keyword of item.keywords) {
+          expect(keyword).toBe(keyword.toLowerCase());
+          expect(keyword.trim()).toBe(keyword);
+          expect(keyword.length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    test("keeps widget labels unique inside each category", () => {
+      for (const category of WIDGET_CATALOG) {
+        const labels: Array<string> = category.items.map(
+          (item: WidgetCatalogItem) => {
+            return item.label;
+          },
+        );
+
+        expect(new Set(labels).size).toBe(labels.length);
+      }
+    });
+  });
+
+  describe("category grouping", () => {
+    test("groups Text, Clock, and HTML under Essentials", () => {
+      expect(getTypesIn("Essentials")).toEqual([
+        DashboardComponentType.Text,
+        DashboardComponentType.Clock,
+        DashboardComponentType.Html,
+      ]);
+      expect(getCategory("Essentials").group).toBe(WidgetCategoryGroup.General);
+    });
+
+    test("groups the metrics-query widgets under Metrics", () => {
+      expect(getTypesIn("Metrics")).toEqual([
+        DashboardComponentType.Chart,
+        DashboardComponentType.Value,
+        DashboardComponentType.Gauge,
+        DashboardComponentType.Table,
+      ]);
+      expect(getCategory("Metrics").group).toBe(WidgetCategoryGroup.General);
+    });
+
+    test("splits telemetry into separate Logs and Traces categories", () => {
+      expect(getTypesIn("Logs")).toEqual([
+        DashboardComponentType.LogStream,
+        DashboardComponentType.LogChart,
+      ]);
+      expect(getTypesIn("Traces")).toEqual([
+        DashboardComponentType.TraceList,
+        DashboardComponentType.TraceChart,
+        DashboardComponentType.TraceTable,
+      ]);
+    });
+
+    test("splits alerts and status into Incidents, Alerts, Monitors, and SLOs", () => {
+      expect(getTypesIn("Incidents")).toEqual([
+        DashboardComponentType.IncidentList,
+      ]);
+      expect(getTypesIn("Alerts")).toEqual([DashboardComponentType.AlertList]);
+      expect(getTypesIn("Monitors")).toEqual([
+        DashboardComponentType.MonitorList,
+      ]);
+      expect(getTypesIn("SLOs")).toEqual([DashboardComponentType.Slo]);
+    });
+
+    test("keeps every observability category in the Observability group", () => {
+      for (const name of [
+        "Logs",
+        "Traces",
+        "Incidents",
+        "Alerts",
+        "Monitors",
+        "SLOs",
+      ]) {
+        expect(getCategory(name).group).toBe(WidgetCategoryGroup.Observability);
+      }
+    });
+
+    test("keeps every platform inventory category in the Infrastructure group", () => {
+      for (const name of [
+        "Hosts",
+        "Kubernetes",
+        "Docker",
+        "Docker Swarm",
+        "Podman",
+        "Proxmox",
+        "Ceph",
+      ]) {
+        expect(getCategory(name).group).toBe(
+          WidgetCategoryGroup.Infrastructure,
+        );
+      }
+    });
+
+    test("lists General categories before Observability and Infrastructure ones", () => {
+      const groupsInCatalogOrder: Array<WidgetCategoryGroup> =
+        WIDGET_CATALOG.map((category: WidgetCatalogCategory) => {
+          return category.group;
+        });
+
+      const firstIndexOfGroup: Array<number> = WIDGET_CATEGORY_GROUP_ORDER.map(
+        (group: WidgetCategoryGroup) => {
+          return groupsInCatalogOrder.indexOf(group);
+        },
+      );
+
+      expect(firstIndexOfGroup).toEqual(
+        [...firstIndexOfGroup].sort((a: number, b: number) => {
+          return a - b;
+        }),
+      );
+    });
+  });
+
+  describe("groupWidgetCategories", () => {
+    test("returns sections in WIDGET_CATEGORY_GROUP_ORDER", () => {
+      const sections: Array<WidgetCategoryGroupSection> =
+        groupWidgetCategories(WIDGET_CATALOG);
+
+      expect(
+        sections.map((section: WidgetCategoryGroupSection) => {
+          return section.group;
+        }),
+      ).toEqual([...WIDGET_CATEGORY_GROUP_ORDER]);
+    });
+
+    test("keeps every category and preserves catalog order inside a group", () => {
+      const sections: Array<WidgetCategoryGroupSection> =
+        groupWidgetCategories(WIDGET_CATALOG);
+
+      const flattened: Array<string> = sections.flatMap(
+        (section: WidgetCategoryGroupSection) => {
+          return section.categories.map((category: WidgetCatalogCategory) => {
+            return category.name;
+          });
+        },
+      );
+
+      expect(flattened).toHaveLength(WIDGET_CATALOG.length);
+
+      const infrastructure: WidgetCategoryGroupSection | undefined =
+        sections.find((section: WidgetCategoryGroupSection) => {
+          return section.group === WidgetCategoryGroup.Infrastructure;
+        });
+
+      expect(
+        infrastructure?.categories.map((category: WidgetCatalogCategory) => {
+          return category.name;
+        }),
+      ).toEqual([
+        "Hosts",
+        "Kubernetes",
+        "Docker",
+        "Docker Swarm",
+        "Podman",
+        "Proxmox",
+        "Ceph",
+      ]);
+    });
+
+    test("drops groups that have no categories left", () => {
+      const sections: Array<WidgetCategoryGroupSection> = groupWidgetCategories(
+        [getCategory("Essentials")],
+      );
+
+      expect(sections).toHaveLength(1);
+      expect(sections[0]?.group).toBe(WidgetCategoryGroup.General);
+    });
+
+    test("returns nothing for an empty category list", () => {
+      expect(groupWidgetCategories([])).toEqual([]);
+    });
+  });
+
+  describe("tokenizeSearchTerm", () => {
+    test("lower-cases and splits on whitespace", () => {
+      expect(tokenizeSearchTerm("Docker Volume")).toEqual(["docker", "volume"]);
+    });
+
+    test("collapses repeated and surrounding whitespace", () => {
+      expect(tokenizeSearchTerm("   log    chart \n")).toEqual([
+        "log",
+        "chart",
+      ]);
+    });
+
+    test("returns no tokens for empty or whitespace-only input", () => {
+      expect(tokenizeSearchTerm("")).toEqual([]);
+      expect(tokenizeSearchTerm("    ")).toEqual([]);
+    });
+  });
+
+  describe("searchWidgetCatalog", () => {
+    test("returns the whole catalog for an empty search", () => {
+      expect(searchWidgetCatalog("")).toEqual([...WIDGET_CATALOG]);
+      expect(searchWidgetCatalog("   ")).toEqual([...WIDGET_CATALOG]);
+    });
+
+    test("returns a new array so callers cannot mutate the catalog", () => {
+      const result: Array<WidgetCatalogCategory> = searchWidgetCatalog("");
+
+      expect(result).not.toBe(WIDGET_CATALOG);
+      result.pop();
+      expect(WIDGET_CATALOG).toHaveLength(result.length + 1);
+    });
+
+    test("matches widget labels regardless of case", () => {
+      expect(getMatchedTypes("GAUGE")).toContain(DashboardComponentType.Gauge);
+      expect(getMatchedTypes("gauge")).toContain(DashboardComponentType.Gauge);
+    });
+
+    test("matches text that only appears in the description", () => {
+      expect(getMatchedTypes("honeycomb")).toEqual([
+        DashboardComponentType.CephOsdList,
+      ]);
+    });
+
+    test("matches keywords that are not in the visible copy", () => {
+      expect(getMatchedTypes("burn rate")).toEqual([
+        DashboardComponentType.Slo,
+      ]);
+      expect(getMatchedTypes("iframe")).toEqual([DashboardComponentType.Html]);
+      expect(getMatchedTypes("timezone")).toEqual([
+        DashboardComponentType.Clock,
+      ]);
+    });
+
+    test("matches a category name and keeps all of its widgets", () => {
+      expect(getMatchedTypes("kubernetes")).toEqual(getTypesIn("Kubernetes"));
+    });
+
+    test("matches a group name", () => {
+      const matched: Array<string> = getMatchedTypes("observability");
+
+      expect(matched).toContain(DashboardComponentType.IncidentList);
+      expect(matched).toContain(DashboardComponentType.LogStream);
+      expect(matched).not.toContain(DashboardComponentType.Text);
+    });
+
+    test("requires every token to match, so multi-word searches narrow results", () => {
+      expect(getMatchedTypes("docker volume")).toEqual([
+        DashboardComponentType.DockerVolumeList,
+      ]);
+      expect(getMatchedTypes("podman volume")).toEqual([
+        DashboardComponentType.PodmanVolumeList,
+      ]);
+    });
+
+    test("matches tokens spread across different fields", () => {
+      expect(getMatchedTypes("essentials clock")).toEqual([
+        DashboardComponentType.Clock,
+      ]);
+    });
+
+    test("returns no categories when nothing matches", () => {
+      expect(searchWidgetCatalog("zzzzz-not-a-widget")).toEqual([]);
+    });
+
+    test("drops categories that have no matching widgets", () => {
+      const result: Array<WidgetCatalogCategory> = searchWidgetCatalog("gauge");
+
+      expect(
+        result.map((category: WidgetCatalogCategory) => {
+          return category.name;
+        }),
+      ).toEqual(["Metrics"]);
+      expect(result[0]?.items).toHaveLength(1);
+    });
+
+    test("does not mutate the source catalog", () => {
+      const before: string = JSON.stringify(WIDGET_CATALOG);
+
+      searchWidgetCatalog("docker");
+      searchWidgetCatalog("");
+      searchWidgetCatalog("nothing at all here");
+
+      expect(JSON.stringify(WIDGET_CATALOG)).toBe(before);
+    });
+
+    test("searches the supplied catalog when one is passed", () => {
+      const result: Array<WidgetCatalogCategory> = searchWidgetCatalog(
+        "clock",
+        [getCategory("Metrics")],
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("countWidgets", () => {
+    test("counts nothing for an empty list", () => {
+      expect(countWidgets([])).toBe(0);
+    });
+
+    test("counts every widget in the catalog", () => {
+      expect(countWidgets(WIDGET_CATALOG)).toBe(ALL_COMPONENT_TYPES.length);
+    });
+
+    test("counts only the widgets left after a search", () => {
+      expect(countWidgets(searchWidgetCatalog("kubernetes"))).toBe(
+        getCategory("Kubernetes").items.length,
+      );
+    });
+  });
+
+  describe("getFirstWidget", () => {
+    test("returns the first widget in catalog order", () => {
+      expect(getFirstWidget(WIDGET_CATALOG)?.type).toBe(
+        DashboardComponentType.Text,
+      );
+    });
+
+    test("returns the first match of a search", () => {
+      expect(getFirstWidget(searchWidgetCatalog("trace"))?.type).toBe(
+        DashboardComponentType.TraceList,
+      );
+    });
+
+    test("returns null when there are no categories", () => {
+      expect(getFirstWidget([])).toBeNull();
+    });
+
+    test("skips categories that have no widgets", () => {
+      const emptyCategory: WidgetCatalogCategory = {
+        ...getCategory("Metrics"),
+        name: "Empty",
+        items: [],
+      };
+
+      expect(
+        getFirstWidget([emptyCategory, getCategory("Essentials")])?.type,
+      ).toBe(DashboardComponentType.Text);
+    });
+  });
+
+  describe("findCategoryByName", () => {
+    test("finds a category by its exact name", () => {
+      expect(findCategoryByName(WIDGET_CATALOG, "Docker Swarm")?.name).toBe(
+        "Docker Swarm",
+      );
+    });
+
+    test("returns null for an unknown name", () => {
+      expect(findCategoryByName(WIDGET_CATALOG, "Nope")).toBeNull();
+    });
+
+    test("returns null when no name is selected", () => {
+      expect(findCategoryByName(WIDGET_CATALOG, null)).toBeNull();
+    });
+
+    test("returns null when the name was filtered out of the given list", () => {
+      expect(
+        findCategoryByName(searchWidgetCatalog("kubernetes"), "Metrics"),
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Why

The widget picker had a single **Visualization** bucket holding Text, Clock, HTML *and* the metrics widgets, and a **Telemetry** bucket mixing logs with traces. With 41 widgets in the catalog that meant scrolling past unrelated cards to find anything, and the flat list only got longer as integrations landed.

## What changed

**Regrouped categories** — each category is now one kind of thing:

| Group | Categories |
| --- | --- |
| General | Essentials (Text, Clock, HTML), Metrics (Chart, Value, Gauge, Table) |
| Observability | Logs, Traces, Incidents, Alerts, Monitors, SLOs |
| Infrastructure | Hosts, Kubernetes, Docker, Docker Swarm, Podman, Proxmox, Ceph |

The three groups are what the picker renders as rail headings, so navigation stays short as more integrations land.

**Extracted the catalog** into [`WidgetCatalog.ts`](App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts) — data plus pure helpers (`searchWidgetCatalog`, `groupWidgetCategories`, `countWidgets`, `getFirstWidget`, `findCategoryByName`), so the grouping and search rules are testable without rendering.

**Reworked the modal UI:**

- Category rail with live per-category match counts; a horizontally scrolling chip row below `md`, a vertical list with group headings above it.
- Search now matches on label, description, category, group, **and per-widget keywords** that are not in the visible copy — "error budget" finds SLO, "iframe" finds HTML, "k8s" finds the Kubernetes widgets.
- Multi-token AND matching, so "podman volume" narrows to one card.
- Result count with an `aria-live` announcement, an inline clear (×) button, and Enter-to-add-the-top-match (only while searching, so it can never fire on an untouched picker).
- Selecting a category and then searching outside it falls back to showing every match instead of an empty pane, and picks the selection back up once it matches again.
- Empty state gains a Clear search action; the rail hides when nothing matches.

## Tests

83 new tests, all passing:

- [`WidgetCatalog.test.ts`](Common/Tests/App/Dashboard/WidgetCatalog.test.ts) — 45 tests. Catalog integrity (every `DashboardComponentType` covered exactly once, unique category names, non-empty copy, lower-cased de-duplicated keywords), the exact grouping this PR introduces, group ordering, and full search/count/lookup semantics including non-mutation of the source catalog.
- [`AddWidgetModal.test.tsx`](Common/Tests/App/Dashboard/AddWidgetModal.test.tsx) — 38 RTL tests. Default render, rail selection and `aria-pressed`, adding widgets (including the identically-labelled Docker vs Podman cards), search filtering and counts, empty state, clear buttons, category-fallback behaviour, and the keyboard path.

```bash
cd Common && npx jest --runInBand Tests/App/Dashboard
```

`npx tsc --noEmit` in `App/FeatureSet/Dashboard` and `npx eslint` on the touched files are both clean.

## Verification

Rendered the real component against the app's own vendored Tailwind build and exercised it in a browser — default view, category selection, keyword search, empty state, and the mobile chip rail all behave as described, with no console errors.