### PR TITLE
fix(database): make analytics list pagination deterministic

### DIFF
--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -1440,6 +1440,75 @@ export default class AnalyticsDatabaseService<
     return { statement, columns: select.columns };
   }
 
+  /**
+   * Append the unique `_id` as a final sort key so the ORDER BY is a TOTAL
+   * order.
+   *
+   * `ORDER BY time DESC` alone is not: rows tying on `time` may come back
+   * in any order, and ClickHouse is free to order them differently between
+   * two executions of the same query (part order, thread scheduling and
+   * `optimize_read_in_order` all feed into it). Paging with LIMIT/OFFSET on
+   * top of a non-total order silently drops rows at page boundaries and
+   * repeats others: a row that sat at offset 49 on page 1 can shift to
+   * offset 50 before page 2 is fetched, so nobody ever sees it.
+   *
+   * Ties are the normal case, not an edge case — a service emitting a burst
+   * of logs writes many rows with an identical timestamp.
+   *
+   * `_id` is stamped per row with `ObjectID.generateTimeOrdered()`, so it is
+   * unique and its ordering agrees with time order.
+   *
+   * Two cases must NOT get the tiebreaker:
+   * - GROUP BY queries, where `_id` is neither a grouping key nor an
+   *   aggregate, so referencing it is an error.
+   * - Models with no `_id` column: derived aggregate targets deliberately
+   *   omit it because the aggregation key is the row identity (see _findBy).
+   */
+  private toPaginationStableSort(
+    sort: Sort<TBaseModel>,
+    options: { hasGroupBy: boolean },
+  ): Sort<TBaseModel> {
+    if (options.hasGroupBy) {
+      return sort;
+    }
+
+    const sortKeys: Array<string> = Object.keys(sort || {});
+
+    // Already a total order; adding `_id` again would be a no-op term.
+    if (sortKeys.includes("_id")) {
+      return sort;
+    }
+
+    const hasIdColumn: boolean = this.model.tableColumns.some(
+      (column: AnalyticsTableColumn): boolean => {
+        return column.key === "_id";
+      },
+    );
+
+    if (!hasIdColumn) {
+      return sort;
+    }
+
+    /*
+     * Tie-break in the same direction as the last declared sort key, so a
+     * newest-first list stays newest-first within a single timestamp.
+     */
+    const lastSortKey: string | undefined = sortKeys[sortKeys.length - 1];
+
+    const direction: SortOrder =
+      (lastSortKey
+        ? ((sort as Record<string, SortOrder | undefined>)[lastSortKey] as
+            | SortOrder
+            | undefined)
+        : undefined) ?? SortOrder.Descending;
+
+    /*
+     * `_id` is absent from `sort` (checked above), so spreading appends it
+     * last and the caller's own keys keep their relative order.
+     */
+    return { ...sort, _id: direction } as Sort<TBaseModel>;
+  }
+
   public toFindStatement(findBy: FindBy<TBaseModel>): {
     statement: Statement;
     columns: Array<string>;
@@ -1470,7 +1539,9 @@ export default class AnalyticsDatabaseService<
     );
 
     const sortStatement: Statement = this.statementGenerator.toSortStatement(
-      findBy.sort!,
+      this.toPaginationStableSort(findBy.sort!, {
+        hasGroupBy: Boolean(groupByStatement),
+      }),
     );
 
     const statement: Statement = SQL``;

--- a/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/StatementGenerator.ts
@@ -1169,9 +1169,22 @@ export default class StatementGenerator<TBaseModel extends AnalyticsBaseModel> {
   public toSortStatement(sort: Sort<TBaseModel>): Statement {
     const sortStatement: Statement = new Statement();
 
+    /*
+     * Keys must be comma separated. Without the separator a multi-key sort
+     * concatenates into a single malformed term (`time DESCseverity ASC`),
+     * so every ORDER BY beyond the first key was unusable. Mirrors
+     * toGroupByStatement above.
+     */
+    let first: boolean = true;
     for (const key in sort) {
       if (!this.model.getTableColumn(key)) {
         throw new BadDataException(`Unknown column: ${key}`);
+      }
+
+      if (first) {
+        first = false;
+      } else {
+        sortStatement.append(SQL`, `);
       }
 
       const value: SortOrder = sort[key]!;

--- a/Common/Tests/Server/Services/AnalyticsDatabasePaginationStability.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabasePaginationStability.test.ts
@@ -1,0 +1,582 @@
+import AnalyticsDatabaseService from "../../../Server/Services/AnalyticsDatabaseService";
+import {
+  SQL,
+  Statement,
+} from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import logger from "../../../Server/Utils/Logger";
+import "../TestingUtils/Init";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../../Types/API/Route";
+import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableColumn from "../../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import GenericObject from "../../../Types/GenericObject";
+import {
+  describe,
+  expect,
+  beforeEach,
+  afterEach,
+  test,
+  jest,
+} from "@jest/globals";
+
+/*
+ * Pagination stability for analytics reads.
+ *
+ * `ORDER BY time DESC` is not a TOTAL order: rows that tie on `time` may be
+ * returned in any order, and ClickHouse is free to order them differently
+ * between two executions of the same query. Paging with LIMIT/OFFSET on top
+ * of a partial order silently drops rows at page boundaries and repeats
+ * others — a row sitting at offset 49 on page 1 can shift to offset 50
+ * before page 2 is fetched, so it is never rendered.
+ *
+ * Ties are the normal case, not an edge case: a service emitting a burst of
+ * logs writes many rows carrying an identical timestamp.
+ *
+ * The fix appends the unique, time-ordered `_id` as a final sort key.
+ *
+ * Two suites below:
+ *  - "sort shape" pins the sort object the service hands to the generator.
+ *  - "page boundary behaviour" simulates the engine's freedom to reorder
+ *    ties and proves paging is lossless with the tiebreaker and lossy
+ *    without it.
+ */
+
+const TIME_COLUMN: string = "time";
+const BODY_COLUMN: string = "body";
+
+class LogLikeModel extends AnalyticsBaseModel {
+  public constructor() {
+    super({
+      tableName: "<log-like-table>",
+      singularName: "<singular-name>",
+      pluralName: "<plural-name>",
+      tableColumns: [
+        new AnalyticsTableColumn({
+          key: TIME_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.DateTime64,
+        }),
+        new AnalyticsTableColumn({
+          key: BODY_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: false,
+          type: TableColumnType.Text,
+        }),
+      ],
+      crudApiPath: new Route("route"),
+      primaryKeys: [TIME_COLUMN],
+      sortKeys: [TIME_COLUMN],
+      partitionKey: TIME_COLUMN,
+      tableEngine: AnalyticsTableEngine.MergeTree,
+      defaultSortColumn: TIME_COLUMN,
+    });
+  }
+}
+
+/*
+ * Stands in for a derived aggregate target. `includeBaseColumns: false`
+ * omits `_id` because the aggregation key IS the row identity there, so the
+ * tiebreaker has nothing to append and must not invent a column.
+ */
+class NoIdModel extends AnalyticsBaseModel {
+  public constructor() {
+    super({
+      tableName: "<no-id-table>",
+      singularName: "<singular-name>",
+      pluralName: "<plural-name>",
+      includeBaseColumns: false,
+      tableColumns: [
+        new AnalyticsTableColumn({
+          key: TIME_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.DateTime64,
+        }),
+      ],
+      crudApiPath: new Route("route"),
+      primaryKeys: [TIME_COLUMN],
+      sortKeys: [TIME_COLUMN],
+      partitionKey: TIME_COLUMN,
+      tableEngine: AnalyticsTableEngine.MergeTree,
+      defaultSortColumn: TIME_COLUMN,
+    });
+  }
+}
+
+describe("AnalyticsDatabaseService pagination stability", () => {
+  describe("sort shape", () => {
+    let service: AnalyticsDatabaseService<LogLikeModel>;
+    let capturedSorts: Array<Record<string, SortOrder>>;
+
+    beforeEach(() => {
+      service = new AnalyticsDatabaseService({ modelType: LogLikeModel });
+      capturedSorts = [];
+
+      service.statementGenerator.toSelectStatement = jest.fn(() => {
+        return { statement: SQL`<select>`, columns: ["<column>"] };
+      });
+      service.statementGenerator.toWhereStatement = jest.fn(() => {
+        return SQL`<where>`;
+      });
+      service.statementGenerator.toGroupByStatement = jest.fn(() => {
+        return SQL`<group-by>`;
+      });
+      service.statementGenerator.toSortStatement = jest.fn(
+        (sort: unknown): Statement => {
+          capturedSorts.push({ ...(sort as Record<string, SortOrder>) });
+          return SQL`<sort>`;
+        },
+      ) as never;
+
+      jest.spyOn(logger, "debug").mockImplementation(() => {
+        return undefined!;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    type FindArgs = {
+      sort: GenericObject;
+      groupBy?: GenericObject | undefined;
+    };
+
+    const runFind: (args: FindArgs) => void = (args: FindArgs): void => {
+      service.toFindStatement({
+        select: {} as GenericObject,
+        query: {} as GenericObject,
+        props: {} as GenericObject,
+        sort: args.sort,
+        groupBy: args.groupBy,
+        limit: 50,
+        skip: 0,
+      } as never);
+    };
+
+    test("appends _id when the caller did not sort by it", () => {
+      runFind({ sort: { [TIME_COLUMN]: SortOrder.Descending } });
+
+      expect(capturedSorts[0]).toStrictEqual({
+        [TIME_COLUMN]: SortOrder.Descending,
+        _id: SortOrder.Descending,
+      });
+    });
+
+    test("_id is the LAST key, so it only ever breaks ties", () => {
+      runFind({ sort: { [TIME_COLUMN]: SortOrder.Descending } });
+
+      expect(Object.keys(capturedSorts[0]!)).toStrictEqual([
+        TIME_COLUMN,
+        "_id",
+      ]);
+    });
+
+    test("tiebreaker direction follows a descending sort", () => {
+      runFind({ sort: { [TIME_COLUMN]: SortOrder.Descending } });
+
+      expect(capturedSorts[0]!["_id"]).toBe(SortOrder.Descending);
+    });
+
+    test("tiebreaker direction follows an ascending sort", () => {
+      runFind({ sort: { [TIME_COLUMN]: SortOrder.Ascending } });
+
+      expect(capturedSorts[0]!["_id"]).toBe(SortOrder.Ascending);
+    });
+
+    test("follows the LAST key when several columns are sorted", () => {
+      runFind({
+        sort: {
+          [TIME_COLUMN]: SortOrder.Descending,
+          [BODY_COLUMN]: SortOrder.Ascending,
+        },
+      });
+
+      expect(Object.keys(capturedSorts[0]!)).toStrictEqual([
+        TIME_COLUMN,
+        BODY_COLUMN,
+        "_id",
+      ]);
+      expect(capturedSorts[0]!["_id"]).toBe(SortOrder.Ascending);
+    });
+
+    test("does not append a second _id when already sorted by it", () => {
+      runFind({ sort: { _id: SortOrder.Ascending } });
+
+      expect(capturedSorts[0]).toStrictEqual({ _id: SortOrder.Ascending });
+    });
+
+    test("keeps a caller's _id in its original position and direction", () => {
+      runFind({
+        sort: {
+          _id: SortOrder.Descending,
+          [TIME_COLUMN]: SortOrder.Ascending,
+        },
+      });
+
+      expect(Object.keys(capturedSorts[0]!)).toStrictEqual([
+        "_id",
+        TIME_COLUMN,
+      ]);
+      expect(capturedSorts[0]!["_id"]).toBe(SortOrder.Descending);
+    });
+
+    /*
+     * Under GROUP BY, `_id` is neither a grouping key nor an aggregate, so
+     * referencing it is an error rather than a tiebreak.
+     */
+    test("does not append _id to a GROUP BY query", () => {
+      runFind({
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+        groupBy: { [TIME_COLUMN]: true },
+      });
+
+      expect(capturedSorts[0]).toStrictEqual({
+        [TIME_COLUMN]: SortOrder.Descending,
+      });
+    });
+
+    test("falls back to descending when the sort is empty", () => {
+      runFind({ sort: {} });
+
+      expect(capturedSorts[0]).toStrictEqual({ _id: SortOrder.Descending });
+    });
+
+    test("does not mutate the caller's sort object", () => {
+      const callerSort: GenericObject = {
+        [TIME_COLUMN]: SortOrder.Descending,
+      };
+
+      runFind({ sort: callerSort });
+
+      expect(callerSort).toStrictEqual({ [TIME_COLUMN]: SortOrder.Descending });
+      expect(callerSort).not.toHaveProperty("_id");
+    });
+
+    test("a model without an _id column is left alone", () => {
+      const noIdService: AnalyticsDatabaseService<NoIdModel> =
+        new AnalyticsDatabaseService({ modelType: NoIdModel });
+
+      const noIdSorts: Array<Record<string, SortOrder>> = [];
+
+      noIdService.statementGenerator.toSelectStatement = jest.fn(() => {
+        return { statement: SQL`<select>`, columns: ["<column>"] };
+      });
+      noIdService.statementGenerator.toWhereStatement = jest.fn(() => {
+        return SQL`<where>`;
+      });
+      noIdService.statementGenerator.toSortStatement = jest.fn(
+        (sort: unknown): Statement => {
+          noIdSorts.push({ ...(sort as Record<string, SortOrder>) });
+          return SQL`<sort>`;
+        },
+      ) as never;
+
+      noIdService.toFindStatement({
+        select: {} as GenericObject,
+        query: {} as GenericObject,
+        props: {} as GenericObject,
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+        limit: 50,
+        skip: 0,
+      } as never);
+
+      expect(noIdSorts[0]).toStrictEqual({
+        [TIME_COLUMN]: SortOrder.Descending,
+      });
+    });
+  });
+
+  describe("rendered SQL", () => {
+    let service: AnalyticsDatabaseService<LogLikeModel>;
+
+    beforeEach(() => {
+      service = new AnalyticsDatabaseService({ modelType: LogLikeModel });
+
+      service.statementGenerator.toSelectStatement = jest.fn(() => {
+        return { statement: SQL`<select>`, columns: ["<column>"] };
+      });
+      service.statementGenerator.toWhereStatement = jest.fn(() => {
+        return SQL`<where>`;
+      });
+      jest.spyOn(logger, "debug").mockImplementation(() => {
+        return undefined!;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    /*
+     * The generator is NOT mocked here, so this asserts the real ORDER BY
+     * text — the separator fix and the tiebreaker together.
+     */
+    test("emits a comma separated, _id terminated ORDER BY", () => {
+      const { statement } = service.toFindStatement({
+        select: {} as GenericObject,
+        query: {} as GenericObject,
+        props: {} as GenericObject,
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+        limit: 50,
+        skip: 100,
+      } as never);
+
+      expect(statement.query).toContain(
+        "ORDER BY {p2:Identifier} DESC, {p3:Identifier} DESC",
+      );
+      expect(statement.query_params).toMatchObject({
+        p2: TIME_COLUMN,
+        p3: "_id",
+      });
+    });
+
+    test("the ORDER BY ends with _id, immediately before LIMIT", () => {
+      const { statement } = service.toFindStatement({
+        select: {} as GenericObject,
+        query: {} as GenericObject,
+        props: {} as GenericObject,
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+        limit: 50,
+        skip: 0,
+      } as never);
+
+      const orderBy: string = statement.query
+        .split("ORDER BY ")[1]!
+        .split(" LIMIT")[0]!;
+      const lastTerm: string = orderBy.split(", ").pop()!;
+      const lastParam: string = lastTerm.split(":")[0]!.replace("{", "");
+
+      expect(statement.query_params[lastParam]).toBe("_id");
+    });
+  });
+
+  /*
+   * The regression itself. These tests do not touch SQL text; they model
+   * what the engine is ALLOWED to do with a partial order and check whether
+   * paging survives it.
+   */
+  describe("page boundary behaviour", () => {
+    interface Row {
+      _id: string;
+      time: number;
+      body: string;
+    }
+
+    /*
+     * Order rows the way an engine may for a given ORDER BY spec. Rows that
+     * tie on every sort key fall back to `tieOrder` — standing in for the
+     * arbitrary, between-query-unstable order the engine is free to return.
+     */
+    const orderRows: (
+      rows: Array<Row>,
+      sort: Record<string, SortOrder>,
+      tieOrder: Array<string>,
+    ) => Array<Row> = (
+      rows: Array<Row>,
+      sort: Record<string, SortOrder>,
+      tieOrder: Array<string>,
+    ): Array<Row> => {
+      return [...rows].sort((a: Row, b: Row): number => {
+        for (const key of Object.keys(sort)) {
+          const left: string | number = (
+            a as unknown as Record<string, string | number>
+          )[key]!;
+          const right: string | number = (
+            b as unknown as Record<string, string | number>
+          )[key]!;
+
+          if (left !== right) {
+            const ascending: number = left < right ? -1 : 1;
+            return sort[key] === SortOrder.Ascending ? ascending : -ascending;
+          }
+        }
+
+        return tieOrder.indexOf(a._id) - tieOrder.indexOf(b._id);
+      });
+    };
+
+    const fetchPage: (
+      rows: Array<Row>,
+      sort: Record<string, SortOrder>,
+      tieOrder: Array<string>,
+      skip: number,
+      limit: number,
+    ) => Array<Row> = (
+      rows: Array<Row>,
+      sort: Record<string, SortOrder>,
+      tieOrder: Array<string>,
+      skip: number,
+      limit: number,
+    ): Array<Row> => {
+      return orderRows(rows, sort, tieOrder).slice(skip, skip + limit);
+    };
+
+    /*
+     * 12 rows across 3 timestamps, 4 rows tied on each — the shape a burst
+     * of logs produces.
+     */
+    const buildRows: () => Array<Row> = (): Array<Row> => {
+      const rows: Array<Row> = [];
+      for (let bucket: number = 0; bucket < 3; bucket++) {
+        for (let index: number = 0; index < 4; index++) {
+          const ordinal: number = bucket * 4 + index;
+          rows.push({
+            // Zero padded so lexical order matches numeric order.
+            _id: `id-${String(ordinal).padStart(2, "0")}`,
+            time: 1000 - bucket,
+            body: `Solver ${ordinal}% complete`,
+          });
+        }
+      }
+      return rows;
+    };
+
+    /*
+     * Three different tie orders, one per page fetch, modelling the engine
+     * returning ties differently for each of the three queries the UI runs.
+     */
+    const tieOrders: Array<Array<string>> = [
+      buildRows().map((row: Row): string => {
+        return row._id;
+      }),
+      [...buildRows()].reverse().map((row: Row): string => {
+        return row._id;
+      }),
+      buildRows()
+        .map((row: Row): string => {
+          return row._id;
+        })
+        .sort(),
+    ];
+
+    /*
+     * Page size 5 against tie groups of 4 is deliberate: the page boundaries
+     * (offset 5 and 10) fall INSIDE a tie group. Aligning them with group
+     * boundaries would hide the bug, because a reordering that stays within
+     * one page is unobservable.
+     */
+    const pageThrough: (sort: Record<string, SortOrder>) => Array<string> = (
+      sort: Record<string, SortOrder>,
+    ): Array<string> => {
+      const pageSize: number = 5;
+      const rows: Array<Row> = buildRows();
+      const seen: Array<string> = [];
+
+      for (let page: number = 0; page < 3; page++) {
+        const fetched: Array<Row> = fetchPage(
+          rows,
+          sort,
+          tieOrders[page]!,
+          page * pageSize,
+          pageSize,
+        );
+        for (const row of fetched) {
+          seen.push(row._id);
+        }
+      }
+
+      return seen;
+    };
+
+    test("WITHOUT the tiebreaker, paging loses and repeats rows", () => {
+      const seen: Array<string> = pageThrough({ time: SortOrder.Descending });
+      const unique: Set<string> = new Set(seen);
+
+      // Rows were fetched, but not the right ones.
+      expect(seen).toHaveLength(12);
+      expect(unique.size).toBeLessThan(12);
+    });
+
+    test("WITH the tiebreaker, every row is returned exactly once", () => {
+      const seen: Array<string> = pageThrough({
+        time: SortOrder.Descending,
+        _id: SortOrder.Descending,
+      });
+
+      expect(seen).toHaveLength(12);
+      expect(new Set(seen).size).toBe(12);
+      expect([...seen].sort()).toStrictEqual(
+        buildRows()
+          .map((row: Row): string => {
+            return row._id;
+          })
+          .sort(),
+      );
+    });
+
+    test("WITH the tiebreaker, page contents do not depend on tie order", () => {
+      const sort: Record<string, SortOrder> = {
+        time: SortOrder.Descending,
+        _id: SortOrder.Descending,
+      };
+      const rows: Array<Row> = buildRows();
+
+      // Offset 3 / limit 5 straddles two tie groups.
+      const underFirstTieOrder: Array<Row> = fetchPage(
+        rows,
+        sort,
+        tieOrders[0]!,
+        3,
+        5,
+      );
+      const underSecondTieOrder: Array<Row> = fetchPage(
+        rows,
+        sort,
+        tieOrders[1]!,
+        3,
+        5,
+      );
+
+      expect(underFirstTieOrder).toStrictEqual(underSecondTieOrder);
+    });
+
+    test("WITH the tiebreaker, ordering is fully deterministic", () => {
+      const sort: Record<string, SortOrder> = {
+        time: SortOrder.Descending,
+        _id: SortOrder.Descending,
+      };
+      const rows: Array<Row> = buildRows();
+
+      const ordered: Array<string> = orderRows(rows, sort, tieOrders[0]!).map(
+        (row: Row): string => {
+          return row._id;
+        },
+      );
+
+      /*
+       * `time` is 1000 - bucket, so bucket 0 (ids 00-03) is newest and comes
+       * first under DESC; within each tied bucket, _id descends.
+       */
+      expect(ordered).toStrictEqual([
+        "id-03",
+        "id-02",
+        "id-01",
+        "id-00",
+        "id-07",
+        "id-06",
+        "id-05",
+        "id-04",
+        "id-11",
+        "id-10",
+        "id-09",
+        "id-08",
+      ]);
+    });
+
+    test("an ascending tiebreaker is equally stable", () => {
+      const seen: Array<string> = pageThrough({
+        time: SortOrder.Ascending,
+        _id: SortOrder.Ascending,
+      });
+
+      expect(new Set(seen).size).toBe(12);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
@@ -206,8 +206,13 @@ describe("AnalyticsDatabaseService", () => {
       expect(service.statementGenerator.toWhereStatement).toBeCalledWith({
         field: "value",
       });
+      /*
+       * `_id` is appended as a pagination tiebreaker so the ORDER BY is a
+       * total order. See the PaginationStableSort suite below.
+       */
       expect(service.statementGenerator.toSortStatement).toBeCalledWith({
         field: "asc",
+        _id: "asc",
       });
 
       expect(jest.mocked(logger.debug)).toHaveBeenCalledTimes(2);

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/StatementGenerator.test.ts
@@ -24,6 +24,7 @@ import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
 import MultiSearch from "../../../../Types/BaseDatabase/MultiSearch";
 import Search from "../../../../Types/BaseDatabase/Search";
 import StartsWith from "../../../../Types/BaseDatabase/StartsWith";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 
 function expectStatement(actual: Statement, expected: Statement): void {
@@ -1428,6 +1429,125 @@ describe("StatementGenerator", () => {
         p1: "createdAt",
       });
       expect(columns).toStrictEqual(["_id", "createdAt"]);
+    });
+  });
+
+  /*
+   * The separator here is load-bearing for pagination. `toSortStatement`
+   * used to append sort keys with no delimiter, so anything past the first
+   * key produced a malformed term (`col_1 DESCcol_2 ASC`) — which meant a
+   * multi-key ORDER BY was unusable and, in practice, every paginated read
+   * ran on a single, non-unique sort column. See the pagination-stability
+   * suite in Tests/Server/Services/AnalyticsDatabasePaginationStability.
+   */
+  describe("toSortStatement", () => {
+    /*
+     * TestModel declares its columns through `tableColumns`, not as TS
+     * properties, so a `Sort<TestModel>` literal would fail excess-property
+     * checking on every key. Funnelling through one helper keeps the cast
+     * in a single place instead of on each call.
+     */
+    const sortStatementFor: (sort: Record<string, SortOrder>) => Statement = (
+      sort: Record<string, SortOrder>,
+    ): Statement => {
+      return generator.toSortStatement(sort as any);
+    };
+
+    test("renders a single ascending key with no trailing separator", () => {
+      const statement: Statement = sortStatementFor({
+        column_1: SortOrder.Ascending,
+      });
+
+      expect(statement.query).toBe("{p0:Identifier} ASC");
+      expect(statement.query_params).toStrictEqual({ p0: "column_1" });
+    });
+
+    test("renders a single descending key", () => {
+      const statement: Statement = sortStatementFor({
+        column_1: SortOrder.Descending,
+      });
+
+      expect(statement.query).toBe("{p0:Identifier} DESC");
+      expect(statement.query_params).toStrictEqual({ p0: "column_1" });
+    });
+
+    test("comma separates two keys", () => {
+      const statement: Statement = sortStatementFor({
+        column_1: SortOrder.Descending,
+        column_2: SortOrder.Ascending,
+      });
+
+      expect(statement.query).toBe("{p0:Identifier} DESC, {p1:Identifier} ASC");
+      expect(statement.query_params).toStrictEqual({
+        p0: "column_1",
+        p1: "column_2",
+      });
+    });
+
+    test("comma separates three keys and preserves declaration order", () => {
+      const statement: Statement = sortStatementFor({
+        column_2: SortOrder.Ascending,
+        column_1: SortOrder.Descending,
+        column_ObjectID: SortOrder.Ascending,
+      });
+
+      expect(statement.query).toBe(
+        "{p0:Identifier} ASC, {p1:Identifier} DESC, {p2:Identifier} ASC",
+      );
+      expect(statement.query_params).toStrictEqual({
+        p0: "column_2",
+        p1: "column_1",
+        p2: "column_ObjectID",
+      });
+    });
+
+    /*
+     * Regression guard for the exact malformed shape. Asserting on the
+     * rendered text rather than the param map is deliberate: the old bug
+     * produced correct PARAMS and broken SQL, so a params-only assertion
+     * would have passed straight through it.
+     */
+    test("never concatenates a direction into the next identifier", () => {
+      const statement: Statement = sortStatementFor({
+        column_1: SortOrder.Descending,
+        column_2: SortOrder.Ascending,
+      });
+
+      expect(statement.query).not.toContain("DESC{");
+      expect(statement.query).not.toContain("ASC{");
+      expect(statement.query).toContain(", ");
+    });
+
+    test("separator count is always one fewer than the key count", () => {
+      const statement: Statement = sortStatementFor({
+        column_ObjectID: SortOrder.Ascending,
+        column_1: SortOrder.Ascending,
+        column_2: SortOrder.Ascending,
+      });
+
+      expect(statement.query.split(", ")).toHaveLength(3);
+    });
+
+    test("an empty sort produces an empty statement", () => {
+      const statement: Statement = sortStatementFor({});
+
+      expect(statement.query).toBe("");
+      expect(statement.query_params).toStrictEqual({});
+    });
+
+    test("still rejects an unknown column", () => {
+      expect(() => {
+        return sortStatementFor({ not_a_column: SortOrder.Ascending });
+      }).toThrow(BadDataException);
+    });
+
+    test("rejects an unknown column that appears after a valid one", () => {
+      expect(() => {
+        return sortStatementFor({
+          column_1: SortOrder.Ascending,
+          not_a_column: SortOrder.Descending,
+        });
+      }).toThrow(BadDataException);
     });
   });
 


### PR DESCRIPTION
## What

Makes analytics list pagination deterministic. Two defects, both in the read path:

1. **`toSortStatement` emitted sort keys with no separator.** A multi-key sort concatenated into a single malformed term — `col_1 DESCcol_2 ASC` — so any `ORDER BY` past the first key was unusable. `toGroupByStatement`, directly above it, has always kept the `first` flag and appended `SQL", "`; the sort variant just never did.

2. **`toFindStatement` paged over a non-unique `ORDER BY`.** `ORDER BY time DESC LIMIT n OFFSET m` is not a *total* order. Rows tying on `time` may come back in any order, and ClickHouse is free to order them differently between two executions of the same query — part order, thread scheduling and `optimize_read_in_order` all feed into it. A row sitting at offset 49 when page 1 is fetched can move to offset 50 before page 2 is fetched, so nobody ever sees it. Others get returned twice.

Ties are the normal case here, not an edge case: a service emitting a burst of logs writes many rows carrying an identical timestamp.

## How

- `StatementGenerator.toSortStatement` now comma-separates keys, mirroring `toGroupByStatement`.
- `AnalyticsDatabaseService.toFindStatement` appends the unique, time-ordered `_id` as a final sort key via a new private `toPaginationStableSort`.

`_id` is a good tiebreaker because it is stamped per row with `ObjectID.generateTimeOrdered()`, so it is unique and its ordering already agrees with time order. The tiebreaker takes the direction of the last declared sort key, so a newest-first list stays newest-first within one timestamp.

Two cases deliberately do **not** get the tiebreaker:

- **`GROUP BY` queries** — `_id` is neither a grouping key nor an aggregate there, so referencing it would be an error.
- **Models with no `_id` column** — derived aggregate targets omit it on purpose, because the aggregation key *is* the row identity (same condition `_findBy` already guards on).

The caller's sort object is not mutated, and a caller that already sorts by `_id` is left alone.

## Blast radius

`toSortStatement` has 8 call sites (5 in `MetricService`), so the separator fix reaches all of them — but since multi-key sorts produced invalid SQL before, nothing could have depended on the old output. The tiebreaker is scoped to `toFindStatement` only, so aggregate queries are untouched.

## Tests

`Common/Tests/Server/Services/AnalyticsDatabasePaginationStability.test.ts` (new, 18 tests) plus 9 new `toSortStatement` cases in the existing `StatementGenerator` suite.

**Sort shape** — `_id` appended when absent; always last; direction follows the last sort key both ways; follows the last key across a multi-column sort; not appended twice when the caller already sorts by `_id`; caller's `_id` position and direction preserved; not appended under `GROUP BY`; not appended for a model without `_id`; caller's object not mutated; empty-sort fallback.

**Rendered SQL** — the generator is *not* mocked, so these assert the real `ORDER BY` text: comma-separated and `_id`-terminated, with `_id` the final term immediately before `LIMIT`.

**Page boundary behaviour** — the actual regression. These model what the engine is *allowed* to do with a partial order rather than asserting SQL text: 12 rows across 3 timestamps with 4 rows tied on each, paged 5 at a time so page boundaries fall *inside* a tie group (aligning them would hide the bug), with a different tie ordering per page fetch to stand in for the engine reordering ties between queries. Without the tiebreaker, paging returns 12 rows but only 9 distinct ones — rows lost and repeated. With it, every row comes back exactly once, page contents no longer depend on tie order, and the full ordering is pinned.

The separator regression guard asserts on rendered text rather than the params map on purpose: the old bug produced *correct params and broken SQL*, so a params-only assertion would have passed straight through it.

Verified the suite actually guards the fix by reverting both source changes and re-running: 12 of the new tests fail, all pass with the fix restored.

## Notes

Found while auditing a customer report of dropped logs. This was **not** the cause of that report — the whole burst fit inside one 100-row page at `OFFSET 0`, where the mechanism is inert — but it is a real defect that will bite on high-volume services, so it is fixed here on its own.
