### PR TITLE
feat(slo): attach monitors to an SLO by label rule

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Slo/Slos.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Slo/Slos.tsx
@@ -223,8 +223,34 @@ export const getSloFormFields: GetSloFormFieldsFunction = (
         labelField: "name",
         valueField: "_id",
       },
-      required: true,
+      /*
+       * Required only when nothing else can fill the list. An SLO driven
+       * entirely by the label rule below starts with no monitors picked by
+       * hand, and the server attaches the matching ones the moment it is
+       * saved — demanding a manual pick there would force the user to attach
+       * a monitor they did not mean to curate.
+       */
+      required: (item: FormValues<ServiceLevelObjective>): boolean => {
+        const monitorLabels: unknown = item.monitorLabels;
+        return !Array.isArray(monitorLabels) || monitorLabels.length === 0;
+      },
       placeholder: "Select Monitors",
+    },
+    {
+      field: {
+        monitorLabels: true,
+      },
+      title: "Auto-Add Monitors With Labels",
+      description:
+        "Keep this SLO's monitor list in step with your labels: every monitor carrying one of these labels is attached automatically, and is detached again when it stops carrying any of them. Monitors you attach by hand above are never removed.",
+      fieldType: FormFieldSchemaType.MultiSelectDropdown,
+      dropdownModal: {
+        type: Label,
+        labelField: "name",
+        valueField: "_id",
+      },
+      required: false,
+      placeholder: "Select Monitor Labels",
     },
     {
       field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Slo/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Slo/View/Index.tsx
@@ -474,6 +474,36 @@ const SloView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             },
             {
               field: {
+                monitorLabels: {
+                  name: true,
+                  color: true,
+                },
+              },
+              title: "Auto-Add Monitors With Labels",
+              fieldType: FieldType.Element,
+              getElement: (item: ServiceLevelObjective): ReactElement => {
+                const monitorLabels: Array<Label> =
+                  (item.monitorLabels as Array<Label>) || [];
+
+                /*
+                 * Spelled out rather than left blank: an empty cell here and
+                 * a rule that matches nothing look identical, and the
+                 * difference decides whether the Monitors list above is
+                 * maintained for you or entirely yours to curate.
+                 */
+                if (monitorLabels.length === 0) {
+                  return (
+                    <span className="text-gray-400">
+                      No label rule — monitors are attached by hand.
+                    </span>
+                  );
+                }
+
+                return <LabelsElement labels={monitorLabels} />;
+              },
+            },
+            {
+              field: {
                 downtimeMonitorStatuses: {
                   name: true,
                 },

--- a/App/FeatureSet/Docs/Content/en/slo/introduction.md
+++ b/App/FeatureSet/Docs/Content/en/slo/introduction.md
@@ -17,7 +17,7 @@ The value of the error budget framing is that it turns reliability into a spenda
 
 An SLO in OneUptime is made of:
 
-- **One or more monitors** — the SLI source. OneUptime computes good and bad time from each monitor's status timeline, the same data that powers your status pages.
+- **One or more monitors** — the SLI source. OneUptime computes good and bad time from each monitor's status timeline, the same data that powers your status pages. Attach them by hand, or by label so the list maintains itself.
 - **A target percentage** — for example `99.9`. The target must be below 100% (a 100% target has no error budget, so there is nothing to track).
 - **A compliance window** — either a **rolling window** of any length from 1 to 366 days (7, 28, 30 and 90 are the usual choices), or a **calendar month**.
 - **Downtime statuses** — which monitor statuses count as downtime for this SLO.
@@ -33,10 +33,10 @@ You can tune this per SLO. A common pattern is two SLOs over the same monitors:
 
 ### Compliance windows
 
-| Window type        | Behavior                                                                                                                                   |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Window type        | Behavior                                                                                                                                      |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Rolling**        | Always looks back a fixed number of days from now (1 to 366). Bad time gradually ages out of the window, so the budget recovers continuously. |
-| **Calendar month** | Measures from the first of the month in the SLO's timezone. The budget resets in full at the start of each month.                          |
+| **Calendar month** | Measures from the first of the month in the SLO's timezone. The budget resets in full at the start of each month.                             |
 
 Calendar-month SLOs have a **timezone** setting (defaulting to UTC) that determines exactly when the month rolls over.
 
@@ -44,9 +44,9 @@ Calendar-month SLOs have a **timezone** setting (defaulting to UTC) that determi
 
 When an SLO has more than one monitor attached, you choose how their downtime combines:
 
-| Mode                           | Semantics                                                                                                                                                                                    | Use when…                                                                                            |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| **Any Monitor Down** (default) | Any moment where _at least one_ attached monitor is in a downtime status counts as downtime for the whole SLO. Overlapping outages are not double-counted — the union of down time is taken. | The monitors together represent one user-facing service: if any of them is down, users are affected. |
+| Mode                           | Semantics                                                                                                                                                                                                                                                  | Use when…                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Any Monitor Down** (default) | Any moment where _at least one_ attached monitor is in a downtime status counts as downtime for the whole SLO. Overlapping outages are not double-counted — the union of down time is taken.                                                               | The monitors together represent one user-facing service: if any of them is down, users are affected. |
 | **Monitor Seconds Average**    | Each monitor's downtime is counted separately and averaged: SLI = 1 − (total down seconds across monitors ÷ total monitored seconds across monitors). This changes the denominator as well as the numerator — see [Error Budgets](/docs/slo/error-budget). | The monitors are a fleet of similar resources and partial impact should count partially.             |
 
 An example: Monitor A is down from 10:00 to 11:00 while Monitor B stays up.
@@ -54,17 +54,34 @@ An example: Monitor A is down from 10:00 to 11:00 while Monitor B stays up.
 - **Any Monitor Down** — the SLO records 60 minutes of downtime (the service was impaired for that hour).
 - **Monitor Seconds Average** — the SLO records the equivalent of 30 minutes (one of two monitors was down for an hour, so half the fleet-seconds were bad).
 
+### Attaching monitors by label
+
+Picking monitors by hand goes stale: someone adds the fourth checkout monitor and nobody remembers to add it to the checkout SLO, so the SLO quietly under-reports for weeks.
+
+**Auto-Add Monitors With Labels** on the SLO form fixes that. Name one or more monitor labels, and every monitor in the project carrying at least one of them is attached automatically:
+
+- when the SLO is created or the rule is edited, every matching monitor is attached at once;
+- when a monitor is created with a matching label — including a label one of your monitor label rules gave it — it is attached;
+- when a monitor gains a matching label, it is attached;
+- when a monitor loses its last matching label, it is detached again.
+
+A monitor matches if it carries **any** of the rule's labels, not all of them.
+
+**Monitors you attach by hand are never removed.** The SLO remembers which monitors the rule attached and only ever takes those back, so a monitor you picked deliberately stays attached even when it stops matching — and stays attached if you delete the rule entirely. Deleting the rule (clearing the labels) detaches everything the rule had attached, and nothing else.
+
+If you use a rule, the Monitors picker becomes optional — you can create an SLO with only a rule and let it fill in. Its list still shows the full attached set, so the Overview tab always tells you exactly what is being measured.
+
 ## SLO status
 
 Every SLO carries a status computed from its remaining error budget:
 
-| Status               | Meaning                                                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **Healthy**          | Plenty of budget left.                                                                                                    |
-| **At Risk**          | Remaining budget has dropped to or below the at-risk threshold — **20% of the budget by default** (configurable per SLO). |
-| **Budget Exhausted** | The budget is fully spent (or overspent).                                                                                 |
+| Status               | Meaning                                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Healthy**          | Plenty of budget left.                                                                                                                          |
+| **At Risk**          | Remaining budget has dropped to or below the at-risk threshold — **20% of the budget by default** (configurable per SLO).                       |
+| **Budget Exhausted** | The budget is fully spent (or overspent).                                                                                                       |
 | **Misconfigured**    | The SLO cannot be evaluated — no monitors attached, no monitor data in the window yet, or a target outside 0–100%. The SLO page explains which. |
-| **Paused**           | All attached monitors are disabled, so there is no signal to evaluate.                                                    |
+| **Paused**           | All attached monitors are disabled, so there is no signal to evaluate.                                                                          |
 
 SLO owners are notified when the status changes to **At Risk** or **Budget Exhausted** — see [Error Budgets](/docs/slo/error-budget) for details.
 
@@ -73,7 +90,7 @@ SLO owners are notified when the status changes to **At Risk** or **Budget Exhau
 1. Go to **SLOs** in the OneUptime Dashboard
 2. Click **Create SLO**
 3. Give it a name and description
-4. Attach one or more **monitors**
+4. Attach one or more **monitors**, or name the monitor labels to attach them by under **Auto-Add Monitors With Labels** (or both)
 5. Set the **target percentage** (e.g., `99.9`)
 6. Pick the **window type** — **Rolling** (then set the window length in days, 1 to 366) or **Calendar Month** (then pick the **timezone** the month rolls over in)
 7. Optionally adjust the **at-risk threshold**, the **downtime statuses**, and — for multiple monitors — the **multi-monitor mode**
@@ -93,13 +110,13 @@ The SLO's **Overview** tab shows, live:
 
 The SLO's other tabs are:
 
-| Tab | What it shows |
-| --- | --- |
-| **Charts** | SLI, budget remaining and burn rate over time, with reference lines at your target, at the at-risk and exhausted budget boundaries, and at each enabled burn rate rule's threshold. |
-| **Burn Rate Rules** | The rules that page you when the budget burns too fast, and whether each one is currently firing. |
-| **Alerts** | Every alert this SLO's burn rate rules have raised. |
-| **Audit Logs** | Every change made to this SLO's definition. |
-| **Owners** | The users and teams notified when the status changes. |
+| Tab                 | What it shows                                                                                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Charts**          | SLI, budget remaining and burn rate over time, with reference lines at your target, at the at-risk and exhausted budget boundaries, and at each enabled burn rate rule's threshold. |
+| **Burn Rate Rules** | The rules that page you when the budget burns too fast, and whether each one is currently firing.                                                                                   |
+| **Alerts**          | Every alert this SLO's burn rate rules have raised.                                                                                                                                 |
+| **Audit Logs**      | Every change made to this SLO's definition.                                                                                                                                         |
+| **Owners**          | The users and teams notified when the status changes.                                                                                                                               |
 
 For a brand-new SLO with a rolling window, the window is not full yet — a 30-day SLO created yesterday only has one day of data. OneUptime measures over the data that exists and flags the SLO as "window not yet full", so early numbers move around more than they will once the window fills.
 

--- a/App/Tests/Dashboard/SloMonitorLabelRuleFormFields.test.ts
+++ b/App/Tests/Dashboard/SloMonitorLabelRuleFormFields.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "@jest/globals";
+import { getSloFormFields } from "../../FeatureSet/Dashboard/src/Pages/Slo/Slos";
+import Label from "Common/Models/DatabaseModels/Label";
+import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import ModelField from "Common/UI/Components/Forms/Types/Field";
+
+/*
+ * The SLO form gained a label rule: "attach every monitor carrying one of
+ * these labels". Two things about it are load-bearing and easy to break by
+ * accident.
+ *
+ * First the key. `monitorLabels` is the rule; `labels` is how the SLO itself
+ * is categorised. They are both multi-selects over Label sitting a few rows
+ * apart, and swapping them would silently point the rule at the wrong column
+ * — the form would look right and attach nothing.
+ *
+ * Second, Monitors stops being unconditionally required. An SLO driven
+ * entirely by the rule is saved with an empty picker and filled in by the
+ * server; demanding a manual pick there would force the user to attach a
+ * monitor they did not mean to curate. It stays required when there is no
+ * rule, because an SLO with neither is one that can never be evaluated.
+ */
+
+const FIELD_KEY_MONITORS: string = "monitors";
+const FIELD_KEY_MONITOR_LABELS: string = "monitorLabels";
+const FIELD_KEY_LABELS: string = "labels";
+
+function getFieldKey(field: ModelField<ServiceLevelObjective>): string {
+  return Object.keys(field.field || {})[0] as string;
+}
+
+function getField(key: string): ModelField<ServiceLevelObjective> {
+  const field: ModelField<ServiceLevelObjective> | undefined =
+    getSloFormFields().find((item: ModelField<ServiceLevelObjective>) => {
+      return getFieldKey(item) === key;
+    });
+
+  if (!field) {
+    throw new Error(`SLO form field "${key}" not found`);
+  }
+
+  return field;
+}
+
+function isMonitorsRequired(
+  values: Partial<FormValues<ServiceLevelObjective>>,
+): boolean {
+  const required: unknown = getField(FIELD_KEY_MONITORS).required;
+
+  if (typeof required === "function") {
+    return (required as (item: FormValues<ServiceLevelObjective>) => boolean)(
+      values as FormValues<ServiceLevelObjective>,
+    );
+  }
+
+  return Boolean(required);
+}
+
+describe("getSloFormFields — the monitor label rule", () => {
+  test("offers the rule as its own field, distinct from the SLO's own labels", () => {
+    const keys: Array<string> = getSloFormFields().map(
+      (field: ModelField<ServiceLevelObjective>) => {
+        return getFieldKey(field);
+      },
+    );
+
+    expect(keys).toContain(FIELD_KEY_MONITOR_LABELS);
+    expect(keys).toContain(FIELD_KEY_LABELS);
+    expect(keys.indexOf(FIELD_KEY_MONITOR_LABELS)).not.toBe(
+      keys.indexOf(FIELD_KEY_LABELS),
+    );
+  });
+
+  test("places the rule directly after the monitor list it maintains", () => {
+    const keys: Array<string> = getSloFormFields().map(
+      (field: ModelField<ServiceLevelObjective>) => {
+        return getFieldKey(field);
+      },
+    );
+
+    expect(keys.indexOf(FIELD_KEY_MONITOR_LABELS)).toBe(
+      keys.indexOf(FIELD_KEY_MONITORS) + 1,
+    );
+  });
+
+  test("renders the rule as a multi-select over Label", () => {
+    const field: ModelField<ServiceLevelObjective> = getField(
+      FIELD_KEY_MONITOR_LABELS,
+    );
+
+    expect(field.fieldType).toBe(FormFieldSchemaType.MultiSelectDropdown);
+    expect(field.dropdownModal?.type).toBe(Label);
+    expect(field.dropdownModal?.valueField).toBe("_id");
+  });
+
+  test("never makes the rule itself mandatory — a hand-curated SLO is still valid", () => {
+    expect(getField(FIELD_KEY_MONITOR_LABELS).required).toBe(false);
+  });
+
+  test("explains that hand-attached monitors survive the rule", () => {
+    expect(getField(FIELD_KEY_MONITOR_LABELS).description).toContain(
+      "never removed",
+    );
+  });
+
+  test("keeps Monitors required when there is no rule to fill it", () => {
+    expect(isMonitorsRequired({})).toBe(true);
+    expect(isMonitorsRequired({ monitorLabels: [] })).toBe(true);
+  });
+
+  test("drops the Monitors requirement once a rule can fill it", () => {
+    expect(
+      isMonitorsRequired({
+        monitorLabels: [{ _id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd" }],
+      } as unknown as Partial<FormValues<ServiceLevelObjective>>),
+    ).toBe(false);
+  });
+
+  test("treats a non-array rule value as no rule at all", () => {
+    expect(
+      isMonitorsRequired({
+        monitorLabels: undefined,
+      } as unknown as Partial<FormValues<ServiceLevelObjective>>),
+    ).toBe(true);
+  });
+});

--- a/Common/Models/DatabaseModels/ServiceLevelObjective.ts
+++ b/Common/Models/DatabaseModels/ServiceLevelObjective.ts
@@ -515,6 +515,97 @@ export default class ServiceLevelObjective extends BaseModel {
   @TableColumn({
     required: false,
     type: TableColumnType.EntityArray,
+    modelType: Label,
+    title: "Auto-Add Monitors With Labels",
+    description:
+      "Monitor labels that automatically attach monitors to this SLO. Any monitor in the project carrying at least one of these labels is added to the Monitors list, and is removed again when it stops carrying any of them.",
+  })
+  @ManyToMany(
+    () => {
+      return Label;
+    },
+    { eager: false },
+  )
+  @JoinTable({
+    name: "ServiceLevelObjectiveMonitorLabel",
+    inverseJoinColumn: {
+      name: "labelId",
+      referencedColumnName: "_id",
+    },
+    joinColumn: {
+      name: "serviceLevelObjectiveId",
+      referencedColumnName: "_id",
+    },
+  })
+  public monitorLabels?: Array<Label> = undefined;
+
+  /*
+   * Bookkeeping shadow of `monitors`: the subset of attached monitors that the
+   * label rule put there. Without it the rule could not tell a monitor it
+   * added from one a human attached by hand, so "this monitor no longer
+   * matches, detach it" would silently delete deliberate, manual attachments.
+   * Root-only: it is derived state, never something a client sets.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadServiceLevelObjective,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.EntityArray,
+    modelType: Monitor,
+    title: "Auto Added Monitors",
+    description:
+      "Monitors that were attached to this SLO by its label rule rather than by hand. Maintained by the server.",
+  })
+  @ManyToMany(
+    () => {
+      return Monitor;
+    },
+    { eager: false },
+  )
+  @JoinTable({
+    name: "ServiceLevelObjectiveAutoAddedMonitor",
+    inverseJoinColumn: {
+      name: "monitorId",
+      referencedColumnName: "_id",
+    },
+    joinColumn: {
+      name: "serviceLevelObjectiveId",
+      referencedColumnName: "_id",
+    },
+  })
+  public autoAddedMonitors?: Array<Monitor> = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateServiceLevelObjective,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadServiceLevelObjective,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditServiceLevelObjective,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.EntityArray,
     modelType: MonitorStatus,
     isDefaultValueColumn: true,
     computed: true,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785900000000-AddSloMonitorLabelRule.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1785900000000-AddSloMonitorLabelRule.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * The SLO monitor label rule: two many-to-many join tables for
+ * ServiceLevelObjective.
+ *
+ *   - ServiceLevelObjectiveMonitorLabel is the rule itself — the monitor
+ *     labels an SLO auto-attaches monitors by.
+ *
+ *   - ServiceLevelObjectiveAutoAddedMonitor is its bookkeeping: which of the
+ *     SLO's attached monitors the rule put there. It is what lets the rule
+ *     detach a monitor that stopped matching without ever touching one a
+ *     human attached by hand.
+ *
+ * Both are pure additions; no backfill. An existing SLO has no rule, so it
+ * keeps its hand-curated monitor list untouched until someone gives it one.
+ */
+export class AddSloMonitorLabelRule1785900000000 implements MigrationInterface {
+  public name = "AddSloMonitorLabelRule1785900000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "ServiceLevelObjectiveMonitorLabel" ("serviceLevelObjectiveId" uuid NOT NULL, "labelId" uuid NOT NULL, CONSTRAINT "PK_daea26f6963106215a4fea2da89" PRIMARY KEY ("serviceLevelObjectiveId", "labelId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_cfda767c33fdbaa6ef9f268b8e" ON "ServiceLevelObjectiveMonitorLabel" ("serviceLevelObjectiveId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_46d9376cbba06f4911ed521b30" ON "ServiceLevelObjectiveMonitorLabel" ("labelId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "ServiceLevelObjectiveAutoAddedMonitor" ("serviceLevelObjectiveId" uuid NOT NULL, "monitorId" uuid NOT NULL, CONSTRAINT "PK_2a43ef3a0f312cd6a591838383b" PRIMARY KEY ("serviceLevelObjectiveId", "monitorId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f6f19994d02713e1f0021843ce" ON "ServiceLevelObjectiveAutoAddedMonitor" ("serviceLevelObjectiveId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1c0e494a9f1082373a8b7efda5" ON "ServiceLevelObjectiveAutoAddedMonitor" ("monitorId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveMonitorLabel" ADD CONSTRAINT "FK_cfda767c33fdbaa6ef9f268b8e7" FOREIGN KEY ("serviceLevelObjectiveId") REFERENCES "ServiceLevelObjective"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveMonitorLabel" ADD CONSTRAINT "FK_46d9376cbba06f4911ed521b308" FOREIGN KEY ("labelId") REFERENCES "Label"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveAutoAddedMonitor" ADD CONSTRAINT "FK_f6f19994d02713e1f0021843ce6" FOREIGN KEY ("serviceLevelObjectiveId") REFERENCES "ServiceLevelObjective"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveAutoAddedMonitor" ADD CONSTRAINT "FK_1c0e494a9f1082373a8b7efda5b" FOREIGN KEY ("monitorId") REFERENCES "Monitor"("_id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveAutoAddedMonitor" DROP CONSTRAINT "FK_1c0e494a9f1082373a8b7efda5b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveAutoAddedMonitor" DROP CONSTRAINT "FK_f6f19994d02713e1f0021843ce6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveMonitorLabel" DROP CONSTRAINT "FK_46d9376cbba06f4911ed521b308"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ServiceLevelObjectiveMonitorLabel" DROP CONSTRAINT "FK_cfda767c33fdbaa6ef9f268b8e7"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1c0e494a9f1082373a8b7efda5"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_f6f19994d02713e1f0021843ce"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "ServiceLevelObjectiveAutoAddedMonitor"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_46d9376cbba06f4911ed521b30"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_cfda767c33fdbaa6ef9f268b8e"`,
+    );
+    await queryRunner.query(`DROP TABLE "ServiceLevelObjectiveMonitorLabel"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -492,6 +492,7 @@ import { SessionReplayDefaultToSensitiveInputMasking1785860000000 } from "./1785
 import { AddAiCommandRemediation1785870000000 } from "./1785870000000-AddAiCommandRemediation";
 import { AlignRunnerSchemaWithEntities1785880000000 } from "./1785880000000-AlignRunnerSchemaWithEntities";
 import { AddFixVerificationAndAutomaticCodeFixes1785890000000 } from "./1785890000000-AddFixVerificationAndAutomaticCodeFixes";
+import { AddSloMonitorLabelRule1785900000000 } from "./1785900000000-AddSloMonitorLabelRule";
 import { AddIncidentInvestigationGating1785790000000 } from "./1785790000000-AddIncidentInvestigationGating";
 import { AddRemediationVerification1785768089408 } from "./1785768089408-AddRemediationVerification";
 
@@ -992,4 +993,5 @@ export default [
   AddAiCommandRemediation1785870000000,
   AlignRunnerSchemaWithEntities1785880000000,
   AddFixVerificationAndAutomaticCodeFixes1785890000000,
+  AddSloMonitorLabelRule1785900000000,
 ];

--- a/Common/Server/Services/LabelService.ts
+++ b/Common/Server/Services/LabelService.ts
@@ -1,14 +1,20 @@
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate } from "../Types/Database/Hooks";
+import DeleteBy from "../Types/Database/DeleteBy";
+import { OnCreate, OnDelete } from "../Types/Database/Hooks";
 import QueryHelper from "../Types/Database/QueryHelper";
 import DatabaseService from "./DatabaseService";
+import ServiceLevelObjectiveMonitorRuleEngineService from "./ServiceLevelObjectiveMonitorRuleEngineService";
+import ServiceLevelObjectiveService from "./ServiceLevelObjectiveService";
+import ServiceLevelObjective from "../../Models/DatabaseModels/ServiceLevelObjective";
 import BadDataException from "../../Types/Exception/BadDataException";
+import LIMIT_MAX from "../../Types/Database/LimitMax";
 import ObjectID from "../../Types/ObjectID";
 import Color from "../../Types/Color";
 import { BrightColors } from "../../Types/BrandColors";
 import GlobalCache from "../Infrastructure/GlobalCache";
 import Model from "../../Models/DatabaseModels/Label";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import logger from "../Utils/Logger";
 
 const AUTO_LABEL_ID_CACHE_NAMESPACE: string = "auto-label-id";
 const AUTO_LABEL_ID_CACHE_TTL_SECONDS: number = 24 * 60 * 60;
@@ -55,6 +61,105 @@ export class Service extends DatabaseService<Model> {
     }
 
     return Promise.resolve({ createBy, carryForward: null });
+  }
+
+  /*
+   * Deleting a label cascades its join rows away at the database level, so no
+   * service hook ever fires for the SLO label rules that referenced it. Those
+   * SLOs would keep the monitors the rule attached, with nothing left to
+   * explain why. Note the ids down while the label still exists, and re-run
+   * the (now smaller) rules once it is gone.
+   */
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    let serviceLevelObjectiveIds: Array<ObjectID> = [];
+
+    try {
+      const labels: Array<Model> = await this.findBy({
+        query: deleteBy.query,
+        select: {
+          _id: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      const labelIds: Array<ObjectID> = labels
+        .map((label: Model) => {
+          return label.id;
+        })
+        .filter((id: ObjectID | null): id is ObjectID => {
+          return Boolean(id);
+        });
+
+      if (labelIds.length > 0) {
+        const slos: Array<ServiceLevelObjective> =
+          await ServiceLevelObjectiveService.findBy({
+            query: {
+              monitorLabels: labelIds,
+            },
+            select: {
+              _id: true,
+            },
+            limit: LIMIT_MAX,
+            skip: 0,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        serviceLevelObjectiveIds = slos
+          .map((slo: ServiceLevelObjective) => {
+            return slo.id;
+          })
+          .filter((id: ObjectID | null): id is ObjectID => {
+            return Boolean(id);
+          });
+      }
+    } catch (err) {
+      logger.error(
+        `Error collecting SLO label rules affected by a label delete: ${err}`,
+      );
+    }
+
+    return {
+      deleteBy,
+      carryForward: {
+        serviceLevelObjectiveIds: serviceLevelObjectiveIds,
+      },
+    };
+  }
+
+  @CaptureSpan()
+  protected override async onDeleteSuccess(
+    onDelete: OnDelete<Model>,
+    _itemIdsBeforeDelete: Array<ObjectID>,
+  ): Promise<OnDelete<Model>> {
+    const serviceLevelObjectiveIds: Array<ObjectID> =
+      (
+        onDelete.carryForward as {
+          serviceLevelObjectiveIds?: Array<ObjectID>;
+        } | null
+      )?.serviceLevelObjectiveIds || [];
+
+    for (const serviceLevelObjectiveId of serviceLevelObjectiveIds) {
+      try {
+        await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+          serviceLevelObjectiveId: serviceLevelObjectiveId,
+        });
+      } catch (err) {
+        logger.error(
+          `Error re-applying the monitor label rule for SLO ${serviceLevelObjectiveId.toString()} after a label delete: ${err}`,
+        );
+      }
+    }
+
+    return onDelete;
   }
 
   /**

--- a/Common/Server/Services/MonitorService.ts
+++ b/Common/Server/Services/MonitorService.ts
@@ -14,6 +14,7 @@ import MonitorOwnerTeamService from "./MonitorOwnerTeamService";
 import MonitorOwnerUserService from "./MonitorOwnerUserService";
 import MonitorProbeService from "./MonitorProbeService";
 import MonitorStatusService from "./MonitorStatusService";
+import ServiceLevelObjectiveMonitorRuleEngineService from "./ServiceLevelObjectiveMonitorRuleEngineService";
 import NetworkSiteService from "./NetworkSiteService";
 import MonitorStatusTimelineService, {
   MONITOR_STATUS_SAME_AS_PREVIOUS_ERROR_MESSAGE,
@@ -612,6 +613,37 @@ export class Service extends DatabaseService<Model> {
       }
     }
 
+    /*
+     * Labels decide SLO membership, so a label added or removed here can pull
+     * this monitor into an SLO's error budget or push it out of one. Keyed on
+     * `!== undefined` rather than on a non-empty array: clearing every label
+     * arrives as `[]`, and that is precisely the edit that should detach the
+     * monitor from every rule-driven SLO.
+     */
+    if (
+      onUpdate.updateBy.data.labels !== undefined &&
+      updatedItemIds.length > 0
+    ) {
+      for (const monitorId of updatedItemIds) {
+        try {
+          await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor(
+            {
+              monitorId: monitorId,
+              projectId: onUpdate.updateBy.props.tenantId as ObjectID,
+            },
+          );
+        } catch (error) {
+          logger.error(
+            "Syncing SLO label rules failed in MonitorService.onUpdateSuccess",
+            {
+              monitorId: monitorId?.toString(),
+            } as LogAttributes,
+          );
+          logger.error(error as Error);
+        }
+      }
+    }
+
     return onUpdate;
   }
 
@@ -980,6 +1012,31 @@ ${createdItem.description?.trim() || "No description provided."}
           );
           logger.error(error as Error);
           return Promise.resolve();
+        }
+        return Promise.resolve();
+      })
+      .then(async () => {
+        /*
+         * Runs after the label rules above so a monitor created with no labels
+         * of its own, but given some by a MonitorLabelRule, still lands in the
+         * SLOs those labels imply.
+         */
+        try {
+          await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor(
+            {
+              monitorId: createdItem.id!,
+              projectId: createdItem.projectId!,
+            },
+          );
+        } catch (error) {
+          logger.error(
+            "Syncing SLO label rules failed in MonitorService.onCreateSuccess",
+            {
+              projectId: createdItem.projectId?.toString(),
+              monitorId: createdItem.id?.toString(),
+            } as LogAttributes,
+          );
+          logger.error(error as Error);
         }
         return Promise.resolve();
       })

--- a/Common/Server/Services/ServiceLevelObjectiveMonitorRuleEngineService.ts
+++ b/Common/Server/Services/ServiceLevelObjectiveMonitorRuleEngineService.ts
@@ -1,0 +1,426 @@
+import Monitor from "../../Models/DatabaseModels/Monitor";
+import ServiceLevelObjective from "../../Models/DatabaseModels/ServiceLevelObjective";
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import PartialEntity from "../../Types/Database/PartialEntity";
+import ObjectID from "../../Types/ObjectID";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import logger, { LogAttributes } from "../Utils/Logger";
+import MonitorService from "./MonitorService";
+import ServiceLevelObjectiveService from "./ServiceLevelObjectiveService";
+
+/**
+ * What a sync did, so callers (and tests) can assert on the outcome without
+ * re-reading the SLO.
+ */
+export interface SloMonitorSyncResult {
+  monitorIdsAdded: Array<string>;
+  monitorIdsRemoved: Array<string>;
+}
+
+function emptyResult(): SloMonitorSyncResult {
+  return { monitorIdsAdded: [], monitorIdsRemoved: [] };
+}
+
+function toIdSet(
+  items: Array<{ id?: ObjectID | null }> | undefined,
+): Set<string> {
+  const ids: Set<string> = new Set<string>();
+
+  for (const item of items || []) {
+    const id: string = item?.id?.toString() || "";
+
+    if (id) {
+      ids.add(id);
+    }
+  }
+
+  return ids;
+}
+
+function toMonitors(ids: Iterable<string>): Array<Monitor> {
+  const monitors: Array<Monitor> = [];
+
+  for (const id of ids) {
+    const monitor: Monitor = new Monitor();
+    monitor.id = new ObjectID(id);
+    monitors.push(monitor);
+  }
+
+  return monitors;
+}
+
+function isSameSet(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+
+  for (const value of a) {
+    if (!b.has(value)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Keeps an SLO's monitor list in step with its label rule.
+ *
+ * An SLO can name a set of monitor labels ("Auto-Add Monitors With Labels").
+ * Every monitor in the project carrying at least one of them belongs to the
+ * SLO, and stops belonging to it the moment it carries none. Two entry points
+ * drive that, because the membership can be invalidated from either side:
+ *
+ *   - the SLO side (its rule changed) -> syncMonitorsForSlo
+ *   - the monitor side (its labels changed) -> syncSlosForMonitor
+ *
+ * Both write through ServiceLevelObjective.autoAddedMonitors, which records
+ * which attachments the rule owns. Only those are ever detached, so a monitor
+ * a human attached by hand survives every rule evaluation — including the one
+ * that runs when the rule is deleted.
+ */
+export class ServiceLevelObjectiveMonitorRuleEngineServiceClass {
+  /**
+   * Re-evaluates one SLO's label rule against every monitor in its project.
+   * Use when the SLO's rule changed (created, edited, or cleared) — it is the
+   * authoritative, self-healing path and repairs any drift it finds.
+   */
+  @CaptureSpan()
+  public async syncMonitorsForSlo(data: {
+    serviceLevelObjectiveId: ObjectID;
+  }): Promise<SloMonitorSyncResult> {
+    const slo: ServiceLevelObjective | null =
+      await ServiceLevelObjectiveService.findOneById({
+        id: data.serviceLevelObjectiveId,
+        select: {
+          _id: true,
+          projectId: true,
+          monitorLabels: {
+            _id: true,
+          },
+          monitors: {
+            _id: true,
+          },
+          autoAddedMonitors: {
+            _id: true,
+          },
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    if (!slo || !slo.id || !slo.projectId) {
+      return emptyResult();
+    }
+
+    const ruleLabelIds: Set<string> = toIdSet(slo.monitorLabels);
+
+    /*
+     * No rule (or the rule was just cleared) means nothing matches, which in
+     * turn detaches everything the rule had attached. Deleting the rule
+     * therefore undoes the rule rather than leaving its monitors stranded on
+     * an SLO nobody remembers configuring.
+     */
+    const matchedMonitorIds: Set<string> =
+      ruleLabelIds.size === 0
+        ? new Set<string>()
+        : await this.findMonitorIdsWithAnyLabel({
+            projectId: slo.projectId,
+            labelIds: ruleLabelIds,
+          });
+
+    return await this.writeMembership({
+      slo: slo,
+      attachedMonitorIds: toIdSet(slo.monitors),
+      autoAddedMonitorIds: toIdSet(slo.autoAddedMonitors),
+      matchedMonitorIds: matchedMonitorIds,
+    });
+  }
+
+  /**
+   * Re-evaluates every label rule in the project against a single monitor.
+   * Use when the monitor's labels changed: it touches only this monitor's
+   * membership, so it costs one query per project regardless of how many
+   * monitors the rules match.
+   */
+  @CaptureSpan()
+  public async syncSlosForMonitor(data: {
+    monitorId: ObjectID;
+    projectId?: ObjectID | undefined;
+  }): Promise<Array<SloMonitorSyncResult>> {
+    const monitor: Monitor | null = await MonitorService.findOneById({
+      id: data.monitorId,
+      select: {
+        _id: true,
+        projectId: true,
+        labels: {
+          _id: true,
+        },
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (!monitor || !monitor.id) {
+      return [];
+    }
+
+    const projectId: ObjectID | undefined =
+      monitor.projectId || data.projectId || undefined;
+
+    if (!projectId) {
+      return [];
+    }
+
+    const monitorLabelIds: Set<string> = toIdSet(monitor.labels);
+    const monitorId: string = monitor.id.toString();
+
+    const slos: Array<ServiceLevelObjective> =
+      await ServiceLevelObjectiveService.findBy({
+        query: {
+          projectId: projectId,
+        },
+        select: {
+          _id: true,
+          projectId: true,
+          monitorLabels: {
+            _id: true,
+          },
+          monitors: {
+            _id: true,
+          },
+          autoAddedMonitors: {
+            _id: true,
+          },
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const results: Array<SloMonitorSyncResult> = [];
+
+    for (const slo of slos) {
+      const ruleLabelIds: Set<string> = toIdSet(slo.monitorLabels);
+
+      // SLOs without a label rule are curated by hand. Never touch them.
+      if (ruleLabelIds.size === 0) {
+        continue;
+      }
+
+      const attachedMonitorIds: Set<string> = toIdSet(slo.monitors);
+      const autoAddedMonitorIds: Set<string> = toIdSet(slo.autoAddedMonitors);
+
+      const doesMatch: boolean = this.doesLabelSetMatchRule({
+        labelIds: monitorLabelIds,
+        ruleLabelIds: ruleLabelIds,
+      });
+
+      /*
+       * Only this monitor's membership is in question, so the "matched" set
+       * handed to writeMembership is the SLO's current auto-added set with
+       * this monitor toggled in or out. Every other auto-added monitor is
+       * reported as still matching and is left exactly where it is.
+       */
+      const matchedMonitorIds: Set<string> = new Set<string>(
+        autoAddedMonitorIds,
+      );
+
+      if (doesMatch) {
+        matchedMonitorIds.add(monitorId);
+      } else {
+        matchedMonitorIds.delete(monitorId);
+      }
+
+      try {
+        const result: SloMonitorSyncResult = await this.writeMembership({
+          slo: slo,
+          attachedMonitorIds: attachedMonitorIds,
+          autoAddedMonitorIds: autoAddedMonitorIds,
+          matchedMonitorIds: matchedMonitorIds,
+        });
+
+        if (
+          result.monitorIdsAdded.length > 0 ||
+          result.monitorIdsRemoved.length > 0
+        ) {
+          results.push(result);
+        }
+      } catch (error) {
+        /*
+         * One SLO failing must not stop the others: the monitor's labels have
+         * already changed, and half a sync is better than none.
+         */
+        logger.error(
+          `Error syncing SLO ${slo.id?.toString()} for monitor ${monitorId}: ${error}`,
+          {
+            projectId: projectId.toString(),
+            monitorId: monitorId,
+          } as LogAttributes,
+        );
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Every monitor in the project carrying at least one of `labelIds`.
+   */
+  @CaptureSpan()
+  private async findMonitorIdsWithAnyLabel(data: {
+    projectId: ObjectID;
+    labelIds: Set<string>;
+  }): Promise<Set<string>> {
+    const labelIds: Array<ObjectID> = Array.from(data.labelIds).map(
+      (id: string) => {
+        return new ObjectID(id);
+      },
+    );
+
+    if (labelIds.length === 0) {
+      return new Set<string>();
+    }
+
+    const monitors: Array<Monitor> = await MonitorService.findBy({
+      query: {
+        projectId: data.projectId,
+        labels: labelIds,
+      },
+      select: {
+        _id: true,
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return toIdSet(monitors);
+  }
+
+  public doesLabelSetMatchRule(data: {
+    labelIds: Set<string>;
+    ruleLabelIds: Set<string>;
+  }): boolean {
+    if (data.ruleLabelIds.size === 0 || data.labelIds.size === 0) {
+      return false;
+    }
+
+    for (const labelId of data.labelIds) {
+      if (data.ruleLabelIds.has(labelId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Applies a computed match set to one SLO and persists the difference.
+   *
+   * `matchedMonitorIds` is the full set of monitors the rule claims. Anything
+   * in it that is not attached gets attached and recorded as rule-owned;
+   * anything recorded as rule-owned that the rule no longer claims gets
+   * detached. Attachments that are not rule-owned are invisible to both
+   * halves, which is what keeps manual monitors safe.
+   */
+  private async writeMembership(data: {
+    slo: ServiceLevelObjective;
+    attachedMonitorIds: Set<string>;
+    autoAddedMonitorIds: Set<string>;
+    matchedMonitorIds: Set<string>;
+  }): Promise<SloMonitorSyncResult> {
+    const { slo, attachedMonitorIds, autoAddedMonitorIds, matchedMonitorIds } =
+      data;
+
+    if (!slo.id) {
+      return emptyResult();
+    }
+
+    const monitorIdsAdded: Array<string> = Array.from(matchedMonitorIds).filter(
+      (id: string) => {
+        return !attachedMonitorIds.has(id);
+      },
+    );
+
+    const monitorIdsRemoved: Array<string> = Array.from(
+      autoAddedMonitorIds,
+    ).filter((id: string) => {
+      return !matchedMonitorIds.has(id);
+    });
+
+    /*
+     * A monitor the rule still matches but that a human attached by hand stays
+     * manual: it is never promoted into autoAddedMonitors, so dropping the
+     * label later detaches nothing.
+     */
+    const nextAutoAddedMonitorIds: Set<string> = new Set<string>(
+      Array.from(autoAddedMonitorIds).filter((id: string) => {
+        return matchedMonitorIds.has(id);
+      }),
+    );
+
+    for (const id of monitorIdsAdded) {
+      nextAutoAddedMonitorIds.add(id);
+    }
+
+    const nextAttachedMonitorIds: Set<string> = new Set<string>(
+      Array.from(attachedMonitorIds).filter((id: string) => {
+        return !monitorIdsRemoved.includes(id);
+      }),
+    );
+
+    for (const id of monitorIdsAdded) {
+      nextAttachedMonitorIds.add(id);
+    }
+
+    /*
+     * Nothing to write. Checked against both sets rather than against
+     * added/removed alone, because a repair can leave the monitor list
+     * untouched while still needing to fix the auto-added bookkeeping.
+     */
+    if (
+      isSameSet(nextAttachedMonitorIds, attachedMonitorIds) &&
+      isSameSet(nextAutoAddedMonitorIds, autoAddedMonitorIds)
+    ) {
+      return emptyResult();
+    }
+
+    /*
+     * Cast through unknown: PartialEntity is a deep mapped type, and letting
+     * the compiler infer it for two arrays of Monitor (whose own relations
+     * fan out across most of the schema) trips TS2589 "type instantiation is
+     * excessively deep". The shape is exactly what the column types say.
+     */
+    const updateData: PartialEntity<ServiceLevelObjective> = {
+      monitors: toMonitors(nextAttachedMonitorIds),
+      autoAddedMonitors: toMonitors(nextAutoAddedMonitorIds),
+    } as unknown as PartialEntity<ServiceLevelObjective>;
+
+    await ServiceLevelObjectiveService.updateOneById({
+      id: slo.id,
+      data: updateData,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    logger.debug(
+      `SLO monitor label rule synced SLO ${slo.id.toString()}: +${monitorIdsAdded.length} / -${monitorIdsRemoved.length} monitors`,
+      { projectId: slo.projectId?.toString() } as LogAttributes,
+    );
+
+    return {
+      monitorIdsAdded: monitorIdsAdded,
+      monitorIdsRemoved: monitorIdsRemoved,
+    };
+  }
+}
+
+export default new ServiceLevelObjectiveMonitorRuleEngineServiceClass();

--- a/Common/Server/Services/ServiceLevelObjectiveService.ts
+++ b/Common/Server/Services/ServiceLevelObjectiveService.ts
@@ -25,6 +25,7 @@ import DatabaseService from "./DatabaseService";
 import MonitorStatusService from "./MonitorStatusService";
 import ProjectService from "./ProjectService";
 import ServiceLevelObjectiveBurnRateRuleService from "./ServiceLevelObjectiveBurnRateRuleService";
+import ServiceLevelObjectiveMonitorRuleEngineService from "./ServiceLevelObjectiveMonitorRuleEngineService";
 import ServiceLevelObjectiveOwnerTeamService from "./ServiceLevelObjectiveOwnerTeamService";
 import ServiceLevelObjectiveOwnerUserService from "./ServiceLevelObjectiveOwnerUserService";
 import TeamMemberService from "./TeamMemberService";
@@ -156,6 +157,22 @@ export class Service extends DatabaseService<Model> {
       );
     }
 
+    /*
+     * An SLO created with a label rule must already carry the monitors that
+     * rule matches — otherwise it reads "no monitors attached, cannot be
+     * evaluated" until someone happens to edit a monitor.
+     */
+    try {
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: createdItem.id!,
+      });
+    } catch (err) {
+      logger.error(
+        `Error applying the monitor label rule for SLO ${createdItem.id?.toString()}: ${err}`,
+        { projectId: createdItem.projectId?.toString() } as LogAttributes,
+      );
+    }
+
     return createdItem;
   }
 
@@ -232,6 +249,28 @@ export class Service extends DatabaseService<Model> {
         } catch (err) {
           logger.error(
             `Error resolving open burn rate alerts for disabled SLO ${updatedItemId.toString()}: ${err}`,
+          );
+        }
+      }
+    }
+
+    /*
+     * The label rule changed, so the monitor set it implies changed with it.
+     * Re-run it before the re-evaluation stamp below: the sync writes
+     * `monitors`, which goes through this same hook and stamps
+     * nextEvaluationAt itself once the new set is persisted.
+     */
+    if (onUpdate.updateBy.data.monitorLabels !== undefined) {
+      for (const updatedItemId of updatedItemIds) {
+        try {
+          await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo(
+            {
+              serviceLevelObjectiveId: updatedItemId,
+            },
+          );
+        } catch (err) {
+          logger.error(
+            `Error applying the monitor label rule for SLO ${updatedItemId.toString()}: ${err}`,
           );
         }
       }

--- a/Common/Tests/Server/Services/ServiceLevelObjectiveMonitorRuleEngineService.test.ts
+++ b/Common/Tests/Server/Services/ServiceLevelObjectiveMonitorRuleEngineService.test.ts
@@ -1,0 +1,770 @@
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import ServiceLevelObjective from "../../../Models/DatabaseModels/ServiceLevelObjective";
+import MonitorService from "../../../Server/Services/MonitorService";
+import ServiceLevelObjectiveMonitorRuleEngineService, {
+  SloMonitorSyncResult,
+} from "../../../Server/Services/ServiceLevelObjectiveMonitorRuleEngineService";
+import ServiceLevelObjectiveService from "../../../Server/Services/ServiceLevelObjectiveService";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - the SLO monitor label rule.
+ *
+ * An SLO can say "measure every monitor labelled Production" instead of
+ * naming monitors one by one. That promise has two halves, and both have to
+ * hold or the SLO quietly measures the wrong thing:
+ *
+ *   - a monitor that starts matching gets attached (whether the rule moved or
+ *     the monitor's labels did), and a monitor that stops matching gets
+ *     detached again;
+ *
+ *   - a monitor a human attached by hand is never touched. It is not adopted
+ *     into the rule when it happens to match, and - the case that would
+ *     actually lose someone's configuration - it is never detached when it
+ *     stops matching, or when the rule is deleted outright.
+ *
+ * The second half is what ServiceLevelObjective.autoAddedMonitors exists for,
+ * so most of what follows is about that boundary.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "23232323-2323-4323-8323-232323232323",
+);
+const SLO_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const OTHER_SLO_ID: ObjectID = new ObjectID(
+  "1a1a1a1a-1a1a-4a1a-8a1a-1a1a1a1a1a1a",
+);
+const MONITOR_A_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const MONITOR_B_ID: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+const MONITOR_C_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const LABEL_PRODUCTION_ID: ObjectID = new ObjectID(
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+);
+const LABEL_TIER1_ID: ObjectID = new ObjectID(
+  "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+);
+const LABEL_STAGING_ID: ObjectID = new ObjectID(
+  "ffffffff-ffff-4fff-8fff-ffffffffffff",
+);
+
+function fakeLabel(id: ObjectID): Label {
+  return { id: id, _id: id.toString() } as unknown as Label;
+}
+
+function fakeMonitor(id: ObjectID): Monitor {
+  return { id: id, _id: id.toString() } as unknown as Monitor;
+}
+
+function fakeSlo(fields: {
+  id?: ObjectID | undefined;
+  projectId?: ObjectID | undefined;
+  monitorLabels?: Array<ObjectID> | undefined;
+  monitors?: Array<ObjectID> | undefined;
+  autoAddedMonitors?: Array<ObjectID> | undefined;
+}): ServiceLevelObjective {
+  const id: ObjectID = fields.id || SLO_ID;
+
+  return {
+    id: id,
+    _id: id.toString(),
+    projectId:
+      fields.projectId === undefined ? PROJECT_ID : fields.projectId || null,
+    monitorLabels: (fields.monitorLabels || []).map(fakeLabel),
+    monitors: (fields.monitors || []).map(fakeMonitor),
+    autoAddedMonitors: (fields.autoAddedMonitors || []).map(fakeMonitor),
+  } as unknown as ServiceLevelObjective;
+}
+
+function fakeMonitorWithLabels(
+  labelIds: Array<ObjectID>,
+  overrides?: {
+    id?: ObjectID | undefined;
+    projectId?: ObjectID | null | undefined;
+  },
+): Monitor {
+  return {
+    id: overrides?.id || MONITOR_A_ID,
+    _id: (overrides?.id || MONITOR_A_ID).toString(),
+    projectId:
+      overrides?.projectId === undefined ? PROJECT_ID : overrides.projectId,
+    labels: labelIds.map(fakeLabel),
+  } as unknown as Monitor;
+}
+
+/**
+ * The ids the engine wrote to one of the two monitor relations, sorted so
+ * assertions do not depend on Set iteration order.
+ */
+function writtenIds(
+  updateOneByIdSpy: jest.SpyInstance,
+  relation: "monitors" | "autoAddedMonitors",
+  callIndex: number = 0,
+): Array<string> {
+  const call: { data: Record<string, Array<Monitor>> } = updateOneByIdSpy.mock
+    .calls[callIndex]![0] as {
+    data: Record<string, Array<Monitor>>;
+  };
+
+  return (call.data[relation] || [])
+    .map((monitor: Monitor) => {
+      return monitor.id?.toString() || "";
+    })
+    .sort();
+}
+
+function writtenSloId(
+  updateOneByIdSpy: jest.SpyInstance,
+  callIndex: number = 0,
+): string {
+  const call: { id: ObjectID } = updateOneByIdSpy.mock.calls[callIndex]![0] as {
+    id: ObjectID;
+  };
+
+  return call.id.toString();
+}
+
+describe("ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo", () => {
+  let updateOneByIdSpy: jest.SpyInstance;
+  let sloFindOneByIdSpy: jest.SpyInstance;
+  let monitorFindBySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    updateOneByIdSpy = jest
+      .spyOn(ServiceLevelObjectiveService, "updateOneById")
+      .mockResolvedValue(1);
+    sloFindOneByIdSpy = jest.spyOn(ServiceLevelObjectiveService, "findOneById");
+    monitorFindBySpy = jest.spyOn(MonitorService, "findBy");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("attaches every monitor in the project that carries a rule label", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({ monitorLabels: [LABEL_PRODUCTION_ID] }),
+    );
+    monitorFindBySpy.mockResolvedValue([
+      fakeMonitor(MONITOR_A_ID),
+      fakeMonitor(MONITOR_B_ID),
+    ]);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(updateOneByIdSpy).toHaveBeenCalledTimes(1);
+    expect(writtenSloId(updateOneByIdSpy)).toBe(SLO_ID.toString());
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual(
+      [MONITOR_A_ID.toString(), MONITOR_B_ID.toString()].sort(),
+    );
+    expect(result.monitorIdsAdded.sort()).toEqual(
+      [MONITOR_A_ID.toString(), MONITOR_B_ID.toString()].sort(),
+    );
+    expect(result.monitorIdsRemoved).toEqual([]);
+  });
+
+  it("records what it attached in autoAddedMonitors so it can undo it later", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({ monitorLabels: [LABEL_PRODUCTION_ID] }),
+    );
+    monitorFindBySpy.mockResolvedValue([fakeMonitor(MONITOR_A_ID)]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([
+      MONITOR_A_ID.toString(),
+    ]);
+  });
+
+  it("writes as root - the rule is server-side and must not need the caller's permissions", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({ monitorLabels: [LABEL_PRODUCTION_ID] }),
+    );
+    monitorFindBySpy.mockResolvedValue([fakeMonitor(MONITOR_A_ID)]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    const call: { props: Record<string, unknown> } = updateOneByIdSpy.mock
+      .calls[0]![0] as { props: Record<string, unknown> };
+    expect(call.props).toEqual({ isRoot: true });
+  });
+
+  it("matches on any of the rule's labels, not all of them", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({ monitorLabels: [LABEL_PRODUCTION_ID, LABEL_TIER1_ID] }),
+    );
+    monitorFindBySpy.mockResolvedValue([fakeMonitor(MONITOR_A_ID)]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    const query: { projectId: ObjectID; labels: Array<ObjectID> } =
+      monitorFindBySpy.mock.calls[0]![0]!.query;
+
+    expect(query.projectId).toEqual(PROJECT_ID);
+    expect(
+      query.labels.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([LABEL_PRODUCTION_ID.toString(), LABEL_TIER1_ID.toString()]);
+  });
+
+  it("scopes the monitor lookup to the SLO's own project", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        projectId: OTHER_PROJECT_ID,
+        monitorLabels: [LABEL_PRODUCTION_ID],
+      }),
+    );
+    monitorFindBySpy.mockResolvedValue([]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    expect(monitorFindBySpy.mock.calls[0]![0]!.query.projectId).toEqual(
+      OTHER_PROJECT_ID,
+    );
+  });
+
+  it("leaves a hand-attached monitor out of autoAddedMonitors even when it matches the rule", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID],
+        autoAddedMonitors: [],
+      }),
+    );
+    // Monitor A matches the rule, but a human put it there first.
+    monitorFindBySpy.mockResolvedValue([
+      fakeMonitor(MONITOR_A_ID),
+      fakeMonitor(MONITOR_B_ID),
+    ]);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(result.monitorIdsAdded).toEqual([MONITOR_B_ID.toString()]);
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([
+      MONITOR_B_ID.toString(),
+    ]);
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual(
+      [MONITOR_A_ID.toString(), MONITOR_B_ID.toString()].sort(),
+    );
+  });
+
+  it("detaches a monitor it had attached once the monitor stops matching", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID, MONITOR_B_ID],
+        autoAddedMonitors: [MONITOR_A_ID, MONITOR_B_ID],
+      }),
+    );
+    monitorFindBySpy.mockResolvedValue([fakeMonitor(MONITOR_A_ID)]);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(result.monitorIdsRemoved).toEqual([MONITOR_B_ID.toString()]);
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([
+      MONITOR_A_ID.toString(),
+    ]);
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([
+      MONITOR_A_ID.toString(),
+    ]);
+  });
+
+  it("never detaches a hand-attached monitor, however badly it fails the rule", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID, MONITOR_C_ID],
+        autoAddedMonitors: [MONITOR_A_ID],
+      }),
+    );
+    // Neither A nor C matches any more; only A is the rule's to take back.
+    monitorFindBySpy.mockResolvedValue([]);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(result.monitorIdsRemoved).toEqual([MONITOR_A_ID.toString()]);
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([
+      MONITOR_C_ID.toString(),
+    ]);
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([]);
+  });
+
+  it("gives back every rule-attached monitor when the rule is cleared, and keeps the manual ones", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        monitorLabels: [],
+        monitors: [MONITOR_A_ID, MONITOR_B_ID, MONITOR_C_ID],
+        autoAddedMonitors: [MONITOR_A_ID, MONITOR_B_ID],
+      }),
+    );
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    // No rule means nothing to look up - the monitor query must not even run.
+    expect(monitorFindBySpy).not.toHaveBeenCalled();
+    expect(result.monitorIdsRemoved.sort()).toEqual(
+      [MONITOR_A_ID.toString(), MONITOR_B_ID.toString()].sort(),
+    );
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([
+      MONITOR_C_ID.toString(),
+    ]);
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([]);
+  });
+
+  it("writes nothing when the rule already agrees with the SLO", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID, MONITOR_C_ID],
+        autoAddedMonitors: [MONITOR_A_ID],
+      }),
+    );
+    monitorFindBySpy.mockResolvedValue([fakeMonitor(MONITOR_A_ID)]);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ monitorIdsAdded: [], monitorIdsRemoved: [] });
+  });
+
+  it("writes nothing for an SLO with neither a rule nor anything it attached", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({ monitorLabels: [], monitors: [MONITOR_C_ID] }),
+    );
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-attaches a monitor that is recorded as rule-attached but has gone missing from the list", async () => {
+    /*
+     * Bookkeeping drift, e.g. a monitor removed straight out of the Monitors
+     * picker while the rule still claims it. The sync is authoritative and
+     * repairs it rather than leaving the two relations disagreeing.
+     */
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [],
+        autoAddedMonitors: [MONITOR_A_ID],
+      }),
+    );
+    monitorFindBySpy.mockResolvedValue([fakeMonitor(MONITOR_A_ID)]);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(result.monitorIdsAdded).toEqual([MONITOR_A_ID.toString()]);
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([
+      MONITOR_A_ID.toString(),
+    ]);
+  });
+
+  it("does nothing for an SLO it cannot read", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(null);
+
+    const result: SloMonitorSyncResult =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+        serviceLevelObjectiveId: SLO_ID,
+      });
+
+    expect(monitorFindBySpy).not.toHaveBeenCalled();
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ monitorIdsAdded: [], monitorIdsRemoved: [] });
+  });
+
+  it("does nothing for an SLO with no project - there is no tenant to scope the lookup to", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(
+      fakeSlo({ projectId: null as unknown as ObjectID }),
+    );
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    expect(monitorFindBySpy).not.toHaveBeenCalled();
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("reads the relations it needs to decide - the rule, the list, and the bookkeeping", async () => {
+    sloFindOneByIdSpy.mockResolvedValue(fakeSlo({ monitorLabels: [] }));
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncMonitorsForSlo({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+
+    const select: Record<string, unknown> =
+      sloFindOneByIdSpy.mock.calls[0]![0]!.select;
+
+    expect(Object.keys(select).sort()).toEqual([
+      "_id",
+      "autoAddedMonitors",
+      "monitorLabels",
+      "monitors",
+      "projectId",
+    ]);
+  });
+});
+
+describe("ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor", () => {
+  let updateOneByIdSpy: jest.SpyInstance;
+  let sloFindBySpy: jest.SpyInstance;
+  let monitorFindOneByIdSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    updateOneByIdSpy = jest
+      .spyOn(ServiceLevelObjectiveService, "updateOneById")
+      .mockResolvedValue(1);
+    sloFindBySpy = jest.spyOn(ServiceLevelObjectiveService, "findBy");
+    monitorFindOneByIdSpy = jest.spyOn(MonitorService, "findOneById");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("attaches the monitor to an SLO whose rule its new labels satisfy", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({ monitorLabels: [LABEL_PRODUCTION_ID] }),
+    ]);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(updateOneByIdSpy).toHaveBeenCalledTimes(1);
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([
+      MONITOR_A_ID.toString(),
+    ]);
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([
+      MONITOR_A_ID.toString(),
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.monitorIdsAdded).toEqual([MONITOR_A_ID.toString()]);
+  });
+
+  it("detaches the monitor once its last matching label is taken away", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_STAGING_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID],
+        autoAddedMonitors: [MONITOR_A_ID],
+      }),
+    ]);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([]);
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([]);
+    expect(results[0]!.monitorIdsRemoved).toEqual([MONITOR_A_ID.toString()]);
+  });
+
+  it("detaches the monitor when every label is cleared at once", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(fakeMonitorWithLabels([]));
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID],
+        autoAddedMonitors: [MONITOR_A_ID],
+      }),
+    ]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+      monitorId: MONITOR_A_ID,
+    });
+
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual([]);
+  });
+
+  it("leaves the other monitors an SLO's rule attached exactly where they are", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_STAGING_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID, MONITOR_B_ID, MONITOR_C_ID],
+        autoAddedMonitors: [MONITOR_A_ID, MONITOR_B_ID],
+      }),
+    ]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+      monitorId: MONITOR_A_ID,
+    });
+
+    /*
+     * Only monitor A's membership was in question. B keeps its rule-attached
+     * status without the engine re-checking B's labels, and the manual C is
+     * untouched.
+     */
+    expect(writtenIds(updateOneByIdSpy, "monitors")).toEqual(
+      [MONITOR_B_ID.toString(), MONITOR_C_ID.toString()].sort(),
+    );
+    expect(writtenIds(updateOneByIdSpy, "autoAddedMonitors")).toEqual([
+      MONITOR_B_ID.toString(),
+    ]);
+  });
+
+  it("never touches an SLO with no label rule - that list is curated by hand", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({ monitorLabels: [], monitors: [] }),
+    ]);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("does not detach a monitor a human attached to a rule-driven SLO", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_STAGING_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID],
+        autoAddedMonitors: [],
+      }),
+    ]);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("does not adopt a hand-attached monitor into the rule when it starts matching", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({
+        monitorLabels: [LABEL_PRODUCTION_ID],
+        monitors: [MONITOR_A_ID],
+        autoAddedMonitors: [],
+      }),
+    ]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+      monitorId: MONITOR_A_ID,
+    });
+
+    // Already attached and still manual: nothing to write, nothing to adopt.
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies every rule in the project, not just the first one that matches", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({ id: SLO_ID, monitorLabels: [LABEL_PRODUCTION_ID] }),
+      fakeSlo({ id: OTHER_SLO_ID, monitorLabels: [LABEL_PRODUCTION_ID] }),
+    ]);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(updateOneByIdSpy).toHaveBeenCalledTimes(2);
+    expect(writtenSloId(updateOneByIdSpy, 0)).toBe(SLO_ID.toString());
+    expect(writtenSloId(updateOneByIdSpy, 1)).toBe(OTHER_SLO_ID.toString());
+    expect(results).toHaveLength(2);
+  });
+
+  it("carries on with the remaining SLOs when one of them fails to write", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID]),
+    );
+    sloFindBySpy.mockResolvedValue([
+      fakeSlo({ id: SLO_ID, monitorLabels: [LABEL_PRODUCTION_ID] }),
+      fakeSlo({ id: OTHER_SLO_ID, monitorLabels: [LABEL_PRODUCTION_ID] }),
+    ]);
+    updateOneByIdSpy
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValueOnce(1);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(updateOneByIdSpy).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(1);
+  });
+
+  it("looks up the SLOs of the monitor's own project", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID], {
+        projectId: OTHER_PROJECT_ID,
+      }),
+    );
+    sloFindBySpy.mockResolvedValue([]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+      monitorId: MONITOR_A_ID,
+      projectId: PROJECT_ID,
+    });
+
+    // The monitor row wins over the caller's hint - it cannot be stale.
+    expect(sloFindBySpy.mock.calls[0]![0]!.query.projectId).toEqual(
+      OTHER_PROJECT_ID,
+    );
+  });
+
+  it("falls back to the caller's project when the monitor row does not carry one", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID], { projectId: null }),
+    );
+    sloFindBySpy.mockResolvedValue([]);
+
+    await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+      monitorId: MONITOR_A_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(sloFindBySpy.mock.calls[0]![0]!.query.projectId).toEqual(PROJECT_ID);
+  });
+
+  it("does nothing for a monitor that no longer exists", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(null);
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+        projectId: PROJECT_ID,
+      });
+
+    expect(sloFindBySpy).not.toHaveBeenCalled();
+    expect(updateOneByIdSpy).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("does nothing when no project can be determined at all", async () => {
+    monitorFindOneByIdSpy.mockResolvedValue(
+      fakeMonitorWithLabels([LABEL_PRODUCTION_ID], { projectId: null }),
+    );
+
+    const results: Array<SloMonitorSyncResult> =
+      await ServiceLevelObjectiveMonitorRuleEngineService.syncSlosForMonitor({
+        monitorId: MONITOR_A_ID,
+      });
+
+    expect(sloFindBySpy).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+});
+
+describe("ServiceLevelObjectiveMonitorRuleEngineService.doesLabelSetMatchRule", () => {
+  const cases: Array<{
+    label: string;
+    labelIds: Array<string>;
+    ruleLabelIds: Array<string>;
+    expected: boolean;
+  }> = [
+    {
+      label: "one shared label is enough",
+      labelIds: ["a", "b"],
+      ruleLabelIds: ["b", "c"],
+      expected: true,
+    },
+    {
+      label: "no overlap does not match",
+      labelIds: ["a"],
+      ruleLabelIds: ["b"],
+      expected: false,
+    },
+    {
+      label: "a monitor with no labels never matches",
+      labelIds: [],
+      ruleLabelIds: ["a"],
+      expected: false,
+    },
+    {
+      label: "an empty rule matches nothing, not everything",
+      labelIds: ["a"],
+      ruleLabelIds: [],
+      expected: false,
+    },
+    {
+      label: "both empty is still no match",
+      labelIds: [],
+      ruleLabelIds: [],
+      expected: false,
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.label, () => {
+      expect(
+        ServiceLevelObjectiveMonitorRuleEngineService.doesLabelSetMatchRule({
+          labelIds: new Set(testCase.labelIds),
+          ruleLabelIds: new Set(testCase.ruleLabelIds),
+        }),
+      ).toBe(testCase.expected);
+    });
+  }
+});

--- a/Common/Tests/Server/Services/ServiceLevelObjectiveService.test.ts
+++ b/Common/Tests/Server/Services/ServiceLevelObjectiveService.test.ts
@@ -13,6 +13,7 @@ import AlertStateTimelineService from "../../../Server/Services/AlertStateTimeli
 import MonitorStatusService from "../../../Server/Services/MonitorStatusService";
 import ServiceLevelObjectiveService from "../../../Server/Services/ServiceLevelObjectiveService";
 import ServiceLevelObjectiveBurnRateRuleService from "../../../Server/Services/ServiceLevelObjectiveBurnRateRuleService";
+import ServiceLevelObjectiveMonitorRuleEngineService from "../../../Server/Services/ServiceLevelObjectiveMonitorRuleEngineService";
 import ServiceLevelObjectiveOwnerTeamService from "../../../Server/Services/ServiceLevelObjectiveOwnerTeamService";
 import ServiceLevelObjectiveOwnerUserService from "../../../Server/Services/ServiceLevelObjectiveOwnerUserService";
 import TeamMemberService from "../../../Server/Services/TeamMemberService";
@@ -1984,5 +1985,134 @@ describe("ServiceLevelObjectiveService.getSloLinkInDashboard", () => {
       path.indexOf(SLO_ID.toString()),
     );
     expect(path).toContain("/slos/");
+  });
+});
+
+/*
+ * The label rule has to be applied by the service that owns the column, not
+ * only by the dashboard that sets it: an SLO created or edited over the API
+ * must come out carrying the monitors its rule implies. Both hooks are
+ * best-effort - a rule that cannot be applied is logged, never allowed to
+ * fail the write that triggered it.
+ */
+describe("ServiceLevelObjectiveService - applying the monitor label rule", () => {
+  let syncMonitorsForSloSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    syncMonitorsForSloSpy = jest
+      .spyOn(
+        ServiceLevelObjectiveMonitorRuleEngineService,
+        "syncMonitorsForSlo",
+      )
+      .mockResolvedValue({ monitorIdsAdded: [], monitorIdsRemoved: [] });
+
+    jest
+      .spyOn(ServiceLevelObjectiveService, "updateOneById")
+      .mockResolvedValue(1);
+    jest
+      .spyOn(ServiceLevelObjectiveService, "findOneById")
+      .mockResolvedValue(makeSlo({ projectId: PROJECT_ID }));
+    jest
+      .spyOn(ServiceLevelObjectiveService, "resolveOpenBurnRateAlertsForSlo")
+      .mockResolvedValue(undefined);
+    jest.spyOn(AlertSeverityService, "findOneBy").mockResolvedValue(null);
+    jest
+      .spyOn(ServiceLevelObjectiveBurnRateRuleService, "create")
+      .mockResolvedValue(makeBurnRateRule(RULE_ID));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("runs the rule for a newly created SLO so it is not born with an empty monitor list", async () => {
+    const createdItem: ServiceLevelObjective = makeSlo({
+      _id: SLO_ID.toString(),
+      id: SLO_ID,
+      projectId: PROJECT_ID,
+      targetPercentage: 99.9,
+    });
+
+    await callHook(
+      "onCreateSuccess",
+      {
+        createBy: makeCreateBy({
+          projectId: PROJECT_ID,
+          targetPercentage: 99.9,
+        }),
+        carryForward: null,
+      },
+      createdItem,
+    );
+
+    expect(syncMonitorsForSloSpy).toHaveBeenCalledTimes(1);
+    expect(syncMonitorsForSloSpy).toHaveBeenCalledWith({
+      serviceLevelObjectiveId: SLO_ID,
+    });
+  });
+
+  it("does not fail the create when the rule cannot be applied", async () => {
+    syncMonitorsForSloSpy.mockRejectedValue(new Error("db down"));
+
+    const createdItem: ServiceLevelObjective = makeSlo({
+      _id: SLO_ID.toString(),
+      id: SLO_ID,
+      projectId: PROJECT_ID,
+    });
+
+    await expect(
+      callHook(
+        "onCreateSuccess",
+        {
+          createBy: makeCreateBy({ projectId: PROJECT_ID }),
+          carryForward: null,
+        },
+        createdItem,
+      ),
+    ).resolves.toBe(createdItem);
+  });
+
+  it("re-runs the rule for every SLO whose rule was just edited", async () => {
+    await callHook(
+      "onUpdateSuccess",
+      makeOnUpdate({ monitorLabels: [{ _id: RULE_ID.toString() }] }),
+      [SLO_ID, OTHER_RULE_ID],
+    );
+
+    expect(syncMonitorsForSloSpy).toHaveBeenCalledTimes(2);
+    expect(syncMonitorsForSloSpy).toHaveBeenNthCalledWith(1, {
+      serviceLevelObjectiveId: SLO_ID,
+    });
+    expect(syncMonitorsForSloSpy).toHaveBeenNthCalledWith(2, {
+      serviceLevelObjectiveId: OTHER_RULE_ID,
+    });
+  });
+
+  it("re-runs the rule when it is cleared, which is what gives the monitors back", async () => {
+    await callHook("onUpdateSuccess", makeOnUpdate({ monitorLabels: [] }), [
+      SLO_ID,
+    ]);
+
+    expect(syncMonitorsForSloSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the rule alone for an edit that does not touch it", async () => {
+    await callHook(
+      "onUpdateSuccess",
+      makeOnUpdate({ targetPercentage: 99.5 }),
+      [SLO_ID],
+    );
+
+    expect(syncMonitorsForSloSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the update when the rule cannot be applied", async () => {
+    syncMonitorsForSloSpy.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      callHook("onUpdateSuccess", makeOnUpdate({ monitorLabels: [] }), [
+        SLO_ID,
+      ]),
+    ).resolves.toBeDefined();
   });
 });

--- a/Common/Tests/Server/Services/SloMonitorLabelRuleHooks.test.ts
+++ b/Common/Tests/Server/Services/SloMonitorLabelRuleHooks.test.ts
@@ -1,0 +1,352 @@
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import ServiceLevelObjective from "../../../Models/DatabaseModels/ServiceLevelObjective";
+import DatabaseConfig from "../../../Server/DatabaseConfig";
+import LabelService from "../../../Server/Services/LabelService";
+import MonitorFeedService from "../../../Server/Services/MonitorFeedService";
+import MonitorService from "../../../Server/Services/MonitorService";
+import ServiceLevelObjectiveMonitorRuleEngineService from "../../../Server/Services/ServiceLevelObjectiveMonitorRuleEngineService";
+import ServiceLevelObjectiveService from "../../../Server/Services/ServiceLevelObjectiveService";
+import DeleteBy from "../../../Server/Types/Database/DeleteBy";
+import { OnDelete, OnUpdate } from "../../../Server/Types/Database/Hooks";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import URL from "../../../Types/API/URL";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - the three places that have to notice a label rule
+ * became stale. The engine itself is covered separately; what matters here is
+ * that something actually calls it.
+ *
+ *   - MonitorService, when a monitor's labels change. Keyed on the field
+ *     being present rather than non-empty, because clearing every label
+ *     arrives as `[]` and is exactly the edit that should detach the monitor
+ *     from its rule-driven SLOs.
+ *
+ *   - LabelService, when a label is deleted. Postgres cascades the rule's
+ *     join rows away without any service hook firing, so the SLOs that used
+ *     that label would otherwise keep monitors nothing explains.
+ *
+ * Every one of them is best-effort: the sync must never fail the write that
+ * triggered it.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const OTHER_MONITOR_ID: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+const LABEL_ID: ObjectID = new ObjectID("dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+const SLO_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const OTHER_SLO_ID: ObjectID = new ObjectID(
+  "1a1a1a1a-1a1a-4a1a-8a1a-1a1a1a1a1a1a",
+);
+
+// Calls a protected hook without widening the service's public surface.
+function callHook(
+  service: unknown,
+  name: string,
+  ...args: Array<unknown>
+): Promise<unknown> {
+  const hooks: Record<
+    string,
+    (...hookArgs: Array<unknown>) => Promise<unknown>
+  > = service as Record<
+    string,
+    (...hookArgs: Array<unknown>) => Promise<unknown>
+  >;
+
+  return hooks[name]!.apply(service, args);
+}
+
+function monitorUpdate(data: Record<string, unknown>): OnUpdate<Monitor> {
+  return {
+    updateBy: {
+      query: { _id: MONITOR_ID.toString() },
+      data: data,
+      props: { isRoot: true, tenantId: PROJECT_ID },
+      limit: 1,
+      skip: 0,
+    } as unknown as UpdateBy<Monitor>,
+    carryForward: null,
+  };
+}
+
+function fakeMonitorRow(): Monitor {
+  return {
+    id: MONITOR_ID,
+    _id: MONITOR_ID.toString(),
+    projectId: PROJECT_ID,
+    name: "API",
+  } as unknown as Monitor;
+}
+
+function fakeLabelRow(id: ObjectID): Label {
+  return { id: id, _id: id.toString(), name: "Production" } as unknown as Label;
+}
+
+function fakeSloRow(id: ObjectID): ServiceLevelObjective {
+  return {
+    id: id,
+    _id: id.toString(),
+    projectId: PROJECT_ID,
+  } as unknown as ServiceLevelObjective;
+}
+
+describe("MonitorService.onUpdateSuccess - keeping SLO label rules honest", () => {
+  let syncSlosForMonitorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    syncSlosForMonitorSpy = jest
+      .spyOn(
+        ServiceLevelObjectiveMonitorRuleEngineService,
+        "syncSlosForMonitor",
+      )
+      .mockResolvedValue([]);
+
+    jest
+      .spyOn(MonitorService, "findOneById")
+      .mockResolvedValue(fakeMonitorRow());
+    jest
+      .spyOn(DatabaseConfig, "getDashboardUrl")
+      .mockResolvedValue(URL.fromString("https://oneuptime.test/dashboard"));
+    jest.spyOn(LabelService, "findBy").mockResolvedValue([]);
+    jest
+      .spyOn(MonitorFeedService, "createMonitorFeedItem")
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("re-runs the SLO label rules when a monitor gains a label", async () => {
+    await callHook(
+      MonitorService,
+      "onUpdateSuccess",
+      monitorUpdate({ labels: [{ _id: LABEL_ID.toString() }] }),
+      [MONITOR_ID],
+    );
+
+    expect(syncSlosForMonitorSpy).toHaveBeenCalledTimes(1);
+    expect(syncSlosForMonitorSpy).toHaveBeenCalledWith({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it("re-runs them when the last label is removed - `[]` is an edit, not an absence", async () => {
+    await callHook(
+      MonitorService,
+      "onUpdateSuccess",
+      monitorUpdate({ labels: [] }),
+      [MONITOR_ID],
+    );
+
+    expect(syncSlosForMonitorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs them for every monitor a bulk label edit touched", async () => {
+    await callHook(
+      MonitorService,
+      "onUpdateSuccess",
+      monitorUpdate({ labels: [{ _id: LABEL_ID.toString() }] }),
+      [MONITOR_ID, OTHER_MONITOR_ID],
+    );
+
+    expect(syncSlosForMonitorSpy).toHaveBeenCalledTimes(2);
+    expect(syncSlosForMonitorSpy).toHaveBeenNthCalledWith(2, {
+      monitorId: OTHER_MONITOR_ID,
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it("does not run them for an edit that cannot change SLO membership", async () => {
+    await callHook(
+      MonitorService,
+      "onUpdateSuccess",
+      monitorUpdate({ description: "just a doc tweak" }),
+      [MONITOR_ID],
+    );
+
+    expect(syncSlosForMonitorSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the monitor update when the sync throws", async () => {
+    syncSlosForMonitorSpy.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      callHook(
+        MonitorService,
+        "onUpdateSuccess",
+        monitorUpdate({ labels: [] }),
+        [MONITOR_ID],
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("keeps syncing the remaining monitors after one of them fails", async () => {
+    syncSlosForMonitorSpy
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValueOnce([]);
+
+    await callHook(
+      MonitorService,
+      "onUpdateSuccess",
+      monitorUpdate({ labels: [] }),
+      [MONITOR_ID, OTHER_MONITOR_ID],
+    );
+
+    expect(syncSlosForMonitorSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("LabelService - a deleted label takes its SLO rule with it", () => {
+  let syncMonitorsForSloSpy: jest.SpyInstance;
+  let sloFindBySpy: jest.SpyInstance;
+  let labelFindBySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    syncMonitorsForSloSpy = jest
+      .spyOn(
+        ServiceLevelObjectiveMonitorRuleEngineService,
+        "syncMonitorsForSlo",
+      )
+      .mockResolvedValue({ monitorIdsAdded: [], monitorIdsRemoved: [] });
+    sloFindBySpy = jest.spyOn(ServiceLevelObjectiveService, "findBy");
+    labelFindBySpy = jest.spyOn(LabelService, "findBy");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function deleteBy(): DeleteBy<Label> {
+    return {
+      query: { _id: LABEL_ID.toString() },
+      props: { isRoot: true },
+      limit: 1,
+      skip: 0,
+    } as unknown as DeleteBy<Label>;
+  }
+
+  it("notes down the SLOs whose rule uses the label, while the label still exists", async () => {
+    labelFindBySpy.mockResolvedValue([fakeLabelRow(LABEL_ID)]);
+    sloFindBySpy.mockResolvedValue([
+      fakeSloRow(SLO_ID),
+      fakeSloRow(OTHER_SLO_ID),
+    ]);
+
+    const onDelete: OnDelete<Label> = (await callHook(
+      LabelService,
+      "onBeforeDelete",
+      deleteBy(),
+    )) as OnDelete<Label>;
+
+    const query: { monitorLabels: Array<ObjectID> } = sloFindBySpy.mock
+      .calls[0]![0]!.query as { monitorLabels: Array<ObjectID> };
+
+    expect(
+      query.monitorLabels.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([LABEL_ID.toString()]);
+
+    const carried: { serviceLevelObjectiveIds: Array<ObjectID> } =
+      onDelete.carryForward as { serviceLevelObjectiveIds: Array<ObjectID> };
+
+    expect(
+      carried.serviceLevelObjectiveIds.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([SLO_ID.toString(), OTHER_SLO_ID.toString()]);
+  });
+
+  it("does not go looking for SLOs when the delete matched no labels", async () => {
+    labelFindBySpy.mockResolvedValue([]);
+
+    await callHook(LabelService, "onBeforeDelete", deleteBy());
+
+    expect(sloFindBySpy).not.toHaveBeenCalled();
+  });
+
+  it("re-runs the now-smaller rule for each noted SLO once the label is gone", async () => {
+    await callHook(
+      LabelService,
+      "onDeleteSuccess",
+      {
+        deleteBy: deleteBy(),
+        carryForward: { serviceLevelObjectiveIds: [SLO_ID, OTHER_SLO_ID] },
+      },
+      [LABEL_ID],
+    );
+
+    expect(syncMonitorsForSloSpy).toHaveBeenCalledTimes(2);
+    expect(syncMonitorsForSloSpy).toHaveBeenNthCalledWith(1, {
+      serviceLevelObjectiveId: SLO_ID,
+    });
+    expect(syncMonitorsForSloSpy).toHaveBeenNthCalledWith(2, {
+      serviceLevelObjectiveId: OTHER_SLO_ID,
+    });
+  });
+
+  it("does nothing after deleting a label no SLO rule referenced", async () => {
+    await callHook(
+      LabelService,
+      "onDeleteSuccess",
+      { deleteBy: deleteBy(), carryForward: { serviceLevelObjectiveIds: [] } },
+      [LABEL_ID],
+    );
+
+    expect(syncMonitorsForSloSpy).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a delete that carried nothing forward", async () => {
+    await expect(
+      callHook(
+        LabelService,
+        "onDeleteSuccess",
+        { deleteBy: deleteBy(), carryForward: null },
+        [LABEL_ID],
+      ),
+    ).resolves.toBeDefined();
+
+    expect(syncMonitorsForSloSpy).not.toHaveBeenCalled();
+  });
+
+  it("still deletes the label when the SLO lookup fails", async () => {
+    labelFindBySpy.mockRejectedValue(new Error("db down"));
+
+    const onDelete: OnDelete<Label> = (await callHook(
+      LabelService,
+      "onBeforeDelete",
+      deleteBy(),
+    )) as OnDelete<Label>;
+
+    expect(
+      (onDelete.carryForward as { serviceLevelObjectiveIds: Array<ObjectID> })
+        .serviceLevelObjectiveIds,
+    ).toEqual([]);
+  });
+
+  it("still reports the delete as done when re-running a rule fails", async () => {
+    syncMonitorsForSloSpy.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      callHook(
+        LabelService,
+        "onDeleteSuccess",
+        {
+          deleteBy: deleteBy(),
+          carryForward: { serviceLevelObjectiveIds: [SLO_ID] },
+        },
+        [LABEL_ID],
+      ),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

feat(slo): attach monitors to an SLO by label rule

### Small Description?

An SLO's monitor list had to be curated by hand, so it went stale the moment someone added a monitor to the service it measures — the SLO quietly under-reported and nobody noticed.

`ServiceLevelObjective` gains **`monitorLabels`** ("Auto-Add Monitors With Labels"): name a set of monitor labels, and every monitor in the project carrying at least one of them is attached automatically, and detached again when it carries none. A monitor matches on **any** of the rule's labels, not all.

**Membership is re-evaluated from both sides**, because it can be invalidated from either:

| Trigger | Hook |
| --- | --- |
| SLO created, or its rule edited / cleared | `ServiceLevelObjectiveService.onCreateSuccess` / `onUpdateSuccess` |
| A monitor's labels change (including cleared to `[]`) | `MonitorService.onUpdateSuccess` |
| A monitor is created — after the label/owner rule engines, so rule-added labels count | `MonitorService.onCreateSuccess` |
| A label is deleted | `LabelService.onBeforeDelete` / `onDeleteSuccess` |

The monitor-update hook keys on `data.labels !== undefined` rather than on a non-empty array: clearing every label arrives as `[]`, and that is precisely the edit that should detach the monitor. The label-delete hook exists because Postgres cascades the rule's join rows away without any service hook firing — the affected SLO ids are noted down while the label still exists, then the now-smaller rules are re-run.

**The design decision worth reviewing:** a second relation, **`autoAddedMonitors`**, records which attachments the rule owns. Only those are ever detached. A monitor attached by hand is never adopted into the rule, and never removed by it — including when the rule is deleted outright, which detaches everything the rule added and nothing else. Without that bookkeeping, "this monitor stopped matching, detach it" would silently delete deliberate configuration. The column is root-only (`create: []` / `update: []`, mirroring `nextEvaluationAt`) since it is derived state.

Every sync is best-effort: it is logged on failure and never fails the write that triggered it. `syncMonitorsForSlo` is the authoritative, self-healing path (it repairs drift between the two relations); `syncSlosForMonitor` is the cheap hot path that toggles only the one monitor's membership, costing one query per project regardless of how many monitors the rules match.

On the UI, the Monitors picker becomes required **only when there is no rule to fill it** — an SLO driven entirely by a rule is saved with an empty picker and filled in by the server. Its list still shows the full attached set, so the Overview tab always says exactly what is being measured.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Tests** — 46 new tests, all green locally, plus the full `Common` service suite at **2054 tests / 106 suites**:

- `ServiceLevelObjectiveMonitorRuleEngineService.test.ts` (33) — attach/detach in both directions; the manual-vs-rule boundary (not adopted when it matches, not detached when it stops, survives rule deletion); clearing the rule; idempotence; bookkeeping-drift repair; project scoping; missing SLO / missing project; the exact relations the sync reads.
- `SloMonitorLabelRuleHooks.test.ts` (13) — that `MonitorService` and `LabelService` actually call the engine, including `labels: []`, bulk edits, and that a failing sync never fails the delete or the update.
- `ServiceLevelObjectiveService.test.ts` (+6) — the create/update hooks fire on `monitorLabels` and stay quiet otherwise.
- `SloMonitorLabelRuleFormFields.test.ts` (9) — pins `monitorLabels` apart from the SLO's own `labels` (two multi-selects over `Label` a few rows apart — swapping them would look right and attach nothing) and the conditional Monitors requirement.

### Two things a reviewer should know

**The migration is hand-written**, against AGENTS.md's instruction to use `npm run generate-postgres-migration`. There was no Docker and no `config.env` in the dev environment, so no database to generate against. The constraint and index names were derived from TypeORM's own `DefaultNamingStrategy` + `RandomGenerator.sha1`, and the algorithm was confirmed to reproduce the existing `ServiceLevelObjectiveMonitor` migration's names byte-for-byte before being applied to the two new join tables. **Please run `npm run check-postgres-schema-drift` against a real database before merging.** The migration is a pure addition with no backfill — an existing SLO has no rule, so its hand-curated monitor list is untouched until someone gives it one.

**`App/Tests/Dashboard/SloMonitorLabelRuleFormFields.test.ts` was not run locally.** App's jest cannot start in that environment: `App/node_modules` has jest 28 while the hoisted root has jest 30, and `@types/jest` / `@types/node` are absent from `App/node_modules/@types` so App's `tsc` fails too. A pre-existing App test fails identically on `master`, so this is not from these changes — but those 9 tests are unverified until CI runs them. `Common` typechecks clean and the Dashboard feature-set typechecks clean apart from the pre-existing `rrweb` error.

### Related Issue?

N/A

### Screenshots (if appropriate):

N/A — the change adds one multi-select ("Auto-Add Monitors With Labels") directly below Monitors on the SLO create/edit form, and a matching row on the SLO Details card that reads "No label rule — monitors are attached by hand." when unset.
