### PR TITLE
fix(dashboard): close anonymous whole-project telemetry disclosure on public dashboards (GHSA-w332-x78m-vf3v)

### DIFF
--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -1297,9 +1297,25 @@ export default class DashboardAPI extends BaseAPI<
             DashboardAPI.collectDashboardMetricNames(
               dashboard.dashboardViewConfig,
             );
-          const requestedMetricName: unknown = aggregateBy.query
-            ? (aggregateBy.query as Record<string, unknown>)["name"]
-            : undefined;
+
+          /*
+           * Read the query through an OWN-properties copy. JSON.parse turns a
+           * literal "__proto__" member into a real own key and
+           * JSONFunctions.deserialize copies it with `newVal[key] = ...`,
+           * which fires Object.prototype's __proto__ setter — so a plain
+           * `query["name"]` lookup walks the prototype chain and sees a name
+           * that a later own-properties spread would silently drop, leaving
+           * the aggregation with no metric predicate at all. The check and
+           * the object that reaches the database must read the same keys.
+           */
+          const requestedQuery: Record<string, unknown> =
+            aggregateBy.query &&
+            typeof aggregateBy.query === "object" &&
+            !Array.isArray(aggregateBy.query)
+              ? { ...(aggregateBy.query as Record<string, unknown>) }
+              : {};
+
+          const requestedMetricName: unknown = requestedQuery["name"];
 
           if (
             typeof requestedMetricName !== "string" ||
@@ -1327,7 +1343,15 @@ export default class DashboardAPI extends BaseAPI<
           const requestedGroupByAttributeKeys: unknown =
             aggregateBy.groupByAttributeKeys;
 
-          if (requestedGroupByAttributeKeys !== undefined) {
+          /*
+           * `null` means "not grouped" here: JSONFunctions.serialize drops
+           * undefined but preserves null, and both downstream sinks already
+           * treat a null grouping as absent.
+           */
+          if (
+            requestedGroupByAttributeKeys !== undefined &&
+            requestedGroupByAttributeKeys !== null
+          ) {
             if (!Array.isArray(requestedGroupByAttributeKeys)) {
               throw new BadDataException(
                 "groupByAttributeKeys must be an array of attribute keys.",
@@ -1352,9 +1376,8 @@ export default class DashboardAPI extends BaseAPI<
             );
           const requestedGroupBy: unknown = aggregateBy.groupBy;
 
-          if (requestedGroupBy !== undefined) {
+          if (requestedGroupBy !== undefined && requestedGroupBy !== null) {
             if (
-              !requestedGroupBy ||
               typeof requestedGroupBy !== "object" ||
               Array.isArray(requestedGroupBy)
             ) {
@@ -1368,17 +1391,92 @@ export default class DashboardAPI extends BaseAPI<
                 );
               }
             }
+
+            /*
+             * Hand the SQL builder the same keys this guard validated. The
+             * guard reads Object.keys but the GROUP BY builder walks the
+             * object with for...in, so an inherited key would otherwise
+             * reach the query without ever being checked.
+             */
+            aggregateBy.groupBy = {
+              ...(requestedGroupBy as Record<string, unknown>),
+            } as typeof aggregateBy.groupBy;
           }
 
           /*
-           * Security: never trust a client-supplied projectId on a public,
-           * unauthenticated endpoint. Pin the aggregation to the dashboard's
-           * project before it reaches the database service.
+           * The client never chooses what is aggregated over what: every
+           * widget aggregates `value` over `time`. Left open, an anonymous
+           * caller could aggregate `attributes` instead — `max(attributes)`
+           * returns the whole map and the row mapper passes non-numeric
+           * aggregates through untouched, handing back a full attribute map
+           * per time bucket.
            */
+          if (aggregateBy.aggregateColumnName !== "value") {
+            throw new BadDataException("Invalid aggregateColumnName.");
+          }
+
+          if (aggregateBy.aggregationTimestampColumnName !== "time") {
+            throw new BadDataException(
+              "Invalid aggregationTimestampColumnName.",
+            );
+          }
+
+          // Never let an anonymous caller choose an unbounded page.
+          aggregateBy.limit = Math.min(
+            Math.max(Number(aggregateBy.limit) || LIMIT_PER_PROJECT, 1),
+            LIMIT_PER_PROJECT,
+          );
+          aggregateBy.skip = Math.max(Number(aggregateBy.skip) || 0, 0);
+
+          /*
+           * Security: the client does not get to choose what is filtered on a
+           * public, unauthenticated endpoint. Rebuild the query from the
+           * fields the dashboard's own widgets legitimately send — the
+           * allowlisted metric name, the time window, and attribute filters
+           * on keys those widgets already filter by — and pin the project.
+           * Everything else the client sent is dropped rather than merged: a
+           * foreign projectId, a filter on an arbitrary attribute key used as
+           * a blind ILIKE oracle, a key smuggled in on the prototype
+           * (GHSA-w332-x78m-vf3v).
+           */
+          const allowedFilterAttributeKeys: Set<string> =
+            DashboardAPI.collectDashboardFilterAttributeKeys(
+              dashboard.dashboardViewConfig,
+            );
+
+          const sanitizedAttributes: Record<string, unknown> = {};
+          const requestedAttributes: unknown = requestedQuery["attributes"];
+
+          if (
+            requestedAttributes &&
+            typeof requestedAttributes === "object" &&
+            !Array.isArray(requestedAttributes)
+          ) {
+            for (const requestedAttributeKey of Object.keys(
+              requestedAttributes as Record<string, unknown>,
+            )) {
+              if (!allowedFilterAttributeKeys.has(requestedAttributeKey)) {
+                throw new BadDataException(
+                  "This attribute is not part of this dashboard.",
+                );
+              }
+
+              sanitizedAttributes[requestedAttributeKey] = (
+                requestedAttributes as Record<string, unknown>
+              )[requestedAttributeKey];
+            }
+          }
+
           aggregateBy.query = {
-            ...(aggregateBy.query || {}),
+            name: requestedMetricName,
+            ...(requestedQuery["time"] !== undefined
+              ? { time: requestedQuery["time"] }
+              : {}),
+            ...(Object.keys(sanitizedAttributes).length > 0
+              ? { attributes: sanitizedAttributes }
+              : {}),
             projectId: dashboard.projectId,
-          };
+          } as unknown as typeof aggregateBy.query;
 
           const aggregateResult: AggregatedResult =
             await MetricService.aggregateBy(aggregateBy);
@@ -1706,6 +1804,71 @@ export default class DashboardAPI extends BaseAPI<
           }
         }
       }
+
+      for (const key of Object.keys(obj)) {
+        walk(obj[key]);
+      }
+    };
+
+    walk(dashboardViewConfig);
+
+    return attributeKeys;
+  }
+
+  /*
+   * Attribute keys a public metric aggregation may FILTER on.
+   *
+   * Two sources, and both are needed:
+   *
+   * - Keys the widgets themselves persist — `filterData.attributes` on a
+   *   chart/value/gauge query, and the table widget's widget-level
+   *   `attributeFilters`.
+   * - Keys the dashboard's `Telemetry Attribute` variables bind to. The
+   *   shipped templates store `filterData: { metricName, aggegationType }`
+   *   and no attributes at all; the filter on e.g.
+   *   `resource.k8s.cluster.name` only appears once the viewer picks a value
+   *   and DashboardVariableInterpolation injects it at render time. An
+   *   allowlist built from stored filters alone would refuse every real
+   *   templated dashboard the moment its variable is used.
+   */
+  private static collectDashboardFilterAttributeKeys(
+    dashboardViewConfig: unknown,
+  ): Set<string> {
+    const attributeKeys: Set<string> =
+      DashboardAPI.collectDashboardVariableAttributeKeys(dashboardViewConfig);
+
+    const addKeysOf: (value: unknown) => void = (value: unknown): void => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return;
+      }
+
+      for (const key of Object.keys(value as Record<string, unknown>)) {
+        if (key.length > 0) {
+          attributeKeys.add(key);
+        }
+      }
+    };
+
+    const walk: (node: unknown) => void = (node: unknown): void => {
+      if (!node || typeof node !== "object") {
+        return;
+      }
+
+      if (Array.isArray(node)) {
+        for (const item of node) {
+          walk(item);
+        }
+        return;
+      }
+
+      const obj: Record<string, unknown> = node as Record<string, unknown>;
+
+      const filterData: unknown = obj["filterData"];
+      if (filterData && typeof filterData === "object") {
+        addKeysOf((filterData as Record<string, unknown>)["attributes"]);
+      }
+
+      addKeysOf(obj["attributeFilters"]);
 
       for (const key of Object.keys(obj)) {
         walk(obj[key]);

--- a/Common/Tests/Server/API/DashboardPublicAttributeValuesAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicAttributeValuesAPI.test.ts
@@ -2,17 +2,22 @@ import Dashboard from "../../../Models/DatabaseModels/Dashboard";
 import DashboardAPI from "../../../Server/API/DashboardAPI";
 import DashboardService from "../../../Server/Services/DashboardService";
 import TelemetryAttributeService from "../../../Server/Services/TelemetryAttributeService";
+import { EncryptionSecret } from "../../../Server/EnvironmentConfig";
 import {
   ExpressRequest,
   ExpressResponse,
   NextFunction,
 } from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
 import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
 import { DashboardVariableType } from "../../../Types/Dashboard/DashboardVariable";
 import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import ForbiddenException from "../../../Types/Exception/ForbiddenException";
+import MasterPasswordRequiredException from "../../../Types/Exception/MasterPasswordRequiredException";
 import NotAuthenticatedException from "../../../Types/Exception/NotAuthenticatedException";
 import NotFoundException from "../../../Types/Exception/NotFoundException";
+import HashedString from "../../../Types/HashedString";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import TelemetryType from "../../../Types/Telemetry/TelemetryType";
@@ -57,6 +62,8 @@ const ATTRIBUTE_VALUES_ROUTE: string =
 
 const NOT_ON_DASHBOARD_MESSAGE: string =
   "This attribute is not part of this dashboard.";
+
+const MASTER_PASSWORD: string = "correct-horse-battery-staple";
 
 /*
  * The attribute keys the advisory's proof of concept reaches for: none of
@@ -157,21 +164,36 @@ describe("DashboardAPI public attribute-values", () => {
     });
   };
 
-  type CallRouteFunction = (body?: JSONObject) => Promise<void>;
+  interface RequestOptions {
+    cookies?: Record<string, string> | undefined;
+    headers?: Record<string, string> | undefined;
+    dashboardIdParam?: string | undefined;
+    socket?: JSONObject | undefined;
+    ips?: Array<string> | undefined;
+  }
+
+  type CallRouteFunction = (
+    body?: JSONObject,
+    options?: RequestOptions,
+  ) => Promise<void>;
 
   const callRoute: CallRouteFunction = async (
     body?: JSONObject,
+    options?: RequestOptions,
   ): Promise<void> => {
     const request: ExpressRequest = {
       params: {
-        dashboardId: dashboardId.toString(),
+        dashboardId:
+          options?.dashboardIdParam === undefined
+            ? dashboardId.toString()
+            : options.dashboardIdParam,
       },
       body: body === undefined ? {} : body,
       query: {},
-      cookies: {},
-      headers: {},
-      socket: {},
-      ips: [],
+      cookies: options?.cookies || {},
+      headers: options?.headers || {},
+      socket: options?.socket || {},
+      ips: options?.ips || [],
     } as unknown as ExpressRequest;
 
     await mockRouter
@@ -519,6 +541,142 @@ describe("DashboardAPI public attribute-values", () => {
     });
   });
 
+  /*
+   * The load-bearing line of the fix is `dashboardViewConfig: true` in the
+   * handler's select. A mock that ignores `select` would keep every test in
+   * this file green if that line were deleted — while taking down every real
+   * public dashboard — so these pin the projection itself.
+   */
+  describe("dashboard lookup", () => {
+    type GetHandlerLookupFunction = () => JSONObject;
+
+    const getHandlerLookup: GetHandlerLookupFunction = (): JSONObject => {
+      const calls: Array<Array<unknown>> = (
+        DashboardService.findOneById as jest.Mock
+      ).mock.calls as Array<Array<unknown>>;
+
+      /*
+       * hasReadAccess looks the dashboard up first with its own projection;
+       * the handler's is the one that asks for the view config.
+       */
+      const handlerCall: Array<unknown> | undefined = calls.find(
+        (call: Array<unknown>) => {
+          const select: JSONObject = (call[0] as JSONObject)[
+            "select"
+          ] as JSONObject;
+
+          return Boolean(select && select["dashboardViewConfig"]);
+        },
+      );
+
+      expect(handlerCall).toBeDefined();
+
+      return handlerCall![0] as JSONObject;
+    };
+
+    it("selects the view config, pinned to the path id, as root", async () => {
+      setAttributeVariables(["host.name"]);
+
+      await callRoute({ attributeKey: "host.name" });
+
+      const lookup: JSONObject = getHandlerLookup();
+
+      expect(lookup["select"]).toEqual({
+        _id: true,
+        projectId: true,
+        dashboardViewConfig: true,
+      });
+      expect(lookup["props"]).toEqual({ isRoot: true });
+      expect((lookup["id"] as ObjectID).toString()).toBe(
+        dashboardId.toString(),
+      );
+    });
+
+    it("refuses when the view config was not part of the projection", async () => {
+      /*
+       * A projection-aware mock: the handler only sees the columns it asked
+       * for, the way the real service behaves. Drop `dashboardViewConfig`
+       * from the handler's select and this test fails instead of silently
+       * allowlisting nothing.
+       */
+      const source: Dashboard = dashboard;
+
+      setAttributeVariables(["host.name"]);
+
+      jest
+        .spyOn(DashboardService, "findOneById")
+        .mockImplementation(async (data: any) => {
+          const projected: Dashboard = new Dashboard();
+
+          for (const column of Object.keys((data.select || {}) as JSONObject)) {
+            (projected as unknown as Record<string, unknown>)[column] = (
+              source as unknown as Record<string, unknown>
+            )[column];
+          }
+
+          projected.id = source.id;
+
+          return projected;
+        });
+
+      await callRoute({ attributeKey: "host.name" });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(
+        TelemetryAttributeService.fetchAttributeValues,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails closed when the dashboard lookup throws", async () => {
+      jest
+        .spyOn(DashboardService, "findOneById")
+        .mockRejectedValue(new Error("connection reset"));
+
+      await callRoute({ attributeKey: "host.name" });
+
+      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      expectNothingRead();
+    });
+
+    /*
+     * ObjectID does not validate its input, so a malformed path id is not
+     * rejected up front — it simply matches no row. Pin that this stays
+     * fail-closed: an id-aware lookup means the caller gets "no access"
+     * and no telemetry is read, rather than the id being passed through to
+     * a query.
+     */
+    it("refuses a dashboardId that matches no dashboard, malformed or not", async () => {
+      setAttributeVariables(["host.name"]);
+
+      const realDashboard: Dashboard = dashboard;
+
+      jest
+        .spyOn(DashboardService, "findOneById")
+        .mockImplementation(async (data: any) => {
+          return data.id?.toString() === dashboardId.toString()
+            ? realDashboard
+            : null;
+        });
+
+      for (const badId of [
+        "not-an-object-id",
+        "' OR 1=1--",
+        "",
+        ObjectID.generate().toString(),
+      ]) {
+        jest.clearAllMocks();
+
+        await callRoute(
+          { attributeKey: "host.name" },
+          { dashboardIdParam: badId },
+        );
+
+        expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+        expectNothingRead();
+      }
+    });
+  });
+
   describe("authorization", () => {
     it("rejects a dashboard that is not public before reading anything", async () => {
       dashboard.isPublicDashboard = false;
@@ -530,6 +688,193 @@ describe("DashboardAPI public attribute-values", () => {
       expectNothingRead();
     });
 
+    it("refuses a password-protected dashboard with no cookie", async () => {
+      setAttributeVariables(["host.name"]);
+      dashboard.enableMasterPassword = true;
+      dashboard.masterPassword = new HashedString(
+        await HashedString.hashValue(MASTER_PASSWORD, EncryptionSecret),
+        true,
+      );
+
+      await callRoute({ attributeKey: "host.name" });
+
+      expect(getThrownError()).toBeInstanceOf(MasterPasswordRequiredException);
+      expectNothingRead();
+    });
+
+    it("serves an allowlisted key once the master-password cookie is presented", async () => {
+      setAttributeVariables(["host.name"]);
+      dashboard.enableMasterPassword = true;
+      dashboard.masterPassword = new HashedString(
+        await HashedString.hashValue(MASTER_PASSWORD, EncryptionSecret),
+        true,
+      );
+
+      /*
+       * Mint the cookie through the real unlock route rather than forging a
+       * JWT — hasValidMasterPasswordCookie does a genuine jwt.verify.
+       */
+      await mockRouter
+        .match("post", "/dashboard/master-password/:dashboardId")
+        .handlerFunction(
+          {
+            params: { dashboardId: dashboardId.toString() },
+            body: { password: MASTER_PASSWORD },
+            cookies: {},
+            headers: {},
+            socket: {},
+            ips: [],
+          } as unknown as ExpressRequest,
+          mockResponse,
+          nextFunction,
+        );
+
+      const cookieCall: Array<unknown> = (mockResponse.cookie as jest.Mock).mock
+        .calls[0] as Array<unknown>;
+
+      expect(cookieCall).toBeDefined();
+
+      await callRoute(
+        { attributeKey: "host.name" },
+        {
+          cookies: {
+            [cookieCall[0] as string]: cookieCall[1] as string,
+          },
+        },
+      );
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(getFetchArgs()["attributeKey"]).toBe("host.name");
+    });
+
+    it("fails closed when protection is enabled but no password was ever set", async () => {
+      setAttributeVariables(["host.name"]);
+      dashboard.enableMasterPassword = true;
+      delete dashboard.masterPassword;
+
+      await callRoute({ attributeKey: "host.name" });
+
+      expect(getThrownError()).toBeInstanceOf(MasterPasswordRequiredException);
+      expectNothingRead();
+    });
+
+    it("serves a whitelisted IP", async () => {
+      setAttributeVariables(["host.name"]);
+      dashboard.ipWhitelist = "10.0.0.0/8\n203.0.113.7";
+
+      await callRoute(
+        { attributeKey: "host.name" },
+        { headers: { "x-forwarded-for": "203.0.113.7" } },
+      );
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(getFetchArgs()["attributeKey"]).toBe("host.name");
+    });
+
+    it("refuses a blocked IP before reading any telemetry", async () => {
+      setAttributeVariables(["host.name"]);
+      dashboard.ipWhitelist = "10.0.0.0/8\n203.0.113.7";
+
+      await callRoute(
+        { attributeKey: "host.name" },
+        { headers: { "x-forwarded-for": "198.51.100.5" } },
+      );
+
+      expect(getThrownError()).toBeInstanceOf(ForbiddenException);
+      expectNothingRead();
+    });
+
+    it("refuses when the client IP cannot be determined at all", async () => {
+      setAttributeVariables(["host.name"]);
+      dashboard.ipWhitelist = "203.0.113.7";
+
+      await callRoute({ attributeKey: "host.name" });
+
+      expect(getThrownError()).toBeInstanceOf(ForbiddenException);
+      expectNothingRead();
+    });
+  });
+
+  describe("response", () => {
+    it("returns exactly the values the telemetry service found", async () => {
+      setAttributeVariables(["host.name"]);
+      jest
+        .spyOn(TelemetryAttributeService, "fetchAttributeValues")
+        .mockResolvedValue(["prod", "staging"]);
+
+      await callRoute({ attributeKey: "host.name" });
+
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+
+      const responseCall: Array<unknown> = (
+        Response.sendJsonObjectResponse as jest.Mock
+      ).mock.calls[0] as Array<unknown>;
+
+      expect(responseCall[2]).toEqual({ values: ["prod", "staging"] });
+    });
+
+    it("hands the telemetry service exactly three arguments", async () => {
+      setAttributeVariables(["host.name"]);
+
+      await callRoute({
+        attributeKey: "host.name",
+        searchText: "%",
+        metricName: "billing.revenue",
+        limit: 999999,
+        projectId: ObjectID.generate().toString(),
+        extra: 1,
+      });
+
+      expect(Object.keys(getFetchArgs()).sort()).toEqual([
+        "attributeKey",
+        "projectId",
+        "telemetryType",
+      ]);
+    });
+
+    it("sends no response at all when the key is refused", async () => {
+      setAttributeVariables(["host.name"]);
+
+      await callRoute({ attributeKey: "user.email" });
+
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("normalization", () => {
+    it("matches attribute keys case-sensitively", async () => {
+      // ClickHouse map subscripts are case-sensitive; the allowlist must be too.
+      setAttributeVariables(["host.name"]);
+
+      for (const attributeKey of ["Host.Name", "HOST.NAME", "Host.name"]) {
+        jest.clearAllMocks();
+
+        await callRoute({ attributeKey: attributeKey });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingRead();
+      }
+    });
+
+    it("does not treat a key that merely contains a configured key as configured", async () => {
+      setAttributeVariables(["host.name"]);
+
+      for (const attributeKey of [
+        "host.name.extra",
+        "prefix.host.name",
+        "host_name",
+      ]) {
+        jest.clearAllMocks();
+
+        await callRoute({ attributeKey: attributeKey });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingRead();
+      }
+    });
+  });
+
+  describe("dashboard existence", () => {
     /*
      * A missing dashboard never reaches the attribute lookup: hasReadAccess
      * fails closed first, so the viewer is told they have no access rather

--- a/Common/Tests/Server/API/DashboardPublicMetricsAggregateAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicMetricsAggregateAPI.test.ts
@@ -7,12 +7,18 @@ import {
   ExpressResponse,
   NextFunction,
 } from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
 import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import { DashboardVariableType } from "../../../Types/Dashboard/DashboardVariable";
 import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import NotAuthenticatedException from "../../../Types/Exception/NotAuthenticatedException";
 import NotFoundException from "../../../Types/Exception/NotFoundException";
 import { JSONObject } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
 import ObjectID from "../../../Types/ObjectID";
 import { mockRouter } from "./Helpers";
 import {
@@ -74,10 +80,21 @@ describe("DashboardAPI public metrics-aggregate", () => {
     groupByAttributeKeys?: Array<string> | undefined;
     groupByAttributes?: Array<JSONObject> | undefined;
     groupBy?: JSONObject | undefined;
+    /*
+     * `metricQueryData.filterData.attributes` — the attribute filter a chart
+     * widget persists when the author pins a value in the query editor.
+     */
+    attributes?: JSONObject | undefined;
+    /*
+     * `arguments.attributeFilters` — the table widget's widget-level filter,
+     * spread into every column's query by resolveQueries().
+     */
+    attributeFilters?: JSONObject | undefined;
   };
 
   type BuildViewConfigFunction = (
     widgets: Array<MetricWidgetSpec>,
+    variableAttributeKeys?: Array<string> | undefined,
   ) => DashboardViewConfig;
 
   /*
@@ -86,10 +103,22 @@ describe("DashboardAPI public metrics-aggregate", () => {
    */
   const buildViewConfig: BuildViewConfigFunction = (
     widgets: Array<MetricWidgetSpec>,
+    variableAttributeKeys?: Array<string> | undefined,
   ): DashboardViewConfig => {
     return {
       _type: "DashboardViewConfig",
       heightInDashboardUnits: 24,
+      variables: (variableAttributeKeys || []).map(
+        (attributeKey: string, index: number): JSONObject => {
+          return {
+            id: ObjectID.generate().toString(),
+            name: `variable-${index}`,
+            label: `Variable ${index}`,
+            type: DashboardVariableType.TelemetryAttribute,
+            attributeKey: attributeKey,
+          };
+        },
+      ),
       components: widgets.map(
         (widget: MetricWidgetSpec, index: number): JSONObject => {
           return {
@@ -104,11 +133,17 @@ describe("DashboardAPI public metrics-aggregate", () => {
               ...(widget.groupByAttributes
                 ? { groupByAttributes: widget.groupByAttributes }
                 : {}),
+              ...(widget.attributeFilters
+                ? { attributeFilters: widget.attributeFilters }
+                : {}),
               metricQueryConfigs: [
                 {
                   metricQueryData: {
                     filterData: {
                       metricName: widget.metricName,
+                      ...(widget.attributes
+                        ? { attributes: widget.attributes }
+                        : {}),
                     },
                     ...(widget.groupByAttributeKeys
                       ? { groupByAttributeKeys: widget.groupByAttributeKeys }
@@ -124,12 +159,19 @@ describe("DashboardAPI public metrics-aggregate", () => {
     } as unknown as DashboardViewConfig;
   };
 
-  type SetWidgetsFunction = (widgets: Array<MetricWidgetSpec>) => void;
+  type SetWidgetsFunction = (
+    widgets: Array<MetricWidgetSpec>,
+    variableAttributeKeys?: Array<string> | undefined,
+  ) => void;
 
   const setWidgets: SetWidgetsFunction = (
     widgets: Array<MetricWidgetSpec>,
+    variableAttributeKeys?: Array<string> | undefined,
   ): void => {
-    dashboard.dashboardViewConfig = buildViewConfig(widgets);
+    dashboard.dashboardViewConfig = buildViewConfig(
+      widgets,
+      variableAttributeKeys,
+    );
   };
 
   type BuildAggregateByFunction = (overrides?: JSONObject) => JSONObject;
@@ -529,6 +571,415 @@ describe("DashboardAPI public metrics-aggregate", () => {
     });
   });
 
+  describe("query filter allowlist", () => {
+    /*
+     * Pinning `query.name` left the rest of the client's query merged in.
+     * An `attributes` filter on an arbitrary key is a blind oracle: the
+     * caller cannot see the values, but "did this aggregation return rows"
+     * leaks them a character at a time through operators like StartsWith.
+     * MetricService deliberately leaves the pre-aggregated fast path when an
+     * attributes filter is present, so the probe runs against raw rows.
+     */
+    it("refuses an attributes filter on a key the dashboard never filters by", async () => {
+      await callWithAggregate({
+        query: {
+          name: CHARTED_METRIC_NAME,
+          attributes: {
+            "enduser.id": { _type: "StartsWith", value: "a" },
+          },
+        },
+      });
+
+      const error: unknown = getThrownError();
+
+      expect(error).toBeInstanceOf(BadDataException);
+      expect((error as BadDataException).message).toBe(
+        "This attribute is not part of this dashboard.",
+      );
+      expectNothingAggregated();
+    });
+
+    it("refuses every operator shape usable as a blind oracle", async () => {
+      const operatorTypes: Array<string> = [
+        "Search",
+        "StartsWith",
+        "EndsWith",
+        "NotContains",
+        "EqualTo",
+        "NotEqual",
+        "Includes",
+      ];
+
+      for (const operatorType of operatorTypes) {
+        jest.clearAllMocks();
+
+        await callWithAggregate({
+          query: {
+            name: CHARTED_METRIC_NAME,
+            attributes: {
+              "user.email": { _type: operatorType, value: "a" },
+            },
+          },
+        });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingAggregated();
+      }
+    });
+
+    it("forwards an attributes filter on a key the widget itself filters by", async () => {
+      setWidgets([
+        {
+          metricName: CHARTED_METRIC_NAME,
+          attributes: { "host.name": "web-1" },
+        },
+      ]);
+
+      await callWithAggregate({
+        query: {
+          name: CHARTED_METRIC_NAME,
+          attributes: { "host.name": "web-2" },
+        },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+
+      expect((query["attributes"] as JSONObject)["host.name"]).toBe("web-2");
+    });
+
+    it("forwards an attributes filter on a key only a dashboard variable binds to", async () => {
+      /*
+       * The shipped templates persist `filterData: { metricName,
+       * aggegationType }` and no attributes at all — the filter on
+       * `resource.k8s.cluster.name` is injected at render time by
+       * DashboardVariableInterpolation once the viewer picks a cluster. An
+       * allowlist built only from stored filters would reject every real
+       * templated dashboard the moment its variable is used.
+       */
+      setWidgets(
+        [{ metricName: CHARTED_METRIC_NAME }],
+        ["resource.k8s.cluster.name"],
+      );
+
+      await callWithAggregate({
+        query: {
+          name: CHARTED_METRIC_NAME,
+          attributes: { "resource.k8s.cluster.name": "prod-eu" },
+        },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+
+      expect(
+        (query["attributes"] as JSONObject)["resource.k8s.cluster.name"],
+      ).toBe("prod-eu");
+    });
+
+    it("forwards the widget-level attributeFilters a table widget persists", async () => {
+      setWidgets([
+        {
+          metricName: CHARTED_METRIC_NAME,
+          attributeFilters: { environment: "production" },
+        },
+      ]);
+
+      await callWithAggregate({
+        query: {
+          name: CHARTED_METRIC_NAME,
+          attributes: { environment: "production" },
+        },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops every other client-supplied query key", async () => {
+      await callWithAggregate({
+        query: {
+          name: CHARTED_METRIC_NAME,
+          serviceId: ObjectID.generate().toString(),
+          primaryEntityId: "smuggled",
+          retentionDate: "2020-01-01",
+          value: { _type: "GreaterThan", value: 0 },
+        },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+
+      expect(Object.keys(query).sort()).toEqual(["name", "projectId"]);
+    });
+
+    it("keeps the time window the widget asks for", async () => {
+      await callWithAggregate({
+        query: {
+          name: CHARTED_METRIC_NAME,
+          time: {
+            _type: "InBetween",
+            value: {
+              startValue: "2026-01-01T00:00:00.000Z",
+              endValue: "2026-01-02T00:00:00.000Z",
+            },
+          },
+        },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+
+      expect(query["time"]).toBeDefined();
+    });
+
+    it("pins the metric name as an own property of the query it aggregates", async () => {
+      await callWithAggregate();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+
+      expect(Object.prototype.hasOwnProperty.call(query, "name")).toBe(true);
+      expect(query["name"]).toBe(CHARTED_METRIC_NAME);
+    });
+
+    it("refuses a query that is not an object", async () => {
+      const badQueries: Array<unknown> = [null, "name", ["name"], 42, true];
+
+      for (const badQuery of badQueries) {
+        jest.clearAllMocks();
+
+        await callWithAggregate({ query: badQuery as JSONObject });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingAggregated();
+      }
+    });
+  });
+
+  /*
+   * JSON.parse turns a literal "__proto__" member into a real own key, and
+   * JSONFunctions.deserialize copies it with `newVal[key] = ...`, which fires
+   * Object.prototype's __proto__ setter. Every one of these bodies must be
+   * built with JSON.parse — a JS object literal sets the prototype at parse
+   * time and never produces the own key that makes the attack work.
+   */
+  describe("prototype-carried keys", () => {
+    type ProtoBodyFunction = (json: string) => JSONObject;
+
+    const protoBody: ProtoBodyFunction = (json: string): JSONObject => {
+      return JSON.parse(json) as JSONObject;
+    };
+
+    it("refuses a metric name inherited through __proto__", async () => {
+      /*
+       * The allowlist check used to read `query["name"]` (which walks the
+       * prototype chain and saw the allowlisted name) while the project pin
+       * spread only own properties (which dropped it) — so the aggregation
+       * reached ClickHouse with NO name predicate at all: every metric in
+       * the project, from one anonymous request.
+       */
+      await callRoute(
+        protoBody(
+          `{"aggregateBy":{"query":{"__proto__":{"name":"${CHARTED_METRIC_NAME}"}},` +
+            `"aggregateColumnName":"value","aggregationType":"Avg",` +
+            `"aggregationTimestampColumnName":"time",` +
+            `"startTimestamp":"2026-01-01T00:00:00.000Z",` +
+            `"endTimestamp":"2026-01-02T00:00:00.000Z","limit":100,"skip":0}}`,
+        ),
+      );
+
+      const error: unknown = getThrownError();
+
+      expect(error).toBeInstanceOf(BadDataException);
+      expect((error as BadDataException).message).toBe(
+        "This metric is not part of this dashboard.",
+      );
+      expectNothingAggregated();
+    });
+
+    it("refuses an attributes filter smuggled through __proto__", async () => {
+      await callRoute(
+        protoBody(
+          `{"aggregateBy":{"query":{"name":"${CHARTED_METRIC_NAME}",` +
+            `"attributes":{"__proto__":{"user.email":"a"}}},` +
+            `"aggregateColumnName":"value","aggregationType":"Avg",` +
+            `"aggregationTimestampColumnName":"time",` +
+            `"startTimestamp":"2026-01-01T00:00:00.000Z",` +
+            `"endTimestamp":"2026-01-02T00:00:00.000Z","limit":100,"skip":0}}`,
+        ),
+      );
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+      const attributes: unknown = query["attributes"];
+
+      // Nothing inherited may survive into the object handed to the service.
+      for (const key in (attributes || {}) as Record<string, unknown>) {
+        expect(key).not.toBe("user.email");
+      }
+    });
+
+    it("does not let a group-by column hide on the prototype", async () => {
+      setWidgets([
+        {
+          metricName: CHARTED_METRIC_NAME,
+          groupBy: { serviceEntityKey: true },
+        },
+      ]);
+
+      await callRoute(
+        protoBody(
+          `{"aggregateBy":{"query":{"name":"${CHARTED_METRIC_NAME}"},` +
+            `"groupBy":{"serviceEntityKey":true,"__proto__":{"attributes":true}},` +
+            `"aggregateColumnName":"value","aggregationType":"Avg",` +
+            `"aggregationTimestampColumnName":"time",` +
+            `"startTimestamp":"2026-01-01T00:00:00.000Z",` +
+            `"endTimestamp":"2026-01-02T00:00:00.000Z","limit":100,"skip":0}}`,
+        ),
+      );
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      /*
+       * The guard uses Object.keys but the SQL builder walks groupBy with
+       * for...in, so an inherited key would reach GROUP BY unvalidated.
+       * Assert the two agree on the object actually handed to the service.
+       */
+      const groupBy: Record<string, unknown> = getAggregateArgs()[
+        "groupBy"
+      ] as Record<string, unknown>;
+      const enumerated: Array<string> = [];
+
+      for (const key in groupBy) {
+        enumerated.push(key);
+      }
+
+      expect(enumerated).toEqual(["serviceEntityKey"]);
+    });
+
+    it("does not treat a prototype key as a configured grouping", async () => {
+      await callWithAggregate({
+        groupByAttributeKeys: ["__proto__", "constructor", "toString"],
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingAggregated();
+    });
+  });
+
+  describe("aggregate column and pagination", () => {
+    /*
+     * `aggregateColumnName` was forwarded verbatim. A non-`value` column
+     * skips every MetricService fast path and falls through to
+     * `max(<column>) as <column>`; the row mapper only parseFloats strings
+     * and copies anything else into `value` untouched — so asking to
+     * aggregate `attributes` returned a whole attribute map per time bucket.
+     */
+    it("refuses an aggregateColumnName the widgets never aggregate", async () => {
+      const columns: Array<string> = [
+        "attributes",
+        "name",
+        "serviceEntityKey",
+        "projectId",
+        "time",
+      ];
+
+      for (const column of columns) {
+        jest.clearAllMocks();
+
+        await callWithAggregate({ aggregateColumnName: column });
+
+        const error: unknown = getThrownError();
+
+        expect(error).toBeInstanceOf(BadDataException);
+        expect((error as BadDataException).message).toBe(
+          "Invalid aggregateColumnName.",
+        );
+        expectNothingAggregated();
+      }
+    });
+
+    it("refuses an aggregationTimestampColumnName other than time", async () => {
+      for (const column of ["createdAt", "attributes", "value"]) {
+        jest.clearAllMocks();
+
+        await callWithAggregate({ aggregationTimestampColumnName: column });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingAggregated();
+      }
+    });
+
+    it("accepts the value/time pair every widget actually sends", async () => {
+      await callWithAggregate({
+        aggregateColumnName: "value",
+        aggregationTimestampColumnName: "time",
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+    });
+
+    it("clamps an oversized limit and a negative skip", async () => {
+      await callWithAggregate({ limit: 10000000, skip: -5 });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const args: JSONObject = getAggregateArgs();
+
+      expect(args["limit"]).toBe(LIMIT_PER_PROJECT);
+      expect(args["skip"]).toBe(0);
+    });
+
+    it("falls back to a sane limit for a nonsensical one", async () => {
+      for (const limit of [0, -1, "not-a-number", null]) {
+        jest.clearAllMocks();
+
+        await callWithAggregate({ limit: limit as number });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+
+        const limitSent: unknown = getAggregateArgs()["limit"];
+
+        expect(typeof limitSent).toBe("number");
+        expect(limitSent as number).toBeGreaterThan(0);
+        expect(limitSent as number).toBeLessThanOrEqual(LIMIT_PER_PROJECT);
+      }
+    });
+
+    it("honours a sensible limit and skip", async () => {
+      await callWithAggregate({ limit: 25, skip: 50 });
+
+      const args: JSONObject = getAggregateArgs();
+
+      expect(args["limit"]).toBe(25);
+      expect(args["skip"]).toBe(50);
+    });
+  });
+
+  describe("null handling", () => {
+    /*
+     * JSONFunctions.serialize drops `undefined` but preserves `null`, and
+     * both downstream sinks already treat a null groupBy as absent — so the
+     * route must too, or an ungrouped widget round-tripped through the wire
+     * would 400.
+     */
+    it("treats an explicit null groupBy and groupByAttributeKeys as absent", async () => {
+      await callWithAggregate({
+        groupBy: null as unknown as JSONObject,
+        groupByAttributeKeys: null as unknown as Array<string>,
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("authorization", () => {
     it("rejects a dashboard that is not public before aggregating anything", async () => {
       dashboard.isPublicDashboard = false;
@@ -555,6 +1006,265 @@ describe("DashboardAPI public metrics-aggregate", () => {
 
       expect(getThrownError()).toBeInstanceOf(NotFoundException);
       expectNothingAggregated();
+    });
+  });
+
+  describe("stored config shapes", () => {
+    it("collects group-by keys from every shape the widgets persist", async () => {
+      const shapes: Array<{ label: string; config: JSONObject }> = [
+        {
+          label: "table widget groupByAttributes",
+          config: {
+            arguments: {
+              groupByAttributes: [{ key: "shape.key" }],
+              metricQueryConfigs: [
+                { metricQueryData: { filterData: { metricName: "m" } } },
+              ],
+            },
+          },
+        },
+        {
+          label: "table widget groupByAttributeKeys",
+          config: {
+            arguments: {
+              groupByAttributeKeys: ["shape.key"],
+              metricQueryConfigs: [
+                { metricQueryData: { filterData: { metricName: "m" } } },
+              ],
+            },
+          },
+        },
+        {
+          label: "legacy singular metricQueryConfig",
+          config: {
+            arguments: {
+              metricQueryConfig: {
+                metricQueryData: {
+                  filterData: { metricName: "m" },
+                  groupByAttributeKeys: ["shape.key"],
+                },
+              },
+            },
+          },
+        },
+        {
+          label: "plural metricQueryConfigs",
+          config: {
+            arguments: {
+              metricQueryConfigs: [
+                {
+                  metricQueryData: {
+                    filterData: { metricName: "m" },
+                    groupByAttributeKeys: ["shape.key"],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      for (const shape of shapes) {
+        jest.clearAllMocks();
+
+        dashboard.dashboardViewConfig = {
+          _type: "DashboardViewConfig",
+          heightInDashboardUnits: 24,
+          components: [
+            {
+              componentType: DashboardComponentType.Chart,
+              ...shape.config,
+            },
+          ],
+        } as unknown as DashboardViewConfig;
+
+        await callWithAggregate({
+          query: { name: "m" },
+          groupByAttributeKeys: ["shape.key"],
+        });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it("survives malformed groupByAttributes without widening the allowlist", async () => {
+      const malformed: Array<unknown> = [
+        null,
+        7,
+        "shape.key",
+        {},
+        { key: 42 },
+        { key: "" },
+        [],
+      ];
+
+      for (const entry of malformed) {
+        jest.clearAllMocks();
+
+        setWidgets([
+          {
+            metricName: CHARTED_METRIC_NAME,
+            groupByAttributes: [entry as JSONObject],
+          },
+        ]);
+
+        await callWithAggregate({ groupByAttributeKeys: ["shape.key"] });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingAggregated();
+      }
+    });
+
+    it("allows whole-attribute-map grouping when the widget itself is configured that way", async () => {
+      // Legacy stored configs still carry groupBy: { attributes: true }.
+      setWidgets([
+        {
+          metricName: CHARTED_METRIC_NAME,
+          groupBy: { attributes: true },
+        },
+      ]);
+
+      await callWithAggregate({ groupBy: { attributes: true } });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+    });
+
+    it("accepts an aggregateBy that has been through the wire serializer", async () => {
+      /*
+       * The client serializes AggregateBy before POSTing it, so operators
+       * and dates arrive as `_type`-tagged objects and are revived by
+       * JSONFunctions.deserialize inside the handler. Round-trip a realistic
+       * payload through serialize -> JSON -> the route.
+       */
+      setWidgets([
+        {
+          metricName: CHARTED_METRIC_NAME,
+          attributes: { "host.name": "web-1" },
+          groupByAttributeKeys: [CHARTED_GROUP_BY_KEY],
+        },
+      ]);
+
+      const startDate: Date = new Date("2026-01-01T00:00:00.000Z");
+      const endDate: Date = new Date("2026-01-02T00:00:00.000Z");
+
+      const wirePayload: JSONObject = JSON.parse(
+        JSON.stringify(
+          JSONFunctions.serialize({
+            query: {
+              projectId: ObjectID.generate(),
+              name: CHARTED_METRIC_NAME,
+              time: new InBetween(startDate, endDate),
+              attributes: { "host.name": new Includes(["web-1", "web-2"]) },
+            },
+            aggregationType: "Avg",
+            aggregateColumnName: "value",
+            aggregationTimestampColumnName: "time",
+            startTimestamp: startDate,
+            endTimestamp: endDate,
+            limit: LIMIT_PER_PROJECT,
+            skip: 0,
+            groupByAttributeKeys: [CHARTED_GROUP_BY_KEY],
+            topK: { count: 10, rankBy: "max" },
+          } as unknown as JSONObject),
+        ),
+      ) as JSONObject;
+
+      await callRoute({ aggregateBy: wirePayload });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const args: JSONObject = getAggregateArgs();
+      const query: JSONObject = args["query"] as JSONObject;
+
+      expect(args["startTimestamp"]).toBeInstanceOf(Date);
+      expect(args["groupByAttributeKeys"]).toEqual([CHARTED_GROUP_BY_KEY]);
+      expect(args["topK"]).toEqual({ count: 10, rankBy: "max" });
+      expect(query["name"]).toBe(CHARTED_METRIC_NAME);
+      expect(query["projectId"]).toBe(projectId);
+      expect((query["attributes"] as JSONObject)["host.name"]).toBeInstanceOf(
+        Includes,
+      );
+      expect(query["time"]).toBeInstanceOf(InBetween);
+    });
+
+    it("refuses an aggregateBy that is not an object", async () => {
+      const badPayloads: Array<unknown> = [0, "", "aggregate", [], true, 42];
+
+      for (const payload of badPayloads) {
+        jest.clearAllMocks();
+
+        await callRoute({ aggregateBy: payload as JSONObject });
+
+        expect(nextFunction).toHaveBeenCalled();
+        expectNothingAggregated();
+      }
+    });
+  });
+
+  describe("normalization", () => {
+    it("does not trim the requested metric name", async () => {
+      await callWithAggregate({
+        query: { name: ` ${CHARTED_METRIC_NAME} ` },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingAggregated();
+    });
+
+    it("does not trim a requested group-by key", async () => {
+      setWidgets([
+        {
+          metricName: CHARTED_METRIC_NAME,
+          groupByAttributeKeys: [CHARTED_GROUP_BY_KEY],
+        },
+      ]);
+
+      await callWithAggregate({
+        groupByAttributeKeys: [` ${CHARTED_GROUP_BY_KEY} `],
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingAggregated();
+    });
+
+    it("matches metric names case-sensitively", async () => {
+      await callWithAggregate({
+        query: { name: CHARTED_METRIC_NAME.toUpperCase() },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingAggregated();
+    });
+  });
+
+  describe("response", () => {
+    it("returns the aggregated rows unchanged", async () => {
+      const aggregated: JSONObject = {
+        data: [{ time: "2026-01-01T00:00:00.000Z", value: 1 }],
+        totalGroups: 7,
+      };
+
+      jest
+        .spyOn(MetricService, "aggregateBy")
+        .mockResolvedValue(aggregated as never);
+
+      await callWithAggregate();
+
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+
+      const responseCall: Array<unknown> = (
+        Response.sendJsonObjectResponse as jest.Mock
+      ).mock.calls[0] as Array<unknown>;
+
+      expect(responseCall[2]).toEqual(aggregated);
+    });
+
+    it("sends no response at all when the request is refused", async () => {
+      await callWithAggregate({ query: { name: "billing.revenue.total" } });
+
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
     });
   });
 

--- a/Common/Tests/Server/API/DashboardPublicTemplatePayloads.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicTemplatePayloads.test.ts
@@ -1,0 +1,598 @@
+import Dashboard from "../../../Models/DatabaseModels/Dashboard";
+import DashboardAPI from "../../../Server/API/DashboardAPI";
+import DashboardService from "../../../Server/Services/DashboardService";
+import MetricService from "../../../Server/Services/MetricService";
+import TelemetryAttributeService from "../../../Server/Services/TelemetryAttributeService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import {
+  DashboardTemplateType,
+  getTemplateConfig,
+} from "../../../Types/Dashboard/DashboardTemplates";
+import { DashboardVariableType } from "../../../Types/Dashboard/DashboardVariable";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { mockRouter } from "./Helpers";
+import {
+  beforeAll,
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendJsonObjectResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendErrorResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+  };
+});
+
+const ATTRIBUTE_VALUES_ROUTE: string =
+  "/dashboard/attribute-values/:dashboardId";
+const METRICS_AGGREGATE_ROUTE: string =
+  "/dashboard/metrics-aggregate/:dashboardId";
+
+/*
+ * Every template a user can actually create a dashboard from. Blank has no
+ * config at all, so it is excluded rather than special-cased.
+ */
+const TEMPLATE_TYPES: Array<DashboardTemplateType> = Object.values(
+  DashboardTemplateType,
+).filter((type: DashboardTemplateType) => {
+  return type !== DashboardTemplateType.Blank;
+});
+
+/*
+ * Small, deliberately independent readers over a stored config. These
+ * duplicate a little of what the server's allowlist walkers do on purpose:
+ * if the walkers stop reaching a shape the templates actually ship, these
+ * still find the key and the request they build starts failing.
+ */
+type CollectFunction = (config: unknown) => Array<string>;
+
+const collectVariableAttributeKeys: CollectFunction = (
+  config: unknown,
+): Array<string> => {
+  const variables: unknown =
+    config && typeof config === "object"
+      ? (config as Record<string, unknown>)["variables"]
+      : undefined;
+
+  if (!Array.isArray(variables)) {
+    return [];
+  }
+
+  return variables
+    .filter((variable: unknown) => {
+      return (
+        variable &&
+        typeof variable === "object" &&
+        (variable as Record<string, unknown>)["type"] ===
+          DashboardVariableType.TelemetryAttribute &&
+        typeof (variable as Record<string, unknown>)["attributeKey"] ===
+          "string"
+      );
+    })
+    .map((variable: unknown) => {
+      return (variable as Record<string, unknown>)["attributeKey"] as string;
+    });
+};
+
+type WalkCollectFunction = (config: unknown, field: string) => Array<string>;
+
+const collectStringsUnderKey: WalkCollectFunction = (
+  config: unknown,
+  field: string,
+): Array<string> => {
+  const found: Array<string> = [];
+
+  const walk: (node: unknown) => void = (node: unknown): void => {
+    if (!node || typeof node !== "object") {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        walk(item);
+      }
+      return;
+    }
+
+    const obj: Record<string, unknown> = node as Record<string, unknown>;
+    const value: unknown = obj[field];
+
+    if (typeof value === "string" && value.length > 0) {
+      found.push(value);
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === "string" && item.length > 0) {
+          found.push(item);
+        }
+      }
+    }
+
+    for (const key of Object.keys(obj)) {
+      walk(obj[key]);
+    }
+  };
+
+  walk(config);
+
+  return Array.from(new Set(found));
+};
+
+describe("public dashboard allowlists vs the shipped templates", () => {
+  let dashboardId: ObjectID;
+  let projectId: ObjectID;
+  let dashboard: Dashboard;
+  let mockResponse: ExpressResponse;
+  let nextFunction: NextFunction;
+
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new DashboardAPI();
+  });
+
+  type LoadTemplateFunction = (type: DashboardTemplateType) => JSONObject;
+
+  /*
+   * Round-trip the template through JSON the way the JSONB column does, so
+   * ObjectID instances become strings and the handler sees exactly the shape
+   * a real stored dashboard has.
+   */
+  const loadTemplate: LoadTemplateFunction = (
+    type: DashboardTemplateType,
+  ): JSONObject => {
+    const config: DashboardViewConfig | null = getTemplateConfig(type);
+
+    expect(config).not.toBeNull();
+
+    return JSON.parse(JSON.stringify(config)) as JSONObject;
+  };
+
+  type CallAttributeValuesFunction = (attributeKey: string) => Promise<void>;
+
+  const callAttributeValues: CallAttributeValuesFunction = async (
+    attributeKey: string,
+  ): Promise<void> => {
+    const request: ExpressRequest = {
+      params: { dashboardId: dashboardId.toString() },
+      body: { attributeKey: attributeKey },
+      query: {},
+      cookies: {},
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    await mockRouter
+      .match("post", ATTRIBUTE_VALUES_ROUTE)
+      .handlerFunction(request, mockResponse, nextFunction);
+  };
+
+  type CallAggregateFunction = (overrides: JSONObject) => Promise<void>;
+
+  const callAggregate: CallAggregateFunction = async (
+    overrides: JSONObject,
+  ): Promise<void> => {
+    const request: ExpressRequest = {
+      params: { dashboardId: dashboardId.toString() },
+      body: {
+        aggregateBy: {
+          aggregateColumnName: "value",
+          aggregationType: "Avg",
+          aggregationTimestampColumnName: "time",
+          startTimestamp: "2026-01-01T00:00:00.000Z",
+          endTimestamp: "2026-01-02T00:00:00.000Z",
+          limit: 100,
+          skip: 0,
+          ...overrides,
+        },
+      },
+      query: {},
+      cookies: {},
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    await mockRouter
+      .match("post", METRICS_AGGREGATE_ROUTE)
+      .handlerFunction(request, mockResponse, nextFunction);
+  };
+
+  type ExpectNoErrorFunction = (context: string) => void;
+
+  const expectNoError: ExpectNoErrorFunction = (context: string): void => {
+    const calls: Array<Array<unknown>> = (nextFunction as jest.Mock).mock
+      .calls as Array<Array<unknown>>;
+
+    if (calls.length > 0) {
+      const error: unknown = calls[0]![0];
+
+      throw new Error(
+        `${context} was refused: ${(error as Error)?.message || String(error)}`,
+      );
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    dashboardId = ObjectID.generate();
+    projectId = ObjectID.generate();
+
+    dashboard = new Dashboard();
+    dashboard.id = dashboardId;
+    dashboard.projectId = projectId;
+    dashboard.isPublicDashboard = true;
+    dashboard.enableMasterPassword = false;
+
+    jest.spyOn(DashboardService, "findOneById").mockResolvedValue(dashboard);
+    jest
+      .spyOn(TelemetryAttributeService, "fetchAttributeValues")
+      .mockResolvedValue([]);
+    jest.spyOn(MetricService, "aggregateBy").mockResolvedValue({ data: [] });
+
+    mockResponse = {
+      cookie: jest.fn(),
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The suite above is only meaningful if the templates actually carry the
+   * shapes it replays. Pin that here so a template refactor that drops all
+   * variables (or all metrics) turns this red instead of quietly making
+   * every case above pass on an empty loop.
+   */
+  describe("fixture invariants", () => {
+    it("still ships templates with telemetry-attribute variables and charted metrics", async () => {
+      const kubernetes: JSONObject = loadTemplate(
+        DashboardTemplateType.Kubernetes,
+      );
+
+      expect(
+        collectVariableAttributeKeys(kubernetes).length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        collectStringsUnderKey(kubernetes, "metricName").length,
+      ).toBeGreaterThanOrEqual(1);
+
+      const totalVariableKeys: number = TEMPLATE_TYPES.reduce(
+        (total: number, type: DashboardTemplateType): number => {
+          return (
+            total + collectVariableAttributeKeys(loadTemplate(type)).length
+          );
+        },
+        0,
+      );
+
+      const totalGroupByKeys: number = TEMPLATE_TYPES.reduce(
+        (total: number, type: DashboardTemplateType): number => {
+          return (
+            total +
+            collectStringsUnderKey(loadTemplate(type), "groupByAttributeKeys")
+              .length
+          );
+        },
+        0,
+      );
+
+      expect(totalVariableKeys).toBeGreaterThanOrEqual(1);
+      expect(totalGroupByKeys).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("every shipped template still works when published", () => {
+    it.each(TEMPLATE_TYPES)(
+      "serves the %s template's own variables, metrics and groupings",
+      async (templateType: DashboardTemplateType) => {
+        const config: JSONObject = loadTemplate(templateType);
+
+        dashboard.dashboardViewConfig =
+          config as unknown as DashboardViewConfig;
+
+        const variableKeys: Array<string> =
+          collectVariableAttributeKeys(config);
+        const metricNames: Array<string> = collectStringsUnderKey(
+          config,
+          "metricName",
+        );
+        const groupByKeys: Array<string> = collectStringsUnderKey(
+          config,
+          "groupByAttributeKeys",
+        );
+
+        let requests: number = 0;
+
+        // 1. Every variable dropdown must still be able to load its options.
+        for (const attributeKey of variableKeys) {
+          jest.clearAllMocks();
+
+          await callAttributeValues(attributeKey);
+
+          expectNoError(`${templateType} variable "${attributeKey}"`);
+          expect(
+            TelemetryAttributeService.fetchAttributeValues,
+          ).toHaveBeenCalledTimes(1);
+          requests++;
+        }
+
+        // 2. Every charted metric must still aggregate.
+        for (const metricName of metricNames) {
+          jest.clearAllMocks();
+
+          await callAggregate({ query: { name: metricName } });
+
+          expectNoError(`${templateType} metric "${metricName}"`);
+          expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+          requests++;
+        }
+
+        /*
+         * 3. Every configured grouping must still be accepted, on a metric
+         *    the same dashboard charts.
+         */
+        if (metricNames.length > 0) {
+          for (const groupByKey of groupByKeys) {
+            jest.clearAllMocks();
+
+            await callAggregate({
+              query: { name: metricNames[0] as string },
+              groupByAttributeKeys: [groupByKey],
+            });
+
+            expectNoError(`${templateType} grouping "${groupByKey}"`);
+            expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+            requests++;
+          }
+
+          /*
+           * 4. The interpolation case: once a viewer picks a value from a
+           *    template variable, the client sends it as an attribute filter
+           *    on a key the widgets never stored themselves.
+           */
+          for (const attributeKey of variableKeys) {
+            jest.clearAllMocks();
+
+            await callAggregate({
+              query: {
+                name: metricNames[0] as string,
+                attributes: { [attributeKey]: "selected-value" },
+              },
+            });
+
+            expectNoError(
+              `${templateType} interpolated filter "${attributeKey}"`,
+            );
+            expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+            requests++;
+          }
+        }
+
+        // The template must actually have exercised something.
+        expect(requests).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  describe("templates do not become readers for anything else", () => {
+    it("refuses a sensitive attribute key on every template", async () => {
+      for (const templateType of TEMPLATE_TYPES) {
+        const config: JSONObject = loadTemplate(templateType);
+
+        dashboard.dashboardViewConfig =
+          config as unknown as DashboardViewConfig;
+
+        for (const attributeKey of ["user.email", "db.statement"]) {
+          jest.clearAllMocks();
+
+          await callAttributeValues(attributeKey);
+
+          expect(nextFunction).toHaveBeenCalled();
+          expect(
+            TelemetryAttributeService.fetchAttributeValues,
+          ).not.toHaveBeenCalled();
+        }
+      }
+    });
+
+    it("refuses an uncharted metric on every template", async () => {
+      for (const templateType of TEMPLATE_TYPES) {
+        const config: JSONObject = loadTemplate(templateType);
+
+        dashboard.dashboardViewConfig =
+          config as unknown as DashboardViewConfig;
+
+        jest.clearAllMocks();
+
+        await callAggregate({ query: { name: "billing.revenue.total" } });
+
+        expect(nextFunction).toHaveBeenCalled();
+        expect(MetricService.aggregateBy).not.toHaveBeenCalled();
+      }
+    });
+
+    it("refuses an unconfigured grouping on every template that charts a metric", async () => {
+      for (const templateType of TEMPLATE_TYPES) {
+        const config: JSONObject = loadTemplate(templateType);
+        const metricNames: Array<string> = collectStringsUnderKey(
+          config,
+          "metricName",
+        );
+
+        if (metricNames.length === 0) {
+          continue;
+        }
+
+        dashboard.dashboardViewConfig =
+          config as unknown as DashboardViewConfig;
+
+        jest.clearAllMocks();
+
+        await callAggregate({
+          query: { name: metricNames[0] as string },
+          groupByAttributeKeys: ["enduser.id"],
+        });
+
+        expect(nextFunction).toHaveBeenCalled();
+        expect(MetricService.aggregateBy).not.toHaveBeenCalled();
+      }
+    });
+
+    it("refuses an attribute filter on a key no widget or variable uses", async () => {
+      for (const templateType of TEMPLATE_TYPES) {
+        const config: JSONObject = loadTemplate(templateType);
+        const metricNames: Array<string> = collectStringsUnderKey(
+          config,
+          "metricName",
+        );
+
+        if (metricNames.length === 0) {
+          continue;
+        }
+
+        dashboard.dashboardViewConfig =
+          config as unknown as DashboardViewConfig;
+
+        jest.clearAllMocks();
+
+        await callAggregate({
+          query: {
+            name: metricNames[0] as string,
+            attributes: { "user.email": { _type: "StartsWith", value: "a" } },
+          },
+        });
+
+        expect(nextFunction).toHaveBeenCalled();
+        expect(MetricService.aggregateBy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("cross-route isolation", () => {
+    /*
+     * The two routes read two different parts of the config. A key that
+     * unlocks one must not unlock the other.
+     */
+    const CHART_METRIC: string = "system.cpu.utilization";
+    const VARIABLE_KEY: string = "resource.k8s.cluster.name";
+    const GROUP_BY_KEY: string = "resource.host.name";
+
+    type SetMixedDashboardFunction = () => void;
+
+    const setMixedDashboard: SetMixedDashboardFunction = (): void => {
+      dashboard.dashboardViewConfig = {
+        _type: "DashboardViewConfig",
+        heightInDashboardUnits: 24,
+        variables: [
+          {
+            id: ObjectID.generate().toString(),
+            name: "cluster",
+            label: "Cluster",
+            type: DashboardVariableType.TelemetryAttribute,
+            attributeKey: VARIABLE_KEY,
+          },
+        ],
+        components: [
+          {
+            componentId: ObjectID.generate().toString(),
+            componentType: "Chart",
+            arguments: {
+              metricQueryConfigs: [
+                {
+                  metricQueryData: {
+                    filterData: { metricName: CHART_METRIC },
+                    groupByAttributeKeys: [GROUP_BY_KEY],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      } as unknown as DashboardViewConfig;
+    };
+
+    it("does not let a chart's group-by key become a readable variable attribute", async () => {
+      setMixedDashboard();
+
+      await callAttributeValues(GROUP_BY_KEY);
+
+      expect(nextFunction).toHaveBeenCalled();
+      expect(
+        TelemetryAttributeService.fetchAttributeValues,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("does not let a variable's attribute key become a group-by dimension", async () => {
+      setMixedDashboard();
+
+      await callAggregate({
+        query: { name: CHART_METRIC },
+        groupByAttributeKeys: [VARIABLE_KEY],
+      });
+
+      expect(nextFunction).toHaveBeenCalled();
+      expect(MetricService.aggregateBy).not.toHaveBeenCalled();
+    });
+
+    it("serves the variable key on attribute-values (positive control)", async () => {
+      setMixedDashboard();
+
+      await callAttributeValues(VARIABLE_KEY);
+
+      expectNoError("variable key");
+      expect(
+        TelemetryAttributeService.fetchAttributeValues,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("serves the chart's group-by key on metrics-aggregate (positive control)", async () => {
+      setMixedDashboard();
+
+      await callAggregate({
+        query: { name: CHART_METRIC },
+        groupByAttributeKeys: [GROUP_BY_KEY],
+      });
+
+      expectNoError("chart group-by key");
+      expect(MetricService.aggregateBy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Fixes [GHSA-w332-x78m-vf3v](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-w332-x78m-vf3v) (High).

> **Scope note.** The first half of this work — the `/attribute-values` key allowlist (`5e69594c40`) — was pushed straight to `master` and is no longer part of this diff. What remains here is the **second** half: four further bypasses of the same data class, found while adversarially re-reviewing that first fix, plus the full test suite for both halves. Background on the original hole is kept below for context.

## Background: the reported hole (already on master)

`POST /dashboard/attribute-values/:dashboardId` authorized only on "is this dashboard public", then took `attributeKey` and `telemetryType` verbatim from the anonymous request body and ran `SELECT DISTINCT attributes[<key>]` across every log, span, metric and exception in the owning project. It never loaded `dashboardViewConfig`, so a public dashboard containing nothing but a text widget was a reader for `http.url`, `db.statement`, `enduser.id`, `user.email` — 100 distinct values per request, for anyone who knew a dashboard id.

Every adjacent public route on the same controller already carried an allowlist (`/metric-types` filters to charted metrics, `/resource-list` got a widget allowlist in the GHSA-qv79-j844-cc7m fix). That one was the sibling that got missed. It now allowlists the requested key against the keys the dashboard's own `Telemetry Attribute` variables bind to.

## This PR: four more bypasses, same data class

The advisory closed with a "related, weaker" note about `/metrics-aggregate/:dashboardId`. Reviewing it turned up that the route pinned the metric name but spread the rest of the anonymous `aggregateBy` verbatim. Each of these is reproduced by a test that fails against `5e69594c40`:

| | Vector | Impact |
|---|---|---|
| 1 | **Prototype-smuggled metric name.** The allowlist read `query["name"]` (walks the prototype chain); the project pin was an own-properties spread (drops it). `JSON.parse` makes a literal `__proto__` member a real own key and `JSONFunctions.deserialize` copies it with `newVal[key] = ...`, firing `Object.prototype`'s `__proto__` setter. | `{"query":{"__proto__":{"name":"<charted metric>"}}}` passed the check, then aggregated with **no name predicate at all** — every metric in the project. |
| 2 | **Arbitrary attribute filters.** `query.attributes` reached ClickHouse untouched, and `MetricService` deliberately leaves the pre-aggregated fast path when an attributes filter is present. | `StartsWith` compiled to an `ILIKE` over the raw table — a blind character-by-character oracle over any attribute value. |
| 3 | **Unconstrained `aggregateColumnName`.** A non-`value` column skips every fast path and falls through to `max(<column>)`; the row mapper passes non-numeric aggregates through untouched. | `aggregateColumnName: "attributes"` returned a **full attribute map per time bucket**. |
| 4 | **`groupBy` guard/sink disagreement.** The guard used `Object.keys`, the GROUP BY builder walks with `for...in`. | Not exploitable today (no product path writes a non-`undefined` `groupBy` other than legacy `{attributes:true}`), fixed as hardening. |

The query is now **rebuilt from an allowlist** — name / time / permitted attribute filters / pinned `projectId` — rather than merged into. `aggregateColumnName` and `aggregationTimestampColumnName` are pinned to the only pair any widget sends, `limit`/`skip` are clamped to `LIMIT_PER_PROJECT` (the sibling resource-list route already did this), and an explicit `null` grouping is treated as absent.

### One subtlety worth reviewing

The attribute-filter allowlist deliberately **unions** the keys widgets persist (`filterData.attributes`, the table widget's `attributeFilters`) with the keys the dashboard's `Telemetry Attribute` variables bind to.

Every shipped template stores `filterData: { metricName, aggegationType }` and no attributes at all — the filter on e.g. `resource.k8s.cluster.name` only exists once a viewer picks a value and `DashboardVariableInterpolation` injects it at render time. An allowlist built from stored filters alone would have refused **every real templated dashboard** the moment its variable was used.

## Tests

43 → 109 across three files, all passing; the full `Tests/Server/API` + `Tests/*/Dashboard` sweep is green (1134 tests on the merged tree).

- **`DashboardPublicAttributeValuesAPI`** — the advisory's PoC verbatim, all six sensitive keys it names crossed with all five telemetry types, non-telemetry variables, malformed configs, prototype keys, case sensitivity, response body, and master-password / IP-whitelist authorization variants. Uses a **projection-aware** `findOneById` mock, so deleting `dashboardViewConfig: true` from the select now fails a test instead of silently allowlisting nothing.
- **`DashboardPublicMetricsAggregateAPI`** — query-filter allowlist, prototype-carried keys (bodies built with `JSON.parse`, since an object literal sets the prototype instead of creating the own key), aggregate-column pinning, pagination clamping, null handling, stored-config shapes, wire-serializer round trip.
- **`DashboardPublicTemplatePayloads`** (new) — replays **all 12 shipped dashboard templates** through both public routes: every variable, charted metric, configured grouping and interpolated variable filter is accepted; sensitive keys, uncharted metrics and unconfigured groupings are refused. Fixture invariants keep the suite from passing on an empty loop.

## Out of scope — being handled separately

Two pre-existing issues of the same class surfaced during the review and are **not** touched here: the public `resource-list/:id/log` route never applies the LogStream widget's own stored filters, and `POST /api/status-page/test-email-report` has no authorization at all.
