### PR TITLE
Fix public Status Page Subscribe logout

### DIFF
--- a/App/FeatureSet/StatusPage/src/Pages/Accounts/ForgotPassword.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Accounts/ForgotPassword.tsx
@@ -1,4 +1,5 @@
 import { FORGOT_PASSWORD_API_URL } from "../../Utils/ApiPaths";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -106,6 +107,7 @@ const ForgotPassword: FunctionComponent<ComponentProps> = (
           <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
             <ModelForm<StatusPagePrivateUser>
               modelType={StatusPagePrivateUser}
+              modelAPI={StatusPageModelAPI}
               id="login-form"
               name="Status Page > Forgot Password"
               createOrUpdateApiUrl={apiUrl}

--- a/App/FeatureSet/StatusPage/src/Pages/Accounts/Login.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Accounts/Login.tsx
@@ -1,5 +1,6 @@
 import { LOGIN_API_URL } from "../../Utils/ApiPaths";
 import LoginUtil from "../../Utils/Login";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -124,6 +125,7 @@ const LoginPage: FunctionComponent<ComponentProps> = (
         <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
           <ModelForm<StatusPagePrivateUser>
             modelType={StatusPagePrivateUser}
+            modelAPI={StatusPageModelAPI}
             id="login-form"
             name="Status Page Login"
             fields={[

--- a/App/FeatureSet/StatusPage/src/Pages/Accounts/ResetPassword.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Accounts/ResetPassword.tsx
@@ -1,4 +1,5 @@
 import { RESET_PASSWORD_API_URL } from "../../Utils/ApiPaths";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -105,6 +106,7 @@ const ResetPassword: FunctionComponent<ComponentProps> = (
           <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
             <ModelForm<StatusPagePrivateUser>
               modelType={StatusPagePrivateUser}
+              modelAPI={StatusPageModelAPI}
               id="register-form"
               name="Status Page > Reset Password"
               onBeforeCreate={(

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/EmailSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/EmailSubscribe.tsx
@@ -1,6 +1,7 @@
 import Page from "../../Components/Page/Page";
 import API from "../../Utils/API";
 import { STATUS_PAGE_API_URL } from "../../Utils/Config";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -63,6 +64,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
             URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
               `/resources/${id.toString()}`,
             ),
+            StatusPageModelAPI,
           );
 
         setCategoryCheckboxOptionsAndCategories(result);
@@ -74,10 +76,14 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
     };
 
   useEffect(() => {
+    if (!props.allowSubscribersToChooseResources) {
+      return;
+    }
+
     fetchCheckboxOptionsAndCategories().catch((error: Error) => {
       setError(error.message);
     });
-  }, []);
+  }, [props.allowSubscribersToChooseResources]);
 
   if (!id) {
     throw new BadDataException("Status Page ID is required");
@@ -162,6 +168,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="email-form"
           name="Status Page > Email Subscribe"
           fields={fields}
@@ -195,6 +202,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="email-form"
           name="Status Page > Mage Subscribe"
           fields={[

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/MicrosoftTeamsSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/MicrosoftTeamsSubscribe.tsx
@@ -1,6 +1,7 @@
 import Page from "../../Components/Page/Page";
 import API from "../../Utils/API";
 import { STATUS_PAGE_API_URL } from "../../Utils/Config";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -66,6 +67,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
             URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
               `/resources/${id.toString()}`,
             ),
+            StatusPageModelAPI,
           );
 
         setCategoryCheckboxOptionsAndCategories(result);
@@ -77,10 +79,14 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
     };
 
   useEffect(() => {
+    if (!props.allowSubscribersToChooseResources) {
+      return;
+    }
+
     fetchCheckboxOptionsAndCategories().catch((error: Error) => {
       setError(error.message);
     });
-  }, []);
+  }, [props.allowSubscribersToChooseResources]);
 
   if (!id) {
     throw new BadDataException("Status Page ID is required");
@@ -170,6 +176,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="microsoft-teams-form"
           name="Status Page > Microsoft Teams Subscribe"
           fields={fields}
@@ -203,6 +210,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="microsoft-teams-manage-form"
           name="Status Page > Manage Teams Subscription"
           fields={[

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/SlackSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/SlackSubscribe.tsx
@@ -1,6 +1,7 @@
 import Page from "../../Components/Page/Page";
 import API from "../../Utils/API";
 import { STATUS_PAGE_API_URL } from "../../Utils/Config";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -66,6 +67,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
             URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
               `/resources/${id.toString()}`,
             ),
+            StatusPageModelAPI,
           );
 
         setCategoryCheckboxOptionsAndCategories(result);
@@ -77,10 +79,14 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
     };
 
   useEffect(() => {
+    if (!props.allowSubscribersToChooseResources) {
+      return;
+    }
+
     fetchCheckboxOptionsAndCategories().catch((error: Error) => {
       setError(error.message);
     });
-  }, []);
+  }, [props.allowSubscribersToChooseResources]);
 
   if (!id) {
     throw new BadDataException("Status Page ID is required");
@@ -170,6 +176,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="slack-form"
           name="Status Page > Slack Subscribe"
           fields={fields}
@@ -203,6 +210,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="slack-manage-form"
           name="Status Page > Manage Slack Subscription"
           fields={[

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/SmsSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/SmsSubscribe.tsx
@@ -1,6 +1,7 @@
 import Page from "../../Components/Page/Page";
 import API from "../../Utils/API";
 import { STATUS_PAGE_API_URL } from "../../Utils/Config";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -63,6 +64,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
             URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
               `/resources/${id.toString()}`,
             ),
+            StatusPageModelAPI,
           );
 
         setCategoryCheckboxOptionsAndCategories(result);
@@ -74,10 +76,14 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
     };
 
   useEffect(() => {
+    if (!props.allowSubscribersToChooseResources) {
+      return;
+    }
+
     fetchCheckboxOptionsAndCategories().catch((error: Error) => {
       setError(error.message);
     });
-  }, []);
+  }, [props.allowSubscribersToChooseResources]);
 
   if (!id) {
     throw new BadDataException("Status Page ID is required");
@@ -157,6 +163,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="sms-form"
           name="Status Page > SMS Subscribe"
           fields={fields}
@@ -190,6 +197,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="sms-manage-form"
           name="Status Page > Manage SMS Subscription"
           fields={[

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/UpdateSubscription.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/UpdateSubscription.tsx
@@ -1,6 +1,7 @@
 import Page from "../../Components/Page/Page";
 import API from "../../Utils/API";
 import { STATUS_PAGE_API_URL } from "../../Utils/Config";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import StatusPageUtil from "../../Utils/StatusPage";
 import { SubscribePageProps } from "./SubscribePageUtils";
 import URL from "Common/Types/API/URL";
@@ -30,7 +31,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 
 const SubscribePage: FunctionComponent<SubscribePageProps> = (
-  _props: SubscribePageProps,
+  props: SubscribePageProps,
 ): ReactElement => {
   const { t } = useTranslation();
   const statusPageSubscriberId: string | undefined =
@@ -78,6 +79,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
             URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
               `/resources/${statusPageId.toString()}`,
             ),
+            StatusPageModelAPI,
           );
 
         setCategoryCheckboxOptionsAndCategories(result);
@@ -89,10 +91,14 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
     };
 
   useEffect(() => {
+    if (!props.allowSubscribersToChooseResources) {
+      return;
+    }
+
     fetchCheckboxOptionsAndCategories().catch((error: Error) => {
       setError(error.message);
     });
-  }, []);
+  }, [props.allowSubscribersToChooseResources]);
 
   if (!statusPageId) {
     throw new BadDataException("Status Page ID is required");
@@ -155,59 +161,63 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
     },
   ];
 
-  fields.push({
-    field: {
-      isSubscribedToAllResources: true,
-    },
-    showEvenIfPermissionDoesNotExist: true,
-    title: t("subscribe.resources.all"),
-    description: t("subscribe.resources.allDescription"),
-    fieldType: FormFieldSchemaType.Checkbox,
-    required: false,
-    defaultValue: true,
-  });
+  if (props.allowSubscribersToChooseResources) {
+    fields.push({
+      field: {
+        isSubscribedToAllResources: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      title: t("subscribe.resources.all"),
+      description: t("subscribe.resources.allDescription"),
+      fieldType: FormFieldSchemaType.Checkbox,
+      required: false,
+      defaultValue: true,
+    });
 
-  fields.push({
-    field: {
-      statusPageResources: true,
-    },
-    showEvenIfPermissionDoesNotExist: true,
-    title: t("subscribe.resources.select"),
-    description: t("subscribe.resources.selectDescription"),
-    fieldType: FormFieldSchemaType.CategoryCheckbox,
-    required: false,
-    categoryCheckboxProps: categoryCheckboxOptionsAndCategories,
-    showIf: (model: FormValues<StatusPageSubscriber>) => {
-      return !model || !model.isSubscribedToAllResources;
-    },
-  });
+    fields.push({
+      field: {
+        statusPageResources: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      title: t("subscribe.resources.select"),
+      description: t("subscribe.resources.selectDescription"),
+      fieldType: FormFieldSchemaType.CategoryCheckbox,
+      required: false,
+      categoryCheckboxProps: categoryCheckboxOptionsAndCategories,
+      showIf: (model: FormValues<StatusPageSubscriber>) => {
+        return !model || !model.isSubscribedToAllResources;
+      },
+    });
+  }
 
-  fields.push({
-    field: {
-      isSubscribedToAllEventTypes: true,
-    },
-    showEvenIfPermissionDoesNotExist: true,
-    title: t("subscribe.eventTypes.all"),
-    description: t("subscribe.eventTypes.allDescription"),
-    fieldType: FormFieldSchemaType.Checkbox,
-    required: false,
-    defaultValue: true,
-  });
+  if (props.allowSubscribersToChooseEventTypes) {
+    fields.push({
+      field: {
+        isSubscribedToAllEventTypes: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      title: t("subscribe.eventTypes.all"),
+      description: t("subscribe.eventTypes.allDescription"),
+      fieldType: FormFieldSchemaType.Checkbox,
+      required: false,
+      defaultValue: true,
+    });
 
-  fields.push({
-    field: {
-      statusPageEventTypes: true,
-    },
-    showEvenIfPermissionDoesNotExist: true,
-    title: t("subscribe.eventTypes.select"),
-    description: t("subscribe.eventTypes.selectDescription"),
-    fieldType: FormFieldSchemaType.MultiSelectDropdown,
-    required: false,
-    dropdownOptions: SubscriberUtil.getDropdownPropsBasedOnEventTypes(),
-    showIf: (model: FormValues<StatusPageSubscriber>) => {
-      return !model || !model.isSubscribedToAllEventTypes;
-    },
-  });
+    fields.push({
+      field: {
+        statusPageEventTypes: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      title: t("subscribe.eventTypes.select"),
+      description: t("subscribe.eventTypes.selectDescription"),
+      fieldType: FormFieldSchemaType.MultiSelectDropdown,
+      required: false,
+      dropdownOptions: SubscriberUtil.getDropdownPropsBasedOnEventTypes(),
+      showIf: (model: FormValues<StatusPageSubscriber>) => {
+        return !model || !model.isSubscribedToAllEventTypes;
+      },
+    });
+  }
 
   fields.push({
     field: {
@@ -244,6 +254,7 @@ const SubscribePage: FunctionComponent<SubscribePageProps> = (
                 >
                   <ModelForm<StatusPageSubscriber>
                     modelType={StatusPageSubscriber}
+                    modelAPI={StatusPageModelAPI}
                     id="email-form"
                     name="Status Page > Update Subscription"
                     fields={fields}

--- a/App/FeatureSet/StatusPage/src/Pages/Subscribe/WebhookSubscribe.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Subscribe/WebhookSubscribe.tsx
@@ -1,6 +1,7 @@
 import Page from "../../Components/Page/Page";
 import API from "../../Utils/API";
 import { STATUS_PAGE_API_URL } from "../../Utils/Config";
+import StatusPageModelAPI from "../../Utils/ModelAPI";
 import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import StatusPageUtil from "../../Utils/StatusPage";
@@ -65,6 +66,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
             URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
               `/resources/${id.toString()}`,
             ),
+            StatusPageModelAPI,
           );
 
         setCategoryCheckboxOptionsAndCategories(result);
@@ -76,10 +78,14 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
     };
 
   useEffect(() => {
+    if (!props.allowSubscribersToChooseResources) {
+      return;
+    }
+
     fetchCheckboxOptionsAndCategories().catch((error: Error) => {
       setError(error.message);
     });
-  }, []);
+  }, [props.allowSubscribersToChooseResources]);
 
   if (!id) {
     throw new BadDataException("Status Page ID is required");
@@ -159,6 +165,7 @@ const SubscribePage: FunctionComponent<ComponentProps> = (
       return (
         <ModelForm<StatusPageSubscriber>
           modelType={StatusPageSubscriber}
+          modelAPI={StatusPageModelAPI}
           id="webhook-form"
           name="Status Page > Webhook Subscribe"
           fields={fields}

--- a/App/FeatureSet/StatusPage/src/Utils/API.ts
+++ b/App/FeatureSet/StatusPage/src/Utils/API.ts
@@ -5,6 +5,7 @@ import HTTPMethod from "Common/Types/API/HTTPMethod";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import Route from "Common/Types/API/Route";
 import URL from "Common/Types/API/URL";
+import APIException from "Common/Types/Exception/ApiException";
 import ObjectID from "Common/Types/ObjectID";
 import { JSONObject } from "Common/Types/JSON";
 import BaseAPI from "Common/UI/Utils/API/API";
@@ -26,6 +27,28 @@ export default class API extends BaseAPI {
       "status-page-id": statusPageId.toString(),
       tenantid: "",
     };
+  }
+
+  public static override handleError(
+    error: HTTPErrorResponse | APIException,
+  ): HTTPErrorResponse | APIException {
+    /*
+     * A public Status Page does not require an account session. An expired or
+     * otherwise unrelated dashboard cookie must therefore not turn a public
+     * request failure into either a dashboard logout or a Status Page login
+     * redirect. Callers can display the response as a local inline error.
+     *
+     * Private Status Pages retain the existing page-scoped login behavior.
+     */
+    if (
+      error instanceof HTTPErrorResponse &&
+      !StatusPageUtil.isPrivateStatusPage() &&
+      (error.statusCode === 401 || error.statusCode === 405)
+    ) {
+      return error;
+    }
+
+    return super.handleError(error);
   }
 
   public static override getLoginRoute(): Route {

--- a/App/FeatureSet/StatusPage/src/Utils/ModelAPI.ts
+++ b/App/FeatureSet/StatusPage/src/Utils/ModelAPI.ts
@@ -1,0 +1,27 @@
+import API from "./API";
+import Dictionary from "Common/Types/Dictionary";
+import BaseAPI from "Common/UI/Utils/API/API";
+import ModelAPI, { RequestOptions } from "Common/UI/Utils/ModelAPI/ModelAPI";
+
+/**
+ * ModelAPI adapter for the public Status Page application.
+ *
+ * Shared forms and resource pickers normally use the dashboard API client.
+ * That client's 401/405 handler performs a global account logout. Status Page
+ * requests must instead use the page-scoped client so an unrelated dashboard
+ * session can never be cleared by a public subscription request.
+ */
+export default class StatusPageModelAPI extends ModelAPI {
+  protected static override getApiClient(): typeof BaseAPI {
+    return API;
+  }
+
+  public static override getCommonHeaders(
+    requestOptions?: RequestOptions,
+  ): Dictionary<string> {
+    return {
+      ...API.getDefaultHeaders(),
+      ...(requestOptions?.requestHeaders || {}),
+    };
+  }
+}

--- a/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
+++ b/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Status Page subscriber screens reuse Common's ModelForm and resource
+ * helpers. Their default ModelAPI belongs to the authenticated dashboard: a
+ * 401/405 invokes the dashboard logout routine, which clears all browser
+ * storage. On a public Status Page that erases `statusPageId`, so the next
+ * render replaces the subscribe form with "Status Page ID is required".
+ *
+ * These tests cover every hand-written Status Page call site. That is useful
+ * in addition to the ModelAPI unit tests because a future subscriber channel
+ * can compile while silently omitting the page-scoped adapter prop.
+ */
+
+const STATUS_PAGE_SRC: string = path.join(
+  __dirname,
+  "../../FeatureSet/StatusPage/src",
+);
+
+const SUBSCRIBE_PAGES: ReadonlyArray<string> = [
+  "Pages/Subscribe/EmailSubscribe.tsx",
+  "Pages/Subscribe/SmsSubscribe.tsx",
+  "Pages/Subscribe/SlackSubscribe.tsx",
+  "Pages/Subscribe/MicrosoftTeamsSubscribe.tsx",
+  "Pages/Subscribe/WebhookSubscribe.tsx",
+  "Pages/Subscribe/UpdateSubscription.tsx",
+];
+
+const ACCOUNT_FORM_PAGES: ReadonlyArray<string> = [
+  "Pages/Accounts/Login.tsx",
+  "Pages/Accounts/ForgotPassword.tsx",
+  "Pages/Accounts/ResetPassword.tsx",
+];
+
+function readSource(relativePath: string): string {
+  return fs
+    .readFileSync(path.join(STATUS_PAGE_SRC, relativePath), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+function occurrences(source: string, expression: RegExp): number {
+  return source.match(expression)?.length || 0;
+}
+
+describe("Status Page model requests stay in the Status Page auth boundary", () => {
+  test.each([...SUBSCRIBE_PAGES, ...ACCOUNT_FORM_PAGES])(
+    "%s gives every ModelForm the page-scoped ModelAPI",
+    (relativePath: string) => {
+      const source: string = readSource(relativePath);
+      const forms: number = occurrences(source, /<ModelForm(?:<[^>]+>)?/g);
+
+      expect(forms).toBeGreaterThan(0);
+      expect(occurrences(source, /modelAPI=\{StatusPageModelAPI\}/g)).toBe(
+        forms,
+      );
+      expect(source).toContain(
+        'import StatusPageModelAPI from "../../Utils/ModelAPI"',
+      );
+    },
+  );
+
+  test.each(SUBSCRIBE_PAGES)(
+    "%s loads selectable resources through the page-scoped ModelAPI",
+    (relativePath: string) => {
+      const source: string = readSource(relativePath).replace(/\s+/g, " ");
+
+      expect(source).toMatch(
+        /getCategoryCheckboxPropsBasedOnResources\([\s\S]*?StatusPageModelAPI,?\s*\)/,
+      );
+    },
+  );
+
+  test.each(SUBSCRIBE_PAGES)(
+    "%s does not request resources when resource selection is disabled",
+    (relativePath: string) => {
+      const source: string = readSource(relativePath).replace(/\s+/g, " ");
+
+      expect(source).toContain(
+        "if (!props.allowSubscribersToChooseResources) { return; }",
+      );
+      expect(source).toContain("[props.allowSubscribersToChooseResources]");
+    },
+  );
+
+  test("the adapter supplies Status Page headers and the Status Page client", () => {
+    const source: string = readSource("Utils/ModelAPI.ts");
+
+    expect(source).toContain("extends ModelAPI");
+    expect(source).toContain("return API;");
+    expect(source).toContain("...API.getDefaultHeaders()");
+    expect(source).toContain("...(requestOptions?.requestHeaders || {})");
+  });
+});

--- a/Common/Tests/App/StatusPage/PublicStatusPageAPIErrorHandling.test.ts
+++ b/Common/Tests/App/StatusPage/PublicStatusPageAPIErrorHandling.test.ts
@@ -1,0 +1,117 @@
+import StatusPageAPI from "../../../../App/FeatureSet/StatusPage/src/Utils/API";
+import StatusPageUtil from "../../../../App/FeatureSet/StatusPage/src/Utils/StatusPage";
+import StatusPageUser from "../../../../App/FeatureSet/StatusPage/src/Utils/User";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import CookieName from "../../../Types/CookieName";
+import ObjectID from "../../../Types/ObjectID";
+import LocalStorage from "../../../UI/Utils/LocalStorage";
+import Navigation from "../../../UI/Utils/Navigation";
+import DashboardUser from "../../../UI/Utils/User";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const STATUS_PAGE_ID: string = "22222222-2222-4222-8222-222222222222";
+const PREVIEW_PATH: string = `/status-page/${STATUS_PAGE_ID}/subscribe/email`;
+
+type SetUrlFunction = (url: string) => void;
+
+interface RecordedSpy {
+  mock: { calls: Array<Array<unknown>> };
+}
+
+const setUrl: SetUrlFunction = (url: string): void => {
+  window.history.replaceState(window.history.state, "", url);
+};
+
+describe("public Status Page API authentication errors", () => {
+  let dashboardLogoutSpy: RecordedSpy;
+  let statusPageLogoutSpy: RecordedSpy;
+  let navigateSpy: RecordedSpy;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    setUrl(PREVIEW_PATH);
+
+    StatusPageUtil.setStatusPageId(new ObjectID(STATUS_PAGE_ID));
+    StatusPageUtil.setIsPrivateStatusPage(false);
+
+    LocalStorage.setItem("dashboard-session-marker", "keep-me");
+    window.sessionStorage.setItem("dashboard-tab-marker", "keep-me-too");
+    document.cookie = `${CookieName.Token}=dashboard-token; path=/`;
+
+    dashboardLogoutSpy = jest
+      .spyOn(DashboardUser, "logout")
+      .mockImplementation(() => {}) as unknown as RecordedSpy;
+    statusPageLogoutSpy = jest
+      .spyOn(StatusPageUser, "logout")
+      .mockResolvedValue(undefined) as unknown as RecordedSpy;
+    navigateSpy = jest
+      .spyOn(Navigation, "navigate")
+      .mockImplementation(() => {}) as unknown as RecordedSpy;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.cookie = `${CookieName.Token}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  test.each([401, 405])(
+    "keeps the dashboard and Status Page state intact on HTTP %s",
+    (statusCode: number) => {
+      const error: HTTPErrorResponse = new HTTPErrorResponse(
+        statusCode,
+        { message: "Unrelated account authentication error" },
+        {},
+      );
+
+      const result: HTTPErrorResponse = StatusPageAPI.handleError(
+        error,
+      ) as HTTPErrorResponse;
+
+      expect(result).toBe(error);
+      expect(dashboardLogoutSpy).not.toHaveBeenCalled();
+      expect(statusPageLogoutSpy).not.toHaveBeenCalled();
+      expect(navigateSpy).not.toHaveBeenCalled();
+
+      expect(StatusPageUtil.getStatusPageId()?.toString()).toBe(STATUS_PAGE_ID);
+      expect(LocalStorage.getItem("dashboard-session-marker")).toBe("keep-me");
+      expect(window.sessionStorage.getItem("dashboard-tab-marker")).toBe(
+        "keep-me-too",
+      );
+      expect(document.cookie).toContain(`${CookieName.Token}=dashboard-token`);
+      expect(window.location.pathname).toBe(PREVIEW_PATH);
+    },
+  );
+
+  test("retains page-scoped login handling for a private Status Page", () => {
+    StatusPageUtil.setIsPrivateStatusPage(true);
+
+    const error: HTTPErrorResponse = new HTTPErrorResponse(
+      401,
+      { message: "Status Page session expired" },
+      {},
+    );
+
+    StatusPageAPI.handleError(error);
+
+    expect(dashboardLogoutSpy).not.toHaveBeenCalled();
+    expect(statusPageLogoutSpy).toHaveBeenCalledTimes(1);
+    expect(statusPageLogoutSpy).toHaveBeenCalledWith(
+      new ObjectID(STATUS_PAGE_ID),
+    );
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy.mock.calls[0]?.[0]?.toString()).toBe(
+      `/status-page/${STATUS_PAGE_ID}/login`,
+    );
+    expect(navigateSpy.mock.calls[0]?.[1]).toEqual({ forceNavigate: true });
+  });
+});

--- a/Common/Tests/App/StatusPage/StatusPageModelAPIPolymorphism.test.ts
+++ b/Common/Tests/App/StatusPage/StatusPageModelAPIPolymorphism.test.ts
@@ -1,0 +1,223 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import StatusPageAPI from "../../../../App/FeatureSet/StatusPage/src/Utils/API";
+import StatusPageModelAPI from "../../../../App/FeatureSet/StatusPage/src/Utils/ModelAPI";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import HTTPMethod from "../../../Types/API/HTTPMethod";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import URL from "../../../Types/API/URL";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { JSONArray, JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { FormType } from "../../../UI/Components/Forms/ModelForm";
+import DashboardAPI from "../../../UI/Utils/API/API";
+
+/*
+ * StatusPageModelAPI is deliberately a ModelAPI subclass instead of a second
+ * copy of the model request implementation. The polymorphic boundary is
+ * security-sensitive: falling back to DashboardAPI means a public status-page
+ * request can inherit a dashboard tenant and, on a 401/405, clear the user's
+ * unrelated dashboard session.
+ *
+ * These tests spy on the status-page and dashboard clients independently.
+ * They therefore fail if ModelAPI ever hard-codes DashboardAPI again, even if
+ * the request payload and successful response happen to look identical.
+ */
+
+const STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "019acd10-1111-4111-8111-111111111111",
+);
+const RESOURCE_ID: string = "019acd10-2222-4222-8222-222222222222";
+const DASHBOARD_PROJECT_ID: string = "019acd10-3333-4333-8333-333333333333";
+
+interface StaticSpy {
+  mockResolvedValue: (value: unknown) => StaticSpy;
+  mockRejectedValue: (value: unknown) => StaticSpy;
+  mock: { calls: Array<Array<unknown>> };
+}
+
+type FetchArguments = {
+  method: HTTPMethod;
+  url: URL;
+  data?: JSONObject | undefined;
+  headers?: Record<string, string> | undefined;
+  params?: Record<string, string> | undefined;
+};
+
+let statusPageFetchSpy: StaticSpy;
+let dashboardFetchSpy: StaticSpy;
+
+const buildResource: () => StatusPageResource = (): StatusPageResource => {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource._id = RESOURCE_ID;
+  resource.statusPageId = STATUS_PAGE_ID;
+  resource.displayName = "Checkout API";
+  resource.order = 1;
+  return resource;
+};
+
+const buildListResponse: (
+  resource: StatusPageResource,
+) => HTTPResponse<JSONArray> = (
+  resource: StatusPageResource,
+): HTTPResponse<JSONArray> => {
+  return new HTTPResponse<JSONArray>(
+    200,
+    {
+      data: [BaseModel.toJSON(resource, StatusPageResource)],
+      count: 1,
+      skip: 0,
+      limit: 25,
+    },
+    {},
+  );
+};
+
+const buildModelResponse: (
+  resource: StatusPageResource,
+) => HTTPResponse<StatusPageResource> = (
+  resource: StatusPageResource,
+): HTTPResponse<StatusPageResource> => {
+  return new HTTPResponse<StatusPageResource>(
+    200,
+    BaseModel.toJSON(resource, StatusPageResource),
+    {},
+  );
+};
+
+const statusPageFetchArguments: () => FetchArguments = (): FetchArguments => {
+  return statusPageFetchSpy.mock.calls[0]![0] as FetchArguments;
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `/status-page/${STATUS_PAGE_ID.toString()}/subscribe/email`,
+  );
+
+  /*
+   * Keep an unrelated dashboard project in the same tab. This is the browser
+   * state from the reported bug and proves that the explicit blank tenant
+   * wins over any dashboard context that ModelAPI could otherwise discover.
+   */
+  window.localStorage.setItem("statusPageId", STATUS_PAGE_ID.toString());
+  window.sessionStorage.setItem("current_project_id", DASHBOARD_PROJECT_ID);
+
+  /*
+   * Spy on the inherited method on the subclass first. Jest then installs an
+   * own spy on StatusPageAPI; the later DashboardAPI spy remains independent.
+   */
+  statusPageFetchSpy = jest.spyOn(
+    StatusPageAPI,
+    "fetch",
+  ) as unknown as StaticSpy;
+  dashboardFetchSpy = jest.spyOn(DashboardAPI, "fetch") as unknown as StaticSpy;
+
+  dashboardFetchSpy.mockRejectedValue(
+    new Error("the dashboard API client must not receive this request"),
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.history.replaceState(window.history.state, "", "/");
+});
+
+describe("StatusPageModelAPI polymorphic API client", () => {
+  test("getList dispatches through the status-page client with page-scoped headers", async () => {
+    const resource: StatusPageResource = buildResource();
+    statusPageFetchSpy.mockResolvedValue(buildListResponse(resource));
+
+    const overrideRequestUrl: URL = URL.fromString(
+      `https://status.example.com/api/status-page/resources/${STATUS_PAGE_ID.toString()}`,
+    );
+
+    const result: {
+      data: Array<StatusPageResource>;
+      count: number;
+      skip: number;
+      limit: number;
+    } = await StatusPageModelAPI.getList<StatusPageResource>({
+      modelType: StatusPageResource,
+      query: { statusPageId: STATUS_PAGE_ID },
+      limit: 25,
+      skip: 0,
+      select: { _id: true, displayName: true },
+      sort: { order: SortOrder.Ascending },
+      requestOptions: {
+        overrideRequestUrl,
+        requestHeaders: { "x-status-page-test": "list" },
+      },
+    });
+
+    expect(statusPageFetchSpy.mock.calls).toHaveLength(1);
+    expect(dashboardFetchSpy.mock.calls).toHaveLength(0);
+
+    const request: FetchArguments = statusPageFetchArguments();
+    expect(request.method).toBe(HTTPMethod.POST);
+    expect(request.url.toString()).toBe(overrideRequestUrl.toString());
+    expect(request.params).toEqual({ limit: "25", skip: "0" });
+    expect(request.headers).toEqual({
+      "status-page-id": STATUS_PAGE_ID.toString(),
+      tenantid: "",
+      "x-status-page-test": "list",
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toBeInstanceOf(StatusPageResource);
+    expect(result.data[0]?._id?.toString()).toBe(RESOURCE_ID);
+  });
+
+  test("createOrUpdate dispatches through the status-page client with the same isolated headers", async () => {
+    const resource: StatusPageResource = buildResource();
+    statusPageFetchSpy.mockResolvedValue(buildModelResponse(resource));
+
+    const overrideRequestUrl: URL = URL.fromString(
+      `https://status.example.com/api/status-page/subscribe/${STATUS_PAGE_ID.toString()}`,
+    );
+
+    const result: {
+      data: StatusPageResource;
+    } = await StatusPageModelAPI.createOrUpdate<StatusPageResource>({
+      model: resource,
+      modelType: StatusPageResource,
+      formType: FormType.Create,
+      miscDataProps: { source: "public-status-page" },
+      requestOptions: {
+        overrideRequestUrl,
+        requestHeaders: { "x-status-page-test": "create" },
+      },
+    });
+
+    expect(statusPageFetchSpy.mock.calls).toHaveLength(1);
+    expect(dashboardFetchSpy.mock.calls).toHaveLength(0);
+
+    const request: FetchArguments = statusPageFetchArguments();
+    expect(request.method).toBe(HTTPMethod.POST);
+    expect(request.url.toString()).toBe(overrideRequestUrl.toString());
+    expect(request.headers).toEqual({
+      "status-page-id": STATUS_PAGE_ID.toString(),
+      tenantid: "",
+      "x-status-page-test": "create",
+    });
+    expect(request.data?.["miscDataProps"]).toEqual({
+      source: "public-status-page",
+    });
+
+    expect(result.data).toBeInstanceOf(StatusPageResource);
+    expect(result.data._id?.toString()).toBe(RESOURCE_ID);
+  });
+});

--- a/Common/Tests/UI/Utils/Project.test.ts
+++ b/Common/Tests/UI/Utils/Project.test.ts
@@ -185,6 +185,21 @@ describe("ProjectUtil", () => {
 
       expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
     });
+
+    test.each([
+      ["the overview", `/status-page/${PROJECT_Y_ID}`],
+      [
+        "a nested subscribe page",
+        `/status-page/${PROJECT_Y_ID}/subscribe/email`,
+      ],
+    ])(
+      "does not mistake a status-page id for a project id on %s",
+      (_description: string, url: string) => {
+        setUrl(url);
+
+        expect(ProjectUtil.getProjectIdFromUrl()).toBeNull();
+      },
+    );
   });
 
   describe("getCurrentProjectId precedence", () => {
@@ -278,6 +293,22 @@ describe("ProjectUtil", () => {
       setUrl(`/dashboard/${PROJECT_Y_ID}/alerts`);
 
       expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_Y_ID);
+    });
+
+    test("a status-page preview does not override this tab's dashboard project", () => {
+      window.sessionStorage.setItem(
+        CURRENT_PROJECT_ID_STORAGE_KEY,
+        PROJECT_X_ID,
+      );
+      setUrl(`/status-page/${PROJECT_Y_ID}/subscribe/email`);
+
+      expect(ProjectUtil.getCurrentProjectId()?.toString()).toBe(PROJECT_X_ID);
+    });
+
+    test("a status-page preview is not project-scoped when no project is stored", () => {
+      setUrl(`/status-page/${PROJECT_Y_ID}/subscribe/email`);
+
+      expect(ProjectUtil.getCurrentProjectId()).toBeNull();
     });
   });
 

--- a/Common/Tests/UI/Utils/StatusPageModelAPIInjection.test.ts
+++ b/Common/Tests/UI/Utils/StatusPageModelAPIInjection.test.ts
@@ -1,0 +1,245 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import StatusPageResource from "../../../Models/DatabaseModels/StatusPageResource";
+import URL from "../../../Types/API/URL";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import ObjectID from "../../../Types/ObjectID";
+import { CategoryCheckboxOptionsAndCategories } from "../../../UI/Components/CategoryCheckbox/Index";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import StatusPageUtil from "../../../UI/Utils/StatusPage";
+
+/*
+ * The public Status Page supplies its own ModelAPI subclass to the shared
+ * resource-to-checkbox helper. Losing that injected class silently routes the
+ * read back through the dashboard client, which is precisely the behavior that
+ * caused the Subscribe page to clear an unrelated dashboard session.
+ */
+
+const STATUS_PAGE_ID: ObjectID = new ObjectID(
+  "019acd20-1111-4111-8111-111111111111",
+);
+const GROUP_ONE_ID: string = "019acd20-2222-4222-8222-222222222222";
+const GROUP_TWO_ID: string = "019acd20-3333-4333-8333-333333333333";
+const RESOURCE_ONE_ID: string = "019acd20-4444-4444-8444-444444444444";
+const RESOURCE_TWO_ID: string = "019acd20-5555-4555-8555-555555555555";
+const RESOURCE_THREE_ID: string = "019acd20-6666-4666-8666-666666666666";
+
+class InjectedModelAPI extends ModelAPI {}
+
+interface StaticSpy {
+  mockResolvedValue: (value: unknown) => StaticSpy;
+  mockRejectedValue: (value: unknown) => StaticSpy;
+  mock: { calls: Array<Array<unknown>> };
+}
+
+type GetListArguments = {
+  modelType: typeof StatusPageResource;
+  query: { statusPageId: ObjectID };
+  limit: number;
+  skip: number;
+  select: Record<string, unknown>;
+  sort: Record<string, unknown>;
+  requestOptions?: { overrideRequestUrl: URL } | undefined;
+};
+
+let injectedGetListSpy: StaticSpy;
+let defaultGetListSpy: StaticSpy;
+
+const makeGroup: (data: {
+  id: string;
+  name: string;
+  order: number;
+}) => StatusPageGroup = (data: {
+  id: string;
+  name: string;
+  order: number;
+}): StatusPageGroup => {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id;
+  group.name = data.name;
+  group.order = data.order;
+  return group;
+};
+
+const makeResource: (data: {
+  id: string;
+  name: string;
+  order: number;
+  group?: StatusPageGroup | undefined;
+}) => StatusPageResource = (data: {
+  id: string;
+  name: string;
+  order: number;
+  group?: StatusPageGroup | undefined;
+}): StatusPageResource => {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource._id = data.id;
+  resource.statusPageId = STATUS_PAGE_ID;
+  resource.displayName = data.name;
+  resource.order = data.order;
+  if (data.group) {
+    resource.statusPageGroup = data.group;
+  }
+  return resource;
+};
+
+const mockInjectedResources: (resources: Array<StatusPageResource>) => void = (
+  resources: Array<StatusPageResource>,
+): void => {
+  injectedGetListSpy.mockResolvedValue({
+    data: resources,
+    count: resources.length,
+    skip: 0,
+    limit: LIMIT_PER_PROJECT,
+  });
+};
+
+const injectedGetListArguments: () => GetListArguments =
+  (): GetListArguments => {
+    return injectedGetListSpy.mock.calls[0]![0] as GetListArguments;
+  };
+
+beforeEach(() => {
+  /*
+   * Install the subclass spy first so it is an own static method and remains
+   * independent from the guard spy subsequently installed on ModelAPI.
+   */
+  injectedGetListSpy = jest.spyOn(
+    InjectedModelAPI,
+    "getList",
+  ) as unknown as StaticSpy;
+  defaultGetListSpy = jest.spyOn(ModelAPI, "getList") as unknown as StaticSpy;
+
+  defaultGetListSpy.mockRejectedValue(
+    new Error("the default ModelAPI must not receive this request"),
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("StatusPageUtil model API injection", () => {
+  test("getResources delegates the complete public-resource query to the supplied model API", async () => {
+    const resource: StatusPageResource = makeResource({
+      id: RESOURCE_ONE_ID,
+      name: "Checkout API",
+      order: 1,
+    });
+    mockInjectedResources([resource]);
+
+    const overrideRequestUrl: URL = URL.fromString(
+      `https://status.example.com/api/status-page/resources/${STATUS_PAGE_ID.toString()}`,
+    );
+
+    const result: Array<StatusPageResource> = await StatusPageUtil.getResources(
+      STATUS_PAGE_ID,
+      overrideRequestUrl,
+      InjectedModelAPI,
+    );
+
+    expect(injectedGetListSpy.mock.calls).toHaveLength(1);
+    expect(defaultGetListSpy.mock.calls).toHaveLength(0);
+    expect(result).toEqual([resource]);
+
+    const request: GetListArguments = injectedGetListArguments();
+    expect(request.modelType).toBe(StatusPageResource);
+    expect(request.query.statusPageId).toBe(STATUS_PAGE_ID);
+    expect(request.limit).toBe(LIMIT_PER_PROJECT);
+    expect(request.skip).toBe(0);
+    expect(request.sort).toEqual({});
+    expect(request.select).toEqual({
+      _id: true,
+      displayName: true,
+      order: true,
+      statusPageGroup: {
+        _id: true,
+        name: true,
+        order: true,
+      },
+    });
+    expect(request.requestOptions?.overrideRequestUrl.toString()).toBe(
+      overrideRequestUrl.toString(),
+    );
+  });
+
+  test("the checkbox helper preserves the supplied model API while sorting and deduplicating resources", async () => {
+    const laterGroup: StatusPageGroup = makeGroup({
+      id: GROUP_ONE_ID,
+      name: "Customer-facing",
+      order: 2,
+    });
+    const earlierGroup: StatusPageGroup = makeGroup({
+      id: GROUP_TWO_ID,
+      name: "Core services",
+      order: 1,
+    });
+
+    mockInjectedResources([
+      makeResource({
+        id: RESOURCE_ONE_ID,
+        name: "Web application",
+        order: 3,
+        group: laterGroup,
+      }),
+      makeResource({
+        id: RESOURCE_TWO_ID,
+        name: "API",
+        order: 1,
+        group: earlierGroup,
+      }),
+      makeResource({
+        id: RESOURCE_THREE_ID,
+        name: "Worker",
+        order: 2,
+        group: laterGroup,
+      }),
+    ]);
+
+    const overrideRequestUrl: URL = URL.fromString(
+      `https://status.example.com/api/status-page/resources/${STATUS_PAGE_ID.toString()}`,
+    );
+
+    const result: CategoryCheckboxOptionsAndCategories =
+      await StatusPageUtil.getCategoryCheckboxPropsBasedOnResources(
+        STATUS_PAGE_ID,
+        overrideRequestUrl,
+        InjectedModelAPI,
+      );
+
+    expect(injectedGetListSpy.mock.calls).toHaveLength(1);
+    expect(defaultGetListSpy.mock.calls).toHaveLength(0);
+    expect(
+      injectedGetListArguments().requestOptions?.overrideRequestUrl.toString(),
+    ).toBe(overrideRequestUrl.toString());
+
+    expect(result.categories).toEqual([
+      { id: GROUP_TWO_ID, title: "Core services" },
+      { id: GROUP_ONE_ID, title: "Customer-facing" },
+    ]);
+    expect(result.options).toEqual([
+      {
+        value: RESOURCE_TWO_ID,
+        label: "API",
+        categoryId: GROUP_TWO_ID,
+      },
+      {
+        value: RESOURCE_THREE_ID,
+        label: "Worker",
+        categoryId: GROUP_ONE_ID,
+      },
+      {
+        value: RESOURCE_ONE_ID,
+        label: "Web application",
+        categoryId: GROUP_ONE_ID,
+      },
+    ]);
+  });
+});

--- a/Common/UI/Utils/ModelAPI/ModelAPI.ts
+++ b/Common/UI/Utils/ModelAPI/ModelAPI.ts
@@ -36,6 +36,17 @@ export interface RequestOptions extends BaseRequestOptions {
 }
 
 export default class ModelAPI {
+  /**
+   * The API client used for model requests.
+   *
+   * Most applications use the authenticated dashboard client. Public-facing
+   * applications can override this accessor so a model request cannot inherit
+   * dashboard logout and redirect behavior merely because it reuses ModelAPI.
+   */
+  protected static getApiClient(): typeof API {
+    return API;
+  }
+
   public static async create<TBaseModel extends BaseModel>(data: {
     model: TBaseModel;
     modelType: { new (): TBaseModel };
@@ -43,7 +54,7 @@ export default class ModelAPI {
   }): Promise<
     HTTPResponse<JSONObject | JSONArray | TBaseModel | Array<TBaseModel>>
   > {
-    return await ModelAPI.createOrUpdate({
+    return await this.createOrUpdate({
       model: data.model,
       modelType: data.modelType,
       formType: FormType.Create,
@@ -58,7 +69,7 @@ export default class ModelAPI {
   }): Promise<
     HTTPResponse<JSONObject | JSONArray | TBaseModel | Array<TBaseModel>>
   > {
-    return await ModelAPI.createOrUpdate({
+    return await this.createOrUpdate({
       model: data.model,
       modelType: data.modelType,
       formType: FormType.Update,
@@ -92,7 +103,7 @@ export default class ModelAPI {
 
     const result: HTTPResponse<
       JSONObject | JSONArray | TBaseModel | Array<TBaseModel>
-    > = await API.fetch<
+    > = await this.getApiClient().fetch<
       JSONObject | JSONArray | TBaseModel | Array<TBaseModel>
     >({
       method: HTTPMethod.PUT,
@@ -146,7 +157,7 @@ export default class ModelAPI {
     }
 
     const apiResult: HTTPErrorResponse | HTTPResponse<TBaseModel> =
-      await API.fetch<TBaseModel>({
+      await this.getApiClient().fetch<TBaseModel>({
         method: httpMethod,
         url: apiUrl,
         data: {
@@ -223,7 +234,7 @@ export default class ModelAPI {
     }
 
     const result: HTTPResponse<JSONArray> | HTTPErrorResponse =
-      await API.fetch<JSONArray>({
+      await this.getApiClient().fetch<JSONArray>({
         method: HTTPMethod.POST,
         url: apiUrl,
         data: {
@@ -296,7 +307,7 @@ export default class ModelAPI {
     }
 
     const result: HTTPResponse<JSONObject> | HTTPErrorResponse =
-      await API.fetch<JSONObject>({
+      await this.getApiClient().fetch<JSONObject>({
         method: HTTPMethod.POST,
         url: apiUrl,
         data: {
@@ -398,7 +409,7 @@ export default class ModelAPI {
     requestOptions?: RequestOptions | undefined;
   }): Promise<TBaseModel | null> {
     const result: HTTPResponse<TBaseModel> | HTTPErrorResponse =
-      await API.fetch<TBaseModel>({
+      await this.getApiClient().fetch<TBaseModel>({
         method: HTTPMethod.POST,
         url: data.apiUrl,
         data: {
@@ -447,7 +458,7 @@ export default class ModelAPI {
     }
 
     const result: HTTPResponse<TBaseModel> | HTTPErrorResponse =
-      await API.fetch<TBaseModel>({
+      await this.getApiClient().fetch<TBaseModel>({
         method: HTTPMethod.DELETE,
         url: apiUrl,
         headers: this.getCommonHeaders(data.requestOptions),

--- a/Common/UI/Utils/Project.ts
+++ b/Common/UI/Utils/Project.ts
@@ -67,6 +67,10 @@ export default class ProjectUtil {
    * project id (`/dashboard`, `/dashboard/welcome`, ...).
    */
   public static getProjectIdFromUrl(): ObjectID | null {
+    if (Navigation.getFirstParam(1) !== "dashboard") {
+      return null;
+    }
+
     const projectId: string | undefined = Navigation.getFirstParam(2);
 
     if (!projectId || projectId.includes(":projectId")) {

--- a/Common/UI/Utils/StatusPage.ts
+++ b/Common/UI/Utils/StatusPage.ts
@@ -21,12 +21,17 @@ export default class StatusPageUtil {
   public static async getCategoryCheckboxPropsBasedOnResources(
     statusPageId: ObjectID,
     overrideRequestUrl?: URL,
+    modelAPI: typeof ModelAPI = ModelAPI,
   ): Promise<CategoryCheckboxOptionsAndCategories> {
     const categories: Array<CheckboxCategory> = [];
     const options: Array<CategoryCheckboxOption> = [];
 
     let resources: Array<StatusPageResource> =
-      await StatusPageUtil.getResources(statusPageId, overrideRequestUrl);
+      await StatusPageUtil.getResources(
+        statusPageId,
+        overrideRequestUrl,
+        modelAPI,
+      );
 
     let resourceGroups: Array<StatusPageGroup> = resources
       .map((resource: StatusPageResource) => {
@@ -90,9 +95,10 @@ export default class StatusPageUtil {
   public static async getResources(
     statusPageId: ObjectID,
     overrideRequestUrl?: URL,
+    modelAPI: typeof ModelAPI = ModelAPI,
   ): Promise<Array<StatusPageResource>> {
     const resources: ListResult<StatusPageResource> =
-      await ModelAPI.getList<StatusPageResource>({
+      await modelAPI.getList<StatusPageResource>({
         modelType: StatusPageResource,
         query: {
           statusPageId: statusPageId,

--- a/E2E/Tests/Dashboard/StatusPagePublic.spec.ts
+++ b/E2E/Tests/Dashboard/StatusPagePublic.spec.ts
@@ -2,10 +2,14 @@ import {
   APIRequestContext,
   Browser,
   BrowserContext,
+  Cookie,
+  Locator,
   Page,
+  Response,
   expect,
   test,
 } from "@playwright/test";
+import CookieName from "Common/Types/CookieName";
 import Faker from "Common/Utils/Faker";
 import { IS_BILLING_ENABLED } from "../../Config";
 import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
@@ -330,6 +334,170 @@ test.describe("public status page", () => {
     } finally {
       await visitorContext.close();
     }
+  });
+
+  test("should keep the dashboard session when an authenticated user opens Subscribe", async ({
+    page,
+  }: {
+    page: Page;
+  }) => {
+    test.setTimeout(600000);
+
+    const unique: string = Faker.generateName().toString().replace(/\s/g, "-");
+
+    const projectId: string = await registerAndCreateProject({
+      page,
+      projectNamePrefix: "Status Page Subscribe E2E",
+    });
+
+    const defaults: ProjectDefaults = await getProjectDefaults({
+      page,
+      projectId,
+    });
+
+    const monitor: JSONish = await createItem({
+      page,
+      projectId,
+      path: "/api/monitor",
+      item: {
+        name: `subscribe-monitor-${unique}`,
+        description: "Manual monitor backing the Subscribe regression test.",
+        projectId,
+        monitorType: "Manual",
+        currentMonitorStatusId: defaults.operationalMonitorStatusId,
+      },
+    });
+
+    const monitorId: string = toId(monitor["_id"]);
+    expect(monitorId, "monitor should have been created").not.toBe("");
+
+    const statusPage: JSONish = await createItem({
+      page,
+      projectId,
+      path: "/api/status-page",
+      item: {
+        name: `Subscribe Status Page ${unique}`,
+        description: "Created by the authenticated Subscribe regression test.",
+        projectId,
+        pageTitle: `Subscribe Status Page ${unique}`,
+        isPublicStatusPage: true,
+        enableEmailSubscribers: true,
+        showSubscriberPageOnStatusPage: true,
+        allowSubscribersToChooseResources: true,
+      },
+    });
+
+    const statusPageId: string = toId(statusPage["_id"]);
+    expect(statusPageId, "status page should have been created").not.toBe("");
+
+    const resourceDisplayName: string = `Subscribe Resource ${unique}`;
+
+    await createItem({
+      page,
+      projectId,
+      path: "/api/status-page-resource",
+      item: {
+        projectId,
+        statusPageId,
+        monitorId,
+        displayName: resourceDisplayName,
+        displayDescription: "Selectable resource for the Subscribe form.",
+        showStatusHistoryChart: false,
+        showCurrentStatus: true,
+        order: 1,
+      },
+    });
+
+    const dashboardLoginCookieBefore: Cookie | undefined = (
+      await page.context().cookies()
+    ).find((cookie: Cookie) => {
+      return cookie.name === CookieName.Token;
+    });
+    expect(
+      dashboardLoginCookieBefore?.value,
+      "registration should establish the dashboard login cookie",
+    ).toBeTruthy();
+
+    const dashboardUserEmailBefore: string | null = await page.evaluate(() => {
+      return window.localStorage.getItem("user_email");
+    });
+    expect(
+      dashboardUserEmailBefore,
+      "registration should establish the dashboard login state in local storage",
+    ).not.toBeNull();
+
+    await waitForStatusPageToRender({ page, statusPageId });
+
+    const storedStatusPageIdBeforeSubscribe: string | null =
+      await page.evaluate(() => {
+        return window.localStorage.getItem("statusPageId");
+      });
+    expect(
+      storedStatusPageIdBeforeSubscribe || "",
+      "the rendered status page should persist its ID before navigation",
+    ).toContain(statusPageId);
+
+    const resourcesResponsePromise: Promise<Response> = page.waitForResponse(
+      (response: Response) => {
+        return (
+          response.request().method() === "POST" &&
+          response.url().includes(`/status-page-api/resources/${statusPageId}`)
+        );
+      },
+      { timeout: 120000 },
+    );
+
+    await page.locator("#subscribe-nav-bar-item").click();
+
+    const resourcesResponse: Response = await resourcesResponsePromise;
+    expect(
+      resourcesResponse.status(),
+      "the Status Page resource request should succeed for a dashboard user",
+    ).toBe(200);
+
+    const resourceRequestHeaders: Record<string, string> =
+      await resourcesResponse.request().allHeaders();
+    expect(resourceRequestHeaders["status-page-id"]).toBe(statusPageId);
+    expect(resourceRequestHeaders["tenantid"]).toBe("");
+    expect(await resourcesResponse.text()).toContain(resourceDisplayName);
+
+    await expect(page).toHaveURL(
+      buildUrl(`/status-page/${statusPageId}/subscribe/email`),
+      { timeout: 120000 },
+    );
+
+    const emailForm: Locator = page.locator("#email-form").first();
+    await expect(emailForm).toBeVisible({ timeout: 120000 });
+    await expect(emailForm.locator('input[type="email"]')).toBeVisible();
+
+    const dashboardLoginCookieAfter: Cookie | undefined = (
+      await page.context().cookies()
+    ).find((cookie: Cookie) => {
+      return cookie.name === CookieName.Token;
+    });
+    expect(
+      dashboardLoginCookieAfter?.value,
+      "opening Subscribe must not clear the dashboard login cookie",
+    ).toBeTruthy();
+
+    const browserStateAfterSubscribe: {
+      dashboardUserEmail: string | null;
+      statusPageId: string | null;
+    } = await page.evaluate(() => {
+      return {
+        dashboardUserEmail: window.localStorage.getItem("user_email"),
+        statusPageId: window.localStorage.getItem("statusPageId"),
+      };
+    });
+
+    expect(
+      browserStateAfterSubscribe.dashboardUserEmail,
+      "opening Subscribe must not clear the dashboard login state",
+    ).toBe(dashboardUserEmailBefore);
+    expect(
+      browserStateAfterSubscribe.statusPageId,
+      "opening Subscribe must not clear or replace the status page ID",
+    ).toBe(storedStatusPageIdBeforeSubscribe);
   });
 
   test("should not expose a private status page to an anonymous visitor", async ({


### PR DESCRIPTION
### Title of this pull request?

Fix public Status Page Subscribe logout

### Small Description?

Public Status Page subscription screens were using the dashboard ModelAPI. On preview routes, the Status Page ID was consequently sent as the dashboard tenant ID; the resulting 405 was handled as a dashboard logout, which cleared `statusPageId`, redirected to `/accounts/login`, and left the page showing “Status Page ID is required.”

This change:

- routes Status Page model reads and writes through a page-scoped ModelAPI/client with `status-page-id` and a blank `tenantid`
- prevents public Status Page 401/405 responses from clearing an unrelated dashboard session, while retaining private-page login behavior
- ensures only `/dashboard/:projectId` routes can supply a dashboard project ID
- applies the scoped client to all subscriber/account forms and skips resource requests when resource selection is disabled

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review. (GitHub jobs start after this PR is opened.)
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

Closes #3051

### Verification

- `npm run fix`
- Common TypeScript compilation
- Status Page App TypeScript compilation
- Status Page production frontend build
- 4 focused Common Jest suites: 82 tests passed
- Status Page wiring Jest suite: 22 tests passed
- E2E TypeScript compilation and Playwright test discovery
- Targeted Chromium E2E against the local Docker Compose stack: passed in 36.7s
- 34 new regression cases in total, including the authenticated Subscribe browser flow

### Screenshots (if appropriate):

Not applicable; this fixes request/session behavior without changing the UI.