### PR TITLE
fix(ui): stop the modal body from clipping the colour and icon pickers

### DIFF
--- a/Common/Tests/UI/Components/Forms/ColorPickerPopup.test.tsx
+++ b/Common/Tests/UI/Components/Forms/ColorPickerPopup.test.tsx
@@ -1,0 +1,222 @@
+import ColorPicker from "../../../../UI/Components/Forms/Fields/ColorPicker";
+import Modal from "../../../../UI/Components/Modal/Modal";
+import DROPDOWN_MENU_Z_INDEX from "../../../../UI/Components/Dropdown/DropdownMenuZIndex";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+
+/*
+ * The ChromePicker popup used to be absolutely positioned inside Modal's
+ * scrolling body, so everything below the first strip of the saturation square
+ * was clipped away. It is now portalled to document.body and positioned fixed
+ * against the field.
+ */
+describe("ColorPicker popup", () => {
+  const originalInnerHeight: number = window.innerHeight;
+  const originalInnerWidth: number = window.innerWidth;
+
+  const setViewport: (width: number, height: number) => void = (
+    width: number,
+    height: number,
+  ): void => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: height,
+    });
+  };
+
+  const makeRect: (
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+  ) => DOMRect = (
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+  ): DOMRect => {
+    return {
+      bottom: top + height,
+      height,
+      left,
+      right: left + width,
+      top,
+      width,
+      x: left,
+      y: top,
+      toJSON: (): Record<string, never> => {
+        return {};
+      },
+    } as DOMRect;
+  };
+
+  const renderInModal: (onClose?: MockFunction) => void = (
+    onClose?: MockFunction,
+  ): void => {
+    render(
+      <Modal title="Create Label" onClose={onClose}>
+        <ColorPicker
+          placeholder="No color"
+          dataTestId="color-value"
+          onChange={getJestMockFunction()}
+        />
+      </Modal>,
+    );
+  };
+
+  const getAnchor: () => HTMLElement = (): HTMLElement => {
+    const input: HTMLElement = screen.getByTestId("color-value");
+    const anchor: HTMLElement | null | undefined =
+      input.parentElement?.parentElement;
+
+    if (!anchor) {
+      throw new Error("ColorPicker anchor was not rendered.");
+    }
+
+    return anchor;
+  };
+
+  const openPickerAt: (rect: DOMRect) => HTMLElement = (
+    rect: DOMRect,
+  ): HTMLElement => {
+    const anchor: HTMLElement = getAnchor();
+
+    jest.spyOn(anchor, "getBoundingClientRect").mockReturnValue(rect);
+    fireEvent.click(screen.getByTestId("color-value"));
+
+    return screen.getByTestId("color-picker-popup");
+  };
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    setViewport(originalInnerWidth, originalInnerHeight);
+  });
+
+  test("escapes the modal body scroll container", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const modalContent: HTMLElement = screen.getByTestId("modal-content");
+
+    expect(modalContent.contains(popup)).toBe(false);
+    expect(popup.parentElement).toBe(document.body);
+    expect(popup.classList.contains("fixed")).toBe(true);
+    expect(popup.style.zIndex).toBe(String(DROPDOWN_MENU_Z_INDEX));
+  });
+
+  test("positions the popup below the field", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+
+    expect(popup.style.top).toBe("244px");
+    expect(popup.style.bottom).toBe("");
+    expect(popup.style.left).toBe("120px");
+    expect(popup.style.maxHeight).toBe("320px");
+    expect(popup.style.visibility).toBe("visible");
+  });
+
+  test("flips the popup above a field near the modal footer", () => {
+    setViewport(1000, 600);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 520, 320, 40));
+
+    expect(popup.style.top).toBe("");
+    expect(popup.style.bottom).toBe("84px");
+    expect(popup.style.visibility).toBe("visible");
+  });
+
+  test("clamps the popup inside a narrow viewport", () => {
+    setViewport(300, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(260, 200, 30, 40));
+
+    // 300 - 8 (padding) - 225 (ChromePicker width).
+    expect(popup.style.left).toBe("67px");
+  });
+
+  test("repositions when the modal body scrolls", async () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 400, 320, 40));
+    expect(popup.style.top).toBe("444px");
+
+    const anchor: HTMLElement = getAnchor();
+    jest
+      .spyOn(anchor, "getBoundingClientRect")
+      .mockReturnValue(makeRect(120, 260, 320, 40));
+
+    // Does not bubble - only a capture phase listener sees this.
+    screen.getByTestId("modal-content").dispatchEvent(new Event("scroll"));
+
+    await waitFor(() => {
+      expect(popup.style.top).toBe("304px");
+    });
+  });
+
+  test("Escape closes the popup, keeps the modal open and restores focus", () => {
+    const onClose: MockFunction = getJestMockFunction();
+    setViewport(1000, 800);
+    renderInModal(onClose);
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const popupInput: HTMLElement = within(popup).getAllByRole("textbox")[0]!;
+
+    popupInput.focus();
+    expect(document.activeElement).toBe(popupInput);
+
+    fireEvent.keyDown(popupInput, { key: "Escape" });
+
+    expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+    expect(screen.getByTestId("modal")).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByTestId("color-value"));
+  });
+
+  test("Tab keeps focus inside the portalled popup", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const popupInputs: Array<HTMLElement> =
+      within(popup).getAllByRole("textbox");
+    const lastInput: HTMLElement = popupInputs[popupInputs.length - 1]!;
+
+    lastInput.focus();
+    fireEvent.keyDown(lastInput, { key: "Tab" });
+
+    // Without the popup's own trap, Modal would pull focus back into itself.
+    expect(popup.contains(document.activeElement)).toBe(true);
+    expect(screen.getByTestId("color-picker-popup")).toBeTruthy();
+  });
+
+  test("clicking outside closes the popup", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    openPickerAt(makeRect(120, 200, 320, 40));
+
+    fireEvent.mouseDown(screen.getByTestId("modal-title"));
+
+    expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Forms/IconPickerPopup.test.tsx
+++ b/Common/Tests/UI/Components/Forms/IconPickerPopup.test.tsx
@@ -1,0 +1,270 @@
+import IconPicker from "../../../../UI/Components/Forms/Fields/IconPicker";
+import Modal from "../../../../UI/Components/Modal/Modal";
+import DROPDOWN_MENU_Z_INDEX from "../../../../UI/Components/Dropdown/DropdownMenuZIndex";
+import IconProp from "../../../../Types/Icon/IconProp";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+
+/*
+ * The icon grid used to be absolutely positioned inside Modal's scrolling body,
+ * which is capped at calc(100vh - 3rem), so only the search box and a row or two
+ * of icons were reachable. It is now portalled to document.body and positioned
+ * fixed against the field.
+ */
+describe("IconPicker popup", () => {
+  const originalInnerHeight: number = window.innerHeight;
+  const originalInnerWidth: number = window.innerWidth;
+
+  const setViewport: (width: number, height: number) => void = (
+    width: number,
+    height: number,
+  ): void => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: height,
+    });
+  };
+
+  const makeRect: (
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+  ) => DOMRect = (
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+  ): DOMRect => {
+    return {
+      bottom: top + height,
+      height,
+      left,
+      right: left + width,
+      top,
+      width,
+      x: left,
+      y: top,
+      toJSON: (): Record<string, never> => {
+        return {};
+      },
+    } as DOMRect;
+  };
+
+  const renderInModal: (
+    onChange?: MockFunction,
+    onClose?: MockFunction,
+  ) => void = (onChange?: MockFunction, onClose?: MockFunction): void => {
+    render(
+      <Modal title="Create Incident Role" onClose={onClose}>
+        <IconPicker
+          placeholder="No icon"
+          dataTestId="icon-value"
+          onChange={onChange || getJestMockFunction()}
+        />
+      </Modal>,
+    );
+  };
+
+  const getAnchor: () => HTMLElement = (): HTMLElement => {
+    const input: HTMLElement = screen.getByTestId("icon-value");
+    const anchor: HTMLElement | null | undefined =
+      input.parentElement?.parentElement;
+
+    if (!anchor) {
+      throw new Error("IconPicker anchor was not rendered.");
+    }
+
+    return anchor;
+  };
+
+  const openPickerAt: (rect: DOMRect) => HTMLElement = (
+    rect: DOMRect,
+  ): HTMLElement => {
+    const anchor: HTMLElement = getAnchor();
+
+    jest.spyOn(anchor, "getBoundingClientRect").mockReturnValue(rect);
+    fireEvent.click(screen.getByTestId("icon-value"));
+
+    return screen.getByTestId("icon-picker-popup");
+  };
+
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    setViewport(originalInnerWidth, originalInnerHeight);
+  });
+
+  test("escapes the modal body scroll container", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const modalContent: HTMLElement = screen.getByTestId("modal-content");
+
+    expect(modalContent.contains(popup)).toBe(false);
+    expect(popup.parentElement).toBe(document.body);
+    expect(popup.classList.contains("fixed")).toBe(true);
+    expect(popup.style.zIndex).toBe(String(DROPDOWN_MENU_Z_INDEX));
+  });
+
+  test("positions the grid below the field and sizes it to the viewport", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+
+    expect(popup.style.top).toBe("244px");
+    expect(popup.style.bottom).toBe("");
+    expect(popup.style.left).toBe("120px");
+    expect(popup.style.width).toBe("320px");
+    expect(popup.style.maxHeight).toBe("400px");
+    expect(popup.style.visibility).toBe("visible");
+  });
+
+  test("shrinks the grid to the space left below the field", () => {
+    setViewport(1000, 500);
+    renderInModal();
+
+    // 500 - 140 (field bottom) - 4 (gap) - 8 (viewport padding) = 348px.
+    const popup: HTMLElement = openPickerAt(makeRect(120, 100, 320, 40));
+
+    expect(popup.style.top).toBe("144px");
+    expect(popup.style.maxHeight).toBe("348px");
+  });
+
+  test("flips the grid above a field near the modal footer", () => {
+    setViewport(1000, 600);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 520, 320, 40));
+
+    expect(popup.style.top).toBe("");
+    expect(popup.style.bottom).toBe("84px");
+    expect(popup.style.visibility).toBe("visible");
+  });
+
+  test("clamps the grid inside a narrow viewport", () => {
+    setViewport(400, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(300, 200, 60, 40));
+
+    // 400 - 8 (padding) - 320 (grid width).
+    expect(popup.style.left).toBe("72px");
+    expect(popup.style.width).toBe("320px");
+  });
+
+  test("repositions when the modal body scrolls", async () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 400, 320, 40));
+    expect(popup.style.top).toBe("444px");
+
+    const anchor: HTMLElement = getAnchor();
+    jest
+      .spyOn(anchor, "getBoundingClientRect")
+      .mockReturnValue(makeRect(120, 260, 320, 40));
+
+    // Does not bubble - only a capture phase listener sees this.
+    screen.getByTestId("modal-content").dispatchEvent(new Event("scroll"));
+
+    await waitFor(() => {
+      expect(popup.style.top).toBe("304px");
+    });
+  });
+
+  test("Escape closes the popup, keeps the modal open and restores focus", () => {
+    const onClose: MockFunction = getJestMockFunction();
+    setViewport(1000, 800);
+    renderInModal(undefined, onClose);
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const searchInput: HTMLElement =
+      within(popup).getByPlaceholderText("Search icons...");
+
+    searchInput.focus();
+    expect(document.activeElement).toBe(searchInput);
+
+    fireEvent.keyDown(searchInput, { key: "Escape" });
+
+    expect(screen.queryByTestId("icon-picker-popup")).toBeNull();
+    expect(screen.getByTestId("modal")).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByTestId("icon-value"));
+  });
+
+  test("Tab keeps focus inside the portalled popup", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const searchInput: HTMLElement =
+      within(popup).getByPlaceholderText("Search icons...");
+
+    searchInput.focus();
+    fireEvent.keyDown(searchInput, { key: "Tab" });
+
+    // Without the popup's own trap, Modal would pull focus back into itself.
+    expect(popup.contains(document.activeElement)).toBe(true);
+    expect(screen.getByTestId("icon-picker-popup")).toBeTruthy();
+  });
+
+  test("searching filters the portalled grid", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const searchInput: HTMLElement =
+      within(popup).getByPlaceholderText("Search icons...");
+
+    fireEvent.change(searchInput, {
+      target: { value: "there-is-no-such-icon" },
+    });
+
+    expect(within(popup).getByText("No icons found")).toBeTruthy();
+  });
+
+  test("picking an icon closes the popup and restores focus", () => {
+    const onChange: MockFunction = getJestMockFunction();
+    setViewport(1000, 800);
+    renderInModal(onChange);
+
+    const popup: HTMLElement = openPickerAt(makeRect(120, 200, 320, 40));
+    const iconCell: HTMLElement | null = popup.querySelector(
+      `[title="${IconProp.Alert}"]`,
+    );
+
+    expect(iconCell).not.toBeNull();
+    fireEvent.click(iconCell!);
+
+    expect(onChange).toHaveBeenLastCalledWith(IconProp.Alert);
+    expect(screen.queryByTestId("icon-picker-popup")).toBeNull();
+    expect(document.activeElement).toBe(screen.getByTestId("icon-value"));
+  });
+
+  test("clicking outside closes the popup", () => {
+    setViewport(1000, 800);
+    renderInModal();
+
+    openPickerAt(makeRect(120, 200, 320, 40));
+
+    fireEvent.mouseDown(screen.getByTestId("modal-title"));
+
+    expect(screen.queryByTestId("icon-picker-popup")).toBeNull();
+  });
+});

--- a/Common/UI/Components/Dropdown/Dropdown.tsx
+++ b/Common/UI/Components/Dropdown/Dropdown.tsx
@@ -1,4 +1,5 @@
 import ObjectID from "../../../Types/ObjectID";
+import DROPDOWN_MENU_Z_INDEX from "./DropdownMenuZIndex";
 import useTranslateValue from "../../Utils/Translation";
 import React, {
   FunctionComponent,
@@ -41,11 +42,7 @@ export interface DropdownOptionGroup {
   options: Array<DropdownOption>;
 }
 
-/*
- * Modal surfaces use z-50. The portalled menu must sit above that stacking
- * context so options are not painted underneath an anchored modal footer.
- */
-export const DROPDOWN_MENU_Z_INDEX: number = 60;
+export { DROPDOWN_MENU_Z_INDEX };
 
 export interface ComponentProps {
   options: Array<DropdownOption | DropdownOptionGroup>;

--- a/Common/UI/Components/Dropdown/DropdownMenuZIndex.ts
+++ b/Common/UI/Components/Dropdown/DropdownMenuZIndex.ts
@@ -1,0 +1,7 @@
+/*
+ * Modal surfaces use z-50. Portalled menus and field popups must sit above that
+ * stacking context so they are not painted underneath an anchored modal footer.
+ */
+const DROPDOWN_MENU_Z_INDEX: number = 60;
+
+export default DROPDOWN_MENU_Z_INDEX;

--- a/Common/UI/Components/Forms/Fields/ColorPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/ColorPicker.tsx
@@ -1,4 +1,7 @@
-import useComponentOutsideClick from "../../../Types/UseComponentOutsideClick";
+import useAnchoredFieldPopup, {
+  AnchoredFieldPopup,
+} from "../../../Types/UseAnchoredFieldPopup";
+import DROPDOWN_MENU_Z_INDEX from "../../Dropdown/DropdownMenuZIndex";
 import Icon from "../../Icon/Icon";
 import Input, { InputType } from "../../Input/Input";
 import Color from "../../../../Types/Color";
@@ -9,7 +12,12 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { ChromePicker, ColorResult } from "react-color";
+
+// ChromePicker renders at a fixed intrinsic width.
+const COLOR_PICKER_POPUP_WIDTH_PX: number = 225;
+const COLOR_PICKER_POPUP_MAX_HEIGHT_PX: number = 320;
 
 export interface ComponentProps {
   onChange: (value: Color | null) => void;
@@ -31,8 +39,17 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   const [color, setColor] = useState<string>("");
-  const { ref, isComponentVisible, setIsComponentVisible } =
-    useComponentOutsideClick(false);
+  const {
+    anchorRef,
+    popupRef,
+    isPopupOpen,
+    popupPosition,
+    portalTarget,
+    togglePopup,
+  }: AnchoredFieldPopup = useAnchoredFieldPopup({
+    popupMaxHeight: COLOR_PICKER_POPUP_MAX_HEIGHT_PX,
+    popupWidth: COLOR_PICKER_POPUP_WIDTH_PX,
+  });
 
   const [isInitialValuesInitialized, setIsInitialValuesInitialized] =
     useState<boolean>(false);
@@ -56,11 +73,14 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
 
   return (
     <div>
-      <div className="flex block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
+      <div
+        ref={anchorRef}
+        className="flex block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
+      >
         <div
           onClick={() => {
             if (!props.readOnly) {
-              setIsComponentVisible(!isComponentVisible);
+              togglePopup();
             }
           }}
           className="rounded h-5 w-5 border border-gray-200 cursor-pointer"
@@ -70,7 +90,7 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
         <Input
           onClick={() => {
             if (!props.readOnly) {
-              setIsComponentVisible(!isComponentVisible);
+              togglePopup();
             }
           }}
           disabled={props.disabled}
@@ -104,27 +124,40 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
             }}
           />
         )}
-        {isComponentVisible ? (
-          <div
-            ref={ref}
-            style={{
-              position: "absolute",
-            }}
-          >
-            <ChromePicker
-              color={color}
-              onChange={(color: ColorResult) => {
-                setColor(color.hex);
-              }}
-              onChangeComplete={(color: ColorResult) => {
-                return handleChange(color.hex);
-              }}
-            />
-          </div>
-        ) : (
-          <></>
-        )}
       </div>
+      {/*
+       * Portalled out of the modal body, which is a scroll container and would
+       * otherwise clip the saturation square, hue slider and hex input.
+       */}
+      {isPopupOpen && portalTarget
+        ? createPortal(
+            <div
+              ref={popupRef}
+              data-testid="color-picker-popup"
+              tabIndex={-1}
+              className="fixed overflow-auto rounded-md shadow-lg"
+              style={{
+                bottom: popupPosition?.bottom,
+                left: popupPosition?.left ?? 0,
+                maxHeight: popupPosition?.maxHeight,
+                top: popupPosition?.top,
+                visibility: popupPosition ? "visible" : "hidden",
+                zIndex: DROPDOWN_MENU_Z_INDEX,
+              }}
+            >
+              <ChromePicker
+                color={color}
+                onChange={(color: ColorResult) => {
+                  setColor(color.hex);
+                }}
+                onChangeComplete={(color: ColorResult) => {
+                  return handleChange(color.hex);
+                }}
+              />
+            </div>,
+            portalTarget,
+          )
+        : null}
       {props.error && (
         <p data-testid="error-message" className="mt-1 text-sm text-red-400">
           {props.error}

--- a/Common/UI/Components/Forms/Fields/IconPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/IconPicker.tsx
@@ -1,4 +1,7 @@
-import useComponentOutsideClick from "../../../Types/UseComponentOutsideClick";
+import useAnchoredFieldPopup, {
+  AnchoredFieldPopup,
+} from "../../../Types/UseAnchoredFieldPopup";
+import DROPDOWN_MENU_Z_INDEX from "../../Dropdown/DropdownMenuZIndex";
 import Icon from "../../Icon/Icon";
 import Input, { InputType } from "../../Input/Input";
 import IconProp from "../../../../Types/Icon/IconProp";
@@ -8,6 +11,10 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
+
+const ICON_PICKER_POPUP_WIDTH_PX: number = 320;
+const ICON_PICKER_POPUP_MAX_HEIGHT_PX: number = 400;
 
 export interface ComponentProps {
   onChange: (value: IconProp | null) => void;
@@ -30,8 +37,18 @@ const IconPicker: FunctionComponent<ComponentProps> = (
 ): ReactElement => {
   const [selectedIcon, setSelectedIcon] = useState<IconProp | null>(null);
   const [searchQuery, setSearchQuery] = useState<string>("");
-  const { ref, isComponentVisible, setIsComponentVisible } =
-    useComponentOutsideClick(false);
+  const {
+    anchorRef,
+    popupRef,
+    isPopupOpen,
+    popupPosition,
+    portalTarget,
+    closePopup,
+    togglePopup,
+  }: AnchoredFieldPopup = useAnchoredFieldPopup({
+    popupMaxHeight: ICON_PICKER_POPUP_MAX_HEIGHT_PX,
+    popupWidth: ICON_PICKER_POPUP_WIDTH_PX,
+  });
 
   const [isInitialValuesInitialized, setIsInitialValuesInitialized] =
     useState<boolean>(false);
@@ -48,7 +65,7 @@ const IconPicker: FunctionComponent<ComponentProps> = (
   const handleChange: HandleChangeFunction = (icon: IconProp | null): void => {
     setSelectedIcon(icon);
     props.onChange(icon);
-    setIsComponentVisible(false);
+    closePopup(true);
   };
 
   // Get all icons from IconProp enum
@@ -61,11 +78,14 @@ const IconPicker: FunctionComponent<ComponentProps> = (
 
   return (
     <div>
-      <div className="flex block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm">
+      <div
+        ref={anchorRef}
+        className="flex block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:text-gray-900 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
+      >
         <div
           onClick={() => {
             if (!props.readOnly && !props.disabled) {
-              setIsComponentVisible(!isComponentVisible);
+              togglePopup();
             }
           }}
           className="flex items-center justify-center h-5 w-5 cursor-pointer"
@@ -80,7 +100,7 @@ const IconPicker: FunctionComponent<ComponentProps> = (
         <Input
           onClick={() => {
             if (!props.readOnly && !props.disabled) {
-              setIsComponentVisible(!isComponentVisible);
+              togglePopup();
             }
           }}
           disabled={props.disabled}
@@ -108,63 +128,72 @@ const IconPicker: FunctionComponent<ComponentProps> = (
             }}
           />
         )}
-        {isComponentVisible ? (
-          <div
-            ref={ref}
-            className="absolute z-50 mt-8 bg-white border border-gray-200 rounded-lg shadow-lg p-3"
-            style={{
-              width: "320px",
-              maxHeight: "400px",
-            }}
-          >
-            {/* Search input */}
-            <div className="mb-3">
-              <Input
-                type={InputType.TEXT}
-                placeholder="Search icons..."
-                value={searchQuery}
-                onChange={(value: string) => {
-                  setSearchQuery(value);
-                }}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
-              />
-            </div>
-
-            {/* Icons grid */}
-            <div
-              className="grid grid-cols-6 gap-2 overflow-y-auto"
-              style={{ maxHeight: "300px" }}
-            >
-              {filteredIcons.map((icon: IconProp) => {
-                return (
-                  <div
-                    key={icon}
-                    onClick={() => {
-                      handleChange(icon);
-                    }}
-                    className={`flex items-center justify-center p-2 rounded cursor-pointer hover:bg-gray-100 ${
-                      selectedIcon === icon
-                        ? "bg-indigo-100 ring-2 ring-indigo-500"
-                        : ""
-                    }`}
-                    title={icon}
-                  >
-                    <Icon icon={icon} className="h-5 w-5 text-gray-600" />
-                  </div>
-                );
-              })}
-            </div>
-
-            {filteredIcons.length === 0 && (
-              <div className="text-center text-gray-500 py-4">
-                No icons found
-              </div>
-            )}
-          </div>
-        ) : (
-          <></>
-        )}
       </div>
+      {/*
+       * Portalled out of the modal body, which is a scroll container capped at
+       * calc(100vh - 3rem) and would otherwise clip the icon grid.
+       */}
+      {isPopupOpen && portalTarget
+        ? createPortal(
+            <div
+              ref={popupRef}
+              data-testid="icon-picker-popup"
+              tabIndex={-1}
+              className="fixed flex flex-col overflow-hidden bg-white border border-gray-200 rounded-lg shadow-lg p-3"
+              style={{
+                bottom: popupPosition?.bottom,
+                left: popupPosition?.left ?? 0,
+                maxHeight: popupPosition?.maxHeight,
+                top: popupPosition?.top,
+                visibility: popupPosition ? "visible" : "hidden",
+                width: popupPosition?.width ?? ICON_PICKER_POPUP_WIDTH_PX,
+                zIndex: DROPDOWN_MENU_Z_INDEX,
+              }}
+            >
+              {/* Search input */}
+              <div className="mb-3 flex-shrink-0">
+                <Input
+                  type={InputType.TEXT}
+                  placeholder="Search icons..."
+                  value={searchQuery}
+                  onChange={(value: string) => {
+                    setSearchQuery(value);
+                  }}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+                />
+              </div>
+
+              {/* Icons grid */}
+              <div className="grid grid-cols-6 gap-2 min-h-0 flex-1 overflow-y-auto">
+                {filteredIcons.map((icon: IconProp) => {
+                  return (
+                    <div
+                      key={icon}
+                      onClick={() => {
+                        handleChange(icon);
+                      }}
+                      className={`flex items-center justify-center p-2 rounded cursor-pointer hover:bg-gray-100 ${
+                        selectedIcon === icon
+                          ? "bg-indigo-100 ring-2 ring-indigo-500"
+                          : ""
+                      }`}
+                      title={icon}
+                    >
+                      <Icon icon={icon} className="h-5 w-5 text-gray-600" />
+                    </div>
+                  );
+                })}
+              </div>
+
+              {filteredIcons.length === 0 && (
+                <div className="text-center text-gray-500 py-4">
+                  No icons found
+                </div>
+              )}
+            </div>,
+            portalTarget,
+          )
+        : null}
       {props.error && (
         <p data-testid="error-message" className="mt-1 text-sm text-red-400">
           {props.error}

--- a/Common/UI/Types/UseAnchoredFieldPopup.ts
+++ b/Common/UI/Types/UseAnchoredFieldPopup.ts
@@ -1,0 +1,321 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+/*
+ * Form field popups (colour pickers, icon grids, ...) are rendered inside
+ * Modal's scrolling body, which clips absolutely positioned children. This hook
+ * drives a popup that is portalled into document.body and positioned `fixed`
+ * against its anchor, so it escapes the clipping container entirely.
+ *
+ * It mirrors the menu placement rules used by EntityDropdown: prefer below the
+ * anchor, flip above when there is not enough room, and clamp horizontally to
+ * the viewport.
+ */
+
+const POPUP_GAP_PX: number = 4;
+const POPUP_VIEWPORT_PADDING_PX: number = 8;
+const POPUP_MIN_USEFUL_HEIGHT_PX: number = 160;
+
+const FOCUSABLE_SELECTOR: string =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export interface AnchoredFieldPopupPosition {
+  bottom: number | undefined;
+  left: number;
+  maxHeight: number;
+  top: number | undefined;
+  width: number;
+}
+
+export interface AnchoredFieldPopupOptions {
+  // Intrinsic width of the popup, used to clamp it inside the viewport.
+  popupWidth: number;
+  popupMaxHeight: number;
+}
+
+export interface AnchoredFieldPopup {
+  anchorRef: React.MutableRefObject<HTMLDivElement | null>;
+  popupRef: React.MutableRefObject<HTMLDivElement | null>;
+  isPopupOpen: boolean;
+  popupPosition: AnchoredFieldPopupPosition | null;
+  portalTarget: HTMLElement | null;
+  closePopup: (shouldReturnFocus?: boolean) => void;
+  togglePopup: () => void;
+}
+
+type GetFocusableElementsFunction = (
+  container: HTMLElement,
+) => Array<HTMLElement>;
+
+const getFocusableElements: GetFocusableElementsFunction = (
+  container: HTMLElement,
+): Array<HTMLElement> => {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((element: HTMLElement) => {
+    return (
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true"
+    );
+  });
+};
+
+type UseAnchoredFieldPopupFunction = (
+  options: AnchoredFieldPopupOptions,
+) => AnchoredFieldPopup;
+
+const useAnchoredFieldPopup: UseAnchoredFieldPopupFunction = (
+  options: AnchoredFieldPopupOptions,
+): AnchoredFieldPopup => {
+  const { popupWidth, popupMaxHeight } = options;
+
+  const [isPopupOpen, setIsPopupOpen] = useState<boolean>(false);
+  const [popupPosition, setPopupPosition] =
+    useState<AnchoredFieldPopupPosition | null>(null);
+
+  const anchorRef: React.MutableRefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement | null>(null);
+  const popupRef: React.MutableRefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement | null>(null);
+
+  const closePopup: (shouldReturnFocus?: boolean) => void = useCallback(
+    (shouldReturnFocus?: boolean): void => {
+      setIsPopupOpen(false);
+
+      if (!shouldReturnFocus) {
+        return;
+      }
+
+      /*
+       * The popup lives outside the modal, so on close we hand focus back to the
+       * field that opened it rather than letting it fall through to the body.
+       */
+      const anchor: HTMLDivElement | null = anchorRef.current;
+
+      if (!anchor) {
+        return;
+      }
+
+      const focusTarget: HTMLElement =
+        anchor.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) || anchor;
+
+      focusTarget.focus();
+    },
+    [],
+  );
+
+  const togglePopup: () => void = useCallback((): void => {
+    setIsPopupOpen((isOpen: boolean) => {
+      return !isOpen;
+    });
+  }, []);
+
+  const updatePopupPosition: () => void = useCallback((): void => {
+    if (!anchorRef.current || typeof window === "undefined") {
+      return;
+    }
+
+    const anchorRect: DOMRect = anchorRef.current.getBoundingClientRect();
+    const availableWidth: number = Math.max(
+      0,
+      window.innerWidth - POPUP_VIEWPORT_PADDING_PX * 2,
+    );
+    const width: number = Math.min(popupWidth, availableWidth);
+    const maximumLeft: number = Math.max(
+      POPUP_VIEWPORT_PADDING_PX,
+      window.innerWidth - POPUP_VIEWPORT_PADDING_PX - width,
+    );
+    const left: number = Math.min(
+      Math.max(anchorRect.left, POPUP_VIEWPORT_PADDING_PX),
+      maximumLeft,
+    );
+    const spaceBelow: number = Math.max(
+      0,
+      window.innerHeight -
+        anchorRect.bottom -
+        POPUP_GAP_PX -
+        POPUP_VIEWPORT_PADDING_PX,
+    );
+    const spaceAbove: number = Math.max(
+      0,
+      anchorRect.top - POPUP_GAP_PX - POPUP_VIEWPORT_PADDING_PX,
+    );
+    const shouldOpenAbove: boolean =
+      spaceBelow < POPUP_MIN_USEFUL_HEIGHT_PX && spaceAbove > spaceBelow;
+    const availableHeight: number = shouldOpenAbove ? spaceAbove : spaceBelow;
+
+    setPopupPosition({
+      bottom: shouldOpenAbove
+        ? window.innerHeight - anchorRect.top + POPUP_GAP_PX
+        : undefined,
+      left,
+      maxHeight: Math.min(popupMaxHeight, availableHeight),
+      top: shouldOpenAbove ? undefined : anchorRect.bottom + POPUP_GAP_PX,
+      width,
+    });
+  }, [popupWidth, popupMaxHeight]);
+
+  useLayoutEffect(() => {
+    if (!isPopupOpen) {
+      setPopupPosition(null);
+      return;
+    }
+
+    let animationFrame: number | null = null;
+
+    const schedulePositionUpdate: () => void = (): void => {
+      if (animationFrame !== null) {
+        return;
+      }
+      animationFrame = window.requestAnimationFrame((): void => {
+        animationFrame = null;
+        updatePopupPosition();
+      });
+    };
+
+    updatePopupPosition();
+
+    /*
+     * Capture phase so scrolling the modal body - which does not bubble a scroll
+     * event to window - still repositions the popup against its anchor.
+     */
+    window.addEventListener("resize", schedulePositionUpdate);
+    document.addEventListener("scroll", schedulePositionUpdate, true);
+
+    return () => {
+      window.removeEventListener("resize", schedulePositionUpdate);
+      document.removeEventListener("scroll", schedulePositionUpdate, true);
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [isPopupOpen, updatePopupPosition]);
+
+  // Outside click. Portal aware: the popup is not a DOM child of the anchor.
+  useEffect(() => {
+    if (!isPopupOpen) {
+      return;
+    }
+
+    type HandlePointerDownFunction = (event: MouseEvent) => void;
+
+    const handlePointerDown: HandlePointerDownFunction = (
+      event: MouseEvent,
+    ): void => {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+
+      const target: Node = event.target;
+
+      if (anchorRef.current?.contains(target)) {
+        // The trigger toggles itself, so leave the state change to its handler.
+        return;
+      }
+
+      if (popupRef.current?.contains(target)) {
+        return;
+      }
+
+      closePopup(false);
+    };
+
+    document.addEventListener("mousedown", handlePointerDown, true);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown, true);
+    };
+  }, [isPopupOpen, closePopup]);
+
+  useEffect(() => {
+    if (!isPopupOpen) {
+      return;
+    }
+
+    type HandleKeyDownFunction = (event: KeyboardEvent) => void;
+
+    const handleKeyDown: HandleKeyDownFunction = (
+      event: KeyboardEvent,
+    ): void => {
+      if (event.key === "Escape") {
+        /*
+         * Swallow Escape during the capture phase so Modal's document level
+         * handler never sees it. Escape dismisses this popup, not the modal.
+         */
+        event.preventDefault();
+        event.stopPropagation();
+        closePopup(true);
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const popup: HTMLDivElement | null = popupRef.current;
+
+      if (!popup) {
+        return;
+      }
+
+      const focusableElements: Array<HTMLElement> = getFocusableElements(popup);
+
+      if (focusableElements.length === 0) {
+        return;
+      }
+
+      /*
+       * Modal builds its focus trap from its own subtree, so once focus is in
+       * the portalled popup it would drag focus back into the modal on every
+       * Tab. Keep Tab cycling within the popup until Escape or a selection
+       * closes it.
+       */
+      event.stopPropagation();
+
+      const firstElement: HTMLElement = focusableElements[0]!;
+      const lastElement: HTMLElement =
+        focusableElements[focusableElements.length - 1]!;
+      const activeElement: Element | null = document.activeElement;
+
+      if (!popup.contains(activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? lastElement : firstElement).focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [isPopupOpen, closePopup]);
+
+  return {
+    anchorRef,
+    closePopup,
+    isPopupOpen,
+    popupPosition,
+    popupRef,
+    portalTarget: typeof document === "undefined" ? null : document.body,
+    togglePopup,
+  };
+};
+
+export default useAnchoredFieldPopup;


### PR DESCRIPTION
`ColorPicker` and `IconPicker` both rendered their popup as an `absolute`
child of the field row, so Modal's body - `overflow-y-auto` on a panel
capped at `max-h-[calc(100vh-3rem)]` - cropped them:

- Settings > Labels > "Create Label": the colour field is the last field,
  so clicking the swatch showed only the top strip of the saturation
  square. The hue slider and hex input were cut off entirely.
- Incidents > Settings > Incident Roles > "Create Incident Role": only the
  search box and a row or two of the 320x400 icon grid were reachable.

Both popups are now portalled into `document.body` and positioned `fixed`
from the field's `getBoundingClientRect()`, the same treatment
`AutocompleteTextInput` got in #2993 and that `EntityDropdown` already
used. They flip above the field when there is no room below, shrink to
whatever vertical space is left, and clamp horizontally so they cannot run
off either edge. They re-measure on capture-phase `scroll` - the modal
body's scrolling does not bubble to window - and on `resize`. z-index 60
matches `DROPDOWN_MENU_Z_INDEX`, one above the z-50 modal surface.

The shared placement, dismissal and focus logic lives in a new
`useAnchoredFieldPopup` hook rather than being written twice.

Two consequences of portalling are handled explicitly:

- Outside-click detection checks the popup and the field row, not just one
  wrapper. A wrapper-only `contains()` check reads a click on a swatch or
  an icon cell as "outside" and unmounts the target before its handler
  runs.
- Modal builds its focus trap from `modalRef.current.querySelectorAll`,
  which can no longer see the popup's controls, so it would drag focus
  back into the modal on every Tab. Unlike the autocomplete list these
  popups hold real form controls - a hex field, an icon search box - that
  have to stay typeable, so Tab now cycles within the popup while it is
  open. Escape closes the popup during the capture phase and hands focus
  back to the field instead of taking the whole dialog down with it;
  picking an icon does the same.

`DROPDOWN_MENU_Z_INDEX` moves to its own module so the hook can share the
constant without pulling react-select into every field that uses it.
`Dropdown` re-exports it, so existing importers are unaffected.

Covered by `ColorPickerPopup.test.tsx` and `IconPickerPopup.test.tsx`,
which render each picker inside a real Modal and assert the open popup
escapes `modal-content`, lands where it should, flips, clamps, follows a
capture-phase scroll, and keeps Escape and Tab off the dialog.