### PR TITLE
fix(ui): stop the modal body from clipping autocomplete suggestions

### DIFF
--- a/Common/Tests/UI/Components/AutocompleteTextInputMenu.test.tsx
+++ b/Common/Tests/UI/Components/AutocompleteTextInputMenu.test.tsx
@@ -1,0 +1,555 @@
+import AutocompleteTextInput, {
+  SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX,
+  SUGGESTIONS_MENU_Z_INDEX,
+} from "../../../UI/Components/AutocompleteTextInput/AutocompleteTextInput";
+import Modal from "../../../UI/Components/Modal/Modal";
+/*
+ * The main entry, not "/extend-expect": the latter no longer ships type
+ * declarations, so every jest-dom matcher in this file fails to typecheck and
+ * the whole suite is skipped before a single assertion runs.
+ */
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const INPUT_TEST_ID: string = "attribute-key";
+const MENU_TEST_ID: string = `${INPUT_TEST_ID}-suggestions`;
+
+const SUGGESTIONS: Array<string> = [
+  "k8s.cluster.name",
+  "k8s.namespace.name",
+  "service.name",
+];
+
+const ORIGINAL_INNER_WIDTH: number = window.innerWidth;
+const ORIGINAL_INNER_HEIGHT: number = window.innerHeight;
+const originalGetBoundingClientRect: () => DOMRect =
+  Element.prototype.getBoundingClientRect;
+
+/*
+ * jsdom performs no layout, so every rect comes back zero-sized. These helpers
+ * let a test describe where the input sits inside a viewport of a given size,
+ * which is the only input the positioning logic reads.
+ */
+function setViewportSize(width: number, height: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: height,
+  });
+}
+
+/*
+ * The component measures its wrapper div, so the stub answers for whichever
+ * element directly wraps the input under test and defers everything else to
+ * jsdom.
+ */
+function stubTriggerRect(rect: {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}): void {
+  Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    const input: Element | null = this.querySelector(
+      `[data-testid="${INPUT_TEST_ID}"]`,
+    );
+
+    if (input && input.parentElement === this) {
+      return {
+        top: rect.top,
+        bottom: rect.top + rect.height,
+        left: rect.left,
+        right: rect.left + rect.width,
+        width: rect.width,
+        height: rect.height,
+        x: rect.left,
+        y: rect.top,
+        toJSON: (): Record<string, unknown> => {
+          return {};
+        },
+      } as DOMRect;
+    }
+
+    return originalGetBoundingClientRect.call(this);
+  };
+}
+
+function renderInput(
+  overrides: Partial<React.ComponentProps<typeof AutocompleteTextInput>> = {},
+): void {
+  render(
+    <AutocompleteTextInput
+      dataTestId={INPUT_TEST_ID}
+      suggestions={SUGGESTIONS}
+      {...overrides}
+    />,
+  );
+}
+
+/*
+ * The real defect: the "Filter <Resource>" modal body is a scroll container
+ * (`overflow-y-auto` in Modal.tsx), so an absolutely positioned menu was
+ * clipped to it. Rendering through the actual Modal keeps that regression
+ * honest rather than approximating it with a hand-rolled wrapper.
+ */
+function renderInputInsideModal(): void {
+  render(
+    <Modal title="Filter Logs">
+      <AutocompleteTextInput
+        dataTestId={INPUT_TEST_ID}
+        suggestions={SUGGESTIONS}
+      />
+    </Modal>,
+  );
+}
+
+function getInput(): HTMLElement {
+  return screen.getByTestId(INPUT_TEST_ID);
+}
+
+function getMenu(): HTMLElement {
+  return screen.getByTestId(MENU_TEST_ID);
+}
+
+function openMenu(): HTMLElement {
+  fireEvent.focus(getInput());
+  return getMenu();
+}
+
+function getOptions(): Array<HTMLElement> {
+  return screen.getAllByRole("option");
+}
+
+describe("AutocompleteTextInput suggestion menu", () => {
+  beforeEach(() => {
+    setViewportSize(1440, 900);
+    stubTriggerRect({ top: 200, left: 300, width: 240, height: 36 });
+  });
+
+  afterEach(() => {
+    cleanup();
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    setViewportSize(ORIGINAL_INNER_WIDTH, ORIGINAL_INNER_HEIGHT);
+  });
+
+  describe("escaping clipping ancestors", () => {
+    test("portals the menu to document.body instead of the input wrapper", () => {
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      expect(menu.parentElement).toBe(document.body);
+      expect(getInput().parentElement?.contains(menu)).toBe(false);
+    });
+
+    test("renders outside the modal's scrolling body", () => {
+      /*
+       * Regression: with `absolute` positioning the list was painted inside
+       * `modal-content`, whose `overflow-y-auto` cropped it to a sliver when the
+       * filter row sat in the lower half of a scrolled modal.
+       */
+      renderInputInsideModal();
+
+      const menu: HTMLElement = openMenu();
+      const modalBody: HTMLElement = screen.getByTestId("modal-content");
+
+      expect(modalBody).toHaveClass("overflow-y-auto");
+      expect(modalBody.contains(menu)).toBe(false);
+      expect(screen.getByTestId("modal").contains(menu)).toBe(false);
+      expect(menu.parentElement).toBe(document.body);
+    });
+
+    test("is fixed positioned so no ancestor's overflow can clip it", () => {
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      expect(menu.style.position).toBe("fixed");
+      expect(menu.className).not.toContain("absolute");
+    });
+
+    test("draws above modal surfaces at the shared dropdown z-index", () => {
+      renderInput();
+
+      // Modal surfaces are z-50; react-select portals its menu at 60 too.
+      expect(SUGGESTIONS_MENU_Z_INDEX).toBe(60);
+      expect(openMenu().style.zIndex).toBe(String(SUGGESTIONS_MENU_Z_INDEX));
+    });
+
+    test("removes the portalled menu from the document once closed", () => {
+      renderInput();
+      openMenu();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("positioning", () => {
+    test("anchors below the input and matches its width", () => {
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      // 200 top + 36 height + 4px offset.
+      expect(menu.style.top).toBe("240px");
+      expect(menu.style.left).toBe("300px");
+      expect(menu.style.width).toBe("240px");
+      expect(menu.getAttribute("data-placement")).toBe("below");
+    });
+
+    test("caps its height at the max-h-56 the menu used to carry as a class", () => {
+      renderInput();
+
+      expect(SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX).toBe(224);
+      expect(openMenu().style.maxHeight).toBe(
+        `${SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX}px`,
+      );
+    });
+
+    test("flips above the input when there is no room below", () => {
+      // 60px of room below the input, 796px above it.
+      stubTriggerRect({ top: 800, left: 300, width: 240, height: 36 });
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      expect(menu.getAttribute("data-placement")).toBe("above");
+      expect(menu.style.maxHeight).toBe("224px");
+      // 800 top - 4 offset - 224 height.
+      expect(menu.style.top).toBe("572px");
+    });
+
+    test("shrinks to the space available when flipped up", () => {
+      // 300px above the input: 300 - 4 offset - 8 padding = 288, capped at 224.
+      stubTriggerRect({ top: 300, left: 300, width: 240, height: 36 });
+      setViewportSize(1440, 400);
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      expect(menu.getAttribute("data-placement")).toBe("above");
+      expect(menu.style.maxHeight).toBe("224px");
+      // 300 - 4 offset - 224 height.
+      expect(menu.style.top).toBe("72px");
+    });
+
+    test("shrinks rather than overflowing when neither side has full room", () => {
+      setViewportSize(1440, 300);
+      stubTriggerRect({ top: 100, left: 300, width: 240, height: 36 });
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      // 300 - 136 bottom - 4 offset - 8 padding = 152px of usable space below.
+      expect(menu.getAttribute("data-placement")).toBe("below");
+      expect(menu.style.maxHeight).toBe("152px");
+    });
+
+    test("clamps to the viewport when the input sits near the right edge", () => {
+      setViewportSize(1000, 900);
+      stubTriggerRect({ top: 200, left: 900, width: 240, height: 36 });
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      // 1000 viewport - 240 width - 8 padding.
+      expect(menu.style.left).toBe("752px");
+    });
+
+    test("never positions the menu off the left edge", () => {
+      stubTriggerRect({ top: 200, left: -50, width: 240, height: 36 });
+      renderInput();
+
+      expect(openMenu().style.left).toBe("8px");
+    });
+
+    test("narrows the menu on a viewport smaller than the input", () => {
+      setViewportSize(320, 900);
+      stubTriggerRect({ top: 200, left: 0, width: 400, height: 36 });
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      // 320 viewport minus 8px of padding on each side.
+      expect(menu.style.width).toBe("304px");
+      expect(menu.style.left).toBe("8px");
+    });
+
+    test("repositions when an ancestor scroll container scrolls", () => {
+      renderInput();
+
+      expect(openMenu().style.top).toBe("240px");
+
+      /*
+       * Scrolling the modal body does not bubble to window, which is why the
+       * listener has to be registered in the capture phase.
+       */
+      act(() => {
+        stubTriggerRect({ top: 120, left: 300, width: 240, height: 36 });
+        document.body.dispatchEvent(new Event("scroll", { bubbles: false }));
+      });
+
+      expect(getMenu().style.top).toBe("160px");
+    });
+
+    test("repositions when the window is resized", () => {
+      renderInput();
+
+      expect(openMenu().style.left).toBe("300px");
+
+      act(() => {
+        setViewportSize(500, 900);
+        window.dispatchEvent(new Event("resize"));
+      });
+
+      // 500 viewport - 240 width - 8 padding.
+      expect(getMenu().style.left).toBe("252px");
+    });
+
+    test("stops listening for layout changes once the menu closes", () => {
+      const removedEvents: Array<string> = [];
+      const originalRemoveEventListener: typeof window.removeEventListener =
+        window.removeEventListener.bind(window);
+
+      window.removeEventListener = ((
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+      ): void => {
+        removedEvents.push(type);
+        originalRemoveEventListener(type, listener, options);
+      }) as typeof window.removeEventListener;
+
+      try {
+        renderInput();
+        openMenu();
+        fireEvent.mouseDown(document.body);
+
+        expect(removedEvents).toContain("scroll");
+        expect(removedEvents).toContain("resize");
+      } finally {
+        window.removeEventListener = originalRemoveEventListener;
+      }
+    });
+
+    test("ignores layout events fired after the menu closed", () => {
+      renderInput();
+      openMenu();
+      fireEvent.mouseDown(document.body);
+
+      act(() => {
+        setViewportSize(400, 400);
+        window.dispatchEvent(new Event("resize"));
+        document.body.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("portal-aware outside click", () => {
+    test("keeps the menu open while pressing a suggestion in the portal", () => {
+      renderInput();
+      const menu: HTMLElement = openMenu();
+
+      /*
+       * The menu is no longer a descendant of the component's wrapper, so a
+       * container-only `contains()` check would treat this as an outside click
+       * and unmount the option before its click handler ever ran.
+       */
+      fireEvent.mouseDown(getOptions()[0]!);
+
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBe(menu);
+    });
+
+    test("selects a suggestion clicked inside the portal", () => {
+      const onChange: (value: string) => void = jest.fn();
+      renderInput({ onChange: onChange });
+      openMenu();
+
+      fireEvent.mouseDown(getOptions()[1]!);
+      fireEvent.click(getOptions()[1]!);
+
+      expect(onChange).toHaveBeenCalledWith("k8s.namespace.name");
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBeNull();
+      expect(getInput()).toHaveValue("k8s.namespace.name");
+    });
+
+    test("closes when clicking elsewhere in the modal", () => {
+      renderInputInsideModal();
+      openMenu();
+
+      fireEvent.mouseDown(screen.getByTestId("modal-title"));
+
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBeNull();
+    });
+
+    test("stays open when clicking the input itself", () => {
+      renderInput();
+      openMenu();
+
+      fireEvent.mouseDown(getInput());
+
+      expect(screen.queryByTestId(MENU_TEST_ID)).not.toBeNull();
+    });
+  });
+
+  describe("keyboard contract outside the modal focus trap", () => {
+    test("keeps focus on the input so Modal's trap still owns Tab", () => {
+      renderInputInsideModal();
+      const input: HTMLElement = getInput();
+      openMenu();
+
+      /*
+       * Modal builds its focus trap from `modalRef.current.querySelectorAll`,
+       * so portalled options can never be part of it. Holding them out of the
+       * tab order keeps Tab cycling the modal's own controls.
+       */
+      getOptions().forEach((option: HTMLElement) => {
+        expect(option).toHaveAttribute("tabindex", "-1");
+      });
+      expect(screen.getByTestId("modal").contains(input)).toBe(true);
+    });
+
+    test("moves the highlight down with ArrowDown", () => {
+      renderInput();
+      const input: HTMLElement = getInput();
+      openMenu();
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+
+      expect(getOptions()[0]).toHaveAttribute("aria-selected", "true");
+      expect(input).toHaveAttribute(
+        "aria-activedescendant",
+        getOptions()[0]!.id,
+      );
+    });
+
+    test("wraps the highlight to the last option with ArrowUp", () => {
+      renderInput();
+      openMenu();
+
+      fireEvent.keyDown(getInput(), { key: "ArrowUp" });
+
+      expect(getOptions()[SUGGESTIONS.length - 1]).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    test("picks the highlighted option with Enter", () => {
+      const onChange: (value: string) => void = jest.fn();
+      renderInput({ onChange: onChange });
+      const input: HTMLElement = getInput();
+      openMenu();
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onChange).toHaveBeenCalledWith("k8s.namespace.name");
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBeNull();
+    });
+
+    test("closes the menu on Escape without closing the modal", () => {
+      /*
+       * Modal listens for Escape on the document and bails on
+       * `event.defaultPrevented`, so the menu must mark the key as handled.
+       * Otherwise one Escape would take the whole filter dialog down with it.
+       */
+      const onClose: () => void = jest.fn();
+      render(
+        <Modal title="Filter Logs" onClose={onClose}>
+          <AutocompleteTextInput
+            dataTestId={INPUT_TEST_ID}
+            suggestions={SUGGESTIONS}
+          />
+        </Modal>,
+      );
+      openMenu();
+
+      fireEvent.keyDown(getInput(), { key: "Escape" });
+
+      expect(screen.queryByTestId(MENU_TEST_ID)).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("leaves Escape to the modal once the menu is closed", () => {
+      const onClose: () => void = jest.fn();
+      render(
+        <Modal title="Filter Logs" onClose={onClose}>
+          <AutocompleteTextInput
+            dataTestId={INPUT_TEST_ID}
+            suggestions={SUGGESTIONS}
+          />
+        </Modal>,
+      );
+      openMenu();
+
+      // First Escape is swallowed by the menu, the second reaches the dialog.
+      fireEvent.keyDown(getInput(), { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(getInput(), { key: "Escape" });
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test("points aria-controls at the portalled listbox", () => {
+      renderInput();
+
+      const menu: HTMLElement = openMenu();
+
+      expect(getInput()).toHaveAttribute("aria-controls", menu.id);
+      expect(getInput()).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+
+  describe("loading and filtering", () => {
+    test("portals the loading row when suggestions are still being fetched", () => {
+      renderInput({
+        suggestions: [],
+        isLoadingSuggestions: true,
+        loadingMessage: "Loading attributes...",
+      });
+
+      const menu: HTMLElement = openMenu();
+
+      expect(menu.parentElement).toBe(document.body);
+      expect(menu).toHaveTextContent("Loading attributes...");
+    });
+
+    test("keeps the menu anchored as typing narrows the list", () => {
+      renderInput();
+      const input: HTMLElement = getInput();
+      openMenu();
+
+      fireEvent.change(input, { target: { value: "k8s" } });
+
+      expect(getOptions()).toHaveLength(2);
+      expect(getMenu().style.top).toBe("240px");
+    });
+  });
+});

--- a/Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput.tsx
+++ b/Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput.tsx
@@ -1,11 +1,14 @@
 import React, {
   FunctionComponent,
   ReactElement,
+  useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 export interface ComponentProps {
   value?: string;
@@ -37,6 +40,92 @@ const BASE_INPUT_CLASS: string =
  */
 const MAX_SUGGESTIONS: number = 100;
 
+/*
+ * Modal surfaces sit at z-50 (see Modal.tsx), and react-select portals its menu
+ * at DROPDOWN_MENU_Z_INDEX (60). The suggestion list matches the latter so it
+ * draws above a modal without fighting other portalled menus.
+ */
+export const SUGGESTIONS_MENU_Z_INDEX: number = 60;
+
+// Tailwind's max-h-56 — the tallest the menu is allowed to grow.
+export const SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX: number = 224;
+
+// Gap between the input and the menu, matching the old `mt-1`.
+const MENU_OFFSET_IN_PX: number = 4;
+
+// Smallest gap the menu keeps from the viewport edges.
+const VIEWPORT_PADDING_IN_PX: number = 8;
+
+export interface MenuPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+  placement: "below" | "above";
+}
+
+/*
+ * The menu used to be `absolute` inside the input's `relative` wrapper, which
+ * meant any ancestor with `overflow: auto` clipped it. The "Filter <Resource>"
+ * modal body is exactly that (`overflow-y-auto` in Modal.tsx), so opening the
+ * JSON/attributes key input near the bottom of a scrolled modal showed only a
+ * sliver of the list and made suggestions unpickable. The menu is now portalled
+ * to document.body and positioned `fixed` from the trigger's viewport rect.
+ */
+export function getMenuPosition(
+  triggerRect: DOMRect,
+  viewportWidth: number,
+  viewportHeight: number,
+): MenuPosition {
+  const spaceBelow: number =
+    viewportHeight - triggerRect.bottom - MENU_OFFSET_IN_PX;
+  const spaceAbove: number = triggerRect.top - MENU_OFFSET_IN_PX;
+
+  /*
+   * Prefer opening downwards. Flip up only when below is too cramped to be
+   * usable *and* above genuinely has more room, so the menu does not jump
+   * around for a few pixels of difference.
+   */
+  const shouldFlipUp: boolean =
+    spaceBelow < SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX && spaceAbove > spaceBelow;
+
+  const availableHeight: number = shouldFlipUp ? spaceAbove : spaceBelow;
+  const maxHeight: number = Math.max(
+    0,
+    Math.min(
+      SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX,
+      availableHeight - VIEWPORT_PADDING_IN_PX,
+    ),
+  );
+
+  // Never wider than the viewport allows, even when the input itself is.
+  const width: number = Math.min(
+    triggerRect.width,
+    Math.max(0, viewportWidth - VIEWPORT_PADDING_IN_PX * 2),
+  );
+
+  const maximumLeft: number = viewportWidth - width - VIEWPORT_PADDING_IN_PX;
+  const left: number = Math.max(
+    VIEWPORT_PADDING_IN_PX,
+    Math.min(triggerRect.left, Math.max(VIEWPORT_PADDING_IN_PX, maximumLeft)),
+  );
+
+  const top: number = shouldFlipUp
+    ? Math.max(
+        VIEWPORT_PADDING_IN_PX,
+        triggerRect.top - MENU_OFFSET_IN_PX - maxHeight,
+      )
+    : triggerRect.bottom + MENU_OFFSET_IN_PX;
+
+  return {
+    top: top,
+    left: left,
+    width: width,
+    maxHeight: maxHeight,
+    placement: shouldFlipUp ? "above" : "below",
+  };
+}
+
 // Provides a free-form text input with an optional suggestion dropdown.
 const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -44,7 +133,10 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
   const [inputValue, setInputValue] = useState<string>(props.value || "");
   const [isMenuVisible, setIsMenuVisible] = useState<boolean>(false);
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const containerRef: React.MutableRefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement | null>(null);
+  const menuRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef<HTMLDivElement | null>(null);
   const blurTimeoutRef: React.MutableRefObject<number | null> = useRef<
     number | null
@@ -61,11 +153,23 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
     const handleClickOutside: (event: MouseEvent) => void = (
       event: MouseEvent,
     ) => {
-      if (
-        containerRef.current &&
-        event.target instanceof Node &&
-        !containerRef.current.contains(event.target)
-      ) {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+
+      /*
+       * The menu is portalled out of `containerRef`, so a click on a suggestion
+       * is "outside" the container as far as the DOM is concerned. Check the
+       * menu too, otherwise the list closes before the click lands on it.
+       */
+      const isInsideContainer: boolean = Boolean(
+        containerRef.current?.contains(event.target),
+      );
+      const isInsideMenu: boolean = Boolean(
+        menuRef.current?.contains(event.target),
+      );
+
+      if (!isInsideContainer && !isInsideMenu) {
         setIsMenuVisible(false);
         setHighlightedIndex(-1);
       }
@@ -102,6 +206,48 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
   const isLoadingSuggestions: boolean = Boolean(props.isLoadingSuggestions);
   const showMenu: boolean =
     isMenuVisible && (suggestions.length > 0 || isLoadingSuggestions);
+
+  const updateMenuPosition: () => void = useCallback((): void => {
+    const container: HTMLDivElement | null = containerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    setMenuPosition(
+      getMenuPosition(
+        container.getBoundingClientRect(),
+        window.innerWidth,
+        window.innerHeight,
+      ),
+    );
+  }, []);
+
+  /*
+   * Measure before paint so the menu never renders at a stale position, then
+   * keep it glued to the input: capture-phase scroll catches scrolling in the
+   * modal body (and any other ancestor), which does not bubble to window.
+   */
+  useLayoutEffect(() => {
+    if (!showMenu) {
+      setMenuPosition(null);
+      return;
+    }
+
+    updateMenuPosition();
+
+    const handleLayoutChange: () => void = (): void => {
+      updateMenuPosition();
+    };
+
+    window.addEventListener("scroll", handleLayoutChange, true);
+    window.addEventListener("resize", handleLayoutChange);
+
+    return () => {
+      window.removeEventListener("scroll", handleLayoutChange, true);
+      window.removeEventListener("resize", handleLayoutChange);
+    };
+  }, [showMenu, updateMenuPosition]);
 
   const getInputClassName: () => string = (): string => {
     let className: string = props.className || BASE_INPUT_CLASS;
@@ -156,6 +302,18 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
   const handleKeyDown: (
     event: React.KeyboardEvent<HTMLInputElement>,
   ) => void = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    /*
+     * Escape closes the list even when there is nothing to pick (the loading
+     * row counts as an open menu). Marking the event handled stops Modal's
+     * document-level listener from closing the whole dialog behind the menu.
+     */
+    if (event.key === "Escape" && showMenu) {
+      event.preventDefault();
+      setIsMenuVisible(false);
+      setHighlightedIndex(-1);
+      return;
+    }
+
     if (!showMenu || suggestions.length === 0) {
       return;
     }
@@ -187,11 +345,6 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
         handleSuggestionSelect(suggestions[highlightedIndex]!);
       }
     }
-
-    if (event.key === "Escape") {
-      setIsMenuVisible(false);
-      setHighlightedIndex(-1);
-    }
   };
 
   useEffect(() => {
@@ -199,6 +352,101 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
       setHighlightedIndex(suggestions.length - 1);
     }
   }, [suggestions, highlightedIndex]);
+
+  const activeOptionId: string | undefined =
+    highlightedIndex >= 0 && highlightedIndex < suggestions.length
+      ? `${listboxIdRef.current}-option-${highlightedIndex}`
+      : undefined;
+
+  const menu: ReactElement | null = showMenu ? (
+    <div
+      ref={menuRef}
+      className={
+        props.menuClassName ||
+        "overflow-auto rounded-md border border-gray-200 bg-white py-1 text-sm shadow-lg"
+      }
+      style={{
+        position: "fixed",
+        top: menuPosition?.top ?? 0,
+        left: menuPosition?.left ?? 0,
+        width: menuPosition?.width ?? 0,
+        maxHeight: menuPosition?.maxHeight ?? SUGGESTIONS_MENU_MAX_HEIGHT_IN_PX,
+        zIndex: SUGGESTIONS_MENU_Z_INDEX,
+        // Avoid a flash at (0, 0) on the first frame before the rect is read.
+        visibility: menuPosition ? "visible" : "hidden",
+      }}
+      data-testid={
+        props.dataTestId ? `${props.dataTestId}-suggestions` : undefined
+      }
+      data-placement={menuPosition?.placement}
+      id={listboxIdRef.current}
+      role="listbox"
+    >
+      {isLoadingSuggestions && (
+        <div className="flex w-full items-center px-3 py-2 text-left text-gray-500">
+          <svg
+            className="animate-spin -ml-0.5 mr-2 h-4 w-4 text-indigo-500"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            ></path>
+          </svg>
+          <span>{props.loadingMessage || "Loading..."}</span>
+        </div>
+      )}
+      {!isLoadingSuggestions &&
+        suggestions.length === 0 &&
+        props.noSuggestionsMessage && (
+          <div className="flex w-full items-center px-3 py-2 text-left text-gray-500">
+            {props.noSuggestionsMessage}
+          </div>
+        )}
+      {!isLoadingSuggestions &&
+        suggestions.map((suggestion: string, index: number) => {
+          const isActive: boolean = index === highlightedIndex;
+          return (
+            <button
+              key={`${suggestion}-${index}`}
+              id={`${listboxIdRef.current}-option-${index}`}
+              type="button"
+              role="option"
+              /*
+               * Portalling puts these buttons outside Modal's focus trap, which
+               * is built from `modalRef.current.querySelectorAll(...)`. Keeping
+               * them out of the tab order means Tab still cycles the modal's own
+               * controls instead of dead-ending here; the list stays reachable
+               * through the arrow keys and Enter on the input.
+               */
+              tabIndex={-1}
+              aria-selected={isActive}
+              className={`flex w-full items-center px-3 py-2 text-left hover:bg-indigo-50 ${isActive ? "bg-indigo-600 text-white hover:bg-indigo-500" : "text-gray-700"}`}
+              onMouseDown={(event: React.MouseEvent<HTMLButtonElement>) => {
+                event.preventDefault();
+              }}
+              onClick={() => {
+                handleSuggestionSelect(suggestion);
+              }}
+            >
+              {suggestion}
+            </button>
+          );
+        })}
+    </div>
+  ) : null;
 
   return (
     <div
@@ -213,6 +461,7 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
         aria-autocomplete="list"
         aria-controls={listboxIdRef.current}
         aria-expanded={showMenu}
+        aria-activedescendant={activeOptionId}
         role="combobox"
         onBlur={handleInputBlur}
         onChange={handleInputChange}
@@ -223,71 +472,7 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
         type="text"
         value={inputValue}
       />
-      {showMenu && (
-        <div
-          className={
-            props.menuClassName ||
-            "absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 text-sm shadow-lg"
-          }
-          id={listboxIdRef.current}
-          role="listbox"
-        >
-          {isLoadingSuggestions && (
-            <div className="flex w-full items-center px-3 py-2 text-left text-gray-500">
-              <svg
-                className="animate-spin -ml-0.5 mr-2 h-4 w-4 text-indigo-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                ></circle>
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-                ></path>
-              </svg>
-              <span>{props.loadingMessage || "Loading..."}</span>
-            </div>
-          )}
-          {!isLoadingSuggestions &&
-            suggestions.length === 0 &&
-            props.noSuggestionsMessage && (
-              <div className="flex w-full items-center px-3 py-2 text-left text-gray-500">
-                {props.noSuggestionsMessage}
-              </div>
-            )}
-          {!isLoadingSuggestions &&
-            suggestions.map((suggestion: string, index: number) => {
-              const isActive: boolean = index === highlightedIndex;
-              return (
-                <button
-                  key={`${suggestion}-${index}`}
-                  type="button"
-                  role="option"
-                  aria-selected={isActive}
-                  className={`flex w-full items-center px-3 py-2 text-left hover:bg-indigo-50 ${isActive ? "bg-indigo-600 text-white hover:bg-indigo-500" : "text-gray-700"}`}
-                  onMouseDown={(event: React.MouseEvent<HTMLButtonElement>) => {
-                    event.preventDefault();
-                  }}
-                  onClick={() => {
-                    handleSuggestionSelect(suggestion);
-                  }}
-                >
-                  {suggestion}
-                </button>
-              );
-            })}
-        </div>
-      )}
+      {menu && createPortal(menu, document.body)}
     </div>
   );
 };


### PR DESCRIPTION
## Problem

`AutocompleteTextInput` rendered its suggestion listbox as an `absolute` child of its own `relative` wrapper, so any ancestor with `overflow: auto` cropped it.

The "Filter <Resource>" modal body is exactly that — `min-h-0 flex-1 overflow-y-auto overscroll-contain` in `Modal.tsx`. Repro: open a table with a JSON/attributes filter, click **Filter \<Resource\>**, scroll so the JSON filter row sits in the lower half of the modal body, then click the **Key** input. Only a sliver of the list is visible and suggestions cannot be picked.

Same defect class as the `OperatorSelector` popup.

## Fix

The menu is portalled into `document.body` and positioned `fixed` from the input's `getBoundingClientRect()`:

- flips above the input when there is no room below,
- shrinks to whatever vertical space is left rather than overflowing,
- clamps horizontally so it can never run off either edge, and narrows on viewports smaller than the input,
- re-measures on capture-phase `scroll` (the modal body's scrolling does not bubble to `window`) and on `resize`,
- `z-index: 60`, matching `DROPDOWN_MENU_Z_INDEX`, one above the z-50 modal surface.

## Consequences of portalling, handled explicitly

**Outside-click detection** now checks the menu as well as the wrapper. A container-only `contains()` check treats a click on a suggestion as "outside" and would unmount the option before its handler ran.

**Keyboard contract.** `Modal` builds its focus trap from `modalRef.current.querySelectorAll(...)`, which can no longer see the options. So:

- options are held out of the tab order, keeping Tab on the modal's own controls,
- the input grows `aria-activedescendant` so arrow-key movement stays announced,
- Escape marks itself handled while the menu is open, so it closes the list instead of taking the whole filter dialog down with it. A second Escape still closes the dialog.

## Tests

New `Common/Tests/UI/Components/AutocompleteTextInputMenu.test.tsx` — 30 jsdom tests, all passing. The clipping tests render through the real `Modal` rather than a hand-rolled wrapper, and assert the menu is not contained by `modal-content`.

```bash
cd Common && npx jest Tests/UI/Components/AutocompleteTextInputMenu
```

`npx eslint` and `npx tsc --noEmit -p tsconfig.json` are both clean.