### PR TITLE
feat(helm): support existingSecret for microsoftTeamsApp

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -119,9 +119,23 @@ its userlist at startup.
 - name: IS_ENTERPRISE_EDITION
   value: {{ (ternary "true" "false" $isEnterpriseEdition) | squote }}
 - name: MICROSOFT_TEAMS_APP_CLIENT_ID
+  {{- if $.Values.microsoftTeamsApp.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.microsoftTeamsApp.existingSecret.name }}
+      key: {{ $.Values.microsoftTeamsApp.existingSecret.clientIdKey }}
+  {{- else }}
   value: {{ $.Values.microsoftTeamsApp.clientId }}
+  {{- end }}
 - name: MICROSOFT_TEAMS_APP_TENANT_ID
+  {{- if $.Values.microsoftTeamsApp.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.microsoftTeamsApp.existingSecret.name }}
+      key: {{ $.Values.microsoftTeamsApp.existingSecret.tenantIdKey }}
+  {{- else }}
   value: {{ $.Values.microsoftTeamsApp.tenantId }}
+  {{- end }}
 
 {{- if $.Values.openTelemetryExporter.endpoint }}
 - name: OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT
@@ -387,7 +401,14 @@ GLOBAL_LLM_PROVIDER_API_KEY is rendered only when an API key is configured.
   {{- end }}
 
 - name: MICROSOFT_TEAMS_APP_CLIENT_SECRET
+  {{- if $.Values.microsoftTeamsApp.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.microsoftTeamsApp.existingSecret.name }}
+      key: {{ $.Values.microsoftTeamsApp.existingSecret.clientSecretKey }}
+  {{- else }}
   value: {{ $.Values.microsoftTeamsApp.clientSecret }}
+  {{- end }}
 
 - name: GITHUB_APP_CLIENT_SECRET
   value: {{ $.Values.gitHubApp.clientSecret }}

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -122,8 +122,8 @@ its userlist at startup.
   {{- if $.Values.microsoftTeamsApp.existingSecret }}
   valueFrom:
     secretKeyRef:
-      name: {{ $.Values.microsoftTeamsApp.existingSecret.name }}
-      key: {{ $.Values.microsoftTeamsApp.existingSecret.clientIdKey }}
+      name: {{ $.Values.microsoftTeamsApp.existingSecret.name | quote }}
+      key: {{ $.Values.microsoftTeamsApp.existingSecret.clientIdKey | quote }}
   {{- else }}
   value: {{ $.Values.microsoftTeamsApp.clientId }}
   {{- end }}
@@ -131,8 +131,8 @@ its userlist at startup.
   {{- if $.Values.microsoftTeamsApp.existingSecret }}
   valueFrom:
     secretKeyRef:
-      name: {{ $.Values.microsoftTeamsApp.existingSecret.name }}
-      key: {{ $.Values.microsoftTeamsApp.existingSecret.tenantIdKey }}
+      name: {{ $.Values.microsoftTeamsApp.existingSecret.name | quote }}
+      key: {{ $.Values.microsoftTeamsApp.existingSecret.tenantIdKey | quote }}
   {{- else }}
   value: {{ $.Values.microsoftTeamsApp.tenantId }}
   {{- end }}
@@ -404,8 +404,8 @@ GLOBAL_LLM_PROVIDER_API_KEY is rendered only when an API key is configured.
   {{- if $.Values.microsoftTeamsApp.existingSecret }}
   valueFrom:
     secretKeyRef:
-      name: {{ $.Values.microsoftTeamsApp.existingSecret.name }}
-      key: {{ $.Values.microsoftTeamsApp.existingSecret.clientSecretKey }}
+      name: {{ $.Values.microsoftTeamsApp.existingSecret.name | quote }}
+      key: {{ $.Values.microsoftTeamsApp.existingSecret.clientSecretKey | quote }}
   {{- else }}
   value: {{ $.Values.microsoftTeamsApp.clientSecret }}
   {{- end }}

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -3101,6 +3101,30 @@
                         "string",
                         "null"
                     ]
+                },
+                "existingSecret": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "clientIdKey": {
+                            "type": "string"
+                        },
+                        "clientSecretKey": {
+                            "type": "string"
+                        },
+                        "tenantIdKey": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "clientIdKey",
+                        "clientSecretKey",
+                        "tenantIdKey"
+                    ],
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1892,6 +1892,12 @@ microsoftTeamsApp:
   clientId:
   clientSecret:
   tenantId:
+  # If you're using an existing secret for the configuration, please use this and update accordingly instead of the parameters above.
+  # existingSecret:
+  #   name: "app-secret"
+  #   clientIdKey: clientId
+  #   clientSecretKey: clientSecret
+  #   tenantIdKey: tenantId
 
 # GitHub Example Configuration
 # gitHubApp:


### PR DESCRIPTION
The chart lets you supply Slack credentials from an existing Kubernetes Secret via `slackApp.existingSecret`, but `microsoftTeamsApp` only accepts literals — which means the Teams client secret has to be written into `values.yaml` in plaintext. For GitOps deployments that puts a credential in git.

This adds `microsoftTeamsApp.existingSecret`, mirroring the existing `slackApp` implementation:

- `templates/_helpers.tpl` — the same conditional structure, applied to `MICROSOFT_TEAMS_APP_CLIENT_ID`, `MICROSOFT_TEAMS_APP_TENANT_ID` and `MICROSOFT_TEAMS_APP_CLIENT_SECRET`
- `values.schema.json` — the same schema shape as `slackApp.existingSecret`, with `tenantIdKey` in place of `signingSecretKey` (needed because `microsoftTeamsApp` is `additionalProperties: false`)
- `values.yaml` — the same commented example

Purely additive: with `existingSecret` unset, the rendered output is unchanged.

## Testing

- `existingSecret` unset → renders `value:` exactly as before
- `existingSecret` set → all three variables render `secretKeyRef`
- Incomplete `existingSecret` → rejected by the schema: `missing properties 'clientIdKey', 'clientSecretKey', 'tenantIdKey'`
- Unknown keys still rejected — `additionalProperties` remains intact
- `helm lint` passes
- Default render compared patched vs unpatched: identical apart from the chart's own `randAlphaNum` secrets and the per-render `date` label