### PR TITLE
feat(topology): star and parent-child views for a site's network map

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/ParentChildTopologyLayout.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/ParentChildTopologyLayout.ts
@@ -1,0 +1,779 @@
+import {
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import { isFdbEdge } from "./EndpointNodeUtil";
+import {
+  UNLINKED_BOX_KEY,
+  UNLINKED_STRIP_PITCH_X,
+  UNLINKED_STRIP_PITCH_Y,
+  UNLINKED_STRIP_TOP_GAP,
+} from "./ForceTopologyLayout";
+import {
+  DEFAULT_FOOTPRINT,
+  TopologyNodeFootprint,
+  buildFootprints,
+  footprintOrDefault,
+} from "./TopologyFootprint";
+import {
+  TopologyAdjacency,
+  TopologyComponent,
+  TopologyPoint,
+  bfsChildrenOf,
+  buildTopologyAdjacency,
+  canonicalNodeOrder,
+  compareNodeIds,
+  findTopologyComponents,
+} from "./TopologyGraphUtil";
+import { tierForNode } from "./TopologyLayout";
+import { TopologyComponentBox, TopologyLayoutModel } from "./TopologyModel";
+import {
+  PackInput,
+  PackResult,
+  PackedBox,
+  packComponentBoxes,
+} from "./TopologyPacking";
+
+/*
+ * Parent-child layout: the org chart of the network.
+ *
+ * WHY THIS IS NOT THE TIERED LAYOUT. Tiered is ROLE-banded — every router
+ * in one row, every switch in the next, endpoints in blocks underneath. It
+ * answers "what kinds of thing are on this site", and it answers it well,
+ * but a switch in it is drawn in the switch row rather than under the
+ * router it actually hangs off: two switches sitting side by side there
+ * may have nothing to do with each other. This layout instead places every
+ * node directly beneath ITS OWN parent, recursively, so the picture is the
+ * hierarchy of the network rather than a census of it. Follow a line down
+ * from the core and you are following a real cable.
+ *
+ * The tree is the BFS spanning tree of each connected component, so a
+ * cyclic graph (a pair of redundantly cabled distribution switches, say)
+ * still renders every link — the extra edges simply do not decide where a
+ * node goes, they are drawn back across the tree the layout produced.
+ *
+ * Placement is the classic tidy-tree pass: children first, each subtree
+ * laid out in its own band, the parent centred over its children. No
+ * simulation, so it is exact, instant and trivially deterministic — the
+ * same graph always yields the same coordinates whatever order the poll
+ * returned its rows in.
+ */
+
+/** Vertical distance from a parent's centre to its children's centres. */
+export const PARENT_CHILD_LEVEL_GAP: number = 132;
+/** Horizontal clearance kept between two adjacent painted ink boxes. */
+export const PARENT_CHILD_SIBLING_GAP: number = 26;
+/** Clearance between two separate trees, which must read as separate. */
+export const PARENT_CHILD_TREE_GAP: number = 90;
+export const PARENT_CHILD_TOP_MARGIN: number = 64;
+export const PARENT_CHILD_LAYOUT_MARGIN: number = 48;
+
+/**
+ * The spanning forest the layout draws: one tree per connected component,
+ * plus a one-node tree for every device that reports no neighbours at all.
+ *
+ * Exported separately from the geometry because the parent/child relation
+ * is useful on its own — "what hangs off this switch" is a question the
+ * detail panel and the tests both ask, and neither wants coordinates.
+ */
+export interface ParentChildForest {
+  /** Tree roots, in canonical id order. */
+  rootIds: Array<string>;
+  /** Every non-root node's parent. Roots have no entry. */
+  parentById: Map<string, string>;
+  /** Children per node — every node has an entry, in canonical id order. */
+  childrenById: Map<string, Array<string>>;
+  /** Depth below the node's own root; a root is 0. */
+  depthById: Map<string, number>;
+}
+
+/** The painted extent of a set of nodes: glyph plus label, not centres. */
+interface ParentChildInkBox {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+const inkBoxFor: (
+  ids: Array<string>,
+  positions: Map<string, TopologyPoint>,
+  footprints: Map<string, TopologyNodeFootprint>,
+) => ParentChildInkBox | null = (
+  ids: Array<string>,
+  positions: Map<string, TopologyPoint>,
+  footprints: Map<string, TopologyNodeFootprint>,
+): ParentChildInkBox | null => {
+  let minX: number = Infinity;
+  let minY: number = Infinity;
+  let maxX: number = -Infinity;
+  let maxY: number = -Infinity;
+  let seen: boolean = false;
+
+  for (const id of ids) {
+    const point: TopologyPoint | undefined = positions.get(id);
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+      continue;
+    }
+    const footprint: TopologyNodeFootprint = footprintOrDefault(footprints, id);
+    minX = Math.min(minX, point.x - footprint.inkHalfWidth);
+    maxX = Math.max(maxX, point.x + footprint.inkHalfWidth);
+    minY = Math.min(minY, point.y - footprint.halfHeight);
+    maxY = Math.max(maxY, point.y + footprint.labelBottom);
+    seen = true;
+  }
+
+  return seen ? { minX: minX, minY: minY, maxX: maxX, maxY: maxY } : null;
+};
+
+/*
+ * Half the painted width of a node, guaranteed positive and finite. Every
+ * band width in this file is built out of this number, so one non-finite
+ * value would propagate into every ancestor's band and blank the graph:
+ * a NaN in an SVG coordinate makes the element vanish and takes the bounds
+ * calculation with it.
+ */
+const inkHalfWidthOf: (
+  footprints: Map<string, TopologyNodeFootprint>,
+  nodeId: string,
+) => number = (
+  footprints: Map<string, TopologyNodeFootprint>,
+  nodeId: string,
+): number => {
+  const value: number = footprintOrDefault(footprints, nodeId).inkHalfWidth;
+  return Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_FOOTPRINT.inkHalfWidth;
+};
+
+/** Role rank per node id, using the tiered layout's already-tested rule. */
+const buildTierById: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  orderedNodeIds: Array<string>,
+) => Map<string, number> = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  orderedNodeIds: Array<string>,
+): Map<string, number> => {
+  const nodeIdsWithFdbEdges: Set<string> = new Set<string>();
+  for (const edge of edges || []) {
+    if (edge && isFdbEdge(edge)) {
+      nodeIdsWithFdbEdges.add(edge.fromNodeId);
+      nodeIdsWithFdbEdges.add(edge.toNodeId);
+    }
+  }
+
+  const nodeById: Map<string, NetworkTopologyNode> = new Map<
+    string,
+    NetworkTopologyNode
+  >();
+  for (const node of nodes || []) {
+    if (node && typeof node.id === "string" && !nodeById.has(node.id)) {
+      nodeById.set(node.id, node);
+    }
+  }
+
+  const tierById: Map<string, number> = new Map<string, number>();
+  for (const id of orderedNodeIds) {
+    const node: NetworkTopologyNode | undefined = nodeById.get(id);
+    // A position without a node behind it is ranked as an access device.
+    tierById.set(id, node ? tierForNode(node, nodeIdsWithFdbEdges) : 1);
+  }
+  return tierById;
+};
+
+/**
+ * Pick the node a component's tree hangs from.
+ *
+ * Role first, degree second. This deliberately overrides the component's
+ * own `rootId`, which is degree-first: an access switch with forty
+ * endpoints out-degrees the router it uplinks to, and rooting there draws
+ * the router as a child of the switch — precisely upside down from the
+ * hierarchy the reader came here for. Ties fall through to the id so the
+ * choice is a function of the graph and never of the response ordering.
+ */
+const chooseTreeRoot: (
+  memberIds: Array<string>,
+  adjacency: TopologyAdjacency,
+  tierById: Map<string, number>,
+) => string = (
+  memberIds: Array<string>,
+  adjacency: TopologyAdjacency,
+  tierById: Map<string, number>,
+): string => {
+  let bestId: string = memberIds[0]!;
+  let bestTier: number = tierById.get(bestId) ?? 1;
+  let bestDegree: number = adjacency.degreeById.get(bestId) || 0;
+
+  for (const id of memberIds) {
+    const tier: number = tierById.get(id) ?? 1;
+    const degree: number = adjacency.degreeById.get(id) || 0;
+    const isBetter: boolean =
+      tier < bestTier ||
+      (tier === bestTier &&
+        (degree > bestDegree ||
+          (degree === bestDegree && compareNodeIds(id, bestId) < 0)));
+    if (isBetter) {
+      bestId = id;
+      bestTier = tier;
+      bestDegree = degree;
+    }
+  }
+  return bestId;
+};
+
+/** BFS depths from `rootId`, plus the order the traversal visited them. */
+interface RootedTraversal {
+  order: Array<string>;
+  depthById: Map<string, number>;
+}
+
+const traverseFromRoot: (
+  rootId: string,
+  adjacency: TopologyAdjacency,
+) => RootedTraversal = (
+  rootId: string,
+  adjacency: TopologyAdjacency,
+): RootedTraversal => {
+  const depthById: Map<string, number> = new Map<string, number>();
+  const order: Array<string> = [rootId];
+  depthById.set(rootId, 0);
+
+  /*
+   * Neighbour lists are already in canonical id order and the queue drains
+   * FIFO, so the traversal — and therefore every depth it assigns — is a
+   * function of the graph alone. The read cursor replaces Array.shift so a
+   * ten-thousand-device site does not pay a quadratic re-index per pop.
+   */
+  let head: number = 0;
+  while (head < order.length) {
+    const current: string = order[head]!;
+    head++;
+    const depth: number = depthById.get(current)!;
+    for (const neighbor of adjacency.neighborsById.get(current) || []) {
+      if (!depthById.has(neighbor)) {
+        depthById.set(neighbor, depth + 1);
+        order.push(neighbor);
+      }
+    }
+  }
+
+  return { order: order, depthById: depthById };
+};
+
+/**
+ * Build the parent-child spanning forest of a topology.
+ *
+ * Each connected component becomes one tree, rooted by role (see
+ * {@link chooseTreeRoot}); a node's parent is its canonically-first
+ * neighbour exactly one level up, the same rule the radial and seeding
+ * layouts already use, so all three agree about what hangs off what. A
+ * device with no links at all is a one-node tree rather than a dropped
+ * node.
+ *
+ * Total: every non-root has exactly one parent, every node has a children
+ * entry and a depth, and no node is its own ancestor — parents are always
+ * strictly shallower than their children.
+ */
+export const buildParentChildForest: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+) => ParentChildForest = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+): ParentChildForest => {
+  const orderedNodeIds: Array<string> = canonicalNodeOrder(nodes);
+  const adjacency: TopologyAdjacency = buildTopologyAdjacency(nodes, edges);
+  const components: Array<TopologyComponent> = findTopologyComponents(
+    adjacency,
+    orderedNodeIds,
+  );
+  const tierById: Map<string, number> = buildTierById(
+    nodes,
+    edges,
+    orderedNodeIds,
+  );
+
+  const rootIds: Array<string> = [];
+  const parentById: Map<string, string> = new Map<string, string>();
+  const childrenById: Map<string, Array<string>> = new Map<
+    string,
+    Array<string>
+  >();
+  const depthById: Map<string, number> = new Map<string, number>();
+
+  for (const component of components) {
+    if (component.nodeIds.length === 0) {
+      continue;
+    }
+    const rootId: string = chooseTreeRoot(
+      component.nodeIds,
+      adjacency,
+      tierById,
+    );
+    const traversal: RootedTraversal = traverseFromRoot(rootId, adjacency);
+
+    /*
+     * Re-rooting the component means its own nodeIds/depthById no longer
+     * describe this tree, so bfsChildrenOf is handed a component re-stated
+     * around the root chosen above.
+     */
+    const rooted: TopologyComponent = {
+      nodeIds: traversal.order,
+      rootId: rootId,
+      edges: component.edges,
+      depthById: traversal.depthById,
+    };
+    const childrenOfRooted: Map<string, Array<string>> = bfsChildrenOf(
+      rooted,
+      adjacency,
+    );
+
+    rootIds.push(rootId);
+    for (const [id, depth] of traversal.depthById) {
+      depthById.set(id, depth);
+    }
+    for (const [id, children] of childrenOfRooted) {
+      childrenById.set(id, children);
+      // Derived from the child lists so the two can never disagree.
+      for (const childId of children) {
+        parentById.set(childId, id);
+      }
+    }
+  }
+
+  rootIds.sort(compareNodeIds);
+
+  return {
+    rootIds: rootIds,
+    parentById: parentById,
+    childrenById: childrenById,
+    depthById: depthById,
+  };
+};
+
+/**
+ * One tree's members with every parent ahead of its own children.
+ *
+ * Walked with an explicit stack, never recursion: a two-thousand-device
+ * chain of switches is a legal topology and a legal tree of depth two
+ * thousand, which is enough to blow the JavaScript stack on a recursive
+ * walk and take the whole dashboard down with it.
+ */
+const orderTreeMembers: (
+  rootId: string,
+  forest: ParentChildForest,
+) => Array<string> = (
+  rootId: string,
+  forest: ParentChildForest,
+): Array<string> => {
+  const members: Array<string> = [];
+  const stack: Array<string> = [rootId];
+  while (stack.length > 0) {
+    const current: string = stack.pop()!;
+    members.push(current);
+    const children: Array<string> = forest.childrenById.get(current) || [];
+    // Pushed in reverse so they pop — and therefore draw — left to right.
+    for (let index: number = children.length - 1; index >= 0; index--) {
+      stack.push(children[index]!);
+    }
+  }
+  return members;
+};
+
+/**
+ * Tidy-tree placement of one tree, in a band-local space starting at x = 0.
+ *
+ * `memberIds` must list every parent before its children, which is what
+ * {@link orderTreeMembers} guarantees. That ordering is the whole trick
+ * here: walked backwards it visits every child before its parent, which is
+ * exactly the post-order the band widths need, so neither pass needs
+ * recursion or an explicit traversal stack at all.
+ */
+const layoutTreeBand: (
+  rootId: string,
+  memberIds: Array<string>,
+  forest: ParentChildForest,
+  footprints: Map<string, TopologyNodeFootprint>,
+) => Map<string, TopologyPoint> = (
+  rootId: string,
+  memberIds: Array<string>,
+  forest: ParentChildForest,
+  footprints: Map<string, TopologyNodeFootprint>,
+): Map<string, TopologyPoint> => {
+  const bandWidthById: Map<string, number> = new Map<string, number>();
+  const centreInBandById: Map<string, number> = new Map<string, number>();
+  const childBandStartsById: Map<string, Array<number>> = new Map<
+    string,
+    Array<number>
+  >();
+
+  /*
+   * Pass one, bottom up: how wide is each subtree, and where in its own
+   * band does its node sit.
+   */
+  for (let index: number = memberIds.length - 1; index >= 0; index--) {
+    const id: string = memberIds[index]!;
+    const inkHalfWidth: number = inkHalfWidthOf(footprints, id);
+    const children: Array<string> = forest.childrenById.get(id) || [];
+
+    if (children.length === 0) {
+      bandWidthById.set(id, 2 * inkHalfWidth);
+      centreInBandById.set(id, inkHalfWidth);
+      childBandStartsById.set(id, []);
+      continue;
+    }
+
+    const childStarts: Array<number> = [];
+    let cursor: number = 0;
+    let firstChildCentre: number = 0;
+    let lastChildCentre: number = 0;
+    children.forEach((childId: string, childIndex: number): void => {
+      const childWidth: number = bandWidthById.get(childId) || 0;
+      const childCentre: number = cursor + (centreInBandById.get(childId) || 0);
+      childStarts.push(cursor);
+      if (childIndex === 0) {
+        firstChildCentre = childCentre;
+      }
+      lastChildCentre = childCentre;
+      cursor += childWidth + PARENT_CHILD_SIBLING_GAP;
+    });
+    const childrenExtent: number = cursor - PARENT_CHILD_SIBLING_GAP;
+    const desiredCentre: number = (firstChildCentre + lastChildCentre) / 2;
+
+    /*
+     * The band has to cover the parent's own ink as well as its children's,
+     * and the parent is not necessarily inside the children's extent: a
+     * core router with a sixty-pixel label and one narrow endpoint below it
+     * wants to sit centred over an eighteen-pixel band, which puts half its
+     * label to the left of x = 0 and half past the right edge. Widening the
+     * band on both sides (and then shifting it back to start at zero) is
+     * what keeps that overhang inside this subtree's own territory instead
+     * of letting it paint over the neighbouring branch.
+     */
+    const bandMin: number = Math.min(0, desiredCentre - inkHalfWidth);
+    const bandMax: number = Math.max(
+      childrenExtent,
+      desiredCentre + inkHalfWidth,
+    );
+    const shift: number = -bandMin;
+
+    bandWidthById.set(id, bandMax - bandMin);
+    centreInBandById.set(id, desiredCentre + shift);
+    childBandStartsById.set(
+      id,
+      childStarts.map((start: number): number => {
+        return start + shift;
+      }),
+    );
+  }
+
+  /*
+   * Pass two, top down: turn the band offsets into coordinates. Depth
+   * alone fixes y, so a child is always exactly one level gap below its
+   * parent however wide the tree gets.
+   */
+  const bandStartById: Map<string, number> = new Map<string, number>();
+  bandStartById.set(rootId, 0);
+  const local: Map<string, TopologyPoint> = new Map<string, TopologyPoint>();
+
+  for (const id of memberIds) {
+    const bandStart: number = bandStartById.get(id) || 0;
+    const depth: number = forest.depthById.get(id) || 0;
+    local.set(id, {
+      x: bandStart + (centreInBandById.get(id) || 0),
+      y: PARENT_CHILD_TOP_MARGIN + depth * PARENT_CHILD_LEVEL_GAP,
+    });
+
+    const children: Array<string> = forest.childrenById.get(id) || [];
+    const childStarts: Array<number> = childBandStartsById.get(id) || [];
+    children.forEach((childId: string, childIndex: number): void => {
+      bandStartById.set(childId, bandStart + (childStarts[childIndex] || 0));
+    });
+  }
+
+  return local;
+};
+
+/**
+ * Compute the parent-child topology layout.
+ *
+ * Pure and deterministic: the same graph always produces the same
+ * coordinates, whatever order its nodes and edges arrive in.
+ *
+ * `pinned` carries positions the user established by dragging. They are
+ * applied last and win outright — the point of dragging a device is that
+ * it stays where you put it — and are still counted in the reported
+ * content extent so fit-to-view cannot leave one off screen.
+ */
+export const computeParentChildTopologyModel: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  width: number,
+  height: number,
+  pinned?: ReadonlyMap<string, TopologyPoint> | undefined,
+) => TopologyLayoutModel = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  width: number,
+  height: number,
+  pinned?: ReadonlyMap<string, TopologyPoint> | undefined,
+): TopologyLayoutModel => {
+  const positions: Map<string, TopologyPoint> = new Map<
+    string,
+    TopologyPoint
+  >();
+  const componentBoxes: Array<TopologyComponentBox> = [];
+  const orderedNodeIds: Array<string> = canonicalNodeOrder(nodes);
+
+  const frameWidth: number = Number.isFinite(width) && width > 0 ? width : 1000;
+  const frameHeight: number =
+    Number.isFinite(height) && height > 0 ? height : 700;
+
+  if (orderedNodeIds.length === 0) {
+    return {
+      positions: positions,
+      componentBoxes: componentBoxes,
+      groups: [],
+      contentWidth: frameWidth,
+      contentHeight: frameHeight,
+    };
+  }
+
+  const adjacency: TopologyAdjacency = buildTopologyAdjacency(nodes, edges);
+  const footprints: Map<string, TopologyNodeFootprint> = buildFootprints(nodes);
+  const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+
+  /*
+   * Devices with no links at all get their own strip rather than a place
+   * in the packing — a lone one-node "tree" is not a hierarchy, and
+   * scattering forty of them through the map buries the actual structure.
+   * Presented exactly as the force layout presents its strip so the two
+   * modes read the same.
+   */
+  const linkedRootIds: Array<string> = [];
+  const unlinkedIds: Array<string> = [];
+  const membersByRoot: Map<string, Array<string>> = new Map<
+    string,
+    Array<string>
+  >();
+  for (const rootId of forest.rootIds) {
+    const members: Array<string> = orderTreeMembers(rootId, forest);
+    membersByRoot.set(rootId, members);
+    const isIsolated: boolean =
+      members.length === 1 && (adjacency.degreeById.get(rootId) || 0) === 0;
+    if (isIsolated) {
+      unlinkedIds.push(rootId);
+    } else {
+      linkedRootIds.push(rootId);
+    }
+  }
+
+  // Lay each tree out in its own band-local coordinate space.
+  const localPositions: Array<Map<string, TopologyPoint>> = [];
+  const localBoxes: Array<ParentChildInkBox> = [];
+  for (const rootId of linkedRootIds) {
+    const members: Array<string> = membersByRoot.get(rootId) || [];
+    const local: Map<string, TopologyPoint> = layoutTreeBand(
+      rootId,
+      members,
+      forest,
+      footprints,
+    );
+    const box: ParentChildInkBox = inkBoxFor(members, local, footprints) || {
+      minX: 0,
+      minY: 0,
+      maxX: 0,
+      maxY: 0,
+    };
+    localPositions.push(local);
+    localBoxes.push(box);
+  }
+
+  /*
+   * Each tree's band is one box for the shared shelf packer, ordered by
+   * ROOT ID rather than by the packer's usual decreasing height.
+   *
+   * A tidy tree's height is a quantized function of its depth: one newly
+   * discovered POS terminal deepens its tree by a whole level gap, and
+   * under a height-ordered pack that is enough to make two side-by-side
+   * trees trade ends of the map — every node in both of them moving,
+   * sixty seconds after the last poll, because one till came online. The
+   * same goes for width, which steps whenever a switch gains a sibling.
+   * Neither is a fact about the tree's identity, and the reader's mental
+   * map of "the warehouse is on the left" is worth more than the shelf
+   * space decreasing height would save.
+   */
+  const packInputs: Array<PackInput> = linkedRootIds.map(
+    (rootId: string, index: number): PackInput => {
+      const box: ParentChildInkBox = localBoxes[index]!;
+      return {
+        width: box.maxX - box.minX,
+        height: box.maxY - box.minY,
+        key: rootId,
+      };
+    },
+  );
+  const packed: PackResult = packComponentBoxes(
+    packInputs,
+    Math.max(1, frameWidth - 2 * PARENT_CHILD_LAYOUT_MARGIN),
+    PARENT_CHILD_TREE_GAP,
+    "key",
+  );
+
+  linkedRootIds.forEach((rootId: string, index: number): void => {
+    const local: Map<string, TopologyPoint> = localPositions[index]!;
+    const box: ParentChildInkBox = localBoxes[index]!;
+    const slot: PackedBox = packed.placements[index]!;
+    const offsetX: number = slot.x - box.minX;
+    const offsetY: number = slot.y - box.minY;
+    const members: Array<string> = membersByRoot.get(rootId) || [];
+    for (const nodeId of members) {
+      const point: TopologyPoint = local.get(nodeId) || { x: 0, y: 0 };
+      positions.set(nodeId, { x: point.x + offsetX, y: point.y + offsetY });
+    }
+    componentBoxes.push({
+      key: rootId,
+      nodeIds: members.slice(),
+      x: slot.x,
+      y: slot.y,
+      width: slot.width,
+      height: slot.height,
+      nodeCount: members.length,
+      isUnlinked: false,
+    });
+  });
+
+  // The unlinked strip: a wrapped grid under everything else.
+  if (unlinkedIds.length > 0) {
+    const usableWidth: number = Math.max(
+      UNLINKED_STRIP_PITCH_X,
+      Math.max(frameWidth - 2 * PARENT_CHILD_LAYOUT_MARGIN, packed.width),
+    );
+    const perRow: number = Math.max(
+      1,
+      Math.floor(usableWidth / UNLINKED_STRIP_PITCH_X),
+    );
+    const rows: number = Math.ceil(unlinkedIds.length / perRow);
+    const stripTop: number =
+      packed.height > 0 ? packed.height + UNLINKED_STRIP_TOP_GAP : 0;
+
+    let stripMaxX: number = 0;
+    unlinkedIds.forEach((nodeId: string, index: number): void => {
+      const row: number = Math.floor(index / perRow);
+      const column: number = index % perRow;
+      const x: number =
+        column * UNLINKED_STRIP_PITCH_X + UNLINKED_STRIP_PITCH_X / 2;
+      const y: number =
+        stripTop + row * UNLINKED_STRIP_PITCH_Y + UNLINKED_STRIP_PITCH_Y / 2;
+      positions.set(nodeId, { x: x, y: y });
+      stripMaxX = Math.max(stripMaxX, x);
+    });
+
+    const stripBox: ParentChildInkBox = inkBoxFor(
+      unlinkedIds,
+      positions,
+      footprints,
+    ) || {
+      minX: 0,
+      minY: stripTop,
+      maxX: stripMaxX,
+      maxY: stripTop + rows * UNLINKED_STRIP_PITCH_Y,
+    };
+    componentBoxes.push({
+      key: UNLINKED_BOX_KEY,
+      nodeIds: unlinkedIds.slice(),
+      x: stripBox.minX,
+      y: stripBox.minY,
+      width: stripBox.maxX - stripBox.minX,
+      height: stripBox.maxY - stripBox.minY,
+      nodeCount: unlinkedIds.length,
+      isUnlinked: true,
+    });
+  }
+
+  /*
+   * Centre the PAINTED extent, not the box of node centres: glyphs and
+   * labels are a fixed size in viewBox units, so a tree measured by its
+   * centres sits visibly high in its card by half a label height. The
+   * layout is never scaled to fit — the viewport zooms instead, which is
+   * the only way to keep the level gap meaning what it says.
+   */
+  const finalBox: ParentChildInkBox = inkBoxFor(
+    orderedNodeIds,
+    positions,
+    footprints,
+  ) || { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  const spanX: number = finalBox.maxX - finalBox.minX;
+  const spanY: number = finalBox.maxY - finalBox.minY;
+  const contentWidth: number = Math.max(
+    frameWidth,
+    spanX + 2 * PARENT_CHILD_LAYOUT_MARGIN,
+  );
+  const contentHeight: number = Math.max(
+    frameHeight,
+    spanY + 2 * PARENT_CHILD_LAYOUT_MARGIN,
+  );
+  const originX: number = (contentWidth - spanX) / 2 - finalBox.minX;
+  const originY: number = (contentHeight - spanY) / 2 - finalBox.minY;
+
+  for (const nodeId of orderedNodeIds) {
+    const point: TopologyPoint | undefined = positions.get(nodeId);
+    if (!point) {
+      continue;
+    }
+    positions.set(nodeId, { x: point.x + originX, y: point.y + originY });
+  }
+
+  /*
+   * Re-derive each hull from where its members actually ended up rather
+   * than translating the box it had before, so the outline stays snug
+   * against the tree it describes.
+   */
+  for (const box of componentBoxes) {
+    const memberBox: ParentChildInkBox | null = inkBoxFor(
+      box.nodeIds,
+      positions,
+      footprints,
+    );
+    if (!memberBox) {
+      continue;
+    }
+    box.x = memberBox.minX;
+    box.y = memberBox.minY;
+    box.width = memberBox.maxX - memberBox.minX;
+    box.height = memberBox.maxY - memberBox.minY;
+  }
+
+  // Pins last, and bit for bit: a dragged device stays where it was dropped.
+  let pinnedMaxX: number = -Infinity;
+  let pinnedMaxY: number = -Infinity;
+  if (pinned && pinned.size > 0) {
+    for (const nodeId of orderedNodeIds) {
+      const point: TopologyPoint | undefined = pinned.get(nodeId);
+      if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+        continue;
+      }
+      positions.set(nodeId, { x: point.x, y: point.y });
+      const footprint: TopologyNodeFootprint = footprintOrDefault(
+        footprints,
+        nodeId,
+      );
+      pinnedMaxX = Math.max(pinnedMaxX, point.x + footprint.inkHalfWidth);
+      pinnedMaxY = Math.max(pinnedMaxY, point.y + footprint.labelBottom);
+    }
+  }
+
+  return {
+    positions: positions,
+    componentBoxes: componentBoxes,
+    groups: [],
+    contentWidth: Number.isFinite(pinnedMaxX)
+      ? Math.max(contentWidth, pinnedMaxX + PARENT_CHILD_LAYOUT_MARGIN)
+      : contentWidth,
+    contentHeight: Number.isFinite(pinnedMaxY)
+      ? Math.max(contentHeight, pinnedMaxY + PARENT_CHILD_LAYOUT_MARGIN)
+      : contentHeight,
+  };
+};

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/StarTopologyLayout.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/StarTopologyLayout.ts
@@ -1,0 +1,722 @@
+import {
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import { isEndpointNode, isFdbEdge } from "./EndpointNodeUtil";
+import {
+  TopologyNodeFootprint,
+  buildFootprints,
+  footprintOrDefault,
+} from "./TopologyFootprint";
+import {
+  TopologyAdjacency,
+  TopologyPoint,
+  buildTopologyAdjacency,
+  canonicalNodeOrder,
+  compareNodeIds,
+} from "./TopologyGraphUtil";
+import { TopologyComponentBox, TopologyLayoutModel } from "./TopologyModel";
+
+/*
+ * Star layout: one hub dead centre, everything else on a ring per hop.
+ *
+ * This is deliberately NOT the radial layout, even though both draw
+ * circles. Radial ranks a node by its ROLE — routers inside, switches
+ * next, endpoints on the rim — so two devices land on the same ring
+ * because they are the same kind of box, however far apart they are on
+ * the wire. Star ranks a node by its DISTANCE FROM ONE CHOSEN HUB, so a
+ * ring means "this many hops from the core" and nothing else.
+ *
+ * The two therefore answer different questions. Radial answers "what
+ * hangs off what". Star answers "what hangs off THIS, and how far away is
+ * it" — the hub-and-spoke picture an operator draws on a whiteboard when
+ * asked to explain a site: the router in the middle, its switches around
+ * it, their devices beyond. When the hub is the thing that just went
+ * down, the ring a node sits on is exactly the blast radius.
+ *
+ * Like radial, no simulation: angles come from wedge subdivision and
+ * radii are derived from those angles, so the result is exact, instant,
+ * and a pure function of the graph.
+ */
+
+/** Hub centre to the first ring. */
+export const STAR_HUB_RING_GAP: number = 150;
+/** Centre-to-centre distance between two consecutive rings. */
+export const STAR_RING_MIN_GAP: number = 120;
+/** Clearance between two neighbours sitting on the same ring. */
+export const STAR_SLOT_PADDING: number = 18;
+export const STAR_LAYOUT_MARGIN: number = 48;
+
+/*
+ * Wedge spans below this are treated as zero when sizing a ring: dividing
+ * a node's painted width by a span of ~1e-12 produces a radius no screen
+ * and no float can honour, and the node it would have spaced is invisible
+ * at that angular size anyway.
+ */
+const STAR_MIN_WEDGE_SPAN: number = 1e-9;
+
+const TWO_PI: number = Math.PI * 2;
+
+interface StarNode {
+  id: string;
+  /** BFS hops from the hub; the hub is 0. */
+  ring: number;
+  weight: number;
+  children: Array<string>;
+}
+
+interface StarWedge {
+  nodeId: string;
+  start: number;
+  end: number;
+}
+
+/** First occurrence of each id wins, so a duplicated row cannot shadow. */
+const indexNodesById: (
+  nodes: Array<NetworkTopologyNode>,
+) => Map<string, NetworkTopologyNode> = (
+  nodes: Array<NetworkTopologyNode>,
+): Map<string, NetworkTopologyNode> => {
+  const nodeById: Map<string, NetworkTopologyNode> = new Map<
+    string,
+    NetworkTopologyNode
+  >();
+  for (const node of nodes || []) {
+    if (node && typeof node.id === "string" && !nodeById.has(node.id)) {
+      nodeById.set(node.id, node);
+    }
+  }
+  return nodeById;
+};
+
+/** Ids of every node touched by at least one FDB edge. */
+const collectFdbNodeIds: (edges: Array<NetworkTopologyEdge>) => Set<string> = (
+  edges: Array<NetworkTopologyEdge>,
+): Set<string> => {
+  const nodeIdsWithFdbEdges: Set<string> = new Set<string>();
+  for (const edge of edges || []) {
+    if (edge && isFdbEdge(edge)) {
+      nodeIdsWithFdbEdges.add(edge.fromNodeId);
+      nodeIdsWithFdbEdges.add(edge.toNodeId);
+    }
+  }
+  return nodeIdsWithFdbEdges;
+};
+
+/**
+ * True for a link a device reported about ITSELF over LLDP or CDP, as
+ * opposed to a MAC address its bridge happened to learn. Edges from older
+ * payloads carry no protocols at all and were only ever discovery links.
+ */
+const isDiscoveryEdge: (edge: NetworkTopologyEdge) => boolean = (
+  edge: NetworkTopologyEdge,
+): boolean => {
+  if (!edge.protocols || edge.protocols.length === 0) {
+    return true;
+  }
+  return edge.protocols.includes("lldp") || edge.protocols.includes("cdp");
+};
+
+/**
+ * Distinct discovery-protocol neighbours per node — the count of other
+ * network devices this one is actually cabled to, with learned endpoints
+ * left out. Deduped per pair, so a link reported by both LLDP and CDP, or
+ * from both ends, counts once.
+ */
+const collectDiscoveryDegrees: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+) => Map<string, number> = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+): Map<string, number> => {
+  const known: Set<string> = new Set<string>(canonicalNodeOrder(nodes));
+  const neighborsById: Map<string, Set<string>> = new Map<
+    string,
+    Set<string>
+  >();
+
+  const link: (self: string, other: string) => void = (
+    self: string,
+    other: string,
+  ): void => {
+    const existing: Set<string> | undefined = neighborsById.get(self);
+    if (existing) {
+      existing.add(other);
+      return;
+    }
+    neighborsById.set(self, new Set<string>([other]));
+  };
+
+  for (const edge of edges || []) {
+    if (!edge || !isDiscoveryEdge(edge)) {
+      continue;
+    }
+    const from: string = edge.fromNodeId;
+    const to: string = edge.toNodeId;
+    if (!known.has(from) || !known.has(to) || from === to) {
+      continue;
+    }
+    link(from, to);
+    link(to, from);
+  }
+
+  const degreeById: Map<string, number> = new Map<string, number>();
+  for (const [id, neighbors] of neighborsById) {
+    degreeById.set(id, neighbors.size);
+  }
+  return degreeById;
+};
+
+/**
+ * What KIND of thing a hub candidate is, before any measure of how busy
+ * it is: managed devices first, then unmanaged discovery peers, then
+ * endpoints.
+ *
+ * Deliberately NOT {@link tierForNode}, which the tiered and radial
+ * layouts use: that rule demotes a managed device to the switch tier the
+ * moment it appears in one FDB row, which is the right call for a layout
+ * that BANDS by role and the wrong one for choosing a centre. A core
+ * router learns a directly-attached host the day someone plugs a laptop
+ * into it, and if that single row could drop it out of the candidate tier
+ * the centre of the map would jump to an access switch on the next poll.
+ */
+const hubRoleRank: (node: NetworkTopologyNode) => number = (
+  node: NetworkTopologyNode,
+): number => {
+  if (isEndpointNode(node)) {
+    return 2;
+  }
+  return node.isManaged ? 0 : 1;
+};
+
+/** One node measured against every signal the hub choice reads. */
+interface StarHubCandidate {
+  id: string;
+  role: number;
+  discoveryDegree: number;
+  /** 1 when the node appears in an FDB row, so ties prefer 0. */
+  fdbRank: number;
+  degree: number;
+}
+
+/**
+ * Total order on hub candidates: better sorts first, and no two distinct
+ * candidates ever compare equal.
+ */
+const compareStarHubCandidates: (
+  a: StarHubCandidate,
+  b: StarHubCandidate,
+) => number = (a: StarHubCandidate, b: StarHubCandidate): number => {
+  if (a.role !== b.role) {
+    return a.role - b.role;
+  }
+  if (a.discoveryDegree !== b.discoveryDegree) {
+    return b.discoveryDegree - a.discoveryDegree;
+  }
+  if (a.fdbRank !== b.fdbRank) {
+    return a.fdbRank - b.fdbRank;
+  }
+  if (a.degree !== b.degree) {
+    return b.degree - a.degree;
+  }
+  return compareNodeIds(a.id, b.id);
+};
+
+/**
+ * Choose the node the star is drawn around.
+ *
+ * Three rules, in this order, and the order is the whole design:
+ *
+ * CONNECTED FIRST. A candidate with no links at all cannot be the middle
+ * of anything — every other node would be an unreachable island fanned
+ * onto one ring around a device none of them is cabled to, and since star
+ * publishes no component hulls nothing on screen would say so. A spare
+ * switch racked and polled but not yet patched is an ordinary thing to
+ * find in a site, so this is not a corner case. Only when the graph has
+ * no edges whatsoever does an unlinked node become eligible.
+ *
+ * ROLE SECOND. An access switch with forty endpoints hanging off it
+ * out-degrees the router it uplinks to by an order of magnitude, so a
+ * pure highest-degree pick would enthrone the switch and push the router
+ * out to ring one. Nobody draws a site that way — the hub of a site is
+ * its core device, and every ring reads as "hops from the core" only if
+ * the core is what sits in the middle.
+ *
+ * CABLING THIRD. Within one role the ranking is by DISCOVERY-protocol
+ * neighbours — how many other network devices this one is cabled to —
+ * rather than by raw degree. Raw degree counts learned MAC addresses,
+ * which is a number an access switch always wins and which changes every
+ * time a till is switched on. Discovery neighbours change when someone
+ * patches a cable, which is exactly when the centre of the map should be
+ * allowed to move. "Has any FDB row at all" then separates a router from
+ * a switch of otherwise equal cabling, and raw degree and the node id
+ * settle whatever is left, so the choice is always a function of the
+ * graph and never of the row order the poll returned.
+ *
+ * Endpoints are excluded from the candidate set outright (a POS terminal
+ * is never the middle of anything), unless the graph is nothing but
+ * endpoints, in which case they are all we have to choose from.
+ *
+ * Returns null only for an empty or absent node list.
+ */
+export const selectStarHubNodeId: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+) => string | null = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+): string | null => {
+  const orderedNodeIds: Array<string> = canonicalNodeOrder(nodes);
+  if (orderedNodeIds.length === 0) {
+    return null;
+  }
+
+  const nodeById: Map<string, NetworkTopologyNode> = indexNodesById(nodes);
+  const nodeIdsWithFdbEdges: Set<string> = collectFdbNodeIds(edges);
+  const adjacency: TopologyAdjacency = buildTopologyAdjacency(nodes, edges);
+  const discoveryDegreeById: Map<string, number> = collectDiscoveryDegrees(
+    nodes,
+    edges,
+  );
+
+  const nonEndpointIds: Array<string> = orderedNodeIds.filter(
+    (id: string): boolean => {
+      const node: NetworkTopologyNode | undefined = nodeById.get(id);
+      return !node || !isEndpointNode(node);
+    },
+  );
+  const candidates: Array<string> =
+    nonEndpointIds.length > 0 ? nonEndpointIds : orderedNodeIds;
+  const linkedCandidates: Array<string> = candidates.filter(
+    (id: string): boolean => {
+      return (adjacency.degreeById.get(id) || 0) > 0;
+    },
+  );
+  const rankable: Array<string> =
+    linkedCandidates.length > 0 ? linkedCandidates : candidates;
+
+  let best: StarHubCandidate | null = null;
+  for (const id of rankable) {
+    const node: NetworkTopologyNode | undefined = nodeById.get(id);
+    const candidate: StarHubCandidate = {
+      id: id,
+      // A position with no node behind it is ranked as an unmanaged peer.
+      role: node ? hubRoleRank(node) : 1,
+      discoveryDegree: discoveryDegreeById.get(id) || 0,
+      fdbRank: nodeIdsWithFdbEdges.has(id) ? 1 : 0,
+      degree: adjacency.degreeById.get(id) || 0,
+    };
+    if (best === null || compareStarHubCandidates(candidate, best) < 0) {
+      best = candidate;
+    }
+  }
+
+  return best ? best.id : null;
+};
+
+/**
+ * Hops from the hub for every node, hub included at 0.
+ *
+ * Nodes the hub cannot reach — a satellite office whose uplink was never
+ * discovered, a switch pair cabled only to each other — are not dropped
+ * and are never given depth 0, which would stack them on top of the hub
+ * and make the picture a lie. They land one ring past the furthest
+ * reachable node, where "outside everything the hub can see" is exactly
+ * what the geometry says about them.
+ *
+ * Returns an empty map when the hub is not part of the graph.
+ */
+export const computeStarRingDepths: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  hubNodeId: string,
+) => Map<string, number> = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  hubNodeId: string,
+): Map<string, number> => {
+  const depthById: Map<string, number> = new Map<string, number>();
+  const orderedNodeIds: Array<string> = canonicalNodeOrder(nodes);
+  if (
+    orderedNodeIds.length === 0 ||
+    typeof hubNodeId !== "string" ||
+    !orderedNodeIds.includes(hubNodeId)
+  ) {
+    return depthById;
+  }
+
+  const adjacency: TopologyAdjacency = buildTopologyAdjacency(nodes, edges);
+
+  /*
+   * Level-by-level BFS with each frontier sorted by id before it is
+   * drained. The depths themselves do not depend on visit order, but
+   * spelling the order out keeps the traversal a function of the graph
+   * rather than of the row order the topology query happened to return
+   * on this poll.
+   */
+  depthById.set(hubNodeId, 0);
+  let frontier: Array<string> = [hubNodeId];
+  let depth: number = 0;
+  let maxReachableDepth: number = 0;
+  while (frontier.length > 0) {
+    const nextFrontier: Array<string> = [];
+    for (const current of frontier) {
+      for (const neighborId of adjacency.neighborsById.get(current) || []) {
+        if (depthById.has(neighborId)) {
+          continue;
+        }
+        depthById.set(neighborId, depth + 1);
+        nextFrontier.push(neighborId);
+      }
+    }
+    if (nextFrontier.length > 0) {
+      maxReachableDepth = depth + 1;
+    }
+    nextFrontier.sort(compareNodeIds);
+    frontier = nextFrontier;
+    depth++;
+  }
+
+  const islandDepth: number = maxReachableDepth + 1;
+  for (const id of orderedNodeIds) {
+    if (!depthById.has(id)) {
+      depthById.set(id, islandDepth);
+    }
+  }
+
+  return depthById;
+};
+
+/**
+ * Compute a hub-and-spoke layout around the node
+ * {@link selectStarHubNodeId} picks.
+ */
+export const computeStarTopologyModel: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  width: number,
+  height: number,
+  pinned?: ReadonlyMap<string, TopologyPoint> | undefined,
+) => TopologyLayoutModel = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  width: number,
+  height: number,
+  pinned?: ReadonlyMap<string, TopologyPoint> | undefined,
+): TopologyLayoutModel => {
+  const positions: Map<string, TopologyPoint> = new Map<
+    string,
+    TopologyPoint
+  >();
+  const orderedNodeIds: Array<string> = canonicalNodeOrder(nodes);
+
+  const frameWidth: number = Number.isFinite(width) && width > 0 ? width : 1000;
+  const frameHeight: number =
+    Number.isFinite(height) && height > 0 ? height : 700;
+
+  if (orderedNodeIds.length === 0) {
+    return {
+      positions: positions,
+      componentBoxes: [],
+      groups: [],
+      contentWidth: frameWidth,
+      contentHeight: frameHeight,
+    };
+  }
+
+  const footprints: Map<string, TopologyNodeFootprint> = buildFootprints(nodes);
+  const adjacency: TopologyAdjacency = buildTopologyAdjacency(nodes, edges);
+
+  /*
+   * A non-null hub is guaranteed for a non-empty node list; the fallback
+   * exists so a future change to the selection rules cannot silently turn
+   * the whole map into one node stacked at the origin.
+   */
+  const hubNodeId: string =
+    selectStarHubNodeId(nodes, edges) || orderedNodeIds[0]!;
+  const depthById: Map<string, number> = computeStarRingDepths(
+    nodes,
+    edges,
+    hubNodeId,
+  );
+
+  const starById: Map<string, StarNode> = new Map<string, StarNode>();
+  let maxRing: number = 0;
+  for (const id of orderedNodeIds) {
+    const depth: number | undefined = depthById.get(id);
+    const ring: number =
+      typeof depth === "number" && Number.isFinite(depth) && depth >= 0
+        ? Math.floor(depth)
+        : id === hubNodeId
+          ? 0
+          : 1;
+    maxRing = Math.max(maxRing, ring);
+    starById.set(id, { id: id, ring: ring, weight: 1, children: [] });
+  }
+
+  /*
+   * The hub tree: a node's parent is its canonically-first neighbour
+   * exactly one ring inward. Cycles make several neighbours eligible and
+   * the id order picks between them, so the tree — and every wedge
+   * derived from it — is a function of the graph.
+   *
+   * Nodes with no such neighbour are the unreachable ones. They share the
+   * outermost ring and get their own even split of the circle below,
+   * because there is no parent wedge to carve theirs out of.
+   */
+  const orphanIds: Array<string> = [];
+  for (const id of orderedNodeIds) {
+    const self: StarNode = starById.get(id)!;
+    if (id === hubNodeId || self.ring === 0) {
+      continue;
+    }
+    let parentId: string | null = null;
+    for (const neighborId of adjacency.neighborsById.get(id) || []) {
+      const neighbor: StarNode | undefined = starById.get(neighborId);
+      if (!neighbor || neighbor.ring !== self.ring - 1) {
+        continue;
+      }
+      if (parentId === null || compareNodeIds(neighborId, parentId) < 0) {
+        parentId = neighborId;
+      }
+    }
+    if (parentId === null) {
+      orphanIds.push(id);
+    } else {
+      starById.get(parentId)!.children.push(id);
+    }
+  }
+  orphanIds.sort(compareNodeIds);
+  for (const [, star] of starById) {
+    star.children.sort(compareNodeIds);
+  }
+
+  /*
+   * Subtree weight, accumulated from the outermost ring inward. A switch
+   * carrying forty endpoints needs forty times the wedge of one carrying
+   * a single endpoint; sized evenly instead, the busy switch's endpoints
+   * pile up while the quiet one keeps a quarter of the circle empty.
+   */
+  const byRingDescending: Array<string> = orderedNodeIds
+    .slice()
+    .sort((a: string, b: string): number => {
+      const ringDelta: number = starById.get(b)!.ring - starById.get(a)!.ring;
+      return ringDelta === 0 ? compareNodeIds(a, b) : ringDelta;
+    });
+  for (const id of byRingDescending) {
+    const star: StarNode = starById.get(id)!;
+    let childWeight: number = 0;
+    for (const childId of star.children) {
+      childWeight += starById.get(childId)!.weight;
+    }
+    star.weight = Math.max(1, childWeight);
+  }
+
+  /*
+   * Pass one: angles.
+   *
+   * The hub owns the full circle and hands wedges to its children; each
+   * child then subdivides the wedge it was given, and so on outward.
+   * Because a child's wedge is always CONTAINED in its parent's, no spoke
+   * can cross another one — which is the entire reason to offer this mode
+   * instead of letting a force simulation approximate it.
+   *
+   * The split is half even and half by subtree weight. Pure weighting
+   * collapses at the top: a router carrying four switches and
+   * twenty-four endpoints would give one switch 24/27ths of the circle
+   * and squeeze the other three into four degrees each, where they
+   * overlap. Pure evenness is wrong the other way — it hands a bare
+   * access point as much room as a twenty-four-endpoint subtree. The
+   * blend floors every child at half an even share while still letting a
+   * heavy subtree claim most of the space.
+   */
+  const wedgeById: Map<string, StarWedge> = new Map<string, StarWedge>();
+
+  const shareOf: (
+    memberIds: Array<string>,
+    index: number,
+    totalWeight: number,
+  ) => number = (
+    memberIds: Array<string>,
+    index: number,
+    totalWeight: number,
+  ): number => {
+    const even: number = 1 / memberIds.length;
+    const weighted: number =
+      starById.get(memberIds[index]!)!.weight / Math.max(1, totalWeight);
+    return 0.5 * even + 0.5 * weighted;
+  };
+
+  const hubWedge: StarWedge = { nodeId: hubNodeId, start: 0, end: TWO_PI };
+  wedgeById.set(hubNodeId, hubWedge);
+  const queue: Array<StarWedge> = [hubWedge];
+
+  // Islands get the circle to themselves on the ring they alone occupy.
+  if (orphanIds.length > 0) {
+    const orphanSpan: number = TWO_PI / orphanIds.length;
+    orphanIds.forEach((orphanId: string, index: number): void => {
+      const wedge: StarWedge = {
+        nodeId: orphanId,
+        start: index * orphanSpan,
+        end: (index + 1) * orphanSpan,
+      };
+      wedgeById.set(orphanId, wedge);
+      queue.push(wedge);
+    });
+  }
+
+  while (queue.length > 0) {
+    const current: StarWedge = queue.shift()!;
+    const star: StarNode = starById.get(current.nodeId)!;
+    if (star.children.length === 0) {
+      continue;
+    }
+    let childTotal: number = 0;
+    for (const childId of star.children) {
+      childTotal += starById.get(childId)!.weight;
+    }
+    const parentSpan: number = current.end - current.start;
+    let childCursor: number = current.start;
+    star.children.forEach((childId: string, index: number): void => {
+      const span: number =
+        shareOf(star.children, index, childTotal) * parentSpan;
+      const wedge: StarWedge = {
+        nodeId: childId,
+        start: childCursor,
+        end: childCursor + span,
+      };
+      wedgeById.set(childId, wedge);
+      queue.push(wedge);
+      childCursor += span;
+    });
+  }
+
+  /*
+   * Pass two: radii, derived from the angles rather than guessed before
+   * them. A ring is pushed outward until the NARROWEST wedge on it is
+   * wide enough for that node's own painted width, so two neighbours on
+   * one ring cannot overlap by construction rather than because a
+   * relaxation pass happened to converge.
+   */
+  const radiusByRing: Array<number> = new Array<number>(maxRing + 1).fill(0);
+  for (let ring: number = 1; ring <= maxRing; ring++) {
+    let needed: number = 0;
+    for (const id of orderedNodeIds) {
+      if (starById.get(id)!.ring !== ring) {
+        continue;
+      }
+      const wedge: StarWedge | undefined = wedgeById.get(id);
+      const span: number = wedge ? wedge.end - wedge.start : TWO_PI;
+      const slotWidth: number =
+        footprintOrDefault(footprints, id).inkHalfWidth * 2 + STAR_SLOT_PADDING;
+      if (span > STAR_MIN_WEDGE_SPAN) {
+        needed = Math.max(needed, slotWidth / span);
+      }
+    }
+    radiusByRing[ring] =
+      ring === 1
+        ? Math.max(STAR_HUB_RING_GAP, needed)
+        : Math.max(radiusByRing[ring - 1]! + STAR_RING_MIN_GAP, needed);
+  }
+
+  for (const id of orderedNodeIds) {
+    const star: StarNode = starById.get(id)!;
+    const wedge: StarWedge | undefined = wedgeById.get(id);
+    const angle: number = wedge ? (wedge.start + wedge.end) / 2 : 0;
+    const radius: number = radiusByRing[star.ring] || 0;
+    const x: number = radius * Math.cos(angle);
+    const y: number = radius * Math.sin(angle);
+    // A NaN here would blank the element and the graph bounds with it.
+    positions.set(id, {
+      x: Number.isFinite(x) ? x : 0,
+      y: Number.isFinite(y) ? y : 0,
+    });
+  }
+
+  /*
+   * Translate the painted extent to the origin, then centre it — with one
+   * difference from the radial tail: the extent is taken SYMMETRICALLY
+   * about the hub (the widest side is mirrored) instead of hugging the
+   * ink. Hugging it puts the hub at the centre of the drawn ink, which is
+   * not the centre of the box whenever the spokes are uneven — a
+   * three-way fan, or one deep branch — and a hub-and-spoke picture whose
+   * hub sits off to one side has given up the one thing it promises. The
+   * cost is some empty space opposite the longest spoke, which reads as
+   * headroom rather than as an error.
+   */
+  let halfSpanX: number = 0;
+  let halfSpanY: number = 0;
+  for (const id of orderedNodeIds) {
+    const point: TopologyPoint | undefined = positions.get(id);
+    if (!point) {
+      continue;
+    }
+    const footprint: TopologyNodeFootprint = footprintOrDefault(footprints, id);
+    halfSpanX = Math.max(halfSpanX, Math.abs(point.x) + footprint.inkHalfWidth);
+    halfSpanY = Math.max(
+      halfSpanY,
+      Math.abs(point.y - footprint.halfHeight),
+      Math.abs(point.y + footprint.labelBottom),
+    );
+  }
+
+  const minX: number = -halfSpanX;
+  const minY: number = -halfSpanY;
+  const spanX: number = 2 * halfSpanX;
+  const spanY: number = 2 * halfSpanY;
+  const contentWidth: number = Math.max(
+    frameWidth,
+    spanX + 2 * STAR_LAYOUT_MARGIN,
+  );
+  const contentHeight: number = Math.max(
+    frameHeight,
+    spanY + 2 * STAR_LAYOUT_MARGIN,
+  );
+  const offsetX: number = (contentWidth - spanX) / 2 - minX;
+  const offsetY: number = (contentHeight - spanY) / 2 - minY;
+
+  for (const id of orderedNodeIds) {
+    const point: TopologyPoint | undefined = positions.get(id);
+    if (point) {
+      positions.set(id, { x: point.x + offsetX, y: point.y + offsetY });
+    }
+  }
+
+  /*
+   * Star draws one hub-centred picture, so it publishes no component
+   * hulls: the outermost ring already says "these are not connected to
+   * the hub", and a box drawn round them would only repeat it.
+   */
+  const componentBoxes: Array<TopologyComponentBox> = [];
+
+  let pinnedMaxX: number = -Infinity;
+  let pinnedMaxY: number = -Infinity;
+  if (pinned && pinned.size > 0) {
+    for (const id of orderedNodeIds) {
+      const point: TopologyPoint | undefined = pinned.get(id);
+      if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+        continue;
+      }
+      positions.set(id, { x: point.x, y: point.y });
+      const footprint: TopologyNodeFootprint = footprintOrDefault(
+        footprints,
+        id,
+      );
+      pinnedMaxX = Math.max(pinnedMaxX, point.x + footprint.inkHalfWidth);
+      pinnedMaxY = Math.max(pinnedMaxY, point.y + footprint.labelBottom);
+    }
+  }
+
+  return {
+    positions: positions,
+    componentBoxes: componentBoxes,
+    groups: [],
+    contentWidth: Number.isFinite(pinnedMaxX)
+      ? Math.max(contentWidth, pinnedMaxX + STAR_LAYOUT_MARGIN)
+      : contentWidth,
+    contentHeight: Number.isFinite(pinnedMaxY)
+      ? Math.max(contentHeight, pinnedMaxY + STAR_LAYOUT_MARGIN)
+      : contentHeight,
+  };
+};

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyPacking.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyPacking.ts
@@ -23,6 +23,11 @@ import { compareNodeIds } from "./TopologyGraphUtil";
  * box list, so a new island lands at the end and everything earlier stays
  * put. It also produces rows, which read as "here are your islands", and
  * puts the largest component alone on the top shelf where the eye lands.
+ *
+ * "Stays put" is a claim about the SORTED list, though, not about the
+ * caller's identities: a component whose box grows past its neighbour's
+ * still trades places with it. Callers whose box size steps with the
+ * graph — see {@link PackOrder} — ask for the identity order instead.
  */
 
 // Clearance between two packed component boxes.
@@ -49,12 +54,56 @@ export interface PackResult {
   height: number;
 }
 
+/**
+ * Which order the boxes are laid onto the shelves in.
+ *
+ * "decreasingHeight" is the NFDH default described above and is right
+ * whenever a box's size is stable: it wastes the least vertical space.
+ *
+ * "key" orders by identity instead, and exists for callers whose box
+ * HEIGHT is a quantized function of the graph — a tidy tree is exactly
+ * that, its pixel height stepping by one level gap the moment a single
+ * new leaf is discovered. Sorted by height, two side-by-side trees swap
+ * ends of the map when one of them grows a row, which reads as the whole
+ * network having been rearranged when all that happened was that a till
+ * came online. Ordering by root id costs some shelf space and buys a map
+ * whose left-to-right order a reader can rely on between polls.
+ */
+export type PackOrder = "decreasingHeight" | "key";
+
 interface SortableBox {
   index: number;
   width: number;
   height: number;
   key: string;
 }
+
+/*
+ * Tallest first so a shelf's wasted vertical space is bounded by the
+ * height of its own first box. Width then key so the order is total —
+ * two same-sized components must not be able to swap places between
+ * renders.
+ */
+const compareByDecreasingHeight: (a: SortableBox, b: SortableBox) => number = (
+  a: SortableBox,
+  b: SortableBox,
+): number => {
+  if (a.height !== b.height) {
+    return b.height - a.height;
+  }
+  if (a.width !== b.width) {
+    return b.width - a.width;
+  }
+  return compareNodeIds(a.key, b.key);
+};
+
+/** Identity alone, so no measurement of the box can reorder the shelves. */
+const compareByKey: (a: SortableBox, b: SortableBox) => number = (
+  a: SortableBox,
+  b: SortableBox,
+): number => {
+  return compareNodeIds(a.key, b.key);
+};
 
 /**
  * Pack boxes into shelves no wider than `maxRowWidth`.
@@ -67,10 +116,12 @@ export const packComponentBoxes: (
   boxes: Array<PackInput>,
   maxRowWidth: number,
   gap: number,
+  order?: PackOrder | undefined,
 ) => PackResult = (
   boxes: Array<PackInput>,
   maxRowWidth: number,
   gap: number,
+  order?: PackOrder | undefined,
 ): PackResult => {
   const placements: Array<PackedBox> = boxes.map((): PackedBox => {
     return { x: 0, y: 0, width: 0, height: 0 };
@@ -95,21 +146,7 @@ export const packComponentBoxes: (
     },
   );
 
-  /*
-   * Tallest first so a shelf's wasted vertical space is bounded by the
-   * height of its own first box. Width then key so the order is total —
-   * two same-sized components must not be able to swap places between
-   * renders.
-   */
-  sortable.sort((a: SortableBox, b: SortableBox): number => {
-    if (a.height !== b.height) {
-      return b.height - a.height;
-    }
-    if (a.width !== b.width) {
-      return b.width - a.width;
-    }
-    return compareNodeIds(a.key, b.key);
-  });
+  sortable.sort(order === "key" ? compareByKey : compareByDecreasingHeight);
 
   let shelfTop: number = 0;
   let shelfHeight: number = 0;

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkDeviceGraph.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkDeviceGraph.tsx
@@ -12,6 +12,8 @@ import {
 } from "../NetworkDevice/TopologyLayout";
 import { computeForceTopologyModel } from "../NetworkDevice/ForceTopologyLayout";
 import { computeRadialTopologyModel } from "../NetworkDevice/RadialTopologyLayout";
+import { computeStarTopologyModel } from "../NetworkDevice/StarTopologyLayout";
+import { computeParentChildTopologyModel } from "../NetworkDevice/ParentChildTopologyLayout";
 import { TopologyPoint } from "../NetworkDevice/TopologyGraphUtil";
 import {
   LABEL_VISIBILITY_MIN_SCALE,
@@ -106,7 +108,10 @@ export interface ComponentProps {
   /*
    * "force" (the default) is the organic project-wide map, "tiered" lays
    * routers over switches over endpoints for a single site, and "radial"
-   * puts the core at the centre with everything hanging off it.
+   * puts the core at the centre with everything hanging off it. "star"
+   * also centres one hub, but ranks by hops from it rather than by role,
+   * so a ring reads as blast radius; "parentChild" draws the same
+   * hierarchy as a top-down tree, every node under its own parent.
    */
   layoutMode?: TopologyLayoutMode | undefined;
   /** Node kinds to draw. Absent means all of them. */
@@ -225,6 +230,17 @@ const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
     }
     if (layoutMode === "radial") {
       return computeRadialTopologyModel(nodes, edges, VIEW_WIDTH, VIEW_HEIGHT);
+    }
+    if (layoutMode === "star") {
+      return computeStarTopologyModel(nodes, edges, VIEW_WIDTH, VIEW_HEIGHT);
+    }
+    if (layoutMode === "parentChild") {
+      return computeParentChildTopologyModel(
+        nodes,
+        edges,
+        VIEW_WIDTH,
+        VIEW_HEIGHT,
+      );
     }
     return computeForceTopologyModel(nodes, edges, VIEW_WIDTH, VIEW_HEIGHT);
     /*
@@ -458,12 +474,12 @@ const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
   }, [viewModel]);
 
   /*
-   * A new layout mode is a new coordinate system — force, tiered and
-   * radial each centre their own content independently — so the viewport
-   * the user framed in the old one means nothing in the new one. Without
-   * this, panning down a tall tiered graph and then switching to radial
-   * leaves the camera pointing at empty canvas with no way back except
-   * Fit to view.
+   * A new layout mode is a new coordinate system — every mode centres its
+   * own content independently, and a tree is a different shape from a
+   * ring — so the viewport the user framed in the old one means nothing in
+   * the new one. Without this, panning down a tall tiered graph and then
+   * switching to radial leaves the camera pointing at empty canvas with no
+   * way back except Fit to view.
    */
   useEffect(() => {
     hasUserAdjustedView.current = false;

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyLiveView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyLiveView.tsx
@@ -8,13 +8,13 @@ import {
   kindOfNode,
 } from "./NetworkTopologyViewModel";
 import {
+  ArrangementPersistence,
   PositionOverrides,
   TopologyLayoutMode,
   TopologyOverrideStorage,
+  createArrangementPersistence,
   positionOverridesStorageKey,
   prunePositionOverrides,
-  readPersistedOverrides,
-  writePersistedOverrides,
 } from "./TopologyPositionOverrides";
 import { isEndpointNode } from "../NetworkDevice/EndpointNodeUtil";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
@@ -73,7 +73,7 @@ export interface ComponentProps {
   siteId?: string | undefined;
   /*
    * The layout the view opens on. The user can switch between force,
-   * tiered and radial from the toolbar afterwards.
+   * tiered, radial, star and parent-child from the toolbar afterwards.
    */
   layoutMode?: TopologyLayoutMode | undefined;
 }
@@ -391,46 +391,50 @@ const NetworkTopologyLiveView: FunctionComponent<ComponentProps> = (
   }, [props.siteId, layoutMode]);
 
   /*
+   * Which arrangement is pending a write, and which key it belongs to.
+   * Kept in one object precisely so the two cannot drift apart — see
+   * ArrangementPersistence for what happens when they do. Built once and
+   * held in a ref: the storage handle is feature-detected once at mount
+   * and never changes, so there is nothing here to rebuild.
+   */
+  const persistenceRef: React.MutableRefObject<ArrangementPersistence | null> =
+    useRef<ArrangementPersistence | null>(null);
+  if (persistenceRef.current === null) {
+    persistenceRef.current = createArrangementPersistence(
+      overrideStorage,
+      overridesStorageKey,
+    );
+  }
+  const persistence: ArrangementPersistence = persistenceRef.current;
+
+  /*
+   * Render phase: refresh the coordinates a flush would write, and
+   * nothing else. `overridesStorageKey` has ALREADY advanced to the mode
+   * the user just picked while `positionOverrides` still holds the
+   * outgoing mode's coordinates, so the key must not be touched here;
+   * only `adopt` below moves it, and only alongside the arrangement it
+   * belongs to.
+   */
+  persistence.hold(positionOverrides);
+
+  /*
    * Load the saved arrangement for this (project, site, layout mode).
    * Each layout is its own coordinate system, so switching modes loads a
    * different arrangement rather than reinterpreting the current one.
    */
   useEffect(() => {
-    setPositionOverrides(
-      readPersistedOverrides(overrideStorage, overridesStorageKey),
-    );
-  }, [overrideStorage, overridesStorageKey]);
-
-  /*
-   * The latest arrangement and the key it belongs to, so a write can be
-   * flushed from a cleanup — which runs after `positionOverrides` has
-   * already moved on — without the flush itself depending on them.
-   */
-  const pendingWrite: React.MutableRefObject<{
-    key: string;
-    overrides: PositionOverrides;
-  }> = useRef<{ key: string; overrides: PositionOverrides }>({
-    key: overridesStorageKey,
-    overrides: positionOverrides,
-  });
-  pendingWrite.current = {
-    key: overridesStorageKey,
-    overrides: positionOverrides,
-  };
+    setPositionOverrides(persistence.adopt(overridesStorageKey));
+  }, [persistence, overridesStorageKey]);
 
   // Persist, debounced, so a drag does not write on every commit.
   useEffect(() => {
     const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
-      writePersistedOverrides(
-        overrideStorage,
-        overridesStorageKey,
-        positionOverrides,
-      );
+      persistence.flush();
     }, 500);
     return () => {
       clearTimeout(timer);
     };
-  }, [overrideStorage, overridesStorageKey, positionOverrides]);
+  }, [persistence, overridesStorageKey, positionOverrides]);
 
   /*
    * Flush a pending write when the key changes or the view goes away.
@@ -440,20 +444,16 @@ const NetworkTopologyLiveView: FunctionComponent<ComponentProps> = (
    *
    * Deliberately NOT folded into the debounce effect above: that one
    * depends on `positionOverrides`, so its cleanup fires on every commit
-   * and would write on each one, defeating the debounce. This effect's
-   * cleanup runs only on a key change or unmount, and because cleanups
-   * run before any effect body, the ref still holds the OLD key at that
-   * moment — which is the key the pending arrangement belongs to.
+   * and would write on each one, defeating the debounce. This cleanup
+   * runs only on a key change or unmount, and because every cleanup runs
+   * before any effect body, it happens before the `adopt` that switches
+   * modes — so the outgoing arrangement is still the held one.
    */
   useEffect(() => {
     return () => {
-      writePersistedOverrides(
-        overrideStorage,
-        pendingWrite.current.key,
-        pendingWrite.current.overrides,
-      );
+      persistence.flush();
     };
-  }, [overrideStorage, overridesStorageKey]);
+  }, [persistence, overridesStorageKey]);
 
   /*
    * Forget positions for devices that have left the topology. Runs
@@ -524,13 +524,23 @@ const NetworkTopologyLiveView: FunctionComponent<ComponentProps> = (
         <div
           role="group"
           aria-label={translateString("Topology layout") || "Topology layout"}
-          className="inline-flex flex-shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-0.5"
+          /*
+           * flex-wrap because five pills no longer fit a phone. The group
+           * is flex-shrink-0 inside a flex-shrink-0 header column, so
+           * without it the row simply grows past the card and the last
+           * option is unreachable rather than merely cramped — and
+           * "Parent-Child" is the widest label of the five, so it is the
+           * one that would be lost.
+           */
+          className="inline-flex flex-wrap flex-shrink-0 rounded-lg border border-gray-200 bg-gray-50 p-0.5"
         >
           {(
             [
               { mode: "force", label: "Force" },
               { mode: "tiered", label: "Tiered" },
               { mode: "radial", label: "Radial" },
+              { mode: "star", label: "Star" },
+              { mode: "parentChild", label: "Parent-Child" },
             ] as Array<{ mode: TopologyLayoutMode; label: string }>
           ).map(
             (option: {

--- a/App/FeatureSet/Dashboard/src/Components/Topology/TopologyPositionOverrides.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/TopologyPositionOverrides.ts
@@ -19,7 +19,12 @@ import { MAX_WORLD_COORDINATE, clampWorldPoint } from "./TopologyViewport";
 
 export type PositionOverrides = ReadonlyMap<string, TopologyPoint>;
 
-export type TopologyLayoutMode = "force" | "tiered" | "radial";
+export type TopologyLayoutMode =
+  | "force"
+  | "tiered"
+  | "radial"
+  | "star"
+  | "parentChild";
 
 export const PERSISTED_OVERRIDES_VERSION: number = 1;
 /*
@@ -46,12 +51,17 @@ export interface TopologyOverrideStorage {
 /**
  * Storage key for one arrangement.
  *
- * Keyed by layout mode because force, tiered and radial are different
- * coordinate systems — a position saved in tiered mode would fling the
- * node off-screen in force mode. Keyed by site because the node set and
- * the framing differ. The version appears in the key AND inside the
- * payload so a future format change is a clean miss rather than a
- * half-understood read.
+ * Keyed by layout mode because force, tiered, radial, star and
+ * parent-child are all different coordinate systems — a position saved in
+ * tiered mode would fling the node off-screen in force mode. Keyed by site
+ * because the node set and the framing differ. The version appears in the
+ * key AND inside the payload so a future format change is a clean miss
+ * rather than a half-understood read.
+ *
+ * Adding a mode therefore costs nothing here: the new mode simply names a
+ * key nobody has written yet and starts with an empty arrangement, and
+ * every arrangement saved under the older modes keeps its own key and
+ * stays valid.
  */
 export const positionOverridesStorageKey: (
   projectId: string,
@@ -353,6 +363,80 @@ export const writePersistedOverrides: (
   } catch {
     // Quota exhausted or storage disabled — persistence is best effort.
   }
+};
+
+/**
+ * The persistence side of one topology view: the arrangement currently on
+ * screen, the storage key it belongs to, and — the whole point — when
+ * each of those two is allowed to move.
+ *
+ * They do not move together, and that is what makes this worth a type of
+ * its own. Picking a new layout mode re-renders the view with the
+ * INCOMING mode's storage key while the arrangement in state is still the
+ * OUTGOING mode's coordinates, and the flush that saves the outgoing
+ * arrangement runs inside exactly that window. Pair the two up there and
+ * the write files tiered coordinates under the star key, the load that
+ * immediately follows reads them straight back, and the node is drawn at
+ * a position from a coordinate system it was never in — the off-screen
+ * fling the mode-keyed storage exists to prevent. Worse, the star
+ * arrangement the operator actually built is gone, overwritten by the
+ * mode they just left.
+ *
+ * So {@link ArrangementPersistence.hold} carries coordinates and never
+ * touches the key, {@link ArrangementPersistence.adopt} is the only thing
+ * that moves the key and it moves it together with the arrangement it
+ * just read from that key, and a flush is therefore always a write of an
+ * arrangement to the key it came from.
+ */
+export interface ArrangementPersistence {
+  /** The key the held arrangement belongs to. */
+  keyInUse: () => string;
+  /** The arrangement a flush would write. */
+  held: () => PositionOverrides;
+  /** The coordinates moved — a drag, a prune — but the mode did not. */
+  hold: (overrides: PositionOverrides) => void;
+  /**
+   * Switch to `key`: load its arrangement and make that the held one.
+   * Returns what was loaded so the caller can put it on screen.
+   */
+  adopt: (key: string) => PositionOverrides;
+  /** Write what is held, under the key it belongs to. */
+  flush: () => void;
+}
+
+export const createArrangementPersistence: (
+  storage: TopologyOverrideStorage | null | undefined,
+  key: string,
+) => ArrangementPersistence = (
+  storage: TopologyOverrideStorage | null | undefined,
+  key: string,
+): ArrangementPersistence => {
+  let heldKey: string = key;
+  let heldOverrides: PositionOverrides = EMPTY_OVERRIDES;
+
+  return {
+    keyInUse: (): string => {
+      return heldKey;
+    },
+    held: (): PositionOverrides => {
+      return heldOverrides;
+    },
+    hold: (overrides: PositionOverrides): void => {
+      heldOverrides = overrides;
+    },
+    adopt: (nextKey: string): PositionOverrides => {
+      const loaded: PositionOverrides = readPersistedOverrides(
+        storage,
+        nextKey,
+      );
+      heldKey = nextKey;
+      heldOverrides = loaded;
+      return loaded;
+    },
+    flush: (): void => {
+      writePersistedOverrides(storage, heldKey, heldOverrides);
+    },
+  };
 };
 
 export { MAX_WORLD_COORDINATE };

--- a/App/Tests/Dashboard/ParentChildTopologyLayout.test.ts
+++ b/App/Tests/Dashboard/ParentChildTopologyLayout.test.ts
@@ -1,0 +1,1772 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import { UNLINKED_BOX_KEY } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/ForceTopologyLayout";
+import {
+  PARENT_CHILD_LAYOUT_MARGIN,
+  PARENT_CHILD_LEVEL_GAP,
+  PARENT_CHILD_SIBLING_GAP,
+  PARENT_CHILD_TREE_GAP,
+  ParentChildForest,
+  buildParentChildForest,
+  computeParentChildTopologyModel,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/ParentChildTopologyLayout";
+import { countNodeOverlaps } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyCollision";
+import {
+  TopologyNodeFootprint,
+  buildFootprints,
+  footprintOrDefault,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyFootprint";
+import {
+  TopologyAdjacency,
+  TopologyEdgePair,
+  TopologyPoint,
+  buildTopologyAdjacency,
+  canonicalNodeOrder,
+  compareNodeIds,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyGraphUtil";
+import {
+  TopologyComponentBox,
+  TopologyLayoutModel,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyModel";
+
+const WIDTH: number = 1000;
+const HEIGHT: number = 700;
+
+/*
+ * Floating point slack for assertions that compare a value against a sum
+ * the layout arrived at by a different route. Every coordinate here is a
+ * dyadic rational built from integer constants, so the real error is zero
+ * or a few ulps — this is deliberately far larger than anything the layout
+ * can produce and far smaller than any error a reader could see.
+ */
+const EPSILON: number = 1e-6;
+
+type MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+) => NetworkTopologyNode;
+
+const makeDevice: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: true,
+    status: "up",
+    kind: "device",
+    ...overrides,
+  };
+};
+
+const makeUnmanaged: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "unmanaged",
+    ...overrides,
+  };
+};
+
+const makeEndpoint: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "endpoint",
+    ...overrides,
+  };
+};
+
+type MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+) => NetworkTopologyEdge;
+
+const makeEdge: MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+): NetworkTopologyEdge => {
+  return { fromNodeId: from, toNodeId: to, protocols: protocols };
+};
+
+/* A switch with `count` endpoints attached over FDB, names zero padded. */
+interface SwitchWithEndpoints {
+  device: NetworkTopologyNode;
+  endpoints: Array<NetworkTopologyNode>;
+  nodes: Array<NetworkTopologyNode>;
+  edges: Array<NetworkTopologyEdge>;
+  endpointIds: Array<string>;
+}
+
+type MakeSwitchFunction = (id: string, count: number) => SwitchWithEndpoints;
+
+const makeSwitchWithEndpoints: MakeSwitchFunction = (
+  id: string,
+  count: number,
+): SwitchWithEndpoints => {
+  const device: NetworkTopologyNode = makeDevice(id);
+  const endpoints: Array<NetworkTopologyNode> = [];
+  const edges: Array<NetworkTopologyEdge> = [];
+  for (let i: number = 0; i < count; i++) {
+    const endpointId: string = `endpoint:${id}-${String(i).padStart(3, "0")}`;
+    endpoints.push(
+      makeEndpoint(endpointId, {
+        name: `${id}-${String(i).padStart(3, "0")}`,
+      }),
+    );
+    edges.push(makeEdge(id, endpointId, ["fdb"]));
+  }
+  return {
+    device: device,
+    endpoints: endpoints,
+    nodes: [device, ...endpoints],
+    edges: edges,
+    endpointIds: endpoints.map((endpoint: NetworkTopologyNode): string => {
+      return endpoint.id;
+    }),
+  };
+};
+
+/*
+ * A chain rooted at a managed device with unmanaged links behind it. The
+ * head is the only tier-0 node, so the tree really is `length` deep rather
+ * than branching from whichever interior node happened to win on degree.
+ */
+interface ChainGraph {
+  nodes: Array<NetworkTopologyNode>;
+  edges: Array<NetworkTopologyEdge>;
+  ids: Array<string>;
+}
+
+type MakeChainFunction = (length: number) => ChainGraph;
+
+const makeChain: MakeChainFunction = (length: number): ChainGraph => {
+  const nodes: Array<NetworkTopologyNode> = [makeDevice("core-000")];
+  const edges: Array<NetworkTopologyEdge> = [];
+  const ids: Array<string> = ["core-000"];
+  for (let i: number = 1; i < length; i++) {
+    const id: string = `unmanaged:link-${String(i).padStart(4, "0")}`;
+    nodes.push(makeUnmanaged(id, { name: `link-${String(i)}` }));
+    edges.push(makeEdge(ids[i - 1]!, id, ["lldp"]));
+    ids.push(id);
+  }
+  return { nodes: nodes, edges: edges, ids: ids };
+};
+
+type OverlapCountFunction = (
+  model: TopologyLayoutModel,
+  nodes: Array<NetworkTopologyNode>,
+) => number;
+
+const overlapCount: OverlapCountFunction = (
+  model: TopologyLayoutModel,
+  nodes: Array<NetworkTopologyNode>,
+): number => {
+  return countNodeOverlaps(
+    model.positions,
+    canonicalNodeOrder(nodes),
+    buildFootprints(nodes),
+  );
+};
+
+/* The painted horizontal extent of one placed node. */
+type InkRangeFunction = (
+  model: TopologyLayoutModel,
+  footprints: Map<string, TopologyNodeFootprint>,
+  nodeId: string,
+) => [number, number];
+
+const inkRangeOf: InkRangeFunction = (
+  model: TopologyLayoutModel,
+  footprints: Map<string, TopologyNodeFootprint>,
+  nodeId: string,
+): [number, number] => {
+  const point: TopologyPoint = model.positions.get(nodeId)!;
+  const footprint: TopologyNodeFootprint = footprintOrDefault(
+    footprints,
+    nodeId,
+  );
+  return [point.x - footprint.inkHalfWidth, point.x + footprint.inkHalfWidth];
+};
+
+type ExpectFiniteModelFunction = (model: TopologyLayoutModel) => void;
+
+const expectEveryNumberFinite: ExpectFiniteModelFunction = (
+  model: TopologyLayoutModel,
+): void => {
+  expect(Number.isFinite(model.contentWidth)).toBe(true);
+  expect(Number.isFinite(model.contentHeight)).toBe(true);
+  for (const [, point] of model.positions) {
+    expect(Number.isFinite(point.x)).toBe(true);
+    expect(Number.isFinite(point.y)).toBe(true);
+  }
+  for (const box of model.componentBoxes) {
+    expect(Number.isFinite(box.x)).toBe(true);
+    expect(Number.isFinite(box.y)).toBe(true);
+    expect(Number.isFinite(box.width)).toBe(true);
+    expect(Number.isFinite(box.height)).toBe(true);
+  }
+};
+
+type ExpectIdenticalFunction = (
+  actual: TopologyLayoutModel,
+  expected: TopologyLayoutModel,
+) => void;
+
+/* Byte-for-byte, not "close enough": a re-poll must not nudge the map. */
+const expectIdenticalPlacement: ExpectIdenticalFunction = (
+  actual: TopologyLayoutModel,
+  expected: TopologyLayoutModel,
+): void => {
+  expect(actual.positions.size).toBe(expected.positions.size);
+  for (const [id, point] of expected.positions) {
+    const other: TopologyPoint | undefined = actual.positions.get(id);
+    expect(other).toBeDefined();
+    expect(other!.x).toBe(point.x);
+    expect(other!.y).toBe(point.y);
+  }
+  expect(actual.contentWidth).toBe(expected.contentWidth);
+  expect(actual.contentHeight).toBe(expected.contentHeight);
+  expect(actual.componentBoxes).toEqual(expected.componentBoxes);
+};
+
+/* Walk from a node to its root, reporting whether the walk found a loop. */
+interface ParentChainWalk {
+  chain: Array<string>;
+  hitCycle: boolean;
+}
+
+type ParentChainFunction = (
+  forest: ParentChildForest,
+  nodeId: string,
+) => ParentChainWalk;
+
+const parentChainOf: ParentChainFunction = (
+  forest: ParentChildForest,
+  nodeId: string,
+): ParentChainWalk => {
+  const chain: Array<string> = [];
+  const seen: Set<string> = new Set<string>();
+  let current: string | undefined = nodeId;
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current);
+    current = forest.parentById.get(current);
+  }
+  // A defined cursor here means the walk came back to somewhere it had been.
+  return { chain: chain, hitCycle: current !== undefined };
+};
+
+/* Every id reachable from `rootId` by following child lists only. */
+type ReachableFunction = (
+  forest: ParentChildForest,
+  rootId: string,
+) => Set<string>;
+
+const reachableFromRoot: ReachableFunction = (
+  forest: ParentChildForest,
+  rootId: string,
+): Set<string> => {
+  const seen: Set<string> = new Set<string>([rootId]);
+  const stack: Array<string> = [rootId];
+  while (stack.length > 0) {
+    const current: string = stack.pop()!;
+    for (const child of forest.childrenById.get(current) || []) {
+      if (!seen.has(child)) {
+        seen.add(child);
+        stack.push(child);
+      }
+    }
+  }
+  return seen;
+};
+
+type RotateNodesFunction = (
+  items: Array<NetworkTopologyNode>,
+  by: number,
+) => Array<NetworkTopologyNode>;
+
+const rotateNodes: RotateNodesFunction = (
+  items: Array<NetworkTopologyNode>,
+  by: number,
+): Array<NetworkTopologyNode> => {
+  const offset: number = ((by % items.length) + items.length) % items.length;
+  return [...items.slice(offset), ...items.slice(0, offset)];
+};
+
+type RotateEdgesFunction = (
+  items: Array<NetworkTopologyEdge>,
+  by: number,
+) => Array<NetworkTopologyEdge>;
+
+const rotateEdges: RotateEdgesFunction = (
+  items: Array<NetworkTopologyEdge>,
+  by: number,
+): Array<NetworkTopologyEdge> => {
+  const offset: number = ((by % items.length) + items.length) % items.length;
+  return [...items.slice(offset), ...items.slice(0, offset)];
+};
+
+/*
+ * Canonical branch site, and a genuine tree: one router uplinking two
+ * switches over LLDP, endpoints hanging off the switches over FDB. The
+ * router is the only tier-0 node, so the hierarchy the layout finds must
+ * be exactly the hierarchy written here.
+ */
+const branchNodes: Array<NetworkTopologyNode> = [
+  makeDevice("core-01"),
+  makeDevice("switch-a"),
+  makeDevice("switch-b"),
+  makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+  makeEndpoint("endpoint:pos-2", { name: "pos-2" }),
+  makeEndpoint("endpoint:pos-3", { name: "pos-3" }),
+];
+
+/*
+ * Written child-last and out of order on purpose: the forest must be a
+ * function of the graph, not of the row order the poll happened to return.
+ */
+const branchEdges: Array<NetworkTopologyEdge> = [
+  makeEdge("switch-b", "endpoint:pos-3", ["fdb"]),
+  makeEdge("switch-a", "endpoint:pos-2", ["fdb"]),
+  makeEdge("core-01", "switch-b", ["lldp"]),
+  makeEdge("switch-a", "endpoint:pos-1", ["fdb"]),
+  makeEdge("core-01", "switch-a", ["lldp"]),
+];
+
+describe("buildParentChildForest — a clean tree comes back exactly as written", () => {
+  const forest: ParentChildForest = buildParentChildForest(
+    branchNodes,
+    branchEdges,
+  );
+
+  test("the router roots the only tree", () => {
+    expect(forest.rootIds).toEqual(["core-01"]);
+  });
+
+  test("every node's parent is the device it is actually cabled to", () => {
+    expect(forest.parentById.get("switch-a")).toBe("core-01");
+    expect(forest.parentById.get("switch-b")).toBe("core-01");
+    expect(forest.parentById.get("endpoint:pos-1")).toBe("switch-a");
+    expect(forest.parentById.get("endpoint:pos-2")).toBe("switch-a");
+    expect(forest.parentById.get("endpoint:pos-3")).toBe("switch-b");
+    // A root has no entry at all rather than a null one.
+    expect(forest.parentById.has("core-01")).toBe(false);
+    expect(forest.parentById.size).toBe(branchNodes.length - 1);
+  });
+
+  test("children come back in canonical id order, not edge order", () => {
+    expect(forest.childrenById.get("core-01")).toEqual([
+      "switch-a",
+      "switch-b",
+    ]);
+    // pos-2's edge was listed first; canonical order still puts pos-1 first.
+    expect(forest.childrenById.get("switch-a")).toEqual([
+      "endpoint:pos-1",
+      "endpoint:pos-2",
+    ]);
+    expect(forest.childrenById.get("switch-b")).toEqual(["endpoint:pos-3"]);
+  });
+
+  test("every node has a children entry, leaves included", () => {
+    expect(forest.childrenById.size).toBe(branchNodes.length);
+    expect(forest.childrenById.get("endpoint:pos-1")).toEqual([]);
+    expect(forest.childrenById.get("endpoint:pos-3")).toEqual([]);
+  });
+
+  test("the root is depth zero and depth counts cable hops", () => {
+    expect(forest.depthById.get("core-01")).toBe(0);
+    expect(forest.depthById.get("switch-a")).toBe(1);
+    expect(forest.depthById.get("switch-b")).toBe(1);
+    expect(forest.depthById.get("endpoint:pos-1")).toBe(2);
+    expect(forest.depthById.get("endpoint:pos-3")).toBe(2);
+    expect(forest.depthById.size).toBe(branchNodes.length);
+  });
+
+  test("a parent is always exactly one level shallower than its child", () => {
+    for (const [childId, parentId] of forest.parentById) {
+      expect(forest.depthById.get(childId)).toBe(
+        forest.depthById.get(parentId)! + 1,
+      );
+    }
+  });
+
+  test("childrenById and parentById describe the same relation", () => {
+    for (const [parentId, children] of forest.childrenById) {
+      for (const childId of children) {
+        expect(forest.parentById.get(childId)).toBe(parentId);
+      }
+    }
+    for (const [childId, parentId] of forest.parentById) {
+      expect(forest.childrenById.get(parentId)).toContain(childId);
+    }
+  });
+});
+
+describe("buildParentChildForest — choosing the root", () => {
+  test("a two-link router outranks a switch carrying forty endpoints", () => {
+    /*
+     * The whole reason this layout does not reuse the component's own
+     * degree-first rootId: the access switch out-degrees the router 41 to
+     * 2, and rooting there would draw the router as a child of the switch.
+     */
+    const busy: SwitchWithEndpoints = makeSwitchWithEndpoints("switch-a", 40);
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      makeUnmanaged("unmanaged:ap-1", { name: "ap-1" }),
+      ...busy.nodes,
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("router-1", "switch-a", ["lldp"]),
+      makeEdge("router-1", "unmanaged:ap-1", ["cdp"]),
+      ...busy.edges,
+    ];
+
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expect(forest.rootIds).toEqual(["router-1"]);
+    expect(forest.parentById.get("switch-a")).toBe("router-1");
+    expect(forest.depthById.get("switch-a")).toBe(1);
+    for (const id of busy.endpointIds) {
+      expect(forest.parentById.get(id)).toBe("switch-a");
+      expect(forest.depthById.get(id)).toBe(2);
+    }
+  });
+
+  test("degree breaks a tie between two nodes of the same role", () => {
+    /*
+     * All three are managed with no FDB edges, so all three are tier 0.
+     * The hub sorts LAST by id, which is what makes this a degree test
+     * rather than an accidental id test.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("aa-core"),
+      makeDevice("bb-core"),
+      makeDevice("zz-core"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("zz-core", "aa-core", ["lldp"]),
+      makeEdge("zz-core", "bb-core", ["lldp"]),
+    ];
+
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expect(forest.rootIds).toEqual(["zz-core"]);
+    expect(forest.childrenById.get("zz-core")).toEqual(["aa-core", "bb-core"]);
+  });
+
+  test("compareNodeIds breaks a full tie on role and degree", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-b"),
+      makeDevice("core-a"),
+    ];
+    const forest: ParentChildForest = buildParentChildForest(nodes, [
+      makeEdge("core-b", "core-a", ["lldp"]),
+    ]);
+    // Same tier, same degree of one: the lower id roots the tree.
+    expect(forest.rootIds).toEqual(["core-a"]);
+    expect(forest.parentById.get("core-b")).toBe("core-a");
+  });
+
+  test("role beats degree even when the switch also sorts first", () => {
+    const busy: SwitchWithEndpoints = makeSwitchWithEndpoints("aa-switch", 6);
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("zz-router"),
+      ...busy.nodes,
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("zz-router", "aa-switch", ["lldp"]),
+      ...busy.edges,
+    ];
+    expect(buildParentChildForest(nodes, edges).rootIds).toEqual(["zz-router"]);
+  });
+
+  test("with no router at all the switch roots its own tree", () => {
+    const busy: SwitchWithEndpoints = makeSwitchWithEndpoints("switch-1", 4);
+    const forest: ParentChildForest = buildParentChildForest(
+      busy.nodes,
+      busy.edges,
+    );
+    expect(forest.rootIds).toEqual(["switch-1"]);
+    expect(forest.depthById.get("switch-1")).toBe(0);
+  });
+});
+
+/*
+ * A redundantly cabled distribution block: a ring with two chords, plus a
+ * separate triangle. Nothing here is a tree, and the forest must still be
+ * one.
+ */
+const meshNodes: Array<NetworkTopologyNode> = [
+  makeDevice("core-01"),
+  makeUnmanaged("unmanaged:sw-a", { name: "sw-a" }),
+  makeUnmanaged("unmanaged:sw-b", { name: "sw-b" }),
+  makeUnmanaged("unmanaged:sw-c", { name: "sw-c" }),
+  makeUnmanaged("unmanaged:sw-d", { name: "sw-d" }),
+  makeDevice("edge-01"),
+  makeDevice("edge-02"),
+  makeDevice("edge-03"),
+];
+
+const meshEdges: Array<NetworkTopologyEdge> = [
+  makeEdge("core-01", "unmanaged:sw-a", ["lldp"]),
+  makeEdge("core-01", "unmanaged:sw-d", ["lldp"]),
+  makeEdge("unmanaged:sw-a", "unmanaged:sw-b", ["lldp"]),
+  makeEdge("unmanaged:sw-b", "unmanaged:sw-c", ["lldp"]),
+  makeEdge("unmanaged:sw-c", "unmanaged:sw-d", ["lldp"]),
+  makeEdge("unmanaged:sw-a", "unmanaged:sw-c", ["lldp"]),
+  makeEdge("unmanaged:sw-b", "unmanaged:sw-d", ["lldp"]),
+  makeEdge("edge-01", "edge-02", ["lldp"]),
+  makeEdge("edge-02", "edge-03", ["lldp"]),
+  makeEdge("edge-03", "edge-01", ["lldp"]),
+];
+
+describe("buildParentChildForest — a cyclic graph still yields a tree", () => {
+  const forest: ParentChildForest = buildParentChildForest(
+    meshNodes,
+    meshEdges,
+  );
+
+  test("one root per connected component, in canonical order", () => {
+    expect(forest.rootIds).toEqual(["core-01", "edge-01"]);
+  });
+
+  test("every non-root has exactly one parent", () => {
+    expect(forest.parentById.size).toBe(
+      meshNodes.length - forest.rootIds.length,
+    );
+    for (const node of meshNodes) {
+      const isRoot: boolean = forest.rootIds.includes(node.id);
+      expect(forest.parentById.has(node.id)).toBe(!isRoot);
+    }
+  });
+
+  test("walking the parent chain terminates at the node's own root", () => {
+    for (const node of meshNodes) {
+      const walk: ParentChainWalk = parentChainOf(forest, node.id);
+      expect(walk.hitCycle).toBe(false);
+      const top: string = walk.chain[walk.chain.length - 1]!;
+      expect(forest.rootIds).toContain(top);
+      // The walk took exactly one step per level, so depth and hops agree.
+      expect(walk.chain.length).toBe(forest.depthById.get(node.id)! + 1);
+    }
+  });
+
+  test("no node is its own ancestor", () => {
+    for (const node of meshNodes) {
+      const walk: ParentChainWalk = parentChainOf(forest, node.id);
+      expect(new Set<string>(walk.chain).size).toBe(walk.chain.length);
+      expect(walk.chain.slice(1)).not.toContain(node.id);
+    }
+  });
+
+  test("every member of a component is reachable from its root", () => {
+    const reachedFromCore: Set<string> = reachableFromRoot(forest, "core-01");
+    expect(Array.from(reachedFromCore).sort(compareNodeIds)).toEqual([
+      "core-01",
+      "unmanaged:sw-a",
+      "unmanaged:sw-b",
+      "unmanaged:sw-c",
+      "unmanaged:sw-d",
+    ]);
+    const reachedFromEdge: Set<string> = reachableFromRoot(forest, "edge-01");
+    expect(Array.from(reachedFromEdge).sort(compareNodeIds)).toEqual([
+      "edge-01",
+      "edge-02",
+      "edge-03",
+    ]);
+  });
+
+  test("a parent is always exactly one level shallower than its child", () => {
+    for (const [childId, parentId] of forest.parentById) {
+      expect(forest.depthById.get(childId)).toBe(
+        forest.depthById.get(parentId)! + 1,
+      );
+    }
+  });
+
+  test("when several neighbours qualify as parent the canonical first wins", () => {
+    /*
+     * sw-b and sw-c both sit two hops out and both touch sw-a AND sw-d.
+     * Picking by id rather than by traversal luck is what stops the tree
+     * from re-shaping itself on the next poll.
+     */
+    expect(forest.depthById.get("unmanaged:sw-b")).toBe(2);
+    expect(forest.depthById.get("unmanaged:sw-c")).toBe(2);
+    expect(forest.parentById.get("unmanaged:sw-b")).toBe("unmanaged:sw-a");
+    expect(forest.parentById.get("unmanaged:sw-c")).toBe("unmanaged:sw-a");
+    expect(forest.childrenById.get("unmanaged:sw-d")).toEqual([]);
+  });
+
+  test("the chords decide nothing, but the graph still reports them", () => {
+    /*
+     * The core component is cabled with seven links; a tree over its five
+     * nodes has four edges. The other three are the redundant paths, and
+     * they are still in the adjacency the renderer draws from — they just
+     * do not get to decide where a node goes.
+     */
+    const adjacency: TopologyAdjacency = buildTopologyAdjacency(
+      meshNodes,
+      meshEdges,
+    );
+    const coreLinks: Array<TopologyEdgePair> = adjacency.uniqueEdges.filter(
+      (edge: TopologyEdgePair): boolean => {
+        return !edge.a.startsWith("edge-");
+      },
+    );
+    expect(coreLinks.length).toBe(7);
+
+    let treeEdgesInCore: number = 0;
+    for (const [childId] of forest.parentById) {
+      if (!childId.startsWith("edge-")) {
+        treeEdgesInCore++;
+      }
+    }
+    expect(treeEdgesInCore).toBe(4);
+  });
+});
+
+describe("buildParentChildForest — components and islands", () => {
+  test("three components yield three roots", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-a"),
+      makeDevice("leaf-a"),
+      makeDevice("core-b"),
+      makeDevice("leaf-b"),
+      makeDevice("core-c"),
+      makeDevice("leaf-c"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("core-a", "leaf-a", ["lldp"]),
+      makeEdge("core-b", "leaf-b", ["lldp"]),
+      makeEdge("core-c", "leaf-c", ["lldp"]),
+    ];
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expect(forest.rootIds).toEqual(["core-a", "core-b", "core-c"]);
+    expect(forest.parentById.get("leaf-a")).toBe("core-a");
+    expect(forest.parentById.get("leaf-b")).toBe("core-b");
+    expect(forest.parentById.get("leaf-c")).toBe("core-c");
+  });
+
+  test("a device with no links at all is a one-node tree", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01"),
+      makeDevice("switch-a"),
+      makeDevice("island-1"),
+      makeDevice("island-2"),
+    ];
+    const forest: ParentChildForest = buildParentChildForest(nodes, [
+      makeEdge("core-01", "switch-a", ["lldp"]),
+    ]);
+    expect(forest.rootIds).toEqual(["core-01", "island-1", "island-2"]);
+    for (const id of ["island-1", "island-2"]) {
+      expect(forest.depthById.get(id)).toBe(0);
+      expect(forest.childrenById.get(id)).toEqual([]);
+      expect(forest.parentById.has(id)).toBe(false);
+    }
+  });
+
+  test("an empty topology has no roots and no relations", () => {
+    const forest: ParentChildForest = buildParentChildForest([], []);
+    expect(forest.rootIds).toEqual([]);
+    expect(forest.parentById.size).toBe(0);
+    expect(forest.childrenById.size).toBe(0);
+    expect(forest.depthById.size).toBe(0);
+  });
+
+  test("edges naming unknown nodes cannot invent a parent", () => {
+    const forest: ParentChildForest = buildParentChildForest(
+      [makeDevice("switch-a")],
+      [
+        makeEdge("switch-a", "endpoint:not-in-view", ["fdb"]),
+        makeEdge("switch-a", "switch-a", ["lldp"]),
+      ],
+    );
+    expect(forest.rootIds).toEqual(["switch-a"]);
+    expect(forest.parentById.size).toBe(0);
+    expect(forest.childrenById.get("switch-a")).toEqual([]);
+  });
+
+  test("the forest is a pure function of the graph, not of row order", () => {
+    const reversed: ParentChildForest = buildParentChildForest(
+      [...meshNodes].reverse(),
+      [...meshEdges]
+        .reverse()
+        .map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+          return makeEdge(edge.toNodeId, edge.fromNodeId, edge.protocols);
+        }),
+    );
+    const original: ParentChildForest = buildParentChildForest(
+      meshNodes,
+      meshEdges,
+    );
+    expect(reversed.rootIds).toEqual(original.rootIds);
+    expect(reversed.parentById).toEqual(original.parentById);
+    expect(reversed.childrenById).toEqual(original.childrenById);
+    expect(reversed.depthById).toEqual(original.depthById);
+  });
+});
+
+/* Balanced three-level tree: one core, three switches, three endpoints each. */
+const balancedSwitches: Array<SwitchWithEndpoints> = [
+  makeSwitchWithEndpoints("switch-a", 3),
+  makeSwitchWithEndpoints("switch-b", 3),
+  makeSwitchWithEndpoints("switch-c", 3),
+];
+
+const balancedNodes: Array<NetworkTopologyNode> = [
+  makeDevice("core-01"),
+  ...balancedSwitches[0]!.nodes,
+  ...balancedSwitches[1]!.nodes,
+  ...balancedSwitches[2]!.nodes,
+];
+
+const balancedEdges: Array<NetworkTopologyEdge> = [
+  makeEdge("core-01", "switch-a", ["lldp"]),
+  makeEdge("core-01", "switch-b", ["lldp"]),
+  makeEdge("core-01", "switch-c", ["lldp"]),
+  ...balancedSwitches[0]!.edges,
+  ...balancedSwitches[1]!.edges,
+  ...balancedSwitches[2]!.edges,
+];
+
+describe("computeParentChildTopologyModel — the org chart geometry", () => {
+  const model: TopologyLayoutModel = computeParentChildTopologyModel(
+    balancedNodes,
+    balancedEdges,
+    WIDTH,
+    HEIGHT,
+  );
+  const forest: ParentChildForest = buildParentChildForest(
+    balancedNodes,
+    balancedEdges,
+  );
+
+  test("places every node exactly once with finite coordinates", () => {
+    expect(model.positions.size).toBe(balancedNodes.length);
+    expectEveryNumberFinite(model);
+  });
+
+  test("every child sits exactly one level gap below its parent", () => {
+    for (const [childId, parentId] of forest.parentById) {
+      const child: TopologyPoint = model.positions.get(childId)!;
+      const parent: TopologyPoint = model.positions.get(parentId)!;
+      expect(child.y - parent.y).toBe(PARENT_CHILD_LEVEL_GAP);
+    }
+  });
+
+  test("a leaf never sits above its own parent", () => {
+    for (const [nodeId, children] of forest.childrenById) {
+      if (children.length > 0) {
+        continue;
+      }
+      const parentId: string | undefined = forest.parentById.get(nodeId);
+      if (!parentId) {
+        continue;
+      }
+      expect(model.positions.get(nodeId)!.y).toBeGreaterThan(
+        model.positions.get(parentId)!.y,
+      );
+    }
+  });
+
+  test("every node at one depth shares one row", () => {
+    const yByDepth: Map<number, number> = new Map<number, number>();
+    for (const [nodeId, depth] of forest.depthById) {
+      const y: number = model.positions.get(nodeId)!.y;
+      if (!yByDepth.has(depth)) {
+        yByDepth.set(depth, y);
+      }
+      expect(y).toBe(yByDepth.get(depth));
+    }
+    expect(yByDepth.size).toBe(3);
+  });
+
+  test("a parent is centred over its first and last child", () => {
+    for (const [parentId, children] of forest.childrenById) {
+      if (children.length === 0) {
+        continue;
+      }
+      const first: number = model.positions.get(children[0]!)!.x;
+      const last: number = model.positions.get(
+        children[children.length - 1]!,
+      )!.x;
+      expect(model.positions.get(parentId)!.x).toBeCloseTo(
+        (first + last) / 2,
+        6,
+      );
+    }
+  });
+
+  test("siblings run left to right in canonical id order", () => {
+    for (const [, children] of forest.childrenById) {
+      for (let i: number = 1; i < children.length; i++) {
+        expect(compareNodeIds(children[i - 1]!, children[i]!)).toBeLessThan(0);
+        expect(model.positions.get(children[i]!)!.x).toBeGreaterThan(
+          model.positions.get(children[i - 1]!)!.x,
+        );
+      }
+    }
+  });
+
+  test("a subtree occupies its own horizontal band, never a sibling's", () => {
+    const footprints: Map<string, TopologyNodeFootprint> =
+      buildFootprints(balancedNodes);
+    const spans: Array<[number, number]> = balancedSwitches.map(
+      (group: SwitchWithEndpoints): [number, number] => {
+        const ids: Array<string> = [group.device.id, ...group.endpointIds];
+        let min: number = Infinity;
+        let max: number = -Infinity;
+        for (const id of ids) {
+          const range: [number, number] = inkRangeOf(model, footprints, id);
+          min = Math.min(min, range[0]);
+          max = Math.max(max, range[1]);
+        }
+        return [min, max];
+      },
+    );
+    for (let i: number = 1; i < spans.length; i++) {
+      expect(spans[i]![0] - spans[i - 1]![1]).toBeGreaterThanOrEqual(
+        PARENT_CHILD_SIBLING_GAP - EPSILON,
+      );
+    }
+  });
+
+  test("the parent-child mode reports no tiered group boxes", () => {
+    expect(model.groups).toEqual([]);
+  });
+
+  test("the content box never shrinks below the frame it was given", () => {
+    expect(model.contentWidth).toBeGreaterThanOrEqual(WIDTH);
+    expect(model.contentHeight).toBeGreaterThanOrEqual(HEIGHT);
+  });
+
+  test("the painted extent is centred inside the reported content box", () => {
+    const footprints: Map<string, TopologyNodeFootprint> =
+      buildFootprints(balancedNodes);
+    let minX: number = Infinity;
+    let maxX: number = -Infinity;
+    let minY: number = Infinity;
+    let maxY: number = -Infinity;
+    for (const node of balancedNodes) {
+      const point: TopologyPoint = model.positions.get(node.id)!;
+      const footprint: TopologyNodeFootprint = footprintOrDefault(
+        footprints,
+        node.id,
+      );
+      minX = Math.min(minX, point.x - footprint.inkHalfWidth);
+      maxX = Math.max(maxX, point.x + footprint.inkHalfWidth);
+      minY = Math.min(minY, point.y - footprint.halfHeight);
+      maxY = Math.max(maxY, point.y + footprint.labelBottom);
+    }
+    expect((minX + maxX) / 2).toBeCloseTo(model.contentWidth / 2, 6);
+    expect((minY + maxY) / 2).toBeCloseTo(model.contentHeight / 2, 6);
+  });
+});
+
+describe("computeParentChildTopologyModel — glyphs never overlap", () => {
+  test("a balanced three-level tree", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(balancedNodes.length);
+    expect(overlapCount(model, balancedNodes)).toBe(0);
+    expectEveryNumberFinite(model);
+  });
+
+  test("one switch fanning out three hundred endpoints", () => {
+    const wide: SwitchWithEndpoints = makeSwitchWithEndpoints("switch-01", 300);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      wide.nodes,
+      wide.edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(301);
+    expect(overlapCount(model, wide.nodes)).toBe(0);
+    // The frame is a preference: a 300-wide fan is allowed to exceed it.
+    expect(model.contentWidth).toBeGreaterThan(WIDTH);
+    expectEveryNumberFinite(model);
+  });
+
+  test("a fifty-device chain", () => {
+    const chain: ChainGraph = makeChain(50);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      chain.nodes,
+      chain.edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(50);
+    expect(overlapCount(model, chain.nodes)).toBe(0);
+    // One node per level, so the chain is fifty levels tall.
+    const forest: ParentChildForest = buildParentChildForest(
+      chain.nodes,
+      chain.edges,
+    );
+    expect(forest.depthById.get(chain.ids[49]!)).toBe(49);
+    expect(
+      model.positions.get(chain.ids[49]!)!.y -
+        model.positions.get(chain.ids[0]!)!.y,
+    ).toBe(PARENT_CHILD_LEVEL_GAP * 49);
+  });
+
+  test("three separate components on one map", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      meshNodes,
+      meshEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(meshNodes.length);
+    expect(overlapCount(model, meshNodes)).toBe(0);
+
+    const islandNodes: Array<NetworkTopologyNode> = [
+      ...meshNodes,
+      makeDevice("solo-a"),
+      makeDevice("solo-b"),
+    ];
+    const islandModel: TopologyLayoutModel = computeParentChildTopologyModel(
+      islandNodes,
+      [...meshEdges, makeEdge("solo-a", "solo-b", ["lldp"])],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(overlapCount(islandModel, islandNodes)).toBe(0);
+  });
+
+  test("trees mixed with devices that report no neighbours at all", () => {
+    const nodes: Array<NetworkTopologyNode> = [...balancedNodes];
+    for (let i: number = 0; i < 17; i++) {
+      nodes.push(
+        makeDevice(`island-${String(i).padStart(2, "0")}`, {
+          name: `island-${String(i)}`,
+        }),
+      );
+    }
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      nodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(nodes.length);
+    expect(overlapCount(model, nodes)).toBe(0);
+    expectEveryNumberFinite(model);
+  });
+
+  test("a very wide parent beside a narrow subtree keeps its ink at home", () => {
+    /*
+     * THE CASE THE BAND CLAMPING EXISTS FOR. `aa-switch` carries a name
+     * almost twice as wide as its own subtree, so centring it over its one
+     * tiny child would hang half its label out past the band and paint it
+     * straight over `bb-peer`'s branch. Widening the band and shifting it
+     * back is what keeps that overhang inside its own territory.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01", { name: "core" }),
+      makeDevice("aa-switch", { name: "Distribution Switch Building C" }),
+      makeEndpoint("endpoint:aa-leaf", { name: "" }),
+      makeUnmanaged("bb-peer", { name: "bb" }),
+      makeEndpoint("endpoint:bb-1", { name: "b1" }),
+      makeEndpoint("endpoint:bb-2", { name: "b2" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("core-01", "aa-switch", ["lldp"]),
+      makeEdge("core-01", "bb-peer", ["cdp"]),
+      makeEdge("aa-switch", "endpoint:aa-leaf", ["fdb"]),
+      makeEdge("bb-peer", "endpoint:bb-1", ["fdb"]),
+      makeEdge("bb-peer", "endpoint:bb-2", ["fdb"]),
+    ];
+
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const footprints: Map<string, TopologyNodeFootprint> =
+      buildFootprints(nodes);
+
+    // The premise: the parent really is wider than its whole subtree below.
+    const wideRange: [number, number] = inkRangeOf(
+      model,
+      footprints,
+      "aa-switch",
+    );
+    const childRange: [number, number] = inkRangeOf(
+      model,
+      footprints,
+      "endpoint:aa-leaf",
+    );
+    expect(wideRange[1] - wideRange[0]).toBeGreaterThan(
+      (childRange[1] - childRange[0]) * 4,
+    );
+
+    // The assertion: no part of that label reaches the neighbouring branch.
+    const neighbourIds: Array<string> = [
+      "bb-peer",
+      "endpoint:bb-1",
+      "endpoint:bb-2",
+    ];
+    let neighbourLeft: number = Infinity;
+    for (const id of neighbourIds) {
+      neighbourLeft = Math.min(
+        neighbourLeft,
+        inkRangeOf(model, footprints, id)[0],
+      );
+    }
+    expect(neighbourLeft - wideRange[1]).toBeGreaterThanOrEqual(
+      PARENT_CHILD_SIBLING_GAP - EPSILON,
+    );
+
+    // ...and the narrow child is still centred under its oversized parent.
+    expect(model.positions.get("endpoint:aa-leaf")!.x).toBeCloseTo(
+      model.positions.get("aa-switch")!.x,
+      6,
+    );
+    expect(overlapCount(model, nodes)).toBe(0);
+  });
+
+  test("separate trees never overlap each other, in x or in y", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      ...meshNodes,
+      makeDevice("solo-1"),
+      makeDevice("solo-2"),
+    ];
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      nodes,
+      meshEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    const boxes: Array<TopologyComponentBox> = model.componentBoxes;
+    expect(boxes.length).toBeGreaterThan(1);
+    for (let i: number = 0; i < boxes.length; i++) {
+      for (let j: number = i + 1; j < boxes.length; j++) {
+        const a: TopologyComponentBox = boxes[i]!;
+        const b: TopologyComponentBox = boxes[j]!;
+        const disjointX: boolean =
+          a.x + a.width <= b.x + EPSILON || b.x + b.width <= a.x + EPSILON;
+        const disjointY: boolean =
+          a.y + a.height <= b.y + EPSILON || b.y + b.height <= a.y + EPSILON;
+        expect(disjointX || disjointY).toBe(true);
+      }
+    }
+  });
+
+  test("trees sharing a shelf are a full tree gap apart horizontally", () => {
+    /*
+     * A frame wide enough that the shelf packer never wraps, so every tree
+     * is on one row and the gap between them is the horizontal one.
+     */
+    const wideFrame: number = 6000;
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      meshNodes,
+      meshEdges,
+      wideFrame,
+      HEIGHT,
+    );
+    const ordered: Array<TopologyComponentBox> = [...model.componentBoxes].sort(
+      (a: TopologyComponentBox, b: TopologyComponentBox): number => {
+        return a.x - b.x;
+      },
+    );
+    expect(ordered.length).toBe(2);
+    for (let i: number = 1; i < ordered.length; i++) {
+      expect(
+        ordered[i]!.x - (ordered[i - 1]!.x + ordered[i - 1]!.width),
+      ).toBeCloseTo(PARENT_CHILD_TREE_GAP, 6);
+    }
+  });
+});
+
+describe("computeParentChildTopologyModel — determinism", () => {
+  const original: TopologyLayoutModel = computeParentChildTopologyModel(
+    balancedNodes,
+    balancedEdges,
+    WIDTH,
+    HEIGHT,
+  );
+
+  test("identical input yields identical coordinates", () => {
+    expectIdenticalPlacement(
+      computeParentChildTopologyModel(
+        balancedNodes,
+        balancedEdges,
+        WIDTH,
+        HEIGHT,
+      ),
+      original,
+    );
+  });
+
+  test("reversing the node and edge arrays changes nothing", () => {
+    expectIdenticalPlacement(
+      computeParentChildTopologyModel(
+        [...balancedNodes].reverse(),
+        [...balancedEdges].reverse(),
+        WIDTH,
+        HEIGHT,
+      ),
+      original,
+    );
+  });
+
+  test("rotating the node and edge arrays changes nothing", () => {
+    /*
+     * A rotation is the shape a re-poll actually takes — the same rows in
+     * the same cyclic order, starting somewhere else — so this is the case
+     * that would flap the map every sixty seconds if any decision here
+     * were keyed off array position.
+     */
+    for (const by of [1, 5, 13]) {
+      expectIdenticalPlacement(
+        computeParentChildTopologyModel(
+          rotateNodes(balancedNodes, by),
+          rotateEdges(balancedEdges, by),
+          WIDTH,
+          HEIGHT,
+        ),
+        original,
+      );
+    }
+  });
+
+  test("flipping every edge's direction changes nothing", () => {
+    expectIdenticalPlacement(
+      computeParentChildTopologyModel(
+        balancedNodes,
+        balancedEdges.map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+          return makeEdge(edge.toNodeId, edge.fromNodeId, edge.protocols);
+        }),
+        WIDTH,
+        HEIGHT,
+      ),
+      original,
+    );
+  });
+
+  test("a link reported twice does not shift the layout", () => {
+    expectIdenticalPlacement(
+      computeParentChildTopologyModel(
+        balancedNodes,
+        [
+          ...balancedEdges,
+          makeEdge("switch-a", "core-01", ["cdp"]),
+          makeEdge("core-01", "switch-a", ["lldp"]),
+        ],
+        WIDTH,
+        HEIGHT,
+      ),
+      original,
+    );
+  });
+
+  test("a cyclic, multi-component graph is just as stable", () => {
+    const mesh: TopologyLayoutModel = computeParentChildTopologyModel(
+      meshNodes,
+      meshEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expectIdenticalPlacement(
+      computeParentChildTopologyModel(
+        rotateNodes([...meshNodes].reverse(), 3),
+        rotateEdges(
+          meshEdges.map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+            return makeEdge(edge.toNodeId, edge.fromNodeId, edge.protocols);
+          }),
+          4,
+        ),
+        WIDTH,
+        HEIGHT,
+      ),
+      mesh,
+    );
+  });
+
+  test("islands stay put when a new island is discovered", () => {
+    /*
+     * The shelf packer is Next-Fit-Decreasing-Height precisely so this
+     * holds: a newly discovered island must not relocate the trees that
+     * were already on the map.
+     */
+    const withIslands: TopologyLayoutModel = computeParentChildTopologyModel(
+      [...balancedNodes, makeDevice("island-a")],
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    const withMoreIslands: TopologyLayoutModel =
+      computeParentChildTopologyModel(
+        [...balancedNodes, makeDevice("island-a"), makeDevice("island-b")],
+        balancedEdges,
+        WIDTH,
+        HEIGHT,
+      );
+    // The tree's own shape is unchanged; only the strip below it grew.
+    for (const node of balancedNodes) {
+      const a: TopologyPoint = withIslands.positions.get(node.id)!;
+      const b: TopologyPoint = withMoreIslands.positions.get(node.id)!;
+      expect(b.x - a.x).toBeCloseTo(
+        withMoreIslands.positions.get("core-01")!.x -
+          withIslands.positions.get("core-01")!.x,
+        6,
+      );
+      expect(b.y - a.y).toBeCloseTo(
+        withMoreIslands.positions.get("core-01")!.y -
+          withIslands.positions.get("core-01")!.y,
+        6,
+      );
+    }
+  });
+
+  /*
+   * Two trees side by side on one shelf. Their SHAPE changes constantly —
+   * a till comes online and its tree grows a level, a switch is patched
+   * and its tree grows a column — and none of that is a fact about which
+   * tree is which. A reader who learned "the warehouse is on the left"
+   * must not have to relearn it every sixty seconds.
+   */
+  const twoTreeNodes: Array<NetworkTopologyNode> = [
+    makeDevice("core-a"),
+    makeDevice("switch-a1"),
+    makeDevice("core-b"),
+    makeDevice("switch-b1"),
+  ];
+  const twoTreeEdges: Array<NetworkTopologyEdge> = [
+    makeEdge("core-a", "switch-a1", ["lldp"]),
+    makeEdge("core-b", "switch-b1", ["lldp"]),
+  ];
+
+  type TreeOrderFunction = (
+    nodes: Array<NetworkTopologyNode>,
+    edges: Array<NetworkTopologyEdge>,
+  ) => Array<string>;
+
+  /* The root ids of the packed trees, left to right across the map. */
+  const treesLeftToRight: TreeOrderFunction = (
+    nodes: Array<NetworkTopologyNode>,
+    edges: Array<NetworkTopologyEdge>,
+  ): Array<string> => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    return [...model.componentBoxes]
+      .filter((box: TopologyComponentBox): boolean => {
+        return !box.isUnlinked;
+      })
+      .sort((a: TopologyComponentBox, b: TopologyComponentBox): number => {
+        return a.x - b.x;
+      })
+      .map((box: TopologyComponentBox): string => {
+        return box.key;
+      });
+  };
+
+  test("a tree that gains a level keeps its side of the map", () => {
+    expect(treesLeftToRight(twoTreeNodes, twoTreeEdges)).toEqual([
+      "core-a",
+      "core-b",
+    ]);
+
+    /*
+     * One POS terminal discovered under tree B. That deepens B by a whole
+     * level gap, which under a height-ordered pack is enough to send B to
+     * the head of the shelf and move every node on the map.
+     */
+    const grown: Array<string> = treesLeftToRight(
+      [...twoTreeNodes, makeEndpoint("endpoint:pos-1", { name: "pos-1" })],
+      [...twoTreeEdges, makeEdge("switch-b1", "endpoint:pos-1", ["fdb"])],
+    );
+    expect(grown).toEqual(["core-a", "core-b"]);
+  });
+
+  test("a tree that gains a sibling column keeps its side of the map", () => {
+    /*
+     * The same failure through the packer's width tie-break rather than
+     * its height sort: one more switch patched into core-b widens B past
+     * A without changing its depth at all.
+     */
+    expect(
+      treesLeftToRight(
+        [...twoTreeNodes, makeDevice("switch-b2")],
+        [...twoTreeEdges, makeEdge("core-b", "switch-b2", ["lldp"])],
+      ),
+    ).toEqual(["core-a", "core-b"]);
+  });
+
+  test("the left-to-right order survives a tree growing on either side", () => {
+    /*
+     * Symmetry check, so the fix cannot be "A happens to sort first".
+     * Growing tree A instead must leave the order alone just as firmly.
+     */
+    expect(
+      treesLeftToRight(
+        [...twoTreeNodes, makeEndpoint("endpoint:pos-2", { name: "pos-2" })],
+        [...twoTreeEdges, makeEdge("switch-a1", "endpoint:pos-2", ["fdb"])],
+      ),
+    ).toEqual(["core-a", "core-b"]);
+  });
+});
+
+describe("computeParentChildTopologyModel — pinned nodes", () => {
+  const unpinned: TopologyLayoutModel = computeParentChildTopologyModel(
+    balancedNodes,
+    balancedEdges,
+    WIDTH,
+    HEIGHT,
+  );
+
+  test("a pinned node lands exactly on its pin, even on top of a neighbour", () => {
+    const onTopOfSwitchA: TopologyPoint = unpinned.positions.get("switch-a")!;
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["switch-c", { x: onTopOfSwitchA.x, y: onTopOfSwitchA.y }]]);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    // The user dropped it there; the tidy-tree pass does not tidy it away.
+    expect(model.positions.get("switch-c")).toEqual(onTopOfSwitchA);
+  });
+
+  test("pinning one node leaves every other node exactly where it was", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["switch-b", { x: 42, y: 43 }]]);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.positions.get("switch-b")).toEqual({ x: 42, y: 43 });
+    for (const node of balancedNodes) {
+      if (node.id === "switch-b") {
+        continue;
+      }
+      expect(model.positions.get(node.id)).toEqual(
+        unpinned.positions.get(node.id),
+      );
+    }
+  });
+
+  test("a pin outside the computed extent grows the content box", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["core-01", { x: 5000, y: 4000 }]]);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    const footprint: TopologyNodeFootprint = footprintOrDefault(
+      buildFootprints(balancedNodes),
+      "core-01",
+    );
+    expect(model.contentWidth).toBeCloseTo(
+      5000 + footprint.inkHalfWidth + PARENT_CHILD_LAYOUT_MARGIN,
+      6,
+    );
+    expect(model.contentHeight).toBeCloseTo(
+      4000 + footprint.labelBottom + PARENT_CHILD_LAYOUT_MARGIN,
+      6,
+    );
+  });
+
+  test("a pin inside the computed extent does not shrink the content box", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["core-01", { x: 10, y: 10 }]]);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+    expect(model.contentHeight).toBe(unpinned.contentHeight);
+  });
+
+  test("a pin for a node that left the graph adds no placement", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+      new Map<string, TopologyPoint>([["endpoint:gone", { x: 5, y: 6 }]]),
+    );
+    expect(model.positions.has("endpoint:gone")).toBe(false);
+    expect(model.positions.size).toBe(balancedNodes.length);
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+  });
+
+  test("a non-finite pin is ignored rather than blanking the node", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([
+      ["switch-a", { x: Number.NaN, y: 10 }],
+      ["switch-b", { x: 10, y: Number.POSITIVE_INFINITY }],
+      ["switch-c", { x: Number.NEGATIVE_INFINITY, y: Number.NaN }],
+    ]);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    for (const id of ["switch-a", "switch-b", "switch-c"]) {
+      expect(model.positions.get(id)).toEqual(unpinned.positions.get(id));
+    }
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+    expect(model.contentHeight).toBe(unpinned.contentHeight);
+    expectEveryNumberFinite(model);
+  });
+
+  test("an empty pin map behaves exactly like no pin map", () => {
+    expectIdenticalPlacement(
+      computeParentChildTopologyModel(
+        balancedNodes,
+        balancedEdges,
+        WIDTH,
+        HEIGHT,
+        new Map<string, TopologyPoint>(),
+      ),
+      unpinned,
+    );
+  });
+});
+
+describe("computeParentChildTopologyModel — component boxes", () => {
+  const islandIds: Array<string> = ["zz-island-1", "zz-island-2"];
+  const boxNodes: Array<NetworkTopologyNode> = [
+    makeDevice("core-01"),
+    makeDevice("switch-a"),
+    makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+    makeDevice("edge-01"),
+    makeDevice("edge-02"),
+    ...islandIds.map((id: string): NetworkTopologyNode => {
+      return makeDevice(id, { name: id });
+    }),
+  ];
+  const boxEdges: Array<NetworkTopologyEdge> = [
+    makeEdge("core-01", "switch-a", ["lldp"]),
+    makeEdge("switch-a", "endpoint:pos-1", ["fdb"]),
+    makeEdge("edge-01", "edge-02", ["lldp"]),
+  ];
+  const model: TopologyLayoutModel = computeParentChildTopologyModel(
+    boxNodes,
+    boxEdges,
+    WIDTH,
+    HEIGHT,
+  );
+
+  test("one box per linked tree, keyed by that tree's root id", () => {
+    const keys: Array<string> = model.componentBoxes
+      .map((box: TopologyComponentBox): string => {
+        return box.key;
+      })
+      .sort(compareNodeIds);
+    expect(keys).toEqual(["core-01", "edge-01", UNLINKED_BOX_KEY]);
+  });
+
+  test("a tree's box lists exactly that tree's members", () => {
+    const coreBox: TopologyComponentBox = model.componentBoxes.find(
+      (box: TopologyComponentBox): boolean => {
+        return box.key === "core-01";
+      },
+    )!;
+    expect([...coreBox.nodeIds].sort(compareNodeIds)).toEqual([
+      "core-01",
+      "endpoint:pos-1",
+      "switch-a",
+    ]);
+    expect(coreBox.nodeCount).toBe(3);
+    expect(coreBox.isUnlinked).toBe(false);
+  });
+
+  test("the unlinked strip is flagged and keyed as the strip", () => {
+    const strip: TopologyComponentBox = model.componentBoxes.find(
+      (box: TopologyComponentBox): boolean => {
+        return box.isUnlinked;
+      },
+    )!;
+    expect(strip.key).toBe(UNLINKED_BOX_KEY);
+    expect([...strip.nodeIds].sort(compareNodeIds)).toEqual(islandIds);
+    expect(strip.nodeCount).toBe(islandIds.length);
+  });
+
+  test("every node belongs to exactly one box", () => {
+    const seen: Array<string> = [];
+    for (const box of model.componentBoxes) {
+      seen.push(...box.nodeIds);
+    }
+    expect(seen.length).toBe(boxNodes.length);
+    expect(seen.slice().sort(compareNodeIds)).toEqual(
+      canonicalNodeOrder(boxNodes),
+    );
+  });
+
+  test("a box actually contains its own members' positions", () => {
+    for (const box of model.componentBoxes) {
+      expect(box.width).toBeGreaterThan(0);
+      expect(box.height).toBeGreaterThan(0);
+      for (const id of box.nodeIds) {
+        const point: TopologyPoint = model.positions.get(id)!;
+        expect(point.x).toBeGreaterThanOrEqual(box.x - EPSILON);
+        expect(point.x).toBeLessThanOrEqual(box.x + box.width + EPSILON);
+        expect(point.y).toBeGreaterThanOrEqual(box.y - EPSILON);
+        expect(point.y).toBeLessThanOrEqual(box.y + box.height + EPSILON);
+      }
+    }
+  });
+
+  test("a graph with no islands reports no strip", () => {
+    const noIslands: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(noIslands.componentBoxes.length).toBe(1);
+    expect(noIslands.componentBoxes[0]!.key).toBe("core-01");
+    expect(noIslands.componentBoxes[0]!.isUnlinked).toBe(false);
+  });
+
+  test("a graph of nothing but islands is one strip", () => {
+    const islands: Array<NetworkTopologyNode> = [
+      makeDevice("solo-a"),
+      makeDevice("solo-b"),
+      makeDevice("solo-c"),
+    ];
+    const stripOnly: TopologyLayoutModel = computeParentChildTopologyModel(
+      islands,
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(stripOnly.componentBoxes.length).toBe(1);
+    expect(stripOnly.componentBoxes[0]!.isUnlinked).toBe(true);
+    expect(stripOnly.componentBoxes[0]!.nodeCount).toBe(3);
+    expect(overlapCount(stripOnly, islands)).toBe(0);
+  });
+});
+
+describe("computeParentChildTopologyModel — degenerate and hostile input", () => {
+  test("empty input returns an empty map and the frame it was given", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      [],
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(0);
+    expect(model.componentBoxes).toEqual([]);
+    expect(model.groups).toEqual([]);
+    expect(model.contentWidth).toBe(WIDTH);
+    expect(model.contentHeight).toBe(HEIGHT);
+  });
+
+  test("a zero, negative or non-finite frame falls back to 1000 by 700", () => {
+    const frames: Array<[number, number]> = [
+      [0, 0],
+      [-10, -10],
+      [Number.NaN, Number.NaN],
+      [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+    ];
+    for (const [frameWidth, frameHeight] of frames) {
+      const empty: TopologyLayoutModel = computeParentChildTopologyModel(
+        [],
+        [],
+        frameWidth,
+        frameHeight,
+      );
+      expect(empty.contentWidth).toBe(1000);
+      expect(empty.contentHeight).toBe(700);
+
+      const populated: TopologyLayoutModel = computeParentChildTopologyModel(
+        balancedNodes,
+        balancedEdges,
+        frameWidth,
+        frameHeight,
+      );
+      expect(populated.contentWidth).toBeGreaterThanOrEqual(1000);
+      expect(populated.contentHeight).toBeGreaterThanOrEqual(700);
+      expect(populated.positions.size).toBe(balancedNodes.length);
+      expectEveryNumberFinite(populated);
+    }
+  });
+
+  test("duplicate node ids collapse to one placement", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      [...balancedNodes, makeDevice("switch-a"), makeDevice("core-01")],
+      balancedEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(balancedNodes.length);
+    expect(overlapCount(model, balancedNodes)).toBe(0);
+  });
+
+  test("a self-loop is not a link, so the device is still an island", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      [makeDevice("switch-a"), makeDevice("switch-b")],
+      [
+        makeEdge("switch-a", "switch-a", ["lldp"]),
+        makeEdge("switch-b", "switch-b", ["fdb"]),
+      ],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(2);
+    expect(model.componentBoxes.length).toBe(1);
+    expect(model.componentBoxes[0]!.isUnlinked).toBe(true);
+    expectEveryNumberFinite(model);
+  });
+
+  test("edges naming nodes outside the view add no phantom placements", () => {
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      [makeDevice("switch-a")],
+      [
+        makeEdge("switch-a", "endpoint:not-in-view", ["fdb"]),
+        makeEdge("endpoint:also-gone", "endpoint:not-in-view", ["fdb"]),
+      ],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(1);
+    expect(model.positions.has("endpoint:not-in-view")).toBe(false);
+    expectEveryNumberFinite(model);
+  });
+
+  test("a node with an empty id is dropped, an unnamed node still places", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("switch-1", { name: "" }),
+      makeDevice("", { name: "ghost" }),
+      makeEndpoint("endpoint:x", { name: "" }),
+    ];
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      nodes,
+      [makeEdge("switch-1", "endpoint:x", ["fdb"])],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(2);
+    expect(model.positions.has("")).toBe(false);
+    expect(
+      model.positions.get("endpoint:x")!.y - model.positions.get("switch-1")!.y,
+    ).toBe(PARENT_CHILD_LEVEL_GAP);
+    expect(overlapCount(model, nodes)).toBe(0);
+  });
+
+  test("a null edge in the payload is skipped rather than thrown on", () => {
+    const edges: Array<NetworkTopologyEdge> = [
+      ...balancedEdges,
+      null as unknown as NetworkTopologyEdge,
+    ];
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      balancedNodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(balancedNodes.length);
+    expectEveryNumberFinite(model);
+  });
+
+  test("a single node alone in the view sits centred and finite", () => {
+    const only: NetworkTopologyNode = makeDevice("core-01");
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      [only],
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(1);
+    expect(model.positions.get("core-01")!.x).toBeCloseTo(
+      model.contentWidth / 2,
+      6,
+    );
+    expectEveryNumberFinite(model);
+  });
+
+  test("a two-thousand-device chain returns instead of blowing the stack", () => {
+    const chain: ChainGraph = makeChain(2000);
+    const model: TopologyLayoutModel = computeParentChildTopologyModel(
+      chain.nodes,
+      chain.edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(2000);
+    expectEveryNumberFinite(model);
+    // Two thousand levels of hierarchy, drawn as two thousand rows.
+    expect(
+      model.positions.get(chain.ids[1999]!)!.y -
+        model.positions.get(chain.ids[0]!)!.y,
+    ).toBe(PARENT_CHILD_LEVEL_GAP * 1999);
+    expect(model.contentHeight).toBeGreaterThan(PARENT_CHILD_LEVEL_GAP * 1999);
+  });
+
+  test("no coordinate is ever NaN or Infinity, whatever the input", () => {
+    const scenarios: Array<TopologyLayoutModel> = [
+      computeParentChildTopologyModel([], [], Number.NaN, Number.NaN),
+      computeParentChildTopologyModel(balancedNodes, balancedEdges, 0, 0),
+      computeParentChildTopologyModel(meshNodes, meshEdges, WIDTH, HEIGHT),
+      computeParentChildTopologyModel(
+        [makeDevice("switch-a")],
+        [makeEdge("switch-a", "switch-a", ["lldp"])],
+        WIDTH,
+        HEIGHT,
+      ),
+      computeParentChildTopologyModel(
+        balancedNodes,
+        balancedEdges,
+        WIDTH,
+        HEIGHT,
+        new Map<string, TopologyPoint>([
+          ["core-01", { x: Number.NaN, y: Number.NaN }],
+          ["switch-a", { x: Number.POSITIVE_INFINITY, y: 1 }],
+        ]),
+      ),
+    ];
+    for (const model of scenarios) {
+      expectEveryNumberFinite(model);
+    }
+  });
+});

--- a/App/Tests/Dashboard/StarTopologyLayout.test.ts
+++ b/App/Tests/Dashboard/StarTopologyLayout.test.ts
@@ -1,0 +1,1953 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  STAR_HUB_RING_GAP,
+  STAR_LAYOUT_MARGIN,
+  STAR_RING_MIN_GAP,
+  STAR_SLOT_PADDING,
+  computeStarRingDepths,
+  computeStarTopologyModel,
+  selectStarHubNodeId,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/StarTopologyLayout";
+import { countNodeOverlaps } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyCollision";
+import {
+  TopologyNodeFootprint,
+  buildFootprints,
+  footprintOrDefault,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyFootprint";
+import {
+  TopologyAdjacency,
+  TopologyPoint,
+  buildTopologyAdjacency,
+  canonicalNodeOrder,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyGraphUtil";
+import { TopologyLayoutModel } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyModel";
+
+const WIDTH: number = 1000;
+const HEIGHT: number = 700;
+
+/*
+ * Two device glyphs are 16px radii plus 8px of collision padding each, so
+ * anything closer than this is a literal overlap. Named here so the ring
+ * assertions read as the contract rather than as a magic number.
+ */
+const DEVICE_PAIR_CLEARANCE: number = 48;
+
+/*
+ * A radius is asserted by measuring back from the placed coordinates, and
+ * those went through a cosine, a sine and a translation on the way out. A
+ * ring the layout put at exactly 270 measures 269.99999999999994, so a gap
+ * of exactly 120 reads as 119.99999999999991. This slack is a billionth of
+ * a pixel — small enough that no real regression can hide under it, large
+ * enough that the arithmetic cannot fail the contract.
+ */
+const RADIUS_EPSILON: number = 1e-9;
+
+type MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+) => NetworkTopologyNode;
+
+const makeDevice: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: true,
+    status: "up",
+    kind: "device",
+    ...overrides,
+  };
+};
+
+const makeUnmanaged: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "unmanaged",
+    ...overrides,
+  };
+};
+
+const makeEndpoint: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "endpoint",
+    ...overrides,
+  };
+};
+
+type MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+) => NetworkTopologyEdge;
+
+const makeEdge: MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+): NetworkTopologyEdge => {
+  return { fromNodeId: from, toNodeId: to, protocols: protocols };
+};
+
+/* A switch with `count` endpoints attached over FDB, names zero padded. */
+interface SwitchWithEndpoints {
+  device: NetworkTopologyNode;
+  endpoints: Array<NetworkTopologyNode>;
+  nodes: Array<NetworkTopologyNode>;
+  edges: Array<NetworkTopologyEdge>;
+  endpointIds: Array<string>;
+}
+
+type MakeSwitchFunction = (id: string, count: number) => SwitchWithEndpoints;
+
+const makeSwitchWithEndpoints: MakeSwitchFunction = (
+  id: string,
+  count: number,
+): SwitchWithEndpoints => {
+  const device: NetworkTopologyNode = makeDevice(id);
+  const endpoints: Array<NetworkTopologyNode> = [];
+  const edges: Array<NetworkTopologyEdge> = [];
+  for (let i: number = 0; i < count; i++) {
+    const endpointId: string = `endpoint:${id}-${String(i).padStart(2, "0")}`;
+    endpoints.push(
+      makeEndpoint(endpointId, {
+        name: `${id}-${String(i).padStart(2, "0")}`,
+      }),
+    );
+    edges.push(makeEdge(id, endpointId, ["fdb"]));
+  }
+  return {
+    device: device,
+    endpoints: endpoints,
+    nodes: [device, ...endpoints],
+    edges: edges,
+    endpointIds: endpoints.map((endpoint: NetworkTopologyNode): string => {
+      return endpoint.id;
+    }),
+  };
+};
+
+type DistanceFunction = (a: TopologyPoint, b: TopologyPoint) => number;
+const distanceBetween: DistanceFunction = (
+  a: TopologyPoint,
+  b: TopologyPoint,
+): number => {
+  return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+};
+
+type RadiusFunction = (
+  model: TopologyLayoutModel,
+  centre: TopologyPoint,
+  id: string,
+) => number;
+const radiusOf: RadiusFunction = (
+  model: TopologyLayoutModel,
+  centre: TopologyPoint,
+  id: string,
+): number => {
+  return distanceBetween(centre, model.positions.get(id)!);
+};
+
+type OverlapCountFunction = (
+  model: TopologyLayoutModel,
+  nodes: Array<NetworkTopologyNode>,
+) => number;
+const overlapCount: OverlapCountFunction = (
+  model: TopologyLayoutModel,
+  nodes: Array<NetworkTopologyNode>,
+): number => {
+  return countNodeOverlaps(
+    model.positions,
+    canonicalNodeOrder(nodes),
+    buildFootprints(nodes),
+  );
+};
+
+type MinPairDistanceFunction = (
+  model: TopologyLayoutModel,
+  ids: Array<string>,
+) => number;
+const minPairDistance: MinPairDistanceFunction = (
+  model: TopologyLayoutModel,
+  ids: Array<string>,
+): number => {
+  let smallest: number = Infinity;
+  for (let i: number = 0; i < ids.length; i++) {
+    for (let j: number = i + 1; j < ids.length; j++) {
+      smallest = Math.min(
+        smallest,
+        distanceBetween(
+          model.positions.get(ids[i]!)!,
+          model.positions.get(ids[j]!)!,
+        ),
+      );
+    }
+  }
+  return smallest;
+};
+
+type DegreeFunction = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  id: string,
+) => number;
+const degreeOf: DegreeFunction = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+  id: string,
+): number => {
+  const adjacency: TopologyAdjacency = buildTopologyAdjacency(nodes, edges);
+  return adjacency.degreeById.get(id) || 0;
+};
+
+/*
+ * Deterministic permutations. The topology endpoint returns rows in an
+ * order nothing guarantees and re-polls every minute, so these stand in
+ * for "the same graph, delivered differently" — never Math.random, which
+ * would make a failure here unreproducible.
+ */
+type RotateNodesFunction = (
+  nodes: Array<NetworkTopologyNode>,
+  by: number,
+) => Array<NetworkTopologyNode>;
+const rotateNodes: RotateNodesFunction = (
+  nodes: Array<NetworkTopologyNode>,
+  by: number,
+): Array<NetworkTopologyNode> => {
+  const offset: number = ((by % nodes.length) + nodes.length) % nodes.length;
+  return [...nodes.slice(offset), ...nodes.slice(0, offset)];
+};
+
+type RotateEdgesFunction = (
+  edges: Array<NetworkTopologyEdge>,
+  by: number,
+) => Array<NetworkTopologyEdge>;
+const rotateEdges: RotateEdgesFunction = (
+  edges: Array<NetworkTopologyEdge>,
+  by: number,
+): Array<NetworkTopologyEdge> => {
+  const offset: number = ((by % edges.length) + edges.length) % edges.length;
+  return [...edges.slice(offset), ...edges.slice(0, offset)];
+};
+
+type FiniteModelAssertion = (model: TopologyLayoutModel) => void;
+const expectFiniteModel: FiniteModelAssertion = (
+  model: TopologyLayoutModel,
+): void => {
+  expect(Number.isFinite(model.contentWidth)).toBe(true);
+  expect(Number.isFinite(model.contentHeight)).toBe(true);
+  expect(model.contentWidth).toBeGreaterThan(0);
+  expect(model.contentHeight).toBeGreaterThan(0);
+  for (const [, point] of model.positions) {
+    expect(Number.isFinite(point.x)).toBe(true);
+    expect(Number.isFinite(point.y)).toBe(true);
+  }
+};
+
+/*
+ * Canonical branch site: one router (no FDB edges of its own, so tier 0
+ * and the only hub candidate), two access switches, an unmanaged access
+ * point hanging off one of them, and three POS terminals.
+ */
+const branchRouter: NetworkTopologyNode = makeDevice("router-1");
+const branchSwitchA: NetworkTopologyNode = makeDevice("switch-a");
+const branchSwitchB: NetworkTopologyNode = makeDevice("switch-b");
+const branchAp: NetworkTopologyNode = makeUnmanaged("unmanaged:ap-1", {
+  name: "ap-lobby",
+});
+const branchPos1: NetworkTopologyNode = makeEndpoint("endpoint:pos-1", {
+  name: "pos-1",
+});
+const branchPos2: NetworkTopologyNode = makeEndpoint("endpoint:pos-2", {
+  name: "pos-2",
+});
+const branchPos3: NetworkTopologyNode = makeEndpoint("endpoint:pos-3", {
+  name: "pos-3",
+});
+
+const branchNodes: Array<NetworkTopologyNode> = [
+  branchRouter,
+  branchSwitchA,
+  branchSwitchB,
+  branchAp,
+  branchPos1,
+  branchPos2,
+  branchPos3,
+];
+
+const branchEdges: Array<NetworkTopologyEdge> = [
+  makeEdge("router-1", "switch-a", ["lldp"]),
+  makeEdge("router-1", "switch-b", ["lldp", "cdp"]),
+  makeEdge("switch-a", "unmanaged:ap-1", ["cdp"]),
+  makeEdge("switch-a", "endpoint:pos-1", ["fdb"]),
+  makeEdge("switch-a", "endpoint:pos-2", ["fdb"]),
+  makeEdge("switch-b", "endpoint:pos-3", ["fdb"]),
+];
+
+/*
+ * The same site plus a switch pair whose uplink was never discovered, so
+ * the hub cannot reach it at all.
+ */
+const islandNodes: Array<NetworkTopologyNode> = [
+  ...branchNodes,
+  makeDevice("device:island-a"),
+  makeDevice("device:island-b"),
+  makeEndpoint("endpoint:iso-1", { name: "iso-1" }),
+];
+
+const islandEdges: Array<NetworkTopologyEdge> = [
+  ...branchEdges,
+  makeEdge("device:island-a", "device:island-b", ["lldp"]),
+  makeEdge("device:island-a", "endpoint:iso-1", ["fdb"]),
+];
+
+describe("selectStarHubNodeId — who the star is drawn around", () => {
+  test("an empty node list has no hub", () => {
+    expect(selectStarHubNodeId([], [])).toBeNull();
+  });
+
+  test("an absent node or edge list has no hub rather than throwing", () => {
+    expect(
+      selectStarHubNodeId(
+        undefined as unknown as Array<NetworkTopologyNode>,
+        undefined as unknown as Array<NetworkTopologyEdge>,
+      ),
+    ).toBeNull();
+    expect(
+      selectStarHubNodeId(
+        [makeDevice("router-1")],
+        undefined as unknown as Array<NetworkTopologyEdge>,
+      ),
+    ).toBe("router-1");
+  });
+
+  test("rows with no usable id contribute no hub", () => {
+    expect(
+      selectStarHubNodeId(
+        [
+          null as unknown as NetworkTopologyNode,
+          makeDevice("", { name: "ghost" }),
+        ],
+        [],
+      ),
+    ).toBeNull();
+  });
+
+  test("role beats degree: a two-link router outranks a forty-endpoint switch", () => {
+    const heavy: SwitchWithEndpoints = makeSwitchWithEndpoints("switch-a", 40);
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      makeUnmanaged("unmanaged:peer-1", { name: "peer-1" }),
+      ...heavy.nodes,
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("router-1", "switch-a", ["lldp"]),
+      makeEdge("router-1", "unmanaged:peer-1", ["cdp"]),
+      ...heavy.edges,
+    ];
+
+    /*
+     * The switch out-degrees the router twenty to one; a highest-degree
+     * pick would enthrone it and push the core out to ring one, which is
+     * not how anyone draws a site.
+     */
+    expect(degreeOf(nodes, edges, "switch-a")).toBe(41);
+    expect(degreeOf(nodes, edges, "router-1")).toBe(2);
+    expect(selectStarHubNodeId(nodes, edges)).toBe("router-1");
+  });
+
+  test("degree breaks a tie inside one tier", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("device:core-a"),
+      makeDevice("device:core-z"),
+      makeUnmanaged("unmanaged:peer-1", { name: "peer-1" }),
+      makeUnmanaged("unmanaged:peer-2", { name: "peer-2" }),
+      makeUnmanaged("unmanaged:peer-3", { name: "peer-3" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("device:core-z", "unmanaged:peer-1", ["lldp"]),
+      makeEdge("device:core-z", "unmanaged:peer-2", ["lldp"]),
+      makeEdge("device:core-z", "unmanaged:peer-3", ["lldp"]),
+      makeEdge("device:core-a", "unmanaged:peer-1", ["lldp"]),
+    ];
+    // Both are tier 0; core-z wins on degree despite the later id.
+    expect(selectStarHubNodeId(nodes, edges)).toBe("device:core-z");
+  });
+
+  test("the node id breaks a tie nothing else can", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("device:core-b"),
+      makeDevice("device:core-a"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("device:core-a", "device:core-b", ["lldp"]),
+    ];
+    // Same tier, same degree: the total order on id decides, not arrival.
+    expect(selectStarHubNodeId(nodes, edges)).toBe("device:core-a");
+    expect(selectStarHubNodeId([...nodes].reverse(), edges)).toBe(
+      "device:core-a",
+    );
+  });
+
+  test("an endpoint never wins while any non-endpoint is in view", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeUnmanaged("unmanaged:lonely", { name: "lonely" }),
+      makeEndpoint("endpoint:hub-e", { name: "hub-e" }),
+      makeEndpoint("endpoint:leaf-1", { name: "leaf-1" }),
+      makeEndpoint("endpoint:leaf-2", { name: "leaf-2" }),
+      makeEndpoint("endpoint:leaf-3", { name: "leaf-3" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("endpoint:hub-e", "endpoint:leaf-1", ["fdb"]),
+      makeEdge("endpoint:hub-e", "endpoint:leaf-2", ["fdb"]),
+      makeEdge("endpoint:hub-e", "endpoint:leaf-3", ["fdb"]),
+    ];
+    // The unmanaged peer has no links at all and still takes the middle.
+    expect(degreeOf(nodes, edges, "unmanaged:lonely")).toBe(0);
+    expect(selectStarHubNodeId(nodes, edges)).toBe("unmanaged:lonely");
+  });
+
+  test("endpoints are candidates only when the graph is nothing else", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeEndpoint("endpoint:a", { name: "a" }),
+      makeEndpoint("endpoint:b", { name: "b" }),
+      makeEndpoint("endpoint:c", { name: "c" }),
+      makeEndpoint("endpoint:d", { name: "d" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("endpoint:c", "endpoint:a", ["fdb"]),
+      makeEdge("endpoint:c", "endpoint:b", ["fdb"]),
+      makeEdge("endpoint:c", "endpoint:d", ["fdb"]),
+    ];
+    expect(selectStarHubNodeId(nodes, edges)).toBe("endpoint:c");
+  });
+
+  test("a lone endpoint is its own hub", () => {
+    expect(
+      selectStarHubNodeId(
+        [makeEndpoint("endpoint:solo", { name: "solo" })],
+        [],
+      ),
+    ).toBe("endpoint:solo");
+  });
+
+  test("the branch site puts its router in the middle", () => {
+    expect(selectStarHubNodeId(branchNodes, branchEdges)).toBe("router-1");
+  });
+
+  test("an unpatched spare never takes the centre from a cabled device", () => {
+    /*
+     * A managed switch racked and polled but not yet patched. Ranked by
+     * role alone it looks MORE core than anything else on the site —
+     * nothing has attached an endpoint to it, so nothing marks it as an
+     * access switch — and enthroning it makes every genuinely cabled
+     * device an unreachable island, fanned onto one ring around a box
+     * none of them is connected to. Star publishes no component hulls, so
+     * that collapse is invisible: every real link simply becomes a chord
+     * across the ring and the picture reads as a site with no structure.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("switch-a"),
+      makeDevice("switch-b"),
+      makeDevice("aaa-spare"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("switch-a", "switch-b", ["lldp"]),
+    ];
+    for (const owner of ["a", "b"]) {
+      for (let i: number = 0; i < 6; i++) {
+        const endpointId: string = `endpoint:${owner}-${String(i)}`;
+        nodes.push(makeEndpoint(endpointId, { name: `${owner}-${String(i)}` }));
+        edges.push(makeEdge(`switch-${owner}`, endpointId, ["fdb"]));
+      }
+    }
+
+    // The premise: the spare really does report no links whatsoever.
+    expect(degreeOf(nodes, edges, "aaa-spare")).toBe(0);
+    expect(selectStarHubNodeId(nodes, edges)).toBe("switch-a");
+
+    // A ring is a hop count again, for every node in the picture.
+    const depths: Map<string, number> = computeStarRingDepths(
+      nodes,
+      edges,
+      "switch-a",
+    );
+    expect(depths.get("switch-b")).toBe(1);
+    expect(depths.get("endpoint:a-0")).toBe(1);
+    expect(depths.get("endpoint:b-0")).toBe(2);
+    // The spare is the island now, one ring past everything reachable.
+    expect(depths.get("aaa-spare")).toBe(3);
+
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("switch-a")!;
+    expect(radiusOf(model, hub, "endpoint:b-0")).toBeGreaterThan(
+      radiusOf(model, hub, "switch-b"),
+    );
+    expect(radiusOf(model, hub, "aaa-spare")).toBeGreaterThan(
+      radiusOf(model, hub, "endpoint:b-0"),
+    );
+  });
+
+  test("with nothing cabled anywhere an unlinked device is still eligible", () => {
+    /*
+     * Connectivity outranks role only while there is connectivity to
+     * rank by. A site whose discovery has not run yet is all spares, and
+     * one of them still has to be the middle.
+     */
+    expect(
+      selectStarHubNodeId(
+        [makeDevice("zzz-spare"), makeDevice("aaa-spare")],
+        [],
+      ),
+    ).toBe("aaa-spare");
+  });
+
+  test("one host learned on the core's own bridge table does not move the hub", () => {
+    /*
+     * The moment somebody plugs a laptop into the router, the router
+     * appears in an FDB row of its own. Read as a role signal that single
+     * row says "this is an access switch", and the centre of the site
+     * jumps to a genuine access switch on the next sixty-second poll —
+     * exactly the picture the role rule exists to prevent, produced by
+     * the role rule itself. Cabling is what decides here, and one learned
+     * MAC address is not cabling.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      makeDevice("switch-a"),
+      makeDevice("switch-b"),
+      makeEndpoint("endpoint:b-0", { name: "b-0" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("router-1", "switch-a", ["lldp"]),
+      makeEdge("router-1", "switch-b", ["lldp"]),
+      makeEdge("switch-b", "endpoint:b-0", ["fdb"]),
+    ];
+    for (let i: number = 0; i < 6; i++) {
+      const endpointId: string = `endpoint:a-${String(i)}`;
+      nodes.push(makeEndpoint(endpointId, { name: `a-${String(i)}` }));
+      edges.push(makeEdge("switch-a", endpointId, ["fdb"]));
+    }
+    expect(selectStarHubNodeId(nodes, edges)).toBe("router-1");
+
+    // Next poll: one directly-attached host appears on the router.
+    const nextNodes: Array<NetworkTopologyNode> = [
+      ...nodes,
+      makeEndpoint("endpoint:r-0", { name: "r-0" }),
+    ];
+    const nextEdges: Array<NetworkTopologyEdge> = [
+      ...edges,
+      makeEdge("router-1", "endpoint:r-0", ["fdb"]),
+    ];
+    expect(selectStarHubNodeId(nextNodes, nextEdges)).toBe("router-1");
+
+    // ...and the whole map does not re-centre on the access switch.
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nextNodes,
+      nextEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    const router: TopologyPoint = model.positions.get("router-1")!;
+    expect(router.x).toBeCloseTo(model.contentWidth / 2, 6);
+    expect(router.y).toBeCloseTo(model.contentHeight / 2, 6);
+    expect(radiusOf(model, router, "switch-a")).toBeGreaterThanOrEqual(
+      STAR_HUB_RING_GAP - RADIUS_EPSILON,
+    );
+  });
+
+  test("permuting the input does not change the hub", () => {
+    const reversed: string | null = selectStarHubNodeId(
+      [...branchNodes].reverse(),
+      [...branchEdges].reverse(),
+    );
+    const rotated: string | null = selectStarHubNodeId(
+      rotateNodes(branchNodes, 3),
+      rotateEdges(branchEdges, 4),
+    );
+    expect(reversed).toBe("router-1");
+    expect(rotated).toBe("router-1");
+  });
+});
+
+describe("computeStarRingDepths — hops from the hub", () => {
+  test("the hub is zero and its direct neighbours are one", () => {
+    const depths: Map<string, number> = computeStarRingDepths(
+      branchNodes,
+      branchEdges,
+      "router-1",
+    );
+    expect(depths.get("router-1")).toBe(0);
+    expect(depths.get("switch-a")).toBe(1);
+    expect(depths.get("switch-b")).toBe(1);
+    expect(depths.get("unmanaged:ap-1")).toBe(2);
+    expect(depths.get("endpoint:pos-1")).toBe(2);
+    expect(depths.get("endpoint:pos-3")).toBe(2);
+    expect(depths.size).toBe(branchNodes.length);
+  });
+
+  test("a five node chain gives depths zero through four", () => {
+    const nodes: Array<NetworkTopologyNode> = [];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 5; i++) {
+      nodes.push(makeDevice(`device:hop-${String(i)}`));
+      if (i > 0) {
+        edges.push(
+          makeEdge(`device:hop-${String(i - 1)}`, `device:hop-${String(i)}`, [
+            "lldp",
+          ]),
+        );
+      }
+    }
+    const depths: Map<string, number> = computeStarRingDepths(
+      nodes,
+      edges,
+      "device:hop-0",
+    );
+    for (let i: number = 0; i < 5; i++) {
+      expect(depths.get(`device:hop-${String(i)}`)).toBe(i);
+    }
+  });
+
+  test("a hub in the middle of a chain counts hops in both directions", () => {
+    const nodes: Array<NetworkTopologyNode> = [];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 5; i++) {
+      nodes.push(makeDevice(`device:hop-${String(i)}`));
+      if (i > 0) {
+        edges.push(
+          makeEdge(`device:hop-${String(i - 1)}`, `device:hop-${String(i)}`, [
+            "lldp",
+          ]),
+        );
+      }
+    }
+    const depths: Map<string, number> = computeStarRingDepths(
+      nodes,
+      edges,
+      "device:hop-2",
+    );
+    expect(depths.get("device:hop-2")).toBe(0);
+    expect(depths.get("device:hop-1")).toBe(1);
+    expect(depths.get("device:hop-3")).toBe(1);
+    expect(depths.get("device:hop-0")).toBe(2);
+    expect(depths.get("device:hop-4")).toBe(2);
+  });
+
+  test("a cycle is measured by its shortest path, not by its edge count", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("device:a"),
+      makeDevice("device:b"),
+      makeDevice("device:c"),
+      makeDevice("device:d"),
+    ];
+    // A square: b and d are one hop from a, c is two whichever way round.
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("device:a", "device:b", ["lldp"]),
+      makeEdge("device:b", "device:c", ["lldp"]),
+      makeEdge("device:c", "device:d", ["lldp"]),
+      makeEdge("device:d", "device:a", ["lldp"]),
+    ];
+    const depths: Map<string, number> = computeStarRingDepths(
+      nodes,
+      edges,
+      "device:a",
+    );
+    expect(depths.get("device:a")).toBe(0);
+    expect(depths.get("device:b")).toBe(1);
+    expect(depths.get("device:d")).toBe(1);
+    expect(depths.get("device:c")).toBe(2);
+  });
+
+  test("a node the hub cannot reach lands one ring past the furthest one", () => {
+    const depths: Map<string, number> = computeStarRingDepths(
+      islandNodes,
+      islandEdges,
+      "router-1",
+    );
+    let maxReachable: number = 0;
+    for (const node of branchNodes) {
+      maxReachable = Math.max(maxReachable, depths.get(node.id)!);
+    }
+    expect(maxReachable).toBe(2);
+    for (const id of ["device:island-a", "device:island-b", "endpoint:iso-1"]) {
+      expect(depths.get(id)).toBe(maxReachable + 1);
+    }
+  });
+
+  test("an unreachable node is never given depth zero on top of the hub", () => {
+    const depths: Map<string, number> = computeStarRingDepths(
+      islandNodes,
+      islandEdges,
+      "router-1",
+    );
+    let zeroes: number = 0;
+    for (const [, depth] of depths) {
+      if (depth === 0) {
+        zeroes++;
+      }
+    }
+    expect(zeroes).toBe(1);
+    expect(depths.size).toBe(islandNodes.length);
+  });
+
+  test("a hub with no links at all still ranks every island at one", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("device:alone"),
+      makeDevice("device:pair-a"),
+      makeDevice("device:pair-b"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("device:pair-a", "device:pair-b", ["lldp"]),
+    ];
+    const depths: Map<string, number> = computeStarRingDepths(
+      nodes,
+      edges,
+      "device:alone",
+    );
+    expect(depths.get("device:alone")).toBe(0);
+    expect(depths.get("device:pair-a")).toBe(1);
+    expect(depths.get("device:pair-b")).toBe(1);
+  });
+
+  test("a hub that is not in the graph produces no depths at all", () => {
+    expect(
+      computeStarRingDepths(branchNodes, branchEdges, "device:nope").size,
+    ).toBe(0);
+    expect(computeStarRingDepths(branchNodes, branchEdges, "").size).toBe(0);
+    expect(
+      computeStarRingDepths(
+        branchNodes,
+        branchEdges,
+        undefined as unknown as string,
+      ).size,
+    ).toBe(0);
+    expect(computeStarRingDepths([], [], "router-1").size).toBe(0);
+  });
+
+  test("permuting the input does not change one depth", () => {
+    const original: Map<string, number> = computeStarRingDepths(
+      islandNodes,
+      islandEdges,
+      "router-1",
+    );
+    const permuted: Map<string, number> = computeStarRingDepths(
+      rotateNodes([...islandNodes].reverse(), 5),
+      rotateEdges([...islandEdges].reverse(), 3),
+      "router-1",
+    );
+    expect(permuted).toEqual(original);
+  });
+});
+
+describe("computeStarTopologyModel — a branch site", () => {
+  const model: TopologyLayoutModel = computeStarTopologyModel(
+    branchNodes,
+    branchEdges,
+    WIDTH,
+    HEIGHT,
+  );
+  const hub: TopologyPoint = model.positions.get("router-1")!;
+
+  test("places every node exactly once with finite coordinates", () => {
+    expect(model.positions.size).toBe(branchNodes.length);
+    for (const node of branchNodes) {
+      const point: TopologyPoint | undefined = model.positions.get(node.id);
+      expect(point).toBeDefined();
+      expect(Number.isFinite(point!.x)).toBe(true);
+      expect(Number.isFinite(point!.y)).toBe(true);
+    }
+  });
+
+  test("no two glyphs overlap", () => {
+    expect(overlapCount(model, branchNodes)).toBe(0);
+  });
+
+  test("the hub sits dead centre of the content box", () => {
+    expect(hub.x).toBeCloseTo(model.contentWidth / 2, 6);
+    expect(hub.y).toBeCloseTo(model.contentHeight / 2, 6);
+  });
+
+  test("every node one hop out shares one radius from the hub", () => {
+    const ringOne: number = radiusOf(model, hub, "switch-a");
+    expect(radiusOf(model, hub, "switch-b")).toBeCloseTo(ringOne, 6);
+    expect(ringOne).toBeGreaterThanOrEqual(STAR_HUB_RING_GAP - RADIUS_EPSILON);
+  });
+
+  test("every node two hops out shares one radius, whichever switch it hangs off", () => {
+    const ringTwo: number = radiusOf(model, hub, "endpoint:pos-1");
+    expect(radiusOf(model, hub, "endpoint:pos-2")).toBeCloseTo(ringTwo, 6);
+    // pos-3 is on the other switch and the AP is not an endpoint at all.
+    expect(radiusOf(model, hub, "endpoint:pos-3")).toBeCloseTo(ringTwo, 6);
+    expect(radiusOf(model, hub, "unmanaged:ap-1")).toBeCloseTo(ringTwo, 6);
+  });
+
+  test("a ring-two node is strictly further out than every ring-one node", () => {
+    const ringOneIds: Array<string> = ["switch-a", "switch-b"];
+    const ringTwoIds: Array<string> = [
+      "unmanaged:ap-1",
+      "endpoint:pos-1",
+      "endpoint:pos-2",
+      "endpoint:pos-3",
+    ];
+    for (const outer of ringTwoIds) {
+      for (const inner of ringOneIds) {
+        expect(radiusOf(model, hub, outer)).toBeGreaterThan(
+          radiusOf(model, hub, inner),
+        );
+      }
+    }
+  });
+
+  test("rings step outward by at least the ring gap", () => {
+    const ringOne: number = radiusOf(model, hub, "switch-a");
+    const ringTwo: number = radiusOf(model, hub, "endpoint:pos-1");
+    expect(ringTwo - ringOne).toBeGreaterThanOrEqual(
+      STAR_RING_MIN_GAP - RADIUS_EPSILON,
+    );
+  });
+
+  test("a ring is a hop count, not a role: the unmanaged AP shares the endpoints' ring", () => {
+    /*
+     * This is the whole difference from the radial layout, which would
+     * rank the AP inside the endpoints because it is a different kind of
+     * box. Here it is two hops from the core and so are they.
+     */
+    expect(radiusOf(model, hub, "unmanaged:ap-1")).toBeCloseTo(
+      radiusOf(model, hub, "endpoint:pos-1"),
+      6,
+    );
+  });
+
+  test("every node's painted box stays inside the content box", () => {
+    const footprints: Map<string, TopologyNodeFootprint> =
+      buildFootprints(branchNodes);
+    for (const node of branchNodes) {
+      const point: TopologyPoint = model.positions.get(node.id)!;
+      const footprint: TopologyNodeFootprint = footprintOrDefault(
+        footprints,
+        node.id,
+      );
+      expect(point.x - footprint.inkHalfWidth).toBeGreaterThanOrEqual(-1e-6);
+      expect(point.x + footprint.inkHalfWidth).toBeLessThanOrEqual(
+        model.contentWidth + 1e-6,
+      );
+      expect(point.y - footprint.halfHeight).toBeGreaterThanOrEqual(-1e-6);
+      expect(point.y + footprint.labelBottom).toBeLessThanOrEqual(
+        model.contentHeight + 1e-6,
+      );
+    }
+  });
+
+  test("the content box never shrinks below the frame it was given", () => {
+    expect(model.contentWidth).toBeGreaterThanOrEqual(WIDTH);
+    expect(model.contentHeight).toBeGreaterThanOrEqual(HEIGHT);
+  });
+
+  test("star mode reports no component boxes and no group boxes", () => {
+    expect(model.componentBoxes).toEqual([]);
+    expect(model.groups).toEqual([]);
+  });
+});
+
+describe("computeStarTopologyModel — the hub is the centre", () => {
+  test("a lone device is its own hub and sits at the middle of the frame", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [makeDevice("device:solo")],
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    const point: TopologyPoint = model.positions.get("device:solo")!;
+    expect(model.positions.size).toBe(1);
+    expect(point.x).toBeCloseTo(model.contentWidth / 2, 6);
+    expect(point.y).toBeCloseTo(model.contentHeight / 2, 6);
+  });
+
+  test("a symmetric fan puts the hub at the mean of its own ring", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 8; i++) {
+      const peerId: string = `unmanaged:peer-${String(i)}`;
+      nodes.push(makeUnmanaged(peerId, { name: `peer-${String(i)}` }));
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+
+    let sumX: number = 0;
+    let sumY: number = 0;
+    for (const node of nodes.slice(1)) {
+      const point: TopologyPoint = model.positions.get(node.id)!;
+      sumX += point.x;
+      sumY += point.y;
+    }
+    const hub: TopologyPoint = model.positions.get("device:core")!;
+    expect(sumX / 8).toBeCloseTo(hub.x, 6);
+    expect(sumY / 8).toBeCloseTo(hub.y, 6);
+    expect(hub.x).toBeCloseTo(model.contentWidth / 2, 6);
+    expect(hub.y).toBeCloseTo(model.contentHeight / 2, 6);
+  });
+
+  test("a one-sided fan still centres the hub, not the ink", () => {
+    /*
+     * The extent is mirrored about the hub deliberately: hugging the ink
+     * would slide the hub off to one side the moment the spokes are
+     * uneven, and a hub-and-spoke picture whose hub is not central has
+     * given up the one thing it promises. The cost is headroom opposite
+     * the only spoke, which is what this asserts.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("device:core"),
+      makeUnmanaged("unmanaged:only", { name: "only-peer" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("device:core", "unmanaged:only", ["cdp"]),
+    ];
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+
+    const hub: TopologyPoint = model.positions.get("device:core")!;
+    const peer: TopologyPoint = model.positions.get("unmanaged:only")!;
+    expect(hub.x).toBeCloseTo(model.contentWidth / 2, 6);
+    expect(hub.y).toBeCloseTo(model.contentHeight / 2, 6);
+    // The drawn ink genuinely is off centre; the hub is not.
+    expect(
+      Math.abs((hub.x + peer.x) / 2 - model.contentWidth / 2),
+    ).toBeGreaterThan(1);
+  });
+
+  test("no node other than the hub is at the centre", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("router-1")!;
+    for (const node of branchNodes) {
+      if (node.id === "router-1") {
+        continue;
+      }
+      expect(radiusOf(model, hub, node.id)).toBeGreaterThanOrEqual(
+        STAR_HUB_RING_GAP - RADIUS_EPSILON,
+      );
+    }
+  });
+});
+
+describe("computeStarTopologyModel — ring sizing", () => {
+  test("ring one is at least the hub gap and grows only to fit its slots", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 8; i++) {
+      const peerId: string = `unmanaged:peer-${String(i)}`;
+      nodes.push(makeUnmanaged(peerId, { name: `peer-${String(i)}` }));
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("device:core")!;
+    // Eight roomy wedges: nothing forces the ring past the minimum gap.
+    for (const node of nodes.slice(1)) {
+      expect(radiusOf(model, hub, node.id)).toBeCloseTo(STAR_HUB_RING_GAP, 6);
+    }
+  });
+
+  test("a crowded ring is pushed out until every slot fits its own glyph", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 200; i++) {
+      const peerId: string = `unmanaged:peer-${String(i).padStart(3, "0")}`;
+      nodes.push(
+        makeUnmanaged(peerId, { name: `peer-${String(i).padStart(3, "0")}` }),
+      );
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("device:core")!;
+    const footprints: Map<string, TopologyNodeFootprint> =
+      buildFootprints(nodes);
+
+    const radius: number = radiusOf(model, hub, nodes[1]!.id);
+    const wedge: number = (Math.PI * 2) / 200;
+    const slotWidth: number =
+      footprintOrDefault(footprints, nodes[1]!.id).inkHalfWidth * 2 +
+      STAR_SLOT_PADDING;
+    /*
+     * Two hundred even wedges, so the arc each node owns is exactly the
+     * width it paints plus its slot padding — the ring is sized from the
+     * angles rather than guessed before them.
+     */
+    expect(radius * wedge).toBeCloseTo(slotWidth, 6);
+    expect(radius).toBeGreaterThan(STAR_HUB_RING_GAP);
+  });
+
+  test("each successive ring clears the one inside it by the ring gap", () => {
+    /*
+     * router (0) -> switch (1) -> unmanaged AP (2) -> camera endpoint (3):
+     * four rings, so three gaps to check.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      makeDevice("switch-1"),
+      makeDevice("switch-2"),
+      makeUnmanaged("unmanaged:ap-1", { name: "ap-1" }),
+      makeEndpoint("endpoint:cam-1", { name: "cam-1" }),
+      makeEndpoint("endpoint:cam-2", { name: "cam-2" }),
+      makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("router-1", "switch-1", ["lldp"]),
+      makeEdge("router-1", "switch-2", ["lldp"]),
+      makeEdge("switch-1", "unmanaged:ap-1", ["cdp"]),
+      makeEdge("switch-2", "endpoint:pos-1", ["fdb"]),
+      makeEdge("unmanaged:ap-1", "endpoint:cam-1", ["fdb"]),
+      makeEdge("unmanaged:ap-1", "endpoint:cam-2", ["fdb"]),
+    ];
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("router-1")!;
+
+    const ringOne: number = radiusOf(model, hub, "switch-1");
+    const ringTwo: number = radiusOf(model, hub, "unmanaged:ap-1");
+    const ringThree: number = radiusOf(model, hub, "endpoint:cam-1");
+    expect(radiusOf(model, hub, "switch-2")).toBeCloseTo(ringOne, 6);
+    expect(radiusOf(model, hub, "endpoint:pos-1")).toBeCloseTo(ringTwo, 6);
+    expect(radiusOf(model, hub, "endpoint:cam-2")).toBeCloseTo(ringThree, 6);
+
+    expect(ringOne).toBeGreaterThanOrEqual(STAR_HUB_RING_GAP - RADIUS_EPSILON);
+    expect(ringTwo - ringOne).toBeGreaterThanOrEqual(
+      STAR_RING_MIN_GAP - RADIUS_EPSILON,
+    );
+    expect(ringThree - ringTwo).toBeGreaterThanOrEqual(
+      STAR_RING_MIN_GAP - RADIUS_EPSILON,
+    );
+    expect(overlapCount(model, nodes)).toBe(0);
+  });
+
+  test("a heavy subtree claims more of the circle than a quiet neighbour", () => {
+    const heavy: SwitchWithEndpoints = makeSwitchWithEndpoints("switch-a", 12);
+    const quiet: SwitchWithEndpoints = makeSwitchWithEndpoints("switch-b", 1);
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      ...heavy.nodes,
+      ...quiet.nodes,
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("router-1", "switch-a", ["lldp"]),
+      makeEdge("router-1", "switch-b", ["lldp"]),
+      ...heavy.edges,
+      ...quiet.edges,
+    ];
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("router-1")!;
+
+    /*
+     * The twelve endpoints of the busy switch span a wider arc than the
+     * one endpoint of the quiet one, but the blended split still leaves
+     * the quiet branch a workable slice — nothing collides.
+     */
+    const heavySpread: number = Math.max(
+      ...heavy.endpointIds.map((id: string): number => {
+        return distanceBetween(
+          model.positions.get(heavy.endpointIds[0]!)!,
+          model.positions.get(id)!,
+        );
+      }),
+    );
+    expect(heavySpread).toBeGreaterThan(0);
+    expect(radiusOf(model, hub, "switch-a")).toBeCloseTo(
+      radiusOf(model, hub, "switch-b"),
+      6,
+    );
+    expect(overlapCount(model, nodes)).toBe(0);
+  });
+});
+
+describe("computeStarTopologyModel — glyphs never overlap", () => {
+  test("a hub with eight spokes", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 8; i++) {
+      const peerId: string = `unmanaged:peer-${String(i)}`;
+      nodes.push(makeUnmanaged(peerId, { name: `peer-${String(i)}` }));
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(9);
+    expect(overlapCount(model, nodes)).toBe(0);
+    expect(
+      minPairDistance(
+        model,
+        nodes.map((node: NetworkTopologyNode): string => {
+          return node.id;
+        }),
+      ),
+    ).toBeGreaterThanOrEqual(DEVICE_PAIR_CLEARANCE);
+    expectFiniteModel(model);
+  });
+
+  test("a hub with two hundred spokes", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 200; i++) {
+      const peerId: string = `unmanaged:peer-${String(i).padStart(3, "0")}`;
+      nodes.push(
+        makeUnmanaged(peerId, { name: `peer-${String(i).padStart(3, "0")}` }),
+      );
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(201);
+    expect(overlapCount(model, nodes)).toBe(0);
+    expectFiniteModel(model);
+  });
+
+  test("a two level tree of four switches with six endpoints each", () => {
+    const groups: Array<SwitchWithEndpoints> = [
+      makeSwitchWithEndpoints("switch-a", 6),
+      makeSwitchWithEndpoints("switch-b", 6),
+      makeSwitchWithEndpoints("switch-c", 6),
+      makeSwitchWithEndpoints("switch-d", 6),
+    ];
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("router-1")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (const group of groups) {
+      nodes.push(...group.nodes);
+      edges.push(
+        makeEdge("router-1", group.device.id, ["lldp"]),
+        ...group.edges,
+      );
+    }
+
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(29);
+    expect(overlapCount(model, nodes)).toBe(0);
+    expectFiniteModel(model);
+  });
+
+  test("a graph with an unreachable island", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      islandNodes,
+      islandEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(islandNodes.length);
+    expect(overlapCount(model, islandNodes)).toBe(0);
+    expectFiniteModel(model);
+  });
+
+  test("islands are drawn outside everything the hub can see", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      islandNodes,
+      islandEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("router-1")!;
+    let furthestReachable: number = 0;
+    for (const node of branchNodes) {
+      furthestReachable = Math.max(
+        furthestReachable,
+        radiusOf(model, hub, node.id),
+      );
+    }
+    /*
+     * "Outside everything the hub can see" is exactly what the outermost
+     * ring means, so the island needs no hull drawn round it to say so.
+     */
+    for (const id of ["device:island-a", "device:island-b", "endpoint:iso-1"]) {
+      expect(radiusOf(model, hub, id)).toBeGreaterThan(furthestReachable);
+    }
+    expect(model.componentBoxes).toEqual([]);
+  });
+
+  test("a graph of nothing but islands still fans them around the hub", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("device:core"),
+      makeUnmanaged("unmanaged:a", { name: "a" }),
+      makeUnmanaged("unmanaged:b", { name: "b" }),
+      makeUnmanaged("unmanaged:c", { name: "c" }),
+      makeEndpoint("endpoint:d", { name: "d" }),
+    ];
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    const hub: TopologyPoint = model.positions.get("device:core")!;
+    expect(overlapCount(model, nodes)).toBe(0);
+    for (const node of nodes.slice(1)) {
+      expect(radiusOf(model, hub, node.id)).toBeCloseTo(STAR_HUB_RING_GAP, 6);
+    }
+  });
+
+  test("a seeded pseudo-random site of switches and endpoints", () => {
+    /* xorshift32 — deterministic, so a failure here is reproducible. */
+    type NextUnitFunction = () => number;
+    let state: number = 0x2f6e2b1 >>> 0;
+    const nextUnit: NextUnitFunction = (): number => {
+      state ^= state << 13;
+      state >>>= 0;
+      state ^= state >> 17;
+      state ^= state << 5;
+      state >>>= 0;
+      return state / 4294967296;
+    };
+
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("router-1")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 6; i++) {
+      const switchId: string = `switch-${String(i)}`;
+      const count: number = 1 + Math.floor(nextUnit() * 6);
+      const group: SwitchWithEndpoints = makeSwitchWithEndpoints(
+        switchId,
+        count,
+      );
+      nodes.push(...group.nodes);
+      edges.push(makeEdge("router-1", switchId, ["lldp"]), ...group.edges);
+      if (nextUnit() < 0.5) {
+        const peerId: string = `unmanaged:peer-${String(i)}`;
+        nodes.push(makeUnmanaged(peerId, { name: `peer-${String(i)}` }));
+        edges.push(makeEdge(switchId, peerId, ["cdp"]));
+      }
+    }
+
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(nodes.length);
+    expect(overlapCount(model, nodes)).toBe(0);
+    expectFiniteModel(model);
+  });
+});
+
+describe("computeStarTopologyModel — determinism", () => {
+  /*
+   * The single most important property in this file. The topology endpoint
+   * returns rows in an order nothing guarantees and re-polls every sixty
+   * seconds; a layout that reads array position instead of node id
+   * reshuffles the whole map every minute for no reason.
+   */
+  const original: TopologyLayoutModel = computeStarTopologyModel(
+    islandNodes,
+    islandEdges,
+    WIDTH,
+    HEIGHT,
+  );
+
+  test("the same input twice gives byte-identical coordinates", () => {
+    const again: TopologyLayoutModel = computeStarTopologyModel(
+      islandNodes,
+      islandEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(again.positions).toEqual(original.positions);
+    expect(again.contentWidth).toBe(original.contentWidth);
+    expect(again.contentHeight).toBe(original.contentHeight);
+  });
+
+  test("reversing both input arrays changes nothing", () => {
+    const reversed: TopologyLayoutModel = computeStarTopologyModel(
+      [...islandNodes].reverse(),
+      [...islandEdges].reverse(),
+      WIDTH,
+      HEIGHT,
+    );
+    expect(reversed.positions).toEqual(original.positions);
+    expect(reversed.contentWidth).toBe(original.contentWidth);
+    expect(reversed.contentHeight).toBe(original.contentHeight);
+  });
+
+  test("rotating both input arrays changes nothing", () => {
+    for (const offset of [1, 3, 7]) {
+      const rotated: TopologyLayoutModel = computeStarTopologyModel(
+        rotateNodes(islandNodes, offset),
+        rotateEdges(islandEdges, offset),
+        WIDTH,
+        HEIGHT,
+      );
+      expect(rotated.positions).toEqual(original.positions);
+      expect(rotated.contentWidth).toBe(original.contentWidth);
+      expect(rotated.contentHeight).toBe(original.contentHeight);
+    }
+  });
+
+  test("flipping every edge end for end changes nothing", () => {
+    const flipped: TopologyLayoutModel = computeStarTopologyModel(
+      islandNodes,
+      islandEdges.map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+        // Attachment is undirected: reporting it from the far end is the same link.
+        return makeEdge(edge.toNodeId, edge.fromNodeId, edge.protocols);
+      }),
+      WIDTH,
+      HEIGHT,
+    );
+    expect(flipped.positions).toEqual(original.positions);
+  });
+
+  test("a duplicated edge does not shift the layout", () => {
+    const withDuplicate: TopologyLayoutModel = computeStarTopologyModel(
+      islandNodes,
+      [...islandEdges, makeEdge("switch-a", "router-1", ["cdp"])],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(withDuplicate.positions).toEqual(original.positions);
+  });
+
+  test("a big crowded ring is just as stable under permutation", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 60; i++) {
+      const peerId: string = `unmanaged:peer-${String(i).padStart(2, "0")}`;
+      nodes.push(
+        makeUnmanaged(peerId, { name: `peer-${String(i).padStart(2, "0")}` }),
+      );
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const first: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const second: TopologyLayoutModel = computeStarTopologyModel(
+      rotateNodes([...nodes].reverse(), 17),
+      rotateEdges([...edges].reverse(), 29),
+      WIDTH,
+      HEIGHT,
+    );
+    expect(second.positions).toEqual(first.positions);
+  });
+});
+
+describe("computeStarTopologyModel — pins", () => {
+  const unpinned: TopologyLayoutModel = computeStarTopologyModel(
+    branchNodes,
+    branchEdges,
+    WIDTH,
+    HEIGHT,
+  );
+
+  test("a pinned node lands exactly on its pin, even on top of a neighbour", () => {
+    const onTopOfSwitchA: TopologyPoint = unpinned.positions.get("switch-a")!;
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["endpoint:pos-1", { x: onTopOfSwitchA.x, y: onTopOfSwitchA.y }]]);
+
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    // The user put it there: the layout does not relax it away.
+    expect(model.positions.get("endpoint:pos-1")).toEqual(onTopOfSwitchA);
+  });
+
+  test("pinning one node leaves every other node exactly where it was", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["switch-b", { x: 42, y: 43 }]]);
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.positions.get("switch-b")).toEqual({ x: 42, y: 43 });
+    for (const node of branchNodes) {
+      if (node.id === "switch-b") {
+        continue;
+      }
+      expect(model.positions.get(node.id)).toEqual(
+        unpinned.positions.get(node.id),
+      );
+    }
+  });
+
+  test("even the hub can be dragged off centre and stays where it was put", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["router-1", { x: 120, y: 90 }]]);
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.positions.get("router-1")).toEqual({ x: 120, y: 90 });
+  });
+
+  test("a pin outside the computed extent grows the content box", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["router-1", { x: 5000, y: 4000 }]]);
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    const footprint: TopologyNodeFootprint = footprintOrDefault(
+      buildFootprints(branchNodes),
+      "router-1",
+    );
+    expect(model.contentWidth).toBeCloseTo(
+      5000 + footprint.inkHalfWidth + STAR_LAYOUT_MARGIN,
+      6,
+    );
+    expect(model.contentHeight).toBeCloseTo(
+      4000 + footprint.labelBottom + STAR_LAYOUT_MARGIN,
+      6,
+    );
+    expectFiniteModel(model);
+  });
+
+  test("a pin inside the computed extent leaves the content box alone", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["switch-a", { x: 10, y: 12 }]]);
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+    expect(model.contentHeight).toBe(unpinned.contentHeight);
+  });
+
+  test("a non-finite pin is ignored rather than blanking the node", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([
+      ["switch-a", { x: Number.NaN, y: 10 }],
+      ["switch-b", { x: 10, y: Number.POSITIVE_INFINITY }],
+      ["unmanaged:ap-1", { x: Number.NEGATIVE_INFINITY, y: Number.NaN }],
+    ]);
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.positions).toEqual(unpinned.positions);
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+    expect(model.contentHeight).toBe(unpinned.contentHeight);
+    expectFiniteModel(model);
+  });
+
+  test("a pin for a node that left the graph adds no placement", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["endpoint:gone", { x: 9000, y: 9000 }]]);
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(model.positions.has("endpoint:gone")).toBe(false);
+    expect(model.positions.size).toBe(branchNodes.length);
+    // A stale pin must not stretch the box around a node nobody draws.
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+    expect(model.contentHeight).toBe(unpinned.contentHeight);
+  });
+
+  test("an empty pin map behaves exactly like no pin map", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      new Map<string, TopologyPoint>(),
+    );
+    expect(model.positions).toEqual(unpinned.positions);
+    expect(model.contentWidth).toBe(unpinned.contentWidth);
+    expect(model.contentHeight).toBe(unpinned.contentHeight);
+  });
+
+  test("pinning is deterministic under a permuted input", () => {
+    const pinned: ReadonlyMap<string, TopologyPoint> = new Map<
+      string,
+      TopologyPoint
+    >([["switch-b", { x: 1200, y: 900 }]]);
+    const first: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    const second: TopologyLayoutModel = computeStarTopologyModel(
+      rotateNodes([...branchNodes].reverse(), 2),
+      rotateEdges([...branchEdges].reverse(), 5),
+      WIDTH,
+      HEIGHT,
+      pinned,
+    );
+    expect(second.positions).toEqual(first.positions);
+    expect(second.contentWidth).toBe(first.contentWidth);
+    expect(second.contentHeight).toBe(first.contentHeight);
+  });
+});
+
+describe("computeStarTopologyModel — degenerate and hostile input", () => {
+  test("empty input returns an empty map and the frame it was given", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [],
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(0);
+    expect(model.componentBoxes).toEqual([]);
+    expect(model.groups).toEqual([]);
+    expect(model.contentWidth).toBe(WIDTH);
+    expect(model.contentHeight).toBe(HEIGHT);
+  });
+
+  test("a non-finite or non-positive frame falls back to a usable default", () => {
+    for (const frame of [
+      { width: Number.NaN, height: Number.NaN },
+      { width: 0, height: 0 },
+      { width: -10, height: -700 },
+      { width: Number.POSITIVE_INFINITY, height: Number.NEGATIVE_INFINITY },
+    ]) {
+      const empty: TopologyLayoutModel = computeStarTopologyModel(
+        [],
+        [],
+        frame.width,
+        frame.height,
+      );
+      expect(empty.contentWidth).toBe(1000);
+      expect(empty.contentHeight).toBe(700);
+
+      const populated: TopologyLayoutModel = computeStarTopologyModel(
+        branchNodes,
+        branchEdges,
+        frame.width,
+        frame.height,
+      );
+      expect(populated.contentWidth).toBeGreaterThanOrEqual(1000);
+      expect(populated.contentHeight).toBeGreaterThanOrEqual(700);
+      expectFiniteModel(populated);
+    }
+  });
+
+  test("an absent edge list lays the nodes out as isolated islands", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      undefined as unknown as Array<NetworkTopologyEdge>,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(branchNodes.length);
+    expect(overlapCount(model, branchNodes)).toBe(0);
+    expectFiniteModel(model);
+  });
+
+  test("duplicate node ids collapse to one placement", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [...branchNodes, branchSwitchA, makeDevice("switch-a")],
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    const clean: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(branchNodes.length);
+    // First row wins, so a duplicated row cannot move anything either.
+    expect(model.positions).toEqual(clean.positions);
+  });
+
+  test("a self-loop edge neither places nor moves anything", () => {
+    const withLoops: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      [
+        ...branchEdges,
+        makeEdge("switch-a", "switch-a", ["lldp"]),
+        makeEdge("router-1", "router-1", ["cdp"]),
+      ],
+      WIDTH,
+      HEIGHT,
+    );
+    const clean: TopologyLayoutModel = computeStarTopologyModel(
+      branchNodes,
+      branchEdges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(withLoops.positions).toEqual(clean.positions);
+  });
+
+  test("edges naming nodes outside the view add no phantom placements", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [branchSwitchA],
+      [
+        makeEdge("switch-a", "endpoint:not-in-view", ["fdb"]),
+        makeEdge("device:also-gone", "switch-a", ["lldp"]),
+      ],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(1);
+    expect(model.positions.has("endpoint:not-in-view")).toBe(false);
+    expect(model.positions.has("device:also-gone")).toBe(false);
+    // The only node in view is the hub, so it is dead centre.
+    expect(model.positions.get("switch-a")!.x).toBeCloseTo(
+      model.contentWidth / 2,
+      6,
+    );
+  });
+
+  test("a node with an empty id is dropped and an unnamed node still places", () => {
+    const nameless: NetworkTopologyNode = makeDevice("switch-1", { name: "" });
+    const ghost: NetworkTopologyNode = makeDevice("", { name: "ghost" });
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [nameless, ghost, makeEndpoint("endpoint:x", { name: "" })],
+      [makeEdge("switch-1", "endpoint:x", ["fdb"])],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(2);
+    expect(model.positions.has("")).toBe(false);
+    expectFiniteModel(model);
+  });
+
+  test("null rows in the node list are skipped, not placed", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [
+        branchRouter,
+        null as unknown as NetworkTopologyNode,
+        branchSwitchA,
+        undefined as unknown as NetworkTopologyNode,
+      ],
+      [...branchEdges, null as unknown as NetworkTopologyEdge],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(2);
+    expectFiniteModel(model);
+  });
+
+  test("a five hundred character name lays out exactly like a forty character one", () => {
+    /*
+     * Label width is capped, so past two full lines a longer hostname
+     * claims no more room — one device name must not be able to distort
+     * the whole picture around itself.
+     */
+    const long: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      makeDevice("switch-a", { name: "a".repeat(500) }),
+      makeDevice("switch-b"),
+    ];
+    const short: Array<NetworkTopologyNode> = [
+      makeDevice("router-1"),
+      makeDevice("switch-a", { name: "a".repeat(40) }),
+      makeDevice("switch-b"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("router-1", "switch-a", ["lldp"]),
+      makeEdge("router-1", "switch-b", ["lldp"]),
+    ];
+    const longModel: TopologyLayoutModel = computeStarTopologyModel(
+      long,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    const shortModel: TopologyLayoutModel = computeStarTopologyModel(
+      short,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(longModel.positions).toEqual(shortModel.positions);
+    expect(longModel.contentWidth).toBe(shortModel.contentWidth);
+    expect(overlapCount(longModel, long)).toBe(0);
+  });
+
+  test("a ring of long-named devices still keeps its glyphs apart", () => {
+    const nodes: Array<NetworkTopologyNode> = [makeDevice("device:core")];
+    const edges: Array<NetworkTopologyEdge> = [];
+    for (let i: number = 0; i < 24; i++) {
+      const peerId: string = `unmanaged:ap-${String(i).padStart(2, "0")}`;
+      nodes.push(
+        makeUnmanaged(peerId, {
+          name: `ap-hall-${String(i)}.branch.example.com`,
+        }),
+      );
+      edges.push(makeEdge("device:core", peerId, ["cdp"]));
+    }
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      nodes,
+      edges,
+      WIDTH,
+      HEIGHT,
+    );
+    expect(overlapCount(model, nodes)).toBe(0);
+    expectFiniteModel(model);
+  });
+
+  test("a graph of a single endpoint is placed at the centre", () => {
+    const model: TopologyLayoutModel = computeStarTopologyModel(
+      [makeEndpoint("endpoint:solo", { name: "solo" })],
+      [],
+      WIDTH,
+      HEIGHT,
+    );
+    expect(model.positions.size).toBe(1);
+    expect(model.positions.get("endpoint:solo")!.x).toBeCloseTo(
+      model.contentWidth / 2,
+      6,
+    );
+    expect(model.positions.get("endpoint:solo")!.y).toBeCloseTo(
+      model.contentHeight / 2,
+      6,
+    );
+  });
+});
+
+describe("computeStarTopologyModel — nothing non-finite ever escapes", () => {
+  /*
+   * A NaN in an SVG coordinate makes that element vanish and takes the
+   * graph bounds with it, so this sweeps every shape of input the rest of
+   * the file exercises and checks the one thing that must never happen.
+   */
+  interface LayoutScenario {
+    name: string;
+    nodes: Array<NetworkTopologyNode>;
+    edges: Array<NetworkTopologyEdge>;
+    width: number;
+    height: number;
+    pinned?: ReadonlyMap<string, TopologyPoint> | undefined;
+  }
+
+  const scenarios: Array<LayoutScenario> = [
+    { name: "empty", nodes: [], edges: [], width: WIDTH, height: HEIGHT },
+    {
+      name: "branch site",
+      nodes: branchNodes,
+      edges: branchEdges,
+      width: WIDTH,
+      height: HEIGHT,
+    },
+    {
+      name: "island",
+      nodes: islandNodes,
+      edges: islandEdges,
+      width: WIDTH,
+      height: HEIGHT,
+    },
+    {
+      name: "no edges at all",
+      nodes: islandNodes,
+      edges: [],
+      width: WIDTH,
+      height: HEIGHT,
+    },
+    {
+      name: "hostile frame",
+      nodes: branchNodes,
+      edges: branchEdges,
+      width: Number.NaN,
+      height: Number.NEGATIVE_INFINITY,
+    },
+    {
+      name: "duplicate ids and self loops",
+      nodes: [...branchNodes, branchSwitchA],
+      edges: [...branchEdges, makeEdge("switch-a", "switch-a", ["lldp"])],
+      width: 0,
+      height: -5,
+    },
+    {
+      name: "non-finite pins",
+      nodes: branchNodes,
+      edges: branchEdges,
+      width: WIDTH,
+      height: HEIGHT,
+      pinned: new Map<string, TopologyPoint>([
+        ["router-1", { x: Number.NaN, y: Number.NaN }],
+        ["switch-a", { x: Number.POSITIVE_INFINITY, y: 0 }],
+        ["switch-b", { x: 0, y: Number.NEGATIVE_INFINITY }],
+        ["endpoint:gone", { x: Number.NaN, y: Number.NaN }],
+      ]),
+    },
+    {
+      name: "a pin far outside the frame",
+      nodes: branchNodes,
+      edges: branchEdges,
+      width: WIDTH,
+      height: HEIGHT,
+      pinned: new Map<string, TopologyPoint>([
+        ["endpoint:pos-2", { x: -9000, y: 12000 }],
+      ]),
+    },
+    {
+      name: "unnamed nodes",
+      nodes: [
+        makeDevice("router-1", { name: "" }),
+        makeDevice("switch-a", { name: "" }),
+        makeEndpoint("endpoint:x", { name: "" }),
+      ],
+      edges: [
+        makeEdge("router-1", "switch-a", ["lldp"]),
+        makeEdge("switch-a", "endpoint:x", ["fdb"]),
+      ],
+      width: WIDTH,
+      height: HEIGHT,
+    },
+  ];
+
+  test("no scenario produces a NaN or Infinity anywhere in the model", () => {
+    for (const scenario of scenarios) {
+      const model: TopologyLayoutModel = computeStarTopologyModel(
+        scenario.nodes,
+        scenario.edges,
+        scenario.width,
+        scenario.height,
+        scenario.pinned,
+      );
+      expectFiniteModel(model);
+    }
+  });
+
+  test("every scenario is idempotent", () => {
+    for (const scenario of scenarios) {
+      const first: TopologyLayoutModel = computeStarTopologyModel(
+        scenario.nodes,
+        scenario.edges,
+        scenario.width,
+        scenario.height,
+        scenario.pinned,
+      );
+      const second: TopologyLayoutModel = computeStarTopologyModel(
+        scenario.nodes,
+        scenario.edges,
+        scenario.width,
+        scenario.height,
+        scenario.pinned,
+      );
+      expect(second.positions).toEqual(first.positions);
+      expect(second.contentWidth).toBe(first.contentWidth);
+      expect(second.contentHeight).toBe(first.contentHeight);
+    }
+  });
+
+  test("every scenario survives a permuted input unchanged", () => {
+    for (const scenario of scenarios) {
+      if (scenario.nodes.length === 0 || scenario.edges.length === 0) {
+        continue;
+      }
+      const first: TopologyLayoutModel = computeStarTopologyModel(
+        scenario.nodes,
+        scenario.edges,
+        scenario.width,
+        scenario.height,
+        scenario.pinned,
+      );
+      const permuted: TopologyLayoutModel = computeStarTopologyModel(
+        rotateNodes([...scenario.nodes].reverse(), 3),
+        rotateEdges([...scenario.edges].reverse(), 2),
+        scenario.width,
+        scenario.height,
+        scenario.pinned,
+      );
+      expect(permuted.positions).toEqual(first.positions);
+      expect(permuted.contentWidth).toBe(first.contentWidth);
+      expect(permuted.contentHeight).toBe(first.contentHeight);
+    }
+  });
+});

--- a/App/Tests/Dashboard/TopologyPositionOverrides.test.ts
+++ b/App/Tests/Dashboard/TopologyPositionOverrides.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import { TopologyPoint } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyGraphUtil";
 import {
+  ArrangementPersistence,
   EMPTY_OVERRIDES,
   MAX_PERSISTED_KEY_LENGTH,
   MAX_PERSISTED_OVERRIDES,
@@ -9,6 +10,7 @@ import {
   PositionOverrides,
   TopologyLayoutMode,
   TopologyOverrideStorage,
+  createArrangementPersistence,
   mergePositionOverrides,
   parsePersistedOverrides,
   positionOverridesStorageKey,
@@ -140,6 +142,26 @@ const makeThrowingStorage: MakeThrowingStorageFunction =
 
 const STORAGE_KEY: string = "test.topology.positions";
 
+/*
+ * Every mode the layout switcher can select, in toolbar order. Force,
+ * tiered and radial shipped first; star and parent-child were added
+ * beside them without a version bump, so the list doubles as the record
+ * of which keys must already exist in the wild.
+ */
+const ALL_LAYOUT_MODES: Array<TopologyLayoutMode> = [
+  "force",
+  "tiered",
+  "radial",
+  "star",
+  "parentChild",
+];
+
+const LEGACY_LAYOUT_MODES: Array<TopologyLayoutMode> = [
+  "force",
+  "tiered",
+  "radial",
+];
+
 /* ------------------------------------------------------------------ */
 /* Constants                                                           */
 /* ------------------------------------------------------------------ */
@@ -219,6 +241,76 @@ describe("positionOverridesStorageKey", () => {
   test("the key is pure — repeated calls agree", () => {
     expect(positionOverridesStorageKey("p", "s", "force")).toBe(
       positionOverridesStorageKey("p", "s", "force"),
+    );
+  });
+
+  test("all five layout modes name their own key for one project and site", () => {
+    /*
+     * Star and parent-child are coordinate systems of their own — a hub
+     * placed at the origin in star mode means nothing in the tiered grid —
+     * so the two newer modes have to namespace their arrangements exactly
+     * the way the original three already do.
+     */
+    const keys: Set<string> = new Set<string>();
+    for (const layoutMode of ALL_LAYOUT_MODES) {
+      keys.add(positionOverridesStorageKey("proj-1", "site-9", layoutMode));
+    }
+    expect(keys.size).toBe(ALL_LAYOUT_MODES.length);
+    expect(Array.from(keys)).toEqual([
+      "oneuptime.networkTopology.positions.v1.proj-1.site-9.force",
+      "oneuptime.networkTopology.positions.v1.proj-1.site-9.tiered",
+      "oneuptime.networkTopology.positions.v1.proj-1.site-9.radial",
+      "oneuptime.networkTopology.positions.v1.proj-1.site-9.star",
+      "oneuptime.networkTopology.positions.v1.proj-1.site-9.parentChild",
+    ]);
+  });
+
+  test("star and parent-child differ from each other and from the older three", () => {
+    const starKey: string = positionOverridesStorageKey(
+      "proj-1",
+      "site-9",
+      "star",
+    );
+    const parentChildKey: string = positionOverridesStorageKey(
+      "proj-1",
+      "site-9",
+      "parentChild",
+    );
+    expect(starKey).not.toBe(parentChildKey);
+    for (const layoutMode of LEGACY_LAYOUT_MODES) {
+      const legacyKey: string = positionOverridesStorageKey(
+        "proj-1",
+        "site-9",
+        layoutMode,
+      );
+      expect(starKey).not.toBe(legacyKey);
+      expect(parentChildKey).not.toBe(legacyKey);
+    }
+    expect(starKey).toContain("star");
+    expect(parentChildKey).toContain("parentChild");
+    // The mode is the only segment that moved: everything else is shared.
+    expect(starKey).toContain("proj-1");
+    expect(starKey).toContain("site-9");
+    expect(parentChildKey).toContain(`v${String(PERSISTED_OVERRIDES_VERSION)}`);
+  });
+
+  test("the key stays pure for the two new modes as well", () => {
+    for (const layoutMode of ALL_LAYOUT_MODES) {
+      expect(positionOverridesStorageKey("proj-1", "site-9", layoutMode)).toBe(
+        positionOverridesStorageKey("proj-1", "site-9", layoutMode),
+      );
+      expect(positionOverridesStorageKey("proj-1", undefined, layoutMode)).toBe(
+        positionOverridesStorageKey("proj-1", undefined, layoutMode),
+      );
+    }
+  });
+
+  test("the site-less and project-less fallbacks apply to the new modes too", () => {
+    expect(positionOverridesStorageKey("proj-1", undefined, "star")).toBe(
+      "oneuptime.networkTopology.positions.v1.proj-1.project.star",
+    );
+    expect(positionOverridesStorageKey("", "site-9", "parentChild")).toBe(
+      "oneuptime.networkTopology.positions.v1.unknown.site-9.parentChild",
     );
   });
 });
@@ -1198,5 +1290,414 @@ describe("storage round trip", () => {
     expect(merged.size).toBe(2);
     expect(merged.get("core")).toEqual({ x: 500, y: -250 });
     expect(merged.get("switch-a")).toEqual({ x: 100, y: 100 });
+  });
+
+  test("an arrangement saved under one mode is invisible to the other four", () => {
+    /*
+     * The five modes put the same device in five different places, so a
+     * star hub coordinate leaking into the tiered map would fling that
+     * node off the grid the instant the operator switched views. Isolation
+     * is the whole reason the mode is in the key.
+     */
+    const storage: FakeStorage = makeFakeStorage();
+    const starKey: string = positionOverridesStorageKey(
+      "proj-1",
+      "site-9",
+      "star",
+    );
+    writePersistedOverrides(
+      storage,
+      starKey,
+      makeMap([["core", { x: 42, y: -17 }]]),
+    );
+
+    expect(readPersistedOverrides(storage, starKey).get("core")).toEqual({
+      x: 42,
+      y: -17,
+    });
+    for (const layoutMode of ALL_LAYOUT_MODES) {
+      if (layoutMode === "star") {
+        continue;
+      }
+      const otherKey: string = positionOverridesStorageKey(
+        "proj-1",
+        "site-9",
+        layoutMode,
+      );
+      expect(readPersistedOverrides(storage, otherKey).size).toBe(0);
+    }
+  });
+
+  test("each of the five modes keeps its own arrangement side by side", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    /* One-based so no mode's coordinate is the -0 that JSON flattens to 0. */
+    for (let i: number = 0; i < ALL_LAYOUT_MODES.length; i++) {
+      const layoutMode: TopologyLayoutMode = ALL_LAYOUT_MODES[i]!;
+      writePersistedOverrides(
+        storage,
+        positionOverridesStorageKey("proj-1", "site-9", layoutMode),
+        makeMap([["core", { x: (i + 1) * 10, y: (i + 1) * -10 }]]),
+      );
+    }
+    expect(storage.data.size).toBe(ALL_LAYOUT_MODES.length);
+
+    for (let i: number = 0; i < ALL_LAYOUT_MODES.length; i++) {
+      const layoutMode: TopologyLayoutMode = ALL_LAYOUT_MODES[i]!;
+      const restored: PositionOverrides = readPersistedOverrides(
+        storage,
+        positionOverridesStorageKey("proj-1", "site-9", layoutMode),
+      );
+      expect(restored.size).toBe(1);
+      expect(restored.get("core")).toEqual({
+        x: (i + 1) * 10,
+        y: (i + 1) * -10,
+      });
+    }
+  });
+
+  test("arrangements saved before star and parent-child existed still load", () => {
+    /*
+     * Adding the two modes did not bump PERSISTED_OVERRIDES_VERSION, so
+     * every arrangement an operator saved beforehand has to survive the
+     * upgrade untouched. One key is spelled out literally: a rename of the
+     * prefix or of a mode would orphan those saved layouts silently — the
+     * map would simply come back unarranged, with nothing to show that a
+     * drag had ever been remembered.
+     */
+    const storage: FakeStorage = makeFakeStorage();
+    for (const layoutMode of LEGACY_LAYOUT_MODES) {
+      writePersistedOverrides(
+        storage,
+        positionOverridesStorageKey("proj-1", "site-9", layoutMode),
+        makeMap([
+          ["core", { x: 10, y: 20 }],
+          [`switch-${layoutMode}`, { x: 30.125, y: -40.5 }],
+        ]),
+      );
+    }
+
+    expect(
+      storage.data.has(
+        "oneuptime.networkTopology.positions.v1.proj-1.site-9.tiered",
+      ),
+    ).toBe(true);
+
+    for (const layoutMode of LEGACY_LAYOUT_MODES) {
+      const restored: PositionOverrides = readPersistedOverrides(
+        storage,
+        positionOverridesStorageKey("proj-1", "site-9", layoutMode),
+      );
+      expect(restored.size).toBe(2);
+      expect(restored.get("core")).toEqual({ x: 10, y: 20 });
+      expect(restored.get(`switch-${layoutMode}`)).toEqual({
+        x: 30.13,
+        y: -40.5,
+      });
+    }
+
+    // The new modes inherit nothing — they open on the computed layout.
+    expect(
+      readPersistedOverrides(
+        storage,
+        positionOverridesStorageKey("proj-1", "site-9", "star"),
+      ).size,
+    ).toBe(0);
+    expect(
+      readPersistedOverrides(
+        storage,
+        positionOverridesStorageKey("proj-1", "site-9", "parentChild"),
+      ).size,
+    ).toBe(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* The arrangement / key pairing                                       */
+/* ------------------------------------------------------------------ */
+
+/*
+ * NetworkTopologyLiveView's persistence hooks, replayed by hand.
+ *
+ * React is deliberately absent from App's resolution path (these modules
+ * are react-free so they can be tested in plain Node), so this
+ * transcribes the component's three effects rather than mounting it, in
+ * the order React actually runs them: the render phase first, then EVERY
+ * cleanup, then EVERY effect body. That order is the whole subject —
+ * switching layout mode re-renders with the incoming mode's key while
+ * state still holds the outgoing mode's coordinates, and the flush
+ * happens inside that window.
+ */
+interface TopologyViewSession {
+  /** A drag: new coordinates, same mode. */
+  drag: (overrides: PositionOverrides) => void;
+  /** The user clicks another layout pill. */
+  switchTo: (key: string) => void;
+  /** Navigating away. */
+  unmount: () => void;
+  /** The arrangement the graph is currently drawing. */
+  onScreen: () => PositionOverrides;
+}
+
+type MountViewFunction = (
+  storage: TopologyOverrideStorage,
+  initialKey: string,
+) => TopologyViewSession;
+
+const mountTopologyView: MountViewFunction = (
+  storage: TopologyOverrideStorage,
+  initialKey: string,
+): TopologyViewSession => {
+  const persistence: ArrangementPersistence = createArrangementPersistence(
+    storage,
+    initialKey,
+  );
+  let onScreen: PositionOverrides = EMPTY_OVERRIDES;
+
+  // Mount: render, then the load effect, then the re-render it causes.
+  persistence.hold(onScreen);
+  onScreen = persistence.adopt(initialKey);
+  persistence.hold(onScreen);
+
+  return {
+    drag: (overrides: PositionOverrides): void => {
+      onScreen = overrides;
+      persistence.hold(onScreen);
+    },
+    switchTo: (key: string): void => {
+      // Render: the key has advanced, the arrangement in state has not.
+      persistence.hold(onScreen);
+      // Cleanup of the flush effect, which runs before any effect body.
+      persistence.flush();
+      // Load effect body, then the re-render its state update causes.
+      onScreen = persistence.adopt(key);
+      persistence.hold(onScreen);
+    },
+    unmount: (): void => {
+      persistence.flush();
+    },
+    onScreen: (): PositionOverrides => {
+      return onScreen;
+    },
+  };
+};
+
+const TIERED_KEY: string = positionOverridesStorageKey(
+  "proj-1",
+  "site-9",
+  "tiered",
+);
+const STAR_KEY: string = positionOverridesStorageKey(
+  "proj-1",
+  "site-9",
+  "star",
+);
+const FORCE_KEY: string = positionOverridesStorageKey(
+  "proj-1",
+  "site-9",
+  "force",
+);
+
+describe("createArrangementPersistence — the key never leads the arrangement", () => {
+  test("holding new coordinates cannot move the key they will be filed under", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    const persistence: ArrangementPersistence = createArrangementPersistence(
+      storage,
+      TIERED_KEY,
+    );
+    persistence.hold(makeMap([["core", { x: 4800, y: 3000 }]]));
+    expect(persistence.keyInUse()).toBe(TIERED_KEY);
+
+    persistence.flush();
+    expect(storage.data.has(STAR_KEY)).toBe(false);
+    expect(readPersistedOverrides(storage, TIERED_KEY).get("core")).toEqual({
+      x: 4800,
+      y: 3000,
+    });
+  });
+
+  test("adopting a key moves the key and the arrangement together", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    writePersistedOverrides(
+      storage,
+      STAR_KEY,
+      makeMap([["core", { x: 12, y: 34 }]]),
+    );
+    const persistence: ArrangementPersistence = createArrangementPersistence(
+      storage,
+      TIERED_KEY,
+    );
+    persistence.hold(makeMap([["core", { x: 4800, y: 3000 }]]));
+
+    expect(persistence.adopt(STAR_KEY).get("core")).toEqual({ x: 12, y: 34 });
+    expect(persistence.keyInUse()).toBe(STAR_KEY);
+    expect(persistence.held().get("core")).toEqual({ x: 12, y: 34 });
+  });
+
+  test("a flush with nothing held clears only its own key", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    writePersistedOverrides(
+      storage,
+      STAR_KEY,
+      makeMap([["core", { x: 12, y: 34 }]]),
+    );
+    const persistence: ArrangementPersistence = createArrangementPersistence(
+      storage,
+      TIERED_KEY,
+    );
+    persistence.hold(EMPTY_OVERRIDES);
+    persistence.flush();
+
+    expect(storage.removeCalls).toEqual([TIERED_KEY]);
+    expect(storage.data.has(STAR_KEY)).toBe(true);
+  });
+});
+
+describe("switching layout mode", () => {
+  test("a tiered arrangement is never written into the star entry", () => {
+    /*
+     * The failure this exists for: the tiered coordinate lands under the
+     * star key, the load that immediately follows reads it back, and the
+     * node is drawn at (4800, 3000) in a coordinate system it was never
+     * in — the off-screen fling the mode-keyed storage exists to prevent.
+     */
+    const storage: FakeStorage = makeFakeStorage();
+    writePersistedOverrides(
+      storage,
+      TIERED_KEY,
+      makeMap([["core", { x: 4800, y: 3000 }]]),
+    );
+    writePersistedOverrides(
+      storage,
+      STAR_KEY,
+      makeMap([["core", { x: 12, y: 34 }]]),
+    );
+
+    const view: TopologyViewSession = mountTopologyView(storage, TIERED_KEY);
+    expect(view.onScreen().get("core")).toEqual({ x: 4800, y: 3000 });
+
+    view.switchTo(STAR_KEY);
+    expect(view.onScreen().get("core")).toEqual({ x: 12, y: 34 });
+    expect(readPersistedOverrides(storage, STAR_KEY).get("core")).toEqual({
+      x: 12,
+      y: 34,
+    });
+    expect(readPersistedOverrides(storage, TIERED_KEY).get("core")).toEqual({
+      x: 4800,
+      y: 3000,
+    });
+  });
+
+  test("leaving a mode with no arrangement does not delete the next mode's", () => {
+    /*
+     * The same bug with an empty outgoing arrangement: the write becomes
+     * a removeItem, so the star arrangement the operator built earlier is
+     * silently deleted by the act of opening star mode.
+     */
+    const storage: FakeStorage = makeFakeStorage();
+    writePersistedOverrides(
+      storage,
+      STAR_KEY,
+      makeMap([["core", { x: 12, y: 34 }]]),
+    );
+
+    const view: TopologyViewSession = mountTopologyView(storage, TIERED_KEY);
+    expect(view.onScreen().size).toBe(0);
+
+    view.switchTo(STAR_KEY);
+    expect(storage.data.has(STAR_KEY)).toBe(true);
+    expect(view.onScreen().get("core")).toEqual({ x: 12, y: 34 });
+    expect(storage.removeCalls).toEqual([TIERED_KEY]);
+  });
+
+  test("a drag inside the debounce window is saved to the mode it happened in", () => {
+    /*
+     * Drag in force mode, switch to star before the 500ms write fires.
+     * The debounce is cancelled by the switch, so the flush is the only
+     * thing that saves the drag — and it has to save it under the FORCE
+     * key, not under whichever mode the user landed in.
+     */
+    const storage: FakeStorage = makeFakeStorage();
+    const view: TopologyViewSession = mountTopologyView(storage, FORCE_KEY);
+    view.drag(makeMap([["core", { x: 5000, y: 200 }]]));
+    view.switchTo(STAR_KEY);
+
+    expect(readPersistedOverrides(storage, FORCE_KEY).get("core")).toEqual({
+      x: 5000,
+      y: 200,
+    });
+    expect(readPersistedOverrides(storage, STAR_KEY).size).toBe(0);
+    expect(view.onScreen().size).toBe(0);
+  });
+
+  test("a round trip through another mode brings the arrangement back", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    const view: TopologyViewSession = mountTopologyView(storage, TIERED_KEY);
+    view.drag(
+      makeMap([
+        ["core", { x: 120, y: 240 }],
+        ["switch-a", { x: 300, y: 480 }],
+      ]),
+    );
+
+    view.switchTo(STAR_KEY);
+    view.drag(makeMap([["core", { x: 12, y: 34 }]]));
+    view.switchTo(TIERED_KEY);
+
+    expect(view.onScreen().get("core")).toEqual({ x: 120, y: 240 });
+    expect(view.onScreen().get("switch-a")).toEqual({ x: 300, y: 480 });
+    expect(readPersistedOverrides(storage, STAR_KEY).get("core")).toEqual({
+      x: 12,
+      y: 34,
+    });
+  });
+
+  test("navigating away saves the mode that is actually on screen", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    const view: TopologyViewSession = mountTopologyView(storage, TIERED_KEY);
+    view.switchTo(STAR_KEY);
+    view.drag(makeMap([["core", { x: 12, y: 34 }]]));
+    view.unmount();
+
+    expect(readPersistedOverrides(storage, STAR_KEY).get("core")).toEqual({
+      x: 12,
+      y: 34,
+    });
+    expect(storage.data.has(TIERED_KEY)).toBe(false);
+  });
+
+  test("switching sites is the same rule and keeps the two apart", () => {
+    const storage: FakeStorage = makeFakeStorage();
+    const siteNine: string = positionOverridesStorageKey(
+      "proj-1",
+      "site-9",
+      "tiered",
+    );
+    const siteTen: string = positionOverridesStorageKey(
+      "proj-1",
+      "site-10",
+      "tiered",
+    );
+    const view: TopologyViewSession = mountTopologyView(storage, siteNine);
+    view.drag(makeMap([["core", { x: 700, y: 100 }]]));
+    view.switchTo(siteTen);
+
+    expect(readPersistedOverrides(storage, siteNine).get("core")).toEqual({
+      x: 700,
+      y: 100,
+    });
+    expect(readPersistedOverrides(storage, siteTen).size).toBe(0);
+  });
+
+  test("storage that throws on every access never breaks a mode switch", () => {
+    const view: TopologyViewSession = mountTopologyView(
+      makeThrowingStorage(),
+      TIERED_KEY,
+    );
+    view.drag(makeMap([["core", { x: 1, y: 2 }]]));
+    expect(() => {
+      view.switchTo(STAR_KEY);
+      view.unmount();
+    }).not.toThrow();
+    expect(view.onScreen().size).toBe(0);
   });
 });

--- a/E2E/Tests/Dashboard/Topology.spec.ts
+++ b/E2E/Tests/Dashboard/Topology.spec.ts
@@ -102,6 +102,12 @@ test.describe("Topology page", () => {
     await expect(
       page.getByTestId("network-topology-layout-mode-radial"),
     ).toBeVisible();
+    await expect(
+      page.getByTestId("network-topology-layout-mode-star"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("network-topology-layout-mode-parentChild"),
+    ).toBeVisible();
 
     // Force is the default, and it says so to assistive technology.
     await expect(
@@ -109,6 +115,12 @@ test.describe("Topology page", () => {
     ).toHaveAttribute("aria-pressed", "true");
     await expect(
       page.getByTestId("network-topology-layout-mode-tiered"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-star"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-parentChild"),
     ).toHaveAttribute("aria-pressed", "false");
 
     // Switching modes moves the pressed state, and only one is ever pressed.
@@ -121,6 +133,48 @@ test.describe("Topology page", () => {
     ).toHaveAttribute("aria-pressed", "false");
     await expect(
       page.getByTestId("network-topology-layout-mode-tiered"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-star"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-parentChild"),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    // Star is a mode of its own, not a variant of radial.
+    await page.getByTestId("network-topology-layout-mode-star").click();
+    await expect(
+      page.getByTestId("network-topology-layout-mode-star"),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-force"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-tiered"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-radial"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-parentChild"),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    // ...and so is parent-child, the last option in the group.
+    await page.getByTestId("network-topology-layout-mode-parentChild").click();
+    await expect(
+      page.getByTestId("network-topology-layout-mode-parentChild"),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-force"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-tiered"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-radial"),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByTestId("network-topology-layout-mode-star"),
     ).toHaveAttribute("aria-pressed", "false");
 
     // The empty state survives a layout change rather than blanking.


### PR DESCRIPTION
## Why

Viewing a site's network topology, you could read it three ways — Force, Tiered, Radial — and none of them is the picture an operator actually draws on a whiteboard:

- **Radial** ranks by *role* onto rings. It isn't a hub-and-spoke, and its centre moves when a device changes role.
- **Tiered** is role-*banded* — every router in one row, every switch in the next — so a switch is not drawn under the router it actually hangs off.

This adds the two views that were missing, as options on the same toolbar.

## Star (hub and spoke)

One hub dead centre, everything else ranked by **hops from it**, so a ring reads as blast radius.

The hub is chosen by role, then by how many devices it is actually **cabled** to (discovery-protocol neighbours; learned MACs excluded). That is deliberately *not* `tierForNode`: that rule demotes a managed device the moment it appears in a single FDB row, so somebody plugging a laptop into the core router would move the centre of the map on the next poll.

Geometry is exact rather than simulated — a child's wedge is contained in its parent's, so spokes cannot cross, and each ring is pushed out until its narrowest wedge fits its widest node, so neighbours on a ring cannot overlap by construction.

## Parent-Child

A tidy top-down tree over a spanning forest, every node drawn directly beneath **its own** parent. Roots are role-ranked so a router roots the tree rather than the busiest access switch.

Subtree bands are widened to contain a wide parent — that is what stops a long device name from spilling into the neighbouring subtree — and the post-order runs off a reverse walk of a parents-first list, so a 2000-node chain cannot blow the stack.

## Scope

Additive. Force, Tiered and Radial are untouched, the site/unit view still opens on Tiered, and saved arrangements keep their existing storage keys (no version bump).

## Two bugs found by review

Both pre-existing; fixed here because the new modes make them reachable far more often.

1. **Switching layout mode wrote the outgoing mode's arrangement under the incoming mode's key.** The storage key advanced a render before the coordinates did, so a position saved in one coordinate system was applied in another. Arrangement state and the key it belongs to now travel together through `ArrangementPersistence` and cannot drift.
2. **`packComponentBoxes` ordered shelves by box height.** A tidy tree's height steps by a whole level gap the moment one leaf is discovered, so trees swapped ends of the map when a single till came online. Callers whose box size steps with the graph can now ask for identity order; the force layout's default is unchanged.

## Tests

- `StarTopologyLayout.test.ts` — 78 tests
- `ParentChildTopologyLayout.test.ts` — 77 tests
- `TopologyPositionOverrides.test.ts` — +501 lines: distinct keys for all five modes, the mode-switch round trip, and proof that arrangements saved under the old three modes still load
- `E2E/Tests/Dashboard/Topology.spec.ts` — both new toolbar buttons, visibility and exclusive `aria-pressed`

Covering determinism under reversed/rotated/direction-flipped input, zero glyph overlaps (including a 200-spoke fan, a 300-child parent and a 50-deep chain), hierarchy invariants, pinned-position handling, and NaN/Infinity/malformed-payload robustness.

**Full App suite green: 5435 passing.** The one failing suite, `Tests/Dashboard/RecommendationFilterUtil`, is unrelated and pre-existing — it fails only in a git worktree (dual `Common` type resolution) and passes in the main checkout; verified by stashing this branch's changes and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)