### PR TITLE
fix(kubernetes-agent): keep the agent off Windows nodes

### DIFF
--- a/App/FeatureSet/Docs/Content/en/telemetry/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/kubernetes-agent.md
@@ -383,6 +383,17 @@ kubectl delete namespace oneuptime-agent
 | **TCP Stats** _(via eBPF)_                         | Node-level RTT, failed-connection, and retransmit counters                                                                             |
 | **Workload Costs** _(opt-in, `cost.enabled=true`)_ | Pre-priced spend per namespace/workload/pod with idle and efficiency, plus node/PV hourly cost metrics — see [Kubernetes Cost Observability](/docs/telemetry/kubernetes-cost) |
 
+### Mixed Windows / Linux clusters
+
+Every workload the chart ships is Linux-only — the collector, OBI, and cost-agent images have no `windows/amd64` build, the DaemonSets mount Linux host paths (`/var/log/pods`, `/proc`, `/sys`), and eBPF has no Windows equivalent. All of them therefore carry a `kubernetes.io/os: linux` node selector, so on a mixed-OS cluster the agent runs entirely on your Linux nodes.
+
+Your Windows nodes and the pods on them are still monitored, just from the cluster level rather than from the node:
+
+- **Collected** — node conditions, capacity and allocatable, pod counts, pod phase and restarts, deployment/replicaset state, and Kubernetes events (from the `k8s_cluster` receiver and, if enabled, kube-state-metrics — both of which read the API server and cover every node regardless of OS).
+- **Not collected** — per-node kubelet/cAdvisor and host-level metrics, pod logs, and eBPF traces from Windows nodes, because all three need an agent pod running on the node itself.
+
+To get logs and application telemetry out of Windows workloads, instrument them with an [OpenTelemetry SDK](/docs/telemetry/open-telemetry) pointed at your OneUptime OTLP endpoint.
+
 ## Application Traces & HTTP Metrics via eBPF (on by default)
 
 The chart runs a DaemonSet with [OpenTelemetry eBPF Instrumentation (OBI)](https://opentelemetry.io/docs/zero-code/obi/) on every node. It loads eBPF programs into the kernel and auto-captures HTTP/HTTPS, gRPC, and SQL/Redis traffic from every supported runtime (Go, .NET, Java, Node.js, Python, Ruby, Rust) — no SDK and no sidecar required. Traces and request metrics then flow through the in-cluster collector to OneUptime.
@@ -681,6 +692,43 @@ helm upgrade kubernetes-agent oneuptime/kubernetes-agent \
   --reuse-values \
   --set preset=gke-autopilot   # or eks-fargate
 ```
+
+### Agent pods stuck in `ImagePullBackOff` (mixed Windows / Linux clusters)
+
+Symptom: the DaemonSets report far fewer available pods than scheduled, and the missing ones are all on Windows nodes.
+
+```
+Desired Number of Nodes Scheduled: 12
+Number of Nodes Scheduled with Available Pods: 4
+Pods Status:  4 Running / 8 Waiting / 0 Succeeded / 0 Failed
+```
+
+```bash
+# Confirm it: every stuck pod should land on a Windows node.
+kubectl get pods -n oneuptime-agent -o wide
+kubectl get nodes -L kubernetes.io/os
+```
+
+The agent's images are Linux-only, so a pull on a Windows node can never succeed — the registry is reachable, the manifest list simply has no `windows/amd64` entry. A DaemonSet with no node selector targets **every** node, and the agent's default blanket toleration (`operator: Exists`, there so it covers tainted Linux pools) also swallows the Windows OS taint that GKE applies and that AKS/EKS apply when configured. So nothing held the pods back.
+
+Chart **0.6.2** and later pin every workload with `kubernetes.io/os: linux`, which fixes this. Upgrade:
+
+```bash
+helm repo update
+helm upgrade kubernetes-agent oneuptime/kubernetes-agent \
+  --namespace oneuptime-agent --reuse-values
+```
+
+The stuck pods are removed as the DaemonSets roll; nothing else changes, because those pods were never running. If you cannot upgrade yet, patch the selector onto the workloads directly — on earlier charts only the eBPF DaemonSet exposes a `nodeSelector` value, so a `helm --set` alone would leave the log collector stranded:
+
+```bash
+kubectl -n oneuptime-agent patch daemonset kubernetes-agent-ebpf --type=merge \
+  -p '{"spec":{"template":{"spec":{"nodeSelector":{"kubernetes.io/os":"linux"}}}}}'
+```
+
+Repeat for each of `kubernetes-agent-logs`, `kubernetes-agent-profiling` (if profiling is on), and any agent Deployment that landed on a Windows node. A later `helm upgrade` to 0.6.2+ makes the patches permanent.
+
+See [Mixed Windows / Linux clusters](#mixed-windows-linux-clusters) for what is and isn't collected from Windows nodes afterwards.
 
 ### Agent shows "Disconnected"
 

--- a/HelmChart/Public/kubernetes-agent/Chart.yaml
+++ b/HelmChart/Public/kubernetes-agent/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
 
 type: application
 
-version: 0.6.1
+version: 0.6.2
 
 appVersion: "1.0.0"
 

--- a/HelmChart/Public/kubernetes-agent/README.md
+++ b/HelmChart/Public/kubernetes-agent/README.md
@@ -409,6 +409,23 @@ When `ebpf.enabled` is also true (the default), the profiler correlates samples 
 - **`csi.*`** — auto-discovers pods labeled `app=csi-driver` (or `app.kubernetes.io/component=csi-driver`) and scrapes their `metrics` port. Most cloud-provider CSI drivers fit this convention.
 - **`coreDns.*`** — scrapes the cluster's CoreDNS service on `:9153/metrics`. Surfaces DNS query rate, latency, cache hit rate, and error counts — a common P99 latency culprit.
 
+### Node placement on mixed Windows and Linux clusters
+
+Every workload the chart ships is pinned to `kubernetes.io/os: linux`, because every one of them is Linux-only: no agent image has a `windows/amd64` build, the DaemonSets mount Linux host paths (`/var/log/pods`, `/proc`, `/sys`, `/sys/fs/bpf`), and eBPF has no Windows equivalent.
+
+Without that pin the DaemonSets place one pod per Windows node that can only ever sit in `ImagePullBackOff` — a DaemonSet with no node selector targets every node, and the chart's blanket `operator: Exists` toleration (there so the agent covers tainted Linux pools) swallows the Windows OS taint too.
+
+Anything you set in `ebpf.nodeSelector` is merged on top of the pin, so pool selectors keep working:
+
+```bash
+--set ebpf.nodeSelector.agentpool=observability
+# renders: {agentpool: observability, kubernetes.io/os: linux}
+```
+
+Setting `kubernetes.io/os` yourself overrides the pin — the chart assumes you mean it.
+
+Windows nodes stay visible through the cluster-level receivers (node conditions, capacity, pod phase and restarts, events, and kube-state-metrics if enabled). What you don't get from them is per-node kubelet/cAdvisor and host metrics, pod logs, and eBPF traces — all three need an agent pod on the node itself.
+
 ### eBPF auto-instrumentation (`ebpf.*`) — on by default
 
 The agent ships a DaemonSet running [OpenTelemetry eBPF Instrumentation (OBI)](https://opentelemetry.io/docs/zero-code/obi/) on every node. OBI loads eBPF programs into the kernel to capture HTTP/HTTPS, gRPC, and SQL/Redis calls from any process — Go, .NET, Java, Node.js, Python, Ruby, or Rust — with no code changes, no SDK, and no sidecar. Captured traffic is exported as OTLP traces (and request/latency metrics) directly to OneUptime, where it appears under **Telemetry → Traces** and the service map.
@@ -538,6 +555,30 @@ To validate a key by hand (`200` = valid, `401` = unknown/revoked):
 ```bash
 curl -i -H "x-oneuptime-token: <YOUR_API_KEY>" "$ONEUPTIME_URL/otlp/v1/validate"
 ```
+
+### Agent pods stuck in `ImagePullBackOff` on Windows nodes
+
+The DaemonSets report many more scheduled pods than available, and the stuck ones are all on Windows nodes:
+
+```
+Desired Number of Nodes Scheduled: 12
+Number of Nodes Scheduled with Available Pods: 4
+```
+
+```bash
+kubectl get pods -n oneuptime-kubernetes-agent -o wide
+kubectl get nodes -L kubernetes.io/os
+```
+
+The registry is fine — the agent images have no `windows/amd64` entry in their manifest list, so the pull can never succeed there. Chart **0.6.2+** pins every workload to `kubernetes.io/os: linux`; upgrading is the fix:
+
+```bash
+helm repo update
+helm upgrade oneuptime-agent oneuptime/kubernetes-agent \
+  --namespace oneuptime-kubernetes-agent --reuse-values
+```
+
+Nothing is lost in the roll — those pods never ran. See [Node placement on mixed Windows and Linux clusters](#node-placement-on-mixed-windows-and-linux-clusters) for what Windows nodes still report afterwards.
 
 ### Application pods crash with SIGSEGV after enabling log ↔ trace correlation
 

--- a/HelmChart/Public/kubernetes-agent/templates/_helpers.tpl
+++ b/HelmChart/Public/kubernetes-agent/templates/_helpers.tpl
@@ -59,6 +59,39 @@ Service account name
 {{- end }}
 
 {{/*
+Node selector for every workload this chart ships.
+
+All of them are Linux-only, and not by accident: the collector, OBI and
+cost-agent images are published for linux/{amd64,arm64} with no windows/amd64
+variant in the manifest list, the DaemonSets mount Linux-only host paths
+(/var/log/pods, /proc, /sys, /sys/fs/bpf, /sys/kernel/{tracing,debug}), and
+eBPF has no Windows equivalent at all.
+
+DaemonSets are where this bites on a mixed-OS cluster. A DaemonSet with no
+nodeSelector targets EVERY node, and this chart's blanket `operator: Exists`
+toleration — there so the agent covers tainted Linux pools — also swallows the
+Windows OS taint that GKE applies and that AKS/EKS apply when configured. So
+the pods land on Windows nodes and sit in ImagePullBackOff forever, one per
+node, with the DaemonSet reporting far fewer available pods than scheduled.
+Deployments hit the same wall whenever the scheduler happens to pick a Windows
+node. `kubernetes.io/os: linux` is the standard fix, and it is a well-known
+label kubelet sets on every node.
+
+Callers pass their component's own nodeSelector (when it has one) as `extra`.
+Its keys WIN, so an operator who deliberately sets `kubernetes.io/os` keeps
+control. `merge` mutates its destination argument in place, hence the fresh
+`dict` — merging into .Values.<component>.nodeSelector directly would write
+the OS key back into the values tree and leak it into every later template.
+
+Usage:
+  nodeSelector:
+    {{`{{- include "kubernetes-agent.nodeSelector" (dict "extra" .Values.ebpf.nodeSelector) | nindent 8 }}`}}
+*/}}
+{{- define "kubernetes-agent.nodeSelector" -}}
+{{- toYaml (merge (dict) (.extra | default dict) (dict "kubernetes.io/os" "linux")) -}}
+{{- end -}}
+
+{{/*
 Build the OTEL_EBPF_METRICS_FEATURES env var value from .Values.ebpf.features
 toggles. Returns a comma-separated string of the OBI feature names that are
 currently enabled. Empty list -> empty string (OBI then exports no metrics).

--- a/HelmChart/Public/kubernetes-agent/templates/daemonset-ebpf.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/daemonset-ebpf.yaml
@@ -20,10 +20,11 @@ spec:
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
       hostPID: true
-      {{- with .Values.ebpf.nodeSelector }}
+      # Always pinned to Linux nodes — OBI is an eBPF agent and there is no
+      # Windows build of the image. See the helper for why the toleration
+      # below cannot be relied on to keep it off Windows nodes.
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "kubernetes-agent.nodeSelector" (dict "extra" .Values.ebpf.nodeSelector) | nindent 8 }}
       {{- with .Values.ebpf.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/kubernetes-agent/templates/daemonset-profiling.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/daemonset-profiling.yaml
@@ -22,6 +22,11 @@ spec:
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
       hostPID: true
+      # eBPF-based profiler: Linux-only image, Linux-only host mounts. The
+      # toleration below covers every taint, including the Windows OS taint,
+      # so the OS pin is what keeps this off Windows nodes.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       tolerations:
         - operator: Exists
       containers:

--- a/HelmChart/Public/kubernetes-agent/templates/daemonset.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/daemonset.yaml
@@ -34,6 +34,11 @@ spec:
       # Lets the debug sidecar see the collector's processes (ps, /proc, strace).
       shareProcessNamespace: true
       {{- end }}
+      # The collector image is Linux-only and the host mounts below
+      # (/var/log/pods, /proc, /sys) are Linux paths, so this must never land
+      # on a Windows node — the toleration alone would let it.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       tolerations:
         - operator: Exists
       containers:

--- a/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
@@ -23,6 +23,9 @@ spec:
         component: cost-agent
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux-only image — keep it off Windows nodes in a mixed-OS cluster.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       # No privileged containers, no hostPath, no hostNetwork — GKE Autopilot
       # compatible. The poller only talks HTTP to the cost engine's Service
       # and to OneUptime.

--- a/HelmChart/Public/kubernetes-agent/templates/deployment-logs-api.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-logs-api.yaml
@@ -20,6 +20,9 @@ spec:
         component: log-collector
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux-only image — keep it off Windows nodes in a mixed-OS cluster.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       # No privileged containers, no hostPath, no hostNetwork — GKE Autopilot
       # compatible. The tailer only needs the ServiceAccount's API access.
       securityContext:

--- a/HelmChart/Public/kubernetes-agent/templates/deployment.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       # Lets the debug sidecar see the collector's processes (ps, /proc, strace).
       shareProcessNamespace: true
       {{- end }}
+      # Linux-only image — without this the scheduler is free to place the
+      # collector on a Windows node in a mixed-OS cluster.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       containers:
         - name: otel-collector
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/HelmChart/Public/kubernetes-agent/templates/kube-state-metrics.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/kube-state-metrics.yaml
@@ -87,6 +87,9 @@ spec:
     spec:
       serviceAccountName: {{ include "kubernetes-agent.fullname" . }}-kube-state-metrics
       automountServiceAccountToken: true
+      # Linux-only image — keep it off Windows nodes in a mixed-OS cluster.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/HelmChart/Public/kubernetes-agent/templates/opencost.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/opencost.yaml
@@ -52,6 +52,9 @@ spec:
         component: opencost
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux-only image — keep it off Windows nodes in a mixed-OS cluster.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       # No privileged containers, no hostPath, no hostNetwork — GKE
       # Autopilot compatible. OpenCost only needs API reads (RBAC) and
       # HTTP to its Prometheus.

--- a/HelmChart/Public/kubernetes-agent/templates/prometheus-cost.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/prometheus-cost.yaml
@@ -104,6 +104,9 @@ spec:
         checksum/config: {{ toYaml .Values.cost.prometheus | sha256sum | trunc 32 }}
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux-only image — keep it off Windows nodes in a mixed-OS cluster.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/HelmChart/Public/kubernetes-agent/troubleshoot.sh
+++ b/HelmChart/Public/kubernetes-agent/troubleshoot.sh
@@ -280,7 +280,20 @@ if [ -n "$PODS" ]; then
         *CreateContainerConfigError*|*CreateContainerError*)
           add_finding "Pod $pod has a config error (often a missing/renamed Secret or key). Verify the api-key Secret exists — see the Token section." ;;
         *ImagePull*|*ErrImage*)
-          add_finding "Pod $pod cannot pull its image (ImagePullBackOff). Check image registry access / airgap mirror." ;;
+          # On a mixed-OS cluster the overwhelmingly common cause is a
+          # Linux-only agent image scheduled onto a Windows node — the
+          # registry is reachable, the manifest list just has no
+          # windows/amd64 entry. Say so instead of sending people to audit
+          # their registry.
+          podnode=$(kubectl get pod "$pod" -n "$NS" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+          nodeos=""
+          [ -n "$podnode" ] && nodeos=$(kubectl get node "$podnode" \
+            -o jsonpath='{.metadata.labels.kubernetes\.io/os}' 2>/dev/null)
+          if [ "$nodeos" = "windows" ]; then
+            add_finding "Pod $pod is on Windows node '$podnode' — every agent image is Linux-only, so the pull can never succeed. Upgrade to a chart version that pins the workloads with 'kubernetes.io/os: linux', or add that nodeSelector yourself."
+          else
+            add_finding "Pod $pod cannot pull its image (ImagePullBackOff). Check image registry access / airgap mirror."
+          fi ;;
         *CrashLoop*)
           add_finding "Pod $pod is CrashLooping. Inspect: kubectl logs -n $NS $pod -c otel-collector --previous" ;;
         *)

--- a/HelmChart/Public/kubernetes-agent/values.yaml
+++ b/HelmChart/Public/kubernetes-agent/values.yaml
@@ -774,6 +774,13 @@ ebpf:
   # Exists) so the DaemonSet covers all nodes. To keep it OFF a tainted DB-only
   # pool — so it doesn't compete with or instrument the database tier — override
   # `tolerations` with a narrower list and/or set `nodeSelector` / `affinity`.
+  #
+  # Whatever you put in `nodeSelector`, the chart also adds
+  # `kubernetes.io/os: linux` to it — as it does for every workload it ships.
+  # That pin is not decorative: the blanket toleration above swallows the
+  # Windows OS taint too, so without it this DaemonSet places one
+  # permanently-ImagePullBackOff pod on each Windows node of a mixed-OS
+  # cluster. Setting `kubernetes.io/os` here yourself overrides the pin.
   nodeSelector: {}
   tolerations:
     - operator: Exists


### PR DESCRIPTION
## The report

On a 12-node AKS cluster, both agent DaemonSets showed 12 nodes scheduled but only 4 available — 8 pods permanently in `ImagePullBackOff`, all of them on the Windows node pool:

```
Desired Number of Nodes Scheduled: 12
Number of Nodes Scheduled with Available Pods: 4
Pods Status:  4 Running / 8 Waiting / 0 Succeeded / 0 Failed

Normal   Pulling  Pulling image "otel/ebpf-instrument:v0.9.0"
Warning  Failed   Error: ErrImagePull
Normal   BackOff  Error: ImagePullBackOff
```

## Cause

Two things, neither of them the registry.

**The images are Linux-only.** Everything the chart ships is published for `linux/{amd64,arm64}` with no `windows/amd64` variant, so on a Windows node there is no manifest entry to pull and the kubelet backs off forever.

**Nothing kept the pods off those nodes.** A DaemonSet with no `nodeSelector` targets *every* node, and none of the chart's workloads had one — `ebpf.nodeSelector` existed but defaults to `{}`. The blanket `operator: Exists` toleration, there so the agent covers tainted Linux pools, also swallows the Windows OS taint on platforms that apply one, so a taint would not have helped either.

## Fix

Pin every workload to `kubernetes.io/os: linux` via a new `kubernetes-agent.nodeSelector` helper — both collector DaemonSets, profiling, the metrics Deployment, the API-mode log tailer, the cost agent, kube-state-metrics, OpenCost, and the bundled Prometheus. The pin is right for all of them, not just eBPF: the node collector mounts `/var/log/pods`, `/proc` and `/sys`, and the Deployments would fail identically whenever the scheduler picked a Windows node.

A caller's own selector merges on top and wins, so `--set ebpf.nodeSelector.agentpool=obs` renders `{agentpool: obs, kubernetes.io/os: linux}`, and setting `kubernetes.io/os` explicitly still overrides the pin. The merge destination is a fresh `dict` because sprig's `merge` mutates in place — merging into `.Values.ebpf.nodeSelector` would leak the OS key into the values tree for every later template.

## What Windows nodes still report

The `k8s_cluster` receiver and kube-state-metrics read the API server, so node conditions, capacity, pod phase, restarts and events keep flowing for Windows nodes and their pods. What is not available is per-node kubelet/cAdvisor and host metrics, pod logs, and eBPF traces — all three need an agent pod on the node itself, which on Windows was never running, only pending. This is documented in the chart README and the docs page instead of left implicit.

## Also

`troubleshoot.sh` reported this as *"Check image registry access / airgap mirror"*, sending people to audit a registry that works fine. It now resolves the pod's node and names the real cause when that node is Windows.

## Upgrade path

`helm upgrade --reuse-values` is enough — the fix is entirely in templates. The stuck pods are removed as the DaemonSets roll; nothing is lost, since they never ran.

## Verification

- `helm lint` (bare, as CI runs it) and with values
- Rendered manifests across the `standard`, `gke-autopilot` and `eks-fargate` presets with logs / profiling / cost / KSM / debug enabled — all nine workloads carry the pin
- A custom `ebpf.nodeSelector` merges correctly and does **not** leak into the other workloads
- An explicit `kubernetes.io/os` override still wins
- `bash -n troubleshoot.sh`, and `npm run docs:check-anchors` passes