### PR TITLE
fix(users): one row per person in the project Users table

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Users/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Users/Index.tsx
@@ -6,7 +6,7 @@ import UserElement from "../../Components/User/User";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import { ModalTableBulkDefaultActions } from "Common/UI/Components/ModelTable/BaseModelTable";
 import Team from "Common/Models/DatabaseModels/Team";
-import TeamElement from "../../Components/Team/Team";
+import TeamsElement from "../../Components/Team/TeamsElement";
 import Route from "Common/Types/API/Route";
 import { RouteUtil } from "../../Utils/RouteMap";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
@@ -23,6 +23,8 @@ import Pill from "Common/UI/Components/Pill/Pill";
 import { Green, Yellow } from "Common/Types/BrandColors";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUsersModelAPI from "Common/UI/Utils/ModelAPI/ProjectUsersModelAPI";
+import { ProjectUserRow } from "Common/UI/Utils/TeamMembersByUser";
 import ProjectSCIM from "Common/Models/DatabaseModels/ProjectSCIM";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
 import Banner from "Common/UI/Components/Banner/Banner";
@@ -207,6 +209,16 @@ const Users: FunctionComponent<PageComponentProps> = (
 
       <ModelTable<TeamMember>
         modelType={TeamMember}
+        /*
+         * One row per user, not per team membership. TeamMember is a
+         * (user, team) pair, so the default API would list someone who belongs
+         * to three teams as three rows - three lines with the same name and
+         * avatar, which reads as three different people. This one pages over
+         * users and hands each row every team that user belongs to.
+         */
+        modelAPI={ProjectUsersModelAPI}
+        singularName="User"
+        pluralName="Users"
         id="teams-table"
         name="Settings > Users"
         userPreferencesKey="users-table"
@@ -214,6 +226,12 @@ const Users: FunctionComponent<PageComponentProps> = (
           tableId: "settings-users-table",
         }}
         isDeleteable={!isPushGroupsManaged}
+        /*
+         * A row is a person, so removing one removes them from the project -
+         * every team they are on. Removing someone from a single team is done
+         * from that user's own Teams tab.
+         */
+        deleteButtonText="Remove from Project"
         bulkActions={
           !isPushGroupsManaged
             ? {
@@ -238,7 +256,7 @@ const Users: FunctionComponent<PageComponentProps> = (
         cardProps={{
           title: "Users",
           description:
-            "Here is a list of all the team members in this project.",
+            "Here is a list of everyone in this project, and the teams they belong to.",
           buttons: [
             {
               title: "Invite User",
@@ -296,13 +314,16 @@ const Users: FunctionComponent<PageComponentProps> = (
                 _id: true,
               },
             },
-            title: "Team",
+            title: "Teams",
             type: FieldType.Element,
             getElement: (item: TeamMember) => {
-              if (!item.team) {
+              const teams: Array<Team> = (item as ProjectUserRow).teamsForUser;
+
+              if (!teams || teams.length === 0) {
                 return <p>No team assigned</p>;
               }
-              return <TeamElement team={item.team!} />;
+
+              return <TeamsElement teams={teams} />;
             },
           },
           {
@@ -312,10 +333,32 @@ const Users: FunctionComponent<PageComponentProps> = (
             title: "Status",
             type: FieldType.Element,
             getElement: (item: TeamMember) => {
-              if (item.hasAcceptedInvitation) {
-                return <Pill text="Member" color={Green} />;
+              if (!item.hasAcceptedInvitation) {
+                return <Pill text="Invitation Sent" color={Yellow} />;
               }
-              return <Pill text="Invitation Sent" color={Yellow} />;
+
+              /*
+               * Accepted on at least one team makes them a member of the
+               * project. Any team they have not accepted yet is called out
+               * next to it, because that state is otherwise invisible now that
+               * the row no longer shows one team at a time.
+               */
+              const pendingTeamCount: number =
+                (item as ProjectUserRow).pendingTeamCountForUser || 0;
+
+              return (
+                <div className="flex space-x-2">
+                  <Pill text="Member" color={Green} />
+                  {pendingTeamCount > 0 && (
+                    <Pill
+                      text={`${pendingTeamCount} Invitation${
+                        pendingTeamCount === 1 ? "" : "s"
+                      } Pending`}
+                      color={Yellow}
+                    />
+                  )}
+                </div>
+              );
             },
           },
         ]}

--- a/Common/Tests/UI/Utils/ProjectUsersModelAPI.test.ts
+++ b/Common/Tests/UI/Utils/ProjectUsersModelAPI.test.ts
@@ -1,0 +1,557 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import ModelAPI, { ListResult } from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUsersModelAPI from "../../../UI/Utils/ModelAPI/ProjectUsersModelAPI";
+import { ProjectUserRow } from "../../../UI/Utils/TeamMembersByUser";
+import Project from "../../../Models/DatabaseModels/Project";
+import Team from "../../../Models/DatabaseModels/Team";
+import TeamMember from "../../../Models/DatabaseModels/TeamMember";
+import User from "../../../Models/DatabaseModels/User";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import Query from "../../../Types/BaseDatabase/Query";
+import Select from "../../../Types/BaseDatabase/Select";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * This API is what makes the Users table page over people instead of over
+ * memberships. The table itself is unchanged, so every behaviour below is
+ * invisible from the component: if the skip/limit is applied to the wrong list
+ * the table pages over memberships again and duplicates come back; if `count`
+ * is a membership count the pager offers pages that render empty; and if
+ * deleting a row only deletes one membership the row stays on screen and the
+ * delete looks like it silently failed.
+ *
+ * ModelAPI's statics are spied rather than the module being mocked, because
+ * ProjectUsersModelAPI extends ModelAPI and delegates to it by name.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "00000000-0000-4000-8000-000000000001",
+);
+
+type MembershipSpec = {
+  id: string;
+  userId: string;
+  userName?: string | undefined;
+  teamId?: string | undefined;
+  teamName?: string | undefined;
+  hasAcceptedInvitation?: boolean | undefined;
+  projectId?: ObjectID | undefined;
+};
+
+const buildMembership: (spec: MembershipSpec) => TeamMember = (
+  spec: MembershipSpec,
+): TeamMember => {
+  const teamMember: TeamMember = new TeamMember();
+
+  teamMember._id = spec.id;
+  teamMember.userId = new ObjectID(spec.userId);
+  teamMember.projectId = spec.projectId || PROJECT_ID;
+  teamMember.hasAcceptedInvitation = spec.hasAcceptedInvitation ?? true;
+
+  const user: User = new User();
+  user._id = spec.userId;
+
+  if (spec.userName) {
+    user.name = new Name(spec.userName);
+  }
+
+  teamMember.user = user;
+
+  if (spec.teamId) {
+    teamMember.teamId = new ObjectID(spec.teamId);
+
+    const team: Team = new Team();
+    team._id = spec.teamId;
+    team.name = spec.teamName || spec.teamId;
+    teamMember.team = team;
+  }
+
+  return teamMember;
+};
+
+const asListResult: (
+  teamMembers: Array<TeamMember>,
+) => ListResult<TeamMember> = (
+  teamMembers: Array<TeamMember>,
+): ListResult<TeamMember> => {
+  return {
+    data: teamMembers,
+    count: teamMembers.length,
+    skip: 0,
+    limit: teamMembers.length,
+  };
+};
+
+type GetListArgs = {
+  modelType: { new (): TeamMember };
+  query: Query<TeamMember>;
+  limit: number;
+  skip: number;
+  select: Select<TeamMember>;
+  sort: Record<string, unknown>;
+};
+
+/*
+ * Hand-rolled rather than jest.SpiedFunction<typeof ModelAPI.getList>: both
+ * statics are generic, and the installed jest typings cannot describe a spy on
+ * a generic method without collapsing it to one instantiation.
+ */
+interface Spy {
+  mockResolvedValue: (value: unknown) => Spy;
+  mockResolvedValueOnce: (value: unknown) => Spy;
+  mockImplementation: (fn: (...args: Array<unknown>) => unknown) => Spy;
+  mock: { calls: Array<Array<unknown>> };
+}
+
+let getListSpy: Spy;
+let deleteItemSpy: Spy;
+
+const getListCallArgs: (callIndex: number) => GetListArgs = (
+  callIndex: number,
+): GetListArgs => {
+  return getListSpy.mock.calls[callIndex]![0] as GetListArgs;
+};
+
+beforeEach(() => {
+  getListSpy = jest.spyOn(ModelAPI, "getList") as unknown as Spy;
+  deleteItemSpy = (
+    jest.spyOn(ModelAPI, "deleteItem") as unknown as Spy
+  ).mockImplementation(async () => {
+    return undefined;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ProjectUsersModelAPI.getList", () => {
+  const listUsers: (data: {
+    skip?: number | undefined;
+    limit?: number | undefined;
+    query?: Query<TeamMember> | undefined;
+    sort?: Record<string, unknown> | undefined;
+    select?: Select<TeamMember> | undefined;
+  }) => Promise<ListResult<TeamMember>> = async (data: {
+    skip?: number | undefined;
+    limit?: number | undefined;
+    query?: Query<TeamMember> | undefined;
+    sort?: Record<string, unknown> | undefined;
+    select?: Select<TeamMember> | undefined;
+  }): Promise<ListResult<TeamMember>> => {
+    return ProjectUsersModelAPI.getList<TeamMember>({
+      modelType: TeamMember,
+      query: data.query || ({ projectId: PROJECT_ID } as Query<TeamMember>),
+      limit: data.limit ?? 10,
+      skip: data.skip ?? 0,
+      select: data.select || ({} as Select<TeamMember>),
+      sort: (data.sort || {}) as never,
+    });
+  };
+
+  it("returns one row per user and counts people, not memberships", async () => {
+    getListSpy.mockResolvedValue(
+      asListResult([
+        buildMembership({
+          id: "m1",
+          userId: "u1",
+          userName: "Thomas Stock",
+          teamId: "t1",
+          teamName: "NTW_Online Operations",
+        }),
+        buildMembership({
+          id: "m2",
+          userId: "u1",
+          userName: "Thomas Stock",
+          teamId: "t2",
+          teamName: "Owners",
+        }),
+        buildMembership({
+          id: "m3",
+          userId: "u2",
+          userName: "Jason Apel",
+          teamId: "t2",
+          teamName: "Owners",
+        }),
+      ]) as never,
+    );
+
+    const result: ListResult<TeamMember> = await listUsers({});
+
+    expect(result.count).toBe(2);
+    expect(result.data).toHaveLength(2);
+    expect(
+      (result.data as Array<ProjectUserRow>).map((row: ProjectUserRow) => {
+        return row.teamsForUser.map((team: Team) => {
+          return team.name?.toString();
+        });
+      }),
+    ).toEqual([["Owners"], ["NTW_Online Operations", "Owners"]]);
+  });
+
+  it("reads the whole membership list once, not one page of it", async () => {
+    getListSpy.mockResolvedValue(asListResult([]) as never);
+
+    await listUsers({ skip: 20, limit: 10 });
+
+    expect(getListCallArgs(0).skip).toBe(0);
+    expect(getListCallArgs(0).limit).toBeGreaterThan(10);
+  });
+
+  it("applies skip and limit to the users, so a page boundary never splits a person", async () => {
+    getListSpy.mockResolvedValue(
+      asListResult([
+        buildMembership({
+          id: "m1",
+          userId: "u1",
+          userName: "A",
+          teamId: "t1",
+        }),
+        buildMembership({
+          id: "m2",
+          userId: "u1",
+          userName: "A",
+          teamId: "t2",
+        }),
+        buildMembership({
+          id: "m3",
+          userId: "u2",
+          userName: "B",
+          teamId: "t1",
+        }),
+        buildMembership({
+          id: "m4",
+          userId: "u3",
+          userName: "C",
+          teamId: "t1",
+        }),
+        buildMembership({
+          id: "m5",
+          userId: "u4",
+          userName: "D",
+          teamId: "t1",
+        }),
+      ]) as never,
+    );
+
+    const firstPage: ListResult<TeamMember> = await listUsers({
+      skip: 0,
+      limit: 2,
+    });
+    const secondPage: ListResult<TeamMember> = await listUsers({
+      skip: 2,
+      limit: 2,
+    });
+
+    expect(firstPage.count).toBe(4);
+    expect(
+      firstPage.data.map((row: TeamMember) => {
+        return row.userId?.toString();
+      }),
+    ).toEqual(["u1", "u2"]);
+    expect(
+      secondPage.data.map((row: TeamMember) => {
+        return row.userId?.toString();
+      }),
+    ).toEqual(["u3", "u4"]);
+    expect(secondPage.skip).toBe(2);
+    expect(secondPage.limit).toBe(2);
+  });
+
+  it("returns an empty page past the end rather than wrapping around", async () => {
+    getListSpy.mockResolvedValue(
+      asListResult([
+        buildMembership({ id: "m1", userId: "u1", teamId: "t1" }),
+      ]) as never,
+    );
+
+    const result: ListResult<TeamMember> = await listUsers({
+      skip: 50,
+      limit: 10,
+    });
+
+    expect(result.data).toEqual([]);
+    expect(result.count).toBe(1);
+  });
+
+  it("asks for the fields grouping needs on top of the ones the columns asked for", async () => {
+    getListSpy.mockResolvedValue(asListResult([]) as never);
+
+    await listUsers({
+      select: {
+        user: { name: true, profilePictureId: true },
+        team: { name: true },
+      } as Select<TeamMember>,
+    });
+
+    const select: Record<string, unknown> = getListCallArgs(0)
+      .select as unknown as Record<string, unknown>;
+
+    expect(select["userId"]).toBe(true);
+    expect(select["teamId"]).toBe(true);
+    expect(select["hasAcceptedInvitation"]).toBe(true);
+    // The columns' own fields survive.
+    expect(select["user"]).toEqual({
+      name: true,
+      profilePictureId: true,
+      _id: true,
+    });
+    expect(select["team"]).toEqual({ name: true, _id: true });
+  });
+
+  it("sorts users by name when the table has no sort of its own", async () => {
+    getListSpy.mockResolvedValue(
+      asListResult([
+        buildMembership({ id: "m1", userId: "u1", userName: "Zoe Baker" }),
+        buildMembership({ id: "m2", userId: "u2", userName: "aaron Falzon" }),
+      ]) as never,
+    );
+
+    const result: ListResult<TeamMember> = await listUsers({ sort: {} });
+
+    expect(
+      result.data.map((row: TeamMember) => {
+        return row.user?.name?.toString();
+      }),
+    ).toEqual(["aaron Falzon", "Zoe Baker"]);
+  });
+
+  it("keeps the server's order when the table asked for a sort", async () => {
+    getListSpy.mockResolvedValue(
+      asListResult([
+        buildMembership({ id: "m1", userId: "u1", userName: "Zoe Baker" }),
+        buildMembership({ id: "m2", userId: "u2", userName: "aaron Falzon" }),
+      ]) as never,
+    );
+
+    const result: ListResult<TeamMember> = await listUsers({
+      sort: { createdAt: "DESC" },
+    });
+
+    expect(
+      result.data.map((row: TeamMember) => {
+        return row.user?.name?.toString();
+      }),
+    ).toEqual(["Zoe Baker", "aaron Falzon"]);
+  });
+
+  it("does not re-read teams when nothing is filtering the table", async () => {
+    getListSpy.mockResolvedValue(
+      asListResult([
+        buildMembership({ id: "m1", userId: "u1", teamId: "t1" }),
+      ]) as never,
+    );
+
+    await listUsers({ query: { projectId: PROJECT_ID } as Query<TeamMember> });
+
+    expect(getListSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows every team a user is on even when the table is filtered to one team", async () => {
+    const teamFilteredMemberships: ListResult<TeamMember> = asListResult([
+      buildMembership({
+        id: "m1",
+        userId: "u1",
+        userName: "Thomas Stock",
+        teamId: "t1",
+        teamName: "NTW_Online Operations",
+      }),
+    ]);
+
+    const allMembershipsOfThoseUsers: ListResult<TeamMember> = asListResult([
+      buildMembership({
+        id: "m1",
+        userId: "u1",
+        teamId: "t1",
+        teamName: "NTW_Online Operations",
+      }),
+      buildMembership({
+        id: "m2",
+        userId: "u1",
+        teamId: "t2",
+        teamName: "Owners",
+      }),
+    ]);
+
+    getListSpy
+      .mockResolvedValueOnce(teamFilteredMemberships as never)
+      .mockResolvedValueOnce(allMembershipsOfThoseUsers as never);
+
+    const result: ListResult<TeamMember> = await listUsers({
+      query: {
+        projectId: PROJECT_ID,
+        teamId: new ObjectID("t1"),
+      } as unknown as Query<TeamMember>,
+    });
+
+    expect(getListSpy).toHaveBeenCalledTimes(2);
+
+    const refetchQuery: Record<string, unknown> = getListCallArgs(1)
+      .query as unknown as Record<string, unknown>;
+
+    expect(refetchQuery["projectId"]).toEqual(PROJECT_ID);
+    expect(refetchQuery["userId"]).toBeInstanceOf(Includes);
+    expect((refetchQuery["userId"] as Includes).values.map(String)).toEqual([
+      "u1",
+    ]);
+    // The team filter itself must not be carried into the re-read.
+    expect(refetchQuery["teamId"]).toBeUndefined();
+
+    expect(
+      (result.data[0] as ProjectUserRow).teamsForUser.map((team: Team) => {
+        return team.name?.toString();
+      }),
+    ).toEqual(["NTW_Online Operations", "Owners"]);
+  });
+
+  it("only re-reads teams for the users on the current page", async () => {
+    getListSpy
+      .mockResolvedValueOnce(
+        asListResult([
+          buildMembership({ id: "m1", userId: "u1", userName: "A" }),
+          buildMembership({ id: "m2", userId: "u2", userName: "B" }),
+          buildMembership({ id: "m3", userId: "u3", userName: "C" }),
+        ]) as never,
+      )
+      .mockResolvedValueOnce(asListResult([]) as never);
+
+    await listUsers({
+      skip: 0,
+      limit: 1,
+      query: {
+        projectId: PROJECT_ID,
+        hasAcceptedInvitation: true,
+      } as unknown as Query<TeamMember>,
+    });
+
+    const refetchQuery: Record<string, unknown> = getListCallArgs(1)
+      .query as unknown as Record<string, unknown>;
+
+    expect((refetchQuery["userId"] as Includes).values.map(String)).toEqual([
+      "u1",
+    ]);
+  });
+
+  it("skips the re-read when a filtered page came back empty", async () => {
+    getListSpy.mockResolvedValue(asListResult([]) as never);
+
+    await listUsers({
+      query: {
+        projectId: PROJECT_ID,
+        hasAcceptedInvitation: true,
+      } as unknown as Query<TeamMember>,
+    });
+
+    expect(getListSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands other models straight to the plain API", async () => {
+    const projects: ListResult<Project> = {
+      data: [],
+      count: 0,
+      skip: 0,
+      limit: 10,
+    };
+
+    getListSpy.mockResolvedValue(projects as never);
+
+    const result: ListResult<Project> =
+      await ProjectUsersModelAPI.getList<Project>({
+        modelType: Project,
+        query: {} as Query<Project>,
+        limit: 10,
+        skip: 0,
+        select: {} as Select<Project>,
+        sort: {} as never,
+      });
+
+    expect(result).toBe(projects);
+    expect(getListSpy).toHaveBeenCalledTimes(1);
+    expect(getListCallArgs(0).limit).toBe(10);
+  });
+});
+
+describe("ProjectUsersModelAPI.deleteItem", () => {
+  it("removes every membership the user has in the project, not just the row's own", async () => {
+    getListSpy
+      .mockResolvedValueOnce(
+        asListResult([
+          buildMembership({ id: "m1", userId: "u1", teamId: "t1" }),
+        ]) as never,
+      )
+      .mockResolvedValueOnce(
+        asListResult([
+          buildMembership({ id: "m1", userId: "u1", teamId: "t1" }),
+          buildMembership({ id: "m2", userId: "u1", teamId: "t2" }),
+          buildMembership({ id: "m3", userId: "u1", teamId: "t3" }),
+        ]) as never,
+      );
+
+    await ProjectUsersModelAPI.deleteItem<TeamMember>({
+      modelType: TeamMember,
+      id: new ObjectID("m1"),
+    });
+
+    expect(deleteItemSpy).toHaveBeenCalledTimes(3);
+    expect(
+      deleteItemSpy.mock.calls.map((call: Array<unknown>) => {
+        return (call[0] as { id: ObjectID }).id.toString();
+      }),
+    ).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("looks up the siblings by the row's user and project", async () => {
+    getListSpy
+      .mockResolvedValueOnce(
+        asListResult([
+          buildMembership({ id: "m1", userId: "u1", teamId: "t1" }),
+        ]) as never,
+      )
+      .mockResolvedValueOnce(asListResult([]) as never);
+
+    await ProjectUsersModelAPI.deleteItem<TeamMember>({
+      modelType: TeamMember,
+      id: new ObjectID("m1"),
+    });
+
+    const siblingQuery: Record<string, unknown> = getListCallArgs(1)
+      .query as unknown as Record<string, unknown>;
+
+    expect((siblingQuery["userId"] as ObjectID).toString()).toBe("u1");
+    expect((siblingQuery["projectId"] as ObjectID).toString()).toBe(
+      PROJECT_ID.toString(),
+    );
+  });
+
+  it("falls back to deleting just the row when its user cannot be resolved", async () => {
+    getListSpy.mockResolvedValueOnce(asListResult([]) as never);
+
+    await ProjectUsersModelAPI.deleteItem<TeamMember>({
+      modelType: TeamMember,
+      id: new ObjectID("m1"),
+    });
+
+    expect(deleteItemSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (deleteItemSpy.mock.calls[0]![0] as { id: ObjectID }).id.toString(),
+    ).toBe("m1");
+  });
+
+  it("hands other models straight to the plain API", async () => {
+    await ProjectUsersModelAPI.deleteItem<Project>({
+      modelType: Project,
+      id: new ObjectID("p1"),
+    });
+
+    expect(getListSpy).not.toHaveBeenCalled();
+    expect(deleteItemSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/UI/Utils/TeamMembersByUser.test.ts
+++ b/Common/Tests/UI/Utils/TeamMembersByUser.test.ts
@@ -1,0 +1,580 @@
+import { describe, expect, it } from "@jest/globals";
+import TeamMembersByUser, {
+  ProjectUserRow,
+} from "../../../UI/Utils/TeamMembersByUser";
+import Team from "../../../Models/DatabaseModels/Team";
+import TeamMember from "../../../Models/DatabaseModels/TeamMember";
+import User from "../../../Models/DatabaseModels/User";
+import Email from "../../../Types/Email";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * The Users table lists TeamMember, which is a (user, team) pair. Before this
+ * util a person on three teams rendered as three rows with the same name and
+ * avatar, which customers read as three different people. Everything below
+ * pins the collapse of those rows into one row per person, because every way
+ * it can go wrong is silent: a group key read off the wrong field merges
+ * nobody (duplicates come straight back), a shared key merges strangers, and a
+ * team that is dropped or double-counted just shows a slightly wrong Teams
+ * column that nobody notices until a customer asks who is on which team.
+ */
+
+type MembershipSpec = {
+  id?: string | undefined;
+  userId?: string | undefined;
+  userIdOnUserObject?: string | undefined;
+  userName?: string | undefined;
+  userEmail?: string | undefined;
+  teamId?: string | undefined;
+  teamName?: string | undefined;
+  hasAcceptedInvitation?: boolean | undefined;
+};
+
+const buildMembership: (spec: MembershipSpec) => TeamMember = (
+  spec: MembershipSpec,
+): TeamMember => {
+  const teamMember: TeamMember = new TeamMember();
+
+  if (spec.id) {
+    teamMember._id = spec.id;
+  }
+
+  if (spec.userId) {
+    teamMember.userId = new ObjectID(spec.userId);
+  }
+
+  if (spec.userId || spec.userIdOnUserObject || spec.userName) {
+    const user: User = new User();
+
+    const userId: string | undefined = spec.userIdOnUserObject || spec.userId;
+
+    if (userId) {
+      user._id = userId;
+    }
+
+    if (spec.userName) {
+      user.name = new Name(spec.userName);
+    }
+
+    if (spec.userEmail) {
+      user.email = new Email(spec.userEmail);
+    }
+
+    teamMember.user = user;
+  }
+
+  if (spec.teamId) {
+    teamMember.teamId = new ObjectID(spec.teamId);
+  }
+
+  if (spec.teamId || spec.teamName) {
+    const team: Team = new Team();
+
+    if (spec.teamId) {
+      team._id = spec.teamId;
+    }
+
+    if (spec.teamName) {
+      team.name = spec.teamName;
+    }
+
+    teamMember.team = team;
+  }
+
+  teamMember.hasAcceptedInvitation = spec.hasAcceptedInvitation ?? true;
+
+  return teamMember;
+};
+
+const teamNamesOf: (row: ProjectUserRow) => Array<string> = (
+  row: ProjectUserRow,
+): Array<string> => {
+  return row.teamsForUser.map((team: Team) => {
+    return team.name?.toString() || "";
+  });
+};
+
+describe("TeamMembersByUser.getGroupKey", () => {
+  it("groups on the membership's userId", () => {
+    const key: string | null = TeamMembersByUser.getGroupKey(
+      buildMembership({ userId: "user-1", teamId: "team-1" }),
+    );
+
+    expect(key).toBe("user-1");
+  });
+
+  it("falls back to the id on the joined user when userId was not selected", () => {
+    const teamMember: TeamMember = buildMembership({
+      userIdOnUserObject: "user-1",
+      teamId: "team-1",
+    });
+
+    expect(teamMember.userId).toBeUndefined();
+    expect(TeamMembersByUser.getGroupKey(teamMember)).toBe("user-1");
+  });
+
+  it("returns null when the membership carries no user at all", () => {
+    const teamMember: TeamMember = new TeamMember();
+
+    expect(TeamMembersByUser.getGroupKey(teamMember)).toBeNull();
+  });
+});
+
+describe("TeamMembersByUser.groupByUser", () => {
+  it("returns nothing for no memberships", () => {
+    expect(TeamMembersByUser.groupByUser([])).toEqual([]);
+  });
+
+  it("returns one row for a user on one team", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        userName: "Colton Hawkins",
+        teamId: "team-1",
+        teamName: "NTW_Online Operations",
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(teamNamesOf(rows[0]!)).toEqual(["NTW_Online Operations"]);
+    expect(rows[0]!.teamCountForUser).toBe(1);
+  });
+
+  it("collapses one user on several teams into a single row carrying every team", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        userName: "Thomas Stock",
+        teamId: "team-1",
+        teamName: "NTW_Online Operations",
+      }),
+      buildMembership({
+        userId: "user-1",
+        userName: "Thomas Stock",
+        teamId: "team-2",
+        teamName: "Owners",
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(teamNamesOf(rows[0]!)).toEqual(["NTW_Online Operations", "Owners"]);
+    expect(rows[0]!.teamCountForUser).toBe(2);
+  });
+
+  it("keeps different users apart", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        userName: "Thomas Stock",
+        teamId: "team-1",
+        teamName: "NTW_Online Operations",
+      }),
+      buildMembership({
+        userId: "user-2",
+        userName: "Jason Apel",
+        teamId: "team-1",
+        teamName: "NTW_Online Operations",
+      }),
+      buildMembership({
+        userId: "user-1",
+        userName: "Thomas Stock",
+        teamId: "team-2",
+        teamName: "Owners",
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(TeamMembersByUser.getDisplayName(rows[0]!)).toBe("Thomas Stock");
+    expect(TeamMembersByUser.getDisplayName(rows[1]!)).toBe("Jason Apel");
+    expect(teamNamesOf(rows[0]!)).toEqual(["NTW_Online Operations", "Owners"]);
+    expect(teamNamesOf(rows[1]!)).toEqual(["NTW_Online Operations"]);
+  });
+
+  it("keeps the order the server returned, by first appearance of each user", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-3", teamId: "team-1" }),
+      buildMembership({ userId: "user-1", teamId: "team-1" }),
+      buildMembership({ userId: "user-3", teamId: "team-2" }),
+      buildMembership({ userId: "user-2", teamId: "team-1" }),
+    ]);
+
+    expect(
+      rows.map((row: ProjectUserRow) => {
+        return row.userId?.toString();
+      }),
+    ).toEqual(["user-3", "user-1", "user-2"]);
+  });
+
+  it("sorts the teams on a row by name, whatever order the memberships arrived in", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "t3", teamName: "Zulu" }),
+      buildMembership({ userId: "user-1", teamId: "t1", teamName: "alpha" }),
+      buildMembership({ userId: "user-1", teamId: "t2", teamName: "Bravo" }),
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["alpha", "Bravo", "Zulu"]);
+  });
+
+  it("lists a team once even if the same membership pair comes back twice", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "team-1", teamName: "Ops" }),
+      buildMembership({ userId: "user-1", teamId: "team-1", teamName: "Ops" }),
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["Ops"]);
+    expect(rows[0]!.teamCountForUser).toBe(1);
+  });
+
+  it("de-dupes on the team's own id when the membership has no teamId", () => {
+    const first: TeamMember = buildMembership({
+      userId: "user-1",
+      teamId: "team-1",
+      teamName: "Ops",
+    });
+    const second: TeamMember = buildMembership({
+      userId: "user-1",
+      teamId: "team-1",
+      teamName: "Ops",
+    });
+
+    // The select asked for the joined team but not the foreign key.
+    delete first.teamId;
+    delete second.teamId;
+
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      first,
+      second,
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["Ops"]);
+  });
+
+  it("keeps a row whose membership has no team, with an empty team list", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", userName: "Karsten Huster" }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.teamsForUser).toEqual([]);
+    expect(rows[0]!.teamCountForUser).toBe(0);
+  });
+
+  it("never merges memberships that carry no user, however many there are", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      new TeamMember(),
+      new TeamMember(),
+    ]);
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it("counts a user as a member as soon as one of their invitations is accepted", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-1",
+        hasAcceptedInvitation: false,
+      }),
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-2",
+        hasAcceptedInvitation: true,
+      }),
+    ]);
+
+    expect(rows[0]!.hasAcceptedInvitation).toBe(true);
+    expect(rows[0]!.pendingTeamCountForUser).toBe(1);
+  });
+
+  it("leaves a user with no accepted invitation as an invitee", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-1",
+        hasAcceptedInvitation: false,
+      }),
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-2",
+        hasAcceptedInvitation: false,
+      }),
+    ]);
+
+    expect(rows[0]!.hasAcceptedInvitation).toBe(false);
+    expect(rows[0]!.pendingTeamCountForUser).toBe(2);
+  });
+
+  it("reports no pending invitations when every membership is accepted", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "team-1" }),
+      buildMembership({ userId: "user-1", teamId: "team-2" }),
+    ]);
+
+    expect(rows[0]!.hasAcceptedInvitation).toBe(true);
+    expect(rows[0]!.pendingTeamCountForUser).toBe(0);
+  });
+
+  it("keeps the first membership's id on the row so the table has a stable row key", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ id: "member-1", userId: "user-1", teamId: "team-1" }),
+      buildMembership({ id: "member-2", userId: "user-1", teamId: "team-2" }),
+    ]);
+
+    expect(rows[0]!._id).toBe("member-1");
+  });
+
+  it("groups by user even when the same person's memberships are not adjacent", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "t1", teamName: "A" }),
+      buildMembership({ userId: "user-2", teamId: "t1", teamName: "A" }),
+      buildMembership({ userId: "user-3", teamId: "t1", teamName: "A" }),
+      buildMembership({ userId: "user-1", teamId: "t2", teamName: "B" }),
+    ]);
+
+    expect(rows).toHaveLength(3);
+    expect(teamNamesOf(rows[0]!)).toEqual(["A", "B"]);
+  });
+});
+
+describe("TeamMembersByUser.mergeAllTeamsIntoRows", () => {
+  it("replaces a filtered-down team list with the user's full one", () => {
+    /*
+     * What the table sees when it is filtered by one team: the membership for
+     * the other team never came back, so the row claims one team.
+     */
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-1",
+        teamName: "NTW_IT Operations",
+      }),
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["NTW_IT Operations"]);
+
+    TeamMembersByUser.mergeAllTeamsIntoRows(rows, [
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-1",
+        teamName: "NTW_IT Operations",
+      }),
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-2",
+        teamName: "Owners",
+      }),
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["NTW_IT Operations", "Owners"]);
+    expect(rows[0]!.teamCountForUser).toBe(2);
+  });
+
+  it("merges into the right row when several users are on the page", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "team-1", teamName: "Ops" }),
+      buildMembership({ userId: "user-2", teamId: "team-1", teamName: "Ops" }),
+    ]);
+
+    TeamMembersByUser.mergeAllTeamsIntoRows(rows, [
+      buildMembership({ userId: "user-1", teamId: "team-1", teamName: "Ops" }),
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-2",
+        teamName: "Owners",
+      }),
+      buildMembership({ userId: "user-2", teamId: "team-1", teamName: "Ops" }),
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["Ops", "Owners"]);
+    expect(teamNamesOf(rows[1]!)).toEqual(["Ops"]);
+  });
+
+  it("re-reads the member status from the unfiltered memberships", () => {
+    /*
+     * Filtering by a team the user has not accepted yet would otherwise leave
+     * a full member of the project labelled "Invitation Sent".
+     */
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-2",
+        hasAcceptedInvitation: false,
+      }),
+    ]);
+
+    expect(rows[0]!.hasAcceptedInvitation).toBe(false);
+
+    TeamMembersByUser.mergeAllTeamsIntoRows(rows, [
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-1",
+        hasAcceptedInvitation: true,
+      }),
+      buildMembership({
+        userId: "user-1",
+        teamId: "team-2",
+        hasAcceptedInvitation: false,
+      }),
+    ]);
+
+    expect(rows[0]!.hasAcceptedInvitation).toBe(true);
+    expect(rows[0]!.pendingTeamCountForUser).toBe(1);
+  });
+
+  it("leaves a row alone when the merge source knows nothing about that user", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "team-1", teamName: "Ops" }),
+    ]);
+
+    TeamMembersByUser.mergeAllTeamsIntoRows(rows, [
+      buildMembership({
+        userId: "user-9",
+        teamId: "team-2",
+        teamName: "Owners",
+      }),
+    ]);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["Ops"]);
+  });
+
+  it("leaves the rows alone when there is nothing to merge", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", teamId: "team-1", teamName: "Ops" }),
+    ]);
+
+    TeamMembersByUser.mergeAllTeamsIntoRows(rows, []);
+
+    expect(teamNamesOf(rows[0]!)).toEqual(["Ops"]);
+  });
+});
+
+describe("TeamMembersByUser.sortRowsByUserName", () => {
+  it("sorts by name, ignoring case", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", userName: "colton Hawkins" }),
+      buildMembership({ userId: "user-2", userName: "Aaron Falzon" }),
+      buildMembership({ userId: "user-3", userName: "Thomas Stock" }),
+    ]);
+
+    expect(
+      TeamMembersByUser.sortRowsByUserName(rows).map(
+        (row: ProjectUserRow): string => {
+          return TeamMembersByUser.getDisplayName(row);
+        },
+      ),
+    ).toEqual(["Aaron Falzon", "colton Hawkins", "Thomas Stock"]);
+  });
+
+  it("sorts a user with no name under their email", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", userName: "Zoe Baker" }),
+      buildMembership({ userId: "user-2", userEmail: "aaron@company.com" }),
+    ]);
+
+    expect(
+      TeamMembersByUser.sortRowsByUserName(rows).map(
+        (row: ProjectUserRow): string => {
+          return TeamMembersByUser.getDisplayName(row);
+        },
+      ),
+    ).toEqual(["aaron@company.com", "Zoe Baker"]);
+  });
+
+  it("puts rows with nothing to sort on last rather than at the top", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      new TeamMember(),
+      buildMembership({ userId: "user-1", userName: "Aaron Falzon" }),
+    ]);
+
+    const sorted: Array<ProjectUserRow> =
+      TeamMembersByUser.sortRowsByUserName(rows);
+
+    expect(TeamMembersByUser.getDisplayName(sorted[0]!)).toBe("Aaron Falzon");
+    expect(TeamMembersByUser.getDisplayName(sorted[1]!)).toBe("");
+  });
+
+  it("does not reorder the array it was given", () => {
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({ userId: "user-1", userName: "Zoe Baker" }),
+      buildMembership({ userId: "user-2", userName: "Aaron Falzon" }),
+    ]);
+
+    TeamMembersByUser.sortRowsByUserName(rows);
+
+    expect(TeamMembersByUser.getDisplayName(rows[0]!)).toBe("Zoe Baker");
+  });
+});
+
+describe("the duplicate rows customers reported", () => {
+  it("renders the reported project as one row per person", () => {
+    /*
+     * The exact list from the bug report: Thomas Stock and Jason Apel each
+     * appeared twice because each belongs to two teams.
+     */
+    const rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser([
+      buildMembership({
+        userId: "thomas",
+        userName: "Thomas Stock",
+        teamId: "online-ops",
+        teamName: "NTW_Online Operations",
+      }),
+      buildMembership({
+        userId: "thomas",
+        userName: "Thomas Stock",
+        teamId: "owners",
+        teamName: "Owners",
+      }),
+      buildMembership({
+        userId: "jason",
+        userName: "Jason Apel",
+        teamId: "owners",
+        teamName: "Owners",
+      }),
+      buildMembership({
+        userId: "colton",
+        userName: "Colton Hawkins",
+        teamId: "online-ops",
+        teamName: "NTW_Online Operations",
+      }),
+      buildMembership({
+        userId: "karsten",
+        userName: "Karsten Huster",
+        teamId: "it-ops",
+        teamName: "NTW_IT Operations",
+      }),
+      buildMembership({
+        userId: "jason",
+        userName: "Jason Apel",
+        teamId: "online-ops",
+        teamName: "NTW_Online Operations",
+      }),
+    ]);
+
+    expect(
+      rows.map((row: ProjectUserRow) => {
+        return {
+          name: TeamMembersByUser.getDisplayName(row),
+          teams: teamNamesOf(row),
+        };
+      }),
+    ).toEqual([
+      {
+        name: "Thomas Stock",
+        teams: ["NTW_Online Operations", "Owners"],
+      },
+      {
+        name: "Jason Apel",
+        teams: ["NTW_Online Operations", "Owners"],
+      },
+      {
+        name: "Colton Hawkins",
+        teams: ["NTW_Online Operations"],
+      },
+      {
+        name: "Karsten Huster",
+        teams: ["NTW_IT Operations"],
+      },
+    ]);
+  });
+});

--- a/Common/UI/Utils/ModelAPI/ProjectUsersModelAPI.ts
+++ b/Common/UI/Utils/ModelAPI/ProjectUsersModelAPI.ts
@@ -1,0 +1,270 @@
+import ModelAPI, { ListResult, RequestOptions } from "./ModelAPI";
+import TeamMembersByUser, { ProjectUserRow } from "../TeamMembersByUser";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import TeamMember from "../../../Models/DatabaseModels/TeamMember";
+import GroupBy from "../../../Types/BaseDatabase/GroupBy";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import Query from "../../../Types/BaseDatabase/Query";
+import Select from "../../../Types/BaseDatabase/Select";
+import Sort from "../../../Types/BaseDatabase/Sort";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * A drop-in ModelAPI for tables that list TeamMember but mean to list *people*
+ * - the project's Users table being the one that does.
+ *
+ * TeamMember rows are (user, team) pairs, so the plain API pages over
+ * memberships: a user on three teams occupies three rows and reads as three
+ * different people with the same name. This API pages over users instead. It
+ * reads the project's memberships in one request, folds them into one row per
+ * user (see TeamMembersByUser), and then applies the table's skip/limit to
+ * *that* list, so `count` is a number of people and every page boundary falls
+ * between two people rather than between two of one person's teams.
+ *
+ * Paging cannot be pushed to the server here: the list endpoint has no DISTINCT
+ * or GROUP BY, so there is no way to ask it for the Nth user. Reading the whole
+ * membership list up front is what the project user pickers already do, and it
+ * is bounded by LIMIT_PER_PROJECT.
+ *
+ * Deleting is redefined to match what a row now means - see deleteItem.
+ */
+export default class ProjectUsersModelAPI extends ModelAPI {
+  public static override async getList<TBaseModel extends BaseModel>(data: {
+    modelType: { new (): TBaseModel };
+    query: Query<TBaseModel>;
+    groupBy?: GroupBy<TBaseModel> | undefined;
+    limit: number;
+    skip: number;
+    select: Select<TBaseModel>;
+    sort: Sort<TBaseModel>;
+    requestOptions?: RequestOptions | undefined;
+  }): Promise<ListResult<TBaseModel>> {
+    if (!(new data.modelType() instanceof TeamMember)) {
+      // Not the model this API exists for. Behave like the plain one.
+      return ModelAPI.getList<TBaseModel>(data);
+    }
+
+    const query: Query<TeamMember> = data.query as Query<TeamMember>;
+    const sort: Sort<TeamMember> = data.sort as Sort<TeamMember>;
+
+    const memberships: ListResult<TeamMember> =
+      await ModelAPI.getList<TeamMember>({
+        modelType: TeamMember,
+        query: query,
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        select: this.getMembershipSelect(data.select as Select<TeamMember>),
+        sort: sort,
+        requestOptions: data.requestOptions,
+      });
+
+    let rows: Array<ProjectUserRow> = TeamMembersByUser.groupByUser(
+      memberships.data,
+    );
+
+    /*
+     * An explicit sort was already applied by the server and grouping kept it.
+     * Without one the server's order is arbitrary, and an arbitrary order that
+     * is then sliced into pages is worse here than elsewhere - so fall back to
+     * something a reader of a people directory expects, and that pages the same
+     * way every time.
+     */
+    if (Object.keys(sort || {}).length === 0) {
+      rows = TeamMembersByUser.sortRowsByUserName(rows);
+    }
+
+    const pageRows: Array<ProjectUserRow> = rows.slice(
+      data.skip,
+      data.skip + data.limit,
+    );
+
+    await this.fillInTeamsHiddenByFilters({
+      query: query,
+      pageRows: pageRows,
+      requestOptions: data.requestOptions,
+    });
+
+    return {
+      data: pageRows as unknown as Array<TBaseModel>,
+      count: rows.length,
+      skip: data.skip,
+      limit: data.limit,
+    };
+  }
+
+  /**
+   * Removes the user on this row from the project - every one of their team
+   * memberships, not just the one whose id the row happens to carry.
+   *
+   * A grouped row stands for a person, so deleting one membership would leave
+   * the row on screen (still a member, via their other teams) and look like the
+   * delete silently failed. Removing a user from a single team is done from
+   * that user's own Teams tab, where a row is a membership again.
+   */
+  public static override async deleteItem<TBaseModel extends BaseModel>(data: {
+    modelType: { new (): TBaseModel };
+    id: ObjectID;
+    requestOptions?: RequestOptions | undefined;
+  }): Promise<void> {
+    if (!(new data.modelType() instanceof TeamMember)) {
+      return ModelAPI.deleteItem<TBaseModel>(data);
+    }
+
+    const rowMembership: ListResult<TeamMember> =
+      await ModelAPI.getList<TeamMember>({
+        modelType: TeamMember,
+        query: {
+          _id: data.id.toString(),
+        } as Query<TeamMember>,
+        limit: 1,
+        skip: 0,
+        select: {
+          _id: true,
+          userId: true,
+          projectId: true,
+        },
+        sort: {},
+        requestOptions: data.requestOptions,
+      });
+
+    const userId: ObjectID | undefined = rowMembership.data[0]?.userId;
+    const projectId: ObjectID | undefined = rowMembership.data[0]?.projectId;
+
+    if (!userId || !projectId) {
+      /*
+       * The row is gone, or was returned without the fields needed to find its
+       * siblings. Fall back to the single delete the table asked for.
+       */
+      return ModelAPI.deleteItem<TBaseModel>(data);
+    }
+
+    const allMembershipsOfUser: ListResult<TeamMember> =
+      await ModelAPI.getList<TeamMember>({
+        modelType: TeamMember,
+        query: {
+          userId: userId,
+          projectId: projectId,
+        } as Query<TeamMember>,
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        select: {
+          _id: true,
+        },
+        sort: {},
+        requestOptions: data.requestOptions,
+      });
+
+    for (const membership of allMembershipsOfUser.data) {
+      if (!membership.id) {
+        continue;
+      }
+
+      await ModelAPI.deleteItem<TeamMember>({
+        modelType: TeamMember,
+        id: membership.id,
+        requestOptions: data.requestOptions,
+      });
+    }
+  }
+
+  /**
+   * The table's own select plus the fields grouping needs. Columns ask for what
+   * they render; grouping also needs to know which user and which team each
+   * membership belongs to, and whether it was accepted.
+   */
+  private static getMembershipSelect(
+    select: Select<TeamMember>,
+  ): Select<TeamMember> {
+    const teamSelect: Record<string, boolean> =
+      typeof select?.team === "object" && select.team !== null
+        ? { ...(select.team as Record<string, boolean>) }
+        : {};
+
+    const userSelect: Record<string, boolean> =
+      typeof select?.user === "object" && select.user !== null
+        ? { ...(select.user as Record<string, boolean>) }
+        : {};
+
+    return {
+      ...select,
+      _id: true,
+      userId: true,
+      teamId: true,
+      hasAcceptedInvitation: true,
+      user: {
+        ...userSelect,
+        _id: true,
+      },
+      team: {
+        ...teamSelect,
+        _id: true,
+        name: true,
+      },
+    } as Select<TeamMember>;
+  }
+
+  /**
+   * When the table is filtered, the memberships that were read are only the
+   * matching ones - filter by a team and every user's Teams column would show
+   * that one team and nothing else, which is exactly the "which teams is this
+   * person on?" question the grouped row exists to answer.
+   *
+   * So for the users actually on this page (at most one page's worth), re-read
+   * their memberships unfiltered and merge the full team list back in.
+   */
+  private static async fillInTeamsHiddenByFilters(data: {
+    query: Query<TeamMember>;
+    pageRows: Array<ProjectUserRow>;
+    requestOptions?: RequestOptions | undefined;
+  }): Promise<void> {
+    const projectId: unknown = (data.query as Record<string, unknown>)[
+      "projectId"
+    ];
+
+    const isFiltered: boolean = Object.keys(data.query).some((key: string) => {
+      return key !== "projectId";
+    });
+
+    if (!isFiltered || !projectId || data.pageRows.length === 0) {
+      return;
+    }
+
+    const userIds: Array<string> = data.pageRows
+      .map((row: ProjectUserRow) => {
+        return TeamMembersByUser.getGroupKey(row) || "";
+      })
+      .filter((userId: string) => {
+        return Boolean(userId);
+      });
+
+    if (userIds.length === 0) {
+      return;
+    }
+
+    const allMemberships: ListResult<TeamMember> =
+      await ModelAPI.getList<TeamMember>({
+        modelType: TeamMember,
+        query: {
+          projectId: projectId,
+          userId: new Includes(userIds),
+        } as Query<TeamMember>,
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        select: {
+          _id: true,
+          userId: true,
+          teamId: true,
+          hasAcceptedInvitation: true,
+          team: {
+            _id: true,
+            name: true,
+          },
+        } as Select<TeamMember>,
+        sort: {},
+        requestOptions: data.requestOptions,
+      });
+
+    TeamMembersByUser.mergeAllTeamsIntoRows(data.pageRows, allMemberships.data);
+  }
+}

--- a/Common/UI/Utils/TeamMembersByUser.ts
+++ b/Common/UI/Utils/TeamMembersByUser.ts
@@ -1,0 +1,259 @@
+import Team from "../../Models/DatabaseModels/Team";
+import TeamMember from "../../Models/DatabaseModels/TeamMember";
+
+/*
+ * TeamMember is a (user, team) pair, so a list of team members is a list of
+ * memberships - not a list of people. Rendering it straight into a "Users"
+ * table gives one row per membership, and someone who belongs to three teams
+ * reads as three separate people with the same name and avatar.
+ *
+ * These helpers collapse memberships into one row per person, carrying every
+ * team that person belongs to on the row so the table can show them together.
+ * The row is still a TeamMember (the table, its columns and its delete action
+ * are all typed against the model) - it just stands for the user rather than
+ * for one of their memberships.
+ */
+
+export interface ProjectUserExtras {
+  // Every team this user belongs to, sorted by name.
+  teamsForUser: Array<Team>;
+  teamCountForUser: number;
+  /*
+   * How many of those memberships are still unaccepted invitations. A user can
+   * be a fully accepted member of one team and a pending invite on another.
+   */
+  pendingTeamCountForUser: number;
+}
+
+export type ProjectUserRow = TeamMember & ProjectUserExtras;
+
+export default class TeamMembersByUser {
+  /**
+   * The identity a membership is grouped under. Null when the row carries no
+   * user at all - those rows are never merged, because merging them would put
+   * unrelated memberships on one line.
+   */
+  public static getGroupKey(teamMember: TeamMember): string | null {
+    const userId: string =
+      teamMember.userId?.toString() || teamMember.user?._id?.toString() || "";
+
+    return userId || null;
+  }
+
+  /**
+   * The name this row sorts and reads under. Falls back to the email so a user
+   * who was invited but has not set a name yet still lands somewhere sensible.
+   */
+  public static getDisplayName(teamMember: TeamMember): string {
+    return (
+      teamMember.user?.name?.toString() ||
+      teamMember.user?.email?.toString() ||
+      ""
+    );
+  }
+
+  /**
+   * One row per user, in the order each user was first seen. The input order is
+   * whatever the server sorted by, so first-seen order keeps that sort intact.
+   *
+   * The returned rows are the same TeamMember instances that came in (the first
+   * membership seen for each user), mutated with the aggregate fields.
+   */
+  public static groupByUser(
+    teamMembers: Array<TeamMember>,
+  ): Array<ProjectUserRow> {
+    const rowsByGroupKey: Map<string, ProjectUserRow> = new Map<
+      string,
+      ProjectUserRow
+    >();
+    const rows: Array<ProjectUserRow> = [];
+
+    /*
+     * Which teams are already on a row, keyed the same way for every
+     * membership. Tracked here rather than re-derived from `teamsForUser`
+     * because a membership identifies its team by `teamId` while the team
+     * object it carries identifies itself by `_id`, and either one can be
+     * missing from a given select.
+     */
+    const teamKeysByRow: Map<ProjectUserRow, Set<string>> = new Map<
+      ProjectUserRow,
+      Set<string>
+    >();
+
+    for (const teamMember of teamMembers) {
+      const groupKey: string | null = this.getGroupKey(teamMember);
+
+      const existingRow: ProjectUserRow | undefined = groupKey
+        ? rowsByGroupKey.get(groupKey)
+        : undefined;
+
+      if (existingRow) {
+        this.addMembershipToRow(
+          existingRow,
+          teamMember,
+          teamKeysByRow.get(existingRow)!,
+          Boolean(teamMember.hasAcceptedInvitation),
+        );
+        continue;
+      }
+
+      const row: ProjectUserRow = teamMember as ProjectUserRow;
+      const teamKeys: Set<string> = new Set<string>();
+
+      /*
+       * The row *is* this membership, so read its acceptance before the reset
+       * below overwrites it.
+       */
+      const hasAcceptedInvitation: boolean = Boolean(
+        teamMember.hasAcceptedInvitation,
+      );
+
+      row.teamsForUser = [];
+      row.teamCountForUser = 0;
+      row.pendingTeamCountForUser = 0;
+
+      /*
+       * Reset before folding the row's own membership back in: on a grouped row
+       * this field means "is a member of this project", which is true as soon as
+       * any one of the memberships has been accepted.
+       */
+      row.hasAcceptedInvitation = false;
+
+      teamKeysByRow.set(row, teamKeys);
+      this.addMembershipToRow(row, teamMember, teamKeys, hasAcceptedInvitation);
+
+      if (groupKey) {
+        rowsByGroupKey.set(groupKey, row);
+      }
+
+      rows.push(row);
+    }
+
+    for (const row of rows) {
+      this.finalizeRow(row);
+    }
+
+    return rows;
+  }
+
+  /**
+   * Replaces the team aggregate on each row with the one derived from
+   * `allTeamMembers`.
+   *
+   * Needed because the rows on screen may have been built from a *filtered*
+   * membership list - filter the table by one team and grouping only ever sees
+   * that team, so the Teams column would claim each user belongs to exactly the
+   * team that was filtered for. The caller re-reads the unfiltered memberships
+   * for the users on the current page and merges them back in here.
+   *
+   * Rows with no matching membership in `allTeamMembers` are left untouched.
+   */
+  public static mergeAllTeamsIntoRows(
+    rows: Array<ProjectUserRow>,
+    allTeamMembers: Array<TeamMember>,
+  ): Array<ProjectUserRow> {
+    const groupedRows: Array<ProjectUserRow> = this.groupByUser(allTeamMembers);
+
+    const groupedRowsByKey: Map<string, ProjectUserRow> = new Map<
+      string,
+      ProjectUserRow
+    >();
+
+    for (const groupedRow of groupedRows) {
+      const groupKey: string | null = this.getGroupKey(groupedRow);
+
+      if (groupKey) {
+        groupedRowsByKey.set(groupKey, groupedRow);
+      }
+    }
+
+    for (const row of rows) {
+      const groupKey: string | null = this.getGroupKey(row);
+      const groupedRow: ProjectUserRow | undefined = groupKey
+        ? groupedRowsByKey.get(groupKey)
+        : undefined;
+
+      if (!groupedRow) {
+        continue;
+      }
+
+      row.teamsForUser = groupedRow.teamsForUser;
+      row.teamCountForUser = groupedRow.teamCountForUser;
+      row.pendingTeamCountForUser = groupedRow.pendingTeamCountForUser;
+      row.hasAcceptedInvitation = Boolean(groupedRow.hasAcceptedInvitation);
+    }
+
+    return rows;
+  }
+
+  /**
+   * Alphabetical by display name, case-insensitively. Rows with no name at all
+   * sort last so the list does not open on a run of blanks.
+   *
+   * Returns a new array; the input is left alone.
+   */
+  public static sortRowsByUserName(
+    rows: Array<ProjectUserRow>,
+  ): Array<ProjectUserRow> {
+    return [...rows].sort((a: ProjectUserRow, b: ProjectUserRow) => {
+      const nameA: string = this.getDisplayName(a).toLowerCase();
+      const nameB: string = this.getDisplayName(b).toLowerCase();
+
+      if (!nameA && !nameB) {
+        return 0;
+      }
+
+      if (!nameA) {
+        return 1;
+      }
+
+      if (!nameB) {
+        return -1;
+      }
+
+      return nameA.localeCompare(nameB);
+    });
+  }
+
+  private static addMembershipToRow(
+    row: ProjectUserRow,
+    teamMember: TeamMember,
+    teamKeys: Set<string>,
+    hasAcceptedInvitation: boolean,
+  ): void {
+    if (hasAcceptedInvitation) {
+      row.hasAcceptedInvitation = true;
+    } else {
+      row.pendingTeamCountForUser = row.pendingTeamCountForUser + 1;
+    }
+
+    const team: Team | undefined = teamMember.team;
+
+    if (!team) {
+      return;
+    }
+
+    const teamKey: string =
+      teamMember.teamId?.toString() ||
+      team._id?.toString() ||
+      team.name?.toString() ||
+      "";
+
+    if (!teamKey || teamKeys.has(teamKey)) {
+      return;
+    }
+
+    teamKeys.add(teamKey);
+    row.teamsForUser.push(team);
+  }
+
+  private static finalizeRow(row: ProjectUserRow): void {
+    row.teamsForUser.sort((a: Team, b: Team) => {
+      return (a.name?.toString() || "")
+        .toLowerCase()
+        .localeCompare((b.name?.toString() || "").toLowerCase());
+    });
+
+    row.teamCountForUser = row.teamsForUser.length;
+  }
+}


### PR DESCRIPTION
## The problem

Settings > Users lists `TeamMember`, which is a `(user, team)` pair. Someone who belongs to three teams filled three rows with the same name and the same avatar, and customers read that as three different people:

| User | Team | Status |
| --- | --- | --- |
| Thomas Stock | NTW_Online Operations | Member |
| Thomas Stock | Owners | Member |
| Jason Apel | Owners | Member |
| … | | |
| Jason Apel | NTW_Online Operations | Member |

## What changed

The table now pages over **people** instead of over memberships.

- **`Common/UI/Utils/TeamMembersByUser.ts`** — folds a membership list into one row per user, carrying every team that user belongs to, how many of their invitations are still unaccepted, and whether they are a member of the project at all.
- **`Common/UI/Utils/ModelAPI/ProjectUsersModelAPI.ts`** — a drop-in `ModelAPI` the Users table is handed via the existing `modelAPI` prop. It reads the project's memberships in one request, groups them, and applies the table's `skip`/`limit` to *that* list, so `count` is a number of people and no page boundary falls between two of one person's teams. Everything the table already does — the facet filter bar, saved filters, bulk actions, pagination, the view page — is untouched.
- **`Pages/Users/Index.tsx`** — "Team" becomes "Teams" and lists all of them (via the existing `TeamsElement`, which collapses to "+N more teams"). "Status" reports project membership, with any still-unaccepted team invitations called out beside it.

Two behaviours follow from a row now standing for a person:

- **Delete removes the user from the project**, not from whichever team the row happened to carry — deleting one membership would have left the row on screen and looked like a silent failure. The button reads "Remove from Project". Removing someone from a *single* team is still done from that user's own Teams tab, where a row is a membership again.
- **Filtered views re-read the current page's users unfiltered**, so filtering by one team does not leave the Teams column claiming everyone belongs to exactly that team.

Paging cannot be pushed to the server: `DatabaseService` rejects `GroupBy` on the find path and only supports `distinctOn` for `countBy`, so there is no way to ask the list endpoint for the Nth *user*. Reading the membership list up front is what the project user pickers already do and is bounded by `LIMIT_PER_PROJECT`.

## Tests

44 new tests, all passing (`Common/Tests/UI/Utils/`):

- **`TeamMembersByUser.test.ts`** (28) — grouping, team de-duplication and ordering, group keys falling back from `userId` to the joined user, memberships with no user never merging, member/invitee aggregation across teams, the merge that undoes filter narrowing, name sorting, and the exact list from the bug report collapsing to four people.
- **`ProjectUsersModelAPI.test.ts`** (16) — `count` being a people count, `skip`/`limit` landing on user boundaries, the select carrying the fields grouping needs on top of the columns', the filtered re-read (and its absence when unfiltered or empty), delete removing every membership, and non-`TeamMember` models passing straight through.

The grouping tests caught a real aliasing bug during development: the row *is* the first membership, so resetting `hasAcceptedInvitation` before reading it dropped that membership's acceptance.

Also ran the 1,274 existing tests under `Common/Tests/UI/Components/ModelTable` and `Common/Tests/UI/Utils` — all pass. `tsc --noEmit` is clean for `Common` and `FeatureSet/Dashboard`, and `eslint --fix` reported no remaining issues.

Not verified in a running browser — Docker was not available in this environment, so this rests on the compile and the test suites above.