### PR TITLE
Add Real User Monitoring dashboard template

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceTableData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/TraceTableData.ts
@@ -97,12 +97,29 @@ export function buildTraceTableRequest(
   return requestData;
 }
 
-// Friendly labels for the built-in top-level dimensions a row can group by.
+/*
+ * Friendly labels for the built-in top-level dimensions a row can group by.
+ * The resource dimensions below are not offered by the widget's own split
+ * picker (TraceChartQueryEditor deliberately omits opaque ids) — they arrive
+ * from dashboard templates, which use them because grouping by one also
+ * constrains the query to that resource type server-side. Their VALUES are
+ * resolved to display names by TraceAggregationService; only the column
+ * header is named here.
+ */
 const DIMENSION_LABELS: Record<string, string> = {
   name: "Span Name",
   statusCode: "Status Code",
   kind: "Span Kind",
   primaryEntityId: "Service",
+  rumApplicationId: "Application",
+  hostId: "Host",
+  dockerHostId: "Docker Host",
+  podmanHostId: "Podman Host",
+  kubernetesClusterId: "Kubernetes Cluster",
+  proxmoxClusterId: "Proxmox Cluster",
+  cephClusterId: "Ceph Cluster",
+  serverlessFunctionId: "Serverless Function",
+  cloudResourceId: "Cloud Resource",
 };
 
 export function dimensionLabel(key: string): string {

--- a/Common/Server/Services/TraceAggregationService.ts
+++ b/Common/Server/Services/TraceAggregationService.ts
@@ -11,6 +11,10 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { DbJSONResponse, Results } from "./AnalyticsDatabaseService";
 import logger from "../Utils/Logger";
 import ServiceType from "../../Types/Telemetry/ServiceType";
+import ResourceFacetResolver, {
+  ResolvedFacetValue,
+  ResourceFacetSpec,
+} from "../Utils/Telemetry/ResourceFacetResolver";
 
 export interface HistogramBucket {
   time: string;
@@ -1229,7 +1233,116 @@ export class TraceAggregationService {
    * (LogAggregationService.getAnalyticsTimeseries and friends) and shares
    * appendCommonFilters with the histogram/facets, so every explorer filter
    * applies identically.
+   *
+   * A resource dimension (rumApplicationId, hostId, kubernetesClusterId, …)
+   * selects the bare `toString(primaryEntityId)`, so grouping by one returns
+   * internal ObjectIDs. Nothing downstream turns those into names: the traces
+   * explorer resolves only its own `primaryEntityId` split, client-side, and
+   * the dashboard TraceChart / TraceTable widgets have no equivalent — so the
+   * raw id reaches the chart legend, the tooltip series name and the table
+   * cell. Resolve them here, once per query, through the same resolver the
+   * facet sidebar uses.
+   *
+   * Deliberately NOT applied to getAnalyticsTopList: the timeseries path
+   * feeds that method's values straight back into the query as an IN filter
+   * (see getAnalyticsTimeseries), and the AI latency detectors match on them,
+   * so those must stay raw.
+   *
+   * Unresolvable ids — a deleted resource, or one past the resolver's page
+   * size — keep their raw value rather than vanishing from the result.
    */
+  private static async applyResourceDisplayValues<
+    TRow extends { groupValues: Record<string, string> },
+  >(
+    projectId: ObjectID,
+    groupByKeys: Array<string>,
+    rows: Array<TRow>,
+  ): Promise<Array<TRow>> {
+    /*
+     * Both memberships are required, and the two sets genuinely differ:
+     *
+     * - `proxmoxClusterId` / `cephClusterId` are resource dimensions here
+     *   but have no branch in ResourceFacetResolver.resolveOne, which
+     *   returns [] for them. Asking anyway would cost a round-trip and
+     *   still leave the cell raw.
+     * - `primaryEntityId` / `serviceId` are resolvable but are NOT resource
+     *   dimensions here — they select the OpenTelemetry-service slot, and
+     *   the traces explorer already resolves that split client-side
+     *   (TracesAnalyticsView's serviceNameMap). Renaming their values
+     *   server-side would change an existing surface for no gain.
+     *
+     * Taking the intersection means a key becomes resolvable here the
+     * moment the resolver learns it, with no second list to update.
+     */
+    const resourceKeys: Array<string> = groupByKeys.filter(
+      (key: string): boolean => {
+        return (
+          TraceAggregationService.RESOURCE_FACET_KEYS.has(key) &&
+          ResourceFacetResolver.isResourceFacet(key)
+        );
+      },
+    );
+
+    if (resourceKeys.length === 0 || rows.length === 0) {
+      return rows;
+    }
+
+    const specs: Array<ResourceFacetSpec> = resourceKeys.map(
+      (key: string): ResourceFacetSpec => {
+        const counts: Map<string, number> = new Map();
+
+        for (const row of rows) {
+          const raw: string | undefined = row.groupValues[key];
+          if (raw) {
+            counts.set(raw, (counts.get(raw) || 0) + 1);
+          }
+        }
+
+        return { facetKey: key, counts: counts };
+      },
+    );
+
+    let resolved: Record<string, Array<ResolvedFacetValue>> = {};
+
+    try {
+      resolved = await ResourceFacetResolver.resolve(projectId, specs);
+    } catch (err: unknown) {
+      logger.warn(
+        `Could not resolve resource display names for trace analytics group-by; falling back to raw ids: ${err}`,
+      );
+      return rows;
+    }
+
+    const displayNamesByKey: Map<string, Map<string, string>> = new Map();
+
+    for (const key of resourceKeys) {
+      const displayNames: Map<string, string> = new Map();
+
+      for (const entry of resolved[key] || []) {
+        if (entry.displayName) {
+          displayNames.set(entry.value, entry.displayName);
+        }
+      }
+
+      displayNamesByKey.set(key, displayNames);
+    }
+
+    for (const row of rows) {
+      for (const key of resourceKeys) {
+        const raw: string | undefined = row.groupValues[key];
+        const displayName: string | undefined = raw
+          ? displayNamesByKey.get(key)?.get(raw)
+          : undefined;
+
+        if (displayName) {
+          row.groupValues[key] = displayName;
+        }
+      }
+    }
+
+    return rows;
+  }
+
   @CaptureSpan()
   public static async getAnalyticsTimeseries(
     request: TraceAnalyticsRequest,
@@ -1285,20 +1398,31 @@ export class TraceAggregationService {
       );
     }
 
-    return rows.map((row: JSONObject): TraceAnalyticsTimeseriesRow => {
-      const groupValues: Record<string, string> = {};
+    const timeseriesRows: Array<TraceAnalyticsTimeseriesRow> = rows.map(
+      (row: JSONObject): TraceAnalyticsTimeseriesRow => {
+        const groupValues: Record<string, string> = {};
 
-      for (const [index, key] of groupByKeys.entries()) {
-        const alias: string = TraceAggregationService.groupByAlias(key, index);
-        groupValues[key] = String(row[alias] ?? "");
-      }
+        for (const [index, key] of groupByKeys.entries()) {
+          const alias: string = TraceAggregationService.groupByAlias(
+            key,
+            index,
+          );
+          groupValues[key] = String(row[alias] ?? "");
+        }
 
-      return {
-        time: String(row["bucket"] || ""),
-        value: Number(row["val"] || 0),
-        groupValues,
-      };
-    });
+        return {
+          time: String(row["bucket"] || ""),
+          value: Number(row["val"] || 0),
+          groupValues,
+        };
+      },
+    );
+
+    return TraceAggregationService.applyResourceDisplayValues(
+      request.projectId,
+      groupByKeys,
+      timeseriesRows,
+    );
   }
 
   @CaptureSpan()
@@ -1370,27 +1494,38 @@ export class TraceAggregationService {
 
     const groupByKeys: Array<string> = request.groupBy;
 
-    return rows.map((row: JSONObject): TraceAnalyticsTableRow => {
-      const groupValues: Record<string, string> = {};
+    const tableRows: Array<TraceAnalyticsTableRow> = rows.map(
+      (row: JSONObject): TraceAnalyticsTableRow => {
+        const groupValues: Record<string, string> = {};
 
-      for (const [index, key] of groupByKeys.entries()) {
-        const alias: string = TraceAggregationService.groupByAlias(key, index);
-        groupValues[key] = String(row[alias] ?? "");
-      }
+        for (const [index, key] of groupByKeys.entries()) {
+          const alias: string = TraceAggregationService.groupByAlias(
+            key,
+            index,
+          );
+          groupValues[key] = String(row[alias] ?? "");
+        }
 
-      return {
-        groupValues,
-        count: Number(row["cnt"] || 0),
-        errorCount: Number(row["err_cnt"] || 0),
-        avgDurationMs: Number(row["avg_ms"] || 0),
-        p50DurationMs: Number(row["p50_ms"] || 0),
-        p90DurationMs: Number(row["p90_ms"] || 0),
-        p95DurationMs: Number(row["p95_ms"] || 0),
-        p99DurationMs: Number(row["p99_ms"] || 0),
-        minDurationMs: Number(row["min_ms"] || 0),
-        maxDurationMs: Number(row["max_ms"] || 0),
-      };
-    });
+        return {
+          groupValues,
+          count: Number(row["cnt"] || 0),
+          errorCount: Number(row["err_cnt"] || 0),
+          avgDurationMs: Number(row["avg_ms"] || 0),
+          p50DurationMs: Number(row["p50_ms"] || 0),
+          p90DurationMs: Number(row["p90_ms"] || 0),
+          p95DurationMs: Number(row["p95_ms"] || 0),
+          p99DurationMs: Number(row["p99_ms"] || 0),
+          minDurationMs: Number(row["min_ms"] || 0),
+          maxDurationMs: Number(row["max_ms"] || 0),
+        };
+      },
+    );
+
+    return TraceAggregationService.applyResourceDisplayValues(
+      request.projectId,
+      groupByKeys,
+      tableRows,
+    );
   }
 
   /*

--- a/Common/Tests/Server/Services/TraceAnalyticsResourceDisplayNames.test.ts
+++ b/Common/Tests/Server/Services/TraceAnalyticsResourceDisplayNames.test.ts
@@ -1,0 +1,855 @@
+import TraceAggregationService, {
+  TraceAnalyticsRequest,
+  TraceAnalyticsTableRow,
+  TraceAnalyticsTimeseriesRow,
+  TraceAnalyticsTopItem,
+} from "../../../Server/Services/TraceAggregationService";
+import SpanService from "../../../Server/Services/SpanService";
+import ResourceFacetResolver, {
+  ResolvedFacetValue,
+  ResourceFacetSpec,
+} from "../../../Server/Utils/Telemetry/ResourceFacetResolver";
+import { Results } from "../../../Server/Services/AnalyticsDatabaseService";
+import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Resource group-by dimensions (rumApplicationId, hostId, ...) come out of
+ * ClickHouse as bare internal ObjectIDs, and nothing downstream of the trace
+ * analytics endpoints turns those into names — the raw id would otherwise land
+ * in a dashboard TraceChart legend or a TraceTable cell. getAnalyticsTimeseries
+ * and getAnalyticsTable therefore run their rows through
+ * ResourceFacetResolver before returning.
+ *
+ * getAnalyticsTopList deliberately does NOT: its values are fed straight back
+ * into the timeseries query as an `IN` filter and the AI latency detectors
+ * match on them, so a display name there would silently break both.
+ *
+ * WHICH keys get rewritten is NOT a single membership check — it is the
+ * INTERSECTION of two sets that genuinely differ, and both halves are pinned
+ * by tests below:
+ *
+ *   TraceAggregationService.RESOURCE_FACET_KEYS.has(key)
+ *     && ResourceFacetResolver.isResourceFacet(key)
+ *
+ * - `proxmoxClusterId` / `cephClusterId` are resource dimensions in the
+ *   aggregation service but have NO branch in ResourceFacetResolver.resolveOne
+ *   (it returns [] for them). They must not cost a resolve round-trip, and
+ *   their ids stay raw.
+ * - `primaryEntityId` / `serviceId` are resolvable by the resolver but are
+ *   deliberately not resource dimensions here — the traces explorer resolves
+ *   that service split client-side, so the server leaves them alone.
+ */
+
+const projectId: ObjectID = ObjectID.generate();
+const startTime: Date = new Date("2026-07-14T11:00:00.000Z");
+const endTime: Date = new Date("2026-07-14T12:00:00.000Z");
+
+const checkoutAppId: string = ObjectID.generate().toString();
+const marketingAppId: string = ObjectID.generate().toString();
+const deletedAppId: string = ObjectID.generate().toString();
+const hostId: string = ObjectID.generate().toString();
+const proxmoxClusterId: string = ObjectID.generate().toString();
+const cephClusterId: string = ObjectID.generate().toString();
+const serviceEntityId: string = ObjectID.generate().toString();
+/*
+ * Every resource dimension reads out of the SAME primaryEntityId column, so
+ * one raw id can legitimately arrive under two different resource keys in one
+ * result set — and must resolve independently under each.
+ */
+const sharedEntityId: string = ObjectID.generate().toString();
+
+const analyticsRequest: (
+  overrides: Partial<TraceAnalyticsRequest>,
+) => TraceAnalyticsRequest = (
+  overrides: Partial<TraceAnalyticsRequest>,
+): TraceAnalyticsRequest => {
+  return {
+    projectId,
+    startTime,
+    endTime,
+    bucketSizeInMinutes: 5,
+    chartType: "timeseries",
+    metric: "count",
+    ...overrides,
+  };
+};
+
+/*
+ * getAnalyticsTimeseries issues TWO ClickHouse queries when a groupBy is
+ * present — the top-list pre-pass that caps the series count, then the
+ * timeseries itself. Dispatch on the SELECT alias so each gets its own rows.
+ *
+ * BRITTLE SEAM — deliberately coupled to two private implementation details,
+ * because there is no public seam that separates the two queries:
+ *
+ * 1. The dispatch sniffs the SQL text for `" AS dim,"`, which is the top-list
+ *    SELECT alias in buildAnalyticsTopListStatement. A behaviour-preserving
+ *    rename of that alias (or dropping the trailing comma by reordering the
+ *    SELECT list) makes `isTopList` false for BOTH queries, so the stub serves
+ *    `main` rows to the top-list pre-pass too. Symptom: series-cap assertions
+ *    start seeing bucket rows, and `dim` reads as "" so the cap silently
+ *    disappears — tests fail confusingly rather than at the rename.
+ * 2. The raw row keys below hardcode TraceAggregationService's private
+ *    `groupByAlias` scheme: resource + top-level keys alias to themselves,
+ *    every other (attribute) key aliases to `attr_<groupBy index>_<key with
+ *    non-alphanumerics replaced by _>`. Change that scheme — or reorder a
+ *    groupBy so an attribute key lands on a different index — and the row
+ *    lookup misses, yielding "" group values instead of the fixture data.
+ *
+ * If either changes, update the fixtures here; do not relax the assertions.
+ */
+const stubQuery: (rows: {
+  main?: Array<JSONObject> | undefined;
+  topList?: Array<JSONObject> | undefined;
+}) => jest.SpyInstance = (rows: {
+  main?: Array<JSONObject> | undefined;
+  topList?: Array<JSONObject> | undefined;
+}): jest.SpyInstance => {
+  return jest.spyOn(SpanService, "executeQuery").mockImplementation(((
+    statement: Statement,
+  ): Promise<Results> => {
+    const isTopList: boolean = statement.query.includes(" AS dim,");
+    const data: Array<JSONObject> =
+      (isTopList ? rows.topList : rows.main) || [];
+
+    const fakeResult: Results = {
+      json: (): Promise<unknown> => {
+        return Promise.resolve({
+          data: data,
+          statistics: { elapsed: 0.004, rows_read: 10, bytes_read: 100 },
+        });
+      },
+    } as unknown as Results;
+
+    return Promise.resolve(fakeResult);
+  }) as never);
+};
+
+const stubResolver: (
+  resolved: Record<string, Array<ResolvedFacetValue>>,
+) => jest.SpyInstance = (
+  resolved: Record<string, Array<ResolvedFacetValue>>,
+): jest.SpyInstance => {
+  return jest
+    .spyOn(ResourceFacetResolver, "resolve")
+    .mockResolvedValue(resolved as never);
+};
+
+const failingResolver: () => jest.SpyInstance = (): jest.SpyInstance => {
+  return jest
+    .spyOn(ResourceFacetResolver, "resolve")
+    .mockRejectedValue(new Error("postgres unavailable") as never);
+};
+
+const valuesFor: (
+  rows: Array<{ groupValues: Record<string, string> }>,
+  key: string,
+) => Array<string> = (
+  rows: Array<{ groupValues: Record<string, string> }>,
+  key: string,
+): Array<string> => {
+  return rows.map((row: { groupValues: Record<string, string> }): string => {
+    return row.groupValues[key] ?? "<missing>";
+  });
+};
+
+const specsPassedTo: (spy: jest.SpyInstance) => Array<ResourceFacetSpec> = (
+  spy: jest.SpyInstance,
+): Array<ResourceFacetSpec> => {
+  return spy.mock.calls[0]![1] as Array<ResourceFacetSpec>;
+};
+
+describe("TraceAggregationService.getAnalyticsTimeseries (resource display names)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("rewrites a rumApplicationId group-by from raw ObjectIDs to display names", async () => {
+    stubQuery({
+      topList: [{ dim: checkoutAppId, val: "12", cnt: "12" }],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+        {
+          bucket: "2026-07-14 11:05:00",
+          val: "7",
+          rumApplicationId: checkoutAppId,
+        },
+      ],
+    });
+    stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 2, displayName: "Checkout Web" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([
+      "Checkout Web",
+      "Checkout Web",
+    ]);
+    // The metric payload must survive the rewrite untouched.
+    expect(
+      rows.map((row: TraceAnalyticsTimeseriesRow): number => {
+        return row.value;
+      }),
+    ).toEqual([12, 7]);
+  });
+
+  test("maps each distinct id in one result set to its own display name", async () => {
+    stubQuery({
+      topList: [
+        { dim: checkoutAppId, val: "12", cnt: "12" },
+        { dim: marketingAppId, val: "5", cnt: "5" },
+      ],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "5",
+          rumApplicationId: marketingAppId,
+        },
+      ],
+    });
+    stubResolver({
+      rumApplicationId: [
+        { value: marketingAppId, count: 1, displayName: "Marketing Site" },
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([
+      "Checkout Web",
+      "Marketing Site",
+    ]);
+  });
+
+  test("an id the resolver does not return keeps its RAW value", async () => {
+    stubQuery({
+      topList: [
+        { dim: checkoutAppId, val: "12", cnt: "12" },
+        { dim: deletedAppId, val: "3", cnt: "3" },
+      ],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "3",
+          rumApplicationId: deletedAppId,
+        },
+      ],
+    });
+    // Deleted app / past the resolver's page size — absent from the response.
+    stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toHaveLength(2);
+    // The row must not vanish and must not blank — it falls back to the id.
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([
+      "Checkout Web",
+      deletedAppId,
+    ]);
+  });
+
+  test("an empty display name does not blank out the row", async () => {
+    stubQuery({
+      topList: [{ dim: checkoutAppId, val: "12", cnt: "12" }],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+      ],
+    });
+    stubResolver({
+      rumApplicationId: [{ value: checkoutAppId, count: 1, displayName: "" }],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([checkoutAppId]);
+  });
+
+  test("a row whose group value is the empty string survives and is not asked about", async () => {
+    /*
+     * A span with no primaryEntityId makes toString(primaryEntityId) "" for
+     * the dimension. getAnalyticsTimeseries charts those as one "(empty)"
+     * series on purpose, so the row must not be dropped or blanked — and the
+     * two `if (raw)` guards in applyResourceDisplayValues must keep "" out of
+     * the spec counts (asking Postgres for the empty id is pure waste).
+     */
+    stubQuery({
+      topList: [{ dim: checkoutAppId, val: "12", cnt: "12" }],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+        { bucket: "2026-07-14 11:00:00", val: "4", rumApplicationId: "" },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+        // A stray "" mapping must not be applied either.
+        { value: "", count: 1, displayName: "SHOULD NOT APPEAR" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual(["Checkout Web", ""]);
+    expect(
+      rows.map((row: TraceAnalyticsTimeseriesRow): number => {
+        return row.value;
+      }),
+    ).toEqual([12, 4]);
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+
+    const specs: Array<ResourceFacetSpec> = specsPassedTo(resolveSpy);
+    expect(specs).toHaveLength(1);
+
+    const counts: Record<string, number> = Object.fromEntries(
+      specs[0]!.counts.entries(),
+    );
+    expect(counts).toEqual({ [checkoutAppId]: 1 });
+    expect(specs[0]!.counts.has("")).toBe(false);
+  });
+
+  test("a non-resource group-by is passed through untouched and never hits the resolver", async () => {
+    stubQuery({
+      topList: [{ dim: "GET /checkout", val: "12", cnt: "12" }],
+      main: [
+        { bucket: "2026-07-14 11:00:00", val: "12", name: "GET /checkout" },
+        { bucket: "2026-07-14 11:05:00", val: "4", name: "GET /cart" },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      name: [{ value: "GET /checkout", count: 1, displayName: "NOPE" }],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["name"] }),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(valuesFor(rows, "name")).toEqual(["GET /checkout", "GET /cart"]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("a query with no groupBy does not call the resolver", async () => {
+    stubQuery({
+      main: [
+        { bucket: "2026-07-14 11:00:00", val: "12" },
+        { bucket: "2026-07-14 11:05:00", val: "9" },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({});
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({}),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(
+      rows.map((row: TraceAnalyticsTimeseriesRow): number => {
+        return row.value;
+      }),
+    ).toEqual([12, 9]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("zero rows does not call the resolver", async () => {
+    stubQuery({ topList: [], main: [] });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toEqual([]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("asks the resolver for one spec per resource key, counting exactly the distinct raw ids present", async () => {
+    stubQuery({
+      topList: [
+        { dim: checkoutAppId, val: "12", cnt: "12" },
+        { dim: marketingAppId, val: "5", cnt: "5" },
+      ],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+        {
+          bucket: "2026-07-14 11:05:00",
+          val: "8",
+          rumApplicationId: checkoutAppId,
+        },
+        {
+          bucket: "2026-07-14 11:05:00",
+          val: "5",
+          rumApplicationId: marketingAppId,
+        },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({ rumApplicationId: [] });
+
+    await TraceAggregationService.getAnalyticsTimeseries(
+      analyticsRequest({ groupBy: ["rumApplicationId"] }),
+    );
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+
+    const resolvedProjectId: ObjectID = resolveSpy.mock
+      .calls[0]![0] as ObjectID;
+    expect(resolvedProjectId.toString()).toBe(projectId.toString());
+
+    const specs: Array<ResourceFacetSpec> = specsPassedTo(resolveSpy);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.facetKey).toBe("rumApplicationId");
+
+    const counts: Record<string, number> = Object.fromEntries(
+      specs[0]!.counts.entries(),
+    );
+    expect(counts).toEqual({
+      [checkoutAppId]: 2,
+      [marketingAppId]: 1,
+    });
+  });
+
+  test("a resolver failure returns raw ids instead of failing the whole query", async () => {
+    stubQuery({
+      topList: [{ dim: checkoutAppId, val: "12", cnt: "12" }],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = failingResolver();
+
+    const rows: Array<TraceAnalyticsTimeseriesRow> =
+      await TraceAggregationService.getAnalyticsTimeseries(
+        analyticsRequest({ groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([checkoutAppId]);
+  });
+});
+
+describe("TraceAggregationService.getAnalyticsTable (resource display names)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("rewrites a rumApplicationId group-by from raw ObjectIDs to display names", async () => {
+    stubQuery({
+      main: [
+        { rumApplicationId: checkoutAppId, cnt: "120", p95_ms: "410" },
+        { rumApplicationId: marketingAppId, cnt: "40", p95_ms: "180" },
+      ],
+    });
+    stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+        { value: marketingAppId, count: 1, displayName: "Marketing Site" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({ chartType: "table", groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([
+      "Checkout Web",
+      "Marketing Site",
+    ]);
+    // The stat columns must be untouched by the rewrite.
+    expect(
+      rows.map((row: TraceAnalyticsTableRow): number => {
+        return row.count;
+      }),
+    ).toEqual([120, 40]);
+  });
+
+  test("resolves a non-RUM resource key (hostId) the same way", async () => {
+    stubQuery({ main: [{ hostId: hostId, cnt: "9" }] });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      hostId: [{ value: hostId, count: 1, displayName: "prod-web-01" }],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({ chartType: "table", groupBy: ["hostId"] }),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "hostId")).toEqual(["prod-web-01"]);
+
+    // One batched resolve for the whole group-by, not one call per key.
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+
+    const specs: Array<ResourceFacetSpec> = specsPassedTo(resolveSpy);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.facetKey).toBe("hostId");
+  });
+
+  test("a group-by with TWO resource dimensions resolves each key independently", async () => {
+    /*
+     * Both dimensions read out of primaryEntityId, so the SAME raw id shows up
+     * under both keys — and each key must be resolved against its OWN spec.
+     * One spec per resource key, no cross-key leakage of display names.
+     */
+    stubQuery({
+      main: [
+        {
+          rumApplicationId: sharedEntityId,
+          hostId: sharedEntityId,
+          cnt: "30",
+        },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      rumApplicationId: [
+        { value: sharedEntityId, count: 1, displayName: "Checkout Web" },
+      ],
+      hostId: [{ value: sharedEntityId, count: 1, displayName: "prod-web-01" }],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({
+          chartType: "table",
+          groupBy: ["rumApplicationId", "hostId"],
+        }),
+      );
+
+    expect(rows).toHaveLength(1);
+    // Same raw id in, two DIFFERENT names out — neither key wins both cells.
+    expect(valuesFor(rows, "rumApplicationId")).toEqual(["Checkout Web"]);
+    expect(valuesFor(rows, "hostId")).toEqual(["prod-web-01"]);
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+
+    // Every resource dimension is asked about, not just the first one.
+    const specs: Array<ResourceFacetSpec> = specsPassedTo(resolveSpy);
+    expect(specs).toHaveLength(2);
+    expect(
+      specs.map((spec: ResourceFacetSpec): string => {
+        return spec.facetKey;
+      }),
+    ).toEqual(["rumApplicationId", "hostId"]);
+
+    const secondCounts: Record<string, number> = Object.fromEntries(
+      specs[1]!.counts.entries(),
+    );
+    expect(secondCounts).toEqual({ [sharedEntityId]: 1 });
+  });
+
+  test("proxmoxClusterId / cephClusterId are resource dimensions the resolver cannot resolve — no round-trip, ids stay raw", async () => {
+    /*
+     * Both keys live in TraceAggregationService.RESOURCE_FACET_KEYS but have
+     * no branch in ResourceFacetResolver.resolveOne (it returns [] for them),
+     * so asking would burn a Postgres round-trip and still leave the cell raw.
+     * applyResourceDisplayValues takes the INTERSECTION of the two sets, so
+     * the resolver must not be touched at all.
+     */
+    stubQuery({
+      main: [
+        {
+          proxmoxClusterId: proxmoxClusterId,
+          cephClusterId: cephClusterId,
+          cnt: "4",
+        },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      proxmoxClusterId: [
+        { value: proxmoxClusterId, count: 1, displayName: "NOPE" },
+      ],
+      cephClusterId: [{ value: cephClusterId, count: 1, displayName: "NOPE" }],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({
+          chartType: "table",
+          groupBy: ["proxmoxClusterId", "cephClusterId"],
+        }),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "proxmoxClusterId")).toEqual([proxmoxClusterId]);
+    expect(valuesFor(rows, "cephClusterId")).toEqual([cephClusterId]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("primaryEntityId / serviceId are resolvable but are NOT resource dimensions here — left alone", async () => {
+    /*
+     * The other half of the intersection: the resolver knows both keys, but
+     * they select the OpenTelemetry-service slot, which the traces explorer
+     * already renames client-side. Rewriting them server-side would change an
+     * existing surface, so neither is resolved.
+     */
+    stubQuery({
+      main: [
+        {
+          primaryEntityId: serviceEntityId,
+          attr_1_serviceId: serviceEntityId,
+          cnt: "7",
+        },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      primaryEntityId: [
+        { value: serviceEntityId, count: 1, displayName: "NOPE" },
+      ],
+      serviceId: [{ value: serviceEntityId, count: 1, displayName: "NOPE" }],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({
+          chartType: "table",
+          groupBy: ["primaryEntityId", "serviceId"],
+        }),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "primaryEntityId")).toEqual([serviceEntityId]);
+    expect(valuesFor(rows, "serviceId")).toEqual([serviceEntityId]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("an attribute group-by (resource.browser.platform) is passed through and never hits the resolver", async () => {
+    stubQuery({
+      main: [
+        { attr_0_resource_browser_platform: "macOS", cnt: "90" },
+        { attr_0_resource_browser_platform: "Windows", cnt: "60" },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({});
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({
+          chartType: "table",
+          groupBy: ["resource.browser.platform"],
+        }),
+      );
+
+    expect(rows).toHaveLength(2);
+    expect(valuesFor(rows, "resource.browser.platform")).toEqual([
+      "macOS",
+      "Windows",
+    ]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("in a mixed group-by only the resource dimension is rewritten", async () => {
+    stubQuery({
+      main: [
+        {
+          rumApplicationId: checkoutAppId,
+          attr_1_app_route: "/checkout/payment",
+          cnt: "30",
+        },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({
+          chartType: "table",
+          groupBy: ["rumApplicationId", "app.route"],
+        }),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual(["Checkout Web"]);
+    expect(valuesFor(rows, "app.route")).toEqual(["/checkout/payment"]);
+
+    // One batched resolve for the whole group-by, not one call per key.
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+
+    // No spec is requested for the attribute dimension.
+    const specs: Array<ResourceFacetSpec> = specsPassedTo(resolveSpy);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]!.facetKey).toBe("rumApplicationId");
+  });
+
+  test("zero rows does not call the resolver", async () => {
+    stubQuery({ main: [] });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+      ],
+    });
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({ chartType: "table", groupBy: ["rumApplicationId"] }),
+      );
+
+    expect(rows).toEqual([]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("a resolver failure returns raw ids instead of failing the whole query", async () => {
+    stubQuery({ main: [{ rumApplicationId: checkoutAppId, cnt: "120" }] });
+    const resolveSpy: jest.SpyInstance = failingResolver();
+
+    const rows: Array<TraceAnalyticsTableRow> =
+      await TraceAggregationService.getAnalyticsTable(
+        analyticsRequest({ chartType: "table", groupBy: ["rumApplicationId"] }),
+      );
+
+    // Without this the test also passes if the table path never resolves at all.
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(rows).toHaveLength(1);
+    expect(valuesFor(rows, "rumApplicationId")).toEqual([checkoutAppId]);
+  });
+});
+
+/*
+ * The top list is the odd one out ON PURPOSE. getAnalyticsTimeseries feeds
+ * these values back into its own query as an `IN (...)` predicate against
+ * toString(primaryEntityId), and the AI latency detectors key off them. A
+ * display name here would match zero spans and silently empty the chart.
+ */
+describe("TraceAggregationService.getAnalyticsTopList (raw ids preserved)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("does NOT resolve display names for a rumApplicationId group-by", async () => {
+    stubQuery({
+      topList: [
+        { dim: checkoutAppId, val: "12", cnt: "12" },
+        { dim: marketingAppId, val: "5", cnt: "5" },
+      ],
+    });
+    const resolveSpy: jest.SpyInstance = stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 12, displayName: "Checkout Web" },
+        { value: marketingAppId, count: 5, displayName: "Marketing Site" },
+      ],
+    });
+
+    const items: Array<TraceAnalyticsTopItem> =
+      await TraceAggregationService.getAnalyticsTopList(
+        analyticsRequest({
+          chartType: "toplist",
+          groupBy: ["rumApplicationId"],
+        }),
+      );
+
+    expect(items).toHaveLength(2);
+    expect(
+      items.map((item: TraceAnalyticsTopItem): string => {
+        return item.value;
+      }),
+    ).toEqual([checkoutAppId, marketingAppId]);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  test("the series cap the timeseries applies is built from raw ids, not display names", async () => {
+    const querySpy: jest.SpyInstance = stubQuery({
+      topList: [{ dim: checkoutAppId, val: "12", cnt: "12" }],
+      main: [
+        {
+          bucket: "2026-07-14 11:00:00",
+          val: "12",
+          rumApplicationId: checkoutAppId,
+        },
+      ],
+    });
+    stubResolver({
+      rumApplicationId: [
+        { value: checkoutAppId, count: 1, displayName: "Checkout Web" },
+      ],
+    });
+
+    await TraceAggregationService.getAnalyticsTimeseries(
+      analyticsRequest({ groupBy: ["rumApplicationId"] }),
+    );
+
+    expect(querySpy).toHaveBeenCalledTimes(2);
+
+    const timeseriesStatement: Statement = querySpy.mock
+      .calls[1]![0] as Statement;
+    // The `IN (...)` value binds as an array param — flatten before matching.
+    const params: Array<unknown> = Object.values(
+      timeseriesStatement.query_params,
+    ).flat();
+
+    // The IN filter carries the raw id; a display name would match no spans.
+    expect(params).toContain(checkoutAppId);
+    expect(params).not.toContain("Checkout Web");
+  });
+});

--- a/Common/Tests/Types/Dashboard/DashboardTemplateInvariants.test.ts
+++ b/Common/Tests/Types/Dashboard/DashboardTemplateInvariants.test.ts
@@ -1,0 +1,811 @@
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import {
+  DashboardTemplate,
+  DashboardTemplateCategories,
+  DashboardTemplateCategory,
+  DashboardTemplates,
+  DashboardTemplateType,
+  getDashboardTemplatesByCategory,
+  getTemplateConfig,
+} from "../../../Types/Dashboard/DashboardTemplates";
+
+/*
+ * Structural invariants that must hold for EVERY dashboard template,
+ * present and future. Nothing here encodes the editorial content of any
+ * one template — these are the rules the renderer, the "Create from
+ * Template" modal and the metric fetch layer silently depend on. A new
+ * template that breaks one of them ships a dashboard that overlaps
+ * itself, renders off-grid, or queries nothing.
+ */
+
+// The grid the dashboard renderer lays out against (DashboardSize.widthInDashboardUnits).
+const GRID_WIDTH_IN_UNITS: number = 12;
+
+/*
+ * Blank is the "start from scratch" entry: it has a catalog card so it
+ * shows up in the modal, but deliberately resolves to no config.
+ */
+const TEMPLATE_TYPES_WITH_CONFIG: Array<DashboardTemplateType> = Object.values(
+  DashboardTemplateType,
+).filter((type: DashboardTemplateType): boolean => {
+  return type !== DashboardTemplateType.Blank;
+});
+
+interface LoadedTemplate {
+  type: DashboardTemplateType;
+  config: DashboardViewConfig;
+}
+
+function loadAllTemplates(): Array<LoadedTemplate> {
+  return TEMPLATE_TYPES_WITH_CONFIG.map(
+    (type: DashboardTemplateType): LoadedTemplate => {
+      const config: DashboardViewConfig | null = getTemplateConfig(type);
+
+      if (!config) {
+        throw new Error(`Expected ${type} to resolve to a config`);
+      }
+
+      return { type: type, config: config };
+    },
+  );
+}
+
+function getArguments(
+  component: DashboardBaseComponent,
+): Record<string, unknown> {
+  return (component.arguments as Record<string, unknown>) || {};
+}
+
+/*
+ * Widgets keep their human label under different argument keys depending
+ * on the component type. Tests report failures by label, never by index.
+ */
+function describeComponent(component: DashboardBaseComponent): string {
+  const args: Record<string, unknown> = getArguments(component);
+  const label: unknown =
+    args["title"] ??
+    args["chartTitle"] ??
+    args["gaugeTitle"] ??
+    args["tableTitle"] ??
+    args["text"];
+
+  return `${component.componentType} "${String(label ?? "<untitled>")}"`;
+}
+
+/*
+ * The filterData block that actually reaches the metric fetch layer.
+ * Returns undefined for widgets that do not query metrics at all (text,
+ * log streams, trace widgets, entity lists).
+ */
+function getMetricFilterData(
+  component: DashboardBaseComponent,
+): Record<string, unknown> | undefined {
+  const queryConfig: Record<string, unknown> | undefined = getArguments(
+    component,
+  )["metricQueryConfig"] as Record<string, unknown> | undefined;
+
+  if (!queryConfig) {
+    return undefined;
+  }
+
+  const queryData: Record<string, unknown> | undefined = queryConfig[
+    "metricQueryData"
+  ] as Record<string, unknown> | undefined;
+
+  return queryData?.["filterData"] as Record<string, unknown> | undefined;
+}
+
+interface MetricWidget {
+  type: DashboardTemplateType;
+  component: DashboardBaseComponent;
+  filterData: Record<string, unknown>;
+}
+
+function collectMetricWidgets(): Array<MetricWidget> {
+  const widgets: Array<MetricWidget> = [];
+
+  for (const loaded of loadAllTemplates()) {
+    for (const component of loaded.config.components) {
+      const filterData: Record<string, unknown> | undefined =
+        getMetricFilterData(component);
+
+      if (filterData) {
+        widgets.push({
+          type: loaded.type,
+          component: component,
+          filterData: filterData,
+        });
+      }
+    }
+  }
+
+  return widgets;
+}
+
+interface TemplateComponent {
+  type: DashboardTemplateType;
+  component: DashboardBaseComponent;
+}
+
+/*
+ * Widgets that carry no `metricQueryConfig` — trace charts, trace tables,
+ * text headers — are invisible to collectMetricWidgets(), so they need
+ * their own collector or their arguments go unchecked entirely.
+ */
+function collectComponentsByType(
+  componentTypes: Array<DashboardComponentType>,
+): Array<TemplateComponent> {
+  const collected: Array<TemplateComponent> = [];
+
+  for (const loaded of loadAllTemplates()) {
+    for (const component of loaded.config.components) {
+      if (componentTypes.includes(component.componentType)) {
+        collected.push({ type: loaded.type, component: component });
+      }
+    }
+  }
+
+  return collected;
+}
+
+function describeTemplateComponent(entry: TemplateComponent): string {
+  return `${entry.type} ${describeComponent(entry.component)}`;
+}
+
+describe("DashboardTemplates invariants (all templates)", () => {
+  describe("catalog", () => {
+    test("every template type except Blank resolves to a config with at least one component", (): void => {
+      expect(TEMPLATE_TYPES_WITH_CONFIG.length).toBeGreaterThan(0);
+
+      for (const type of TEMPLATE_TYPES_WITH_CONFIG) {
+        const config: DashboardViewConfig | null = getTemplateConfig(type);
+
+        expect(config).not.toBeNull();
+        expect(
+          (config as DashboardViewConfig).components.length,
+        ).toBeGreaterThan(0);
+      }
+    });
+
+    test("Blank resolves to null so the user starts from an empty canvas", (): void => {
+      expect(getTemplateConfig(DashboardTemplateType.Blank)).toBeNull();
+    });
+
+    test("every enum member has exactly one catalog entry", (): void => {
+      const enumMembers: Array<DashboardTemplateType> = Object.values(
+        DashboardTemplateType,
+      );
+
+      expect(enumMembers.length).toBeGreaterThan(0);
+
+      for (const type of enumMembers) {
+        const entries: Array<DashboardTemplate> = DashboardTemplates.filter(
+          (template: DashboardTemplate): boolean => {
+            return template.type === type;
+          },
+        );
+
+        expect(`${type}: ${entries.length} catalog entries`).toBe(
+          `${type}: 1 catalog entries`,
+        );
+      }
+    });
+
+    test("catalog names and types are unique, and names are non-empty", (): void => {
+      expect(DashboardTemplates.length).toBeGreaterThan(0);
+
+      const names: Array<string> = DashboardTemplates.map(
+        (template: DashboardTemplate): string => {
+          return template.name;
+        },
+      );
+      const types: Array<DashboardTemplateType> = DashboardTemplates.map(
+        (template: DashboardTemplate): DashboardTemplateType => {
+          return template.type;
+        },
+      );
+
+      for (const name of names) {
+        expect(name.trim().length).toBeGreaterThan(0);
+      }
+
+      expect(Array.from(new Set(names)).sort()).toEqual(names.slice().sort());
+      expect(Array.from(new Set(types)).sort()).toEqual(types.slice().sort());
+    });
+
+    test("every template's category is one of the ordered display categories", (): void => {
+      expect(DashboardTemplates.length).toBeGreaterThan(0);
+
+      for (const template of DashboardTemplates) {
+        expect(DashboardTemplateCategories).toContain(template.category);
+      }
+    });
+
+    test("getDashboardTemplatesByCategory partitions the catalog exactly", (): void => {
+      expect(DashboardTemplateCategories.length).toBeGreaterThan(0);
+
+      const seen: Array<DashboardTemplateType> = [];
+
+      for (const category of DashboardTemplateCategories) {
+        const templates: Array<DashboardTemplate> =
+          getDashboardTemplatesByCategory(category);
+
+        for (const template of templates) {
+          expect(template.category).toBe(category);
+          seen.push(template.type);
+        }
+      }
+
+      // Union covers the catalog: nothing dropped, nothing counted twice.
+      expect(seen.length).toBe(DashboardTemplates.length);
+      expect(seen.slice().sort()).toEqual(
+        DashboardTemplates.map(
+          (template: DashboardTemplate): DashboardTemplateType => {
+            return template.type;
+          },
+        ).sort(),
+      );
+    });
+
+    /*
+     * A category nothing matches must return NOTHING, not fall back to the
+     * whole catalog. Asserted against a category that is empty by
+     * construction: filtering the live categories for empty ones and then
+     * asserting they are empty is a tautology that passes vacuously today
+     * (every declared category is populated) and stays green even if the
+     * lookup grows a "no matches -> return everything" fallback.
+     */
+    test("a category no template uses yields an empty list, not the whole catalog", (): void => {
+      expect(DashboardTemplates.length).toBeGreaterThan(0);
+
+      const neverUsedCategory: DashboardTemplateCategory =
+        "Nonexistent Category" as DashboardTemplateCategory;
+
+      expect(getDashboardTemplatesByCategory(neverUsedCategory)).toEqual([]);
+
+      // Every declared category still has to contribute at least one card.
+      const usedCategories: Array<DashboardTemplateCategory> =
+        DashboardTemplateCategories.filter(
+          (category: DashboardTemplateCategory): boolean => {
+            return getDashboardTemplatesByCategory(category).length > 0;
+          },
+        );
+
+      expect(usedCategories.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("layout", () => {
+    test("no component is placed outside the 12-unit grid", (): void => {
+      const loadedTemplates: Array<LoadedTemplate> = loadAllTemplates();
+
+      expect(loadedTemplates.length).toBeGreaterThan(0);
+
+      for (const loaded of loadedTemplates) {
+        expect(loaded.config.components.length).toBeGreaterThan(0);
+
+        for (const component of loaded.config.components) {
+          const label: string = `${loaded.type} ${describeComponent(component)}`;
+
+          expect(`${label} left=${component.leftInDashboardUnits}`).toBe(
+            `${label} left=${Math.max(component.leftInDashboardUnits, 0)}`,
+          );
+          expect(`${label} top=${component.topInDashboardUnits}`).toBe(
+            `${label} top=${Math.max(component.topInDashboardUnits, 0)}`,
+          );
+          expect(
+            `${label} width=${component.widthInDashboardUnits} positive=${component.widthInDashboardUnits > 0}`,
+          ).toBe(
+            `${label} width=${component.widthInDashboardUnits} positive=true`,
+          );
+          expect(
+            `${label} height=${component.heightInDashboardUnits} positive=${component.heightInDashboardUnits > 0}`,
+          ).toBe(
+            `${label} height=${component.heightInDashboardUnits} positive=true`,
+          );
+
+          const rightEdge: number =
+            component.leftInDashboardUnits + component.widthInDashboardUnits;
+
+          expect(`${label} rightEdge=${rightEdge}`).toBe(
+            `${label} rightEdge=${Math.min(rightEdge, GRID_WIDTH_IN_UNITS)}`,
+          );
+        }
+      }
+    });
+
+    test("no two components in a template overlap", (): void => {
+      const loadedTemplates: Array<LoadedTemplate> = loadAllTemplates();
+
+      expect(loadedTemplates.length).toBeGreaterThan(0);
+
+      for (const loaded of loadedTemplates) {
+        const components: Array<DashboardBaseComponent> =
+          loaded.config.components;
+
+        expect(components.length).toBeGreaterThan(0);
+
+        const occupiedCellToLabel: Map<string, string> = new Map<
+          string,
+          string
+        >();
+        const collisions: Array<string> = [];
+
+        for (const component of components) {
+          const label: string = describeComponent(component);
+
+          for (
+            let row: number = component.topInDashboardUnits;
+            row <
+            component.topInDashboardUnits + component.heightInDashboardUnits;
+            row++
+          ) {
+            for (
+              let column: number = component.leftInDashboardUnits;
+              column <
+              component.leftInDashboardUnits + component.widthInDashboardUnits;
+              column++
+            ) {
+              const cell: string = `${row}:${column}`;
+              const existing: string | undefined =
+                occupiedCellToLabel.get(cell);
+
+              if (existing) {
+                collisions.push(
+                  `${loaded.type} cell ${cell} shared by ${existing} and ${label}`,
+                );
+              }
+
+              occupiedCellToLabel.set(cell, label);
+            }
+          }
+        }
+
+        expect(collisions).toEqual([]);
+      }
+    });
+
+    test("every template is tall enough to contain its lowest component", (): void => {
+      const loadedTemplates: Array<LoadedTemplate> = loadAllTemplates();
+
+      expect(loadedTemplates.length).toBeGreaterThan(0);
+
+      for (const loaded of loadedTemplates) {
+        expect(loaded.config.components.length).toBeGreaterThan(0);
+
+        const lowestOccupiedEdge: number = Math.max(
+          ...loaded.config.components.map(
+            (component: DashboardBaseComponent): number => {
+              return (
+                component.topInDashboardUnits + component.heightInDashboardUnits
+              );
+            },
+          ),
+        );
+
+        expect(
+          `${loaded.type} height=${loaded.config.heightInDashboardUnits} lowest=${lowestOccupiedEdge}`,
+        ).toBe(
+          `${loaded.type} height=${Math.max(
+            loaded.config.heightInDashboardUnits,
+            lowestOccupiedEdge,
+          )} lowest=${lowestOccupiedEdge}`,
+        );
+      }
+    });
+
+    test("no component is rendered smaller than the minimum size it declares", (): void => {
+      const loadedTemplates: Array<LoadedTemplate> = loadAllTemplates();
+
+      expect(loadedTemplates.length).toBeGreaterThan(0);
+
+      for (const loaded of loadedTemplates) {
+        expect(loaded.config.components.length).toBeGreaterThan(0);
+
+        for (const component of loaded.config.components) {
+          const label: string = `${loaded.type} ${describeComponent(component)}`;
+
+          expect(
+            `${label} w=${component.widthInDashboardUnits} minW=${component.minWidthInDashboardUnits}`,
+          ).toBe(
+            `${label} w=${Math.max(
+              component.widthInDashboardUnits,
+              component.minWidthInDashboardUnits,
+            )} minW=${component.minWidthInDashboardUnits}`,
+          );
+
+          expect(
+            `${label} h=${component.heightInDashboardUnits} minH=${component.minHeightInDashboardUnits}`,
+          ).toBe(
+            `${label} h=${Math.max(
+              component.heightInDashboardUnits,
+              component.minHeightInDashboardUnits,
+            )} minH=${component.minHeightInDashboardUnits}`,
+          );
+        }
+      }
+    });
+  });
+
+  describe("component identity", () => {
+    test("component ids are unique within a single config", (): void => {
+      const loadedTemplates: Array<LoadedTemplate> = loadAllTemplates();
+
+      expect(loadedTemplates.length).toBeGreaterThan(0);
+
+      for (const loaded of loadedTemplates) {
+        const ids: Array<string> = loaded.config.components.map(
+          (component: DashboardBaseComponent): string => {
+            return component.componentId.toString();
+          },
+        );
+
+        expect(ids.length).toBeGreaterThan(0);
+        expect(`${loaded.type}: ${new Set(ids).size}`).toBe(
+          `${loaded.type}: ${ids.length}`,
+        );
+      }
+    });
+
+    test("two calls for the same template share no component ids", (): void => {
+      expect(TEMPLATE_TYPES_WITH_CONFIG.length).toBeGreaterThan(0);
+
+      for (const type of TEMPLATE_TYPES_WITH_CONFIG) {
+        const first: DashboardViewConfig = getTemplateConfig(
+          type,
+        ) as DashboardViewConfig;
+        const second: DashboardViewConfig = getTemplateConfig(
+          type,
+        ) as DashboardViewConfig;
+
+        expect(first.components.length).toBeGreaterThan(0);
+        expect(second.components.length).toBe(first.components.length);
+
+        const firstIds: Set<string> = new Set<string>(
+          first.components.map((component: DashboardBaseComponent): string => {
+            return component.componentId.toString();
+          }),
+        );
+        const shared: Array<string> = second.components
+          .map((component: DashboardBaseComponent): string => {
+            return component.componentId.toString();
+          })
+          .filter((id: string): boolean => {
+            return firstIds.has(id);
+          });
+
+        expect(`${type}: ${shared.length} shared ids`).toBe(
+          `${type}: 0 shared ids`,
+        );
+      }
+    });
+  });
+
+  describe("metric queries", () => {
+    /*
+     * The fetch layer reads the MISSPELLED `aggegationType`. A template
+     * that "fixes" the spelling compiles fine and renders an empty
+     * widget, so pin the misspelling in both directions.
+     */
+    test("every metric-bearing widget stores its aggregation under aggegationType", (): void => {
+      const widgets: Array<MetricWidget> = collectMetricWidgets();
+
+      expect(widgets.length).toBeGreaterThan(0);
+
+      /*
+       * An empty or unrecognised value breaks the fetch layer exactly as a
+       * missing key does, and both are type-legal, so pin the value against
+       * the real AggregationType members rather than only checking the key
+       * is present. Mutation testing showed `aggegationType: ""` and
+       * `"Avgerage"` both survived a typeof-string check.
+       */
+      const validAggregations: Array<string> = Object.values(AggregationType);
+
+      for (const widget of widgets) {
+        const label: string = `${widget.type} ${describeComponent(widget.component)}`;
+        const aggregation: unknown = widget.filterData["aggegationType"];
+
+        expect(`${label} aggegationType=${String(aggregation)}`).not.toBe(
+          `${label} aggegationType=undefined`,
+        );
+        expect(typeof aggregation).toBe("string");
+        expect(`${label} aggegationType=${String(aggregation)}`).toBe(
+          `${label} aggegationType=${
+            validAggregations.includes(String(aggregation))
+              ? String(aggregation)
+              : "<not an AggregationType>"
+          }`,
+        );
+      }
+    });
+
+    test("no metric-bearing widget uses the correctly spelled aggregationType", (): void => {
+      const widgets: Array<MetricWidget> = collectMetricWidgets();
+
+      expect(widgets.length).toBeGreaterThan(0);
+
+      for (const widget of widgets) {
+        const label: string = `${widget.type} ${describeComponent(widget.component)}`;
+        const hasCorrectSpelling: boolean =
+          Object.prototype.hasOwnProperty.call(
+            widget.filterData,
+            "aggregationType",
+          );
+
+        expect(`${label} hasAggregationType=${hasCorrectSpelling}`).toBe(
+          `${label} hasAggregationType=false`,
+        );
+      }
+    });
+
+    test("every metric-bearing widget queries a non-empty metric name", (): void => {
+      const widgets: Array<MetricWidget> = collectMetricWidgets();
+
+      expect(widgets.length).toBeGreaterThan(0);
+
+      for (const widget of widgets) {
+        const label: string = `${widget.type} ${describeComponent(widget.component)}`;
+        const metricName: unknown = widget.filterData["metricName"];
+
+        expect(`${label} metricName is a ${typeof metricName}`).toBe(
+          `${label} metricName is a string`,
+        );
+        expect(`${label} metricName=${String(metricName).trim()}`).not.toBe(
+          `${label} metricName=`,
+        );
+      }
+    });
+  });
+
+  /*
+   * Trace widgets carry no metricQueryConfig, so every invariant above
+   * skips them: their query arguments live directly on `arguments` and
+   * the aggregation layer reads them verbatim. `groupByAttribute` is
+   * declared optional on the trace chart factory, so the compiler accepts
+   * a chart that groups by nothing — only these tests reject it.
+   */
+  describe("trace queries", () => {
+    test("every TraceChart requests a non-empty metric", (): void => {
+      const charts: Array<TemplateComponent> = collectComponentsByType([
+        DashboardComponentType.TraceChart,
+      ]);
+
+      expect(charts.length).toBeGreaterThan(0);
+
+      for (const chart of charts) {
+        const label: string = describeTemplateComponent(chart);
+        const metric: unknown = getArguments(chart.component)["metric"];
+
+        expect(`${label} metric is a ${typeof metric}`).toBe(
+          `${label} metric is a string`,
+        );
+        expect(`${label} metric=${String(metric).trim()}`).not.toBe(
+          `${label} metric=`,
+        );
+      }
+    });
+
+    test("every trace widget groups by a non-empty attribute key", (): void => {
+      const traceWidgets: Array<TemplateComponent> = collectComponentsByType([
+        DashboardComponentType.TraceChart,
+        DashboardComponentType.TraceTable,
+      ]);
+
+      expect(traceWidgets.length).toBeGreaterThan(0);
+
+      for (const widget of traceWidgets) {
+        const label: string = describeTemplateComponent(widget);
+        const groupByAttribute: unknown = getArguments(widget.component)[
+          "groupByAttribute"
+        ];
+
+        expect(
+          `${label} groupByAttribute is a ${typeof groupByAttribute}`,
+        ).toBe(`${label} groupByAttribute is a string`);
+        expect(
+          `${label} groupByAttribute=${String(groupByAttribute).trim()}`,
+        ).not.toBe(`${label} groupByAttribute=`);
+      }
+    });
+
+    test("every trace widget caps its rows with a positive topLimit", (): void => {
+      const traceWidgets: Array<TemplateComponent> = collectComponentsByType([
+        DashboardComponentType.TraceChart,
+        DashboardComponentType.TraceTable,
+      ]);
+
+      expect(traceWidgets.length).toBeGreaterThan(0);
+
+      for (const widget of traceWidgets) {
+        const label: string = describeTemplateComponent(widget);
+        const topLimit: unknown = getArguments(widget.component)["topLimit"];
+
+        expect(`${label} topLimit is a ${typeof topLimit}`).toBe(
+          `${label} topLimit is a number`,
+        );
+        expect(
+          `${label} topLimit=${String(topLimit)} positive=${
+            typeof topLimit === "number" && topLimit > 0
+          }`,
+        ).toBe(`${label} topLimit=${String(topLimit)} positive=true`);
+      }
+    });
+  });
+
+  describe("text widgets", () => {
+    test("every Text widget renders a non-empty string", (): void => {
+      const textWidgets: Array<TemplateComponent> = collectComponentsByType([
+        DashboardComponentType.Text,
+      ]);
+
+      expect(textWidgets.length).toBeGreaterThan(0);
+
+      for (const widget of textWidgets) {
+        const label: string = `${widget.type} Text widget at row ${widget.component.topInDashboardUnits}`;
+        const text: unknown = getArguments(widget.component)["text"];
+
+        expect(`${label} text is a ${typeof text}`).toBe(
+          `${label} text is a string`,
+        );
+        expect(`${label} text=${String(text).trim()}`).not.toBe(
+          `${label} text=`,
+        );
+      }
+    });
+  });
+
+  describe("gauges", () => {
+    test("every gauge's thresholds sit inside its own range with warning below critical", (): void => {
+      const gauges: Array<TemplateComponent> = collectComponentsByType([
+        DashboardComponentType.Gauge,
+      ]);
+
+      expect(gauges.length).toBeGreaterThan(0);
+
+      for (const gauge of gauges) {
+        const args: Record<string, unknown> = getArguments(gauge.component);
+        const label: string = describeTemplateComponent(gauge);
+        const minValue: number = args["minValue"] as number;
+        const maxValue: number = args["maxValue"] as number;
+        const warning: number = args["warningThreshold"] as number;
+        const critical: number = args["criticalThreshold"] as number;
+
+        expect(`${label} min=${typeof minValue}`).toBe(`${label} min=number`);
+        expect(`${label} max=${typeof maxValue}`).toBe(`${label} max=number`);
+        expect(`${label} warning=${typeof warning}`).toBe(
+          `${label} warning=number`,
+        );
+        expect(`${label} critical=${typeof critical}`).toBe(
+          `${label} critical=number`,
+        );
+
+        /*
+         * min <= max needs no separate assertion: the ordering check below
+         * chains min <= warning < critical <= max, which implies it.
+         */
+        const orderedCorrectly: boolean =
+          minValue <= warning && warning < critical && critical <= maxValue;
+
+        expect(
+          `${label} ${minValue} <= ${warning} < ${critical} <= ${maxValue} : ${orderedCorrectly}`,
+        ).toBe(
+          `${label} ${minValue} <= ${warning} < ${critical} <= ${maxValue} : true`,
+        );
+      }
+    });
+  });
+
+  describe("variables", () => {
+    test("variables within a template have unique ids and unique names", (): void => {
+      const loadedTemplates: Array<LoadedTemplate> = loadAllTemplates();
+
+      expect(loadedTemplates.length).toBeGreaterThan(0);
+
+      let templatesWithVariables: number = 0;
+
+      for (const loaded of loadedTemplates) {
+        const variables: Array<DashboardVariable> =
+          loaded.config.variables || [];
+
+        if (variables.length === 0) {
+          continue;
+        }
+
+        templatesWithVariables++;
+
+        const ids: Array<string> = variables.map(
+          (variable: DashboardVariable): string => {
+            return variable.id;
+          },
+        );
+        const names: Array<string> = variables.map(
+          (variable: DashboardVariable): string => {
+            return variable.name;
+          },
+        );
+
+        expect(`${loaded.type} ids: ${new Set(ids).size}`).toBe(
+          `${loaded.type} ids: ${ids.length}`,
+        );
+        expect(`${loaded.type} names: ${new Set(names).size}`).toBe(
+          `${loaded.type} names: ${names.length}`,
+        );
+      }
+
+      expect(templatesWithVariables).toBeGreaterThan(0);
+    });
+
+    test("every TelemetryAttribute variable binds to a non-empty attribute key", (): void => {
+      const telemetryVariables: Array<{
+        type: DashboardTemplateType;
+        variable: DashboardVariable;
+      }> = [];
+
+      for (const loaded of loadAllTemplates()) {
+        for (const variable of loaded.config.variables || []) {
+          if (variable.type === DashboardVariableType.TelemetryAttribute) {
+            telemetryVariables.push({ type: loaded.type, variable: variable });
+          }
+        }
+      }
+
+      expect(telemetryVariables.length).toBeGreaterThan(0);
+
+      for (const entry of telemetryVariables) {
+        const label: string = `${entry.type} variable "${entry.variable.name}"`;
+
+        expect(
+          `${label} attributeKey=${(entry.variable.attributeKey ?? "").trim()}`,
+        ).not.toBe(`${label} attributeKey=`);
+        expect(entry.variable.name.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    test("variable ids are freshly generated on every call", (): void => {
+      const typesWithVariables: Array<DashboardTemplateType> =
+        TEMPLATE_TYPES_WITH_CONFIG.filter(
+          (type: DashboardTemplateType): boolean => {
+            const config: DashboardViewConfig = getTemplateConfig(
+              type,
+            ) as DashboardViewConfig;
+
+            return (config.variables || []).length > 0;
+          },
+        );
+
+      expect(typesWithVariables.length).toBeGreaterThan(0);
+
+      for (const type of typesWithVariables) {
+        const first: DashboardViewConfig = getTemplateConfig(
+          type,
+        ) as DashboardViewConfig;
+        const second: DashboardViewConfig = getTemplateConfig(
+          type,
+        ) as DashboardViewConfig;
+
+        const firstIds: Set<string> = new Set<string>(
+          (first.variables || []).map((variable: DashboardVariable): string => {
+            return variable.id;
+          }),
+        );
+        const shared: Array<string> = (second.variables || [])
+          .map((variable: DashboardVariable): string => {
+            return variable.id;
+          })
+          .filter((id: string): boolean => {
+            return firstIds.has(id);
+          });
+
+        expect(`${type}: ${shared.length} shared variable ids`).toBe(
+          `${type}: 0 shared variable ids`,
+        );
+      }
+    });
+  });
+});

--- a/Common/Tests/Types/Dashboard/RumDashboardTemplate.test.ts
+++ b/Common/Tests/Types/Dashboard/RumDashboardTemplate.test.ts
@@ -1,0 +1,1238 @@
+import DashboardChartType from "../../../Types/Dashboard/Chart/ChartType";
+import { ComponentArgument } from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
+import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import DashboardTraceChartComponent from "../../../Types/Dashboard/DashboardComponents/DashboardTraceChartComponent";
+import { DashboardValueTrendDirection } from "../../../Types/Dashboard/DashboardComponents/DashboardValueComponent";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import {
+  DashboardTemplate,
+  DashboardTemplateCategory,
+  DashboardTemplates,
+  DashboardTemplateType,
+  getDashboardTemplatesByCategory,
+  getTemplateConfig,
+} from "../../../Types/Dashboard/DashboardTemplates";
+import IconProp from "../../../Types/Icon/IconProp";
+import DashboardTraceChartComponentUtil from "../../../Utils/Dashboard/Components/DashboardTraceChartComponent";
+import type { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+
+/*
+ * The canonical names from /docs/rum/web-vitals — the ones the docs tell
+ * new instrumentation to emit and the ones RumAlertTemplates.ts already
+ * alerts on. A widget can only query one spelling, so anything outside
+ * this set renders permanently empty, which is the exact failure the
+ * comment at the top of DashboardTemplates.ts warns about.
+ */
+const CANONICAL_WEB_VITAL_METRICS: Array<string> = [
+  "web_vital.lcp",
+  "web_vital.inp",
+  "web_vital.cls",
+  "web_vital.fcp",
+  "web_vital.ttfb",
+];
+
+const GRID_WIDTH_IN_UNITS: number = 12;
+
+/*
+ * The aggregation is persisted into the saved dashboard as a raw string, so
+ * the wire contract is the string VALUE, not the enum member. Asserting
+ * against `AggregationType.Avg` would compare the source to itself —
+ * `Types/Metrics/MetricsAggregationType.ts` is a bare re-export of the same
+ * enum the template imports — and renaming `Avg = "Avg"` to `"avg"` would
+ * break every stored dashboard with the suite still green. So the literals
+ * are pinned here, exactly as the metric names and the misspelled
+ * `aggegationType` key already are.
+ */
+const AVG_AGGREGATION: string = "Avg";
+const P95_AGGREGATION: string = "P95";
+
+// -- Helpers ---------------------------------------------------------------
+
+type WidgetArguments = Record<string, unknown>;
+
+function getConfig(): DashboardViewConfig {
+  const config: DashboardViewConfig | null = getTemplateConfig(
+    DashboardTemplateType.Rum,
+  );
+  expect(config).not.toBeNull();
+  return config as DashboardViewConfig;
+}
+
+function argumentsOf(component: DashboardBaseComponent): WidgetArguments {
+  return (component.arguments as WidgetArguments | undefined) || {};
+}
+
+/*
+ * Every widget family stores its title under a different argument key
+ * (Text uses `text`, Chart uses `chartTitle`, Gauge uses `gaugeTitle`,
+ * the trace / log widgets use `title`). Looking widgets up by title is
+ * the only stable handle: component ids are freshly generated on every
+ * call and array positions move whenever a row is inserted.
+ */
+const TITLE_ARGUMENT_KEYS: Array<string> = [
+  "title",
+  "chartTitle",
+  "gaugeTitle",
+  "tableTitle",
+  "text",
+];
+
+function titleOf(component: DashboardBaseComponent): string {
+  const args: WidgetArguments = argumentsOf(component);
+
+  for (const key of TITLE_ARGUMENT_KEYS) {
+    const value: unknown = args[key];
+
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+// Fails loudly (rather than returning undefined) when the widget is gone.
+function findWidget(
+  config: DashboardViewConfig,
+  title: string,
+): DashboardBaseComponent {
+  const matches: Array<DashboardBaseComponent> = config.components.filter(
+    (component: DashboardBaseComponent): boolean => {
+      return titleOf(component) === title;
+    },
+  );
+
+  expect(matches).toHaveLength(1);
+  return matches[0] as DashboardBaseComponent;
+}
+
+function componentsOfType(
+  config: DashboardViewConfig,
+  componentType: DashboardComponentType,
+): Array<DashboardBaseComponent> {
+  return config.components.filter(
+    (component: DashboardBaseComponent): boolean => {
+      return component.componentType === componentType;
+    },
+  );
+}
+
+function metricQueryConfigOf(
+  component: DashboardBaseComponent,
+): WidgetArguments {
+  return (
+    (argumentsOf(component)["metricQueryConfig"] as
+      | WidgetArguments
+      | undefined) || {}
+  );
+}
+
+function metricQueryDataOf(component: DashboardBaseComponent): WidgetArguments {
+  return (
+    (metricQueryConfigOf(component)["metricQueryData"] as
+      | WidgetArguments
+      | undefined) || {}
+  );
+}
+
+function filterDataOf(component: DashboardBaseComponent): WidgetArguments {
+  return (
+    (metricQueryDataOf(component)["filterData"] as
+      | WidgetArguments
+      | undefined) || {}
+  );
+}
+
+function metricNameOf(component: DashboardBaseComponent): string | undefined {
+  const value: unknown = filterDataOf(component)["metricName"];
+  return typeof value === "string" ? value : undefined;
+}
+
+/*
+ * The aggregation is stored under the MISSPELLED key `aggegationType`.
+ * That misspelling is what the fetch layer reads, so it is the contract:
+ * "fixing" the spelling silently drops the aggregation.
+ */
+function aggregationOf(component: DashboardBaseComponent): unknown {
+  return filterDataOf(component)["aggegationType"];
+}
+
+function groupByAttributeKeysOf(component: DashboardBaseComponent): unknown {
+  return metricQueryDataOf(component)["groupByAttributeKeys"];
+}
+
+function metricAliasDataOf(
+  component: DashboardBaseComponent,
+): WidgetArguments | undefined {
+  return metricQueryConfigOf(component)["metricAliasData"] as
+    | WidgetArguments
+    | undefined;
+}
+
+function metricWidgetsOf(
+  config: DashboardViewConfig,
+): Array<DashboardBaseComponent> {
+  return config.components.filter(
+    (component: DashboardBaseComponent): boolean => {
+      return metricNameOf(component) !== undefined;
+    },
+  );
+}
+
+function traceWidgetsOf(
+  config: DashboardViewConfig,
+): Array<DashboardBaseComponent> {
+  return [
+    ...componentsOfType(config, DashboardComponentType.TraceChart),
+    ...componentsOfType(config, DashboardComponentType.TraceTable),
+  ];
+}
+
+/*
+ * The grid slot IS the reading order: swapping two widgets of the same size
+ * leaves every other assertion green while silently re-ordering the
+ * dashboard, so top/left/width/height are pinned per widget.
+ */
+interface GridSlot {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function componentIdsOf(config: DashboardViewConfig): Array<string> {
+  return config.components.map((component: DashboardBaseComponent): string => {
+    return component.componentId.toString();
+  });
+}
+
+function variableIdsOf(config: DashboardViewConfig): Array<string> {
+  return (config.variables || []).map((variable: DashboardVariable): string => {
+    return variable.id;
+  });
+}
+
+function slotOf(component: DashboardBaseComponent): GridSlot {
+  return {
+    top: component.topInDashboardUnits,
+    left: component.leftInDashboardUnits,
+    width: component.widthInDashboardUnits,
+    height: component.heightInDashboardUnits,
+  };
+}
+
+/*
+ * The trace widgets store a bare `metric` string that the analytics endpoint
+ * has to recognise. The widget's own editor is the importable oracle for the
+ * accepted set: its Metric dropdown is what a user picks from, so a template
+ * metric outside it is a value no one could have chosen and the endpoint has
+ * no branch for.
+ */
+function traceChartMetricsOfferedByEditor(): Array<string> {
+  const componentArguments: Array<
+    ComponentArgument<DashboardTraceChartComponent>
+  > = DashboardTraceChartComponentUtil.getComponentConfigArguments();
+
+  const metricArgument:
+    | ComponentArgument<DashboardTraceChartComponent>
+    | undefined = componentArguments.find(
+    (candidate: ComponentArgument<DashboardTraceChartComponent>): boolean => {
+      return candidate.id === "metric";
+    },
+  );
+
+  expect(metricArgument).toBeDefined();
+
+  const options: Array<DropdownOption> =
+    (metricArgument as ComponentArgument<DashboardTraceChartComponent>)
+      .dropdownOptions || [];
+
+  expect(options.length).toBeGreaterThan(0);
+
+  return options.map((option: DropdownOption): string => {
+    return String(option.value);
+  });
+}
+
+// -- Fixtures --------------------------------------------------------------
+
+/*
+ * Named rather than indexed out of SECTION_HEADERS so that inserting a
+ * header cannot silently retarget the tests that reach for it.
+ */
+const SPAN_SECTION_HEADER: string =
+  "Page Loads & Browser Errors (span-based — not narrowed by the filters above)";
+
+const LOG_STREAM_TITLE: string = "Recent Browser Logs";
+
+const EXPECTED_WIDGETS: Record<string, DashboardComponentType> = {
+  "Real User Monitoring Dashboard": DashboardComponentType.Text,
+
+  "Avg LCP": DashboardComponentType.Value,
+  "Avg INP": DashboardComponentType.Value,
+  "Avg CLS": DashboardComponentType.Value,
+  "Avg TTFB": DashboardComponentType.Value,
+
+  "Largest Contentful Paint": DashboardComponentType.Gauge,
+  "Interaction to Next Paint": DashboardComponentType.Gauge,
+  "Cumulative Layout Shift": DashboardComponentType.Gauge,
+  "First Contentful Paint": DashboardComponentType.Gauge,
+
+  "Core Web Vital Trends": DashboardComponentType.Text,
+
+  "Largest Contentful Paint Over Time": DashboardComponentType.Chart,
+  "Interaction to Next Paint Over Time": DashboardComponentType.Chart,
+  "Cumulative Layout Shift Over Time": DashboardComponentType.Chart,
+  "First Contentful Paint Over Time": DashboardComponentType.Chart,
+  "Time to First Byte Over Time": DashboardComponentType.Chart,
+  "Largest Contentful Paint by Route (P95)": DashboardComponentType.Chart,
+
+  [SPAN_SECTION_HEADER]: DashboardComponentType.Text,
+
+  "Page Loads & Requests": DashboardComponentType.TraceChart,
+  "Browser Errors Over Time": DashboardComponentType.TraceChart,
+  "Page Load & Request Time (P95)": DashboardComponentType.TraceChart,
+  "Route Change Duration (Avg)": DashboardComponentType.TraceChart,
+
+  Breakdowns: DashboardComponentType.Text,
+
+  Applications: DashboardComponentType.TraceTable,
+  "Top Route Changes": DashboardComponentType.TraceTable,
+  "Browsers & Platforms": DashboardComponentType.TraceTable,
+  [LOG_STREAM_TITLE]: DashboardComponentType.LogStream,
+};
+
+interface ValueTileFixture {
+  title: string;
+  metricName: string;
+  slot: GridSlot;
+}
+
+const VALUE_TILES: Array<ValueTileFixture> = [
+  {
+    title: "Avg LCP",
+    metricName: "web_vital.lcp",
+    slot: { top: 1, left: 0, width: 3, height: 1 },
+  },
+  {
+    title: "Avg INP",
+    metricName: "web_vital.inp",
+    slot: { top: 1, left: 3, width: 3, height: 1 },
+  },
+  {
+    title: "Avg CLS",
+    metricName: "web_vital.cls",
+    slot: { top: 1, left: 6, width: 3, height: 1 },
+  },
+  {
+    title: "Avg TTFB",
+    metricName: "web_vital.ttfb",
+    slot: { top: 1, left: 9, width: 3, height: 1 },
+  },
+];
+
+interface GaugeFixture {
+  title: string;
+  metricName: string;
+  minValue: number;
+  maxValue: number;
+  warningThreshold: number;
+  criticalThreshold: number;
+  slot: GridSlot;
+}
+
+/*
+ * Warning / critical are Google's published "needs improvement" / "poor"
+ * boundaries for each vital. Drifting off them turns the gauge colour into
+ * an opinion nobody can look up.
+ */
+const GAUGES: Array<GaugeFixture> = [
+  {
+    title: "Largest Contentful Paint",
+    metricName: "web_vital.lcp",
+    minValue: 0,
+    maxValue: 6000,
+    warningThreshold: 2500,
+    criticalThreshold: 4000,
+    slot: { top: 2, left: 0, width: 3, height: 3 },
+  },
+  {
+    title: "Interaction to Next Paint",
+    metricName: "web_vital.inp",
+    minValue: 0,
+    maxValue: 1000,
+    warningThreshold: 200,
+    criticalThreshold: 500,
+    slot: { top: 2, left: 3, width: 3, height: 3 },
+  },
+  {
+    title: "Cumulative Layout Shift",
+    metricName: "web_vital.cls",
+    minValue: 0,
+    maxValue: 0.5,
+    warningThreshold: 0.1,
+    criticalThreshold: 0.25,
+    slot: { top: 2, left: 6, width: 3, height: 3 },
+  },
+  {
+    title: "First Contentful Paint",
+    metricName: "web_vital.fcp",
+    minValue: 0,
+    maxValue: 5000,
+    warningThreshold: 1800,
+    criticalThreshold: 3000,
+    slot: { top: 2, left: 9, width: 3, height: 3 },
+  },
+];
+
+interface ChartFixture {
+  title: string;
+  chartType: DashboardChartType;
+  metricName: string;
+  aggregationType: string;
+  legend: string;
+  legendUnit: string | undefined;
+  slot: GridSlot;
+}
+
+const CHARTS: Array<ChartFixture> = [
+  {
+    title: "Largest Contentful Paint Over Time",
+    chartType: DashboardChartType.Line,
+    metricName: "web_vital.lcp",
+    aggregationType: AVG_AGGREGATION,
+    legend: "LCP",
+    legendUnit: "ms",
+    slot: { top: 6, left: 0, width: 6, height: 3 },
+  },
+  {
+    title: "Interaction to Next Paint Over Time",
+    chartType: DashboardChartType.Line,
+    metricName: "web_vital.inp",
+    aggregationType: AVG_AGGREGATION,
+    legend: "INP",
+    legendUnit: "ms",
+    slot: { top: 6, left: 6, width: 6, height: 3 },
+  },
+  {
+    // CLS is unitless, so it deliberately ships no legendUnit.
+    title: "Cumulative Layout Shift Over Time",
+    chartType: DashboardChartType.Line,
+    metricName: "web_vital.cls",
+    aggregationType: AVG_AGGREGATION,
+    legend: "CLS",
+    legendUnit: undefined,
+    slot: { top: 9, left: 0, width: 6, height: 3 },
+  },
+  {
+    title: "First Contentful Paint Over Time",
+    chartType: DashboardChartType.Line,
+    metricName: "web_vital.fcp",
+    aggregationType: AVG_AGGREGATION,
+    legend: "FCP",
+    legendUnit: "ms",
+    slot: { top: 9, left: 6, width: 6, height: 3 },
+  },
+  {
+    title: "Time to First Byte Over Time",
+    chartType: DashboardChartType.Line,
+    metricName: "web_vital.ttfb",
+    aggregationType: AVG_AGGREGATION,
+    legend: "TTFB",
+    legendUnit: "ms",
+    slot: { top: 12, left: 0, width: 6, height: 3 },
+  },
+  {
+    title: "Largest Contentful Paint by Route (P95)",
+    chartType: DashboardChartType.Bar,
+    metricName: "web_vital.lcp",
+    aggregationType: P95_AGGREGATION,
+    legend: "P95 LCP",
+    legendUnit: "ms",
+    slot: { top: 12, left: 6, width: 6, height: 3 },
+  },
+];
+
+const P95_CHART_TITLE: string = "Largest Contentful Paint by Route (P95)";
+
+interface TraceWidgetFixture {
+  title: string;
+  metric?: string;
+  groupByAttribute: string;
+  slot: GridSlot;
+}
+
+const TRACE_CHARTS: Array<TraceWidgetFixture> = [
+  {
+    title: "Page Loads & Requests",
+    metric: "count",
+    groupByAttribute: "rumApplicationId",
+    slot: { top: 16, left: 0, width: 6, height: 3 },
+  },
+  {
+    title: "Browser Errors Over Time",
+    metric: "errorCount",
+    groupByAttribute: "rumApplicationId",
+    slot: { top: 16, left: 6, width: 6, height: 3 },
+  },
+  {
+    title: "Page Load & Request Time (P95)",
+    metric: "p95Duration",
+    groupByAttribute: "rumApplicationId",
+    slot: { top: 19, left: 0, width: 6, height: 3 },
+  },
+  {
+    title: "Route Change Duration (Avg)",
+    metric: "avgDuration",
+    groupByAttribute: "app.route",
+    slot: { top: 19, left: 6, width: 6, height: 3 },
+  },
+];
+
+const TRACE_TABLES: Array<TraceWidgetFixture> = [
+  {
+    title: "Applications",
+    groupByAttribute: "rumApplicationId",
+    slot: { top: 23, left: 0, width: 6, height: 3 },
+  },
+  {
+    title: "Top Route Changes",
+    groupByAttribute: "app.route",
+    slot: { top: 23, left: 6, width: 6, height: 3 },
+  },
+  {
+    title: "Browsers & Platforms",
+    groupByAttribute: "resource.browser.platform",
+    slot: { top: 26, left: 0, width: 6, height: 3 },
+  },
+];
+
+const LOG_STREAM_SLOT: GridSlot = { top: 26, left: 6, width: 6, height: 3 };
+
+const SECTION_HEADERS: Array<string> = [
+  "Real User Monitoring Dashboard",
+  "Core Web Vital Trends",
+  SPAN_SECTION_HEADER,
+  "Breakdowns",
+];
+
+// -- Tests -----------------------------------------------------------------
+
+describe("RUM dashboard template", () => {
+  describe("catalog registration", () => {
+    test("registers exactly one Real User Monitoring entry under Monitoring & APM", () => {
+      const entries: Array<DashboardTemplate> = DashboardTemplates.filter(
+        (candidate: DashboardTemplate): boolean => {
+          return candidate.type === DashboardTemplateType.Rum;
+        },
+      );
+
+      expect(entries).toHaveLength(1);
+
+      const template: DashboardTemplate = entries[0] as DashboardTemplate;
+      expect(template.name).toBe("Real User Monitoring Dashboard");
+      expect(template.icon).toBe(IconProp.Globe);
+      expect(template.category).toBe(DashboardTemplateCategory.Monitoring);
+    });
+
+    test("describes every vital the dashboard actually charts", () => {
+      const template: DashboardTemplate | undefined = DashboardTemplates.find(
+        (candidate: DashboardTemplate): boolean => {
+          return candidate.type === DashboardTemplateType.Rum;
+        },
+      );
+
+      expect(template).toBeDefined();
+
+      const description: string = (template as DashboardTemplate).description;
+
+      for (const vital of ["LCP", "INP", "CLS", "FCP", "TTFB"]) {
+        expect(description).toContain(vital);
+      }
+    });
+
+    test("is surfaced by the Monitoring category grouping the modal renders", () => {
+      const grouped: Array<DashboardTemplate> = getDashboardTemplatesByCategory(
+        DashboardTemplateCategory.Monitoring,
+      );
+
+      const types: Array<DashboardTemplateType> = grouped.map(
+        (template: DashboardTemplate): DashboardTemplateType => {
+          return template.type;
+        },
+      );
+
+      expect(types).toContain(DashboardTemplateType.Rum);
+    });
+
+    /*
+     * DashboardService validates the string it receives in
+     * miscDataProps.dashboardTemplateType against Object.values(
+     * DashboardTemplateType) before handing it to getTemplateConfig, so the
+     * enum VALUE — not the member name — is the wire contract with the UI.
+     */
+    test("accepts the raw wire value 'Rum' DashboardService validates against", () => {
+      const wireValue: string = "Rum";
+
+      expect(DashboardTemplateType.Rum).toBe(wireValue);
+      expect(
+        getTemplateConfig(wireValue as DashboardTemplateType),
+      ).not.toBeNull();
+    });
+  });
+
+  describe("widget inventory", () => {
+    test("renders exactly the expected widgets, each with its expected type", () => {
+      const config: DashboardViewConfig = getConfig();
+      const actual: Record<string, DashboardComponentType> = {};
+
+      expect(config.components).toHaveLength(
+        Object.keys(EXPECTED_WIDGETS).length,
+      );
+
+      for (const component of config.components) {
+        const title: string = titleOf(component);
+        expect(title).not.toBe("");
+        // Titles are the lookup handle, so they have to stay unique.
+        expect(actual[title]).toBeUndefined();
+        actual[title] = component.componentType;
+      }
+
+      expect(actual).toEqual(EXPECTED_WIDGETS);
+    });
+
+    test("splits those widgets across the expected widget families", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      expect(
+        componentsOfType(config, DashboardComponentType.Text),
+      ).toHaveLength(4);
+      expect(
+        componentsOfType(config, DashboardComponentType.Value),
+      ).toHaveLength(4);
+      expect(
+        componentsOfType(config, DashboardComponentType.Gauge),
+      ).toHaveLength(4);
+      expect(
+        componentsOfType(config, DashboardComponentType.Chart),
+      ).toHaveLength(6);
+      expect(
+        componentsOfType(config, DashboardComponentType.TraceChart),
+      ).toHaveLength(4);
+      expect(
+        componentsOfType(config, DashboardComponentType.TraceTable),
+      ).toHaveLength(3);
+      expect(
+        componentsOfType(config, DashboardComponentType.LogStream),
+      ).toHaveLength(1);
+    });
+
+    // TraceList has no group-by, so it cannot be scoped to RUM traffic.
+    test("does not use the unscopable trace list widget", () => {
+      expect(
+        componentsOfType(getConfig(), DashboardComponentType.TraceList),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("metric queries", () => {
+    test("queries only canonical web_vital.* metric names", () => {
+      const config: DashboardViewConfig = getConfig();
+      const metricWidgets: Array<DashboardBaseComponent> =
+        metricWidgetsOf(config);
+
+      expect(metricWidgets).toHaveLength(14);
+
+      for (const widget of metricWidgets) {
+        expect(CANONICAL_WEB_VITAL_METRICS).toContain(metricNameOf(widget));
+      }
+    });
+
+    test("covers all five Core Web Vitals", () => {
+      const queried: Set<string> = new Set(
+        metricWidgetsOf(getConfig()).map(
+          (component: DashboardBaseComponent): string => {
+            return metricNameOf(component) as string;
+          },
+        ),
+      );
+
+      for (const canonical of CANONICAL_WEB_VITAL_METRICS) {
+        expect(queried.has(canonical)).toBe(true);
+      }
+    });
+
+    /*
+     * The fetch layer reads `aggegationType`. Correcting the spelling here
+     * would leave every widget with no aggregation at all, so the
+     * misspelling is pinned in both directions.
+     */
+    test("stores every aggregation under the misspelled aggegationType key", () => {
+      const config: DashboardViewConfig = getConfig();
+      const metricWidgets: Array<DashboardBaseComponent> =
+        metricWidgetsOf(config);
+
+      expect(metricWidgets).toHaveLength(14);
+
+      for (const widget of metricWidgets) {
+        const filterData: WidgetArguments = filterDataOf(widget);
+
+        expect(Object.keys(filterData)).toContain("aggegationType");
+        expect(Object.keys(filterData)).not.toContain("aggregationType");
+        // The stored value is the raw string the fetch layer compares on.
+        expect([AVG_AGGREGATION, P95_AGGREGATION]).toContain(
+          aggregationOf(widget),
+        );
+      }
+    });
+
+    test("uses the P95 aggregation on exactly the one per-route chart, and fans out by app.route only there", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      const p95Titles: Array<string> = config.components
+        .filter((component: DashboardBaseComponent): boolean => {
+          return aggregationOf(component) === P95_AGGREGATION;
+        })
+        .map((component: DashboardBaseComponent): string => {
+          return titleOf(component);
+        });
+
+      expect(p95Titles).toEqual([P95_CHART_TITLE]);
+
+      const fanOutTitles: Array<string> = config.components
+        .filter((component: DashboardBaseComponent): boolean => {
+          return groupByAttributeKeysOf(component) !== undefined;
+        })
+        .map((component: DashboardBaseComponent): string => {
+          return titleOf(component);
+        });
+
+      expect(fanOutTitles).toEqual([P95_CHART_TITLE]);
+      expect(
+        groupByAttributeKeysOf(findWidget(config, P95_CHART_TITLE)),
+      ).toEqual(["app.route"]);
+    });
+  });
+
+  describe("headline value tiles", () => {
+    for (const tile of VALUE_TILES) {
+      test(`"${tile.title}" averages ${tile.metricName} in its own grid slot`, () => {
+        const config: DashboardViewConfig = getConfig();
+        const widget: DashboardBaseComponent = findWidget(config, tile.title);
+
+        expect(widget.componentType).toBe(DashboardComponentType.Value);
+        expect(metricNameOf(widget)).toBe(tile.metricName);
+        expect(aggregationOf(widget)).toBe(AVG_AGGREGATION);
+        expect(slotOf(widget)).toEqual(tile.slot);
+      });
+    }
+
+    /*
+     * The renderer's trend-arrow heuristic keys off the metric name and
+     * does not recognise `web_vital.*`, so every vital would get a
+     * "rising is good" green arrow unless the direction is set explicitly.
+     */
+    test("pins HigherIsWorse on every tile rather than trusting the name heuristic", () => {
+      const config: DashboardViewConfig = getConfig();
+      const tiles: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.Value,
+      );
+
+      expect(tiles).toHaveLength(VALUE_TILES.length);
+
+      for (const tile of tiles) {
+        expect(argumentsOf(tile)["trendDirection"]).toBe(
+          DashboardValueTrendDirection.HigherIsWorse,
+        );
+      }
+    });
+  });
+
+  describe("Core Web Vital gauges", () => {
+    for (const gauge of GAUGES) {
+      test(`"${gauge.title}" sweeps ${gauge.minValue}-${gauge.maxValue} with Google's published boundaries`, () => {
+        const config: DashboardViewConfig = getConfig();
+        const widget: DashboardBaseComponent = findWidget(config, gauge.title);
+        const args: WidgetArguments = argumentsOf(widget);
+
+        expect(widget.componentType).toBe(DashboardComponentType.Gauge);
+        expect(metricNameOf(widget)).toBe(gauge.metricName);
+        expect(aggregationOf(widget)).toBe(AVG_AGGREGATION);
+        expect(args["minValue"]).toBe(gauge.minValue);
+        expect(args["maxValue"]).toBe(gauge.maxValue);
+        expect(args["warningThreshold"]).toBe(gauge.warningThreshold);
+        expect(args["criticalThreshold"]).toBe(gauge.criticalThreshold);
+        expect(slotOf(widget)).toEqual(gauge.slot);
+      });
+    }
+
+    // A gauge whose bands are out of order colours the dial nonsensically.
+    test("keeps min < warning < critical <= max on every gauge", () => {
+      const config: DashboardViewConfig = getConfig();
+      const gauges: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.Gauge,
+      );
+
+      expect(gauges).toHaveLength(GAUGES.length);
+
+      for (const gauge of gauges) {
+        const args: WidgetArguments = argumentsOf(gauge);
+        const minValue: number = args["minValue"] as number;
+        const maxValue: number = args["maxValue"] as number;
+        const warning: number = args["warningThreshold"] as number;
+        const critical: number = args["criticalThreshold"] as number;
+
+        expect(minValue).toBeLessThan(warning);
+        expect(warning).toBeLessThan(critical);
+        expect(critical).toBeLessThanOrEqual(maxValue);
+      }
+    });
+  });
+
+  describe("Core Web Vital trend charts", () => {
+    for (const chart of CHARTS) {
+      test(`"${chart.title}" is a ${chart.chartType} chart of ${chart.metricName}`, () => {
+        const config: DashboardViewConfig = getConfig();
+        const widget: DashboardBaseComponent = findWidget(config, chart.title);
+        const alias: WidgetArguments | undefined = metricAliasDataOf(widget);
+
+        expect(widget.componentType).toBe(DashboardComponentType.Chart);
+        expect(argumentsOf(widget)["chartType"]).toBe(chart.chartType);
+        expect(metricNameOf(widget)).toBe(chart.metricName);
+        expect(aggregationOf(widget)).toBe(chart.aggregationType);
+        expect(alias).toBeDefined();
+        expect((alias as WidgetArguments)["legend"]).toBe(chart.legend);
+        expect((alias as WidgetArguments)["legendUnit"]).toBe(chart.legendUnit);
+        expect(slotOf(widget)).toEqual(chart.slot);
+      });
+    }
+
+    /*
+     * Charts go through buildMetricQueryConfig (which carries
+     * metricAliasData); Value tiles and gauges go through
+     * buildMetricQueryData, which omits it entirely — so a legend or
+     * legendUnit set on those would be inert config that reads as if it
+     * were doing something.
+     *
+     * NOTE ON WHAT THIS GUARDS: the "never" half is enforced structurally by
+     * the shared buildMetricQueryData factory, so no edit confined to
+     * createRumDashboardConfig can break it — it is a regression guard on
+     * that shared factory, not on this template. The legend-uniqueness
+     * assertion below is the half a template edit can break: two charts
+     * sharing a legend render two indistinguishable series names.
+     */
+    test("carries metricAliasData on charts only, never on value tiles or gauges", () => {
+      const config: DashboardViewConfig = getConfig();
+      const charts: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.Chart,
+      );
+      const aliaslessWidgets: Array<DashboardBaseComponent> = [
+        ...componentsOfType(config, DashboardComponentType.Value),
+        ...componentsOfType(config, DashboardComponentType.Gauge),
+      ];
+
+      expect(charts).toHaveLength(CHARTS.length);
+      expect(aliaslessWidgets).toHaveLength(VALUE_TILES.length + GAUGES.length);
+
+      const legends: Array<string> = [];
+
+      for (const chart of charts) {
+        const alias: WidgetArguments | undefined = metricAliasDataOf(chart);
+        expect(alias).toBeDefined();
+
+        const legend: unknown = (alias as WidgetArguments)["legend"];
+        expect(typeof legend).toBe("string");
+        expect((legend as string).length).toBeGreaterThan(0);
+        legends.push(legend as string);
+      }
+
+      // Two charts sharing a legend render two series nobody can tell apart.
+      expect(new Set(legends).size).toBe(charts.length);
+
+      for (const widget of aliaslessWidgets) {
+        expect(metricAliasDataOf(widget)).toBeUndefined();
+        expect(Object.keys(metricQueryConfigOf(widget))).not.toContain(
+          "metricAliasData",
+        );
+      }
+    });
+  });
+
+  describe("span-based trace widgets", () => {
+    test("charts each analytics metric against its own group-by dimension", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      expect(
+        componentsOfType(config, DashboardComponentType.TraceChart),
+      ).toHaveLength(TRACE_CHARTS.length);
+
+      for (const traceChart of TRACE_CHARTS) {
+        const widget: DashboardBaseComponent = findWidget(
+          config,
+          traceChart.title,
+        );
+        const args: WidgetArguments = argumentsOf(widget);
+
+        expect(widget.componentType).toBe(DashboardComponentType.TraceChart);
+        expect(args["metric"]).toBe(traceChart.metric);
+        expect(args["groupByAttribute"]).toBe(traceChart.groupByAttribute);
+        expect(args["topLimit"]).toBe(10);
+        expect(slotOf(widget)).toEqual(traceChart.slot);
+      }
+    });
+
+    /*
+     * The `metric` strings above are free-form in the type, so pinning them
+     * against a local fixture only proves the template matches itself. The
+     * TraceChart widget's own Metric dropdown is the accepted vocabulary a
+     * user could otherwise have picked from — a template metric outside it
+     * is one the editor cannot even express.
+     */
+    test("charts only metrics the TraceChart editor itself offers", () => {
+      const config: DashboardViewConfig = getConfig();
+      const offered: Array<string> = traceChartMetricsOfferedByEditor();
+      const traceCharts: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.TraceChart,
+      );
+
+      expect(traceCharts).toHaveLength(TRACE_CHARTS.length);
+      // The offered set is closed — otherwise `toContain` proves nothing.
+      expect(offered).not.toContain("web_vital.lcp");
+
+      for (const widget of traceCharts) {
+        expect(offered).toContain(argumentsOf(widget)["metric"]);
+      }
+    });
+
+    test("breaks traffic down by application, route and platform", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      expect(
+        componentsOfType(config, DashboardComponentType.TraceTable),
+      ).toHaveLength(TRACE_TABLES.length);
+
+      for (const traceTable of TRACE_TABLES) {
+        const widget: DashboardBaseComponent = findWidget(
+          config,
+          traceTable.title,
+        );
+        const args: WidgetArguments = argumentsOf(widget);
+
+        expect(widget.componentType).toBe(DashboardComponentType.TraceTable);
+        expect(args["groupByAttribute"]).toBe(traceTable.groupByAttribute);
+        expect(args["topLimit"]).toBe(10);
+        expect(slotOf(widget)).toEqual(traceTable.slot);
+      }
+    });
+
+    /*
+     * Trace widgets are scoped by their group-by dimension, not by a
+     * filter: `rumApplicationId` compiles to
+     * `primaryEntityType = 'RealUserMonitor'` and a plain attribute key to
+     * `mapContains(attributes, key)` (TraceAggregationService). A trace
+     * widget without one would silently chart every span in the project,
+     * backend included.
+     */
+    test("gives every trace widget a scoping group-by dimension", () => {
+      const config: DashboardViewConfig = getConfig();
+      const traceWidgets: Array<DashboardBaseComponent> =
+        traceWidgetsOf(config);
+
+      expect(traceWidgets).toHaveLength(
+        TRACE_CHARTS.length + TRACE_TABLES.length,
+      );
+
+      for (const widget of traceWidgets) {
+        const groupBy: unknown = argumentsOf(widget)["groupByAttribute"];
+        expect(typeof groupBy).toBe("string");
+        expect((groupBy as string).length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("recent logs stream", () => {
+    test("sits beside the platform breakdown in the bottom row", () => {
+      const config: DashboardViewConfig = getConfig();
+      const widget: DashboardBaseComponent = findWidget(
+        config,
+        LOG_STREAM_TITLE,
+      );
+
+      expect(widget.componentType).toBe(DashboardComponentType.LogStream);
+      expect(slotOf(widget)).toEqual(LOG_STREAM_SLOT);
+    });
+  });
+
+  describe("variables", () => {
+    test("ships exactly the application and platform pickers, in order", () => {
+      const config: DashboardViewConfig = getConfig();
+      const variables: Array<DashboardVariable> = config.variables || [];
+
+      expect(variables).toHaveLength(2);
+      expect(
+        variables.map(
+          (variable: DashboardVariable): Record<string, unknown> => {
+            return {
+              name: variable.name,
+              label: variable.label,
+              type: variable.type,
+              attributeKey: variable.attributeKey,
+              isMultiSelect: variable.isMultiSelect,
+            };
+          },
+        ),
+      ).toEqual([
+        {
+          name: "application",
+          label: "Application",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "resource.service.name",
+          isMultiSelect: true,
+        },
+        {
+          name: "platform",
+          label: "Platform",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "resource.browser.platform",
+          isMultiSelect: true,
+        },
+      ]);
+    });
+
+    /*
+     * `app.route` is recorded on metrics and spans but never on logs, so
+     * binding a variable to it would empty "Recent Browser Logs" whenever
+     * a route is selected, reading as "this route produced no logs".
+     */
+    test("never binds a variable to app.route, which logs do not carry", () => {
+      const config: DashboardViewConfig = getConfig();
+      const variables: Array<DashboardVariable> = config.variables || [];
+
+      expect(variables.length).toBeGreaterThan(0);
+
+      for (const variable of variables) {
+        expect(variable.attributeKey).not.toBe("app.route");
+      }
+    });
+  });
+
+  describe("section headers", () => {
+    test("lays out the four bold section headers in row order", () => {
+      const config: DashboardViewConfig = getConfig();
+      const headers: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.Text,
+      ).sort((a: DashboardBaseComponent, b: DashboardBaseComponent): number => {
+        return a.topInDashboardUnits - b.topInDashboardUnits;
+      });
+
+      expect(headers).toHaveLength(SECTION_HEADERS.length);
+      expect(
+        headers.map((header: DashboardBaseComponent): string => {
+          return titleOf(header);
+        }),
+      ).toEqual(SECTION_HEADERS);
+
+      for (const header of headers) {
+        expect(argumentsOf(header)["isBold"]).toBe(true);
+        expect(header.widthInDashboardUnits).toBe(GRID_WIDTH_IN_UNITS);
+      }
+    });
+
+    /*
+     * The trace analytics endpoint does not read dashboard variables, so
+     * the toolbar pickers narrow the metric widgets and the log stream but
+     * not this section. A header that does not say so invites reading the
+     * two halves of the dashboard as one filtered view.
+     */
+    test("warns that the span-based section is not narrowed by the variables", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      /*
+       * Found STRUCTURALLY — the Text widget sitting immediately above the
+       * first trace chart — rather than by its own text, so that dropping
+       * the warning, or moving the header away from the section it
+       * introduces, fails instead of merely retargeting the lookup.
+       */
+      const traceCharts: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.TraceChart,
+      );
+
+      expect(traceCharts.length).toBeGreaterThan(0);
+
+      const firstTraceChartTop: number = Math.min(
+        ...traceCharts.map((chart: DashboardBaseComponent): number => {
+          return chart.topInDashboardUnits;
+        }),
+      );
+
+      const headersAbove: Array<DashboardBaseComponent> = componentsOfType(
+        config,
+        DashboardComponentType.Text,
+      ).filter((header: DashboardBaseComponent): boolean => {
+        return header.topInDashboardUnits < firstTraceChartTop;
+      });
+
+      expect(headersAbove.length).toBeGreaterThan(0);
+
+      const header: DashboardBaseComponent = headersAbove.reduce(
+        (
+          lowest: DashboardBaseComponent,
+          candidate: DashboardBaseComponent,
+        ): DashboardBaseComponent => {
+          return candidate.topInDashboardUnits > lowest.topInDashboardUnits
+            ? candidate
+            : lowest;
+        },
+      );
+
+      const text: string = argumentsOf(header)["text"] as string;
+
+      expect(text).toContain("span-based");
+      expect(text).toContain("not narrowed by the filters above");
+      // And it introduces the section rather than floating far above it.
+      expect(header.topInDashboardUnits).toBe(firstTraceChartTop - 1);
+    });
+  });
+
+  describe("layout", () => {
+    test("lays widgets out inside the 12-unit grid without overlapping", () => {
+      const config: DashboardViewConfig = getConfig();
+      const occupied: Set<string> = new Set();
+
+      expect(config.components.length).toBeGreaterThan(0);
+
+      for (const component of config.components) {
+        expect(component.leftInDashboardUnits).toBeGreaterThanOrEqual(0);
+        expect(component.topInDashboardUnits).toBeGreaterThanOrEqual(0);
+        expect(
+          component.leftInDashboardUnits + component.widthInDashboardUnits,
+        ).toBeLessThanOrEqual(GRID_WIDTH_IN_UNITS);
+
+        for (
+          let row: number = component.topInDashboardUnits;
+          row <
+          component.topInDashboardUnits + component.heightInDashboardUnits;
+          row++
+        ) {
+          for (
+            let column: number = component.leftInDashboardUnits;
+            column <
+            component.leftInDashboardUnits + component.widthInDashboardUnits;
+            column++
+          ) {
+            const cell: string = `${row}:${column}`;
+            expect(occupied.has(cell)).toBe(false);
+            occupied.add(cell);
+          }
+        }
+      }
+    });
+
+    // A blank band mid-dashboard reads as a widget that failed to render.
+    test("leaves no empty rows between the title and the last widget", () => {
+      const config: DashboardViewConfig = getConfig();
+      const occupiedRows: Set<number> = new Set();
+
+      expect(config.components.length).toBeGreaterThan(0);
+
+      for (const component of config.components) {
+        for (
+          let row: number = component.topInDashboardUnits;
+          row <
+          component.topInDashboardUnits + component.heightInDashboardUnits;
+          row++
+        ) {
+          occupiedRows.add(row);
+        }
+      }
+
+      const lastRow: number = Math.max(...Array.from(occupiedRows));
+
+      for (let row: number = 0; row <= lastRow; row++) {
+        expect(occupiedRows.has(row)).toBe(true);
+      }
+    });
+
+    test("is tall enough to hold its bottom row", () => {
+      const config: DashboardViewConfig = getConfig();
+      const lowestRow: number = Math.max(
+        ...config.components.map(
+          (component: DashboardBaseComponent): number => {
+            return (
+              component.topInDashboardUnits + component.heightInDashboardUnits
+            );
+          },
+        ),
+      );
+
+      expect(config.heightInDashboardUnits).toBeGreaterThanOrEqual(lowestRow);
+    });
+
+    // Below its own minimum a widget renders clipped from the moment it loads.
+    test("sizes every widget at or above its declared minimum", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      expect(config.components).toHaveLength(
+        Object.keys(EXPECTED_WIDGETS).length,
+      );
+
+      for (const component of config.components) {
+        expect(component.widthInDashboardUnits).toBeGreaterThanOrEqual(
+          component.minWidthInDashboardUnits,
+        );
+        expect(component.heightInDashboardUnits).toBeGreaterThanOrEqual(
+          component.minHeightInDashboardUnits,
+        );
+      }
+    });
+  });
+
+  /*
+   * Each call has to mint fresh ids: reusing them would make two dashboards
+   * created from this template collide in any per-component stored state.
+   */
+  test("mints disjoint component and variable ids on every call", () => {
+    const first: DashboardViewConfig = getConfig();
+    const second: DashboardViewConfig = getConfig();
+
+    expect(second.components).toHaveLength(first.components.length);
+    expect(second.components.length).toBeGreaterThan(0);
+
+    const firstComponentIds: Array<string> = componentIdsOf(first);
+    const secondComponentIds: Array<string> = componentIdsOf(second);
+
+    // Unique WITHIN each config, not just across the two.
+    expect(new Set(firstComponentIds).size).toBe(firstComponentIds.length);
+    expect(new Set(secondComponentIds).size).toBe(secondComponentIds.length);
+
+    const seenComponentIds: Set<string> = new Set(firstComponentIds);
+
+    for (const componentId of secondComponentIds) {
+      expect(seenComponentIds.has(componentId)).toBe(false);
+    }
+
+    const firstVariableIds: Array<string> = variableIdsOf(first);
+    const secondVariableIds: Array<string> = variableIdsOf(second);
+
+    expect(firstVariableIds.length).toBeGreaterThan(0);
+    expect(secondVariableIds).toHaveLength(firstVariableIds.length);
+    expect(new Set(firstVariableIds).size).toBe(firstVariableIds.length);
+    expect(new Set(secondVariableIds).size).toBe(secondVariableIds.length);
+
+    const seenVariableIds: Set<string> = new Set(firstVariableIds);
+
+    for (const variableId of secondVariableIds) {
+      expect(seenVariableIds.has(variableId)).toBe(false);
+    }
+  });
+});

--- a/Common/Types/Dashboard/DashboardTemplates.ts
+++ b/Common/Types/Dashboard/DashboardTemplates.ts
@@ -20,6 +20,11 @@ import { DashboardValueTrendDirection } from "./DashboardComponents/DashboardVal
  * define names that are not emitted anywhere in the codebase, so the
  * templates only ever rendered empty widgets. Reach for the Logs /
  * Traces / Exceptions pages directly until those metrics exist.
+ *
+ * The Rum template does use span data, but through the TraceChart /
+ * TraceTable widgets, which query the trace analytics endpoint directly
+ * rather than through a metric catalog — so it is not subject to the
+ * caveat above.
  */
 export enum DashboardTemplateType {
   Blank = "Blank",
@@ -33,6 +38,7 @@ export enum DashboardTemplateType {
   Ceph = "Ceph",
   DockerSwarm = "DockerSwarm",
   Metrics = "Metrics",
+  Rum = "Rum",
 }
 
 /*
@@ -85,6 +91,14 @@ export const DashboardTemplates: Array<DashboardTemplate> = [
     description:
       "HTTP request rate, latency, error rate, CPU utilization gauge, memory usage, disk and network I/O, and runtime metrics.",
     icon: IconProp.ChartBar,
+    category: DashboardTemplateCategory.Monitoring,
+  },
+  {
+    type: DashboardTemplateType.Rum,
+    name: "Real User Monitoring Dashboard",
+    description:
+      "Core Web Vitals gauges and trends (LCP, INP, CLS, FCP, TTFB), page-load volume and duration, browser errors, and breakdowns by application, route and platform.",
+    icon: IconProp.Globe,
     category: DashboardTemplateCategory.Monitoring,
   },
   {
@@ -432,6 +446,75 @@ function createTableComponent(data: {
               groupBy: undefined,
             },
           },
+    },
+  };
+}
+
+/*
+ * Trace analytics widgets query POST /telemetry/traces/analytics rather
+ * than the metric store, so they work off raw spans.
+ *
+ * `groupByAttribute` is what scopes them. A resource dimension key such
+ * as `rumApplicationId` compiles to `primaryEntityType = 'RealUserMonitor'`
+ * server-side (TraceAggregationService.appendGroupByDimensionFilters), so
+ * grouping by it both splits the series per RUM application AND excludes
+ * backend spans. A plain attribute key compiles to
+ * `mapContains(attributes, '<key>')`, which excludes any span that does
+ * not carry it — that is how the route / browser breakdowns below stay
+ * browser-only without a hand-written filter.
+ */
+function createTraceChartComponent(data: {
+  title: string;
+  metric: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  groupByAttribute?: string;
+  topLimit?: number;
+}): DashboardBaseComponent {
+  return {
+    _type: ObjectType.DashboardComponent,
+    componentType: DashboardComponentType.TraceChart,
+    componentId: ObjectID.generate(),
+    topInDashboardUnits: data.top,
+    leftInDashboardUnits: data.left,
+    widthInDashboardUnits: data.width,
+    heightInDashboardUnits: data.height,
+    minHeightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 6,
+    arguments: {
+      title: data.title,
+      metric: data.metric,
+      groupByAttribute: data.groupByAttribute,
+      topLimit: data.topLimit ?? 10,
+    },
+  };
+}
+
+function createTraceTableComponent(data: {
+  title: string;
+  groupByAttribute: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  topLimit?: number;
+}): DashboardBaseComponent {
+  return {
+    _type: ObjectType.DashboardComponent,
+    componentType: DashboardComponentType.TraceTable,
+    componentId: ObjectID.generate(),
+    topInDashboardUnits: data.top,
+    leftInDashboardUnits: data.left,
+    widthInDashboardUnits: data.width,
+    heightInDashboardUnits: data.height,
+    minHeightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 6,
+    arguments: {
+      title: data.title,
+      groupByAttribute: data.groupByAttribute,
+      topLimit: data.topLimit ?? 10,
     },
   };
 }
@@ -2187,6 +2270,437 @@ function createMetricsDashboardConfig(): DashboardViewConfig {
   };
 }
 
+/*
+ * Canonical Core Web Vital metric names. OneUptime probes several
+ * community spellings per vital when it reads them (see WEB_VITAL_DEFS in
+ * the RUM overview page and the /docs/rum/web-vitals table), but a widget
+ * can only query one name, so the template uses the `web_vital.*` names —
+ * the ones the docs tell new instrumentation to emit, and the ones the
+ * RUM alert templates in RumAlertTemplates.ts already alert on.
+ */
+enum RumWebVitalMetric {
+  Lcp = "web_vital.lcp",
+  Inp = "web_vital.inp",
+  Cls = "web_vital.cls",
+  Fcp = "web_vital.fcp",
+  Ttfb = "web_vital.ttfb",
+}
+
+function createRumDashboardConfig(): DashboardViewConfig {
+  /*
+   * Layout notes:
+   *
+   * - The value tiles and gauges aggregate with Avg so they read exactly
+   *   like the Core Web Vitals card on a RUM application's overview, and
+   *   so the gauge thresholds below can be Google's published good /
+   *   needs-improvement / poor boundaries unchanged (2500/4000 ms LCP,
+   *   200/500 ms INP, 0.1/0.25 CLS, 1800/3000 ms FCP). An average is a
+   *   trend indicator, not the p75 Google's field tooling reports — the
+   *   per-route chart uses P95 for exactly that reason.
+   *
+   * - CLS is emitted with unit "1" but is NOT an OTel ratio metric, and
+   *   `isFractionMetric` keys off the metric NAME (`.utilization`,
+   *   `.ratio`, `.fraction`, `.percent`), so `web_vital.cls` renders raw
+   *   rather than being multiplied to a percent. The 0-0.5 gauge sweep is
+   *   therefore in the vital's own units.
+   *
+   * - Every trace widget is scoped by its group-by dimension rather than
+   *   by a filter — see the comment on createTraceChartComponent. That is
+   *   also why there is no TraceList widget here: it has no group-by, so
+   *   it would list every span in the project, backend included.
+   *
+   * - `legendUnit` is set on the charts only. Value tiles and gauges go
+   *   through buildMetricQueryData, which drops metricAliasData (the only
+   *   carrier of legendUnit), and take their unit from the stored
+   *   MetricType instead — so setting it there would be inert config that
+   *   reads as if it were doing something.
+   */
+  const components: Array<DashboardBaseComponent> = [
+    // Row 0: Title
+    createTextComponent({
+      text: "Real User Monitoring Dashboard",
+      top: 0,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    // Row 1: Headline vitals. Every one of these is worse when it rises.
+    createValueComponent({
+      title: "Avg LCP",
+      top: 1,
+      left: 0,
+      width: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Lcp,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsWorse,
+    }),
+    createValueComponent({
+      title: "Avg INP",
+      top: 1,
+      left: 3,
+      width: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Inp,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsWorse,
+    }),
+    createValueComponent({
+      title: "Avg CLS",
+      top: 1,
+      left: 6,
+      width: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Cls,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsWorse,
+    }),
+    createValueComponent({
+      title: "Avg TTFB",
+      top: 1,
+      left: 9,
+      width: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Ttfb,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsWorse,
+    }),
+
+    // Row 2-4: The same vitals against their rating boundaries.
+    createGaugeComponent({
+      title: "Largest Contentful Paint",
+      top: 2,
+      left: 0,
+      width: 3,
+      height: 3,
+      minValue: 0,
+      maxValue: 6000,
+      warningThreshold: 2500,
+      criticalThreshold: 4000,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Lcp,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+    }),
+    createGaugeComponent({
+      title: "Interaction to Next Paint",
+      top: 2,
+      left: 3,
+      width: 3,
+      height: 3,
+      minValue: 0,
+      maxValue: 1000,
+      warningThreshold: 200,
+      criticalThreshold: 500,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Inp,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+    }),
+    createGaugeComponent({
+      title: "Cumulative Layout Shift",
+      top: 2,
+      left: 6,
+      width: 3,
+      height: 3,
+      minValue: 0,
+      maxValue: 0.5,
+      warningThreshold: 0.1,
+      criticalThreshold: 0.25,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Cls,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+    }),
+    createGaugeComponent({
+      title: "First Contentful Paint",
+      top: 2,
+      left: 9,
+      width: 3,
+      height: 3,
+      minValue: 0,
+      maxValue: 5000,
+      warningThreshold: 1800,
+      criticalThreshold: 3000,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Fcp,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+    }),
+
+    // Row 5: Section header
+    createTextComponent({
+      text: "Core Web Vital Trends",
+      top: 5,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    // Row 6-14: One trend per vital, plus the per-route P95 breakdown.
+    createChartComponent({
+      title: "Largest Contentful Paint Over Time",
+      chartType: DashboardChartType.Line,
+      top: 6,
+      left: 0,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Lcp,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "LCP",
+        legendUnit: "ms",
+      },
+    }),
+    createChartComponent({
+      title: "Interaction to Next Paint Over Time",
+      chartType: DashboardChartType.Line,
+      top: 6,
+      left: 6,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Inp,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "INP",
+        legendUnit: "ms",
+      },
+    }),
+    createChartComponent({
+      title: "Cumulative Layout Shift Over Time",
+      chartType: DashboardChartType.Line,
+      top: 9,
+      left: 0,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Cls,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "CLS",
+      },
+    }),
+    createChartComponent({
+      title: "First Contentful Paint Over Time",
+      chartType: DashboardChartType.Line,
+      top: 9,
+      left: 6,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Fcp,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "FCP",
+        legendUnit: "ms",
+      },
+    }),
+    createChartComponent({
+      title: "Time to First Byte Over Time",
+      chartType: DashboardChartType.Line,
+      top: 12,
+      left: 0,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Ttfb,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "TTFB",
+        legendUnit: "ms",
+      },
+    }),
+    /*
+     * `app.route` is the low-cardinality route PATTERN the web-vitals doc
+     * tells you to record alongside each vital. A metric group-by does NOT
+     * emit a presence predicate — a missing map key reads back as "" — so
+     * until you record it this renders a single `app.route=(unset)` series
+     * carrying the ungrouped P95, not an empty chart. That series is
+     * labelled, so it reads as "no route attribution" rather than as a
+     * one-route site.
+     */
+    createChartComponent({
+      title: "Largest Contentful Paint by Route (P95)",
+      chartType: DashboardChartType.Bar,
+      top: 12,
+      left: 6,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: RumWebVitalMetric.Lcp,
+        aggregationType: MetricsAggregationType.P95,
+        legend: "P95 LCP",
+        legendUnit: "ms",
+        groupByAttributeKeys: ["app.route"],
+      },
+    }),
+
+    /*
+     * Row 15: Section header. It says "span-based" because these widgets
+     * query the trace analytics endpoint, which does not read dashboard
+     * variables — the toolbar pickers above narrow the metric widgets and
+     * the log stream but not this section, and a header that does not say
+     * so invites reading the two halves as one filtered view.
+     */
+    createTextComponent({
+      text: "Page Loads & Browser Errors (span-based — not narrowed by the filters above)",
+      top: 15,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    /*
+     * Rows 16-21: root browser spans. "Root" is the trace-explorer default
+     * and is what excludes documentLoad's documentFetch / resourceFetch
+     * children — but a fetch or XHR started outside an active span is
+     * itself a root, and the documented setup installs both fetch and XHR
+     * instrumentation. So the population here is document loads PLUS AJAX
+     * calls PLUS any manual route-change spans, which is why these are
+     * titled "requests" rather than "page loads".
+     */
+    createTraceChartComponent({
+      title: "Page Loads & Requests",
+      metric: "count",
+      top: 16,
+      left: 0,
+      width: 6,
+      height: 3,
+      groupByAttribute: "rumApplicationId",
+    }),
+    createTraceChartComponent({
+      title: "Browser Errors Over Time",
+      metric: "errorCount",
+      top: 16,
+      left: 6,
+      width: 6,
+      height: 3,
+      groupByAttribute: "rumApplicationId",
+    }),
+    createTraceChartComponent({
+      title: "Page Load & Request Time (P95)",
+      metric: "p95Duration",
+      top: 19,
+      left: 0,
+      width: 6,
+      height: 3,
+      groupByAttribute: "rumApplicationId",
+    }),
+    /*
+     * Only route-change spans carry `app.route` (the SPA snippet in
+     * /docs/rum/browser-setup sets it on the span it creates), and a plain
+     * attribute group-by compiles to `mapContains(attributes, key)` — so
+     * this measures route changes, never document loads. Titled as such,
+     * and empty on a site that does not emit them.
+     */
+    createTraceChartComponent({
+      title: "Route Change Duration (Avg)",
+      metric: "avgDuration",
+      top: 19,
+      left: 6,
+      width: 6,
+      height: 3,
+      groupByAttribute: "app.route",
+    }),
+
+    // Row 22: Section header
+    createTextComponent({
+      text: "Breakdowns",
+      top: 22,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    /*
+     * Rows 23-28: each table returns count / errorCount / p50 / p95 per
+     * row, so one query answers "how much traffic, how broken, how slow"
+     * per application, route, and platform. The `rumApplicationId` column
+     * holds internal ids; TraceAggregationService resolves them to
+     * application names before the rows leave the server.
+     */
+    createTraceTableComponent({
+      title: "Applications",
+      groupByAttribute: "rumApplicationId",
+      top: 23,
+      left: 0,
+      width: 6,
+      height: 3,
+    }),
+    // Route-change spans only, for the same reason as the chart above.
+    createTraceTableComponent({
+      title: "Top Route Changes",
+      groupByAttribute: "app.route",
+      top: 23,
+      left: 6,
+      width: 6,
+      height: 3,
+    }),
+    /*
+     * `browser.platform` is a RESOURCE attribute, stored on spans under
+     * the `resource.` prefix at ingest. It is Chromium-only unless the app
+     * sets it explicitly — see "Setting browser.* without the detector"
+     * in /docs/rum/browser-setup.
+     */
+    createTraceTableComponent({
+      title: "Browsers & Platforms",
+      groupByAttribute: "resource.browser.platform",
+      top: 26,
+      left: 0,
+      width: 6,
+      height: 3,
+    }),
+    createLogStreamComponent({
+      title: "Recent Browser Logs",
+      top: 26,
+      left: 6,
+      width: 6,
+      height: 3,
+    }),
+  ];
+
+  /*
+   * These narrow the metric widgets and the log stream; the trace widgets
+   * do not read variables and carry their own group-by scoping instead
+   * (the section header above says so).
+   *
+   * Both keys are RESOURCE attributes, which is deliberate: resource
+   * attributes are stamped onto metrics, logs AND spans from the same
+   * OTel Resource, so a selection means the same thing on every widget
+   * that reads it. `app.route` is NOT offered here even though the metric
+   * charts group by it — it is recorded on metrics and spans but never on
+   * logs, so selecting a route would empty "Recent Browser Logs" and read
+   * as "this route produced no logs".
+   */
+  const variables: Array<DashboardVariable> = [
+    createTelemetryAttributeVariable({
+      name: "application",
+      label: "Application",
+      attributeKey: "resource.service.name",
+      isMultiSelect: true,
+    }),
+    createTelemetryAttributeVariable({
+      name: "platform",
+      label: "Platform",
+      attributeKey: "resource.browser.platform",
+      isMultiSelect: true,
+    }),
+  ];
+
+  return {
+    _type: ObjectType.DashboardViewConfig,
+    components,
+    variables,
+    heightInDashboardUnits: Math.max(DashboardSize.heightInDashboardUnits, 29),
+  };
+}
+
 function createHostDashboardConfig(): DashboardViewConfig {
   /*
    * Layout notes:
@@ -2921,6 +3435,8 @@ export function getTemplateConfig(
       return createDockerSwarmDashboardConfig();
     case DashboardTemplateType.Metrics:
       return createMetricsDashboardConfig();
+    case DashboardTemplateType.Rum:
+      return createRumDashboardConfig();
     case DashboardTemplateType.Blank:
       return null;
   }


### PR DESCRIPTION
## What

Adds a **Real User Monitoring** dashboard template under *Monitoring & APM* — the one product area that had no template — plus the trace-analytics fix it needs to render readably.

### The template (26 widgets)

| Section | Widgets |
|---|---|
| Headline | Avg LCP / INP / CLS / TTFB value tiles |
| Ratings | Gauges for LCP, INP, CLS, FCP against Google's good / needs-improvement / poor boundaries |
| Trends | A line chart per vital, plus LCP by route (P95) |
| Page loads & errors | Trace charts: volume, error count, P95 duration, route-change duration |
| Breakdowns | Trace tables by application / route / browser platform, plus a browser log stream |
| Variables | Application and Platform pickers |

Metric widgets query the canonical `web_vital.*` names — the ones [`/docs/rum/web-vitals`](App/FeatureSet/Docs/Content/en/rum/web-vitals.md) tells new instrumentation to emit and the ones `RumAlertTemplates.ts` already alerts on. Gauges aggregate with `Avg` so they read exactly like the Core Web Vitals card on a RUM application's overview, which is what makes Google's published thresholds applicable unchanged.

### The supporting fix

Trace widgets have no service filter, so each is scoped by its **group-by dimension**: `rumApplicationId` compiles to `primaryEntityType = 'RealUserMonitor'` server-side, and a plain attribute key to `mapContains(attributes, key)`. That is also why there is no `TraceList` widget — it has no group-by, so it would list every span in the project, backend included.

But a resource dimension selects the bare `toString(primaryEntityId)`, and nothing downstream turned that into a name — so four of the seven trace widgets would have rendered raw ObjectIDs in the legend, the tooltip and the table, under a column headed `rumApplicationId`. The first commit resolves them server-side through the same `ResourceFacetResolver` the facet sidebar already uses. This path was previously unreachable from the UI (the widget editor omits opaque ids from its split picker on purpose), so only a template can produce this config.

## Two limitations the template is explicit about

Rather than paper over them:

- **Trace widgets do not read dashboard variables.** The span-based section header says so, instead of letting the two halves of the dashboard look like one filtered view. Fixing this properly needs multi-value attribute filtering in the trace analytics request — `parseTraceFilterBody` silently drops non-string values, so a multi-select variable would appear to work and filter nothing.
- **`app.route` is not offered as a variable**, even though the metric charts group by it. It is recorded on metrics and spans but never on logs, so selecting a route would empty "Recent Browser Logs" and read as "this route produced no logs".

Widget titles say "requests" rather than "page loads" where the query returns root browser spans — that population is document loads *plus* AJAX *plus* any manual route-change spans.

## Tests

**87 new tests, all passing**; 2061 pass across the 105 Common suites with no regressions.

- `RumDashboardTemplate.test.ts` — 42 tests pinning the catalog entry, every widget's identity and grid slot, metric names, aggregations, Google's gauge boundaries, trace metrics and group-by dimensions, variables, and layout invariants.
- `DashboardTemplateInvariants.test.ts` — 24 tests that hold for **every** template, so they guard the eleven existing ones too: grid bounds, overlap, id freshness, the misspelled `aggegationType` key the fetch layer actually reads, gauge threshold ordering, variable uniqueness.
- `TraceAnalyticsResourceDisplayNames.test.ts` — 21 tests for the server fix, including that `getAnalyticsTopList` deliberately does *not* resolve names (its values feed back into the timeseries query as an IN filter and the AI latency detectors match on them).

Every suite was mutation-tested. The invariants suite caught 11 of 14 injected defects on its first pass; the surviving holes (empty `metric` / `groupByAttribute` / `text`, a dead category test that stayed green against the exact bug in its own name) were closed and re-verified.

## Notes for the reviewer

- `App/` tests could not be run locally: repo-root `jest-runtime@30` shadows App's `jest@28` and every App suite fails to start with `Cannot read properties of undefined (reading 'bind')` — including untouched ones, in a clean checkout. The App-side change here is nine label entries in a `Record<string, string>`.
- Three pre-existing issues surfaced during review and are **not** addressed here: the gauge value arc is drawn off-track above the midpoint of its range; Value tiles render a confident `0` when a metric has no data (so an empty RUM dashboard reads as a flawless site); and dashboard variables not reaching trace widgets, as above.