### PR TITLE
fix(dashboard): narrow trace widgets with dashboard variables

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceChartComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceChartComponent.tsx
@@ -100,6 +100,7 @@ const DashboardTraceChartComponentElement: FunctionComponent<ComponentProps> = (
         arguments: props.component.arguments,
         startTime: startAndEndDate.startValue,
         endTime: startAndEndDate.endValue,
+        variables: props.variables,
       });
 
       const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
@@ -141,6 +142,7 @@ const DashboardTraceChartComponentElement: FunctionComponent<ComponentProps> = (
     props.component.arguments.attributeFilters,
     props.component.arguments.topLimit,
     props.component.arguments.includeChildSpans,
+    props.variables,
   ]);
 
   useEffect(() => {
@@ -354,10 +356,18 @@ function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
     return false;
   }
 
-  return JSONFunctions.deepEqual(
-    prev.component.arguments,
-    next.component.arguments,
-  );
+  if (
+    !JSONFunctions.deepEqual(prev.component.arguments, next.component.arguments)
+  ) {
+    return false;
+  }
+
+  /*
+   * Variable selections feed the request's attribute filter, so a toolbar
+   * pick has to get past the memo — without this the widget keeps rendering
+   * the pre-selection data.
+   */
+  return JSONFunctions.deepEqual(prev.variables, next.variables);
 }
 
 export default React.memo(DashboardTraceChartComponentElement, arePropsEqual);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceTableComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceTableComponent.tsx
@@ -95,6 +95,7 @@ const DashboardTraceTableComponentElement: FunctionComponent<ComponentProps> = (
         arguments: props.component.arguments,
         startTime: startAndEndDate.startValue,
         endTime: startAndEndDate.endValue,
+        variables: props.variables,
       });
 
       const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
@@ -135,6 +136,7 @@ const DashboardTraceTableComponentElement: FunctionComponent<ComponentProps> = (
     props.component.arguments.attributeFilters,
     props.component.arguments.topLimit,
     props.component.arguments.includeChildSpans,
+    props.variables,
   ]);
 
   useEffect(() => {
@@ -284,10 +286,18 @@ function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
     return false;
   }
 
-  return JSONFunctions.deepEqual(
-    prev.component.arguments,
-    next.component.arguments,
-  );
+  if (
+    !JSONFunctions.deepEqual(prev.component.arguments, next.component.arguments)
+  ) {
+    return false;
+  }
+
+  /*
+   * Variable selections feed the request's attribute filter, so a toolbar
+   * pick has to get past the memo — without this the widget keeps rendering
+   * the pre-selection data.
+   */
+  return JSONFunctions.deepEqual(prev.variables, next.variables);
 }
 
 export default React.memo(DashboardTraceTableComponentElement, arePropsEqual);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceChartData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceChartData.ts
@@ -1,6 +1,9 @@
 import { JSONObject } from "Common/Types/JSON";
 import OneUptimeDate from "Common/Types/Date";
+import Includes from "Common/Types/BaseDatabase/Includes";
 import DashboardTraceChartComponent from "Common/Types/Dashboard/DashboardComponents/DashboardTraceChartComponent";
+import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
+import DashboardVariableInterpolation from "Common/Utils/Dashboard/VariableInterpolation";
 
 /*
  * Pure, React-free data helpers for the trace chart widget. Kept out of the
@@ -222,10 +225,59 @@ export function parseAttributeFilters(
   return filters;
 }
 
+/*
+ * The exact-attribute predicate map the trace analytics endpoint expects.
+ * A single value is `attributes[key] = v`; a list is `attributes[key] IN (...)`
+ * — see TraceAggregationService.appendCommonFilters.
+ */
+export type TraceAttributeFilters = Record<string, string | Array<string>>;
+
+/*
+ * Layer the dashboard's TelemetryAttribute variable selections on top of the
+ * widget's own saved attribute filters, so a toolbar picker narrows trace
+ * widgets the same way it narrows the metric charts and log stream beside
+ * them. A variable set to "All" removes any widget filter on that key, which
+ * is the same precedence the metric widgets use.
+ */
+export function resolveTraceAttributeFilters(data: {
+  attributeFilters?: string | Record<string, unknown> | undefined;
+  variables?: Array<DashboardVariable> | undefined;
+}): TraceAttributeFilters {
+  const interpolated: Record<string, unknown> =
+    DashboardVariableInterpolation.applyToAttributes(
+      parseAttributeFilters(data.attributeFilters),
+      data.variables,
+    );
+
+  const filters: TraceAttributeFilters = {};
+  for (const [key, value] of Object.entries(interpolated)) {
+    if (value instanceof Includes) {
+      const values: Array<string> = value.values.map(
+        (item: unknown): string => {
+          return String(item);
+        },
+      );
+      if (values.length > 0) {
+        filters[key] = values;
+      }
+      continue;
+    }
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const scalar: string = String(value).trim();
+    if (scalar) {
+      filters[key] = scalar;
+    }
+  }
+  return filters;
+}
+
 export interface BuildTraceAnalyticsRequestParams {
   arguments: TraceChartArguments;
   startTime: Date;
   endTime: Date;
+  variables?: Array<DashboardVariable> | undefined;
 }
 
 /*
@@ -266,9 +318,10 @@ export function buildTraceAnalyticsRequest(
     requestData["spanNameSearches"] = [spanNameContains];
   }
 
-  const attributes: Record<string, string> = parseAttributeFilters(
-    args.attributeFilters,
-  );
+  const attributes: TraceAttributeFilters = resolveTraceAttributeFilters({
+    attributeFilters: args.attributeFilters,
+    variables: params.variables,
+  });
   if (Object.keys(attributes).length > 0) {
     requestData["attributes"] = attributes;
   }

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceTableData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceTableData.ts
@@ -1,10 +1,12 @@
 import { JSONObject } from "Common/Types/JSON";
 import DashboardTraceTableComponent from "Common/Types/Dashboard/DashboardComponents/DashboardTraceTableComponent";
+import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
 import {
+  TraceAttributeFilters,
   computeBucketSizeInMinutes,
   formatCount,
   formatDurationMs,
-  parseAttributeFilters,
+  resolveTraceAttributeFilters,
 } from "./TraceChartData";
 
 /*
@@ -42,6 +44,7 @@ export interface BuildTraceTableRequestParams {
   arguments: TraceTableArguments;
   startTime: Date;
   endTime: Date;
+  variables?: Array<DashboardVariable> | undefined;
 }
 
 /*
@@ -81,9 +84,10 @@ export function buildTraceTableRequest(
     requestData["spanNameSearches"] = [spanNameContains];
   }
 
-  const attributes: Record<string, string> = parseAttributeFilters(
-    args.attributeFilters,
-  );
+  const attributes: TraceAttributeFilters = resolveTraceAttributeFilters({
+    attributeFilters: args.attributeFilters,
+    variables: params.variables,
+  });
   if (Object.keys(attributes).length > 0) {
     requestData["attributes"] = attributes;
   }

--- a/App/Tests/Dashboard/TraceChartData.test.ts
+++ b/App/Tests/Dashboard/TraceChartData.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
 import { JSONObject } from "Common/Types/JSON";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "Common/Types/Dashboard/DashboardVariable";
 import {
   TRACE_CHART_PALETTE,
   TimeseriesRow,
@@ -13,6 +16,7 @@ import {
   isDurationMetric,
   parseAttributeFilters,
   pivotTimeseries,
+  resolveTraceAttributeFilters,
   resolveTraceSeriesColor,
 } from "../../FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceChartData";
 
@@ -106,6 +110,116 @@ describe("TraceChartData.parseAttributeFilters", () => {
     expect(parseAttributeFilters(undefined)).toEqual({});
     expect(parseAttributeFilters("")).toEqual({});
     expect(parseAttributeFilters({})).toEqual({});
+  });
+});
+
+describe("TraceChartData.resolveTraceAttributeFilters", () => {
+  const telemetryVariable: (
+    overrides: Partial<DashboardVariable>,
+  ) => DashboardVariable = (
+    overrides: Partial<DashboardVariable>,
+  ): DashboardVariable => {
+    return {
+      id: "v1",
+      name: "cluster",
+      type: DashboardVariableType.TelemetryAttribute,
+      attributeKey: "k8s.cluster.name",
+      ...overrides,
+    };
+  };
+
+  test("no variables leaves the widget's own filters untouched", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        attributeFilters: { "url.host": "torginol.starship.online" },
+      }),
+    ).toEqual({ "url.host": "torginol.starship.online" });
+  });
+
+  test("single-select variable adds an exact predicate", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        attributeFilters: { "url.host": "torginol.starship.online" },
+        variables: [telemetryVariable({ selectedValue: "prod-eu" })],
+      }),
+    ).toEqual({
+      "url.host": "torginol.starship.online",
+      "k8s.cluster.name": "prod-eu",
+    });
+  });
+
+  /*
+   * The regression this whole change exists for: a multi-select resolves to
+   * an Includes operator, which must reach the wire as a plain array. Sending
+   * the operator object instead is what the server used to silently drop.
+   */
+  test("multi-select variable becomes a plain array of values", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        variables: [
+          telemetryVariable({
+            isMultiSelect: true,
+            selectedValues: ["prod-eu", "prod-us"],
+          }),
+        ],
+      }),
+    ).toEqual({ "k8s.cluster.name": ["prod-eu", "prod-us"] });
+  });
+
+  test('variable set to "All" removes the widget filter on that key', () => {
+    expect(
+      resolveTraceAttributeFilters({
+        attributeFilters: { "k8s.cluster.name": "prod-eu", "url.host": "x" },
+        variables: [telemetryVariable({ selectedValue: "" })],
+      }),
+    ).toEqual({ "url.host": "x" });
+  });
+
+  test("empty multi-select selection means All, not an empty IN list", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        variables: [
+          telemetryVariable({ isMultiSelect: true, selectedValues: [] }),
+        ],
+      }),
+    ).toEqual({});
+  });
+
+  test("variable value overrides a widget filter on the same key", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        attributeFilters: { "k8s.cluster.name": "prod-eu" },
+        variables: [telemetryVariable({ selectedValue: "prod-us" })],
+      }),
+    ).toEqual({ "k8s.cluster.name": "prod-us" });
+  });
+
+  test("non-telemetry-attribute variables are ignored", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        attributeFilters: { "url.host": "x" },
+        variables: [
+          {
+            id: "v2",
+            name: "env",
+            type: DashboardVariableType.TextInput,
+            selectedValue: "prod",
+          },
+        ],
+      }),
+    ).toEqual({ "url.host": "x" });
+  });
+
+  test("legacy semicolon filters still interpolate", () => {
+    expect(
+      resolveTraceAttributeFilters({
+        attributeFilters: "url.host=torginol.starship.online",
+        variables: [telemetryVariable({ selectedValue: "prod-eu" })],
+      }),
+    ).toEqual({
+      "url.host": "torginol.starship.online",
+      "k8s.cluster.name": "prod-eu",
+    });
   });
 });
 
@@ -213,6 +327,48 @@ describe("TraceChartData.buildTraceAnalyticsRequest", () => {
     expect(buildRequest({ spanNameContains: "   " })["spanNameSearches"]).toBe(
       undefined,
     );
+  });
+
+  test("dashboard variable selections reach request.attributes", () => {
+    const request: JSONObject = buildTraceAnalyticsRequest({
+      arguments: { metric: "count", attributeFilters: { "url.host": "x" } },
+      startTime: START,
+      endTime: END_1H,
+      variables: [
+        {
+          id: "v1",
+          name: "cluster",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "k8s.cluster.name",
+          isMultiSelect: true,
+          selectedValues: ["prod-eu", "prod-us"],
+        },
+      ],
+    });
+
+    expect(request["attributes"]).toEqual({
+      "url.host": "x",
+      "k8s.cluster.name": ["prod-eu", "prod-us"],
+    });
+  });
+
+  test("a variable alone is enough to emit request.attributes", () => {
+    const request: JSONObject = buildTraceAnalyticsRequest({
+      arguments: { metric: "count" },
+      startTime: START,
+      endTime: END_1H,
+      variables: [
+        {
+          id: "v1",
+          name: "cluster",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "k8s.cluster.name",
+          selectedValue: "prod-eu",
+        },
+      ],
+    });
+
+    expect(request["attributes"]).toEqual({ "k8s.cluster.name": "prod-eu" });
   });
 
   test("all options together compose into one coherent request", () => {

--- a/App/Tests/Dashboard/TraceTableData.test.ts
+++ b/App/Tests/Dashboard/TraceTableData.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import { JSONObject } from "Common/Types/JSON";
+import { DashboardVariableType } from "Common/Types/Dashboard/DashboardVariable";
 import {
   TraceTableArguments,
   buildTraceTableRequest,
@@ -110,6 +111,34 @@ describe("TraceTableData.buildTraceTableRequest", () => {
         "attributes"
       ],
     ).toEqual({ "url.host": "x", "http.method": "POST" });
+  });
+
+  /*
+   * The table has to narrow with the toolbar pickers alongside the metric
+   * widgets on the same dashboard — see TraceChartData.test.ts for the full
+   * interpolation matrix; this pins that the table request carries it too.
+   */
+  test("dashboard variable selections reach request.attributes", () => {
+    const request: JSONObject = buildTraceTableRequest({
+      arguments: { groupByAttribute: "name", attributeFilters: { a: "b" } },
+      startTime: START,
+      endTime: END_1H,
+      variables: [
+        {
+          id: "v1",
+          name: "cluster",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "k8s.cluster.name",
+          isMultiSelect: true,
+          selectedValues: ["prod-eu", "prod-us"],
+        },
+      ],
+    });
+
+    expect(request["attributes"]).toEqual({
+      a: "b",
+      "k8s.cluster.name": ["prod-eu", "prod-us"],
+    });
   });
 
   test("all options together compose into one coherent table request", () => {

--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -31,6 +31,7 @@ import TraceAggregationService, {
   FacetValue as TraceFacetValue,
   MultiFacetRequest as TraceMultiFacetRequest,
   TraceFilters,
+  TraceAttributeFilters,
   TraceAnalyticsChartType,
   TraceAnalyticsRequest,
   TraceAnalyticsTimeseriesRow,
@@ -708,6 +709,42 @@ function parseTraceFilterBody(body: JSONObject): TraceFilters {
     return Object.fromEntries(entries);
   };
 
+  /*
+   * Exact attribute predicates accept a single value or a list of values
+   * (`IN (...)`) — a multi-select dashboard variable resolves to the latter.
+   * Non-string array entries are dropped, and an array left empty by that
+   * filtering is dropped entirely so it cannot narrow to nothing.
+   */
+  const attributeFilterRecord: () => TraceAttributeFilters | undefined = ():
+    | TraceAttributeFilters
+    | undefined => {
+    const raw: unknown = body["attributes"];
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return undefined;
+    }
+    const filters: TraceAttributeFilters = {};
+    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof value === "string") {
+        filters[key] = value;
+        continue;
+      }
+      if (Array.isArray(value)) {
+        const values: Array<string> = (value as Array<unknown>).filter(
+          (v: unknown): v is string => {
+            return typeof v === "string";
+          },
+        );
+        if (values.length > 0) {
+          filters[key] = values;
+        }
+      }
+    }
+    if (Object.keys(filters).length === 0) {
+      return undefined;
+    }
+    return filters;
+  };
+
   return {
     serviceIds,
     entityKeys: stringArray("entityKeys"),
@@ -754,7 +791,7 @@ function parseTraceFilterBody(body: JSONObject): TraceFilters {
         : undefined,
     rootOnly:
       body["rootOnly"] === undefined ? undefined : Boolean(body["rootOnly"]),
-    attributes: stringRecord("attributes"),
+    attributes: attributeFilterRecord(),
     attributeSearches: stringRecord("attributeSearches"),
   };
 }

--- a/Common/Server/Services/TraceAggregationService.ts
+++ b/Common/Server/Services/TraceAggregationService.ts
@@ -18,6 +18,14 @@ export interface HistogramBucket {
   count: number;
 }
 
+/*
+ * An exact attribute predicate. A single string is `= value`; an array is
+ * `IN (...)`, which is what a multi-select dashboard variable resolves to.
+ * Mirrors LogAttributeFilterValue so both explorers filter identically.
+ */
+export type TraceAttributeFilterValue = string | Array<string>;
+export type TraceAttributeFilters = Record<string, TraceAttributeFilterValue>;
+
 export interface TraceFilters {
   serviceIds?: Array<ObjectID> | undefined;
   entityKeys?: Array<string> | undefined;
@@ -47,7 +55,7 @@ export interface TraceFilters {
   maxDurationNano?: number | undefined;
   exactDurationNano?: number | undefined;
   rootOnly?: boolean | undefined;
-  attributes?: Record<string, string> | undefined;
+  attributes?: TraceAttributeFilters | undefined;
   /*
    * Substring (contains) attribute matches — `@key:~value` in the explorer.
    * Same case-insensitive key matching as `attributes`, value via ILIKE.
@@ -1151,6 +1159,27 @@ export class TraceAggregationService {
          * LogAggregationService.appendCommonFilters. Casings vary across
          * OTEL conventions and app-emitted attributes.
          */
+        if (Array.isArray(attrValue)) {
+          /*
+           * Multi-value selection (a multi-select dashboard variable) — an
+           * empty array means "no selection", which must widen to everything
+           * rather than compile to `IN ()` and match nothing.
+           */
+          if (attrValue.length === 0) {
+            continue;
+          }
+          statement.append(
+            SQL` AND arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(${{
+              type: TableColumnType.Text,
+              value: attrKey,
+            }}) AND v IN (${{
+              type: TableColumnType.Text,
+              value: new Includes(attrValue),
+            }}), mapKeys(attributes), mapValues(attributes))`,
+          );
+          continue;
+        }
+
         statement.append(
           SQL` AND arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(${{
             type: TableColumnType.Text,

--- a/Common/Tests/Server/Services/TraceAggregationService.test.ts
+++ b/Common/Tests/Server/Services/TraceAggregationService.test.ts
@@ -220,6 +220,54 @@ describe("TraceAggregationService", () => {
     expect(paramValues(statement)).toContain("%starship.online%");
   });
 
+  test("a single-value attribute filter compiles to an equality match", () => {
+    const statement: Statement = buildHistogramStatement({
+      attributes: { "k8s.cluster.name": "prod-eu" },
+    });
+
+    expect(normalizedQuery(statement)).toContain(") AND v = ");
+    expect(normalizedQuery(statement)).not.toContain(") AND v IN (");
+    expect(paramValues(statement)).toContain("prod-eu");
+  });
+
+  /*
+   * A multi-select dashboard variable resolves to a list of values. Without
+   * the IN branch these arrived as a single stringified value and matched
+   * nothing, so the widget silently emptied instead of widening.
+   */
+  test("a multi-value attribute filter compiles to an IN match", () => {
+    const statement: Statement = buildHistogramStatement({
+      attributes: { "k8s.cluster.name": ["prod-eu", "prod-us"] },
+    });
+
+    const query: string = normalizedQuery(statement);
+    expect(query).toContain("arrayExists((k, v) -> lowerUTF8(k) = lowerUTF8(");
+    expect(query).toContain(") AND v IN (");
+    expect(paramValues(statement)).toContain("k8s.cluster.name");
+    expect(paramValues(statement)).toContainEqual(["prod-eu", "prod-us"]);
+  });
+
+  /*
+   * An empty list is "nothing selected", which must widen to everything —
+   * emitting `IN ()` would narrow the widget to zero rows instead.
+   */
+  test("an empty multi-value attribute filter adds no predicate", () => {
+    const statement: Statement = buildHistogramStatement({
+      attributes: { "k8s.cluster.name": [] },
+    });
+
+    expect(normalizedQuery(statement)).not.toContain(") AND v IN (");
+    expect(normalizedQuery(statement)).not.toContain(") AND v = ");
+  });
+
+  test("multi-value attribute keys are validated like single-value ones", () => {
+    expect(() => {
+      buildHistogramStatement({
+        attributes: { "x') OR 1=1 --": ["v"] },
+      });
+    }).toThrow("Invalid facetKey");
+  });
+
   test("attributeSearches rejects malicious keys and skips blank values", () => {
     expect(() => {
       buildHistogramStatement({


### PR DESCRIPTION
### Title of this pull request?

fix(dashboard): narrow trace widgets with dashboard variables

### Small Description?

Dashboard TelemetryAttribute variables (the toolbar pickers) were applied to metric widgets and the log stream via `VariableInterpolation.applyToAttributes` / `applyToQueryConfig`, but the **TraceChart** and **TraceTable** widgets ignored them entirely. On a dashboard mixing widget types, selecting a variable narrowed the top half and left the bottom half showing everything.

**Why this wasn't a client-side-only fix.** Both request builders already emit an `attributes` map, so merging variables in there looks like a two-line change — and for a single-valued variable it would have worked. But a multi-select variable resolves to an `Includes` object, and the server's `parseTraceFilterBody` used a `stringRecord` helper that silently **dropped** non-string values. A multi-select variable would have appeared to apply and filtered nothing. So this adds multi-value attribute filtering to the trace analytics request end to end.

**Server**

- `TraceFilters.attributes` widens to `string | Array<string>` (new `TraceAttributeFilterValue` / `TraceAttributeFilters`, mirroring `LogAttributeFilterValue` so both explorers filter identically).
- `TraceAggregationService.appendCommonFilters` branches on `Array.isArray` and emits `v IN (...)` via `Includes`, alongside the existing exact `v = ...` and contains-match `attributeSearches`. An empty array is skipped so "nothing selected" widens to everything rather than compiling `IN ()` and matching nothing. `validateFacetKey` runs before the branch, so both paths are equally guarded.
- `parseTraceFilterBody` parses `attributes` with a new helper accepting a string or a list of strings (non-string array entries dropped; an array emptied by that filtering is dropped entirely). `attributeSearches` stays on `stringRecord` — contains-match is single-valued.

**Client**

- New `resolveTraceAttributeFilters()` in `TraceChartData.ts` parses the widget's saved filters, layers variable selections on via `applyToAttributes`, then normalizes `Includes` → plain array for the wire. Both trace request builders take an optional `variables` param and use it.
- Both components pass `props.variables` and add it to the fetch dependency array.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Reviewer notes

**One thing worth a look that wasn't in the original scope.** Adding `props.variables` to the fetch dependency array is not sufficient on its own — both components are wrapped in `React.memo` with a custom `arePropsEqual` that did not compare `variables`, so the memo swallowed every toolbar pick before the dependency array ever saw it. Both comparators now end with `JSONFunctions.deepEqual(prev.variables, next.variables)`, matching what `DashboardChartComponent` already does.

**Tests** — 15 new, all passing:

- Client (`TraceChartData.test.ts`, `TraceTableData.test.ts`): single-select, multi-select → plain array, variable set to "All" clearing a widget filter on that key, empty multi-select meaning All rather than an empty `IN` list, variable overriding a widget filter on the same key, non-TelemetryAttribute variables ignored, legacy semicolon filters still interpolating, and both request builders carrying it through.
- Server (`TraceAggregationService.test.ts`): `= ` vs `IN` compilation, empty array adding no predicate, and multi-value keys rejected by `validateFacetKey` the same as single-value ones.

Verified: `Common` typecheck clean; `App` typecheck has zero errors outside `Identity/` (the `SSO.ts` / `SSO.test.ts` `xml-crypto` errors are pre-existing on this branch and untouched here). 68 App + 44 Common tests pass. `npm run fix` run, touched only these files.

### Related Issue?

_None — reported directly._

### Screenshots (if appropriate):

_n/a — the visible change is that trace widgets narrow along with the metric widgets when a toolbar variable is selected._
