### PR TITLE
fix(dashboard): keep the gauge value arc on its background track

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardGaugeComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardGaugeComponent.tsx
@@ -20,6 +20,12 @@ import { RangeStartAndEndDateTimeUtil } from "Common/Types/Time/RangeStartAndEnd
 import DashboardVariableInterpolation from "Common/Utils/Dashboard/VariableInterpolation";
 import MetricType from "Common/Models/DatabaseModels/MetricType";
 import ValueFormatter from "Common/Utils/ValueFormatter";
+import {
+  GaugeArcGeometry,
+  computeGaugeArcGeometry,
+  computeGaugePercentage,
+  gaugeAngleForPercentage,
+} from "./GaugeArcData";
 
 /*
  * Split a ValueFormatter output like "6.91 hours" / "25.00%" / "1.5 MB"
@@ -366,8 +372,11 @@ const DashboardGaugeComponentElement: FunctionComponent<ComponentProps> = (
 
   // Calculate percentage for the gauge arc
   const range: number = maxValue - minValue;
-  const percentage: number =
-    range > 0 ? Math.min(Math.max((scaledValue - minValue) / range, 0), 1) : 0;
+  const percentage: number = computeGaugePercentage(
+    scaledValue,
+    minValue,
+    maxValue,
+  );
 
   // Determine color based on thresholds
   let gaugeColor: string = "#10b981"; // green
@@ -403,25 +412,14 @@ const DashboardGaugeComponentElement: FunctionComponent<ComponentProps> = (
   );
   const gaugeSize: number = Math.max(size, 96);
   const strokeWidth: number = Math.max(gaugeSize * 0.06, 7);
-  const radius: number = (gaugeSize - strokeWidth) / 2;
-  const centerX: number = gaugeSize / 2;
-  const centerY: number = gaugeSize / 2;
 
-  // Semi-circle arc (180 degrees, from left to right)
-  const startAngle: number = Math.PI;
-  const endAngle: number = 0;
-  const sweepAngle: number = startAngle - endAngle;
-  const currentAngle: number = startAngle - sweepAngle * percentage;
-
-  const arcStartX: number = centerX + radius * Math.cos(startAngle);
-  const arcStartY: number = centerY - radius * Math.sin(startAngle);
-  const arcEndX: number = centerX + radius * Math.cos(endAngle);
-  const arcEndY: number = centerY - radius * Math.sin(endAngle);
-  const arcCurrentX: number = centerX + radius * Math.cos(currentAngle);
-  const arcCurrentY: number = centerY - radius * Math.sin(currentAngle);
-
-  const backgroundPath: string = `M ${arcStartX} ${arcStartY} A ${radius} ${radius} 0 0 1 ${arcEndX} ${arcEndY}`;
-  const valuePath: string = `M ${arcStartX} ${arcStartY} A ${radius} ${radius} 0 ${percentage > 0.5 ? 1 : 0} 1 ${arcCurrentX} ${arcCurrentY}`;
+  // Semi-circle arc (180 degrees, from left to right) — see GaugeArcData.
+  const arc: GaugeArcGeometry = computeGaugeArcGeometry({
+    gaugeSize,
+    strokeWidth,
+    percentage,
+  });
+  const { radius, centerX, centerY, backgroundPath, valuePath } = arc;
 
   const { value: displayValue, unit: displayUnit } =
     splitFormattedDisplay(formattedDisplay);
@@ -480,12 +478,13 @@ const DashboardGaugeComponentElement: FunctionComponent<ComponentProps> = (
   const thresholdTicks: Array<ThresholdTick> = [];
 
   if (warningThreshold !== undefined && range > 0) {
-    const warningPct: number = Math.min(
-      Math.max((warningThreshold - minValue) / range, 0),
-      1,
+    const warningPct: number = computeGaugePercentage(
+      warningThreshold,
+      minValue,
+      maxValue,
     );
     thresholdTicks.push({
-      angle: startAngle - sweepAngle * warningPct,
+      angle: gaugeAngleForPercentage(warningPct),
       color: "#f59e0b",
       label: ValueFormatter.formatValue(
         isFractionScale ? warningThreshold / 100 : warningThreshold,
@@ -496,12 +495,13 @@ const DashboardGaugeComponentElement: FunctionComponent<ComponentProps> = (
   }
 
   if (criticalThreshold !== undefined && range > 0) {
-    const criticalPct: number = Math.min(
-      Math.max((criticalThreshold - minValue) / range, 0),
-      1,
+    const criticalPct: number = computeGaugePercentage(
+      criticalThreshold,
+      minValue,
+      maxValue,
     );
     thresholdTicks.push({
-      angle: startAngle - sweepAngle * criticalPct,
+      angle: gaugeAngleForPercentage(criticalPct),
       color: "#ef4444",
       label: ValueFormatter.formatValue(
         isFractionScale ? criticalThreshold / 100 : criticalThreshold,
@@ -603,8 +603,8 @@ const DashboardGaugeComponentElement: FunctionComponent<ComponentProps> = (
           {/* Indicator dot at current position */}
           {percentage > 0 && (
             <circle
-              cx={arcCurrentX}
-              cy={arcCurrentY}
+              cx={arc.arcCurrent.x}
+              cy={arc.arcCurrent.y}
               r={strokeWidth * 0.5}
               fill="var(--ou-chart-marker-ring, #ffffff)"
               stroke={gaugeColor}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/GaugeArcData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/GaugeArcData.ts
@@ -1,0 +1,142 @@
+/*
+ * Pure, React-free geometry for the gauge widget's arc. Kept out of the .tsx
+ * so the maths — the part that decides whether the coloured value arc
+ * actually lands on the grey background track — can be unit-tested in the
+ * node test environment.
+ */
+
+/*
+ * The gauge is a fixed half circle drawn left-to-right. Angles are measured
+ * counter-clockwise from the positive x-axis, so the sweep runs from PI (the
+ * left end of the track) down to 0 (the right end) as the value grows.
+ */
+export const GAUGE_START_ANGLE: number = Math.PI;
+export const GAUGE_END_ANGLE: number = 0;
+export const GAUGE_SWEEP_ANGLE: number = GAUGE_START_ANGLE - GAUGE_END_ANGLE;
+
+export interface GaugeArcPoint {
+  x: number;
+  y: number;
+}
+
+/*
+ * Where the value sits within min..max, clamped to [0, 1]. A non-positive
+ * range has no meaningful position, so it reads as empty rather than
+ * dividing by zero.
+ */
+export function computeGaugePercentage(
+  value: number,
+  minValue: number,
+  maxValue: number,
+): number {
+  const range: number = maxValue - minValue;
+  if (range <= 0) {
+    return 0;
+  }
+  return Math.min(Math.max((value - minValue) / range, 0), 1);
+}
+
+// Map a [0, 1] position along the gauge onto its angle on the circle.
+export function gaugeAngleForPercentage(percentage: number): number {
+  return GAUGE_START_ANGLE - GAUGE_SWEEP_ANGLE * percentage;
+}
+
+export function gaugePointAtAngle(
+  centerX: number,
+  centerY: number,
+  radius: number,
+  angle: number,
+): GaugeArcPoint {
+  return {
+    x: centerX + radius * Math.cos(angle),
+    // SVG's y grows downward, so the upper half of the circle subtracts sin.
+    y: centerY - radius * Math.sin(angle),
+  };
+}
+
+/*
+ * Build the SVG elliptical-arc command joining two points on the gauge circle.
+ *
+ * large-arc-flag is always 0. The gauge sweep is fixed at a half circle
+ * (GAUGE_SWEEP_ANGLE === PI), so nothing drawn on it — the full background
+ * track included — can ever exceed 180 degrees. Deriving the flag from the
+ * value instead (`percentage > 0.5 ? 1 : 0`) asked the renderer for the long
+ * way round between the same two endpoints, which is only satisfiable on a
+ * *different* circle: past the midpoint the value arc left the track, bulged
+ * away from it, and rejoined only at the indicator dot.
+ *
+ * sweep-flag is 1 because angles decrease as the value grows, which in
+ * SVG's y-down space is the positive-angle (clockwise) direction.
+ */
+export function buildGaugeArcPath(
+  from: GaugeArcPoint,
+  to: GaugeArcPoint,
+  radius: number,
+): string {
+  return `M ${from.x} ${from.y} A ${radius} ${radius} 0 0 1 ${to.x} ${to.y}`;
+}
+
+export interface GaugeArcGeometryParams {
+  // Width of the square the gauge is inscribed in, in px.
+  gaugeSize: number;
+  // Arc thickness in px; the track is inset by half of it on each side.
+  strokeWidth: number;
+  // Value position along the gauge, in [0, 1].
+  percentage: number;
+}
+
+export interface GaugeArcGeometry {
+  radius: number;
+  centerX: number;
+  centerY: number;
+  currentAngle: number;
+  arcStart: GaugeArcPoint;
+  arcEnd: GaugeArcPoint;
+  arcCurrent: GaugeArcPoint;
+  backgroundPath: string;
+  valuePath: string;
+}
+
+/*
+ * Everything the gauge needs to draw: the track, the value arc that must lie
+ * on top of it, and the point where the indicator dot goes.
+ */
+export function computeGaugeArcGeometry(
+  params: GaugeArcGeometryParams,
+): GaugeArcGeometry {
+  const radius: number = (params.gaugeSize - params.strokeWidth) / 2;
+  const centerX: number = params.gaugeSize / 2;
+  const centerY: number = params.gaugeSize / 2;
+  const currentAngle: number = gaugeAngleForPercentage(params.percentage);
+
+  const arcStart: GaugeArcPoint = gaugePointAtAngle(
+    centerX,
+    centerY,
+    radius,
+    GAUGE_START_ANGLE,
+  );
+  const arcEnd: GaugeArcPoint = gaugePointAtAngle(
+    centerX,
+    centerY,
+    radius,
+    GAUGE_END_ANGLE,
+  );
+  const arcCurrent: GaugeArcPoint = gaugePointAtAngle(
+    centerX,
+    centerY,
+    radius,
+    currentAngle,
+  );
+
+  return {
+    radius,
+    centerX,
+    centerY,
+    currentAngle,
+    arcStart,
+    arcEnd,
+    arcCurrent,
+    backgroundPath: buildGaugeArcPath(arcStart, arcEnd, radius),
+    valuePath: buildGaugeArcPath(arcStart, arcCurrent, radius),
+  };
+}

--- a/App/Tests/Dashboard/GaugeArcData.test.ts
+++ b/App/Tests/Dashboard/GaugeArcData.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  GAUGE_END_ANGLE,
+  GAUGE_START_ANGLE,
+  GaugeArcGeometry,
+  GaugeArcPoint,
+  buildGaugeArcPath,
+  computeGaugeArcGeometry,
+  computeGaugePercentage,
+  gaugeAngleForPercentage,
+  gaugePointAtAngle,
+} from "../../FeatureSet/Dashboard/src/Components/Dashboard/Components/GaugeArcData";
+
+/*
+ * The gauge draws a coloured value arc on top of a grey background track.
+ * Both must lie on the same circle, at every value — a value arc that asks
+ * SVG for a different circle leaves the track, bulges away from it, and
+ * rejoins only at the indicator dot. These tests check that geometrically
+ * (by deriving the circle each path actually implies) rather than by pinning
+ * path strings, so they describe the defect and not the formatting.
+ */
+
+// A gauge big enough that mis-centred arcs are unmistakable in the numbers.
+const GAUGE_SIZE: number = 200;
+const STROKE_WIDTH: number = 12;
+const RADIUS: number = (GAUGE_SIZE - STROKE_WIDTH) / 2; // 94
+const CENTER: number = GAUGE_SIZE / 2; // 100
+
+interface ParsedArcPath {
+  start: GaugeArcPoint;
+  end: GaugeArcPoint;
+  radius: number;
+  largeArcFlag: number;
+  sweepFlag: number;
+}
+
+const ARC_PATH_PATTERN: RegExp =
+  /^M (\S+) (\S+) A (\S+) (\S+) 0 (\d) (\d) (\S+) (\S+)$/;
+
+function parseArcPath(path: string): ParsedArcPath {
+  const match: RegExpMatchArray | null = path.match(ARC_PATH_PATTERN);
+  if (!match) {
+    throw new Error(`Not a single-arc path: ${path}`);
+  }
+  return {
+    start: { x: Number(match[1]), y: Number(match[2]) },
+    radius: Number(match[3]),
+    largeArcFlag: Number(match[5]),
+    sweepFlag: Number(match[6]),
+    end: { x: Number(match[7]), y: Number(match[8]) },
+  };
+}
+
+/*
+ * SVG's endpoint-to-centre parameterisation (spec appendix F.6.5), reduced to
+ * the circular, unrotated case. This is what a renderer does with the flags,
+ * so it is the honest way to ask "which circle did we just draw on?".
+ */
+function arcCenter(arc: ParsedArcPath): GaugeArcPoint {
+  const halfDx: number = (arc.start.x - arc.end.x) / 2;
+  const halfDy: number = (arc.start.y - arc.end.y) / 2;
+  const chordSquared: number = halfDx * halfDx + halfDy * halfDy;
+  const radiusSquared: number = arc.radius * arc.radius;
+  // Clamped per the spec; a half-turn makes this exactly zero.
+  const scale: number = Math.sqrt(
+    Math.max(0, (radiusSquared - chordSquared) / chordSquared),
+  );
+  const sign: number = arc.largeArcFlag === arc.sweepFlag ? -1 : 1;
+  return {
+    x: sign * scale * halfDy + (arc.start.x + arc.end.x) / 2,
+    y: -sign * scale * halfDx + (arc.start.y + arc.end.y) / 2,
+  };
+}
+
+function geometryAt(percentage: number): GaugeArcGeometry {
+  return computeGaugeArcGeometry({
+    gaugeSize: GAUGE_SIZE,
+    strokeWidth: STROKE_WIDTH,
+    percentage,
+  });
+}
+
+// Values straddling the midpoint, where the large-arc-flag regression began.
+const PERCENTAGES: Array<number> = [
+  0.01, 0.25, 0.49, 0.5, 0.500001, 0.51, 0.6667, 0.75, 0.9, 0.99, 1,
+];
+
+describe("GaugeArcData.computeGaugePercentage", () => {
+  test("maps a value to its position within min..max", () => {
+    expect(computeGaugePercentage(50, 0, 100)).toBe(0.5);
+    expect(computeGaugePercentage(0, 0, 100)).toBe(0);
+    expect(computeGaugePercentage(100, 0, 100)).toBe(1);
+  });
+
+  test("handles a range that does not start at zero", () => {
+    expect(computeGaugePercentage(75, 50, 100)).toBe(0.5);
+  });
+
+  test("clamps values outside the range", () => {
+    expect(computeGaugePercentage(-20, 0, 100)).toBe(0);
+    expect(computeGaugePercentage(250, 0, 100)).toBe(1);
+  });
+
+  test("a non-positive range reads as empty instead of dividing by zero", () => {
+    expect(computeGaugePercentage(5, 10, 10)).toBe(0);
+    expect(computeGaugePercentage(5, 10, 0)).toBe(0);
+  });
+});
+
+describe("GaugeArcData.gaugeAngleForPercentage", () => {
+  test("sweeps from the left end of the track to the right end", () => {
+    expect(gaugeAngleForPercentage(0)).toBe(GAUGE_START_ANGLE);
+    expect(gaugeAngleForPercentage(1)).toBe(GAUGE_END_ANGLE);
+    expect(gaugeAngleForPercentage(0.5)).toBeCloseTo(Math.PI / 2, 10);
+  });
+
+  test("never exceeds a half turn, which is why the arc is never large", () => {
+    for (const percentage of PERCENTAGES) {
+      const swept: number =
+        GAUGE_START_ANGLE - gaugeAngleForPercentage(percentage);
+      expect(swept).toBeLessThanOrEqual(Math.PI);
+    }
+  });
+});
+
+describe("GaugeArcData.gaugePointAtAngle", () => {
+  test("places the track ends level with the centre, left and right", () => {
+    const left: GaugeArcPoint = gaugePointAtAngle(
+      CENTER,
+      CENTER,
+      RADIUS,
+      GAUGE_START_ANGLE,
+    );
+    const right: GaugeArcPoint = gaugePointAtAngle(
+      CENTER,
+      CENTER,
+      RADIUS,
+      GAUGE_END_ANGLE,
+    );
+
+    expect(left.x).toBeCloseTo(CENTER - RADIUS, 9);
+    expect(left.y).toBeCloseTo(CENTER, 9);
+    expect(right.x).toBeCloseTo(CENTER + RADIUS, 9);
+    expect(right.y).toBeCloseTo(CENTER, 9);
+  });
+
+  test("the midpoint sits at the top of the arc (SVG y grows downward)", () => {
+    const top: GaugeArcPoint = gaugePointAtAngle(
+      CENTER,
+      CENTER,
+      RADIUS,
+      Math.PI / 2,
+    );
+    expect(top.x).toBeCloseTo(CENTER, 9);
+    expect(top.y).toBeCloseTo(CENTER - RADIUS, 9);
+  });
+});
+
+describe("GaugeArcData.buildGaugeArcPath", () => {
+  test("always emits large-arc-flag 0 and sweep-flag 1", () => {
+    const path: string = buildGaugeArcPath(
+      { x: 6, y: 100 },
+      { x: 194, y: 100 },
+      94,
+    );
+    expect(path).toBe("M 6 100 A 94 94 0 0 1 194 100");
+  });
+});
+
+describe("GaugeArcData.computeGaugeArcGeometry", () => {
+  test("derives the radius and centre from the gauge box", () => {
+    const arc: GaugeArcGeometry = geometryAt(0.5);
+    expect(arc.radius).toBe(RADIUS);
+    expect(arc.centerX).toBe(CENTER);
+    expect(arc.centerY).toBe(CENTER);
+  });
+
+  test("the background track is a single non-large arc", () => {
+    const track: ParsedArcPath = parseArcPath(geometryAt(0).backgroundPath);
+    expect(track.largeArcFlag).toBe(0);
+    expect(track.sweepFlag).toBe(1);
+    expect(track.radius).toBe(RADIUS);
+  });
+
+  /*
+   * The regression: past the midpoint the value arc used large-arc-flag 1,
+   * asking for the long way round between the same two endpoints. That is
+   * only satisfiable on a different circle, so the arc left the track.
+   */
+  test("the value arc is never flagged large, at any value", () => {
+    for (const percentage of PERCENTAGES) {
+      const value: ParsedArcPath = parseArcPath(
+        geometryAt(percentage).valuePath,
+      );
+      expect(value.largeArcFlag).toBe(0);
+      expect(value.sweepFlag).toBe(1);
+    }
+  });
+
+  test("the value arc stays on the track's circle, at any value", () => {
+    for (const percentage of PERCENTAGES) {
+      const arc: GaugeArcGeometry = geometryAt(percentage);
+      const center: GaugeArcPoint = arcCenter(parseArcPath(arc.valuePath));
+
+      expect(center.x).toBeCloseTo(CENTER, 6);
+      expect(center.y).toBeCloseTo(CENTER, 6);
+    }
+  });
+
+  test("value arc and background track agree on their circle", () => {
+    const arc: GaugeArcGeometry = geometryAt(0.75);
+    const track: ParsedArcPath = parseArcPath(arc.backgroundPath);
+    const value: ParsedArcPath = parseArcPath(arc.valuePath);
+
+    expect(value.radius).toBe(track.radius);
+    expect(value.start).toEqual(track.start);
+    expect(arcCenter(value).x).toBeCloseTo(arcCenter(track).x, 6);
+    expect(arcCenter(value).y).toBeCloseTo(arcCenter(track).y, 6);
+  });
+
+  test("a full gauge draws exactly the background track", () => {
+    const arc: GaugeArcGeometry = geometryAt(1);
+    expect(arc.valuePath).toBe(arc.backgroundPath);
+  });
+
+  test("the indicator dot sits on the end of the value arc, on the track", () => {
+    for (const percentage of PERCENTAGES) {
+      const arc: GaugeArcGeometry = geometryAt(percentage);
+      const value: ParsedArcPath = parseArcPath(arc.valuePath);
+
+      expect(arc.arcCurrent.x).toBeCloseTo(value.end.x, 9);
+      expect(arc.arcCurrent.y).toBeCloseTo(value.end.y, 9);
+
+      const distanceFromCenter: number = Math.hypot(
+        arc.arcCurrent.x - CENTER,
+        arc.arcCurrent.y - CENTER,
+      );
+      expect(distanceFromCenter).toBeCloseTo(RADIUS, 9);
+    }
+  });
+});
+
+/*
+ * The reported repros, end to end: percentage from the widget's configured
+ * range, then the arc that percentage produces.
+ */
+describe("GaugeArcData dashboard template repros", () => {
+  test("Largest Contentful Paint at 4000ms of 0..6000 stays on the track", () => {
+    const percentage: number = computeGaugePercentage(4000, 0, 6000);
+    expect(percentage).toBeCloseTo(2 / 3, 10);
+
+    const center: GaugeArcPoint = arcCenter(
+      parseArcPath(geometryAt(percentage).valuePath),
+    );
+    expect(center.x).toBeCloseTo(CENTER, 6);
+    expect(center.y).toBeCloseTo(CENTER, 6);
+  });
+
+  test("CPU Utilization above 50% stays on the track", () => {
+    for (const cpuPercent of [51, 62.5, 80, 99.9]) {
+      const percentage: number = computeGaugePercentage(cpuPercent, 0, 100);
+      const center: GaugeArcPoint = arcCenter(
+        parseArcPath(geometryAt(percentage).valuePath),
+      );
+      expect(center.x).toBeCloseTo(CENTER, 6);
+      expect(center.y).toBeCloseTo(CENTER, 6);
+    }
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix(dashboard): keep the gauge value arc on its background track

### Small Description?

The gauge widget's coloured value arc derived its SVG `large-arc-flag` from the value:

```
A ${radius} ${radius} 0 ${percentage > 0.5 ? 1 : 0} 1 ...
```

Once a gauge passed the midpoint of its `min..max` range the flag flipped to `1`, asking the renderer for the *long* way round between the same two endpoints. That is only satisfiable on a different circle, so the coloured arc left the grey background track, bulged away from it, and rejoined only at the indicator dot — which was always positioned correctly, making the break look like the arc peeling off the track.

The gauge sweep is fixed at a half circle (`startAngle` = PI, `endAngle` = 0), so nothing drawn on it can ever exceed 180 degrees and the flag must always be `0`. That is the form the background track on the adjacent line already hard-codes, and the fix is to match it.

This is shared renderer code, so it affected **every gauge in every dashboard template** whose value sat above the midpoint of its range — e.g. Largest Contentful Paint in the Real User Monitoring template (range 0–6000, avg LCP 4000ms) and CPU Utilization in the Metrics and Hosts templates above 50%.

**What changed**

- New `GaugeArcData.ts` alongside the component, following the existing `TraceChartData.ts` convention of pulling pure helpers into a sibling `.ts` so they can be tested in the node environment. `buildGaugeArcPath` hard-codes the flag to `0` with a comment explaining why it cannot be anything else.
- `DashboardGaugeComponent.tsx` now sources its arc paths, indicator-dot position and threshold-tick angles from the helper. The component had been duplicating the same clamp-and-map maths for its threshold ticks; both paths now share `computeGaugePercentage`. Aside from the flag, this is a move with no behaviour change.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). — n/a, no tracking issue
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

None — reported directly.

### Screenshots (if appropriate):

Rendering the real module output for three above-midpoint gauges, the only difference being the flag:

| | Before (flag from value) | After (flag always 0) |
|---|---|---|
| LCP 4000ms of 0–6000 | arc swings far outside the widget, rejoining only at the dot | arc hugs the track, ends at the dot |
| CPU 62.5% | arc swings far outside the widget | arc hugs the track |
| CPU 88% | arc visibly off the track | arc hugs the track |

### Notes for the reviewer

`App/Tests/Dashboard/GaugeArcData.test.ts` adds 18 tests. Rather than pinning path strings, the load-bearing ones run SVG's endpoint-to-centre parameterisation (spec appendix F.6.5) over the emitted path to ask *which circle did we actually draw on* — it must be the track's centre at every value. Both reported repros are covered explicitly.

I confirmed the tests fail against the old logic by temporarily restoring `percentage > 0.5 ? 1 : 0`: 5 failures, with the derived arc centre landing at (72.47, 33.53) instead of (100, 100) at 75%. The "indicator dot sits on the track" test kept passing under the bug, matching the observed symptom.

Unrelated, but worth flagging: `npm test` in `App/` does not currently run in a fresh worktree — existing suites such as `Tests/Dashboard/TraceChartData.test.ts` fail the same way on a clean checkout. `App/node_modules/.bin/jest` uses `import-local`, which redirects to the repo root's jest 30 while App's own toolchain is jest 28, and the root has no `ts-jest`, so the run dies in `_createJestObjectFor` with `Cannot read properties of undefined (reading 'bind')`. I left it alone as out of scope and ran the suite through App's own CLI directly:

```
cd App && node -e "require('./node_modules/jest-cli/build').run(['--runInBand','--config','jest.config.json','./Tests/Dashboard/GaugeArcData.test.ts'])"
```

`tsc --noEmit`, eslint and prettier are all clean on the changed files.

