### PR TITLE
feat(slo): bulk add/remove labels and owners on SLO tables

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Slo/useSloBulkActions.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Slo/useSloBulkActions.tsx
@@ -1,0 +1,71 @@
+import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
+import ServiceLevelObjectiveOwnerTeam from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
+import ServiceLevelObjectiveOwnerUser from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
+import useBulkLabelActions from "Common/UI/Components/BulkUpdate/BulkLabelActions";
+import useBulkOwnerActions from "Common/UI/Components/BulkUpdate/BulkOwnerActions";
+import { BulkActionButtonSchema } from "Common/UI/Components/BulkUpdate/BulkUpdateForm";
+import React, { ReactElement } from "react";
+
+/**
+ * The foreign key both SLO owner junction tables use to point back at the
+ * SLO.
+ *
+ * Typed as the intersection of the two tables' keys rather than as `string`
+ * so a typo is a compile error. It has to be: `resourceIdField` is a plain
+ * string on the hook's config, and a wrong value there does not fail — it
+ * queries a column nothing matches, finds no existing owners, and reports
+ * every item as a success while changing nothing.
+ */
+export type SloOwnerResourceIdField = keyof ServiceLevelObjectiveOwnerUser &
+  keyof ServiceLevelObjectiveOwnerTeam;
+
+export const SLO_OWNER_RESOURCE_ID_FIELD: SloOwnerResourceIdField =
+  "serviceLevelObjectiveId";
+
+export interface SloBulkActionsResult {
+  bulkActions: Array<BulkActionButtonSchema<ServiceLevelObjective>>;
+  modals: ReactElement;
+}
+
+export type UseSloBulkActionsFunction = () => SloBulkActionsResult;
+
+/**
+ * "Add Labels" / "Remove Labels" / "Add Owner" / "Remove Owner" for a table
+ * of SLOs.
+ *
+ * Labels are how SLOs get grouped into a team's or a service's view, and
+ * owners are who gets notified when one of them changes status — both were
+ * previously reachable only one SLO at a time, through the edit form and the
+ * SLO's Owners tab. Every other resource list in the product already offers
+ * these in bulk.
+ *
+ * Lives here rather than on the SLOs page because two surfaces mount it (the
+ * SLOs list and the monitor's SLOs tab) and they must not drift apart in
+ * which junction tables or foreign key they write.
+ */
+export const useSloBulkActions: UseSloBulkActionsFunction =
+  (): SloBulkActionsResult => {
+    const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
+      useBulkLabelActions<ServiceLevelObjective>({
+        modelType: ServiceLevelObjective,
+      });
+
+    const { bulkActions: ownerBulkActions, modals: ownerBulkActionModals } =
+      useBulkOwnerActions<ServiceLevelObjective>({
+        ownerUserModelType: ServiceLevelObjectiveOwnerUser,
+        ownerTeamModelType: ServiceLevelObjectiveOwnerTeam,
+        resourceIdField: SLO_OWNER_RESOURCE_ID_FIELD,
+      });
+
+    return {
+      bulkActions: [...labelBulkActions, ...ownerBulkActions],
+      modals: (
+        <>
+          {labelBulkActionModals}
+          {ownerBulkActionModals}
+        </>
+      ),
+    };
+  };
+
+export default useSloBulkActions;

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Slos.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Slos.tsx
@@ -5,6 +5,15 @@ import {
   getSloViewRoute,
   SLO_TABLE_SELECT_MORE_FIELDS,
 } from "../../Slo/Slos";
+import useSloBulkActions, {
+  SLO_OWNER_RESOURCE_ID_FIELD,
+  SloBulkActionsResult,
+} from "../../../Components/Slo/useSloBulkActions";
+import OwnersCell from "../../../Components/ResourceOwners/OwnersCell";
+import useResourceOwners from "../../../Components/ResourceOwners/useResourceOwners";
+import ServiceLevelObjectiveOwnerTeam from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
+import ServiceLevelObjectiveOwnerUser from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
+import LabelsElement from "Common/UI/Components/Label/Labels";
 import Route from "Common/Types/API/Route";
 import ObjectID from "Common/Types/ObjectID";
 import Includes from "Common/Types/BaseDatabase/Includes";
@@ -32,6 +41,21 @@ import React, { Fragment, FunctionComponent, ReactElement } from "react";
 const MonitorSlos: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID(1);
 
+  /*
+   * Same bulk label / owner actions as the SLOs page. Reaching several SLOs
+   * at once is if anything more useful here: "everything this flapping
+   * monitor measures" is exactly the set an SRE wants to re-label or hand to
+   * an owner, and it is already the set this table has selected.
+   */
+  const { bulkActions, modals }: SloBulkActionsResult = useSloBulkActions();
+
+  const { getOwnersForResource, isLoadingOwners, onResourcesFetched } =
+    useResourceOwners<ServiceLevelObjective>({
+      ownerUserModelType: ServiceLevelObjectiveOwnerUser,
+      ownerTeamModelType: ServiceLevelObjectiveOwnerTeam,
+      resourceIdField: SLO_OWNER_RESOURCE_ID_FIELD,
+    });
+
   return (
     <Fragment>
       <DisabledWarning monitorId={modelId} />
@@ -55,6 +79,9 @@ const MonitorSlos: FunctionComponent<PageComponentProps> = (): ReactElement => {
         query={{
           projectId: ProjectUtil.getCurrentProjectId()!,
           monitors: new Includes([modelId]),
+        }}
+        onFetchSuccess={(data: Array<ServiceLevelObjective>) => {
+          onResourcesFetched(data);
         }}
         cardProps={{
           title: "Service Level Objectives",
@@ -81,12 +108,53 @@ const MonitorSlos: FunctionComponent<PageComponentProps> = (): ReactElement => {
           },
         ]}
         documentationLink={new Route("/docs/slo/introduction")}
-        columns={getSloTableColumns()}
+        bulkActions={{
+          buttons: [...bulkActions],
+        }}
+        columns={[
+          ...getSloTableColumns(),
+          /*
+           * Not part of the shared column set, but this table can now
+           * re-label SLOs in bulk — without a Labels column the only
+           * feedback on "Add Labels" would be the progress modal closing.
+           */
+          {
+            field: {
+              labels: {
+                name: true,
+                color: true,
+              },
+            },
+            title: "Labels",
+            type: FieldType.EntityArray,
+            hideOnMobile: true,
+            getElement: (item: ServiceLevelObjective): ReactElement => {
+              return <LabelsElement labels={item["labels"] || []} />;
+            },
+          },
+          {
+            field: {
+              _id: true,
+            },
+            title: "Owners",
+            type: FieldType.Element,
+            hideOnMobile: true,
+            getElement: (item: ServiceLevelObjective): ReactElement => {
+              return (
+                <OwnersCell
+                  owners={getOwnersForResource(item)}
+                  isLoading={isLoadingOwners}
+                />
+              );
+            },
+          },
+        ]}
         selectMoreFields={SLO_TABLE_SELECT_MORE_FIELDS}
         onViewPage={(item: ServiceLevelObjective): Promise<Route> => {
           return Promise.resolve(getSloViewRoute(item));
         }}
       />
+      {modals}
     </Fragment>
   );
 };

--- a/App/FeatureSet/Dashboard/src/Pages/Slo/Slos.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Slo/Slos.tsx
@@ -5,6 +5,14 @@ import SloStatusPill from "../../Components/Slo/SloStatusPill";
 import MonitorsElement from "../../Components/Monitor/Monitors";
 import Route from "Common/Types/API/Route";
 import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
+import ServiceLevelObjectiveOwnerTeam from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
+import ServiceLevelObjectiveOwnerUser from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
+import useSloBulkActions, {
+  SLO_OWNER_RESOURCE_ID_FIELD,
+  SloBulkActionsResult,
+} from "../../Components/Slo/useSloBulkActions";
+import OwnersCell from "../../Components/ResourceOwners/OwnersCell";
+import useResourceOwners from "../../Components/ResourceOwners/useResourceOwners";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorStatus from "Common/Models/DatabaseModels/MonitorStatus";
 import Label from "Common/Models/DatabaseModels/Label";
@@ -587,12 +595,30 @@ export const getSloViewRoute: GetSloViewRouteFunction = (
 };
 
 const Slos: FunctionComponent<PageComponentProps> = (): ReactElement => {
+  const { bulkActions, modals }: SloBulkActionsResult = useSloBulkActions();
+
+  /*
+   * Only the owners cell, not the facet filter bar the peer lists also take
+   * from this hook: "Add Owner" needs somewhere to show its result, and
+   * without a column the whole bulk action would land with nothing on
+   * screen changing.
+   */
+  const { getOwnersForResource, isLoadingOwners, onResourcesFetched } =
+    useResourceOwners<ServiceLevelObjective>({
+      ownerUserModelType: ServiceLevelObjectiveOwnerUser,
+      ownerTeamModelType: ServiceLevelObjectiveOwnerTeam,
+      resourceIdField: SLO_OWNER_RESOURCE_ID_FIELD,
+    });
+
   return (
     <Fragment>
       <ModelTable<ServiceLevelObjective>
         modelType={ServiceLevelObjective}
         id="slos-table"
         userPreferencesKey="slos-table"
+        onFetchSuccess={(data: Array<ServiceLevelObjective>) => {
+          onResourcesFetched(data);
+        }}
         isDeleteable={false}
         isEditable={false}
         isCreateable={true}
@@ -616,6 +642,9 @@ const Slos: FunctionComponent<PageComponentProps> = (): ReactElement => {
         }}
         documentationLink={new Route("/docs/slo/introduction")}
         showViewIdButton={true}
+        bulkActions={{
+          buttons: [...bulkActions],
+        }}
         filters={[
           {
             field: {
@@ -756,12 +785,29 @@ const Slos: FunctionComponent<PageComponentProps> = (): ReactElement => {
               return <LabelsElement labels={item["labels"] || []} />;
             },
           },
+          {
+            field: {
+              _id: true,
+            },
+            title: "Owners",
+            type: FieldType.Element,
+            hideOnMobile: true,
+            getElement: (item: ServiceLevelObjective): ReactElement => {
+              return (
+                <OwnersCell
+                  owners={getOwnersForResource(item)}
+                  isLoading={isLoadingOwners}
+                />
+              );
+            },
+          },
         ]}
         selectMoreFields={SLO_TABLE_SELECT_MORE_FIELDS}
         onViewPage={(item: ServiceLevelObjective): Promise<Route> => {
           return Promise.resolve(getSloViewRoute(item));
         }}
       />
+      {modals}
     </Fragment>
   );
 };

--- a/App/Tests/Dashboard/SloBulkActionsWiring.test.ts
+++ b/App/Tests/Dashboard/SloBulkActionsWiring.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
+import ServiceLevelObjectiveOwnerTeam from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
+import ServiceLevelObjectiveOwnerUser from "Common/Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
+import { TableColumnMetadata } from "Common/Types/Database/TableColumn";
+import TableColumnType from "Common/Types/Database/TableColumnType";
+
+/*
+ * Bulk "Add Labels" / "Remove Labels" / "Add Owner" / "Remove Owner" on the SLO
+ * tables is entirely wiring: a hook call, a prop on ModelTable, and a `{modals}`
+ * rendered as a sibling. The App suite runs in a plain Node environment with no
+ * renderer, so every way of getting it wrong is silent. Drop the prop and the
+ * table still renders, with checkboxes that select rows and then offer nothing.
+ * Drop the `{modals}` and the buttons appear, are clickable, and open a modal
+ * that was never mounted. Neither fails to compile, and neither fails anywhere
+ * else in this repo.
+ *
+ * So these read the sources and assert the exact expressions, the same way
+ * RecommendationPageWiring.test.ts pins the recommendation pages. Sources are
+ * whitespace-squashed first so prettier re-wrapping a line cannot turn a real
+ * regression check into a red herring, and the negative assertions read a
+ * comment-stripped copy so that prose naming the thing that was removed cannot
+ * fail the test checking it is gone.
+ *
+ * The last describe walks the dashboard tree rather than naming files, so a
+ * third SLO table added later fails here until it is wired too. It matches raw
+ * text with three regexes rather than parsing JSX: an earlier revision of this
+ * file carried a hand-rolled tag scanner that ran on the comment-stripped copy,
+ * where a `videoLink={URL.fromString("https://...")}` prop leaves an
+ * unterminated quote and the scan slides past the element it was reading.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+const HOOK_MODULE: Array<string> = [
+  "Components",
+  "Slo",
+  "useSloBulkActions.tsx",
+];
+const SLOS_PAGE: Array<string> = ["Pages", "Slo", "Slos.tsx"];
+const MONITOR_SLOS_PAGE: Array<string> = [
+  "Pages",
+  "Monitor",
+  "View",
+  "Slos.tsx",
+];
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readRawAt(absolutePath: string): string {
+  return fs.readFileSync(absolutePath, "utf8");
+}
+
+function readSourceAt(absolutePath: string): string {
+  return squash(readRawAt(absolutePath));
+}
+
+function readCodeAt(absolutePath: string): string {
+  return squash(stripComments(readRawAt(absolutePath)));
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return readSourceAt(path.join(DASHBOARD_SRC, ...relativeParts));
+}
+
+function readCode(...relativeParts: Array<string>): string {
+  return readCodeAt(path.join(DASHBOARD_SRC, ...relativeParts));
+}
+
+const HOOK_CODE: string = readCode(...HOOK_MODULE);
+
+describe("the shared hook module hands each bulk-action hook what it needs", () => {
+  test("it imports both hooks, and the action type they return", () => {
+    expect(HOOK_CODE).toContain(
+      'import useBulkLabelActions from "Common/UI/Components/BulkUpdate/BulkLabelActions";',
+    );
+    expect(HOOK_CODE).toContain(
+      'import useBulkOwnerActions from "Common/UI/Components/BulkUpdate/BulkOwnerActions";',
+    );
+    expect(HOOK_CODE).toContain(
+      'import { BulkActionButtonSchema } from "Common/UI/Components/BulkUpdate/BulkUpdateForm";',
+    );
+    expect(HOOK_CODE).toContain(
+      "bulkActions: Array<BulkActionButtonSchema<ServiceLevelObjective>>;",
+    );
+  });
+
+  test("the label hook is told which model the table lists", () => {
+    expect(HOOK_CODE).toContain(
+      squash(
+        "useBulkLabelActions<ServiceLevelObjective>({ modelType: ServiceLevelObjective, })",
+      ),
+    );
+  });
+
+  test("the owner hook gets both junction models and the shared key", () => {
+    expect(HOOK_CODE).toContain(
+      squash(
+        "useBulkOwnerActions<ServiceLevelObjective>({ ownerUserModelType: ServiceLevelObjectiveOwnerUser, ownerTeamModelType: ServiceLevelObjectiveOwnerTeam, resourceIdField: SLO_OWNER_RESOURCE_ID_FIELD, })",
+      ),
+    );
+
+    /*
+     * Through the constant, not a literal spelled out again at the call site.
+     * Inlining it would leave the model-backed check below guarding a constant
+     * that nothing reads, and would drop the typed annotation with it.
+     */
+    expect(HOOK_CODE).not.toContain('resourceIdField: "');
+  });
+
+  test("it returns both hooks' actions and mounts both modal trees", () => {
+    /*
+     * Returning one set is the failure that looks most like it works: four
+     * buttons become two, and nothing says the other two are missing.
+     */
+    expect(HOOK_CODE).toContain(
+      squash("bulkActions: [...labelBulkActions, ...ownerBulkActions],"),
+    );
+
+    const modals: string = HOOK_CODE.split("modals: (")[1]!.split("),")[0]!;
+
+    expect(modals).toContain("{labelBulkActionModals}");
+    expect(modals).toContain("{ownerBulkActionModals}");
+  });
+});
+
+const OWNER_FIELD_DECLARATION: RegExpMatchArray | null = HOOK_CODE.match(
+  /export const SLO_OWNER_RESOURCE_ID_FIELD: (\w+) = "([^"]+)";/,
+);
+
+type OwnerModel =
+  | ServiceLevelObjectiveOwnerUser
+  | ServiceLevelObjectiveOwnerTeam;
+
+type OwnerModelCase = [string, OwnerModel];
+
+const OWNER_MODEL_CASES: Array<OwnerModelCase> = [
+  ["ServiceLevelObjectiveOwnerUser", new ServiceLevelObjectiveOwnerUser()],
+  ["ServiceLevelObjectiveOwnerTeam", new ServiceLevelObjectiveOwnerTeam()],
+];
+
+/*
+ * This is the assertion the whole file exists for. `resourceIdField` is a
+ * string on the generic hook's config, so a wrong value there does not fail —
+ * it filters on a column nothing matches, which comes back empty, so "Remove
+ * Owner" reports every selected SLO as a success while removing nothing. The
+ * constant is therefore parsed out of the source and checked against the two
+ * models it names, rather than against another copy of itself.
+ */
+describe("SLO_OWNER_RESOURCE_ID_FIELD names a real column on both owner tables", () => {
+  test("the module declares it as a literal, typed against both junction tables", () => {
+    expect(OWNER_FIELD_DECLARATION).not.toBeNull();
+
+    const annotation: string = OWNER_FIELD_DECLARATION![1]!;
+
+    /*
+     * The annotation is the compile-time half of the same guarantee: as the
+     * intersection of both tables' keys, a typo stops being a value the hook
+     * silently accepts and becomes a build error. Annotated `string` — which is
+     * what it was — nothing but this test stands between a typo and shipping.
+     */
+    expect(HOOK_CODE).toContain(
+      squash(
+        `export type ${annotation} = keyof ServiceLevelObjectiveOwnerUser & keyof ServiceLevelObjectiveOwnerTeam;`,
+      ),
+    );
+
+    expect(OWNER_FIELD_DECLARATION![2]).toBe("serviceLevelObjectiveId");
+  });
+
+  test.each(OWNER_MODEL_CASES)(
+    "%s declares it, as the required foreign key",
+    (_modelName: string, model: OwnerModel) => {
+      const field: string = OWNER_FIELD_DECLARATION![2]!;
+
+      expect(model.getTableColumns().columns).toContain(field);
+
+      /*
+       * Not merely present under that name: the hook writes an ObjectID into it
+       * when creating a junction row, and a nullable column would accept a row
+       * that points at no SLO at all.
+       */
+      const metadata: TableColumnMetadata = model.getTableColumnMetadata(field);
+
+      expect(metadata.type).toBe(TableColumnType.ObjectID);
+      expect(metadata.required).toBe(true);
+    },
+  );
+
+  test("the label half has a column to write to as well", () => {
+    /*
+     * The same silent failure on the other hook — useBulkLabelActions merges
+     * into `labels` by name, and a model without that column would take the
+     * update and drop it.
+     */
+    expect(new ServiceLevelObjective().getTableColumns().columns).toContain(
+      "labels",
+    );
+  });
+});
+
+describe("the SLOs page does not own the hook", () => {
+  test("the hook, its key and its result type live in the shared module only", () => {
+    /*
+     * They were exported from this page first, and the monitor tab imported
+     * them from here. Leaving a re-export behind is worse than either layout:
+     * the two surfaces could then import the same names down two paths, and a
+     * change made to one copy would look global while reaching one table.
+     */
+    const code: string = readCode(...SLOS_PAGE);
+
+    expect(code).not.toContain("export const useSloBulkActions");
+    expect(code).not.toContain("export const SLO_OWNER_RESOURCE_ID_FIELD");
+    expect(code).not.toContain("export interface SloBulkActionsResult");
+    expect(code).not.toContain('from "../../Slo/Slos"');
+  });
+});
+
+type ConsumerCase = [string, Array<string>, string];
+
+const CONSUMER_CASES: Array<ConsumerCase> = [
+  ["Pages/Slo/Slos.tsx", SLOS_PAGE, "../../Components/Slo/useSloBulkActions"],
+  [
+    "Pages/Monitor/View/Slos.tsx",
+    MONITOR_SLOS_PAGE,
+    "../../../Components/Slo/useSloBulkActions",
+  ],
+];
+
+describe("both SLO tables consume the shared hook", () => {
+  test.each(CONSUMER_CASES)(
+    "%s calls it, passes the buttons, and renders the modals",
+    (_label: string, relativeParts: Array<string>, specifier: string) => {
+      const code: string = readCode(...relativeParts);
+
+      expect(code).toContain(
+        squash(
+          `import useSloBulkActions, { SLO_OWNER_RESOURCE_ID_FIELD, SloBulkActionsResult, } from "${specifier}";`,
+        ),
+      );
+      expect(code).toContain(
+        squash(
+          "const { bulkActions, modals }: SloBulkActionsResult = useSloBulkActions();",
+        ),
+      );
+      expect(code).toContain(
+        squash("bulkActions={{ buttons: [...bulkActions], }}"),
+      );
+
+      /*
+       * A sibling of the table, not a child of it: ModelTable renders no
+       * children, so a `{modals}` nested inside the element would be dropped
+       * and every action button would open nothing.
+       */
+      expect(code).toContain("/> {modals}");
+
+      /*
+       * And through the shared hook rather than a local re-implementation,
+       * which would satisfy every assertion above and still be a second thing
+       * to keep in step with the first.
+       */
+      expect(code).not.toContain("useBulkLabelActions");
+      expect(code).not.toContain("useBulkOwnerActions");
+    },
+  );
+
+  test.each(CONSUMER_CASES)(
+    "%s shows the owners its Add Owner action writes",
+    (_label: string, relativeParts: Array<string>, _specifier: string) => {
+      const code: string = readCode(...relativeParts);
+
+      /*
+       * A bulk owner action on a table with no Owners column is indistinguishable
+       * from a no-op: the progress modal closes and every row looks the same.
+       * The column has to read through the SAME foreign key the action writes,
+       * or the two disagree about which junction rows belong to which SLO.
+       */
+      expect(code).toContain(
+        squash(
+          "useResourceOwners<ServiceLevelObjective>({ ownerUserModelType: ServiceLevelObjectiveOwnerUser, ownerTeamModelType: ServiceLevelObjectiveOwnerTeam, resourceIdField: SLO_OWNER_RESOURCE_ID_FIELD, })",
+        ),
+      );
+      expect(code).toContain(
+        squash('title: "Owners", type: FieldType.Element,'),
+      );
+      expect(code).toContain(
+        squash(
+          "<OwnersCell owners={getOwnersForResource(item)} isLoading={isLoadingOwners} />",
+        ),
+      );
+
+      /*
+       * The owners are fetched in one query for the page of rows the table just
+       * loaded, so the hook has to be handed that page. Without onFetchSuccess
+       * it is never told any rows exist and every cell renders empty forever.
+       */
+      expect(code).toContain(
+        squash(
+          "onFetchSuccess={(data: Array<ServiceLevelObjective>) => { onResourcesFetched(data); }}",
+        ),
+      );
+    },
+  );
+});
+
+/*
+ * "Add Labels" on a table with no Labels column is a no-op as far as the reader
+ * can tell: the progress modal closes and the page looks exactly as it did. The
+ * SLOs page already had the column; the monitor's SLOs tab had to grow one.
+ */
+describe("the monitor's SLOs tab shows the labels it can now edit", () => {
+  const SOURCE: string = readSource(...MONITOR_SLOS_PAGE);
+
+  test("renders a Labels column", () => {
+    expect(SOURCE).toContain(
+      'import LabelsElement from "Common/UI/Components/Label/Labels";',
+    );
+    expect(SOURCE).toContain(
+      squash(
+        'title: "Labels", type: FieldType.EntityArray, hideOnMobile: true,',
+      ),
+    );
+    expect(SOURCE).toContain(
+      squash('return <LabelsElement labels={item["labels"] || []} />;'),
+    );
+  });
+
+  test("and asks the API for the fields that column renders", () => {
+    /*
+     * ModelTable builds its `select` out of the keys each column declares.
+     * Naming only `labels: true` returns rows with no name and no colour, which
+     * draws as a row of blank pills.
+     */
+    expect(SOURCE).toContain(
+      squash(
+        'field: { labels: { name: true, color: true, }, }, title: "Labels",',
+      ),
+    );
+  });
+
+  test("the column is added to the shared set rather than replacing it", () => {
+    expect(SOURCE).toContain(squash("columns={[ ...getSloTableColumns(),"));
+  });
+});
+
+/*
+ * Everything above names the two files by hand. This sweeps the dashboard for
+ * ModelTables over ServiceLevelObjective instead, so the day a third one is
+ * added — an incident's SLOs tab, a team's — it fails here until it is wired.
+ */
+
+function findTsxFiles(directory: string): Array<string> {
+  const found: Array<string> = [];
+
+  const entries: Array<fs.Dirent> = fs.readdirSync(directory, {
+    withFileTypes: true,
+  });
+
+  for (const entry of entries) {
+    const fullPath: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      found.push(...findTsxFiles(fullPath));
+    } else if (entry.name.endsWith(".tsx")) {
+      found.push(fullPath);
+    }
+  }
+
+  return found;
+}
+
+/*
+ * ModelTable is always written with an explicit type argument, so the model a
+ * table lists can be read off the opening tag with a regex — no JSX parsing,
+ * and nothing that a prop's contents can throw off. The `\s*` absorbs prettier
+ * wrapping the type argument onto its own line.
+ */
+const SLO_MODEL_TABLE: RegExp = /<ModelTable<\s*ServiceLevelObjective\s*>/;
+
+const CALLS_SHARED_HOOK: RegExp = /useSloBulkActions\(\)/;
+const PASSES_BULK_ACTIONS: RegExp = /bulkActions=\{\{/;
+const MOUNTS_MODALS: RegExp = /\{modals\}/;
+
+const SLO_TABLE_FILES: Array<string> = findTsxFiles(DASHBOARD_SRC)
+  .filter((file: string): boolean => {
+    return SLO_MODEL_TABLE.test(readRawAt(file));
+  })
+  .map((file: string): string => {
+    return path.relative(DASHBOARD_SRC, file);
+  })
+  .sort();
+
+describe("every ModelTable over ServiceLevelObjective offers the bulk actions", () => {
+  test("each one calls the hook, passes the buttons and mounts the modals", () => {
+    /*
+     * A guard on the sweep itself: the checks below run per matched file, so a
+     * pattern that quietly stopped matching would pass by examining nothing.
+     * Named files rather than a count, because a third table is meant to be
+     * checked here, not rejected.
+     */
+    expect(SLO_TABLE_FILES).toContain(path.join("Pages", "Slo", "Slos.tsx"));
+    expect(SLO_TABLE_FILES).toContain(
+      path.join("Pages", "Monitor", "View", "Slos.tsx"),
+    );
+
+    const unwired: Array<string> = SLO_TABLE_FILES.filter(
+      (relativePath: string): boolean => {
+        const raw: string = readRawAt(path.join(DASHBOARD_SRC, relativePath));
+
+        return (
+          !CALLS_SHARED_HOOK.test(raw) ||
+          !PASSES_BULK_ACTIONS.test(raw) ||
+          !MOUNTS_MODALS.test(raw)
+        );
+      },
+    );
+
+    expect(unwired).toEqual([]);
+  });
+});

--- a/Common/Tests/UI/Components/BulkLabelActions.test.tsx
+++ b/Common/Tests/UI/Components/BulkLabelActions.test.tsx
@@ -1,0 +1,1502 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { act, FunctionComponent, ReactElement } from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * useBulkLabelActions is the single mutator behind "Add Labels" and "Remove
+ * Labels" on every resource list in the product, and it had no test coverage at
+ * all before this change. Most of what follows is therefore baseline coverage
+ * of a previously untested shared hook - the merge/subtract arithmetic, the
+ * per-item failure isolation, and the progress accounting the bulk progress bar
+ * is drawn from - not coverage of the SLO tables that prompted the work. Its
+ * failure mode is silent: each write is a read-modify-write of the item's own
+ * label array, so anything that goes wrong in the middle overwrites labels the
+ * user never selected and still reports the item as a success.
+ *
+ * The tests that pin the fixes actually made in this change are:
+ *   - "does not fetch labels at all when there is no current project"
+ *     (projectId: null went out as a filter matching nothing)
+ *   - "drops a dropdown option that came back without an id before merging"
+ *     (a blank id in the labels array failed the whole item)
+ *   - "reads the item's current label ids before merging" (the select now asks
+ *     for _id, which the guard below depends on)
+ *   - "fails an item whose current read carries no id ..." and
+ *     "... comes back as null ..." (a deleted or filtered row answers 200 with
+ *     {}, which hydrates truthy, so add mode used to clobber its whole label
+ *     set)
+ *   - "starts nothing and reports nothing when every submitted label id is
+ *     blank" (that path used to report every item as a success)
+ *   - "keeps the newest selection's remove options when an older fetch settles
+ *     last" (the stale response used to win)
+ *   - the two "opening X closes an open Y modal" tests (stacked modals share
+ *     one bulkActionProps and the loser goes silently inert)
+ */
+
+/*
+ * react-i18next is not initialized in the test environment. Mock the hook so
+ * translate helpers echo their input and the component renders synchronously.
+ */
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, opts?: { defaultValue?: string }): string => {
+          return opts?.defaultValue ?? key;
+        },
+      };
+    },
+  };
+});
+
+const getListMock: MockFunction = getJestMockFunction();
+const getItemMock: MockFunction = getJestMockFunction();
+const updateByIdMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the compiled
+ * requires, so naming the mocks directly would capture them before their
+ * initializers have run.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      updateById: (...args: Array<any>) => {
+        return updateByIdMock(...args);
+      },
+    },
+  };
+});
+
+import useBulkLabelActions, {
+  BulkLabelActionsResult,
+} from "../../../UI/Components/BulkUpdate/BulkLabelActions";
+import {
+  BulkActionButtonSchema,
+  BulkActionFailed,
+  BulkActionOnClickProps,
+  ProgressInfo,
+} from "../../../UI/Components/BulkUpdate/BulkUpdateForm";
+import { ButtonStyleType } from "../../../UI/Components/Button/Button";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import API from "../../../UI/Utils/API/API";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import IconProp from "../../../Types/Icon/IconProp";
+import { Red } from "../../../Types/BrandColors";
+
+/*
+ * These tests drive real Formik + react-select trees behind a modal, so the
+ * testing-library default of 1s flakes on a loaded box.
+ */
+const WAIT_TIMEOUT: number = 20000;
+
+const PROJECT_ID: string = "11111111-1111-4111-8111-111111111111";
+const ITEM_ONE_ID: string = "22222222-2222-4222-8222-222222222221";
+const ITEM_TWO_ID: string = "22222222-2222-4222-8222-222222222222";
+const ITEM_THREE_ID: string = "22222222-2222-4222-8222-222222222223";
+const LABEL_ALPHA_ID: string = "33333333-3333-4333-8333-333333333331";
+const LABEL_BETA_ID: string = "33333333-3333-4333-8333-333333333332";
+const LABEL_GAMMA_ID: string = "33333333-3333-4333-8333-333333333333";
+
+type MakeLabelFunction = (id: string, name: string) => Label;
+
+const makeLabel: MakeLabelFunction = (id: string, name: string): Label => {
+  const label: Label = new Label();
+  label._id = id;
+  label.name = name;
+  return label;
+};
+
+type MakeItemFunction = (id: string) => Monitor;
+
+const makeItem: MakeItemFunction = (id: string): Monitor => {
+  const item: Monitor = new Monitor();
+  item._id = id;
+  return item;
+};
+
+type MakeItemWithLabelsFunction = (id: string, labels: Array<Label>) => Monitor;
+
+const makeItemWithLabels: MakeItemWithLabelsFunction = (
+  id: string,
+  labels: Array<Label>,
+): Monitor => {
+  const item: Monitor = makeItem(id);
+  item.labels = labels;
+  return item;
+};
+
+interface ProgressSnapshot {
+  totalIds: Array<string>;
+  inProgressIds: Array<string>;
+  successIds: Array<string>;
+  failedIds: Array<string>;
+  failedMessages: Array<string>;
+}
+
+type IdsOfFunction = (items: Array<Monitor>) => Array<string>;
+
+const idsOf: IdsOfFunction = (items: Array<Monitor>): Array<string> => {
+  return items.map((item: Monitor) => {
+    return item._id || "";
+  });
+};
+
+type SnapshotProgressFunction = (
+  progressInfo: ProgressInfo<Monitor>,
+) => ProgressSnapshot;
+
+/*
+ * The hook allocates the four progress arrays once and hands the same
+ * references to every onProgressInfo call, so anything held by reference
+ * mutates retroactively into the final state. Copy out of them on arrival or
+ * the per-step assertions below are meaningless.
+ */
+const snapshotProgress: SnapshotProgressFunction = (
+  progressInfo: ProgressInfo<Monitor>,
+): ProgressSnapshot => {
+  return {
+    totalIds: idsOf(progressInfo.totalItems),
+    inProgressIds: idsOf(progressInfo.inProgressItems),
+    successIds: idsOf(progressInfo.successItems),
+    failedIds: idsOf(
+      progressInfo.failed.map((failure: BulkActionFailed<Monitor>) => {
+        return failure.item;
+      }),
+    ),
+    failedMessages: progressInfo.failed.map(
+      (failure: BulkActionFailed<Monitor>) => {
+        return String(failure.failedMessage);
+      },
+    ),
+  };
+};
+
+const onProgressInfoMock: MockFunction = getJestMockFunction();
+const onBulkActionStartMock: MockFunction = getJestMockFunction();
+const onBulkActionEndMock: MockFunction = getJestMockFunction();
+
+let progressSnapshots: Array<ProgressSnapshot> = [];
+let callOrder: Array<string> = [];
+let capturedActions: Array<BulkActionButtonSchema<Monitor>> = [];
+let capturedModals: ReactElement | null = null;
+
+type MakeActionPropsFunction = (
+  items: Array<Monitor>,
+) => BulkActionOnClickProps<Monitor>;
+
+const makeActionProps: MakeActionPropsFunction = (
+  items: Array<Monitor>,
+): BulkActionOnClickProps<Monitor> => {
+  return {
+    items: items,
+    onProgressInfo:
+      onProgressInfoMock as unknown as BulkActionOnClickProps<Monitor>["onProgressInfo"],
+    onBulkActionStart: onBulkActionStartMock as unknown as () => void,
+    onBulkActionEnd: onBulkActionEndMock as unknown as () => void,
+  };
+};
+
+interface HarnessProps {
+  items: Array<Monitor>;
+}
+
+/*
+ * `modals` has to be mounted for any of the modal behavior to exist, which
+ * renderHook cannot do, so the hook is driven through a component that renders
+ * a plain trigger per action.
+ */
+const Harness: FunctionComponent<HarnessProps> = (
+  props: HarnessProps,
+): ReactElement => {
+  const { bulkActions, modals }: BulkLabelActionsResult<Monitor> =
+    useBulkLabelActions<Monitor>({ modelType: Monitor });
+
+  capturedActions = bulkActions;
+  capturedModals = modals;
+
+  return (
+    <div>
+      {bulkActions.map((action: BulkActionButtonSchema<Monitor>) => {
+        return (
+          <button
+            key={action.title}
+            type="button"
+            onClick={() => {
+              void action.onClick(makeActionProps(props.items));
+            }}
+          >
+            {`Trigger ${action.title}`}
+          </button>
+        );
+      })}
+      {modals}
+    </div>
+  );
+};
+
+type ClickTriggerFunction = (title: string) => void;
+
+const clickTrigger: ClickTriggerFunction = (title: string): void => {
+  fireEvent.click(screen.getByText(`Trigger ${title}`));
+};
+
+type WaitForModalTitleFunction = (title: string) => Promise<void>;
+
+const waitForModalTitle: WaitForModalTitleFunction = async (
+  title: string,
+): Promise<void> => {
+  await waitFor(
+    () => {
+      expect(screen.getByTestId("modal-title")).toHaveTextContent(title);
+    },
+    { timeout: WAIT_TIMEOUT },
+  );
+};
+
+type WaitForMountedLabelFetchFunction = () => Promise<void>;
+
+/*
+ * The mount effect writes state after its fetch settles; waiting for the call
+ * keeps that write inside act() instead of leaking into the next test.
+ */
+const waitForMountedLabelFetch: WaitForMountedLabelFetchFunction =
+  async (): Promise<void> => {
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+  };
+
+type OpenMenuFunction = () => Promise<Array<HTMLElement>>;
+
+/*
+ * react-select renders its menu lazily; ArrowDown on the combobox is the only
+ * interaction that mounts the option list.
+ */
+const openMenu: OpenMenuFunction = async (): Promise<Array<HTMLElement>> => {
+  const combobox: HTMLElement = await screen.findByRole("combobox", undefined, {
+    timeout: WAIT_TIMEOUT,
+  });
+  fireEvent.keyDown(combobox, { key: "ArrowDown", code: "ArrowDown" });
+  return screen.queryAllByRole("option");
+};
+
+type OptionTextsFunction = (options: Array<HTMLElement>) => Array<string>;
+
+const optionTexts: OptionTextsFunction = (
+  options: Array<HTMLElement>,
+): Array<string> => {
+  return options.map((option: HTMLElement) => {
+    return option.textContent || "";
+  });
+};
+
+type SelectLabelFunction = (name: string) => Promise<void>;
+
+const selectLabel: SelectLabelFunction = async (
+  name: string,
+): Promise<void> => {
+  const combobox: HTMLElement = await screen.findByRole("combobox", undefined, {
+    timeout: WAIT_TIMEOUT,
+  });
+  fireEvent.keyDown(combobox, { key: "ArrowDown", code: "ArrowDown" });
+  fireEvent.click(
+    await screen.findByText(name, undefined, { timeout: WAIT_TIMEOUT }),
+  );
+};
+
+type SubmitModalFunction = () => void;
+
+const submitModal: SubmitModalFunction = (): void => {
+  fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+};
+
+interface LabelFormData {
+  labelIds: Array<string>;
+}
+
+type ModalSubmitFunction = (formData: LabelFormData) => Promise<void>;
+
+type GetModalSubmitFunction = (title: string) => ModalSubmitFunction;
+
+/*
+ * react-select cannot deliver an all-blank selection through the UI: the form's
+ * required check rejects a lone blank-valued option (`[""].toString()` is "")
+ * and hideSelectedOptions hides every other option sharing that same blank
+ * value the moment one is picked. The hook's contract with BasicFormModal is
+ * the onSubmit prop, so that boundary is driven directly instead.
+ */
+const getModalSubmit: GetModalSubmitFunction = (
+  title: string,
+): ModalSubmitFunction => {
+  const modal: any = React.Children.toArray(
+    (capturedModals as any).props.children,
+  ).find((child: any) => {
+    return child?.props?.title === title;
+  });
+
+  if (!modal) {
+    throw new Error(`No "${title}" modal is mounted.`);
+  }
+
+  return modal.props.onSubmit as ModalSubmitFunction;
+};
+
+interface DeferredListResult {
+  promise: Promise<any>;
+  resolve: (value: any) => void;
+}
+
+type CreateDeferredListResultFunction = () => DeferredListResult;
+
+const createDeferredListResult: CreateDeferredListResultFunction =
+  (): DeferredListResult => {
+    let settle: (value: any) => void = (): void => {};
+
+    const promise: Promise<any> = new Promise<any>(
+      (resolve: (value: any) => void): void => {
+        settle = resolve;
+      },
+    );
+
+    return {
+      promise: promise,
+      resolve: (value: any): void => {
+        settle(value);
+      },
+    };
+  };
+
+type ActAsyncFunction = (body: () => Promise<void>) => Promise<void>;
+
+/*
+ * zone.js reschedules the microtask React's act() uses to check that its
+ * thenable was awaited, so it runs before `await` gets round to attaching a
+ * handler and every plain `await act(...)` is reported as un-awaited. Hooking
+ * then() up synchronously answers that check in time; the scope still exits
+ * exactly when act says it does.
+ */
+const actAsync: ActAsyncFunction = (
+  body: () => Promise<void>,
+): Promise<void> => {
+  const scope: PromiseLike<void> = act(body) as unknown as PromiseLike<void>;
+
+  return new Promise<void>(
+    (resolve: () => void, reject: (reason: unknown) => void): void => {
+      scope.then(resolve, reject);
+    },
+  );
+};
+
+type GetUpdatedLabelIdsFunction = (callIndex: number) => Array<string>;
+
+const getUpdatedLabelIds: GetUpdatedLabelIdsFunction = (
+  callIndex: number,
+): Array<string> => {
+  const call: Array<any> = updateByIdMock.mock.calls[callIndex] as Array<any>;
+  return (call[0] as any).data.labels as Array<string>;
+};
+
+type GetListCallFunction = (callIndex: number) => any;
+
+const getListCall: GetListCallFunction = (callIndex: number): any => {
+  const call: Array<any> = getListMock.mock.calls[callIndex] as Array<any>;
+  return call[0];
+};
+
+type WaitForBulkRunToEndFunction = () => Promise<void>;
+
+const waitForBulkRunToEnd: WaitForBulkRunToEndFunction =
+  async (): Promise<void> => {
+    await waitFor(
+      () => {
+        expect(onBulkActionEndMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+  };
+
+type AddAlphaOverCurrentReadFunction = (
+  currentRead: Monitor | null,
+) => Promise<void>;
+
+/*
+ * Shared driver for the two "the current read is unusable" cases: one item,
+ * one project label, add mode, with getItem answering whatever the caller
+ * wants. Assertions stay in the tests so a failure points at the real case.
+ */
+const addAlphaOverCurrentRead: AddAlphaOverCurrentReadFunction = async (
+  currentRead: Monitor | null,
+): Promise<void> => {
+  getListMock.mockResolvedValue({
+    data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+    count: 1,
+  });
+  getItemMock.mockImplementation((): Promise<Monitor | null> => {
+    return Promise.resolve(currentRead);
+  });
+
+  render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+  await waitForMountedLabelFetch();
+
+  clickTrigger("Add Labels");
+  await waitForModalTitle("Add Labels");
+  await selectLabel("Alpha");
+  submitModal();
+
+  await waitForBulkRunToEnd();
+};
+
+/*
+ * These mount the real Modal, Formik and react-select trees, so a cold
+ * ts-jest transform of that import graph can push individual tests past
+ * jest's 5s default - which CI, always starting cold, would report as a
+ * red build with no assertion having failed. The slowest test here runs
+ * in ~1.3s warm; 30s is the same ceiling App/jest.config.json already
+ * sets for its whole suite.
+ */
+jest.setTimeout(30000);
+
+describe("useBulkLabelActions", () => {
+  beforeEach(() => {
+    /*
+     * resetAllMocks rather than clearAllMocks: implementations set by one test
+     * would otherwise silently answer another test's requests.
+     */
+    jest.resetAllMocks();
+
+    progressSnapshots = [];
+    callOrder = [];
+    capturedActions = [];
+    capturedModals = null;
+
+    onProgressInfoMock.mockImplementation((progressInfo: any) => {
+      callOrder.push("progress");
+      progressSnapshots.push(
+        snapshotProgress(progressInfo as ProgressInfo<Monitor>),
+      );
+    });
+    onBulkActionStartMock.mockImplementation(() => {
+      callOrder.push("start");
+    });
+    onBulkActionEndMock.mockImplementation(() => {
+      callOrder.push("end");
+    });
+
+    getListMock.mockResolvedValue({ data: [], count: 0, skip: 0, limit: 0 });
+    updateByIdMock.mockResolvedValue({});
+
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    // ProjectUtil.getCurrentProjectId() reads pathname.split("/")[2].
+    window.history.replaceState({}, "", `/dashboard/${PROJECT_ID}/monitors`);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("exposes Add Labels then Remove Labels, in that order", async () => {
+    render(<Harness items={[]} />);
+
+    await waitForMountedLabelFetch();
+
+    /*
+     * Consumers spread these into ModelTable's button list and BulkUpdateForm
+     * renders them in array order, so the order is part of the contract.
+     */
+    expect(capturedActions).toHaveLength(2);
+    expect(capturedActions[0]!.title).toBe("Add Labels");
+    expect(capturedActions[1]!.title).toBe("Remove Labels");
+  });
+
+  test("keeps both actions in the non-destructive button group", async () => {
+    render(<Harness items={[]} />);
+
+    await waitForMountedLabelFetch();
+
+    expect(capturedActions[0]!.icon).toBe(IconProp.Label);
+    expect(capturedActions[0]!.buttonStyleType).toBe(ButtonStyleType.NORMAL);
+    expect(capturedActions[1]!.icon).toBe(IconProp.Close);
+
+    /*
+     * Remove Labels borrows the Close icon but must not borrow a danger style:
+     * BulkUpdateForm splits danger buttons into a separate red menu group
+     * behind a divider, which is for irreversible actions.
+     */
+    expect(capturedActions[1]!.buttonStyleType).toBe(ButtonStyleType.NORMAL);
+  });
+
+  test("leaves the click contract unconditional on both actions", async () => {
+    render(<Harness items={[]} />);
+
+    await waitForMountedLabelFetch();
+
+    expect(capturedActions).toHaveLength(2);
+
+    for (const action of capturedActions) {
+      /*
+       * A confirmMessage would make BulkUpdateForm open a ConfirmModal instead
+       * of calling onClick, and isVisible/disabled can drop the click entirely
+       * - each of those quietly changes how the modal gets opened.
+       */
+      expect(action.confirmMessage).toBeUndefined();
+      expect(action.confirmTitle).toBeUndefined();
+      expect(action.isVisible).toBeUndefined();
+      expect(action.disabled).toBeUndefined();
+    }
+  });
+
+  test("renders no modal until an action is clicked", async () => {
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    expect(screen.queryByTestId("modal")).toBeNull();
+  });
+
+  test("fetches the project's labels once on mount with the full query", async () => {
+    render(<Harness items={[]} />);
+
+    await waitForMountedLabelFetch();
+
+    const call: any = getListCall(0);
+
+    expect(call.modelType).toBe(Label);
+    expect(call.query.projectId.toString()).toBe(PROJECT_ID);
+    expect(call.limit).toBe(LIMIT_PER_PROJECT);
+    expect(call.skip).toBe(0);
+    /*
+     * `color` has to be selected or the add dropdown loses the colour swatch;
+     * `labels` must not be, since Label has no labels of its own.
+     */
+    expect(call.select).toEqual({ _id: true, name: true, color: true });
+    expect(call.sort).toEqual({ name: SortOrder.Ascending });
+  });
+
+  test("does not fetch labels at all when there is no current project", async () => {
+    window.history.replaceState({}, "", "/dashboard");
+
+    render(<Harness items={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Trigger Add Labels")).toBeInTheDocument();
+    });
+
+    /*
+     * The query used to go out as projectId: null, which matches nothing, so
+     * the user got an empty dropdown after a pointless round trip.
+     */
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("leaves the add dropdown empty when the label fetch fails", async () => {
+    /*
+     * Throwing from inside the call rather than handing back a promise that is
+     * already rejected (mockRejectedValue, or an equivalent Promise.reject):
+     * zone.js sees the rejection before the hook's catch is attached and
+     * prints the whole stack as a console error on every run.
+     */
+    getListMock.mockImplementation(async (): Promise<never> => {
+      throw new Error("network down");
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+
+    const options: Array<HTMLElement> = await openMenu();
+
+    expect(options).toHaveLength(0);
+  });
+
+  test("keeps Remove Labels working when the project label fetch failed", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        throw new Error("network down");
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_BETA_ID, "Beta")]),
+        ],
+        count: 1,
+      };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    /*
+     * Remove reads only from the per-item fetch, so the mount failure that
+     * empties the add dropdown must not degrade it.
+     */
+    const options: Array<HTMLElement> = await openMenu();
+
+    expect(options).toHaveLength(1);
+    expect(options[0]!).toHaveTextContent("Beta");
+  });
+
+  test("adds the picked label without clobbering labels the user did not pick", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockResolvedValue(
+      makeItemWithLabels(ITEM_ONE_ID, [
+        makeLabel(LABEL_BETA_ID, "Beta"),
+        makeLabel(LABEL_GAMMA_ID, "Gamma"),
+      ]),
+    );
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    expect(getUpdatedLabelIds(0)).toEqual([
+      LABEL_BETA_ID,
+      LABEL_GAMMA_ID,
+      LABEL_ALPHA_ID,
+    ]);
+  });
+
+  test("de-dupes a picked label the item already carries", async () => {
+    getListMock.mockResolvedValue({
+      data: [
+        makeLabel(LABEL_ALPHA_ID, "Alpha"),
+        makeLabel(LABEL_BETA_ID, "Beta"),
+      ],
+      count: 2,
+    });
+    getItemMock.mockResolvedValue(
+      makeItemWithLabels(ITEM_ONE_ID, [
+        makeLabel(LABEL_ALPHA_ID, "Alpha"),
+        makeLabel(LABEL_GAMMA_ID, "Gamma"),
+      ]),
+    );
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    await selectLabel("Beta");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    // Alpha was on the item and was picked again; it must land once.
+    expect(getUpdatedLabelIds(0)).toEqual([
+      LABEL_ALPHA_ID,
+      LABEL_GAMMA_ID,
+      LABEL_BETA_ID,
+    ]);
+  });
+
+  test("reads the item's current label ids before merging", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockResolvedValue(makeItemWithLabels(ITEM_ONE_ID, []));
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    const call: any = (getItemMock.mock.calls[0] as Array<any>)[0];
+
+    expect(call.modelType).toBe(Monitor);
+    expect(call.id.toString()).toBe(ITEM_ONE_ID);
+    /*
+     * `_id` is not cosmetic here: it is the only field that separates a real
+     * read of an unlabelled item from the empty body a deleted or filtered row
+     * answers with, and the guard below leans on it entirely.
+     */
+    expect(call.select).toEqual({ _id: true, labels: { _id: true } });
+    expect(getUpdatedLabelIds(0)).toEqual([LABEL_ALPHA_ID]);
+  });
+
+  test("drops a dropdown option that came back without an id before merging", async () => {
+    const orphan: Label = new Label();
+    orphan.name = "Orphan";
+
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha"), orphan],
+      count: 2,
+    });
+    getItemMock.mockResolvedValue(
+      makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_GAMMA_ID, "Gamma")]),
+    );
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Orphan");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    /*
+     * An id-less label renders as an option with an empty value; sending ""
+     * inside the labels array makes the API reject the whole item, so one
+     * unusable option would fail the entire bulk run.
+     */
+    expect(getUpdatedLabelIds(0)).toEqual([LABEL_GAMMA_ID, LABEL_ALPHA_ID]);
+  });
+
+  test("starts nothing and reports nothing when every submitted label id is blank", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID), makeItem(ITEM_TWO_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+
+    await actAsync(async (): Promise<void> => {
+      await getModalSubmit("Add Labels")({ labelIds: ["", ""] });
+    });
+
+    /*
+     * Nothing survives the blank-id filter, so there is nothing to apply. The
+     * loop used to run anyway: every item matched the no-op short-circuit and
+     * was pushed onto successItems, so the user was told a bulk edit landed on
+     * their whole selection when not one label had been asked for.
+     */
+    expect(onBulkActionStartMock).not.toHaveBeenCalled();
+    expect(onProgressInfoMock).not.toHaveBeenCalled();
+    expect(onBulkActionEndMock).not.toHaveBeenCalled();
+    expect(getItemMock).not.toHaveBeenCalled();
+    expect(updateByIdMock).not.toHaveBeenCalled();
+    // The submit still dismisses the form rather than leaving it hanging open.
+    expect(screen.queryByTestId("modal")).toBeNull();
+  });
+
+  test("fails an item whose current read carries no id instead of overwriting its labels", async () => {
+    /*
+     * This is the reachable case. A row deleted or filtered out between the
+     * table load and the action still answers HTTP 200, with an empty body
+     * that BaseModel.fromJSONObject turns into a truthy model carrying neither
+     * _id nor labels - so a plain null check never fires and add mode reads it
+     * as "this item has no labels".
+     */
+    await addAlphaOverCurrentRead(BaseModel.fromJSONObject({}, Monitor));
+
+    /*
+     * Any update at all is the bug: the only thing the hook could have sent is
+     * `labels: [LABEL_ALPHA_ID]`, which is the item's entire label set replaced
+     * by the one label just picked.
+     */
+    expect(updateByIdMock).not.toHaveBeenCalled();
+    expect(progressSnapshots[0]!.failedIds).toEqual([ITEM_ONE_ID]);
+    expect(progressSnapshots[0]!.failedMessages[0]).toBe(
+      "Could not read the current labels for this item.",
+    );
+    expect(progressSnapshots[0]!.successIds).toEqual([]);
+  });
+
+  test("fails an item whose current read comes back as null instead of overwriting its labels", async () => {
+    await addAlphaOverCurrentRead(null);
+
+    // ModelAPI.getItem is typed to allow null, so the guard has to cover it too.
+    expect(updateByIdMock).not.toHaveBeenCalled();
+    expect(progressSnapshots[0]!.failedIds).toEqual([ITEM_ONE_ID]);
+    expect(progressSnapshots[0]!.failedMessages[0]).toBe(
+      "Could not read the current labels for this item.",
+    );
+    expect(progressSnapshots[0]!.successIds).toEqual([]);
+  });
+
+  test("removes only the picked labels and keeps the rest", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [], count: 0 };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [
+            makeLabel(LABEL_ALPHA_ID, "Alpha"),
+            makeLabel(LABEL_BETA_ID, "Beta"),
+            makeLabel(LABEL_GAMMA_ID, "Gamma"),
+          ]),
+        ],
+        count: 1,
+      };
+    });
+    getItemMock.mockResolvedValue(
+      makeItemWithLabels(ITEM_ONE_ID, [
+        makeLabel(LABEL_ALPHA_ID, "Alpha"),
+        makeLabel(LABEL_BETA_ID, "Beta"),
+        makeLabel(LABEL_GAMMA_ID, "Gamma"),
+      ]),
+    );
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+    await selectLabel("Beta");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    expect(getUpdatedLabelIds(0)).toEqual([LABEL_ALPHA_ID, LABEL_GAMMA_ID]);
+  });
+
+  test("skips the update but still counts the item as processed when nothing changes", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockResolvedValue(
+      makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_ALPHA_ID, "Alpha")]),
+    );
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    /*
+     * A skipped write still has to advance the progress bar, otherwise a
+     * selection of already-labelled items looks like a stalled run.
+     */
+    expect(updateByIdMock).not.toHaveBeenCalled();
+    expect(progressSnapshots[0]!.successIds).toEqual([ITEM_ONE_ID]);
+    expect(progressSnapshots[0]!.failedIds).toEqual([]);
+  });
+
+  test("keeps going after one item fails and reports only that item as failed", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.id.toString() === ITEM_TWO_ID) {
+        throw new Error("item two is gone");
+      }
+
+      return makeItemWithLabels(data.id.toString(), []);
+    });
+
+    render(
+      <Harness
+        items={[
+          makeItem(ITEM_ONE_ID),
+          makeItem(ITEM_TWO_ID),
+          makeItem(ITEM_THREE_ID),
+        ]}
+      />,
+    );
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    expect(getItemMock).toHaveBeenCalledTimes(3);
+    expect(updateByIdMock).toHaveBeenCalledTimes(2);
+
+    const finalSnapshot: ProgressSnapshot = progressSnapshots[2]!;
+
+    expect(finalSnapshot.successIds).toEqual([ITEM_ONE_ID, ITEM_THREE_ID]);
+    expect(finalSnapshot.failedIds).toEqual([ITEM_TWO_ID]);
+    expect(finalSnapshot.failedMessages).toEqual(["item two is gone"]);
+  });
+
+  test("takes the failure message from API.getFriendlyMessage", async () => {
+    const friendlyMessage: MockFunction = jest.spyOn(
+      API,
+      "getFriendlyMessage",
+    ) as unknown as MockFunction;
+    friendlyMessage.mockReturnValue("Something went wrong. Try again.");
+
+    const sentinel: Error = new Error("raw upstream text");
+
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    /*
+     * mockRejectedValue hands zone.js a rejected promise it sees before the
+     * hook attaches its catch, and it prints the whole stack as a console
+     * error on every run. Throwing from inside the call keeps CI readable.
+     */
+    getItemMock.mockImplementation(async (): Promise<never> => {
+      throw sentinel;
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    // The raw error must go through the formatter, not into the UI verbatim.
+    expect(friendlyMessage).toHaveBeenCalledWith(sentinel);
+    expect(progressSnapshots[0]!.failedMessages).toEqual([
+      "Something went wrong. Try again.",
+    ]);
+  });
+
+  test("fails an item that has no id without calling the API for it", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockResolvedValue(makeItemWithLabels(ITEM_ONE_ID, []));
+
+    render(<Harness items={[new Monitor(), makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    expect(progressSnapshots[0]!.failedMessages).toEqual(["Item ID not found"]);
+    // Only the second item is addressable, so only it may reach the API.
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+    expect(updateByIdMock).toHaveBeenCalledTimes(1);
+    expect(progressSnapshots[1]!.successIds).toEqual([ITEM_ONE_ID]);
+  });
+
+  test("brackets the run with one start and one end around a progress call per item", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockImplementation(async (data: any): Promise<any> => {
+      return makeItemWithLabels(data.id.toString(), []);
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID), makeItem(ITEM_TWO_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    expect(callOrder).toEqual(["start", "progress", "progress", "end"]);
+    expect(onBulkActionStartMock).toHaveBeenCalledTimes(1);
+    expect(onProgressInfoMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("reports the running success and failure split after each item", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+    getItemMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.id.toString() === ITEM_TWO_ID) {
+        throw new Error("boom");
+      }
+
+      return makeItemWithLabels(data.id.toString(), []);
+    });
+
+    render(
+      <Harness
+        items={[
+          makeItem(ITEM_ONE_ID),
+          makeItem(ITEM_TWO_ID),
+          makeItem(ITEM_THREE_ID),
+        ]}
+      />,
+    );
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+    await selectLabel("Alpha");
+    submitModal();
+
+    await waitForBulkRunToEnd();
+
+    expect(progressSnapshots).toHaveLength(3);
+
+    /*
+     * The item being worked on is spliced out of inProgressItems before its own
+     * callback fires, so the remaining count is the work still queued.
+     */
+    expect(progressSnapshots[0]).toEqual({
+      totalIds: [ITEM_ONE_ID, ITEM_TWO_ID, ITEM_THREE_ID],
+      inProgressIds: [ITEM_TWO_ID, ITEM_THREE_ID],
+      successIds: [ITEM_ONE_ID],
+      failedIds: [],
+      failedMessages: [],
+    });
+    expect(progressSnapshots[1]).toEqual({
+      totalIds: [ITEM_ONE_ID, ITEM_TWO_ID, ITEM_THREE_ID],
+      inProgressIds: [ITEM_THREE_ID],
+      successIds: [ITEM_ONE_ID],
+      failedIds: [ITEM_TWO_ID],
+      failedMessages: ["boom"],
+    });
+    expect(progressSnapshots[2]).toEqual({
+      totalIds: [ITEM_ONE_ID, ITEM_TWO_ID, ITEM_THREE_ID],
+      inProgressIds: [],
+      successIds: [ITEM_ONE_ID, ITEM_THREE_ID],
+      failedIds: [ITEM_TWO_ID],
+      failedMessages: ["boom"],
+    });
+  });
+
+  test("offers the de-duplicated union of the selection's labels, sorted by name", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [], count: 0 };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [
+            makeLabel(LABEL_ALPHA_ID, "Zulu"),
+            makeLabel(LABEL_BETA_ID, "apple"),
+          ]),
+          makeItemWithLabels(ITEM_TWO_ID, [
+            makeLabel(LABEL_BETA_ID, "apple"),
+            makeLabel(LABEL_GAMMA_ID, "Mike"),
+          ]),
+        ],
+        count: 2,
+      };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID), makeItem(ITEM_TWO_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    const options: Array<HTMLElement> = await openMenu();
+
+    expect(options).toHaveLength(3);
+
+    /*
+     * localeCompare, not codepoint order - a lowercase name would otherwise
+     * sort below every capitalised one and look like a broken list.
+     */
+    expect(optionTexts(options)).toEqual(["apple", "Mike", "Zulu"]);
+  });
+
+  test("scopes the option fetch to the selected ids", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [], count: 0 };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_ALPHA_ID, "Alpha")]),
+        ],
+        count: 1,
+      };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID), makeItem(ITEM_TWO_ID)]} />);
+
+    clickTrigger("Remove Labels");
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(2);
+    });
+
+    const call: any = getListCall(1);
+
+    expect(call.modelType).toBe(Monitor);
+    expect(call.query._id).toBeInstanceOf(Includes);
+    expect(call.query._id.values).toEqual([ITEM_ONE_ID, ITEM_TWO_ID]);
+    expect(call.select).toEqual({
+      labels: { _id: true, name: true, color: true },
+    });
+  });
+
+  test("carries a label's colour into its remove option", async () => {
+    const coloured: Label = makeLabel(LABEL_ALPHA_ID, "Alpha");
+    coloured.color = Red;
+
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [], count: 0 };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [
+            coloured,
+            makeLabel(LABEL_BETA_ID, "Beta"),
+          ]),
+        ],
+        count: 1,
+      };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    const options: Array<HTMLElement> = await openMenu();
+    const alphaSwatch: Element | null =
+      options[0]!.querySelector("span[title]");
+
+    expect(alphaSwatch).not.toBeNull();
+    expect(alphaSwatch!.getAttribute("title")).toBe(Red.toString());
+    // A colourless label must not inherit a swatch from anywhere.
+    expect(options[1]!.querySelector("span[title]")).toBeNull();
+  });
+
+  test("offers nothing to remove for an empty selection", async () => {
+    render(<Harness items={[]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("No Labels to Remove");
+
+    // No addressable ids means there is nothing to ask the server about.
+    expect(getListMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("offers nothing to remove when the option fetch fails, rather than the whole project's labels", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return {
+          data: [
+            makeLabel(LABEL_ALPHA_ID, "Alpha"),
+            makeLabel(LABEL_BETA_ID, "Beta"),
+          ],
+          count: 2,
+        };
+      }
+
+      throw new Error("selection fetch failed");
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("No Labels to Remove");
+
+    /*
+     * Falling back to the project label list here would offer labels the items
+     * do not have, and removing one would look like it silently did nothing.
+     */
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  test("the No Labels to Remove modal is a dead end with only a way out", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [], count: 0 };
+      }
+
+      return { data: [makeItemWithLabels(ITEM_ONE_ID, [])], count: 1 };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("No Labels to Remove");
+
+    expect(screen.getByTestId("modal-footer-close-button")).toHaveTextContent(
+      "Close",
+    );
+    // There is nothing to submit, so offering a submit button would be a trap.
+    expect(screen.queryByTestId("modal-footer-submit-button")).toBeNull();
+  });
+
+  test("opening Remove Labels closes an open Add Labels modal", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [makeLabel(LABEL_ALPHA_ID, "Alpha")], count: 1 };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_BETA_ID, "Beta")]),
+        ],
+        count: 1,
+      };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    /*
+     * The two modals are independent siblings sharing one set of action props;
+     * stacked, whichever submits first leaves the other silently inert.
+     */
+    expect(screen.getAllByTestId("modal-title")).toHaveLength(1);
+  });
+
+  test("opening Add Labels closes an open Remove Labels modal", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [makeLabel(LABEL_ALPHA_ID, "Alpha")], count: 1 };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_BETA_ID, "Beta")]),
+        ],
+        count: 1,
+      };
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+
+    expect(screen.getAllByTestId("modal-title")).toHaveLength(1);
+  });
+
+  test("re-opening the remove modal re-reads the new selection instead of reusing the old options", async () => {
+    getListMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return { data: [], count: 0 };
+      }
+
+      const ids: Array<string> = data.query._id.values as Array<string>;
+
+      if (ids.includes(ITEM_ONE_ID)) {
+        return {
+          data: [
+            makeItemWithLabels(ITEM_ONE_ID, [
+              makeLabel(LABEL_ALPHA_ID, "Alpha"),
+            ]),
+          ],
+          count: 1,
+        };
+      }
+
+      return {
+        data: [
+          makeItemWithLabels(ITEM_TWO_ID, [makeLabel(LABEL_BETA_ID, "Beta")]),
+        ],
+        count: 1,
+      };
+    });
+
+    const { rerender } = render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    const firstOptions: Array<HTMLElement> = await openMenu();
+
+    expect(firstOptions[0]!).toHaveTextContent("Alpha");
+
+    fireEvent.click(screen.getByTestId("modal-footer-close-button"));
+
+    rerender(<Harness items={[makeItem(ITEM_TWO_ID)]} />);
+
+    clickTrigger("Remove Labels");
+    await waitForModalTitle("Remove Labels");
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(3);
+    });
+
+    const secondOptions: Array<HTMLElement> = await openMenu();
+
+    /*
+     * The options are keyed to the selection, so a cached list from the last
+     * open would offer labels the newly selected item does not have.
+     */
+    expect(secondOptions).toHaveLength(1);
+    expect(secondOptions[0]!).toHaveTextContent("Beta");
+  });
+
+  test("keeps the newest selection's remove options when an older fetch settles last", async () => {
+    const firstSelectionFetch: DeferredListResult = createDeferredListResult();
+    const secondSelectionFetch: DeferredListResult = createDeferredListResult();
+
+    getListMock.mockImplementation((data: any): Promise<any> => {
+      if (data.modelType === Label) {
+        return Promise.resolve({ data: [], count: 0 });
+      }
+
+      const ids: Array<string> = data.query._id.values as Array<string>;
+
+      return ids.includes(ITEM_ONE_ID)
+        ? firstSelectionFetch.promise
+        : secondSelectionFetch.promise;
+    });
+
+    render(<Harness items={[]} />);
+
+    await waitForMountedLabelFetch();
+
+    /*
+     * Driven through onClick rather than the trigger button because the two
+     * opens have to carry different selections while both fetches are still
+     * in flight, which one mounted Harness cannot express.
+     */
+    const runs: Array<Promise<void>> = [];
+
+    await actAsync(async (): Promise<void> => {
+      runs.push(
+        capturedActions[1]!.onClick(makeActionProps([makeItem(ITEM_ONE_ID)])),
+      );
+    });
+
+    await actAsync(async (): Promise<void> => {
+      runs.push(
+        capturedActions[1]!.onClick(makeActionProps([makeItem(ITEM_TWO_ID)])),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getListMock).toHaveBeenCalledTimes(3);
+    });
+
+    // The newest selection answers first...
+    await actAsync(async (): Promise<void> => {
+      secondSelectionFetch.resolve({
+        data: [
+          makeItemWithLabels(ITEM_TWO_ID, [makeLabel(LABEL_BETA_ID, "Beta")]),
+        ],
+        count: 1,
+      });
+      await runs[1]!;
+    });
+
+    // ...and the abandoned first selection lands afterwards.
+    await actAsync(async (): Promise<void> => {
+      firstSelectionFetch.resolve({
+        data: [
+          makeItemWithLabels(ITEM_ONE_ID, [makeLabel(LABEL_ALPHA_ID, "Alpha")]),
+        ],
+        count: 1,
+      });
+      await runs[0]!;
+    });
+
+    await waitForModalTitle("Remove Labels");
+
+    const options: Array<HTMLElement> = await openMenu();
+
+    /*
+     * Last writer wins without the request stamp, and the slow first fetch is
+     * the last writer here: the user would be offered Alpha, a label the item
+     * they actually selected does not carry, and removing it would appear to
+     * do nothing.
+     */
+    expect(optionTexts(options)).toEqual(["Beta"]);
+  });
+
+  test("blocks a submit with nothing picked and touches no API", async () => {
+    getListMock.mockResolvedValue({
+      data: [makeLabel(LABEL_ALPHA_ID, "Alpha")],
+      count: 1,
+    });
+
+    render(<Harness items={[makeItem(ITEM_ONE_ID)]} />);
+
+    await waitForMountedLabelFetch();
+
+    clickTrigger("Add Labels");
+    await waitForModalTitle("Add Labels");
+
+    submitModal();
+
+    expect(
+      await screen.findByText("Select Labels is required.", undefined, {
+        timeout: WAIT_TIMEOUT,
+      }),
+    ).toBeInTheDocument();
+
+    /*
+     * An empty submit would otherwise start a bulk run that reads and rewrites
+     * every selected item to no effect.
+     */
+    expect(onBulkActionStartMock).not.toHaveBeenCalled();
+    expect(getItemMock).not.toHaveBeenCalled();
+    expect(updateByIdMock).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/UI/Components/BulkOwnerActions.test.tsx
+++ b/Common/Tests/UI/Components/BulkOwnerActions.test.tsx
@@ -1,0 +1,1255 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import { FunctionComponent, ReactElement } from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * Scope: this is baseline coverage, not change coverage. Read the green count
+ * accordingly. useBulkOwnerActions is a shared hook that shipped with no tests
+ * at all, and all but two of the cases below characterise behaviour that
+ * already existed - they pass just as well against the pre-change hook. They
+ * are written now because this change is what makes the SLO lists depend on
+ * that behaviour.
+ *
+ * Exactly two tests pin this change: "opening Add Owner closes an open Remove
+ * Owner modal" and "opening Remove Owner closes an open Add Owner modal". The
+ * hook now clears the sibling modal's flag, and both fail without it.
+ *
+ * The model under test is the ServiceLevelObjectiveOwnerUser /
+ * ServiceLevelObjectiveOwnerTeam junction pair because the SLO lists are the
+ * adoption this change adds; the hook itself is model-agnostic.
+ *
+ * The hook is not a thin wrapper: it flattens every team's membership into a
+ * single de-duped people list, tags each option with a "user:"/"team:" prefix
+ * so one dropdown can drive two different junction tables, and then - per
+ * selected item - reads that item's existing owners so a second "Add Owner"
+ * run does not create duplicate rows. Every one of those steps is silent when
+ * it goes wrong: a wrong resourceIdField or a dropped prefix does not fail, it
+ * just queries nothing and reports the item as a success. So the suite drives
+ * the real modal, the real form and the real dropdown, and asserts on what
+ * actually reaches ModelAPI.
+ */
+
+/*
+ * react-i18next is not initialized in the test environment. Mock the hook so
+ * translate helpers echo their input and the component renders synchronously.
+ */
+jest.mock("react-i18next", () => {
+  return {
+    useTranslation: () => {
+      return {
+        t: (key: string, opts?: { defaultValue?: string }): string => {
+          return opts?.defaultValue ?? key;
+        },
+      };
+    },
+  };
+});
+
+/*
+ * Declared before jest.mock but dereferenced inside the factory: ts-jest
+ * hoists the jest.mock call above these initializers, so naming the mocks
+ * directly in the factory would capture undefined.
+ */
+const getListMock: MockFunction = getJestMockFunction();
+const createMock: MockFunction = getJestMockFunction();
+const deleteItemMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      create: (...args: Array<any>) => {
+        return createMock(...args);
+      },
+      deleteItem: (...args: Array<any>) => {
+        return deleteItemMock(...args);
+      },
+    },
+  };
+});
+
+import useBulkOwnerActions, {
+  BulkOwnerActionsConfig,
+  BulkOwnerActionsResult,
+} from "../../../UI/Components/BulkUpdate/BulkOwnerActions";
+import {
+  BulkActionButtonSchema,
+  BulkActionFailed,
+  BulkActionOnClickProps,
+  ProgressInfo,
+} from "../../../UI/Components/BulkUpdate/BulkUpdateForm";
+import { ButtonStyleType } from "../../../UI/Components/Button/Button";
+import ServiceLevelObjective from "../../../Models/DatabaseModels/ServiceLevelObjective";
+import ServiceLevelObjectiveOwnerTeam from "../../../Models/DatabaseModels/ServiceLevelObjectiveOwnerTeam";
+import ServiceLevelObjectiveOwnerUser from "../../../Models/DatabaseModels/ServiceLevelObjectiveOwnerUser";
+import Team from "../../../Models/DatabaseModels/Team";
+import TeamMember from "../../../Models/DatabaseModels/TeamMember";
+import User from "../../../Models/DatabaseModels/User";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Email from "../../../Types/Email";
+import IconProp from "../../../Types/Icon/IconProp";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Rendering the real modal pulls in Formik and react-select, which are slow
+ * to mount on a loaded box; the testing-library default of 1s flakes there.
+ */
+const WAIT_TIMEOUT: number = 20000;
+
+const PROJECT_ID: string = "11111111-1111-4111-8111-111111111111";
+const SLO_ONE_ID: string = "22222222-2222-4222-8222-222222222221";
+const SLO_TWO_ID: string = "22222222-2222-4222-8222-222222222222";
+const ALICE_ID: string = "33333333-3333-4333-8333-333333333331";
+const BOB_ID: string = "33333333-3333-4333-8333-333333333332";
+const CAROL_ID: string = "33333333-3333-4333-8333-333333333333";
+const TEAM_ONE_ID: string = "44444444-4444-4444-8444-444444444441";
+const TEAM_TWO_ID: string = "44444444-4444-4444-8444-444444444442";
+const OWNER_ROW_ID: string = "55555555-5555-4555-8555-555555555551";
+const OWNER_ROW_TWO_ID: string = "55555555-5555-4555-8555-555555555552";
+
+const SLO_OWNER_CONFIG: BulkOwnerActionsConfig = {
+  ownerUserModelType: ServiceLevelObjectiveOwnerUser,
+  ownerTeamModelType: ServiceLevelObjectiveOwnerTeam,
+  resourceIdField: "serviceLevelObjectiveId",
+};
+
+interface TeamMemberSeed {
+  userId: string;
+  name?: string;
+  email?: string;
+}
+
+type MakeTeamMemberFunction = (seed: TeamMemberSeed) => TeamMember;
+
+const makeTeamMember: MakeTeamMemberFunction = (
+  seed: TeamMemberSeed,
+): TeamMember => {
+  const user: User = new User();
+  user._id = seed.userId;
+
+  if (seed.name) {
+    user.name = new Name(seed.name);
+  }
+
+  if (seed.email) {
+    user.email = new Email(seed.email);
+  }
+
+  const member: TeamMember = new TeamMember();
+  member.user = user;
+
+  return member;
+};
+
+type MakeTeamFunction = (id: string, name: string) => Team;
+
+const makeTeam: MakeTeamFunction = (id: string, name: string): Team => {
+  const team: Team = new Team();
+  team._id = id;
+  team.name = name;
+
+  return team;
+};
+
+type MakeSloFunction = (id?: string) => ServiceLevelObjective;
+
+const makeSlo: MakeSloFunction = (id?: string): ServiceLevelObjective => {
+  const slo: ServiceLevelObjective = new ServiceLevelObjective();
+
+  if (id) {
+    slo._id = id;
+  }
+
+  return slo;
+};
+
+interface OwnerRowSeed {
+  id?: string;
+  userId?: string;
+  teamId?: string;
+}
+
+type MakeOwnerUserRowFunction = (
+  seed: OwnerRowSeed,
+) => ServiceLevelObjectiveOwnerUser;
+
+const makeOwnerUserRow: MakeOwnerUserRowFunction = (
+  seed: OwnerRowSeed,
+): ServiceLevelObjectiveOwnerUser => {
+  const row: ServiceLevelObjectiveOwnerUser =
+    new ServiceLevelObjectiveOwnerUser();
+
+  if (seed.id) {
+    row._id = seed.id;
+  }
+
+  if (seed.userId) {
+    row.userId = new ObjectID(seed.userId);
+  }
+
+  return row;
+};
+
+type MakeOwnerTeamRowFunction = (
+  seed: OwnerRowSeed,
+) => ServiceLevelObjectiveOwnerTeam;
+
+const makeOwnerTeamRow: MakeOwnerTeamRowFunction = (
+  seed: OwnerRowSeed,
+): ServiceLevelObjectiveOwnerTeam => {
+  const row: ServiceLevelObjectiveOwnerTeam =
+    new ServiceLevelObjectiveOwnerTeam();
+
+  if (seed.id) {
+    row._id = seed.id;
+  }
+
+  if (seed.teamId) {
+    row.teamId = new ObjectID(seed.teamId);
+  }
+
+  return row;
+};
+
+interface ListSeeds {
+  teamMembers?: Array<TeamMember>;
+  teams?: Array<Team>;
+  ownerUsers?: Array<ServiceLevelObjectiveOwnerUser>;
+  ownerTeams?: Array<ServiceLevelObjectiveOwnerTeam>;
+}
+
+type MockListsFunction = (seeds: ListSeeds) => void;
+
+/*
+ * All four reads go through the same ModelAPI.getList, so every assertion
+ * about "which table did it ask for" has to branch on modelType rather than
+ * on call order.
+ */
+const mockLists: MockListsFunction = (seeds: ListSeeds): void => {
+  getListMock.mockImplementation(async (listData: any): Promise<any> => {
+    let rows: Array<any> = [];
+
+    if (listData.modelType === TeamMember) {
+      rows = seeds.teamMembers || [];
+    } else if (listData.modelType === Team) {
+      rows = seeds.teams || [];
+    } else if (listData.modelType === ServiceLevelObjectiveOwnerUser) {
+      rows = seeds.ownerUsers || [];
+    } else if (listData.modelType === ServiceLevelObjectiveOwnerTeam) {
+      rows = seeds.ownerTeams || [];
+    }
+
+    return {
+      data: rows,
+      count: rows.length,
+      skip: 0,
+      limit: LIMIT_PER_PROJECT,
+    };
+  });
+};
+
+interface ProgressSnapshot {
+  totalItems: Array<string>;
+  inProgressItems: Array<string>;
+  successItems: Array<string>;
+  failed: Array<{ id: string; failedMessage: string }>;
+}
+
+const progressSnapshots: Array<ProgressSnapshot> = [];
+
+const onProgressInfo: MockFunction = getJestMockFunction();
+const onBulkActionStart: MockFunction = getJestMockFunction();
+const onBulkActionEnd: MockFunction = getJestMockFunction();
+
+type IdsOfFunction = (items: Array<ServiceLevelObjective>) => Array<string>;
+
+const idsOf: IdsOfFunction = (
+  items: Array<ServiceLevelObjective>,
+): Array<string> => {
+  return items.map((item: ServiceLevelObjective) => {
+    return item._id || "no-id";
+  });
+};
+
+interface HarnessProps {
+  items: Array<ServiceLevelObjective>;
+}
+
+/*
+ * The hook hands back action descriptors that render nothing plus a `modals`
+ * element, so the modals only exist once something mounts them - renderHook
+ * alone cannot reach the form.
+ */
+const Harness: FunctionComponent<HarnessProps> = (
+  props: HarnessProps,
+): ReactElement => {
+  const { bulkActions, modals }: BulkOwnerActionsResult<ServiceLevelObjective> =
+    useBulkOwnerActions<ServiceLevelObjective>(SLO_OWNER_CONFIG);
+
+  return (
+    <div>
+      {bulkActions.map(
+        (action: BulkActionButtonSchema<ServiceLevelObjective>) => {
+          return (
+            <button
+              key={action.title}
+              type="button"
+              onClick={() => {
+                void action.onClick({
+                  items: props.items,
+                  onProgressInfo: onProgressInfo,
+                  onBulkActionStart: onBulkActionStart,
+                  onBulkActionEnd: onBulkActionEnd,
+                } as BulkActionOnClickProps<ServiceLevelObjective>);
+              }}
+            >
+              {`Trigger ${action.title}`}
+            </button>
+          );
+        },
+      )}
+      {modals}
+    </div>
+  );
+};
+
+type WaitForOwnerSourcesFunction = () => Promise<void>;
+
+const waitForOwnerSources: WaitForOwnerSourcesFunction =
+  async (): Promise<void> => {
+    /*
+     * Drained inside act() first: waitFor's own await would otherwise let
+     * the mount fetch settle between checks, landing the dropdown state
+     * outside act and burying the run in warnings.
+     */
+    await act(async () => {
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 0);
+      });
+    });
+
+    await waitFor(
+      () => {
+        expect(getListMock).toHaveBeenCalledTimes(2);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+  };
+
+type OpenOwnerModalFunction = (title: string) => Promise<void>;
+
+const openOwnerModal: OpenOwnerModalFunction = async (
+  title: string,
+): Promise<void> => {
+  fireEvent.click(screen.getByText(`Trigger ${title}`));
+
+  await waitFor(
+    () => {
+      expect(screen.getByTestId("modal-title")).toHaveTextContent(title);
+    },
+    { timeout: WAIT_TIMEOUT },
+  );
+};
+
+type ClickOwnerActionFunction = (title: string) => void;
+
+/*
+ * openOwnerModal is unusable for the exclusion tests: its getByTestId gate
+ * throws on a multiple match, so a stacked second modal makes the helper spin
+ * until the test times out and neither assertion ever runs. Clicking without
+ * the gate leaves the count assertion as the thing that reports the
+ * regression. Safe to read the DOM straight after: fireEvent is act-wrapped
+ * and the onClick sets both flags before its first await.
+ */
+const clickOwnerAction: ClickOwnerActionFunction = (title: string): void => {
+  fireEvent.click(screen.getByText(`Trigger ${title}`));
+};
+
+type SelectOwnerFunction = (optionLabel: string) => Promise<void>;
+
+/*
+ * react-select closes its menu after each pick and hides already-selected
+ * options, so re-opening between picks is what makes multi-select reachable
+ * and keeps the option text unambiguous against the value pill.
+ */
+const selectOwner: SelectOwnerFunction = async (
+  optionLabel: string,
+): Promise<void> => {
+  const combobox: HTMLElement = screen.getByRole("combobox");
+  fireEvent.keyDown(combobox, { key: "ArrowDown", code: "ArrowDown" });
+  fireEvent.click(
+    await screen.findByText(optionLabel, {}, { timeout: WAIT_TIMEOUT }),
+  );
+};
+
+type OpenOwnerMenuFunction = () => void;
+
+const openOwnerMenu: OpenOwnerMenuFunction = (): void => {
+  const combobox: HTMLElement = screen.getByRole("combobox");
+  fireEvent.keyDown(combobox, { key: "ArrowDown", code: "ArrowDown" });
+};
+
+type SubmitOwnerModalFunction = () => void;
+
+const submitOwnerModal: SubmitOwnerModalFunction = (): void => {
+  fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+};
+
+type GetListCallsForFunction = (modelType: unknown) => Array<any>;
+
+const getListCallsFor: GetListCallsForFunction = (
+  modelType: unknown,
+): Array<any> => {
+  return (getListMock.mock.calls as Array<Array<any>>)
+    .map((call: Array<any>) => {
+      return call[0];
+    })
+    .filter((listData: any) => {
+      return listData.modelType === modelType;
+    });
+};
+
+/*
+ * These mount the real Modal, Formik and react-select trees, so a cold
+ * ts-jest transform of that import graph can push individual tests past
+ * jest's 5s default - which CI, always starting cold, would report as a
+ * red build with no assertion having failed. The slowest test here runs
+ * in ~1.3s warm; 30s is the same ceiling App/jest.config.json already
+ * sets for its whole suite.
+ */
+jest.setTimeout(30000);
+
+describe("useBulkOwnerActions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    progressSnapshots.length = 0;
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+
+    /*
+     * ProjectUtil.getCurrentProjectId() reads pathname.split("/")[2] before
+     * falling back to storage, so the URL is the whole "current project"
+     * fixture.
+     */
+    window.history.replaceState({}, "", `/dashboard/${PROJECT_ID}/slos`);
+
+    /*
+     * The progress arrays are allocated once and handed to every callback by
+     * reference, so anything kept without copying reads back as the final
+     * state of the run.
+     */
+    onProgressInfo.mockImplementation(
+      (progressInfo: ProgressInfo<ServiceLevelObjective>): void => {
+        progressSnapshots.push({
+          totalItems: idsOf(progressInfo.totalItems),
+          inProgressItems: idsOf(progressInfo.inProgressItems),
+          successItems: idsOf(progressInfo.successItems),
+          failed: progressInfo.failed.map(
+            (failure: BulkActionFailed<ServiceLevelObjective>) => {
+              return {
+                id: failure.item._id || "no-id",
+                failedMessage: failure.failedMessage as string,
+              };
+            },
+          ),
+        });
+      },
+    );
+
+    mockLists({});
+    createMock.mockResolvedValue({});
+    deleteItemMock.mockResolvedValue({});
+  });
+
+  test("offers Add Owner then Remove Owner, in that order", async () => {
+    const { result } = renderHook(() => {
+      return useBulkOwnerActions<ServiceLevelObjective>(SLO_OWNER_CONFIG);
+    });
+
+    await waitForOwnerSources();
+
+    /*
+     * Consumers splice these straight into ModelTable's button list, which
+     * renders them in array order.
+     */
+    expect(result.current.bulkActions).toHaveLength(2);
+    expect(result.current.bulkActions[0]!.title).toBe("Add Owner");
+    expect(result.current.bulkActions[1]!.title).toBe("Remove Owner");
+  });
+
+  test("gives both actions the user icons and a non-danger button style", async () => {
+    const { result } = renderHook(() => {
+      return useBulkOwnerActions<ServiceLevelObjective>(SLO_OWNER_CONFIG);
+    });
+
+    await waitForOwnerSources();
+
+    expect(result.current.bulkActions[0]!.icon).toBe(IconProp.UserPlus);
+    expect(result.current.bulkActions[0]!.buttonStyleType).toBe(
+      ButtonStyleType.NORMAL,
+    );
+    expect(result.current.bulkActions[1]!.icon).toBe(IconProp.UserMinus);
+
+    /*
+     * BulkUpdateForm splits danger-styled buttons into their own red menu
+     * group below a divider. Removing an owner is reversible, so it has to
+     * stay with the ordinary actions.
+     */
+    expect(result.current.bulkActions[1]!.buttonStyleType).toBe(
+      ButtonStyleType.NORMAL,
+    );
+  });
+
+  test("fetches this project's team members and teams on mount", async () => {
+    render(<Harness items={[]} />);
+
+    await waitForOwnerSources();
+
+    const memberCall: any = getListCallsFor(TeamMember)[0];
+    expect(memberCall.query.projectId.toString()).toBe(PROJECT_ID);
+    expect(memberCall.limit).toBe(LIMIT_PER_PROJECT);
+    expect(memberCall.skip).toBe(0);
+    expect(memberCall.select).toEqual({
+      _id: true,
+      user: { _id: true, name: true, email: true },
+    });
+
+    const teamCall: any = getListCallsFor(Team)[0];
+    expect(teamCall.query.projectId.toString()).toBe(PROJECT_ID);
+    expect(teamCall.limit).toBe(LIMIT_PER_PROJECT);
+    expect(teamCall.select).toEqual({ _id: true, name: true });
+    expect(teamCall.sort).toEqual({ name: SortOrder.Ascending });
+  });
+
+  test("fetches team members and teams in parallel", async () => {
+    getListMock.mockImplementation((listData: any): Promise<any> => {
+      if (listData.modelType === TeamMember) {
+        // Never settles, so the team read can only happen if it did not await this one.
+        return new Promise((): void => {});
+      }
+
+      return Promise.resolve({ data: [], count: 0, skip: 0, limit: 0 });
+    });
+
+    render(<Harness items={[]} />);
+
+    /*
+     * A project with a large membership table would otherwise hold the Teams
+     * group out of the dropdown for as long as that read takes.
+     */
+    await waitForOwnerSources();
+    expect(getListCallsFor(TeamMember)).toHaveLength(1);
+    expect(getListCallsFor(Team)).toHaveLength(1);
+  });
+
+  test("fetches nothing when there is no current project", async () => {
+    window.history.replaceState({}, "", "/dashboard");
+
+    render(<Harness items={[]} />);
+
+    await screen.findByText("Trigger Add Owner", {}, { timeout: WAIT_TIMEOUT });
+
+    /*
+     * Without the guard the query goes out with projectId undefined, which
+     * the API answers with every team member the caller can read.
+     */
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("lists a user once even when they are on several teams", async () => {
+    mockLists({
+      teamMembers: [
+        makeTeamMember({ userId: ALICE_ID, name: "Alice" }),
+        makeTeamMember({ userId: BOB_ID, name: "Bob" }),
+        makeTeamMember({ userId: ALICE_ID, name: "Alice" }),
+      ],
+      teams: [],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    await screen.findByText("Bob", {}, { timeout: WAIT_TIMEOUT });
+    expect(screen.getAllByText("Alice")).toHaveLength(1);
+  });
+
+  test("sorts people case-insensitively by name", async () => {
+    mockLists({
+      teamMembers: [
+        makeTeamMember({ userId: CAROL_ID, name: "carol" }),
+        makeTeamMember({ userId: BOB_ID, name: "Bob" }),
+        makeTeamMember({ userId: ALICE_ID, name: "alice" }),
+      ],
+      teams: [],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    await screen.findByText("alice", {}, { timeout: WAIT_TIMEOUT });
+
+    const optionLabels: Array<string> = screen
+      .getAllByRole("option")
+      .map((option: HTMLElement) => {
+        return option.textContent || "";
+      });
+
+    /*
+     * A plain codepoint sort puts every capitalised name ahead of every
+     * lowercase one, so "Bob" would jump the queue ahead of "alice".
+     */
+    expect(optionLabels).toEqual(["alice", "Bob", "carol"]);
+  });
+
+  test("falls back to a member's email when they have no name", async () => {
+    mockLists({
+      teamMembers: [
+        makeTeamMember({ userId: ALICE_ID, email: "alice@example.com" }),
+      ],
+      teams: [],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    expect(
+      await screen.findByText(
+        "alice@example.com",
+        {},
+        { timeout: WAIT_TIMEOUT },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("groups the options under People and Teams", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    expect(
+      await screen.findByText("People", {}, { timeout: WAIT_TIMEOUT }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Teams")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Team One")).toBeInTheDocument();
+  });
+
+  test("offers every team in the project, in the order the API returned them", async () => {
+    mockLists({
+      teamMembers: [],
+      teams: [
+        makeTeam(TEAM_TWO_ID, "Zebra Team"),
+        makeTeam(TEAM_ONE_ID, "Apple Team"),
+      ],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    await screen.findByText("Zebra Team", {}, { timeout: WAIT_TIMEOUT });
+
+    /*
+     * Teams keep the server's ordering (the query asks for name ASC); only
+     * the people list is re-sorted in the hook, because it is stitched
+     * together from every team's membership.
+     */
+    expect(
+      screen.getAllByRole("option").map((option: HTMLElement) => {
+        return option.textContent || "";
+      }),
+    ).toEqual(["Zebra Team", "Apple Team"]);
+  });
+
+  test("omits the People group when the project has no team members", async () => {
+    mockLists({
+      teamMembers: [],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    await screen.findByText("Teams", {}, { timeout: WAIT_TIMEOUT });
+
+    /*
+     * An empty group still renders its heading, so the dropdown would show a
+     * "People" label with nothing under it.
+     */
+    expect(screen.queryByText("People")).not.toBeInTheDocument();
+  });
+
+  test("omits the Teams group when the project has no teams", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    openOwnerMenu();
+
+    await screen.findByText("People", {}, { timeout: WAIT_TIMEOUT });
+    expect(screen.queryByText("Teams")).not.toBeInTheDocument();
+  });
+
+  test("creates one owner row per picked user and per picked team", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    await selectOwner("Team One");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(createMock).toHaveBeenCalledTimes(2);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const userCall: any = (createMock.mock.calls[0] as Array<any>)[0];
+    expect(userCall.modelType).toBe(ServiceLevelObjectiveOwnerUser);
+    expect(userCall.model.userId.toString()).toBe(ALICE_ID);
+    expect(userCall.model.serviceLevelObjectiveId.toString()).toBe(SLO_ONE_ID);
+    expect(userCall.model.projectId.toString()).toBe(PROJECT_ID);
+
+    const teamCall: any = (createMock.mock.calls[1] as Array<any>)[0];
+    expect(teamCall.modelType).toBe(ServiceLevelObjectiveOwnerTeam);
+    expect(teamCall.model.teamId.toString()).toBe(TEAM_ONE_ID);
+    expect(teamCall.model.serviceLevelObjectiveId.toString()).toBe(SLO_ONE_ID);
+    expect(teamCall.model.projectId.toString()).toBe(PROJECT_ID);
+  });
+
+  test("creates a row for every selected item", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID), makeSlo(SLO_TWO_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(createMock).toHaveBeenCalledTimes(2);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const resourceIds: Array<string> = (
+      createMock.mock.calls as Array<Array<any>>
+    ).map((call: Array<any>) => {
+      return call[0].model.serviceLevelObjectiveId.toString();
+    });
+
+    expect(resourceIds).toEqual([SLO_ONE_ID, SLO_TWO_ID]);
+  });
+
+  test("skips an owner the item already has", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+      ownerUsers: [makeOwnerUserRow({ id: OWNER_ROW_ID, userId: ALICE_ID })],
+      ownerTeams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    await selectOwner("Team One");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(createMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    /*
+     * Re-adding an existing owner is not a harmless duplicate: the owner
+     * lists on the resource render one row per junction record.
+     */
+    const onlyCall: any = (createMock.mock.calls[0] as Array<any>)[0];
+    expect(onlyCall.modelType).toBe(ServiceLevelObjectiveOwnerTeam);
+  });
+
+  test("reads the item's existing user owners with the resource-scoped query", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(createMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const ownerUserCall: any = getListCallsFor(
+      ServiceLevelObjectiveOwnerUser,
+    )[0];
+
+    /*
+     * The foreign key is a config string. Spelling it wrong compiles, and
+     * then this query matches every owner row in the project.
+     */
+    expect(ownerUserCall.query.serviceLevelObjectiveId.toString()).toBe(
+      SLO_ONE_ID,
+    );
+    expect(ownerUserCall.query.projectId.toString()).toBe(PROJECT_ID);
+    expect(ownerUserCall.select).toEqual({ userId: true });
+    expect(ownerUserCall.limit).toBe(LIMIT_PER_PROJECT);
+    expect(ownerUserCall.skip).toBe(0);
+  });
+
+  test("does not touch the team owner table when only a user was picked", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(createMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    expect(getListCallsFor(ServiceLevelObjectiveOwnerUser)).toHaveLength(1);
+    expect(getListCallsFor(ServiceLevelObjectiveOwnerTeam)).toHaveLength(0);
+  });
+
+  test("does not touch the user owner table when only a team was picked", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Team One");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(createMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    expect(getListCallsFor(ServiceLevelObjectiveOwnerTeam)).toHaveLength(1);
+    expect(getListCallsFor(ServiceLevelObjectiveOwnerUser)).toHaveLength(0);
+  });
+
+  test("deletes the junction rows that match the removed owners", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+      ownerUsers: [makeOwnerUserRow({ id: OWNER_ROW_ID, userId: ALICE_ID })],
+      ownerTeams: [
+        makeOwnerTeamRow({ id: OWNER_ROW_TWO_ID, teamId: TEAM_ONE_ID }),
+      ],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Remove Owner");
+    await selectOwner("Alice");
+    await selectOwner("Team One");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(deleteItemMock).toHaveBeenCalledTimes(2);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const userDelete: any = (deleteItemMock.mock.calls[0] as Array<any>)[0];
+    expect(userDelete.modelType).toBe(ServiceLevelObjectiveOwnerUser);
+    expect(userDelete.id.toString()).toBe(OWNER_ROW_ID);
+
+    const teamDelete: any = (deleteItemMock.mock.calls[1] as Array<any>)[0];
+    expect(teamDelete.modelType).toBe(ServiceLevelObjectiveOwnerTeam);
+    expect(teamDelete.id.toString()).toBe(OWNER_ROW_TWO_ID);
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test("looks the removable rows up by the selected owner ids", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+      ownerUsers: [makeOwnerUserRow({ id: OWNER_ROW_ID, userId: ALICE_ID })],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Remove Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(deleteItemMock).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const lookup: any = getListCallsFor(ServiceLevelObjectiveOwnerUser)[0];
+    expect(lookup.query.serviceLevelObjectiveId.toString()).toBe(SLO_ONE_ID);
+    expect(lookup.query.userId).toBeInstanceOf(Includes);
+    expect(
+      (lookup.query.userId.values as Array<ObjectID>).map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([ALICE_ID]);
+    expect(lookup.select).toEqual({ _id: true });
+  });
+
+  test("skips a junction row that came back without an id", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+      ownerUsers: [
+        makeOwnerUserRow({ userId: ALICE_ID }),
+        makeOwnerUserRow({ id: OWNER_ROW_ID, userId: ALICE_ID }),
+      ],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Remove Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    /*
+     * A select that drops _id would otherwise send DELETE with an undefined
+     * id, which the API resolves to "delete by query".
+     */
+    expect(deleteItemMock).toHaveBeenCalledTimes(1);
+    expect((deleteItemMock.mock.calls[0] as Array<any>)[0].id.toString()).toBe(
+      OWNER_ROW_ID,
+    );
+  });
+
+  test("counts an item that has none of the removed owners as a success", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+      ownerUsers: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Remove Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    expect(deleteItemMock).not.toHaveBeenCalled();
+    expect(progressSnapshots).toHaveLength(1);
+    expect(progressSnapshots[0]!.successItems).toEqual([SLO_ONE_ID]);
+    expect(progressSnapshots[0]!.failed).toEqual([]);
+  });
+
+  test("keeps going after one item fails and reports why", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    createMock.mockImplementation(async (data: any): Promise<any> => {
+      if (data.model.serviceLevelObjectiveId.toString() === SLO_ONE_ID) {
+        throw new BadDataException("Owner could not be added");
+      }
+
+      return {};
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID), makeSlo(SLO_TWO_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const finalSnapshot: ProgressSnapshot = progressSnapshots[1]!;
+    expect(finalSnapshot.successItems).toEqual([SLO_TWO_ID]);
+    expect(finalSnapshot.failed).toEqual([
+      { id: SLO_ONE_ID, failedMessage: "Owner could not be added" },
+    ]);
+  });
+
+  test("fails an item with no id without calling the API for it", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(), makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    const finalSnapshot: ProgressSnapshot = progressSnapshots[1]!;
+    expect(finalSnapshot.failed).toEqual([
+      { id: "no-id", failedMessage: "Item ID not found" },
+    ]);
+    expect(finalSnapshot.successItems).toEqual([SLO_ONE_ID]);
+
+    /*
+     * An id-less item must not reach the junction query: with the resource
+     * id missing the filter collapses to the whole project.
+     */
+    expect(getListCallsFor(ServiceLevelObjectiveOwnerUser)).toHaveLength(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails every item when the project is gone by the time the form is submitted", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+
+    window.history.replaceState({}, "", "/dashboard");
+
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    expect(progressSnapshots[0]!.failed).toEqual([
+      { id: SLO_ONE_ID, failedMessage: "Project not found" },
+    ]);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test("brackets the run with onBulkActionStart and onBulkActionEnd", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID), makeSlo(SLO_TWO_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    expect(onBulkActionStart).toHaveBeenCalledTimes(1);
+    expect(onProgressInfo).toHaveBeenCalledTimes(2);
+    expect(onBulkActionStart.mock.invocationCallOrder[0]!).toBeLessThan(
+      onProgressInfo.mock.invocationCallOrder[0]!,
+    );
+    expect(onBulkActionEnd.mock.invocationCallOrder[0]!).toBeGreaterThan(
+      onProgressInfo.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  test("moves each item from in-progress to success as it is processed", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID), makeSlo(SLO_TWO_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    await selectOwner("Alice");
+    submitOwnerModal();
+
+    await waitFor(
+      () => {
+        expect(onBulkActionEnd).toHaveBeenCalledTimes(1);
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    /*
+     * The item being worked on is spliced out of inProgressItems before its
+     * own callback fires, so the progress bar never double-counts it.
+     */
+    expect(progressSnapshots).toEqual([
+      {
+        totalItems: [SLO_ONE_ID, SLO_TWO_ID],
+        inProgressItems: [SLO_TWO_ID],
+        successItems: [SLO_ONE_ID],
+        failed: [],
+      },
+      {
+        totalItems: [SLO_ONE_ID, SLO_TWO_ID],
+        inProgressItems: [],
+        successItems: [SLO_ONE_ID, SLO_TWO_ID],
+        failed: [],
+      },
+    ]);
+  });
+
+  test("opening Add Owner closes an open Remove Owner modal", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Remove Owner");
+    clickOwnerAction("Add Owner");
+
+    const openTitles: Array<HTMLElement> = screen.getAllByTestId("modal-title");
+
+    /*
+     * Both dialogs share one bulkActionProps, and the first submit nulls it -
+     * so a second one left stacked behind would swallow its own submit.
+     */
+    expect(openTitles).toHaveLength(1);
+    expect(openTitles[0]!).toHaveTextContent("Add Owner");
+  });
+
+  test("opening Remove Owner closes an open Add Owner modal", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    clickOwnerAction("Remove Owner");
+
+    const openTitles: Array<HTMLElement> = screen.getAllByTestId("modal-title");
+
+    expect(openTitles).toHaveLength(1);
+    expect(openTitles[0]!).toHaveTextContent("Remove Owner");
+  });
+
+  test("blocks a submit with nothing selected", async () => {
+    mockLists({
+      teamMembers: [makeTeamMember({ userId: ALICE_ID, name: "Alice" })],
+      teams: [makeTeam(TEAM_ONE_ID, "Team One")],
+    });
+
+    render(<Harness items={[makeSlo(SLO_ONE_ID)]} />);
+    await waitForOwnerSources();
+    await openOwnerModal("Add Owner");
+    submitOwnerModal();
+
+    expect(
+      await screen.findByText(
+        "Select Owners is required.",
+        {},
+        { timeout: WAIT_TIMEOUT },
+      ),
+    ).toBeInTheDocument();
+
+    /*
+     * Without the required rule an empty submit still walks every selected
+     * item, reporting a batch of successes that changed nothing.
+     */
+    expect(createMock).not.toHaveBeenCalled();
+    expect(onBulkActionStart).not.toHaveBeenCalled();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Common/UI/Components/BulkUpdate/BulkLabelActions.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkLabelActions.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, {
+  MutableRefObject,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import Label from "../../../Models/DatabaseModels/Label";
@@ -63,14 +69,27 @@ function useBulkLabelActions<T extends BaseModel>(
   >([]);
   const [isLoadingRemoveLabels, setIsLoadingRemoveLabels] =
     useState<boolean>(false);
+  const removeLabelsRequestRef: MutableRefObject<number> = useRef<number>(0);
 
   useEffect(() => {
+    /*
+     * Without the guard the query went out as `projectId: null`, which is
+     * not "every project" — it is a filter nothing matches, so the add
+     * modal silently offered an empty dropdown. Skipping the request says
+     * the same thing without the round trip. Mirrors BulkOwnerActions.
+     */
+    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+
+    if (!projectId) {
+      return;
+    }
+
     const fetchLabels: () => Promise<void> = async (): Promise<void> => {
       try {
         const result: ListResult<Label> = await ModelAPI.getList<Label>({
           modelType: Label,
           query: {
-            projectId: ProjectUtil.getCurrentProjectId()!,
+            projectId: projectId,
           },
           limit: LIMIT_PER_PROJECT,
           skip: 0,
@@ -110,6 +129,26 @@ function useBulkLabelActions<T extends BaseModel>(
     setShowAddModal(false);
     setShowRemoveModal(false);
 
+    /*
+     * A label whose row came back without an `_id` would render as an
+     * option with an empty value, and submitting it would put "" into the
+     * labels array, failing the whole item over one unusable option.
+     */
+    const selectedLabelIds: Array<string> = labelIds.filter((id: string) => {
+      return Boolean(id);
+    });
+
+    /*
+     * Bail before starting rather than running the loop with nothing to
+     * apply: every item would fall through the no-op short-circuit below
+     * and be reported as a success, telling the user a bulk action landed
+     * when nothing was asked for.
+     */
+    if (selectedLabelIds.length === 0) {
+      setBulkActionProps(null);
+      return;
+    }
+
     onBulkActionStart();
 
     const totalItems: Array<T> = [...items];
@@ -133,14 +172,32 @@ function useBulkLabelActions<T extends BaseModel>(
           modelType: config.modelType,
           id: item.id,
           select: {
+            _id: true,
             labels: {
               _id: true,
             },
           } as any,
         });
 
+        /*
+         * A row that was deleted or filtered out between the table load
+         * and this action comes back as HTTP 200 with an empty body, which
+         * hydrates into a truthy but empty model — so "no labels" and
+         * "could not read it" are the same value here unless we look at
+         * `_id`, which a real read always carries. Without the check, add
+         * mode would treat the item as unlabelled and replace its entire
+         * label set with the selection: exactly the clobber the merge
+         * below exists to prevent. Fail the item instead; the user sees it
+         * in the failed list and nothing is lost.
+         */
+        if (!currentItem || !currentItem._id) {
+          throw new BadDataException(
+            "Could not read the current labels for this item.",
+          );
+        }
+
         const existingLabelIds: Array<string> = (
-          ((currentItem as any)?.labels as Array<Label> | undefined) || []
+          ((currentItem as any).labels as Array<Label> | undefined) || []
         )
           .map((label: Label) => {
             return label._id?.toString() || "";
@@ -153,11 +210,11 @@ function useBulkLabelActions<T extends BaseModel>(
 
         if (mode === "add") {
           newLabelIds = Array.from(
-            new Set<string>([...existingLabelIds, ...labelIds]),
+            new Set<string>([...existingLabelIds, ...selectedLabelIds]),
           );
         } else {
           newLabelIds = existingLabelIds.filter((id: string) => {
-            return !labelIds.includes(id);
+            return !selectedLabelIds.includes(id);
           });
         }
 
@@ -211,6 +268,20 @@ function useBulkLabelActions<T extends BaseModel>(
   const loadLabelsForSelectedItems: (items: Array<T>) => Promise<void> = async (
     items: Array<T>,
   ): Promise<void> => {
+    /*
+     * Close the modal and reopen it on a different selection and there are
+     * two fetches in flight; the slower one settles last and wins, so the
+     * modal ends up offering the previous selection's labels. Stamp each
+     * run and let only the newest one write state.
+     */
+    const requestId: number = ++removeLabelsRequestRef.current;
+
+    type IsCurrentRequestFunction = () => boolean;
+
+    const isCurrentRequest: IsCurrentRequestFunction = (): boolean => {
+      return requestId === removeLabelsRequestRef.current;
+    };
+
     setIsLoadingRemoveLabels(true);
 
     try {
@@ -223,7 +294,9 @@ function useBulkLabelActions<T extends BaseModel>(
         });
 
       if (itemIds.length === 0) {
-        setRemoveLabelDropdownOptions([]);
+        if (isCurrentRequest()) {
+          setRemoveLabelDropdownOptions([]);
+        }
         return;
       }
 
@@ -278,12 +351,18 @@ function useBulkLabelActions<T extends BaseModel>(
         return a.label.localeCompare(b.label);
       });
 
-      setRemoveLabelDropdownOptions(options);
+      if (isCurrentRequest()) {
+        setRemoveLabelDropdownOptions(options);
+      }
     } catch {
       // on error, show no options rather than every label in the project
-      setRemoveLabelDropdownOptions([]);
+      if (isCurrentRequest()) {
+        setRemoveLabelDropdownOptions([]);
+      }
     } finally {
-      setIsLoadingRemoveLabels(false);
+      if (isCurrentRequest()) {
+        setIsLoadingRemoveLabels(false);
+      }
     }
   };
 
@@ -306,8 +385,18 @@ function useBulkLabelActions<T extends BaseModel>(
     title: "Add Labels",
     buttonStyleType: ButtonStyleType.NORMAL,
     icon: IconProp.Label,
+    /*
+     * The two modals are independent booleans rendered as sibling
+     * branches, so nothing in the hook keeps them mutually exclusive —
+     * only the modal backdrop covering the action bar does, which is a
+     * property of a different component. Resetting the sibling here makes
+     * the invariant local: two stacked dialogs would share one
+     * bulkActionProps, and whichever submitted first would null it and
+     * leave the other silently inert.
+     */
     onClick: async (actionProps: BulkActionOnClickProps<T>): Promise<void> => {
       setBulkActionProps(actionProps);
+      setShowRemoveModal(false);
       setShowAddModal(true);
     },
   };
@@ -319,6 +408,7 @@ function useBulkLabelActions<T extends BaseModel>(
     onClick: async (actionProps: BulkActionOnClickProps<T>): Promise<void> => {
       setBulkActionProps(actionProps);
       setRemoveLabelDropdownOptions([]);
+      setShowAddModal(false);
       setShowRemoveModal(true);
       await loadLabelsForSelectedItems(actionProps.items);
     },

--- a/Common/UI/Components/BulkUpdate/BulkOwnerActions.tsx
+++ b/Common/UI/Components/BulkUpdate/BulkOwnerActions.tsx
@@ -415,8 +415,18 @@ function useBulkOwnerActions<T extends BaseModel>(
     title: "Add Owner",
     buttonStyleType: ButtonStyleType.NORMAL,
     icon: IconProp.UserPlus,
+    /*
+     * The two modals are independent booleans rendered as sibling
+     * branches, so nothing in the hook keeps them mutually exclusive —
+     * only the modal backdrop covering the action bar does, which is a
+     * property of a different component. Resetting the sibling here makes
+     * the invariant local: two stacked dialogs would share one
+     * bulkActionProps, and whichever submitted first would null it and
+     * leave the other silently inert.
+     */
     onClick: async (actionProps: BulkActionOnClickProps<T>): Promise<void> => {
       setBulkActionProps(actionProps);
+      setShowRemoveModal(false);
       setShowAddModal(true);
     },
   };
@@ -427,6 +437,7 @@ function useBulkOwnerActions<T extends BaseModel>(
     icon: IconProp.UserMinus,
     onClick: async (actionProps: BulkActionOnClickProps<T>): Promise<void> => {
       setBulkActionProps(actionProps);
+      setShowAddModal(false);
       setShowRemoveModal(true);
     },
   };


### PR DESCRIPTION
## What

The SLI/SLO product was the one resource list in the dashboard without bulk label and owner actions. Relabelling a dozen objectives, or handing them to a new on-call team, meant opening each SLO's edit form and Owners tab one at a time.

Both SLO surfaces now offer **Add Labels**, **Remove Labels**, **Add Owner** and **Remove Owner** on the selected rows, from the same shared hooks every other list already uses:

- `Pages/Slo/Slos.tsx` — the SLOs list
- `Pages/Monitor/View/Slos.tsx` — the monitor's SLOs tab

The wiring lives in a new `Components/Slo/useSloBulkActions.tsx` rather than on the page, so the two tables cannot drift apart in which junction tables or foreign key they write. `SLO_OWNER_RESOURCE_ID_FIELD` is typed `keyof ServiceLevelObjectiveOwnerUser & keyof ServiceLevelObjectiveOwnerTeam`, so a typo there is a build error — it needs to be, because a wrong `resourceIdField` does not fail at runtime: it queries a column nothing matches and reports every item as a success.

Both tables also gained the columns those actions write to — a Labels column on the monitor tab, an Owners column on both. Without them a completed bulk action changes nothing on screen and the user has no way to confirm it landed.

## Bug fixes in the shared hooks

These hooks back ~28 other resource lists and had **zero test coverage**. Writing the first tests turned up four real bugs, each fixed here and pinned by a test:

| Bug | Impact |
|---|---|
| A deleted or filtered-out row answers `getItem` with HTTP 200 and an empty body, which hydrates into a **truthy** empty model. Add mode read that as "has no labels" and replaced the item's entire label set with the selection. | Silent label loss. Now guarded on `_id`, which a real read always carries. |
| Submitting only blank label ids ran the whole loop, changed nothing, and reported **every item as a success**. | False confirmation. Now returns before starting. |
| A slow option fetch for a previous selection could settle after a newer one, leaving the Remove modal offering the wrong labels. | Wrong options shown. Each fetch is now stamped; only the newest may write. |
| The mount fetch sent `projectId: null` — a filter matching nothing — when there was no current project. | Empty dropdown after a wasted round trip. Now skips the request, as `BulkOwnerActions` already did. |

Also made the Add/Remove modals mutually exclusive in both hooks. Today the modal backdrop covers the action bar so both cannot be opened at once, but nothing *in the hooks* enforced it, and two stacked dialogs would share one `bulkActionProps` with the loser going silently inert.

## Tests — 80 new

| Suite | Tests | What it covers |
|---|---|---|
| `Common/Tests/UI/Components/BulkLabelActions.test.tsx` | 33 | First coverage of the shared label hook |
| `Common/Tests/UI/Components/BulkOwnerActions.test.tsx` | 30 | First coverage of the shared owner hook |
| `App/Tests/Dashboard/SloBulkActionsWiring.test.ts` | 17 | The SLO page wiring |

The two Common suites drive the **real** Modal, Formik and react-select and assert on what actually reaches `ModelAPI` — only `ModelAPI` and `react-i18next` are mocked. Most of their coverage is baseline characterisation of hooks that had none; the file headers name exactly which tests pin the fixes above, so 63 green checks are not misread as 63 checks on this change.

Every load-bearing assertion was **mutation-verified**: the source was temporarily broken, the intended test confirmed to fail, and the source restored. Reverting the whole feature diff fails exactly the tests that should fail (5 in the label suite, 2 in the owner suite, 15 of 17 in the wiring suite).

The wiring suite checks the owner foreign key against the **real** `ServiceLevelObjectiveOwnerUser` / `ServiceLevelObjectiveOwnerTeam` models via `getTableColumnMetadata()`, not against itself, and sweeps `Dashboard/src` so a third SLO `ModelTable` added later fails here until it is wired too (verified by dropping in an unwired scratch table).

## Reviewer notes

- **`ServiceLevelObjective` carries `@AccessControlColumn("labels")`**, so bulk label edits are also *access-control* edits: a label-scoped user can remove their own visibility of many SLOs in one action. `Monitor`, `Service` and `IncidentEpisode` carry the same decorator and already ship these actions, so this is parity rather than a new class of risk, and `@EnableAuditLog()` records it. Worth knowing all the same.
- **No privilege escalation**: update goes through the same label scoping as read, so a user cannot relabel a row they cannot already see. A labels-only update does not trip `ServiceLevelObjectiveService.onBeforeUpdate` or flag `isEvaluationConfigUpdated`, so there is no spurious re-evaluation or burn-rate-rule churn.
- **Row selection is newly visible to edit-only users.** `BaseModelTable` only renders checkboxes when at least one bulk button exists, and previously the only one was the auto-added Delete — so `ProjectMember` / `Viewer` saw no checkboxes on these tables at all. This also surfaces the built-in Export CSV action there.
- Both SLO tables take only the owners cell from `useResourceOwners`, not the facet filter bar the 20 peer call sites also adopt. Adding the filter bar to the SLOs list is a larger UI change and is left as a follow-up.

## Follow-ups (not in this PR)

- The owner facet filter bar on the SLOs list, for full parity with peer resource lists.
- Both hooks fetch project-wide Labels / TeamMembers / Teams (`limit: 10000`) on mount rather than on modal open. That cost now lands on a secondary tab inside the monitor view too. Making the fetch lazy would benefit all ~28 call sites.
- `onProgressInfo` hands the same mutable arrays to every call, so consumers memoising on array identity never see a change.

## Verification

- `Common`: 63/63 green from a **cold** ts-jest cache (`jest.setTimeout(30000)` added to both new suites — the real Modal + Formik + react-select import graph pushed individual tests past jest's 5s default on a cold cache, which is exactly how CI starts).
- `App`: 17/17 green; full `Tests/Dashboard` run is 3088/3089, the single failure being a pre-existing one in `HtmlWidgetSandbox.test.ts` (confirmed to fail identically with this branch stashed).
- `npm run fix` produces no changes; `tsc --noEmit` clean in both packages apart from 8 pre-existing errors in `FeatureSet/Identity/Utils/SSO.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)