### PR TITLE
fix(dashboard): stop the Value tile rendering an empty metric as "0"

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardValueComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardValueComponent.tsx
@@ -34,6 +34,12 @@ import {
   ValueWidgetStackMode,
   VALUE_LINE_HEIGHT_RATIO,
 } from "Common/Utils/Dashboard/ValueWidgetLayout";
+import {
+  aggregateValues,
+  collectDataPoints,
+  getNumericValues,
+  getResultsErrorMessage,
+} from "./ValueWidgetData";
 
 export interface ComponentProps extends DashboardBaseComponentProps {
   component: DashboardValueComponentType;
@@ -324,6 +330,13 @@ const DashboardValueComponentElement: FunctionComponent<ComponentProps> = (
    */
   const showStateIcon: boolean = contentBox.heightInPx >= 76;
 
+  /*
+   * Same trade one step further down: below this the tile cannot hold the
+   * title AND a two-line explanation, and the explanation is the part that
+   * carries the meaning.
+   */
+  const showStateTitle: boolean = contentBox.heightInPx >= 60;
+
   if (isLoading && metricResults.length === 0) {
     // Skeleton loading state - only on initial load
     return (
@@ -408,65 +421,65 @@ const DashboardValueComponentElement: FunctionComponent<ComponentProps> = (
   }
 
   // Collect all data points for sparkline and aggregation
-  const allDataPoints: Array<AggregatedModel> = [];
-  for (const result of metricResults) {
-    for (const item of result.data) {
-      allDataPoints.push(item);
-    }
-  }
+  const allDataPoints: Array<AggregatedModel> =
+    collectDataPoints(metricResults);
+
+  const numericValues: Array<number> = getNumericValues(allDataPoints);
+
+  const hasData: boolean = numericValues.length > 0;
 
   /*
-   * Flatten the per-bucket values, discarding any non-finite entries.
-   * AggregatedModel.value is typed `number` but the model carries a
-   * JSONValue index signature, and a ClickHouse NULL / missing column
-   * arrives as null — left unchecked it poisons the reduction with NaN.
-   */
-  const numericValues: Array<number> = [];
-  for (const item of allDataPoints) {
-    const value: number = item.value as number;
-    if (typeof value === "number" && Number.isFinite(value)) {
-      numericValues.push(value);
-    }
-  }
-
-  /*
-   * Reduce the per-bucket values into the single displayed number.
+   * A configured query that came back empty — or one that failed and
+   * surfaced a reason via AggregatedResult.errorMessage — used to fall
+   * through to the reduction's 0 seed and render a confident "0",
+   * indistinguishable from a metric that is genuinely zero. On the RUM
+   * template that made an untouched dashboard read as a flawless site
+   * ("AVG LCP 0", "AVG CLS 0"), while the gauges directly beneath it
+   * correctly said they had nothing. Show the same explicit no-data state
+   * DashboardGaugeComponent shows.
    *
-   * - Percentiles (P50/P90/P95/P99) are computed per bucket server-side,
-   *   so — like Avg — we take the mean across the window. Without an
-   *   explicit branch they fell through the old if/else chain entirely
-   *   and the value stayed pinned at its 0 seed even though the query
-   *   returned real percentile data (a P95 tile read "0").
-   * - Count sums the per-bucket counts the server already returned
-   *   (`count(value) as value`); the old `+= 1` counted time buckets, not
-   *   samples.
-   * - Min/Max fold over the real values instead of a 0 seed, which
-   *   previously forced any all-positive metric's Min to exactly 0.
+   * The loading case is already owned by the skeleton above, so this
+   * deliberately carries no `!isLoading` term: adding one would re-render
+   * the very "0" this removes for the duration of every auto-refresh of a
+   * metric that is still empty.
    */
-  let aggregatedValue: number = 0;
-  if (numericValues.length > 0) {
-    switch (aggregationType) {
-      case AggregationType.Sum:
-      case AggregationType.Count:
-        aggregatedValue = numericValues.reduce((sum: number, value: number) => {
-          return sum + value;
-        }, 0);
-        break;
-      case AggregationType.Min:
-        aggregatedValue = Math.min(...numericValues);
-        break;
-      case AggregationType.Max:
-        aggregatedValue = Math.max(...numericValues);
-        break;
-      default:
-        // Avg and every percentile aggregation: mean of per-bucket values.
-        aggregatedValue =
-          numericValues.reduce((sum: number, value: number) => {
-            return sum + value;
-          }, 0) / numericValues.length;
-        break;
-    }
+  if (!hasData) {
+    const noDataMessage: string =
+      getResultsErrorMessage(metricResults) ||
+      "No data for the selected time range";
+
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full gap-1.5 overflow-hidden">
+        {showStateIcon && (
+          <div className="w-10 h-10 rounded-full bg-gray-50 flex items-center justify-center shrink-0">
+            <div className="h-5 w-5 text-gray-300">
+              <Icon icon={IconProp.ChartBar} />
+            </div>
+          </div>
+        )}
+        {showStateTitle && props.component.arguments.title ? (
+          <p
+            className="text-xs font-medium text-gray-500 max-w-full line-clamp-1 px-1"
+            title={props.component.arguments.title}
+          >
+            {props.component.arguments.title}
+          </p>
+        ) : (
+          <></>
+        )}
+        <p
+          className="text-xs text-gray-400 text-center max-w-full line-clamp-2 px-1"
+          title={noDataMessage}
+        >
+          {noDataMessage}
+        </p>
+      </div>
+    );
   }
+
+  // Guarded by `hasData` above, so the fallback is unreachable.
+  const aggregatedValue: number =
+    aggregateValues(numericValues, aggregationType) ?? 0;
 
   /*
    * Sparkline data — preserve timestamp alongside value so the parent

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/ValueWidgetData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/ValueWidgetData.ts
@@ -1,0 +1,99 @@
+import AggregatedModel from "Common/Types/BaseDatabase/AggregatedModel";
+import AggregatedResult from "Common/Types/BaseDatabase/AggregatedResult";
+import AggregationType from "Common/Types/BaseDatabase/AggregationType";
+
+/*
+ * Pure, React-free data helpers for the value widget. Kept out of the .tsx so
+ * the reduction that produces the single displayed number — and, just as
+ * importantly, its "there was nothing to reduce" answer — can be unit-tested
+ * in the node test environment.
+ */
+
+// Flatten every result's buckets into one list, in result then bucket order.
+export function collectDataPoints(
+  results: Array<AggregatedResult>,
+): Array<AggregatedModel> {
+  const dataPoints: Array<AggregatedModel> = [];
+  for (const result of results) {
+    for (const item of result.data) {
+      dataPoints.push(item);
+    }
+  }
+  return dataPoints;
+}
+
+/*
+ * Keep only the finite per-bucket values. AggregatedModel.value is typed
+ * `number` but the model carries a JSONValue index signature, and a ClickHouse
+ * NULL / missing column arrives as null — left unchecked it poisons the
+ * reduction with NaN.
+ */
+export function getNumericValues(
+  dataPoints: Array<AggregatedModel>,
+): Array<number> {
+  const numericValues: Array<number> = [];
+  for (const item of dataPoints) {
+    const value: number = item.value as number;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      numericValues.push(value);
+    }
+  }
+  return numericValues;
+}
+
+/*
+ * Reduce the per-bucket values into the single displayed number, or null when
+ * there is nothing to reduce.
+ *
+ * The null is the point: seeding an accumulator at 0 and rendering it made an
+ * empty metric indistinguishable from a genuine measurement of zero, which on
+ * the RUM template read as a flawless site ("AVG LCP 0", "AVG CLS 0"). Callers
+ * must render a no-data state rather than substituting a number.
+ *
+ * - Percentiles (P50/P90/P95/P99) are computed per bucket server-side, so —
+ *   like Avg — we take the mean across the window.
+ * - Count sums the per-bucket counts the server already returned
+ *   (`count(value) as value`) rather than counting time buckets.
+ * - Min/Max fold over the real values, so an all-positive metric's Min is not
+ *   forced to exactly 0.
+ */
+export function aggregateValues(
+  values: Array<number>,
+  aggregationType: AggregationType,
+): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  switch (aggregationType) {
+    case AggregationType.Sum:
+    case AggregationType.Count:
+      return values.reduce((sum: number, value: number) => {
+        return sum + value;
+      }, 0);
+    case AggregationType.Min:
+      return Math.min(...values);
+    case AggregationType.Max:
+      return Math.max(...values);
+    default:
+      // Avg and every percentile aggregation: mean of per-bucket values.
+      return (
+        values.reduce((sum: number, value: number) => {
+          return sum + value;
+        }, 0) / values.length
+      );
+  }
+}
+
+/*
+ * The first reason any result carries for being empty — set by client-side
+ * formula evaluation, never by the server — so the widget can explain itself
+ * instead of showing a bare "no data".
+ */
+export function getResultsErrorMessage(
+  results: Array<AggregatedResult>,
+): string | undefined {
+  return results.find((result: AggregatedResult) => {
+    return Boolean(result.errorMessage);
+  })?.errorMessage;
+}

--- a/App/Tests/Dashboard/ValueWidgetData.test.ts
+++ b/App/Tests/Dashboard/ValueWidgetData.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "@jest/globals";
+import AggregatedModel from "Common/Types/BaseDatabase/AggregatedModel";
+import AggregatedResult from "Common/Types/BaseDatabase/AggregatedResult";
+import AggregationType from "Common/Types/BaseDatabase/AggregationType";
+import {
+  aggregateValues,
+  collectDataPoints,
+  getNumericValues,
+  getResultsErrorMessage,
+} from "../../FeatureSet/Dashboard/src/Components/Dashboard/Components/ValueWidgetData";
+
+/*
+ * Covers the reduction behind a Value tile's single big number. The case that
+ * matters most is the empty one: a metric with no points must report "nothing
+ * to reduce" rather than a 0 the tile would render as a real measurement — an
+ * LCP or TTFB of 0ms is physically impossible and a CLS of 0 is the best
+ * possible score, so a template dashboard with no telemetry read as perfect.
+ */
+
+const TIMESTAMP: Date = new Date("2026-06-01T00:00:00.000Z");
+
+type MakePoint = (value: unknown) => AggregatedModel;
+
+const point: MakePoint = (value: unknown): AggregatedModel => {
+  return { timestamp: TIMESTAMP, value: value as number };
+};
+
+type MakeResult = (values: Array<unknown>) => AggregatedResult;
+
+const result: MakeResult = (values: Array<unknown>): AggregatedResult => {
+  return { data: values.map(point) };
+};
+
+describe("ValueWidgetData.aggregateValues", () => {
+  test("returns null when there is nothing to reduce", () => {
+    for (const type of Object.values(AggregationType)) {
+      expect(aggregateValues([], type)).toBeNull();
+    }
+  });
+
+  test("null is distinct from a genuine measurement of zero", () => {
+    expect(aggregateValues([], AggregationType.Avg)).toBeNull();
+    expect(aggregateValues([0], AggregationType.Avg)).toBe(0);
+    expect(aggregateValues([0, 0], AggregationType.Avg)).toBe(0);
+  });
+
+  test("Avg is the mean of the per-bucket values", () => {
+    expect(aggregateValues([2, 4, 9], AggregationType.Avg)).toBe(5);
+  });
+
+  test("percentiles are averaged across buckets, not left at zero", () => {
+    // Each bucket's P95 is computed server-side; the tile shows their mean.
+    expect(aggregateValues([100, 200, 300], AggregationType.P50)).toBe(200);
+    expect(aggregateValues([100, 200, 300], AggregationType.P90)).toBe(200);
+    expect(aggregateValues([100, 200, 300], AggregationType.P95)).toBe(200);
+    expect(aggregateValues([100, 200, 300], AggregationType.P99)).toBe(200);
+  });
+
+  test("Sum and Count add the per-bucket values", () => {
+    expect(aggregateValues([1, 2, 3], AggregationType.Sum)).toBe(6);
+    // Count sums the counts the server returned, it does not count buckets.
+    expect(aggregateValues([5, 5, 5], AggregationType.Count)).toBe(15);
+  });
+
+  test("Min and Max fold over the real values, not a zero seed", () => {
+    expect(aggregateValues([7, 3, 11], AggregationType.Min)).toBe(3);
+    expect(aggregateValues([7, 3, 11], AggregationType.Max)).toBe(11);
+  });
+
+  test("Min of an all-positive metric is not forced to zero", () => {
+    expect(aggregateValues([120, 340], AggregationType.Min)).toBe(120);
+  });
+
+  test("negative values are reduced without a zero floor or ceiling", () => {
+    expect(aggregateValues([-5, -1], AggregationType.Max)).toBe(-1);
+    expect(aggregateValues([-5, -1], AggregationType.Min)).toBe(-5);
+    expect(aggregateValues([-4, -2], AggregationType.Avg)).toBe(-3);
+  });
+});
+
+describe("ValueWidgetData.getNumericValues", () => {
+  test("drops nulls arriving from a ClickHouse NULL / missing column", () => {
+    expect(getNumericValues([point(1), point(null), point(3)])).toEqual([1, 3]);
+  });
+
+  test("drops NaN and infinities so they cannot poison the reduction", () => {
+    expect(
+      getNumericValues([
+        point(Number.NaN),
+        point(Number.POSITIVE_INFINITY),
+        point(Number.NEGATIVE_INFINITY),
+        point(2),
+      ]),
+    ).toEqual([2]);
+  });
+
+  test("drops non-numeric values", () => {
+    expect(getNumericValues([point("12"), point(undefined), point(4)])).toEqual(
+      [4],
+    );
+  });
+
+  test("keeps zero — it is a real measurement", () => {
+    expect(getNumericValues([point(0)])).toEqual([0]);
+  });
+
+  test("a bucket set that is entirely non-finite reduces to no data", () => {
+    const values: Array<number> = getNumericValues([
+      point(null),
+      point(Number.NaN),
+    ]);
+    expect(values).toEqual([]);
+    expect(aggregateValues(values, AggregationType.Avg)).toBeNull();
+  });
+});
+
+describe("ValueWidgetData.collectDataPoints", () => {
+  test("flattens every result's buckets in order", () => {
+    expect(
+      collectDataPoints([result([1, 2]), result([3])]).map(
+        (item: AggregatedModel) => {
+          return item.value;
+        },
+      ),
+    ).toEqual([1, 2, 3]);
+  });
+
+  test("results present but empty yield no points", () => {
+    expect(collectDataPoints([result([])])).toEqual([]);
+    expect(collectDataPoints([])).toEqual([]);
+  });
+});
+
+describe("ValueWidgetData.getResultsErrorMessage", () => {
+  test("surfaces the first reason a result carries", () => {
+    const results: Array<AggregatedResult> = [
+      result([]),
+      { data: [], errorMessage: "Unknown variable in formula" },
+      { data: [], errorMessage: "Second reason" },
+    ];
+    expect(getResultsErrorMessage(results)).toBe("Unknown variable in formula");
+  });
+
+  test("undefined when no result explains itself", () => {
+    expect(getResultsErrorMessage([result([1])])).toBeUndefined();
+    expect(getResultsErrorMessage([])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix(dashboard): stop the Value tile rendering an empty metric as "0"

### Small Description?

`DashboardValueComponent` seeded its aggregation accumulator at `0` and rendered that seed even when the metric returned no data points, so a tile with nothing behind it was indistinguishable from a genuine measurement of zero.

This is worst on the **Real User Monitoring** template. A dashboard created from it before any telemetry arrives shows:

> **AVG LCP 0** · **AVG INP 0** · **AVG CLS 0** · **AVG TTFB 0**

An LCP or TTFB of 0ms is physically impossible, and CLS 0 is literally the best possible score — so an empty dashboard reads as a flawless site. The four gauges directly beneath that row already render an explicit no-data state, so the same screen contradicted itself.

**What changed**

- `DashboardValueComponent.tsx` now computes `hasData` and renders the same state the gauge does — `"No data for the selected time range"`, or the `AggregatedResult.errorMessage` when a client-side formula evaluation set one — instead of a number.
- The reduction moves into a sibling `ValueWidgetData.ts`, following the `TraceChartData.ts` pattern of keeping pure, testable helpers out of the `.tsx`. `aggregateValues()` returns `number | null`, so "nothing to reduce" is no longer representable as `0` at the type level.
- New `App/Tests/Dashboard/ValueWidgetData.test.ts` — 17 tests. The load-bearing ones assert `null` for every `AggregationType` on empty input while `[0]` still returns `0`, and that a bucket set of all nulls/`NaN` collapses to no-data rather than a number.

**One deliberate deviation worth a reviewer's eye**

The guard is `if (!hasData)`, *not* `if (!hasData && !isLoading)` as the gauge has it. The skeleton above already owns the initial-load case (`isLoading && metricResults.length === 0`), so an `!isLoading` term would only ever apply to a *re-fetch* of a still-empty metric — and there it would re-render the exact "0" this PR removes, for the duration of every auto-refresh tick. There's a comment at the guard so it doesn't read as accidental drift from the gauge.

**Scope**

Pre-existing behaviour affecting every dashboard template that ships a Value tile: Monitor, Metrics, Incident, Alert, Kubernetes, Hosts and RUM.

`DashboardGaugeComponent.tsx` still carries its own byte-identical copy of this reduction. It's left alone here to keep the diff to the reported bug; pointing it at the shared helper is a one-line follow-up if you'd like it.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verification run locally:

- `npm run fix` (root, repo-wide `eslint --fix`) — exit 0, no changes to the files in this PR.
- `tsc --noEmit` in `App/FeatureSet/Dashboard` — clean.
- `npm run compile` in `App` — the three files in this PR are clean. It does report 8 **pre-existing** errors in `FeatureSet/Identity/Utils/SSO.ts` and `Tests/Identity/SSO.test.ts` (xml-crypto typings), untouched by this change.
- `npx jest ./Tests/Dashboard/ValueWidgetData.test.ts` — 17 passed.

### Related Issue?

None.

### Screenshots (if appropriate):

None — the local dev host was returning 502 and `.claude/launch.json` only covers the Home site, so this was not reproduced in a browser. The change is verified by the unit tests and by matching the no-data state `DashboardGaugeComponent` already renders.
