### PR TITLE
feat(filters): filter incidents and other resources by custom field values

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "Common/UI/Components/ModelTable/BaseModelTable";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import useBulkLabelActions from "Common/UI/Components/BulkUpdate/BulkLabelActions";
+import useCustomFieldFacets from "../CustomFields/useCustomFieldFacets";
 import useBulkOwnerActions from "Common/UI/Components/BulkUpdate/BulkOwnerActions";
 import Pill from "Common/UI/Components/Pill/Pill";
 import FieldType from "Common/UI/Components/Types/FieldType";
@@ -347,6 +348,13 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
   const tableUrlStateKey: string =
     props.saveFilterProps?.tableId || "alerts-table";
 
+  /*
+   * One chip per custom field this project has defined, appended after the
+   * built-in ones. They arrive a render or two late (the definitions are
+   * fetched), which is what `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({ customFieldsModelType: AlertCustomField });
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -361,7 +369,8 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
     ownerTeamModelType: AlertOwnerTeam,
     resourceIdField: "alertId",
     showLabelsFacet: true,
-    extraFacets: alertExtraFacets,
+    extraFacets: [...alertExtraFacets, ...customFieldFacets],
+    areFacetsLoading: areCustomFieldFacetsLoading,
   });
 
   // Fetch alert states on mount

--- a/App/FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets.ts
+++ b/App/FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets.ts
@@ -1,0 +1,459 @@
+import {
+  FilterChipDropdownOption,
+  FilterOperator,
+  NUMBER_FACET_OPERATORS,
+  OPTION_FACET_OPERATORS,
+  TEXT_FACET_OPERATORS,
+} from "../ResourceOwners/FilterChipDropdownTypes";
+import { ResourceFacet } from "../ResourceOwners/ResourceFacet";
+import EndsWith from "Common/Types/BaseDatabase/EndsWith";
+import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import LessThan from "Common/Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "Common/Types/BaseDatabase/LessThanOrEqual";
+import NotContains from "Common/Types/BaseDatabase/NotContains";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
+import NotNull from "Common/Types/BaseDatabase/NotNull";
+import Search from "Common/Types/BaseDatabase/Search";
+import StartsWith from "Common/Types/BaseDatabase/StartsWith";
+import CustomFieldType from "Common/Types/CustomField/CustomFieldType";
+import {
+  CustomFieldDropdownOption,
+  parseCustomFieldDropdownOptions,
+} from "Common/Types/CustomField/CustomFieldDropdownOption";
+import IconProp from "Common/Types/Icon/IconProp";
+import { JSONObject } from "Common/Types/JSON";
+import { CustomFieldDefinition } from "Common/Types/CustomField/CustomFieldDefinition";
+
+/*
+ * Custom fields as chips in the facet bar.
+ *
+ * A project defines its own categories — Team, Region, Ticket, Impacted Users —
+ * and until now could see them in a table column but not filter by them, which
+ * is the thing people actually want to do with a category. These chips sit
+ * beside State, Severity and Labels and behave the same way.
+ *
+ * Where this differs from every other facet: the values do not live in a column
+ * of their own. They live under the field's *name* inside one `customFields`
+ * jsonb column, so every chip on the bar writes the same query field. Two
+ * consequences run through this whole module:
+ *
+ *  - each chip's query value is an *object* keyed by the field name, and the
+ *    hook ANDs them together through `mergeQueryValue` rather than letting the
+ *    last one win (see ResourceFacet.mergeQueryValue);
+ *
+ *  - "is empty" has to mean "this key is unset", not "the column is null", so
+ *    the chips claim `handlesValuelessOperators` and build that predicate
+ *    themselves.
+ *
+ * Deliberately free of React and of the API client, like DeviceFacets: the
+ * definitions are fetched by the hook next door, while the mapping from "what
+ * the chip says" to "what the database is asked" lives here where it can be
+ * pinned in tests.
+ */
+
+/**
+ * Namespaces a chip's key so a custom field called "labels" cannot collide with
+ * the bar's own Labels chip — and so the settle-time reconciliation in
+ * useResourceOwners can recognise a selection whose definition has since been
+ * renamed or deleted.
+ */
+export const CUSTOM_FIELD_FACET_KEY_PREFIX: string = "customField:";
+
+/** The one column every custom field chip filters on. */
+export const CUSTOM_FIELD_QUERY_FIELD: string = "customFields";
+
+export type GetCustomFieldFacetKeyFunction = (name: string) => string;
+
+export const getCustomFieldFacetKey: GetCustomFieldFacetKeyFunction = (
+  name: string,
+): string => {
+  return `${CUSTOM_FIELD_FACET_KEY_PREFIX}${name}`;
+};
+
+export type GetCustomFieldNameFromFacetKeyFunction = (
+  key: string,
+) => string | null;
+
+export const getCustomFieldNameFromFacetKey: GetCustomFieldNameFromFacetKeyFunction =
+  (key: string): string | null => {
+    if (!key.startsWith(CUSTOM_FIELD_FACET_KEY_PREFIX)) {
+      return null;
+    }
+
+    const name: string = key.slice(CUSTOM_FIELD_FACET_KEY_PREFIX.length);
+
+    return name.length > 0 ? name : null;
+  };
+
+/**
+ * The chip kind a definition gets.
+ *
+ * A dropdown with no options configured falls back to a text chip rather than
+ * rendering an empty picker: the field is real and has values in it, so
+ * offering nothing to choose from would be worse than letting the user type.
+ */
+export type GetCustomFieldFacetKindFunction = (
+  definition: CustomFieldDefinition,
+) => "options" | "text" | "number";
+
+export const getCustomFieldFacetKind: GetCustomFieldFacetKindFunction = (
+  definition: CustomFieldDefinition,
+): "options" | "text" | "number" => {
+  if (definition.customFieldType === CustomFieldType.Number) {
+    return "number";
+  }
+
+  if (definition.customFieldType === CustomFieldType.Boolean) {
+    return "options";
+  }
+
+  if (
+    definition.customFieldType === CustomFieldType.Dropdown ||
+    definition.customFieldType === CustomFieldType.MultiSelectDropdown
+  ) {
+    return parseCustomFieldDropdownOptions(definition.dropdownOptions).length >
+      0
+      ? "options"
+      : "text";
+  }
+
+  return "text";
+};
+
+/**
+ * A boolean custom field is stored as a real JSON boolean, and these are the
+ * two values it can hold. Labelled the way the table column renders them so
+ * the chip and the cell agree.
+ */
+export const BOOLEAN_CUSTOM_FIELD_OPTIONS: Array<FilterChipDropdownOption> = [
+  { value: "true", label: "Yes" },
+  { value: "false", label: "No" },
+];
+
+export type GetCustomFieldFacetOptionsFunction = (
+  definition: CustomFieldDefinition,
+) => Array<FilterChipDropdownOption>;
+
+export const getCustomFieldFacetOptions: GetCustomFieldFacetOptionsFunction = (
+  definition: CustomFieldDefinition,
+): Array<FilterChipDropdownOption> => {
+  if (definition.customFieldType === CustomFieldType.Boolean) {
+    return BOOLEAN_CUSTOM_FIELD_OPTIONS;
+  }
+
+  /*
+   * Colours come along: a dropdown option that renders as an amber badge in
+   * the table should be the same amber in the picker, or the two read as
+   * different vocabularies.
+   */
+  return parseCustomFieldDropdownOptions(definition.dropdownOptions).map(
+    (option: CustomFieldDropdownOption): FilterChipDropdownOption => {
+      return {
+        value: option.value,
+        label: option.value,
+        color: option.color,
+      };
+    },
+  );
+};
+
+export type GetCustomFieldFacetOperatorsFunction = (
+  definition: CustomFieldDefinition,
+) => Array<FilterOperator>;
+
+export const getCustomFieldFacetOperators: GetCustomFieldFacetOperatorsFunction =
+  (definition: CustomFieldDefinition): Array<FilterOperator> => {
+    const kind: "options" | "text" | "number" =
+      getCustomFieldFacetKind(definition);
+
+    if (kind === "number") {
+      return NUMBER_FACET_OPERATORS;
+    }
+
+    if (kind === "text") {
+      return TEXT_FACET_OPERATORS;
+    }
+
+    return OPTION_FACET_OPERATORS;
+  };
+
+type IsMultiSelectFunction = (definition: CustomFieldDefinition) => boolean;
+
+const isMultiSelectDefinition: IsMultiSelectFunction = (
+  definition: CustomFieldDefinition,
+): boolean => {
+  return (
+    definition.customFieldType === CustomFieldType.MultiSelectDropdown &&
+    getCustomFieldFacetKind(definition) === "options"
+  );
+};
+
+type ToFacetValueFunction = (
+  definition: CustomFieldDefinition,
+  value: string,
+) => string | number | boolean;
+
+/**
+ * Restore the value's original JSON type where the definition tells us what it
+ * was. Chip selections are strings — that is the bar's universal encoding —
+ * but a boolean field holds `true`, not `"true"`, and a match against an array
+ * of booleans is a containment check against `[true]`.
+ */
+const toFacetValue: ToFacetValueFunction = (
+  definition: CustomFieldDefinition,
+  value: string,
+): string | number | boolean => {
+  if (definition.customFieldType === CustomFieldType.Boolean) {
+    return value === "true";
+  }
+
+  return value;
+};
+
+export interface CustomFieldFacetQueryInput {
+  definition: CustomFieldDefinition;
+  values: Array<string>;
+  operator: FilterOperator;
+}
+
+export type BuildCustomFieldFacetQueryFunction = (
+  input: CustomFieldFacetQueryInput,
+) => JSONObject | undefined;
+
+/**
+ * The query value one chip contributes: an object holding this field's
+ * predicate under its own name, ready to be merged with every other chip's.
+ *
+ * `undefined` means "do not constrain" — nothing selected, or a value this
+ * operator cannot use. Returning an object with an empty predicate instead
+ * would filter the list by something the chip is not showing.
+ */
+const buildCustomFieldFacetQuery: BuildCustomFieldFacetQueryFunction = (
+  input: CustomFieldFacetQueryInput,
+): JSONObject | undefined => {
+  const { definition, operator } = input;
+  const name: string = definition.name;
+
+  if (!name) {
+    return undefined;
+  }
+
+  type WrapFunction = (value: unknown) => JSONObject;
+
+  const wrap: WrapFunction = (value: unknown): JSONObject => {
+    return { [name]: value } as JSONObject;
+  };
+
+  if (operator === "is_empty") {
+    return wrap(new IsNull());
+  }
+
+  if (operator === "is_not_empty") {
+    return wrap(new NotNull());
+  }
+
+  const values: Array<string> = (input.values || []).filter((value: string) => {
+    return typeof value === "string" && value.trim() !== "";
+  });
+
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const first: string = values[0]!.trim();
+
+  if (operator === "contains") {
+    return wrap(new Search(first));
+  }
+
+  if (operator === "not_contains") {
+    return wrap(new NotContains(first));
+  }
+
+  if (operator === "starts_with") {
+    return wrap(new StartsWith(first));
+  }
+
+  if (operator === "ends_with") {
+    return wrap(new EndsWith(first));
+  }
+
+  if (
+    operator === "greater_than" ||
+    operator === "greater_than_or_equal" ||
+    operator === "less_than" ||
+    operator === "less_than_or_equal"
+  ) {
+    const numeric: number = Number(first);
+
+    /*
+     * The number chip's input keeps this from happening, but a hand-edited URL
+     * does not. A comparison against NaN would compile to a predicate that
+     * matches nothing, with a chip on screen claiming otherwise.
+     */
+    if (!Number.isFinite(numeric)) {
+      return undefined;
+    }
+
+    if (operator === "greater_than") {
+      return wrap(new GreaterThan(numeric));
+    }
+
+    if (operator === "greater_than_or_equal") {
+      return wrap(new GreaterThanOrEqual(numeric));
+    }
+
+    if (operator === "less_than") {
+      return wrap(new LessThan(numeric));
+    }
+
+    return wrap(new LessThanOrEqual(numeric));
+  }
+
+  const isMulti: boolean = isMultiSelectDefinition(definition);
+
+  if (operator === "is_not") {
+    if (isMulti) {
+      return wrap(
+        new IncludesNone(
+          values.map((value: string) => {
+            return value;
+          }),
+        ),
+      );
+    }
+
+    return wrap(new NotEqual(first));
+  }
+
+  /*
+   * "is". A multi-select chip means "holds any of these"; a single-select
+   * chip means "equals this". The server treats a bare value as equality and
+   * matches it whether the stored value is a scalar or sits inside an array,
+   * so a field switched from single- to multi-select keeps filtering.
+   */
+  if (isMulti) {
+    return wrap(new Includes(values));
+  }
+
+  return wrap(toFacetValue(definition, first));
+};
+
+export { buildCustomFieldFacetQuery };
+
+export type MergeCustomFieldQueryValueFunction = (
+  existing: unknown,
+  incoming: unknown,
+) => unknown;
+
+/**
+ * AND two chips' contributions to the `customFields` column.
+ *
+ * Both sides are plain objects keyed by field name, so the merge is a shallow
+ * spread — and because the chips are built from a deterministically sorted
+ * definition list, the merged object's key order is stable across renders.
+ * That matters: the table compares `JSON.stringify(query)` to decide whether
+ * to refetch, so an unstable order would loop.
+ */
+export const mergeCustomFieldQueryValue: MergeCustomFieldQueryValueFunction = (
+  existing: unknown,
+  incoming: unknown,
+): unknown => {
+  /*
+   * Prototype-checked, not just `typeof === "object"`. Every query operator
+   * (IsNull, Includes, Search, ...) is also an object with no own enumerable
+   * properties, so a looser check would spread one into the accumulator, add
+   * nothing, and silently drop the constraint it carried.
+   */
+  const isPlainObject: (value: unknown) => boolean = (
+    value: unknown,
+  ): boolean => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+
+    const prototype: unknown = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null;
+  };
+
+  if (!isPlainObject(existing) || !isPlainObject(incoming)) {
+    /*
+     * Something other than a custom field chip wrote this column — a page's
+     * own `query` prop, say. Its constraint wins rather than being silently
+     * blended into a shape it did not choose.
+     */
+    return incoming;
+  }
+
+  return {
+    ...(existing as JSONObject),
+    ...(incoming as JSONObject),
+  };
+};
+
+export type BuildCustomFieldFacetsFunction = (
+  definitions: Array<CustomFieldDefinition>,
+) => Array<ResourceFacet>;
+
+/**
+ * One chip per custom field definition, in the order the definitions arrive
+ * (which `getCustomFieldDefinitions` has already sorted by name).
+ */
+export const buildCustomFieldFacets: BuildCustomFieldFacetsFunction = (
+  definitions: Array<CustomFieldDefinition>,
+): Array<ResourceFacet> => {
+  return (definitions || [])
+    .filter((definition: CustomFieldDefinition) => {
+      return Boolean(definition && definition.name);
+    })
+    .map((definition: CustomFieldDefinition): ResourceFacet => {
+      const kind: "options" | "text" | "number" =
+        getCustomFieldFacetKind(definition);
+      const isMulti: boolean = isMultiSelectDefinition(definition);
+
+      return {
+        key: getCustomFieldFacetKey(definition.name),
+        label: definition.name,
+        type: kind,
+        icon:
+          kind === "number"
+            ? IconProp.Hashtag
+            : kind === "text"
+              ? IconProp.Text
+              : IconProp.List,
+        isMultiSelect: isMulti,
+        options:
+          kind === "options"
+            ? getCustomFieldFacetOptions(definition)
+            : undefined,
+        searchPlaceholder:
+          kind === "options"
+            ? `Search ${definition.name}...`
+            : `Enter ${definition.name}`,
+        supportedOperators: getCustomFieldFacetOperators(definition),
+        queryField: CUSTOM_FIELD_QUERY_FIELD,
+        /*
+         * Every chip writes `customFields`, so without these two the last chip
+         * would overwrite the rest and "is empty" would ask about the whole
+         * column instead of this one key.
+         */
+        mergeQueryValue: mergeCustomFieldQueryValue,
+        handlesValuelessOperators: true,
+        toQueryValue: (
+          values: Array<string>,
+          operator: FilterOperator,
+        ): unknown => {
+          return buildCustomFieldFacetQuery({
+            definition: definition,
+            values: values,
+            operator: operator,
+          });
+        },
+      };
+    });
+};

--- a/App/FeatureSet/Dashboard/src/Components/CustomFields/useCustomFieldFacets.ts
+++ b/App/FeatureSet/Dashboard/src/Components/CustomFields/useCustomFieldFacets.ts
@@ -1,0 +1,77 @@
+import { buildCustomFieldFacets } from "./CustomFieldFacets";
+import { ResourceFacet } from "../ResourceOwners/ResourceFacet";
+import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import ObjectID from "Common/Types/ObjectID";
+import useCustomFieldColumns, {
+  CustomFieldColumnsResult,
+} from "Common/UI/Components/ModelTable/useCustomFieldColumns";
+import { useMemo } from "react";
+
+/*
+ * The facet-bar half of a resource's custom fields.
+ *
+ * Reuses `useCustomFieldColumns` rather than fetching the definitions again:
+ * a table that shows custom field columns is exactly a table that should offer
+ * custom field chips, the request is the same one, and two copies of it would
+ * drift the moment a definition changed. The hook already swallows a failure
+ * to load them — custom fields are a paid feature the viewer may not be able
+ * to read — so a project without them simply gets no chips.
+ */
+
+export interface CustomFieldFacetsResult {
+  facets: Array<ResourceFacet>;
+  /**
+   * True until the definitions have settled. Pass straight through to
+   * `useResourceOwners({ areFacetsLoading })`: until it goes false, a facet
+   * restored from a shared link has no chip to belong to, and the bar must not
+   * treat that as the user having cleared it.
+   */
+  isLoading: boolean;
+}
+
+export type UseCustomFieldFacetsFunction = (data: {
+  /**
+   * The model holding this resource's custom field *definitions* — e.g.
+   * `IncidentCustomField` for a table of incidents. Omit to switch the chips
+   * off entirely.
+   */
+  customFieldsModelType?: { new (): BaseModel } | undefined;
+  projectId?: ObjectID | null | undefined;
+}) => CustomFieldFacetsResult;
+
+const useCustomFieldFacets: UseCustomFieldFacetsFunction = (data: {
+  customFieldsModelType?: { new (): BaseModel } | undefined;
+  projectId?: ObjectID | null | undefined;
+}): CustomFieldFacetsResult => {
+  const definitionsResult: CustomFieldColumnsResult<BaseModel> =
+    useCustomFieldColumns<BaseModel>({
+      customFieldsModelType: data.customFieldsModelType,
+      projectId: data.projectId,
+    });
+
+  const facets: Array<ResourceFacet> = useMemo(() => {
+    if (!data.customFieldsModelType) {
+      return [];
+    }
+
+    return buildCustomFieldFacets(definitionsResult.definitions);
+    /*
+     * Memoised on the definitions themselves: the facet array's identity is
+     * what the bar's conflict map and its settle-time reconciliation key on,
+     * so rebuilding it every render would re-run both on every keystroke.
+     */
+  }, [definitionsResult.definitions, data.customFieldsModelType]);
+
+  return {
+    facets: facets,
+    /*
+     * A table with no definition model has nothing to wait for. Reporting
+     * `false` there keeps the bar from holding the URL snapshot hostage on
+     * every page that does not use custom fields.
+     */
+    isLoading:
+      Boolean(data.customFieldsModelType) && definitionsResult.isLoading,
+  };
+};
+
+export default useCustomFieldFacets;

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
@@ -45,6 +45,7 @@ import {
 } from "../ResourceOwners/FilterChipDropdown";
 import Includes from "Common/Types/BaseDatabase/Includes";
 import buildAffectedResourcesFacet from "../AffectedResources/buildAffectedResourcesFacet";
+import useCustomFieldFacets from "../CustomFields/useCustomFieldFacets";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -269,6 +270,14 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
   ];
 
   /*
+   * One chip per custom field this project has defined, appended after the
+   * built-in ones. They arrive a render or two late (the definitions are
+   * fetched), which is what `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({ customFieldsModelType: IncidentCustomField });
+
+  /*
    * One namespace for everything this table mirrors into the URL, so the
    * column filters (persisted by ModelTable) and the facet chips (persisted
    * by useResourceOwners) always travel together. Falls back to a stable
@@ -291,7 +300,8 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
     ownerTeamModelType: IncidentOwnerTeam,
     resourceIdField: "incidentId",
     showLabelsFacet: true,
-    extraFacets: incidentExtraFacets,
+    extraFacets: [...incidentExtraFacets, ...customFieldFacets],
+    areFacetsLoading: areCustomFieldFacetsLoading,
   });
 
   // Fetch incident states on mount

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "Common/UI/Components/ModelTable/BaseModelTable";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import useBulkLabelActions from "Common/UI/Components/BulkUpdate/BulkLabelActions";
+import useCustomFieldFacets from "../CustomFields/useCustomFieldFacets";
 import useBulkOwnerActions from "Common/UI/Components/BulkUpdate/BulkOwnerActions";
 import Statusbubble from "Common/UI/Components/StatusBubble/StatusBubble";
 import FieldType from "Common/UI/Components/Types/FieldType";
@@ -192,6 +193,13 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
   const tableUrlStateKey: string =
     props.saveFilterProps?.tableId || "monitors-table";
 
+  /*
+   * One chip per custom field this project has defined, appended after the
+   * built-in ones. They arrive a render or two late (the definitions are
+   * fetched), which is what `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({ customFieldsModelType: MonitorCustomField });
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -205,7 +213,8 @@ const MonitorsTable: FunctionComponent<ComponentProps> = (
     ownerTeamModelType: MonitorOwnerTeam,
     resourceIdField: "monitorId",
     showLabelsFacet: true,
-    extraFacets: monitorExtraFacets,
+    extraFacets: [...monitorExtraFacets, ...customFieldFacets],
+    areFacetsLoading: areCustomFieldFacetsLoading,
     persistKey: tableUrlStateKey,
   });
 

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetColumnQuery.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetColumnQuery.ts
@@ -1,0 +1,146 @@
+import { FilterOperator } from "./FilterChipDropdownTypes";
+import { ResourceFacet } from "./ResourceFacet";
+import { buildFacetDateRangeQuery } from "./FacetDateRange";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
+import NotNull from "Common/Types/BaseDatabase/NotNull";
+
+/*
+ * What one chip writes into the outgoing query.
+ *
+ * Lifted out of useResourceOwners' merge loop so the two rules that are easy
+ * to get wrong and impossible to see going wrong can be pinned in tests:
+ *
+ *  - two chips over the same query field must not silently replace each other
+ *    (a facet says so with `mergeQueryValue`), and
+ *
+ *  - "is empty" writes IsNull *at the field* — which is wrong for a chip over
+ *    one key inside a JSON column, so those chips opt out with
+ *    `handlesValuelessOperators` and build the predicate themselves.
+ *
+ * Both failures look identical from the outside: a chip lit over a list it is
+ * not filtering.
+ */
+
+/**
+ * Default query value for a facet that supplies no `toQueryValue`. Handles
+ * is / is_not / is_empty / is_not_empty for raw-string fields.
+ */
+export type DefaultFacetQueryValueFunction = (
+  values: Array<string>,
+  operator: FilterOperator,
+  isMulti: boolean,
+) => unknown;
+
+export const defaultFacetQueryValue: DefaultFacetQueryValueFunction = (
+  values: Array<string>,
+  operator: FilterOperator,
+  isMulti: boolean,
+): unknown => {
+  if (operator === "is_empty") {
+    return new IsNull();
+  }
+  if (operator === "is_not_empty") {
+    return new NotNull();
+  }
+  /*
+   * Operators that compare against something the user typed have no typed
+   * value here — these values are option ids. Only a hand-edited URL can pair
+   * the two, and sanitizeFacetSelectionState clamps that before it reaches
+   * here; refusing it again is what keeps "cannot express this" from becoming
+   * a filter on a string that happens to parse.
+   */
+  if (
+    operator === "before" ||
+    operator === "after" ||
+    operator === "between" ||
+    operator === "contains" ||
+    operator === "not_contains" ||
+    operator === "starts_with" ||
+    operator === "ends_with" ||
+    operator === "greater_than" ||
+    operator === "greater_than_or_equal" ||
+    operator === "less_than" ||
+    operator === "less_than_or_equal"
+  ) {
+    return undefined;
+  }
+  if (values.length === 0) {
+    return undefined;
+  }
+  if (isMulti) {
+    return operator === "is_not"
+      ? new IncludesNone(values)
+      : new Includes(values);
+  }
+  return operator === "is_not" ? new NotEqual(values[0]!) : values[0];
+};
+
+export interface FacetColumnQuery {
+  /** The query key this chip writes. */
+  field: string;
+  /** The value to assign there, already merged with anything present. */
+  value: unknown;
+}
+
+export type BuildFacetColumnQueryFunction = (data: {
+  facet: ResourceFacet;
+  operator: FilterOperator;
+  values: Array<string>;
+  /**
+   * Whatever an earlier facet already wrote at this field, or `undefined` when
+   * nothing has.
+   */
+  existingValue: unknown;
+}) => FacetColumnQuery | null;
+
+/**
+ * `null` means "this chip constrains nothing" — an empty selection, a
+ * half-entered range, a value the operator cannot use. The caller leaves the
+ * field out of the request entirely, which is a different statement from
+ * writing the key with an undefined value.
+ */
+export const buildFacetColumnQuery: BuildFacetColumnQueryFunction = (data: {
+  facet: ResourceFacet;
+  operator: FilterOperator;
+  values: Array<string>;
+  existingValue: unknown;
+}): FacetColumnQuery | null => {
+  const { facet, operator } = data;
+  const values: Array<string> = data.values || [];
+  const field: string = facet.queryField || facet.key;
+
+  const isValueless: boolean =
+    operator === "is_empty" || operator === "is_not_empty";
+
+  if (isValueless && !facet.handlesValuelessOperators) {
+    return {
+      field: field,
+      value: operator === "is_empty" ? new IsNull() : new NotNull(),
+    };
+  }
+
+  if (values.length === 0 && !isValueless) {
+    return null;
+  }
+
+  const value: unknown = facet.toQueryValue
+    ? facet.toQueryValue(values, operator)
+    : facet.type === "dateRange"
+      ? buildFacetDateRangeQuery(values, operator)
+      : defaultFacetQueryValue(values, operator, Boolean(facet.isMultiSelect));
+
+  if (value === undefined) {
+    return null;
+  }
+
+  return {
+    field: field,
+    value:
+      facet.mergeQueryValue && data.existingValue !== undefined
+        ? facet.mergeQueryValue(data.existingValue, value)
+        : value,
+  };
+};

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FacetSelectionState.ts
@@ -3,7 +3,10 @@ import {
   FILTER_OPERATOR_LABELS,
   FacetKind,
   FilterOperator,
+  NUMBER_FACET_OPERATORS,
   OPTION_FACET_OPERATORS,
+  TEXT_FACET_OPERATORS,
+  isTypedValueFacetKind,
 } from "./FilterChipDropdownTypes";
 import { isFacetDateRangeActive } from "./FacetDateRange";
 import { JSONObject } from "Common/Types/JSON";
@@ -307,6 +310,7 @@ export const sanitizeFacetSelectionState: SanitizeFacetSelectionStateFunction =
 
     for (const facet of facets) {
       const isDateRange: boolean = facet.type === "dateRange";
+      const isTypedValue: boolean = isTypedValueFacetKind(facet.type);
       const operator: FilterOperator | undefined =
         sanitized.facetOperators[facet.key];
       const supported: Array<FilterOperator> =
@@ -314,23 +318,64 @@ export const sanitizeFacetSelectionState: SanitizeFacetSelectionStateFunction =
           ? facet.supportedOperators
           : isDateRange
             ? DATE_FACET_OPERATORS
-            : OPTION_FACET_OPERATORS;
+            : facet.type === "number"
+              ? NUMBER_FACET_OPERATORS
+              : facet.type === "text"
+                ? TEXT_FACET_OPERATORS
+                : OPTION_FACET_OPERATORS;
 
       const resolvedOperator: FilterOperator =
         operator !== undefined && !supported.includes(operator)
           ? supported[0]!
           : operator || "is";
 
+      const values: Array<string> | undefined =
+        sanitized.facetSelections[facet.key];
+
       if (operator !== undefined && !supported.includes(operator)) {
         sanitized.facetOperators[facet.key] = supported[0]!;
       }
 
-      const values: Array<string> | undefined =
-        sanitized.facetSelections[facet.key];
-
-      if (!facet.isMultiSelect && values && values.length > 1) {
+      if (
+        (!facet.isMultiSelect || isTypedValue) &&
+        values &&
+        values.length > 1
+      ) {
         // The chip shows only the first value, so only the first may filter.
         sanitized.facetSelections[facet.key] = [values[0]!];
+      }
+
+      /*
+       * A number chip's input can only show a number. A restored selection
+       * holding anything else — a hand-edited URL, or a definition whose type
+       * was changed under a saved view — would leave the chip lit over a
+       * filter the user can neither see nor correct, so it is dropped and the
+       * chip comes back empty.
+       */
+      if (facet.type === "number") {
+        const numericValue: string | undefined =
+          sanitized.facetSelections[facet.key]?.[0];
+
+        if (
+          numericValue !== undefined &&
+          (numericValue.trim() === "" || !Number.isFinite(Number(numericValue)))
+        ) {
+          sanitized.facetSelections[facet.key] = [];
+        }
+      }
+
+      /*
+       * A blank text value is not a filter — it is the chip in its empty
+       * state — and letting it through would light the chip over an unfiltered
+       * list.
+       */
+      if (facet.type === "text") {
+        const textValue: string | undefined =
+          sanitized.facetSelections[facet.key]?.[0];
+
+        if (textValue !== undefined && textValue.trim() === "") {
+          sanitized.facetSelections[facet.key] = [];
+        }
       }
 
       /*

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes.ts
@@ -23,8 +23,13 @@ import IconProp from "Common/Types/Icon/IconProp";
  *   option list to offer (every instant is a distinct value), so the question a
  *   user actually has of one — "not polled since last Tuesday" — is only
  *   expressible by typing a date.
+ * - "text" / "number" — an operator plus one typed value. Same reason as dates:
+ *   a free-text custom field's values are whatever anyone has ever entered, so
+ *   there is no list to offer, and the question a user has of one ("Ticket
+ *   contains JIRA-", "Impacted Users is over 500") is only expressible by
+ *   typing.
  */
-export type FacetKind = "options" | "dateRange";
+export type FacetKind = "options" | "dateRange" | "text" | "number";
 
 export interface FilterChipDropdownOption {
   value: string;
@@ -58,6 +63,9 @@ export interface FilterChipDropdownOption {
  * - "before" / "after" / "between" — date-range chips only, and never offered
  *   by an option-list chip: they compare against a date the user typed rather
  *   than against anything in an option list.
+ * - "contains" / "not_contains" / "starts_with" / "ends_with" — text chips.
+ * - "greater_than" / "greater_than_or_equal" / "less_than" /
+ *   "less_than_or_equal" — number chips.
  */
 export type FilterOperator =
   | "is"
@@ -66,7 +74,15 @@ export type FilterOperator =
   | "is_not_empty"
   | "before"
   | "after"
-  | "between";
+  | "between"
+  | "contains"
+  | "not_contains"
+  | "starts_with"
+  | "ends_with"
+  | "greater_than"
+  | "greater_than_or_equal"
+  | "less_than"
+  | "less_than_or_equal";
 
 export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
   is: "is",
@@ -76,6 +92,14 @@ export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
   before: "is before",
   after: "is after",
   between: "is between",
+  contains: "contains",
+  not_contains: "does not contain",
+  starts_with: "starts with",
+  ends_with: "ends with",
+  greater_than: "is greater than",
+  greater_than_or_equal: "is greater than or equal to",
+  less_than: "is less than",
+  less_than_or_equal: "is less than or equal to",
 };
 
 /**
@@ -109,6 +133,78 @@ export const OPTION_FACET_OPERATORS: Array<FilterOperator> = [
   "is_not_empty",
 ];
 
+/**
+ * The operators a free-text chip offers.
+ *
+ * "is" leads rather than "contains" because an exact match is what a user
+ * picking a value out of a column they can see is usually after; "contains" is
+ * one click away and is what makes the chip a *search* rather than a filter.
+ */
+export const TEXT_FACET_OPERATORS: Array<FilterOperator> = [
+  "is",
+  "is_not",
+  "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
+  "is_empty",
+  "is_not_empty",
+];
+
+/** The operators a numeric chip offers. */
+export const NUMBER_FACET_OPERATORS: Array<FilterOperator> = [
+  "is",
+  "is_not",
+  "greater_than",
+  "greater_than_or_equal",
+  "less_than",
+  "less_than_or_equal",
+  "is_empty",
+  "is_not_empty",
+];
+
+/**
+ * Does this chip hold one value the user typed, rather than a selection from a
+ * list? Both kinds render the same control and store their value the same way
+ * (a single-element array), so most call sites want to ask this rather than
+ * compare against each kind.
+ */
+export const isTypedValueFacetKind: (kind: FacetKind | undefined) => boolean = (
+  kind: FacetKind | undefined,
+): boolean => {
+  return kind === "text" || kind === "number";
+};
+
+/**
+ * Is this operator one only a numeric chip can answer? Kept next to the
+ * operator list it comes from so a new comparison cannot be added to one
+ * without the other noticing.
+ */
+export const isNumericComparisonOperator: (op: FilterOperator) => boolean = (
+  op: FilterOperator,
+): boolean => {
+  return (
+    op === "greater_than" ||
+    op === "greater_than_or_equal" ||
+    op === "less_than" ||
+    op === "less_than_or_equal"
+  );
+};
+
+/**
+ * Is this operator one of the substring comparisons a text chip offers?
+ */
+export const isTextMatchOperator: (op: FilterOperator) => boolean = (
+  op: FilterOperator,
+): boolean => {
+  return (
+    op === "contains" ||
+    op === "not_contains" ||
+    op === "starts_with" ||
+    op === "ends_with"
+  );
+};
+
 export const isValueOperator: (op: FilterOperator) => boolean = (
   op: FilterOperator,
 ): boolean => {
@@ -116,8 +212,10 @@ export const isValueOperator: (op: FilterOperator) => boolean = (
 };
 
 /**
- * Does this operator carry no value at all? Both chip kinds hide their value
- * input on these, and both write IsNull / NotNull for them.
+ * Does this operator carry no value at all? Every chip kind hides its value
+ * input on these, and they all write IsNull / NotNull for them — except a chip
+ * over one key inside a JSON column, which writes the same pair *inside* that
+ * column (see ResourceFacet.handlesValuelessOperators).
  */
 export const isValuelessOperator: (op: FilterOperator) => boolean = (
   op: FilterOperator,

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipValueInput.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipValueInput.tsx
@@ -1,0 +1,325 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Input, { InputType } from "Common/UI/Components/Input/Input";
+import useComponentOutsideClick from "Common/UI/Types/UseComponentOutsideClick";
+import {
+  FILTER_OPERATOR_LABELS,
+  FilterOperator,
+  NUMBER_FACET_OPERATORS,
+  TEXT_FACET_OPERATORS,
+  isValuelessOperator,
+} from "./FilterChipDropdownTypes";
+import {
+  FILTER_CHIP_ACTIVE_CLASSES,
+  FILTER_CHIP_BASE_CLASSES,
+  FILTER_CHIP_CLEAR_CLASSES,
+  FILTER_CHIP_INACTIVE_CLASSES,
+  FILTER_CHIP_OPERATOR_SELECT_CLASSES,
+  FILTER_CHIP_POPOVER_CLASSES,
+} from "./FilterChipStyles";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/*
+ * The facet bar's chip for a value the user types.
+ *
+ * Same shell as FilterChipDropdown and FilterChipDateRange — same pill, same
+ * operator row, same clear affordance — with a single input where the option
+ * list would be. A free-text custom field has no option list to offer: its
+ * values are whatever anyone has ever typed into it, and the questions people
+ * have of one ("Ticket contains JIRA-", "Impacted Users is over 500") can only
+ * be asked by typing.
+ *
+ * Unlike the other two chips this one keeps a *draft*. Every change to a facet
+ * selection re-runs the table's query, and a controlled input would do that per
+ * keystroke — eight requests to type "payments", each one superseded. So the
+ * input is local until the user commits with Enter, with the Apply button, or
+ * by dismissing the popover; the committed value is the prop, and it is the
+ * only thing the bar, the URL and the query ever see.
+ */
+
+export interface ComponentProps {
+  label: string;
+  /**
+   * The committed value, as the bar stores it: a single-element array, or
+   * empty when nothing is set. The array shape is the bar's universal
+   * selection encoding, shared with the option and date chips.
+   */
+  values: Array<string>;
+  operator: FilterOperator;
+  /** "text" renders a text input, "number" a numeric one. */
+  valueType: "text" | "number";
+  /**
+   * Values and operator always travel together, so a render can never show one
+   * operator while the query carries another.
+   */
+  onChange: (values: Array<string>, operator: FilterOperator) => void;
+  /** Defaults to TEXT_FACET_OPERATORS / NUMBER_FACET_OPERATORS. */
+  supportedOperators?: Array<FilterOperator> | undefined;
+  /** Icon shown on the chip while it has no value. */
+  emptyIcon?: IconProp | undefined;
+  placeholder?: string | undefined;
+}
+
+type ReadCommittedValueFunction = (values: Array<string>) => string;
+
+const readCommittedValue: ReadCommittedValueFunction = (
+  values: Array<string>,
+): string => {
+  return (values || [])[0] || "";
+};
+
+const FilterChipValueInput: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const { ref, isComponentVisible, setIsComponentVisible } =
+    useComponentOutsideClick(false);
+
+  const committedValue: string = readCommittedValue(props.values);
+  const operator: FilterOperator = props.operator || "is";
+  const valueless: boolean = isValuelessOperator(operator);
+
+  const [draft, setDraft] = React.useState<string>(committedValue);
+
+  /*
+   * The committed value can change without this chip doing anything — a saved
+   * view loading, a "clear all", a deep link. Re-seed the draft from it so the
+   * popover never opens showing a value the list is not filtered by.
+   */
+  React.useEffect(() => {
+    setDraft(committedValue);
+  }, [committedValue]);
+
+  const supportedOperators: Array<FilterOperator> =
+    props.supportedOperators && props.supportedOperators.length > 0
+      ? props.supportedOperators
+      : props.valueType === "number"
+        ? NUMBER_FACET_OPERATORS
+        : TEXT_FACET_OPERATORS;
+
+  const isChipActive: boolean = valueless || committedValue.length > 0;
+
+  type CommitFunction = (nextOperator?: FilterOperator | undefined) => void;
+
+  const commit: CommitFunction = (
+    nextOperator?: FilterOperator | undefined,
+  ): void => {
+    const effectiveOperator: FilterOperator = nextOperator || operator;
+    const trimmed: string = draft.trim();
+
+    if (isValuelessOperator(effectiveOperator)) {
+      /*
+       * "is empty" needs no value, but the draft is kept in local state so it
+       * is still there if the user switches back to a value operator.
+       */
+      props.onChange([], effectiveOperator);
+      return;
+    }
+
+    props.onChange(trimmed ? [trimmed] : [], effectiveOperator);
+  };
+
+  type ChangeOperatorFunction = (next: FilterOperator) => void;
+
+  const changeOperator: ChangeOperatorFunction = (
+    next: FilterOperator,
+  ): void => {
+    /*
+     * Commit in the same gesture as the switch. Reporting the operator alone
+     * would leave a render where the chip reads "contains" over a list still
+     * filtered by "is".
+     */
+    commit(next);
+  };
+
+  const clearChipFully: () => void = (): void => {
+    setDraft("");
+    // Back to the default operator too, so a cleared chip is fully cleared.
+    props.onChange([], "is");
+  };
+
+  /*
+   * Dismissing the popover commits, and it has to be done here rather than in
+   * the handlers: a click anywhere else on the page closes it through
+   * useComponentOutsideClick, which sets the flag directly. Committing only in
+   * the Apply / Enter paths would silently discard a value the user can still
+   * see in the box they typed it into.
+   */
+  const wasPopoverVisible: React.MutableRefObject<boolean> =
+    React.useRef<boolean>(false);
+
+  React.useEffect(() => {
+    const isClosing: boolean = wasPopoverVisible.current && !isComponentVisible;
+    wasPopoverVisible.current = isComponentVisible;
+
+    if (!isClosing || isValuelessOperator(operator)) {
+      return;
+    }
+
+    /*
+     * Only when it actually changed. An unchanged commit would re-run the
+     * table's query comparison on every open-and-close of the popover.
+     */
+    if (draft.trim() !== committedValue) {
+      commit();
+    }
+  }, [isComponentVisible]);
+
+  const closePopover: () => void = (): void => {
+    setIsComponentVisible(false);
+  };
+
+  const togglePopover: () => void = (): void => {
+    setIsComponentVisible(!isComponentVisible);
+  };
+
+  const summary: string = valueless
+    ? FILTER_OPERATOR_LABELS[operator]
+    : `${FILTER_OPERATOR_LABELS[operator]} ${committedValue}`;
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={togglePopover}
+        className={`${FILTER_CHIP_BASE_CLASSES} ${
+          isChipActive
+            ? FILTER_CHIP_ACTIVE_CLASSES
+            : FILTER_CHIP_INACTIVE_CLASSES
+        }`}
+        aria-expanded={isComponentVisible}
+        aria-haspopup="dialog"
+      >
+        {isChipActive ? (
+          <>
+            {props.emptyIcon && (
+              <Icon
+                icon={props.emptyIcon}
+                className="h-3.5 w-3.5 text-indigo-500"
+              />
+            )}
+            <span className="whitespace-nowrap">
+              <span className="text-indigo-500/80">{props.label}</span>
+              <span className="mx-1 text-indigo-300">·</span>
+              <span className="font-semibold">{summary}</span>
+            </span>
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                clearChipFully();
+              }}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  clearChipFully();
+                }
+              }}
+              className={FILTER_CHIP_CLEAR_CLASSES}
+              aria-label={`Clear ${props.label} filter`}
+            >
+              <Icon icon={IconProp.Close} className="h-3 w-3" />
+            </span>
+          </>
+        ) : (
+          <>
+            {props.emptyIcon && (
+              <Icon
+                icon={props.emptyIcon}
+                className="h-3.5 w-3.5 text-gray-400"
+              />
+            )}
+            <span className="whitespace-nowrap">{props.label}</span>
+            <Icon
+              icon={IconProp.ChevronDown}
+              className="h-3 w-3 text-gray-400 transition-transform group-aria-expanded:rotate-180"
+            />
+          </>
+        )}
+      </button>
+
+      {isComponentVisible && (
+        <div
+          ref={ref}
+          className={`${FILTER_CHIP_POPOVER_CLASSES} w-72`}
+          role="dialog"
+        >
+          {supportedOperators.length > 1 && (
+            <div className="flex items-center gap-1.5 border-b border-gray-100 px-2 py-1.5 text-xs text-gray-500">
+              <span className="shrink-0">{props.label.toLowerCase()}</span>
+              <select
+                value={operator}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                  changeOperator(e.target.value as FilterOperator);
+                }}
+                className={FILTER_CHIP_OPERATOR_SELECT_CLASSES}
+                aria-label={`${props.label} operator`}
+              >
+                {supportedOperators.map((op: FilterOperator) => {
+                  return (
+                    <option key={op} value={op}>
+                      {FILTER_OPERATOR_LABELS[op]}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+          )}
+
+          {valueless ? (
+            <div className="px-3 py-4 text-center text-xs text-gray-500">
+              No value needed.
+            </div>
+          ) : (
+            <div className="p-2">
+              <div
+                onKeyDown={(e: React.KeyboardEvent) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    closePopover();
+                  }
+                }}
+              >
+                <Input
+                  /*
+                   * Re-keyed on the operator for the same reason the date chip
+                   * is: the shared Input keeps its display string in state, so
+                   * a switch has to remount rather than leave the previous
+                   * operator's value rendered.
+                   */
+                  key={`value-${operator}`}
+                  type={
+                    props.valueType === "number"
+                      ? InputType.NUMBER
+                      : InputType.TEXT
+                  }
+                  value={draft}
+                  placeholder={props.placeholder || `Enter ${props.label}`}
+                  outerDivClassName="relative rounded-md w-full"
+                  onChange={(changed: string) => {
+                    setDraft(changed);
+                  }}
+                />
+              </div>
+              <div className="mt-2 flex items-center justify-between">
+                <p className="px-0.5 text-xs text-gray-400">
+                  Press Enter to apply.
+                </p>
+                <button
+                  type="button"
+                  onClick={closePopover}
+                  className="rounded border border-gray-200 bg-white px-2 py-0.5 text-xs font-medium text-gray-700 hover:border-gray-300 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                >
+                  Apply
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FilterChipValueInput;

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/ResourceFacet.ts
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/ResourceFacet.ts
@@ -1,0 +1,156 @@
+import {
+  FacetKind,
+  FilterChipDropdownOption,
+  FilterOperator,
+} from "./FilterChipDropdownTypes";
+import IconProp from "Common/Types/Icon/IconProp";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * The React-free half of the facet bar's contract.
+ *
+ * `ResourceFacet` lives here rather than in useResourceOwners.tsx for the same
+ * reason FilterChipDropdownTypes does: a module that only *describes* a facet
+ * — the custom field chips, the device chips — has to be importable from
+ * App/Tests, and App's compile has no React in it. useResourceOwners re-exports
+ * the interface, so every existing `import { ResourceFacet } from
+ * "./useResourceOwners"` keeps working.
+ */
+
+export interface ResourceFacet {
+  /** Internal state key; also the default query field name. */
+  key: string;
+  /** Chip label (e.g. "Status", "Type"). */
+  label: string;
+  /**
+   * What the chip's popover holds. Defaults to "options" — a searchable option
+   * list. Use "dateRange" for a date column, where there is no option list to
+   * offer and the useful questions ("not seen since last Tuesday", "between the
+   * 1st and the 5th") are only expressible by typing a date. Use "text" or
+   * "number" for a free-form value the user types, where the set of values is
+   * whatever anyone has ever entered and so cannot be listed.
+   *
+   * A "dateRange" facet stores its selection in FacetDateRange's encoding and
+   * ignores `options` / `fetchOptions` / `loadOptions`; so do "text" and
+   * "number", which store the typed value as a single-element array.
+   */
+  type?: FacetKind | undefined;
+  /** Icon shown on the empty chip. */
+  icon?: IconProp | undefined;
+  /** Allow selecting multiple values. Defaults to false. */
+  isMultiSelect?: boolean | undefined;
+  /** Hint shown inside the popover search box. */
+  searchPlaceholder?: string | undefined;
+  /** Static option list (use either this or `fetchOptions` / `loadOptions`). */
+  options?: Array<FilterChipDropdownOption> | undefined;
+  /**
+   * Dynamic option list, fetched once on mount. Receives the current
+   * project's id. Suitable for bounded option sets (state, severity,
+   * status — typically <100 rows).
+   */
+  fetchOptions?:
+    | ((projectId: ObjectID) => Promise<Array<FilterChipDropdownOption>>)
+    | undefined;
+  /**
+   * Async loader for unbounded / very large option sets (e.g. a Monitor
+   * picker on a project with thousands of monitors). The chip calls this
+   * on open and on each (debounced) keystroke, so the server does the
+   * heavy lifting. When set, `options` / `fetchOptions` are ignored.
+   */
+  loadOptions?:
+    | ((
+        projectId: ObjectID,
+        searchTerm: string,
+      ) => Promise<Array<FilterChipDropdownOption>>)
+    | undefined;
+  /**
+   * Companion to `loadOptions`. Resolves a set of previously-selected
+   * values (e.g. from a saved view) into options so the chip can show
+   * proper labels even when the values aren't in the current search page.
+   */
+  resolveOptions?:
+    | ((
+        projectId: ObjectID,
+        values: Array<string>,
+      ) => Promise<Array<FilterChipDropdownOption>>)
+    | undefined;
+  /**
+   * Query field name. Defaults to `key`. Useful when the chip key differs
+   * from the actual entity field (e.g. internal key "status" mapped to
+   * `currentMonitorStatus`).
+   */
+  queryField?: string | undefined;
+  /**
+   * Convert selected raw string values into the query value. Defaults:
+   * - multi-select: new Includes(values) (raw strings)
+   * - single-select: values[0] (raw string)
+   * Override for ObjectID-wrapped values or booleans:
+   *   `(values) => values[0] === "true"`
+   *   `(values) => new Includes(values.map((v) => new ObjectID(v)))`
+   */
+  toQueryValue?:
+    | ((values: Array<string>, operator: FilterOperator) => unknown)
+    | undefined;
+  /**
+   * Which operators this facet should expose in the chip dropdown.
+   * Defaults to ["is", "is_not", "is_empty", "is_not_empty"], or to
+   * DATE_FACET_OPERATORS for a "dateRange" facet.
+   */
+  supportedOperators?: Array<FilterOperator> | undefined;
+  /**
+   * Other facet keys this chip cannot be active alongside, because they write
+   * the same column.
+   *
+   * `mergeFiltersIntoQuery` builds one object, so two chips over one field do
+   * not AND — the later one simply overwrites the earlier, silently, while both
+   * chips stay lit and claim to apply. Naming the conflict here makes activating
+   * either of them clear the other, so the bar always shows the filter the table
+   * is actually running.
+   *
+   * Declaring it on one side is enough; the hook reads it symmetrically.
+   *
+   * The alternative, for facets that write *different keys inside* one column,
+   * is `mergeQueryValue` — those chips genuinely do AND and should stay lit
+   * together.
+   */
+  exclusiveWith?: Array<string> | undefined;
+  /**
+   * Combine this facet's query value with whatever an earlier facet already
+   * wrote at the same `queryField`. Without it the value overwrites — correct
+   * for a facet that owns its column outright, wrong for the custom field
+   * chips, which all write different keys inside one `customFields` column.
+   *
+   * Called only when something is already there, so an implementation never
+   * has to handle an absent `existing`.
+   */
+  mergeQueryValue?:
+    | ((existing: unknown, incoming: unknown) => unknown)
+    | undefined;
+  /**
+   * Let `toQueryValue` handle "is empty" / "is not empty" itself instead of the
+   * hook writing IsNull / NotNull at `queryField`.
+   *
+   * Required for a facet over a *key inside* a JSON column, where "empty" means
+   * that key is unset — writing IsNull at the field would ask whether the whole
+   * column is null, which is a different and almost always wrong question.
+   */
+  handlesValuelessOperators?: boolean | undefined;
+  /**
+   * For facets that filter across *multiple* relationship fields with OR
+   * semantics (e.g. an "Affected Resources" chip spanning monitors / hosts /
+   * services / dockerHosts / kubernetesClusters), supply this resolver. It
+   * receives the current selection and returns the set of parent-row IDs
+   * (e.g. incident IDs) that match. The hook unions these into an
+   * `_id` filter, intersected with the owner filter when both are active.
+   *
+   * When set, `toQueryValue` and `queryField` are ignored — the facet
+   * never writes directly to a column.
+   */
+  computeMatchingResourceIds?:
+    | ((
+        projectId: ObjectID,
+        values: Array<string>,
+        operator: FilterOperator,
+      ) => Promise<Array<string>>)
+    | undefined;
+}

--- a/App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ResourceOwners/useResourceOwners.tsx
@@ -31,8 +31,18 @@ import FilterChipDropdown, {
   FilterOperator,
 } from "./FilterChipDropdown";
 import FilterChipDateRange from "./FilterChipDateRange";
-import { FacetKind, OPTION_FACET_OPERATORS } from "./FilterChipDropdownTypes";
-import { buildFacetDateRangeQuery } from "./FacetDateRange";
+import FilterChipValueInput from "./FilterChipValueInput";
+import { CUSTOM_FIELD_FACET_KEY_PREFIX } from "../CustomFields/CustomFieldFacets";
+import { ResourceFacet } from "./ResourceFacet";
+import {
+  FacetColumnQuery,
+  buildFacetColumnQuery,
+  defaultFacetQueryValue,
+} from "./FacetColumnQuery";
+import {
+  OPTION_FACET_OPERATORS,
+  isTypedValueFacetKind,
+} from "./FilterChipDropdownTypes";
 import { ResourceOwnerEntry } from "./OwnerEntry";
 import {
   FacetConflictMap,
@@ -46,44 +56,6 @@ import {
 } from "./FacetSelectionState";
 
 const PICKER_PAGE_SIZE: number = 50;
-
-/**
- * Default query value builder when a facet doesn't supply its own
- * `toQueryValue`. Handles is / is_not / is_empty / is_not_empty for
- * raw-string fields.
- */
-const defaultFacetQueryValue: (
-  values: Array<string>,
-  operator: FilterOperator,
-  isMulti: boolean,
-) => unknown = (
-  values: Array<string>,
-  operator: FilterOperator,
-  isMulti: boolean,
-): unknown => {
-  if (operator === "is_empty") {
-    return new IsNull();
-  }
-  if (operator === "is_not_empty") {
-    return new NotNull();
-  }
-  /*
-   * Date operators against an option list have no date to compare with — the
-   * values here are option ids. Only a hand-edited URL can pair the two, and
-   * sanitizeFacetSelectionState clamps that before it reaches here; refusing it
-   * again is what keeps "cannot express this" from becoming a filter on a
-   * string that happens to parse.
-   */
-  if (operator === "before" || operator === "after" || operator === "between") {
-    return undefined;
-  }
-  if (isMulti) {
-    return operator === "is_not"
-      ? new IncludesNone(values)
-      : new Includes(values);
-  }
-  return operator === "is_not" ? new NotEqual(values[0]!) : values[0];
-};
 
 /**
  * Helper for facets whose values are ObjectIDs (entity references like
@@ -184,115 +156,7 @@ type OwnerJunctionModel = BaseModel & {
   team?: Team;
 };
 
-export interface ResourceFacet {
-  /** Internal state key; also the default query field name. */
-  key: string;
-  /** Chip label (e.g. "Status", "Type"). */
-  label: string;
-  /**
-   * What the chip's popover holds. Defaults to "options" — a searchable option
-   * list. Use "dateRange" for a date column, where there is no option list to
-   * offer and the useful questions ("not seen since last Tuesday", "between the
-   * 1st and the 5th") are only expressible by typing a date.
-   *
-   * A "dateRange" facet stores its selection in FacetDateRange's encoding and
-   * ignores `options` / `fetchOptions` / `loadOptions`.
-   */
-  type?: FacetKind | undefined;
-  /** Icon shown on the empty chip. */
-  icon?: IconProp | undefined;
-  /** Allow selecting multiple values. Defaults to false. */
-  isMultiSelect?: boolean | undefined;
-  /** Hint shown inside the popover search box. */
-  searchPlaceholder?: string | undefined;
-  /** Static option list (use either this or `fetchOptions` / `loadOptions`). */
-  options?: Array<FilterChipDropdownOption> | undefined;
-  /**
-   * Dynamic option list, fetched once on mount. Receives the current
-   * project's id. Suitable for bounded option sets (state, severity,
-   * status — typically <100 rows).
-   */
-  fetchOptions?:
-    | ((projectId: ObjectID) => Promise<Array<FilterChipDropdownOption>>)
-    | undefined;
-  /**
-   * Async loader for unbounded / very large option sets (e.g. a Monitor
-   * picker on a project with thousands of monitors). The chip calls this
-   * on open and on each (debounced) keystroke, so the server does the
-   * heavy lifting. When set, `options` / `fetchOptions` are ignored.
-   */
-  loadOptions?:
-    | ((
-        projectId: ObjectID,
-        searchTerm: string,
-      ) => Promise<Array<FilterChipDropdownOption>>)
-    | undefined;
-  /**
-   * Companion to `loadOptions`. Resolves a set of previously-selected
-   * values (e.g. from a saved view) into options so the chip can show
-   * proper labels even when the values aren't in the current search page.
-   */
-  resolveOptions?:
-    | ((
-        projectId: ObjectID,
-        values: Array<string>,
-      ) => Promise<Array<FilterChipDropdownOption>>)
-    | undefined;
-  /**
-   * Query field name. Defaults to `key`. Useful when the chip key differs
-   * from the actual entity field (e.g. internal key "status" mapped to
-   * `currentMonitorStatus`).
-   */
-  queryField?: string | undefined;
-  /**
-   * Convert selected raw string values into the query value. Defaults:
-   * - multi-select: new Includes(values) (raw strings)
-   * - single-select: values[0] (raw string)
-   * Override for ObjectID-wrapped values or booleans:
-   *   `(values) => values[0] === "true"`
-   *   `(values) => new Includes(values.map((v) => new ObjectID(v)))`
-   */
-  toQueryValue?:
-    | ((values: Array<string>, operator: FilterOperator) => unknown)
-    | undefined;
-  /**
-   * Which operators this facet should expose in the chip dropdown.
-   * Defaults to ["is", "is_not", "is_empty", "is_not_empty"], or to
-   * DATE_FACET_OPERATORS for a "dateRange" facet.
-   */
-  supportedOperators?: Array<FilterOperator> | undefined;
-  /**
-   * Other facet keys this chip cannot be active alongside, because they write
-   * the same column.
-   *
-   * `mergeFiltersIntoQuery` builds one object, so two chips over one field do
-   * not AND — the later one simply overwrites the earlier, silently, while both
-   * chips stay lit and claim to apply. Naming the conflict here makes activating
-   * either of them clear the other, so the bar always shows the filter the table
-   * is actually running.
-   *
-   * Declaring it on one side is enough; the hook reads it symmetrically.
-   */
-  exclusiveWith?: Array<string> | undefined;
-  /**
-   * For facets that filter across *multiple* relationship fields with OR
-   * semantics (e.g. an "Affected Resources" chip spanning monitors / hosts /
-   * services / dockerHosts / kubernetesClusters), supply this resolver. It
-   * receives the current selection and returns the set of parent-row IDs
-   * (e.g. incident IDs) that match. The hook unions these into an
-   * `_id` filter, intersected with the owner filter when both are active.
-   *
-   * When set, `toQueryValue` and `queryField` are ignored — the facet
-   * never writes directly to a column.
-   */
-  computeMatchingResourceIds?:
-    | ((
-        projectId: ObjectID,
-        values: Array<string>,
-        operator: FilterOperator,
-      ) => Promise<Array<string>>)
-    | undefined;
-}
+export type { ResourceFacet } from "./ResourceFacet";
 
 export interface UseResourceOwnersOptions {
   /**
@@ -325,6 +189,24 @@ export interface UseResourceOwnersOptions {
    * makes the filtered view shareable. Omit to disable URL persistence.
    */
   persistKey?: string | undefined;
+  /**
+   * True while `extraFacets` is still being assembled from an async source —
+   * today, a resource's custom field definitions.
+   *
+   * While it is true the hook neither writes nor clears the URL snapshot,
+   * because a facet that has not arrived yet cannot be told apart from one the
+   * user cleared, and the two call for opposite things. When it goes false the
+   * hook reconciles once: late facets get their clamp, and selections for
+   * facets that never arrived are dropped.
+   */
+  areFacetsLoading?: boolean | undefined;
+  /**
+   * Facet-key prefixes the settle-time reconciliation is allowed to drop.
+   * Defaults to the custom field prefix. A key outside these prefixes is left
+   * alone however long it goes unclaimed — the hook cannot know whether a page
+   * puts its own bookkeeping in the snapshot.
+   */
+  reconcilableFacetKeyPrefixes?: Array<string> | undefined;
 }
 
 export interface UseResourceOwnersResult<TResource extends BaseModel> {
@@ -424,6 +306,9 @@ const useResourceOwners: <TResource extends BaseModel>(
   const showLabelsFacet: boolean = Boolean(options.showLabelsFacet);
   const extraFacets: Array<ResourceFacet> = options.extraFacets || [];
   const persistKey: string | undefined = options.persistKey;
+  const areFacetsLoading: boolean = Boolean(options.areFacetsLoading);
+  const reconcilableFacetKeyPrefixes: Array<string> =
+    options.reconcilableFacetKeyPrefixes || [CUSTOM_FIELD_FACET_KEY_PREFIX];
 
   const [ownersByResourceId, setOwnersByResourceId] = useState<{
     [resourceId: string]: Array<ResourceOwnerEntry>;
@@ -1121,33 +1006,26 @@ const useResourceOwners: <TResource extends BaseModel>(
         continue;
       }
 
-      if (op === "is_empty" || op === "is_not_empty") {
-        (merged as unknown as Record<string, unknown>)[field] =
-          op === "is_empty" ? new IsNull() : new NotNull();
-        continue;
-      }
-
-      if (selected.length === 0) {
-        continue;
-      }
-
-      const value: unknown = facet.toQueryValue
-        ? facet.toQueryValue(selected, op)
-        : facet.type === "dateRange"
-          ? buildFacetDateRangeQuery(selected, op)
-          : defaultFacetQueryValue(selected, op, Boolean(facet.isMultiSelect));
-
       /*
-       * `undefined` is a query builder's way of saying "do not constrain this
-       * column" — a half-entered date range, or a value this build cannot read.
-       * Writing the key anyway would leave the field present-but-undefined in
-       * the request, which is a different statement from not filtering on it.
+       * Which column this chip writes, and what — including how it combines
+       * with a chip that already wrote the same column. See FacetColumnQuery;
+       * it lives outside the hook so the two rules that fail invisibly (chips
+       * clobbering each other, and "is empty" asking about the wrong thing)
+       * can be pinned in tests.
        */
-      if (value === undefined) {
+      const columnQuery: FacetColumnQuery | null = buildFacetColumnQuery({
+        facet: facet,
+        operator: op,
+        values: selected,
+        existingValue: (merged as unknown as Record<string, unknown>)[field],
+      });
+
+      if (!columnQuery) {
         continue;
       }
 
-      (merged as unknown as Record<string, unknown>)[field] = value;
+      (merged as unknown as Record<string, unknown>)[columnQuery.field] =
+        columnQuery.value;
     }
 
     // Combine the collected _id sets.
@@ -1753,6 +1631,27 @@ const useResourceOwners: <TResource extends BaseModel>(
             );
           }
 
+          if (isTypedValueFacetKind(facet.type)) {
+            return (
+              <FilterChipValueInput
+                key={facet.key}
+                label={facet.label}
+                emptyIcon={facet.icon}
+                values={selected}
+                valueType={facet.type === "number" ? "number" : "text"}
+                operator={facetOperators[facet.key] || "is"}
+                supportedOperators={facet.supportedOperators}
+                placeholder={facet.searchPlaceholder}
+                onChange={(
+                  nextValues: Array<string>,
+                  nextOperator: FilterOperator,
+                ) => {
+                  applyFacetChange(facet.key, nextValues, nextOperator);
+                }}
+              />
+            );
+          }
+
           const opts: Array<FilterChipDropdownOption> =
             facet.options || facetDynamicOptions[facet.key] || [];
           const value: string | Array<string> | null = facet.isMultiSelect
@@ -1897,12 +1796,113 @@ const useResourceOwners: <TResource extends BaseModel>(
    * and then threw it away.
    */
   useEffect(() => {
+    /*
+     * While the facet list is still being assembled from an async source
+     * (custom field definitions), a restored selection whose chip has not
+     * arrived yet is indistinguishable from one the user cleared — and
+     * `hasActiveFilters` reads it as cleared. Writing then would delete the
+     * very param the link was opened with, before the chips that justify it
+     * exist. So the URL is left exactly as found until the list settles.
+     */
+    if (areFacetsLoading) {
+      return;
+    }
+
     TableFilterUrlState.write(
       persistKey,
       "facets",
       hasActiveFilters ? facetSaveState : null,
     );
-  }, [persistKey, hasActiveFilters, facetSaveState]);
+  }, [persistKey, hasActiveFilters, facetSaveState, areFacetsLoading]);
+
+  /*
+   * Reconcile once the facet list settles.
+   *
+   * Two things can only be decided here. A late-arriving facet's restored
+   * selection has never been clamped against the chip that now owns it, and a
+   * selection whose facet never arrives at all — a custom field that was
+   * renamed or deleted since the link was made — would otherwise filter the
+   * list forever with no chip on screen to explain or clear it.
+   *
+   * Scoped to `reconcilableFacetKeyPrefixes` so a page carrying keys this hook
+   * does not know about (a summary tile's own bookkeeping, say) is untouched.
+   */
+  const hasReconciledFacets: React.MutableRefObject<boolean> =
+    React.useRef<boolean>(false);
+
+  useEffect(() => {
+    if (areFacetsLoading) {
+      /*
+       * A reload — the project changed under the page — deserves the same
+       * reconciliation the first load got, so the flag is armed again rather
+       * than left set from last time.
+       */
+      hasReconciledFacets.current = false;
+      return;
+    }
+
+    if (hasReconciledFacets.current) {
+      return;
+    }
+
+    hasReconciledFacets.current = true;
+
+    const declaredKeys: Set<string> = new Set<string>(
+      extraFacets.map((facet: ResourceFacet) => {
+        return facet.key;
+      }),
+    );
+
+    const isOrphaned: (key: string) => boolean = (key: string): boolean => {
+      if (declaredKeys.has(key)) {
+        return false;
+      }
+
+      return reconcilableFacetKeyPrefixes.some((prefix: string) => {
+        return key.startsWith(prefix);
+      });
+    };
+
+    const clamped: FacetSelectionState = sanitizeFacetSelectionState(
+      {
+        selectedOwnerKeys: selectedOwnerKeys,
+        selectedLabelIds: selectedLabelIds,
+        facetSelections: facetSelections,
+        ownerOperator: ownerOperator,
+        labelOperator: labelOperator,
+        facetOperators: facetOperators,
+      },
+      extraFacets,
+    );
+
+    const nextSelections: { [facetKey: string]: Array<string> } = {};
+    const nextOperators: { [facetKey: string]: FilterOperator } = {};
+
+    for (const key of Object.keys(clamped.facetSelections)) {
+      if (!isOrphaned(key)) {
+        nextSelections[key] = clamped.facetSelections[key]!;
+      }
+    }
+
+    for (const key of Object.keys(clamped.facetOperators)) {
+      if (!isOrphaned(key)) {
+        nextOperators[key] = clamped.facetOperators[key]!;
+      }
+    }
+
+    /*
+     * Both setters run through the same equality check so a settled list with
+     * nothing to fix does not schedule a re-render — and, through
+     * `facetSaveState`, a redundant URL write.
+     */
+    if (
+      JSON.stringify(nextSelections) !== JSON.stringify(facetSelections) ||
+      JSON.stringify(nextOperators) !== JSON.stringify(facetOperators)
+    ) {
+      setFacetSelections(nextSelections);
+      setFacetOperators(nextOperators);
+    }
+  }, [areFacetsLoading, extraFacets]);
 
   const getOwnersForResource: (
     resource: TResource,

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
@@ -8,6 +8,7 @@ import { Black } from "Common/Types/BrandColors";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import useBulkLabelActions from "Common/UI/Components/BulkUpdate/BulkLabelActions";
+import useCustomFieldFacets from "../CustomFields/useCustomFieldFacets";
 import useBulkOwnerActions from "Common/UI/Components/BulkUpdate/BulkOwnerActions";
 import Pill from "Common/UI/Components/Pill/Pill";
 import FieldType from "Common/UI/Components/Types/FieldType";
@@ -192,6 +193,15 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
   const tableUrlStateKey: string =
     props.saveFilterProps?.tableId || "scheduled-maintenance-table";
 
+  /*
+   * One chip per custom field this project has defined, appended after the
+   * built-in ones. They arrive a render or two late (the definitions are
+   * fetched), which is what `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({
+      customFieldsModelType: ScheduledMaintenanceCustomField,
+    });
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -206,7 +216,8 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
     ownerTeamModelType: ScheduledMaintenanceOwnerTeam,
     resourceIdField: "scheduledMaintenanceId",
     showLabelsFacet: true,
-    extraFacets: scheduledMaintenanceExtraFacets,
+    extraFacets: [...scheduledMaintenanceExtraFacets, ...customFieldFacets],
+    areFacetsLoading: areCustomFieldFacetsLoading,
   });
 
   // Fetch scheduled maintenance states on mount

--- a/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutyPolicies.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutyPolicies.tsx
@@ -10,6 +10,7 @@ import Navigation from "Common/UI/Utils/Navigation";
 import Label from "Common/Models/DatabaseModels/Label";
 import OnCallDutyPolicy from "Common/Models/DatabaseModels/OnCallDutyPolicy";
 import OnCallDutyPolicyCustomField from "Common/Models/DatabaseModels/OnCallDutyPolicyCustomField";
+import useCustomFieldFacets from "../../Components/CustomFields/useCustomFieldFacets";
 import OnCallDutyPolicyOwnerTeam from "Common/Models/DatabaseModels/OnCallDutyPolicyOwnerTeam";
 import OnCallDutyPolicyOwnerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyOwnerUser";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
@@ -29,6 +30,16 @@ const OnCallDutyPage: FunctionComponent<
       resourceIdField: "onCallDutyPolicyId",
     });
 
+  /*
+   * One chip per custom field this project has defined. They arrive a render
+   * or two late (the definitions are fetched), which is what
+   * `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({
+      customFieldsModelType: OnCallDutyPolicyCustomField,
+    });
+
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -43,6 +54,8 @@ const OnCallDutyPage: FunctionComponent<
     ownerTeamModelType: OnCallDutyPolicyOwnerTeam,
     resourceIdField: "onCallDutyPolicyId",
     showLabelsFacet: true,
+    extraFacets: customFieldFacets,
+    areFacetsLoading: areCustomFieldFacetsLoading,
   });
 
   return (

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/StatusPages.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/StatusPages.tsx
@@ -9,6 +9,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPage from "Common/Models/DatabaseModels/StatusPage";
 import StatusPageCustomField from "Common/Models/DatabaseModels/StatusPageCustomField";
+import useCustomFieldFacets from "../../Components/CustomFields/useCustomFieldFacets";
 import StatusPageOwnerTeam from "Common/Models/DatabaseModels/StatusPageOwnerTeam";
 import StatusPageOwnerUser from "Common/Models/DatabaseModels/StatusPageOwnerUser";
 import React, { FunctionComponent, ReactElement } from "react";
@@ -27,6 +28,14 @@ const StatusPages: FunctionComponent<PageComponentProps> = (): ReactElement => {
       resourceIdField: "statusPageId",
     });
 
+  /*
+   * One chip per custom field this project has defined. They arrive a render
+   * or two late (the definitions are fetched), which is what
+   * `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({ customFieldsModelType: StatusPageCustomField });
+
   const {
     getOwnersForResource,
     isLoadingOwners,
@@ -41,6 +50,8 @@ const StatusPages: FunctionComponent<PageComponentProps> = (): ReactElement => {
     ownerTeamModelType: StatusPageOwnerTeam,
     resourceIdField: "statusPageId",
     showLabelsFacet: true,
+    extraFacets: customFieldFacets,
+    areFacetsLoading: areCustomFieldFacetsLoading,
   });
 
   return (

--- a/App/FeatureSet/Dashboard/src/Pages/Teams/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Teams/Index.tsx
@@ -6,6 +6,7 @@ import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Team from "Common/Models/DatabaseModels/Team";
 import TeamCustomField from "Common/Models/DatabaseModels/TeamCustomField";
+import useCustomFieldFacets from "../../Components/CustomFields/useCustomFieldFacets";
 import IconProp from "Common/Types/Icon/IconProp";
 import Query from "Common/Types/BaseDatabase/Query";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
@@ -59,6 +60,14 @@ const Teams: FunctionComponent<PageComponentProps> = (
     },
   ];
 
+  /*
+   * One chip per custom field this project has defined. They arrive a render
+   * or two late (the definitions are fetched), which is what
+   * `areFacetsLoading` below tells the bar.
+   */
+  const { facets: customFieldFacets, isLoading: areCustomFieldFacetsLoading } =
+    useCustomFieldFacets({ customFieldsModelType: TeamCustomField });
+
   const {
     filterBar,
     mergeFiltersIntoQuery,
@@ -67,7 +76,8 @@ const Teams: FunctionComponent<PageComponentProps> = (
   } = useResourceOwners<Team>({
     persistKey: "settings-teams-table",
     showOwnerFacet: false,
-    extraFacets: teamExtraFacets,
+    extraFacets: [...teamExtraFacets, ...customFieldFacets],
+    areFacetsLoading: areCustomFieldFacetsLoading,
   });
 
   return (

--- a/App/Tests/Dashboard/CustomFieldFacets.test.ts
+++ b/App/Tests/Dashboard/CustomFieldFacets.test.ts
@@ -1,0 +1,635 @@
+import {
+  BOOLEAN_CUSTOM_FIELD_OPTIONS,
+  CUSTOM_FIELD_FACET_KEY_PREFIX,
+  CUSTOM_FIELD_QUERY_FIELD,
+  buildCustomFieldFacetQuery,
+  buildCustomFieldFacets,
+  getCustomFieldFacetKey,
+  getCustomFieldFacetKind,
+  getCustomFieldFacetOperators,
+  getCustomFieldFacetOptions,
+  getCustomFieldNameFromFacetKey,
+  mergeCustomFieldQueryValue,
+} from "../../FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets";
+import {
+  FilterChipDropdownOption,
+  FilterOperator,
+  NUMBER_FACET_OPERATORS,
+  OPTION_FACET_OPERATORS,
+  TEXT_FACET_OPERATORS,
+} from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes";
+import { ResourceFacet } from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/ResourceFacet";
+import EndsWith from "Common/Types/BaseDatabase/EndsWith";
+import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import LessThan from "Common/Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "Common/Types/BaseDatabase/LessThanOrEqual";
+import NotContains from "Common/Types/BaseDatabase/NotContains";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
+import NotNull from "Common/Types/BaseDatabase/NotNull";
+import Search from "Common/Types/BaseDatabase/Search";
+import StartsWith from "Common/Types/BaseDatabase/StartsWith";
+import { CustomFieldDefinition } from "Common/Types/CustomField/CustomFieldDefinition";
+import CustomFieldType from "Common/Types/CustomField/CustomFieldType";
+import { JSONObject } from "Common/Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * This module is the contract between what a custom field chip in the facet
+ * bar says and what the database is actually asked. If a value here stops
+ * meaning what the chip claims, the product lies: the chip reads "Team is
+ * Payments" over a list of incidents that is not the Payments incidents, and
+ * there is nothing on screen to explain it.
+ *
+ * Two things about custom fields make that easier to get wrong than for the
+ * built-in chips. The values live inside one shared jsonb column keyed by the
+ * field's *name*, so every chip on the bar writes the same query field and
+ * they have to be merged rather than overwrite each other. And a field's type
+ * decides both which control appears and how its value is compared, so the
+ * mapping from CustomFieldType to chip kind is load-bearing in two directions
+ * at once.
+ *
+ * The key strings are also the URL / saved-view vocabulary, so their literal
+ * form is pinned — a rename has to be a conscious edit here rather than a
+ * silent orphaning of every link already pasted into a ticket.
+ */
+
+type DefinitionFunction = (
+  overrides: Partial<CustomFieldDefinition>,
+) => CustomFieldDefinition;
+
+const definition: DefinitionFunction = (
+  overrides: Partial<CustomFieldDefinition>,
+): CustomFieldDefinition => {
+  return {
+    name: "Team",
+    customFieldType: CustomFieldType.Text,
+    ...overrides,
+  };
+};
+
+type QueryForFunction = (
+  def: CustomFieldDefinition,
+  values: Array<string>,
+  operator: FilterOperator,
+) => JSONObject | undefined;
+
+const queryFor: QueryForFunction = (
+  def: CustomFieldDefinition,
+  values: Array<string>,
+  operator: FilterOperator,
+): JSONObject | undefined => {
+  return buildCustomFieldFacetQuery({
+    definition: def,
+    values: values,
+    operator: operator,
+  });
+};
+
+describe("custom field facet keys", () => {
+  test("namespaces the key so a field cannot collide with a built-in chip", () => {
+    /*
+     * A custom field called "labels" would otherwise take over the bar's own
+     * Labels chip's slot in the persisted selection.
+     */
+    expect(CUSTOM_FIELD_FACET_KEY_PREFIX).toBe("customField:");
+    expect(getCustomFieldFacetKey("labels")).toBe("customField:labels");
+  });
+
+  test("round-trips a name through the key", () => {
+    expect(getCustomFieldNameFromFacetKey(getCustomFieldFacetKey("Team"))).toBe(
+      "Team",
+    );
+  });
+
+  test("survives a name with a colon in it", () => {
+    const key: string = getCustomFieldFacetKey("Region: EU");
+
+    expect(getCustomFieldNameFromFacetKey(key)).toBe("Region: EU");
+  });
+
+  test("returns null for a key that is not a custom field's", () => {
+    expect(getCustomFieldNameFromFacetKey("currentIncidentState")).toBeNull();
+    expect(getCustomFieldNameFromFacetKey("customField:")).toBeNull();
+  });
+
+  test("every chip writes the customFields column", () => {
+    expect(CUSTOM_FIELD_QUERY_FIELD).toBe("customFields");
+  });
+});
+
+describe("chip kind per custom field type", () => {
+  test("Text and Number get a typed-value chip", () => {
+    expect(
+      getCustomFieldFacetKind(
+        definition({ customFieldType: CustomFieldType.Text }),
+      ),
+    ).toBe("text");
+    expect(
+      getCustomFieldFacetKind(
+        definition({ customFieldType: CustomFieldType.Number }),
+      ),
+    ).toBe("number");
+  });
+
+  test("Boolean gets an option chip with Yes / No", () => {
+    const def: CustomFieldDefinition = definition({
+      customFieldType: CustomFieldType.Boolean,
+    });
+
+    expect(getCustomFieldFacetKind(def)).toBe("options");
+    expect(getCustomFieldFacetOptions(def)).toEqual(
+      BOOLEAN_CUSTOM_FIELD_OPTIONS,
+    );
+  });
+
+  test("a dropdown with options gets an option chip", () => {
+    expect(
+      getCustomFieldFacetKind(
+        definition({
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "Low\nHigh",
+        }),
+      ),
+    ).toBe("options");
+  });
+
+  test("a dropdown with no options configured falls back to a text chip", () => {
+    /*
+     * The field is real and has values in it. An empty picker would offer the
+     * user nothing at all; a text box at least lets them type what they know
+     * is in there.
+     */
+    expect(
+      getCustomFieldFacetKind(
+        definition({
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "",
+        }),
+      ),
+    ).toBe("text");
+  });
+
+  test("a definition with no type at all is treated as text", () => {
+    expect(
+      getCustomFieldFacetKind(definition({ customFieldType: undefined })),
+    ).toBe("text");
+  });
+
+  test("offers the operator set that matches the chip kind", () => {
+    expect(
+      getCustomFieldFacetOperators(
+        definition({ customFieldType: CustomFieldType.Text }),
+      ),
+    ).toEqual(TEXT_FACET_OPERATORS);
+    expect(
+      getCustomFieldFacetOperators(
+        definition({ customFieldType: CustomFieldType.Number }),
+      ),
+    ).toEqual(NUMBER_FACET_OPERATORS);
+    expect(
+      getCustomFieldFacetOperators(
+        definition({
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "Low\nHigh",
+        }),
+      ),
+    ).toEqual(OPTION_FACET_OPERATORS);
+  });
+});
+
+describe("dropdown options reach the chip", () => {
+  test("reads the legacy one-per-line format", () => {
+    const options: Array<FilterChipDropdownOption> = getCustomFieldFacetOptions(
+      definition({
+        customFieldType: CustomFieldType.Dropdown,
+        dropdownOptions: "Low\nHigh",
+      }),
+    );
+
+    expect(options).toEqual([
+      { value: "Low", label: "Low", color: undefined },
+      { value: "High", label: "High", color: undefined },
+    ]);
+  });
+
+  test("carries colours across from the JSON format", () => {
+    /*
+     * An option that renders as an amber badge in the table has to be the same
+     * amber in the picker, or the two read as different vocabularies.
+     */
+    const options: Array<FilterChipDropdownOption> = getCustomFieldFacetOptions(
+      definition({
+        customFieldType: CustomFieldType.Dropdown,
+        dropdownOptions: '[{"value":"Low","color":"#fef08a"}]',
+      }),
+    );
+
+    expect(options).toEqual([{ value: "Low", label: "Low", color: "#fef08a" }]);
+  });
+});
+
+describe("building the query — equality", () => {
+  test("a single-select chip writes a bare value under the field name", () => {
+    expect(
+      queryFor(
+        definition({
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "Low\nHigh",
+        }),
+        ["Low"],
+        "is",
+      ),
+    ).toEqual({ Team: "Low" });
+  });
+
+  test("a multi-select chip writes Includes", () => {
+    const query: JSONObject | undefined = queryFor(
+      definition({
+        customFieldType: CustomFieldType.MultiSelectDropdown,
+        dropdownOptions: "Low\nHigh",
+      }),
+      ["Low", "High"],
+      "is",
+    );
+
+    expect(query!["Team"]).toBeInstanceOf(Includes);
+    expect((query!["Team"] as unknown as Includes).values).toEqual([
+      "Low",
+      "High",
+    ]);
+  });
+
+  test("a boolean chip writes a real boolean, not the string", () => {
+    /*
+     * The value is stored as a JSON boolean, and a multi-select that happens
+     * to hold booleans is matched by containment against `[true]` — which
+     * `"true"` would not satisfy.
+     */
+    expect(
+      queryFor(
+        definition({ customFieldType: CustomFieldType.Boolean }),
+        ["true"],
+        "is",
+      ),
+    ).toEqual({ Team: true });
+    expect(
+      queryFor(
+        definition({ customFieldType: CustomFieldType.Boolean }),
+        ["false"],
+        "is",
+      ),
+    ).toEqual({ Team: false });
+  });
+
+  test("a multi-select whose dropdown lost its options is treated as single", () => {
+    /*
+     * It renders as a text chip in that state, and a text chip holds one
+     * typed value — so "is" has to mean equality rather than membership.
+     */
+    expect(
+      queryFor(
+        definition({
+          customFieldType: CustomFieldType.MultiSelectDropdown,
+          dropdownOptions: "",
+        }),
+        ["Low"],
+        "is",
+      ),
+    ).toEqual({ Team: "Low" });
+  });
+});
+
+describe("building the query — negation", () => {
+  test("a single-select chip writes NotEqual", () => {
+    const query: JSONObject | undefined = queryFor(
+      definition({
+        customFieldType: CustomFieldType.Dropdown,
+        dropdownOptions: "Low\nHigh",
+      }),
+      ["Low"],
+      "is_not",
+    );
+
+    expect(query!["Team"]).toBeInstanceOf(NotEqual);
+  });
+
+  test("a multi-select chip writes IncludesNone", () => {
+    const query: JSONObject | undefined = queryFor(
+      definition({
+        customFieldType: CustomFieldType.MultiSelectDropdown,
+        dropdownOptions: "Low\nHigh",
+      }),
+      ["Low", "High"],
+      "is_not",
+    );
+
+    expect(query!["Team"]).toBeInstanceOf(IncludesNone);
+    expect((query!["Team"] as unknown as IncludesNone).values).toEqual([
+      "Low",
+      "High",
+    ]);
+  });
+});
+
+describe("building the query — emptiness", () => {
+  test("is_empty asks about the key, not the whole column", () => {
+    /*
+     * The predicate goes *inside* the customFields object. Writing IsNull at
+     * the column instead would ask whether the resource has no custom fields
+     * at all — a different and almost always wrong question.
+     */
+    const query: JSONObject | undefined = queryFor(
+      definition({}),
+      [],
+      "is_empty",
+    );
+
+    expect(query!["Team"]).toBeInstanceOf(IsNull);
+  });
+
+  test("is_not_empty likewise", () => {
+    const query: JSONObject | undefined = queryFor(
+      definition({}),
+      [],
+      "is_not_empty",
+    );
+
+    expect(query!["Team"]).toBeInstanceOf(NotNull);
+  });
+
+  test("the empty operators need no selection", () => {
+    expect(queryFor(definition({}), [], "is_empty")).toBeDefined();
+    expect(queryFor(definition({}), [], "is_not_empty")).toBeDefined();
+  });
+});
+
+describe("building the query — text operators", () => {
+  test("maps each substring operator to its query type", () => {
+    expect(
+      queryFor(definition({}), ["pay"], "contains")!["Team"],
+    ).toBeInstanceOf(Search);
+    expect(
+      queryFor(definition({}), ["pay"], "not_contains")!["Team"],
+    ).toBeInstanceOf(NotContains);
+    expect(
+      queryFor(definition({}), ["pay"], "starts_with")!["Team"],
+    ).toBeInstanceOf(StartsWith);
+    expect(
+      queryFor(definition({}), ["pay"], "ends_with")!["Team"],
+    ).toBeInstanceOf(EndsWith);
+  });
+
+  test("trims the typed value", () => {
+    const query: JSONObject | undefined = queryFor(
+      definition({}),
+      ["  pay  "],
+      "contains",
+    );
+
+    expect((query!["Team"] as unknown as Search<string>).value).toBe("pay");
+  });
+});
+
+describe("building the query — numeric operators", () => {
+  const numberDefinition: CustomFieldDefinition = definition({
+    name: "Impacted Users",
+    customFieldType: CustomFieldType.Number,
+  });
+
+  test("maps each comparison to its query type, with a real number", () => {
+    const gt: JSONObject | undefined = queryFor(
+      numberDefinition,
+      ["500"],
+      "greater_than",
+    );
+
+    expect(gt!["Impacted Users"]).toBeInstanceOf(GreaterThan);
+    expect(
+      (gt!["Impacted Users"] as unknown as GreaterThan<number>).value,
+    ).toBe(500);
+
+    expect(
+      queryFor(numberDefinition, ["500"], "greater_than_or_equal")![
+        "Impacted Users"
+      ],
+    ).toBeInstanceOf(GreaterThanOrEqual);
+    expect(
+      queryFor(numberDefinition, ["500"], "less_than")!["Impacted Users"],
+    ).toBeInstanceOf(LessThan);
+    expect(
+      queryFor(numberDefinition, ["500"], "less_than_or_equal")![
+        "Impacted Users"
+      ],
+    ).toBeInstanceOf(LessThanOrEqual);
+  });
+
+  test("refuses a comparison against something that is not a number", () => {
+    /*
+     * The chip's input prevents this; a hand-edited URL does not. Compiling it
+     * anyway would produce a predicate matching nothing, under a chip claiming
+     * to filter by "over abc".
+     */
+    expect(queryFor(numberDefinition, ["abc"], "greater_than")).toBeUndefined();
+    expect(
+      queryFor(numberDefinition, ["Infinity"], "less_than"),
+    ).toBeUndefined();
+  });
+});
+
+describe("building the query — nothing to constrain", () => {
+  test("an empty selection on a value operator constrains nothing", () => {
+    /*
+     * `undefined` is how mergeFiltersIntoQuery is told to skip the key
+     * entirely. Returning `{ Team: "" }` instead would filter for the empty
+     * string under a chip showing nothing.
+     */
+    expect(queryFor(definition({}), [], "is")).toBeUndefined();
+    expect(queryFor(definition({}), [], "is_not")).toBeUndefined();
+    expect(queryFor(definition({}), [], "contains")).toBeUndefined();
+  });
+
+  test("a whitespace-only value constrains nothing", () => {
+    expect(queryFor(definition({}), ["   "], "is")).toBeUndefined();
+  });
+
+  test("a definition with no name constrains nothing", () => {
+    expect(queryFor(definition({ name: "" }), ["Low"], "is")).toBeUndefined();
+  });
+});
+
+describe("merging two chips over the same column", () => {
+  test("ANDs both fields into one object", () => {
+    /*
+     * The single most important behaviour here. Both chips write
+     * `customFields`, and the bar's merge is the only thing keeping the second
+     * from silently replacing the first while both stay lit.
+     */
+    const first: JSONObject = queryFor(
+      definition({ name: "Team" }),
+      ["Payments"],
+      "is",
+    )!;
+    const second: JSONObject = queryFor(
+      definition({ name: "Region" }),
+      ["eu-west-1"],
+      "is",
+    )!;
+
+    expect(mergeCustomFieldQueryValue(first, second)).toEqual({
+      Team: "Payments",
+      Region: "eu-west-1",
+    });
+  });
+
+  test("a later chip on the same field replaces the earlier predicate", () => {
+    // One key can only carry one predicate; the newer one is the live filter.
+    expect(
+      mergeCustomFieldQueryValue({ Team: "Payments" }, { Team: "Billing" }),
+    ).toEqual({ Team: "Billing" });
+  });
+
+  test("hands the column to a non-custom-field constraint rather than blending", () => {
+    /*
+     * A page's own `query` prop can write this column. Spreading an operator
+     * instance into an object would produce a shape neither side chose.
+     */
+    const isNull: IsNull = new IsNull();
+
+    expect(mergeCustomFieldQueryValue(isNull, { Team: "x" })).toEqual({
+      Team: "x",
+    });
+    expect(mergeCustomFieldQueryValue({ Team: "x" }, isNull)).toBe(isNull);
+  });
+});
+
+describe("buildCustomFieldFacets", () => {
+  const definitions: Array<CustomFieldDefinition> = [
+    { name: "Team", customFieldType: CustomFieldType.Text },
+    { name: "Impacted Users", customFieldType: CustomFieldType.Number },
+    { name: "Regulated", customFieldType: CustomFieldType.Boolean },
+    {
+      name: "Severity Band",
+      customFieldType: CustomFieldType.Dropdown,
+      dropdownOptions: "P1\nP2",
+    },
+    {
+      name: "Squads",
+      customFieldType: CustomFieldType.MultiSelectDropdown,
+      dropdownOptions: "infra\napps",
+    },
+  ];
+
+  const facets: Array<ResourceFacet> = buildCustomFieldFacets(definitions);
+
+  test("makes one chip per definition, in order", () => {
+    expect(
+      facets.map((facet: ResourceFacet) => {
+        return facet.key;
+      }),
+    ).toEqual([
+      "customField:Team",
+      "customField:Impacted Users",
+      "customField:Regulated",
+      "customField:Severity Band",
+      "customField:Squads",
+    ]);
+  });
+
+  test("labels each chip with the field's name", () => {
+    expect(facets[0]!.label).toBe("Team");
+  });
+
+  test("every chip writes customFields and knows how to share it", () => {
+    for (const facet of facets) {
+      expect(facet.queryField).toBe("customFields");
+      expect(facet.mergeQueryValue).toBeDefined();
+      expect(facet.handlesValuelessOperators).toBe(true);
+      expect(facet.toQueryValue).toBeDefined();
+    }
+  });
+
+  test("marks only the multi-select dropdown as multi-select", () => {
+    expect(
+      facets
+        .filter((facet: ResourceFacet) => {
+          return facet.isMultiSelect;
+        })
+        .map((facet: ResourceFacet) => {
+          return facet.key;
+        }),
+    ).toEqual(["customField:Squads"]);
+  });
+
+  test("gives option chips their options and typed chips none", () => {
+    expect(facets[3]!.options).toHaveLength(2);
+    expect(facets[4]!.options).toHaveLength(2);
+    expect(facets[0]!.options).toBeUndefined();
+    expect(facets[1]!.options).toBeUndefined();
+  });
+
+  test("routes toQueryValue through the same builder", () => {
+    expect(facets[0]!.toQueryValue!(["Payments"], "is")).toEqual({
+      Team: "Payments",
+    });
+  });
+
+  test("skips a definition with no name", () => {
+    expect(
+      buildCustomFieldFacets([
+        { name: "" },
+        { name: "Team", customFieldType: CustomFieldType.Text },
+      ]),
+    ).toHaveLength(1);
+  });
+
+  test("tolerates an empty definition list", () => {
+    expect(buildCustomFieldFacets([])).toEqual([]);
+  });
+
+  test("produces a stable query for the same definitions", () => {
+    /*
+     * The table refetches when `JSON.stringify(query)` changes, so an unstable
+     * key order here would loop it.
+     */
+    const build: () => string = (): string => {
+      return JSON.stringify(
+        buildCustomFieldFacets(definitions).reduce(
+          (accumulated: JSONObject, facet: ResourceFacet): JSONObject => {
+            const value: unknown = facet.toQueryValue!(["x"], "is");
+
+            return value
+              ? (mergeCustomFieldQueryValue(accumulated, value) as JSONObject)
+              : accumulated;
+          },
+          {} as JSONObject,
+        ),
+      );
+    };
+
+    expect(build()).toBe(build());
+  });
+});
+
+describe("names that are hostile to a query builder", () => {
+  test("a name with quotes reaches the query key untouched", () => {
+    /*
+     * The server binds the key as a parameter, so nothing here needs escaping
+     * — and escaping it here would filter for a name no resource has.
+     */
+    const name: string = `x' OR 1=1 --`;
+
+    expect(queryFor(definition({ name: name }), ["v"], "is")).toEqual({
+      [name]: "v",
+    });
+  });
+
+  test("a name with a percent sign reaches the query key untouched", () => {
+    expect(
+      queryFor(definition({ name: "100% Coverage" }), ["v"], "is"),
+    ).toEqual({ "100% Coverage": "v" });
+  });
+});

--- a/App/Tests/Dashboard/CustomFieldFilteringInvariants.test.ts
+++ b/App/Tests/Dashboard/CustomFieldFilteringInvariants.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  CUSTOM_FIELD_QUERY_FIELD,
+  buildCustomFieldFacets,
+} from "../../FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets";
+import { ResourceFacet } from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/ResourceFacet";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Custom field chips are wired into seven resource tables, and the wiring is
+ * three lines each: load the definitions, append them to `extraFacets`, and
+ * pass `areFacetsLoading` on. The App suite runs in a plain Node environment
+ * with no renderer, so — like SummaryTileFilteringInvariants and
+ * NetworkSitePageInvariants — these read the sources and assert the exact
+ * expressions. Every assertion corresponds to a way the feature can be broken
+ * while every other test in the repo stays green.
+ *
+ * The one that matters most is the last section. BaseModelTable builds its
+ * request as `{...props.query, ...columnFilterQuery}`, where `props.query`
+ * carries the facet-merged query — so a classic column filter over
+ * `customFields` would replace every chip's constraint outright, silently,
+ * while the chips carried on claiming to apply.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+type SquashFunction = (text: string) => string;
+
+const squash: SquashFunction = (text: string): string => {
+  return text.replace(/\s+/g, " ");
+};
+
+type ReadSourceFunction = (...relativeParts: Array<string>) => string;
+
+const readSource: ReadSourceFunction = (
+  ...relativeParts: Array<string>
+): string => {
+  return squash(
+    fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+  );
+};
+
+interface WiredTable {
+  label: string;
+  source: string;
+  definitionModel: string;
+  /** The variable its own facets are already in, when it has any. */
+  existingFacetsVariable?: string | undefined;
+}
+
+const WIRED_TABLES: Array<WiredTable> = [
+  {
+    label: "Incidents",
+    source: readSource("Components", "Incident", "IncidentsTable.tsx"),
+    definitionModel: "IncidentCustomField",
+    existingFacetsVariable: "incidentExtraFacets",
+  },
+  {
+    label: "Alerts",
+    source: readSource("Components", "Alert", "AlertsTable.tsx"),
+    definitionModel: "AlertCustomField",
+    existingFacetsVariable: "alertExtraFacets",
+  },
+  {
+    label: "Monitors",
+    source: readSource("Components", "Monitor", "MonitorTable.tsx"),
+    definitionModel: "MonitorCustomField",
+    existingFacetsVariable: "monitorExtraFacets",
+  },
+  {
+    label: "Scheduled Maintenance",
+    source: readSource(
+      "Components",
+      "ScheduledMaintenance",
+      "ScheduledMaintenanceTable.tsx",
+    ),
+    definitionModel: "ScheduledMaintenanceCustomField",
+    existingFacetsVariable: "scheduledMaintenanceExtraFacets",
+  },
+  {
+    label: "On-Call Duty Policies",
+    source: readSource("Pages", "OnCallDuty", "OnCallDutyPolicies.tsx"),
+    definitionModel: "OnCallDutyPolicyCustomField",
+  },
+  {
+    label: "Teams",
+    source: readSource("Pages", "Teams", "Index.tsx"),
+    definitionModel: "TeamCustomField",
+    existingFacetsVariable: "teamExtraFacets",
+  },
+  {
+    label: "Status Pages",
+    source: readSource("Pages", "StatusPages", "StatusPages.tsx"),
+    definitionModel: "StatusPageCustomField",
+  },
+];
+
+describe("every table with custom fields offers chips for them", () => {
+  for (const table of WIRED_TABLES) {
+    describe(table.label, () => {
+      test("loads its definitions with the right definition model", () => {
+        /*
+         * A regex rather than a literal: prettier wraps the longer model names
+         * onto their own line, which adds a trailing comma. The wiring is what
+         * this pins, not the line width it happens to fit in.
+         */
+        expect(table.source).toMatch(
+          new RegExp(
+            `useCustomFieldFacets\\(\\{ customFieldsModelType: ${table.definitionModel},? \\}\\)`,
+          ),
+        );
+      });
+
+      test("appends the chips to the facet bar", () => {
+        /*
+         * Appended, not replacing: a table's own chips (State, Severity,
+         * Affected Resources) have to survive.
+         */
+        const expected: string = table.existingFacetsVariable
+          ? `extraFacets: [...${table.existingFacetsVariable}, ...customFieldFacets],`
+          : "extraFacets: customFieldFacets,";
+
+        expect(table.source).toContain(expected);
+      });
+
+      test("tells the bar the chips are still loading", () => {
+        /*
+         * Without this the bar reads a link's restored chip as "the user
+         * cleared it" on the first render and deletes the URL param before
+         * the definitions have arrived.
+         */
+        expect(table.source).toContain(
+          "areFacetsLoading: areCustomFieldFacetsLoading,",
+        );
+      });
+
+      test("still declares its custom field columns", () => {
+        // The chips and the columns read the same definitions; both or neither.
+        expect(table.source).toContain(
+          `customFieldsModelType={${table.definitionModel}}`,
+        );
+      });
+    });
+  }
+});
+
+describe("no table filters customFields from the column-filter popup", () => {
+  /*
+   * The popup's query is spread over the facet-merged query in
+   * BaseModelTable.fetchItems, so a `customFields` entry in a `filters` array
+   * would overwrite every chip on the bar. There is no way to see that
+   * happening from the screen: the chips stay lit.
+   */
+  for (const table of WIRED_TABLES) {
+    test(`${table.label} declares no customFields column filter`, () => {
+      expect(table.source).not.toContain(`${CUSTOM_FIELD_QUERY_FIELD}: true`);
+    });
+  }
+});
+
+describe("the facet bar's merge rules are actually claimed by the chips", () => {
+  /*
+   * Pinned here rather than only in CustomFieldFacets.test because these two
+   * flags are the difference between "several chips AND together over one
+   * column" and "the last chip silently wins" — and between "this field is
+   * unset" and "this resource has no custom fields at all".
+   */
+  const facets: Array<ResourceFacet> = buildCustomFieldFacets([
+    { name: "Team" },
+    { name: "Region" },
+  ]);
+
+  test("every chip writes the same column", () => {
+    for (const facet of facets) {
+      expect(facet.queryField).toBe(CUSTOM_FIELD_QUERY_FIELD);
+    }
+  });
+
+  test("every chip declares how to share it", () => {
+    for (const facet of facets) {
+      expect(typeof facet.mergeQueryValue).toBe("function");
+    }
+  });
+
+  test("every chip owns its own empty operators", () => {
+    for (const facet of facets) {
+      expect(facet.handlesValuelessOperators).toBe(true);
+    }
+  });
+
+  test("no chip declares itself exclusive with another", () => {
+    // They AND. Declaring a conflict would make picking one clear the rest.
+    for (const facet of facets) {
+      expect(facet.exclusiveWith).toBeUndefined();
+    }
+  });
+});
+
+describe("the hook that feeds the chips", () => {
+  const hookSource: string = readSource(
+    "Components",
+    "CustomFields",
+    "useCustomFieldFacets.ts",
+  );
+
+  test("reuses the definitions the columns already fetch", () => {
+    /*
+     * Two requests for the same definitions would drift the moment one was
+     * edited, and would show the table a different set of custom fields than
+     * the bar.
+     */
+    expect(hookSource).toContain("useCustomFieldColumns");
+  });
+
+  test("reports nothing to wait for when there is no definition model", () => {
+    expect(hookSource).toContain(
+      "isLoading: Boolean(data.customFieldsModelType) && definitionsResult.isLoading",
+    );
+  });
+});

--- a/App/Tests/Dashboard/FacetColumnQuery.test.ts
+++ b/App/Tests/Dashboard/FacetColumnQuery.test.ts
@@ -1,0 +1,402 @@
+import {
+  FacetColumnQuery,
+  buildFacetColumnQuery,
+  defaultFacetQueryValue,
+} from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FacetColumnQuery";
+import { FilterOperator } from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/FilterChipDropdownTypes";
+import { ResourceFacet } from "../../FeatureSet/Dashboard/src/Components/ResourceOwners/ResourceFacet";
+import { buildCustomFieldFacets } from "../../FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
+import IsNull from "Common/Types/BaseDatabase/IsNull";
+import NotEqual from "Common/Types/BaseDatabase/NotEqual";
+import NotNull from "Common/Types/BaseDatabase/NotNull";
+import { CustomFieldDefinition } from "Common/Types/CustomField/CustomFieldDefinition";
+import CustomFieldType from "Common/Types/CustomField/CustomFieldType";
+import { JSONObject } from "Common/Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The rule this file exists for: the facet bar builds ONE query object, so two
+ * chips writing the same field do not AND on their own — the second assignment
+ * replaces the first, silently, while both chips stay lit and claim to apply.
+ *
+ * Every built-in chip owns its column outright, so that never came up. The
+ * custom field chips all write `customFields` — one per key inside it — so it
+ * comes up on every project that defines more than one custom field, and the
+ * symptom is a list filtered by the last chip the user touched with no way to
+ * tell from the screen.
+ *
+ * The second rule is smaller and fails the same way: "is empty" normally means
+ * IsNull at the field, which for a chip over a key inside a JSON column would
+ * ask whether the resource has no custom fields at all.
+ */
+
+type FacetFunction = (overrides: Partial<ResourceFacet>) => ResourceFacet;
+
+const facet: FacetFunction = (
+  overrides: Partial<ResourceFacet>,
+): ResourceFacet => {
+  return {
+    key: "status",
+    label: "Status",
+    ...overrides,
+  };
+};
+
+type QueryFunction = (data: {
+  facet: ResourceFacet;
+  operator: FilterOperator;
+  values: Array<string>;
+  existingValue?: unknown;
+}) => FacetColumnQuery | null;
+
+const query: QueryFunction = (data: {
+  facet: ResourceFacet;
+  operator: FilterOperator;
+  values: Array<string>;
+  existingValue?: unknown;
+}): FacetColumnQuery | null => {
+  return buildFacetColumnQuery({
+    facet: data.facet,
+    operator: data.operator,
+    values: data.values,
+    existingValue: data.existingValue,
+  });
+};
+
+describe("which field a chip writes", () => {
+  test("defaults to the facet key", () => {
+    expect(
+      query({ facet: facet({}), operator: "is", values: ["up"] })!.field,
+    ).toBe("status");
+  });
+
+  test("uses queryField when the chip key differs from the column", () => {
+    expect(
+      query({
+        facet: facet({ queryField: "currentMonitorStatus" }),
+        operator: "is",
+        values: ["up"],
+      })!.field,
+    ).toBe("currentMonitorStatus");
+  });
+});
+
+describe("chips that constrain nothing", () => {
+  test("an empty selection on a value operator is dropped", () => {
+    /*
+     * `null`, not a key with an undefined value: the field has to be absent
+     * from the request, which is a different statement from filtering on
+     * nothing.
+     */
+    expect(query({ facet: facet({}), operator: "is", values: [] })).toBeNull();
+  });
+
+  test("a value the operator cannot use is dropped", () => {
+    // A date operator against an option list has no date to compare with.
+    expect(
+      query({ facet: facet({}), operator: "between", values: ["up"] }),
+    ).toBeNull();
+  });
+
+  test("a facet whose toQueryValue returns undefined is dropped", () => {
+    expect(
+      query({
+        facet: facet({
+          toQueryValue: (): unknown => {
+            return undefined;
+          },
+        }),
+        operator: "is",
+        values: ["up"],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("the valueless operators", () => {
+  test("write IsNull / NotNull at the field by default", () => {
+    expect(
+      query({ facet: facet({}), operator: "is_empty", values: [] })!.value,
+    ).toBeInstanceOf(IsNull);
+    expect(
+      query({ facet: facet({}), operator: "is_not_empty", values: [] })!.value,
+    ).toBeInstanceOf(NotNull);
+  });
+
+  test("go through toQueryValue when the facet opts in", () => {
+    /*
+     * A chip over one key inside a JSON column has to build this itself —
+     * IsNull at the field would ask whether the whole column is null.
+     */
+    const result: FacetColumnQuery | null = query({
+      facet: facet({
+        handlesValuelessOperators: true,
+        queryField: "customFields",
+        toQueryValue: (
+          _values: Array<string>,
+          operator: FilterOperator,
+        ): unknown => {
+          return {
+            Team: operator === "is_empty" ? new IsNull() : new NotNull(),
+          };
+        },
+      }),
+      operator: "is_empty",
+      values: [],
+    });
+
+    expect(result!.field).toBe("customFields");
+    expect((result!.value as JSONObject)["Team"]).toBeInstanceOf(IsNull);
+  });
+
+  test("an opted-in facet still applies them with nothing selected", () => {
+    expect(
+      query({
+        facet: facet({
+          handlesValuelessOperators: true,
+          toQueryValue: (): unknown => {
+            return { Team: new IsNull() };
+          },
+        }),
+        operator: "is_empty",
+        values: [],
+      }),
+    ).not.toBeNull();
+  });
+});
+
+describe("two chips over one field", () => {
+  test("the second replaces the first when no merge is declared", () => {
+    /*
+     * The behaviour every built-in chip relies on, and the reason
+     * `exclusiveWith` exists for the ones that would otherwise collide.
+     */
+    const result: FacetColumnQuery | null = query({
+      facet: facet({ key: "b", queryField: "shared" }),
+      operator: "is",
+      values: ["second"],
+      existingValue: "first",
+    });
+
+    expect(result!.value).toBe("second");
+  });
+
+  test("mergeQueryValue combines them instead", () => {
+    const result: FacetColumnQuery | null = query({
+      facet: facet({
+        key: "b",
+        queryField: "shared",
+        mergeQueryValue: (existing: unknown, incoming: unknown): unknown => {
+          return `${existing as string}+${incoming as string}`;
+        },
+      }),
+      operator: "is",
+      values: ["second"],
+      existingValue: "first",
+    });
+
+    expect(result!.value).toBe("first+second");
+  });
+
+  test("mergeQueryValue is not called when nothing is there yet", () => {
+    let called: boolean = false;
+
+    const result: FacetColumnQuery | null = query({
+      facet: facet({
+        queryField: "shared",
+        mergeQueryValue: (): unknown => {
+          called = true;
+          return "merged";
+        },
+      }),
+      operator: "is",
+      values: ["first"],
+      existingValue: undefined,
+    });
+
+    expect(called).toBe(false);
+    expect(result!.value).toBe("first");
+  });
+});
+
+describe("several custom field chips, end to end", () => {
+  const definitions: Array<CustomFieldDefinition> = [
+    {
+      name: "Team",
+      customFieldType: CustomFieldType.Dropdown,
+      dropdownOptions: "Payments\nBilling",
+    },
+    {
+      name: "Squads",
+      customFieldType: CustomFieldType.MultiSelectDropdown,
+      dropdownOptions: "infra\napps",
+    },
+    { name: "Ticket", customFieldType: CustomFieldType.Text },
+    { name: "Impacted Users", customFieldType: CustomFieldType.Number },
+  ];
+
+  const facets: Array<ResourceFacet> = buildCustomFieldFacets(definitions);
+
+  type MergeAllFunction = (
+    selections: Array<{
+      index: number;
+      values: Array<string>;
+      operator: FilterOperator;
+    }>,
+  ) => Record<string, unknown>;
+
+  /**
+   * Exactly what useResourceOwners' merge loop does, over the same helper.
+   */
+  const mergeAll: MergeAllFunction = (
+    selections: Array<{
+      index: number;
+      values: Array<string>;
+      operator: FilterOperator;
+    }>,
+  ): Record<string, unknown> => {
+    const merged: Record<string, unknown> = {};
+
+    for (const selection of selections) {
+      const result: FacetColumnQuery | null = buildFacetColumnQuery({
+        facet: facets[selection.index]!,
+        operator: selection.operator,
+        values: selection.values,
+        existingValue: merged[facets[selection.index]!.queryField!],
+      });
+
+      if (result) {
+        merged[result.field] = result.value;
+      }
+    }
+
+    return merged;
+  };
+
+  test("four chips produce one customFields object holding all four keys", () => {
+    const merged: Record<string, unknown> = mergeAll([
+      { index: 0, values: ["Payments"], operator: "is" },
+      { index: 1, values: ["infra", "apps"], operator: "is" },
+      { index: 2, values: ["JIRA-1"], operator: "contains" },
+      { index: 3, values: ["500"], operator: "greater_than" },
+    ]);
+
+    expect(Object.keys(merged)).toEqual(["customFields"]);
+
+    const customFields: JSONObject = merged["customFields"] as JSONObject;
+
+    expect(Object.keys(customFields).sort()).toEqual(
+      ["Impacted Users", "Squads", "Team", "Ticket"].sort(),
+    );
+    expect(customFields["Team"]).toBe("Payments");
+    expect(customFields["Squads"]).toBeInstanceOf(Includes);
+  });
+
+  test("a chip left empty contributes nothing and does not disturb the others", () => {
+    const merged: Record<string, unknown> = mergeAll([
+      { index: 0, values: ["Payments"], operator: "is" },
+      { index: 2, values: [], operator: "contains" },
+    ]);
+
+    expect(merged["customFields"]).toEqual({ Team: "Payments" });
+  });
+
+  test("is-not on a multi-select chip merges alongside the others", () => {
+    const merged: Record<string, unknown> = mergeAll([
+      { index: 0, values: ["Payments"], operator: "is" },
+      { index: 1, values: ["infra"], operator: "is_not" },
+    ]);
+
+    const customFields: JSONObject = merged["customFields"] as JSONObject;
+
+    expect(customFields["Team"]).toBe("Payments");
+    expect(customFields["Squads"]).toBeInstanceOf(IncludesNone);
+  });
+
+  test("is-empty on one chip does not null out the whole column", () => {
+    /*
+     * The regression this guards: writing IsNull at `customFields` would ask
+     * for incidents with no custom fields at all, and would also wipe the
+     * other chip's predicate on the way.
+     */
+    const merged: Record<string, unknown> = mergeAll([
+      { index: 0, values: ["Payments"], operator: "is" },
+      { index: 2, values: [], operator: "is_empty" },
+    ]);
+
+    const customFields: unknown = merged["customFields"];
+
+    expect(customFields).not.toBeInstanceOf(IsNull);
+    expect((customFields as JSONObject)["Team"]).toBe("Payments");
+    expect((customFields as JSONObject)["Ticket"]).toBeInstanceOf(IsNull);
+  });
+
+  test("the merge is order-independent in content", () => {
+    const forwards: Record<string, unknown> = mergeAll([
+      { index: 0, values: ["Payments"], operator: "is" },
+      { index: 2, values: ["JIRA-1"], operator: "contains" },
+    ]);
+    const backwards: Record<string, unknown> = mergeAll([
+      { index: 2, values: ["JIRA-1"], operator: "contains" },
+      { index: 0, values: ["Payments"], operator: "is" },
+    ]);
+
+    expect(Object.keys(forwards["customFields"] as JSONObject).sort()).toEqual(
+      Object.keys(backwards["customFields"] as JSONObject).sort(),
+    );
+  });
+});
+
+describe("defaultFacetQueryValue", () => {
+  test("wraps a multi-select selection", () => {
+    expect(defaultFacetQueryValue(["a", "b"], "is", true)).toBeInstanceOf(
+      Includes,
+    );
+    expect(defaultFacetQueryValue(["a", "b"], "is_not", true)).toBeInstanceOf(
+      IncludesNone,
+    );
+  });
+
+  test("passes a single-select selection through", () => {
+    expect(defaultFacetQueryValue(["a"], "is", false)).toBe("a");
+    expect(defaultFacetQueryValue(["a"], "is_not", false)).toBeInstanceOf(
+      NotEqual,
+    );
+  });
+
+  test("refuses every operator it has no typed value for", () => {
+    /*
+     * These reach an option chip only from a hand-edited URL. Producing a
+     * filter on an option id that happens to parse as a date or a number is
+     * worse than producing none.
+     */
+    const unusable: Array<FilterOperator> = [
+      "before",
+      "after",
+      "between",
+      "contains",
+      "not_contains",
+      "starts_with",
+      "ends_with",
+      "greater_than",
+      "greater_than_or_equal",
+      "less_than",
+      "less_than_or_equal",
+    ];
+
+    for (const operator of unusable) {
+      expect(defaultFacetQueryValue(["a"], operator, false)).toBeUndefined();
+    }
+  });
+
+  test("handles the valueless operators", () => {
+    expect(defaultFacetQueryValue([], "is_empty", false)).toBeInstanceOf(
+      IsNull,
+    );
+    expect(defaultFacetQueryValue([], "is_not_empty", false)).toBeInstanceOf(
+      NotNull,
+    );
+  });
+});

--- a/App/Tests/Dashboard/FacetSelectionState.test.ts
+++ b/App/Tests/Dashboard/FacetSelectionState.test.ts
@@ -2,6 +2,7 @@ import {
   FacetSelectionConstraint,
   FacetSelectionState,
   getEmptyFacetSelectionState,
+  isFacetActive,
   isFacetSelectionActive,
   isFilterOperator,
   normalizeFacetValues,
@@ -29,15 +30,21 @@ import { describe, expect, test } from "@jest/globals";
  */
 
 describe("isFilterOperator", () => {
-  test("accepts the four supported operators", () => {
+  test("accepts the operators every chip kind offers", () => {
     expect(isFilterOperator("is")).toBe(true);
     expect(isFilterOperator("is_not")).toBe(true);
     expect(isFilterOperator("is_empty")).toBe(true);
     expect(isFilterOperator("is_not_empty")).toBe(true);
+    // Date chips.
+    expect(isFilterOperator("before")).toBe(true);
+    expect(isFilterOperator("between")).toBe(true);
+    // Text and number chips.
+    expect(isFilterOperator("contains")).toBe(true);
+    expect(isFilterOperator("greater_than")).toBe(true);
   });
 
   test("rejects anything else", () => {
-    expect(isFilterOperator("contains")).toBe(false);
+    expect(isFilterOperator("matches")).toBe(false);
     expect(isFilterOperator("")).toBe(false);
     expect(isFilterOperator(null)).toBe(false);
     expect(isFilterOperator(undefined)).toBe(false);
@@ -383,7 +390,7 @@ describe("resolveFacetOperator", () => {
       "IS",
       " is",
       "is ",
-      "contains",
+      "matches",
       "isnt",
       "is_empty_",
       "__proto__",
@@ -598,5 +605,193 @@ describe("sanitizeFacetSelectionState", () => {
         ).toBeLessThanOrEqual(1);
       }
     }
+  });
+});
+
+/*
+ * Custom field chips arrive asynchronously — the definitions have to be
+ * fetched — while a shared link is restored synchronously on the first render.
+ * So a selection routinely exists before the facet that owns it does, and this
+ * parser is the only thing standing between that and a lost filter.
+ *
+ * The asymmetry with the column-filter popup's `sanitizeFilterData`, which
+ * drops any key it does not recognise, is deliberate and load-bearing: here an
+ * unknown key survives, and useResourceOwners reconciles it once the facet
+ * list settles.
+ */
+describe("selections whose facet has not arrived yet", () => {
+  test("parse preserves a custom field key verbatim", () => {
+    const state: FacetSelectionState = parseFacetSelectionState({
+      facetSelections: { "customField:Severity Band": ["P1"] },
+      facetOperators: { "customField:Severity Band": "is_not" },
+    } as JSONObject);
+
+    expect(state.facetSelections["customField:Severity Band"]).toEqual(["P1"]);
+    expect(state.facetOperators["customField:Severity Band"]).toBe("is_not");
+  });
+
+  test("sanitize against an empty facet list leaves it alone", () => {
+    /*
+     * This runs on the first render, before the definitions land. Clamping
+     * here would throw away the link's filter a moment before the chip that
+     * could show it appears.
+     */
+    const restored: FacetSelectionState = {
+      ...getEmptyFacetSelectionState(),
+      facetSelections: { "customField:Team": ["Payments"] },
+      facetOperators: { "customField:Team": "contains" },
+    };
+
+    const sanitized: FacetSelectionState = sanitizeFacetSelectionState(
+      restored,
+      [],
+    );
+
+    expect(sanitized.facetSelections["customField:Team"]).toEqual(["Payments"]);
+    expect(sanitized.facetOperators["customField:Team"]).toBe("contains");
+  });
+
+  test("counts as an active selection while the facet is missing", () => {
+    // Otherwise the URL effect reads the link as "nothing selected" and deletes it.
+    expect(
+      isFacetSelectionActive({
+        ...getEmptyFacetSelectionState(),
+        facetSelections: { "customField:Team": ["Payments"] },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("text and number chips", () => {
+  const TEXT: FacetSelectionConstraint = {
+    key: "customField:Ticket",
+    type: "text",
+    supportedOperators: [
+      "is",
+      "is_not",
+      "contains",
+      "not_contains",
+      "starts_with",
+      "ends_with",
+      "is_empty",
+      "is_not_empty",
+    ],
+  };
+
+  const NUMBER: FacetSelectionConstraint = {
+    key: "customField:Impacted Users",
+    type: "number",
+    supportedOperators: [
+      "is",
+      "is_not",
+      "greater_than",
+      "greater_than_or_equal",
+      "less_than",
+      "less_than_or_equal",
+      "is_empty",
+      "is_not_empty",
+    ],
+  };
+
+  function stateWith(
+    facetSelections: { [key: string]: Array<string> },
+    facetOperators: { [key: string]: FilterOperator },
+  ): FacetSelectionState {
+    return {
+      ...getEmptyFacetSelectionState(),
+      facetSelections: facetSelections,
+      facetOperators: facetOperators,
+    };
+  }
+
+  test("accepts the text and numeric operators", () => {
+    for (const operator of [
+      "contains",
+      "not_contains",
+      "starts_with",
+      "ends_with",
+      "greater_than",
+      "greater_than_or_equal",
+      "less_than",
+      "less_than_or_equal",
+    ]) {
+      expect(isFilterOperator(operator)).toBe(true);
+    }
+  });
+
+  test("keeps a typed operator the chip offers", () => {
+    const sanitized: FacetSelectionState = sanitizeFacetSelectionState(
+      stateWith({ [TEXT.key]: ["JIRA-1"] }, { [TEXT.key]: "contains" }),
+      [TEXT],
+    );
+
+    expect(sanitized.facetOperators[TEXT.key]).toBe("contains");
+    expect(sanitized.facetSelections[TEXT.key]).toEqual(["JIRA-1"]);
+  });
+
+  test("keeps only the first value — the input can show one", () => {
+    const sanitized: FacetSelectionState = sanitizeFacetSelectionState(
+      stateWith({ [TEXT.key]: ["a", "b"] }, {}),
+      [TEXT],
+    );
+
+    expect(sanitized.facetSelections[TEXT.key]).toEqual(["a"]);
+  });
+
+  test("drops a blank text value", () => {
+    // A lit chip over an unfiltered list is worse than an empty chip.
+    expect(
+      sanitizeFacetSelectionState(stateWith({ [TEXT.key]: ["   "] }, {}), [
+        TEXT,
+      ]).facetSelections[TEXT.key],
+    ).toEqual([]);
+  });
+
+  test("keeps a numeric value that is a number", () => {
+    expect(
+      sanitizeFacetSelectionState(
+        stateWith({ [NUMBER.key]: ["42"] }, { [NUMBER.key]: "greater_than" }),
+        [NUMBER],
+      ).facetSelections[NUMBER.key],
+    ).toEqual(["42"]);
+  });
+
+  test("drops a numeric value that is not a number", () => {
+    /*
+     * The number input can only show a number, so a hand-edited URL carrying
+     * anything else would leave the chip lit with an empty box under it.
+     */
+    for (const value of ["abc", "", "Infinity", "1,000"]) {
+      expect(
+        sanitizeFacetSelectionState(stateWith({ [NUMBER.key]: [value] }, {}), [
+          NUMBER,
+        ]).facetSelections[NUMBER.key],
+      ).toEqual([]);
+    }
+  });
+
+  test("a negative or decimal number survives", () => {
+    for (const value of ["-5", "3.14", "0"]) {
+      expect(
+        sanitizeFacetSelectionState(stateWith({ [NUMBER.key]: [value] }, {}), [
+          NUMBER,
+        ]).facetSelections[NUMBER.key],
+      ).toEqual([value]);
+    }
+  });
+
+  test("an operator the chip does not offer still clamps", () => {
+    expect(
+      sanitizeFacetSelectionState(
+        stateWith({ [NUMBER.key]: ["42"] }, { [NUMBER.key]: "contains" }),
+        [NUMBER],
+      ).facetOperators[NUMBER.key],
+    ).toBe("is");
+  });
+
+  test("a typed chip is active once it holds a value", () => {
+    expect(isFacetActive(TEXT, ["JIRA-1"], "contains")).toBe(true);
+    expect(isFacetActive(TEXT, [], "contains")).toBe(false);
+    expect(isFacetActive(TEXT, [], "is_empty")).toBe(true);
   });
 });

--- a/Common/Server/Types/Database/JSONColumnQuery.ts
+++ b/Common/Server/Types/Database/JSONColumnQuery.ts
@@ -1,0 +1,621 @@
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Dictionary from "../../../Types/Dictionary";
+import EndsWith from "../../../Types/BaseDatabase/EndsWith";
+import EqualTo from "../../../Types/BaseDatabase/EqualTo";
+import EqualToOrNull from "../../../Types/BaseDatabase/EqualToOrNull";
+import GreaterThan from "../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../Types/BaseDatabase/GreaterThanOrEqual";
+import GreaterThanOrNull from "../../../Types/BaseDatabase/GreaterThanOrNull";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IncludesAll from "../../../Types/BaseDatabase/IncludesAll";
+import IncludesNone from "../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import LessThan from "../../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../../Types/BaseDatabase/LessThanOrEqual";
+import LessThanOrNull from "../../../Types/BaseDatabase/LessThanOrNull";
+import NotContains from "../../../Types/BaseDatabase/NotContains";
+import NotEqual from "../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../Types/BaseDatabase/NotNull";
+import Search from "../../../Types/BaseDatabase/Search";
+import StartsWith from "../../../Types/BaseDatabase/StartsWith";
+import ObjectID from "../../../Types/ObjectID";
+import Text from "../../../Types/Text";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Querying keys inside a jsonb column
+ * ---------------------------------------------------------------------------
+ *
+ * `customFields` (and every other jsonb column) stores a flat object keyed by
+ * the custom field definition's *name*, so "incidents whose Team is Payments"
+ * means reaching inside the column for one key.
+ *
+ * Three properties of this module are load-bearing:
+ *
+ *  1. THE KEY IS A BOUND PARAMETER, never interpolated. A custom field's name
+ *     is user-supplied text that arrives on the query from the browser, so
+ *     splicing it into the SQL string — which is what this code used to do —
+ *     let anyone who could name a key write SQL into the WHERE clause.
+ *
+ *  2. A VALUE MATCHES WHETHER IT IS STORED AS A SCALAR OR INSIDE AN ARRAY.
+ *     A single-select dropdown stores `"Payments"`; the same field switched to
+ *     multi-select stores `["Payments", "Billing"]`. Both have to answer yes to
+ *     "Team is Payments", or a project that changed a field's type would find
+ *     its old rows quietly missing from every filter.
+ *
+ *  3. A ROW MISSING THE KEY SATISFIES A NEGATIVE FILTER. "Team is not
+ *     Payments" includes the incidents with no Team at all — which is what the
+ *     equivalent ClickHouse attribute path already does (StatementGenerator),
+ *     so the two read the same way in the product.
+ *
+ * Operators reuse the vocabulary the rest of the query layer already speaks
+ * (Search, Includes, NotEqual, GreaterThan, IsNull, ...), so a filter built in
+ * the browser serializes and reconstructs with no new wire format.
+ *
+ * Every predicate is composed from `JsonAccessor`, which is derived from the
+ * column reference only at render time — parameters are bound once, up front,
+ * so `toSql` can be called more than once without minting new placeholders.
+ */
+
+/**
+ * The two ways to read one key out of a jsonb column. `->>` yields text, for
+ * comparison; `->` yields jsonb, for array containment and type inspection.
+ */
+interface JsonAccessor {
+  /** `col ->> 'key'` — the value as text. NULL when the key is absent. */
+  asText: string;
+  /** `col -> 'key'` — the value as jsonb. NULL when the key is absent. */
+  asJson: string;
+}
+
+/** A WHERE fragment that still needs to be told which column it reads. */
+type PredicateFragment = (accessor: JsonAccessor) => string;
+
+export interface JSONColumnQuery {
+  /**
+   * Bound parameters for the emitted SQL. The names are opaque; nothing may
+   * depend on them beyond handing them to TypeORM's `Raw`.
+   */
+  parameters: Dictionary<JSONValue>;
+  /**
+   * Render the WHERE fragment for an already-quoted column reference such as
+   * `"Incident"."customFields"`.
+   */
+  toSql: (columnReference: string) => string;
+}
+
+export type ParameterNameGeneratorFunction = () => string;
+
+/**
+ * Matches an optionally-signed decimal with optional surrounding whitespace.
+ * Guards the numeric cast: a jsonb value is arbitrary text, and
+ * `CAST('abc' AS NUMERIC)` aborts the whole query rather than skipping a row.
+ *
+ * This is load-bearing rather than defensive. A Number custom field is stored
+ * as whatever the text input produced — `"42"`, not `42` — so every numeric
+ * comparison runs through a cast, on rows whose value may be anything at all.
+ */
+const NUMERIC_TEXT_REGEX: string = "^\\s*-?[0-9]+(\\.[0-9]+)?\\s*$";
+
+/*
+ * Sanity bounds on an incoming JSON query. Nothing the product builds comes
+ * close to these — a project's custom fields are capped well below the key
+ * limit and a facet selection below the value limit — so exceeding one means
+ * a hand-built request, and answering it with a 400 is better than compiling
+ * a megabyte of SQL.
+ */
+export const MAX_JSON_QUERY_KEYS: number = 50;
+export const MAX_JSON_QUERY_VALUES_PER_KEY: number = 200;
+export const MAX_JSON_QUERY_KEY_LENGTH: number = 500;
+
+/**
+ * Escape the characters Postgres' LIKE grammar reserves, so a custom field
+ * value containing `%` filters for a literal `%` rather than for anything.
+ *
+ * `\` is LIKE's default escape character, so it has to be doubled first.
+ */
+export type EscapeLikePatternFunction = (value: string) => string;
+
+export const escapeLikePattern: EscapeLikePatternFunction = (
+  value: string,
+): string => {
+  return value.replace(/([\\%_])/g, "\\$1");
+};
+
+type IsScalarFunction = (value: unknown) => value is string | number | boolean;
+
+const isScalar: IsScalarFunction = (
+  value: unknown,
+): value is string | number | boolean => {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+};
+
+type ScalarValue = string | number | boolean;
+
+type ToScalarFunction = (value: unknown) => ScalarValue;
+
+/**
+ * Reduce an operator's payload to something comparable against jsonb.
+ * ObjectID and friends stringify; primitives keep their type so the
+ * containment literal below is `[42]` rather than `["42"]`.
+ */
+const toScalar: ToScalarFunction = (value: unknown): ScalarValue => {
+  if (isScalar(value)) {
+    return value;
+  }
+
+  if (value instanceof ObjectID) {
+    return value.toString();
+  }
+
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value);
+};
+
+type ToScalarArrayFunction = (values: unknown) => Array<ScalarValue>;
+
+const toScalarArray: ToScalarArrayFunction = (
+  values: unknown,
+): Array<ScalarValue> => {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return values.map((value: unknown) => {
+    return toScalar(value);
+  });
+};
+
+type IsNumericValueFunction = (value: unknown) => boolean;
+
+const isNumericValue: IsNumericValueFunction = (value: unknown): boolean => {
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    return Number.isFinite(Number(value));
+  }
+
+  return false;
+};
+
+/**
+ * Builds one key's predicate. Every helper binds its parameters immediately
+ * and returns a fragment that only needs the column reference, so the caller
+ * owns a complete parameter bag before any SQL is rendered.
+ */
+class KeyPredicateBuilder {
+  private parameters: Dictionary<JSONValue>;
+  private generateParameterName: ParameterNameGeneratorFunction;
+  private keyParameterName: string;
+
+  public constructor(data: {
+    parameters: Dictionary<JSONValue>;
+    generateParameterName: ParameterNameGeneratorFunction;
+    key: string;
+  }) {
+    this.parameters = data.parameters;
+    this.generateParameterName = data.generateParameterName;
+    this.keyParameterName = this.bind(data.key);
+  }
+
+  /** Register a value and return its `:name` placeholder. */
+  private bind(value: JSONValue): string {
+    const name: string = this.generateParameterName();
+    this.parameters[name] = value;
+    return `:${name}`;
+  }
+
+  /*
+   * The key is cast explicitly because `->` / `->>` are overloaded on
+   * (jsonb, text) and (jsonb, integer); an untyped bind parameter would leave
+   * Postgres unable to choose and fail with "operator is not unique".
+   */
+  public accessorFor(columnReference: string): JsonAccessor {
+    return {
+      asText: `${columnReference} ->> CAST(${this.keyParameterName} AS TEXT)`,
+      asJson: `${columnReference} -> CAST(${this.keyParameterName} AS TEXT)`,
+    };
+  }
+
+  /**
+   * "The value at this key is `value`" — true for a scalar that equals it and
+   * for an array that contains it.
+   */
+  private equals(value: ScalarValue): PredicateFragment {
+    const textParameter: string = this.bind(String(value));
+    const jsonParameter: string = this.bind(JSON.stringify([value]));
+
+    return (accessor: JsonAccessor): string => {
+      return `(${accessor.asText} = CAST(${textParameter} AS TEXT) OR (jsonb_typeof(${accessor.asJson}) = 'array' AND ${accessor.asJson} @> CAST(${jsonParameter} AS JSONB)))`;
+    };
+  }
+
+  private join(
+    fragments: Array<PredicateFragment>,
+    operator: "AND" | "OR",
+  ): PredicateFragment {
+    return (accessor: JsonAccessor): string => {
+      return `(${fragments
+        .map((fragment: PredicateFragment) => {
+          return fragment(accessor);
+        })
+        .join(` ${operator} `)})`;
+    };
+  }
+
+  private anyOf(values: Array<ScalarValue>): PredicateFragment {
+    return this.join(
+      values.map((value: ScalarValue) => {
+        return this.equals(value);
+      }),
+      "OR",
+    );
+  }
+
+  private allOf(values: Array<ScalarValue>): PredicateFragment {
+    return this.join(
+      values.map((value: ScalarValue) => {
+        return this.equals(value);
+      }),
+      "AND",
+    );
+  }
+
+  /**
+   * `pattern` arrives with its wildcards already placed by the caller; the
+   * needle inside it has been escaped, so only the caller's own `%` are live.
+   *
+   * An array-valued key is matched against its JSON text (`["a", "b"]`), which
+   * is what makes "contains" work on a multi-select without a second branch.
+   */
+  private like(pattern: string): PredicateFragment {
+    const parameter: string = this.bind(pattern);
+
+    return (accessor: JsonAccessor): string => {
+      return `(${accessor.asText} ILIKE ${parameter})`;
+    };
+  }
+
+  /**
+   * The value at this key as NUMERIC, or NULL when it does not look like a
+   * number. A CASE rather than an AND guard because Postgres does not promise
+   * to evaluate the guard first, and one stray cast error aborts the query
+   * instead of skipping the row.
+   */
+  private numericExpression(accessor: JsonAccessor): string {
+    return `(CASE WHEN ${accessor.asText} ~ '${NUMERIC_TEXT_REGEX}' THEN CAST(${accessor.asText} AS NUMERIC) ELSE NULL END)`;
+  }
+
+  private compareNumeric(operator: string, value: unknown): PredicateFragment {
+    const parameter: string = this.bind(Number(toScalar(value)));
+
+    return (accessor: JsonAccessor): string => {
+      return `(${this.numericExpression(accessor)} ${operator} CAST(${parameter} AS NUMERIC))`;
+    };
+  }
+
+  private compareText(operator: string, value: unknown): PredicateFragment {
+    const parameter: string = this.bind(String(toScalar(value)));
+
+    return (accessor: JsonAccessor): string => {
+      return `(${accessor.asText} ${operator} CAST(${parameter} AS TEXT))`;
+    };
+  }
+
+  /**
+   * "No value here" — the key is absent, explicitly JSON null, an empty
+   * string, or an empty array. A multi-select cleared in the UI leaves `[]`
+   * behind rather than dropping the key, and a user reading "is empty" on the
+   * chip means all four.
+   */
+  private isEmpty(): PredicateFragment {
+    return (accessor: JsonAccessor): string => {
+      return `(${accessor.asJson} IS NULL OR jsonb_typeof(${accessor.asJson}) = 'null' OR ${accessor.asText} = '' OR (jsonb_typeof(${accessor.asJson}) = 'array' AND jsonb_array_length(${accessor.asJson}) = 0))`;
+    };
+  }
+
+  /*
+   * `IS NOT TRUE` rather than `NOT (...)`: a row missing the key compares to
+   * NULL, and `NOT NULL` is NULL — which would exclude exactly the rows a
+   * negative filter is asked about.
+   */
+  private negate(fragment: PredicateFragment): PredicateFragment {
+    return (accessor: JsonAccessor): string => {
+      return `(${fragment(accessor)} IS NOT TRUE)`;
+    };
+  }
+
+  /**
+   * A multi-value condition expands to one OR-ed predicate per value, so an
+   * unbounded list is an unbounded query. Refuse rather than compile it: the
+   * caller gets a 400 they can act on instead of a statement the database
+   * spends a minute planning.
+   */
+  private assertValueCountWithinLimit(value: unknown): void {
+    let count: number = 0;
+
+    if (Array.isArray(value)) {
+      count = value.length;
+    } else if (
+      value instanceof Includes ||
+      value instanceof IncludesAll ||
+      value instanceof IncludesNone
+    ) {
+      count = (value.values || []).length;
+    }
+
+    if (count > MAX_JSON_QUERY_VALUES_PER_KEY) {
+      throw new BadDataException(
+        `A JSON column filter cannot match against more than ${MAX_JSON_QUERY_VALUES_PER_KEY} values at once.`,
+      );
+    }
+  }
+
+  private containsJson(value: unknown): PredicateFragment {
+    const parameter: string = this.bind(JSON.stringify(value));
+
+    return (accessor: JsonAccessor): string => {
+      return `(${accessor.asJson} @> CAST(${parameter} AS JSONB))`;
+    };
+  }
+
+  /**
+   * Build this key's predicate, or null when the condition constrains nothing
+   * — an "is any of" with nothing selected. Dropping it is right: narrowing to
+   * zero rows would hide the table behind a filter the user just cleared.
+   */
+  public build(value: unknown): PredicateFragment | null {
+    this.assertValueCountWithinLimit(value);
+
+    if (value instanceof IsNull) {
+      return this.isEmpty();
+    }
+
+    if (value instanceof NotNull) {
+      return this.negate(this.isEmpty());
+    }
+
+    if (value instanceof IncludesAll) {
+      const values: Array<ScalarValue> = toScalarArray(value.values);
+      return values.length === 0 ? null : this.allOf(values);
+    }
+
+    if (value instanceof IncludesNone) {
+      const values: Array<ScalarValue> = toScalarArray(value.values);
+      return values.length === 0 ? null : this.negate(this.anyOf(values));
+    }
+
+    if (value instanceof Includes) {
+      const values: Array<ScalarValue> = toScalarArray(value.values);
+      return values.length === 0 ? null : this.anyOf(values);
+    }
+
+    if (value instanceof NotEqual) {
+      return this.negate(this.equals(toScalar(value.value)));
+    }
+
+    if (value instanceof EqualToOrNull) {
+      return this.join(
+        [this.equals(toScalar(value.value)), this.isEmpty()],
+        "OR",
+      );
+    }
+
+    if (value instanceof EqualTo) {
+      return this.equals(toScalar(value.value));
+    }
+
+    if (value instanceof NotContains) {
+      return this.negate(
+        this.like(`%${escapeLikePattern(String(toScalar(value.value)))}%`),
+      );
+    }
+
+    if (value instanceof StartsWith) {
+      return this.like(`${escapeLikePattern(String(toScalar(value.value)))}%`);
+    }
+
+    if (value instanceof EndsWith) {
+      return this.like(`%${escapeLikePattern(String(toScalar(value.value)))}`);
+    }
+
+    if (value instanceof Search) {
+      return this.like(`%${escapeLikePattern(String(toScalar(value.value)))}%`);
+    }
+
+    if (value instanceof InBetween) {
+      const start: unknown = value.startValue;
+      const end: unknown = value.endValue;
+
+      if (isNumericValue(start) && isNumericValue(end)) {
+        return this.join(
+          [this.compareNumeric(">=", start), this.compareNumeric("<=", end)],
+          "AND",
+        );
+      }
+
+      return this.join(
+        [this.compareText(">=", start), this.compareText("<=", end)],
+        "AND",
+      );
+    }
+
+    if (value instanceof GreaterThanOrNull) {
+      return this.join(
+        [this.compareNumeric(">=", value.value), this.isEmpty()],
+        "OR",
+      );
+    }
+
+    if (value instanceof LessThanOrNull) {
+      return this.join(
+        [this.compareNumeric("<=", value.value), this.isEmpty()],
+        "OR",
+      );
+    }
+
+    if (value instanceof GreaterThanOrEqual) {
+      return this.compareNumeric(">=", value.value);
+    }
+
+    if (value instanceof GreaterThan) {
+      return this.compareNumeric(">", value.value);
+    }
+
+    if (value instanceof LessThanOrEqual) {
+      return this.compareNumeric("<=", value.value);
+    }
+
+    if (value instanceof LessThan) {
+      return this.compareNumeric("<", value.value);
+    }
+
+    /*
+     * A bare array reads as "is any of" — the same meaning QueryUtil gives a
+     * top-level array, which it wraps in an ANY.
+     */
+    if (Array.isArray(value)) {
+      const values: Array<ScalarValue> = toScalarArray(value);
+      return values.length === 0 ? null : this.anyOf(values);
+    }
+
+    if (isScalar(value)) {
+      return this.equals(value);
+    }
+
+    if (value === null || value === undefined) {
+      return this.isEmpty();
+    }
+
+    /*
+     * Anything left is a nested object. Containment is the only sensible
+     * reading, and a strict improvement on what this used to do — compare the
+     * column's text against "[object Object]".
+     */
+    return this.containsJson(value);
+  }
+}
+
+export type BuildJSONColumnQueryFunction = (data: {
+  value: JSONObject | string;
+  generateParameterName?: ParameterNameGeneratorFunction | undefined;
+}) => JSONColumnQuery;
+
+/**
+ * Turn `{ Team: Includes(["Payments"]), Region: "us-east-1" }` into one
+ * AND-joined WHERE fragment over a jsonb column, plus the parameters it binds.
+ *
+ * An empty object keeps its historical meaning — "this column holds nothing" —
+ * because that is what a JSON filter with every row cleared has always sent.
+ */
+const buildJSONColumnQuery: BuildJSONColumnQueryFunction = (data: {
+  value: JSONObject | string;
+  generateParameterName?: ParameterNameGeneratorFunction | undefined;
+}): JSONColumnQuery => {
+  const generateParameterName: ParameterNameGeneratorFunction =
+    data.generateParameterName ||
+    ((): string => {
+      return Text.generateRandomText(10);
+    });
+
+  let value: JSONObject = {};
+
+  if (typeof data.value === "string") {
+    try {
+      value = JSON.parse(data.value) as JSONObject;
+    } catch {
+      /*
+       * A JSON column query that is not parseable JSON cannot be turned into a
+       * predicate. Falling back to the empty object below means "this column
+       * holds nothing", which is at least a filter the caller can see the
+       * effect of — as opposed to a 500.
+       */
+      value = {};
+    }
+  } else {
+    value = data.value || {};
+  }
+
+  const parameters: Dictionary<JSONValue> = {};
+  const fragments: Array<(columnReference: string) => string> = [];
+
+  const keys: Array<string> = Object.keys(value || {});
+
+  if (keys.length > MAX_JSON_QUERY_KEYS) {
+    throw new BadDataException(
+      `A JSON column filter cannot carry more than ${MAX_JSON_QUERY_KEYS} keys.`,
+    );
+  }
+
+  for (const key of keys) {
+    if (typeof key !== "string" || key.length === 0) {
+      continue;
+    }
+
+    if (key.length > MAX_JSON_QUERY_KEY_LENGTH) {
+      throw new BadDataException(
+        `A JSON column filter key cannot be longer than ${MAX_JSON_QUERY_KEY_LENGTH} characters.`,
+      );
+    }
+
+    const builder: KeyPredicateBuilder = new KeyPredicateBuilder({
+      parameters: parameters,
+      generateParameterName: generateParameterName,
+      key: key,
+    });
+
+    const fragment: PredicateFragment | null = builder.build(
+      (value as JSONObject)[key],
+    );
+
+    if (!fragment) {
+      continue;
+    }
+
+    fragments.push((columnReference: string): string => {
+      return fragment(builder.accessorFor(columnReference));
+    });
+  }
+
+  return {
+    parameters: parameters,
+    toSql: (columnReference: string): string => {
+      if (keys.length === 0) {
+        /*
+         * Historical meaning of `{}`, kept verbatim: the column itself is
+         * empty. Changing it would silently retarget every saved filter that
+         * has ever sent an empty JSON filter.
+         */
+        return `(${columnReference} IS NULL OR ${columnReference} = '{}')`;
+      }
+
+      if (fragments.length === 0) {
+        /*
+         * Every condition turned out to constrain nothing. Matching everything
+         * is right; matching nothing would hide the whole table behind a
+         * filter the user had cleared.
+         */
+        return "(1 = 1)";
+      }
+
+      return `(${fragments
+        .map((fragment: (columnReference: string) => string) => {
+          return fragment(columnReference);
+        })
+        .join(" AND ")})`;
+    },
+  };
+};
+
+export default buildJSONColumnQuery;

--- a/Common/Server/Types/Database/QueryHelper.ts
+++ b/Common/Server/Types/Database/QueryHelper.ts
@@ -7,6 +7,7 @@ import Typeof from "../../../Types/Typeof";
 import { FindOperator, Raw } from "typeorm";
 import { FindWhereProperty } from "../../../Types/BaseDatabase/Query";
 import CaptureSpan from "../../Utils/Telemetry/CaptureSpan";
+import buildJSONColumnQuery, { JSONColumnQuery } from "./JSONColumnQuery";
 
 export default class QueryHelper {
   @CaptureSpan()
@@ -668,40 +669,25 @@ export default class QueryHelper {
     ) as FindWhereProperty<any>;
   }
 
+  /**
+   * Filter on the keys of a jsonb column — `customFields` above all, whose
+   * keys are the names a project gave its custom fields.
+   *
+   * The per-key predicates (equality, "is any of", contains, numeric
+   * comparison, is-empty, and their negations) live in JSONColumnQuery. Two
+   * things this used to get wrong and no longer does: the key was spliced
+   * straight into the SQL string, and every value was compared with `=`, so an
+   * operator such as `Includes` reached Postgres stringified.
+   */
   @CaptureSpan()
   public static queryJson(value: JSONObject): FindWhereProperty<any> {
-    // seed random text
-    const values: JSONObject = {};
-
-    let queryText: string = "";
-
-    if (typeof value === Typeof.String) {
-      value = JSON.parse(value.toString());
-    }
-
     if (value instanceof FindOperator) {
       return value;
     }
 
-    const hasValue: boolean = value && Object.keys(value).length > 0;
-
-    for (const key in value) {
-      const temp: string = Text.generateRandomText(10);
-
-      values[temp] = value[key];
-
-      if (!queryText) {
-        queryText = `(COLUMN_NAME_ALIAS->>'${key}' = :${temp as string}`;
-      } else {
-        queryText += ` AND COLUMN_NAME_ALIAS->>'${key}' = :${temp as string}`;
-      }
-    }
-
-    if (hasValue) {
-      queryText += ")";
-    } else {
-      queryText = "(COLUMN_NAME_ALIAS IS NULL OR COLUMN_NAME_ALIAS = '{}')";
-    }
+    const jsonQuery: JSONColumnQuery = buildJSONColumnQuery({
+      value: value as JSONObject,
+    });
 
     return Raw((alias: string) => {
       /*
@@ -709,16 +695,15 @@ export default class QueryHelper {
        * we need to convert this to "tableName"."columnName"
        */
 
-      alias = alias
+      const columnReference: string = alias
         .split(".")
         .map((item: string) => {
           return `"${item}"`;
         })
         .join(".");
 
-      queryText = Text.replaceAll(queryText, "COLUMN_NAME_ALIAS", `${alias}`);
-      return queryText;
-    }, values);
+      return jsonQuery.toSql(columnReference);
+    }, jsonQuery.parameters);
   }
 
   @CaptureSpan()

--- a/Common/Tests/Server/Types/Database/JSONColumnQuery.test.ts
+++ b/Common/Tests/Server/Types/Database/JSONColumnQuery.test.ts
@@ -1,0 +1,593 @@
+import buildJSONColumnQuery, {
+  JSONColumnQuery,
+  MAX_JSON_QUERY_KEYS,
+  MAX_JSON_QUERY_KEY_LENGTH,
+  MAX_JSON_QUERY_VALUES_PER_KEY,
+  escapeLikePattern,
+} from "../../../../Server/Types/Database/JSONColumnQuery";
+import EndsWith from "../../../../Types/BaseDatabase/EndsWith";
+import EqualTo from "../../../../Types/BaseDatabase/EqualTo";
+import EqualToOrNull from "../../../../Types/BaseDatabase/EqualToOrNull";
+import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../../Types/BaseDatabase/GreaterThanOrEqual";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import IncludesAll from "../../../../Types/BaseDatabase/IncludesAll";
+import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../../Types/BaseDatabase/IsNull";
+import LessThan from "../../../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../../../Types/BaseDatabase/LessThanOrEqual";
+import NotContains from "../../../../Types/BaseDatabase/NotContains";
+import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../../Types/BaseDatabase/NotNull";
+import Search from "../../../../Types/BaseDatabase/Search";
+import StartsWith from "../../../../Types/BaseDatabase/StartsWith";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../Types/ObjectID";
+import { JSONObject } from "../../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * This module compiles the WHERE clause for "filter incidents by the value of
+ * a custom field", so two whole classes of bug live here and nowhere else.
+ *
+ * The first is injection. A custom field's name is text a project member
+ * types, and it used to be spliced straight into the SQL string — every test
+ * below that inspects `parameters` rather than the SQL is guarding the fix.
+ *
+ * The second is silent wrong answers. A multi-select stores its value as a
+ * JSON array, a Number custom field stores its value as a *string*, and a row
+ * that never had the field at all has no key. Each of those, read naively,
+ * produces a filter that runs, returns rows, and is wrong — the worst possible
+ * failure for something people use to report on their incidents.
+ *
+ * The tests use a deterministic parameter-name generator so the emitted SQL
+ * can be asserted verbatim. Production uses random names purely so two
+ * operators in one query cannot collide.
+ */
+
+const COLUMN: string = '"Incident"."customFields"';
+
+type SequentialNamesFunction = () => () => string;
+
+const sequentialNames: SequentialNamesFunction = (): (() => string) => {
+  let index: number = 0;
+
+  return (): string => {
+    index++;
+    return `p${index}`;
+  };
+};
+
+type BuildFunction = (value: JSONObject) => JSONColumnQuery;
+
+const build: BuildFunction = (value: JSONObject): JSONColumnQuery => {
+  return buildJSONColumnQuery({
+    value: value,
+    generateParameterName: sequentialNames(),
+  });
+};
+
+type SqlOfFunction = (value: JSONObject) => string;
+
+const sqlOf: SqlOfFunction = (value: JSONObject): string => {
+  return build(value).toSql(COLUMN);
+};
+
+describe("buildJSONColumnQuery — the shape of a key lookup", () => {
+  test("reads the key through a bound parameter, never through the SQL text", () => {
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+    const sql: string = query.toSql(COLUMN);
+
+    // The key appears as a parameter value...
+    expect(query.parameters["p1"]).toBe("Team");
+    // ...and never as a literal in the statement.
+    expect(sql).not.toContain("'Team'");
+    expect(sql).toContain("->> CAST(:p1 AS TEXT)");
+    expect(sql).toContain("-> CAST(:p1 AS TEXT)");
+  });
+
+  test("casts the key so the overloaded -> / ->> operators resolve", () => {
+    /*
+     * `jsonb -> text` and `jsonb -> integer` are both defined. An untyped bind
+     * parameter leaves Postgres unable to pick one and the query fails with
+     * "operator is not unique" — which only shows up against a real database,
+     * so it is pinned here.
+     */
+    expect(sqlOf({ Team: "Payments" })).toContain("CAST(:p1 AS TEXT)");
+  });
+
+  test("quotes nothing itself — the caller supplies the column reference", () => {
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+
+    expect(query.toSql('"Alert"."customFields"')).toContain(
+      '"Alert"."customFields"',
+    );
+  });
+});
+
+describe("buildJSONColumnQuery — SQL injection through the key", () => {
+  test("a key that closes the quote and appends a predicate is inert", () => {
+    const key: string = "a' = 'a' OR 1=1 OR 'x";
+    const query: JSONColumnQuery = build({ [key]: "v" });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).not.toContain("OR 1=1");
+    expect(sql).not.toContain(key);
+    expect(Object.values(query.parameters)).toContain(key);
+  });
+
+  test("a key carrying a statement terminator is inert", () => {
+    const key: string = '"; DROP TABLE "Incident"; --';
+    const query: JSONColumnQuery = build({ [key]: "v" });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).not.toContain("DROP TABLE");
+    expect(Object.values(query.parameters)).toContain(key);
+  });
+
+  test("a value that closes the quote is inert", () => {
+    const value: string = "x' OR 'a'='a";
+    const query: JSONColumnQuery = build({ Team: value });
+
+    expect(query.toSql(COLUMN)).not.toContain("OR 'a'='a");
+    expect(Object.values(query.parameters)).toContain(value);
+  });
+
+  test("the emitted statement contains no single-quoted user data at all", () => {
+    const sql: string = sqlOf({
+      "'quoted'": new Includes(["'also quoted'"]),
+      "%wild%": new Search("'sneaky'"),
+    });
+
+    /*
+     * Every literal the builder writes is one it authored: the jsonb type
+     * names, the empty string, and the numeric guard's regex. Anything else
+     * between quotes is user data that reached the statement text.
+     */
+    const authored: Set<string> = new Set<string>([
+      "''",
+      "'array'",
+      "'null'",
+      `'^\\s*-?[0-9]+(\\.[0-9]+)?\\s*$'`,
+    ]);
+
+    for (const literal of sql.match(/'[^']*'/g) || []) {
+      expect(authored.has(literal)).toBe(true);
+    }
+  });
+
+  test("the numeric guard's regex is the only literal a comparison writes", () => {
+    const sql: string = sqlOf({ "'k'": new GreaterThan(1) });
+
+    for (const literal of sql.match(/'[^']*'/g) || []) {
+      expect(literal).toBe(`'^\\s*-?[0-9]+(\\.[0-9]+)?\\s*$'`);
+    }
+  });
+});
+
+describe("buildJSONColumnQuery — statelessness", () => {
+  test("renders the same SQL when asked twice", () => {
+    /*
+     * The previous implementation rewrote its captured template inside the
+     * Raw callback, so the second render (findBy and countBy each resolve the
+     * operator) saw an already-substituted string. Pinning both calls keeps
+     * that from coming back.
+     */
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+
+    expect(query.toSql(COLUMN)).toBe(query.toSql(COLUMN));
+  });
+
+  test("renders correctly for a second, different column reference", () => {
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+
+    query.toSql('"Incident"."customFields"');
+    const second: string = query.toSql('"Alert"."customFields"');
+
+    expect(second).toContain('"Alert"."customFields"');
+    expect(second).not.toContain('"Incident"');
+  });
+
+  test("does not mint new parameters on render", () => {
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+    const before: number = Object.keys(query.parameters).length;
+
+    query.toSql(COLUMN);
+    query.toSql(COLUMN);
+
+    expect(Object.keys(query.parameters).length).toBe(before);
+  });
+});
+
+describe("buildJSONColumnQuery — equality", () => {
+  test("matches a scalar value", () => {
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+
+    expect(query.toSql(COLUMN)).toContain(
+      `${COLUMN} ->> CAST(:p1 AS TEXT) = CAST(:p2 AS TEXT)`,
+    );
+    expect(query.parameters["p2"]).toBe("Payments");
+  });
+
+  test("also matches a value stored inside an array", () => {
+    /*
+     * A multi-select stores ["Payments","Billing"]. Without the containment
+     * arm, `->>` returns the literal text '["Payments", "Billing"]' and the
+     * filter quietly returns nothing — the highest-value assertion in the file.
+     */
+    const query: JSONColumnQuery = build({ Team: "Payments" });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).toContain("jsonb_typeof(");
+    expect(sql).toContain("= 'array'");
+    expect(sql).toContain("@> CAST(:p3 AS JSONB)");
+    expect(query.parameters["p3"]).toBe('["Payments"]');
+  });
+
+  test("keeps a number a number in the containment literal", () => {
+    const query: JSONColumnQuery = build({ Count: 42 });
+
+    expect(query.parameters["p2"]).toBe("42");
+    expect(query.parameters["p3"]).toBe("[42]");
+  });
+
+  test("keeps a boolean a boolean in the containment literal", () => {
+    const query: JSONColumnQuery = build({ Regulated: true });
+
+    expect(query.parameters["p2"]).toBe("true");
+    expect(query.parameters["p3"]).toBe("[true]");
+  });
+
+  test("EqualTo compiles the same predicate as a bare value", () => {
+    expect(sqlOf({ Team: new EqualTo("Payments") })).toBe(
+      sqlOf({ Team: "Payments" }),
+    );
+  });
+
+  test("EqualToOrNull also matches rows with no value", () => {
+    const sql: string = sqlOf({ Team: new EqualToOrNull("Payments") });
+
+    expect(sql).toContain("IS NULL");
+    expect(sql).toContain(" OR ");
+  });
+});
+
+describe("buildJSONColumnQuery — negation includes rows without the key", () => {
+  test("NotEqual uses IS NOT TRUE rather than NOT", () => {
+    /*
+     * A row without the key compares to NULL. `NOT NULL` is NULL, which drops
+     * exactly the rows "Team is not Payments" is asked about; `IS NOT TRUE`
+     * keeps them.
+     */
+    const sql: string = sqlOf({ Team: new NotEqual("Payments") });
+
+    expect(sql).toContain("IS NOT TRUE");
+    expect(sql).not.toMatch(/NOT\s+\(/);
+  });
+
+  test("IncludesNone negates the whole any-of predicate", () => {
+    const sql: string = sqlOf({ Team: new IncludesNone(["a", "b"]) });
+
+    expect(sql).toContain(" OR ");
+    expect(sql).toContain("IS NOT TRUE");
+  });
+
+  test("NotContains negates the ILIKE", () => {
+    const sql: string = sqlOf({ Team: new NotContains("pay") });
+
+    expect(sql).toContain("ILIKE");
+    expect(sql).toContain("IS NOT TRUE");
+  });
+});
+
+describe("buildJSONColumnQuery — multi-value operators", () => {
+  test("Includes ORs one equality per value", () => {
+    const query: JSONColumnQuery = build({
+      Team: new Includes(["Payments", "Billing"]),
+    });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).toContain(" OR ");
+    expect(query.parameters["p2"]).toBe("Payments");
+    expect(query.parameters["p4"]).toBe("Billing");
+  });
+
+  test("IncludesAll ANDs one equality per value", () => {
+    const sql: string = sqlOf({
+      Team: new IncludesAll(["Payments", "Billing"]),
+    });
+
+    expect(sql).toContain(" AND ");
+    expect(sql).not.toContain(" OR CAST");
+  });
+
+  test("a bare array reads as is-any-of", () => {
+    expect(sqlOf({ Team: ["a", "b"] })).toBe(
+      sqlOf({ Team: new Includes(["a", "b"]) }),
+    );
+  });
+
+  test("ObjectID values stringify", () => {
+    const id: ObjectID = ObjectID.generate();
+    const query: JSONColumnQuery = build({ Owner: new Includes([id]) });
+
+    expect(query.parameters["p2"]).toBe(id.toString());
+  });
+
+  test("an empty selection constrains nothing rather than matching nothing", () => {
+    /*
+     * A cleared multi-select must not hide the table. `(1 = 1)` is the honest
+     * compilation of "the user selected nothing".
+     */
+    expect(sqlOf({ Team: new Includes([]) })).toBe("(1 = 1)");
+    expect(sqlOf({ Team: new IncludesNone([]) })).toBe("(1 = 1)");
+    expect(sqlOf({ Team: new IncludesAll([]) })).toBe("(1 = 1)");
+    expect(sqlOf({ Team: [] })).toBe("(1 = 1)");
+  });
+
+  test("an empty selection alongside a real one leaves the real one", () => {
+    const sql: string = sqlOf({
+      Team: new Includes([]),
+      Region: "us-east-1",
+    });
+
+    expect(sql).not.toBe("(1 = 1)");
+    expect(sql).toContain("CAST(:p3 AS TEXT)");
+  });
+});
+
+describe("buildJSONColumnQuery — text search", () => {
+  test("Search wraps the needle on both sides", () => {
+    const query: JSONColumnQuery = build({ Notes: new Search("outage") });
+
+    expect(query.toSql(COLUMN)).toContain("ILIKE :p2");
+    expect(query.parameters["p2"]).toBe("%outage%");
+  });
+
+  test("StartsWith and EndsWith anchor the pattern", () => {
+    expect(build({ Notes: new StartsWith("out") }).parameters["p2"]).toBe(
+      "out%",
+    );
+    expect(build({ Notes: new EndsWith("age") }).parameters["p2"]).toBe("%age");
+  });
+
+  test("wildcards inside the needle are escaped", () => {
+    /*
+     * "contains 100%" must not become "contains 100 followed by anything".
+     */
+    expect(build({ Notes: new Search("100%") }).parameters["p2"]).toBe(
+      "%100\\%%",
+    );
+    expect(build({ Notes: new Search("a_b") }).parameters["p2"]).toBe(
+      "%a\\_b%",
+    );
+    expect(build({ Notes: new Search("c:\\tmp") }).parameters["p2"]).toBe(
+      "%c:\\\\tmp%",
+    );
+  });
+
+  test("escapeLikePattern doubles the escape character first", () => {
+    expect(escapeLikePattern("\\%")).toBe("\\\\\\%");
+  });
+});
+
+describe("buildJSONColumnQuery — numeric comparison", () => {
+  test("guards the cast with a CASE, not an AND", () => {
+    /*
+     * A Number custom field is stored as text, and the column holds every
+     * field's value, so a comparison meets arbitrary strings. Postgres does
+     * not promise to evaluate an AND guard before the cast, and one
+     * "invalid input syntax for type numeric" aborts the whole request.
+     */
+    const sql: string = sqlOf({ Count: new GreaterThan(5) });
+
+    expect(sql).toContain("CASE WHEN");
+    expect(sql).toContain("AS NUMERIC");
+    expect(sql).toContain("ELSE NULL END");
+  });
+
+  test("emits the right operator for each comparison", () => {
+    expect(sqlOf({ Count: new GreaterThan(5) })).toContain(") > CAST(");
+    expect(sqlOf({ Count: new GreaterThanOrEqual(5) })).toContain(") >= CAST(");
+    expect(sqlOf({ Count: new LessThan(5) })).toContain(") < CAST(");
+    expect(sqlOf({ Count: new LessThanOrEqual(5) })).toContain(") <= CAST(");
+  });
+
+  test("binds the comparand as a number", () => {
+    expect(build({ Count: new GreaterThan(5) }).parameters["p2"]).toBe(5);
+  });
+
+  test("InBetween over numbers compares numerically", () => {
+    const sql: string = sqlOf({ Count: new InBetween(1, 10) });
+
+    expect(sql).toContain("AS NUMERIC");
+    expect(sql).toContain(" >= ");
+    expect(sql).toContain(" <= ");
+  });
+
+  test("InBetween over non-numbers compares as text", () => {
+    /*
+     * ISO-8601 dates sort lexicographically in calendar order, so a text
+     * BETWEEN is exact for them — and does not risk a cast error on a row
+     * holding something else.
+     */
+    const sql: string = sqlOf({
+      Window: new InBetween("2026-01-01", "2026-02-01"),
+    });
+
+    expect(sql).not.toContain("AS NUMERIC");
+    expect(sql).toContain("AS TEXT");
+  });
+});
+
+describe("buildJSONColumnQuery — emptiness", () => {
+  test("IsNull covers absent, JSON null, empty string and empty array", () => {
+    const sql: string = sqlOf({ Team: new IsNull() });
+
+    expect(sql).toContain("IS NULL");
+    expect(sql).toContain("jsonb_typeof");
+    expect(sql).toContain("'null'");
+    expect(sql).toContain("= ''");
+    expect(sql).toContain("jsonb_array_length");
+  });
+
+  test("NotNull is the negation of that", () => {
+    const sql: string = sqlOf({ Team: new NotNull() });
+
+    expect(sql).toContain("jsonb_array_length");
+    expect(sql).toContain("IS NOT TRUE");
+  });
+
+  test("an explicit null value reads as is-empty", () => {
+    expect(sqlOf({ Team: null } as unknown as JSONObject)).toBe(
+      sqlOf({ Team: new IsNull() }),
+    );
+  });
+});
+
+describe("buildJSONColumnQuery — backwards compatibility", () => {
+  test("an empty object still means the whole column is empty", () => {
+    /*
+     * Every JSON filter that has ever been cleared sends `{}`. Retargeting it
+     * would silently change what those saved filters mean.
+     */
+    expect(sqlOf({})).toBe(`(${COLUMN} IS NULL OR ${COLUMN} = '{}')`);
+  });
+
+  test("several plain keys AND together, as they always have", () => {
+    const query: JSONColumnQuery = build({ a: "1", b: "2" });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).toContain(" AND ");
+    expect(query.parameters["p1"]).toBe("a");
+    expect(query.parameters["p2"]).toBe("1");
+    expect(query.parameters["p4"]).toBe("b");
+    expect(query.parameters["p5"]).toBe("2");
+  });
+
+  test("a JSON string argument is parsed", () => {
+    const query: JSONColumnQuery = buildJSONColumnQuery({
+      value: '{"Team":"Payments"}',
+      generateParameterName: sequentialNames(),
+    });
+
+    expect(query.parameters["p1"]).toBe("Team");
+    expect(query.parameters["p2"]).toBe("Payments");
+  });
+
+  test("an unparseable string degrades to the empty-column predicate", () => {
+    const query: JSONColumnQuery = buildJSONColumnQuery({
+      value: "not json at all",
+      generateParameterName: sequentialNames(),
+    });
+
+    expect(query.toSql(COLUMN)).toBe(`(${COLUMN} IS NULL OR ${COLUMN} = '{}')`);
+  });
+
+  test("a nested object reads as containment", () => {
+    const query: JSONColumnQuery = build({
+      Address: { city: "Berlin" } as unknown as string,
+    });
+
+    expect(query.toSql(COLUMN)).toContain("@> CAST(:p2 AS JSONB)");
+    expect(query.parameters["p2"]).toBe('{"city":"Berlin"}');
+  });
+
+  test("an empty key is skipped", () => {
+    expect(sqlOf({ "": "x" })).toBe("(1 = 1)");
+  });
+});
+
+describe("buildJSONColumnQuery — limits", () => {
+  test("refuses more keys than the cap", () => {
+    const value: JSONObject = {};
+
+    for (let i: number = 0; i <= MAX_JSON_QUERY_KEYS; i++) {
+      value[`key${i}`] = "v";
+    }
+
+    expect(() => {
+      return build(value);
+    }).toThrow(BadDataException);
+  });
+
+  test("refuses more values on one key than the cap", () => {
+    const values: Array<string> = [];
+
+    for (let i: number = 0; i <= MAX_JSON_QUERY_VALUES_PER_KEY; i++) {
+      values.push(`v${i}`);
+    }
+
+    expect(() => {
+      return build({ Team: new Includes(values) });
+    }).toThrow(BadDataException);
+  });
+
+  test("refuses a key longer than the cap", () => {
+    expect(() => {
+      return build({ ["k".repeat(MAX_JSON_QUERY_KEY_LENGTH + 1)]: "v" });
+    }).toThrow(BadDataException);
+  });
+
+  test("accepts a payload exactly at the caps", () => {
+    const values: Array<string> = [];
+
+    for (let i: number = 0; i < MAX_JSON_QUERY_VALUES_PER_KEY; i++) {
+      values.push(`v${i}`);
+    }
+
+    expect(() => {
+      return build({
+        ["k".repeat(MAX_JSON_QUERY_KEY_LENGTH)]: new Includes(values),
+      });
+    }).not.toThrow();
+  });
+});
+
+describe("buildJSONColumnQuery — parameter hygiene", () => {
+  test("mints a distinct parameter for every bound value", () => {
+    const query: JSONColumnQuery = build({
+      Team: new Includes(["a", "b"]),
+      Region: "us-east-1",
+    });
+
+    const names: Array<string> = Object.keys(query.parameters);
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("production names do not collide across keys", () => {
+    const query: JSONColumnQuery = buildJSONColumnQuery({
+      value: { a: "1", b: "2", c: "3" },
+    });
+
+    const names: Array<string> = Object.keys(query.parameters);
+
+    expect(new Set(names).size).toBe(names.length);
+    expect(names.length).toBe(9);
+  });
+
+  test("every placeholder in the SQL has a parameter behind it", () => {
+    const query: JSONColumnQuery = buildJSONColumnQuery({
+      value: {
+        Team: new Includes(["a", "b"]),
+        Count: new GreaterThan(3),
+        Notes: new Search("x"),
+        Cleared: new IsNull(),
+      },
+    });
+
+    const placeholders: Array<string> = (
+      query.toSql(COLUMN).match(/:[A-Za-z]+/g) || []
+    ).map((placeholder: string) => {
+      return placeholder.slice(1);
+    });
+
+    expect(placeholders.length).toBeGreaterThan(0);
+
+    for (const placeholder of placeholders) {
+      expect(query.parameters).toHaveProperty(placeholder);
+    }
+  });
+});

--- a/Common/Tests/Server/Types/Database/QueryUtil.test.ts
+++ b/Common/Tests/Server/Types/Database/QueryUtil.test.ts
@@ -1,5 +1,8 @@
 import QueryUtil from "../../../../Server/Types/Database/QueryUtil";
+import Incident from "../../../../Models/DatabaseModels/Incident";
 import TeamMember from "../../../../Models/DatabaseModels/TeamMember";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import IsNull from "../../../../Types/BaseDatabase/IsNull";
 import Search from "../../../../Types/BaseDatabase/Search";
 import ObjectID from "../../../../Types/ObjectID";
 import { FindOperator } from "typeorm";
@@ -70,5 +73,115 @@ describe("QueryUtil.serializeQuery — nested relation operators", () => {
 
     // Plain id equality must NOT be rewritten into an ILIKE — it stays a value.
     expect(result["user"]._id).toBe(userId.toString());
+  });
+});
+
+/*
+ * Custom field filters ride the `customFields` jsonb column, so they reach the
+ * database through serializeQuery's JSON branch. These pin the routing: the
+ * branch has to fire for an operator-valued object (the new custom-field
+ * chips) exactly as it always has for a plain one, and the branches above it
+ * have to keep winning for a whole-column IsNull.
+ */
+describe("QueryUtil.serializeQuery — customFields jsonb column", () => {
+  type RawOperatorSqlFunction = (operator: unknown) => string;
+
+  const rawOperatorSql: RawOperatorSqlFunction = (
+    operator: unknown,
+  ): string => {
+    const getSql: ((aliasPath: string) => string) | undefined = (
+      operator as FindOperator<unknown>
+    ).getSql;
+
+    if (!getSql) {
+      throw new Error("Expected a Raw FindOperator with a SQL generator.");
+    }
+
+    return getSql("Incident.customFields");
+  };
+
+  it("compiles a plain key/value object into a raw jsonb predicate", () => {
+    const query: Record<string, unknown> = {
+      projectId: ObjectID.generate(),
+      customFields: { Team: "Payments" },
+    };
+
+    const result: Record<string, any> = QueryUtil.serializeQuery(
+      Incident,
+      query as any,
+    ) as unknown as Record<string, any>;
+
+    expect(result["customFields"]).toBeInstanceOf(FindOperator);
+    expect(result["customFields"].type).toBe("raw");
+    expect(rawOperatorSql(result["customFields"])).toContain(
+      '"Incident"."customFields" ->>',
+    );
+    expect(
+      Object.values(result["customFields"].objectLiteralParameters),
+    ).toContain("Payments");
+  });
+
+  it("compiles an operator nested under a key into the same raw predicate", () => {
+    const query: Record<string, unknown> = {
+      projectId: ObjectID.generate(),
+      customFields: { Team: new Includes(["Payments", "Billing"]) },
+    };
+
+    const result: Record<string, any> = QueryUtil.serializeQuery(
+      Incident,
+      query as any,
+    ) as unknown as Record<string, any>;
+
+    const sql: string = rawOperatorSql(result["customFields"]);
+
+    // Two values means two OR-ed equality arms, each with a containment check.
+    expect(sql).toContain(" OR ");
+    expect(sql).toContain("@> CAST(");
+    expect(
+      Object.values(result["customFields"].objectLiteralParameters),
+    ).toEqual(expect.arrayContaining(["Team", "Payments", "Billing"]));
+  });
+
+  it("never leaves a custom field name in the statement text", () => {
+    const query: Record<string, unknown> = {
+      projectId: ObjectID.generate(),
+      customFields: { "x' OR 1=1 --": "v" },
+    };
+
+    const result: Record<string, any> = QueryUtil.serializeQuery(
+      Incident,
+      query as any,
+    ) as unknown as Record<string, any>;
+
+    expect(rawOperatorSql(result["customFields"])).not.toContain("OR 1=1");
+  });
+
+  it("still routes a whole-column IsNull to the branch above the JSON one", () => {
+    const query: Record<string, unknown> = {
+      projectId: ObjectID.generate(),
+      customFields: new IsNull(),
+    };
+
+    const result: Record<string, any> = QueryUtil.serializeQuery(
+      Incident,
+      query as any,
+    ) as unknown as Record<string, any>;
+
+    expect(rawOperatorSql(result["customFields"])).toContain("IS NULL");
+    expect(rawOperatorSql(result["customFields"])).not.toContain("->>");
+  });
+
+  it("still routes an explicit null to isNull", () => {
+    const query: Record<string, unknown> = {
+      projectId: ObjectID.generate(),
+      customFields: null,
+    };
+
+    const result: Record<string, any> = QueryUtil.serializeQuery(
+      Incident,
+      query as any,
+    ) as unknown as Record<string, any>;
+
+    expect(rawOperatorSql(result["customFields"])).toContain("IS NULL");
   });
 });

--- a/Common/Tests/UI/Components/ModelTable/useCustomFieldColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/useCustomFieldColumns.test.tsx
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+/*
+ * `isLoading` used to start `false` and flip true inside the effect, which was
+ * fine while custom field definitions only ever added optional table columns:
+ * a column that appears late is just a column that appears late.
+ *
+ * The facet bar cannot read it that way. It restores its chips from the URL on
+ * the very first render, and a chip whose definition has not arrived yet is
+ * indistinguishable from a chip the user cleared — the difference being that
+ * the second means "erase the shared link's filter". So the first render has
+ * to be able to say "a request is coming", and these tests pin that.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the compiled
+ * requires, so naming the mock directly would capture it before its
+ * initializer has run.
+ */
+jest.mock("../../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+const getCurrentProjectIdMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: (...args: Array<any>) => {
+        return getCurrentProjectIdMock(...args);
+      },
+    },
+  };
+});
+
+import useCustomFieldColumns, {
+  CustomFieldColumnsResult,
+} from "../../../../UI/Components/ModelTable/useCustomFieldColumns";
+import { CustomFieldDefinition } from "../../../../UI/Components/ModelTable/CustomFieldColumns";
+import BaseModel from "../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import IncidentCustomField from "../../../../Models/DatabaseModels/IncidentCustomField";
+import CustomFieldType from "../../../../Types/CustomField/CustomFieldType";
+import ObjectID from "../../../../Types/ObjectID";
+
+const PROJECT_ID: string = "11111111-1111-4111-8111-111111111111";
+
+interface Snapshot {
+  isLoading: boolean;
+  definitionNames: Array<string>;
+  columnIds: Array<string>;
+}
+
+type HarnessPropsType = {
+  customFieldsModelType?: { new (): BaseModel } | undefined;
+  onRender: (snapshot: Snapshot) => void;
+};
+
+const Harness: React.FunctionComponent<HarnessPropsType> = (
+  props: HarnessPropsType,
+): React.ReactElement => {
+  const result: CustomFieldColumnsResult<BaseModel> =
+    useCustomFieldColumns<BaseModel>({
+      customFieldsModelType: props.customFieldsModelType,
+    });
+
+  props.onRender({
+    isLoading: result.isLoading,
+    definitionNames: result.definitions.map((d: CustomFieldDefinition) => {
+      return d.name;
+    }),
+    columnIds: result.columns.map((column: { id?: string | undefined }) => {
+      return column.id || "";
+    }),
+  });
+
+  return <div />;
+};
+
+type RenderHarnessFunction = (
+  customFieldsModelType?: { new (): BaseModel } | undefined,
+) => Array<Snapshot>;
+
+const renderHarness: RenderHarnessFunction = (
+  customFieldsModelType?: { new (): BaseModel } | undefined,
+): Array<Snapshot> => {
+  const snapshots: Array<Snapshot> = [];
+
+  render(
+    <Harness
+      customFieldsModelType={customFieldsModelType}
+      onRender={(snapshot: Snapshot) => {
+        snapshots.push(snapshot);
+      }}
+    />,
+  );
+
+  return snapshots;
+};
+
+afterEach(() => {
+  cleanup();
+  getListMock.mockReset();
+  getCurrentProjectIdMock.mockReset();
+});
+
+describe("useCustomFieldColumns — isLoading on the first render", () => {
+  test("is true before the request has even been sent", () => {
+    getCurrentProjectIdMock.mockReturnValue(new ObjectID(PROJECT_ID));
+    getListMock.mockReturnValue(new Promise(() => {}));
+
+    const snapshots: Array<Snapshot> = renderHarness(IncidentCustomField);
+
+    expect(snapshots[0]!.isLoading).toBe(true);
+  });
+
+  test("is false when there is no definition model to load", () => {
+    /*
+     * Every table without custom fields renders this hook too. Reporting
+     * "loading" there would make the facet bar hold its URL snapshot hostage
+     * on pages that will never have a chip to wait for.
+     */
+    getCurrentProjectIdMock.mockReturnValue(new ObjectID(PROJECT_ID));
+
+    expect(renderHarness(undefined)[0]!.isLoading).toBe(false);
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+
+  test("is false when there is no current project", () => {
+    getCurrentProjectIdMock.mockReturnValue(null);
+
+    expect(renderHarness(IncidentCustomField)[0]!.isLoading).toBe(false);
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCustomFieldColumns — settling", () => {
+  test("goes false once the definitions land, and reports them sorted", () => {
+    getCurrentProjectIdMock.mockReturnValue(new ObjectID(PROJECT_ID));
+    getListMock.mockReturnValue(
+      Promise.resolve({
+        data: [
+          { name: "Team", customFieldType: CustomFieldType.Text },
+          { name: "Impacted Users", customFieldType: CustomFieldType.Number },
+        ],
+      }),
+    );
+
+    const snapshots: Array<Snapshot> = renderHarness(IncidentCustomField);
+
+    return waitFor(() => {
+      const last: Snapshot = snapshots[snapshots.length - 1]!;
+
+      expect(last.isLoading).toBe(false);
+      // Sorted, so a viewer's column layout does not shuffle between loads.
+      expect(last.definitionNames).toEqual(["Impacted Users", "Team"]);
+      expect(last.columnIds).toEqual([
+        "customFields.Impacted Users",
+        "customFields.Team",
+      ]);
+    });
+  });
+
+  test("goes false and yields nothing when the request fails", () => {
+    /*
+     * Custom fields are a paid feature the viewer may not be able to read, so
+     * a failure here is expected in normal operation. It must settle rather
+     * than leave every caller waiting forever.
+     */
+    getCurrentProjectIdMock.mockReturnValue(new ObjectID(PROJECT_ID));
+    getListMock.mockReturnValue(Promise.reject(new Error("no permission")));
+
+    const snapshots: Array<Snapshot> = renderHarness(IncidentCustomField);
+
+    return waitFor(() => {
+      const last: Snapshot = snapshots[snapshots.length - 1]!;
+
+      expect(last.isLoading).toBe(false);
+      expect(last.definitionNames).toEqual([]);
+      expect(last.columnIds).toEqual([]);
+    });
+  });
+});

--- a/Common/Types/CustomField/CustomFieldDefinition.ts
+++ b/Common/Types/CustomField/CustomFieldDefinition.ts
@@ -1,0 +1,24 @@
+import CustomFieldType from "./CustomFieldType";
+
+/*
+ * One custom field, as the rest of the product needs to read it: the shape
+ * that comes back from a `*CustomField` definition table, narrowed to the four
+ * properties anything rendering or filtering by it actually uses.
+ *
+ * Lives in Types rather than beside the table columns that first needed it
+ * because the facet bar builds its chips from the same definitions, and that
+ * code is compiled by App's `tsc`, which has no React in it — importing the
+ * type from a .tsx would pull React into a program that cannot resolve it.
+ * `CustomFieldColumns` re-exports it, so existing imports keep working.
+ */
+export interface CustomFieldDefinition {
+  name: string;
+  description?: string | undefined;
+  customFieldType?: CustomFieldType | undefined;
+  /**
+   * Serialized options for a Dropdown / MultiSelectDropdown field. Parse with
+   * `parseCustomFieldDropdownOptions` — the value is either the legacy
+   * one-per-line format or a JSON array of `{ value, color }`.
+   */
+  dropdownOptions?: string | undefined;
+}

--- a/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
+++ b/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
@@ -5,6 +5,7 @@ import DropdownValueBadge from "../Dropdown/DropdownValueBadge";
 import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import CustomFieldType from "../../../Types/CustomField/CustomFieldType";
+import { CustomFieldDefinition } from "../../../Types/CustomField/CustomFieldDefinition";
 import {
   CustomFieldDropdownOption,
   parseCustomFieldDropdownOptions,
@@ -45,12 +46,7 @@ import React, { ReactElement } from "react";
  * fall-through text branch understands a dotted key.
  */
 
-export interface CustomFieldDefinition {
-  name: string;
-  description?: string | undefined;
-  customFieldType?: CustomFieldType | undefined;
-  dropdownOptions?: string | undefined;
-}
+export type { CustomFieldDefinition } from "../../../Types/CustomField/CustomFieldDefinition";
 
 export const CustomFieldsColumnKey: string = "customFields";
 

--- a/Common/UI/Components/ModelTable/useCustomFieldColumns.ts
+++ b/Common/UI/Components/ModelTable/useCustomFieldColumns.ts
@@ -55,11 +55,24 @@ const useCustomFieldColumns: UseCustomFieldColumnsFunction = <
   const [definitions, setDefinitions] = useState<Array<CustomFieldDefinition>>(
     [],
   );
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string>("");
 
   const projectId: ObjectID | null =
     data.projectId ?? ProjectUtil.getCurrentProjectId();
+
+  /*
+   * Starts true whenever a request is actually going to happen, rather than
+   * false-until-the-effect-runs.
+   *
+   * Columns did not care — they only ever appear — but a caller that has to
+   * distinguish "no custom fields" from "not yet" does. The facet bar is one:
+   * on the first render it must know that a chip restored from a shared link
+   * may still be on its way, or it drops the link's filter before the request
+   * has even been sent.
+   */
+  const [isLoading, setIsLoading] = useState<boolean>(
+    Boolean(data.customFieldsModelType && projectId),
+  );
+  const [error, setError] = useState<string>("");
 
   const projectIdString: string = projectId?.toString() || "";
   const modelName: string = customFieldsModelType?.name || "";
@@ -67,6 +80,12 @@ const useCustomFieldColumns: UseCustomFieldColumnsFunction = <
   useEffect(() => {
     if (!customFieldsModelType || !projectId) {
       setDefinitions([]);
+      /*
+       * Nothing to wait for. Said explicitly because the initial state is now
+       * "loading" whenever a request is expected, and a model type that goes
+       * away between renders would otherwise leave it stuck there.
+       */
+      setIsLoading(false);
       return;
     }
 


### PR DESCRIPTION
Closes the request to filter and search incidents (and other resources) by Custom Field values, the way State, Severity and Labels already work.

## What you get

One facet chip per custom field, next to the existing chips, on all seven tables that have custom fields: **Incidents, Alerts, Monitors, Scheduled Maintenance, On-Call Duty Policies, Teams, Status Pages**.

| Custom field type | Chip | Operators |
|---|---|---|
| Dropdown | option list, with the configured option colours | is, is not, is empty, is not empty |
| Multi-select dropdown | option list, multi-select | is (any of), is not (none of), is empty, is not empty |
| Boolean | Yes / No | is, is empty, is not empty |
| Text | typed value | is, is not, contains, does not contain, starts with, ends with, is empty, is not empty |
| Number | typed value | is, is not, >, ≥, <, ≤, is empty, is not empty |

Chips **AND** together, and they inherit URL persistence and saved views for free, so a filtered view is shareable and a saved view restores its custom field chips.

## Server

Custom field values live under the field's *name* inside one `customFields` jsonb column. The only path to that column was `QueryHelper.queryJson`, which compared every key with `=`. `Common/Server/Types/Database/JSONColumnQuery.ts` replaces it with a per-key predicate builder.

Three things it fixes along the way, each with tests:

- **The key is now a bound parameter.** It used to be interpolated into the SQL string, so a custom field *name* — text any project member can type — reached the `WHERE` clause verbatim, on any `TableColumnType.JSON` column. See the note at the bottom.
- **A value matches whether it is stored as a scalar or inside an array.** A multi-select stores `["infra","apps"]`, so `->>` alone returns the literal text `["infra", "apps"]` and the filter would silently return nothing. A field switched from single- to multi-select keeps filtering.
- **The operator is stateless.** It used to rewrite its own captured template inside the `Raw` callback, so the second render — `findBy` and `countBy` each resolve it — saw an already-substituted string.

Other decisions worth knowing:

- Operators reuse the vocabulary the query layer already speaks (`Includes`, `Search`, `NotEqual`, `GreaterThan`, `IsNull`, …), so a browser-built query serializes and reconstructs with no new wire format and no new deserialization surface.
- A row **missing** the key satisfies a negative filter — "Team is not Payments" includes incidents with no Team. Same reading the ClickHouse attribute path already gives.
- The numeric cast is guarded by a `CASE`, not an `AND`. A Number custom field is stored as *text*, the column holds every field's value, and Postgres does not promise to evaluate an `AND` guard before the cast — one `invalid input syntax for type numeric` would abort the whole request.
- `%` and `_` in a user's value are escaped, so "contains 100%" is not "contains 100 followed by anything".
- Empty-object semantics, the `FindOperator` early return, and plain key/value equality are unchanged, so existing `FieldType.JSON` filters produce the same SQL.

## UI

Text and number fields needed a chip kind that did not exist — `FilterChipValueInput`, the typed-value counterpart to the existing date-range chip. It keeps a local draft and commits on Enter, Apply, or dismissal, so typing "payments" is one query rather than eight.

Two facet-bar mechanics were needed because every custom field chip writes the same `customFields` column:

- `ResourceFacet.mergeQueryValue` — `mergeFiltersIntoQuery` builds one object, so without it the second chip would replace the first silently while both stayed lit.
- `ResourceFacet.handlesValuelessOperators` — "is empty" at the field would ask whether the whole `customFields` column is null rather than whether this one key is unset.

Both are opt-in; every existing facet behaves exactly as before.

**Async definitions.** Definitions are fetched while a shared link is restored synchronously on the first render, so `useResourceOwners` takes `areFacetsLoading`. While true the hook does not touch the URL — it would read a not-yet-arrived chip as "the user cleared it" and delete the link's filter. When it settles it reconciles once: late chips get their clamp, and selections for custom fields renamed or deleted since the link was made are dropped instead of filtering invisibly.

**Not in the column-filter popup, deliberately.** `BaseModelTable.fetchItems` builds its request as `{...props.query, ...columnFilterQuery}`, so a popup filter on `customFields` would replace every chip's constraint outright, silently, while the chips carried on claiming to apply. `CustomFieldFilteringInvariants` asserts no table declares one.

## Tests

161 new/updated App tests and 56 new Common tests.

- `Common/Tests/Server/Types/Database/JSONColumnQuery.test.ts` — 51 tests: injection through the key and through values, statelessness across two renders, array-vs-scalar matching, negation including unset rows, the numeric CASE guard, LIKE escaping, emptiness, limits, parameter hygiene, and backwards compatibility.
- `Common/Tests/Server/Types/Database/QueryUtil.test.ts` — routing through `serializeQuery`, including that a whole-column `IsNull` still wins over the JSON branch.
- `Common/Tests/UI/Components/ModelTable/useCustomFieldColumns.test.tsx` — the `isLoading` contract the facet bar depends on.
- `App/Tests/Dashboard/CustomFieldFacets.test.ts` — type→chip mapping, dropdown option parsing in both formats, every operator's query value, and field names hostile to a query builder.
- `App/Tests/Dashboard/FacetColumnQuery.test.ts` — the chip-sharing contract end to end: four chips producing one `customFields` object, and "is empty" on one chip not nulling the column.
- `App/Tests/Dashboard/CustomFieldFilteringInvariants.test.ts` — the wiring on all seven tables, and the popup guard.
- `App/Tests/Dashboard/FacetSelectionState.test.ts` — restore-from-URL before definitions land, and clamping for the new chip kinds.

**Verification run:** full Common suite green (717 suites / 14,061 tests), the new App tests green, `Common` and `App/FeatureSet/Dashboard` type-check clean, lint clean.

**Not verified in a browser** — Docker was not available in this environment, and the dashboard needs the full compose stack plus a project with custom fields defined and incidents carrying values. Worth a manual pass before merge.

## Notes for review

- **The injection fix is independently exploitable on `master` today**, against any `TableColumnType.JSON` column, not just `customFields`. If you would rather it went out through your security process than in a feature PR, the `JSONColumnQuery` + `QueryHelper.queryJson` half of this change stands alone and can be split out.
- **No index.** There is no GIN index on any `customFields` column, so these predicates are sequential scans. They are always ANDed with the page's `projectId` scoping, so the planner has something selective to lead with — but on a project with hundreds of thousands of incidents this is a real cost. I would rather measure than add an index speculatively: a `jsonb_path_ops` GIN index accelerates containment, not `->>`, so it would only help the equality shapes and would mean rewriting them.
- **Boolean "is empty" will match almost nothing.** `BasicForm` force-writes `false` for every toggle on save, so any resource ever edited through the detail form has a value. The chip is honest, just not very useful for that operator.
- **Out of scope:** `TeamMemberCustomField` (values live on `ProjectUserProfile` while the page renders `TeamMember` — needs a cross-model join), the `*Template` models (no definition model, no reader), and the cross-project Global pages (custom field definitions are project-scoped, so there is no coherent chip to offer).
- Sorting by a custom field is still not possible, but the `->>` expression it needs is now built here, so a follow-up is materially cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
