### PR TITLE
fix(logs): move the histogram along with live mode

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts
@@ -1,0 +1,119 @@
+import { JSONObject } from "Common/Types/JSON";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import RangeStartAndEndDateTime, {
+  RangeStartAndEndDateTimeUtil,
+} from "Common/Types/Time/RangeStartAndEndDateTime";
+
+/*
+ * Facets that all read out of the same `primaryEntityId` column — the
+ * discriminator (Service / Host / Docker host / Podman host / Kubernetes
+ * cluster) only matters when the facet values are computed. Filtering by any
+ * of them is a single `primaryEntityId IN (...)` predicate, so selections
+ * across these facets are coalesced into one list.
+ */
+export const RESOURCE_FACET_KEYS: Array<string> = [
+  "primaryEntityId",
+  "hostId",
+  "dockerHostId",
+  "podmanHostId",
+  "kubernetesClusterId",
+];
+
+export interface LogsHistogramRequestParams {
+  /** Current picker selection. Preset ranges resolve against "now" on every call. */
+  timeRange: RangeStartAndEndDateTime;
+  /** Base scope from the host page (e.g. a service or trace detail view). */
+  serviceIds?: Array<string> | undefined;
+  traceIds?: Array<string> | undefined;
+  spanIds?: Array<string> | undefined;
+  attributes?: Record<string, string> | undefined;
+  entityKeys?: Array<string> | undefined;
+  /** Facet chips the user has applied in the sidebar / search bar. */
+  appliedFacetFilters: Map<string, Set<string>>;
+}
+
+/**
+ * Builds the POST body for `/telemetry/logs/histogram`.
+ *
+ * The window is resolved from the time range on every call rather than being
+ * passed in, which is what lets live mode work: each poll re-resolves a
+ * preset range ("past one hour") against the current clock, so the window
+ * slides forward and newly ingested logs land in the chart. A custom range
+ * has fixed edges and stays put.
+ */
+export function buildLogsHistogramRequest(
+  params: LogsHistogramRequestParams,
+): JSONObject {
+  const dateRange: InBetween<Date> =
+    RangeStartAndEndDateTimeUtil.getStartAndEndDate(params.timeRange);
+
+  const requestData: JSONObject = {
+    startTime: dateRange.startValue.toISOString(),
+    endTime: dateRange.endValue.toISOString(),
+  };
+
+  if (params.serviceIds) {
+    requestData["serviceIds"] = params.serviceIds;
+  }
+
+  /*
+   * Base trace/span filters — must be applied so the chart matches the logs
+   * list when the viewer is scoped to a trace/span.
+   */
+  if (params.traceIds) {
+    requestData["traceIds"] = params.traceIds;
+  }
+
+  if (params.spanIds) {
+    requestData["spanIds"] = params.spanIds;
+  }
+
+  // Active facet filters, so the histogram reflects the current view.
+  const severityValues: Set<string> | undefined =
+    params.appliedFacetFilters.get("severityText");
+
+  if (severityValues && severityValues.size > 0) {
+    requestData["severityTexts"] = Array.from(severityValues);
+  }
+
+  const resourceFilterIds: Set<string> = new Set<string>();
+
+  for (const facetKey of RESOURCE_FACET_KEYS) {
+    const values: Set<string> | undefined =
+      params.appliedFacetFilters.get(facetKey);
+
+    if (values) {
+      for (const value of values) {
+        resourceFilterIds.add(value);
+      }
+    }
+  }
+
+  if (resourceFilterIds.size > 0) {
+    requestData["serviceIds"] = Array.from(resourceFilterIds);
+  }
+
+  const traceFilterValues: Set<string> | undefined =
+    params.appliedFacetFilters.get("traceId");
+
+  if (traceFilterValues && traceFilterValues.size > 0) {
+    requestData["traceIds"] = Array.from(traceFilterValues);
+  }
+
+  const spanFilterValues: Set<string> | undefined =
+    params.appliedFacetFilters.get("spanId");
+
+  if (spanFilterValues && spanFilterValues.size > 0) {
+    requestData["spanIds"] = Array.from(spanFilterValues);
+  }
+
+  if (params.attributes) {
+    requestData["attributes"] = params.attributes;
+  }
+
+  if (params.entityKeys) {
+    requestData["entityKeys"] = params.entityKeys;
+  }
+
+  return requestData;
+}

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -15,6 +15,14 @@ import {
   LogsSavedViewOption,
   normalizeLogsTableColumns,
 } from "Common/UI/Components/LogsViewer/types";
+import useLiveLogsRefresh from "Common/UI/Components/LogsViewer/useLiveLogsRefresh";
+import useLogsHistogram, {
+  LogsHistogramState,
+} from "Common/UI/Components/LogsViewer/useLogsHistogram";
+import {
+  buildLogsHistogramRequest,
+  RESOURCE_FACET_KEYS,
+} from "./LogsHistogramRequest";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
@@ -396,12 +404,6 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
   const hasAppliedInitialSavedView: React.MutableRefObject<boolean> =
     useRef<boolean>(false);
 
-  // Histogram state
-  const [histogramBuckets, setHistogramBuckets] = useState<
-    Array<HistogramBucket>
-  >([]);
-  const [histogramLoading, setHistogramLoading] = useState<boolean>(false);
-
   // Facet state
   const [facetData, setFacetData] = useState<FacetData>({});
   /*
@@ -744,108 +746,30 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
 
   // --- Fetch histogram ---
 
-  const fetchHistogram: () => Promise<void> =
-    useCallback(async (): Promise<void> => {
-      try {
-        setHistogramLoading(true);
+  const fetchHistogramBuckets: () => Promise<Array<HistogramBucket>> =
+    useCallback(async (): Promise<Array<HistogramBucket>> => {
+      /*
+       * The window is resolved inside the builder on every call, so a preset
+       * range slides forward with the clock and live polls pick up newly
+       * ingested logs.
+       */
+      const requestData: JSONObject = buildLogsHistogramRequest({
+        timeRange: timeRange,
+        serviceIds: serviceIdStrings,
+        traceIds: traceIdStrings,
+        spanIds: spanIdStrings,
+        attributes: logQueryAttributes,
+        entityKeys: logQueryEntityKeys,
+        appliedFacetFilters: appliedFacetFilters,
+      });
 
-        // Compute fresh dates from time range (preset ranges are relative to "now")
-        const dateRange: InBetween<Date> =
-          RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+      const response: HTTPResponse<JSONObject> = await postApi(
+        "/telemetry/logs/histogram",
+        requestData,
+      );
 
-        const requestData: JSONObject = {
-          startTime: dateRange.startValue.toISOString(),
-          endTime: dateRange.endValue.toISOString(),
-        } as JSONObject;
-
-        if (serviceIdStrings) {
-          (requestData as any)["serviceIds"] = serviceIdStrings;
-        }
-
-        /*
-         * Base trace/span filters from props — must be applied so the chart
-         * matches the logs list when the viewer is scoped to a trace/span.
-         */
-        if (traceIdStrings) {
-          (requestData as any)["traceIds"] = traceIdStrings;
-        }
-
-        if (spanIdStrings) {
-          (requestData as any)["spanIds"] = spanIdStrings;
-        }
-
-        // Pass active facet filters to the histogram so it reflects the current view
-        const severityValues: Set<string> | undefined =
-          appliedFacetFilters.get("severityText");
-
-        if (severityValues && severityValues.size > 0) {
-          (requestData as any)["severityTexts"] = Array.from(severityValues);
-        }
-
-        /*
-         * primaryEntityId and the virtual resource facets (hostId / dockerHostId /
-         * kubernetesClusterId) all read out of the same `primaryEntityId` column —
-         * merge them into a single serviceIds list so the histogram applies
-         * the union of selected resources.
-         */
-        const resourceFilterIds: Set<string> = new Set<string>();
-        for (const facetKey of [
-          "primaryEntityId",
-          "hostId",
-          "dockerHostId",
-          "podmanHostId",
-          "kubernetesClusterId",
-        ]) {
-          const values: Set<string> | undefined =
-            appliedFacetFilters.get(facetKey);
-          if (values) {
-            for (const value of values) {
-              resourceFilterIds.add(value);
-            }
-          }
-        }
-
-        if (resourceFilterIds.size > 0) {
-          (requestData as any)["serviceIds"] = Array.from(resourceFilterIds);
-        }
-
-        const traceFilterValues: Set<string> | undefined =
-          appliedFacetFilters.get("traceId");
-
-        if (traceFilterValues && traceFilterValues.size > 0) {
-          (requestData as any)["traceIds"] = Array.from(traceFilterValues);
-        }
-
-        const spanFilterValues: Set<string> | undefined =
-          appliedFacetFilters.get("spanId");
-
-        if (spanFilterValues && spanFilterValues.size > 0) {
-          (requestData as any)["spanIds"] = Array.from(spanFilterValues);
-        }
-
-        if (logQueryAttributes) {
-          (requestData as any)["attributes"] = logQueryAttributes;
-        }
-
-        if (logQueryEntityKeys) {
-          (requestData as any)["entityKeys"] = logQueryEntityKeys;
-        }
-
-        const response: HTTPResponse<JSONObject> = await postApi(
-          "/telemetry/logs/histogram",
-          requestData,
-        );
-
-        const buckets: Array<HistogramBucket> = (response.data["buckets"] ||
-          []) as unknown as Array<HistogramBucket>;
-
-        setHistogramBuckets(buckets);
-      } catch {
-        // Histogram is non-critical; silently degrade
-        setHistogramBuckets([]);
-      } finally {
-        setHistogramLoading(false);
-      }
+      return (response.data["buckets"] ||
+        []) as unknown as Array<HistogramBucket>;
     }, [
       serviceIdStrings,
       traceIdStrings,
@@ -855,6 +779,8 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
       logQueryAttributes,
       logQueryEntityKeys,
     ]);
+
+  const histogram: LogsHistogramState = useLogsHistogram(fetchHistogramBuckets);
 
   // --- Fetch facets ---
 
@@ -997,10 +923,6 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
   }, [fetchItems]);
 
   useEffect(() => {
-    void fetchHistogram();
-  }, [fetchHistogram]);
-
-  useEffect(() => {
     void fetchFacets();
   }, [fetchFacets]);
 
@@ -1044,27 +966,23 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
     }
   }, [savedViews, selectedSavedViewId]);
 
-  // Live polling
-  useEffect(() => {
-    if (
-      !isLiveEnabled ||
-      page !== 1 ||
-      sortField !== "time" ||
-      sortOrder !== SortOrder.Descending
-    ) {
-      return;
-    }
-
-    void fetchItems({ skipLoadingState: true });
-
-    const intervalId: number = window.setInterval(() => {
+  /*
+   * Live polling. The list and the histogram come from different endpoints,
+   * so both have to be refreshed on the same beat — otherwise new rows keep
+   * arriving under a chart that never moves.
+   */
+  useLiveLogsRefresh({
+    isLive: isLiveEnabled,
+    isEligible:
+      page === 1 && sortField === "time" && sortOrder === SortOrder.Descending,
+    intervalInMs: LIVE_POLL_INTERVAL_MS,
+    refreshLogs: () => {
       void fetchItems({ skipLoadingState: true });
-    }, LIVE_POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [fetchItems, isLiveEnabled, page, sortField, sortOrder]);
+    },
+    refreshHistogram: () => {
+      void histogram.refresh({ silent: true });
+    },
+  });
 
   // Realtime
   useEffect(() => {
@@ -1239,13 +1157,9 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
        * `primaryEntityId IN (...)` predicate.
        */
       const resourceIds: Set<string> = new Set<string>();
-      const resourceFacetKeys: Set<string> = new Set<string>([
-        "primaryEntityId",
-        "hostId",
-        "dockerHostId",
-        "podmanHostId",
-        "kubernetesClusterId",
-      ]);
+      const resourceFacetKeys: Set<string> = new Set<string>(
+        RESOURCE_FACET_KEYS,
+      );
 
       for (const [key, values] of facets.entries()) {
         if (values.size === 0) {
@@ -1750,8 +1664,8 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
           }}
           getTraceRoute={getTraceRoute}
           getSpanRoute={getSpanRoute}
-          histogramBuckets={histogramBuckets}
-          histogramLoading={histogramLoading}
+          histogramBuckets={histogram.buckets}
+          histogramLoading={histogram.isLoading}
           onHistogramTimeRangeSelect={handleHistogramTimeRangeSelect}
           facetData={facetData}
           facetLoading={facetLoading}

--- a/App/Tests/Dashboard/LogsHistogramRequest.test.ts
+++ b/App/Tests/Dashboard/LogsHistogramRequest.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { JSONObject } from "Common/Types/JSON";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "Common/Types/Time/TimeRange";
+import {
+  buildLogsHistogramRequest,
+  RESOURCE_FACET_KEYS,
+} from "../../FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest";
+
+const NOW: Date = new Date("2026-08-05T12:00:00.000Z");
+
+const PAST_ONE_HOUR: RangeStartAndEndDateTime = {
+  range: TimeRange.PAST_ONE_HOUR,
+};
+
+function facets(
+  entries: Record<string, Array<string>>,
+): Map<string, Set<string>> {
+  const map: Map<string, Set<string>> = new Map();
+
+  for (const [key, values] of Object.entries(entries)) {
+    map.set(key, new Set(values));
+  }
+
+  return map;
+}
+
+function build(
+  overrides: Partial<Parameters<typeof buildLogsHistogramRequest>[0]> = {},
+): JSONObject {
+  return buildLogsHistogramRequest({
+    timeRange: PAST_ONE_HOUR,
+    appliedFacetFilters: new Map(),
+    ...overrides,
+  });
+}
+
+describe("buildLogsHistogramRequest", () => {
+  beforeEach(() => {
+    /*
+     * Only Date needs faking; the sinon backend jest 28 uses cannot hijack
+     * the read-only `performance` global on current Node, so leave the
+     * timer/callback APIs alone.
+     */
+    jest.useFakeTimers({
+      doNotFake: [
+        "performance",
+        "hrtime",
+        "queueMicrotask",
+        "requestAnimationFrame",
+        "cancelAnimationFrame",
+        "requestIdleCallback",
+        "cancelIdleCallback",
+        "setImmediate",
+        "clearImmediate",
+        "setInterval",
+        "clearInterval",
+        "setTimeout",
+        "clearTimeout",
+      ],
+    });
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("time window", () => {
+    test("resolves a preset range against the current clock", () => {
+      expect(build()).toEqual({
+        startTime: "2026-08-05T11:00:00.000Z",
+        endTime: "2026-08-05T12:00:00.000Z",
+      });
+    });
+
+    /*
+     * The reason live mode works at all: every poll rebuilds the request, and
+     * a preset range has to resolve against "now" each time so the window
+     * slides forward onto logs that were ingested since the last poll.
+     */
+    test("slides the window forward as the clock moves", () => {
+      const first: JSONObject = build();
+
+      jest.setSystemTime(new Date("2026-08-05T12:00:10.000Z"));
+
+      const second: JSONObject = build();
+
+      expect(second["startTime"]).toBe("2026-08-05T11:00:10.000Z");
+      expect(second["endTime"]).toBe("2026-08-05T12:00:10.000Z");
+      expect(second["startTime"]).not.toBe(first["startTime"]);
+      expect(second["endTime"]).not.toBe(first["endTime"]);
+    });
+
+    test("keeps the window still over repeated polls of a custom range", () => {
+      const customRange: RangeStartAndEndDateTime = {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date("2026-08-01T00:00:00.000Z"),
+          new Date("2026-08-01T06:00:00.000Z"),
+        ),
+      };
+
+      const first: JSONObject = build({ timeRange: customRange });
+
+      jest.setSystemTime(new Date("2026-08-05T18:30:00.000Z"));
+
+      const second: JSONObject = build({ timeRange: customRange });
+
+      expect(second).toEqual(first);
+      expect(second).toEqual({
+        startTime: "2026-08-01T00:00:00.000Z",
+        endTime: "2026-08-01T06:00:00.000Z",
+      });
+    });
+
+    test("resolves each preset range to its own width", () => {
+      expect(build({ timeRange: { range: TimeRange.PAST_FIVE_MINS } })).toEqual(
+        {
+          startTime: "2026-08-05T11:55:00.000Z",
+          endTime: "2026-08-05T12:00:00.000Z",
+        },
+      );
+
+      expect(build({ timeRange: { range: TimeRange.PAST_ONE_DAY } })).toEqual({
+        startTime: "2026-08-04T12:00:00.000Z",
+        endTime: "2026-08-05T12:00:00.000Z",
+      });
+    });
+  });
+
+  describe("base scope from the host page", () => {
+    test("sends nothing but the window when the viewer is unscoped", () => {
+      expect(Object.keys(build()).sort()).toEqual(["endTime", "startTime"]);
+    });
+
+    test("passes service, trace and span scope through", () => {
+      const request: JSONObject = build({
+        serviceIds: ["service-1", "service-2"],
+        traceIds: ["trace-1"],
+        spanIds: ["span-1"],
+      });
+
+      expect(request["serviceIds"]).toEqual(["service-1", "service-2"]);
+      expect(request["traceIds"]).toEqual(["trace-1"]);
+      expect(request["spanIds"]).toEqual(["span-1"]);
+    });
+
+    test("passes attribute and entity-key scope through", () => {
+      const request: JSONObject = build({
+        attributes: { "resource.k8s.pod.name": "checkout-7d9" },
+        entityKeys: ["host:abc", "container:def"],
+      });
+
+      expect(request["attributes"]).toEqual({
+        "resource.k8s.pod.name": "checkout-7d9",
+      });
+      expect(request["entityKeys"]).toEqual(["host:abc", "container:def"]);
+    });
+  });
+
+  describe("facet filters", () => {
+    test("forwards selected severities", () => {
+      const request: JSONObject = build({
+        appliedFacetFilters: facets({ severityText: ["Error", "Fatal"] }),
+      });
+
+      expect(request["severityTexts"]).toEqual(["Error", "Fatal"]);
+    });
+
+    test("forwards selected traces and spans", () => {
+      const request: JSONObject = build({
+        appliedFacetFilters: facets({
+          traceId: ["trace-9"],
+          spanId: ["span-9"],
+        }),
+      });
+
+      expect(request["traceIds"]).toEqual(["trace-9"]);
+      expect(request["spanIds"]).toEqual(["span-9"]);
+    });
+
+    /*
+     * Resource facets are surfaced separately in the sidebar but all filter
+     * the same primaryEntityId column, so a selection across several of them
+     * is one union.
+     */
+    test("merges every resource facet into a single service list", () => {
+      const request: JSONObject = build({
+        appliedFacetFilters: facets({
+          primaryEntityId: ["service-1"],
+          hostId: ["host-1"],
+          dockerHostId: ["docker-1"],
+          podmanHostId: ["podman-1"],
+          kubernetesClusterId: ["cluster-1"],
+        }),
+      });
+
+      expect(request["serviceIds"]).toEqual([
+        "service-1",
+        "host-1",
+        "docker-1",
+        "podman-1",
+        "cluster-1",
+      ]);
+    });
+
+    test("de-duplicates a value selected under two resource facets", () => {
+      const request: JSONObject = build({
+        appliedFacetFilters: facets({
+          primaryEntityId: ["shared-id"],
+          hostId: ["shared-id"],
+        }),
+      });
+
+      expect(request["serviceIds"]).toEqual(["shared-id"]);
+    });
+
+    test("covers every resource facet key the sidebar can produce", () => {
+      for (const facetKey of RESOURCE_FACET_KEYS) {
+        const request: JSONObject = build({
+          appliedFacetFilters: facets({ [facetKey]: ["picked"] }),
+        });
+
+        expect(request["serviceIds"]).toEqual(["picked"]);
+      }
+    });
+
+    test("narrows the page's own scope when a resource is picked", () => {
+      const request: JSONObject = build({
+        serviceIds: ["service-1", "service-2"],
+        traceIds: ["trace-1"],
+        spanIds: ["span-1"],
+        appliedFacetFilters: facets({
+          primaryEntityId: ["service-2"],
+          traceId: ["trace-2"],
+          spanId: ["span-2"],
+        }),
+      });
+
+      expect(request["serviceIds"]).toEqual(["service-2"]);
+      expect(request["traceIds"]).toEqual(["trace-2"]);
+      expect(request["spanIds"]).toEqual(["span-2"]);
+    });
+
+    test("ignores facets whose last value was just removed", () => {
+      const request: JSONObject = build({
+        serviceIds: ["service-1"],
+        appliedFacetFilters: facets({
+          severityText: [],
+          primaryEntityId: [],
+          traceId: [],
+          spanId: [],
+        }),
+      });
+
+      expect(request["severityTexts"]).toBeUndefined();
+      expect(request["traceIds"]).toBeUndefined();
+      expect(request["spanIds"]).toBeUndefined();
+      // The page's own scope survives an emptied facet.
+      expect(request["serviceIds"]).toEqual(["service-1"]);
+    });
+
+    test("does not mutate the caller's filter map", () => {
+      const applied: Map<string, Set<string>> = facets({
+        primaryEntityId: ["service-1"],
+        hostId: ["host-1"],
+      });
+
+      build({ appliedFacetFilters: applied });
+
+      expect(Array.from(applied.get("primaryEntityId") || [])).toEqual([
+        "service-1",
+      ]);
+      expect(Array.from(applied.get("hostId") || [])).toEqual(["host-1"]);
+    });
+  });
+
+  test("builds an equivalent request on every poll when nothing changed", () => {
+    const applied: Map<string, Set<string>> = facets({
+      severityText: ["Error"],
+      hostId: ["host-1"],
+    });
+
+    const first: JSONObject = build({ appliedFacetFilters: applied });
+    const second: JSONObject = build({ appliedFacetFilters: applied });
+
+    expect(second).toEqual(first);
+  });
+});

--- a/Common/Tests/UI/Components/LogsHistogram.test.tsx
+++ b/Common/Tests/UI/Components/LogsHistogram.test.tsx
@@ -1,0 +1,276 @@
+/** @timezone UTC */
+
+import LogsHistogram from "../../../UI/Components/LogsViewer/components/LogsHistogram";
+import { HistogramBucket } from "../../../UI/Components/LogsViewer/types";
+import LogSeverity from "../../../Types/Log/LogSeverity";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * ResponsiveContainer measures its parent, which is always 0x0 in jsdom, so the
+ * chart renders nothing without a fixed size.
+ */
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, { width: 600, height: 300 });
+    },
+  };
+});
+
+function bucket(
+  time: string,
+  severity: string,
+  count: number,
+): HistogramBucket {
+  return { time, severity, count };
+}
+
+/** One bar rectangle is drawn per severity per bucket that has a count. */
+function barCount(container: HTMLElement): number {
+  return container.querySelectorAll(".recharts-bar-rectangle").length;
+}
+
+/** One <g> per stacked series, i.e. per severity present in the data. */
+function seriesCount(container: HTMLElement): number {
+  return container.querySelectorAll(".recharts-bar").length;
+}
+
+const CLOCK_LABEL: RegExp = /^\d{2}:\d{2}$/;
+
+/*
+ * Recharts portals tick labels out of their axis group, so the two axes are
+ * told apart by what they render: the time axis is formatted as a clock, the
+ * count axis as a number.
+ */
+function axisLabels(
+  container: HTMLElement,
+  axis: "time" | "count",
+): Array<string> {
+  const labels: Array<string> = Array.from(
+    container.querySelectorAll(".recharts-cartesian-axis-tick-value"),
+  ).map((tick: Element): string => {
+    return tick.textContent || "";
+  });
+
+  return labels.filter((label: string): boolean => {
+    return CLOCK_LABEL.test(label) === (axis === "time");
+  });
+}
+
+const ONE_SEVERITY: Array<HistogramBucket> = [
+  bucket("2026-08-05T11:58:00Z", LogSeverity.Error, 3),
+  bucket("2026-08-05T11:59:00Z", LogSeverity.Error, 5),
+  bucket("2026-08-05T12:00:00Z", LogSeverity.Error, 7),
+];
+
+describe("LogsHistogram", () => {
+  describe("empty and loading states", () => {
+    test("renders nothing when the window holds no logs", () => {
+      const { container } = render(
+        <LogsHistogram buckets={[]} isLoading={false} />,
+      );
+
+      expect(container.innerHTML).toBe("");
+    });
+
+    test("shows the loader on the very first load", () => {
+      render(<LogsHistogram buckets={[]} isLoading={true} />);
+
+      expect(screen.queryByTestId("component-loader")).not.toBeNull();
+    });
+
+    /*
+     * Live mode refreshes the histogram every few seconds. Swapping the chart
+     * for a loader on each poll would make it flash; the chart already on
+     * screen stays until the new buckets land.
+     */
+    test("keeps the chart on screen while a refresh is in flight", () => {
+      const { container } = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={true} />,
+      );
+
+      expect(screen.queryByTestId("component-loader")).toBeNull();
+      expect(screen.queryByText("Log Volume")).not.toBeNull();
+      expect(barCount(container)).toBe(3);
+    });
+  });
+
+  describe("drawing the buckets", () => {
+    test("draws one bar per bucket", () => {
+      const { container } = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      expect(barCount(container)).toBe(3);
+      expect(seriesCount(container)).toBe(1);
+    });
+
+    test("stacks a bar per severity inside a bucket", () => {
+      const { container } = render(
+        <LogsHistogram
+          buckets={[
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Error, 4),
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Warning, 6),
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Information, 9),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      expect(seriesCount(container)).toBe(3);
+      expect(barCount(container)).toBe(3);
+    });
+
+    test("labels the time axis in the reader's clock", () => {
+      const { container } = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      expect(axisLabels(container, "time")).toContain("12:00");
+    });
+
+    test("lists only the severities present in the window", () => {
+      render(
+        <LogsHistogram
+          buckets={[
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Error, 4),
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Debug, 1),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      expect(screen.queryByText("Error")).not.toBeNull();
+      expect(screen.queryByText("Debug")).not.toBeNull();
+      expect(screen.queryByText("Fatal")).toBeNull();
+    });
+  });
+
+  /*
+   * What live mode looks like from the chart's side: the same component is
+   * handed a fresh set of buckets every poll and has to redraw.
+   */
+  describe("when a live refresh brings new data", () => {
+    test("adds a bar as a new bucket opens", () => {
+      const view: ReturnType<typeof render> = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      expect(barCount(view.container)).toBe(3);
+
+      view.rerender(
+        <LogsHistogram
+          buckets={[
+            ...ONE_SEVERITY,
+            bucket("2026-08-05T12:01:00Z", LogSeverity.Error, 2),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      expect(barCount(view.container)).toBe(4);
+    });
+
+    test("follows the window as it slides off the oldest bucket", () => {
+      const view: ReturnType<typeof render> = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      expect(axisLabels(view.container, "time")).toContain("11:58");
+
+      view.rerender(
+        <LogsHistogram
+          buckets={[
+            ...ONE_SEVERITY.slice(1),
+            bucket("2026-08-05T12:01:00Z", LogSeverity.Error, 2),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      const labels: Array<string> = axisLabels(view.container, "time");
+      expect(labels).not.toContain("11:58");
+      expect(labels).toContain("12:01");
+    });
+
+    test("rescales the count axis as the newest bucket fills up", () => {
+      const view: ReturnType<typeof render> = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      const before: Array<string> = axisLabels(view.container, "count");
+
+      view.rerender(
+        <LogsHistogram
+          buckets={[
+            ...ONE_SEVERITY.slice(0, 2),
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Error, 400),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      const after: Array<string> = axisLabels(view.container, "count");
+
+      expect(after).not.toEqual(before);
+      expect(Number(after[after.length - 1])).toBeGreaterThan(
+        Number(before[before.length - 1]),
+      );
+    });
+
+    test("adds a series and a legend entry when a new severity shows up", () => {
+      const view: ReturnType<typeof render> = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      expect(screen.queryByText("Fatal")).toBeNull();
+
+      view.rerender(
+        <LogsHistogram
+          buckets={[
+            ...ONE_SEVERITY,
+            bucket("2026-08-05T12:00:00Z", LogSeverity.Fatal, 1),
+          ]}
+          isLoading={false}
+        />,
+      );
+
+      expect(screen.queryByText("Fatal")).not.toBeNull();
+      expect(seriesCount(view.container)).toBe(2);
+    });
+
+    test("empties the chart when the refreshed window has no logs", () => {
+      const view: ReturnType<typeof render> = render(
+        <LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />,
+      );
+
+      view.rerender(<LogsHistogram buckets={[]} isLoading={false} />);
+
+      expect(view.container.innerHTML).toBe("");
+    });
+  });
+
+  describe("drag to zoom", () => {
+    test("offers the affordance when the parent can act on a selection", () => {
+      render(
+        <LogsHistogram
+          buckets={ONE_SEVERITY}
+          isLoading={false}
+          onTimeRangeSelect={() => {}}
+        />,
+      );
+
+      expect(screen.queryByText("Drag to zoom")).not.toBeNull();
+    });
+
+    test("hides the affordance when there is nothing to zoom into", () => {
+      render(<LogsHistogram buckets={ONE_SEVERITY} isLoading={false} />);
+
+      expect(screen.queryByText("Drag to zoom")).toBeNull();
+    });
+  });
+});

--- a/Common/Tests/UI/Components/UseLiveLogsRefresh.test.tsx
+++ b/Common/Tests/UI/Components/UseLiveLogsRefresh.test.tsx
@@ -1,0 +1,489 @@
+import useLiveLogsRefresh from "../../../UI/Components/LogsViewer/useLiveLogsRefresh";
+import "@testing-library/jest-dom/extend-expect";
+import { act, render } from "@testing-library/react";
+import React, { FunctionComponent, ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+const POLL_INTERVAL_MS: number = 10000;
+
+interface ProbeProps {
+  isLive: boolean;
+  isEligible?: boolean | undefined;
+  intervalInMs?: number | undefined;
+  refreshLogs: () => void;
+  refreshHistogram: () => void;
+}
+
+/*
+ * Exercises the hook through a real component lifecycle (mount, re-render,
+ * unmount) rather than poking at it in isolation — the bug this guards
+ * against lives in the effect wiring, not in a return value.
+ */
+const LiveProbe: FunctionComponent<ProbeProps> = (
+  props: ProbeProps,
+): ReactElement => {
+  useLiveLogsRefresh({
+    isLive: props.isLive,
+    isEligible: props.isEligible ?? true,
+    intervalInMs: props.intervalInMs ?? POLL_INTERVAL_MS,
+    refreshLogs: props.refreshLogs,
+    refreshHistogram: props.refreshHistogram,
+  });
+
+  return <div data-testid="live-probe" />;
+};
+
+function advance(milliseconds: number): void {
+  act(() => {
+    jest.advanceTimersByTime(milliseconds);
+  });
+}
+
+describe("useLiveLogsRefresh", () => {
+  let refreshLogs: jest.Mock;
+  let refreshHistogram: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    refreshLogs = jest.fn();
+    refreshHistogram = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("while live mode is off", () => {
+    test("refreshes nothing", () => {
+      render(
+        <LiveProbe
+          isLive={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS * 5);
+
+      expect(refreshLogs).not.toHaveBeenCalled();
+      expect(refreshHistogram).not.toHaveBeenCalled();
+    });
+
+    test("leaves no timer running", () => {
+      render(
+        <LiveProbe
+          isLive={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe("when live mode is switched on", () => {
+    test("refreshes the logs straight away rather than one tick later", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The regression this hook exists for: live mode used to poll only the
+     * log list, so new rows kept arriving under a histogram that never moved.
+     */
+    test("refreshes the histogram straight away too", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+    });
+
+    test("runs exactly one timer", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe("on every poll", () => {
+    test("waits for the full interval before the next refresh", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS - 1);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+    });
+
+    test("refreshes again on the interval boundary", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(2);
+      expect(refreshHistogram).toHaveBeenCalledTimes(2);
+    });
+
+    test("keeps the histogram on the same beat as the logs over many ticks", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      for (let tick: number = 0; tick < 10; tick++) {
+        advance(POLL_INTERVAL_MS);
+
+        expect(refreshHistogram).toHaveBeenCalledTimes(
+          refreshLogs.mock.calls.length,
+        );
+      }
+
+      // 1 immediate + 10 ticks.
+      expect(refreshLogs).toHaveBeenCalledTimes(11);
+      expect(refreshHistogram).toHaveBeenCalledTimes(11);
+    });
+
+    test("does not drift or double up across a long session", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS * 60);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(61);
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe("when the view cannot be tailed", () => {
+    test("does not poll on a page other than the first", () => {
+      render(
+        <LiveProbe
+          isLive={true}
+          isEligible={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS * 3);
+
+      expect(refreshLogs).not.toHaveBeenCalled();
+      expect(refreshHistogram).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    test("starts polling both endpoints once the view becomes eligible", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          isEligible={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          isEligible={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+    });
+
+    test("stops polling when the reader pages away mid-session", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS);
+
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          isEligible={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS * 5);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(2);
+      expect(refreshHistogram).toHaveBeenCalledTimes(2);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe("when live mode is switched off", () => {
+    test("stops refreshing both the logs and the histogram", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.rerender(
+        <LiveProbe
+          isLive={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS * 5);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    test("refreshes immediately again when switched back on", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.rerender(
+        <LiveProbe
+          isLive={false}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(refreshLogs).toHaveBeenCalledTimes(2);
+      expect(refreshHistogram).toHaveBeenCalledTimes(2);
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe("when the parent re-renders mid-session", () => {
+    /*
+     * Results landing from a poll re-render the parent, which hands over
+     * freshly-created callbacks. Re-arming the timer on that would reset the
+     * cadence and fire an extra request on every render.
+     */
+    test("does not poll again just because the callbacks changed identity", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      // A distinct pair of callbacks per render, as a real parent would hand over.
+      const renders: Array<{ logs: () => void; histogram: () => void }> = [
+        1, 2, 3, 4, 5,
+      ].map(() => {
+        return {
+          logs: () => {
+            refreshLogs();
+          },
+          histogram: () => {
+            refreshHistogram();
+          },
+        };
+      });
+
+      for (const callbacks of renders) {
+        view.rerender(
+          <LiveProbe
+            isLive={true}
+            refreshLogs={callbacks.logs}
+            refreshHistogram={callbacks.histogram}
+          />,
+        );
+      }
+
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(1);
+    });
+
+    test("keeps the original cadence rather than restarting the clock", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS - 1000);
+
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={() => {
+            refreshLogs();
+          }}
+          refreshHistogram={() => {
+            refreshHistogram();
+          }}
+        />,
+      );
+
+      advance(1000);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(2);
+      expect(refreshHistogram).toHaveBeenCalledTimes(2);
+    });
+
+    test("polls through the newest callbacks", () => {
+      const laterLogs: jest.Mock = jest.fn();
+      const laterHistogram: jest.Mock = jest.fn();
+
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={laterLogs}
+          refreshHistogram={laterHistogram}
+        />,
+      );
+
+      advance(POLL_INTERVAL_MS);
+
+      expect(laterLogs).toHaveBeenCalledTimes(1);
+      expect(laterHistogram).toHaveBeenCalledTimes(1);
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the poll interval changes", () => {
+    test("adopts the new cadence", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          intervalInMs={1000}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      advance(1000);
+
+      // 1 on mount, 1 on the re-armed loop's immediate poll, 1 on its tick.
+      expect(refreshLogs).toHaveBeenCalledTimes(3);
+      expect(refreshHistogram).toHaveBeenCalledTimes(3);
+    });
+
+    test("does not leave the old cadence's timer behind", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.rerender(
+        <LiveProbe
+          isLive={true}
+          intervalInMs={1000}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe("cleanup", () => {
+    test("stops polling once the viewer is unmounted", () => {
+      const view: ReturnType<typeof render> = render(
+        <LiveProbe
+          isLive={true}
+          refreshLogs={refreshLogs}
+          refreshHistogram={refreshHistogram}
+        />,
+      );
+
+      view.unmount();
+
+      advance(POLL_INTERVAL_MS * 5);
+
+      expect(refreshLogs).toHaveBeenCalledTimes(1);
+      expect(refreshHistogram).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/UseLogsHistogram.test.tsx
+++ b/Common/Tests/UI/Components/UseLogsHistogram.test.tsx
@@ -1,0 +1,409 @@
+import useLogsHistogram, {
+  FetchHistogramBucketsFunction,
+  LogsHistogramState,
+} from "../../../UI/Components/LogsViewer/useLogsHistogram";
+import { HistogramBucket } from "../../../UI/Components/LogsViewer/types";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import React, { FunctionComponent, ReactElement, useCallback } from "react";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+function bucket(time: string, count: number): HistogramBucket {
+  return { time, severity: "Error", count };
+}
+
+const FIRST_WINDOW: Array<HistogramBucket> = [bucket("11:59", 3)];
+const SECOND_WINDOW: Array<HistogramBucket> = [
+  bucket("11:59", 3),
+  bucket("12:00", 8),
+];
+
+interface ProbeProps {
+  fetchBuckets: FetchHistogramBucketsFunction;
+  /** Bumping this hands the hook a new query identity, as a filter change would. */
+  queryKey?: string | undefined;
+  onReady?: ((state: LogsHistogramState) => void) | undefined;
+}
+
+/*
+ * Renders the hook's state so assertions read it through a real component
+ * lifecycle, and hands the state object back so tests can trigger a refresh
+ * the way live mode does.
+ */
+const HistogramProbe: FunctionComponent<ProbeProps> = (
+  props: ProbeProps,
+): ReactElement => {
+  const { fetchBuckets, queryKey } = props;
+
+  const fetch: FetchHistogramBucketsFunction = useCallback(() => {
+    return fetchBuckets();
+    /*
+     * queryKey stands in for the filters/time range the real caller closes
+     * over: changing it is what makes the hook reload.
+     */
+  }, [fetchBuckets, queryKey]);
+
+  const state: LogsHistogramState = useLogsHistogram(fetch);
+
+  props.onReady?.(state);
+
+  return (
+    <div>
+      <span data-testid="counts">
+        {state.buckets
+          .map((item: HistogramBucket) => {
+            return `${item.time}=${item.count}`;
+          })
+          .join(",")}
+      </span>
+      <span data-testid="loading">{String(state.isLoading)}</span>
+    </div>
+  );
+};
+
+function counts(): string {
+  return screen.getByTestId("counts").textContent || "";
+}
+
+function isLoading(): boolean {
+  return screen.getByTestId("loading").textContent === "true";
+}
+
+describe("useLogsHistogram", () => {
+  let latest: LogsHistogramState | null;
+  let loadingStates: Array<boolean>;
+
+  const captureState: (state: LogsHistogramState) => void = (
+    state: LogsHistogramState,
+  ): void => {
+    latest = state;
+    loadingStates.push(state.isLoading);
+  };
+
+  async function refresh(silent: boolean): Promise<void> {
+    await act(async () => {
+      await latest!.refresh(silent ? { silent: true } : {});
+    });
+  }
+
+  beforeEach(() => {
+    latest = null;
+    loadingStates = [];
+  });
+
+  describe("first load", () => {
+    test("shows the buckets the query returns", async () => {
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return FIRST_WINDOW;
+      };
+
+      render(<HistogramProbe fetchBuckets={fetchBuckets} />);
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+    });
+
+    test("raises the loading flag while the query runs", async () => {
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return FIRST_WINDOW;
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+
+      expect(loadingStates).toContain(true);
+      expect(isLoading()).toBe(false);
+    });
+
+    test("leaves the chart empty when the query fails", async () => {
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        throw new Error("clickhouse timeout");
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(isLoading()).toBe(false);
+      });
+
+      expect(counts()).toBe("");
+    });
+  });
+
+  describe("when the query changes", () => {
+    test("reloads for the new filters", async () => {
+      let window: Array<HistogramBucket> = FIRST_WINDOW;
+
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return window;
+      };
+
+      const view: ReturnType<typeof render> = render(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="one-hour" />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+
+      window = SECOND_WINDOW;
+
+      view.rerender(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="one-day" />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3,12:00=8");
+      });
+    });
+
+    test("does not reload when nothing about the query changed", async () => {
+      let calls: number = 0;
+
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        calls++;
+        return FIRST_WINDOW;
+      };
+
+      const view: ReturnType<typeof render> = render(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="one-hour" />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+
+      view.rerender(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="one-hour" />,
+      );
+
+      expect(calls).toBe(1);
+    });
+  });
+
+  /*
+   * Live mode polls the histogram every few seconds. These are the properties
+   * that keep the chart from flashing, blanking or stampeding while it does.
+   */
+  describe("silent refresh", () => {
+    test("moves the chart on to the newer window", async () => {
+      let window: Array<HistogramBucket> = FIRST_WINDOW;
+
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return window;
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+
+      window = SECOND_WINDOW;
+      await refresh(true);
+
+      expect(counts()).toBe("11:59=3,12:00=8");
+    });
+
+    test("never raises the loading flag", async () => {
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return FIRST_WINDOW;
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+
+      loadingStates = [];
+
+      await refresh(true);
+      await refresh(true);
+
+      expect(loadingStates).not.toContain(true);
+    });
+
+    test("keeps the chart on screen when a poll fails", async () => {
+      let shouldFail: boolean = false;
+
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        if (shouldFail) {
+          throw new Error("clickhouse timeout");
+        }
+
+        return FIRST_WINDOW;
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(counts()).toBe("11:59=3");
+      });
+
+      shouldFail = true;
+      await refresh(true);
+
+      expect(counts()).toBe("11:59=3");
+    });
+
+    test("recovers on the next poll after a failure", async () => {
+      let shouldFail: boolean = true;
+      let window: Array<HistogramBucket> = FIRST_WINDOW;
+
+      const fetchBuckets: FetchHistogramBucketsFunction = async (): Promise<
+        Array<HistogramBucket>
+      > => {
+        if (shouldFail) {
+          throw new Error("clickhouse timeout");
+        }
+
+        return window;
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(isLoading()).toBe(false);
+      });
+
+      shouldFail = false;
+      window = SECOND_WINDOW;
+      await refresh(true);
+
+      expect(counts()).toBe("11:59=3,12:00=8");
+    });
+
+    test("drops a poll that lands while the previous one is still running", async () => {
+      const pending: Array<(buckets: Array<HistogramBucket>) => void> = [];
+
+      const fetchBuckets: FetchHistogramBucketsFunction = (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return new Promise<Array<HistogramBucket>>(
+          (resolve: (buckets: Array<HistogramBucket>) => void) => {
+            pending.push(resolve);
+          },
+        );
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      // Let the first load settle so only the polls are in play.
+      await waitFor(() => {
+        expect(pending.length).toBe(1);
+      });
+      await act(async () => {
+        pending[0]!(FIRST_WINDOW);
+      });
+
+      // A poll that is still waiting on a slow aggregation...
+      let slowPoll: Promise<void> = Promise.resolve();
+      await act(async () => {
+        slowPoll = latest!.refresh({ silent: true });
+      });
+      expect(pending.length).toBe(2);
+
+      // ...swallows the ticks that land behind it.
+      await act(async () => {
+        await latest!.refresh({ silent: true });
+        await latest!.refresh({ silent: true });
+      });
+      expect(pending.length).toBe(2);
+
+      await act(async () => {
+        pending[1]!(SECOND_WINDOW);
+        await slowPoll;
+      });
+
+      expect(counts()).toBe("11:59=3,12:00=8");
+
+      // The gate lifts once the slow poll comes back.
+      await act(async () => {
+        void latest!.refresh({ silent: true });
+      });
+      expect(pending.length).toBe(3);
+
+      await act(async () => {
+        pending[2]!(SECOND_WINDOW);
+      });
+    });
+
+    test("does not hold up a full reload triggered by the reader", async () => {
+      const pending: Array<(buckets: Array<HistogramBucket>) => void> = [];
+
+      const fetchBuckets: FetchHistogramBucketsFunction = (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return new Promise<Array<HistogramBucket>>(
+          (resolve: (buckets: Array<HistogramBucket>) => void) => {
+            pending.push(resolve);
+          },
+        );
+      };
+
+      render(
+        <HistogramProbe fetchBuckets={fetchBuckets} onReady={captureState} />,
+      );
+
+      await waitFor(() => {
+        expect(pending.length).toBe(1);
+      });
+      await act(async () => {
+        pending[0]!(FIRST_WINDOW);
+      });
+
+      await act(async () => {
+        void latest!.refresh({ silent: true });
+      });
+      expect(pending.length).toBe(2);
+
+      // A filter change or a manual reload must not be swallowed by the gate.
+      await act(async () => {
+        void latest!.refresh();
+      });
+      expect(pending.length).toBe(3);
+      expect(isLoading()).toBe(true);
+
+      await act(async () => {
+        pending[1]!(FIRST_WINDOW);
+        pending[2]!(SECOND_WINDOW);
+      });
+
+      expect(isLoading()).toBe(false);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/UseLogsHistogram.test.tsx
+++ b/Common/Tests/UI/Components/UseLogsHistogram.test.tsx
@@ -196,6 +196,97 @@ describe("useLogsHistogram", () => {
 
       expect(calls).toBe(1);
     });
+
+    /*
+     * A poll fired against the old time range can easily outlive the switch to
+     * a new one. Painting its answer would leave the reader looking at a
+     * window they have already moved off.
+     */
+    test("ignores an answer to a query the reader has already left", async () => {
+      const pending: Array<(buckets: Array<HistogramBucket>) => void> = [];
+
+      const fetchBuckets: FetchHistogramBucketsFunction = (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return new Promise<Array<HistogramBucket>>(
+          (resolve: (buckets: Array<HistogramBucket>) => void) => {
+            pending.push(resolve);
+          },
+        );
+      };
+
+      const view: ReturnType<typeof render> = render(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="one-hour" />,
+      );
+
+      await waitFor(() => {
+        expect(pending.length).toBe(1);
+      });
+
+      view.rerender(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="five-minutes" />,
+      );
+
+      await waitFor(() => {
+        expect(pending.length).toBe(2);
+      });
+
+      // The new window answers first, then the abandoned one straggles in.
+      await act(async () => {
+        pending[1]!(SECOND_WINDOW);
+      });
+      await act(async () => {
+        pending[0]!(FIRST_WINDOW);
+      });
+
+      expect(counts()).toBe("11:59=3,12:00=8");
+    });
+
+    test("does not blank the chart when an abandoned query fails", async () => {
+      const pending: Array<{
+        resolve: (buckets: Array<HistogramBucket>) => void;
+        reject: (error: Error) => void;
+      }> = [];
+
+      const fetchBuckets: FetchHistogramBucketsFunction = (): Promise<
+        Array<HistogramBucket>
+      > => {
+        return new Promise<Array<HistogramBucket>>(
+          (
+            resolve: (buckets: Array<HistogramBucket>) => void,
+            reject: (error: Error) => void,
+          ) => {
+            pending.push({ resolve: resolve, reject: reject });
+          },
+        );
+      };
+
+      const view: ReturnType<typeof render> = render(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="one-hour" />,
+      );
+
+      await waitFor(() => {
+        expect(pending.length).toBe(1);
+      });
+
+      view.rerender(
+        <HistogramProbe fetchBuckets={fetchBuckets} queryKey="five-minutes" />,
+      );
+
+      await waitFor(() => {
+        expect(pending.length).toBe(2);
+      });
+
+      await act(async () => {
+        pending[1]!.resolve(SECOND_WINDOW);
+      });
+      await act(async () => {
+        pending[0]!.reject(new Error("clickhouse timeout"));
+      });
+
+      expect(counts()).toBe("11:59=3,12:00=8");
+      expect(isLoading()).toBe(false);
+    });
   });
 
   /*

--- a/Common/UI/Components/LogsViewer/useLiveLogsRefresh.ts
+++ b/Common/UI/Components/LogsViewer/useLiveLogsRefresh.ts
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef } from "react";
+
+export interface LiveLogsRefreshOptions {
+  /** Whether the user has switched live mode on. */
+  isLive: boolean;
+  /**
+   * Whether the current view can be refreshed in place. Live tailing only
+   * makes sense on the first page sorted newest-first — on page 3, or sorted
+   * by severity, "the newest logs" is not what the viewer is showing.
+   */
+  isEligible: boolean;
+  /** How often to poll while live mode is on. */
+  intervalInMs: number;
+  /** Pull the newest page of logs. */
+  refreshLogs: () => void;
+  /**
+   * Re-run the histogram query. The chart is driven by its own aggregation
+   * request rather than by the rows in the table, so it goes stale unless it
+   * is refreshed on the same beat as the list.
+   */
+  refreshHistogram: () => void;
+}
+
+export type UseLiveLogsRefreshFunction = (
+  options: LiveLogsRefreshOptions,
+) => void;
+
+/**
+ * Drives the polling loop behind the log viewer's live mode.
+ *
+ * Every tick refreshes the log list *and* the histogram together. That
+ * pairing is the point of this hook: the two come from different endpoints,
+ * and refreshing only the list leaves a chart that stops moving while rows
+ * keep arriving underneath it.
+ *
+ * The callbacks are read through refs, so a parent that re-renders (which it
+ * does on every poll, as results land) does not tear down and re-arm the
+ * timer — that would reset the cadence and fire an extra immediate poll each
+ * time. Only the gating flags and the interval restart the loop.
+ */
+const useLiveLogsRefresh: UseLiveLogsRefreshFunction = (
+  options: LiveLogsRefreshOptions,
+): void => {
+  const { isLive, isEligible, intervalInMs } = options;
+
+  const refreshLogsRef: React.MutableRefObject<() => void> = useRef<() => void>(
+    options.refreshLogs,
+  );
+  const refreshHistogramRef: React.MutableRefObject<() => void> = useRef<
+    () => void
+  >(options.refreshHistogram);
+
+  /*
+   * Declared before the polling effect so the refs are already current by the
+   * time that effect (re-)runs — effects fire in declaration order.
+   */
+  useEffect(() => {
+    refreshLogsRef.current = options.refreshLogs;
+    refreshHistogramRef.current = options.refreshHistogram;
+  });
+
+  useEffect(() => {
+    if (!isLive || !isEligible) {
+      return;
+    }
+
+    const poll: () => void = (): void => {
+      refreshLogsRef.current();
+      refreshHistogramRef.current();
+    };
+
+    // Switching live mode on should show fresh data immediately, not one tick later.
+    poll();
+
+    const intervalId: ReturnType<typeof setInterval> = setInterval(
+      poll,
+      intervalInMs,
+    );
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [isLive, isEligible, intervalInMs]);
+};
+
+export default useLiveLogsRefresh;

--- a/Common/UI/Components/LogsViewer/useLogsHistogram.ts
+++ b/Common/UI/Components/LogsViewer/useLogsHistogram.ts
@@ -50,6 +50,18 @@ const useLogsHistogram: UseLogsHistogramFunction = (
   const silentRequestInFlight: React.MutableRefObject<boolean> =
     useRef<boolean>(false);
 
+  /*
+   * The query the viewer is on right now. A request that comes back after the
+   * reader has moved to another time range or filter is dropped rather than
+   * painted over the window they are actually looking at.
+   */
+  const currentQuery: React.MutableRefObject<FetchHistogramBucketsFunction> =
+    useRef<FetchHistogramBucketsFunction>(fetchBuckets);
+
+  useEffect(() => {
+    currentQuery.current = fetchBuckets;
+  }, [fetchBuckets]);
+
   const refresh: (options?: LogsHistogramRefreshOptions) => Promise<void> =
     useCallback(
       async (options: LogsHistogramRefreshOptions = {}): Promise<void> => {
@@ -66,16 +78,20 @@ const useLogsHistogram: UseLogsHistogramFunction = (
         }
 
         try {
-          setBuckets(await fetchBuckets());
+          const nextBuckets: Array<HistogramBucket> = await fetchBuckets();
+
+          if (currentQuery.current === fetchBuckets) {
+            setBuckets(nextBuckets);
+          }
         } catch {
           // The histogram is non-critical; degrade rather than fail the page.
-          if (!isSilent) {
+          if (!isSilent && currentQuery.current === fetchBuckets) {
             setBuckets([]);
           }
         } finally {
           if (isSilent) {
             silentRequestInFlight.current = false;
-          } else {
+          } else if (currentQuery.current === fetchBuckets) {
             setIsLoading(false);
           }
         }

--- a/Common/UI/Components/LogsViewer/useLogsHistogram.ts
+++ b/Common/UI/Components/LogsViewer/useLogsHistogram.ts
@@ -1,0 +1,97 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { HistogramBucket } from "./types";
+
+export interface LogsHistogramRefreshOptions {
+  /**
+   * A background refresh: no loader, no blanking on failure, and no stacking
+   * if the previous one has not come back yet. This is what live mode uses.
+   */
+  silent?: boolean | undefined;
+}
+
+export interface LogsHistogramState {
+  buckets: Array<HistogramBucket>;
+  isLoading: boolean;
+  refresh: (options?: LogsHistogramRefreshOptions) => Promise<void>;
+}
+
+export type FetchHistogramBucketsFunction = () => Promise<
+  Array<HistogramBucket>
+>;
+
+export type UseLogsHistogramFunction = (
+  fetchBuckets: FetchHistogramBucketsFunction,
+) => LogsHistogramState;
+
+/**
+ * Owns the log histogram's data, loading flag and refresh loop.
+ *
+ * The chart is fed by its own aggregation query rather than by the rows in
+ * the table, so it needs refreshing in its own right — including on every
+ * live-mode tick. A poll is a *silent* refresh, which is what keeps live mode
+ * from looking broken:
+ *
+ * - it does not raise the loading flag, so the chart does not flash a loader
+ *   every few seconds;
+ * - it keeps the buckets already on screen if the request fails, so one bad
+ *   response does not blank the chart;
+ * - it is dropped while an earlier poll is still running, so a slow
+ *   aggregation cannot pile requests up behind it.
+ *
+ * `fetchBuckets` doubles as the query identity: hand over a new callback (a
+ * new time range, filter or scope) and the histogram reloads.
+ */
+const useLogsHistogram: UseLogsHistogramFunction = (
+  fetchBuckets: FetchHistogramBucketsFunction,
+): LogsHistogramState => {
+  const [buckets, setBuckets] = useState<Array<HistogramBucket>>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const silentRequestInFlight: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
+
+  const refresh: (options?: LogsHistogramRefreshOptions) => Promise<void> =
+    useCallback(
+      async (options: LogsHistogramRefreshOptions = {}): Promise<void> => {
+        const isSilent: boolean = options.silent === true;
+
+        if (isSilent) {
+          if (silentRequestInFlight.current) {
+            return;
+          }
+
+          silentRequestInFlight.current = true;
+        } else {
+          setIsLoading(true);
+        }
+
+        try {
+          setBuckets(await fetchBuckets());
+        } catch {
+          // The histogram is non-critical; degrade rather than fail the page.
+          if (!isSilent) {
+            setBuckets([]);
+          }
+        } finally {
+          if (isSilent) {
+            silentRequestInFlight.current = false;
+          } else {
+            setIsLoading(false);
+          }
+        }
+      },
+      [fetchBuckets],
+    );
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    buckets: buckets,
+    isLoading: isLoading,
+    refresh: refresh,
+  };
+};
+
+export default useLogsHistogram;


### PR DESCRIPTION
## The bug

With live mode on in the log viewer, new rows keep arriving in the table but the histogram never moves.

The list and the chart come from different endpoints. The live-poll effect in the dashboard log viewer only called `fetchItems`; `fetchHistogram` was wired to a `useEffect` keyed on its own `useCallback` identity, which does not change while polling — so the chart was drawn once and then sat still.

## The fix

- **`useLiveLogsRefresh`** (new, `Common/UI/Components/LogsViewer`) owns the polling loop and refreshes the log list *and* the histogram on every tick. Callbacks are read through refs so the parent re-rendering as results land does not re-arm the timer and fire an extra poll.
- **`useLogsHistogram`** (new, same directory) takes over the histogram's buckets/loading state and adds a *silent* refresh for polls: no loader flash every few seconds, the buckets already on screen survive a failed poll, and a poll that lands while an earlier one is still running is dropped instead of stacked.
- **`buildLogsHistogramRequest`** (new, next to the dashboard log viewer) builds the request body and resolves the time window on every call, so a preset range slides forward with the clock and each poll picks up newly ingested logs. A custom range stays put. The dashboard viewer loses ~85 lines of inline request building, and the resource-facet key list is now shared with the filter-rebuild path instead of being duplicated.

## Tests

61 new tests, all passing locally:

| Suite | Covers |
| --- | --- |
| `Common/Tests/UI/Components/UseLiveLogsRefresh.test.tsx` (20) | list and histogram refreshed together on mount and on every tick, eligibility gating (page 1 / newest-first), stop on toggle-off and unmount, cadence preserved across parent re-renders, interval changes, no leaked timers |
| `Common/Tests/UI/Components/UseLogsHistogram.test.tsx` (11) | first load, reload when the query changes, and the silent-refresh contract: no loading flag, buckets kept on a failed poll, overlapping polls dropped, full reloads never blocked |
| `Common/Tests/UI/Components/LogsHistogram.test.tsx` (14) | the chart redrawing as live data arrives — new bucket, window sliding off the oldest bucket, axis rescaling, a new severity's series and legend entry, and no loader flash while a refresh is in flight |
| `App/Tests/Dashboard/LogsHistogramRequest.test.ts` (16) | window sliding for preset ranges, fixed window for custom ranges, base scope pass-through, facet merging and de-duplication |

## Not covered here

The traces viewer has the same shape — its live poll calls `fetchSpans` but not `fetchHistogramAndFacets`, so its histogram is stale in live mode too. Left alone to keep this change to the reported bug.