### PR TITLE
fix(telemetry): unbreak log and trace drop filter creation

### DIFF
--- a/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
+++ b/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
@@ -17,6 +17,10 @@ import TableColumn, {
   getTableColumns,
 } from "../../../Types/Database/TableColumn";
 import TableColumnType from "../../../Types/Database/TableColumnType";
+import {
+  coerceNumericColumnValue,
+  isNumericTableColumnType,
+} from "../../../Types/Database/NumericColumnValue";
 import { getFirstColorFieldColumn } from "../../../Types/Database/ColorField";
 import Dictionary from "../../../Types/Dictionary";
 import Email from "../../../Types/Email";
@@ -727,6 +731,16 @@ export default class DatabaseBaseModel extends BaseEntity {
             json[key] as JSONArray,
             tableColumnMetadata.modelType,
           );
+        } else if (isNumericTableColumnType(tableColumnMetadata.type)) {
+          /*
+           * An `<input type="number">` hands back a string, so the dashboard
+           * posts "10" for a number column. This is the one place that knows
+           * the column's declared type, and it runs on both sides of the
+           * wire — ModelForm on the way out, BaseAPI on the way in — so a
+           * number column holds a number before any hook or validator reads
+           * it. See Types/Database/NumericColumnValue.
+           */
+          (baseModel as any)[key] = coerceNumericColumnValue(json[key]);
         } else {
           (baseModel as any)[key] = json[key];
         }

--- a/Common/Models/DatabaseModels/LogDropFilter.ts
+++ b/Common/Models/DatabaseModels/LogDropFilter.ts
@@ -7,6 +7,7 @@ import TableAccessControl from "../../Types/Database/AccessControl/TableAccessCo
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
+import { getBigIntDatabaseTransformer } from "../../Types/Database/BigIntColumnTransformer";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import TableColumn from "../../Types/Database/TableColumn";
@@ -436,26 +437,14 @@ export default class LogDropFilter extends BaseModel {
     type: ColumnType.BigPositiveNumber,
     nullable: false,
     default: 0,
-    transformer: {
-      to: (value: number | null | undefined): string | null => {
-        if (value === null || value === undefined) {
-          return null;
-        }
-        return Math.trunc(value).toString();
-      },
-      /*
-       * Postgres bigint comes back from the driver as a string. The UI
-       * renders this as a number, so normalize here rather than making
-       * every reader remember.
-       */
-      from: (value: string | null | undefined): number | null => {
-        if (value === null || value === undefined) {
-          return null;
-        }
-        const parsed: number = parseInt(value, 10);
-        return isNaN(parsed) ? null : parsed;
-      },
-    },
+    /*
+     * Shared transformer, not an inline one: it has to preserve `undefined`
+     * so this NOT NULL column's DEFAULT 0 is what a create actually gets.
+     * An inline transformer that mapped `undefined` to `null` made every
+     * drop-filter insert fail the not-null constraint. See
+     * Types/Database/BigIntColumnTransformer.
+     */
+    transformer: getBigIntDatabaseTransformer(),
   })
   public droppedCount?: number = undefined;
 

--- a/Common/Models/DatabaseModels/TraceDropFilter.ts
+++ b/Common/Models/DatabaseModels/TraceDropFilter.ts
@@ -7,6 +7,7 @@ import TableAccessControl from "../../Types/Database/AccessControl/TableAccessCo
 import TableBillingAccessControl from "../../Types/Database/AccessControl/TableBillingAccessControl";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
+import { getBigIntDatabaseTransformer } from "../../Types/Database/BigIntColumnTransformer";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import TableColumn from "../../Types/Database/TableColumn";
@@ -436,26 +437,14 @@ export default class TraceDropFilter extends BaseModel {
     type: ColumnType.BigPositiveNumber,
     nullable: false,
     default: 0,
-    transformer: {
-      to: (value: number | null | undefined): string | null => {
-        if (value === null || value === undefined) {
-          return null;
-        }
-        return Math.trunc(value).toString();
-      },
-      /*
-       * Postgres bigint comes back from the driver as a string. The UI
-       * renders this as a number, so normalize here rather than making
-       * every reader remember.
-       */
-      from: (value: string | null | undefined): number | null => {
-        if (value === null || value === undefined) {
-          return null;
-        }
-        const parsed: number = parseInt(value, 10);
-        return isNaN(parsed) ? null : parsed;
-      },
-    },
+    /*
+     * Shared transformer, not an inline one: it has to preserve `undefined`
+     * so this NOT NULL column's DEFAULT 0 is what a create actually gets.
+     * An inline transformer that mapped `undefined` to `null` made every
+     * drop-filter insert fail the not-null constraint. See
+     * Types/Database/BigIntColumnTransformer.
+     */
+    transformer: getBigIntDatabaseTransformer(),
   })
   public droppedCount?: number = undefined;
 

--- a/Common/Server/API/BaseAPI.ts
+++ b/Common/Server/API/BaseAPI.ts
@@ -22,6 +22,7 @@ import {
   LIMIT_PER_PROJECT,
 } from "../../Types/Database/LimitMax";
 import PartialEntity from "../../Types/Database/PartialEntity";
+import { coerceNumericColumnsInJSON } from "../../Types/Database/NumericColumnValue";
 import BadDataException from "../../Types/Exception/BadDataException";
 import BadRequestException from "../../Types/Exception/BadRequestException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
@@ -418,8 +419,18 @@ export default class BaseAPI<
       );
     }
 
-    const item: PartialEntity<TBaseModel> = JSONFunctions.deserialize(
-      dataInBody as JSONObject,
+    /*
+     * Coerced the same way createItem's BaseModel.fromJSON coerces, so a
+     * PATCH and a POST agree on what a number column holds. The dashboard's
+     * number fields are `<input type="number">`, whose value is a string,
+     * and the save-time hooks read these values before Postgres would
+     * coerce them — a sample percentage of "10" was rejected as "not a
+     * number" on a form that had one filled in.
+     * github.com/OneUptime/oneuptime/issues/3027
+     */
+    const item: PartialEntity<TBaseModel> = coerceNumericColumnsInJSON(
+      JSONFunctions.deserialize(dataInBody as JSONObject),
+      new this.entityType(),
     ) as PartialEntity<TBaseModel>;
 
     delete (item as any)["_id"];

--- a/Common/Tests/Models/DatabaseModels/ColumnTransformerInvariants.test.ts
+++ b/Common/Tests/Models/DatabaseModels/ColumnTransformerInvariants.test.ts
@@ -1,0 +1,306 @@
+import AllModelTypes from "../../../Models/DatabaseModels/Index";
+import LogDropFilter from "../../../Models/DatabaseModels/LogDropFilter";
+import TraceDropFilter from "../../../Models/DatabaseModels/TraceDropFilter";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import { isNumericTableColumnType } from "../../../Types/Database/NumericColumnValue";
+import { TableColumnMetadata } from "../../../Types/Database/TableColumn";
+import { describe, expect, it } from "@jest/globals";
+import { getMetadataArgsStorage } from "typeorm";
+import { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+
+/*
+ * Contract under test — two schema-wide invariants about column
+ * transformers, not any one model's behaviour. Both are traps that are
+ * invisible at the call site: the model reads as a perfectly ordinary
+ * column, and the failure surfaces as a Postgres error a long way away.
+ *
+ * 1. A transformer must not fold `undefined` into `null`.
+ *
+ *    TypeORM runs the transformer BEFORE deciding whether the caller
+ *    supplied the column:
+ *
+ *      InsertQueryBuilder.createColumnValueExpression
+ *        -> driver.preparePersistentValue   (runs transformer.to)
+ *        -> if (value === undefined) expression += "DEFAULT"
+ *
+ *    So on a `NOT NULL DEFAULT x` column, answering `null` makes the DEFAULT
+ *    unreachable and every insert that omits the column dies on the not-null
+ *    constraint. That is what shipped for the drop-filter drop counters, and
+ *    creating any log drop filter in the dashboard returned HTTP 500:
+ *
+ *      null value in column "droppedCount" of relation "LogDropFilter"
+ *      violates not-null constraint
+ *
+ *    github.com/OneUptime/oneuptime/issues/3026
+ *
+ * 2. A transformer on a number column must accept a raw number.
+ *
+ *    `BaseModel.fromJSON` normalizes strings bound for number columns (see
+ *    github.com/OneUptime/oneuptime/issues/3027), so a column declared
+ *    `TableColumnType.Number` now reliably holds a number by the time the
+ *    transformer sees it — even when its in-memory type is a wrapped object
+ *    like `Port` or `Decimal`. A transformer that only knew how to handle
+ *    its own class and a string answered `null` for a number, which wrote
+ *    NULL over a value the user had just typed.
+ */
+
+interface TransformerColumn {
+  entity: string;
+  property: string;
+  transformer: ValueTransformer;
+  defaultValue: unknown;
+}
+
+/*
+ * TypeORM accepts either a single transformer or an array applied in order.
+ * `to` runs last-to-first over an array, so the *last* entry is the one that
+ * sees the raw entity value.
+ */
+function firstTransformerToRun(
+  transformer: ValueTransformer | Array<ValueTransformer>,
+): ValueTransformer {
+  if (Array.isArray(transformer)) {
+    return transformer[transformer.length - 1] as ValueTransformer;
+  }
+
+  return transformer;
+}
+
+function notNullColumnsWithADefaultAndATransformer(): Array<TransformerColumn> {
+  const columns: Array<TransformerColumn> = [];
+
+  for (const column of getMetadataArgsStorage()
+    .columns as Array<ColumnMetadataArgs>) {
+    const options: ColumnMetadataArgs["options"] = column.options || {};
+
+    if (!options.transformer) {
+      continue;
+    }
+
+    if (options.nullable !== false) {
+      continue;
+    }
+
+    if (options.default === undefined || options.default === null) {
+      continue;
+    }
+
+    columns.push({
+      entity:
+        (column.target as { name?: string })?.name || String(column.target),
+      property: column.propertyName,
+      transformer: firstTransformerToRun(options.transformer),
+      defaultValue: options.default,
+    });
+  }
+
+  return columns;
+}
+
+describe("NOT NULL columns that carry both a DEFAULT and a transformer", () => {
+  const columns: Array<TransformerColumn> =
+    notNullColumnsWithADefaultAndATransformer();
+
+  /*
+   * If this ever finds nothing, the filter above has drifted (a renamed
+   * option, a TypeORM upgrade) and the real assertion below is vacuously
+   * passing — which is the same as deleting it.
+   */
+  it("finds the drop-filter counters, so the scan itself is known to work", () => {
+    const scanned: Array<string> = columns.map((column: TransformerColumn) => {
+      return `${column.entity}.${column.property}`;
+    });
+
+    expect(scanned).toContain("LogDropFilter.droppedCount");
+    expect(scanned).toContain("TraceDropFilter.droppedCount");
+  });
+
+  it("never lets a transformer swallow undefined into null", () => {
+    const offenders: Array<string> = [];
+
+    for (const column of columns) {
+      if (!column.transformer.to) {
+        continue;
+      }
+
+      if (column.transformer.to(undefined) !== undefined) {
+        offenders.push(
+          `${column.entity}.${column.property} (NOT NULL DEFAULT ${String(
+            column.defaultValue,
+          )}) maps undefined to ${String(column.transformer.to(undefined))}`,
+        );
+      }
+    }
+
+    /*
+     * Named rather than counted: the message has to say which column will
+     * 500 on every insert, because the failure surfaces as a Postgres
+     * constraint error a long way from the model file.
+     */
+    expect(offenders).toEqual([]);
+  });
+});
+
+/*
+ * Every column declared as a number type that also carries a transformer.
+ *
+ * The declared type is not a perfect proxy for the in-memory one — an SMTP
+ * port is declared `Number` but typed `Port`, a usage figure is declared
+ * `Number` but typed `Decimal` — and those are exactly the columns where a
+ * transformer might never have been handed a bare number before.
+ */
+function numericColumnsWithATransformer(): Array<TransformerColumn> {
+  const columns: Array<TransformerColumn> = [];
+
+  for (const modelType of AllModelTypes) {
+    const model: BaseModel = new modelType();
+    const entity: string = modelType.name;
+
+    for (const columnName of model.getTableColumns().columns) {
+      const metadata: TableColumnMetadata =
+        model.getTableColumnMetadata(columnName);
+
+      if (!metadata || !isNumericTableColumnType(metadata.type)) {
+        continue;
+      }
+
+      const column: ColumnMetadataArgs | undefined = (
+        getMetadataArgsStorage().columns as Array<ColumnMetadataArgs>
+      ).find((candidate: ColumnMetadataArgs) => {
+        return (
+          (candidate.target as { name?: string })?.name === entity &&
+          candidate.propertyName === columnName
+        );
+      });
+
+      if (!column?.options?.transformer) {
+        continue;
+      }
+
+      columns.push({
+        entity: entity,
+        property: columnName,
+        transformer: firstTransformerToRun(column.options.transformer),
+        defaultValue: column.options.default,
+      });
+    }
+  }
+
+  return columns;
+}
+
+describe("number columns that carry a transformer", () => {
+  const columns: Array<TransformerColumn> = numericColumnsWithATransformer();
+
+  /*
+   * The wrapped-type columns are the whole reason this scan exists. If it
+   * stops finding them, the assertion below is passing vacuously.
+   */
+  it("finds the wrapped-type number columns, so the scan is known to work", () => {
+    const scanned: Array<string> = columns.map((column: TransformerColumn) => {
+      return `${column.entity}.${column.property}`;
+    });
+
+    expect(scanned).toContain("GlobalConfig.smtpPort");
+    expect(scanned).toContain("ProjectSmtpConfig.port");
+    expect(scanned).toContain("TelemetryUsageBilling.dataIngestedInGB");
+    expect(scanned).toContain("LogDropFilter.droppedCount");
+  });
+
+  /*
+   * `BaseModel.fromJSON` now hands these transformers a real number where it
+   * used to hand them the string the form produced. A transformer that
+   * answers null for a number writes NULL over a value the user supplied —
+   * silently on a nullable column, and as a 500 on a NOT NULL one.
+   */
+  it("accepts a raw number rather than answering null", () => {
+    const offenders: Array<string> = [];
+
+    for (const column of columns) {
+      if (!column.transformer.to) {
+        continue;
+      }
+
+      /*
+       * 1 is in range for every number column in the schema; 0 is the value
+       * a truthiness check silently drops.
+       */
+      for (const sample of [1, 0]) {
+        let stored: unknown;
+
+        try {
+          stored = column.transformer.to(sample);
+        } catch (error) {
+          offenders.push(
+            `${column.entity}.${column.property} threw on ${sample}: ${
+              (error as Error).message
+            }`,
+          );
+          continue;
+        }
+
+        if (stored === null || stored === undefined) {
+          offenders.push(
+            `${column.entity}.${column.property} maps the number ${sample} to ${String(
+              stored,
+            )}`,
+          );
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("drop filter counter columns", () => {
+  /*
+   * Spelled out for the two columns the bug actually shipped on, so the
+   * regression is legible without reading the scan above.
+   */
+  const CASES: Array<{ name: string }> = [
+    { name: LogDropFilter.name },
+    { name: TraceDropFilter.name },
+  ];
+
+  describe.each(CASES)("$name.droppedCount", ({ name }: { name: string }) => {
+    function droppedCountColumn(): ColumnMetadataArgs {
+      const column: ColumnMetadataArgs | undefined = (
+        getMetadataArgsStorage().columns as Array<ColumnMetadataArgs>
+      ).find((candidate: ColumnMetadataArgs) => {
+        return (
+          (candidate.target as { name?: string })?.name === name &&
+          candidate.propertyName === "droppedCount"
+        );
+      });
+
+      if (!column) {
+        throw new Error(`${name}.droppedCount is not a registered column`);
+      }
+
+      return column;
+    }
+
+    it("is NOT NULL with a zero default, so the UI never renders a blank counter", () => {
+      const options: ColumnMetadataArgs["options"] = droppedCountColumn()
+        .options as ColumnMetadataArgs["options"];
+
+      expect(options.nullable).toBe(false);
+      expect(options.default).toBe(0);
+    });
+
+    /*
+     * The exact regression: an insert that leaves the counter alone — which
+     * is every create, since only the ingest path writes it — has to reach
+     * Postgres as DEFAULT, not as NULL.
+     */
+    it("lets a create fall through to that default instead of writing NULL", () => {
+      const transformer: ValueTransformer = firstTransformerToRun(
+        droppedCountColumn().options.transformer as ValueTransformer,
+      );
+
+      expect(transformer.to!(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/Common/Tests/Models/DatabaseModels/NumberColumnDeserialization.test.ts
+++ b/Common/Tests/Models/DatabaseModels/NumberColumnDeserialization.test.ts
@@ -1,0 +1,333 @@
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import LogDropFilter from "../../../Models/DatabaseModels/LogDropFilter";
+import TraceDropFilter from "../../../Models/DatabaseModels/TraceDropFilter";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import GlobalConfig from "../../../Models/DatabaseModels/GlobalConfig";
+import LogDropFilterAction from "../../../Types/Log/LogDropFilterAction";
+import { coerceNumericColumnsInJSON } from "../../../Types/Database/NumericColumnValue";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Port from "../../../Types/Port";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — what a number column holds after a JSON round trip.
+ *
+ * `BaseModel.fromJSON` is the single door every model comes through, and it
+ * runs on BOTH sides of the wire: ModelForm builds the model it is about to
+ * POST with it, and BaseAPI rebuilds that model from the request body with
+ * it. That makes it the one place that can fix the following, once.
+ *
+ * HTML has no numeric input event — `<input type="number">` gives you
+ * `e.target.value`, a string — so the dashboard posted "10" for every number
+ * field in the product. Postgres coerces '10' to 10 on the way in, so this
+ * was invisible everywhere except where something reads the value before it
+ * is stored. The drop-filter save hook does exactly that, and a user who
+ * typed a perfectly good sample percentage got:
+ *
+ *   HTTP 400 — Sample percentage is required when the action is "Sample".
+ *
+ * github.com/OneUptime/oneuptime/issues/3027
+ */
+
+describe("BaseModel.fromJSON on number columns", () => {
+  /*
+   * The reported payload, as the dashboard actually sends it: every scalar
+   * that came from a text-ish input is a string.
+   */
+  it("turns the dashboard's sample-filter payload into real numbers", () => {
+    const posted: JSONObject = {
+      name: "Sample healthcheck logs",
+      filterQuery: "body LIKE 'healthcheck'",
+      action: LogDropFilterAction.Sample,
+      samplePercentage: "10",
+      sortOrder: "1",
+      isEnabled: true,
+    };
+
+    const model: LogDropFilter = BaseModel.fromJSON(
+      posted,
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.samplePercentage).toBe(10);
+    expect(typeof model.samplePercentage).toBe("number");
+    expect(model.sortOrder).toBe(1);
+    expect(typeof model.sortOrder).toBe("number");
+  });
+
+  it("does the same for trace drop filters", () => {
+    const model: TraceDropFilter = BaseModel.fromJSON(
+      {
+        action: "sample",
+        samplePercentage: "25",
+        filterQuery: "name = 'GET /health'",
+      },
+      TraceDropFilter,
+    ) as TraceDropFilter;
+
+    expect(model.samplePercentage).toBe(25);
+  });
+
+  it("accepts a percentage that was already a number", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      { samplePercentage: 10 },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.samplePercentage).toBe(10);
+  });
+
+  it("keeps the whole usable percentage range intact", () => {
+    for (const percentage of [1, 5, 10, 50, 99]) {
+      const model: LogDropFilter = BaseModel.fromJSON(
+        { samplePercentage: String(percentage) },
+        LogDropFilter,
+      ) as LogDropFilter;
+
+      expect(model.samplePercentage).toBe(percentage);
+    }
+  });
+
+  it("leaves an unset percentage unset rather than defaulting it to zero", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      { action: LogDropFilterAction.Drop, filterQuery: "severityText='Debug'" },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.samplePercentage).toBeUndefined();
+  });
+
+  it("leaves a null percentage null", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      { samplePercentage: null },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.samplePercentage).toBeNull();
+  });
+
+  /*
+   * `Number("")` is 0, and 0 is a meaningful sample percentage the validator
+   * rejects on purpose. Inventing it from a cleared field would turn a
+   * user's blank into a rejection about a value they never typed.
+   */
+  it("does not turn a cleared field into zero", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      { samplePercentage: "" },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.samplePercentage).not.toBe(0);
+  });
+
+  it("leaves unparsable text alone for validation to reject", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      { samplePercentage: "abc" },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.samplePercentage).toBe("abc" as unknown as number);
+  });
+
+  /*
+   * This is deliberately not drop-filter specific: the string arrived from a
+   * shared form component, so the fix has to hold for every number column or
+   * the next hook that reads one before storage repeats issue 3027.
+   */
+  it("applies to number columns on unrelated models too", () => {
+    const monitor: Monitor = BaseModel.fromJSON(
+      { name: "API", minimumProbeAgreement: "3" },
+      Monitor,
+    ) as Monitor;
+
+    expect(monitor.minimumProbeAgreement).toBe(3);
+  });
+
+  it("does not touch columns that merely look numeric", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      {
+        name: "12345",
+        action: "sample",
+        filterQuery: "1234",
+        samplePercentage: "10",
+      },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.name).toBe("12345");
+    expect(model.filterQuery).toBe("1234");
+    expect(model.action).toBe("sample");
+    // ...while the number column beside them is still coerced.
+    expect(model.samplePercentage).toBe(10);
+  });
+
+  it("still deserializes the columns beside it normally", () => {
+    const projectId: string = "22222222-2222-4222-8222-222222222222";
+
+    const model: LogDropFilter = BaseModel.fromJSON(
+      {
+        projectId: new ObjectID(projectId).toJSON(),
+        samplePercentage: "10",
+      },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.projectId).toBeInstanceOf(ObjectID);
+    expect(model.projectId?.toString()).toBe(projectId);
+    expect(model.samplePercentage).toBe(10);
+  });
+
+  /*
+   * The browser leg of the same trip: ModelForm hands fromJSON the raw form
+   * values and then serializes the result as the request body. If coercion
+   * did not survive toJSON, the server would still receive a string.
+   */
+  it("survives the toJSON that turns the model into a request body", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      {
+        name: "Sample healthcheck logs",
+        filterQuery: "body LIKE 'healthcheck'",
+        action: LogDropFilterAction.Sample,
+        samplePercentage: "10",
+      },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    const body: JSONObject = BaseModel.toJSON(model, LogDropFilter);
+
+    expect(body["samplePercentage"]).toBe(10);
+
+    const rebuilt: LogDropFilter = BaseModel.fromJSON(
+      body,
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(rebuilt.samplePercentage).toBe(10);
+  });
+
+  /*
+   * `droppedCount` is bigint and ingest-owned. The API serializes it as a
+   * number, but a client (or a driver) handing back the string form must not
+   * leave a string on a column the dashboard does arithmetic on.
+   */
+  it("normalizes a bigint counter that arrives as a string", () => {
+    const model: LogDropFilter = BaseModel.fromJSON(
+      { droppedCount: "4294967296" },
+      LogDropFilter,
+    ) as LogDropFilter;
+
+    expect(model.droppedCount).toBe(4294967296);
+  });
+
+  /*
+   * Not every `TableColumnType.Number` column holds a bare number in
+   * memory: an SMTP port is declared Number but typed `Port`, and it is
+   * written through Port's own transformer. Coercing "587" to 587 there is
+   * only safe because that transformer accepts a raw number — so assert the
+   * pair, not just the coercion.
+   */
+  it("keeps a Port column storable after coercing its string form", () => {
+    const config: GlobalConfig = BaseModel.fromJSON(
+      { smtpPort: "587" },
+      GlobalConfig,
+    ) as GlobalConfig;
+
+    expect(config.smtpPort).toBe(587 as unknown as Port);
+    expect(Port.getDatabaseTransformer().to(config.smtpPort)).toBe(587);
+  });
+});
+
+/*
+ * The update half. `BaseAPI.updateItem` never builds a model — it goes from
+ * the request body straight to a partial entity — so it needs the same
+ * normalization applied to a loose patch, or a PATCH and a POST disagree
+ * about what "10" is and the save-time hooks see different types depending
+ * on which verb the caller used.
+ */
+describe("coerceNumericColumnsInJSON on an update patch", () => {
+  it("coerces a number column the patch names", () => {
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      { samplePercentage: "25" },
+      new LogDropFilter(),
+    );
+
+    expect(patch["samplePercentage"]).toBe(25);
+  });
+
+  it("leaves the columns it does not own alone", () => {
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      {
+        name: "12345",
+        action: "sample",
+        filterQuery: "severityText = 'Debug'",
+        samplePercentage: "25",
+        isEnabled: false,
+      },
+      new LogDropFilter(),
+    );
+
+    expect(patch["name"]).toBe("12345");
+    expect(patch["action"]).toBe("sample");
+    expect(patch["filterQuery"]).toBe("severityText = 'Debug'");
+    expect(patch["isEnabled"]).toBe(false);
+    expect(patch["samplePercentage"]).toBe(25);
+  });
+
+  it("ignores keys that are not columns at all", () => {
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      { notAColumn: "10" },
+      new LogDropFilter(),
+    );
+
+    expect(patch["notAColumn"]).toBe("10");
+  });
+
+  /*
+   * A PartialEntity may carry a `() => string` raw SQL expression instead of
+   * a literal. Coercion must not stringify or otherwise disturb one.
+   */
+  it("passes a raw SQL expression through untouched", () => {
+    const expression: () => string = (): string => {
+      return '"samplePercentage" + 1';
+    };
+
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      { samplePercentage: expression as unknown as JSONObject },
+      new LogDropFilter(),
+    );
+
+    expect(patch["samplePercentage"]).toBe(expression);
+  });
+
+  it("does not invent a value for a cleared field", () => {
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      { samplePercentage: "" },
+      new LogDropFilter(),
+    );
+
+    expect(patch["samplePercentage"]).not.toBe(0);
+  });
+
+  it("keeps an explicit null so a nullable column can be cleared", () => {
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      { samplePercentage: null },
+      new LogDropFilter(),
+    );
+
+    expect(patch["samplePercentage"]).toBeNull();
+  });
+
+  /*
+   * The API layer hands this a freshly-constructed model of the entity
+   * being updated, so it has to work off an instance rather than the class.
+   */
+  it("works off any model instance, not just drop filters", () => {
+    const patch: JSONObject = coerceNumericColumnsInJSON(
+      { minimumProbeAgreement: "3" },
+      new Monitor(),
+    );
+
+    expect(patch["minimumProbeAgreement"]).toBe(3);
+  });
+});

--- a/Common/Tests/Server/Services/DropFilterSaveValidation.test.ts
+++ b/Common/Tests/Server/Services/DropFilterSaveValidation.test.ts
@@ -1,9 +1,11 @@
 import LogDropFilterService from "../../../Server/Services/LogDropFilterService";
 import TraceDropFilterService from "../../../Server/Services/TraceDropFilterService";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import LogDropFilter from "../../../Models/DatabaseModels/LogDropFilter";
 import TraceDropFilter from "../../../Models/DatabaseModels/TraceDropFilter";
 import LogDropFilterAction from "../../../Types/Log/LogDropFilterAction";
 import TraceDropFilterAction from "../../../Types/Trace/TraceDropFilterAction";
+import { coerceNumericColumnsInJSON } from "../../../Types/Database/NumericColumnValue";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
 import CreateBy from "../../../Server/Types/Database/CreateBy";
@@ -52,6 +54,7 @@ const VALID_QUERY: string = "severityText = 'Debug'";
 const SUITES: Array<{
   name: string;
   service: any;
+  modelType: any;
   makeModel: () => any;
   sampleAction: string;
   dropAction: string;
@@ -60,6 +63,7 @@ const SUITES: Array<{
   {
     name: "LogDropFilterService",
     service: LogDropFilterService,
+    modelType: LogDropFilter,
     makeModel: (): LogDropFilter => {
       return new LogDropFilter();
     },
@@ -70,6 +74,7 @@ const SUITES: Array<{
   {
     name: "TraceDropFilterService",
     service: TraceDropFilterService,
+    modelType: TraceDropFilter,
     makeModel: (): TraceDropFilter => {
       return new TraceDropFilter();
     },
@@ -393,6 +398,246 @@ describe.each(SUITES)(
 
         expect(findBy).not.toHaveBeenCalled();
       });
+    });
+  },
+);
+
+/*
+ * The reported failure, driven the way the product actually drives it.
+ *
+ * The suites above hand the hook a model built in TypeScript, where a number
+ * is a number by construction. Nothing reaches the hook that way in
+ * production: BaseAPI.createItem rebuilds the model from the request body
+ * with BaseModel.fromJSON, and that body comes from a dashboard form whose
+ * "Sample Percentage" field is an `<input type="number">` — a DOM input
+ * whose value is a *string*. So the hook was handed "10", the check read
+ * `typeof samplePercentage !== "number"`, and a user who had filled the form
+ * in correctly got:
+ *
+ *   HTTP 400 — Sample percentage is required when the action is "Sample".
+ *   Enter the percentage of matching logs to keep, between 1 and 99.
+ *
+ * github.com/OneUptime/oneuptime/issues/3027
+ *
+ * These go through fromJSON on purpose. A test that constructs the model
+ * directly cannot fail on this bug, which is precisely why the existing
+ * suite passed while the feature was unusable.
+ */
+describe.each(SUITES)(
+  "$name create from a dashboard request body",
+  ({ service, modelType, sampleAction, dropAction }: any) => {
+    function createByFromRequestBody(body: Record<string, unknown>): any {
+      return {
+        data: BaseModel.fromJSON(body as any, modelType),
+        props: { isRoot: true },
+      };
+    }
+
+    it("accepts the sample percentage as the number input sends it", async () => {
+      await expect(
+        service.onBeforeCreate(
+          createByFromRequestBody({
+            name: "Sample healthcheck logs",
+            filterQuery: VALID_QUERY,
+            action: sampleAction,
+            samplePercentage: "10",
+            sortOrder: "1",
+            isEnabled: true,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("stores it as a number, not as the string it arrived as", async () => {
+      const createBy: any = createByFromRequestBody({
+        filterQuery: VALID_QUERY,
+        action: sampleAction,
+        samplePercentage: "10",
+      });
+
+      await service.onBeforeCreate(createBy);
+
+      expect(createBy.data.samplePercentage).toBe(10);
+      expect(typeof createBy.data.samplePercentage).toBe("number");
+    });
+
+    it("accepts every percentage the form allows", async () => {
+      for (const percentage of ["1", "5", "10", "50", "99"]) {
+        await expect(
+          service.onBeforeCreate(
+            createByFromRequestBody({
+              filterQuery: VALID_QUERY,
+              action: sampleAction,
+              samplePercentage: percentage,
+            }),
+          ),
+        ).resolves.toBeDefined();
+      }
+    });
+
+    /*
+     * Coercion must not become a way around the range check — "0" and "100"
+     * are still the two values that mean something the Sample action cannot
+     * express.
+     */
+    it("still rejects an out-of-range percentage that arrives as a string", async () => {
+      for (const percentage of ["0", "100", "-1", "250"]) {
+        await expect(
+          service.onBeforeCreate(
+            createByFromRequestBody({
+              filterQuery: VALID_QUERY,
+              action: sampleAction,
+              samplePercentage: percentage,
+            }),
+          ),
+        ).rejects.toThrow(BadDataException);
+      }
+    });
+
+    it("still rejects a sample filter whose percentage field was left blank", async () => {
+      await expect(
+        service.onBeforeCreate(
+          createByFromRequestBody({
+            filterQuery: VALID_QUERY,
+            action: sampleAction,
+            samplePercentage: "",
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("still rejects a percentage that is not a number at all", async () => {
+      await expect(
+        service.onBeforeCreate(
+          createByFromRequestBody({
+            filterQuery: VALID_QUERY,
+            action: sampleAction,
+            samplePercentage: "abc",
+          }),
+        ),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    it("accepts the drop payload, which carries no percentage at all", async () => {
+      await expect(
+        service.onBeforeCreate(
+          createByFromRequestBody({
+            name: "Drop debug",
+            filterQuery: VALID_QUERY,
+            action: dropAction,
+            sortOrder: "1",
+            isEnabled: true,
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    /*
+     * The other half of the same create. `droppedCount` is ingest-owned and
+     * never present in a create body, so it has to stay unset all the way to
+     * the INSERT — where the column's DEFAULT 0 applies. A create that
+     * carried an explicit null instead is what made this a 500 rather than a
+     * 400. github.com/OneUptime/oneuptime/issues/3026
+     */
+    it("leaves the ingest-owned counter unset for the column default", async () => {
+      const createBy: any = createByFromRequestBody({
+        name: "Drop debug",
+        filterQuery: VALID_QUERY,
+        action: dropAction,
+      });
+
+      await service.onBeforeCreate(createBy);
+
+      expect(createBy.data.droppedCount).toBeUndefined();
+      expect(createBy.data.lastDroppedAt).toBeUndefined();
+    });
+  },
+);
+
+/*
+ * The same request body, sent as an edit rather than a create.
+ *
+ * `BaseAPI.updateItem` does not build a model — it deserializes the body
+ * into a partial entity — so it normalizes number columns itself. Without
+ * that, changing a saved filter's percentage in the dashboard failed the
+ * same way creating one did, and only on the update verb.
+ */
+describe.each(SUITES)(
+  "$name update from a dashboard request body",
+  ({ service, makeModel, sampleAction, dropAction }: any) => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    function updateByFromRequestBody(body: Record<string, unknown>): any {
+      return {
+        query: { _id: FILTER_ID.toString() },
+        data: coerceNumericColumnsInJSON(body as any, makeModel()),
+        props: { isRoot: true },
+      };
+    }
+
+    function mockStoredRow(row: StoredRow): void {
+      const model: any = makeModel();
+      model._id = FILTER_ID.toString();
+      model.action = row.action;
+      model.filterQuery = row.filterQuery;
+      if (row.samplePercentage !== undefined) {
+        model.samplePercentage = row.samplePercentage;
+      }
+
+      jest
+        .spyOn(service, "findBy")
+        .mockImplementation(async (): Promise<Array<any>> => {
+          return [model];
+        });
+    }
+
+    it("accepts a percentage change sent as a string", async () => {
+      mockStoredRow({
+        action: sampleAction,
+        samplePercentage: 10,
+        filterQuery: VALID_QUERY,
+      });
+
+      await expect(
+        service.onBeforeUpdate(
+          updateByFromRequestBody({ samplePercentage: "25" }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("accepts flipping a drop filter to sample with a string percentage", async () => {
+      mockStoredRow({
+        action: dropAction,
+        samplePercentage: undefined,
+        filterQuery: VALID_QUERY,
+      });
+
+      await expect(
+        service.onBeforeUpdate(
+          updateByFromRequestBody({
+            action: sampleAction,
+            samplePercentage: "5",
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("still rejects an out-of-range percentage sent as a string", async () => {
+      mockStoredRow({
+        action: sampleAction,
+        samplePercentage: 10,
+        filterQuery: VALID_QUERY,
+      });
+
+      for (const percentage of ["0", "100"]) {
+        await expect(
+          service.onBeforeUpdate(
+            updateByFromRequestBody({ samplePercentage: percentage }),
+          ),
+        ).rejects.toThrow(BadDataException);
+      }
     });
   },
 );

--- a/Common/Tests/Types/Database/BigIntColumnTransformer.test.ts
+++ b/Common/Tests/Types/Database/BigIntColumnTransformer.test.ts
@@ -1,0 +1,147 @@
+import { getBigIntDatabaseTransformer } from "../../../Types/Database/BigIntColumnTransformer";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — the Postgres bigint round-trip used by counter
+ * columns.
+ *
+ * The interesting half is `to(undefined)`. TypeORM applies a column
+ * transformer BEFORE it decides whether the column was supplied at all:
+ *
+ *   InsertQueryBuilder.createColumnValueExpression
+ *     -> driver.preparePersistentValue   (runs transformer.to)
+ *     -> if (value === undefined) expression += "DEFAULT"
+ *
+ * so a transformer that answers `null` for `undefined` has already turned
+ * "the caller did not set this column" into "the caller set it to NULL" by
+ * the time that check runs, and the column DEFAULT is unreachable. On the
+ * drop-filter `droppedCount` columns — NOT NULL DEFAULT 0, written only by
+ * the ingest path — that made every single insert fail:
+ *
+ *   null value in column "droppedCount" of relation "LogDropFilter"
+ *   violates not-null constraint
+ *
+ * i.e. creating any log drop filter in the dashboard returned HTTP 500.
+ * github.com/OneUptime/oneuptime/issues/3026
+ */
+
+const transformer: ValueTransformer = getBigIntDatabaseTransformer();
+
+describe("getBigIntDatabaseTransformer().to", () => {
+  /*
+   * The regression. `undefined` and `null` are NOT interchangeable here:
+   * one means "use the column default", the other means "write NULL".
+   */
+  it("passes undefined through so the column DEFAULT applies", () => {
+    expect(transformer.to(undefined)).toBeUndefined();
+  });
+
+  it("does not confuse undefined with null", () => {
+    expect(transformer.to(undefined)).not.toBeNull();
+  });
+
+  it("keeps an explicit null as null", () => {
+    expect(transformer.to(null)).toBeNull();
+  });
+
+  it("stringifies a number, because the pg driver binds bigint as text", () => {
+    expect(transformer.to(0)).toBe("0");
+    expect(transformer.to(1)).toBe("1");
+    expect(transformer.to(42)).toBe("42");
+  });
+
+  it("truncates rather than emitting a decimal Postgres would reject", () => {
+    expect(transformer.to(10.9)).toBe("10");
+    expect(transformer.to(-10.9)).toBe("-10");
+  });
+
+  /*
+   * The reason these columns are bigint at all: a sample filter on a
+   * high-volume project passes 2^31 well within a year, and a silently
+   * wrapped diagnostic counter is worse than no counter.
+   */
+  it("carries a value past the 32-bit range without losing precision", () => {
+    expect(transformer.to(4_294_967_296)).toBe("4294967296");
+    expect(transformer.to(Number.MAX_SAFE_INTEGER)).toBe("9007199254740991");
+  });
+
+  /*
+   * `Math.trunc(NaN).toString()` is the string "NaN", which Postgres
+   * rejects with a syntax error naming neither the column nor the caller.
+   */
+  it("refuses to emit a non-finite value as text", () => {
+    expect(transformer.to(NaN)).toBeNull();
+    expect(transformer.to(Infinity)).toBeNull();
+    expect(transformer.to(-Infinity)).toBeNull();
+  });
+});
+
+describe("getBigIntDatabaseTransformer().from", () => {
+  /*
+   * node-postgres hands bigint back as a string — it does not fit a JS
+   * number in the general case. Every value stored in these counters is
+   * inside MAX_SAFE_INTEGER, and the dashboard renders them as numbers.
+   */
+  it("parses the string the driver returns into a number", () => {
+    expect(transformer.from("0")).toBe(0);
+    expect(transformer.from("42")).toBe(42);
+    expect(transformer.from("9007199254740991")).toBe(9007199254740991);
+  });
+
+  it("accepts a number unchanged, in case a driver already parsed it", () => {
+    expect(transformer.from(7)).toBe(7);
+  });
+
+  it("maps a null column to null rather than 0", () => {
+    expect(transformer.from(null)).toBeNull();
+    expect(transformer.from(undefined)).toBeNull();
+  });
+
+  it("maps unparsable text to null rather than NaN", () => {
+    expect(transformer.from("not a number")).toBeNull();
+    expect(transformer.from("")).toBeNull();
+  });
+
+  it("round-trips a counter value", () => {
+    for (const value of [0, 1, 999, 4_294_967_296]) {
+      expect(transformer.from(transformer.to(value))).toBe(value);
+    }
+  });
+});
+
+/*
+ * A miniature of TypeORM's own decision, so the consequence of the
+ * transformer's answer is asserted rather than left to a comment. Mirrors
+ * PostgresDriver.preparePersistentValue followed by
+ * InsertQueryBuilder.createColumnValueExpression.
+ */
+describe("the INSERT expression TypeORM derives from this transformer", () => {
+  type InsertExpression = "DEFAULT" | "NULL" | string;
+
+  function insertExpressionFor(value: number | null | undefined): string {
+    const prepared: unknown = transformer.to(value);
+
+    if (prepared === undefined) {
+      return "DEFAULT";
+    }
+
+    if (prepared === null) {
+      return "NULL";
+    }
+
+    return String(prepared);
+  }
+
+  it("emits DEFAULT for a counter the caller never set", () => {
+    const expression: InsertExpression = insertExpressionFor(undefined);
+
+    expect(expression).toBe("DEFAULT");
+    // The old inline transformer produced this, and NOT NULL rejected it.
+    expect(expression).not.toBe("NULL");
+  });
+
+  it("emits the value for a counter the caller did set", () => {
+    expect(insertExpressionFor(5)).toBe("5");
+  });
+});

--- a/Common/Tests/Types/Database/DatabasePropertyTransformer.test.ts
+++ b/Common/Tests/Types/Database/DatabasePropertyTransformer.test.ts
@@ -1,0 +1,140 @@
+import Recurring from "../../../Types/Events/Recurring";
+import RestrictionTimes from "../../../Types/OnCallDutyPolicy/RestrictionTimes";
+import ObjectID from "../../../Types/ObjectID";
+import Email from "../../../Types/Email";
+import Color from "../../../Types/Color";
+import EventInterval from "../../../Types/Events/EventInterval";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — `DatabaseProperty.getDatabaseTransformer()`, the one
+ * transformer behind nearly every non-primitive column in the schema.
+ *
+ * Its `to` has to keep `undefined` and `null` apart. TypeORM applies the
+ * transformer BEFORE deciding whether the caller supplied the column:
+ *
+ *   InsertQueryBuilder.createColumnValueExpression
+ *     -> driver.preparePersistentValue   (runs transformer.to)
+ *     -> if (value === undefined) expression += "DEFAULT"
+ *
+ * Every `toDatabase` implementation returns null for a falsy input, so
+ * before this guard an omitted column arrived as an explicit NULL and the
+ * column's DEFAULT was unreachable. On a NOT NULL column with a default that
+ * is a not-null constraint violation — an HTTP 500 — on every create that
+ * does not mention the column. That is the mechanism behind
+ * github.com/OneUptime/oneuptime/issues/3026 (the drop-filter counters), and
+ * `OnCallDutyPolicyScheduleLayer.rotation` / `.restrictionTimes` are the same
+ * shape: NOT NULL, with a JSON default, written through this transformer.
+ *
+ * UPDATE is unaffected in both directions — UpdateQueryBuilder drops
+ * undefined properties before the transformer runs — so this only ever
+ * changes an INSERT from "write NULL" to "use the DEFAULT".
+ */
+
+interface TransformerCase {
+  name: string;
+  transformer: ValueTransformer;
+  sample: unknown;
+}
+
+const CASES: Array<TransformerCase> = [
+  {
+    name: "Recurring",
+    transformer: Recurring.getDatabaseTransformer(),
+    sample: Recurring.getDefault(),
+  },
+  {
+    name: "RestrictionTimes",
+    transformer: RestrictionTimes.getDatabaseTransformer(),
+    sample: RestrictionTimes.getDefault(),
+  },
+  {
+    name: "ObjectID",
+    transformer: ObjectID.getDatabaseTransformer(),
+    sample: new ObjectID("11111111-1111-4111-8111-111111111111"),
+  },
+  {
+    name: "Email",
+    transformer: Email.getDatabaseTransformer(),
+    sample: new Email("someone@oneuptime.com"),
+  },
+  {
+    name: "Color",
+    transformer: Color.getDatabaseTransformer(),
+    sample: new Color("#ff0000"),
+  },
+];
+
+describe.each(CASES)(
+  "$name.getDatabaseTransformer()",
+  ({ transformer, sample }: TransformerCase) => {
+    it("passes undefined through so the column DEFAULT applies", () => {
+      expect(transformer.to(undefined)).toBeUndefined();
+    });
+
+    it("does not collapse undefined into null", () => {
+      expect(transformer.to(undefined)).not.toBeNull();
+    });
+
+    /*
+     * An explicit null is a different instruction — "store nothing here" —
+     * and still has to reach the column as NULL.
+     */
+    it("keeps an explicit null as null", () => {
+      expect(transformer.to(null)).toBeNull();
+    });
+
+    it("still serializes a real value", () => {
+      expect(transformer.to(sample)).not.toBeUndefined();
+      expect(transformer.to(sample)).not.toBeNull();
+    });
+  },
+);
+
+describe("the INSERT expression TypeORM derives for a NOT NULL column", () => {
+  /*
+   * A miniature of PostgresDriver.preparePersistentValue followed by
+   * InsertQueryBuilder.createColumnValueExpression, so the consequence is
+   * asserted rather than described.
+   */
+  function insertExpressionFor(
+    transformer: ValueTransformer,
+    value: unknown,
+  ): string {
+    const prepared: unknown = transformer.to(value);
+
+    if (prepared === undefined) {
+      return "DEFAULT";
+    }
+
+    if (prepared === null) {
+      return "NULL";
+    }
+
+    return "?";
+  }
+
+  it("uses the schedule layer's rotation default instead of NULL", () => {
+    expect(
+      insertExpressionFor(Recurring.getDatabaseTransformer(), undefined),
+    ).toBe("DEFAULT");
+  });
+
+  it("uses the schedule layer's restriction default instead of NULL", () => {
+    expect(
+      insertExpressionFor(RestrictionTimes.getDatabaseTransformer(), undefined),
+    ).toBe("DEFAULT");
+  });
+
+  it("still binds a supplied value", () => {
+    const rotation: Recurring = new Recurring();
+    rotation.intervalType = EventInterval.Week;
+    rotation.intervalCount = new PositiveNumber(2);
+
+    expect(
+      insertExpressionFor(Recurring.getDatabaseTransformer(), rotation),
+    ).toBe("?");
+  });
+});

--- a/Common/Tests/Types/Database/NumericColumnValue.test.ts
+++ b/Common/Tests/Types/Database/NumericColumnValue.test.ts
@@ -1,0 +1,127 @@
+import {
+  coerceNumericColumnValue,
+  isNumericTableColumnType,
+} from "../../../Types/Database/NumericColumnValue";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test — normalizing a JSON value bound for a number column.
+ *
+ * HTML has no numeric input event: `<input type="number">` hands back
+ * `e.target.value`, a string. So the dashboard posted the JSON string "10"
+ * for every number field, and Postgres quietly coerced '10' to 10 on the way
+ * in — which is why nobody noticed until a server-side check read the value
+ * BEFORE it was stored:
+ *
+ *   BadDataException: Sample percentage is required when the action is
+ *   "Sample". Enter the percentage of matching logs to keep, between 1 and 99.
+ *
+ * on a form where the user had typed a percentage. HTTP 400 on a valid
+ * submission. github.com/OneUptime/oneuptime/issues/3027
+ */
+
+describe("isNumericTableColumnType", () => {
+  it("covers every column type stored as a plain JS number", () => {
+    for (const type of [
+      TableColumnType.Number,
+      TableColumnType.SmallNumber,
+      TableColumnType.BigNumber,
+      TableColumnType.PositiveNumber,
+      TableColumnType.SmallPositiveNumber,
+      TableColumnType.BigPositiveNumber,
+    ]) {
+      expect(isNumericTableColumnType(type)).toBe(true);
+    }
+  });
+
+  /*
+   * The types that would be destroyed by coercion. `Port` and `Version` are
+   * wrapped objects and `Date` is a Date, however numeric they look.
+   */
+  it("excludes types that only look numeric", () => {
+    for (const type of [
+      TableColumnType.Port,
+      TableColumnType.Version,
+      TableColumnType.Date,
+      TableColumnType.ShortText,
+      TableColumnType.LongText,
+      TableColumnType.Boolean,
+      TableColumnType.ObjectID,
+      TableColumnType.Entity,
+      TableColumnType.EntityArray,
+      TableColumnType.JSON,
+    ]) {
+      expect(isNumericTableColumnType(type)).toBe(false);
+    }
+  });
+
+  it("treats a missing type as not numeric", () => {
+    expect(isNumericTableColumnType(undefined)).toBe(false);
+    expect(isNumericTableColumnType(null)).toBe(false);
+  });
+});
+
+describe("coerceNumericColumnValue", () => {
+  it("converts the string an <input type=number> produces", () => {
+    expect(coerceNumericColumnValue("10")).toBe(10);
+    expect(coerceNumericColumnValue("1")).toBe(1);
+    expect(coerceNumericColumnValue("99")).toBe(99);
+  });
+
+  it("handles the shapes a browser can put in that string", () => {
+    expect(coerceNumericColumnValue("0")).toBe(0);
+    expect(coerceNumericColumnValue("-5")).toBe(-5);
+    expect(coerceNumericColumnValue("2.5")).toBe(2.5);
+    expect(coerceNumericColumnValue(" 42 ")).toBe(42);
+    expect(coerceNumericColumnValue("1e3")).toBe(1000);
+  });
+
+  it("leaves a value that is already a number alone", () => {
+    expect(coerceNumericColumnValue(10)).toBe(10);
+    expect(coerceNumericColumnValue(0)).toBe(0);
+  });
+
+  it("leaves null and undefined alone", () => {
+    expect(coerceNumericColumnValue(null)).toBeNull();
+    expect(coerceNumericColumnValue(undefined)).toBeUndefined();
+  });
+
+  /*
+   * `Number("")` is 0. Writing a real 0 for a field the user cleared would
+   * be a silent data change, and for a sample percentage specifically, 0 is
+   * the value that used to mean "throw away half". Leave it untouched and
+   * let the field's own validation speak.
+   */
+  it("does not turn a cleared field into zero", () => {
+    expect(coerceNumericColumnValue("")).toBe("");
+    expect(coerceNumericColumnValue("   ")).toBe("   ");
+  });
+
+  it("leaves unparsable text alone so validation can reject it by name", () => {
+    for (const garbage of ["abc", "10abc", "NaN", "Infinity", "--1", "1,000"]) {
+      expect(coerceNumericColumnValue(garbage)).toBe(garbage);
+    }
+  });
+
+  it("never invents a non-finite number", () => {
+    const results: Array<unknown> = ["Infinity", "-Infinity", "NaN"].map(
+      (value: string) => {
+        return coerceNumericColumnValue(value);
+      },
+    );
+
+    for (const result of results) {
+      expect(typeof result).toBe("string");
+    }
+  });
+
+  it("passes non-string, non-number values through untouched", () => {
+    const object: Record<string, string> = { a: "1" };
+    const array: Array<number> = [1];
+
+    expect(coerceNumericColumnValue(object)).toBe(object);
+    expect(coerceNumericColumnValue(array)).toBe(array);
+    expect(coerceNumericColumnValue(true)).toBe(true);
+  });
+});

--- a/Common/Tests/Types/Decimal.test.ts
+++ b/Common/Tests/Types/Decimal.test.ts
@@ -89,4 +89,41 @@ describe("Decimal", () => {
       expect(restored.equals(original)).toBe(true);
     });
   });
+
+  /*
+   * A decimal column is declared `TableColumnType.Number`, so whatever
+   * reaches the transformer may be a Decimal, a string, or a plain number
+   * depending on how far the request body got through deserialization.
+   */
+  describe("getDatabaseTransformer().to", () => {
+    const transformer: ReturnType<typeof Decimal.getDatabaseTransformer> =
+      Decimal.getDatabaseTransformer();
+
+    test("stores a Decimal instance as its string form", () => {
+      expect(transformer.to(new Decimal(125.5))).toBe("125.5");
+    });
+
+    test("stores a raw string", () => {
+      expect(transformer.to("125.5")).toBe("125.5");
+    });
+
+    test("stores a raw number", () => {
+      expect(transformer.to(125.5)).toBe("125.5");
+    });
+
+    /*
+     * `0` is a perfectly good decimal, and both of its columns are NOT NULL.
+     * A truthiness check used to send it to null, which the column rejects.
+     */
+    test("stores zero rather than turning it into null", () => {
+      expect(transformer.to(0)).toBe("0");
+      expect(transformer.to("0")).toBe("0");
+      expect(transformer.to(new Decimal(0))).toBe("0");
+    });
+
+    test("keeps undefined distinct from null so a column DEFAULT applies", () => {
+      expect(transformer.to(undefined)).toBeUndefined();
+      expect(transformer.to(null)).toBeNull();
+    });
+  });
 });

--- a/Common/Tests/Types/Port.test.ts
+++ b/Common/Tests/Types/Port.test.ts
@@ -36,4 +36,42 @@ describe("Testing class port", () => {
     const value: Port = new Port("6000");
     expect(typeof value.port.positiveNumber).toBe("number");
   });
+
+  /*
+   * A port column is declared `TableColumnType.Number`, so whatever reaches
+   * the transformer may be a Port, a string, or a plain number depending on
+   * how far the request body got through deserialization. A raw number used
+   * to fall off the end of `toDatabase` and return null, which wrote NULL
+   * over an SMTP port the user had just typed — silently, since null is a
+   * legal value for the column.
+   */
+  describe("getDatabaseTransformer().to", () => {
+    const transformer: ReturnType<typeof Port.getDatabaseTransformer> =
+      Port.getDatabaseTransformer();
+
+    test("stores a Port instance as its number", () => {
+      expect(transformer.to(new Port(587))).toBe(587);
+    });
+
+    test("stores a raw string port as a number", () => {
+      expect(transformer.to("587")).toBe(587);
+    });
+
+    test("stores a raw number port rather than dropping it", () => {
+      expect(transformer.to(587)).toBe(587);
+      expect(transformer.to(0)).toBe(0);
+      expect(transformer.to(65535)).toBe(65535);
+    });
+
+    test("keeps undefined distinct from null so a column DEFAULT applies", () => {
+      expect(transformer.to(undefined)).toBeUndefined();
+      expect(transformer.to(null)).toBeNull();
+    });
+
+    test("rejects a port outside the valid range instead of storing null", () => {
+      expect(() => {
+        return transformer.to(70000);
+      }).toThrow(BadDataException);
+    });
+  });
 });

--- a/Common/Types/Database/BigIntColumnTransformer.ts
+++ b/Common/Types/Database/BigIntColumnTransformer.ts
@@ -1,0 +1,74 @@
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+
+/*
+ * Round-trip for columns declared `ColumnType.BigPositiveNumber` (Postgres
+ * bigint) that the rest of the codebase wants to read as a plain number.
+ *
+ * `to` MUST pass `undefined` through untouched. TypeORM runs the column
+ * transformer *before* it decides whether the column was supplied at all:
+ *
+ *   InsertQueryBuilder.createColumnValueExpression
+ *     -> driver.preparePersistentValue    (applies transformer.to)
+ *     -> if (value === undefined) expression += "DEFAULT"
+ *
+ * so a transformer that folds `undefined` into `null` rewrites "the caller
+ * did not set this column" into "the caller explicitly set it to NULL". The
+ * column's DEFAULT is then never reached. On a `NOT NULL DEFAULT 0` counter
+ * that is a 500 on *every* insert:
+ *
+ *   null value in column "droppedCount" of relation "LogDropFilter"
+ *   violates not-null constraint
+ *
+ * which is exactly what shipped for the drop-filter drop counters. Nothing
+ * in the product sets those counters on create — they are ingest-owned — so
+ * every drop filter created through the dashboard failed.
+ *
+ * `from` exists because node-postgres hands bigint back as a string (it does
+ * not fit a JS number in the general case). Every value we store here is a
+ * record counter well inside Number.MAX_SAFE_INTEGER, and the UI renders it
+ * as a number, so normalize once here rather than making each reader
+ * remember.
+ */
+export function getBigIntDatabaseTransformer(): ValueTransformer {
+  return {
+    to: (value: number | null | undefined): string | null | undefined => {
+      /*
+       * Not a mistake and not the same as `null`: see the note above. This
+       * is the branch that lets the column DEFAULT apply.
+       */
+      if (value === undefined) {
+        return undefined;
+      }
+
+      if (value === null) {
+        return null;
+      }
+
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        /*
+         * `Math.trunc(NaN).toString()` is the string "NaN", which Postgres
+         * rejects with a syntax error that names neither the column nor the
+         * caller. Null at least fails as a constraint violation on the
+         * column it belongs to.
+         */
+        return null;
+      }
+
+      return Math.trunc(value).toString();
+    },
+
+    from: (value: string | number | null | undefined): number | null => {
+      if (value === null || value === undefined) {
+        return null;
+      }
+
+      if (typeof value === "number") {
+        return Number.isFinite(value) ? value : null;
+      }
+
+      const parsed: number = parseInt(value, 10);
+
+      return isNaN(parsed) ? null : parsed;
+    },
+  };
+}

--- a/Common/Types/Database/DatabaseProperty.ts
+++ b/Common/Types/Database/DatabaseProperty.ts
@@ -45,6 +45,32 @@ export default class DatabaseProperty extends SerializableObject {
   public static getDatabaseTransformer(): ValueTransformer {
     return {
       to: (value: any) => {
+        /*
+         * `undefined` means "the caller did not set this column", and it has
+         * to stay distinguishable from `null` all the way into TypeORM.
+         *
+         * TypeORM runs the transformer BEFORE deciding whether the column
+         * was supplied:
+         *
+         *   InsertQueryBuilder.createColumnValueExpression
+         *     -> driver.preparePersistentValue   (runs this function)
+         *     -> if (value === undefined) expression += "DEFAULT"
+         *
+         * so answering `null` here (which every `toDatabase` does for a
+         * falsy value) rewrites an omitted column into an explicit NULL and
+         * makes the column's DEFAULT unreachable. On a NOT NULL column with
+         * a default — an on-call layer's `rotation`, a drop filter's
+         * `droppedCount` — that is a not-null constraint violation, i.e. an
+         * HTTP 500, on every create that leaves the column alone.
+         *
+         * UPDATE is unaffected either way: UpdateQueryBuilder strips
+         * undefined properties before the transformer ever sees them
+         * ("it doesn't make sense to update undefined properties").
+         */
+        if (value === undefined) {
+          return undefined;
+        }
+
         return this._toDatabase(value);
       },
       from: (value: any) => {

--- a/Common/Types/Database/NumericColumnValue.ts
+++ b/Common/Types/Database/NumericColumnValue.ts
@@ -1,0 +1,128 @@
+import { JSONObject, JSONValue } from "../JSON";
+import { TableColumnMetadata } from "./TableColumn";
+import TableColumnType from "./TableColumnType";
+
+/*
+ * Column types whose in-memory representation is a plain JavaScript number.
+ *
+ * Deliberately excludes the types that merely *look* numeric — `Port`,
+ * `Version`, `Date` — because coercing those would destroy them.
+ *
+ * The declared type is not a perfect proxy for the in-memory one: an SMTP
+ * port is declared `Number` but typed `Port`, and a usage figure is declared
+ * `Number` but typed `Decimal`. Coercing a string to a number is safe for
+ * those only because each of their transformers accepts a raw number —
+ * which is a property their tests pin, not an accident.
+ */
+const NUMERIC_TABLE_COLUMN_TYPES: Set<TableColumnType> =
+  new Set<TableColumnType>([
+    TableColumnType.Number,
+    TableColumnType.SmallNumber,
+    TableColumnType.BigNumber,
+    TableColumnType.PositiveNumber,
+    TableColumnType.SmallPositiveNumber,
+    TableColumnType.BigPositiveNumber,
+  ]);
+
+export function isNumericTableColumnType(
+  type: TableColumnType | undefined | null,
+): boolean {
+  if (!type) {
+    return false;
+  }
+
+  return NUMERIC_TABLE_COLUMN_TYPES.has(type);
+}
+
+/*
+ * Normalize a JSON value destined for a number column.
+ *
+ * The dashboard's number form field is an `<input type="number">`, and a DOM
+ * input's value is a *string* — there is no numeric input event in HTML. So
+ * "10" typed into "Sample Percentage" reached the API as the JSON string
+ * "10", and any server-side check spelled `typeof value === "number"`
+ * rejected a perfectly valid form submission:
+ *
+ *   BadDataException: Sample percentage is required when the action is
+ *   "Sample" ... between 1 and 99.
+ *
+ * Postgres silently coerces '10' to 10 on the way in, which is why this had
+ * gone unnoticed on every other number field in the product: the string only
+ * becomes visible when something reads the value before it is stored.
+ *
+ * Normalizing here — where the column's declared type is known, on both the
+ * browser side (ModelForm -> BaseModel.fromJSON) and the server side
+ * (BaseAPI -> BaseModel.fromJSON) — means a number column holds a number by
+ * the time any hook, validator or query sees it.
+ *
+ * Only strings that parse cleanly to a finite number are converted. A blank
+ * string is left alone rather than turned into `0` (`Number("")` is 0, which
+ * would silently write a real value for a field the user cleared) or into
+ * `null` (which would defeat a column DEFAULT the same way the bigint
+ * transformer used to). Garbage like "abc" is left alone too, so validation
+ * rejects it with a message about the field instead of this function
+ * inventing a value.
+ */
+export function coerceNumericColumnValue(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed: string = value.trim();
+
+  if (trimmed.length === 0) {
+    return value;
+  }
+
+  const parsed: number = Number(trimmed);
+
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+
+  return parsed;
+}
+
+/*
+ * The minimum a model has to offer for its number columns to be found.
+ * Every DatabaseBaseModel satisfies it; asking for only this keeps the
+ * coercion usable from the API layer without dragging the model class in.
+ */
+export interface ColumnMetadataSource {
+  getTableColumnMetadata: (columnName: string) => TableColumnMetadata;
+}
+
+/*
+ * Coerce the number columns of a loose JSON patch, in place.
+ *
+ * `BaseModel.fromJSON` does this on its way to building a model, but an
+ * update never builds one — `BaseAPI.updateItem` goes from the request body
+ * straight to a partial entity — so without this a PATCH and a POST
+ * disagree about whether "10" is a number. That matters because the
+ * save-time hooks read these values before the database gets a chance to
+ * coerce them.
+ *
+ * Values that are not strings are left exactly as they are, including the
+ * `() => string` raw SQL expressions a PartialEntity may carry.
+ */
+export function coerceNumericColumnsInJSON(
+  json: JSONObject,
+  model: ColumnMetadataSource,
+): JSONObject {
+  for (const key of Object.keys(json)) {
+    const tableColumnMetadata: TableColumnMetadata =
+      model.getTableColumnMetadata(key);
+
+    if (!tableColumnMetadata) {
+      continue;
+    }
+
+    if (!isNumericTableColumnType(tableColumnMetadata.type)) {
+      continue;
+    }
+
+    json[key] = coerceNumericColumnValue(json[key]) as JSONValue;
+  }
+
+  return json;
+}

--- a/Common/Types/Decimal.ts
+++ b/Common/Types/Decimal.ts
@@ -35,14 +35,26 @@ export default class Decimal extends DatabaseProperty {
     return this.value.toString();
   }
 
+  /*
+   * A decimal column is declared `TableColumnType.Number`, so what reaches
+   * the transformer may be a Decimal, a string, or a plain number depending
+   * on how far the request body got through deserialization.
+   *
+   * Both raw forms are handled before the truthiness check, because `0` is a
+   * perfectly good decimal and the old `if (value)` sent it to `null` — on a
+   * NOT NULL column that is a constraint violation for a value the caller
+   * supplied.
+   */
   protected static override toDatabase(
     value: Decimal | FindOperator<Decimal>,
   ): string | null {
-    if (value) {
-      if (typeof value === "string") {
-        value = new Decimal(value);
-      }
+    const rawValue: unknown = value;
 
+    if (typeof rawValue === "string" || typeof rawValue === "number") {
+      return new Decimal(rawValue).toString();
+    }
+
+    if (value) {
       return value.toString();
     }
 

--- a/Common/Types/Port.ts
+++ b/Common/Types/Port.ts
@@ -59,17 +59,29 @@ export default class Port extends DatabaseProperty {
     this.port = new PositiveNumber(port);
   }
 
+  /*
+   * A port column is declared `TableColumnType.Number`, so a raw number is
+   * as legitimate an incoming value as a raw string — the SMTP forms send
+   * one or the other depending on how far the value got through
+   * deserialization. Dropping a number on the floor here wrote NULL over a
+   * port the user had just typed, with no error anywhere.
+   */
   public static override toDatabase(
     value: Port | FindOperator<Port>,
   ): number | null {
-    if (typeof value === "string") {
-      value = new Port(value);
+    /*
+     * The declared parameter type stays Port-shaped so this still overrides
+     * DatabaseProperty.toDatabase, but a raw string or number genuinely
+     * arrives here — see the note above — so widen at the check instead.
+     */
+    const rawValue: unknown = value;
+
+    if (typeof rawValue === "string" || typeof rawValue === "number") {
+      value = new Port(rawValue);
     }
 
     if (value instanceof Port) {
       return value.toNumber();
-    } else if (typeof value === "string") {
-      return parseInt(value);
     }
 
     return null;

--- a/E2E/Tests/Dashboard/LogDropFilters.spec.ts
+++ b/E2E/Tests/Dashboard/LogDropFilters.spec.ts
@@ -1,0 +1,337 @@
+import { BASE_URL } from "../../Config";
+import { Browser, Locator, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+import Faker from "Common/Utils/Faker";
+import {
+  gotoProjectPage,
+  registerAndCreateProject,
+} from "./Helpers/ProductOnboarding";
+
+/*
+ * Log drop filters, created the way a customer creates them: through the
+ * dashboard form, against a real API and a real Postgres table.
+ *
+ * Both bugs this covers were invisible to unit tests because both lived in
+ * the plumbing *between* the form and the row, and both made the feature
+ * completely unusable rather than subtly wrong:
+ *
+ *   - Creating any drop filter returned HTTP 500. `droppedCount` is NOT NULL
+ *     DEFAULT 0 and ingest-owned, so no create sends it — but its column
+ *     transformer folded `undefined` into `null`, and TypeORM runs the
+ *     transformer before deciding whether to emit DEFAULT. Every insert hit
+ *     the not-null constraint.
+ *     github.com/OneUptime/oneuptime/issues/3026
+ *
+ *   - Creating a *sample* filter returned HTTP 400 — "Sample percentage is
+ *     required when the action is Sample" — on a form where the percentage
+ *     had been filled in. `<input type="number">` yields a string, so the
+ *     save hook's `typeof === "number"` check rejected "10".
+ *     github.com/OneUptime/oneuptime/issues/3027
+ *
+ * A test that posts a hand-built JSON body would have missed the second one
+ * entirely, which is the whole reason this spec drives the form.
+ *
+ * Serial mode with a shared page: one registration + project is enough for
+ * every case here, and the later steps are pointless once creation breaks.
+ *
+ * To run locally against a full stack:
+ *
+ *   cd E2E && HOST=localhost npx playwright test \
+ *     Tests/Dashboard/LogDropFilters.spec.ts --project=chromium
+ */
+test.describe.configure({ mode: "serial" });
+
+// ModelTable names its create form after the model class.
+const createFormSelector: string = "#create-LogDropFilter-from";
+
+const createButtonName: string = "Create Log Drop Filter";
+
+interface SharedContext {
+  page: Page;
+  projectId: string;
+  dropFilterName: string;
+  sampleFilterName: string;
+}
+
+type DropFiltersUrlFunction = (projectId: string) => string;
+
+const dropFiltersUrl: DropFiltersUrlFunction = (projectId: string): string => {
+  return URL.fromString(BASE_URL.toString())
+    .addRoute(`/dashboard/${projectId}/logs/settings/drop-filters`)
+    .toString();
+};
+
+test.describe("Log Drop Filters", () => {
+  const ctx: SharedContext = {
+    page: undefined as unknown as Page,
+    projectId: "",
+    dropFilterName: "",
+    sampleFilterName: "",
+  };
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    test.setTimeout(300000);
+    ctx.page = await browser.newPage();
+    ctx.projectId = await registerAndCreateProject({
+      page: ctx.page,
+      projectNamePrefix: "E2E Drop Filter Project",
+    });
+
+    // Run-unique, so a re-run never collides with a previous run's rows.
+    const token: string = Faker.generateName().toString();
+    ctx.dropFilterName = `E2E Drop Debug ${token}`;
+    ctx.sampleFilterName = `E2E Sample Debug ${token}`;
+  });
+
+  test.afterAll(async () => {
+    await ctx.page.close();
+  });
+
+  /*
+   * Opens the create modal and fills the first two steps, which are
+   * identical for both actions: a name, then a real filter condition.
+   *
+   * The Filter Query field is a custom query builder, not an input. Its
+   * first condition starts as `severityText = <nothing>` and only emits a
+   * query once a value is picked — and an empty query is rejected on save
+   * (it would match every log and discard the project's telemetry), so this
+   * has to pick one.
+   */
+  async function openCreateModalAndFillConditions(name: string): Promise<void> {
+    const page: Page = ctx.page;
+
+    const createButton: Locator = page.getByRole("button", {
+      name: createButtonName,
+    });
+
+    await gotoProjectPage({
+      page,
+      projectId: ctx.projectId,
+      url: dropFiltersUrl(ctx.projectId),
+      ready: createButton,
+    });
+
+    await createButton.click();
+
+    const modal: Locator = page.getByTestId("modal");
+    await modal.waitFor({ state: "visible", timeout: 30000 });
+
+    const form: Locator = page.locator(createFormSelector);
+    await form.waitFor({ state: "visible", timeout: 30000 });
+
+    // Step 1 — Basic Info.
+    await form.getByLabel("Name").fill(name);
+    await page.getByTestId("modal-footer-submit-button").click();
+
+    /*
+     * Step 2 — Filter Conditions. The step renders exactly one condition
+     * row, and BasicForm renders only the current step's fields, so the
+     * three comboboxes on screen are this row's Field, Operator and Value in
+     * DOM order. Value is the one to set; Field and Operator already default
+     * to Severity / equals.
+     */
+    const valueDropdown: Locator = form.getByRole("combobox").nth(2);
+    await valueDropdown.waitFor({ state: "visible", timeout: 30000 });
+    await valueDropdown.click();
+    await page.getByRole("option", { name: "Debug", exact: true }).click();
+
+    // The preview proves the builder emitted a query rather than staying blank.
+    await form.getByText("Preview query").click();
+    await expect(form.getByText("severityText = 'Debug'")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await page.getByTestId("modal-footer-submit-button").click();
+  }
+
+  test("should reach the log drop filters settings page", async () => {
+    test.setTimeout(120000);
+    const page: Page = ctx.page;
+
+    const createButton: Locator = page.getByRole("button", {
+      name: createButtonName,
+    });
+
+    await gotoProjectPage({
+      page,
+      projectId: ctx.projectId,
+      url: dropFiltersUrl(ctx.projectId),
+      ready: createButton,
+    });
+
+    await expect(createButton).toBeVisible({ timeout: 60000 });
+    await expect(page.getByText("No drop filters found.")).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  /*
+   * Issue 3026. Nothing about this filter is unusual — that is the point.
+   * The create failed on a column the form never mentions.
+   */
+  test("should create a drop-action filter", async () => {
+    test.setTimeout(180000);
+    const page: Page = ctx.page;
+
+    await openCreateModalAndFillConditions(ctx.dropFilterName);
+
+    /*
+     * Step 3 — Action. Drop is the form's initial value, so submitting the
+     * step as-is is exactly the reported reproduction: Logs -> Settings ->
+     * Drop filters -> Create.
+     */
+    const form: Locator = page.locator(createFormSelector);
+    await expect(
+      form.getByText("Action", { exact: false }).first(),
+    ).toBeVisible({ timeout: 30000 });
+
+    await page.getByTestId("modal-footer-submit-button").click();
+
+    // No 500: the modal only closes when the create actually succeeded.
+    await page
+      .getByTestId("modal")
+      .waitFor({ state: "hidden", timeout: 90000 });
+
+    const row: Locator = page
+      .getByRole("row")
+      .filter({ hasText: ctx.dropFilterName });
+    await expect(row).toBeVisible({ timeout: 60000 });
+    await expect(row).toContainText("Drop");
+    await expect(row).toContainText("Enabled");
+
+    /*
+     * The counter the insert used to choke on. It renders its empty state,
+     * which means the column came back as 0 from its DEFAULT — not as the
+     * null that would have failed the constraint.
+     */
+    await expect(row).toContainText("Nothing dropped yet");
+  });
+
+  /*
+   * Issue 3027. The percentage is typed into a real <input type="number">,
+   * so this is the only kind of test that can catch a value arriving at the
+   * API as a string.
+   */
+  test("should create a sample-action filter with a percentage", async () => {
+    test.setTimeout(180000);
+    const page: Page = ctx.page;
+
+    await openCreateModalAndFillConditions(ctx.sampleFilterName);
+
+    // Step 3 — Action: switch to Sample, which reveals the percentage field.
+    const form: Locator = page.locator(createFormSelector);
+    const actionDropdown: Locator = form.getByRole("combobox").first();
+    await actionDropdown.waitFor({ state: "visible", timeout: 30000 });
+    await actionDropdown.click();
+    await page.getByRole("option", { name: "Sample", exact: true }).click();
+
+    const percentage: Locator = form.getByLabel("Sample Percentage");
+    await expect(percentage).toBeVisible({ timeout: 30000 });
+    await percentage.fill("10");
+
+    await page.getByTestId("modal-footer-submit-button").click();
+
+    /*
+     * No 400. The failure mode this replaces left the modal open with
+     * "Sample percentage is required when the action is Sample" above a
+     * field containing 10, so assert the message is absent before waiting on
+     * the modal — it names the bug instead of timing out anonymously.
+     */
+    await expect(
+      page.getByText("Sample percentage is required", { exact: false }),
+    ).toHaveCount(0);
+
+    await page
+      .getByTestId("modal")
+      .waitFor({ state: "hidden", timeout: 90000 });
+
+    /*
+     * "Sample 10%", not "Sample" and not "Sample 0%": the percentage survived
+     * the round trip as a number the list can render.
+     */
+    const row: Locator = page
+      .getByRole("row")
+      .filter({ hasText: ctx.sampleFilterName });
+    await expect(row).toBeVisible({ timeout: 60000 });
+    await expect(row).toContainText("Sample 10%");
+  });
+
+  /*
+   * Reading the row back from the API is the other half of the round trip:
+   * the list renders whatever create wrote, but the view page re-fetches it.
+   */
+  test("should show the saved percentage on the filter's view page", async () => {
+    test.setTimeout(120000);
+    const page: Page = ctx.page;
+
+    const row: Locator = page
+      .getByRole("row")
+      .filter({ hasText: ctx.sampleFilterName });
+    await row.getByRole("button", { name: "View Log Drop Filter" }).click();
+
+    await page.waitForURL(
+      new RegExp(
+        `/dashboard/${ctx.projectId}/logs/settings/drop-filters/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`,
+        "i",
+      ),
+      { timeout: 60000 },
+    );
+
+    await expect(page.getByText(ctx.sampleFilterName)).toBeVisible({
+      timeout: 60000,
+    });
+
+    /*
+     * "10% kept / 90% discarded". The view page renders "Not configured"
+     * for any percentage the engine cannot honour — which is what a value
+     * that stayed a string, or never arrived, would have produced.
+     */
+    await expect(page.getByText("10%", { exact: true }).first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText("kept").first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByText("Not configured")).toHaveCount(0);
+  });
+
+  /*
+   * The save-time guard is still a guard. Coercing "10" to 10 must not have
+   * turned the range check into something a string can walk past.
+   */
+  test("should reject a sample percentage outside the allowed range", async () => {
+    test.setTimeout(180000);
+    const page: Page = ctx.page;
+
+    const rejectedName: string = `E2E Rejected ${Faker.generateName().toString()}`;
+
+    await openCreateModalAndFillConditions(rejectedName);
+
+    const form: Locator = page.locator(createFormSelector);
+    const actionDropdown: Locator = form.getByRole("combobox").first();
+    await actionDropdown.click();
+    await page.getByRole("option", { name: "Sample", exact: true }).click();
+
+    const percentage: Locator = form.getByLabel("Sample Percentage");
+    await percentage.fill("100");
+
+    await page.getByTestId("modal-footer-submit-button").click();
+
+    /*
+     * Rejected client-side by the field's own 1-99 range, or server-side by
+     * the save hook if it ever gets past that. Either way the modal stays
+     * open and no row is created — which is what this asserts, rather than
+     * pinning which of the two layers spoke first.
+     */
+    await expect(page.getByTestId("modal")).toBeVisible({ timeout: 30000 });
+
+    await page.getByTestId("modal-footer-close-button").click();
+    await page
+      .getByTestId("modal")
+      .waitFor({ state: "hidden", timeout: 30000 });
+
+    await expect(
+      page.getByRole("row").filter({ hasText: rejectedName }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Fixes #3026 and #3027 — creating a log (or trace) drop filter in the dashboard was broken outright, on SaaS and self-hosted 12.0.1.

## The two failures

**#3026 — every create returned HTTP 500.**

```
null value in column "droppedCount" of relation "LogDropFilter" violates not-null constraint
```

`droppedCount` is `NOT NULL DEFAULT 0` and ingest-owned, so no create ever sends it. But its column transformer mapped `undefined` to `null`, and TypeORM runs the transformer *before* deciding whether the caller supplied the column:

```
InsertQueryBuilder.createColumnValueExpression
  -> driver.preparePersistentValue    (runs transformer.to)
  -> if (value === undefined) expression += "DEFAULT"
```

By the time that check ran, "not set" had already become an explicit NULL and the column DEFAULT was unreachable.

**#3027 — creating a *sample* filter returned HTTP 400.**

```
Sample percentage is required when the action is "Sample". Enter the percentage of
matching logs to keep, between 1 and 99.
```

…on a form where the percentage *was* filled in. HTML has no numeric input event: `<input type="number">` hands back `e.target.value`, a string. So the dashboard posted `"10"` and the save hook's `typeof samplePercentage === "number"` check rejected it. Postgres silently coerces `'10'` to `10`, which is why this had gone unnoticed on every other number field in the product — the string only becomes visible when something reads the value *before* it is stored.

## The fixes

**#3026 — keep `undefined` distinguishable from `null` on the way into TypeORM**

- `Types/Database/BigIntColumnTransformer.ts` (new) — shared Postgres-bigint round trip that passes `undefined` through so the column DEFAULT applies. Both drop-filter `droppedCount` columns now use it instead of a hand-rolled copy.
- `Types/Database/DatabaseProperty.ts` — the transformer behind nearly every non-primitive column in the schema had the same collapse, because every `toDatabase` implementation answers `null` for a falsy input. `OnCallDutyPolicyScheduleLayer.rotation` and `.restrictionTimes` are `NOT NULL` with JSON defaults and would 500 the same way on any create that omitted them. UPDATE is unaffected in both directions — `UpdateQueryBuilder` strips undefined properties before the transformer runs ("it doesn't make sense to update undefined properties") — so this only ever turns an INSERT's "write NULL" into "use the DEFAULT".

**#3027 — normalize number columns at the boundary that knows their type**

- `Types/Database/NumericColumnValue.ts` (new) + `DatabaseBaseModel.fromJSON` — coerce a string bound for a number column. `fromJSON` runs on *both* sides of the wire (ModelForm building the request, BaseAPI rebuilding it), so one change fixes the browser and the API. Only strings that parse to a finite number are converted: a blank stays blank (`Number("")` is 0, and inventing a 0 for a field the user cleared is a silent data change) and garbage stays garbage so validation rejects it by name.
- `BaseAPI.updateItem` — the update path never builds a model, so it applies the same normalization to the partial entity. Without it a PATCH and a POST disagreed about what `"10"` is.

**Fallout from the coercion, fixed in the same pass**

Not every column declared `TableColumnType.Number` holds a bare number in memory. Feeding those transformers a real number where they previously got a string exposed two falsy/shape gaps, both of which would have written NULL over a value the user supplied:

- `Types/Port.ts` — `toDatabase` accepted a `Port` or a string and dropped a raw number, returning `null`. An SMTP port typed into the admin form would have been wiped.
- `Types/Decimal.ts` — same for a raw number, plus a truthiness check that sent a legitimate `0` to `null` on two `NOT NULL` columns.

## Tests

Verified the new tests fail without the fixes: 34 fail on the un-fixed code for the two issues, and the numeric-column guard names all four affected columns when the Port/Decimal handling is reverted.

`Common`:

- `Types/Database/BigIntColumnTransformer.test.ts` — the `undefined`/`null` distinction, bigint range, and a miniature of TypeORM's own `DEFAULT`-vs-`NULL` decision so the *consequence* is asserted, not just the return value.
- `Types/Database/DatabasePropertyTransformer.test.ts` — the same contract across Recurring / RestrictionTimes / ObjectID / Email / Color.
- `Types/Database/NumericColumnValue.test.ts` — which column types are numeric (and which only look it), and every coercion edge.
- `Models/DatabaseModels/ColumnTransformerInvariants.test.ts` — **two schema-wide guards** over every registered TypeORM column: no `NOT NULL … DEFAULT` column may have a transformer that swallows `undefined`, and no number column may have a transformer that answers `null` for a raw number. The first is what found the on-call columns; the second is what found Port and Decimal. Each guard also asserts its scan still finds known members, so neither can pass vacuously if the metadata shape drifts.
- `Models/DatabaseModels/NumberColumnDeserialization.test.ts` — the dashboard's payload through `fromJSON`, the `toJSON` round trip, the update-patch variant, and the Port pairing.
- `Server/Services/DropFilterSaveValidation.test.ts` — extended with create *and* update driven from a real request body rather than a hand-built model. The pre-existing suite passed throughout the outage precisely because it constructed models in TypeScript, where a number is a number by construction.
- `Types/Port.test.ts`, `Types/Decimal.test.ts` — transformer cases for instance / string / number / zero / undefined / null.

`E2E/Tests/Dashboard/LogDropFilters.spec.ts` (new) — drives the real form against a real stack: create a drop filter, create a sample filter with a percentage typed into the actual `<input type="number">`, read the percentage back on the view page, and confirm the range check still rejects 100.
