### PR TITLE
feat(kubernetes): recommend right-sized CPU and memory requests

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostUtils.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesCostUtils.ts
@@ -159,7 +159,13 @@ type BuildAggregateBy = (data: {
   extraQuery?: Record<string, unknown> | undefined;
 }) => AggregateBy<KubernetesCostAllocation>;
 
-const buildAggregateBy: BuildAggregateBy = (data: {
+/*
+ * Exported so the right-sizing helpers query the same table through the
+ * same project / cluster / window scoping — two spellings of "which rows
+ * count" is how a savings figure ends up disagreeing with the spend figure
+ * sitting next to it.
+ */
+export const buildAggregateBy: BuildAggregateBy = (data: {
   params: FetchCostParams;
   aggregateColumnName: keyof KubernetesCostAllocation;
   aggregationType: AggregationType;
@@ -210,7 +216,7 @@ type RunAggregate = (
   aggregateBy: AggregateBy<KubernetesCostAllocation>,
 ) => Promise<AggregatedResult>;
 
-const runAggregate: RunAggregate = (
+export const runAggregate: RunAggregate = (
   aggregateBy: AggregateBy<KubernetesCostAllocation>,
 ): Promise<AggregatedResult> => {
   return AnalyticsModelAPI.aggregate<KubernetesCostAllocation>({

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesRightSizingUtils.ts
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/Utils/KubernetesRightSizingUtils.ts
@@ -1,0 +1,318 @@
+import KubernetesCostAllocation from "Common/Models/AnalyticsModels/KubernetesCostAllocation";
+import AggregatedResult from "Common/Types/BaseDatabase/AggregatedResult";
+import AggregatedModel from "Common/Types/BaseDatabase/AggregatedModel";
+import AggregationType from "Common/Types/BaseDatabase/AggregationType";
+import AggregationInterval from "Common/Types/BaseDatabase/AggregationInterval";
+import GroupBy from "Common/Server/Types/Database/GroupBy";
+import {
+  FetchCostParams,
+  buildAggregateBy,
+  isSentinelNamespace,
+  runAggregate,
+} from "./KubernetesCostUtils";
+import {
+  RightSizingObservation,
+  RightSizingRecommendation,
+  RightSizingVerdict,
+  buildRightSizingRecommendation,
+  hasActionableRecommendation,
+} from "Common/Types/Kubernetes/KubernetesRightSizing";
+
+/*
+ * Pulls the per-container aggregates right-sizing needs out of the cost
+ * table and hands them to the pure recommender in Common.
+ *
+ * Grouping is by (namespace, controllerKind, controllerName, containerName)
+ * rather than by pod: requests live in the pod template, so per-pod advice
+ * would not be something anyone can act on. Aggregating across replicas is
+ * also what makes the memory peak safe — it becomes the worst peak any
+ * replica hit, which is the number the shared template has to survive.
+ */
+
+/** How the four grouping columns are joined into a map key. */
+const GROUP_COLUMNS: Array<string> = [
+  "namespace",
+  "controllerKind",
+  "controllerName",
+  "containerName",
+];
+
+/*
+ * Kubernetes names are DNS-1123 (lowercase alphanumeric, '-' and '.'), so a
+ * pipe cannot occur inside one and is safe as a composite-key separator.
+ */
+const KEY_SEPARATOR: string = "|";
+
+type GroupedValues = Map<string, number>;
+
+/*
+ * Every aggregation here runs at AggregationInterval.Total, which collapses
+ * to exactly one row per group. `combine` therefore never actually fires —
+ * it is here so that a Max stays a Max rather than becoming a sum if this
+ * ever runs bucketed.
+ */
+function toGroupedValues(
+  result: AggregatedResult,
+  combine: (existing: number, incoming: number) => number,
+): GroupedValues {
+  const values: GroupedValues = new Map<string, number>();
+
+  for (const item of result.data) {
+    const record: Record<string, unknown> = item as Record<string, unknown>;
+    const key: string = GROUP_COLUMNS.map((column: string): string => {
+      return String(record[column] ?? "");
+    }).join(KEY_SEPARATOR);
+
+    const incoming: number = (item as AggregatedModel).value || 0;
+    values.set(
+      key,
+      values.has(key) ? combine(values.get(key)!, incoming) : incoming,
+    );
+  }
+
+  return values;
+}
+
+function sum(existing: number, incoming: number): number {
+  return existing + incoming;
+}
+
+function max(existing: number, incoming: number): number {
+  return Math.max(existing, incoming);
+}
+
+export interface RightSizingSummary {
+  /** Total monthly saving available across every actionable container. */
+  totalMonthlySavings: number;
+  /** Monthly cost of fixing every under-provisioned container. */
+  totalMonthlyIncrease: number;
+  overprovisionedCount: number;
+  underprovisionedCount: number;
+  noRequestSetCount: number;
+  /** Containers examined, including those already right-sized. */
+  analyzedCount: number;
+  /**
+   * Containers whose memory could not be sized because no Prometheus peak
+   * reached us. Surfaced so a half-configured install explains itself
+   * instead of looking like a workload with nothing to fix.
+   */
+  missingMemoryPeakCount: number;
+}
+
+export interface RightSizingResult {
+  recommendations: Array<RightSizingRecommendation>;
+  summary: RightSizingSummary;
+  /** Wall-clock length of the queried window, in hours. */
+  observedHours: number;
+}
+
+function isVerdict(
+  recommendation: RightSizingRecommendation,
+  verdict: RightSizingVerdict,
+): boolean {
+  return (
+    recommendation.cpu.verdict === verdict ||
+    recommendation.memory.verdict === verdict
+  );
+}
+
+function summarize(
+  recommendations: Array<RightSizingRecommendation>,
+  analyzedCount: number,
+  missingMemoryPeakCount: number,
+): RightSizingSummary {
+  const summary: RightSizingSummary = {
+    totalMonthlySavings: 0,
+    totalMonthlyIncrease: 0,
+    overprovisionedCount: 0,
+    underprovisionedCount: 0,
+    noRequestSetCount: 0,
+    analyzedCount: analyzedCount,
+    missingMemoryPeakCount: missingMemoryPeakCount,
+  };
+
+  for (const recommendation of recommendations) {
+    summary.totalMonthlySavings += recommendation.estimatedMonthlySavings;
+    summary.totalMonthlyIncrease += recommendation.estimatedMonthlyIncrease;
+
+    if (isVerdict(recommendation, RightSizingVerdict.Overprovisioned)) {
+      summary.overprovisionedCount++;
+    }
+    if (isVerdict(recommendation, RightSizingVerdict.Underprovisioned)) {
+      summary.underprovisionedCount++;
+    }
+    if (isVerdict(recommendation, RightSizingVerdict.NoRequestSet)) {
+      summary.noRequestSetCount++;
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * Fetches every container's window aggregates and returns the actionable
+ * recommendations, highest saving first.
+ *
+ * CPU demand is a P95 of the hourly averages — high enough to cover real
+ * load, low enough that one spike does not re-inflate the request. Memory
+ * demand is the maximum of the per-window peaks, because the number a
+ * memory request has to survive is the worst moment, not the typical one.
+ */
+export const fetchRightSizingRecommendations: (
+  params: FetchCostParams,
+) => Promise<RightSizingResult> = async (
+  params: FetchCostParams,
+): Promise<RightSizingResult> => {
+  const groupBy: GroupBy<KubernetesCostAllocation> = {
+    namespace: true,
+    controllerKind: true,
+    controllerName: true,
+    containerName: true,
+  };
+
+  type Measure = {
+    column: keyof KubernetesCostAllocation;
+    aggregationType: AggregationType;
+    combine: (existing: number, incoming: number) => number;
+  };
+
+  const measures: Array<Measure> = [
+    {
+      column: "cpuCoreRequestAverage",
+      aggregationType: AggregationType.Avg,
+      combine: max,
+    },
+    {
+      column: "cpuCoreUsageAverage",
+      aggregationType: AggregationType.P95,
+      combine: max,
+    },
+    { column: "cpuCost", aggregationType: AggregationType.Sum, combine: sum },
+    {
+      column: "ramBytesRequestAverage",
+      aggregationType: AggregationType.Avg,
+      combine: max,
+    },
+    {
+      column: "ramBytesUsageMax",
+      aggregationType: AggregationType.Max,
+      combine: max,
+    },
+    { column: "ramCost", aggregationType: AggregationType.Sum, combine: sum },
+    {
+      column: "totalCost",
+      aggregationType: AggregationType.Count,
+      combine: sum,
+    },
+  ];
+
+  const results: Array<AggregatedResult> = await Promise.all(
+    measures.map((measure: Measure): Promise<AggregatedResult> => {
+      return runAggregate(
+        buildAggregateBy({
+          params,
+          aggregateColumnName: measure.column,
+          aggregationType: measure.aggregationType,
+          groupBy,
+          aggregationInterval: AggregationInterval.Total,
+        }),
+      );
+    }),
+  );
+
+  const [
+    cpuRequest,
+    cpuUsageP95,
+    cpuCost,
+    ramRequest,
+    ramUsagePeak,
+    ramCost,
+    sampleCount,
+  ] = results.map((result: AggregatedResult, index: number): GroupedValues => {
+    return toGroupedValues(result, measures[index]!.combine);
+  }) as [
+    GroupedValues,
+    GroupedValues,
+    GroupedValues,
+    GroupedValues,
+    GroupedValues,
+    GroupedValues,
+    GroupedValues,
+  ];
+
+  const observedHours: number = Math.max(
+    0,
+    (params.endDate.getTime() - params.startDate.getTime()) / (1000 * 60 * 60),
+  );
+
+  const recommendations: Array<RightSizingRecommendation> = [];
+  let analyzedCount: number = 0;
+  let missingMemoryPeakCount: number = 0;
+
+  /*
+   * Iterate the sample-count map: it is a Count, so it holds a key for
+   * every group in the window even when every measure on it is zero.
+   */
+  for (const [key, samples] of sampleCount) {
+    const [namespace, controllerKind, controllerName, containerName] =
+      key.split(KEY_SEPARATOR);
+
+    /*
+     * Idle and unallocated capacity are not workloads — they have no
+     * requests to right-size. Rows without a container are the engine's
+     * pod- or controller-level rollups, which the per-container advice
+     * would double-count.
+     */
+    if (isSentinelNamespace(namespace || "") || !containerName) {
+      continue;
+    }
+
+    const observation: RightSizingObservation = {
+      namespace: namespace || "",
+      controllerKind: controllerKind || "",
+      controllerName: controllerName || "",
+      containerName: containerName,
+      sampleCount: samples,
+      cpuCoreRequestAverage: cpuRequest.get(key) || 0,
+      cpuCoreUsageP95: cpuUsageP95.get(key) || 0,
+      cpuCost: cpuCost.get(key) || 0,
+      ramBytesRequestAverage: ramRequest.get(key) || 0,
+      ramBytesUsagePeak: ramUsagePeak.get(key) || 0,
+      ramCost: ramCost.get(key) || 0,
+    };
+
+    analyzedCount++;
+
+    if (observation.ramBytesUsagePeak <= 0) {
+      missingMemoryPeakCount++;
+    }
+
+    const recommendation: RightSizingRecommendation =
+      buildRightSizingRecommendation(observation, observedHours);
+
+    if (hasActionableRecommendation(recommendation)) {
+      recommendations.push(recommendation);
+    }
+  }
+
+  recommendations.sort(
+    (a: RightSizingRecommendation, b: RightSizingRecommendation): number => {
+      /*
+       * Savings first, because that is what the page is for. Containers
+       * with no saving to offer (under-provisioned, or missing a request)
+       * fall below, ordered by what they cost today so the biggest
+       * reliability risks still surface near the top.
+       */
+      if (b.estimatedMonthlySavings !== a.estimatedMonthlySavings) {
+        return b.estimatedMonthlySavings - a.estimatedMonthlySavings;
+      }
+      return b.costInWindow - a.costInWindow;
+    },
+  );
+
+  return {
+    recommendations: recommendations,
+    summary: summarize(recommendations, analyzedCount, missingMemoryPeakCount),
+    observedHours: observedHours,
+  };
+};

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/Costs.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/Costs.tsx
@@ -62,6 +62,7 @@ import {
   getTotalCostElement,
   noCostDataMessage,
 } from "../Utils/KubernetesCostTableCells";
+import KubernetesRightSizingCard from "./KubernetesRightSizingCard";
 
 function getSectionTitle(icon: IconProp, title: string): ReactElement {
   return (
@@ -480,6 +481,13 @@ const KubernetesClusterCosts: FunctionComponent<
           )}
         </div>
       </EmbeddedMetricCard>
+
+      <KubernetesRightSizingCard
+        kubernetesClusterId={modelId}
+        startDate={startAndEndDate.startValue}
+        endDate={startAndEndDate.endValue}
+        refreshToggle={refreshToggle}
+      />
 
       <Card
         title="Spend by Namespace"

--- a/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/KubernetesRightSizingCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Kubernetes/View/KubernetesRightSizingCard.tsx
@@ -1,0 +1,439 @@
+import ObjectID from "Common/Types/ObjectID";
+import GoldenMetricTile from "../../../Components/Infrastructure/GoldenMetricTile";
+import Card, { CardButtonSchema } from "Common/UI/Components/Card/Card";
+import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
+import Table from "Common/UI/Components/Table/Table";
+import Column from "Common/UI/Components/Table/Types/Column";
+import FieldType from "Common/UI/Components/Types/FieldType";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import IconProp from "Common/Types/Icon/IconProp";
+import API from "Common/UI/Utils/API/API";
+import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  COST_ROWS_PER_PAGE,
+  formatCost,
+  pageCostRows,
+  sortCostRows,
+} from "../Utils/KubernetesCostUtils";
+import { getNamespaceElement } from "../Utils/KubernetesCostTableCells";
+import {
+  RightSizingResult,
+  RightSizingSummary,
+  fetchRightSizingRecommendations,
+} from "../Utils/KubernetesRightSizingUtils";
+import {
+  MIN_OBSERVED_HOURS,
+  ResourceRecommendation,
+  RightSizingRecommendation,
+  RightSizingVerdict,
+  formatCpuCores,
+  formatMemoryBytes,
+} from "Common/Types/Kubernetes/KubernetesRightSizing";
+
+export interface ComponentProps {
+  kubernetesClusterId: ObjectID;
+  startDate: Date;
+  endDate: Date;
+  /** Bumped by the parent page's refresh control. */
+  refreshToggle: number;
+}
+
+type ValueFormatter = (value: number | null) => string;
+
+/*
+ * The change cell is the whole point of the table, so it has to read at a
+ * glance: what is set now, what it should be, and which direction that is.
+ * Green means the request comes down (money back), amber means it goes up
+ * (the workload is starved and someone should know before it OOMKills).
+ */
+function getRequestChangeElement(
+  resource: ResourceRecommendation,
+  format: ValueFormatter,
+): ReactElement {
+  if (resource.verdict === RightSizingVerdict.Unavailable) {
+    return (
+      <span
+        className="text-gray-400"
+        title={resource.unavailableReason || "Not enough data."}
+      >
+        -
+      </span>
+    );
+  }
+
+  if (resource.verdict === RightSizingVerdict.Optimal) {
+    return (
+      <span className="inline-flex items-center gap-1.5">
+        <span className="tabular-nums text-gray-600">
+          {format(resource.current)}
+        </span>
+        <span className="text-xs text-gray-400">right-sized</span>
+      </span>
+    );
+  }
+
+  const isIncrease: boolean =
+    resource.verdict === RightSizingVerdict.Underprovisioned ||
+    resource.verdict === RightSizingVerdict.NoRequestSet;
+
+  const arrowClassName: string = isIncrease
+    ? "text-amber-600"
+    : "text-emerald-600";
+
+  return (
+    <span className="inline-flex items-center gap-1.5 tabular-nums">
+      <span className="text-gray-400 line-through">
+        {resource.current === null ? "none" : format(resource.current)}
+      </span>
+      <span className={arrowClassName}>&rarr;</span>
+      <span className="font-medium text-gray-900">
+        {format(resource.recommended)}
+      </span>
+    </span>
+  );
+}
+
+/*
+ * A saving only means something once it is a number someone can put in a
+ * budget, so a container that offers none says why instead of showing $0:
+ * an under-provisioned workload costs more to fix, and one with no request
+ * set is a scheduling risk that happens not to be a billing one.
+ */
+function getSavingsElement(
+  recommendation: RightSizingRecommendation,
+): ReactElement {
+  if (recommendation.estimatedMonthlySavings > 0) {
+    return (
+      <span className="tabular-nums font-medium text-emerald-700">
+        {formatCost(recommendation.estimatedMonthlySavings)}
+        <span className="ml-1 text-xs font-normal text-gray-400">/mo</span>
+      </span>
+    );
+  }
+
+  if (recommendation.estimatedMonthlyIncrease > 0) {
+    return (
+      <span className="tabular-nums text-amber-700">
+        +{formatCost(recommendation.estimatedMonthlyIncrease)}
+        <span className="ml-1 text-xs font-normal text-gray-400">/mo</span>
+      </span>
+    );
+  }
+
+  return <span className="text-gray-400">-</span>;
+}
+
+function getContainerElement(
+  recommendation: RightSizingRecommendation,
+): ReactElement {
+  const controller: string = [
+    recommendation.controllerKind,
+    recommendation.controllerName,
+  ]
+    .filter(Boolean)
+    .join(" / ");
+
+  return (
+    <div>
+      <div className="font-medium text-gray-900">
+        {recommendation.containerName}
+      </div>
+      {controller ? (
+        <div className="text-xs text-gray-500">{controller}</div>
+      ) : null}
+    </div>
+  );
+}
+
+const KubernetesRightSizingCard: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>("");
+  const [result, setResult] = useState<RightSizingResult | null>(null);
+
+  const [page, setPage] = useState<number>(1);
+  const [sortBy, setSortBy] = useState<keyof RightSizingRecommendation | null>(
+    "estimatedMonthlySavings",
+  );
+  const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.Descending);
+
+  // Bumped by this card's own Refresh button, alongside the parent's toggle.
+  const [localRefresh, setLocalRefresh] = useState<number>(0);
+
+  const clusterId: string = props.kubernetesClusterId.toString();
+  const startMs: number = props.startDate.getTime();
+  const endMs: number = props.endDate.getTime();
+
+  useEffect(() => {
+    let cancelled: boolean = false;
+
+    const load: () => Promise<void> = async (): Promise<void> => {
+      setIsLoading(true);
+      setError("");
+      try {
+        const fetched: RightSizingResult =
+          await fetchRightSizingRecommendations({
+            kubernetesClusterId: props.kubernetesClusterId,
+            startDate: new Date(startMs),
+            endDate: new Date(endMs),
+          });
+
+        if (cancelled) {
+          return;
+        }
+
+        setResult(fetched);
+        setPage(1);
+      } catch (err) {
+        if (!cancelled) {
+          setError(API.getFriendlyMessage(err));
+        }
+      }
+      if (!cancelled) {
+        setIsLoading(false);
+      }
+    };
+
+    load().catch((err: Error) => {
+      if (!cancelled) {
+        setError(API.getFriendlyMessage(err));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clusterId, startMs, endMs, props.refreshToggle, localRefresh]);
+
+  const recommendations: Array<RightSizingRecommendation> = useMemo(() => {
+    return result ? result.recommendations : [];
+  }, [result]);
+
+  const sortedRows: Array<RightSizingRecommendation> = useMemo(() => {
+    return sortCostRows<RightSizingRecommendation>(
+      recommendations,
+      sortBy,
+      sortOrder,
+    );
+  }, [recommendations, sortBy, sortOrder]);
+
+  const pagedRows: Array<RightSizingRecommendation> = useMemo(() => {
+    return pageCostRows<RightSizingRecommendation>(sortedRows, page);
+  }, [sortedRows, page]);
+
+  const columns: Array<Column<RightSizingRecommendation>> = useMemo(() => {
+    return [
+      {
+        title: "Container",
+        type: FieldType.Element,
+        key: "containerName",
+        getElement: getContainerElement,
+      },
+      {
+        title: "Namespace",
+        type: FieldType.Element,
+        key: "namespace",
+        getElement: (row: RightSizingRecommendation): ReactElement => {
+          return getNamespaceElement(row.namespace);
+        },
+      },
+      {
+        title: "CPU Request",
+        type: FieldType.Element,
+        key: "cpu",
+        disableSort: true,
+        getElement: (row: RightSizingRecommendation): ReactElement => {
+          return getRequestChangeElement(row.cpu, formatCpuCores);
+        },
+      },
+      {
+        title: "Memory Request",
+        type: FieldType.Element,
+        key: "memory",
+        disableSort: true,
+        getElement: (row: RightSizingRecommendation): ReactElement => {
+          return getRequestChangeElement(row.memory, formatMemoryBytes);
+        },
+      },
+      {
+        title: "Est. Saving",
+        type: FieldType.Element,
+        key: "estimatedMonthlySavings",
+        getElement: getSavingsElement,
+      },
+    ];
+  }, []);
+
+  const summary: RightSizingSummary | null = result ? result.summary : null;
+
+  const refreshButton: CardButtonSchema = {
+    title: "",
+    buttonStyle: ButtonStyleType.ICON,
+    className: "py-0 pr-0 pl-1 mt-1",
+    onClick: () => {
+      setLocalRefresh((toggle: number) => {
+        return toggle + 1;
+      });
+    },
+    icon: IconProp.Refresh,
+  };
+
+  const observedHours: number = result ? result.observedHours : 0;
+  const isWindowTooShort: boolean =
+    !isLoading && observedHours > 0 && observedHours < MIN_OBSERVED_HOURS;
+
+  const noRecommendationsMessage: ReactElement = useMemo(() => {
+    if (isWindowTooShort) {
+      return (
+        <span>
+          Right-sizing needs at least {MIN_OBSERVED_HOURS} hours of cost data.
+          Widen the time range above to see recommendations.
+        </span>
+      );
+    }
+
+    if (summary && summary.analyzedCount > 0) {
+      return (
+        <span>
+          Every container in this window is already within 15% of its
+          recommended request. Nothing to change.
+        </span>
+      );
+    }
+
+    return (
+      <span>
+        No container-level cost data in this window yet. Right-sizing reads the
+        same allocation rows as the spend breakdowns above.
+      </span>
+    );
+  }, [isWindowTooShort, summary]);
+
+  if (error) {
+    return (
+      <Card
+        title="Right-Sizing"
+        description="Recommended CPU and memory requests, derived from what each container actually used."
+      >
+        <ErrorMessage message={error} />
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      title="Right-Sizing"
+      description="Recommended CPU and memory requests per container, derived from observed demand: a P95 of CPU usage and the peak memory working set, each with 25% headroom."
+      buttons={[refreshButton]}
+    >
+      <Fragment>
+        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <GoldenMetricTile
+            title="Potential Saving"
+            icon={IconProp.CurrencyDollar}
+            iconColor="emerald"
+            value={
+              isLoading || !summary
+                ? "—"
+                : formatCost(summary.totalMonthlySavings)
+            }
+            sublabel="per month, if applied"
+          />
+          <GoldenMetricTile
+            title="Over-provisioned"
+            icon={IconProp.BarsArrowDown}
+            iconColor="amber"
+            value={
+              isLoading || !summary ? "—" : `${summary.overprovisionedCount}`
+            }
+            sublabel="containers asking for too much"
+          />
+          <GoldenMetricTile
+            title="Under-provisioned"
+            icon={IconProp.BarsArrowUp}
+            iconColor="violet"
+            value={
+              isLoading || !summary ? "—" : `${summary.underprovisionedCount}`
+            }
+            sublabel="throttle or OOM risk"
+          />
+          <GoldenMetricTile
+            title="Analyzed"
+            icon={IconProp.Cube}
+            iconColor="slate"
+            value={isLoading || !summary ? "—" : `${summary.analyzedCount}`}
+            sublabel="containers with cost data"
+          />
+        </div>
+
+        {/*
+         * Only worth raising once the window is long enough to size anything.
+         * On a short window every container looks unsized, and blaming that
+         * on Prometheus would send people to fix config that is already fine.
+         */}
+        {!isLoading &&
+        !isWindowTooShort &&
+        summary &&
+        summary.missingMemoryPeakCount > 0 &&
+        summary.analyzedCount > 0 ? (
+          <div className="mb-4">
+            <Alert
+              type={AlertType.INFO}
+              strongTitle="Memory recommendations are partly unavailable"
+              title={`${summary.missingMemoryPeakCount} of ${summary.analyzedCount} containers reported no memory peak, so their memory requests were left unsized. Peaks come from Prometheus — a memory request sized from an hourly average is how containers get OOMKilled, so we would rather say nothing. Set cost.engine.prometheusUrl on the agent to fill this in.`}
+            />
+          </div>
+        ) : null}
+
+        {!isLoading && summary && summary.noRequestSetCount > 0 ? (
+          <div className="mb-4">
+            <Alert
+              type={AlertType.WARNING}
+              strongTitle="Containers with no resource requests"
+              title={`${summary.noRequestSetCount} containers run without a request set. They cost nothing extra today, but the scheduler cannot place them safely and they are first to be evicted under pressure.`}
+            />
+          </div>
+        ) : null}
+
+        <Table<RightSizingRecommendation>
+          id="kubernetes-right-sizing-table"
+          columns={columns}
+          data={pagedRows}
+          singularLabel="Recommendation"
+          pluralLabel="Recommendations"
+          isLoading={isLoading}
+          error=""
+          currentPageNumber={page}
+          totalItemsCount={sortedRows.length}
+          itemsOnPage={COST_ROWS_PER_PAGE}
+          onNavigateToPage={(pageNumber: number) => {
+            setPage(pageNumber);
+          }}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSortChanged={(
+            newSortBy: keyof RightSizingRecommendation | null,
+            newSortOrder: SortOrder,
+          ) => {
+            setSortBy(newSortBy);
+            setSortOrder(newSortOrder);
+            setPage(1);
+          }}
+          noItemsMessage={noRecommendationsMessage}
+        />
+      </Fragment>
+    </Card>
+  );
+};
+
+export default KubernetesRightSizingCard;

--- a/App/FeatureSet/Docs/Content/en/telemetry/kubernetes-cost.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/kubernetes-cost.md
@@ -85,7 +85,29 @@ cost:
     scrapeInterval: 60s
 ```
 
-## Right-Sizing Data
+## Right-Sizing
+
+The **Right-Sizing** card on a cluster's Costs page recommends a CPU and memory request for every container it has enough history for, ranked by how much each change saves per month.
+
+A recommendation is observed demand plus 25% headroom, rounded to a value you can paste into a manifest (10m for CPU, 16Mi for memory):
+
+- **CPU** is sized from the **95th percentile** of hourly average usage. High enough to cover real load, low enough that one spike does not re-inflate the request for a month.
+- **Memory** is sized from the **peak** working set — never an average. See below.
+
+Requests are recommended; limits are not. A request is what the scheduler reserves and what the bill is calculated from, so it is the number that moves cost. Limits are a blast-radius decision that depends on whether you would rather a misbehaving container be throttled or killed, and that is not a call usage data can make for you.
+
+Each container is scored against its current request:
+
+- **Over-provisioned** — reserving materially more than it uses. This is where the savings estimate comes from.
+- **Under-provisioned** — reserving less than it uses, so it is being throttled or is at risk of an OOMKill. Fixing this *costs* money, and the card shows that as an increase rather than burying it.
+- **No request set** — nothing to shrink, but the scheduler cannot place the container safely and it is first to be evicted under pressure.
+- Anything within 15% of its recommendation is treated as already right-sized and is left out. Nobody should edit a manifest to shave 3% off a request.
+
+Two guards keep the advice honest. A workload needs at least **24 hours** of cost windows before it is sized at all — a four-hour window catches a nightly batch job at rest and would happily advise shrinking it to nothing. And savings are projected from the length of the window you are looking at, not from the row count, so a Deployment's saving is not multiplied by its replica count.
+
+The estimate assumes spend scales with what the engine allocated, which is `max(request, usage)`. In the over-provisioned case that reduces to the request, so the savings figure is exact rather than approximate.
+
+### The Data Behind It
 
 Alongside spend, the poller collects what a right-sizing recommendation needs: per-container CPU and memory **requests**, **limits**, and **usage**.
 
@@ -115,5 +137,7 @@ Allocation rows are stored in ClickHouse (one row per cluster, window, namespace
 - **Bundled OpenCost not ready** — `kubectl logs -n <agent namespace> deploy/<release>-kubernetes-agent-opencost`. It logs which cloud provider it detected and whether pricing data loaded.
 - **`mkdir /var/configs: permission denied` in the OpenCost log** — a chart bug fixed in chart 0.6.1. OpenCost ran as non-root with no writable config directory, so `Error downloading default pricing data` left its Allocation API unable to answer and the poller stalled — while the pod stayed `Running`, `/healthz` stayed green, and the node cost metrics kept publishing. Upgrade the chart (`helm repo update && helm upgrade ... --reuse-values`); cost rows appear on the next poll.
 - **Dashboard template shows no data** — the template reads the scraped cost metrics; confirm `cost.metrics.enabled` is `true`.
+- **Right-Sizing card is empty** — either the window is shorter than the 24 hours a recommendation needs (widen the time range), or every container is already within 15% of its recommended request, which the card says explicitly.
+- **Memory recommendations show `-` but CPU ones work** — no memory peak reached the server, so memory was deliberately left unsized rather than guessed from an average. On an external-engine install, set `cost.engine.prometheusUrl`. The card reports how many containers this affects.
 - **Numbers differ from the engine's own UI** — OneUptime includes the engine's reconciliation adjustments in each cost component and ships whole closed windows; partial current-hour spend appears after the window closes.
 - **Prometheus pod restarted** — with the default `emptyDir` storage a restart loses a few hours of usage history, so allocations for those windows may be smaller. Set `cost.prometheus.persistence.enabled=true` if that matters to you.

--- a/Common/Tests/Types/Kubernetes/KubernetesRightSizing.test.ts
+++ b/Common/Tests/Types/Kubernetes/KubernetesRightSizing.test.ts
@@ -1,0 +1,323 @@
+import {
+  MIN_RECOMMENDED_CPU_CORES,
+  MIN_RECOMMENDED_MEMORY_BYTES,
+  RightSizingObservation,
+  RightSizingRecommendation,
+  RightSizingVerdict,
+  buildRightSizingRecommendation,
+  formatCpuCores,
+  formatMemoryBytes,
+  hasActionableRecommendation,
+} from "../../../Types/Kubernetes/KubernetesRightSizing";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Right-sizing turns cost-window aggregates into "set this request to that".
+ * The dangerous failure is not an imprecise saving — it is advising a memory
+ * request below what a container actually peaked at, which turns into an
+ * OOMKill in production. So the tests below lean hardest on the cases where
+ * the recommendation must refuse to answer.
+ */
+
+const MIB: number = 1024 * 1024;
+const GIB: number = 1024 * MIB;
+
+// A week of hourly windows for a single replica.
+const WEEK_HOURS: number = 168;
+
+function observation(
+  overrides: Partial<RightSizingObservation> = {},
+): RightSizingObservation {
+  return {
+    namespace: "prod",
+    controllerKind: "Deployment",
+    controllerName: "api",
+    containerName: "api",
+    sampleCount: WEEK_HOURS,
+    cpuCoreRequestAverage: 1,
+    cpuCoreUsageP95: 0.2,
+    cpuCost: 10,
+    ramBytesRequestAverage: GIB,
+    ramBytesUsagePeak: 256 * MIB,
+    ramCost: 6,
+    ...overrides,
+  };
+}
+
+describe("buildRightSizingRecommendation - CPU", () => {
+  test("flags an over-provisioned request and sizes it from P95 plus headroom", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ cpuCoreRequestAverage: 1, cpuCoreUsageP95: 0.2 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Overprovisioned);
+    // 0.2 * 1.25 = 0.25 cores, already on a 10m boundary.
+    expect(result.cpu.recommended).toBeCloseTo(0.25, 5);
+    expect(result.cpu.current).toBe(1);
+  });
+
+  test("rounds the recommendation up to the next 10 millicores", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ cpuCoreUsageP95: 0.101 }),
+      WEEK_HOURS,
+    );
+
+    // 0.101 * 1.25 = 0.12625 -> 0.13
+    expect(result.cpu.recommended).toBeCloseTo(0.13, 5);
+  });
+
+  test("flags an under-provisioned request", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ cpuCoreRequestAverage: 0.1, cpuCoreUsageP95: 0.5 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Underprovisioned);
+    expect(result.cpu.recommended).toBeCloseTo(0.63, 5);
+  });
+
+  test("leaves a request inside the significance band alone", () => {
+    // 0.8 * 1.25 = 1.0 exactly, so the request is already right.
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ cpuCoreRequestAverage: 1, cpuCoreUsageP95: 0.8 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Optimal);
+    expect(result.cpu.costDeltaInWindow).toBe(0);
+  });
+
+  test("never recommends below the CPU floor", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ cpuCoreRequestAverage: 0.5, cpuCoreUsageP95: 0.0001 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.recommended).toBe(MIN_RECOMMENDED_CPU_CORES);
+  });
+
+  test("reports a container with no request as a scheduling problem, not a saving", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({
+        cpuCoreRequestAverage: 0,
+        cpuCoreUsageP95: 0.4,
+        ramBytesRequestAverage: 0,
+      }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.NoRequestSet);
+    expect(result.cpu.current).toBeNull();
+    expect(result.cpu.recommended).toBeCloseTo(0.5, 5);
+    expect(result.cpu.costDeltaInWindow).toBe(0);
+    expect(result.estimatedMonthlySavings).toBe(0);
+  });
+});
+
+describe("buildRightSizingRecommendation - memory", () => {
+  test("sizes memory from the peak, not the request", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({
+        ramBytesRequestAverage: GIB,
+        ramBytesUsagePeak: 256 * MIB,
+      }),
+      WEEK_HOURS,
+    );
+
+    expect(result.memory.verdict).toBe(RightSizingVerdict.Overprovisioned);
+    // 256Mi * 1.25 = 320Mi, already a multiple of the 16Mi step.
+    expect(result.memory.recommended).toBe(320 * MIB);
+  });
+
+  test("refuses to size memory when no peak was reported", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ ramBytesUsagePeak: 0 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.memory.verdict).toBe(RightSizingVerdict.Unavailable);
+    expect(result.memory.recommended).toBeNull();
+    expect(result.memory.costDeltaInWindow).toBe(0);
+    expect(result.memory.unavailableReason).toContain("Prometheus");
+  });
+
+  test("a missing memory peak does not block the CPU recommendation", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ ramBytesUsagePeak: 0 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Overprovisioned);
+    expect(result.estimatedMonthlySavings).toBeGreaterThan(0);
+  });
+
+  test("rounds memory up to the next 16Mi", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ ramBytesUsagePeak: 100 * MIB }),
+      WEEK_HOURS,
+    );
+
+    // 100Mi * 1.25 = 125Mi -> 128Mi
+    expect(result.memory.recommended).toBe(128 * MIB);
+  });
+
+  test("never recommends below the memory floor", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ ramBytesUsagePeak: 1024 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.memory.recommended).toBe(MIN_RECOMMENDED_MEMORY_BYTES);
+  });
+});
+
+describe("buildRightSizingRecommendation - confidence gate", () => {
+  test("advises nothing when the window is shorter than a day", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ sampleCount: 4 }),
+      4,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Unavailable);
+    expect(result.memory.verdict).toBe(RightSizingVerdict.Unavailable);
+    expect(result.estimatedMonthlySavings).toBe(0);
+    expect(hasActionableRecommendation(result)).toBe(false);
+  });
+
+  test("advises nothing when a long window holds only a few samples", () => {
+    // A workload that existed for two hours of a week-long window.
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ sampleCount: 2 }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Unavailable);
+    expect(result.cpu.unavailableReason).toContain("at least a day");
+  });
+});
+
+describe("buildRightSizingRecommendation - savings", () => {
+  test("scales the window saving to a month", () => {
+    /*
+     * CPU: request 1 core, P95 0.2 -> recommend 0.25, so 75% of $10 goes.
+     * RAM: request 1Gi, peak 256Mi -> recommend 320Mi, so 68.75% of $6 goes.
+     * Window saving = 7.5 + 4.125 = 11.625 over 168h; a 730h month is
+     * 4.3452... times that window.
+     */
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation(),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.costDeltaInWindow).toBeCloseTo(-7.5, 5);
+    expect(result.memory.costDeltaInWindow).toBeCloseTo(-4.125, 5);
+    expect(result.estimatedMonthlySavings).toBeCloseTo(11.625 * (730 / 168), 4);
+    expect(result.estimatedMonthlyIncrease).toBe(0);
+  });
+
+  test("an under-provisioned workload reports an increase, never a saving", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({
+        cpuCoreRequestAverage: 0.1,
+        cpuCoreUsageP95: 0.5,
+        ramBytesRequestAverage: 64 * MIB,
+        ramBytesUsagePeak: 512 * MIB,
+      }),
+      WEEK_HOURS,
+    );
+
+    expect(result.estimatedMonthlySavings).toBe(0);
+    expect(result.estimatedMonthlyIncrease).toBeGreaterThan(0);
+  });
+
+  test("prices the increase off actual usage when usage already exceeds the request", () => {
+    /*
+     * Request 0.1 but P95 usage 0.5: the engine already bills for 0.5, so
+     * moving to a 0.63 request costs 26% more, not 530% more.
+     */
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({
+        cpuCoreRequestAverage: 0.1,
+        cpuCoreUsageP95: 0.5,
+        cpuCost: 10,
+        ramBytesUsagePeak: 0,
+      }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.costDeltaInWindow).toBeCloseTo(10 * (0.63 / 0.5 - 1), 5);
+  });
+
+  test("a replica count in sampleCount does not inflate the monthly projection", () => {
+    // Same window, same spend, three replicas' worth of rows.
+    const single: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ sampleCount: WEEK_HOURS }),
+      WEEK_HOURS,
+    );
+    const triple: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({ sampleCount: WEEK_HOURS * 3 }),
+      WEEK_HOURS,
+    );
+
+    expect(triple.estimatedMonthlySavings).toBeCloseTo(
+      single.estimatedMonthlySavings,
+      5,
+    );
+  });
+});
+
+describe("hasActionableRecommendation", () => {
+  test("is false when both resources are already right-sized", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({
+        cpuCoreRequestAverage: 1,
+        cpuCoreUsageP95: 0.8,
+        ramBytesRequestAverage: 320 * MIB,
+        ramBytesUsagePeak: 256 * MIB,
+      }),
+      WEEK_HOURS,
+    );
+
+    expect(result.cpu.verdict).toBe(RightSizingVerdict.Optimal);
+    expect(result.memory.verdict).toBe(RightSizingVerdict.Optimal);
+    expect(hasActionableRecommendation(result)).toBe(false);
+  });
+
+  test("is true when only one resource needs a change", () => {
+    const result: RightSizingRecommendation = buildRightSizingRecommendation(
+      observation({
+        cpuCoreRequestAverage: 1,
+        cpuCoreUsageP95: 0.8,
+        ramBytesRequestAverage: GIB,
+        ramBytesUsagePeak: 128 * MIB,
+      }),
+      WEEK_HOURS,
+    );
+
+    expect(hasActionableRecommendation(result)).toBe(true);
+  });
+});
+
+describe("formatting", () => {
+  test("writes sub-core CPU as millicores", () => {
+    expect(formatCpuCores(0.25)).toBe("250m");
+    expect(formatCpuCores(0.01)).toBe("10m");
+  });
+
+  test("writes whole cores as decimals", () => {
+    expect(formatCpuCores(1)).toBe("1");
+    expect(formatCpuCores(2.5)).toBe("2.5");
+  });
+
+  test("writes memory as Kubernetes binary quantities", () => {
+    expect(formatMemoryBytes(320 * MIB)).toBe("320Mi");
+    expect(formatMemoryBytes(2 * GIB)).toBe("2Gi");
+    expect(formatMemoryBytes(1.5 * GIB)).toBe("1.5Gi");
+  });
+
+  test("renders unknown values as a dash", () => {
+    expect(formatCpuCores(null)).toBe("-");
+    expect(formatMemoryBytes(null)).toBe("-");
+  });
+});

--- a/Common/Types/Kubernetes/KubernetesRightSizing.ts
+++ b/Common/Types/Kubernetes/KubernetesRightSizing.ts
@@ -1,0 +1,353 @@
+/*
+ * Right-sizing recommendations for Kubernetes workloads.
+ *
+ * Pure math over aggregates the cost pipeline already stores, kept out of
+ * the dashboard so it can be unit-tested and reused server-side (digests,
+ * alerts) without a browser.
+ *
+ * One asymmetry drives every choice in this file: a CPU request set too low
+ * throttles a container, a memory request set too low gets it OOMKilled.
+ * So CPU is sized from a P95 of hourly averages, while memory is sized only
+ * ever from a true peak — never from an average, and not at all when the
+ * peak is unknown. See `ramBytesUsageMax` on the KubernetesCostAllocation
+ * model for why a 0 peak has to mean "unknown".
+ */
+
+/** Hours in an average month (365 * 24 / 12), for monthly projections. */
+export const HOURS_IN_MONTH: number = 730;
+
+/*
+ * A workload has to be observed for at least a day before it gets a
+ * recommendation. A four-hour window catches a nightly batch job at rest
+ * and would happily advise shrinking it to nothing.
+ */
+export const MIN_OBSERVED_HOURS: number = 24;
+export const MIN_SAMPLE_COUNT: number = 24;
+
+/*
+ * Headroom over observed demand. CPU can be tighter than memory because
+ * overshooting CPU costs latency while overshooting memory costs the pod.
+ */
+export const CPU_HEADROOM_RATIO: number = 0.25;
+export const MEMORY_HEADROOM_RATIO: number = 0.25;
+
+/*
+ * Floors, so a near-idle sidecar is never told to request 1m of CPU or
+ * 4Mi of RAM — values that schedule badly and read as noise.
+ */
+export const MIN_RECOMMENDED_CPU_CORES: number = 0.01;
+export const MIN_RECOMMENDED_MEMORY_BYTES: number = 32 * 1024 * 1024;
+
+/*
+ * Nobody should edit a manifest to shave 3% off a request, so a
+ * recommendation within this band of the current value reads as "Optimal".
+ */
+export const SIGNIFICANCE_RATIO: number = 0.15;
+
+const CPU_ROUNDING_STEP_CORES: number = 0.01; // 10 millicores
+const MEMORY_ROUNDING_STEP_BYTES: number = 16 * 1024 * 1024; // 16 MiB
+
+export enum RightSizingVerdict {
+  /** Requesting materially more than observed demand — money on the table. */
+  Overprovisioned = "Overprovisioned",
+  /** Requesting materially less than observed demand — throttle / OOM risk. */
+  Underprovisioned = "Underprovisioned",
+  /** Request already sits within the significance band of the recommendation. */
+  Optimal = "Optimal",
+  /** No request set at all. A scheduling problem, not a cost one. */
+  NoRequestSet = "NoRequestSet",
+  /** Not enough signal to advise anything. Never guess here. */
+  Unavailable = "Unavailable",
+}
+
+export interface ResourceRecommendation {
+  /** Current per-container request. Null when none is set. */
+  current: number | null;
+  /** What the request should be. Null when we cannot say. */
+  recommended: number | null;
+  /** Observed demand the recommendation was built from (P95 CPU / peak RAM). */
+  observedDemand: number | null;
+  verdict: RightSizingVerdict;
+  /**
+   * Spend change over the observed window if the recommendation is applied.
+   * Negative saves money, positive costs more (an under-provisioned
+   * workload is under-charged today precisely because it is starved).
+   */
+  costDeltaInWindow: number;
+  /** Why the recommendation is unavailable, for the UI to explain itself. */
+  unavailableReason?: string | undefined;
+}
+
+/**
+ * One container's recommendation. Keyed by controller rather than pod:
+ * requests live in the pod template, so advice has to be per-container of a
+ * controller to be actionable.
+ */
+export interface RightSizingRecommendation {
+  namespace: string;
+  controllerKind: string;
+  controllerName: string;
+  containerName: string;
+  cpu: ResourceRecommendation;
+  memory: ResourceRecommendation;
+  /** Spend on this container over the observed window (CPU + RAM). */
+  costInWindow: number;
+  /** Projected monthly saving. Clamped at 0 — an increase is not a saving. */
+  estimatedMonthlySavings: number;
+  /** Projected monthly cost increase from fixing under-provisioning. */
+  estimatedMonthlyIncrease: number;
+  sampleCount: number;
+}
+
+/**
+ * Per-container aggregates over the whole window. CPU usage is a P95 of the
+ * hourly averages; memory usage is the maximum of the per-window peaks, so
+ * it survives a burst that an average would smooth away.
+ */
+export interface RightSizingObservation {
+  namespace: string;
+  controllerKind: string;
+  controllerName: string;
+  containerName: string;
+  /** Rows behind these aggregates — replicas * windows. */
+  sampleCount: number;
+  cpuCoreRequestAverage: number;
+  cpuCoreUsageP95: number;
+  cpuCost: number;
+  ramBytesRequestAverage: number;
+  /** Max of `ramBytesUsageMax`. 0 means unknown, never a real peak of zero. */
+  ramBytesUsagePeak: number;
+  ramCost: number;
+}
+
+function roundUpTo(value: number, step: number): number {
+  return Math.ceil(value / step) * step;
+}
+
+/*
+ * Cost scales with what the engine allocated, which is max(request, usage)
+ * — a container burning more than it asked for is billed for what it burnt.
+ * Using that as the denominator keeps the delta honest in both directions.
+ *
+ * In the case that actually produces a savings headline (request above
+ * demand) this collapses to the request, so the estimate there is exact
+ * rather than approximate.
+ */
+function getAllocatedBasis(request: number, demand: number): number {
+  return Math.max(request, demand);
+}
+
+interface BuildResourceInput {
+  request: number;
+  demand: number;
+  demandIsKnown: boolean;
+  cost: number;
+  headroomRatio: number;
+  floor: number;
+  roundingStep: number;
+  unknownDemandReason: string;
+}
+
+function buildResourceRecommendation(
+  input: BuildResourceInput,
+): ResourceRecommendation {
+  const request: number = input.request > 0 ? input.request : 0;
+
+  if (!input.demandIsKnown || !Number.isFinite(input.demand)) {
+    return {
+      current: request > 0 ? request : null,
+      recommended: null,
+      observedDemand: null,
+      verdict: RightSizingVerdict.Unavailable,
+      costDeltaInWindow: 0,
+      unavailableReason: input.unknownDemandReason,
+    };
+  }
+
+  const demand: number = Math.max(0, input.demand);
+  const recommended: number = Math.max(
+    input.floor,
+    roundUpTo(demand * (1 + input.headroomRatio), input.roundingStep),
+  );
+
+  /*
+   * A container with no request is a scheduling risk (it can be evicted or
+   * scheduled onto a node that cannot hold it), but there is no request to
+   * shrink, so it never contributes a saving.
+   */
+  if (request <= 0) {
+    return {
+      current: null,
+      recommended: recommended,
+      observedDemand: demand,
+      verdict: RightSizingVerdict.NoRequestSet,
+      costDeltaInWindow: 0,
+    };
+  }
+
+  const basis: number = getAllocatedBasis(request, demand);
+  const costDeltaInWindow: number =
+    basis > 0 ? input.cost * (recommended / basis - 1) : 0;
+
+  const ratio: number = recommended / request;
+
+  let verdict: RightSizingVerdict = RightSizingVerdict.Optimal;
+  if (ratio < 1 - SIGNIFICANCE_RATIO) {
+    verdict = RightSizingVerdict.Overprovisioned;
+  } else if (ratio > 1 + SIGNIFICANCE_RATIO) {
+    verdict = RightSizingVerdict.Underprovisioned;
+  }
+
+  return {
+    current: request,
+    recommended: recommended,
+    observedDemand: demand,
+    verdict: verdict,
+    // Within the significance band we advise no change, so nothing moves.
+    costDeltaInWindow:
+      verdict === RightSizingVerdict.Optimal ? 0 : costDeltaInWindow,
+  };
+}
+
+const INSUFFICIENT_DATA_REASON: string =
+  "Not enough history yet — a workload needs at least a day of cost windows before it can be sized.";
+
+const NO_MEMORY_PEAK_REASON: string =
+  "No memory peak available. The agent reads peaks from Prometheus; without one, a memory request could only be guessed from an average, which is how containers get OOMKilled.";
+
+/**
+ * Turns one container's window aggregates into a recommendation.
+ *
+ * `observedHours` is the wall-clock length of the query window and is what
+ * monthly projections scale by — not the sample count, which counts
+ * replicas too and would multiply a Deployment's savings by its replica
+ * count.
+ */
+export function buildRightSizingRecommendation(
+  observation: RightSizingObservation,
+  observedHours: number,
+): RightSizingRecommendation {
+  const costInWindow: number =
+    (observation.cpuCost || 0) + (observation.ramCost || 0);
+
+  const hasEnoughHistory: boolean =
+    observedHours >= MIN_OBSERVED_HOURS &&
+    observation.sampleCount >= MIN_SAMPLE_COUNT;
+
+  const cpu: ResourceRecommendation = buildResourceRecommendation({
+    request: observation.cpuCoreRequestAverage,
+    demand: observation.cpuCoreUsageP95,
+    demandIsKnown: hasEnoughHistory,
+    cost: observation.cpuCost || 0,
+    headroomRatio: CPU_HEADROOM_RATIO,
+    floor: MIN_RECOMMENDED_CPU_CORES,
+    roundingStep: CPU_ROUNDING_STEP_CORES,
+    unknownDemandReason: INSUFFICIENT_DATA_REASON,
+  });
+
+  /*
+   * A zero peak is indistinguishable from "the agent never reported one",
+   * so it is treated as unknown. Sizing memory off the average instead is
+   * the one shortcut this feature must not take.
+   */
+  const hasMemoryPeak: boolean = observation.ramBytesUsagePeak > 0;
+
+  const memory: ResourceRecommendation = buildResourceRecommendation({
+    request: observation.ramBytesRequestAverage,
+    demand: observation.ramBytesUsagePeak,
+    demandIsKnown: hasEnoughHistory && hasMemoryPeak,
+    cost: observation.ramCost || 0,
+    headroomRatio: MEMORY_HEADROOM_RATIO,
+    floor: MIN_RECOMMENDED_MEMORY_BYTES,
+    roundingStep: MEMORY_ROUNDING_STEP_BYTES,
+    unknownDemandReason: hasEnoughHistory
+      ? NO_MEMORY_PEAK_REASON
+      : INSUFFICIENT_DATA_REASON,
+  });
+
+  const windowDelta: number = cpu.costDeltaInWindow + memory.costDeltaInWindow;
+  const monthlyFactor: number =
+    observedHours > 0 ? HOURS_IN_MONTH / observedHours : 0;
+  const monthlyDelta: number = windowDelta * monthlyFactor;
+
+  return {
+    namespace: observation.namespace,
+    controllerKind: observation.controllerKind,
+    controllerName: observation.controllerName,
+    containerName: observation.containerName,
+    cpu: cpu,
+    memory: memory,
+    costInWindow: costInWindow,
+    estimatedMonthlySavings: monthlyDelta < 0 ? -monthlyDelta : 0,
+    estimatedMonthlyIncrease: monthlyDelta > 0 ? monthlyDelta : 0,
+    sampleCount: observation.sampleCount,
+  };
+}
+
+/** True when a recommendation is worth showing at all. */
+export function hasActionableRecommendation(
+  recommendation: RightSizingRecommendation,
+): boolean {
+  const actionable: Array<RightSizingVerdict> = [
+    RightSizingVerdict.Overprovisioned,
+    RightSizingVerdict.Underprovisioned,
+    RightSizingVerdict.NoRequestSet,
+  ];
+
+  return (
+    actionable.includes(recommendation.cpu.verdict) ||
+    actionable.includes(recommendation.memory.verdict)
+  );
+}
+
+/**
+ * Formats cores the way Kubernetes writes them, so the value can be pasted
+ * straight into a manifest: sub-core as millicores, whole cores as decimals.
+ */
+export function formatCpuCores(cores: number | null): string {
+  if (cores === null || !Number.isFinite(cores)) {
+    return "-";
+  }
+
+  if (cores < 1) {
+    return `${Math.round(cores * 1000)}m`;
+  }
+
+  return `${Number(cores.toFixed(2))}`;
+}
+
+/** Formats bytes as a Kubernetes binary quantity (`512Mi`, `2Gi`). */
+export function formatMemoryBytes(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes)) {
+    return "-";
+  }
+
+  const gibibyte: number = 1024 * 1024 * 1024;
+  const mebibyte: number = 1024 * 1024;
+
+  if (bytes >= gibibyte) {
+    return `${Number((bytes / gibibyte).toFixed(2))}Gi`;
+  }
+
+  if (bytes >= mebibyte) {
+    return `${Math.round(bytes / mebibyte)}Mi`;
+  }
+
+  return `${Math.max(1, Math.round(bytes / 1024))}Ki`;
+}
+
+/** Human label for a verdict. */
+export function getVerdictLabel(verdict: RightSizingVerdict): string {
+  switch (verdict) {
+    case RightSizingVerdict.Overprovisioned:
+      return "Over-provisioned";
+    case RightSizingVerdict.Underprovisioned:
+      return "Under-provisioned";
+    case RightSizingVerdict.Optimal:
+      return "Right-sized";
+    case RightSizingVerdict.NoRequestSet:
+      return "No request set";
+    default:
+      return "Unavailable";
+  }
+}


### PR DESCRIPTION
## What

The Kubernetes cost agent already collected everything a right-sizing recommendation needs — per-container requests, limits, usage averages, and the memory peak read from Prometheus — and `AddRightSizingColumnsToKubernetesCostAllocation` stored it in ClickHouse. **Nothing ever read those three columns back.** The Costs page could tell you a workload ran at 20% efficiency, but never what to set the request to.

This adds the computation and the UI. A **Right-Sizing** card now sits on the cluster Costs page between the spend chart and the breakdowns, ranked by monthly saving.

## How it sizes

The asymmetry between the two resources drives every decision: a CPU request set too low throttles a container, a memory request set too low gets it OOMKilled.

- **CPU** — P95 of hourly average usage, +25% headroom, rounded up to 10m. High enough to cover real load, low enough that one spike does not re-inflate the request for a month.
- **Memory** — the **max** of the per-window peaks, +25% headroom, rounded up to 16Mi. Never an average. When no peak reached the server the memory recommendation is **withheld rather than guessed**, and the card says how many containers that affects so a half-configured agent explains itself instead of looking like a workload with nothing to fix.

Requests only; limits are deliberately not recommended. A request is what the scheduler reserves and what the bill derives from. A limit is a blast-radius decision — throttle or kill — that usage data cannot make for you.

## Guards against bad advice

- A workload needs **24h of cost windows** before it is sized at all. A four-hour window catches a nightly batch job at rest and would happily advise shrinking it to nothing.
- Savings scale by the **wall-clock window**, not the row count, so a Deployment's saving is not multiplied by its replica count. There's a test for exactly this.
- Anything within **15%** of its recommendation reads as already right-sized and is left out. Nobody edits a manifest to shave 3% off a request.
- **Under-provisioning is shown as a cost increase**, not hidden. Fixing a starved workload costs money and that shouldn't be a surprise mid-rollout.
- Containers with **no request set** are called out separately — nothing to shrink, but the scheduler can't place them safely.

The savings estimate assumes spend scales with what the engine allocated, `max(request, usage)`. In the over-provisioned case that reduces to the request, so the headline number is exact rather than approximate.

## Structure

The recommender is pure and lives in `Common/Types/Kubernetes/KubernetesRightSizing.ts`, so it can back a digest or an alert later without a browser. The dashboard side only fetches aggregates and renders.

`buildAggregateBy` / `runAggregate` are now exported from `KubernetesCostUtils` and reused, so right-sizing and the spend tables scope rows identically — two spellings of "which rows count" is how a savings figure ends up disagreeing with the spend figure next to it.

## Tests

23 new unit tests in `Common/Tests/Types/Kubernetes/KubernetesRightSizing.test.ts`, weighted toward the cases where the recommender must **refuse to answer**: no memory peak, too few samples, too short a window. Full suite for the area passes (64 tests including the existing model tests). `tsc --noEmit` clean in both `Common` and `App`; `eslint` clean on all changed files.

## Not verified in a browser

The Dashboard needs the full docker-compose stack plus ClickHouse rows with real allocation data, and neither is available in this environment (the only `launch.json` entry is the marketing site). The rendering path is typechecked and the logic is unit-tested, but **nobody has looked at this card with real data yet** — worth a look on a cluster that has been shipping cost windows for a few days before merge.

## Known limitation

Grouping by `(namespace, controllerKind, controllerName, containerName)` inherits the same `LIMIT_PER_PROJECT` (10,000) cap as the existing namespace and workload breakdowns. A cluster with more than 10k distinct containers in a window would silently truncate. Pre-existing behaviour shared with the sibling tables rather than something introduced here, but it should be fixed for all three together at some point.

## Docs

The `Right-Sizing Data` section of `telemetry/kubernetes-cost.md` described collection as if the recommender already existed ("CPU recommendations still work"). It now documents the actual feature — how each resource is sized, what the verdicts mean, the guards — plus two troubleshooting entries. English only: the 16 translations already lag this page by a section and are updated out-of-band.
