### PR TITLE
perf(status-page): window the Resources tab so a 1500 group status page loads

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/StatusPage/GridResourceEditor.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/StatusPage/GridResourceEditor.tsx
@@ -45,6 +45,19 @@ export interface ComponentProps {
   canCreateStatusPageResource: boolean;
   baseFormFields: Array<ModelField<StatusPageResource>>;
   formSteps: Array<{ title: string; id: string }>;
+  /*
+   * The group's ancestors and its own name - "Corporate › Region 1000". Groups
+   * nest and two of them at different levels very often share a name, so the
+   * Resources tab titles every section with its path. Falls back to the
+   * group's own name.
+   */
+  groupPathLabel?: string | undefined;
+  /*
+   * Set by a caller that can close this editor back down to a header, which is
+   * what keeps a status page with a thousand groups from mounting a thousand
+   * editors. Omitted, no collapse control is shown.
+   */
+  onCollapse?: (() => void) | undefined;
 }
 
 type ParseAxisValuesFunction = (raw?: string | null) => Array<string>;
@@ -292,41 +305,53 @@ const GridResourceEditor: FunctionComponent<ComponentProps> = (
     setIsDeleting(false);
   };
 
-  const cardTitle: string = `${group.name || ""} - Status Page Resources`;
+  const cardTitle: string = `${
+    props.groupPathLabel || group.name || ""
+  } - Status Page Resources`;
   const cardDescription: string = isGrid
     ? "Click a cell to add a monitor at that row × column intersection."
     : "Resources that will be shown on the page";
 
   const hasGridAxes: boolean = rowValues.length > 0 && columnValues.length > 0;
-  const cardButtons: Array<CardButtonSchema | ReactElement> =
-    props.canCreateStatusPageResource && hasGridAxes
-      ? [
-          {
-            title: "Create Status Page Resource",
-            icon: IconProp.Add,
-            buttonStyle: ButtonStyleType.NORMAL,
-            onClick: () => {
-              openCreateForCell(null, null);
-            },
-          },
-          <MoreMenu
-            key="status-page-grid-resource-more-menu"
-            menuIcon={IconProp.EllipsisHorizontal}
-            text=""
-          >
-            {[
-              <MoreMenuItem
-                key="add-multiple-monitors"
-                text="Add Multiple Monitors"
-                icon={IconProp.Add}
-                onClick={() => {
-                  setShowBulkAddModal(true);
-                }}
-              />,
-            ]}
-          </MoreMenu>,
-        ]
-      : [];
+  const cardButtons: Array<CardButtonSchema | ReactElement> = [];
+
+  if (props.canCreateStatusPageResource && hasGridAxes) {
+    cardButtons.push(
+      {
+        title: "Create Status Page Resource",
+        icon: IconProp.Add,
+        buttonStyle: ButtonStyleType.NORMAL,
+        onClick: () => {
+          openCreateForCell(null, null);
+        },
+      },
+      <MoreMenu
+        key="status-page-grid-resource-more-menu"
+        menuIcon={IconProp.EllipsisHorizontal}
+        text=""
+      >
+        {[
+          <MoreMenuItem
+            key="add-multiple-monitors"
+            text="Add Multiple Monitors"
+            icon={IconProp.Add}
+            onClick={() => {
+              setShowBulkAddModal(true);
+            }}
+          />,
+        ]}
+      </MoreMenu>,
+    );
+  }
+
+  if (props.onCollapse) {
+    cardButtons.push({
+      title: "Hide",
+      icon: IconProp.ChevronUp,
+      buttonStyle: ButtonStyleType.OUTLINE,
+      onClick: props.onCollapse,
+    });
+  }
 
   if (rowValues.length === 0 || columnValues.length === 0) {
     return (

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
@@ -11,7 +11,7 @@ import FieldType from "Common/UI/Components/Types/FieldType";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
-import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import { toStatusPageGroupDropdownOptions } from "../../../Utils/StatusPageGroupDropdown";
 import React, {
   Fragment,
   FunctionComponent,
@@ -46,8 +46,9 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
   /*
    * Groups nest, so the parent picker has to show where each candidate sits in
    * the tree - two groups can easily be called "Region 1000" at different
-   * levels. Options are labelled with their full path and fetched every time
-   * the form opens, so a group added a moment ago is immediately selectable.
+   * levels. Options are labelled with their full path, in the order the status
+   * page renders them, and fetched every time the form opens so a group added a
+   * moment ago is immediately selectable.
    *
    * Whether the chosen parent is actually legal (not the group itself, not one
    * of its own sub groups, not past the nesting limit) is decided by
@@ -78,22 +79,8 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
         requestOptions: {},
       });
 
-    const allGroups: Array<StatusPageGroup> = listResult.data;
-
-    return allGroups.map((group: StatusPageGroup) => {
-      const path: Array<string> = StatusPageGroupTreeUtil.getAncestorGroups({
-        statusPageGroup: group,
-        statusPageGroups: allGroups,
-      })
-        .reverse()
-        .map((ancestor: StatusPageGroup) => {
-          return ancestor.name || "";
-        });
-
-      return {
-        value: group._id?.toString() || "",
-        label: [...path, group.name || ""].join(" › "),
-      };
+    return toStatusPageGroupDropdownOptions({
+      statusPageGroups: listResult.data,
     });
   };
 

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/MonitorRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/MonitorRules.tsx
@@ -19,7 +19,7 @@ import ProjectUtil from "Common/UI/Utils/Project";
 import Label from "Common/Models/DatabaseModels/Label";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
 import StatusPageMonitorRule from "Common/Models/DatabaseModels/StatusPageMonitorRule";
-import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import { toStatusPageGroupDropdownOptions } from "../../../Utils/StatusPageGroupDropdown";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
 
 const monitorRuleDocumentation: string = `
@@ -85,22 +85,8 @@ const StatusPageMonitorRulesPage: FunctionComponent<PageComponentProps> = (
         requestOptions: {},
       });
 
-    const allGroups: Array<StatusPageGroup> = listResult.data;
-
-    return allGroups.map((group: StatusPageGroup) => {
-      const path: Array<string> = StatusPageGroupTreeUtil.getAncestorGroups({
-        statusPageGroup: group,
-        statusPageGroups: allGroups,
-      })
-        .reverse()
-        .map((ancestor: StatusPageGroup) => {
-          return ancestor.name || "";
-        });
-
-      return {
-        value: group._id?.toString() || "",
-        label: [...path, group.name || ""].join(" › "),
-      };
+    return toStatusPageGroupDropdownOptions({
+      statusPageGroups: listResult.data,
     });
   };
 

--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
@@ -4,20 +4,27 @@ import BulkAddStatusPageMonitorsModal from "../../../Components/StatusPage/BulkA
 import GridResourceEditor from "../../../Components/StatusPage/GridResourceEditor";
 import { getStatusPageResourceAdvancedFields } from "../../../Components/StatusPage/StatusPageResourceFormFields";
 import PageComponentProps from "../../PageComponentProps";
-import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import ObjectID from "Common/Types/ObjectID";
 import Permission from "Common/Types/Permission";
+import { CardButtonSchema } from "Common/UI/Components/Card/Card";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import { ModelField } from "Common/UI/Components/Forms/ModelForm";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Input from "Common/UI/Components/Input/Input";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import Columns from "Common/UI/Components/ModelTable/Column";
 import Filter from "Common/UI/Components/ModelFilter/Filter";
+import Pagination from "Common/UI/Components/Pagination/Pagination";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import { GetReactElementFunction } from "Common/UI/Types/FunctionTypes";
 import API from "Common/UI/Utils/API/API";
@@ -28,15 +35,23 @@ import User from "Common/UI/Utils/User";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorGroup from "Common/Models/DatabaseModels/MonitorGroup";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
-import StatusPageGroupTreeUtil, {
-  StatusPageGroupTreeNode,
-} from "Common/Utils/StatusPage/GroupTree";
 import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
+import {
+  STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+  StatusPageGroupSection,
+  StatusPageGroupSectionPage,
+  buildStatusPageGroupSections,
+  filterStatusPageGroupSections,
+  getStatusPageGroupSectionPage,
+  isStatusPageGroupSectionExpanded,
+  shouldExpandStatusPageGroupSectionsByDefault,
+} from "../../../Utils/StatusPageGroupSections";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
@@ -63,6 +78,20 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
     null,
   );
   const [bulkAddRefreshCounter, setBulkAddRefreshCounter] = useState<number>(0);
+
+  /*
+   * Which slice of the groups is on screen, and which of those sections the
+   * user has opened or closed by hand. Everything about why the page is
+   * windowed at all is in Utils/StatusPageGroupSections - the short version is
+   * that each open section is a resource table, and each resource table is two
+   * requests, so a status page with a thousand groups cannot render them all.
+   */
+  const [groupSearchText, setGroupSearchText] = useState<string>("");
+  const [groupSectionPageNumber, setGroupSectionPageNumber] =
+    useState<number>(1);
+  const [expandedGroupIdOverrides, setExpandedGroupIdOverrides] = useState<
+    Record<string, boolean>
+  >({});
 
   const permissions: Array<Permission> | null =
     PermissionUtil.getAllPermissions();
@@ -222,64 +251,100 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
     ...getStatusPageResourceAdvancedFields(),
   ]);
 
-  type GetModelTableFunction = (
-    statusPageGroup: StatusPageGroup | null,
-  ) => ReactElement;
-
   /*
-   * Groups can be nested, and two groups at different levels can share a name.
-   * Show the full path so it is obvious which "Region 1000" a table belongs to.
+   * Every group, in the order the status page renders them (a parent directly
+   * above the groups nested under it) and labelled with its full path, because
+   * two groups at different levels can easily share a name. One tree walk does
+   * both for all of them.
    */
-  /*
-   * A parent's table should sit directly above the tables of the groups nested
-   * under it, the same order the public status page renders them in - a flat
-   * sort by `order` would scatter children away from their parent.
-   */
-  type GetGroupsInTreeOrderFunction = () => Array<StatusPageGroup>;
+  const allGroupSections: Array<StatusPageGroupSection> = useMemo(() => {
+    return buildStatusPageGroupSections({ statusPageGroups: groups });
+  }, [groups]);
 
-  const getGroupsInTreeOrder: GetGroupsInTreeOrderFunction =
-    (): Array<StatusPageGroup> => {
-      const flattened: Array<StatusPageGroup> = [];
+  const isGroupSectionExpandedByDefault: boolean =
+    shouldExpandStatusPageGroupSectionsByDefault({
+      totalSectionCount: allGroupSections.length,
+      pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+    });
 
-      const visit: (nodes: Array<StatusPageGroupTreeNode>) => void = (
-        nodes: Array<StatusPageGroupTreeNode>,
-      ): void => {
-        for (const node of nodes) {
-          flattened.push(node.group);
-          visit(node.children);
-        }
-      };
+  const matchingGroupSections: Array<StatusPageGroupSection> = useMemo(() => {
+    return filterStatusPageGroupSections({
+      sections: allGroupSections,
+      searchText: groupSearchText,
+    });
+  }, [allGroupSections, groupSearchText]);
 
-      visit(StatusPageGroupTreeUtil.buildTree({ statusPageGroups: groups }));
+  const groupSectionPage: StatusPageGroupSectionPage =
+    getStatusPageGroupSectionPage({
+      sections: matchingGroupSections,
+      pageNumber: groupSectionPageNumber,
+      pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+    });
 
-      return flattened;
-    };
+  type SetGroupSectionExpandedFunction = (
+    groupId: string,
+    isExpanded: boolean,
+  ) => void;
 
-  type GetGroupPathFunction = (statusPageGroup: StatusPageGroup) => string;
-
-  const getGroupPath: GetGroupPathFunction = (
-    statusPageGroup: StatusPageGroup,
-  ): string => {
-    const ancestorNames: Array<string> =
-      StatusPageGroupTreeUtil.getAncestorGroups({
-        statusPageGroup: statusPageGroup,
-        statusPageGroups: groups,
-      })
-        .reverse()
-        .map((ancestor: StatusPageGroup) => {
-          return ancestor.name || "";
-        });
-
-    return [...ancestorNames, statusPageGroup.name || ""].join(" › ");
+  const setGroupSectionExpanded: SetGroupSectionExpandedFunction = (
+    groupId: string,
+    isExpanded: boolean,
+  ): void => {
+    setExpandedGroupIdOverrides((overrides: Record<string, boolean>) => {
+      return { ...overrides, [groupId]: isExpanded };
+    });
   };
 
+  type GetResourceTableCardButtonsFunction = (
+    section: StatusPageGroupSection | null,
+  ) => Array<CardButtonSchema>;
+
+  const getResourceTableCardButtons: GetResourceTableCardButtonsFunction = (
+    section: StatusPageGroupSection | null,
+  ): Array<CardButtonSchema> => {
+    const buttons: Array<CardButtonSchema> = [];
+
+    if (canCreateStatusPageResource) {
+      buttons.push({
+        title: "Add Multiple Monitors",
+        buttonStyle: ButtonStyleType.OUTLINE,
+        icon: IconProp.Add,
+        onClick: () => {
+          setBulkAddTarget({
+            statusPageGroupId: section?.group.id || null,
+          });
+        },
+      });
+    }
+
+    /*
+     * Only group sections collapse. The ungrouped table is the one table this
+     * page always shows, and there is nothing above it to collapse into.
+     */
+    if (section) {
+      buttons.push({
+        title: "Hide",
+        buttonStyle: ButtonStyleType.OUTLINE,
+        icon: IconProp.ChevronUp,
+        onClick: () => {
+          setGroupSectionExpanded(section.groupId, false);
+        },
+      });
+    }
+
+    return buttons;
+  };
+
+  type GetModelTableFunction = (
+    section: StatusPageGroupSection | null,
+  ) => ReactElement;
+
   const getModelTable: GetModelTableFunction = (
-    statusPageGroup: StatusPageGroup | null,
+    section: StatusPageGroupSection | null,
   ): ReactElement => {
+    const statusPageGroup: StatusPageGroup | null = section?.group || null;
     const statusPageGroupId: ObjectID | null = statusPageGroup?.id || null;
-    const statusPageGroupName: string | null = statusPageGroup
-      ? getGroupPath(statusPageGroup)
-      : null;
+    const statusPageGroupName: string | null = section?.pathLabel || null;
 
     const tableColumns: Array<Columns<StatusPageResource>> = [
       {
@@ -406,18 +471,7 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
                 : ""
           }Status Page Resources`,
           description: "Resources that will be shown on the page",
-          buttons: canCreateStatusPageResource
-            ? [
-                {
-                  title: "Add Multiple Monitors",
-                  buttonStyle: ButtonStyleType.OUTLINE,
-                  icon: IconProp.Add,
-                  onClick: () => {
-                    setBulkAddTarget({ statusPageGroupId });
-                  },
-                },
-              ]
-            : [],
+          buttons: getResourceTableCardButtons(section),
         }}
         noItemsMessage={
           "No status page resources created for this status page."
@@ -449,6 +503,155 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
     );
   };
 
+  type GetGroupSectionFunction = (
+    section: StatusPageGroupSection,
+  ) => ReactElement;
+
+  /*
+   * A closed section. This is the whole point of the windowing: it renders a
+   * header and nothing else, so the group's resource table - and the list and
+   * count requests that table fires the instant it mounts - does not exist
+   * until someone asks for it.
+   */
+  const getCollapsedGroupSection: GetGroupSectionFunction = (
+    section: StatusPageGroupSection,
+  ): ReactElement => {
+    const expand: () => void = (): void => {
+      setGroupSectionExpanded(section.groupId, true);
+    };
+
+    /*
+     * The whole row is clickable for convenience, but the button inside it is
+     * the real control - it is what a keyboard reaches and what a screen
+     * reader announces, so the row itself stays a plain div rather than
+     * nesting one control inside another.
+     */
+    return (
+      <div
+        className="mb-5 bg-white border border-gray-200 rounded-xl shadow-sm px-5 md:px-6 py-4 flex items-center justify-between cursor-pointer hover:bg-gray-50"
+        onClick={expand}
+      >
+        <div className="flex items-center min-w-0">
+          <Icon
+            icon={IconProp.ChevronRight}
+            className="w-4 h-4 text-gray-500 mr-3 flex-shrink-0"
+          />
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold leading-6 text-gray-900 truncate">
+              {section.pathLabel}
+            </h2>
+            <p className="mt-1 text-sm text-gray-500 hidden md:block">
+              Resources that will be shown on the page
+            </p>
+          </div>
+        </div>
+        <div className="ml-4 flex-shrink-0">
+          <Button
+            title="Show Resources"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            buttonSize={ButtonSize.Small}
+            icon={IconProp.ChevronDown}
+            onClick={expand}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  const getGroupSection: GetGroupSectionFunction = (
+    section: StatusPageGroupSection,
+  ): ReactElement => {
+    const isExpanded: boolean = isStatusPageGroupSectionExpanded({
+      groupId: section.groupId,
+      expandedOverrides: expandedGroupIdOverrides,
+      isExpandedByDefault: isGroupSectionExpandedByDefault,
+    });
+
+    if (!isExpanded) {
+      return getCollapsedGroupSection(section);
+    }
+
+    if (section.group.viewMode === StatusPageGroupViewMode.Grid) {
+      return (
+        <GridResourceEditor
+          group={section.group}
+          groupPathLabel={section.pathLabel}
+          statusPageId={modelId}
+          projectId={new ObjectID(props.currentProject!._id!)}
+          currentProject={props.currentProject!}
+          canCreateStatusPageResource={canCreateStatusPageResource}
+          baseFormFields={formFields}
+          formSteps={[
+            { title: "Monitor Details", id: "monitor-details" },
+            { title: "Advanced", id: "advanced" },
+          ]}
+          onCollapse={() => {
+            setGroupSectionExpanded(section.groupId, false);
+          }}
+        />
+      );
+    }
+
+    return getModelTable(section);
+  };
+
+  /*
+   * Only shown once the groups outgrow a single page. Below that the tab looks
+   * exactly like it always has: every group open, no controls above them.
+   */
+  const getGroupSectionToolbar: GetReactElementFunction = (): ReactElement => {
+    if (allGroupSections.length <= STATUS_PAGE_GROUP_SECTIONS_PER_PAGE) {
+      return <></>;
+    }
+
+    return (
+      <div className="mb-5">
+        <Input
+          value={groupSearchText}
+          placeholder="Search groups by name or path..."
+          dataTestId="status-page-group-section-search"
+          onChange={(value: string) => {
+            setGroupSearchText(value);
+            setGroupSectionPageNumber(1);
+          }}
+        />
+        <p className="mt-2 text-sm text-gray-500">
+          {`This status page has ${allGroupSections.length.toLocaleString()} groups${
+            groupSearchText.trim()
+              ? `, ${matchingGroupSections.length.toLocaleString()} matching your search`
+              : ""
+          }. Open a group to load its resources.`}
+        </p>
+      </div>
+    );
+  };
+
+  const getGroupSectionPagination: GetReactElementFunction =
+    (): ReactElement => {
+      if (groupSectionPage.totalPageCount <= 1) {
+        return <></>;
+      }
+
+      return (
+        <div className="mb-5 bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+          <Pagination
+            currentPageNumber={groupSectionPage.pageNumber}
+            totalItemsCount={groupSectionPage.totalSectionCount}
+            itemsOnPage={groupSectionPage.pageSize}
+            itemsOnCurrentPage={groupSectionPage.sections.length}
+            isLoading={false}
+            isError={false}
+            singularLabel="group"
+            pluralLabel="groups"
+            dataTestId="status-page-group-section-pagination"
+            onNavigateToPage={(pageNumber: number) => {
+              setGroupSectionPageNumber(pageNumber);
+            }}
+          />
+        </div>
+      );
+    };
+
   return (
     <Fragment>
       <>
@@ -458,27 +661,30 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
 
         {!isLoading && !error ? getModelTable(null) : <></>}
 
-        {!isLoading && !error && groups && groups.length > 0 ? (
-          getGroupsInTreeOrder().map((group: StatusPageGroup) => {
-            if (group.viewMode === StatusPageGroupViewMode.Grid) {
-              return (
-                <GridResourceEditor
-                  key={group.id?.toString() || ""}
-                  group={group}
-                  statusPageId={modelId}
-                  projectId={new ObjectID(props.currentProject!._id!)}
-                  currentProject={props.currentProject!}
-                  canCreateStatusPageResource={canCreateStatusPageResource}
-                  baseFormFields={formFields}
-                  formSteps={[
-                    { title: "Monitor Details", id: "monitor-details" },
-                    { title: "Advanced", id: "advanced" },
-                  ]}
-                />
-              );
-            }
-            return getModelTable(group);
-          })
+        {!isLoading && !error && allGroupSections.length > 0 ? (
+          <>
+            {getGroupSectionToolbar()}
+
+            {groupSectionPage.sections.map(
+              (section: StatusPageGroupSection) => {
+                return (
+                  <Fragment key={section.groupId}>
+                    {getGroupSection(section)}
+                  </Fragment>
+                );
+              },
+            )}
+
+            {groupSectionPage.sections.length === 0 ? (
+              <div className="mb-5 bg-white border border-gray-200 rounded-xl shadow-sm px-5 md:px-6 py-6 text-sm text-gray-500">
+                No groups match your search.
+              </div>
+            ) : (
+              <></>
+            )}
+
+            {getGroupSectionPagination()}
+          </>
         ) : (
           <></>
         )}

--- a/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupDropdown.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupDropdown.ts
@@ -1,0 +1,51 @@
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil, {
+  StatusPageGroupIndex,
+  StatusPageGroupIndexNode,
+} from "Common/Utils/StatusPage/GroupTree";
+
+/*
+ * Group pickers - "Parent Group" on Status Page > Groups, "Add to Group" on
+ * Status Page > Monitor Rules - list every group on the status page, and a
+ * group's own name is not enough to pick by: two groups at different levels
+ * are very often both called "Region 1000". Each option is labelled with its
+ * full path instead.
+ *
+ * Building those labels one group at a time rederives the whole tree per
+ * option, so a status page with a thousand groups walks a thousand groups a
+ * thousand times just to fill a dropdown. One shared index, built once, is the
+ * whole point of this module.
+ *
+ * React-free on purpose (same reason as StatusPageGroupCsv), so the shape below
+ * is declared here rather than imported from the Dropdown component. It is the
+ * subset of DropdownOption these pickers use.
+ */
+export interface StatusPageGroupDropdownOption {
+  value: string;
+  label: string;
+}
+
+export type ToStatusPageGroupDropdownOptionsFunction = (data: {
+  statusPageGroups: Array<StatusPageGroup>;
+}) => Array<StatusPageGroupDropdownOption>;
+
+/*
+ * Options in the order the status page renders the groups in - a parent
+ * immediately above the groups nested under it - so scrolling the list walks
+ * the tree instead of jumping around it.
+ */
+export const toStatusPageGroupDropdownOptions: ToStatusPageGroupDropdownOptionsFunction =
+  (data: {
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroupDropdownOption> => {
+    const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+      statusPageGroups: data.statusPageGroups,
+    });
+
+    return index.getNodesInTreeOrder().map((node: StatusPageGroupIndexNode) => {
+      return {
+        value: StatusPageGroupTreeUtil.getGroupId(node.group),
+        label: index.getGroupPathLabel(node.group),
+      };
+    });
+  };

--- a/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupSections.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/StatusPageGroupSections.ts
@@ -1,0 +1,222 @@
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil, {
+  StatusPageGroupIndex,
+  StatusPageGroupIndexNode,
+} from "Common/Utils/StatusPage/GroupTree";
+
+/*
+ * Status Page > Resources renders one resource table per group, and each of
+ * those tables asks the API for its own rows and its own count the moment it
+ * mounts. That is fine for the handful of groups most status pages have and
+ * fatal for a page with a thousand of them: mounting every table at once is
+ * thousands of requests and a DOM nothing can hold, which is the "Network
+ * Error / high memory usage" crash on a large status page.
+ *
+ * So the page renders a *window* of groups instead of all of them. This module
+ * owns the pure part of that: turning a flat list of groups into ordered,
+ * labelled sections, narrowing them by a search box, and cutting the result
+ * into pages. Nothing here mounts anything - it decides which groups the page
+ * is allowed to mount.
+ *
+ * React-free on purpose (same reason as StatusPageGroupCsv): it must stay
+ * importable from the node-env jest suite in App/Tests/Dashboard.
+ */
+
+/*
+ * How many group sections a single page of the Resources tab may show.
+ *
+ * This is the ceiling on tables mounted at once, so it is also the ceiling on
+ * requests fired on mount - at two per table, ten sections is twenty. Raising
+ * it raises both.
+ */
+export const STATUS_PAGE_GROUP_SECTIONS_PER_PAGE: number = 10;
+
+export interface StatusPageGroupSection {
+  group: StatusPageGroup;
+  groupId: string;
+  /*
+   * The group's ancestors and its own name - "Corporate › Region 1000". Two
+   * groups at different levels are very often both called "Region 1000", so
+   * the path, not the name, is what tells one section from another.
+   */
+  pathLabel: string;
+  // 0 for a top level group, 1 for its children, and so on.
+  depth: number;
+}
+
+export interface StatusPageGroupSectionPage {
+  sections: Array<StatusPageGroupSection>;
+  // 1 based, and always within [1, totalPageCount].
+  pageNumber: number;
+  pageSize: number;
+  // Sections this page was cut from, i.e. after any search was applied.
+  totalSectionCount: number;
+  // At least 1, so an empty result still has a page to sit on.
+  totalPageCount: number;
+}
+
+export type BuildStatusPageGroupSectionsFunction = (data: {
+  statusPageGroups: Array<StatusPageGroup>;
+}) => Array<StatusPageGroupSection>;
+
+/*
+ * Every group, in the order the status page renders them: a parent immediately
+ * above the groups nested under it, siblings in `order`. A flat sort by `order`
+ * would scatter children away from their parent.
+ *
+ * One tree walk labels all of them. Deriving each label on its own would mean
+ * rebuilding the whole tree once per group, which is the quadratic that made
+ * this page unusable well before the tables did.
+ */
+export const buildStatusPageGroupSections: BuildStatusPageGroupSectionsFunction =
+  (data: {
+    statusPageGroups: Array<StatusPageGroup>;
+  }): Array<StatusPageGroupSection> => {
+    const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+      statusPageGroups: data.statusPageGroups,
+    });
+
+    return index.getNodesInTreeOrder().map((node: StatusPageGroupIndexNode) => {
+      return {
+        group: node.group,
+        groupId: StatusPageGroupTreeUtil.getGroupId(node.group),
+        pathLabel: index.getGroupPathLabel(node.group),
+        depth: node.depth,
+      };
+    });
+  };
+
+export type FilterStatusPageGroupSectionsFunction = (data: {
+  sections: Array<StatusPageGroupSection>;
+  searchText: string;
+}) => Array<StatusPageGroupSection>;
+
+/*
+ * Narrow the sections to the ones a search matches.
+ *
+ * Matching runs against the whole path rather than the group's own name, and
+ * every whitespace separated term has to appear somewhere in it. That is what
+ * makes a path searchable at all: "corporate market" finds
+ * "Corporate › Region 1000 › Market 1001", which a plain substring match on
+ * the joined path never would, and searching for a parent's name brings back
+ * its whole subtree.
+ */
+export const filterStatusPageGroupSections: FilterStatusPageGroupSectionsFunction =
+  (data: {
+    sections: Array<StatusPageGroupSection>;
+    searchText: string;
+  }): Array<StatusPageGroupSection> => {
+    const searchTerms: Array<string> = (data.searchText || "")
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((term: string) => {
+        return term.length > 0;
+      });
+
+    if (searchTerms.length === 0) {
+      return data.sections;
+    }
+
+    return data.sections.filter((section: StatusPageGroupSection) => {
+      const pathLabel: string = section.pathLabel.toLowerCase();
+
+      return searchTerms.every((term: string) => {
+        return pathLabel.includes(term);
+      });
+    });
+  };
+
+export type GetStatusPageGroupSectionPageFunction = (data: {
+  sections: Array<StatusPageGroupSection>;
+  pageNumber: number;
+  pageSize: number;
+}) => StatusPageGroupSectionPage;
+
+/*
+ * One page worth of sections.
+ *
+ * The page number is clamped rather than trusted: the caller's page number
+ * survives a search that shrinks the list under it, and clamping is what keeps
+ * that from rendering an empty page the user cannot navigate out of.
+ */
+export const getStatusPageGroupSectionPage: GetStatusPageGroupSectionPageFunction =
+  (data: {
+    sections: Array<StatusPageGroupSection>;
+    pageNumber: number;
+    pageSize: number;
+  }): StatusPageGroupSectionPage => {
+    const pageSize: number = Math.max(1, Math.floor(data.pageSize || 0));
+    const totalSectionCount: number = data.sections.length;
+    const totalPageCount: number = Math.max(
+      1,
+      Math.ceil(totalSectionCount / pageSize),
+    );
+
+    const requestedPageNumber: number = Math.floor(data.pageNumber || 1);
+    const pageNumber: number = Math.min(
+      Math.max(1, requestedPageNumber),
+      totalPageCount,
+    );
+
+    const startIndex: number = (pageNumber - 1) * pageSize;
+
+    return {
+      sections: data.sections.slice(startIndex, startIndex + pageSize),
+      pageNumber: pageNumber,
+      pageSize: pageSize,
+      totalSectionCount: totalSectionCount,
+      totalPageCount: totalPageCount,
+    };
+  };
+
+export type ShouldExpandStatusPageGroupSectionsByDefaultFunction = (data: {
+  totalSectionCount: number;
+  pageSize: number;
+}) => boolean;
+
+/*
+ * Whether sections start open.
+ *
+ * They do when every group on the status page fits on a single page, which is
+ * the case for almost every status page and is exactly how the tab behaved
+ * before it was windowed - nothing about a five group page changes. Past that
+ * the sections start closed and mount their table on the first expand, so a
+ * page of a thousand groups costs one request for the ungrouped table and
+ * nothing else until the user asks for a group.
+ *
+ * Deliberately measured against the whole status page rather than the current
+ * search: tables appearing and disappearing as someone types is a worse thing
+ * to be surprised by than one extra click.
+ */
+export const shouldExpandStatusPageGroupSectionsByDefault: ShouldExpandStatusPageGroupSectionsByDefaultFunction =
+  (data: { totalSectionCount: number; pageSize: number }): boolean => {
+    return (
+      data.totalSectionCount <= Math.max(1, Math.floor(data.pageSize || 0))
+    );
+  };
+
+export type IsStatusPageGroupSectionExpandedFunction = (data: {
+  groupId: string;
+  expandedOverrides: Record<string, boolean>;
+  isExpandedByDefault: boolean;
+}) => boolean;
+
+/*
+ * A section the user has not touched follows the default; once they open or
+ * close one it stays how they left it, including across searches and page
+ * changes.
+ */
+export const isStatusPageGroupSectionExpanded: IsStatusPageGroupSectionExpandedFunction =
+  (data: {
+    groupId: string;
+    expandedOverrides: Record<string, boolean>;
+    isExpandedByDefault: boolean;
+  }): boolean => {
+    const override: boolean | undefined = data.expandedOverrides[data.groupId];
+
+    if (override === undefined) {
+      return data.isExpandedByDefault;
+    }
+
+    return override;
+  };

--- a/App/Tests/Dashboard/StatusPageGroupDropdown.test.ts
+++ b/App/Tests/Dashboard/StatusPageGroupDropdown.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "@jest/globals";
+import ObjectID from "Common/Types/ObjectID";
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import {
+  StatusPageGroupDropdownOption,
+  toStatusPageGroupDropdownOptions,
+} from "../../FeatureSet/Dashboard/src/Utils/StatusPageGroupDropdown";
+
+/*
+ * Pins the group pickers - "Parent Group" on Status Page > Groups, "Add to
+ * Group" on Status Page > Monitor Rules.
+ *
+ * Both list every group on the status page, and a group's own name does not
+ * identify it: two groups at different levels are very often both called
+ * "Region 1000", and picking the wrong one silently nests a group (or files a
+ * monitor rule) somewhere the author never meant. So every option carries its
+ * full path, and the test that matters most is that two same-named groups come
+ * back distinguishable.
+ *
+ * The other half is cost. Deriving a path per option used to re-walk every
+ * group per option, so a status page with a thousand groups walked a thousand
+ * groups a thousand times to open a dropdown.
+ */
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const REGION_TWO: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const MARKET: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const UNIT: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+const MISSING: ObjectID = new ObjectID("99999999-9999-4999-8999-999999999999");
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  if (data.order !== undefined) {
+    group.order = data.order;
+  }
+
+  return group;
+}
+
+/*
+ * Corporate
+ *   Region 1000
+ *     Market 1001
+ *       Unit 0152
+ *   Region 2000
+ */
+function makeHierarchy(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+    makeGroup({
+      id: REGION_ONE,
+      name: "Region 1000",
+      parentId: CORPORATE,
+      order: 2,
+    }),
+    makeGroup({
+      id: MARKET,
+      name: "Market 1001",
+      parentId: REGION_ONE,
+      order: 3,
+    }),
+    makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET, order: 4 }),
+    makeGroup({
+      id: REGION_TWO,
+      name: "Region 2000",
+      parentId: CORPORATE,
+      order: 5,
+    }),
+  ];
+}
+
+type OptionLabelsFunction = (
+  options: Array<StatusPageGroupDropdownOption>,
+) => Array<string>;
+
+const optionLabels: OptionLabelsFunction = (
+  options: Array<StatusPageGroupDropdownOption>,
+): Array<string> => {
+  return options.map((option: StatusPageGroupDropdownOption) => {
+    return option.label;
+  });
+};
+
+describe("toStatusPageGroupDropdownOptions", () => {
+  test("labels every option with its full path", () => {
+    expect(
+      optionLabels(
+        toStatusPageGroupDropdownOptions({
+          statusPageGroups: makeHierarchy(),
+        }),
+      ),
+    ).toEqual([
+      "Corporate",
+      "Corporate › Region 1000",
+      "Corporate › Region 1000 › Market 1001",
+      "Corporate › Region 1000 › Market 1001 › Unit 0152",
+      "Corporate › Region 2000",
+    ]);
+  });
+
+  test("an option's value is the group id the form writes back", () => {
+    const options: Array<StatusPageGroupDropdownOption> =
+      toStatusPageGroupDropdownOptions({
+        statusPageGroups: makeHierarchy(),
+      });
+
+    expect(options[0]!.value).toBe(CORPORATE.toString());
+    expect(options[3]!.value).toBe(UNIT.toString());
+  });
+
+  /*
+   * The reason the path is there at all. Two groups called the same thing must
+   * not read the same in the list.
+   */
+  test("tells apart two groups that share a name", () => {
+    expect(
+      optionLabels(
+        toStatusPageGroupDropdownOptions({
+          statusPageGroups: [
+            makeGroup({ id: CORPORATE, name: "Region 1000", order: 1 }),
+            makeGroup({
+              id: REGION_ONE,
+              name: "Region 1000",
+              parentId: CORPORATE,
+              order: 2,
+            }),
+          ],
+        }),
+      ),
+    ).toEqual(["Region 1000", "Region 1000 › Region 1000"]);
+  });
+
+  test("lists a parent immediately above the groups nested under it", () => {
+    expect(
+      optionLabels(
+        toStatusPageGroupDropdownOptions({
+          statusPageGroups: [
+            makeGroup({
+              id: UNIT,
+              name: "Unit 0152",
+              parentId: MARKET,
+              order: 4,
+            }),
+            makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+            makeGroup({
+              id: MARKET,
+              name: "Market 1001",
+              parentId: REGION_ONE,
+              order: 3,
+            }),
+            makeGroup({
+              id: REGION_ONE,
+              name: "Region 1000",
+              parentId: CORPORATE,
+              order: 2,
+            }),
+          ],
+        }),
+      ),
+    ).toEqual([
+      "Corporate",
+      "Corporate › Region 1000",
+      "Corporate › Region 1000 › Market 1001",
+      "Corporate › Region 1000 › Market 1001 › Unit 0152",
+    ]);
+  });
+
+  test("a status page with no groups offers no options", () => {
+    expect(toStatusPageGroupDropdownOptions({ statusPageGroups: [] })).toEqual(
+      [],
+    );
+  });
+
+  /*
+   * A dropped option is a group the author cannot pick, so bad data must not
+   * lose one. Each option is still labelled with where it ends up rendering:
+   * of the Market/Unit cycle below, one of the two is promoted to the top
+   * level and the other hangs off it.
+   */
+  test("offers every group even when the data is malformed", () => {
+    const options: Array<StatusPageGroupDropdownOption> =
+      toStatusPageGroupDropdownOptions({
+        statusPageGroups: [
+          makeGroup({ id: CORPORATE, name: "Corporate", parentId: CORPORATE }),
+          makeGroup({ id: REGION_ONE, name: "Region 1000", parentId: MISSING }),
+          makeGroup({ id: MARKET, name: "Market 1001", parentId: UNIT }),
+          makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET }),
+        ],
+      });
+
+    expect(optionLabels(options).sort()).toEqual([
+      "Corporate",
+      "Market 1001",
+      "Market 1001 › Unit 0152",
+      "Region 1000",
+    ]);
+    expect(
+      options.map((option: StatusPageGroupDropdownOption) => {
+        return option.value;
+      }),
+    ).toEqual([
+      CORPORATE.toString(),
+      REGION_ONE.toString(),
+      MARKET.toString(),
+      UNIT.toString(),
+    ]);
+  });
+
+  test("an orphan is offered at the top level rather than hidden", () => {
+    expect(
+      optionLabels(
+        toStatusPageGroupDropdownOptions({
+          statusPageGroups: [
+            makeGroup({
+              id: REGION_ONE,
+              name: "Region 1000",
+              parentId: MISSING,
+            }),
+          ],
+        }),
+      ),
+    ).toEqual(["Region 1000"]);
+  });
+
+  test("builds a thousand options off a single walk of the tree", () => {
+    const groups: Array<StatusPageGroup> = [];
+
+    for (let index: number = 0; index < 1000; index++) {
+      const group: StatusPageGroup = new StatusPageGroup();
+      group._id = `group-${index}`;
+      group.name = `Group ${index}`;
+      group.order = index;
+
+      if (index % 10 !== 0) {
+        group.parentStatusPageGroupId = new ObjectID(`group-${index - 1}`);
+      }
+
+      groups.push(group);
+    }
+
+    const getParentId: typeof StatusPageGroupTreeUtil.getParentId =
+      StatusPageGroupTreeUtil.getParentId;
+
+    let parentPointerReads: number = 0;
+
+    StatusPageGroupTreeUtil.getParentId = (
+      statusPageGroup: StatusPageGroup,
+    ): string | null => {
+      parentPointerReads++;
+      return getParentId.call(StatusPageGroupTreeUtil, statusPageGroup);
+    };
+
+    try {
+      const options: Array<StatusPageGroupDropdownOption> =
+        toStatusPageGroupDropdownOptions({ statusPageGroups: groups });
+
+      expect(options).toHaveLength(1000);
+      expect(options[2]!.label).toBe("Group 0 › Group 1 › Group 2");
+      expect(parentPointerReads).toBeLessThanOrEqual(groups.length * 2);
+    } finally {
+      StatusPageGroupTreeUtil.getParentId = getParentId;
+    }
+  });
+});

--- a/App/Tests/Dashboard/StatusPageGroupSections.test.ts
+++ b/App/Tests/Dashboard/StatusPageGroupSections.test.ts
@@ -1,0 +1,812 @@
+import { describe, expect, test } from "@jest/globals";
+import ObjectID from "Common/Types/ObjectID";
+import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
+import StatusPageGroupTreeUtil from "Common/Utils/StatusPage/GroupTree";
+import {
+  STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+  StatusPageGroupSection,
+  StatusPageGroupSectionPage,
+  buildStatusPageGroupSections,
+  filterStatusPageGroupSections,
+  getStatusPageGroupSectionPage,
+  isStatusPageGroupSectionExpanded,
+  shouldExpandStatusPageGroupSectionsByDefault,
+} from "../../FeatureSet/Dashboard/src/Utils/StatusPageGroupSections";
+
+/*
+ * Pins the windowing behind Status Page > Resources.
+ *
+ * The tab renders a resource table per group, and every one of those tables
+ * fires a list and a count the moment it mounts. A status page with 1500
+ * groups therefore used to fire ~3000 requests and build a DOM to match, which
+ * is the "Network Error / high memory usage" crash it was reported as. So the
+ * page now decides, up front and without mounting anything, which groups it is
+ * allowed to render: this module is that decision.
+ *
+ * The two properties that matter most, and that a future change is most likely
+ * to quietly break:
+ *
+ *   - a page never hands back more sections than it is allowed to mount, no
+ *     matter what page number or search it is given, and
+ *   - a status page small enough to fit on one page behaves exactly as it did
+ *     before any of this existed - every group open, nothing to click.
+ */
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const REGION_TWO: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const MARKET: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const UNIT: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+const MISSING: ObjectID = new ObjectID("99999999-9999-4999-8999-999999999999");
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  if (data.order !== undefined) {
+    group.order = data.order;
+  }
+
+  return group;
+}
+
+/*
+ * Corporate
+ *   Region 1000
+ *     Market 1001
+ *       Unit 0152
+ *   Region 2000
+ */
+function makeHierarchy(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+    makeGroup({
+      id: REGION_ONE,
+      name: "Region 1000",
+      parentId: CORPORATE,
+      order: 2,
+    }),
+    makeGroup({
+      id: MARKET,
+      name: "Market 1001",
+      parentId: REGION_ONE,
+      order: 3,
+    }),
+    makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET, order: 4 }),
+    makeGroup({
+      id: REGION_TWO,
+      name: "Region 2000",
+      parentId: CORPORATE,
+      order: 5,
+    }),
+  ];
+}
+
+type MakeManyGroupsFunction = (count: number) => Array<StatusPageGroup>;
+
+const makeManyGroups: MakeManyGroupsFunction = (
+  count: number,
+): Array<StatusPageGroup> => {
+  const groups: Array<StatusPageGroup> = [];
+
+  for (let index: number = 0; index < count; index++) {
+    const group: StatusPageGroup = new StatusPageGroup();
+    group._id = `group-${index}`;
+    group.name = `Group ${index}`;
+    group.order = index;
+    groups.push(group);
+  }
+
+  return groups;
+};
+
+type LabelsFunction = (
+  sections: Array<StatusPageGroupSection>,
+) => Array<string>;
+
+const labels: LabelsFunction = (
+  sections: Array<StatusPageGroupSection>,
+): Array<string> => {
+  return sections.map((section: StatusPageGroupSection) => {
+    return section.pathLabel;
+  });
+};
+
+describe("buildStatusPageGroupSections", () => {
+  test("returns a section per group, in the order the status page renders them", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: makeHierarchy(),
+      });
+
+    expect(labels(sections)).toEqual([
+      "Corporate",
+      "Corporate › Region 1000",
+      "Corporate › Region 1000 › Market 1001",
+      "Corporate › Region 1000 › Market 1001 › Unit 0152",
+      "Corporate › Region 2000",
+    ]);
+  });
+
+  test("carries the group, its id and its depth", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: makeHierarchy(),
+      });
+
+    expect(sections[0]!.groupId).toBe(CORPORATE.toString());
+    expect(sections[0]!.group.name).toBe("Corporate");
+    expect(
+      sections.map((section: StatusPageGroupSection) => {
+        return section.depth;
+      }),
+    ).toEqual([0, 1, 2, 3, 1]);
+  });
+
+  test("sorts siblings by `order`, not by the order they were fetched in", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: [
+          makeGroup({
+            id: REGION_TWO,
+            name: "Region 2000",
+            parentId: CORPORATE,
+            order: 5,
+          }),
+          makeGroup({
+            id: REGION_ONE,
+            name: "Region 1000",
+            parentId: CORPORATE,
+            order: 2,
+          }),
+          makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+        ],
+      });
+
+    expect(labels(sections)).toEqual([
+      "Corporate",
+      "Corporate › Region 1000",
+      "Corporate › Region 2000",
+    ]);
+  });
+
+  test("a status page with no groups has no sections", () => {
+    expect(buildStatusPageGroupSections({ statusPageGroups: [] })).toEqual([]);
+  });
+
+  test("never drops a group, whatever shape the data is in", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: [
+          makeGroup({ id: CORPORATE, name: "Corporate", parentId: CORPORATE }),
+          makeGroup({ id: REGION_ONE, name: "Region 1000", parentId: MISSING }),
+          makeGroup({ id: MARKET, name: "Market 1001", parentId: UNIT }),
+          makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET }),
+        ],
+      });
+
+    expect(
+      sections
+        .map((section: StatusPageGroupSection) => {
+          return section.group.name;
+        })
+        .sort(),
+    ).toEqual(["Corporate", "Market 1001", "Region 1000", "Unit 0152"]);
+  });
+
+  test("labels the two groups that share a name differently", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: [
+          makeGroup({ id: CORPORATE, name: "Region 1000", order: 1 }),
+          makeGroup({
+            id: REGION_ONE,
+            name: "Region 1000",
+            parentId: CORPORATE,
+            order: 2,
+          }),
+        ],
+      });
+
+    expect(labels(sections)).toEqual([
+      "Region 1000",
+      "Region 1000 › Region 1000",
+    ]);
+  });
+
+  /*
+   * The quadratic that had to go: one label per group, each derived by
+   * re-walking every group, is 1500 walks of 1500 groups on a page this size.
+   */
+  test("labels 1500 groups off a single walk of the tree", () => {
+    const groups: Array<StatusPageGroup> = makeManyGroups(1500);
+    const getParentId: typeof StatusPageGroupTreeUtil.getParentId =
+      StatusPageGroupTreeUtil.getParentId;
+
+    let parentPointerReads: number = 0;
+
+    StatusPageGroupTreeUtil.getParentId = (
+      statusPageGroup: StatusPageGroup,
+    ): string | null => {
+      parentPointerReads++;
+      return getParentId.call(StatusPageGroupTreeUtil, statusPageGroup);
+    };
+
+    try {
+      const sections: Array<StatusPageGroupSection> =
+        buildStatusPageGroupSections({ statusPageGroups: groups });
+
+      expect(sections).toHaveLength(1500);
+      expect(parentPointerReads).toBeLessThanOrEqual(groups.length * 2);
+    } finally {
+      StatusPageGroupTreeUtil.getParentId = getParentId;
+    }
+  });
+});
+
+describe("filterStatusPageGroupSections", () => {
+  const sections: Array<StatusPageGroupSection> = buildStatusPageGroupSections({
+    statusPageGroups: makeHierarchy(),
+  });
+
+  test("an empty search keeps every section", () => {
+    expect(
+      filterStatusPageGroupSections({ sections: sections, searchText: "" }),
+    ).toBe(sections);
+  });
+
+  test("a search that is only whitespace keeps every section", () => {
+    expect(
+      filterStatusPageGroupSections({ sections: sections, searchText: "   " }),
+    ).toBe(sections);
+  });
+
+  test("matches on a group's own name", () => {
+    expect(
+      labels(
+        filterStatusPageGroupSections({
+          sections: sections,
+          searchText: "Unit 0152",
+        }),
+      ),
+    ).toEqual(["Corporate › Region 1000 › Market 1001 › Unit 0152"]);
+  });
+
+  test("ignores case", () => {
+    expect(
+      labels(
+        filterStatusPageGroupSections({
+          sections: sections,
+          searchText: "uNiT 0152",
+        }),
+      ),
+    ).toEqual(["Corporate › Region 1000 › Market 1001 › Unit 0152"]);
+  });
+
+  /*
+   * Searching a parent has to bring back what is under it - that is how you
+   * find a group on a page too big to page through.
+   */
+  test("a parent's name brings back its whole subtree", () => {
+    expect(
+      labels(
+        filterStatusPageGroupSections({
+          sections: sections,
+          searchText: "Region 1000",
+        }),
+      ),
+    ).toEqual([
+      "Corporate › Region 1000",
+      "Corporate › Region 1000 › Market 1001",
+      "Corporate › Region 1000 › Market 1001 › Unit 0152",
+    ]);
+  });
+
+  /*
+   * Terms are matched independently, which is the only way a path is
+   * searchable: nothing in "Corporate › Region 1000 › Market 1001" contains
+   * the substring "corporate market".
+   */
+  test("every term has to appear, but they need not be adjacent", () => {
+    expect(
+      labels(
+        filterStatusPageGroupSections({
+          sections: sections,
+          searchText: "corporate market",
+        }),
+      ),
+    ).toEqual([
+      "Corporate › Region 1000 › Market 1001",
+      "Corporate › Region 1000 › Market 1001 › Unit 0152",
+    ]);
+  });
+
+  test("a term that matches nothing drops everything", () => {
+    expect(
+      filterStatusPageGroupSections({
+        sections: sections,
+        searchText: "corporate nonsense",
+      }),
+    ).toEqual([]);
+  });
+
+  test("collapses runs of whitespace between terms", () => {
+    expect(
+      labels(
+        filterStatusPageGroupSections({
+          sections: sections,
+          searchText: "  corporate    market  ",
+        }),
+      ),
+    ).toEqual([
+      "Corporate › Region 1000 › Market 1001",
+      "Corporate › Region 1000 › Market 1001 › Unit 0152",
+    ]);
+  });
+
+  test("searching an empty list of sections is not an error", () => {
+    expect(
+      filterStatusPageGroupSections({ sections: [], searchText: "corporate" }),
+    ).toEqual([]);
+  });
+});
+
+describe("getStatusPageGroupSectionPage", () => {
+  test("cuts the sections into pages of the given size", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(25),
+      });
+
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: sections,
+      pageNumber: 2,
+      pageSize: 10,
+    });
+
+    expect(labels(page.sections)).toEqual([
+      "Group 10",
+      "Group 11",
+      "Group 12",
+      "Group 13",
+      "Group 14",
+      "Group 15",
+      "Group 16",
+      "Group 17",
+      "Group 18",
+      "Group 19",
+    ]);
+    expect(page.pageNumber).toBe(2);
+    expect(page.pageSize).toBe(10);
+    expect(page.totalSectionCount).toBe(25);
+    expect(page.totalPageCount).toBe(3);
+  });
+
+  test("the last page is short when the count does not divide evenly", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(25),
+      }),
+      pageNumber: 3,
+      pageSize: 10,
+    });
+
+    expect(labels(page.sections)).toEqual([
+      "Group 20",
+      "Group 21",
+      "Group 22",
+      "Group 23",
+      "Group 24",
+    ]);
+  });
+
+  test("a count that divides evenly does not add an empty trailing page", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(20),
+      }),
+      pageNumber: 1,
+      pageSize: 10,
+    });
+
+    expect(page.totalPageCount).toBe(2);
+  });
+
+  /*
+   * The page number outliving the list it indexes into is the everyday case:
+   * you are on page 40 and then you type into the search box.
+   */
+  test("clamps a page number past the end onto the last page", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(25),
+      }),
+      pageNumber: 400,
+      pageSize: 10,
+    });
+
+    expect(page.pageNumber).toBe(3);
+    expect(page.sections).toHaveLength(5);
+  });
+
+  test("clamps a page number below the first page", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(25),
+      }),
+      pageNumber: 0,
+      pageSize: 10,
+    });
+
+    expect(page.pageNumber).toBe(1);
+    expect(labels(page.sections)[0]).toBe("Group 0");
+  });
+
+  test("clamps a negative page number", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(25),
+      }),
+      pageNumber: -7,
+      pageSize: 10,
+    });
+
+    expect(page.pageNumber).toBe(1);
+  });
+
+  test("no sections still leaves a page to sit on", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: [],
+      pageNumber: 5,
+      pageSize: 10,
+    });
+
+    expect(page.sections).toEqual([]);
+    expect(page.pageNumber).toBe(1);
+    expect(page.totalPageCount).toBe(1);
+    expect(page.totalSectionCount).toBe(0);
+  });
+
+  test("a page size of zero does not divide by zero", () => {
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(3),
+      }),
+      pageNumber: 1,
+      pageSize: 0,
+    });
+
+    expect(page.pageSize).toBe(1);
+    expect(page.sections).toHaveLength(1);
+    expect(page.totalPageCount).toBe(3);
+  });
+
+  test("every section is reachable by paging, exactly once", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(53),
+      });
+
+    const seen: Array<string> = [];
+    const totalPageCount: number = getStatusPageGroupSectionPage({
+      sections: sections,
+      pageNumber: 1,
+      pageSize: 10,
+    }).totalPageCount;
+
+    for (
+      let pageNumber: number = 1;
+      pageNumber <= totalPageCount;
+      pageNumber++
+    ) {
+      seen.push(
+        ...labels(
+          getStatusPageGroupSectionPage({
+            sections: sections,
+            pageNumber: pageNumber,
+            pageSize: 10,
+          }).sections,
+        ),
+      );
+    }
+
+    expect(seen).toEqual(labels(sections));
+  });
+
+  /*
+   * The ceiling that stops the crash. Whatever it is asked for, a page can
+   * never hand the tab more tables than it is allowed to mount.
+   */
+  test("a 1500 group status page still yields one page of sections", () => {
+    const sections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: makeManyGroups(1500),
+      });
+
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: sections,
+      pageNumber: 1,
+      pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+    });
+
+    expect(page.sections).toHaveLength(STATUS_PAGE_GROUP_SECTIONS_PER_PAGE);
+    expect(page.totalSectionCount).toBe(1500);
+    expect(page.totalPageCount).toBe(
+      1500 / STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+    );
+  });
+});
+
+describe("shouldExpandStatusPageGroupSectionsByDefault", () => {
+  test("a status page that fits on one page opens every section, as it always did", () => {
+    expect(
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: 5,
+        pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+      }),
+    ).toBe(true);
+  });
+
+  test("exactly one full page still opens", () => {
+    expect(
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+        pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+      }),
+    ).toBe(true);
+  });
+
+  test("one group past a page and the sections start closed", () => {
+    expect(
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE + 1,
+        pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+      }),
+    ).toBe(false);
+  });
+
+  test("the status page this was written for starts closed", () => {
+    expect(
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: 1500,
+        pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+      }),
+    ).toBe(false);
+  });
+
+  test("a status page with no groups is not a special case", () => {
+    expect(
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: 0,
+        pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+      }),
+    ).toBe(true);
+  });
+
+  test("a page size of zero does not open a thousand tables", () => {
+    expect(
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: 1500,
+        pageSize: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isStatusPageGroupSectionExpanded", () => {
+  test("a section nobody has touched follows the default", () => {
+    expect(
+      isStatusPageGroupSectionExpanded({
+        groupId: "group-1",
+        expandedOverrides: {},
+        isExpandedByDefault: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      isStatusPageGroupSectionExpanded({
+        groupId: "group-1",
+        expandedOverrides: {},
+        isExpandedByDefault: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("opening a section beats a default of closed", () => {
+    expect(
+      isStatusPageGroupSectionExpanded({
+        groupId: "group-1",
+        expandedOverrides: { "group-1": true },
+        isExpandedByDefault: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("closing a section beats a default of open", () => {
+    expect(
+      isStatusPageGroupSectionExpanded({
+        groupId: "group-1",
+        expandedOverrides: { "group-1": false },
+        isExpandedByDefault: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("one section's state does not leak into another's", () => {
+    expect(
+      isStatusPageGroupSectionExpanded({
+        groupId: "group-2",
+        expandedOverrides: { "group-1": true },
+        isExpandedByDefault: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("a group with no id falls back to the default rather than a stray key", () => {
+    expect(
+      isStatusPageGroupSectionExpanded({
+        groupId: "",
+        expandedOverrides: { "group-1": true },
+        isExpandedByDefault: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("the Resources tab, end to end", () => {
+  /*
+   * How many resource tables the tab would mount for a given status page -
+   * which is the number the crash was really about, at two requests each.
+   */
+  type CountMountedTablesFunction = (data: {
+    statusPageGroups: Array<StatusPageGroup>;
+    searchText: string;
+    pageNumber: number;
+    expandedOverrides: Record<string, boolean>;
+  }) => number;
+
+  const countMountedTables: CountMountedTablesFunction = (data: {
+    statusPageGroups: Array<StatusPageGroup>;
+    searchText: string;
+    pageNumber: number;
+    expandedOverrides: Record<string, boolean>;
+  }): number => {
+    const allSections: Array<StatusPageGroupSection> =
+      buildStatusPageGroupSections({
+        statusPageGroups: data.statusPageGroups,
+      });
+
+    const isExpandedByDefault: boolean =
+      shouldExpandStatusPageGroupSectionsByDefault({
+        totalSectionCount: allSections.length,
+        pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+      });
+
+    const page: StatusPageGroupSectionPage = getStatusPageGroupSectionPage({
+      sections: filterStatusPageGroupSections({
+        sections: allSections,
+        searchText: data.searchText,
+      }),
+      pageNumber: data.pageNumber,
+      pageSize: STATUS_PAGE_GROUP_SECTIONS_PER_PAGE,
+    });
+
+    return page.sections.filter((section: StatusPageGroupSection) => {
+      return isStatusPageGroupSectionExpanded({
+        groupId: section.groupId,
+        expandedOverrides: data.expandedOverrides,
+        isExpandedByDefault: isExpandedByDefault,
+      });
+    }).length;
+  };
+
+  test("a five group status page mounts all five tables, exactly as before", () => {
+    expect(
+      countMountedTables({
+        statusPageGroups: makeHierarchy(),
+        searchText: "",
+        pageNumber: 1,
+        expandedOverrides: {},
+      }),
+    ).toBe(5);
+  });
+
+  /*
+   * The regression test for the crash: 1500 groups used to mean 1500 tables
+   * and ~3000 requests on mount. It now means none until the user opens one.
+   */
+  test("a 1500 group status page mounts no group tables until asked", () => {
+    expect(
+      countMountedTables({
+        statusPageGroups: makeManyGroups(1500),
+        searchText: "",
+        pageNumber: 1,
+        expandedOverrides: {},
+      }),
+    ).toBe(0);
+  });
+
+  test("opening a group on a huge status page mounts that one table", () => {
+    expect(
+      countMountedTables({
+        statusPageGroups: makeManyGroups(1500),
+        searchText: "",
+        pageNumber: 1,
+        expandedOverrides: { "group-3": true },
+      }),
+    ).toBe(1);
+  });
+
+  test("a group opened on another page mounts nothing on this one", () => {
+    expect(
+      countMountedTables({
+        statusPageGroups: makeManyGroups(1500),
+        searchText: "",
+        pageNumber: 2,
+        expandedOverrides: { "group-3": true },
+      }),
+    ).toBe(0);
+  });
+
+  test("nothing the user can do mounts more tables than a page holds", () => {
+    const statusPageGroups: Array<StatusPageGroup> = makeManyGroups(1500);
+    const expandedOverrides: Record<string, boolean> = {};
+
+    for (const group of statusPageGroups) {
+      expandedOverrides[group._id!.toString()] = true;
+    }
+
+    for (const pageNumber of [1, 2, 75, 150, 9999]) {
+      expect(
+        countMountedTables({
+          statusPageGroups: statusPageGroups,
+          searchText: "",
+          pageNumber: pageNumber,
+          expandedOverrides: expandedOverrides,
+        }),
+      ).toBeLessThanOrEqual(STATUS_PAGE_GROUP_SECTIONS_PER_PAGE);
+    }
+  });
+
+  test("a search that matches nothing mounts nothing", () => {
+    expect(
+      countMountedTables({
+        statusPageGroups: makeHierarchy(),
+        searchText: "no such group",
+        pageNumber: 1,
+        expandedOverrides: {},
+      }),
+    ).toBe(0);
+  });
+
+  /*
+   * Searching does not change the default, only what is on screen. A small
+   * status page keeps its sections open while you filter them.
+   */
+  test("searching a small status page still shows the matches open", () => {
+    expect(
+      countMountedTables({
+        statusPageGroups: makeHierarchy(),
+        searchText: "Region 1000",
+        pageNumber: 1,
+        expandedOverrides: {},
+      }),
+    ).toBe(3);
+  });
+});

--- a/Common/Tests/Utils/StatusPage/GroupTreeIndex.test.ts
+++ b/Common/Tests/Utils/StatusPage/GroupTreeIndex.test.ts
@@ -1,0 +1,731 @@
+import StatusPageGroupTreeUtil, {
+  STATUS_PAGE_GROUP_PATH_SEPARATOR,
+  StatusPageGroupIndex,
+  StatusPageGroupIndexNode,
+  StatusPageGroupTreeNode,
+} from "../../../Utils/StatusPage/GroupTree";
+import ObjectID from "../../../Types/ObjectID";
+import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Contract under test - StatusPageGroupIndex is the answer to "I need this for
+ * every group, not for one of them".
+ *
+ * Two things have to hold, and the second is the whole reason the class
+ * exists:
+ *
+ *   1. It agrees with the static helpers it replaces. A dashboard that labels
+ *      a group differently from the status page that renders it is worse than
+ *      one that is slow, so tree order, ancestors, depth and descendants are
+ *      all pinned against StatusPageGroupTreeUtil - including on the bad data
+ *      shapes (self parent, missing parent, cycles) that the statics are
+ *      already careful about.
+ *
+ *   2. It does its walk once. The page this was written for renders a section
+ *      per group and labels each one with its ancestor path; deriving that
+ *      per group re-walks every group, which is quadratic and is what made a
+ *      1500 group status page unusable. That is pinned by counting parent
+ *      pointer reads, not by timing anything.
+ */
+
+const CORPORATE: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const REGION_ONE: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const REGION_TWO: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const MARKET: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const UNIT: ObjectID = new ObjectID("55555555-5555-4555-8555-555555555555");
+const MISSING: ObjectID = new ObjectID("99999999-9999-4999-8999-999999999999");
+
+function makeGroup(data: {
+  id: ObjectID;
+  name: string;
+  parentId?: ObjectID | undefined;
+  order?: number | undefined;
+}): StatusPageGroup {
+  const group: StatusPageGroup = new StatusPageGroup();
+  group._id = data.id.toString();
+  group.name = data.name;
+
+  if (data.parentId) {
+    group.parentStatusPageGroupId = data.parentId;
+  }
+
+  if (data.order !== undefined) {
+    group.order = data.order;
+  }
+
+  return group;
+}
+
+/*
+ * Corporate
+ *   Region 1000
+ *     Market 1001
+ *       Unit 0152
+ *   Region 2000
+ */
+function makeHierarchy(): Array<StatusPageGroup> {
+  return [
+    makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+    makeGroup({
+      id: REGION_ONE,
+      name: "Region 1000",
+      parentId: CORPORATE,
+      order: 2,
+    }),
+    makeGroup({
+      id: MARKET,
+      name: "Market 1001",
+      parentId: REGION_ONE,
+      order: 3,
+    }),
+    makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET, order: 4 }),
+    makeGroup({
+      id: REGION_TWO,
+      name: "Region 2000",
+      parentId: CORPORATE,
+      order: 5,
+    }),
+  ];
+}
+
+type NamesFunction = (groups: Array<StatusPageGroup>) => Array<string>;
+
+const names: NamesFunction = (
+  groups: Array<StatusPageGroup>,
+): Array<string> => {
+  return groups.map((group: StatusPageGroup) => {
+    return group.name || "";
+  });
+};
+
+type FlattenTreeFunction = (
+  nodes: Array<StatusPageGroupTreeNode>,
+) => Array<StatusPageGroup>;
+
+const flattenTree: FlattenTreeFunction = (
+  nodes: Array<StatusPageGroupTreeNode>,
+): Array<StatusPageGroup> => {
+  const flattened: Array<StatusPageGroup> = [];
+
+  for (const node of nodes) {
+    flattened.push(node.group);
+    flattened.push(...flattenTree(node.children));
+  }
+
+  return flattened;
+};
+
+describe("StatusPageGroupIndex", () => {
+  describe("tree order", () => {
+    test("puts a parent directly above the groups nested under it", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(names(index.getGroupsInTreeOrder())).toEqual([
+        "Corporate",
+        "Region 1000",
+        "Market 1001",
+        "Unit 0152",
+        "Region 2000",
+      ]);
+    });
+
+    test("orders siblings by `order`, not by the order they were fetched in", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({
+          id: REGION_TWO,
+          name: "Region 2000",
+          parentId: CORPORATE,
+          order: 5,
+        }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 1000",
+          parentId: CORPORATE,
+          order: 2,
+        }),
+        makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getGroupsInTreeOrder())).toEqual([
+        "Corporate",
+        "Region 1000",
+        "Region 2000",
+      ]);
+    });
+
+    test("records the depth each group renders at", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(
+        index.getNodesInTreeOrder().map((node: StatusPageGroupIndexNode) => {
+          return [node.group.name, node.depth];
+        }),
+      ).toEqual([
+        ["Corporate", 0],
+        ["Region 1000", 1],
+        ["Market 1001", 2],
+        ["Unit 0152", 3],
+        ["Region 2000", 1],
+      ]);
+    });
+
+    test("records ancestors outermost first, excluding the group itself", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      const unitNode: StatusPageGroupIndexNode | null = index.getNode(
+        index.getGroupById(UNIT.toString())!,
+      );
+
+      expect(names(unitNode!.ancestors)).toEqual([
+        "Corporate",
+        "Region 1000",
+        "Market 1001",
+      ]);
+    });
+
+    test("matches the tree the status page renders, flattened", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getGroupsInTreeOrder())).toEqual(
+        names(
+          flattenTree(
+            StatusPageGroupTreeUtil.buildTree({ statusPageGroups: groups }),
+          ),
+        ),
+      );
+    });
+
+    test("holds every group exactly once, whatever shape the data is in", () => {
+      const groups: Array<StatusPageGroup> = [
+        // points at itself
+        makeGroup({ id: CORPORATE, name: "Corporate", parentId: CORPORATE }),
+        // points at a group nobody fetched
+        makeGroup({ id: REGION_ONE, name: "Region 1000", parentId: MISSING }),
+        // a two group cycle no root points into
+        makeGroup({ id: MARKET, name: "Market 1001", parentId: UNIT }),
+        makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getGroupsInTreeOrder()).sort()).toEqual([
+        "Corporate",
+        "Market 1001",
+        "Region 1000",
+        "Unit 0152",
+      ]);
+    });
+
+    test("an empty status page has an empty tree, not a crash", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: [],
+      });
+
+      expect(index.getGroupsInTreeOrder()).toEqual([]);
+      expect(index.getRootGroups()).toEqual([]);
+      expect(index.getTree()).toEqual([]);
+      expect(index.getGroupCount()).toBe(0);
+    });
+  });
+
+  describe("path labels", () => {
+    test("labels a nested group with the whole path down to it", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(
+        index.getGroupPathLabel(index.getGroupById(UNIT.toString())!),
+      ).toBe("Corporate › Region 1000 › Market 1001 › Unit 0152");
+    });
+
+    test("labels a top level group with just its own name", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(
+        index.getGroupPathLabel(index.getGroupById(CORPORATE.toString())!),
+      ).toBe("Corporate");
+    });
+
+    test("tells apart two groups that share a name at different levels", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Region 1000", order: 1 }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 1000",
+          parentId: CORPORATE,
+          order: 2,
+        }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(
+        groups.map((group: StatusPageGroup) => {
+          return index.getGroupPathLabel(group);
+        }),
+      ).toEqual(["Region 1000", "Region 1000 › Region 1000"]);
+    });
+
+    test("exposes the path as names so a caller can render it its own way", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(
+        index.getGroupPathNames(index.getGroupById(MARKET.toString())!),
+      ).toEqual(["Corporate", "Region 1000", "Market 1001"]);
+    });
+
+    test("accepts a different separator", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(
+        index.getGroupPathLabel(index.getGroupById(MARKET.toString())!, " / "),
+      ).toBe("Corporate / Region 1000 / Market 1001");
+    });
+
+    test("defaults to the separator the product uses everywhere else", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(
+        index.getGroupPathLabel(index.getGroupById(MARKET.toString())!),
+      ).toBe(
+        ["Corporate", "Region 1000", "Market 1001"].join(
+          STATUS_PAGE_GROUP_PATH_SEPARATOR,
+        ),
+      );
+    });
+
+    test("a group with no name still contributes a level to the path", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "", order: 1 }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 1000",
+          parentId: CORPORATE,
+          order: 2,
+        }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(index.getGroupPathLabel(groups[1]!)).toBe(" › Region 1000");
+    });
+
+    test("labels an orphan with just its own name - it renders at the top level", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: REGION_ONE, name: "Region 1000", parentId: MISSING }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(index.getGroupPathLabel(groups[0]!)).toBe("Region 1000");
+    });
+  });
+
+  describe("agreement with the static helpers", () => {
+    test("ancestors come back closest parent first, same as the static", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      for (const group of groups) {
+        expect(names(index.getAncestorGroups(group))).toEqual(
+          names(
+            StatusPageGroupTreeUtil.getAncestorGroups({
+              statusPageGroup: group,
+              statusPageGroups: groups,
+            }),
+          ),
+        );
+      }
+
+      expect(
+        names(index.getAncestorGroups(index.getGroupById(UNIT.toString())!)),
+      ).toEqual(["Market 1001", "Region 1000", "Corporate"]);
+    });
+
+    test("depth agrees with the static", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      for (const group of groups) {
+        expect(index.getDepth(group)).toBe(
+          StatusPageGroupTreeUtil.getDepth({
+            statusPageGroup: group,
+            statusPageGroups: groups,
+          }),
+        );
+      }
+    });
+
+    test("descendants agree with the static", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      for (const group of groups) {
+        expect(names(index.getDescendantGroups(group)).sort()).toEqual(
+          names(
+            StatusPageGroupTreeUtil.getDescendantGroups({
+              statusPageGroup: group,
+              statusPageGroups: groups,
+            }),
+          ).sort(),
+        );
+      }
+
+      expect(
+        names(
+          index.getDescendantGroups(index.getGroupById(REGION_ONE.toString())!),
+        ),
+      ).toEqual(["Market 1001", "Unit 0152"]);
+    });
+
+    test("roots agree with the static, orphan promotion included", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 1000",
+          parentId: CORPORATE,
+          order: 2,
+        }),
+        makeGroup({
+          id: REGION_TWO,
+          name: "Region 2000",
+          parentId: MISSING,
+          order: 3,
+        }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getRootGroups())).toEqual(
+        names(
+          StatusPageGroupTreeUtil.getRootGroups({ statusPageGroups: groups }),
+        ),
+      );
+      expect(names(index.getRootGroups())).toEqual([
+        "Corporate",
+        "Region 2000",
+      ]);
+    });
+
+    test("children agree with the static", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getChildGroups(CORPORATE.toString()))).toEqual(
+        names(
+          StatusPageGroupTreeUtil.getChildGroups({
+            statusPageGroupId: CORPORATE.toString(),
+            statusPageGroups: groups,
+          }),
+        ),
+      );
+      expect(names(index.getChildGroups(CORPORATE.toString()))).toEqual([
+        "Region 1000",
+        "Region 2000",
+      ]);
+    });
+
+    test("a leaf has no children rather than every root", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(index.getChildGroups(UNIT.toString())).toEqual([]);
+    });
+
+    test("asking for the children of nothing asks for the top level", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(names(index.getChildGroups(null))).toEqual(["Corporate"]);
+    });
+  });
+
+  describe("lookups", () => {
+    test("finds a group by id", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(index.getGroupById(MARKET.toString())?.name).toBe("Market 1001");
+    });
+
+    test("returns nothing for an id that is not on this status page", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: makeHierarchy(),
+      });
+
+      expect(index.getGroupById(MISSING.toString())).toBeNull();
+      expect(index.getGroupById(null)).toBeNull();
+      expect(index.getGroupById(undefined)).toBeNull();
+      expect(index.getGroupById("")).toBeNull();
+    });
+
+    test("keeps the group list it was handed", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(index.getStatusPageGroups()).toBe(groups);
+      expect(index.getGroupCount()).toBe(5);
+    });
+  });
+
+  describe("groups the index was not built from", () => {
+    test("walks the parent pointers it does know about", () => {
+      const groups: Array<StatusPageGroup> = makeHierarchy();
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      const newGroup: StatusPageGroup = makeGroup({
+        id: MISSING,
+        name: "Site 9000",
+        parentId: MARKET,
+      });
+
+      expect(names(index.getAncestorGroups(newGroup))).toEqual([
+        "Market 1001",
+        "Region 1000",
+        "Corporate",
+      ]);
+      expect(index.getDepth(newGroup)).toBe(3);
+      expect(index.getGroupPathLabel(newGroup)).toBe(
+        "Corporate › Region 1000 › Market 1001 › Site 9000",
+      );
+    });
+
+    test("stops at a parent it has never heard of", () => {
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: [makeGroup({ id: CORPORATE, name: "Corporate" })],
+      });
+
+      const newGroup: StatusPageGroup = makeGroup({
+        id: MISSING,
+        name: "Site 9000",
+        parentId: REGION_ONE,
+      });
+
+      expect(index.getAncestorGroups(newGroup)).toEqual([]);
+      expect(index.getGroupPathLabel(newGroup)).toBe("Site 9000");
+    });
+  });
+
+  describe("bad data", () => {
+    test("a group that points at itself is a root, not an infinite loop", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", parentId: CORPORATE }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getRootGroups())).toEqual(["Corporate"]);
+      expect(index.getAncestorGroups(groups[0]!)).toEqual([]);
+      expect(index.getDepth(groups[0]!)).toBe(0);
+      expect(index.getGroupPathLabel(groups[0]!)).toBe("Corporate");
+    });
+
+    test("a cycle nothing points into still renders, once, at the top level", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: MARKET, name: "Market 1001", parentId: UNIT }),
+        makeGroup({ id: UNIT, name: "Unit 0152", parentId: MARKET }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      const rendered: Array<string> = names(index.getGroupsInTreeOrder());
+
+      expect(rendered).toHaveLength(2);
+      expect(rendered.sort()).toEqual(["Market 1001", "Unit 0152"]);
+    });
+
+    test("a three group cycle terminates", () => {
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", parentId: REGION_ONE }),
+        makeGroup({ id: REGION_ONE, name: "Region 1000", parentId: MARKET }),
+        makeGroup({ id: MARKET, name: "Market 1001", parentId: CORPORATE }),
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(index.getGroupsInTreeOrder()).toHaveLength(3);
+
+      for (const group of groups) {
+        expect(index.getDescendantGroups(group).length).toBeLessThanOrEqual(2);
+      }
+    });
+
+    test("a group with no id at all does not swallow the top level", () => {
+      const idLess: StatusPageGroup = new StatusPageGroup();
+      idLess.name = "Unsaved";
+
+      const groups: Array<StatusPageGroup> = [
+        makeGroup({ id: CORPORATE, name: "Corporate", order: 1 }),
+        makeGroup({
+          id: REGION_ONE,
+          name: "Region 1000",
+          parentId: CORPORATE,
+          order: 2,
+        }),
+        idLess,
+      ];
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(index.getDescendantGroups(idLess)).toEqual([]);
+      expect(names(index.getGroupsInTreeOrder()).sort()).toEqual([
+        "Corporate",
+        "Region 1000",
+        "Unsaved",
+      ]);
+    });
+  });
+
+  describe("cost", () => {
+    /*
+     * The regression this class was written for: labelling every group with
+     * its ancestor path used to rederive the tree once per group. Counting
+     * parent pointer reads pins that down without timing anything - a walk per
+     * group would read them a multiple of `groupCount` times, not a constant
+     * one.
+     */
+    test("reads each group's parent pointer a bounded number of times", () => {
+      const groupCount: number = 1500;
+      const groups: Array<StatusPageGroup> = [];
+
+      for (let index: number = 0; index < groupCount; index++) {
+        const group: StatusPageGroup = new StatusPageGroup();
+        group._id = `group-${index}`;
+        group.name = `Group ${index}`;
+        group.order = index;
+
+        // A chain 10 deep, then start a new one - the nesting limit in practice.
+        if (index % 10 !== 0) {
+          group.parentStatusPageGroupId = new ObjectID(`group-${index - 1}`);
+        }
+
+        groups.push(group);
+      }
+
+      const getParentId: typeof StatusPageGroupTreeUtil.getParentId =
+        StatusPageGroupTreeUtil.getParentId;
+
+      let parentPointerReads: number = 0;
+
+      StatusPageGroupTreeUtil.getParentId = (
+        statusPageGroup: StatusPageGroup,
+      ): string | null => {
+        parentPointerReads++;
+        return getParentId.call(StatusPageGroupTreeUtil, statusPageGroup);
+      };
+
+      try {
+        const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+          statusPageGroups: groups,
+        });
+
+        // Every group asks for its full path, the way the Resources tab does.
+        for (const group of groups) {
+          index.getGroupPathLabel(group);
+        }
+
+        expect(index.getGroupsInTreeOrder()).toHaveLength(groupCount);
+        expect(parentPointerReads).toBeLessThanOrEqual(groupCount * 2);
+      } finally {
+        StatusPageGroupTreeUtil.getParentId = getParentId;
+      }
+    });
+
+    test("a 1500 group status page still comes back in tree order", () => {
+      const groups: Array<StatusPageGroup> = [];
+
+      for (let index: number = 0; index < 1500; index++) {
+        const group: StatusPageGroup = new StatusPageGroup();
+        group._id = `group-${index}`;
+        group.name = `Group ${index}`;
+        group.order = index;
+
+        if (index % 10 !== 0) {
+          group.parentStatusPageGroupId = new ObjectID(`group-${index - 1}`);
+        }
+
+        groups.push(group);
+      }
+
+      const index: StatusPageGroupIndex = StatusPageGroupTreeUtil.buildIndex({
+        statusPageGroups: groups,
+      });
+
+      expect(names(index.getGroupsInTreeOrder())).toEqual(names(groups));
+      expect(index.getDepth(groups[9]!)).toBe(9);
+      expect(index.getGroupPathLabel(groups[2]!)).toBe(
+        "Group 0 › Group 1 › Group 2",
+      );
+    });
+  });
+});

--- a/Common/Utils/StatusPage/GroupTree.ts
+++ b/Common/Utils/StatusPage/GroupTree.ts
@@ -6,6 +6,20 @@ export interface StatusPageGroupTreeNode {
   children: Array<StatusPageGroupTreeNode>;
 }
 
+export interface StatusPageGroupIndexNode {
+  group: StatusPageGroup;
+  // 0 for a top level group, 1 for its children, and so on.
+  depth: number;
+  // Ancestors outermost first, excluding the group itself.
+  ancestors: Array<StatusPageGroup>;
+}
+
+/*
+ * What separates the levels of a group path when it is shown to a human -
+ * "Corporate › Region 1000 › Market 1001".
+ */
+export const STATUS_PAGE_GROUP_PATH_SEPARATOR: string = " › ";
+
 /*
  * Status page groups form a tree: a group may be nested under another group
  * (Corporate Unit -> Region -> Market -> Site), and each level rolls up the
@@ -25,6 +39,10 @@ export default class StatusPageGroupTreeUtil {
    * refuse to loop.
    */
   public static readonly MaxNestingDepth: number = 10;
+
+  public static getGroupId(statusPageGroup: StatusPageGroup): string {
+    return statusPageGroup._id?.toString() || "";
+  }
 
   public static getParentId(statusPageGroup: StatusPageGroup): string | null {
     const parentId: string | null =
@@ -82,53 +100,21 @@ export default class StatusPageGroupTreeUtil {
   public static buildTree(data: {
     statusPageGroups: Array<StatusPageGroup>;
   }): Array<StatusPageGroupTreeNode> {
-    const visited: Set<string> = new Set<string>();
+    return this.buildIndex(data).getTree();
+  }
 
-    const buildNode: (
-      group: StatusPageGroup,
-      depth: number,
-    ) => StatusPageGroupTreeNode = (
-      group: StatusPageGroup,
-      depth: number,
-    ): StatusPageGroupTreeNode => {
-      const groupId: string = group._id?.toString() || "";
-      visited.add(groupId);
-
-      const children: Array<StatusPageGroupTreeNode> = this.getChildGroups({
-        statusPageGroupId: groupId,
-        statusPageGroups: data.statusPageGroups,
-      })
-        .filter((child: StatusPageGroup) => {
-          return !visited.has(child._id?.toString() || "");
-        })
-        .map((child: StatusPageGroup) => {
-          return buildNode(child, depth + 1);
-        });
-
-      return {
-        group: group,
-        depth: depth,
-        children: children,
-      };
-    };
-
-    const tree: Array<StatusPageGroupTreeNode> = this.getRootGroups({
-      statusPageGroups: data.statusPageGroups,
-    }).map((root: StatusPageGroup) => {
-      return buildNode(root, 0);
-    });
-
-    /*
-     * Anything left unvisited is inside a cycle that no root points into. Pull
-     * each one up to the top level so the page still shows it.
-     */
-    for (const group of this.sortByOrder(data.statusPageGroups)) {
-      if (!visited.has(group._id?.toString() || "")) {
-        tree.push(buildNode(group, 0));
-      }
-    }
-
-    return tree;
+  /*
+   * One walk of the tree, kept around to answer every question about it.
+   *
+   * Reach for this whenever a caller needs an answer for *every* group rather
+   * than for one of them: the static helpers each rederive the tree from the
+   * array they are handed, so asking 1500 groups for their ancestors rebuilds a
+   * 1500 entry map 1500 times. See StatusPageGroupIndex.
+   */
+  public static buildIndex(data: {
+    statusPageGroups: Array<StatusPageGroup>;
+  }): StatusPageGroupIndex {
+    return new StatusPageGroupIndex(data);
   }
 
   /*
@@ -290,7 +276,7 @@ export default class StatusPageGroupTreeUtil {
    * Siblings render in `order`. Groups without an order keep their incoming
    * position, after the ordered ones.
    */
-  private static sortByOrder(
+  public static sortByOrder(
     statusPageGroups: Array<StatusPageGroup>,
   ): Array<StatusPageGroup> {
     return [...statusPageGroups].sort(
@@ -303,5 +289,340 @@ export default class StatusPageGroupTreeUtil {
         return orderA - orderB;
       },
     );
+  }
+}
+
+/*
+ * A snapshot of one set of status page groups, with the tree already walked.
+ *
+ * Every static helper above rederives what it needs from the array it is
+ * handed. That is the right shape for a single question, and the wrong shape
+ * for asking the same question about every group: a page that labels 1500
+ * groups with their ancestor path calls getAncestorGroups 1500 times, and each
+ * of those builds a fresh 1500 entry map before it walks anything. The index
+ * does that walk once, in the constructor, and every lookup afterwards reads
+ * what the walk recorded.
+ *
+ * Build a new index when the group list changes - it does not observe the
+ * groups it was given.
+ *
+ * The walk is the same one buildTree does (buildTree is implemented on top of
+ * this), so `depth` and `ancestors` describe where a group actually renders.
+ * For data with a cycle in it that is not the same as following parent
+ * pointers: a group only reachable through a cycle is promoted to the top
+ * level, so the index reports it with no ancestors, while the static
+ * getAncestorGroups still walks the cycle until it closes.
+ */
+export class StatusPageGroupIndex {
+  private statusPageGroups: Array<StatusPageGroup> = [];
+  private groupsById: Map<string, StatusPageGroup> = new Map<
+    string,
+    StatusPageGroup
+  >();
+
+  private childGroupsByParentId: Map<string, Array<StatusPageGroup>> = new Map<
+    string,
+    Array<StatusPageGroup>
+  >();
+
+  private rootGroups: Array<StatusPageGroup> = [];
+  private tree: Array<StatusPageGroupTreeNode> = [];
+  private nodesInTreeOrder: Array<StatusPageGroupIndexNode> = [];
+  private nodesById: Map<string, StatusPageGroupIndexNode> = new Map<
+    string,
+    StatusPageGroupIndexNode
+  >();
+
+  public constructor(data: { statusPageGroups: Array<StatusPageGroup> }) {
+    this.statusPageGroups = data.statusPageGroups;
+
+    for (const group of data.statusPageGroups) {
+      const groupId: string = StatusPageGroupTreeUtil.getGroupId(group);
+
+      if (groupId) {
+        this.groupsById.set(groupId, group);
+      }
+    }
+
+    const roots: Array<StatusPageGroup> = [];
+
+    for (const group of data.statusPageGroups) {
+      const parentId: string | null =
+        StatusPageGroupTreeUtil.getParentId(group);
+
+      /*
+       * No parent, or a parent that is not part of the supplied list - an
+       * orphan still has to render somewhere, so it becomes a root.
+       */
+      if (!parentId || !this.groupsById.has(parentId)) {
+        roots.push(group);
+        continue;
+      }
+
+      const siblings: Array<StatusPageGroup> =
+        this.childGroupsByParentId.get(parentId) || [];
+
+      siblings.push(group);
+      this.childGroupsByParentId.set(parentId, siblings);
+    }
+
+    this.rootGroups = StatusPageGroupTreeUtil.sortByOrder(roots);
+
+    for (const parentId of Array.from(this.childGroupsByParentId.keys())) {
+      this.childGroupsByParentId.set(
+        parentId,
+        StatusPageGroupTreeUtil.sortByOrder(
+          this.childGroupsByParentId.get(parentId) || [],
+        ),
+      );
+    }
+
+    this.walkTree();
+  }
+
+  private walkTree(): void {
+    const visited: Set<string> = new Set<string>();
+
+    const buildNode: (
+      group: StatusPageGroup,
+      depth: number,
+      ancestors: Array<StatusPageGroup>,
+    ) => StatusPageGroupTreeNode = (
+      group: StatusPageGroup,
+      depth: number,
+      ancestors: Array<StatusPageGroup>,
+    ): StatusPageGroupTreeNode => {
+      const groupId: string = StatusPageGroupTreeUtil.getGroupId(group);
+      visited.add(groupId);
+
+      const indexNode: StatusPageGroupIndexNode = {
+        group: group,
+        depth: depth,
+        ancestors: ancestors,
+      };
+
+      this.nodesInTreeOrder.push(indexNode);
+
+      if (groupId && !this.nodesById.has(groupId)) {
+        this.nodesById.set(groupId, indexNode);
+      }
+
+      /*
+       * Built once per group rather than once per child: siblings all share
+       * the same ancestor path, so the whole index holds one array per level
+       * of nesting instead of one per group.
+       */
+      const ancestorsOfChildren: Array<StatusPageGroup> = [...ancestors, group];
+
+      const children: Array<StatusPageGroupTreeNode> = (
+        this.childGroupsByParentId.get(groupId) || []
+      )
+        .filter((child: StatusPageGroup) => {
+          return !visited.has(StatusPageGroupTreeUtil.getGroupId(child));
+        })
+        .map((child: StatusPageGroup) => {
+          return buildNode(child, depth + 1, ancestorsOfChildren);
+        });
+
+      return {
+        group: group,
+        depth: depth,
+        children: children,
+      };
+    };
+
+    this.tree = this.rootGroups.map((root: StatusPageGroup) => {
+      return buildNode(root, 0, []);
+    });
+
+    /*
+     * Anything left unvisited is inside a cycle that no root points into. Pull
+     * each one up to the top level so the page still shows it.
+     */
+    for (const group of StatusPageGroupTreeUtil.sortByOrder(
+      this.statusPageGroups,
+    )) {
+      if (!visited.has(StatusPageGroupTreeUtil.getGroupId(group))) {
+        this.tree.push(buildNode(group, 0, []));
+      }
+    }
+  }
+
+  // The groups this index was built from, in the order they were supplied.
+  public getStatusPageGroups(): Array<StatusPageGroup> {
+    return this.statusPageGroups;
+  }
+
+  public getGroupCount(): number {
+    return this.statusPageGroups.length;
+  }
+
+  public getTree(): Array<StatusPageGroupTreeNode> {
+    return this.tree;
+  }
+
+  /*
+   * The tree flattened back out, parents immediately above their children -
+   * the order the status page renders them in.
+   */
+  public getNodesInTreeOrder(): Array<StatusPageGroupIndexNode> {
+    return this.nodesInTreeOrder;
+  }
+
+  public getGroupsInTreeOrder(): Array<StatusPageGroup> {
+    return this.nodesInTreeOrder.map((node: StatusPageGroupIndexNode) => {
+      return node.group;
+    });
+  }
+
+  public getGroupById(
+    statusPageGroupId: string | null | undefined,
+  ): StatusPageGroup | null {
+    if (!statusPageGroupId) {
+      return null;
+    }
+
+    return this.groupsById.get(statusPageGroupId) || null;
+  }
+
+  public getNode(
+    statusPageGroup: StatusPageGroup,
+  ): StatusPageGroupIndexNode | null {
+    return (
+      this.nodesById.get(StatusPageGroupTreeUtil.getGroupId(statusPageGroup)) ||
+      null
+    );
+  }
+
+  public getRootGroups(): Array<StatusPageGroup> {
+    return this.rootGroups;
+  }
+
+  /*
+   * The children of a group, in `order`. `null` asks for the top level, which
+   * is the tree's roots - top level groups plus any orphan promoted to one.
+   */
+  public getChildGroups(
+    statusPageGroupId: string | null,
+  ): Array<StatusPageGroup> {
+    if (!statusPageGroupId) {
+      return this.rootGroups;
+    }
+
+    return this.childGroupsByParentId.get(statusPageGroupId) || [];
+  }
+
+  /*
+   * Ancestors, closest parent first - the same order the static
+   * getAncestorGroups returns them in.
+   */
+  public getAncestorGroups(
+    statusPageGroup: StatusPageGroup,
+  ): Array<StatusPageGroup> {
+    const node: StatusPageGroupIndexNode | null = this.getNode(statusPageGroup);
+
+    if (node) {
+      return [...node.ancestors].reverse();
+    }
+
+    /*
+     * A group the index was not built from. Walk its parent pointers through
+     * what the index does know, bounded by a visited set so a cycle stops
+     * instead of looping.
+     */
+    const ancestors: Array<StatusPageGroup> = [];
+    const visited: Set<string> = new Set<string>([
+      StatusPageGroupTreeUtil.getGroupId(statusPageGroup),
+    ]);
+
+    let parentId: string | null =
+      StatusPageGroupTreeUtil.getParentId(statusPageGroup);
+
+    while (parentId && !visited.has(parentId)) {
+      const parent: StatusPageGroup | undefined = this.groupsById.get(parentId);
+
+      if (!parent) {
+        break;
+      }
+
+      ancestors.push(parent);
+      visited.add(parentId);
+      parentId = StatusPageGroupTreeUtil.getParentId(parent);
+    }
+
+    return ancestors;
+  }
+
+  // 0 for a top level group, 1 for its children, and so on.
+  public getDepth(statusPageGroup: StatusPageGroup): number {
+    const node: StatusPageGroupIndexNode | null = this.getNode(statusPageGroup);
+
+    if (node) {
+      return node.depth;
+    }
+
+    return this.getAncestorGroups(statusPageGroup).length;
+  }
+
+  /*
+   * Every group below this one, at any depth. Excludes the group itself, and
+   * comes back in render order.
+   */
+  public getDescendantGroups(
+    statusPageGroup: StatusPageGroup,
+  ): Array<StatusPageGroup> {
+    const descendants: Array<StatusPageGroup> = [];
+    const visited: Set<string> = new Set<string>([
+      StatusPageGroupTreeUtil.getGroupId(statusPageGroup),
+    ]);
+
+    const frontier: Array<StatusPageGroup> = [
+      ...(this.childGroupsByParentId.get(
+        StatusPageGroupTreeUtil.getGroupId(statusPageGroup),
+      ) || []),
+    ];
+
+    while (frontier.length > 0) {
+      const group: StatusPageGroup = frontier.shift()!;
+      const groupId: string = StatusPageGroupTreeUtil.getGroupId(group);
+
+      if (visited.has(groupId)) {
+        continue;
+      }
+
+      visited.add(groupId);
+      descendants.push(group);
+      frontier.push(...(this.childGroupsByParentId.get(groupId) || []));
+    }
+
+    return descendants;
+  }
+
+  /*
+   * The names from the top of the tree down to and including this group. Two
+   * groups can easily both be called "Region 1000" at different levels, so
+   * anywhere a group is picked from a list it is the path, not the name, that
+   * tells them apart.
+   */
+  public getGroupPathNames(statusPageGroup: StatusPageGroup): Array<string> {
+    const node: StatusPageGroupIndexNode | null = this.getNode(statusPageGroup);
+
+    const ancestors: Array<StatusPageGroup> = node
+      ? node.ancestors
+      : [...this.getAncestorGroups(statusPageGroup)].reverse();
+
+    return [
+      ...ancestors.map((ancestor: StatusPageGroup) => {
+        return ancestor.name || "";
+      }),
+      statusPageGroup.name || "",
+    ];
+  }
+
+  public getGroupPathLabel(
+    statusPageGroup: StatusPageGroup,
+    separator: string = STATUS_PAGE_GROUP_PATH_SEPARATOR,
+  ): string {
+    return this.getGroupPathNames(statusPageGroup).join(separator);
   }
 }


### PR DESCRIPTION
## The crash

`Status Page > Resources` rendered one `ModelTable` per group, all of them at once. Every one of those tables fires a list **and** a count the instant it mounts, so a status page with ~1500 groups fired ~3000 requests and built a DOM to match — the "Network Error / high memory usage" crash reported alongside #3043.

Groups were also fetched with `limit: LIMIT_PER_PROJECT` (10000) with no pagination or virtualization of the section list itself.

## What changed

**The Resources tab renders a window of groups instead of all of them.**

- Group sections are paginated, 10 per page, so at most 10 resource tables can ever be mounted at once.
- On a status page with more groups than fit on one page, sections start **closed** and mount their table only when opened. A 1500 group page now costs one request for the ungrouped table and nothing else until the user opens a group.
- A search box narrows sections by group path — 150 pages is not something anyone pages through. Terms match independently against the whole path, so `corporate market` finds `Corporate › Region 1000 › Market 1001`, and searching a parent brings back its subtree.
- **A status page whose groups fit on one page is untouched**: every section open, no controls above them, exactly as before. That is almost every status page.

**The quadratic label building is gone.** Each section is titled with its ancestor path, and each path was derived by rewalking every group — 1500 walks of 1500 groups. The same pattern sat behind `fetchParentGroupOptions` on `Groups.tsx` and `fetchGroupOptions` on `MonitorRules.tsx`, both of which pull every group unpaginated into a dropdown.

`StatusPageGroupTreeUtil.buildIndex` walks the tree **once** and answers ancestors, depth, children, descendants and path labels from what that walk recorded. `buildTree` is now implemented on top of it, so there is a single traversal in the codebase and the dashboard cannot label a group differently from the status page that renders it. Both group pickers now share one option builder.

## Files

| | |
|---|---|
| `Common/Utils/StatusPage/GroupTree.ts` | new `StatusPageGroupIndex`; `buildTree` reimplemented on top of it |
| `App/FeatureSet/Dashboard/src/Utils/StatusPageGroupSections.ts` | new — ordering, path labels, search, pagination, default expansion |
| `App/FeatureSet/Dashboard/src/Utils/StatusPageGroupDropdown.ts` | new — shared group picker options |
| `.../StatusPages/View/Resources.tsx` | windowed sections, lazy mount, search, pagination |
| `.../StatusPages/View/Groups.tsx`, `MonitorRules.tsx` | share the option builder |
| `.../Components/StatusPage/GridResourceEditor.tsx` | optional `groupPathLabel` + `onCollapse` so grid groups collapse too |

## Tests

Both new util modules are React-free so they run in the existing node-env suites.

- **33** — `Common/Tests/Utils/StatusPage/GroupTreeIndex.test.ts`. Agreement with every static helper the index replaces, including the bad-data shapes those statics are already careful about (self parent, missing parent, two- and three-group cycles, groups with no id). The linear walk is pinned by **counting parent pointer reads**, not by timing anything.
- **52** — `App/Tests/Dashboard/StatusPageGroupSections.test.ts`. Tree ordering, path labels, search semantics, pagination clamping (a page number outliving the list it indexes into is the everyday case: you are on page 40 and then you type), default expansion, and an end-to-end count of *how many tables the tab would mount* — including that nothing a user can do exceeds one page's worth.
- **8** — `App/Tests/Dashboard/StatusPageGroupDropdown.test.ts`. Path labels, tree ordering, malformed data, and the same linear-walk check.

Full runs: `Common/Tests/Utils/StatusPage` 185 passed (6 suites), `App/Tests/Dashboard/StatusPage*` 187 passed (5 suites). `tsc --noEmit` clean on `Common` and on `App/FeatureSet/Dashboard` (bar the pre-existing `rrweb` resolution error, which is unrelated and comes from BrowserRecorder's separate install). `eslint` clean on every touched file.

## Note on verification

Not exercised in a browser: the local docker-compose stack serves the main working tree, not this worktree, so a preview there would have shown unchanged code. The behaviour is covered by the counting tests above rather than by a screenshot.