### PR TITLE
feat(dashboard): add a Network Map widget and a Network dashboard template

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/EntityFilterDropdown.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Canvas/EntityFilterDropdown.tsx
@@ -29,6 +29,7 @@ import PodmanHost from "Common/Models/DatabaseModels/PodmanHost";
 import ProxmoxCluster from "Common/Models/DatabaseModels/ProxmoxCluster";
 import CephCluster from "Common/Models/DatabaseModels/CephCluster";
 import DockerSwarmCluster from "Common/Models/DatabaseModels/DockerSwarmCluster";
+import NetworkSiteType from "Common/Models/DatabaseModels/NetworkSiteType";
 import { EntityFilterModelType } from "Common/Types/Dashboard/DashboardComponents/ComponentArgument";
 
 type ModelTypeOf<T extends BaseModel> = { new (): T };
@@ -125,6 +126,17 @@ function getEntityModelDef(
       return {
         modelType: DockerSwarmCluster as unknown as ModelTypeOf<BaseModel>,
         sortField: "name" as keyof BaseModel,
+        sortOrder: SortOrder.Ascending,
+      };
+    case EntityFilterModelType.NetworkSiteType:
+      /*
+       * `order` places a type in the hierarchy (lower is higher up), so
+       * sorting by it lists Region before Market before Store — the order a
+       * customer thinks about their own estate in.
+       */
+      return {
+        modelType: NetworkSiteType as unknown as ModelTypeOf<BaseModel>,
+        sortField: "order" as keyof BaseModel,
         sortOrder: SortOrder.Ascending,
       };
     default:

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent.tsx
@@ -45,6 +45,7 @@ import DashboardDockerSwarmNodeListComponentType from "Common/Types/Dashboard/Da
 import DashboardDockerSwarmServiceListComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardDockerSwarmServiceListComponent";
 import DashboardCephOsdListComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardCephOsdListComponent";
 import DashboardCephPoolListComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardCephPoolListComponent";
+import DashboardNetworkMapComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardNetworkMapComponent";
 import DashboardHtmlComponentType from "Common/Types/Dashboard/DashboardComponents/DashboardHtmlComponent";
 import DashboardBaseComponent from "Common/Types/Dashboard/DashboardComponents/DashboardBaseComponent";
 import DashboardChartComponent from "./DashboardChartComponent";
@@ -87,6 +88,7 @@ import DashboardDockerSwarmNodeListComponent from "./DashboardDockerSwarmNodeLis
 import DashboardDockerSwarmServiceListComponent from "./DashboardDockerSwarmServiceListComponent";
 import DashboardCephOsdListComponent from "./DashboardCephOsdListComponent";
 import DashboardCephPoolListComponent from "./DashboardCephPoolListComponent";
+import DashboardNetworkMapComponent from "./DashboardNetworkMapComponent";
 import DashboardHtmlComponent from "./DashboardHtmlComponent";
 import DefaultDashboardSize, {
   GetDashboardComponentHeightInDashboardUnits,
@@ -986,6 +988,14 @@ const DashboardBaseComponentElement: FunctionComponent<ComponentProps> = (
             isEditMode={props.isEditMode}
             isSelected={props.isSelected}
             component={component as DashboardCephPoolListComponentType}
+          />
+        )}
+        {component.componentType === DashboardComponentType.NetworkMap && (
+          <DashboardNetworkMapComponent
+            {...props}
+            isEditMode={props.isEditMode}
+            isSelected={props.isSelected}
+            component={component as DashboardNetworkMapComponentType}
           />
         )}
         {component.componentType === DashboardComponentType.Html && (

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
@@ -1,0 +1,666 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import DashboardNetworkMapComponent from "Common/Types/Dashboard/DashboardComponents/DashboardNetworkMapComponent";
+import { DEFAULT_MAX_SITES } from "Common/Utils/Dashboard/Components/DashboardNetworkMapComponent";
+import { DashboardBaseComponentProps } from "./DashboardBaseComponent";
+import DashboardResourceListBase, {
+  ResourceListColumn,
+} from "./DashboardResourceListBase";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import DashboardResourceList from "../Utils/DashboardResourceList";
+import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
+import API from "Common/UI/Utils/API/API";
+import IconProp from "Common/Types/Icon/IconProp";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import Query from "Common/Types/BaseDatabase/Query";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import ProjectUtil from "Common/UI/Utils/Project";
+import ObjectID from "Common/Types/ObjectID";
+import Color from "Common/Types/Color";
+import Route from "Common/Types/API/Route";
+import RouteMap, { RouteUtil } from "../../../Utils/RouteMap";
+import PageMap from "../../../Utils/PageMap";
+import AppLink from "../../AppLink/AppLink";
+import Navigation from "Common/UI/Utils/Navigation";
+import {
+  GeometryFeature,
+  GeometryTier,
+  getCachedGeometryFeatures,
+  loadGeometryFeatures,
+} from "../../NetworkSite/Geo/WorldGeometry";
+import {
+  MapViewport,
+  viewBoxOfViewport,
+  zoomOfViewport,
+} from "../../NetworkSite/Geo/GeoViewport";
+import {
+  NETWORK_MAP_LABEL_FONT_SIZE,
+  NETWORK_MAP_LABEL_GAP,
+  NETWORK_MAP_LEGEND,
+  NetworkMapLegendEntry,
+  NetworkMapMarker,
+  NetworkMapSite,
+  NetworkMapSiteInput,
+  NetworkMapSitesResult,
+  NetworkMapStatusSummary,
+  buildNetworkMapMarkers,
+  countNetworkMapSitesInViewport,
+  describeNetworkMapCoverage,
+  fitNetworkMapViewport,
+  networkMapClusterCellSize,
+  networkMapStatusSummary,
+  resolveNetworkMapMaxSites,
+  toNetworkMapSites,
+} from "./NetworkMapWidgetData";
+
+/*
+ * The Network Map widget: this project's network sites drawn on the world,
+ * each marker colored by the monitor status rolled up onto its site.
+ *
+ * Deliberately a PICTURE rather than a place. The full Network Map page
+ * (Pages/NetworkSite/NetworkMap) is a drill-down tool with its own zoom, pan
+ * and hierarchy; a dashboard tile is glanced at from across a room, so this
+ * one has no controls at all — it simply frames itself to the sites it drew
+ * and says, in words above the map, how many of them are down. Clicking a
+ * marker that stands for exactly one site opens that site.
+ *
+ * All of the geometry, clustering and color decisions live in the react-free
+ * NetworkMapWidgetData module so they stay unit-testable; this file is the
+ * fetch and the drawing.
+ */
+
+export interface ComponentProps extends DashboardBaseComponentProps {
+  component: DashboardNetworkMapComponent;
+}
+
+const COLUMNS: Array<ResourceListColumn> = [
+  { label: "Site", widthPct: "40%" },
+  { label: "Type", widthPct: "25%" },
+  { label: "Status", widthPct: "35%" },
+];
+
+const EMPTY_MESSAGE: string =
+  "No network sites with coordinates. Add latitude and longitude to a site to pin it on the map.";
+
+/*
+ * The widget always draws the small overview outlines. The detail tier is
+ * ~6x larger and only earns its download once somebody zooms past continent
+ * scale — which a dashboard tile, having no zoom controls, never does.
+ */
+const GEOMETRY_TIER: GeometryTier = "overview";
+
+interface FetchedSites {
+  rows: Array<NetworkSite>;
+  // The fetch came back at the cap, so there may be sites it never saw.
+  isTruncated: boolean;
+}
+
+function getSiteRoute(siteId: string): Route | undefined {
+  if (!siteId) {
+    return undefined;
+  }
+  return RouteUtil.populateRouteParams(
+    RouteMap[PageMap.NETWORK_SITE_VIEW] as Route,
+    { modelId: new ObjectID(siteId) },
+  );
+}
+
+/**
+ * The one thing a marker links to: the site it stands for, when it stands
+ * for exactly one. A cluster has no single destination, so it gets none —
+ * picking one of its members for the reader would be a guess.
+ */
+function getMarkerRoute(marker: NetworkMapMarker): Route | undefined {
+  if (marker.ids.length !== 1) {
+    return undefined;
+  }
+  return getSiteRoute(marker.ids[0] as string);
+}
+
+const DashboardNetworkMapComponentElement: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const args: DashboardNetworkMapComponent["arguments"] =
+    props.component.arguments;
+
+  /*
+   * COERCED, not type-tested. The settings form renders Max Sites as an
+   * <input type="number"> whose onChange hands back `e.target.value` — a
+   * STRING — and ArgumentsForm copies the form values into the component's
+   * arguments verbatim. So the moment somebody edits this field it stops
+   * being a number, and a `typeof === "number"` guard would silently ignore
+   * the value they typed and keep fetching the default.
+   *
+   * Clamped one below LIMIT_PER_PROJECT because the fetch asks for one row
+   * MORE than the cap (see below) and the server rejects a limit above it.
+   */
+  const maxSites: number = resolveNetworkMapMaxSites(
+    args.maxSites,
+    DEFAULT_MAX_SITES,
+  );
+  const viewMode: "map" | "list" = args.viewMode === "list" ? "list" : "map";
+  const showLabels: boolean = args.showLabels !== false;
+  const statusFilter: string | undefined = args.statusFilter;
+  const networkSiteTypeIds: Array<string> | undefined = args.networkSiteTypeIds;
+  const networkSiteTypeIdsKey: string = (networkSiteTypeIds || []).join(",");
+
+  const [fetched, setFetched] = useState<FetchedSites>({
+    rows: [],
+    isTruncated: false,
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [features, setFeatures] = useState<Array<GeometryFeature> | null>(
+    getCachedGeometryFeatures(GEOMETRY_TIER),
+  );
+
+  const fetchSites: () => Promise<void> = useCallback(async () => {
+    setIsLoading(true);
+
+    const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
+    if (!DashboardResourceList.isPublic() && !projectId) {
+      setIsLoading(false);
+      setError("No project selected.");
+      return;
+    }
+
+    try {
+      const query: Query<NetworkSite> = {
+        projectId: projectId,
+      } as Query<NetworkSite>;
+
+      /*
+       * Filtering on the joined status rather than on a status id keeps the
+       * widget honest across projects: "down" means whatever that project
+       * marked as a non-operational state, not one hardcoded row.
+       */
+      if (statusFilter === "down") {
+        (query as Record<string, unknown>)["currentMonitorStatus"] = {
+          isOperationalState: false,
+        };
+      } else if (statusFilter === "operational") {
+        (query as Record<string, unknown>)["currentMonitorStatus"] = {
+          isOperationalState: true,
+        };
+      }
+
+      if (networkSiteTypeIds && networkSiteTypeIds.length > 0) {
+        (query as Record<string, unknown>)["networkSiteTypeId"] = new Includes(
+          networkSiteTypeIds,
+        );
+      }
+
+      const listResult: ListResult<NetworkSite> =
+        await ModelAPI.getList<NetworkSite>({
+          modelType: NetworkSite,
+          requestOptions:
+            DashboardResourceList.getRequestOptions("network-site"),
+          query: query,
+          /*
+           * One MORE than the cap, on purpose. Asking for exactly the cap
+           * makes "a project with exactly 250 sites" indistinguishable from
+           * "a project with 2,000" — both come back full — and the widget
+           * would tell the first one that sites are being hidden from it.
+           * The extra row is the answer, and it is dropped before drawing.
+           */
+          limit: maxSites + 1,
+          skip: 0,
+          select: {
+            _id: true,
+            name: true,
+            /*
+             * The type NAME comes from the networkSiteType relation, not
+             * from NetworkSite.siteType — that column is the deprecated
+             * pre-lookup-table string and is dropped in a follow-up PR.
+             */
+            networkSiteType: {
+              name: true,
+            },
+            latitude: true,
+            longitude: true,
+            currentMonitorStatus: {
+              name: true,
+              color: true,
+              priority: true,
+              isOperationalState: true,
+            },
+          },
+          sort: {
+            name: SortOrder.Ascending,
+          },
+        });
+
+      setFetched({
+        rows: listResult.data.slice(0, maxSites),
+        isTruncated: listResult.data.length > maxSites,
+      });
+      setError(null);
+    } catch (err: unknown) {
+      setError(API.getFriendlyErrorMessage(err as Error));
+    }
+
+    setIsLoading(false);
+  }, [maxSites, statusFilter, networkSiteTypeIdsKey]);
+
+  useEffect(() => {
+    fetchSites();
+  }, [fetchSites, props.refreshTick]);
+
+  // Outlines are fetched on demand — see Geo/WorldGeometry.ts.
+  useEffect(() => {
+    if (viewMode !== "map" || features !== null) {
+      return;
+    }
+
+    let isMounted: boolean = true;
+
+    loadGeometryFeatures(GEOMETRY_TIER)
+      .then((loaded: Array<GeometryFeature>) => {
+        if (isMounted) {
+          setFeatures(loaded);
+        }
+        return loaded;
+      })
+      .catch(() => {
+        /*
+         * The markers are the subject and the outlines are the backdrop, so
+         * a failed geometry fetch draws the pins on a bare frame rather than
+         * failing the whole widget.
+         */
+        if (isMounted) {
+          setFeatures([]);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [viewMode, features]);
+
+  const parsed: NetworkMapSitesResult = useMemo(() => {
+    return toNetworkMapSites(
+      fetched.rows.map((row: NetworkSite): NetworkMapSiteInput => {
+        const color: Color | undefined = row.currentMonitorStatus?.color as
+          | Color
+          | undefined;
+
+        return {
+          id: (row._id as string) || "",
+          name: row.name as string,
+          siteType: row.networkSiteType?.name as string,
+          latitude: row.latitude as number,
+          longitude: row.longitude as number,
+          statusName: row.currentMonitorStatus?.name as string,
+          statusColor: color ? color.toString() : null,
+          statusPriority: row.currentMonitorStatus?.priority as number,
+          isOperational:
+            typeof row.currentMonitorStatus?.isOperationalState === "boolean"
+              ? row.currentMonitorStatus.isOperationalState
+              : null,
+        };
+      }),
+    );
+  }, [fetched.rows]);
+
+  const sites: Array<NetworkMapSite> = parsed.sites;
+
+  const viewport: MapViewport = useMemo(() => {
+    return fitNetworkMapViewport(sites);
+  }, [sites]);
+
+  const markers: Array<NetworkMapMarker> = useMemo(() => {
+    return buildNetworkMapMarkers({
+      sites: sites,
+      cellSize: networkMapClusterCellSize(viewport),
+      showLabels: showLabels,
+      zoom: zoomOfViewport(viewport),
+    });
+  }, [sites, viewport, showLabels]);
+
+  const summary: NetworkMapStatusSummary = useMemo(() => {
+    return networkMapStatusSummary(sites);
+  }, [sites]);
+
+  const coverage: string = useMemo(() => {
+    return describeNetworkMapCoverage({
+      siteCount: sites.length,
+      inViewCount: countNetworkMapSitesInViewport(sites, viewport),
+      unplacedCount: parsed.unplacedCount,
+      isTruncated: fetched.isTruncated,
+    });
+  }, [sites, viewport, parsed.unplacedCount, fetched.isTruncated]);
+
+  const rows: Array<ReactElement> = useMemo(() => {
+    return sites.map((site: NetworkMapSite): ReactElement => {
+      const route: Route | undefined = getSiteRoute(site.id);
+      const dotColor: string =
+        site.statusColor ||
+        (site.isOperational === false
+          ? "#ef4444"
+          : site.isOperational === true
+            ? "#10b981"
+            : "#9ca3af");
+
+      return (
+        <tr
+          key={site.id}
+          className="hover:bg-gray-50/50 transition-colors duration-100 group"
+        >
+          <td className="px-3 py-2 text-xs text-gray-700 truncate">
+            {route ? (
+              <AppLink
+                to={route}
+                className="hover:underline text-gray-700 group-hover:text-blue-600"
+              >
+                {site.name}
+              </AppLink>
+            ) : (
+              <span>{site.name}</span>
+            )}
+          </td>
+          <td className="px-3 py-2 text-xs text-gray-500 truncate">
+            {site.siteType || "—"}
+          </td>
+          <td className="px-3 py-2">
+            <span
+              className="inline-flex items-center gap-1.5 text-xs font-medium"
+              style={{ fontSize: "10px" }}
+            >
+              <span
+                className="inline-block w-2 h-2 rounded-full"
+                style={{ backgroundColor: dotColor }}
+              ></span>
+              <span style={{ color: dotColor }}>{site.statusName}</span>
+            </span>
+          </td>
+        </tr>
+      );
+    });
+  }, [sites]);
+
+  /*
+   * The list view is the same resource-list chrome every other inventory
+   * widget uses, so a dashboard that mixes them stays visually of a piece.
+   */
+  if (viewMode === "list") {
+    return (
+      <DashboardResourceListBase
+        title={args.title}
+        pluralLabel="sites"
+        columns={COLUMNS}
+        count={sites.length}
+        isLoading={isLoading}
+        error={error}
+        isEmpty={sites.length === 0}
+        emptyMessage={EMPTY_MESSAGE}
+        emptyIcon={IconProp.Map}
+        viewMode="list"
+      >
+        {rows}
+      </DashboardResourceListBase>
+    );
+  }
+
+  if (isLoading && sites.length === 0) {
+    return (
+      <div
+        className="h-full flex flex-col animate-pulse"
+        data-testid="network-map-widget-skeleton"
+      >
+        <div className="h-3 w-24 bg-gray-100 rounded mb-3"></div>
+        <div className="flex-1 rounded-md bg-gray-50"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full gap-2">
+        <div className="w-10 h-10 rounded-full bg-gray-50 flex items-center justify-center">
+          <div className="h-5 w-5 text-gray-300">
+            <span className="sr-only">{error}</span>
+          </div>
+        </div>
+        <p className="text-xs text-gray-400 text-center max-w-48">{error}</p>
+      </div>
+    );
+  }
+
+  const zoom: number = zoomOfViewport(viewport);
+
+  return (
+    <div
+      className="h-full overflow-hidden flex flex-col"
+      data-testid="network-map-widget"
+      style={{
+        opacity: isLoading ? 0.5 : 1,
+        transition: "opacity 0.2s ease-in-out",
+      }}
+    >
+      <div className="flex items-center justify-between mb-2 px-1">
+        <span className="text-xs font-medium text-gray-400 uppercase tracking-wider truncate">
+          {args.title || "Network Map"}
+        </span>
+        <span
+          className="text-xs text-gray-300 tabular-nums flex-shrink-0"
+          data-testid="network-map-widget-summary"
+        >
+          {summary.down > 0
+            ? `${summary.down} down · ${summary.total} sites`
+            : `${summary.total} sites`}
+        </span>
+      </div>
+
+      {sites.length === 0 ? (
+        <div className="flex-1 rounded-md border border-gray-100 flex items-center justify-center px-4 py-8 text-center text-gray-400 text-sm">
+          {EMPTY_MESSAGE}
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 rounded-md border border-gray-100 overflow-hidden relative">
+          <svg
+            /*
+             * `group`, not `img`: the markers inside are focusable buttons,
+             * and role="img" would hide every one of them from assistive
+             * technology along with the rest of the subtree.
+             */
+            role="group"
+            aria-label={`World map of ${summary.total} network sites, ${summary.down} of them down.`}
+            viewBox={viewBoxOfViewport(viewport)}
+            preserveAspectRatio="xMidYMid meet"
+            className="block w-full h-full"
+            data-testid="network-map-widget-svg"
+          >
+            {/* Land outlines under the pins. */}
+            <g>
+              {(features || []).map(
+                (feature: GeometryFeature): ReactElement => {
+                  return (
+                    <path
+                      key={feature.id}
+                      d={feature.path}
+                      fillRule="evenodd"
+                      fill="var(--ou-surface-quaternary, #e5e7eb)"
+                      stroke="var(--ou-chart-tick, #6b7280)"
+                      strokeWidth={0.6 / zoom}
+                      strokeOpacity={0.8}
+                    />
+                  );
+                },
+              )}
+            </g>
+
+            {/* The markers, biggest first so a lone site is never buried. */}
+            <g>
+              {markers.map((marker: NetworkMapMarker): ReactElement => {
+                const radius: number = marker.screenRadius / zoom;
+                const route: Route | undefined = getMarkerRoute(marker);
+
+                const onActivate: () => void = () => {
+                  if (route) {
+                    Navigation.navigate(route);
+                  }
+                };
+
+                return (
+                  <g
+                    key={marker.key}
+                    data-testid="network-map-widget-marker"
+                    role={route ? "button" : undefined}
+                    tabIndex={route ? 0 : undefined}
+                    aria-label={marker.tooltip}
+                    onClick={route ? onActivate : undefined}
+                    onKeyDown={
+                      route
+                        ? (event: React.KeyboardEvent<SVGGElement>) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              onActivate();
+                            }
+                          }
+                        : undefined
+                    }
+                    style={{ cursor: route ? "pointer" : "default" }}
+                  >
+                    <circle
+                      cx={marker.x}
+                      cy={marker.y}
+                      r={radius}
+                      fill={marker.color}
+                      fillOpacity={0.85}
+                      stroke="var(--ou-surface-primary, #ffffff)"
+                      strokeWidth={1.25 / zoom}
+                    />
+                    {marker.count > 1 ? (
+                      <text
+                        x={marker.x}
+                        y={marker.y}
+                        textAnchor="middle"
+                        dominantBaseline="central"
+                        fill="var(--ou-surface-primary, #ffffff)"
+                        /*
+                         * The same three-step band SiteGeoMap uses, against
+                         * the same clusterRadius scale — a size proportional
+                         * to the radius reads fine for "7" and overflows the
+                         * disc for "128".
+                         */
+                        fontSize={
+                          (marker.screenRadius >= 14
+                            ? 13
+                            : marker.screenRadius >= 10
+                              ? 11
+                              : 10) / zoom
+                        }
+                        fontWeight={600}
+                        style={{ pointerEvents: "none" }}
+                      >
+                        {marker.count}
+                      </text>
+                    ) : (
+                      <></>
+                    )}
+                    {marker.label ? (
+                      <text
+                        x={marker.x}
+                        /*
+                         * Below the marker unless the collision pass had to
+                         * put it above — the same geometry resolveMarkerLabels
+                         * measured against, or the placement it chose would
+                         * not be the placement drawn.
+                         */
+                        y={
+                          marker.labelPlacement === "above"
+                            ? marker.y - (radius + NETWORK_MAP_LABEL_GAP / zoom)
+                            : marker.y + radius + NETWORK_MAP_LABEL_GAP / zoom
+                        }
+                        dominantBaseline="central"
+                        textAnchor="middle"
+                        fill="var(--ou-text-secondary, #4b5563)"
+                        fontSize={NETWORK_MAP_LABEL_FONT_SIZE / zoom}
+                        stroke="var(--ou-surface-primary, #ffffff)"
+                        strokeWidth={2.5 / zoom}
+                        paintOrder="stroke"
+                        style={{ pointerEvents: "none" }}
+                      >
+                        {marker.label}
+                      </text>
+                    ) : (
+                      <></>
+                    )}
+                    <title>{marker.tooltip}</title>
+                  </g>
+                );
+              })}
+            </g>
+          </svg>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-2 mt-2 px-1">
+        <div className="flex items-center gap-2 flex-wrap min-w-0">
+          {NETWORK_MAP_LEGEND.map(
+            (entry: NetworkMapLegendEntry): ReactElement => {
+              return (
+                <span
+                  key={entry.key}
+                  className="inline-flex items-center gap-1 text-gray-400"
+                  style={{ fontSize: "10px" }}
+                >
+                  <span
+                    className="inline-block w-2 h-2 rounded-full"
+                    style={{ backgroundColor: entry.color }}
+                  ></span>
+                  {entry.label}
+                </span>
+              );
+            },
+          )}
+        </div>
+        <span
+          className="text-gray-300 tabular-nums flex-shrink-0"
+          style={{ fontSize: "10px" }}
+          data-testid="network-map-widget-coverage"
+        >
+          {coverage}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+/*
+ * Deliberately does NOT compare props.variables, unlike every other
+ * inventory-list widget.
+ *
+ * Dashboard variables bind to TELEMETRY attribute keys and are applied to a
+ * widget's query by DashboardModelQueryInterpolation. NetworkSite is a plain
+ * Postgres row with no telemetry attributes on it — there is no `deviceName`
+ * or `k8s.namespace.name` to interpolate against — so this widget never
+ * applies them, and re-rendering the map because an unrelated variable
+ * changed would refetch and refit the frame for nothing.
+ */
+function arePropsEqual(prev: ComponentProps, next: ComponentProps): boolean {
+  if (
+    prev.componentId.toString() !== next.componentId.toString() ||
+    prev.refreshTick !== next.refreshTick ||
+    prev.isEditMode !== next.isEditMode ||
+    prev.isSelected !== next.isSelected ||
+    prev.dashboardComponentWidthInPx !== next.dashboardComponentWidthInPx ||
+    prev.dashboardComponentHeightInPx !== next.dashboardComponentHeightInPx
+  ) {
+    return false;
+  }
+
+  return JSONFunctions.deepEqual(
+    prev.component.arguments,
+    next.component.arguments,
+  );
+}
+
+export default React.memo(DashboardNetworkMapComponentElement, arePropsEqual);

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/NetworkMapWidgetData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/NetworkMapWidgetData.ts
@@ -1,0 +1,652 @@
+import {
+  ClusterColorKey,
+  decideClusterColorKey,
+  ClusterColorMember,
+  clusterRadius,
+  truncateMarkerLabel,
+  resolveMarkerLabels,
+  LabelPlacement,
+  MapMarker,
+  LABEL_GAP,
+  LABEL_FONT_SIZE,
+  MAX_LABELLED_MARKERS,
+} from "../../NetworkSite/SiteMapViewModel";
+import {
+  GeoCluster,
+  GeoClusterPoint,
+  clusterPoints,
+} from "../../NetworkSite/Geo/GeoClusterUtil";
+import {
+  ProjectedPoint,
+  projectRobinson,
+} from "../../NetworkSite/Geo/GeoProjection";
+import {
+  MapViewport,
+  ViewportPoint,
+  countPointsInViewport,
+  fitViewportToPoints,
+  screenLengthToViewportLength,
+} from "../../NetworkSite/Geo/GeoViewport";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+
+/*
+ * Pure, react-free view-model for the Network Map dashboard widget:
+ * narrowing NetworkSite rows into pins, clustering them, and deciding what
+ * each marker looks like and says.
+ *
+ * Kept out of the component for the same reason the Network Map page's
+ * geometry is (see NetworkSite/Geo/GeoProjection.ts): the App project does
+ * not have `react` on its resolution path, so this logic can only be
+ * unit-tested while it stays out of a .tsx file.
+ *
+ * The widget is NOT the drill-down map from Pages/NetworkSite/NetworkMap. It
+ * never navigates a hierarchy, so there are no containers, no derived
+ * centroids and no rollups here: every marker stands for one or more real,
+ * coordinate-bearing sites, and its color is decided by those sites alone.
+ *
+ * Everything here is deterministic: same input, same output, no randomness
+ * and no clock access.
+ */
+
+/*
+ * Real latitude and longitude ranges. A CSV import that shifts a column by
+ * one puts a longitude in the latitude field, and a latitude of 1246.7 would
+ * otherwise project to a marker — and a frame fitted around it — somewhere no
+ * site is. Same bounds the /network-site/map parser enforces.
+ */
+const MAX_LATITUDE: number = 90;
+const MAX_LONGITUDE: number = 180;
+
+/*
+ * Marker palette, mirroring SiteGeoMap so the widget and the full Network
+ * Map page never disagree about what a color means.
+ */
+export const NETWORK_MAP_COLORS: Record<ClusterColorKey, string> = {
+  none: "#9ca3af", // gray-400
+  ok: "#10b981", // emerald-500
+  down: "#ef4444", // red-500
+  mixed: "#f59e0b", // amber-500
+};
+
+export interface NetworkMapLegendEntry {
+  key: ClusterColorKey;
+  label: string;
+  color: string;
+}
+
+/*
+ * Legend entries in the order a reader scans for trouble: healthy first,
+ * then the two degrees of "look at me", then the absence of data.
+ */
+export const NETWORK_MAP_LEGEND: Array<NetworkMapLegendEntry> = [
+  { key: "ok", label: "Operational", color: NETWORK_MAP_COLORS.ok },
+  { key: "mixed", label: "Degraded", color: NETWORK_MAP_COLORS.mixed },
+  { key: "down", label: "Offline", color: NETWORK_MAP_COLORS.down },
+  { key: "none", label: "No status", color: NETWORK_MAP_COLORS.none },
+];
+
+/*
+ * A NetworkSite row as the widget's fetch hands it over — every field
+ * optional, because ModelAPI returns Postgres NULLs as null and a site that
+ * has never been rolled up carries no status at all.
+ */
+export interface NetworkMapSiteInput {
+  id?: string | null | undefined;
+  name?: string | null | undefined;
+  siteType?: string | null | undefined;
+  latitude?: number | null | undefined;
+  longitude?: number | null | undefined;
+  statusName?: string | null | undefined;
+  statusColor?: string | null | undefined;
+  statusPriority?: number | null | undefined;
+  isOperational?: boolean | null | undefined;
+}
+
+// A site the widget can actually draw: identified, named and placeable.
+export interface NetworkMapSite {
+  id: string;
+  name: string;
+  siteType: string;
+  latitude: number;
+  longitude: number;
+  statusName: string;
+  /*
+   * The customer's own color for this status, when they set one. Null means
+   * "use the palette" — the health key decides instead.
+   */
+  statusColor: string | null;
+  statusPriority: number;
+  isOperational: boolean | null;
+}
+
+export interface NetworkMapSitesResult {
+  sites: Array<NetworkMapSite>;
+  /*
+   * Rows that exist but have no place on the map: no coordinates, or
+   * coordinates outside the real latitude/longitude ranges. Reported rather
+   * than dropped silently — a site missing from the map with nothing saying
+   * so is a bug report waiting to happen.
+   */
+  unplacedCount: number;
+}
+
+export const UNNAMED_SITE_LABEL: string = "Unnamed site";
+export const UNKNOWN_STATUS_LABEL: string = "No status yet";
+
+const asCoordinate: (value: unknown, limit: number) => number | null = (
+  value: unknown,
+  limit: number,
+): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return value >= -limit && value <= limit ? value : null;
+};
+
+const asText: (value: unknown, fallback: string) => string = (
+  value: unknown,
+  fallback: string,
+): string => {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+};
+
+/**
+ * Narrow fetched rows into the sites the widget can draw.
+ *
+ * A row without an id is dropped outright — it could not be keyed, deduped
+ * or linked. A row that has an id but no usable position is counted as
+ * unplaced, so the widget can say how much of the network is missing from
+ * the picture instead of pretending the map is complete.
+ */
+export const toNetworkMapSites: (
+  rows: Array<NetworkMapSiteInput>,
+) => NetworkMapSitesResult = (
+  rows: Array<NetworkMapSiteInput>,
+): NetworkMapSitesResult => {
+  const sites: Array<NetworkMapSite> = [];
+  let unplacedCount: number = 0;
+
+  for (const row of rows || []) {
+    const id: string = asText(row?.id, "");
+    if (!id) {
+      continue;
+    }
+
+    const latitude: number | null = asCoordinate(row?.latitude, MAX_LATITUDE);
+    const longitude: number | null = asCoordinate(
+      row?.longitude,
+      MAX_LONGITUDE,
+    );
+
+    if (latitude === null || longitude === null) {
+      unplacedCount++;
+      continue;
+    }
+
+    const statusPriority: unknown = row?.statusPriority;
+
+    sites.push({
+      id: id,
+      name: asText(row?.name, UNNAMED_SITE_LABEL),
+      siteType: asText(row?.siteType, ""),
+      latitude: latitude,
+      longitude: longitude,
+      statusName: asText(row?.statusName, UNKNOWN_STATUS_LABEL),
+      statusColor: asText(row?.statusColor, "") || null,
+      statusPriority:
+        typeof statusPriority === "number" && Number.isFinite(statusPriority)
+          ? statusPriority
+          : 0,
+      isOperational:
+        typeof row?.isOperational === "boolean" ? row.isOperational : null,
+    });
+  }
+
+  return { sites: sites, unplacedCount: unplacedCount };
+};
+
+/*
+ * Grid cell size for clustering, in whole-world viewBox units — the same
+ * constant SiteGeoMap uses, so two nearby stores merge at the same distance
+ * on both surfaces.
+ */
+export const NETWORK_MAP_CLUSTER_CELL_SIZE: number = 28;
+
+/*
+ * The most sites the widget will ever ask the server for. One below
+ * LIMIT_PER_PROJECT because the fetch deliberately requests one row MORE
+ * than the cap, to tell "exactly at the cap" apart from "there is more" —
+ * and the server rejects a limit above LIMIT_PER_PROJECT outright.
+ */
+export const NETWORK_MAP_MAX_SITES_CEILING: number = LIMIT_PER_PROJECT - 1;
+
+/**
+ * The row cap to actually fetch with, from whatever the saved widget
+ * arguments hold.
+ *
+ * COERCES rather than type-tests. The settings form renders Max Sites as an
+ * `<input type="number">` whose onChange hands back `e.target.value` — a
+ * STRING — and the arguments form copies those values into the component
+ * verbatim. A `typeof === "number"` guard therefore ignores the number the
+ * user just typed and silently keeps the default, which is the one failure
+ * a settings field must never have.
+ */
+export const resolveNetworkMapMaxSites: (
+  value: unknown,
+  fallback: number,
+) => number = (value: unknown, fallback: number): number => {
+  const parsed: number = Number(
+    typeof value === "string" ? value.trim() : value,
+  );
+
+  /*
+   * An empty string coerces to 0 through Number(), and a cleared field is
+   * "use the default", not "draw nothing" — so anything below 1 falls back.
+   */
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return Math.min(Math.floor(parsed), NETWORK_MAP_MAX_SITES_CEILING);
+};
+
+/*
+ * Label geometry, re-exported from the full map so the renderer draws names
+ * at exactly the size and offset resolveMarkerLabels measured them at. Two
+ * different constants would mean the collision pass approving a layout the
+ * map then draws differently — which is worse than no collision pass, since
+ * it would look deliberate.
+ */
+export const NETWORK_MAP_LABEL_GAP: number = LABEL_GAP;
+export const NETWORK_MAP_LABEL_FONT_SIZE: number = LABEL_FONT_SIZE;
+
+/**
+ * Cluster cell size for the current viewport, in viewBox units.
+ *
+ * This is what makes zoom mean something: the cell is a constant distance ON
+ * SCREEN, so it covers less of the world the further in the map is zoomed,
+ * and a lump of nearby sites breaks apart into individual markers instead of
+ * staying one blob at every zoom.
+ */
+export const networkMapClusterCellSize: (viewport: MapViewport) => number = (
+  viewport: MapViewport,
+): number => {
+  return screenLengthToViewportLength(NETWORK_MAP_CLUSTER_CELL_SIZE, viewport);
+};
+
+// One drawable marker. Position is viewBox units; radius is screen units.
+export interface NetworkMapMarker {
+  // Stable for the same geometry — React's key.
+  key: string;
+  x: number;
+  y: number;
+  // The sites this marker stands for, in the order clusterPoints sorted them.
+  ids: Array<string>;
+  count: number;
+  screenRadius: number;
+  colorKey: ClusterColorKey;
+  /*
+   * The color actually painted. A marker that stands for ONE site uses that
+   * site's own status color when the customer set one, so a bespoke
+   * "Maintenance" status looks the same here as everywhere else in the
+   * product. Clusters fall back to the palette — mixing two customer colors
+   * into one dot would say nothing true about either.
+   */
+  color: string;
+  /** Name drawn under the marker, or "" when this marker gets no label. */
+  label: string;
+  /*
+   * Where that name sits relative to the marker. Below reads best — the eye
+   * goes marker-then-name — so it is tried first; above is the escape hatch
+   * for a marker with a neighbour directly beneath it. Null when the marker
+   * carries no name at all.
+   */
+  labelPlacement: LabelPlacement | null;
+  tooltip: string;
+}
+
+const clusterTooltip: (
+  cluster: GeoCluster,
+  siteById: Map<string, NetworkMapSite>,
+) => string = (
+  cluster: GeoCluster,
+  siteById: Map<string, NetworkMapSite>,
+): string => {
+  if (cluster.ids.length === 1) {
+    const site: NetworkMapSite | undefined = siteById.get(cluster.ids[0]!);
+    if (!site) {
+      return "";
+    }
+    const parts: Array<string> = [site.name];
+    if (site.siteType) {
+      parts.push(site.siteType);
+    }
+    parts.push(site.statusName);
+    return parts.join(" · ");
+  }
+
+  const names: Array<string> = cluster.ids
+    .slice(0, 5)
+    .map((id: string): string => {
+      return siteById.get(id)?.name || UNNAMED_SITE_LABEL;
+    });
+  const more: number = cluster.ids.length - names.length;
+
+  return `${cluster.totalCount} sites: ${names.join(", ")}${
+    more > 0 ? `, +${more} more` : ""
+  }`;
+};
+
+export interface BuildNetworkMapMarkersInput {
+  sites: Array<NetworkMapSite>;
+  // Grid cell size for clustering, in viewBox units.
+  cellSize: number;
+  /*
+   * Whether the widget wants names under its markers at all. Even when it
+   * does, a name is dropped when it cannot be placed clear of its
+   * neighbours (see below), and they all come off past
+   * MAX_LABELLED_MARKERS. The tooltip still carries every one.
+   */
+  showLabels: boolean;
+  /*
+   * Magnification of the frame the map will draw in. Label collision is a
+   * SCREEN question — two markers a hair apart in the world are far apart
+   * on a zoomed-in frame — so the layout cannot be decided without it.
+   */
+  zoom: number;
+}
+
+/**
+ * Turn sites into drawable markers.
+ *
+ * Output order is paint order, and it is deterministic: markers are sorted
+ * by descending count with the key as the tie-break, so the smallest marker
+ * is painted last and a single store never disappears under the cluster that
+ * holds its neighbours.
+ *
+ * Names are then placed greedily in that same order — biggest marker first,
+ * since that is the one a reader is most likely to be looking for — trying
+ * below the marker and then above it. A name that fits in neither position
+ * is DROPPED rather than stacked on something: an overlapped label is
+ * unreadable and it hides its neighbour, so two names on top of each other
+ * are worse than one name and a tooltip.
+ */
+export const buildNetworkMapMarkers: (
+  input: BuildNetworkMapMarkersInput,
+) => Array<NetworkMapMarker> = (
+  input: BuildNetworkMapMarkersInput,
+): Array<NetworkMapMarker> => {
+  const siteById: Map<string, NetworkMapSite> = new Map<
+    string,
+    NetworkMapSite
+  >();
+  const pins: Array<GeoClusterPoint> = [];
+
+  for (const site of input.sites) {
+    siteById.set(site.id, site);
+
+    const point: ProjectedPoint = projectRobinson(
+      site.latitude,
+      site.longitude,
+    );
+
+    pins.push({
+      id: site.id,
+      x: point[0],
+      y: point[1],
+      statusPriority: site.statusPriority,
+      count: 1,
+    });
+  }
+
+  /*
+   * Sorted by id before clustering, not for tidiness: clusterPoints averages
+   * member positions by accumulating them in INPUT order, and IEEE-754
+   * addition is not associative. Three sites in one cell arriving in a
+   * different order would otherwise produce a cluster centre differing in
+   * the last bits — and the widget refetches on a timer, so the row order
+   * really does vary between renders.
+   */
+  pins.sort((a: GeoClusterPoint, b: GeoClusterPoint): number => {
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  const clusters: Array<GeoCluster> = clusterPoints(pins, input.cellSize);
+
+  /*
+   * The label budget counts markers that COULD carry a name — only a cluster
+   * of exactly one site does — rather than all markers. Counting every
+   * marker meant an estate of fifty paired sites and three lone ones drew no
+   * names at all, because fifty-three markers cleared the threshold while
+   * only three of them were ever going to be labelled.
+   */
+  const labellableCount: number = clusters.filter(
+    (cluster: GeoCluster): boolean => {
+      return cluster.ids.length === 1;
+    },
+  ).length;
+  const showLabels: boolean =
+    input.showLabels && labellableCount <= MAX_LABELLED_MARKERS;
+
+  const markers: Array<NetworkMapMarker> = clusters.map(
+    (cluster: GeoCluster): NetworkMapMarker => {
+      const members: Array<NetworkMapSite> = cluster.ids
+        .map((id: string): NetworkMapSite | undefined => {
+          return siteById.get(id);
+        })
+        .filter((site: NetworkMapSite | undefined): site is NetworkMapSite => {
+          return site !== undefined;
+        });
+
+      const colorKey: ClusterColorKey = decideClusterColorKey(
+        members.map((site: NetworkMapSite): ClusterColorMember => {
+          return {
+            statusPriority: site.statusPriority,
+            isOperational: site.isOperational,
+          };
+        }),
+      );
+
+      const single: NetworkMapSite | undefined =
+        members.length === 1 ? members[0] : undefined;
+
+      return {
+        /*
+         * Keyed by its lowest member id — clusterPoints sorts ids
+         * lexicographically, and a site belongs to exactly one cluster, so
+         * this is both stable and unique. The cluster's centre must NOT be
+         * in the key: it is a floating-point mean, so it would change in the
+         * last bits with row order and remount every marker on a poll.
+         */
+        key: cluster.ids[0] as string,
+        x: cluster.x,
+        y: cluster.y,
+        ids: cluster.ids,
+        count: cluster.totalCount,
+        screenRadius: clusterRadius(cluster.totalCount),
+        colorKey: colorKey,
+        /*
+         * Always the widget's own palette, never the project's status color.
+         * A project can name a status anything and color it anything, so
+         * painting one site's own hex would mean the same status is one
+         * color alone and another inside a cluster — and a third on the
+         * Network Map page, which has always used this palette. The legend
+         * under the map only tells the truth if every marker obeys it.
+         */
+        color: NETWORK_MAP_COLORS[colorKey],
+        label: showLabels && single ? truncateMarkerLabel(single.name) : "",
+        labelPlacement: null,
+        tooltip: clusterTooltip(cluster, siteById),
+      };
+    },
+  );
+
+  markers.sort((a: NetworkMapMarker, b: NetworkMapMarker): number => {
+    if (a.count !== b.count) {
+      return b.count - a.count;
+    }
+    return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  });
+
+  /*
+   * resolveMarkerLabels works over the full-map marker shape, which carries
+   * an `isContainer` flag deciding whether the label clears a square or a
+   * disc. Every marker here is a disc — this widget draws no containers —
+   * so the flag is fixed false and the rest of the fields map straight over.
+   */
+  const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+    markers.map((marker: NetworkMapMarker): MapMarker => {
+      return {
+        key: marker.key,
+        x: marker.x,
+        y: marker.y,
+        ids: marker.ids,
+        count: marker.count,
+        screenRadius: marker.screenRadius,
+        colorKey: marker.colorKey,
+        isContainer: false,
+        isApproximate: false,
+        label: marker.label,
+        tooltip: marker.tooltip,
+      };
+    }),
+    input.zoom,
+  );
+
+  return markers.map((marker: NetworkMapMarker): NetworkMapMarker => {
+    const placement: LabelPlacement | undefined = placements.get(marker.key);
+
+    if (!marker.label || !placement) {
+      return { ...marker, label: "", labelPlacement: null };
+    }
+
+    return { ...marker, labelPlacement: placement };
+  });
+};
+
+export interface NetworkMapStatusSummary {
+  total: number;
+  operational: number;
+  down: number;
+  unknown: number;
+}
+
+/**
+ * How the drawn sites are doing, counted rather than colored. The widget
+ * prints this above the map so a reader who cannot pick a two-pixel red dot
+ * out of two hundred green ones still learns that one is red.
+ */
+export const networkMapStatusSummary: (
+  sites: Array<NetworkMapSite>,
+) => NetworkMapStatusSummary = (
+  sites: Array<NetworkMapSite>,
+): NetworkMapStatusSummary => {
+  let operational: number = 0;
+  let down: number = 0;
+  let unknown: number = 0;
+
+  for (const site of sites) {
+    if (site.isOperational === true) {
+      operational++;
+    } else if (site.isOperational === false) {
+      down++;
+    } else {
+      unknown++;
+    }
+  }
+
+  return {
+    total: sites.length,
+    operational: operational,
+    down: down,
+    unknown: unknown,
+  };
+};
+
+const pluralize: (count: number, singular: string) => string = (
+  count: number,
+  singular: string,
+): string => {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+};
+
+export interface NetworkMapCoverageInput {
+  // Sites the widget drew.
+  siteCount: number;
+  // How many of them the current frame is holding.
+  inViewCount: number;
+  // Sites that exist but have no usable coordinates.
+  unplacedCount: number;
+  /*
+   * The fetch came back at the row cap, so there may be sites the widget
+   * never saw. Saying nothing here would make a truncated map look complete.
+   */
+  isTruncated: boolean;
+}
+
+/**
+ * The map's coverage line: how much of the network this frame is holding,
+ * and what it is not showing.
+ *
+ * A count that quietly shrinks as somebody zooms reads as sites
+ * disappearing, so once the frame stops holding everything the line says
+ * what it does hold.
+ */
+export const describeNetworkMapCoverage: (
+  input: NetworkMapCoverageInput,
+) => string = (input: NetworkMapCoverageInput): string => {
+  const parts: Array<string> = [];
+
+  if (input.inViewCount < input.siteCount) {
+    parts.push(`${input.inViewCount} of ${input.siteCount} sites in view`);
+  } else {
+    parts.push(`${pluralize(input.siteCount, "site")} mapped`);
+  }
+
+  if (input.unplacedCount > 0) {
+    parts.push(`${input.unplacedCount} without coordinates`);
+  }
+
+  if (input.isTruncated) {
+    parts.push("more sites not shown");
+  }
+
+  return parts.join(" · ");
+};
+
+/**
+ * The frame the widget opens on: fitted to the sites it drew, or the whole
+ * world when it drew none.
+ *
+ * A dashboard tile has no drill state and no viewport controls to recover
+ * from a bad opening frame, so this runs on every render of the site set
+ * rather than once — the map always opens on the data it is showing.
+ */
+export const fitNetworkMapViewport: (
+  sites: Array<NetworkMapSite>,
+) => MapViewport = (sites: Array<NetworkMapSite>): MapViewport => {
+  return fitViewportToPoints(networkMapPoints(sites));
+};
+
+/** Projected positions of these sites, in viewBox units. */
+export const networkMapPoints: (
+  sites: Array<NetworkMapSite>,
+) => Array<ViewportPoint> = (
+  sites: Array<NetworkMapSite>,
+): Array<ViewportPoint> => {
+  return sites.map((site: NetworkMapSite): ViewportPoint => {
+    const point: ProjectedPoint = projectRobinson(
+      site.latitude,
+      site.longitude,
+    );
+    return { x: point[0], y: point[1] };
+  });
+};
+
+/** How many of these sites the given frame is holding. */
+export const countNetworkMapSitesInViewport: (
+  sites: Array<NetworkMapSite>,
+  viewport: MapViewport,
+) => number = (sites: Array<NetworkMapSite>, viewport: MapViewport): number => {
+  return countPointsInViewport(networkMapPoints(sites), viewport);
+};

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/DashboardView.tsx
@@ -57,6 +57,7 @@ import DashboardDockerSwarmNodeListComponentUtil from "Common/Utils/Dashboard/Co
 import DashboardDockerSwarmServiceListComponentUtil from "Common/Utils/Dashboard/Components/DashboardDockerSwarmServiceListComponent";
 import DashboardCephOsdListComponentUtil from "Common/Utils/Dashboard/Components/DashboardCephOsdListComponent";
 import DashboardCephPoolListComponentUtil from "Common/Utils/Dashboard/Components/DashboardCephPoolListComponent";
+import DashboardNetworkMapComponentUtil from "Common/Utils/Dashboard/Components/DashboardNetworkMapComponent";
 import DashboardHtmlComponentUtil from "Common/Utils/Dashboard/Components/DashboardHtmlComponent";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import ObjectID from "Common/Types/ObjectID";
@@ -723,6 +724,11 @@ const DashboardViewer: FunctionComponent<ComponentProps> = (
           if (componentType === DashboardComponentType.CephPoolList) {
             newComponent =
               DashboardCephPoolListComponentUtil.getDefaultComponent();
+          }
+
+          if (componentType === DashboardComponentType.NetworkMap) {
+            newComponent =
+              DashboardNetworkMapComponentUtil.getDefaultComponent();
           }
 
           if (componentType === DashboardComponentType.Html) {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Toolbar/WidgetCatalog.ts
@@ -492,6 +492,33 @@ export const WIDGET_CATALOG: ReadonlyArray<WidgetCatalogCategory> = [
       },
     ],
   },
+  {
+    name: "Network",
+    group: WidgetCategoryGroup.Infrastructure,
+    icon: IconProp.Map,
+    description:
+      "The network estate itself — the sites you model on the Network Map page.",
+    items: [
+      {
+        type: DashboardComponentType.NetworkMap,
+        label: "Network Map",
+        icon: IconProp.Map,
+        description:
+          "Your network sites on the world map, each pinned at its coordinates and colored by its rolled-up status.",
+        keywords: [
+          "map",
+          "site",
+          "geo",
+          "location",
+          "world",
+          "branch",
+          "store",
+          "franchise",
+          "wan",
+        ],
+      },
+    ],
+  },
 ];
 
 export interface WidgetCategoryGroupSection {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList.ts
@@ -29,6 +29,7 @@ export type DashboardResourceType =
   | "proxmox-resource"
   | "ceph-resource"
   | "docker-swarm-resource"
+  | "network-site"
   | "span"
   | "log";
 

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/Geo/WorldGeometry.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/Geo/WorldGeometry.ts
@@ -1,0 +1,80 @@
+/*
+ * On-demand loader for the checked-in world country outlines, shared by
+ * every surface that draws the map — the Network Map page's SiteGeoMap and
+ * the Network Map dashboard widget.
+ *
+ * Kept react-free (and out of either component) so both share ONE cache: the
+ * widget and the page drawn on the same screen fetch the outlines once
+ * between them, and so the loader can be unit-tested in a plain
+ * Node/TypeScript environment — see GeoProjection.ts for why that matters.
+ */
+
+// One country outline, already projected into the Robinson viewBox.
+export interface GeometryFeature {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface GeometryFile {
+  viewBox: string;
+  features: Array<GeometryFeature>;
+}
+
+/*
+ * Outlines ship in two resolutions (see Scripts/Geo/README.md), in the same
+ * viewBox, so swapping between them never moves an outline or a pin:
+ *
+ *   overview — small, drawn at continent-and-wider zoom.
+ *   detail   — ~6x larger, fetched only once somebody zooms in far enough
+ *              for the overview's generalization to read as chunky.
+ *
+ * Neither is statically imported. Every route module in the dashboard lands
+ * in one shared esbuild chunk, so a static import here would make every page
+ * — Incidents, a monitor, Settings — download and parse country outlines it
+ * never draws. They are loaded on demand and memoized for the life of the
+ * tab.
+ *
+ * They stay .json rather than .svg on purpose: esbuild base64-inlines an
+ * imported .svg, which would put us straight back in the shared chunk.
+ */
+export type GeometryTier = "overview" | "detail";
+
+const geometryCache: Partial<Record<GeometryTier, Array<GeometryFeature>>> = {};
+
+/** Outlines already in memory for this tier, or null if none are yet. */
+export const getCachedGeometryFeatures: (
+  tier: GeometryTier,
+) => Array<GeometryFeature> | null = (
+  tier: GeometryTier,
+): Array<GeometryFeature> | null => {
+  return geometryCache[tier] || null;
+};
+
+export const loadGeometryFeatures: (
+  tier: GeometryTier,
+) => Promise<Array<GeometryFeature>> = async (
+  tier: GeometryTier,
+): Promise<Array<GeometryFeature>> => {
+  const cached: Array<GeometryFeature> | undefined = geometryCache[tier];
+  if (cached) {
+    return cached;
+  }
+
+  /*
+   * The two import() calls are written out rather than built from a
+   * variable so esbuild can statically see both targets and emit a chunk
+   * for each.
+   */
+  const loaded: unknown =
+    tier === "detail"
+      ? await import("./WorldCountriesDetailGeometry.json")
+      : await import("./WorldCountriesGeometry.json");
+
+  // JSON modules arrive under `default` once bundled, bare under ts-jest.
+  const file: GeometryFile = ((loaded as { default?: GeometryFile }).default ||
+    loaded) as GeometryFile;
+  const features: Array<GeometryFeature> = file.features || [];
+  geometryCache[tier] = features;
+  return features;
+};

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
@@ -54,6 +54,11 @@ import {
   MapUnplacedSiteView,
   SiteMapMode,
 } from "./SiteHierarchyTypes";
+import {
+  GeometryFeature,
+  getCachedGeometryFeatures,
+  loadGeometryFeatures,
+} from "./Geo/WorldGeometry";
 
 /*
  * Inline-SVG world map of network sites: checked-in country outlines
@@ -83,65 +88,11 @@ import {
  * fallbacks.
  */
 
-interface GeometryFeature {
-  id: string;
-  name: string;
-  path: string;
-}
-
-interface GeometryFile {
-  viewBox: string;
-  features: Array<GeometryFeature>;
-}
-
 /*
- * Outlines ship in two resolutions (see Scripts/Geo/README.md), in the same
- * viewBox, so swapping between them never moves an outline or a pin:
- *
- *   overview — small, drawn at continent-and-wider zoom.
- *   detail   — ~6x larger, fetched only once somebody zooms in far enough
- *              for the overview's generalization to read as chunky.
- *
- * Neither is statically imported. Every route module in the dashboard lands
- * in one shared esbuild chunk, so a static import here would make every page
- * — Incidents, a monitor, Settings — download and parse country outlines it
- * never draws. They are loaded on demand and memoized for the life of the
- * tab.
- *
- * They stay .json rather than .svg on purpose: esbuild base64-inlines an
- * imported .svg, which would put us straight back in the shared chunk.
+ * The outlines themselves — and the on-demand loader that fetches them once
+ * per tab — live in Geo/WorldGeometry.ts, so this component and the Network
+ * Map dashboard widget share one cache rather than fetching a copy each.
  */
-type GeometryTier = "overview" | "detail";
-
-const geometryCache: Partial<Record<GeometryTier, Array<GeometryFeature>>> = {};
-
-const loadGeometryFeatures: (
-  tier: GeometryTier,
-) => Promise<Array<GeometryFeature>> = async (
-  tier: GeometryTier,
-): Promise<Array<GeometryFeature>> => {
-  const cached: Array<GeometryFeature> | undefined = geometryCache[tier];
-  if (cached) {
-    return cached;
-  }
-
-  /*
-   * The two import() calls are written out rather than built from a
-   * variable so esbuild can statically see both targets and emit a chunk
-   * for each.
-   */
-  const loaded: unknown =
-    tier === "detail"
-      ? await import("./Geo/WorldCountriesDetailGeometry.json")
-      : await import("./Geo/WorldCountriesGeometry.json");
-
-  // JSON modules arrive under `default` once bundled, bare under ts-jest.
-  const file: GeometryFile = ((loaded as { default?: GeometryFile }).default ||
-    loaded) as GeometryFile;
-  const features: Array<GeometryFeature> = file.features || [];
-  geometryCache[tier] = features;
-  return features;
-};
 
 const CLUSTER_COLORS: Record<ClusterColorKey, string> = {
   none: "#9ca3af", // gray-400
@@ -412,9 +363,13 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   const [hovered, setHovered] = useState<HoveredCluster | null>(null);
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
   const [overviewFeatures, setOverviewFeatures] =
-    useState<Array<GeometryFeature> | null>(geometryCache["overview"] || null);
+    useState<Array<GeometryFeature> | null>(
+      getCachedGeometryFeatures("overview"),
+    );
   const [detailFeatures, setDetailFeatures] =
-    useState<Array<GeometryFeature> | null>(geometryCache["detail"] || null);
+    useState<Array<GeometryFeature> | null>(
+      getCachedGeometryFeatures("detail"),
+    );
 
   /*
    * Pin geometry, keyed by an order-independent fingerprint rather than by

--- a/App/FeatureSet/Docs/Content/en/dashboards/widgets.md
+++ b/App/FeatureSet/Docs/Content/en/dashboards/widgets.md
@@ -194,6 +194,20 @@ Hosts monitored by OneUptime's server monitor, with status, CPU, memory, and upt
 
 **Settings**: filters by labels or current state.
 
+## Network
+
+### Network Map
+
+Your network sites drawn on the world map, each pinned at its own latitude and longitude and colored by the monitor status rolled up onto it. Sites close together share a marker with the count printed inside it; a marker that stands for exactly one site opens that site when you click it.
+
+The map frames itself to the sites it drew — an estate inside one country fills the frame with that country, one spread across continents opens on the world. There are no zoom or pan controls: a dashboard tile is a picture, and the Network Map page under Network is where you walk the hierarchy.
+
+Above the map it prints how many sites are down, because a two-pixel red dot among two hundred green ones is not something anyone reads at dashboard distance. Below it, a coverage line says what the map is *not* showing — sites with no coordinates, and whether the row cap was hit.
+
+**Settings**: title, map or list view, maximum sites drawn, whether to print site names, and filters by site type and by status. Site names come off automatically when the map gets too busy for them to be readable; the tooltip still names every marker.
+
+A site only appears if it has coordinates. Add latitude and longitude on the site (or import them from CSV) to pin it.
+
 ## Which widget should I use?
 
 A few quick rules:
@@ -204,6 +218,7 @@ A few quick rules:
 - **Breakdown across many things?** Table.
 - **What's happening in the system right now?** Log Stream, Trace List, Incident List.
 - **The state of a specific group of resources?** The matching list widget.
+- **Where in the world your network is, and what's red?** Network Map.
 - **A heading, a paragraph, or a link?** Text.
 - **Something none of the above covers?** HTML — but only after checking that a built-in widget really can't do it.
 

--- a/App/Tests/Dashboard/NetworkMapWidgetData.test.ts
+++ b/App/Tests/Dashboard/NetworkMapWidgetData.test.ts
@@ -1,0 +1,1125 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  NETWORK_MAP_CLUSTER_CELL_SIZE,
+  NETWORK_MAP_COLORS,
+  NETWORK_MAP_LEGEND,
+  NetworkMapLegendEntry,
+  NetworkMapMarker,
+  NetworkMapSite,
+  NetworkMapSiteInput,
+  NetworkMapSitesResult,
+  NetworkMapStatusSummary,
+  UNKNOWN_STATUS_LABEL,
+  UNNAMED_SITE_LABEL,
+  buildNetworkMapMarkers,
+  countNetworkMapSitesInViewport,
+  describeNetworkMapCoverage,
+  fitNetworkMapViewport,
+  networkMapClusterCellSize,
+  NETWORK_MAP_MAX_SITES_CEILING,
+  networkMapPoints,
+  networkMapStatusSummary,
+  resolveNetworkMapMaxSites,
+  toNetworkMapSites,
+} from "../../FeatureSet/Dashboard/src/Components/Dashboard/Components/NetworkMapWidgetData";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import {
+  MapViewport,
+  WORLD_VIEWPORT,
+  zoomOfViewport,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoViewport";
+import {
+  ROBINSON_VIEW_BOX_HEIGHT,
+  ROBINSON_VIEW_BOX_WIDTH,
+  projectRobinson,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoProjection";
+import { MAX_LABELLED_MARKERS } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel";
+
+/*
+ * The react-free half of the Network Map dashboard widget: narrowing
+ * NetworkSite rows into pins, clustering them, coloring them, and the words
+ * printed under the map.
+ *
+ * The cases that matter most are the dishonest ones — a site with no
+ * coordinates silently vanishing, an outage hidden inside a green cluster,
+ * or a footer claiming the map holds a network it has only part of. Every
+ * one of those is a map that looks complete and is not.
+ */
+
+// -- Fixtures --------------------------------------------------------------
+
+type MakeInput = (
+  overrides?: Partial<NetworkMapSiteInput>,
+) => NetworkMapSiteInput;
+
+const input: MakeInput = (
+  overrides: Partial<NetworkMapSiteInput> = {},
+): NetworkMapSiteInput => {
+  return {
+    id: "site-1",
+    name: "London HQ",
+    siteType: "Region",
+    latitude: 51.5,
+    longitude: -0.12,
+    statusName: "Operational",
+    statusColor: "#10b981",
+    statusPriority: 1,
+    isOperational: true,
+    ...overrides,
+  };
+};
+
+type MakeSite = (overrides?: Partial<NetworkMapSite>) => NetworkMapSite;
+
+const site: MakeSite = (
+  overrides: Partial<NetworkMapSite> = {},
+): NetworkMapSite => {
+  return {
+    id: "site-1",
+    name: "London HQ",
+    siteType: "Region",
+    latitude: 51.5,
+    longitude: -0.12,
+    statusName: "Operational",
+    statusColor: null,
+    statusPriority: 1,
+    isOperational: true,
+    ...overrides,
+  };
+};
+
+function narrow(rows: Array<NetworkMapSiteInput>): NetworkMapSitesResult {
+  return toNetworkMapSites(rows);
+}
+
+function markers(
+  sites: Array<NetworkMapSite>,
+  showLabels: boolean = true,
+  cellSize: number = NETWORK_MAP_CLUSTER_CELL_SIZE,
+  zoom: number = 1,
+): Array<NetworkMapMarker> {
+  return buildNetworkMapMarkers({
+    sites: sites,
+    cellSize: cellSize,
+    showLabels: showLabels,
+    zoom: zoom,
+  });
+}
+
+// -- toNetworkMapSites -----------------------------------------------------
+
+describe("toNetworkMapSites", () => {
+  test("narrows a well-formed row faithfully", () => {
+    const result: NetworkMapSitesResult = narrow([input()]);
+
+    expect(result.unplacedCount).toBe(0);
+    expect(result.sites).toEqual([
+      {
+        id: "site-1",
+        name: "London HQ",
+        siteType: "Region",
+        latitude: 51.5,
+        longitude: -0.12,
+        statusName: "Operational",
+        statusColor: "#10b981",
+        statusPriority: 1,
+        isOperational: true,
+      },
+    ]);
+  });
+
+  test("returns an empty result for no rows at all", () => {
+    expect(narrow([])).toEqual({ sites: [], unplacedCount: 0 });
+  });
+
+  /*
+   * A row with no id could not be keyed, deduped or linked, so it is dropped
+   * outright rather than counted as unplaced — it is not a site the reader
+   * is missing from the map, it is not a site.
+   */
+  test("drops rows with no id without counting them as unplaced", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "" }),
+      input({ id: null }),
+      input({ id: undefined }),
+    ]);
+
+    expect(result.sites).toHaveLength(0);
+    expect(result.unplacedCount).toBe(0);
+  });
+
+  /*
+   * The opposite case: a real site that simply has no coordinates yet. It
+   * must be COUNTED, because a site missing from the map while its card sits
+   * right underneath is a bug report waiting to happen.
+   */
+  test("counts a site with no coordinates as unplaced rather than dropping it silently", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "a", latitude: undefined, longitude: undefined }),
+      input({ id: "b", latitude: null, longitude: null }),
+      input({ id: "c", latitude: 10, longitude: undefined }),
+      input({ id: "d", longitude: 10, latitude: undefined }),
+    ]);
+
+    expect(result.sites).toHaveLength(0);
+    expect(result.unplacedCount).toBe(4);
+  });
+
+  /*
+   * A CSV import that shifts a column by one puts a longitude in the
+   * latitude field. 1246.7 would project to a marker — and a frame fitted
+   * around it — somewhere no site is.
+   */
+  test("rejects coordinates outside the real latitude and longitude ranges", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "a", latitude: 91 }),
+      input({ id: "b", latitude: -91 }),
+      input({ id: "c", longitude: 181 }),
+      input({ id: "d", longitude: -181 }),
+      input({ id: "e", latitude: 1246.7 }),
+    ]);
+
+    expect(result.sites).toHaveLength(0);
+    expect(result.unplacedCount).toBe(5);
+  });
+
+  test("accepts the exact poles and the antimeridian", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "a", latitude: 90, longitude: 180 }),
+      input({ id: "b", latitude: -90, longitude: -180 }),
+      input({ id: "c", latitude: 0, longitude: 0 }),
+    ]);
+
+    expect(result.sites).toHaveLength(3);
+    expect(result.unplacedCount).toBe(0);
+  });
+
+  test("rejects non-finite and non-numeric coordinates", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "a", latitude: Number.NaN }),
+      input({ id: "b", longitude: Number.POSITIVE_INFINITY }),
+      input({ id: "c", latitude: "51.5" as unknown as number }),
+    ]);
+
+    expect(result.sites).toHaveLength(0);
+    expect(result.unplacedCount).toBe(3);
+  });
+
+  test("falls back to readable placeholders for a missing name and status", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ name: undefined, statusName: undefined }),
+    ]);
+
+    expect(result.sites[0]?.name).toBe(UNNAMED_SITE_LABEL);
+    expect(result.sites[0]?.statusName).toBe(UNKNOWN_STATUS_LABEL);
+  });
+
+  test("trims whitespace and treats a blank string as absent", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ name: "  Paris  ", siteType: "   ", statusColor: "  " }),
+    ]);
+
+    expect(result.sites[0]?.name).toBe("Paris");
+    expect(result.sites[0]?.siteType).toBe("");
+    expect(result.sites[0]?.statusColor).toBeNull();
+  });
+
+  /*
+   * isOperational is TRI-state. A site that has never been rolled up has no
+   * verdict at all, and collapsing that to `false` would paint a brand new
+   * estate entirely red.
+   */
+  test("keeps isOperational tri-state rather than collapsing unknown to false", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "a", isOperational: true }),
+      input({ id: "b", isOperational: false }),
+      input({ id: "c", isOperational: undefined }),
+      input({ id: "d", isOperational: null }),
+      input({ id: "e", isOperational: "true" as unknown as boolean }),
+    ]);
+
+    expect(
+      result.sites.map((s: NetworkMapSite): boolean | null => {
+        return s.isOperational;
+      }),
+    ).toEqual([true, false, null, null, null]);
+  });
+
+  test("defaults a missing or non-finite status priority to zero", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "a", statusPriority: undefined }),
+      input({ id: "b", statusPriority: Number.NaN }),
+      input({ id: "c", statusPriority: 7 }),
+    ]);
+
+    expect(
+      result.sites.map((s: NetworkMapSite): number => {
+        return s.statusPriority;
+      }),
+    ).toEqual([0, 0, 7]);
+  });
+
+  test("preserves input order for the rows it keeps", () => {
+    const result: NetworkMapSitesResult = narrow([
+      input({ id: "c" }),
+      input({ id: "a" }),
+      input({ id: "b" }),
+    ]);
+
+    expect(
+      result.sites.map((s: NetworkMapSite): string => {
+        return s.id;
+      }),
+    ).toEqual(["c", "a", "b"]);
+  });
+
+  test("never throws on a completely malformed row", () => {
+    expect(() => {
+      return toNetworkMapSites([
+        {} as NetworkMapSiteInput,
+        null as unknown as NetworkMapSiteInput,
+        undefined as unknown as NetworkMapSiteInput,
+      ]);
+    }).not.toThrow();
+  });
+});
+
+// -- buildNetworkMapMarkers ------------------------------------------------
+
+describe("buildNetworkMapMarkers", () => {
+  test("draws nothing for no sites", () => {
+    expect(markers([])).toEqual([]);
+  });
+
+  test("projects a lone site to its Robinson position", () => {
+    const only: NetworkMapMarker = markers([site()])[0] as NetworkMapMarker;
+    const [x, y]: [number, number] = projectRobinson(51.5, -0.12);
+
+    expect(only.x).toBeCloseTo(x, 6);
+    expect(only.y).toBeCloseTo(y, 6);
+    expect(only.ids).toEqual(["site-1"]);
+    expect(only.count).toBe(1);
+  });
+
+  test("merges sites that share a grid cell into one marker", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 51.51, longitude: -0.13 }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.count).toBe(2);
+    expect(result[0]?.ids).toEqual(["a", "b"]);
+  });
+
+  test("keeps distant sites as separate markers", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "london", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "sydney", latitude: -33.87, longitude: 151.21 }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  /*
+   * A smaller cell splits a lump apart. This is what makes the widget's
+   * viewport-scaled cell size mean something rather than being decoration.
+   */
+  test("a smaller cell size separates sites a larger one merged", () => {
+    const nearby: Array<NetworkMapSite> = [
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 51.9, longitude: -0.6 }),
+    ];
+
+    expect(markers(nearby, true, 28)).toHaveLength(1);
+    expect(markers(nearby, true, 0.05)).toHaveLength(2);
+  });
+
+  /*
+   * An outage must never hide inside a calm cluster. Red beats everything.
+   */
+  test("colors a cluster red when any member is down, however many are up", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a", isOperational: true }),
+      site({ id: "b", isOperational: true, latitude: 51.51 }),
+      site({ id: "c", isOperational: false, latitude: 51.52 }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.colorKey).toBe("down");
+    expect(result[0]?.color).toBe(NETWORK_MAP_COLORS.down);
+  });
+
+  test("colors a wholly healthy cluster green", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a", isOperational: true }),
+      site({ id: "b", isOperational: true, latitude: 51.51 }),
+    ]);
+
+    expect(result[0]?.colorKey).toBe("ok");
+  });
+
+  test("colors a cluster gray when no member carries any status at all", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a", isOperational: null, statusPriority: 0 }),
+      site({
+        id: "b",
+        isOperational: null,
+        statusPriority: 0,
+        latitude: 51.51,
+      }),
+    ]);
+
+    expect(result[0]?.colorKey).toBe("none");
+    expect(result[0]?.color).toBe(NETWORK_MAP_COLORS.none);
+  });
+
+  test("colors a partly-known cluster amber", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a", isOperational: true }),
+      site({
+        id: "b",
+        isOperational: null,
+        statusPriority: 0,
+        latitude: 51.51,
+      }),
+    ]);
+
+    expect(result[0]?.colorKey).toBe("mixed");
+    expect(result[0]?.color).toBe(NETWORK_MAP_COLORS.mixed);
+  });
+
+  /*
+   * The legend under the map is only true if every marker obeys it. A
+   * project can color its statuses anything, so painting one site's own hex
+   * would make the same status one color alone, another inside a cluster,
+   * and a third on the Network Map page — which has always used this
+   * palette.
+   */
+  test("paints the palette, never the project's own status color", () => {
+    const single: Array<NetworkMapMarker> = markers([
+      site({ statusColor: "#7c3aed", isOperational: true }),
+    ]);
+
+    expect(single[0]?.colorKey).toBe("ok");
+    expect(single[0]?.color).toBe(NETWORK_MAP_COLORS.ok);
+
+    const clustered: Array<NetworkMapMarker> = markers([
+      site({ id: "a", statusColor: "#7c3aed", isOperational: true }),
+      site({
+        id: "b",
+        statusColor: "#0ea5e9",
+        isOperational: true,
+        latitude: 51.51,
+      }),
+    ]);
+
+    expect(clustered[0]?.count).toBe(2);
+    expect(clustered[0]?.color).toBe(NETWORK_MAP_COLORS.ok);
+  });
+
+  /*
+   * Every marker's color must be one the legend names, whatever the sites
+   * under it are colored.
+   */
+  test("every marker color is one the legend accounts for", () => {
+    const palette: Array<string> = Object.values(NETWORK_MAP_COLORS);
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a", statusColor: "#7c3aed", isOperational: true }),
+      site({
+        id: "b",
+        statusColor: "#123456",
+        isOperational: false,
+        latitude: 40,
+      }),
+      site({
+        id: "c",
+        statusColor: "#abcdef",
+        isOperational: null,
+        latitude: 20,
+      }),
+    ]);
+
+    for (const marker of result) {
+      expect(palette).toContain(marker.color);
+    }
+  });
+
+  test("labels a single-site marker with its site name, placed below it", () => {
+    const only: NetworkMapMarker = markers([
+      site({ name: "Camden Store" }),
+    ])[0] as NetworkMapMarker;
+
+    expect(only.label).toBe("Camden Store");
+    // Below reads best — the eye goes marker, then name.
+    expect(only.labelPlacement).toBe("below");
+  });
+
+  /*
+   * Two names printed on top of each other are worse than one name: the
+   * overlapped label is unreadable AND it hides its neighbour. So a name
+   * that fits in neither position is dropped, and the tooltip carries it.
+   */
+  test("drops a name it cannot place clear of its neighbours", () => {
+    /*
+     * Eight sites in one small city with long names: they are far enough
+     * apart at this cell size to stay separate markers, and far too close
+     * for eight labels to sit side by side.
+     */
+    const crowded: Array<NetworkMapSite> = Array.from(
+      { length: 8 },
+      (_unused: unknown, index: number): NetworkMapSite => {
+        return site({
+          id: `site-${index}`,
+          name: `A Fairly Long Site Name ${index}`,
+          latitude: 51.5 + index * 0.35,
+          longitude: -0.12 + index * 0.35,
+        });
+      },
+    );
+
+    const result: Array<NetworkMapMarker> = markers(crowded, true, 0.5);
+    const labelled: Array<NetworkMapMarker> = result.filter(
+      (marker: NetworkMapMarker): boolean => {
+        return marker.label !== "";
+      },
+    );
+
+    expect(result.length).toBe(8);
+    expect(labelled.length).toBeLessThan(result.length);
+
+    // Whatever survived carries a placement; whatever did not carries none.
+    for (const marker of result) {
+      if (marker.label) {
+        expect(marker.labelPlacement).not.toBeNull();
+      } else {
+        expect(marker.labelPlacement).toBeNull();
+      }
+    }
+  });
+
+  /*
+   * Zoom genuinely separates markers, so a name that could not be placed on
+   * the world view comes back once the frame tightens around the same
+   * sites. This is the property that makes dropping labels acceptable
+   * rather than lossy.
+   */
+  test("places more names as the frame zooms in on the same sites", () => {
+    /*
+     * Short names on purpose: the point under test is that ZOOM recovers
+     * labels, and a name wide enough to never fit at any realistic zoom
+     * would hold the count flat and prove nothing.
+     */
+    const crowded: Array<NetworkMapSite> = Array.from(
+      { length: 8 },
+      (_unused: unknown, index: number): NetworkMapSite => {
+        return site({
+          id: `site-${index}`,
+          name: `S${index}`,
+          latitude: 51.5 + index * 0.35,
+          longitude: -0.12 + index * 0.35,
+        });
+      },
+    );
+
+    const countLabels: (zoom: number) => number = (zoom: number): number => {
+      return markers(crowded, true, 0.5, zoom).filter(
+        (marker: NetworkMapMarker): boolean => {
+          return marker.label !== "";
+        },
+      ).length;
+    };
+
+    /*
+     * These eight sit on a diagonal about 15 screen units apart at zoom 12,
+     * which a 15-unit-wide label box still collides with — so the check
+     * uses a frame tight enough to actually separate them. MAX_ZOOM is 64.
+     */
+    expect(countLabels(40)).toBeGreaterThan(countLabels(1));
+  });
+
+  test("gives a cluster no label, since it stands for more than one name", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "a" }),
+      site({ id: "b", latitude: 51.51 }),
+    ]);
+
+    expect(result[0]?.label).toBe("");
+    expect(result[0]?.labelPlacement).toBeNull();
+  });
+
+  test("drops labels entirely when the widget asks for none", () => {
+    const only: NetworkMapMarker = markers(
+      [site()],
+      false,
+    )[0] as NetworkMapMarker;
+
+    expect(only.label).toBe("");
+    expect(only.labelPlacement).toBeNull();
+  });
+
+  test("truncates a long site name rather than letting it span the map", () => {
+    const label: string = markers([
+      site({ name: "A Very Long Franchise Unit Name That Runs On" }),
+    ])[0]?.label as string;
+
+    expect(label.length).toBeLessThan(
+      "A Very Long Franchise Unit Name That Runs On".length,
+    );
+    expect(label.endsWith("…")).toBe(true);
+  });
+
+  /*
+   * Past a certain density, names overlap into an unreadable mat — which is
+   * worse than no names, because an overlapped label also hides its
+   * neighbour. The tooltip still carries every one.
+   */
+  test("takes every label off once the map is too busy for them", () => {
+    /*
+     * A 7x7 lattice spread across the whole world — far enough apart that
+     * every site is its own marker, so the 49 markers genuinely cross the
+     * MAX_LABELLED_MARKERS threshold rather than clustering back under it.
+     */
+    const busy: Array<NetworkMapSite> = Array.from(
+      { length: 49 },
+      (_unused: unknown, index: number): NetworkMapSite => {
+        return site({
+          id: `site-${index}`,
+          name: `Site ${index}`,
+          latitude: -60 + Math.floor(index / 7) * 20,
+          longitude: -170 + (index % 7) * 50,
+        });
+      },
+    );
+
+    const result: Array<NetworkMapMarker> = markers(busy);
+
+    expect(result.length).toBeGreaterThan(MAX_LABELLED_MARKERS);
+    expect(
+      result.every((marker: NetworkMapMarker): boolean => {
+        return marker.label === "";
+      }),
+    ).toBe(true);
+  });
+
+  test("names a single site, its type and its status in the tooltip", () => {
+    expect(
+      markers([site({ name: "Camden", siteType: "Store" })])[0]?.tooltip,
+    ).toBe("Camden · Store · Operational");
+  });
+
+  test("omits the type from the tooltip when the site has none", () => {
+    expect(markers([site({ name: "Camden", siteType: "" })])[0]?.tooltip).toBe(
+      "Camden · Operational",
+    );
+  });
+
+  test("lists cluster members in the tooltip and counts the overflow", () => {
+    const many: Array<NetworkMapSite> = Array.from(
+      { length: 8 },
+      (_unused: unknown, index: number): NetworkMapSite => {
+        return site({
+          id: `site-${index}`,
+          name: `Site ${index}`,
+          latitude: 51.5 + index * 0.001,
+        });
+      },
+    );
+
+    const tooltip: string = markers(many)[0]?.tooltip as string;
+
+    expect(tooltip.startsWith("8 sites: ")).toBe(true);
+    expect(tooltip).toContain("+3 more");
+  });
+
+  /*
+   * Output order is PAINT order. The smallest marker has to be painted last
+   * or a single store disappears under the cluster holding its neighbours.
+   */
+  test("returns markers biggest-first so small ones are painted on top", () => {
+    const result: Array<NetworkMapMarker> = markers([
+      site({ id: "lone", latitude: -33.87, longitude: 151.21 }),
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 51.51, longitude: -0.13 }),
+      site({ id: "c", latitude: 51.52, longitude: -0.14 }),
+    ]);
+
+    expect(
+      result.map((marker: NetworkMapMarker): number => {
+        return marker.count;
+      }),
+    ).toEqual([3, 1]);
+  });
+
+  /*
+   * The widget refetches on a timer and row order really does vary between
+   * responses. Five members in one cell is the case that used to break:
+   * clusterPoints averages positions by accumulating in input order, and
+   * IEEE-754 addition is not associative, so the cluster centre — and any
+   * key derived from it — differed in the last bits.
+   */
+  test("is deterministic: the same sites in any order draw the same markers", () => {
+    const sites: Array<NetworkMapSite> = [
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 51.53, longitude: -0.17 }),
+      site({ id: "c", latitude: 51.57, longitude: -0.29 }),
+      site({ id: "d", latitude: 51.61, longitude: -0.33 }),
+      site({ id: "e", latitude: 51.67, longitude: -0.41 }),
+      site({ id: "f", latitude: -33.87, longitude: 151.21 }),
+    ];
+
+    expect(markers([...sites].reverse())).toEqual(markers(sites));
+  });
+
+  /*
+   * React keys must survive a poll that returns the same sites in a
+   * different order, or every marker remounts and any hover or focus on one
+   * is lost.
+   */
+  test("keys a marker by its sites, not by its floating-point centre", () => {
+    const sites: Array<NetworkMapSite> = [
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 51.53, longitude: -0.17 }),
+      site({ id: "c", latitude: 51.57, longitude: -0.29 }),
+    ];
+
+    const forward: Array<string> = markers(sites).map(
+      (marker: NetworkMapMarker): string => {
+        return marker.key;
+      },
+    );
+    const reversed: Array<string> = markers([...sites].reverse()).map(
+      (marker: NetworkMapMarker): string => {
+        return marker.key;
+      },
+    );
+
+    expect(reversed).toEqual(forward);
+    expect(forward[0]).toBe("a");
+  });
+
+  /*
+   * The label budget must count markers that CAN carry a name, not all of
+   * them: an estate of paired sites plus a few lone ones would otherwise
+   * clear the threshold on marker count and draw no names at all.
+   */
+  test("spends the label budget on the markers that can actually be labelled", () => {
+    const sites: Array<NetworkMapSite> = [];
+
+    // 50 well-separated PAIRS — none of which can ever carry a label.
+    for (let index: number = 0; index < 50; index++) {
+      const latitude: number = -60 + Math.floor(index / 10) * 25;
+      const longitude: number = -170 + (index % 10) * 36;
+      sites.push(site({ id: `pair-${index}-a`, latitude, longitude }));
+      sites.push(site({ id: `pair-${index}-b`, latitude, longitude }));
+    }
+
+    // Three lone sites, far from everything, that should keep their names.
+    sites.push(
+      site({ id: "lone-1", name: "Alpha", latitude: 10, longitude: 5 }),
+    );
+    sites.push(
+      site({ id: "lone-2", name: "Bravo", latitude: 5, longitude: 100 }),
+    );
+    sites.push(
+      site({ id: "lone-3", name: "Charlie", latitude: -20, longitude: -60 }),
+    );
+
+    const labelled: Array<string> = markers(sites)
+      .filter((marker: NetworkMapMarker): boolean => {
+        return marker.label !== "";
+      })
+      .map((marker: NetworkMapMarker): string => {
+        return marker.label;
+      });
+
+    expect(labelled.sort()).toEqual(["Alpha", "Bravo", "Charlie"]);
+  });
+
+  test("gives every marker a stable, unique key", () => {
+    const keys: Array<string> = markers([
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: -33.87, longitude: 151.21 }),
+      site({ id: "c", latitude: 40.71, longitude: -74.0 }),
+    ]).map((marker: NetworkMapMarker): string => {
+      return marker.key;
+    });
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test("sizes a cluster larger than a single site, up to a cap", () => {
+    const single: number = markers([site()])[0]?.screenRadius as number;
+    const clustered: number = markers([
+      site({ id: "a" }),
+      site({ id: "b", latitude: 51.501 }),
+      site({ id: "c", latitude: 51.502 }),
+      site({ id: "d", latitude: 51.503 }),
+    ])[0]?.screenRadius as number;
+
+    expect(clustered).toBeGreaterThan(single);
+    expect(clustered).toBeLessThanOrEqual(22);
+  });
+});
+
+// -- networkMapStatusSummary -----------------------------------------------
+
+describe("networkMapStatusSummary", () => {
+  test("counts nothing for no sites", () => {
+    expect(networkMapStatusSummary([])).toEqual({
+      total: 0,
+      operational: 0,
+      down: 0,
+      unknown: 0,
+    });
+  });
+
+  test("splits sites across operational, down and unknown", () => {
+    const summary: NetworkMapStatusSummary = networkMapStatusSummary([
+      site({ id: "a", isOperational: true }),
+      site({ id: "b", isOperational: true }),
+      site({ id: "c", isOperational: false }),
+      site({ id: "d", isOperational: null }),
+    ]);
+
+    expect(summary).toEqual({
+      total: 4,
+      operational: 2,
+      down: 1,
+      unknown: 1,
+    });
+  });
+
+  test("the three buckets always add up to the total", () => {
+    const sites: Array<NetworkMapSite> = [
+      site({ id: "a", isOperational: true }),
+      site({ id: "b", isOperational: false }),
+      site({ id: "c", isOperational: null }),
+      site({ id: "d", isOperational: false }),
+    ];
+    const summary: NetworkMapStatusSummary = networkMapStatusSummary(sites);
+
+    expect(summary.operational + summary.down + summary.unknown).toBe(
+      summary.total,
+    );
+  });
+});
+
+// -- describeNetworkMapCoverage --------------------------------------------
+
+describe("describeNetworkMapCoverage", () => {
+  test("says how many sites are mapped when the frame holds them all", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 12,
+        inViewCount: 12,
+        unplacedCount: 0,
+        isTruncated: false,
+      }),
+    ).toBe("12 sites mapped");
+  });
+
+  test("uses the singular for a network of one", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 1,
+        inViewCount: 1,
+        unplacedCount: 0,
+        isTruncated: false,
+      }),
+    ).toBe("1 site mapped");
+  });
+
+  /*
+   * A count that quietly shrinks as the frame tightens reads as sites
+   * disappearing. Once the frame stops holding everything, the line has to
+   * say what it does hold.
+   */
+  test("says what the frame holds once it stops holding everything", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 40,
+        inViewCount: 12,
+        unplacedCount: 0,
+        isTruncated: false,
+      }),
+    ).toBe("12 of 40 sites in view");
+  });
+
+  test("reports sites that have no coordinates at all", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 10,
+        inViewCount: 10,
+        unplacedCount: 3,
+        isTruncated: false,
+      }),
+    ).toBe("10 sites mapped · 3 without coordinates");
+  });
+
+  /*
+   * Silence about the row cap would make a truncated map look complete —
+   * the exact failure the whole coverage line exists to prevent.
+   */
+  test("admits when the fetch hit its cap", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 250,
+        inViewCount: 250,
+        unplacedCount: 0,
+        isTruncated: true,
+      }),
+    ).toBe("250 sites mapped · more sites not shown");
+  });
+
+  test("reports every caveat at once", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 250,
+        inViewCount: 90,
+        unplacedCount: 4,
+        isTruncated: true,
+      }),
+    ).toBe(
+      "90 of 250 sites in view · 4 without coordinates · more sites not shown",
+    );
+  });
+
+  test("still says something when the map drew nothing", () => {
+    expect(
+      describeNetworkMapCoverage({
+        siteCount: 0,
+        inViewCount: 0,
+        unplacedCount: 0,
+        isTruncated: false,
+      }),
+    ).toBe("0 sites mapped");
+  });
+});
+
+// -- viewport --------------------------------------------------------------
+
+describe("fitNetworkMapViewport", () => {
+  test("opens on the whole world when there is nothing to frame", () => {
+    expect(fitNetworkMapViewport([])).toEqual(WORLD_VIEWPORT);
+  });
+
+  test("frames a single-country estate tighter than the world", () => {
+    const viewport: MapViewport = fitNetworkMapViewport([
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 53.48, longitude: -2.24 }),
+    ]);
+
+    expect(zoomOfViewport(viewport)).toBeGreaterThan(1);
+  });
+
+  /*
+   * Equatorial longitudes on purpose: Robinson compresses the parallels
+   * towards the poles, so two sites at 60° north and south of ±170° span
+   * noticeably less of the projected width than the same longitudes do at
+   * the equator, and would fit tighter than the world.
+   */
+  test("stays on the world for an estate that spans it", () => {
+    const viewport: MapViewport = fitNetworkMapViewport([
+      site({ id: "a", latitude: 0, longitude: -175 }),
+      site({ id: "b", latitude: 0, longitude: 175 }),
+    ]);
+
+    expect(zoomOfViewport(viewport)).toBeCloseTo(1, 5);
+  });
+
+  test("keeps the frame inside the world in every direction", () => {
+    const viewport: MapViewport = fitNetworkMapViewport([
+      site({ id: "a", latitude: 89, longitude: 179 }),
+    ]);
+
+    expect(viewport.x).toBeGreaterThanOrEqual(0);
+    expect(viewport.y).toBeGreaterThanOrEqual(0);
+    expect(viewport.x + viewport.width).toBeLessThanOrEqual(
+      ROBINSON_VIEW_BOX_WIDTH + 1e-6,
+    );
+    expect(viewport.y + viewport.height).toBeLessThanOrEqual(
+      ROBINSON_VIEW_BOX_HEIGHT + 1e-6,
+    );
+  });
+
+  test("frames every site it was given", () => {
+    const sites: Array<NetworkMapSite> = [
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: 48.85, longitude: 2.35 }),
+      site({ id: "c", latitude: 52.52, longitude: 13.4 }),
+    ];
+
+    expect(
+      countNetworkMapSitesInViewport(sites, fitNetworkMapViewport(sites)),
+    ).toBe(3);
+  });
+});
+
+describe("networkMapPoints", () => {
+  test("projects each site once, in order", () => {
+    const points: Array<{ x: number; y: number }> = networkMapPoints([
+      site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+      site({ id: "b", latitude: -33.87, longitude: 151.21 }),
+    ]);
+    const [ax, ay]: [number, number] = projectRobinson(51.5, -0.12);
+
+    expect(points).toHaveLength(2);
+    expect(points[0]?.x).toBeCloseTo(ax, 6);
+    expect(points[0]?.y).toBeCloseTo(ay, 6);
+  });
+});
+
+describe("countNetworkMapSitesInViewport", () => {
+  test("counts every site when the frame is the whole world", () => {
+    expect(
+      countNetworkMapSitesInViewport(
+        [
+          site({ id: "a", latitude: 51.5, longitude: -0.12 }),
+          site({ id: "b", latitude: -33.87, longitude: 151.21 }),
+        ],
+        WORLD_VIEWPORT,
+      ),
+    ).toBe(2);
+  });
+
+  test("counts only the sites a tight frame is holding", () => {
+    const london: NetworkMapSite = site({
+      id: "london",
+      latitude: 51.5,
+      longitude: -0.12,
+    });
+    const sydney: NetworkMapSite = site({
+      id: "sydney",
+      latitude: -33.87,
+      longitude: 151.21,
+    });
+
+    expect(
+      countNetworkMapSitesInViewport(
+        [london, sydney],
+        fitNetworkMapViewport([london]),
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("resolveNetworkMapMaxSites", () => {
+  const FALLBACK: number = 250;
+
+  test("takes a plain number through", () => {
+    expect(resolveNetworkMapMaxSites(40, FALLBACK)).toBe(40);
+  });
+
+  /*
+   * THE case this function exists for. The settings form renders Max Sites
+   * as an <input type="number"> whose onChange hands back e.target.value —
+   * a STRING — and the arguments form stores it verbatim. A widget that
+   * type-tested for a number would ignore the value the user just typed and
+   * silently keep fetching the default, which is the one failure a settings
+   * field must never have.
+   */
+  test("accepts the string the settings form actually stores", () => {
+    expect(resolveNetworkMapMaxSites("40", FALLBACK)).toBe(40);
+    expect(resolveNetworkMapMaxSites("  40  ", FALLBACK)).toBe(40);
+  });
+
+  test("falls back for anything that is not a usable count", () => {
+    for (const value of [
+      undefined,
+      null,
+      "",
+      "   ",
+      "not a number",
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      0,
+      "0",
+      -5,
+      {},
+      [],
+    ]) {
+      expect(resolveNetworkMapMaxSites(value, FALLBACK)).toBe(FALLBACK);
+    }
+  });
+
+  test("floors a fractional count rather than sending it to the server", () => {
+    expect(resolveNetworkMapMaxSites(40.9, FALLBACK)).toBe(40);
+    expect(resolveNetworkMapMaxSites("40.9", FALLBACK)).toBe(40);
+  });
+
+  /*
+   * A pasted 100000 would otherwise become a server-side "limit too large"
+   * error and an empty widget — a settings value that breaks the widget
+   * rather than being ignored.
+   */
+  test("clamps an absurd count to something the server will serve", () => {
+    expect(resolveNetworkMapMaxSites(100000, FALLBACK)).toBe(
+      NETWORK_MAP_MAX_SITES_CEILING,
+    );
+    expect(NETWORK_MAP_MAX_SITES_CEILING).toBeLessThan(LIMIT_PER_PROJECT);
+  });
+
+  /*
+   * The widget asks for one row MORE than the cap so it can tell "exactly
+   * at the cap" from "there is more", so the ceiling has to leave room for
+   * that extra row inside the server's own limit.
+   */
+  test("leaves room for the extra probe row inside the server's limit", () => {
+    expect(NETWORK_MAP_MAX_SITES_CEILING + 1).toBeLessThanOrEqual(
+      LIMIT_PER_PROJECT,
+    );
+  });
+});
+
+describe("networkMapClusterCellSize", () => {
+  /*
+   * The cell is a constant distance ON SCREEN, so it covers less and less of
+   * the world as the map zooms in — which is what lets a lump of nearby
+   * sites come apart instead of staying one blob at every zoom.
+   */
+  test("shrinks in world units as the frame zooms in", () => {
+    const world: number = networkMapClusterCellSize(WORLD_VIEWPORT);
+    const zoomed: number = networkMapClusterCellSize({
+      x: 0,
+      y: 0,
+      width: WORLD_VIEWPORT.width / 4,
+      height: WORLD_VIEWPORT.height / 4,
+    });
+
+    expect(world).toBeCloseTo(NETWORK_MAP_CLUSTER_CELL_SIZE, 6);
+    expect(zoomed).toBeLessThan(world);
+    expect(zoomed).toBeCloseTo(NETWORK_MAP_CLUSTER_CELL_SIZE / 4, 6);
+  });
+});
+
+// -- palette and legend ----------------------------------------------------
+
+describe("NETWORK_MAP_LEGEND", () => {
+  test("names every color the markers can be painted", () => {
+    expect(
+      NETWORK_MAP_LEGEND.map((entry: NetworkMapLegendEntry): string => {
+        return entry.key;
+      }).sort(),
+    ).toEqual(Object.keys(NETWORK_MAP_COLORS).sort());
+  });
+
+  test("uses the same hex for a key as the markers do", () => {
+    for (const entry of NETWORK_MAP_LEGEND) {
+      expect(entry.color).toBe(NETWORK_MAP_COLORS[entry.key]);
+      expect(entry.label.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  /*
+   * A reader scans a legend for trouble. Healthy first, then the two
+   * degrees of "look at me", then the absence of data.
+   */
+  test("orders the legend healthy-first", () => {
+    expect(
+      NETWORK_MAP_LEGEND.map((entry: NetworkMapLegendEntry): string => {
+        return entry.key;
+      }),
+    ).toEqual(["ok", "mixed", "down", "none"]);
+  });
+});

--- a/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The Network Map widget's renderer is a React component, and the App suite
+ * runs in a plain Node environment with no renderer — so the invariants that
+ * cannot be expressed against NetworkMapWidgetData (which is pure and tested
+ * directly) are pinned against the source, the same way
+ * NetworkSitePageInvariants pins the Network Site pages.
+ *
+ * Every assertion here corresponds to something that would ship broken and
+ * look fine: a widget that renders nowhere, a column that is about to be
+ * dropped from the schema, an unbounded fetch, or a public dashboard that
+ * silently serves data no widget on it displays.
+ */
+
+const APP_ROOT: string = path.join(__dirname, "..", "..");
+const COMMON_ROOT: string = path.join(APP_ROOT, "..", "Common");
+
+const DASHBOARD_SRC: string = path.join(
+  APP_ROOT,
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function readApp(...relativeParts: Array<string>): string {
+  return squash(
+    fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+  );
+}
+
+function readCommon(...relativeParts: Array<string>): string {
+  return squash(
+    fs.readFileSync(path.join(COMMON_ROOT, ...relativeParts), "utf8"),
+  );
+}
+
+/*
+ * The same source with its comments removed. An assertion that a piece of
+ * code is ABSENT has to read the code, not the commentary — the comment
+ * explaining why role="img" is wrong would otherwise fail the very test
+ * that checks it is gone.
+ */
+function readAppCode(...relativeParts: Array<string>): string {
+  const raw: string = fs.readFileSync(
+    path.join(DASHBOARD_SRC, ...relativeParts),
+    "utf8",
+  );
+  return squash(
+    raw.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " "),
+  );
+}
+
+const WIDGET: Array<string> = [
+  "Components",
+  "Dashboard",
+  "Components",
+  "DashboardNetworkMapComponent.tsx",
+];
+
+describe("Network Map widget wiring", () => {
+  /*
+   * Four registries have to agree or the widget is unreachable, and NONE of
+   * them is a compile error: the enum member, the settings-argument
+   * registry, the "add widget" factory switch, and the render dispatch. A
+   * missing render branch in particular fails silently — the widget adds
+   * fine and draws a blank card.
+   */
+  test("the component type is declared once in the shared enum", () => {
+    expect(
+      readCommon("Types", "Dashboard", "DashboardComponentType.ts"),
+    ).toContain("NetworkMap = `NetworkMap`");
+  });
+
+  test("the settings registry resolves the widget instead of throwing", () => {
+    const source: string = readCommon(
+      "Utils",
+      "Dashboard",
+      "Components",
+      "Index.ts",
+    );
+
+    expect(source).toContain(
+      "if (dashboardComponentType === DashboardComponentType.NetworkMap)",
+    );
+    expect(source).toContain(
+      "DashboardNetworkMapComponentUtil.getComponentConfigArguments()",
+    );
+  });
+
+  test("the toolbar knows how to create one", () => {
+    const source: string = readApp(
+      "Components",
+      "Dashboard",
+      "DashboardView.tsx",
+    );
+
+    expect(source).toContain(
+      "if (componentType === DashboardComponentType.NetworkMap)",
+    );
+    expect(source).toContain(
+      "DashboardNetworkMapComponentUtil.getDefaultComponent()",
+    );
+  });
+
+  test("the canvas actually renders one", () => {
+    const source: string = readApp(
+      "Components",
+      "Dashboard",
+      "Components",
+      "DashboardBaseComponent.tsx",
+    );
+
+    expect(source).toContain(
+      "component.componentType === DashboardComponentType.NetworkMap",
+    );
+    expect(source).toContain("<DashboardNetworkMapComponent");
+  });
+
+  test("the widget picker lists it under Network in Infrastructure", () => {
+    const source: string = readApp(
+      "Components",
+      "Dashboard",
+      "Toolbar",
+      "WidgetCatalog.ts",
+    );
+
+    expect(source).toContain(
+      'name: "Network", group: WidgetCategoryGroup.Infrastructure',
+    );
+    expect(source).toContain("type: DashboardComponentType.NetworkMap");
+  });
+});
+
+describe("Network Map widget data access", () => {
+  /*
+   * NetworkSite.siteType is DEPRECATED — the pre-lookup-table string kept
+   * only so the BackfillNetworkSiteTypes migration can read it, and dropped
+   * in a follow-up PR. Reading it here compiles and works today and goes
+   * blank the day the column is removed, on BOTH the private and the public
+   * path. The type NAME lives on the networkSiteType relation.
+   */
+  test("reads the site type from the relation, never from the deprecated column", () => {
+    const widget: string = readAppCode(...WIDGET);
+
+    expect(widget).toContain("networkSiteType: { name: true, }");
+    expect(widget).toContain("row.networkSiteType?.name");
+    expect(widget).not.toContain("siteType: true");
+    expect(widget).not.toContain("row.siteType");
+  });
+
+  test("the public dashboard proxy reads the relation too", () => {
+    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
+    const entry: string =
+      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
+
+    expect(entry.length).toBeGreaterThan(0);
+    expect(entry).toContain("networkSiteType: { name: true }");
+    expect(entry).not.toContain("siteType: true");
+  });
+
+  /*
+   * "Down" has to mean whatever THIS project marked as a non-operational
+   * state. Filtering on a hardcoded status id or name would be wrong in any
+   * project that renamed its statuses.
+   */
+  test("filters by the joined operational flag rather than a hardcoded status", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain(
+      '(query as Record<string, unknown>)["currentMonitorStatus"] = { isOperationalState: false, };',
+    );
+    expect(widget).toContain(
+      '(query as Record<string, unknown>)["currentMonitorStatus"] = { isOperationalState: true, };',
+    );
+  });
+
+  /*
+   * A map is only readable while its markers can be told apart, and the
+   * fetch is a plain list query. An unbounded limit on a large estate is a
+   * slow endpoint AND an unreadable tile.
+   */
+  /*
+   * The cap is asked for PLUS ONE and the extra row dropped before drawing.
+   * Requesting exactly the cap makes "a project with exactly 250 sites"
+   * indistinguishable from "a project with 2,000" — both come back full —
+   * and the widget would then tell the first one that sites are hidden from
+   * it.
+   */
+  test("caps the fetch, and can tell a full page from a truncated one", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("limit: maxSites + 1,");
+    expect(widget).toContain("rows: listResult.data.slice(0, maxSites),");
+    expect(widget).toContain("isTruncated: listResult.data.length > maxSites,");
+  });
+
+  /*
+   * The settings form stores a number field's value as a STRING, so a
+   * widget that type-tests it silently ignores whatever the user typed. The
+   * coercion lives in the view model where it is unit-tested.
+   */
+  test("coerces the Max Sites setting instead of type-testing it", () => {
+    const widget: string = readAppCode(...WIDGET);
+
+    expect(widget).toContain("resolveNetworkMapMaxSites(");
+    expect(widget).not.toContain('typeof args.maxSites === "number"');
+  });
+
+  /*
+   * The widget must go through the public-dashboard proxy, and the resource
+   * key it names must exist on both sides — the client union and the server
+   * registry. A mismatch is a runtime "Unsupported dashboard resource type".
+   */
+  test("routes through the public-dashboard resource proxy under a registered key", () => {
+    expect(readApp(...WIDGET)).toContain(
+      'DashboardResourceList.getRequestOptions("network-site")',
+    );
+    expect(
+      readApp("Components", "Dashboard", "Utils", "DashboardResourceList.ts"),
+    ).toContain('| "network-site"');
+    expect(readCommon("Server", "API", "DashboardAPI.ts")).toContain(
+      '"network-site": {',
+    );
+  });
+
+  test("the server pins that resource to the Network Map widget alone", () => {
+    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
+    const entry: string =
+      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
+
+    expect(entry).toContain(
+      "widgets: { [DashboardComponentType.NetworkMap]: null, }",
+    );
+  });
+
+  /*
+   * allowedQueryKeys is the allowlist that stops the public endpoint from
+   * becoming a generic query API. The map draws a FLAT set of pins, so the
+   * tree shape (parentSiteId / materializedPath / depth) must not be
+   * filterable by an anonymous viewer — it is structure the map never shows.
+   */
+  test("the public endpoint exposes no filter the map does not use", () => {
+    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
+    const entry: string =
+      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
+
+    expect(entry).toContain(
+      'allowedQueryKeys: [ "networkSiteTypeId", "currentMonitorStatus", "currentMonitorStatusId", ]',
+    );
+
+    for (const forbidden of [
+      "parentSiteId",
+      "materializedPath",
+      "depth",
+      "address",
+      "slug",
+    ]) {
+      expect(entry).not.toContain(`"${forbidden}"`);
+    }
+  });
+
+  /*
+   * Coordinates and a status are the only things a public viewer gets. An
+   * address or a description on a site is business data the map never draws.
+   */
+  test("the public select is limited to what the map actually paints", () => {
+    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
+    const entry: string =
+      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
+
+    for (const forbidden of [
+      "address:",
+      "description:",
+      "slug:",
+      "materializedPath:",
+    ]) {
+      expect(entry).not.toContain(forbidden);
+    }
+  });
+});
+
+describe("Network Map widget rendering", () => {
+  /*
+   * Every decision the map makes about geometry, clustering and color lives
+   * in the react-free view model, which is where it can be tested. A
+   * renderer that starts projecting or clustering inline is a renderer whose
+   * behaviour nothing covers.
+   */
+  test("keeps every geometry and color decision in the pure view model", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("./NetworkMapWidgetData");
+    expect(widget).toContain("buildNetworkMapMarkers");
+    expect(widget).toContain("fitNetworkMapViewport");
+    // No projection, clustering or palette arithmetic in the component.
+    expect(widget).not.toContain("projectRobinson");
+    expect(widget).not.toContain("clusterPoints");
+    expect(widget).not.toContain("decideClusterColorKey");
+  });
+
+  /*
+   * A red dot two pixels across on a map of two hundred green ones is not
+   * information anybody reads. The count above the map is what makes an
+   * outage legible at dashboard distance.
+   */
+  test("prints the number of sites down above the map, not just colors them", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("networkMapStatusSummary");
+    expect(widget).toContain("summary.down > 0");
+    expect(widget).toContain('data-testid="network-map-widget-summary"');
+  });
+
+  test("prints a coverage line that admits what the map is not showing", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("describeNetworkMapCoverage");
+    expect(widget).toContain("unplacedCount: parsed.unplacedCount");
+    expect(widget).toContain("isTruncated: fetched.isTruncated");
+    expect(widget).toContain('data-testid="network-map-widget-coverage"');
+  });
+
+  /*
+   * `role="img"` on an SVG hides its whole subtree from assistive
+   * technology. The markers inside are focusable buttons, so it would make
+   * every one of them unreachable.
+   */
+  test("does not hide its focusable markers behind role=img", () => {
+    const widget: string = readAppCode(...WIDGET);
+
+    expect(widget).not.toContain('role="img"');
+    expect(widget).toContain('role="group"');
+  });
+
+  test("makes a single-site marker keyboard-activatable, and a cluster not", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain(
+      "if (marker.ids.length !== 1) { return undefined; }",
+    );
+    expect(widget).toContain('event.key === "Enter" || event.key === " "');
+    expect(widget).toContain('role={route ? "button" : undefined}');
+  });
+
+  /*
+   * Markers, strokes and label text are UI, not geography: sized in screen
+   * units so zooming the frame does not just produce bigger blobs.
+   */
+  test("sizes markers and strokes against the zoom, not the world", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("const zoom: number = zoomOfViewport(viewport);");
+    expect(widget).toContain("marker.screenRadius / zoom");
+    expect(widget).toContain("strokeWidth={0.6 / zoom}");
+  });
+
+  /*
+   * The outlines are the backdrop; the markers are the subject. A failed
+   * geometry fetch must cost the reader a coastline, not the whole widget.
+   */
+  test("still draws the pins when the outlines fail to load", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("setFeatures([]);");
+    expect(widget).toContain("(features || []).map(");
+  });
+
+  test("offers the same empty-state copy in both view modes", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("const EMPTY_MESSAGE: string =");
+    // Once as the list widget's prop, once in the map's own empty panel.
+    expect(widget.split("EMPTY_MESSAGE").length - 1).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -710,30 +710,6 @@ describe("SiteGeoMap", () => {
     "SiteGeoMap.tsx",
   );
 
-  /*
-   * The geometry is ~600 KB across both tiers. Every route module lands in
-   * one shared esbuild chunk, so a static import here is downloaded and
-   * parsed by every dashboard page — Incidents, a monitor, Settings — none
-   * of which draw a map. They must be loaded on demand, and they must stay
-   * .json: esbuild base64-inlines an imported .svg straight back into the
-   * shared chunk.
-   */
-  test("map geometry is not statically imported", () => {
-    expect(source).not.toMatch(
-      /import \S+ from "\.\/Geo\/WorldCountries\w*Geometry\.json";/,
-    );
-  });
-
-  test("both tiers are loaded lazily, by literal specifier", () => {
-    // Literal specifiers so esbuild can see both targets and split them out.
-    expect(source).toContain(
-      'await import("./Geo/WorldCountriesGeometry.json")',
-    );
-    expect(source).toContain(
-      'await import("./Geo/WorldCountriesDetailGeometry.json")',
-    );
-  });
-
   test("the async load has a rendered pending state", () => {
     expect(source).toContain("overviewFeatures === null ?");
     expect(source).toContain('data-testid="site-geo-map-skeleton"');

--- a/App/Tests/Dashboard/WorldGeometry.test.ts
+++ b/App/Tests/Dashboard/WorldGeometry.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import {
+  GeometryFeature,
+  GeometryTier,
+  getCachedGeometryFeatures,
+  loadGeometryFeatures,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/WorldGeometry";
+import { ROBINSON_VIEW_BOX } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoProjection";
+
+/*
+ * The on-demand loader for the checked-in country outlines, shared by the
+ * Network Map PAGE (SiteGeoMap) and the Network Map dashboard WIDGET.
+ *
+ * Two invariants live here, and both are about bytes a viewer downloads:
+ *
+ *  - The geometry is ~600 KB across both tiers, and every route module in
+ *    the dashboard lands in ONE shared esbuild chunk. A static import would
+ *    make Incidents, a monitor and Settings all download and parse country
+ *    outlines they never draw.
+ *
+ *  - The cache is module-level, so a page showing the full map above a
+ *    dashboard tile fetches the outlines once between them rather than
+ *    once each. That only holds while both surfaces go through THIS module
+ *    — which is why the loader was lifted out of SiteGeoMap.tsx.
+ */
+
+const GEO_DIR: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "NetworkSite",
+  "Geo",
+);
+
+function readSource(fileName: string): string {
+  return fs.readFileSync(path.join(GEO_DIR, fileName), "utf8");
+}
+
+const WIDGET_PATH: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "Dashboard",
+  "Components",
+  "DashboardNetworkMapComponent.tsx",
+);
+
+const SITE_GEO_MAP_PATH: string = path.join(GEO_DIR, "..", "SiteGeoMap.tsx");
+
+describe("WorldGeometry source", () => {
+  test("neither tier is statically imported", () => {
+    expect(readSource("WorldGeometry.ts")).not.toMatch(
+      /import \S+ from "\.\/WorldCountries\w*Geometry\.json";/,
+    );
+  });
+
+  test("both tiers are loaded lazily, by literal specifier", () => {
+    // Literal specifiers so esbuild can see both targets and split them out.
+    const source: string = readSource("WorldGeometry.ts");
+
+    expect(source).toContain('await import("./WorldCountriesGeometry.json")');
+    expect(source).toContain(
+      'await import("./WorldCountriesDetailGeometry.json")',
+    );
+  });
+
+  /*
+   * Both consumers must go through this module, or the shared cache is a
+   * lie and the second surface on screen re-downloads 600 KB.
+   */
+  test("both map surfaces load their outlines through this module", () => {
+    for (const consumer of [SITE_GEO_MAP_PATH, WIDGET_PATH]) {
+      const source: string = fs.readFileSync(consumer, "utf8");
+
+      expect(source).toContain("loadGeometryFeatures");
+      expect(source).toContain("Geo/WorldGeometry");
+      // Nobody re-implements the import() or keeps a second cache.
+      expect(source).not.toContain("WorldCountriesGeometry.json");
+      expect(source).not.toContain("WorldCountriesDetailGeometry.json");
+    }
+  });
+
+  /*
+   * A dashboard tile has no zoom controls, so it can never reach the zoom
+   * at which the detail tier earns its ~500 KB. Fetching it there would
+   * hand that cost to every viewer of every dashboard the widget is on.
+   */
+  test("the widget never asks for the expensive detail tier", () => {
+    const source: string = fs.readFileSync(WIDGET_PATH, "utf8");
+
+    expect(source).not.toContain('loadGeometryFeatures("detail")');
+    expect(source).toContain('const GEOMETRY_TIER: GeometryTier = "overview";');
+  });
+});
+
+describe("loadGeometryFeatures", () => {
+  test("loads the overview tier as drawable outlines", async () => {
+    const features: Array<GeometryFeature> =
+      await loadGeometryFeatures("overview");
+
+    expect(features.length).toBeGreaterThan(0);
+
+    for (const feature of features) {
+      expect(typeof feature.id).toBe("string");
+      expect(feature.id.length).toBeGreaterThan(0);
+      expect(typeof feature.name).toBe("string");
+      expect(typeof feature.path).toBe("string");
+      expect(feature.path.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns the SAME array on a second call, so nothing is re-parsed", async () => {
+    const first: Array<GeometryFeature> =
+      await loadGeometryFeatures("overview");
+    const second: Array<GeometryFeature> =
+      await loadGeometryFeatures("overview");
+
+    expect(second).toBe(first);
+  });
+
+  test("exposes the cached tier synchronously once it has been loaded", async () => {
+    const loaded: Array<GeometryFeature> =
+      await loadGeometryFeatures("overview");
+
+    expect(getCachedGeometryFeatures("overview")).toBe(loaded);
+  });
+
+  test("keeps the two tiers in separate cache slots", async () => {
+    const overview: Array<GeometryFeature> =
+      await loadGeometryFeatures("overview");
+    const detail: Array<GeometryFeature> = await loadGeometryFeatures("detail");
+
+    expect(detail).not.toBe(overview);
+    expect(getCachedGeometryFeatures("detail")).toBe(detail);
+    expect(getCachedGeometryFeatures("overview")).toBe(overview);
+  });
+
+  /*
+   * The two tiers share a viewBox so the map can swap them under a live
+   * frame without every coastline shifting — and so a pin projected at
+   * runtime lands on the outline in either one.
+   */
+  test("both tiers share the runtime projection's viewBox", () => {
+    for (const tier of [
+      "WorldCountriesGeometry",
+      "WorldCountriesDetailGeometry",
+    ]) {
+      const file: { viewBox: string } = JSON.parse(
+        fs.readFileSync(path.join(GEO_DIR, `${tier}.json`), "utf8"),
+      ) as { viewBox: string };
+
+      expect(file.viewBox).toBe(ROBINSON_VIEW_BOX);
+    }
+  });
+
+  test("the detail tier is the richer of the two", async () => {
+    const overview: Array<GeometryFeature> =
+      await loadGeometryFeatures("overview");
+    const detail: Array<GeometryFeature> = await loadGeometryFeatures("detail");
+
+    const totalPathLength: (features: Array<GeometryFeature>) => number = (
+      features: Array<GeometryFeature>,
+    ): number => {
+      return features.reduce(
+        (total: number, feature: GeometryFeature): number => {
+          return total + feature.path.length;
+        },
+        0,
+      );
+    };
+
+    expect(totalPathLength(detail)).toBeGreaterThan(totalPathLength(overview));
+  });
+});
+
+describe("getCachedGeometryFeatures", () => {
+  test("reports null for a tier nothing has loaded yet", () => {
+    /*
+     * Exercised through a tier name that is not a real one: the two real
+     * slots are populated by the tests above, and the loader is a
+     * module-level singleton that cannot be reset between them.
+     */
+    expect(getCachedGeometryFeatures("not-a-tier" as GeometryTier)).toBeNull();
+  });
+});

--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -50,6 +50,7 @@ import PodmanResource from "../../Models/DatabaseModels/PodmanResource";
 import ProxmoxResource from "../../Models/DatabaseModels/ProxmoxResource";
 import CephResource from "../../Models/DatabaseModels/CephResource";
 import DockerSwarmResource from "../../Models/DatabaseModels/DockerSwarmResource";
+import NetworkSite from "../../Models/DatabaseModels/NetworkSite";
 import Span from "../../Models/AnalyticsModels/Span";
 import Log from "../../Models/AnalyticsModels/Log";
 import IncidentService from "../Services/IncidentService";
@@ -64,6 +65,7 @@ import PodmanResourceService from "../Services/PodmanResourceService";
 import ProxmoxResourceService from "../Services/ProxmoxResourceService";
 import CephResourceService from "../Services/CephResourceService";
 import DockerSwarmResourceService from "../Services/DockerSwarmResourceService";
+import NetworkSiteService from "../Services/NetworkSiteService";
 import SpanService from "../Services/SpanService";
 import LogService from "../Services/LogService";
 import DashboardComponentType from "../../Types/Dashboard/DashboardComponentType";
@@ -163,6 +165,43 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
       name: true,
       monitorType: true,
       currentMonitorStatus: { name: true, color: true },
+    },
+  },
+  "network-site": {
+    modelType: NetworkSite,
+    service: NetworkSiteService,
+    widgets: {
+      [DashboardComponentType.NetworkMap]: null,
+    },
+    /*
+     * The map filters by site type and by whether the rolled-up status is
+     * operational — nothing else. Notably NOT `parentSiteId` or
+     * `materializedPath`: the widget draws a flat set of pins rather than
+     * walking a hierarchy, so exposing the tree shape here would hand an
+     * anonymous viewer a structure the map never shows them.
+     */
+    allowedQueryKeys: [
+      "networkSiteTypeId",
+      "currentMonitorStatus",
+      "currentMonitorStatusId",
+    ],
+    select: {
+      _id: true,
+      name: true,
+      /*
+       * The type NAME comes from the networkSiteType relation. NetworkSite
+       * .siteType is the deprecated pre-lookup-table string and is dropped
+       * in a follow-up PR, so it must not be read from new code.
+       */
+      networkSiteType: { name: true },
+      latitude: true,
+      longitude: true,
+      currentMonitorStatus: {
+        name: true,
+        color: true,
+        priority: true,
+        isOperationalState: true,
+      },
     },
   },
   host: {

--- a/Common/Tests/App/Dashboard/WidgetCatalog.test.ts
+++ b/Common/Tests/App/Dashboard/WidgetCatalog.test.ts
@@ -207,6 +207,7 @@ describe("WidgetCatalog", () => {
         "Podman",
         "Proxmox",
         "Ceph",
+        "Network",
       ]) {
         expect(getCategory(name).group).toBe(
           WidgetCategoryGroup.Infrastructure,
@@ -277,6 +278,7 @@ describe("WidgetCatalog", () => {
         "Podman",
         "Proxmox",
         "Ceph",
+        "Network",
       ]);
     });
 

--- a/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
@@ -11,6 +11,7 @@ import IncidentService from "../../../Server/Services/IncidentService";
 import KubernetesResourceService from "../../../Server/Services/KubernetesResourceService";
 import LogService from "../../../Server/Services/LogService";
 import MonitorService from "../../../Server/Services/MonitorService";
+import NetworkSiteService from "../../../Server/Services/NetworkSiteService";
 import PodmanHostService from "../../../Server/Services/PodmanHostService";
 import PodmanResourceService from "../../../Server/Services/PodmanResourceService";
 import ProxmoxResourceService from "../../../Server/Services/ProxmoxResourceService";
@@ -140,6 +141,30 @@ const RESOURCE_CASES: Array<ResourceCase> = [
     selectColumn: "name",
     nonSelectColumn: "monitorSteps",
     selectKeys: ["_id", "name", "monitorType", "currentMonitorStatus"],
+  },
+  {
+    /*
+     * The Network Map draws a FLAT set of pins, so the hierarchy columns
+     * (parentSiteId, materializedPath, depth) are deliberately outside both
+     * the allowlist and the select — structure an anonymous viewer would be
+     * able to walk but the map never shows them.
+     */
+    resourceType: "network-site",
+    componentType: DashboardComponentType.NetworkMap,
+    service: NetworkSiteService,
+    kind: null,
+    allowedQueryKey: "networkSiteTypeId",
+    forbiddenQueryKey: "parentSiteId",
+    selectColumn: "name",
+    nonSelectColumn: "address",
+    selectKeys: [
+      "_id",
+      "name",
+      "networkSiteType",
+      "latitude",
+      "longitude",
+      "currentMonitorStatus",
+    ],
   },
   {
     resourceType: "host",
@@ -465,6 +490,7 @@ const ALL_SERVICES: Array<ListService> = [
   IncidentService,
   AlertService,
   MonitorService,
+  NetworkSiteService,
   HostService,
   KubernetesResourceService,
   DockerHostService,

--- a/Common/Tests/Types/Dashboard/NetworkDashboardTemplate.test.ts
+++ b/Common/Tests/Types/Dashboard/NetworkDashboardTemplate.test.ts
@@ -1,0 +1,793 @@
+import DashboardChartType from "../../../Types/Dashboard/Chart/ChartType";
+import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import { DashboardValueTrendDirection } from "../../../Types/Dashboard/DashboardComponents/DashboardValueComponent";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import {
+  DashboardTemplate,
+  DashboardTemplateCategory,
+  DashboardTemplates,
+  DashboardTemplateType,
+  getDashboardTemplatesByCategory,
+  getTemplateConfig,
+} from "../../../Types/Dashboard/DashboardTemplates";
+import IconProp from "../../../Types/Icon/IconProp";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+
+/*
+ * Editorial invariants for the Network template specifically. The
+ * structural rules every template must satisfy (grid bounds, overlap,
+ * unique ids, aggregation spelling) live in DashboardTemplateInvariants —
+ * this file pins the things that make THIS template the Network one:
+ * which metrics it queries, which attributes it groups and varies by, and
+ * that the map is on it at all.
+ */
+
+/*
+ * The metric names are the wire contract: they are persisted into the
+ * saved dashboard as raw strings and matched against what the probe
+ * emitted. Pinned as literals rather than as MonitorMetricType members so
+ * that renaming a member's VALUE — which would silently empty every
+ * widget on every dashboard already created from this template — fails
+ * here instead of shipping.
+ *
+ * All five are emitted by exactly one code path,
+ * Common/Server/Utils/Monitor/NetworkDeviceMetricUtil.saveWalkMetrics, off
+ * a network device walk. That is the property the template depends on and
+ * the one the tests below defend.
+ */
+const INTERFACE_IN_METRIC: string =
+  "oneuptime.monitor.snmp.interface.in.bits.per.second";
+const INTERFACE_OUT_METRIC: string =
+  "oneuptime.monitor.snmp.interface.out.bits.per.second";
+const INTERFACE_UTILIZATION_METRIC: string =
+  "oneuptime.monitor.snmp.interface.utilization.percent";
+const INTERFACE_ERRORS_METRIC: string =
+  "oneuptime.monitor.snmp.interface.errors.per.second";
+const INTERFACE_OPER_STATUS_METRIC: string =
+  "oneuptime.monitor.snmp.interface.oper.status";
+
+/*
+ * Metrics that every probeable monitor in the project emits, NOT just
+ * network devices. A tile on a network dashboard built from one of these
+ * silently averages every website check in the project, so the template
+ * must not carry any.
+ */
+const PROJECT_WIDE_METRICS: Array<string> = [
+  "oneuptime.monitor.online",
+  "oneuptime.monitor.response.time",
+  "oneuptime.monitor.ping.packet.loss.percent",
+  "oneuptime.monitor.ping.jitter",
+];
+
+/*
+ * The two bare attribute keys NetworkDeviceMetricUtil stamps onto its
+ * rows: `deviceName` on every metric, `interfaceName` on the per-interface
+ * ones. They carry no `resource.` prefix, so a template that guessed
+ * "resource.deviceName" would compile and group by nothing.
+ */
+const DEVICE_ATTRIBUTE: string = "deviceName";
+const INTERFACE_ATTRIBUTE: string = "interfaceName";
+
+const AVG_AGGREGATION: string = "Avg";
+const MAX_AGGREGATION: string = "Max";
+const SUM_AGGREGATION: string = "Sum";
+
+const GRID_WIDTH_IN_UNITS: number = 12;
+
+// -- Helpers ---------------------------------------------------------------
+
+type WidgetArguments = Record<string, unknown>;
+
+function getConfig(): DashboardViewConfig {
+  const config: DashboardViewConfig | null = getTemplateConfig(
+    DashboardTemplateType.Network,
+  );
+  expect(config).not.toBeNull();
+  return config as DashboardViewConfig;
+}
+
+function argumentsOf(component: DashboardBaseComponent): WidgetArguments {
+  return (component.arguments as WidgetArguments | undefined) || {};
+}
+
+/*
+ * Every widget family stores its title under a different argument key, and
+ * titles are the only stable handle: ids are freshly generated on every
+ * call and array positions move whenever a row is inserted.
+ */
+const TITLE_ARGUMENT_KEYS: Array<string> = [
+  "title",
+  "chartTitle",
+  "gaugeTitle",
+  "tableTitle",
+  "text",
+];
+
+function titleOf(component: DashboardBaseComponent): string {
+  const args: WidgetArguments = argumentsOf(component);
+
+  for (const key of TITLE_ARGUMENT_KEYS) {
+    const value: unknown = args[key];
+
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+// Fails loudly (rather than returning undefined) when the widget is gone.
+function findWidget(
+  config: DashboardViewConfig,
+  title: string,
+): DashboardBaseComponent {
+  const matches: Array<DashboardBaseComponent> = config.components.filter(
+    (component: DashboardBaseComponent): boolean => {
+      return titleOf(component) === title;
+    },
+  );
+
+  expect(matches).toHaveLength(1);
+  return matches[0] as DashboardBaseComponent;
+}
+
+function componentsOfType(
+  config: DashboardViewConfig,
+  componentType: DashboardComponentType,
+): Array<DashboardBaseComponent> {
+  return config.components.filter(
+    (component: DashboardBaseComponent): boolean => {
+      return component.componentType === componentType;
+    },
+  );
+}
+
+function metricQueryDataOf(component: DashboardBaseComponent): WidgetArguments {
+  const queryConfig: WidgetArguments =
+    (argumentsOf(component)["metricQueryConfig"] as
+      | WidgetArguments
+      | undefined) || {};
+
+  return (queryConfig["metricQueryData"] as WidgetArguments | undefined) || {};
+}
+
+function filterDataOf(component: DashboardBaseComponent): WidgetArguments {
+  return (
+    (metricQueryDataOf(component)["filterData"] as
+      | WidgetArguments
+      | undefined) || {}
+  );
+}
+
+function metricNameOf(component: DashboardBaseComponent): string | undefined {
+  const value: unknown = filterDataOf(component)["metricName"];
+  return typeof value === "string" ? value : undefined;
+}
+
+/*
+ * The aggregation is stored under the MISSPELLED key `aggegationType`.
+ * That misspelling is what the fetch layer reads, so it is the contract.
+ */
+function aggregationOf(component: DashboardBaseComponent): unknown {
+  return filterDataOf(component)["aggegationType"];
+}
+
+function groupByAttributeKeysOf(component: DashboardBaseComponent): unknown {
+  return metricQueryDataOf(component)["groupByAttributeKeys"];
+}
+
+// -- Tests -----------------------------------------------------------------
+
+describe("Network dashboard template", () => {
+  describe("catalog entry", () => {
+    it("is registered exactly once", () => {
+      const entries: Array<DashboardTemplate> = DashboardTemplates.filter(
+        (template: DashboardTemplate): boolean => {
+          return template.type === DashboardTemplateType.Network;
+        },
+      );
+
+      expect(entries).toHaveLength(1);
+    });
+
+    it("is filed under Infrastructure with a map icon and a real description", () => {
+      const entry: DashboardTemplate = DashboardTemplates.find(
+        (template: DashboardTemplate): boolean => {
+          return template.type === DashboardTemplateType.Network;
+        },
+      ) as DashboardTemplate;
+
+      expect(entry.name).toBe("Network Dashboard");
+      expect(entry.category).toBe(DashboardTemplateCategory.Infrastructure);
+      expect(entry.icon).toBe(IconProp.Map);
+      expect(entry.description.trim().length).toBeGreaterThan(0);
+    });
+
+    it("is listed by getDashboardTemplatesByCategory for Infrastructure", () => {
+      const types: Array<DashboardTemplateType> =
+        getDashboardTemplatesByCategory(
+          DashboardTemplateCategory.Infrastructure,
+        ).map((template: DashboardTemplate): DashboardTemplateType => {
+          return template.type;
+        });
+
+      expect(types).toContain(DashboardTemplateType.Network);
+    });
+
+    it("resolves to a config rather than to null the way Blank does", () => {
+      expect(getTemplateConfig(DashboardTemplateType.Network)).not.toBeNull();
+    });
+  });
+
+  describe("the map", () => {
+    /*
+     * This is the whole reason the template exists: a network dashboard
+     * that does not show WHERE the network is, is just a metrics
+     * dashboard with SNMP metric names on it.
+     */
+    it("puts exactly one Network Map on the dashboard", () => {
+      expect(
+        componentsOfType(getConfig(), DashboardComponentType.NetworkMap),
+      ).toHaveLength(1);
+    });
+
+    it("opens the map in map mode with names on, not as a table", () => {
+      const args: WidgetArguments = argumentsOf(
+        findWidget(getConfig(), "Sites"),
+      );
+
+      expect(args["viewMode"]).toBe("map");
+      expect(args["showLabels"]).toBe(true);
+    });
+
+    it("caps the map's fetch at a positive whole number of sites", () => {
+      const maxSites: unknown = argumentsOf(findWidget(getConfig(), "Sites"))[
+        "maxSites"
+      ];
+
+      expect(typeof maxSites).toBe("number");
+      expect(Number.isInteger(maxSites as number)).toBe(true);
+      expect(maxSites as number).toBeGreaterThan(0);
+    });
+
+    it("does not pre-filter the map to a status, so it opens on the whole estate", () => {
+      expect(
+        argumentsOf(findWidget(getConfig(), "Sites"))["statusFilter"],
+      ).toBeUndefined();
+    });
+
+    /*
+     * The world is roughly 2:1. The map is the largest thing on the
+     * dashboard and it has to be tall as well as wide, or it renders as a
+     * letterboxed strip with every marker on top of every other.
+     */
+    it("gives the map a tile that is big in both axes", () => {
+      const map: DashboardBaseComponent = findWidget(getConfig(), "Sites");
+
+      expect(map.widthInDashboardUnits).toBeGreaterThanOrEqual(6);
+      expect(map.heightInDashboardUnits).toBeGreaterThanOrEqual(4);
+      expect(map.minWidthInDashboardUnits).toBe(4);
+      expect(map.minHeightInDashboardUnits).toBe(4);
+    });
+
+    it("places the map in the top band, above every section header below it", () => {
+      const config: DashboardViewConfig = getConfig();
+      const map: DashboardBaseComponent = findWidget(config, "Sites");
+
+      expect(map.topInDashboardUnits).toBe(1);
+      expect(map.leftInDashboardUnits).toBe(0);
+    });
+  });
+
+  describe("metric queries", () => {
+    it("queries only SNMP metrics the device walk actually emits", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      expect(metricNameOf(findWidget(config, "Interfaces Up (avg)"))).toBe(
+        INTERFACE_OPER_STATUS_METRIC,
+      );
+      expect(
+        metricNameOf(findWidget(config, "Avg Interface Utilization")),
+      ).toBe(INTERFACE_UTILIZATION_METRIC);
+      expect(
+        metricNameOf(findWidget(config, "Worst Interface Errors/sec")),
+      ).toBe(INTERFACE_ERRORS_METRIC);
+      expect(metricNameOf(findWidget(config, "Peak Inbound"))).toBe(
+        INTERFACE_IN_METRIC,
+      );
+      expect(metricNameOf(findWidget(config, "Peak Outbound"))).toBe(
+        INTERFACE_OUT_METRIC,
+      );
+      expect(metricNameOf(findWidget(config, "Inbound by Interface"))).toBe(
+        INTERFACE_IN_METRIC,
+      );
+      expect(metricNameOf(findWidget(config, "Outbound by Interface"))).toBe(
+        INTERFACE_OUT_METRIC,
+      );
+      expect(
+        metricNameOf(findWidget(config, "Peak Interface Utilization")),
+      ).toBe(INTERFACE_UTILIZATION_METRIC);
+      expect(metricNameOf(findWidget(config, "Interface Error Rate"))).toBe(
+        INTERFACE_ERRORS_METRIC,
+      );
+      expect(
+        metricNameOf(findWidget(config, "Interface Errors by Interface")),
+      ).toBe(INTERFACE_ERRORS_METRIC);
+      expect(metricNameOf(findWidget(config, "Utilization by Interface"))).toBe(
+        INTERFACE_UTILIZATION_METRIC,
+      );
+    });
+
+    /*
+     * THE invariant of this template. `oneuptime.monitor.online`,
+     * `.response.time`, `.ping.packet.loss.percent` and `.ping.jitter` are
+     * emitted by MonitorMetricUtil for EVERY probeable monitor in the
+     * project, not just network devices — so a tile built on one of them
+     * would average every website check in the project while wearing a
+     * network label. Device reachability lives on this dashboard as the
+     * Network Device monitor list, which is correctly scoped.
+     */
+    it("carries no metric that monitors outside the network estate also emit", () => {
+      const offenders: Array<string> = [];
+
+      for (const component of getConfig().components) {
+        const metric: string | undefined = metricNameOf(component);
+
+        if (metric && PROJECT_WIDE_METRICS.includes(metric)) {
+          offenders.push(`${titleOf(component)} -> ${metric}`);
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+
+    it("queries an snmp metric namespace on every metric-bearing widget", () => {
+      const metrics: Array<string> = [];
+
+      for (const component of getConfig().components) {
+        const metric: string | undefined = metricNameOf(component);
+
+        if (metric) {
+          metrics.push(metric);
+        }
+      }
+
+      expect(metrics.length).toBeGreaterThan(0);
+
+      for (const metric of metrics) {
+        expect(metric.startsWith("oneuptime.monitor.snmp.")).toBe(true);
+      }
+    });
+
+    /*
+     * The aggregation is not decoration, and Sum is never right here. The
+     * interface series are already per-second RATES, and a Value tile
+     * reduces across time buckets — so a summed rate doubles when somebody
+     * widens the time picker, describing the dashboard rather than the
+     * network. Max answers "how bad did it get", Avg answers "what is
+     * normal"; both are range-independent.
+     */
+    it("never aggregates a per-second rate with Sum", () => {
+      const summed: Array<string> = [];
+
+      for (const component of getConfig().components) {
+        if (
+          metricNameOf(component) &&
+          aggregationOf(component) === SUM_AGGREGATION
+        ) {
+          summed.push(titleOf(component));
+        }
+      }
+
+      expect(summed).toEqual([]);
+    });
+
+    it("picks the aggregation that makes each number mean what its title says", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      for (const title of [
+        "Peak Interface Utilization",
+        "Worst Interface Errors/sec",
+        "Peak Inbound",
+        "Peak Outbound",
+      ]) {
+        expect(aggregationOf(findWidget(config, title))).toBe(MAX_AGGREGATION);
+      }
+
+      for (const title of [
+        "Interfaces Up (avg)",
+        "Avg Interface Utilization",
+        "Interface Error Rate",
+        "Inbound by Interface",
+        "Outbound by Interface",
+        "Interface Errors by Interface",
+        "Utilization by Interface",
+      ]) {
+        expect(aggregationOf(findWidget(config, title))).toBe(AVG_AGGREGATION);
+      }
+    });
+
+    /*
+     * "Is a link saturated" is only answerable per link. A throughput
+     * chart that does not split by interface draws one flat line that is
+     * the average of a saturated uplink and nine idle access ports.
+     */
+    it("splits the per-interface charts by interfaceName", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      for (const title of [
+        "Inbound by Interface",
+        "Outbound by Interface",
+        "Interface Errors by Interface",
+        "Utilization by Interface",
+      ]) {
+        expect(groupByAttributeKeysOf(findWidget(config, title))).toEqual([
+          INTERFACE_ATTRIBUTE,
+        ]);
+      }
+    });
+
+    /*
+     * These two metrics are already RATES computed by the probe from the
+     * SNMP counter deltas, unlike the Ceph template's cumulative
+     * ceph_pool_*_bytes counters. Rate-transforming them would plot the
+     * rate of change of a rate — a chart that reads as noise around zero.
+     */
+    it("does not rate-transform the interface bit-rate charts", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      for (const title of ["Inbound by Interface", "Outbound by Interface"]) {
+        const queryConfig: WidgetArguments =
+          (argumentsOf(findWidget(config, title))["metricQueryConfig"] as
+            | WidgetArguments
+            | undefined) || {};
+
+        expect(queryConfig["transformAsRate"]).toBeUndefined();
+      }
+    });
+
+    it("marks every 'more is worse' number so its trend arrow is colored right", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      for (const title of [
+        "Avg Interface Utilization",
+        "Worst Interface Errors/sec",
+      ]) {
+        expect(argumentsOf(findWidget(config, title))["trendDirection"]).toBe(
+          DashboardValueTrendDirection.HigherIsWorse,
+        );
+      }
+
+      expect(
+        argumentsOf(findWidget(config, "Interfaces Up (avg)"))[
+          "trendDirection"
+        ],
+      ).toBe(DashboardValueTrendDirection.HigherIsBetter);
+
+      /*
+       * Throughput is deliberately unmarked: more traffic through an uplink
+       * is neither good nor bad on its own, and a colored arrow would claim
+       * otherwise. The renderer falls back to its neutral heuristic.
+       */
+      for (const title of ["Peak Inbound", "Peak Outbound"]) {
+        expect(
+          argumentsOf(findWidget(config, title))["trendDirection"],
+        ).toBeUndefined();
+      }
+    });
+
+    /*
+     * A dashboard that prints the same figure under two names is a smaller
+     * dashboard pretending to be a bigger one. A number paired with its own
+     * trend chart is fine — that is a different AGGREGATION shape, not a
+     * repeat — so the check is on (metric, aggregation, widget family).
+     */
+    it("never prints the same metric and aggregation twice in the same widget family", () => {
+      const seen: Map<string, string> = new Map<string, string>();
+      const duplicates: Array<string> = [];
+
+      for (const component of getConfig().components) {
+        const metric: string | undefined = metricNameOf(component);
+
+        if (!metric) {
+          continue;
+        }
+
+        const key: string = `${component.componentType}|${metric}|${String(
+          aggregationOf(component),
+        )}`;
+        const existing: string | undefined = seen.get(key);
+
+        if (existing) {
+          duplicates.push(
+            `${key} on "${existing}" and "${titleOf(component)}"`,
+          );
+        }
+
+        seen.set(key, titleOf(component));
+      }
+
+      expect(duplicates).toEqual([]);
+    });
+
+    it("gives every widget on the dashboard a distinct title", () => {
+      const titles: Array<string> = getConfig().components.map(titleOf);
+
+      expect(
+        titles.every((title: string): boolean => {
+          return title.trim().length > 0;
+        }),
+      ).toBe(true);
+      expect(new Set(titles).size).toBe(titles.length);
+    });
+  });
+
+  describe("gauges", () => {
+    /*
+     * A healthy Ethernet port errors essentially never, while a link at 60%
+     * utilization is simply busy. Putting the error gauge on the same
+     * 0-100 scale as the utilization gauge beside it would render every
+     * real fault as a flat line on the floor.
+     */
+    it("scales the error gauge for a metric that is normally zero", () => {
+      const config: DashboardViewConfig = getConfig();
+      const errors: WidgetArguments = argumentsOf(
+        findWidget(config, "Interface Error Rate"),
+      );
+      const utilization: WidgetArguments = argumentsOf(
+        findWidget(config, "Peak Interface Utilization"),
+      );
+
+      expect(errors["minValue"]).toBe(0);
+      expect(errors["maxValue"]).toBe(10);
+      expect(errors["warningThreshold"]).toBe(1);
+      expect(errors["criticalThreshold"]).toBe(5);
+
+      expect(utilization["minValue"]).toBe(0);
+      expect(utilization["maxValue"]).toBe(100);
+      expect(utilization["warningThreshold"]).toBe(70);
+      expect(utilization["criticalThreshold"]).toBe(90);
+
+      expect(errors["maxValue"] as number).toBeLessThan(
+        utilization["maxValue"] as number,
+      );
+    });
+
+    it("orders every gauge min <= warning < critical <= max", () => {
+      for (const title of [
+        "Peak Interface Utilization",
+        "Interface Error Rate",
+      ]) {
+        const args: WidgetArguments = argumentsOf(
+          findWidget(getConfig(), title),
+        );
+
+        expect(args["minValue"] as number).toBeLessThanOrEqual(
+          args["warningThreshold"] as number,
+        );
+        expect(args["warningThreshold"] as number).toBeLessThan(
+          args["criticalThreshold"] as number,
+        );
+        expect(args["criticalThreshold"] as number).toBeLessThanOrEqual(
+          args["maxValue"] as number,
+        );
+      }
+    });
+  });
+
+  describe("the monitor list", () => {
+    /*
+     * An unfiltered monitor list on a network dashboard is the Monitors
+     * page with fewer columns. Pinning it to Network Device monitors is
+     * what makes it worth the tile.
+     */
+    it("is pinned to Network Device monitors", () => {
+      const args: WidgetArguments = argumentsOf(
+        findWidget(getConfig(), "Network Device Monitors"),
+      );
+
+      expect(args["monitorTypes"]).toEqual([MonitorType.NetworkDevice]);
+    });
+
+    it("renders as a list and caps its rows", () => {
+      const args: WidgetArguments = argumentsOf(
+        findWidget(getConfig(), "Network Device Monitors"),
+      );
+
+      expect(args["viewMode"]).toBe("list");
+      expect(args["maxRows"] as number).toBeGreaterThan(0);
+    });
+  });
+
+  describe("variables", () => {
+    it("ships a Device and an Interface picker, both multi-select", () => {
+      const variables: Array<DashboardVariable> = getConfig().variables || [];
+
+      expect(
+        variables.map((variable: DashboardVariable): string => {
+          return variable.name;
+        }),
+      ).toEqual(["device", "interface"]);
+
+      for (const variable of variables) {
+        expect(variable.type).toBe(DashboardVariableType.TelemetryAttribute);
+        /*
+         * Comparing two uplinks, or two branch routers, is the normal use
+         * of this dashboard rather than the exception.
+         */
+        expect(variable.isMultiSelect).toBe(true);
+        expect((variable.label || "").trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    /*
+     * Network device metrics carry BARE attribute keys — see
+     * NetworkDeviceMetricUtil.buildDeviceMetricRow. A variable bound to
+     * `resource.deviceName` would offer an empty picker.
+     */
+    it("binds to the bare attribute keys, not the resource-prefixed ones", () => {
+      const variables: Array<DashboardVariable> = getConfig().variables || [];
+
+      expect(
+        variables.map((variable: DashboardVariable): string | undefined => {
+          return variable.attributeKey;
+        }),
+      ).toEqual([DEVICE_ATTRIBUTE, INTERFACE_ATTRIBUTE]);
+    });
+  });
+
+  describe("layout", () => {
+    it("lays every widget out inside the 12-unit grid", () => {
+      for (const component of getConfig().components) {
+        expect(component.leftInDashboardUnits).toBeGreaterThanOrEqual(0);
+        expect(component.topInDashboardUnits).toBeGreaterThanOrEqual(0);
+        expect(
+          component.leftInDashboardUnits + component.widthInDashboardUnits,
+        ).toBeLessThanOrEqual(GRID_WIDTH_IN_UNITS);
+      }
+    });
+
+    /*
+     * A band of empty rows in the middle of a template reads as a widget
+     * that failed to render rather than as whitespace. Every row from the
+     * title to the last widget must be occupied by something.
+     */
+    it("leaves no empty row between the title and the last widget", () => {
+      const config: DashboardViewConfig = getConfig();
+      const lowestEdge: number = Math.max(
+        ...config.components.map(
+          (component: DashboardBaseComponent): number => {
+            return (
+              component.topInDashboardUnits + component.heightInDashboardUnits
+            );
+          },
+        ),
+      );
+
+      const occupiedRows: Set<number> = new Set<number>();
+      for (const component of config.components) {
+        for (
+          let row: number = component.topInDashboardUnits;
+          row <
+          component.topInDashboardUnits + component.heightInDashboardUnits;
+          row++
+        ) {
+          occupiedRows.add(row);
+        }
+      }
+
+      const emptyRows: Array<number> = [];
+      for (let row: number = 0; row < lowestEdge; row++) {
+        if (!occupiedRows.has(row)) {
+          emptyRows.push(row);
+        }
+      }
+
+      expect(emptyRows).toEqual([]);
+    });
+
+    it("is tall enough to contain everything on it", () => {
+      const config: DashboardViewConfig = getConfig();
+      const lowestEdge: number = Math.max(
+        ...config.components.map(
+          (component: DashboardBaseComponent): number => {
+            return (
+              component.topInDashboardUnits + component.heightInDashboardUnits
+            );
+          },
+        ),
+      );
+
+      expect(config.heightInDashboardUnits).toBeGreaterThanOrEqual(lowestEdge);
+    });
+
+    it("opens with a bold title row across the full width", () => {
+      const title: DashboardBaseComponent = findWidget(
+        getConfig(),
+        "Network Dashboard",
+      );
+
+      expect(title.componentType).toBe(DashboardComponentType.Text);
+      expect(title.topInDashboardUnits).toBe(0);
+      expect(title.widthInDashboardUnits).toBe(GRID_WIDTH_IN_UNITS);
+      expect(argumentsOf(title)["isBold"]).toBe(true);
+    });
+
+    it("labels each band with its own bold section header", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      for (const heading of [
+        "Interface Throughput",
+        "Utilization & Errors",
+        "Devices & Monitors",
+      ]) {
+        const header: DashboardBaseComponent = findWidget(config, heading);
+
+        expect(header.componentType).toBe(DashboardComponentType.Text);
+        expect(header.widthInDashboardUnits).toBe(GRID_WIDTH_IN_UNITS);
+        expect(argumentsOf(header)["isBold"]).toBe(true);
+      }
+    });
+
+    it("picks a chart shape that suits each series", () => {
+      const config: DashboardViewConfig = getConfig();
+
+      // Filled areas for volume...
+      expect(
+        argumentsOf(findWidget(config, "Inbound by Interface"))["chartType"],
+      ).toBe(DashboardChartType.Area);
+      expect(
+        argumentsOf(findWidget(config, "Outbound by Interface"))["chartType"],
+      ).toBe(DashboardChartType.Area);
+      // ...a line for a percentage that should be read against a threshold...
+      expect(
+        argumentsOf(findWidget(config, "Utilization by Interface"))[
+          "chartType"
+        ],
+      ).toBe(DashboardChartType.Line);
+      // ...and bars for a mostly-zero series where each spike is an event.
+      expect(
+        argumentsOf(findWidget(config, "Interface Errors by Interface"))[
+          "chartType"
+        ],
+      ).toBe(DashboardChartType.Bar);
+    });
+  });
+
+  describe("freshness", () => {
+    /*
+     * Two dashboards created from this template must not share component
+     * or variable ids — they are independent saved rows from the moment
+     * they are created.
+     */
+    it("generates fresh component and variable ids on every call", () => {
+      const first: DashboardViewConfig = getConfig();
+      const second: DashboardViewConfig = getConfig();
+
+      const firstComponentIds: Set<string> = new Set<string>(
+        first.components.map((component: DashboardBaseComponent): string => {
+          return component.componentId.toString();
+        }),
+      );
+      for (const component of second.components) {
+        expect(firstComponentIds.has(component.componentId.toString())).toBe(
+          false,
+        );
+      }
+
+      const firstVariableIds: Set<string> = new Set<string>(
+        (first.variables || []).map((variable: DashboardVariable): string => {
+          return variable.id;
+        }),
+      );
+      for (const variable of second.variables || []) {
+        expect(firstVariableIds.has(variable.id)).toBe(false);
+      }
+    });
+  });
+});

--- a/Common/Tests/Utils/Dashboard/DashboardNetworkMapComponent.test.ts
+++ b/Common/Tests/Utils/Dashboard/DashboardNetworkMapComponent.test.ts
@@ -1,0 +1,327 @@
+import {
+  ComponentArgument,
+  ComponentArgumentSection,
+  ComponentInputType,
+  EntityFilterModelType,
+} from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
+import DashboardBaseComponent from "../../../Types/Dashboard/DashboardComponents/DashboardBaseComponent";
+import DashboardNetworkMapComponent from "../../../Types/Dashboard/DashboardComponents/DashboardNetworkMapComponent";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import { ObjectType } from "../../../Types/JSON";
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+import DashboardComponentsUtil from "../../../Utils/Dashboard/Components/Index";
+import DashboardNetworkMapComponentUtil, {
+  DEFAULT_MAX_SITES,
+} from "../../../Utils/Dashboard/Components/DashboardNetworkMapComponent";
+
+type ArgumentIds = keyof DashboardNetworkMapComponent["arguments"];
+
+function getArguments(): Array<
+  ComponentArgument<DashboardNetworkMapComponent>
+> {
+  return DashboardNetworkMapComponentUtil.getComponentConfigArguments();
+}
+
+function getArgumentById(
+  id: ArgumentIds,
+): ComponentArgument<DashboardNetworkMapComponent> {
+  const found: ComponentArgument<DashboardNetworkMapComponent> | undefined =
+    getArguments().find(
+      (arg: ComponentArgument<DashboardNetworkMapComponent>) => {
+        return arg.id === id;
+      },
+    );
+
+  if (!found) {
+    throw new Error(`No Network Map widget argument declared with id "${id}"`);
+  }
+
+  return found;
+}
+
+function getDropdownValues(id: ArgumentIds): Array<string> {
+  return (getArgumentById(id).dropdownOptions || []).map(
+    (option: DropdownOption): string => {
+      return String(option.value);
+    },
+  );
+}
+
+describe("DashboardNetworkMapComponentUtil", () => {
+  describe("getDefaultComponent", () => {
+    it("declares its componentType as NetworkMap so the renderer dispatch matches", () => {
+      expect(
+        DashboardNetworkMapComponentUtil.getDefaultComponent().componentType,
+      ).toBe(DashboardComponentType.NetworkMap);
+    });
+
+    it("marks itself as a dashboard component so it survives config serialization", () => {
+      expect(DashboardNetworkMapComponentUtil.getDefaultComponent()._type).toBe(
+        ObjectType.DashboardComponent,
+      );
+    });
+
+    it("places a 6x5 tile at the canvas origin", () => {
+      const component: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+
+      expect(component.widthInDashboardUnits).toBe(6);
+      expect(component.heightInDashboardUnits).toBe(5);
+      expect(component.topInDashboardUnits).toBe(0);
+      expect(component.leftInDashboardUnits).toBe(0);
+    });
+
+    /*
+     * The world is roughly 2:1, so a tile that is allowed to be short and
+     * wide letterboxes the map into an unreadable strip. The minimum has to
+     * bound BOTH axes, and the default has to sit at or above it — a widget
+     * that spawns below its own minimum is one the resize handles then
+     * refuse to shrink.
+     */
+    it("cannot be resized below a square-ish 4x4, and spawns at or above that", () => {
+      const component: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+
+      expect(component.minWidthInDashboardUnits).toBe(4);
+      expect(component.minHeightInDashboardUnits).toBe(4);
+      expect(component.widthInDashboardUnits).toBeGreaterThanOrEqual(
+        component.minWidthInDashboardUnits,
+      );
+      expect(component.heightInDashboardUnits).toBeGreaterThanOrEqual(
+        component.minHeightInDashboardUnits,
+      );
+    });
+
+    it("fits inside the 12-unit dashboard grid", () => {
+      const component: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+
+      expect(
+        component.leftInDashboardUnits + component.widthInDashboardUnits,
+      ).toBeLessThanOrEqual(12);
+    });
+
+    it("opens on the map rather than the list, with names on and the row cap seeded", () => {
+      const component: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+
+      expect(component.arguments.viewMode).toBe("map");
+      expect(component.arguments.showLabels).toBe(true);
+      expect(component.arguments.maxSites).toBe(DEFAULT_MAX_SITES);
+    });
+
+    it("seeds no filters, so a freshly added widget shows the whole estate", () => {
+      const component: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+
+      expect(component.arguments.statusFilter).toBeUndefined();
+      expect(component.arguments.networkSiteTypeIds).toBeUndefined();
+    });
+
+    /*
+     * Two widgets dropped on the same dashboard must not share an id — the
+     * canvas keys, selects and persists components by it.
+     */
+    it("generates a fresh component id on every call", () => {
+      const first: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+      const second: DashboardNetworkMapComponent =
+        DashboardNetworkMapComponentUtil.getDefaultComponent();
+
+      expect(first.componentId.toString()).not.toBe(
+        second.componentId.toString(),
+      );
+    });
+
+    it("caps the fetch at a bounded number of sites", () => {
+      expect(DEFAULT_MAX_SITES).toBeGreaterThan(0);
+      expect(Number.isInteger(DEFAULT_MAX_SITES)).toBe(true);
+    });
+  });
+
+  describe("getComponentConfigArguments", () => {
+    it("declares exactly the arguments the widget reads", () => {
+      const ids: Array<unknown> = getArguments().map(
+        (arg: ComponentArgument<DashboardNetworkMapComponent>) => {
+          return arg.id;
+        },
+      );
+
+      expect(ids).toEqual([
+        "title",
+        "viewMode",
+        "maxSites",
+        "showLabels",
+        "networkSiteTypeIds",
+        "statusFilter",
+      ]);
+    });
+
+    it("declares no duplicate argument ids", () => {
+      const ids: Array<unknown> = getArguments().map(
+        (arg: ComponentArgument<DashboardNetworkMapComponent>) => {
+          return arg.id;
+        },
+      );
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("gives every argument a name, a description and no required flag", () => {
+      for (const arg of getArguments()) {
+        expect(arg.name.trim().length).toBeGreaterThan(0);
+        expect(arg.description.trim().length).toBeGreaterThan(0);
+        /*
+         * Every argument has a working default, so none of them may be
+         * required — a required field with a default is a form the user
+         * cannot submit without re-entering what is already true.
+         */
+        expect(arg.required).toBe(false);
+      }
+    });
+
+    it("types each argument as the input the settings form should render", () => {
+      expect(getArgumentById("title").type).toBe(ComponentInputType.Text);
+      expect(getArgumentById("viewMode").type).toBe(
+        ComponentInputType.Dropdown,
+      );
+      expect(getArgumentById("maxSites").type).toBe(ComponentInputType.Number);
+      expect(getArgumentById("showLabels").type).toBe(
+        ComponentInputType.Boolean,
+      );
+      expect(getArgumentById("networkSiteTypeIds").type).toBe(
+        ComponentInputType.EntityMultiSelectDropdown,
+      );
+      expect(getArgumentById("statusFilter").type).toBe(
+        ComponentInputType.Dropdown,
+      );
+    });
+
+    /*
+     * The site-type picker has to name a model the EntityFilterDropdown
+     * switch knows about, or it throws when the settings modal opens.
+     */
+    it("binds the site-type picker to the NetworkSiteType lookup table", () => {
+      expect(getArgumentById("networkSiteTypeIds").entityFilterModelType).toBe(
+        EntityFilterModelType.NetworkSiteType,
+      );
+    });
+
+    it("gives only the entity picker an entityFilterModelType", () => {
+      for (const arg of getArguments()) {
+        if (arg.id === "networkSiteTypeIds") {
+          continue;
+        }
+        expect(arg.entityFilterModelType).toBeUndefined();
+      }
+    });
+
+    it("offers exactly the two view modes the renderer implements", () => {
+      expect(getDropdownValues("viewMode")).toEqual(["map", "list"]);
+    });
+
+    /*
+     * The empty option is what lets somebody UNDO a status filter. Without
+     * it the only way back to "all sites" is to delete the widget.
+     */
+    it("offers an empty status option so the filter can be cleared", () => {
+      expect(getDropdownValues("statusFilter")).toEqual([
+        "",
+        "down",
+        "operational",
+      ]);
+    });
+
+    it("gives every dropdown option a non-empty label", () => {
+      for (const arg of getArguments()) {
+        for (const option of arg.dropdownOptions || []) {
+          expect(String(option.label).trim().length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("splits the arguments into a Display section and a collapsed Filters section", () => {
+      const sectionOf: (
+        id: ArgumentIds,
+      ) => ComponentArgumentSection | undefined = (
+        id: ArgumentIds,
+      ): ComponentArgumentSection | undefined => {
+        return getArgumentById(id).section;
+      };
+
+      for (const id of [
+        "title",
+        "viewMode",
+        "maxSites",
+        "showLabels",
+      ] as Array<ArgumentIds>) {
+        expect(sectionOf(id)?.name).toBe("Display Options");
+      }
+
+      for (const id of [
+        "networkSiteTypeIds",
+        "statusFilter",
+      ] as Array<ArgumentIds>) {
+        expect(sectionOf(id)?.name).toBe("Filters");
+      }
+
+      expect(sectionOf("title")?.order).toBeLessThan(
+        sectionOf("statusFilter")?.order as number,
+      );
+      expect(sectionOf("statusFilter")?.defaultCollapsed).toBe(true);
+    });
+
+    it("returns a fresh array each call so a caller cannot mutate the declaration", () => {
+      const first: Array<ComponentArgument<DashboardNetworkMapComponent>> =
+        getArguments();
+      first.pop();
+
+      expect(getArguments()).toHaveLength(6);
+    });
+  });
+
+  /*
+   * These go through the registry's public lookup rather than the util
+   * directly, so forgetting to wire DashboardComponentType.NetworkMap into
+   * Common/Utils/Dashboard/Components/Index.ts fails the suite. Nothing else
+   * in the codebase asserts that registry is exhaustive.
+   */
+  describe("registration in DashboardComponentsUtil", () => {
+    it("resolves DashboardComponentType.NetworkMap instead of throwing", () => {
+      expect(() => {
+        return DashboardComponentsUtil.getComponentSettingsArguments(
+          DashboardComponentType.NetworkMap,
+        );
+      }).not.toThrow();
+    });
+
+    it("returns the Network Map widget's own arguments for that type", () => {
+      const fromRegistry: Array<ComponentArgument<DashboardBaseComponent>> =
+        DashboardComponentsUtil.getComponentSettingsArguments(
+          DashboardComponentType.NetworkMap,
+        );
+
+      expect(
+        fromRegistry.map(
+          (arg: ComponentArgument<DashboardBaseComponent>): unknown => {
+            return arg.id;
+          },
+        ),
+      ).toEqual(
+        getArguments().map(
+          (arg: ComponentArgument<DashboardNetworkMapComponent>): unknown => {
+            return arg.id;
+          },
+        ),
+      );
+    });
+
+    it("still throws for a component type that is not registered", () => {
+      expect(() => {
+        return DashboardComponentsUtil.getComponentSettingsArguments(
+          "NotARealWidget" as DashboardComponentType,
+        );
+      }).toThrow();
+    });
+  });
+});

--- a/Common/Types/Dashboard/DashboardComponentType.ts
+++ b/Common/Types/Dashboard/DashboardComponentType.ts
@@ -39,6 +39,7 @@ enum DashboardComponentType {
   DockerSwarmServiceList = `DockerSwarmServiceList`,
   CephOsdList = `CephOsdList`,
   CephPoolList = `CephPoolList`,
+  NetworkMap = `NetworkMap`,
   Html = `Html`,
 }
 

--- a/Common/Types/Dashboard/DashboardComponents/ComponentArgument.ts
+++ b/Common/Types/Dashboard/DashboardComponents/ComponentArgument.ts
@@ -39,6 +39,7 @@ export enum EntityFilterModelType {
   ProxmoxCluster = "ProxmoxCluster",
   CephCluster = "CephCluster",
   DockerSwarmCluster = "DockerSwarmCluster",
+  NetworkSiteType = "NetworkSiteType",
 }
 
 export interface ComponentArgumentSection {

--- a/Common/Types/Dashboard/DashboardComponents/DashboardNetworkMapComponent.ts
+++ b/Common/Types/Dashboard/DashboardComponents/DashboardNetworkMapComponent.ts
@@ -1,0 +1,40 @@
+import ObjectID from "../../ObjectID";
+import DashboardComponentType from "../DashboardComponentType";
+import BaseComponent from "./DashboardBaseComponent";
+
+/*
+ * The dashboard-embeddable half of the Network Map: a world map of this
+ * project's NetworkSites, each pinned at its own coordinates and colored by
+ * the monitor status rolled up onto it.
+ *
+ * It is deliberately NOT the drill-down map from Pages/NetworkSite/NetworkMap
+ * — that one navigates, and a dashboard tile is a picture rather than a
+ * place you walk around in. This widget answers one question at a glance:
+ * where is the network, and what is red right now.
+ */
+export default interface DashboardNetworkMapComponent extends BaseComponent {
+  componentType: DashboardComponentType.NetworkMap;
+  componentId: ObjectID;
+  arguments: {
+    title?: string | undefined;
+    /*
+     * How many sites the widget will draw. Sites past the cap are dropped
+     * rather than silently merged, and the footer says so — a count that
+     * quietly disagrees with the Sites page is how somebody concludes a
+     * site has disappeared.
+     */
+    maxSites?: number | undefined;
+    // Restrict the map to sites of these NetworkSiteType rows.
+    networkSiteTypeIds?: Array<string> | undefined;
+    /*
+     * "" / undefined  — every site with coordinates.
+     * "down"          — only sites whose rolled-up status is not operational.
+     * "operational"   — only sites whose rolled-up status is operational.
+     */
+    statusFilter?: string | undefined;
+    // "map" (default) draws the world map; "list" falls back to a table.
+    viewMode?: "map" | "list" | undefined;
+    // Print each marker's site name under it when the map is not too busy.
+    showLabels?: boolean | undefined;
+  };
+}

--- a/Common/Types/Dashboard/DashboardTemplates.ts
+++ b/Common/Types/Dashboard/DashboardTemplates.ts
@@ -11,6 +11,7 @@ import MetricsAggregationType from "../Metrics/MetricsAggregationType";
 import IncidentMetricType from "../Incident/IncidentMetricType";
 import AlertMetricType from "../Alerts/AlertMetricType";
 import MonitorMetricType from "../Monitor/MonitorMetricType";
+import MonitorType from "../Monitor/MonitorType";
 import MetricDashboardMetricType from "../Metrics/MetricDashboardMetricType";
 import { DashboardValueTrendDirection } from "./DashboardComponents/DashboardValueComponent";
 
@@ -39,6 +40,7 @@ export enum DashboardTemplateType {
   DockerSwarm = "DockerSwarm",
   Metrics = "Metrics",
   Rum = "Rum",
+  Network = "Network",
 }
 
 /*
@@ -163,6 +165,14 @@ export const DashboardTemplates: Array<DashboardTemplate> = [
     description:
       "Live node and service inventories with role/status, container CPU and memory trends, PID counts, and cluster logs.",
     icon: IconProp.Cube,
+    category: DashboardTemplateCategory.Infrastructure,
+  },
+  {
+    type: DashboardTemplateType.Network,
+    name: "Network Dashboard",
+    description:
+      "Your sites on the world map, SNMP interface throughput, utilization and errors, device reachability and round-trip latency, and the monitors watching them.",
+    icon: IconProp.Map,
     category: DashboardTemplateCategory.Infrastructure,
   },
 ];
@@ -792,6 +802,71 @@ function createCephPoolListComponent(data: {
     arguments: {
       title: data.title,
       maxRows: data.maxRows ?? 20,
+    },
+  };
+}
+
+function createNetworkMapComponent(data: {
+  title: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  maxSites?: number;
+  statusFilter?: string;
+  showLabels?: boolean;
+}): DashboardBaseComponent {
+  return {
+    _type: ObjectType.DashboardComponent,
+    componentType: DashboardComponentType.NetworkMap,
+    componentId: ObjectID.generate(),
+    topInDashboardUnits: data.top,
+    leftInDashboardUnits: data.left,
+    widthInDashboardUnits: data.width,
+    heightInDashboardUnits: data.height,
+    /*
+     * A map needs room in BOTH axes — the world is roughly 2:1, so a short
+     * tile letterboxes it into a strip. Same floor the widget's own default
+     * declares (Common/Utils/Dashboard/Components/DashboardNetworkMapComponent).
+     */
+    minHeightInDashboardUnits: 4,
+    minWidthInDashboardUnits: 4,
+    arguments: {
+      title: data.title,
+      maxSites: data.maxSites ?? 250,
+      viewMode: "map",
+      showLabels: data.showLabels ?? true,
+      statusFilter: data.statusFilter,
+    },
+  };
+}
+
+function createMonitorListComponent(data: {
+  title: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  maxRows?: number;
+  monitorTypes?: Array<string>;
+  statusFilter?: string;
+}): DashboardBaseComponent {
+  return {
+    _type: ObjectType.DashboardComponent,
+    componentType: DashboardComponentType.MonitorList,
+    componentId: ObjectID.generate(),
+    topInDashboardUnits: data.top,
+    leftInDashboardUnits: data.left,
+    widthInDashboardUnits: data.width,
+    heightInDashboardUnits: data.height,
+    minHeightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 6,
+    arguments: {
+      title: data.title,
+      maxRows: data.maxRows ?? 25,
+      viewMode: "list",
+      monitorTypes: data.monitorTypes,
+      statusFilter: data.statusFilter,
     },
   };
 }
@@ -3411,6 +3486,326 @@ function createCephDashboardConfig(): DashboardViewConfig {
   };
 }
 
+function createNetworkDashboardConfig(): DashboardViewConfig {
+  /*
+   * Layout and metric notes:
+   *
+   * - The map reads the Postgres NetworkSite inventory rather than a metric
+   *   series, so its markers are true right now — the same reasoning the
+   *   Kubernetes / Ceph templates use for their inventory widgets.
+   *
+   * - EVERY metric widget here queries an `oneuptime.monitor.snmp.*` series,
+   *   and those are emitted by exactly one code path:
+   *   NetworkDeviceMetricUtil.saveWalkMetrics, off a network device walk.
+   *   That is deliberate and it is the constraint the rest of this template
+   *   is built around.
+   *
+   *   The obvious tiles to reach for — uptime, round-trip time, packet loss,
+   *   jitter — do NOT belong here, however much a network dashboard wants
+   *   them. `oneuptime.monitor.online` and `oneuptime.monitor.response.time`
+   *   are emitted by MonitorMetricUtil for EVERY probeable monitor in the
+   *   project, and packet loss and jitter come from Ping/IP monitors. A tile
+   *   titled "Round-trip Time" on a network dashboard that silently averages
+   *   every website check in the project is worse than no tile: it is a
+   *   number a reader will act on. Device reachability is on this dashboard
+   *   as the Network Device monitor list, which IS correctly scoped.
+   *
+   * - Because every series here comes from the device walk, every series
+   *   carries `deviceName`, and the per-interface ones also carry
+   *   `interfaceName` — so both template variables bind to something real on
+   *   every widget. Those keys are BARE, not `resource.`-prefixed; see
+   *   NetworkDeviceMetricUtil.buildDeviceMetricRow.
+   *
+   * - No widget aggregates with Sum. The interface series are already
+   *   per-second RATES, and the Value tile reduces across time buckets — so
+   *   a summed rate grows with the dashboard's time range rather than
+   *   describing the network. Max answers "how bad did it get", Avg answers
+   *   "what is normal"; both are range-independent.
+   *
+   * - For the same reason the in/out bit-rate charts are NOT
+   *   transformAsRate'd the way the Ceph template's cumulative
+   *   ceph_pool_*_bytes counters are. They are already rates; rate-of-a-rate
+   *   plots noise around zero.
+   */
+  const components: Array<DashboardBaseComponent> = [
+    // Row 0: Title
+    createTextComponent({
+      text: "Network Dashboard",
+      top: 0,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    /*
+     * Rows 1-5: where the network IS, next to how it is doing. The map is
+     * the subject and takes two thirds of the width; the column beside it
+     * is the numbers a reader checks without leaving the picture.
+     */
+    createNetworkMapComponent({
+      title: "Sites",
+      top: 1,
+      left: 0,
+      width: 8,
+      height: 5,
+      maxSites: 250,
+    }),
+    /*
+     * SnmpInterfaceOperStatus is emitted as 0/1 per interface, so Avg is the
+     * FRACTION of interfaces currently up — in [0, 1], not a percent.
+     * Labelled "(avg)" for the same reason the Monitor template labels its
+     * uptime tile that way rather than printing a misleading "%".
+     */
+    createValueComponent({
+      title: "Interfaces Up (avg)",
+      top: 1,
+      left: 8,
+      width: 4,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceOperStatus,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsBetter,
+    }),
+    createValueComponent({
+      title: "Avg Interface Utilization",
+      top: 2,
+      left: 8,
+      width: 4,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceUtilizationPercent,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsWorse,
+    }),
+    /*
+     * Max, not Sum: this is "how bad did the worst port get", which is what
+     * an operator acts on. Summing a per-second error rate across every
+     * interface and every time bucket produces a number that doubles when
+     * you widen the time picker.
+     */
+    createValueComponent({
+      title: "Worst Interface Errors/sec",
+      top: 3,
+      left: 8,
+      width: 4,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceErrorsPerSecond,
+        aggregationType: MetricsAggregationType.Max,
+      },
+      trendDirection: DashboardValueTrendDirection.HigherIsWorse,
+    }),
+    createValueComponent({
+      title: "Peak Inbound",
+      top: 4,
+      left: 8,
+      width: 4,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceInBitsPerSecond,
+        aggregationType: MetricsAggregationType.Max,
+      },
+    }),
+    createValueComponent({
+      title: "Peak Outbound",
+      top: 5,
+      left: 8,
+      width: 4,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceOutBitsPerSecond,
+        aggregationType: MetricsAggregationType.Max,
+      },
+    }),
+
+    // Row 6: Section header
+    createTextComponent({
+      text: "Interface Throughput",
+      top: 6,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    /*
+     * Rows 7-9: throughput, split per interface. Grouping by
+     * `interfaceName` is what turns one flat line into one line per uplink,
+     * which is the only form in which "is a link saturated" is answerable —
+     * an ungrouped chart averages a saturated uplink with nine idle access
+     * ports and reports that everything is fine.
+     */
+    createChartComponent({
+      title: "Inbound by Interface",
+      chartType: DashboardChartType.Area,
+      top: 7,
+      left: 0,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceInBitsPerSecond,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "Inbound",
+        legendUnit: "bps",
+        groupByAttributeKeys: ["interfaceName"],
+      },
+    }),
+    createChartComponent({
+      title: "Outbound by Interface",
+      chartType: DashboardChartType.Area,
+      top: 7,
+      left: 6,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceOutBitsPerSecond,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "Outbound",
+        legendUnit: "bps",
+        groupByAttributeKeys: ["interfaceName"],
+      },
+    }),
+
+    // Row 10: Section header
+    createTextComponent({
+      text: "Utilization & Errors",
+      top: 10,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    /*
+     * Rows 11-13: the gauge an operator watches during an incident, the
+     * error-rate gauge that leads it, and the per-interface error breakdown
+     * that says WHICH port to look at.
+     */
+    createGaugeComponent({
+      title: "Peak Interface Utilization",
+      top: 11,
+      left: 0,
+      width: 3,
+      height: 3,
+      minValue: 0,
+      maxValue: 100,
+      warningThreshold: 70,
+      criticalThreshold: 90,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceUtilizationPercent,
+        aggregationType: MetricsAggregationType.Max,
+      },
+    }),
+    createGaugeComponent({
+      title: "Interface Error Rate",
+      top: 11,
+      left: 3,
+      width: 3,
+      height: 3,
+      /*
+       * A healthy Ethernet port errors essentially never, so the scale is
+       * deliberately tight: a sustained one error per second is already a
+       * cable, duplex or optic problem worth a ticket, and five is a link
+       * on its way out. A 0-100 scale like the utilization gauge next to it
+       * would render every real fault as a flat line on the floor.
+       */
+      minValue: 0,
+      maxValue: 10,
+      warningThreshold: 1,
+      criticalThreshold: 5,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceErrorsPerSecond,
+        aggregationType: MetricsAggregationType.Avg,
+      },
+    }),
+    createChartComponent({
+      title: "Interface Errors by Interface",
+      chartType: DashboardChartType.Bar,
+      top: 11,
+      left: 6,
+      width: 6,
+      height: 3,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceErrorsPerSecond,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "Errors/sec",
+        groupByAttributeKeys: ["interfaceName"],
+      },
+    }),
+
+    // Row 14: Section header
+    createTextComponent({
+      text: "Devices & Monitors",
+      top: 14,
+      left: 0,
+      width: 12,
+      height: 1,
+      isBold: true,
+    }),
+
+    /*
+     * Rows 15-18: utilization per interface, beside the monitors that page
+     * somebody when a device stops answering. The list is pinned to Network
+     * Device monitors — an unfiltered monitor list on a network dashboard is
+     * just the Monitors page with fewer columns — and it is also this
+     * dashboard's reachability view, correctly scoped in a way a shared
+     * uptime metric could never be.
+     */
+    createChartComponent({
+      title: "Utilization by Interface",
+      chartType: DashboardChartType.Line,
+      top: 15,
+      left: 0,
+      width: 6,
+      height: 4,
+      metricConfig: {
+        metricName: MonitorMetricType.SnmpInterfaceUtilizationPercent,
+        aggregationType: MetricsAggregationType.Avg,
+        legend: "Utilization",
+        legendUnit: "%",
+        groupByAttributeKeys: ["interfaceName"],
+      },
+    }),
+    createMonitorListComponent({
+      title: "Network Device Monitors",
+      top: 15,
+      left: 6,
+      width: 6,
+      height: 4,
+      maxRows: 25,
+      monitorTypes: [MonitorType.NetworkDevice],
+    }),
+  ];
+
+  /*
+   * Network device metrics are stored with BARE attribute keys
+   * (`deviceName`, `interfaceName`) rather than the OTel `resource.` prefix
+   * — see NetworkDeviceMetricUtil.buildDeviceMetricRow — so the variables
+   * bind to the bare keys. Both are multi-select: comparing two uplinks, or
+   * two branch routers, is the normal use rather than the exception.
+   */
+  const variables: Array<DashboardVariable> = [
+    createTelemetryAttributeVariable({
+      name: "device",
+      label: "Device",
+      attributeKey: "deviceName",
+      isMultiSelect: true,
+    }),
+    createTelemetryAttributeVariable({
+      name: "interface",
+      label: "Interface",
+      attributeKey: "interfaceName",
+      isMultiSelect: true,
+    }),
+  ];
+
+  return {
+    _type: ObjectType.DashboardViewConfig,
+    components,
+    variables,
+    heightInDashboardUnits: Math.max(DashboardSize.heightInDashboardUnits, 19),
+  };
+}
+
 export function getTemplateConfig(
   type: DashboardTemplateType,
 ): DashboardViewConfig | null {
@@ -3437,6 +3832,8 @@ export function getTemplateConfig(
       return createMetricsDashboardConfig();
     case DashboardTemplateType.Rum:
       return createRumDashboardConfig();
+    case DashboardTemplateType.Network:
+      return createNetworkDashboardConfig();
     case DashboardTemplateType.Blank:
       return null;
   }

--- a/Common/Utils/Dashboard/Components/DashboardNetworkMapComponent.ts
+++ b/Common/Utils/Dashboard/Components/DashboardNetworkMapComponent.ts
@@ -1,0 +1,136 @@
+import DashboardNetworkMapComponent from "../../../Types/Dashboard/DashboardComponents/DashboardNetworkMapComponent";
+import { ObjectType } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import DashboardBaseComponentUtil from "./DashboardBaseComponent";
+import {
+  ComponentArgument,
+  ComponentArgumentSection,
+  ComponentInputType,
+  EntityFilterModelType,
+} from "../../../Types/Dashboard/DashboardComponents/ComponentArgument";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+
+const DisplaySection: ComponentArgumentSection = {
+  name: "Display Options",
+  description: "Configure the widget title, size of the map and its labels",
+  order: 1,
+};
+
+const FiltersSection: ComponentArgumentSection = {
+  name: "Filters",
+  description: "Narrow down which network sites are drawn",
+  order: 2,
+  defaultCollapsed: true,
+};
+
+/*
+ * A map is only readable while the markers on it can be told apart, and the
+ * fetch is a plain list query — so the widget draws a bounded number of
+ * sites rather than every row in the project. 250 comfortably covers a
+ * franchise estate at the level a dashboard tile is read at, and the footer
+ * says out loud when the cap dropped anything.
+ */
+export const DEFAULT_MAX_SITES: number = 250;
+
+export default class DashboardNetworkMapComponentUtil extends DashboardBaseComponentUtil {
+  public static override getDefaultComponent(): DashboardNetworkMapComponent {
+    return {
+      _type: ObjectType.DashboardComponent,
+      componentType: DashboardComponentType.NetworkMap,
+      /*
+       * A map needs room in BOTH axes: the world is roughly 2:1, so a
+       * short-and-wide tile letterboxes it into a strip. Half the grid
+       * across and five rows down is the smallest shape that still reads
+       * as a map rather than as a banner.
+       */
+      widthInDashboardUnits: 6,
+      heightInDashboardUnits: 5,
+      topInDashboardUnits: 0,
+      leftInDashboardUnits: 0,
+      componentId: ObjectID.generate(),
+      minHeightInDashboardUnits: 4,
+      minWidthInDashboardUnits: 4,
+      arguments: {
+        maxSites: DEFAULT_MAX_SITES,
+        viewMode: "map",
+        showLabels: true,
+      },
+    };
+  }
+
+  public static override getComponentConfigArguments(): Array<
+    ComponentArgument<DashboardNetworkMapComponent>
+  > {
+    const args: Array<ComponentArgument<DashboardNetworkMapComponent>> = [];
+
+    args.push({
+      name: "Title",
+      description: "Header shown above the map",
+      required: false,
+      type: ComponentInputType.Text,
+      id: "title",
+      section: DisplaySection,
+    });
+
+    args.push({
+      name: "View Mode",
+      description:
+        "Draw the sites on a world map (default), or list them in a table.",
+      required: false,
+      type: ComponentInputType.Dropdown,
+      id: "viewMode",
+      section: DisplaySection,
+      dropdownOptions: [
+        { label: "Map", value: "map" },
+        { label: "List", value: "list" },
+      ],
+    });
+
+    args.push({
+      name: "Max Sites",
+      description: "Maximum number of network sites to draw",
+      required: false,
+      type: ComponentInputType.Number,
+      id: "maxSites",
+      placeholder: String(DEFAULT_MAX_SITES),
+      section: DisplaySection,
+    });
+
+    args.push({
+      name: "Show Site Names",
+      description:
+        "Print each site's name under its marker. Names come off automatically when the map gets too busy for them to be readable.",
+      required: false,
+      type: ComponentInputType.Boolean,
+      id: "showLabels",
+      section: DisplaySection,
+    });
+
+    args.push({
+      name: "Site Types",
+      description:
+        "Only draw sites of these types — e.g. just the stores, or just the regional hubs.",
+      required: false,
+      type: ComponentInputType.EntityMultiSelectDropdown,
+      id: "networkSiteTypeIds",
+      section: FiltersSection,
+      entityFilterModelType: EntityFilterModelType.NetworkSiteType,
+    });
+
+    args.push({
+      name: "Status",
+      description: "Quick filter by the status rolled up onto the site",
+      required: false,
+      type: ComponentInputType.Dropdown,
+      id: "statusFilter",
+      section: FiltersSection,
+      dropdownOptions: [
+        { label: "All", value: "" },
+        { label: "Down only", value: "down" },
+        { label: "Operational only", value: "operational" },
+      ],
+    });
+
+    return args;
+  }
+}

--- a/Common/Utils/Dashboard/Components/Index.ts
+++ b/Common/Utils/Dashboard/Components/Index.ts
@@ -27,6 +27,7 @@ import DashboardKubernetesStatefulSetListComponentUtil from "./DashboardKubernet
 import DashboardLogStreamComponentUtil from "./DashboardLogStreamComponent";
 import DashboardLogChartComponentUtil from "./DashboardLogChartComponent";
 import DashboardMonitorListComponentUtil from "./DashboardMonitorListComponent";
+import DashboardNetworkMapComponentUtil from "./DashboardNetworkMapComponent";
 import DashboardPodmanContainerListComponentUtil from "./DashboardPodmanContainerListComponent";
 import DashboardPodmanHostListComponentUtil from "./DashboardPodmanHostListComponent";
 import DashboardPodmanImageListComponentUtil from "./DashboardPodmanImageListComponent";
@@ -297,6 +298,12 @@ export default class DashboardComponentsUtil {
 
     if (dashboardComponentType === DashboardComponentType.CephPoolList) {
       return DashboardCephPoolListComponentUtil.getComponentConfigArguments() as Array<
+        ComponentArgument<DashboardBaseComponent>
+      >;
+    }
+
+    if (dashboardComponentType === DashboardComponentType.NetworkMap) {
+      return DashboardNetworkMapComponentUtil.getComponentConfigArguments() as Array<
         ComponentArgument<DashboardBaseComponent>
       >;
     }


### PR DESCRIPTION
## What

Two things a network estate could not do on a custom dashboard:

1. **A Network Map widget** — this project's sites drawn on the world, colored by the status rolled up onto each one.
2. **A Network dashboard template** — the map paired with SNMP interface throughput, utilization and error widgets, and the Network Device monitor list.

## Why

The widget catalog could describe a network in numbers but never in *place*: there was no way to put "where are my sites, and which of them are dark right now" on a dashboard. The Network Map page answers that, but it is a drill-down tool you navigate, not something you glance at from across a room.

## The widget

`DashboardComponentType.NetworkMap` draws NetworkSites on the Robinson world projection, clustered by screen proximity. It frames itself to the sites it drew — an estate inside one country fills the frame with that country, one across continents opens on the world — and has no zoom or pan controls, because a dashboard tile is a picture. Clicking a marker that stands for exactly one site opens that site.

It says out loud what a map cannot show honestly by drawing alone:

- **the number of sites down is printed above the map**, because a two-pixel red dot among two hundred green ones is not something anybody reads;
- **a coverage line below it** reports sites with no coordinates and whether the row cap was hit, so a partial map never looks complete.

Names under markers go through the full map's collision layout: a name that cannot be placed clear of its neighbours is dropped rather than stacked on one, and the tooltip still carries every one.

Marker colors always come from the widget palette, never from a project's own status color — the legend is only true if every marker obeys it, and the same status must not be one color alone, another inside a cluster, and a third on the Network Map page.

The world outlines were lifted out of `SiteGeoMap` into `Geo/WorldGeometry` so the page and the widget share one lazily-fetched cache rather than downloading ~600 KB of country outlines twice.

Public dashboards get a `network-site` entry in `PUBLIC_DASHBOARD_RESOURCES` whose allowlist and fixed select are narrowed to what the map paints. Notably absent are `parentSiteId`, `materializedPath` and `depth`: the widget draws a flat set of pins, so the tree shape is structure an anonymous viewer could walk but never see.

## The template

Every metric widget on it queries an `oneuptime.monitor.snmp.*` series, which only `NetworkDeviceMetricUtil` emits.

The obvious tiles to reach for — uptime, round-trip time, packet loss, jitter — are **deliberately absent**. Those metric names are emitted by every probeable monitor in the project, so a tile titled "Round-trip Time" on a network dashboard would silently average every website check in the estate. That is worse than no tile, because it is a number somebody will act on. Device reachability is on the dashboard as the Network Device monitor list, which is correctly scoped.

Nothing aggregates with `Sum`: the interface series are already per-second rates and a Value tile reduces across time buckets, so a summed rate grows with the dashboard's time range rather than describing the network.

## Tests

143 new tests across five files, plus updates to three existing suites.

| File | Covers |
| --- | --- |
| `Common/Tests/Utils/Dashboard/DashboardNetworkMapComponent` | the widget util, and — through the registry lookup — that the settings registry was actually wired |
| `Common/Tests/Types/Dashboard/NetworkDashboardTemplate` | the template's metric choices, including that it carries no project-wide metric and no `Sum` |
| `App/Tests/Dashboard/NetworkMapWidgetData` | the view model, weighted toward the dishonest cases: a site vanishing without being counted, an outage hidden inside a green cluster, a footer overstating coverage |
| `App/Tests/Dashboard/NetworkMapWidgetInvariants` | the wiring, the data access, and that the widget never reads the deprecated `NetworkSite.siteType` column |
| `App/Tests/Dashboard/WorldGeometry` | the shared outline cache, and that neither tier is statically imported |

Existing suites updated: `WidgetCatalog` (new Network category), `DashboardPublicResourceListAPI` (new resource case), `NetworkSitePageInvariants` (the two geometry-loader assertions moved to `WorldGeometry` with the loader).

## Verification

- `App` — 3,661 tests / 94 suites pass
- `Common` — 583 dashboard tests + 378 Server API tests pass
- `tsc` clean in `Common`, `App`, `App/FeatureSet/Dashboard`, and `App/FeatureSet/PublicDashboard` (the widget renders in the public bundle too)
- `eslint --fix` clean; docs anchor check passes

Not verified in a running browser — Docker was not up in this environment, so there are no screenshots.

## Notes for review

No migration: `dashboardViewConfig` is an opaque `jsonb` column, and neither a new `DashboardComponentType` nor a new `DashboardTemplateType` touches the schema. Both enum *values* are a wire contract for already-saved dashboards and must never be renamed.
