### PR TITLE
fix(telemetry): stop bad metadata and failed maintenance from stranding resources as disconnected

### DIFF
--- a/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
@@ -51,6 +51,17 @@ import { canonicalizeEntityValue } from "Common/Utils/Telemetry/EntityKey";
 import { normalizeHostIpAddresses } from "Common/Utils/Telemetry/HostIpAddresses";
 import Dictionary from "Common/Types/Dictionary";
 
+/*
+ * A maintenance fence that one autoDiscover* attempt armed, recorded so
+ * that attempt's catch block can release what it armed — and only what it
+ * armed, never a fence another worker is holding. See
+ * OtelIngestBaseService.releaseMaintenanceFences.
+ */
+type MaintenanceFence = {
+  scope: string;
+  id: string;
+};
+
 export default abstract class OtelIngestBaseService {
   private static readonly DOCKER_CONTAINER_NAME_CACHE_NAMESPACE: string =
     "docker-container-name";
@@ -128,6 +139,36 @@ export default abstract class OtelIngestBaseService {
       );
     } catch {
       // best-effort — the fence TTL will expire the key regardless.
+    }
+  }
+
+  /*
+   * Release every fence an autoDiscover* attempt armed. Each of those
+   * methods records its fences in a local `armedFences` array as it arms
+   * them and calls this from its catch block, so a transient failure
+   * anywhere in the method (Postgres contention on a hot row, a label
+   * upsert that lost a race) costs one retry rather than a full 5-minute
+   * window of suppressed lastSeenAt refreshes.
+   *
+   * Recording what was armed — rather than re-deriving a key in the catch —
+   * is what keeps this safe under concurrency: when shouldRunMaintenance
+   * says another worker already holds the fence, nothing is recorded, so a
+   * failure here can never clear a window that worker is relying on.
+   *
+   * It is deliberately all-or-nothing WITHIN one attempt: a method with two
+   * fences (the *-instance / rum-client live-inventory fences run under
+   * their own) releases both even if only the later one failed. The cost of
+   * that is bounded and small — updateLastSeen and attachLabels each carry
+   * their own 60-second throttle, so redoing them next batch is at most one
+   * extra UPDATE per minute, the same tradeoff already accepted for two
+   * callers sharing one extras fingerprint. Tracking per-fence success to
+   * shave that off is not worth the extra invariant.
+   */
+  protected static async releaseMaintenanceFences(
+    fences: Array<MaintenanceFence>,
+  ): Promise<void> {
+    for (const fence of fences) {
+      await this.clearMaintenanceFence(fence.scope, fence.id);
     }
   }
 
@@ -877,8 +918,13 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
-    let clusterIdStr: string | null = null;
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
+      let clusterIdStr: string | null = null;
       const clusterName: string | null = this.getClusterNameFromAttributes(
         data.attributes,
       );
@@ -922,6 +968,7 @@ export default abstract class OtelIngestBaseService {
          * bounded by the TTL.
          */
         if (await this.shouldRunMaintenance("k8s-cluster", clusterIdStr)) {
+          armedFences.push({ scope: "k8s-cluster", id: clusterIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -940,16 +987,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
-      /*
-       * The fence for this cluster is armed before updateLastSeen runs,
-       * so a failure here (e.g. Postgres contention on the shared hot
-       * cluster row) would otherwise suppress the next ~5 minutes of
-       * lastSeenAt refreshes. Release it so the next batch retries and
-       * the cluster does not drift to "disconnected" while data flows.
-       */
-      if (clusterIdStr) {
-        await this.clearMaintenanceFence("k8s-cluster", clusterIdStr);
-      }
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Kubernetes cluster: " + (err as Error).message,
       );
@@ -1020,6 +1058,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const clusterName: string | null =
         this.getProxmoxClusterNameFromAttributes(data.attributes);
@@ -1060,6 +1103,7 @@ export default abstract class OtelIngestBaseService {
          * already ran it within the fence window.
          */
         if (await this.shouldRunMaintenance("proxmox-cluster", clusterIdStr)) {
+          armedFences.push({ scope: "proxmox-cluster", id: clusterIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -1078,6 +1122,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Proxmox cluster: " + (err as Error).message,
       );
@@ -1152,6 +1197,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const fleetName: string | null = this.getIoTFleetNameFromAttributes(
         data.attributes,
@@ -1193,6 +1243,7 @@ export default abstract class OtelIngestBaseService {
          * already ran it within the fence window.
          */
         if (await this.shouldRunMaintenance("iot-fleet", fleetIdStr)) {
+          armedFences.push({ scope: "iot-fleet", id: fleetIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -1211,6 +1262,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering IoT fleet: " + (err as Error).message,
       );
@@ -1282,6 +1334,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const clusterName: string | null =
         this.getDockerSwarmClusterNameFromAttributes(data.attributes);
@@ -1322,6 +1379,10 @@ export default abstract class OtelIngestBaseService {
         if (
           await this.shouldRunMaintenance("docker-swarm-cluster", clusterIdStr)
         ) {
+          armedFences.push({
+            scope: "docker-swarm-cluster",
+            id: clusterIdStr,
+          });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -1340,6 +1401,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Docker Swarm cluster: " +
           (err as Error).message,
@@ -1409,6 +1471,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const clusterName: string | null = this.getCephClusterNameFromAttributes(
         data.attributes,
@@ -1450,6 +1517,7 @@ export default abstract class OtelIngestBaseService {
          * already ran it within the fence window.
          */
         if (await this.shouldRunMaintenance("ceph-cluster", clusterIdStr)) {
+          armedFences.push({ scope: "ceph-cluster", id: clusterIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -1474,6 +1542,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Ceph cluster: " + (err as Error).message,
       );
@@ -1554,6 +1623,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const faasName: string | null = this.getStringAttribute(
         data.attributes,
@@ -1613,6 +1687,10 @@ export default abstract class OtelIngestBaseService {
         if (
           await this.shouldRunMaintenance("serverless-function", functionIdStr)
         ) {
+          armedFences.push({
+            scope: "serverless-function",
+            id: functionIdStr,
+          });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -1662,6 +1740,10 @@ export default abstract class OtelIngestBaseService {
             `${functionIdStr}:${faasInstance}`,
           ))
         ) {
+          armedFences.push({
+            scope: "serverless-fn-instance",
+            id: `${functionIdStr}:${faasInstance}`,
+          });
           await ServerlessFunctionInstanceService.recordInstance({
             projectId: data.projectId,
             serverlessFunctionId: functionId,
@@ -1673,6 +1755,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Serverless function: " + (err as Error).message,
       );
@@ -1766,6 +1849,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const cloudPlatform: string | null = this.getStringAttribute(
         data.attributes,
@@ -1837,6 +1925,7 @@ export default abstract class OtelIngestBaseService {
       if (resourceIdStr) {
         const cloudResourceId: ObjectID = new ObjectID(resourceIdStr);
         if (await this.shouldRunMaintenance("cloud-resource", resourceIdStr)) {
+          armedFences.push({ scope: "cloud-resource", id: resourceIdStr });
           await CloudResourceService.updateLastSeen(cloudResourceId, {
             cloudPlatform: cloudPlatform || undefined,
             cloudProvider: cloudProvider || undefined,
@@ -1862,6 +1951,10 @@ export default abstract class OtelIngestBaseService {
             `${resourceIdStr}:${instanceName}`,
           ))
         ) {
+          armedFences.push({
+            scope: "cloud-resource-instance",
+            id: `${resourceIdStr}:${instanceName}`,
+          });
           await CloudResourceInstanceService.recordInstance({
             projectId: data.projectId,
             cloudResourceId,
@@ -1873,6 +1966,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Cloud resource: " + (err as Error).message,
       );
@@ -1957,6 +2051,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       const clientType: string | null = this.getRumClientType(data.attributes);
       if (!clientType) {
@@ -1997,6 +2096,7 @@ export default abstract class OtelIngestBaseService {
       if (appIdStr) {
         const rumApplicationId: ObjectID = new ObjectID(appIdStr);
         if (await this.shouldRunMaintenance("rum-application", appIdStr)) {
+          armedFences.push({ scope: "rum-application", id: appIdStr });
           const agentVersion: string | null =
             this.getStringAttribute(data.attributes, "telemetry.sdk.version") ||
             this.getStringAttribute(data.attributes, "oneuptime.agent.version");
@@ -2027,6 +2127,10 @@ export default abstract class OtelIngestBaseService {
             `${appIdStr}:${clientName}`,
           ))
         ) {
+          armedFences.push({
+            scope: "rum-client",
+            id: `${appIdStr}:${clientName}`,
+          });
           await RumApplicationClientService.recordClient({
             projectId: data.projectId,
             rumApplicationId,
@@ -2039,6 +2143,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering RUM application: " + (err as Error).message,
       );
@@ -2288,6 +2393,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       if (!this.isDockerRuntime(data.attributes)) {
         return null;
@@ -2341,6 +2451,7 @@ export default abstract class OtelIngestBaseService {
          * already ran it within the fence window.
          */
         if (await this.shouldRunMaintenance("docker-host", hostIdStr)) {
+          armedFences.push({ scope: "docker-host", id: hostIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -2361,6 +2472,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Docker host: " + (err as Error).message,
       );
@@ -2414,6 +2526,11 @@ export default abstract class OtelIngestBaseService {
     projectId: ObjectID;
     attributes: JSONArray;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       if (!this.isPodmanRuntime(data.attributes)) {
         return null;
@@ -2467,6 +2584,7 @@ export default abstract class OtelIngestBaseService {
          * already ran it within the fence window.
          */
         if (await this.shouldRunMaintenance("podman-host", hostIdStr)) {
+          armedFences.push({ scope: "podman-host", id: hostIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -2487,6 +2605,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error(
         "Error auto-discovering Podman host: " + (err as Error).message,
       );
@@ -2587,6 +2706,11 @@ export default abstract class OtelIngestBaseService {
     totalMemoryBytes?: number | undefined;
     processCount?: number | undefined;
   }): Promise<ObjectID | null> {
+    /*
+     * Fences armed below, released by the catch block. See
+     * releaseMaintenanceFences.
+     */
+    const armedFences: Array<MaintenanceFence> = [];
     try {
       /*
        * Docker hosts, Podman hosts and Kubernetes clusters/nodes live in
@@ -2708,6 +2832,7 @@ export default abstract class OtelIngestBaseService {
          * minutes, so a 5-minute stale window is acceptable.
          */
         if (await this.shouldRunMaintenance("host", hostIdStr)) {
+          armedFences.push({ scope: "host", id: hostIdStr });
           const agentVersion: string | null = this.getStringAttribute(
             data.attributes,
             "oneuptime.agent.version",
@@ -2783,6 +2908,7 @@ export default abstract class OtelIngestBaseService {
 
       return null;
     } catch (err) {
+      await this.releaseMaintenanceFences(armedFences);
       logger.error("Error auto-discovering Host: " + (err as Error).message);
       return null;
     }

--- a/App/Tests/Telemetry/OtelIngestMaintenanceFenceRelease.test.ts
+++ b/App/Tests/Telemetry/OtelIngestMaintenanceFenceRelease.test.ts
@@ -1,0 +1,456 @@
+/*
+ * The Queue infrastructure module pulls in BullMQ (ESM-only msgpackr) at
+ * import time via the services' queue imports; nothing queue-related is
+ * under test here, so the module is replaced — same idiom as
+ * HostIpAddressIngest.test.ts in this directory.
+ */
+jest.mock("Common/Server/Infrastructure/Queue", () => {
+  return {
+    __esModule: true,
+    default: {
+      addJob: jest.fn(),
+    },
+    QueueName: {
+      Workflow: "Workflow",
+      Worker: "Worker",
+      Telemetry: "Telemetry",
+      Runbook: "Runbook",
+    },
+  };
+});
+
+import OtelIngestBaseService from "../../FeatureSet/Telemetry/Services/OtelIngestBaseService";
+import GlobalCache from "Common/Server/Infrastructure/GlobalCache";
+import CephClusterService from "Common/Server/Services/CephClusterService";
+import CloudResourceService from "Common/Server/Services/CloudResourceService";
+import CloudResourceInstanceService from "Common/Server/Services/CloudResourceInstanceService";
+import DockerHostService from "Common/Server/Services/DockerHostService";
+import DockerSwarmClusterService from "Common/Server/Services/DockerSwarmClusterService";
+import HostService from "Common/Server/Services/HostService";
+import IoTFleetService from "Common/Server/Services/IoTFleetService";
+import KubernetesClusterService from "Common/Server/Services/KubernetesClusterService";
+import LabelService from "Common/Server/Services/LabelService";
+import PodmanHostService from "Common/Server/Services/PodmanHostService";
+import ProxmoxClusterService from "Common/Server/Services/ProxmoxClusterService";
+import RumApplicationService from "Common/Server/Services/RumApplicationService";
+import RumApplicationClientService from "Common/Server/Services/RumApplicationClientService";
+import ServerlessFunctionService from "Common/Server/Services/ServerlessFunctionService";
+import ServerlessFunctionInstanceService from "Common/Server/Services/ServerlessFunctionInstanceService";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Per-resource ingest maintenance (updateLastSeen + label promotion) is
+ * fenced behind a 5-minute Redis key so a hundred telemetry workers do not
+ * each issue the same UPDATE on the same hot row. The fence is armed on
+ * ATTEMPT — inside shouldRunMaintenance, before the gated work runs.
+ *
+ * That ordering is deliberate and it has a sharp edge: if the gated work
+ * then throws, the fence keeps suppressing every retry for the rest of the
+ * window. lastSeenAt goes stale, and markDisconnected* flips the resource
+ * to "disconnected" while its telemetry is still arriving — the same
+ * user-visible failure as issue #3006, reached by a different route.
+ *
+ * Only the Kubernetes path used to release its fence on failure. Every
+ * autoDiscover* now records what it armed and releases it in its catch
+ * block. This suite pins that for all eleven, plus the two properties that
+ * make "record what you armed" better than "clear the obvious key":
+ *
+ *   - a successful batch releases NOTHING, so the throttle the fence
+ *     exists to provide survives, and
+ *   - a fence another worker armed is never released, whatever this batch
+ *     did — only fences this attempt armed itself are in play.
+ *
+ * The all-or-nothing edge (a method with two fences releases both when only
+ * the second failed) is pinned too, as the deliberate tradeoff it is.
+ *
+ * All Postgres/Redis access is mocked; the attribute walk runs for real.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const RESOURCE_ID: string = "44444444-4444-4444-8444-444444444444";
+
+const FENCE_NAMESPACE: string = "otel-maintenance-fence";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const baseService: Record<string, any> =
+  OtelIngestBaseService as unknown as Record<string, any>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function stringAttribute(key: string, value: string): JSONObject {
+  return { key: key, value: { stringValue: value } };
+}
+
+type FenceCase = {
+  /** describe() title. */
+  name: string;
+  /** The autoDiscover* method under test. */
+  method: string;
+  /** Fence scope the method arms for the resource itself. */
+  scope: string;
+  /** Resource attributes that route a batch to this method. */
+  attributes: JSONArray;
+  /** The service call that the fence gates, and which we make fail. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  gated: { service: any; method: string };
+  /**
+   * The second, independently-fenced piece of work some methods do
+   * (live-inventory registration), if any.
+   */
+  secondary?: {
+    scope: string;
+    /** Fence id suffix — the fence key is `${resourceId}:${suffix}`. */
+    idSuffix: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    gated: { service: any; method: string };
+  };
+};
+
+const FENCE_CASES: Array<FenceCase> = [
+  {
+    name: "autoDiscoverKubernetesCluster",
+    method: "autoDiscoverKubernetesCluster",
+    scope: "k8s-cluster",
+    attributes: [stringAttribute("k8s.cluster.name", "prod-eu")] as JSONArray,
+    gated: { service: KubernetesClusterService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverProxmoxCluster",
+    method: "autoDiscoverProxmoxCluster",
+    scope: "proxmox-cluster",
+    attributes: [stringAttribute("proxmox.cluster.name", "pve-1")] as JSONArray,
+    gated: { service: ProxmoxClusterService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverIoTFleet",
+    method: "autoDiscoverIoTFleet",
+    scope: "iot-fleet",
+    attributes: [stringAttribute("iot.fleet.name", "sensors-eu")] as JSONArray,
+    gated: { service: IoTFleetService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverDockerSwarmCluster",
+    method: "autoDiscoverDockerSwarmCluster",
+    scope: "docker-swarm-cluster",
+    attributes: [
+      stringAttribute("docker.swarm.cluster.name", "swarm-1"),
+    ] as JSONArray,
+    gated: { service: DockerSwarmClusterService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverCephCluster",
+    method: "autoDiscoverCephCluster",
+    scope: "ceph-cluster",
+    attributes: [stringAttribute("ceph.cluster.name", "ceph-1")] as JSONArray,
+    gated: { service: CephClusterService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverServerless",
+    method: "autoDiscoverServerless",
+    scope: "serverless-function",
+    attributes: [
+      stringAttribute("faas.name", "checkout-handler"),
+      stringAttribute("faas.instance", "instance-a"),
+    ] as JSONArray,
+    gated: { service: ServerlessFunctionService, method: "updateLastSeen" },
+    secondary: {
+      scope: "serverless-fn-instance",
+      idSuffix: "instance-a",
+      gated: {
+        service: ServerlessFunctionInstanceService,
+        method: "recordInstance",
+      },
+    },
+  },
+  {
+    name: "autoDiscoverCloudResource",
+    method: "autoDiscoverCloudResource",
+    scope: "cloud-resource",
+    attributes: [
+      stringAttribute("cloud.platform", "aws_ecs"),
+      stringAttribute("service.name", "checkout"),
+      stringAttribute("service.instance.id", "task-a"),
+    ] as JSONArray,
+    gated: { service: CloudResourceService, method: "updateLastSeen" },
+    secondary: {
+      scope: "cloud-resource-instance",
+      idSuffix: "task-a",
+      gated: {
+        service: CloudResourceInstanceService,
+        method: "recordInstance",
+      },
+    },
+  },
+  {
+    name: "autoDiscoverRum",
+    method: "autoDiscoverRum",
+    scope: "rum-application",
+    attributes: [
+      stringAttribute("browser.platform", "macOS"),
+      stringAttribute("service.name", "storefront"),
+    ] as JSONArray,
+    gated: { service: RumApplicationService, method: "updateLastSeen" },
+    secondary: {
+      scope: "rum-client",
+      idSuffix: "macOS",
+      gated: { service: RumApplicationClientService, method: "recordClient" },
+    },
+  },
+  {
+    name: "autoDiscoverDockerHost",
+    method: "autoDiscoverDockerHost",
+    scope: "docker-host",
+    attributes: [
+      stringAttribute("container.runtime", "docker"),
+      stringAttribute("host.name", "docker-host-1"),
+      stringAttribute("os.type", "linux"),
+    ] as JSONArray,
+    gated: { service: DockerHostService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverPodmanHost",
+    method: "autoDiscoverPodmanHost",
+    scope: "podman-host",
+    attributes: [
+      stringAttribute("container.runtime", "podman"),
+      stringAttribute("host.name", "podman-host-1"),
+      stringAttribute("os.type", "linux"),
+    ] as JSONArray,
+    gated: { service: PodmanHostService, method: "updateLastSeen" },
+  },
+  {
+    name: "autoDiscoverHost",
+    method: "autoDiscoverHost",
+    scope: "host",
+    attributes: [
+      stringAttribute("host.name", "vm-1"),
+      stringAttribute("os.type", "linux"),
+    ] as JSONArray,
+    gated: { service: HostService, method: "updateLastSeen" },
+  },
+];
+
+describe.each(FENCE_CASES)(
+  "$name maintenance fence",
+  ({ method, scope, attributes, gated, secondary }: FenceCase) => {
+    let deletedKeys: Array<string>;
+    /** Fence keys (scope:id) that are already held when the batch arrives. */
+    let heldFences: Set<string>;
+
+    const fenceKey: string = `${FENCE_NAMESPACE}:${scope}:${RESOURCE_ID}`;
+
+    beforeEach(() => {
+      deletedKeys = [];
+      heldFences = new Set<string>();
+
+      /*
+       * Every resource-id cache is primed, so findOrCreate* never runs and
+       * each method goes straight to its fence check. The fence namespace
+       * answers from heldFences, so a test can decide whether this batch
+       * arms the fence or finds it already held.
+       */
+      jest
+        .spyOn(GlobalCache, "getString")
+        .mockImplementation(async (namespace: string, key: string) => {
+          if (namespace === FENCE_NAMESPACE) {
+            return heldFences.has(key) ? "1" : null;
+          }
+          return RESOURCE_ID;
+        });
+      jest.spyOn(GlobalCache, "setString").mockResolvedValue(undefined);
+      jest
+        .spyOn(GlobalCache, "deleteKey")
+        .mockImplementation(async (namespace: string, key: string) => {
+          deletedKeys.push(`${namespace}:${key}`);
+        });
+
+      // Label promotion is not what is under test.
+      jest
+        .spyOn(LabelService, "findOrCreateLabelsByNames")
+        .mockResolvedValue([]);
+      jest
+        .spyOn(baseService, "tryLinkHostToProxmoxGuest")
+        .mockResolvedValue(undefined);
+
+      // Both gated calls succeed unless a test says otherwise.
+      jest.spyOn(gated.service, gated.method).mockResolvedValue(undefined);
+      if (secondary) {
+        jest
+          .spyOn(secondary.gated.service, secondary.gated.method)
+          .mockResolvedValue(undefined);
+      }
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    async function run(): Promise<unknown> {
+      return baseService[method]({
+        projectId: PROJECT_ID,
+        attributes: attributes,
+      });
+    }
+
+    test("releases the fence when the gated work throws", async () => {
+      jest
+        .spyOn(gated.service, gated.method)
+        .mockRejectedValue(new Error("Postgres said no"));
+
+      await run();
+
+      expect(deletedKeys).toContain(fenceKey);
+    });
+
+    test("swallows the failure — one bad batch must not break ingest", async () => {
+      jest
+        .spyOn(gated.service, gated.method)
+        .mockRejectedValue(new Error("Postgres said no"));
+
+      await expect(run()).resolves.toBeNull();
+    });
+
+    test("keeps the fence when the gated work succeeds", async () => {
+      await run();
+
+      /*
+       * Releasing here would throw away the throttle the fence exists to
+       * provide and put the per-batch UPDATE storm straight back.
+       */
+      expect(deletedKeys).not.toContain(fenceKey);
+    });
+
+    test("does not release a fence that was already held by another worker", async () => {
+      heldFences.add(`${scope}:${RESOURCE_ID}`);
+      jest
+        .spyOn(gated.service, gated.method)
+        .mockRejectedValue(new Error("Postgres said no"));
+
+      await run();
+
+      /*
+       * The gated work is skipped in this window, so nothing this batch did
+       * can justify clearing another worker's fence.
+       */
+      expect(deletedKeys).not.toContain(fenceKey);
+    });
+
+    if (secondary) {
+      const secondaryKey: string = `${FENCE_NAMESPACE}:${secondary.scope}:${RESOURCE_ID}:${secondary.idSuffix}`;
+
+      test("releases the inventory fence when the inventory write throws", async () => {
+        jest
+          .spyOn(secondary.gated.service, secondary.gated.method)
+          .mockRejectedValue(new Error("Postgres said no"));
+
+        await run();
+
+        expect(deletedKeys).toContain(secondaryKey);
+      });
+
+      test("a failing inventory write also releases the resource fence", async () => {
+        jest
+          .spyOn(secondary.gated.service, secondary.gated.method)
+          .mockRejectedValue(new Error("Postgres said no"));
+
+        await run();
+
+        /*
+         * Release is all-or-nothing within one attempt, so the resource
+         * fence goes too even though updateLastSeen succeeded under it.
+         * Deliberate: updateLastSeen and attachLabels each carry their own
+         * 60-second throttle, so redoing them next batch costs at most one
+         * extra UPDATE per minute. Pinned so the tradeoff stays a decision
+         * rather than something that quietly changes.
+         */
+        expect(deletedKeys).toContain(fenceKey);
+      });
+
+      test("a failing resource write does not release the inventory fence", async () => {
+        jest
+          .spyOn(gated.service, gated.method)
+          .mockRejectedValue(new Error("Postgres said no"));
+
+        await run();
+
+        // The inventory fence was never armed — the method threw before it.
+        expect(deletedKeys).not.toContain(secondaryKey);
+      });
+    }
+  },
+);
+
+describe("releaseMaintenanceFences", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("clears every fence it is handed", async () => {
+    const deletedKeys: Array<string> = [];
+    jest
+      .spyOn(GlobalCache, "deleteKey")
+      .mockImplementation(async (namespace: string, key: string) => {
+        deletedKeys.push(`${namespace}:${key}`);
+      });
+
+    await baseService["releaseMaintenanceFences"]([
+      { scope: "host", id: "a" },
+      { scope: "docker-host", id: "b" },
+    ]);
+
+    expect(deletedKeys).toEqual([
+      `${FENCE_NAMESPACE}:host:a`,
+      `${FENCE_NAMESPACE}:docker-host:b`,
+    ]);
+  });
+
+  test("is a no-op when nothing was armed", async () => {
+    const deleteKey: jest.SpiedFunction<typeof GlobalCache.deleteKey> = jest
+      .spyOn(GlobalCache, "deleteKey")
+      .mockResolvedValue(undefined);
+
+    await baseService["releaseMaintenanceFences"]([]);
+
+    expect(deleteKey).not.toHaveBeenCalled();
+  });
+
+  test("survives a cache outage — the fence TTL expires it anyway", async () => {
+    jest
+      .spyOn(GlobalCache, "deleteKey")
+      .mockRejectedValue(new Error("redis down"));
+
+    await expect(
+      baseService["releaseMaintenanceFences"]([{ scope: "host", id: "a" }]),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("maintenance fence release coverage", () => {
+  test("every autoDiscover* method is covered", () => {
+    /*
+     * A twelfth resource type with an updateLastSeen behind a fence belongs
+     * in FENCE_CASES — an autoDiscover* that only logs in its catch block
+     * is exactly the bug this suite exists to catch.
+     */
+    const covered: Array<string> = FENCE_CASES.map((c: FenceCase) => {
+      return c.method;
+    });
+
+    const declared: Array<string> = Object.getOwnPropertyNames(
+      OtelIngestBaseService,
+    ).filter((property: string) => {
+      return property.startsWith("autoDiscover");
+    });
+
+    expect(declared.length).toBeGreaterThan(0);
+    expect(covered.sort()).toEqual(declared.sort());
+  });
+});

--- a/Common/Server/Services/CephClusterService.ts
+++ b/Common/Server/Services/CephClusterService.ts
@@ -229,10 +229,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.cephVersion) {
       data.cephVersion = extra.cephVersion;
@@ -273,11 +276,50 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: clusterId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedClusters flips a perfectly healthy Ceph cluster to
+       * "disconnected" 15 minutes later — with telemetry still arriving the
+       * whole time. That was issue #3006 on the Host path (a host.ip list
+       * longer than the then-varchar(500) column). Retry with liveness only
+       * so the enrichment is what gets dropped, never the heartbeat.
+       */
+      logger.warn(
+        `CephClusterService.updateLastSeen: metadata write failed for Ceph cluster ${clusterId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/CloudResourceService.ts
+++ b/Common/Server/Services/CloudResourceService.ts
@@ -199,10 +199,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.agentVersion) {
       data.agentVersion = extra.agentVersion;
@@ -230,11 +233,50 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: cloudResourceId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: cloudResourceId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedResources flips a perfectly healthy cloud resource
+       * to "disconnected" 15 minutes later — with telemetry still arriving
+       * the whole time. That was issue #3006 on the Host path (a host.ip
+       * list longer than the then-varchar(500) column). Retry with liveness
+       * only so the enrichment is what gets dropped, never the heartbeat.
+       */
+      logger.warn(
+        `CloudResourceService.updateLastSeen: metadata write failed for cloud resource ${cloudResourceId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: cloudResourceId,
+        data: liveness,
+      });
+    }
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1062,10 +1062,11 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * `text` columns (VeryLongText and friends) declare none and pass
    * through untouched, as do numbers, dates and ObjectIDs.
    *
-   * This is a safety net for the raw, hook-free write paths
-   * (updateColumnsByIdWithoutHooks) that bypass checkMaxLengthOfFields. It
-   * is NOT a substitute for sizing a column correctly: if a field is
-   * legitimately long, widen the column.
+   * The raw, hook-free write paths (updateColumnsByIdWithoutHooks and
+   * atomicAddToColumnsByIdWithoutHooks) call this themselves, so callers do
+   * NOT need to — and must not rely on being able to skip it by writing a
+   * new raw path of their own. It is NOT a substitute for sizing a column
+   * correctly: if a field is legitimately long, widen the column.
    */
   public truncateStringColumnsToMaxLength(
     data: Record<string, unknown>,
@@ -2302,6 +2303,17 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * the caller), and every value is bound as a parameter, so this is not an
    * injection surface. Use ONLY for trusted, internal, side-effect-free
    * column writes where the full pipeline is pure overhead.
+   *
+   * Oversized strings are CLAMPED here (truncateStringColumnsToMaxLength)
+   * rather than rejected. Skipping the hooks also skips
+   * checkMaxLengthOfFields, so before this an over-long value reached
+   * Postgres raw and failed the ENTIRE statement — including whatever else
+   * rode along with it. On the telemetry liveness writes that is fatal: one
+   * over-long OpenTelemetry resource attribute took `lastSeenAt` down with
+   * it and markDisconnected* stranded a healthy resource as "disconnected"
+   * 15 minutes later while its data kept arriving (issue #3006). Clamping
+   * in here, at the choke point, is what makes that unforgettable — every
+   * caller of this path gets it, including ones not written yet.
    */
   @CaptureSpan()
   public async updateColumnsByIdWithoutHooks(input: {
@@ -2327,9 +2339,16 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     const setClauses: Array<string> = [];
     const params: Array<unknown> = [];
 
-    for (const [propertyName, value] of Object.entries(
-      input.data as ObjectLiteral,
-    )) {
+    /*
+     * Clamp on a shallow COPY: callers must not have their own object
+     * mutated behind their back (a liveness-only retry, for instance,
+     * rebuilds its payload from the same source values).
+     */
+    const data: ObjectLiteral = this.truncateStringColumnsToMaxLength({
+      ...(input.data as ObjectLiteral),
+    });
+
+    for (const [propertyName, value] of Object.entries(data)) {
       const column: ColumnMetadata | undefined =
         metadata.findColumnWithPropertyName(propertyName);
       if (!column) {
@@ -2401,6 +2420,11 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * caller) and every value is bound as a parameter, so this is not an
    * injection surface. Use ONLY for trusted, internal, side-effect-free
    * column writes.
+   *
+   * `set` values are clamped to their column widths for the same reason
+   * updateColumnsByIdWithoutHooks clamps: this path also skips
+   * checkMaxLengthOfFields, and an over-long string here would abort the
+   * counter increments riding in the same statement.
    */
   @CaptureSpan()
   public async atomicAddToColumnsByIdWithoutHooks(input: {
@@ -2447,9 +2471,12 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       setClauses.push(`${quoted} = COALESCE(${quoted}, 0) + $${params.length}`);
     }
 
-    for (const [propertyName, value] of Object.entries(
-      (input.set || {}) as ObjectLiteral,
-    )) {
+    // Shallow copy — never mutate the caller's object. See the clamp note above.
+    const set: ObjectLiteral = this.truncateStringColumnsToMaxLength({
+      ...((input.set || {}) as ObjectLiteral),
+    });
+
+    for (const [propertyName, value] of Object.entries(set)) {
       if (typeof value === "function") {
         throw new BadDataException(
           `atomicAddToColumnsByIdWithoutHooks: SQL-expression values are not supported (column "${propertyName}"); pass a literal value.`,

--- a/Common/Server/Services/DockerHostService.ts
+++ b/Common/Server/Services/DockerHostService.ts
@@ -221,10 +221,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.osType) {
       data.osType = extra.osType;
@@ -240,11 +243,50 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: hostId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: hostId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedHosts flips a perfectly healthy Docker host to
+       * "disconnected" 15 minutes later — with telemetry still arriving the
+       * whole time. That was issue #3006 on the Host path (a host.ip list
+       * longer than the then-varchar(500) column). Retry with liveness only
+       * so the enrichment is what gets dropped, never the heartbeat.
+       */
+      logger.warn(
+        `DockerHostService.updateLastSeen: metadata write failed for Docker host ${hostId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: hostId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/DockerSwarmClusterService.ts
+++ b/Common/Server/Services/DockerSwarmClusterService.ts
@@ -231,10 +231,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.dockerVersion) {
       data.dockerVersion = extra.dockerVersion;
@@ -275,11 +278,51 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: clusterId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedClusters flips a perfectly healthy Docker Swarm
+       * cluster to "disconnected" 15 minutes later — with telemetry still
+       * arriving the whole time. That was issue #3006 on the Host path (a
+       * host.ip list longer than the then-varchar(500) column). Retry with
+       * liveness only so the enrichment is what gets dropped, never the
+       * heartbeat.
+       */
+      logger.warn(
+        `DockerSwarmClusterService.updateLastSeen: metadata write failed for Docker Swarm cluster ${clusterId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/HostService.ts
+++ b/Common/Server/Services/HostService.ts
@@ -313,18 +313,14 @@ export class Service extends DatabaseService<Model> {
     }
 
     /*
-     * Every value above comes from an OpenTelemetry resource attribute, so
-     * its length is whatever the collector felt like sending. Clamp to the
-     * declared column widths — this write bypasses the hook pipeline (and
-     * therefore checkMaxLengthOfFields), so an oversized attribute would
-     * otherwise reach Postgres raw and fail the statement.
-     */
-    this.truncateStringColumnsToMaxLength(data);
-
-    /*
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Every optional value above comes from an OpenTelemetry resource
+     * attribute, so its length is whatever the collector felt like sending.
+     * updateColumnsByIdWithoutHooks clamps them to their declared column
+     * widths for us — see truncateStringColumnsToMaxLength.
      */
     try {
       await this.updateColumnsByIdWithoutHooks({

--- a/Common/Server/Services/IoTFleetService.ts
+++ b/Common/Server/Services/IoTFleetService.ts
@@ -214,10 +214,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.agentVersion) {
       data.agentVersion = extra.agentVersion;
@@ -234,11 +237,50 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: fleetId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: fleetId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedFleets flips a perfectly healthy IoT fleet to
+       * "disconnected" 15 minutes later — with telemetry still arriving the
+       * whole time. That was issue #3006 on the Host path (a host.ip list
+       * longer than the then-varchar(500) column). Retry with liveness only
+       * so the enrichment is what gets dropped, never the heartbeat.
+       */
+      logger.warn(
+        `IoTFleetService.updateLastSeen: metadata write failed for IoT fleet ${fleetId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: fleetId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/KubernetesClusterService.ts
+++ b/Common/Server/Services/KubernetesClusterService.ts
@@ -184,10 +184,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.agentVersion) {
       data.agentVersion = extra.agentVersion;
@@ -197,11 +200,51 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: clusterId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedClusters flips a perfectly healthy Kubernetes
+       * cluster to "disconnected" 15 minutes later — with telemetry still
+       * arriving the whole time. That was issue #3006 on the Host path (a
+       * host.ip list longer than the then-varchar(500) column). Retry with
+       * liveness only so the enrichment is what gets dropped, never the
+       * heartbeat.
+       */
+      logger.warn(
+        `KubernetesClusterService.updateLastSeen: metadata write failed for Kubernetes cluster ${clusterId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/PodmanHostService.ts
+++ b/Common/Server/Services/PodmanHostService.ts
@@ -221,10 +221,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.osType) {
       data.osType = extra.osType;
@@ -240,11 +243,50 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: hostId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: hostId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedHosts flips a perfectly healthy Podman host to
+       * "disconnected" 15 minutes later — with telemetry still arriving the
+       * whole time. That was issue #3006 on the Host path (a host.ip list
+       * longer than the then-varchar(500) column). Retry with liveness only
+       * so the enrichment is what gets dropped, never the heartbeat.
+       */
+      logger.warn(
+        `PodmanHostService.updateLastSeen: metadata write failed for Podman host ${hostId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: hostId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/ProxmoxClusterService.ts
+++ b/Common/Server/Services/ProxmoxClusterService.ts
@@ -222,10 +222,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.pveVersion) {
       data.pveVersion = extra.pveVersion;
@@ -254,11 +257,50 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: clusterId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedClusters flips a perfectly healthy Proxmox cluster
+       * to "disconnected" 15 minutes later — with telemetry still arriving
+       * the whole time. That was issue #3006 on the Host path (a host.ip
+       * list longer than the then-varchar(500) column). Retry with liveness
+       * only so the enrichment is what gets dropped, never the heartbeat.
+       */
+      logger.warn(
+        `ProxmoxClusterService.updateLastSeen: metadata write failed for Proxmox cluster ${clusterId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: clusterId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Server/Services/RumApplicationService.ts
+++ b/Common/Server/Services/RumApplicationService.ts
@@ -317,10 +317,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.agentVersion) {
       data.agentVersion = extra.agentVersion;
@@ -336,11 +339,51 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: rumApplicationId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: rumApplicationId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedApplications flips a perfectly healthy RUM
+       * application to "disconnected" 15 minutes later — with telemetry
+       * still arriving the whole time. That was issue #3006 on the Host
+       * path (a host.ip list longer than the then-varchar(500) column).
+       * Retry with liveness only so the enrichment is what gets dropped,
+       * never the heartbeat.
+       */
+      logger.warn(
+        `RumApplicationService.updateLastSeen: metadata write failed for RUM application ${rumApplicationId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: rumApplicationId,
+        data: liveness,
+      });
+    }
   }
 
   /*

--- a/Common/Server/Services/ServerlessFunctionService.ts
+++ b/Common/Server/Services/ServerlessFunctionService.ts
@@ -199,10 +199,13 @@ export class Service extends DatabaseService<Model> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data: any = {
+    const liveness: any = {
       lastSeenAt: OneUptimeDate.getCurrentDate(),
       otelCollectorStatus: "connected",
     };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = { ...liveness };
 
     if (extra?.agentVersion) {
       data.agentVersion = extra.agentVersion;
@@ -233,11 +236,51 @@ export class Service extends DatabaseService<Model> {
      * Heartbeat write: a single-statement UPDATE with no hooks and no
      * `version` bump, avoiding the hot-row Postgres lock convoy that the
      * full updateOneById pipeline causes. See ServiceService.updateLastSeen.
+     *
+     * Collector-supplied strings are clamped to their declared column
+     * widths inside updateColumnsByIdWithoutHooks — see
+     * DatabaseService.truncateStringColumnsToMaxLength.
      */
-    await this.updateColumnsByIdWithoutHooks({
-      id: serverlessFunctionId,
-      data: data,
-    });
+    try {
+      await this.updateColumnsByIdWithoutHooks({
+        id: serverlessFunctionId,
+        data: data,
+      });
+    } catch (err) {
+      /*
+       * Liveness must survive bad metadata. The enriched write carries
+       * `lastSeenAt` and `otelCollectorStatus` alongside optional,
+       * collector-supplied columns; if any one of them makes Postgres
+       * reject the statement, lastSeenAt silently stops advancing and
+       * markDisconnectedFunctions flips a perfectly healthy serverless
+       * function to "disconnected" 15 minutes later — with telemetry still
+       * arriving the whole time. That was issue #3006 on the Host path (a
+       * host.ip list longer than the then-varchar(500) column). Retry with
+       * liveness only so the enrichment is what gets dropped, never the
+       * heartbeat.
+       */
+      logger.warn(
+        `ServerlessFunctionService.updateLastSeen: metadata write failed for serverless function ${serverlessFunctionId.toString()}, falling back to a liveness-only update: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+
+      /*
+       * The throttle fingerprint was already stored, so without this the
+       * next batch would short-circuit on a cache hit and skip the retry
+       * for the rest of the window.
+       */
+      try {
+        await GlobalCache.deleteKey(LAST_SEEN_CACHE_NAMESPACE, cacheKey);
+      } catch {
+        // Best-effort; the fallback write below is what actually matters.
+      }
+
+      await this.updateColumnsByIdWithoutHooks({
+        id: serverlessFunctionId,
+        data: liveness,
+      });
+    }
   }
 
   /**

--- a/Common/Tests/Server/Services/HookFreeWriteLengthClamp.test.ts
+++ b/Common/Tests/Server/Services/HookFreeWriteLengthClamp.test.ts
@@ -1,0 +1,503 @@
+import CephClusterService from "../../../Server/Services/CephClusterService";
+import CloudResourceService from "../../../Server/Services/CloudResourceService";
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import DockerHostService from "../../../Server/Services/DockerHostService";
+import DockerSwarmClusterService from "../../../Server/Services/DockerSwarmClusterService";
+import HostService from "../../../Server/Services/HostService";
+import IoTFleetService from "../../../Server/Services/IoTFleetService";
+import KubernetesClusterService from "../../../Server/Services/KubernetesClusterService";
+import PodmanHostService from "../../../Server/Services/PodmanHostService";
+import ProxmoxClusterService from "../../../Server/Services/ProxmoxClusterService";
+import RumApplicationService from "../../../Server/Services/RumApplicationService";
+import ServerlessFunctionService from "../../../Server/Services/ServerlessFunctionService";
+import CephCluster from "../../../Models/DatabaseModels/CephCluster";
+import CloudResource from "../../../Models/DatabaseModels/CloudResource";
+import DatabaseBaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import DockerHost from "../../../Models/DatabaseModels/DockerHost";
+import DockerSwarmCluster from "../../../Models/DatabaseModels/DockerSwarmCluster";
+import Host from "../../../Models/DatabaseModels/Host";
+import IoTFleet from "../../../Models/DatabaseModels/IoTFleet";
+import KubernetesCluster from "../../../Models/DatabaseModels/KubernetesCluster";
+import PodmanHost from "../../../Models/DatabaseModels/PodmanHost";
+import ProxmoxCluster from "../../../Models/DatabaseModels/ProxmoxCluster";
+import RumApplication from "../../../Models/DatabaseModels/RumApplication";
+import ServerlessFunction from "../../../Models/DatabaseModels/ServerlessFunction";
+import LogDropFilter from "../../../Models/DatabaseModels/LogDropFilter";
+import LogDropFilterService from "../../../Server/Services/LogDropFilterService";
+import ObjectID from "../../../Types/ObjectID";
+import { getMaxLengthFromTableColumnType } from "../../../Types/Database/ColumnLength";
+import { TableColumnMetadata } from "../../../Types/Database/TableColumn";
+import { getJestSpyOn } from "../../Spy";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Follow-up to issue #3006, one layer below where it was first fixed.
+ *
+ * The raw write paths — updateColumnsByIdWithoutHooks and
+ * atomicAddToColumnsByIdWithoutHooks — deliberately skip the whole hook
+ * pipeline, and with it checkMaxLengthOfFields. That made every caller
+ * individually responsible for not handing Postgres an over-long string,
+ * and eleven telemetry services independently forgot to be. When one
+ * oversized OpenTelemetry resource attribute reached Postgres raw, the
+ * ENTIRE statement was rejected — including the lastSeenAt /
+ * otelCollectorStatus columns riding along with it — and markDisconnected*
+ * stranded a healthy resource as "disconnected" 15 minutes later while its
+ * telemetry kept arriving.
+ *
+ * The clamp now lives inside those two methods, so a caller cannot forget
+ * it and a service added tomorrow inherits it. This suite pins that:
+ *
+ *   1. the clamp really runs inside the raw write path (asserted on the
+ *      values BOUND to the SQL, not on what the caller passed),
+ *   2. it clamps to each column's own declared width, model by model,
+ *      for every string column the updateLastSeen paths can write,
+ *   3. it touches nothing it should not — text columns, non-strings, and
+ *      the caller's own object.
+ *
+ * The repository is faked, so no Postgres and no Redis; the column
+ * metadata, the clamp and the SQL generation are all real.
+ */
+
+const ROW_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+
+interface CapturedQuery {
+  sql: string;
+  params: Array<unknown>;
+}
+
+/**
+ * A stand-in for the TypeORM repository that is just faithful enough for
+ * the raw write paths: real column names come from the model itself, and
+ * values are captured rather than sent anywhere.
+ */
+function fakeRepository(
+  model: DatabaseBaseModel,
+  captured: Array<CapturedQuery>,
+): unknown {
+  return {
+    metadata: {
+      tableName: model.tableName || "FakeTable",
+      findColumnWithPropertyName: (
+        propertyName: string,
+      ): { databaseName: string } | undefined => {
+        return model.hasColumn(propertyName)
+          ? { databaseName: propertyName }
+          : undefined;
+      },
+      updateDateColumn: { databaseName: "updatedAt" },
+      primaryColumns: [{ databaseName: "_id" }],
+    },
+    manager: {
+      connection: {
+        driver: {
+          preparePersistentValue: (value: unknown): unknown => {
+            return value;
+          },
+        },
+      },
+      query: async (
+        sql: string,
+        params: Array<unknown>,
+      ): Promise<Array<unknown>> => {
+        captured.push({ sql, params });
+        return [];
+      },
+    },
+  };
+}
+
+/** The width the column declares, or undefined for an unbounded one. */
+function declaredMaxLength(
+  model: DatabaseBaseModel,
+  column: string,
+): number | undefined {
+  const metadata: TableColumnMetadata = model.getTableColumnMetadata(column);
+  return metadata.type
+    ? getMaxLengthFromTableColumnType(metadata.type)
+    : undefined;
+}
+
+/*
+ * Every string column the eleven telemetry updateLastSeen paths can write.
+ * Widths are NOT hardcoded — each case reads the column's own declaration,
+ * so widening a column keeps the suite honest instead of breaking it.
+ */
+type ClampCase = {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  service: DatabaseService<any>;
+  model: DatabaseBaseModel;
+  columns: Array<string>;
+};
+
+/*
+ * `PartialEntity<any>` degenerates to a type that rejects plain strings and
+ * dates, so the model-agnostic cases below go through this one cast rather
+ * than sprinkling casts across every call.
+ */
+async function rawWrite(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  service: DatabaseService<any>,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await service.updateColumnsByIdWithoutHooks({
+    id: ROW_ID,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: data as any,
+  });
+}
+
+const CLAMP_CASES: Array<ClampCase> = [
+  {
+    name: "HostService",
+    service: HostService,
+    model: new Host(),
+    columns: [
+      "osType",
+      "osVersion",
+      "hostId",
+      "hostArch",
+      "hostType",
+      "containerRuntime",
+      "agentVersion",
+      "deploymentEnvironment",
+      "runtimeName",
+      "runtimeVersion",
+      "cloudProvider",
+      "cloudPlatform",
+      "cloudRegion",
+      "cloudAccountId",
+    ],
+  },
+  {
+    name: "DockerHostService",
+    service: DockerHostService,
+    model: new DockerHost(),
+    columns: ["osType", "osVersion", "agentVersion"],
+  },
+  {
+    name: "PodmanHostService",
+    service: PodmanHostService,
+    model: new PodmanHost(),
+    columns: ["osType", "osVersion", "agentVersion"],
+  },
+  {
+    name: "KubernetesClusterService",
+    service: KubernetesClusterService,
+    model: new KubernetesCluster(),
+    columns: ["agentVersion"],
+  },
+  {
+    name: "ProxmoxClusterService",
+    service: ProxmoxClusterService,
+    model: new ProxmoxCluster(),
+    columns: ["pveVersion", "agentVersion"],
+  },
+  {
+    name: "IoTFleetService",
+    service: IoTFleetService,
+    model: new IoTFleet(),
+    columns: ["agentVersion"],
+  },
+  {
+    name: "DockerSwarmClusterService",
+    service: DockerSwarmClusterService,
+    model: new DockerSwarmCluster(),
+    columns: ["dockerVersion", "swarmId", "agentVersion"],
+  },
+  {
+    name: "CephClusterService",
+    service: CephClusterService,
+    model: new CephCluster(),
+    columns: ["cephVersion", "fsid", "agentVersion"],
+  },
+  {
+    name: "ServerlessFunctionService",
+    service: ServerlessFunctionService,
+    model: new ServerlessFunction(),
+    columns: [
+      "agentVersion",
+      "cloudPlatform",
+      "cloudProvider",
+      "cloudRegion",
+      "cloudAccountId",
+      "functionVersion",
+      "runtimeName",
+      "runtimeVersion",
+    ],
+  },
+  {
+    name: "CloudResourceService",
+    service: CloudResourceService,
+    model: new CloudResource(),
+    columns: [
+      "agentVersion",
+      "cloudPlatform",
+      "cloudProvider",
+      "cloudRegion",
+      "cloudAccountId",
+      "runtimeName",
+      "runtimeVersion",
+    ],
+  },
+  {
+    name: "RumApplicationService",
+    service: RumApplicationService,
+    model: new RumApplication(),
+    columns: ["agentVersion", "clientType", "sdkLanguage"],
+  },
+];
+
+describe("updateColumnsByIdWithoutHooks clamps oversized strings", () => {
+  let captured: Array<CapturedQuery>;
+
+  beforeEach(() => {
+    captured = [];
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** The value bound for `column` in the single captured statement. */
+  function boundValue(column: string, columns: Array<string>): unknown {
+    /*
+     * Values are bound in Object.entries order, which for these writes is
+     * insertion order — the same order the caller built the payload in.
+     */
+    return captured[0]!.params[columns.indexOf(column)];
+  }
+
+  describe.each(CLAMP_CASES)(
+    "$name",
+    ({ service, model, columns }: ClampCase) => {
+      beforeEach(() => {
+        getJestSpyOn(service, "getRepository").mockReturnValue(
+          fakeRepository(model, captured),
+        );
+      });
+
+      test.each(columns)(
+        "clamps an oversized %s to the width its column declares",
+        async (column: string) => {
+          const maxLength: number | undefined = declaredMaxLength(
+            model,
+            column,
+          );
+
+          /*
+           * A column with no declared width (text) cannot overflow, so
+           * there is nothing to clamp — that case is covered separately.
+           */
+          expect(maxLength).toBeDefined();
+
+          await rawWrite(service, {
+            [column]: "x".repeat(maxLength! + 250),
+          });
+
+          expect(boundValue(column, [column])).toHaveLength(maxLength!);
+        },
+      );
+
+      test("clamping one bad column never costs the liveness columns", async () => {
+        const column: string = columns[0]!;
+        const lastSeenAt: Date = new Date();
+
+        await rawWrite(service, {
+          lastSeenAt: lastSeenAt,
+          otelCollectorStatus: "connected",
+          [column]: "x".repeat(5000),
+        });
+
+        const order: Array<string> = [
+          "lastSeenAt",
+          "otelCollectorStatus",
+          column,
+        ];
+        expect(boundValue("lastSeenAt", order)).toBe(lastSeenAt);
+        expect(boundValue("otelCollectorStatus", order)).toBe("connected");
+        expect(captured).toHaveLength(1);
+      });
+
+      test("a value that already fits is bound byte-for-byte", async () => {
+        const column: string = columns[0]!;
+
+        await rawWrite(service, { [column]: "fits-easily" });
+
+        expect(boundValue(column, [column])).toBe("fits-easily");
+      });
+
+      test("the caller's own object is not mutated", async () => {
+        const column: string = columns[0]!;
+        const original: string = "x".repeat(5000);
+        const data: Record<string, unknown> = { [column]: original };
+
+        await rawWrite(service, data);
+
+        expect(data[column]).toBe(original);
+      });
+    },
+  );
+});
+
+describe("updateColumnsByIdWithoutHooks clamp boundaries", () => {
+  let captured: Array<CapturedQuery>;
+  const host: Host = new Host();
+
+  beforeEach(() => {
+    captured = [];
+    getJestSpyOn(HostService, "getRepository").mockReturnValue(
+      fakeRepository(host, captured),
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("binds a 55-address host.ip list whole — the column is text now", async () => {
+    const hostIpAddresses: string = Array.from(
+      { length: 55 },
+      (_unused: unknown, i: number) => {
+        return `fe80::42:acff:fe11:${(0x1000 + i).toString(16)}`;
+      },
+    ).join(", ");
+
+    await HostService.updateColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      data: { hostIpAddresses: hostIpAddresses },
+    });
+
+    expect(hostIpAddresses.length).toBeGreaterThan(500);
+    expect(captured[0]!.params[0]).toBe(hostIpAddresses);
+  });
+
+  test("a value exactly at the limit is left alone", async () => {
+    const exact: string = "l".repeat(declaredMaxLength(host, "osType")!);
+
+    await HostService.updateColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      data: { osType: exact },
+    });
+
+    expect(captured[0]!.params[0]).toBe(exact);
+  });
+
+  test("a clamped value stays a prefix of the original", async () => {
+    const original: string = "abcdefghij".repeat(40);
+
+    await HostService.updateColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      data: { osType: original },
+    });
+
+    expect(original.startsWith(captured[0]!.params[0] as string)).toBe(true);
+  });
+
+  test("non-string values pass through untouched", async () => {
+    const lastSeenAt: Date = new Date();
+
+    await HostService.updateColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      data: {
+        lastSeenAt: lastSeenAt,
+        cpuCores: 64,
+        totalMemoryBytes: 274877906944,
+      },
+    });
+
+    expect(captured[0]!.params.slice(0, 3)).toEqual([
+      lastSeenAt,
+      64,
+      274877906944,
+    ]);
+  });
+
+  test("an unknown column is still rejected, not silently clamped away", async () => {
+    await expect(
+      HostService.updateColumnsByIdWithoutHooks({
+        id: ROW_ID,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: { notAColumn: "z".repeat(5000) } as any,
+      }),
+    ).rejects.toThrow("unknown column");
+  });
+
+  test("the clamp does not disturb the primary-key predicate", async () => {
+    await HostService.updateColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      data: { osType: "l".repeat(5000) },
+    });
+
+    expect(captured[0]!.sql).toMatch(/WHERE "_id" = \$\d+$/);
+    expect(captured[0]!.params[captured[0]!.params.length - 1]).toBe(
+      ROW_ID.toString(),
+    );
+  });
+});
+
+/*
+ * The counter-flush primitive is the other raw path, and it has exactly the
+ * same exposure: an over-long string in `set` would abort the increments
+ * bound into the same statement.
+ */
+describe("atomicAddToColumnsByIdWithoutHooks clamps its set values", () => {
+  let captured: Array<CapturedQuery>;
+  const model: LogDropFilter = new LogDropFilter();
+
+  beforeEach(() => {
+    captured = [];
+    getJestSpyOn(LogDropFilterService, "getRepository").mockReturnValue(
+      fakeRepository(model, captured),
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("clamps an oversized set value to its declared width", async () => {
+    const maxLength: number = declaredMaxLength(model, "name")!;
+
+    await LogDropFilterService.atomicAddToColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      add: { droppedCount: 5 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      set: { name: "n".repeat(maxLength + 250) } as any,
+    });
+
+    // params: [delta, set value, ...]
+    expect(captured[0]!.params[1]).toHaveLength(maxLength);
+  });
+
+  test("leaves the numeric delta alone", async () => {
+    await LogDropFilterService.atomicAddToColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      add: { droppedCount: 7 },
+    });
+
+    expect(captured[0]!.params[0]).toBe(7);
+    expect(captured[0]!.sql).toContain("COALESCE");
+  });
+
+  test("does not mutate the caller's set object", async () => {
+    const original: string = "n".repeat(5000);
+    const set: Record<string, unknown> = { name: original };
+
+    await LogDropFilterService.atomicAddToColumnsByIdWithoutHooks({
+      id: ROW_ID,
+      add: { droppedCount: 1 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      set: set as any,
+    });
+
+    expect(set["name"]).toBe(original);
+  });
+});

--- a/Common/Tests/Server/Services/HostServiceUpdateLastSeen.test.ts
+++ b/Common/Tests/Server/Services/HostServiceUpdateLastSeen.test.ts
@@ -22,6 +22,14 @@ import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
  *      liveness columns are retried on their own. Enrichment is what gets
  *      dropped, never the heartbeat.
  *
+ * Guard 1 has since moved DOWN a layer: updateColumnsByIdWithoutHooks
+ * clamps for every caller, so no service can forget it (see
+ * HookFreeWriteLengthClamp.test.ts, which pins that for all eleven
+ * telemetry models). The clamp assertions below therefore run the real
+ * write path against a faked repository and inspect the values actually
+ * BOUND to the SQL — the same end-to-end claim, checked where it is now
+ * true rather than where it used to be.
+ *
  * Everything external is mocked — no Postgres, no Redis.
  */
 
@@ -107,6 +115,58 @@ function mockEnrichedWriteFailing(
     });
 }
 
+/**
+ * Runs the REAL updateColumnsByIdWithoutHooks against a faked repository,
+ * recording the values actually BOUND to the generated SQL. The length
+ * clamp lives inside that method now, so this is the only way to observe
+ * it end-to-end from the service without a database — mocking the method
+ * out (as the other blocks do) would mock the clamp out with it.
+ */
+function mockRealWritePath(): void {
+  const host: Host = new Host();
+  let bound: Record<string, unknown> = {};
+
+  jest.spyOn(HostService, "getRepository").mockReturnValue({
+    metadata: {
+      tableName: "Host",
+      findColumnWithPropertyName: (
+        propertyName: string,
+      ): { databaseName: string } | undefined => {
+        return host.hasColumn(propertyName)
+          ? { databaseName: propertyName }
+          : undefined;
+      },
+      updateDateColumn: { databaseName: "updatedAt" },
+      primaryColumns: [{ databaseName: "_id" }],
+    },
+    manager: {
+      connection: {
+        driver: {
+          preparePersistentValue: (
+            value: unknown,
+            column: { databaseName: string },
+          ): unknown => {
+            bound[column.databaseName] = value;
+            return value;
+          },
+        },
+      },
+      query: async (
+        _sql: string,
+        params: Array<unknown>,
+      ): Promise<Array<unknown>> => {
+        writes.push({
+          id: new ObjectID(String(params[params.length - 1])),
+          data: bound,
+        });
+        bound = {};
+        return [];
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
 function lastWrite(): Record<string, unknown> {
   return writes[writes.length - 1]?.data as Record<string, unknown>;
 }
@@ -158,7 +218,8 @@ describe("HostService.updateLastSeen", () => {
 
   describe("oversized collector metadata", () => {
     beforeEach(() => {
-      mockWritesSucceeding();
+      // The clamp lives in the write path, so run the real one.
+      mockRealWritePath();
     });
 
     test("stores a 55-address host.ip list untouched — the column is text now", async () => {

--- a/Common/Tests/Server/Services/ResourceUpdateLastSeenLivenessFallback.test.ts
+++ b/Common/Tests/Server/Services/ResourceUpdateLastSeenLivenessFallback.test.ts
@@ -1,0 +1,387 @@
+import CephClusterService from "../../../Server/Services/CephClusterService";
+import CloudResourceService from "../../../Server/Services/CloudResourceService";
+import DockerHostService from "../../../Server/Services/DockerHostService";
+import DockerSwarmClusterService from "../../../Server/Services/DockerSwarmClusterService";
+import GlobalCache from "../../../Server/Infrastructure/GlobalCache";
+import HostService from "../../../Server/Services/HostService";
+import IoTFleetService from "../../../Server/Services/IoTFleetService";
+import KubernetesClusterService from "../../../Server/Services/KubernetesClusterService";
+import PodmanHostService from "../../../Server/Services/PodmanHostService";
+import ProxmoxClusterService from "../../../Server/Services/ProxmoxClusterService";
+import RumApplicationService from "../../../Server/Services/RumApplicationService";
+import ServerlessFunctionService from "../../../Server/Services/ServerlessFunctionService";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Issue #3006 was reported against Host, but HostService.updateLastSeen was
+ * never the only service shaped that way. Ten siblings write the same two
+ * liveness columns (lastSeenAt + otelCollectorStatus) in the SAME hook-free
+ * UPDATE as a handful of optional columns harvested from OpenTelemetry
+ * resource attributes — and each has its own markDisconnected* job that
+ * flips the resource to "disconnected" 15 minutes after lastSeenAt stops
+ * advancing.
+ *
+ * The clamp that stops a Postgres rejection now lives inside
+ * updateColumnsByIdWithoutHooks (see HookFreeWriteLengthClamp.test.ts), so
+ * the statement should not fail in the first place. This suite pins the
+ * SECOND, independent guard, per service: if the enriched write fails
+ * ANYWAY — for any reason at all, a constraint nobody predicted, a column
+ * type nobody clamped — the liveness columns are retried on their own.
+ * Enrichment is what gets dropped, never the heartbeat.
+ *
+ * Also pinned per service: the throttle that keeps the steady state cheap
+ * must not swallow the retry, and a Redis outage must fail OPEN. Marking a
+ * live resource disconnected because the cache went down would be the same
+ * bug wearing a different hat.
+ *
+ * Everything external is mocked — no Postgres, no Redis.
+ */
+
+type WriteCall = { id: ObjectID; data: Record<string, unknown> };
+
+type ServiceCase = {
+  /** Name of the service, used as the describe() title. */
+  name: string;
+  service: {
+    updateLastSeen(id: ObjectID, extra?: never): Promise<void>;
+    updateColumnsByIdWithoutHooks(input: {
+      id: ObjectID;
+      data: unknown;
+    }): Promise<void>;
+  };
+  /** A metadata payload this service accepts, and a different one. */
+  extra: Record<string, unknown>;
+  otherExtra: Record<string, unknown>;
+  /** A string column whose value the collector supplies. */
+  oversizedExtra: Record<string, unknown>;
+};
+
+/** Longer than any bounded column on any of these models. */
+const OVERSIZED: string = "x".repeat(5000);
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const SERVICE_CASES: Array<ServiceCase> = [
+  {
+    name: "DockerHostService",
+    service: DockerHostService as any,
+    extra: { osType: "linux" },
+    otherExtra: { osType: "windows" },
+    oversizedExtra: { osVersion: OVERSIZED },
+  },
+  {
+    name: "PodmanHostService",
+    service: PodmanHostService as any,
+    extra: { osType: "linux" },
+    otherExtra: { osType: "windows" },
+    oversizedExtra: { osVersion: OVERSIZED },
+  },
+  {
+    name: "KubernetesClusterService",
+    service: KubernetesClusterService as any,
+    extra: { agentVersion: "1.2.3" },
+    otherExtra: { agentVersion: "1.2.4" },
+    oversizedExtra: { agentVersion: OVERSIZED },
+  },
+  {
+    name: "ProxmoxClusterService",
+    service: ProxmoxClusterService as any,
+    extra: { pveVersion: "8.1.4" },
+    otherExtra: { pveVersion: "8.2.0" },
+    oversizedExtra: { pveVersion: OVERSIZED },
+  },
+  {
+    name: "IoTFleetService",
+    service: IoTFleetService as any,
+    extra: { agentVersion: "1.2.3" },
+    otherExtra: { agentVersion: "1.2.4" },
+    oversizedExtra: { agentVersion: OVERSIZED },
+  },
+  {
+    name: "DockerSwarmClusterService",
+    service: DockerSwarmClusterService as any,
+    extra: { dockerVersion: "25.0.3" },
+    otherExtra: { dockerVersion: "26.0.0" },
+    oversizedExtra: { swarmId: OVERSIZED },
+  },
+  {
+    name: "CephClusterService",
+    service: CephClusterService as any,
+    extra: { cephVersion: "18.2.2" },
+    otherExtra: { cephVersion: "19.0.0" },
+    oversizedExtra: { fsid: OVERSIZED },
+  },
+  {
+    name: "ServerlessFunctionService",
+    service: ServerlessFunctionService as any,
+    extra: { runtimeName: "nodejs" },
+    otherExtra: { runtimeName: "python" },
+    oversizedExtra: { functionVersion: OVERSIZED },
+  },
+  {
+    name: "CloudResourceService",
+    service: CloudResourceService as any,
+    extra: { cloudProvider: "aws" },
+    otherExtra: { cloudProvider: "gcp" },
+    oversizedExtra: { cloudRegion: OVERSIZED },
+  },
+  {
+    name: "RumApplicationService",
+    service: RumApplicationService as any,
+    extra: { sdkLanguage: "webjs" },
+    otherExtra: { sdkLanguage: "swift" },
+    oversizedExtra: { clientType: OVERSIZED },
+  },
+  {
+    /*
+     * Host rides the same table so the eleven paths stay pinned together —
+     * its own richer regression coverage lives in
+     * HostServiceUpdateLastSeen.test.ts.
+     */
+    name: "HostService",
+    service: HostService as any,
+    extra: { osType: "linux" },
+    otherExtra: { osType: "windows" },
+    oversizedExtra: { hostId: OVERSIZED },
+  },
+];
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+describe.each(SERVICE_CASES)(
+  "$name.updateLastSeen",
+  ({ service, extra, otherExtra, oversizedExtra }: ServiceCase) => {
+    let writes: Array<WriteCall>;
+    let cache: Map<string, string>;
+    let deletedCacheKeys: Array<string>;
+
+    const RESOURCE_ID: ObjectID = ObjectID.generate();
+
+    /** Records every hook-free UPDATE instead of issuing it. */
+    function mockWritesSucceeding(): void {
+      jest
+        .spyOn(service, "updateColumnsByIdWithoutHooks")
+        .mockImplementation(async (input: { id: ObjectID; data: unknown }) => {
+          writes.push({
+            id: input.id,
+            data: { ...(input.data as Record<string, unknown>) },
+          });
+        });
+    }
+
+    /**
+     * Fails any write carrying more than the two liveness columns — the
+     * shape of a Postgres rejection caused by one bad optional column.
+     */
+    function mockEnrichedWriteFailing(): void {
+      jest
+        .spyOn(service, "updateColumnsByIdWithoutHooks")
+        .mockImplementation(async (input: { id: ObjectID; data: unknown }) => {
+          const data: Record<string, unknown> = {
+            ...(input.data as Record<string, unknown>),
+          };
+          writes.push({ id: input.id, data: data });
+          if (Object.keys(data).length > 2) {
+            throw new Error("value too long for type character varying(100)");
+          }
+        });
+    }
+
+    function lastWrite(): Record<string, unknown> {
+      return writes[writes.length - 1]!.data;
+    }
+
+    beforeEach(() => {
+      writes = [];
+      cache = new Map<string, string>();
+      deletedCacheKeys = [];
+
+      jest
+        .spyOn(GlobalCache, "getString")
+        .mockImplementation(async (namespace: string, key: string) => {
+          return cache.get(`${namespace}:${key}`) ?? null;
+        });
+      jest
+        .spyOn(GlobalCache, "setString")
+        .mockImplementation(
+          async (namespace: string, key: string, value: string) => {
+            cache.set(`${namespace}:${key}`, value);
+          },
+        );
+      jest
+        .spyOn(GlobalCache, "deleteKey")
+        .mockImplementation(async (namespace: string, key: string) => {
+          deletedCacheKeys.push(`${namespace}:${key}`);
+          cache.delete(`${namespace}:${key}`);
+        });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe("liveness columns", () => {
+      beforeEach(() => {
+        mockWritesSucceeding();
+      });
+
+      test("always writes lastSeenAt and marks the collector connected", async () => {
+        await service.updateLastSeen(RESOURCE_ID);
+
+        expect(writes).toHaveLength(1);
+        expect(lastWrite()["otelCollectorStatus"]).toBe("connected");
+        expect(lastWrite()["lastSeenAt"]).toBeInstanceOf(Date);
+      });
+
+      test("writes to the resource it was given", async () => {
+        await service.updateLastSeen(RESOURCE_ID);
+
+        expect(writes[0]!.id.toString()).toBe(RESOURCE_ID.toString());
+      });
+
+      test("skips the write when the same metadata was written recently", async () => {
+        await service.updateLastSeen(RESOURCE_ID, extra as never);
+        await service.updateLastSeen(RESOURCE_ID, extra as never);
+
+        expect(writes).toHaveLength(1);
+      });
+
+      test("writes again as soon as any metadata changes", async () => {
+        await service.updateLastSeen(RESOURCE_ID, extra as never);
+        await service.updateLastSeen(RESOURCE_ID, otherExtra as never);
+
+        expect(writes).toHaveLength(2);
+      });
+
+      test("passes collector metadata through to the write path", async () => {
+        await service.updateLastSeen(RESOURCE_ID, extra as never);
+
+        for (const [column, value] of Object.entries(extra)) {
+          expect(lastWrite()[column]).toBe(value);
+        }
+      });
+    });
+
+    describe("fallback when the enriched write fails", () => {
+      beforeEach(() => {
+        mockEnrichedWriteFailing();
+      });
+
+      test("does not throw — ingest keeps going", async () => {
+        await expect(
+          service.updateLastSeen(RESOURCE_ID, oversizedExtra as never),
+        ).resolves.toBeUndefined();
+      });
+
+      test("retries with liveness only, so lastSeenAt still advances", async () => {
+        await service.updateLastSeen(RESOURCE_ID, oversizedExtra as never);
+
+        expect(writes).toHaveLength(2);
+        expect(Object.keys(lastWrite()).sort()).toEqual([
+          "lastSeenAt",
+          "otelCollectorStatus",
+        ]);
+        expect(lastWrite()["otelCollectorStatus"]).toBe("connected");
+        expect(lastWrite()["lastSeenAt"]).toBeInstanceOf(Date);
+      });
+
+      test("the retry targets the same resource", async () => {
+        await service.updateLastSeen(RESOURCE_ID, oversizedExtra as never);
+
+        expect(writes[1]!.id.toString()).toBe(RESOURCE_ID.toString());
+      });
+
+      test("busts the throttle cache so the next batch is not skipped", async () => {
+        await service.updateLastSeen(RESOURCE_ID, oversizedExtra as never);
+
+        expect(deletedCacheKeys).toHaveLength(1);
+        expect(deletedCacheKeys[0]).toContain(RESOURCE_ID.toString());
+      });
+
+      test("the next batch retries rather than short-circuiting on a cache hit", async () => {
+        await service.updateLastSeen(RESOURCE_ID, oversizedExtra as never);
+        writes = [];
+
+        await service.updateLastSeen(RESOURCE_ID, oversizedExtra as never);
+
+        // Enriched attempt + liveness fallback, not a silent no-op.
+        expect(writes).toHaveLength(2);
+      });
+
+      test("a failing cache delete does not stop the liveness retry", async () => {
+        jest
+          .spyOn(GlobalCache, "deleteKey")
+          .mockRejectedValue(new Error("redis down"));
+
+        await service.updateLastSeen(RESOURCE_ID, oversizedExtra as never);
+
+        expect(Object.keys(lastWrite()).sort()).toEqual([
+          "lastSeenAt",
+          "otelCollectorStatus",
+        ]);
+      });
+
+      test("surfaces a genuinely broken database instead of hiding it", async () => {
+        // Both attempts fail — the caller must find out.
+        jest
+          .spyOn(service, "updateColumnsByIdWithoutHooks")
+          .mockRejectedValue(new Error("connection terminated"));
+
+        await expect(
+          service.updateLastSeen(RESOURCE_ID, extra as never),
+        ).rejects.toThrow("connection terminated");
+      });
+    });
+
+    describe("cache outages fail open", () => {
+      beforeEach(() => {
+        mockWritesSucceeding();
+      });
+
+      test("a read failure still writes — never mark a live resource disconnected", async () => {
+        jest
+          .spyOn(GlobalCache, "getString")
+          .mockRejectedValue(new Error("redis down"));
+
+        await service.updateLastSeen(RESOURCE_ID, extra as never);
+
+        expect(writes).toHaveLength(1);
+      });
+
+      test("a write failure still writes", async () => {
+        jest
+          .spyOn(GlobalCache, "setString")
+          .mockRejectedValue(new Error("redis down"));
+
+        await service.updateLastSeen(RESOURCE_ID, extra as never);
+
+        expect(writes).toHaveLength(1);
+      });
+    });
+  },
+);
+
+describe("liveness fallback coverage", () => {
+  test("covers every service that writes liveness on the hook-free path", () => {
+    /*
+     * If a twelfth resource type grows an updateLastSeen, it belongs in
+     * SERVICE_CASES — that is the whole point of this suite. Bumping this
+     * number without adding the case defeats it.
+     */
+    expect(SERVICE_CASES).toHaveLength(11);
+  });
+
+  test("no service is listed twice", () => {
+    const names: Array<string> = SERVICE_CASES.map((c: ServiceCase) => {
+      return c.name;
+    });
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+});


### PR DESCRIPTION
Follow-up to #3006. The Host fix closed one instance of two general holes; ten sibling resource services and eleven ingest paths still had both.

## 1. Clamp at the choke point, not per caller

`updateColumnsByIdWithoutHooks` skips the hook pipeline, and with it `checkMaxLengthOfFields`. That made every caller responsible for not handing Postgres an over-long string — and one oversized OpenTelemetry resource attribute aborts the **entire** statement, taking the `lastSeenAt` / `otelCollectorStatus` columns riding along with it. `markDisconnected*` then flips a healthy resource 15 minutes later while its telemetry keeps arriving.

Both raw write paths now clamp a shallow copy of their payload themselves, so no caller can forget it and a service written tomorrow inherits it:

- `updateColumnsByIdWithoutHooks`
- `atomicAddToColumnsByIdWithoutHooks` — same raw path, same exposure: an over-long string in `set` would abort the counter increments bound into the same statement.

The copy matters: a liveness-only retry must not find its source object rewritten underneath it. The now-redundant explicit call in `HostService.updateLastSeen` is removed, leaving exactly one production caller of the helper.

## 2. Liveness-only fallback in the other ten services

`DockerHost`, `PodmanHost`, `KubernetesCluster`, `ProxmoxCluster`, `IoTFleet`, `DockerSwarmCluster`, `CephCluster`, `ServerlessFunction`, `CloudResource` and `RumApplication` each write liveness in the same hook-free UPDATE as their collector-supplied columns.

Each now retries with liveness only when the enriched write fails **for any reason**, busting the throttle cache first so the next batch isn't skipped by a cache hit. Enrichment is what gets dropped, never the heartbeat. The block is duplicated rather than extracted, matching how these eleven services are already kept deliberately near-identical (`fingerprintLabelIds`, the cache namespaces, `markDisconnected*`).

## 3. Release the maintenance fence on failure

The 5-minute fence is armed on *attempt*, before the gated work runs. Only `autoDiscoverKubernetesCluster` released it when that work threw; the other ten logged and left it armed, suppressing every retry for the rest of the window — the same user-visible failure by a different route.

Each `autoDiscover*` now records what it armed in a local `armedFences` array and releases it via a new `releaseMaintenanceFences` in its catch. Recording rather than re-deriving a key in the catch is what makes this correct:

- a fence **another worker** holds is never recorded, so a failure here can never clear a window that worker is relying on, and
- the three methods that arm a **second** fence for live-inventory registration (`serverless-fn-instance`, `cloud-resource-instance`, `rum-client`) are handled without special-casing.

Release is all-or-nothing within one attempt — a method with two fences releases both even if only the later one failed. That's deliberate and bounded: `updateLastSeen` and `attachLabels` each carry their own 60-second throttle, so redoing them next batch costs at most one extra UPDATE per minute. Documented at the helper and pinned by a test so it stays a decision rather than something that quietly changes.

## Tests

| Suite | Covers |
|---|---|
| `Common/Tests/.../HookFreeWriteLengthClamp.test.ts` | 90 tests. Asserts on the values **bound to the SQL** via a faked repository, across all 11 telemetry models × every string column their `updateLastSeen` writes. Widths are read from each column's own declaration, so widening a column doesn't break the suite. |
| `Common/Tests/.../ResourceUpdateLastSeenLivenessFallback.test.ts` | 156 tests. All 11 services × liveness / throttle / fallback / cache-bust / cache-outage-fails-open. |
| `App/Tests/Telemetry/OtelIngestMaintenanceFenceRelease.test.ts` | 57 tests. All 11 `autoDiscover*`, plus a coverage test that reflects over the class so a twelfth method fails the build. |
| `Common/Tests/.../HostServiceUpdateLastSeen.test.ts` | Existing clamp assertions now run the real write path against a faked repository — mocking the method out would mock the clamp out with it. Assertions themselves unchanged. |

## Verification

- `npx eslint . --fix --cache` at repo root — exit 0
- `npm run compile` in `Common` — exit 0
- Common: 14 related suites, **386 passed**; re-run on the current master base, **287 passed**
- App fence suite: **57 passed**

Two pre-existing environment caveats, both reproducible on an unmodified `master` checkout and unrelated to this change: `npm run compile` in `App` fails with `Cannot find type definition file for 'jest'/'node'` (`App/node_modules/@types` is missing them), and `npm test` in `App` fails with `Cannot read properties of undefined (reading 'bind')` (mismatched `jest-runtime` resolution). App changes were verified by compiling with type roots borrowed from `Common` — the resulting error set is **identical to the baseline**, so no new type errors — and the App suite was run with `Common`'s jest binary.
