### PR TITLE
fix(monitor): read domain registration over RDAP, and stop reporting an empty WHOIS reply as healthy

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/DomainMonitor/DomainMonitorStepForm.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/DomainMonitor/DomainMonitorStepForm.tsx
@@ -1,6 +1,12 @@
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import MonitorStepDomainMonitor from "Common/Types/Monitor/MonitorStepDomainMonitor";
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
 import Input, { InputType } from "Common/UI/Components/Input/Input";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "Common/UI/Components/Dropdown/Dropdown";
+import DropdownUtil from "Common/UI/Utils/Dropdown";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 
@@ -14,6 +20,9 @@ const DomainMonitorStepForm: FunctionComponent<ComponentProps> = (
 ): ReactElement => {
   const [showAdvancedOptions, setShowAdvancedOptions] =
     useState<boolean>(false);
+
+  const lookupMethodOptions: Array<DropdownOption> =
+    DropdownUtil.getDropdownOptionsFromEnum(DomainLookupMethod);
 
   return (
     <div className="space-y-5">
@@ -30,6 +39,26 @@ const DomainMonitorStepForm: FunctionComponent<ComponentProps> = (
             props.onChange({
               ...props.monitorStepDomainMonitor,
               domainName: value,
+            });
+          }}
+        />
+      </div>
+
+      <div>
+        <FieldLabelElement
+          title="Lookup Method"
+          description="How registration data is read. Auto uses RDAP when the TLD publishes one and falls back to WHOIS. Some TLDs (such as .digital) have no working WHOIS server, and some (such as .io) have no RDAP service."
+          required={true}
+        />
+        <Dropdown
+          options={lookupMethodOptions}
+          initialValue={lookupMethodOptions.find((option: DropdownOption) => {
+            return option.value === props.monitorStepDomainMonitor.lookupMethod;
+          })}
+          onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+            props.onChange({
+              ...props.monitorStepDomainMonitor,
+              lookupMethod: value as DomainLookupMethod,
             });
           }}
         />
@@ -54,7 +83,7 @@ const DomainMonitorStepForm: FunctionComponent<ComponentProps> = (
           <div>
             <FieldLabelElement
               title="Timeout (ms)"
-              description="How long to wait for a WHOIS response before timing out"
+              description="How long to wait for the registration lookup to respond before timing out"
               required={false}
             />
             <Input

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep.tsx
@@ -2,6 +2,7 @@ import MonitorCriteriaElement from "./MonitorCriteria";
 import MonitorCriteria from "Common/Types/Monitor/MonitorCriteria";
 import MonitorStep, { MonitorStepType } from "Common/Types/Monitor/MonitorStep";
 import MonitorType from "Common/Types/Monitor/MonitorType";
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
 import Detail from "Common/UI/Components/Detail/Detail";
 import Field from "Common/UI/Components/Detail/Field";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
@@ -331,12 +332,25 @@ const MonitorStepElement: FunctionComponent<ComponentProps> = (
       {
         key: "domainMonitor",
         title: "Domain Name",
-        description: "The domain name being monitored via WHOIS.",
+        description: "The domain name whose registration is being monitored.",
         fieldType: FieldType.Element,
         placeholder: "No data entered",
         getElement: (item: MonitorStepType): ReactElement => {
           const domainMonitor: any = item.domainMonitor;
           return <p>{domainMonitor?.domainName || "-"}</p>;
+        },
+      },
+      {
+        key: "domainMonitor",
+        title: "Lookup Method",
+        description: "The protocol used to read domain registration data.",
+        fieldType: FieldType.Element,
+        placeholder: "No data entered",
+        getElement: (item: MonitorStepType): ReactElement => {
+          const domainMonitor: any = item.domainMonitor;
+          return (
+            <p>{domainMonitor?.lookupMethod || DomainLookupMethod.Auto}</p>
+          );
         },
       },
     ];

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/DomainMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/DomainMonitorView.tsx
@@ -39,6 +39,17 @@ const DomainMonitorView: FunctionComponent<ComponentProps> = (
     }
   };
 
+  /*
+   * The lookup's own reason for failing is the useful one - "the WHOIS server
+   * for .digital answered without any registration data" rather than a blank
+   * card. It is normally copied onto the envelope, but read both so a probe
+   * that only filled one of them still explains itself.
+   */
+  const failureCause: string =
+    props.probeMonitorResponse.failureCause?.toString() ||
+    domainResponse?.failureCause ||
+    "";
+
   const probeAttempts: Array<ProbeAttempt> =
     props.probeMonitorResponse.probeAttempts || [];
   const totalAttempts: number =
@@ -83,28 +94,34 @@ const DomainMonitorView: FunctionComponent<ComponentProps> = (
 
       <div className="flex space-x-3">
         <InfoCard
-          className="w-1/3 shadow-none border-2 border-gray-100"
+          className="w-1/4 shadow-none border-2 border-gray-100"
           title="Registrar"
           value={domainResponse?.registrar || "-"}
         />
         <InfoCard
-          className="w-1/3 shadow-none border-2 border-gray-100"
+          className="w-1/4 shadow-none border-2 border-gray-100"
           title="Created"
           value={formatDateText(domainResponse?.createdDate)}
         />
         <InfoCard
-          className="w-1/3 shadow-none border-2 border-gray-100"
+          className="w-1/4 shadow-none border-2 border-gray-100"
           title="DNSSEC"
           value={domainResponse?.dnssec || "-"}
         />
+        {/* With the Auto lookup method this varies by TLD, so it is worth showing. */}
+        <InfoCard
+          className="w-1/4 shadow-none border-2 border-gray-100"
+          title="Lookup Method"
+          value={domainResponse?.lookupMethod || "-"}
+        />
       </div>
 
-      {props.probeMonitorResponse.failureCause && (
+      {failureCause && (
         <div className="flex space-x-3">
           <InfoCard
             className="w-full shadow-none border-2 border-gray-100"
             title="Error"
-            value={props.probeMonitorResponse.failureCause?.toString() || "-"}
+            value={failureCause}
           />
         </div>
       )}

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -368,6 +368,8 @@ export default class CriteriaFilterUtil {
     if (monitorType === MonitorType.Domain) {
       options = options.filter((i: DropdownOption) => {
         return (
+          i.value === CheckOn.IsOnline ||
+          i.value === CheckOn.IsRequestTimeout ||
           i.value === CheckOn.DomainExpiresDaysIn ||
           i.value === CheckOn.DomainRegistrar ||
           i.value === CheckOn.DomainNameServer ||

--- a/App/FeatureSet/Docs/Content/en/monitor/domain-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/domain-monitor.md
@@ -1,10 +1,10 @@
 # Domain Monitor
 
-Domain monitoring allows you to monitor the registration status and expiration of your domain names. OneUptime periodically performs WHOIS lookups to track your domain's health and alert you before it expires.
+Domain monitoring allows you to monitor the registration status and expiration of your domain names. OneUptime periodically looks up your domain's registration record to track its health and alert you before it expires.
 
 ## Overview
 
-Domain monitors query WHOIS data for your domains to track registration details. This enables you to:
+Domain monitors read the registration record for your domains. This enables you to:
 
 - Monitor domain expiration dates
 - Detect expired or soon-to-expire domains
@@ -18,22 +18,46 @@ Domain monitors query WHOIS data for your domains to track registration details.
 2. Click **Create Monitor**
 3. Select **Domain** as the monitor type
 4. Enter the domain name you want to monitor
-5. Configure monitoring criteria as needed
+5. Choose a lookup method (leave it on **Auto** unless you have a reason not to)
+6. Configure monitoring criteria as needed
+
+## Lookup Methods
+
+Registration data can be read over two protocols, and which one works depends on the TLD.
+
+| Method    | Behaviour                                                                                          |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| **Auto**  | Default. Uses RDAP when the TLD publishes an RDAP service, and falls back to WHOIS when it does not. |
+| **RDAP**  | RDAP only. Fails with a clear error if the TLD publishes no RDAP service.                            |
+| **WHOIS** | WHOIS only.                                                                                          |
+
+**RDAP** ([RFC 9083](https://www.rfc-editor.org/rfc/rfc9083)) is the ICANN-mandated replacement for WHOIS. The authoritative server for each TLD is discovered from [IANA's bootstrap registry](https://www.rfc-editor.org/rfc/rfc9224), so it stays correct as registries move. Every gTLD publishes one.
+
+**WHOIS** has no equivalent discovery mechanism — clients ship a static map of TLD to WHOIS host, and those maps go stale. Every Identity Digital TLD (`.digital`, `.email`, `.life`, `.today`, `.zone` and around 290 others) is still mapped to a retired host that now answers every query with the literal text `TLD is not supported.` instead of a record. WHOIS remains the only option for the many ccTLDs that publish no RDAP service at all, such as `.io`, `.co`, `.de`, `.ch` and `.jp`.
+
+If a lookup cannot produce registration data — because the TLD's service is retired, or the domain is not registered — the monitor is reported **offline** with the reason shown on the monitor's probe response, rather than being reported as healthy with a blank expiry date. A registry that answers "this domain is available" (for example DENIC's `Status: free`) is treated as **not registered**, not as a healthy record.
+
+Internationalized domain names are accepted in either form: `münchen.de` is converted to its A-label (`xn--mnchen-3ya.de`) before the lookup.
 
 ## Configuration Options
 
 ### Basic Settings
 
-| Field       | Description                                 | Required |
-| ----------- | ------------------------------------------- | -------- |
-| Domain Name | The domain to monitor (e.g., `example.com`) | Yes      |
+| Field         | Description                                            | Required |
+| ------------- | ------------------------------------------------------ | -------- |
+| Domain Name   | The domain to monitor (e.g., `example.com`)            | Yes      |
+| Lookup Method | `Auto`, `RDAP`, or `WHOIS` — see **Lookup Methods**    | Yes      |
 
 ### Advanced Settings
 
-| Field        | Description                           | Default |
-| ------------ | ------------------------------------- | ------- |
-| Timeout (ms) | How long to wait for a WHOIS response | 10000   |
-| Retries      | Number of retry attempts on failure   | 3       |
+| Field        | Description                                        | Default |
+| ------------ | -------------------------------------------------- | ------- |
+| Timeout (ms) | How long to wait for the registration lookup       | 10000   |
+| Retries      | Number of retry attempts on failure                | 3       |
+
+Failures that cannot change on a retry — the domain is not registered, or the TLD publishes no RDAP service when you have asked for RDAP only — are reported immediately rather than retried. Everything else, including a WHOIS server that answers with no record (a rate-limited registrar looks the same as a retired one), is retried first.
+
+The timeout applies to each lookup, so an **Auto** check that tries RDAP and then falls back to WHOIS can take up to twice this long in the worst case.
 
 ## Monitoring Criteria
 
@@ -41,20 +65,25 @@ You can configure criteria to determine when your domain is considered online, d
 
 ### Available Check Types
 
-| Check Type             | Description                                          |
-| ---------------------- | ---------------------------------------------------- |
-| Domain Expires In Days | Number of days until the domain registration expires |
-| Domain Registrar       | The domain registrar name                            |
-| Domain Name Server     | Nameserver hostnames for the domain                  |
-| Domain Status Code     | WHOIS domain status codes                            |
-| Domain Is Expired      | Whether the domain has expired                       |
+| Check Type             | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| Is Online              | Whether the registration lookup itself succeeded        |
+| Is Request Timeout     | Whether the registration lookup timed out               |
+| Domain Expires In Days | Number of days until the domain registration expires    |
+| Domain Registrar       | The domain registrar name                               |
+| Domain Name Server     | Nameserver hostnames for the domain                     |
+| Domain Status Code     | Domain status codes (EPP status names)                  |
+| Domain Is Expired      | Whether the domain has expired                          |
+
+Status codes are normalized to their EPP names (`clientTransferProhibited`) regardless of which protocol answered, so a criterion keeps matching when **Auto** switches between RDAP and WHOIS. Registrar *names* are whatever the answering service publishes and can differ slightly between the two protocols, so prefer **Contains** over **Equal To** for a **Domain Registrar** criterion.
+
+Dates are normalized to ISO 8601. A date a registry publishes in a form that cannot be parsed is omitted rather than stored, so an expiry criterion reports "cannot decide" instead of silently answering "not expired" forever.
 
 ### Filter Types
 
-For **Domain Is Expired**:
+For **Is Online**, **Is Request Timeout** and **Domain Is Expired**:
 
-- **True** — Domain has expired
-- **False** — Domain has not expired
+- **True** / **False**
 
 For **Domain Expires In Days**:
 
@@ -82,6 +111,11 @@ For **Domain Registrar**, **Domain Name Server**, and **Domain Status Code**:
 - **Check On**: Domain Is Expired
 - **Filter Type**: True
 
+#### Mark as offline if the registration cannot be read
+
+- **Check On**: Is Online
+- **Filter Type**: False
+
 #### Verify nameservers are correct
 
 - **Check On**: Domain Name Server
@@ -91,5 +125,16 @@ For **Domain Registrar**, **Domain Name Server**, and **Domain Status Code**:
 ## Best Practices
 
 1. **Set early warnings** — Configure degraded alerts at 60 days and offline alerts at 14 days before expiry
-2. **Monitor all critical domains** — Include primary domains, subdomains registered separately, and any domains used for email or APIs
-3. **Track registrar changes** — Monitor the registrar field to detect unauthorized domain transfers
+2. **Cover failed lookups** — Include an **Is Online / False** filter in your offline criteria so an unreadable registration is not mistaken for a healthy one. Monitors created from now on get this by default; monitors created earlier need it added by hand
+3. **Monitor all critical domains** — Include primary domains, subdomains registered separately, and any domains used for email or APIs
+4. **Track registrar changes** — Monitor the registrar field to detect unauthorized domain transfers
+
+## Network Requirements
+
+Probes need outbound access to:
+
+- `https://data.iana.org/rdap/dns.json` — the IANA RDAP bootstrap registry, fetched once and cached for 24 hours
+- The registries' RDAP endpoints over HTTPS (port 443)
+- WHOIS servers over TCP port 43
+
+RDAP requests honour the probe's `HTTP_PROXY_URL` / `HTTPS_PROXY_URL` / `NO_PROXY` settings. WHOIS runs over a raw socket and does not. If a probe cannot reach `data.iana.org`, **Auto** degrades to WHOIS and retries the registry periodically.

--- a/Common/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.ts
@@ -8,6 +8,8 @@ import {
 import DomainMonitorResponse from "../../../../Types/Monitor/DomainMonitor/DomainMonitorResponse";
 import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
+import EvaluateOverTime from "./EvaluateOverTime";
+import logger from "../../Logger";
 
 export default class DomainMonitorCriteria {
   @CaptureSpan()
@@ -23,6 +25,60 @@ export default class DomainMonitorCriteria {
 
     const domainResponse: DomainMonitorResponse | undefined =
       dataToProcess.domainResponse;
+
+    let overTimeValue: Array<number | boolean> | number | boolean | undefined =
+      undefined;
+
+    if (
+      input.criteriaFilter.evaluateOverTime &&
+      input.criteriaFilter.evaluateOverTimeOptions
+    ) {
+      try {
+        overTimeValue = await EvaluateOverTime.getValueOverTime({
+          projectId: dataToProcess.projectId,
+          monitorId: input.dataToProcess.monitorId!,
+          evaluateOverTimeOptions: input.criteriaFilter.evaluateOverTimeOptions,
+          metricType: input.criteriaFilter.checkOn,
+        });
+
+        if (Array.isArray(overTimeValue) && overTimeValue.length === 0) {
+          overTimeValue = undefined;
+        }
+      } catch (err) {
+        logger.error(
+          `Error in getting over time value for ${input.criteriaFilter.checkOn}`,
+        );
+        logger.error(err);
+        overTimeValue = undefined;
+      }
+    }
+
+    /*
+     * Whether the registration lookup itself succeeded. Without this, a
+     * domain whose TLD has no working WHOIS or RDAP service produces a
+     * response with no expiry date, every Domain* filter below returns null,
+     * and the monitor silently keeps its previous status - which is what
+     * made an unsupported TLD look healthy.
+     */
+    if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {
+      const currentIsOnline: boolean | Array<boolean> =
+        (overTimeValue as Array<boolean>) || dataToProcess.isOnline;
+
+      return CompareCriteria.compareCriteriaBoolean({
+        value: currentIsOnline,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    if (input.criteriaFilter.checkOn === CheckOn.IsRequestTimeout) {
+      const currentIsTimeout: boolean | Array<boolean> =
+        (overTimeValue as Array<boolean>) || dataToProcess.isTimeout;
+
+      return CompareCriteria.compareCriteriaBoolean({
+        value: currentIsTimeout,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
 
     // Check domain expires in days
     if (input.criteriaFilter.checkOn === CheckOn.DomainExpiresDaysIn) {

--- a/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorTemplateUtil.ts
@@ -424,6 +424,7 @@ export default class MonitorTemplateUtil {
           nameServers: domainResponse?.nameServers,
           domainStatus: domainResponse?.domainStatus,
           dnssec: domainResponse?.dnssec,
+          lookupMethod: domainResponse?.lookupMethod,
         } as JSONObject;
       }
 

--- a/Common/Tests/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.test.ts
@@ -1,0 +1,401 @@
+import DomainMonitorCriteria from "../../../../../Server/Utils/Monitor/Criteria/DomainMonitorCriteria";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import DomainLookupMethod from "../../../../../Types/Monitor/DomainMonitor/DomainLookupMethod";
+import DomainMonitorResponse from "../../../../../Types/Monitor/DomainMonitor/DomainMonitorResponse";
+import ProbeMonitorResponse from "../../../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../../../Types/ObjectID";
+
+function daysFromNow(days: number): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function buildDataToProcess(input: {
+  isOnline?: boolean;
+  isTimeout?: boolean;
+  failureCause?: string;
+  expiresDate?: string | undefined;
+  registrar?: string | undefined;
+  nameServers?: Array<string> | undefined;
+  domainStatus?: Array<string> | undefined;
+  lookupMethod?: DomainLookupMethod | undefined;
+}): ProbeMonitorResponse {
+  const domainResponse: DomainMonitorResponse = {
+    isOnline: input.isOnline ?? true,
+    responseTimeInMs: 42,
+    failureCause: input.failureCause ?? "",
+    domainName: "identity.digital",
+    expiresDate: input.expiresDate,
+    registrar: input.registrar,
+    nameServers: input.nameServers,
+    domainStatus: input.domainStatus,
+    lookupMethod: input.lookupMethod,
+  };
+
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: input.failureCause ?? "",
+    isOnline: input.isOnline ?? true,
+    isTimeout: input.isTimeout,
+    responseTimeInMs: 42,
+    domainResponse: domainResponse,
+    monitoredAt: new Date(),
+  };
+}
+
+async function evaluate(
+  dataToProcess: ProbeMonitorResponse,
+  criteriaFilter: CriteriaFilter,
+): Promise<string | null> {
+  return DomainMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess,
+    criteriaFilter,
+  });
+}
+
+describe("DomainMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
+  /*
+   * Regression for issue #3046. A domain whose TLD has no working WHOIS or
+   * RDAP service comes back with no expiry date, which makes every Domain*
+   * filter undecidable - so without an IsOnline check the monitor keeps its
+   * previous status and the failure is invisible.
+   */
+  describe("IsOnline", () => {
+    test("a failed lookup + False → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: false,
+          expiresDate: undefined,
+          failureCause:
+            "The WHOIS server for identity.digital answered without any registration data.",
+        }),
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("a failed lookup + True → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: false, expiresDate: undefined }),
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("a successful lookup + True → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, expiresDate: daysFromNow(90) }),
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("a successful lookup + False → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true }),
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("IsRequestTimeout", () => {
+    test("timed out + True → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: false, isTimeout: true }),
+        {
+          checkOn: CheckOn.IsRequestTimeout,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("did not time out + True → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, isTimeout: false }),
+        {
+          checkOn: CheckOn.IsRequestTimeout,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    /*
+     * The probe has to send isTimeout: false explicitly on success. If it
+     * left the field unset this filter would be undecidable on every healthy
+     * check, and under FilterCondition.All the monitor could never go back
+     * online.
+     */
+    test("did not time out + False → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, isTimeout: false }),
+        {
+          checkOn: CheckOn.IsRequestTimeout,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("an unset isTimeout is undecidable in both directions", async () => {
+      await expect(
+        evaluate(buildDataToProcess({ isOnline: true }), {
+          checkOn: CheckOn.IsRequestTimeout,
+          filterType: FilterType.False,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+
+      await expect(
+        evaluate(buildDataToProcess({ isOnline: true }), {
+          checkOn: CheckOn.IsRequestTimeout,
+          filterType: FilterType.True,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe("DomainExpiresDaysIn", () => {
+    test("expiring in 10 days + LessThan 30 → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ expiresDate: daysFromNow(10) }),
+        {
+          checkOn: CheckOn.DomainExpiresDaysIn,
+          filterType: FilterType.LessThan,
+          value: 30,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("expiring in 90 days + LessThan 30 → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ expiresDate: daysFromNow(90) }),
+        {
+          checkOn: CheckOn.DomainExpiresDaysIn,
+          filterType: FilterType.LessThan,
+          value: 30,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    // An unreadable registration cannot answer this - hence the IsOnline check.
+    test("no expiry date → undecidable", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ isOnline: false, expiresDate: undefined }),
+        {
+          checkOn: CheckOn.DomainExpiresDaysIn,
+          filterType: FilterType.LessThan,
+          value: 30,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("DomainIsExpired", () => {
+    test("already expired + True → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ expiresDate: daysFromNow(-1) }),
+        {
+          checkOn: CheckOn.DomainIsExpired,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Domain is expired");
+    });
+
+    test("not expired + False → met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ expiresDate: daysFromNow(30) }),
+        {
+          checkOn: CheckOn.DomainIsExpired,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Domain is not expired");
+    });
+
+    test("no expiry date → undecidable in both directions", async () => {
+      await expect(
+        evaluate(buildDataToProcess({ expiresDate: undefined }), {
+          checkOn: CheckOn.DomainIsExpired,
+          filterType: FilterType.True,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+
+      await expect(
+        evaluate(buildDataToProcess({ expiresDate: undefined }), {
+          checkOn: CheckOn.DomainIsExpired,
+          filterType: FilterType.False,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe("DomainRegistrar", () => {
+    test("matches on equality", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ registrar: "Name.com, Inc." }),
+        {
+          checkOn: CheckOn.DomainRegistrar,
+          filterType: FilterType.EqualTo,
+          value: "Name.com, Inc.",
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("no registrar → undecidable", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ registrar: undefined }),
+        {
+          checkOn: CheckOn.DomainRegistrar,
+          filterType: FilterType.EqualTo,
+          value: "Name.com, Inc.",
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("DomainNameServer", () => {
+    test("matches any one of the name servers", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          nameServers: ["ns-525.awsdns-01.net", "ns-341.awsdns-42.com"],
+        }),
+        {
+          checkOn: CheckOn.DomainNameServer,
+          filterType: FilterType.Contains,
+          value: "awsdns-42",
+        },
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Domain name server: ");
+    });
+
+    test("no match → not met", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ nameServers: ["ns1.example.com"] }),
+        {
+          checkOn: CheckOn.DomainNameServer,
+          filterType: FilterType.Contains,
+          value: "cloudflare",
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("DomainStatusCode", () => {
+    /*
+     * RDAP publishes "client transfer prohibited" and WHOIS publishes
+     * "clientTransferProhibited". The probe folds both to the EPP name so a
+     * criterion keeps matching when Auto switches protocol.
+     */
+    test("matches the EPP status name both lookup methods normalize to", async () => {
+      const viaRdap: string | null = await evaluate(
+        buildDataToProcess({
+          domainStatus: ["clientTransferProhibited"],
+          lookupMethod: DomainLookupMethod.RDAP,
+        }),
+        {
+          checkOn: CheckOn.DomainStatusCode,
+          filterType: FilterType.Contains,
+          value: "clientTransferProhibited",
+        },
+      );
+
+      const viaWhois: string | null = await evaluate(
+        buildDataToProcess({
+          domainStatus: ["clientTransferProhibited"],
+          lookupMethod: DomainLookupMethod.WHOIS,
+        }),
+        {
+          checkOn: CheckOn.DomainStatusCode,
+          filterType: FilterType.Contains,
+          value: "clientTransferProhibited",
+        },
+      );
+
+      expect(viaRdap).toBeTruthy();
+      expect(viaRdap).toContain("Domain status: ");
+      expect(viaWhois).toBeTruthy();
+    });
+
+    test("no statuses → undecidable", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({ domainStatus: [] }),
+        {
+          checkOn: CheckOn.DomainStatusCode,
+          filterType: FilterType.Contains,
+          value: "clientHold",
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  test("an unrelated CheckOn is not claimed by this evaluator", async () => {
+    const result: string | null = await evaluate(buildDataToProcess({}), {
+      checkOn: CheckOn.ResponseTime,
+      filterType: FilterType.LessThan,
+      value: 1000,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts
@@ -146,6 +146,28 @@ describe("MonitorCriteriaInstance", () => {
         });
       expect(instance).toBeNull();
     });
+
+    /*
+     * A domain whose registration data cannot be read has no expiry date, so
+     * DomainIsExpired cannot decide anything. Requiring IsOnline as well is
+     * what stops an unreadable registration from being reported as healthy
+     * (issue #3046).
+     */
+    test("Domain monitor requires a successful lookup as well as a live registration", () => {
+      const instance: MonitorCriteriaInstance | null =
+        MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
+          monitorType: MonitorType.Domain,
+          monitorStatusId,
+          monitorName: "identity.digital",
+        });
+
+      expect(instance?.data?.filterCondition).toBe(FilterCondition.All);
+      expect(instance?.data?.filters).toHaveLength(2);
+      expect(instance?.data?.filters[0]?.checkOn).toBe(CheckOn.IsOnline);
+      expect(instance?.data?.filters[0]?.filterType).toBe(FilterType.True);
+      expect(instance?.data?.filters[1]?.checkOn).toBe(CheckOn.DomainIsExpired);
+      expect(instance?.data?.filters[1]?.filterType).toBe(FilterType.False);
+    });
   });
 
   describe("getDefaultOfflineMonitorCriteriaInstance", () => {
@@ -180,6 +202,26 @@ describe("MonitorCriteriaInstance", () => {
         alertSeverityId.toString(),
       );
       expect(instance.data?.incidents[0]?.title).toContain("Edge");
+    });
+
+    test("Domain offline criteria fires on an expired registration or a failed lookup", () => {
+      const instance: MonitorCriteriaInstance =
+        MonitorCriteriaInstance.getDefaultOfflineMonitorCriteriaInstance({
+          monitorType: MonitorType.Domain,
+          monitorStatusId: new ObjectID("bbbbbbbbbbbbbbbbbbbbbbbb"),
+          incidentSeverityId: new ObjectID("cccccccccccccccccccccccc"),
+          alertSeverityId: new ObjectID("dddddddddddddddddddddddd"),
+          monitorName: "identity.digital",
+        });
+
+      expect(instance.data?.filterCondition).toBe(FilterCondition.Any);
+      expect(instance.data?.filters).toHaveLength(2);
+      expect(instance.data?.filters[0]?.checkOn).toBe(CheckOn.DomainIsExpired);
+      expect(instance.data?.filters[0]?.filterType).toBe(FilterType.True);
+      expect(instance.data?.filters[1]?.checkOn).toBe(CheckOn.IsOnline);
+      expect(instance.data?.filters[1]?.filterType).toBe(FilterType.False);
+      expect(instance.data?.createIncidents).toBe(true);
+      expect(instance.data?.incidents[0]?.title).toContain("identity.digital");
     });
   });
 

--- a/Common/Tests/Types/Monitor/MonitorStep.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStep.test.ts
@@ -1,5 +1,6 @@
 import MonitorStep from "../../../Types/Monitor/MonitorStep";
 import MonitorType from "../../../Types/Monitor/MonitorType";
+import DomainLookupMethod from "../../../Types/Monitor/DomainMonitor/DomainLookupMethod";
 import ObjectID from "../../../Types/ObjectID";
 import HTTPMethod from "../../../Types/API/HTTPMethod";
 import { JSONObject, ObjectType } from "../../../Types/JSON";
@@ -178,6 +179,43 @@ describe("MonitorStep", () => {
       const step: MonitorStep = MonitorStep.getDefaultMonitorStep(DEFAULT_ARG);
       const parsed: JSONObject = JSON.parse(step.toString()) as JSONObject;
       expect(parsed["_type"]).toBe(ObjectType.MonitorStep);
+    });
+
+    /*
+     * Domain monitors saved before the lookupMethod option existed carry no
+     * such key. fromJSON has to fill it in, because the probe reads the
+     * deserialized config directly and its type says the field is present.
+     */
+    function restoreWithDomainMonitor(domainMonitor: JSONObject): JSONObject {
+      const json: JSONObject =
+        MonitorStep.getDefaultMonitorStep(DEFAULT_ARG).toJSON();
+
+      (json["value"] as JSONObject)["domainMonitor"] = domainMonitor;
+
+      return MonitorStep.fromJSON(json).data
+        ?.domainMonitor as unknown as JSONObject;
+    }
+
+    test("fills in the domain monitor lookup method for a step saved without one", () => {
+      const domainMonitor: JSONObject = restoreWithDomainMonitor({
+        domainName: "identity.digital",
+        timeout: 10000,
+        retries: 3,
+      });
+
+      expect(domainMonitor["domainName"]).toBe("identity.digital");
+      expect(domainMonitor["lookupMethod"]).toBe(DomainLookupMethod.Auto);
+    });
+
+    test("preserves an explicitly chosen domain monitor lookup method", () => {
+      const domainMonitor: JSONObject = restoreWithDomainMonitor({
+        domainName: "identity.digital",
+        lookupMethod: DomainLookupMethod.WHOIS,
+        timeout: 10000,
+        retries: 3,
+      });
+
+      expect(domainMonitor["lookupMethod"]).toBe(DomainLookupMethod.WHOIS);
     });
   });
 });

--- a/Common/Tests/Types/Monitor/MonitorStepDomainMonitor.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStepDomainMonitor.test.ts
@@ -1,4 +1,5 @@
 import { JSONObject } from "../../../Types/JSON";
+import DomainLookupMethod from "../../../Types/Monitor/DomainMonitor/DomainLookupMethod";
 import MonitorStepDomainMonitor, {
   MonitorStepDomainMonitorUtil,
 } from "../../../Types/Monitor/MonitorStepDomainMonitor";
@@ -13,6 +14,16 @@ describe("MonitorStepDomainMonitorUtil", () => {
       expect(def.timeout).toBe(10000);
       expect(def.retries).toBe(3);
     });
+
+    /*
+     * Auto rather than RDAP: about half the ccTLDs (.io, .co, .de, ...)
+     * publish no RDAP service, so RDAP-only would break them.
+     */
+    test("defaults to the Auto lookup method", () => {
+      expect(MonitorStepDomainMonitorUtil.getDefault().lookupMethod).toBe(
+        DomainLookupMethod.Auto,
+      );
+    });
   });
 
   describe("fromJSON", () => {
@@ -20,11 +31,13 @@ describe("MonitorStepDomainMonitorUtil", () => {
       const parsed: MonitorStepDomainMonitor =
         MonitorStepDomainMonitorUtil.fromJSON({
           domainName: "oneuptime.com",
+          lookupMethod: DomainLookupMethod.RDAP,
           timeout: 3000,
           retries: 7,
         });
 
       expect(parsed.domainName).toBe("oneuptime.com");
+      expect(parsed.lookupMethod).toBe(DomainLookupMethod.RDAP);
       expect(parsed.timeout).toBe(3000);
       expect(parsed.retries).toBe(7);
     });
@@ -41,12 +54,54 @@ describe("MonitorStepDomainMonitorUtil", () => {
       expect(parsed.timeout).toBe(10000);
       expect(parsed.retries).toBe(3);
     });
+
+    /*
+     * Every domain monitor saved before RDAP support existed has no
+     * lookupMethod key at all, and must keep working.
+     */
+    test("treats a monitor saved without a lookup method as Auto", () => {
+      const parsed: MonitorStepDomainMonitor =
+        MonitorStepDomainMonitorUtil.fromJSON({
+          domainName: "identity.digital",
+          timeout: 10000,
+          retries: 3,
+        });
+
+      expect(parsed.lookupMethod).toBe(DomainLookupMethod.Auto);
+    });
+
+    test("treats an unrecognised lookup method as Auto", () => {
+      expect(
+        MonitorStepDomainMonitorUtil.fromJSON({ lookupMethod: "" })
+          .lookupMethod,
+      ).toBe(DomainLookupMethod.Auto);
+
+      expect(
+        MonitorStepDomainMonitorUtil.fromJSON({ lookupMethod: "Telepathy" })
+          .lookupMethod,
+      ).toBe(DomainLookupMethod.Auto);
+
+      expect(
+        MonitorStepDomainMonitorUtil.fromJSON({ lookupMethod: 42 })
+          .lookupMethod,
+      ).toBe(DomainLookupMethod.Auto);
+    });
+
+    test("accepts every declared lookup method", () => {
+      for (const method of Object.values(DomainLookupMethod)) {
+        expect(
+          MonitorStepDomainMonitorUtil.fromJSON({ lookupMethod: method })
+            .lookupMethod,
+        ).toBe(method);
+      }
+    });
   });
 
   describe("round-trip", () => {
     test("toJSON emits every field and fromJSON restores it", () => {
       const monitor: MonitorStepDomainMonitor = {
         domainName: "example.com",
+        lookupMethod: DomainLookupMethod.WHOIS,
         timeout: 5000,
         retries: 2,
       };
@@ -55,6 +110,26 @@ describe("MonitorStepDomainMonitorUtil", () => {
       expect(json).toEqual(monitor);
 
       expect(MonitorStepDomainMonitorUtil.fromJSON(json)).toEqual(monitor);
+    });
+  });
+
+  describe("parseLookupMethod", () => {
+    test("accepts the declared values and rejects anything else", () => {
+      expect(MonitorStepDomainMonitorUtil.parseLookupMethod("RDAP")).toBe(
+        DomainLookupMethod.RDAP,
+      );
+      expect(MonitorStepDomainMonitorUtil.parseLookupMethod("WHOIS")).toBe(
+        DomainLookupMethod.WHOIS,
+      );
+      expect(MonitorStepDomainMonitorUtil.parseLookupMethod("rdap")).toBe(
+        DomainLookupMethod.Auto,
+      );
+      expect(MonitorStepDomainMonitorUtil.parseLookupMethod(null)).toBe(
+        DomainLookupMethod.Auto,
+      );
+      expect(MonitorStepDomainMonitorUtil.parseLookupMethod(undefined)).toBe(
+        DomainLookupMethod.Auto,
+      );
     });
   });
 });

--- a/Common/Types/Monitor/DomainMonitor/DomainLookupMethod.ts
+++ b/Common/Types/Monitor/DomainMonitor/DomainLookupMethod.ts
@@ -1,0 +1,23 @@
+/*
+ * Which protocol the probe uses to read a domain's registration record.
+ *
+ * WHOIS is the legacy protocol and its server list is not authoritative:
+ * clients ship a static map of TLD -> WHOIS host, and registries move. Every
+ * Identity Digital TLD (.digital, .email, .life, .today, .zone, ~290 more)
+ * still points at the retired whois.donuts.co in most of those maps, and that
+ * host now answers every query with the literal text "TLD is not supported."
+ * instead of a record. RDAP (RFC 9083) is the ICANN-mandated replacement and
+ * is discovered from the IANA bootstrap registry (RFC 9224), so it stays
+ * correct as registries move.
+ *
+ * Plenty of ccTLDs (.io, .co, .de, .ch, .jp, ...) publish no RDAP service at
+ * all, which is why Auto - RDAP when the TLD has one, WHOIS otherwise - is
+ * the default rather than RDAP.
+ */
+enum DomainLookupMethod {
+  Auto = "Auto",
+  RDAP = "RDAP",
+  WHOIS = "WHOIS",
+}
+
+export default DomainLookupMethod;

--- a/Common/Types/Monitor/DomainMonitor/DomainMonitorResponse.ts
+++ b/Common/Types/Monitor/DomainMonitor/DomainMonitorResponse.ts
@@ -1,4 +1,5 @@
 import ProbeAttempt from "../../Probe/ProbeAttempt";
+import DomainLookupMethod from "./DomainLookupMethod";
 
 export default interface DomainMonitorResponse {
   isOnline: boolean;
@@ -16,4 +17,10 @@ export default interface DomainMonitorResponse {
   isTimeout?: boolean | undefined;
   probeAttempts?: Array<ProbeAttempt> | undefined;
   totalAttempts?: number | undefined;
+  /*
+   * Which protocol actually produced this record. With the Auto lookup
+   * method the answer varies by TLD, so it is worth surfacing rather than
+   * leaving the operator to guess.
+   */
+  lookupMethod?: DomainLookupMethod | undefined;
 }

--- a/Common/Types/Monitor/MonitorCriteriaInstance.ts
+++ b/Common/Types/Monitor/MonitorCriteriaInstance.ts
@@ -505,6 +505,12 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         monitorStatusId: arg.monitorStatusId,
         filterCondition: FilterCondition.All,
         filters: [
+          // The registration lookup itself has to have worked.
+          {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.True,
+            value: undefined,
+          },
           {
             checkOn: CheckOn.DomainIsExpired,
             filterType: FilterType.False,
@@ -517,7 +523,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         changeMonitorStatus: true,
         createIncidents: false,
         name: `Check if ${arg.monitorName} is not expired`,
-        description: `This criteria checks if the ${arg.monitorName} domain registration is not expired`,
+        description: `This criteria checks if the ${arg.monitorName} domain registration was read successfully and is not expired`,
       };
 
       return monitorCriteriaInstance;
@@ -774,11 +780,22 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
             filterType: FilterType.True,
             value: undefined,
           },
+          /*
+           * Without this, a lookup that returns no registration data at all
+           * leaves every Domain* filter unable to decide, and the monitor
+           * keeps whatever status it had - so a domain whose registration
+           * data cannot be read looks exactly like a healthy one.
+           */
+          {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
         ],
         incidents: [
           {
-            title: `${arg.monitorName} domain is expired`,
-            description: `${arg.monitorName} domain registration has expired.`,
+            title: `${arg.monitorName} domain check failed`,
+            description: `${arg.monitorName} domain registration has expired, or its registration data could not be retrieved.`,
             incidentSeverityId: arg.incidentSeverityId,
             autoResolveIncident: true,
             id: ObjectID.generate().toString(),
@@ -790,16 +807,16 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         createAlerts: false,
         alerts: [
           {
-            title: `${arg.monitorName} domain is expired`,
-            description: `${arg.monitorName} domain registration has expired.`,
+            title: `${arg.monitorName} domain check failed`,
+            description: `${arg.monitorName} domain registration has expired, or its registration data could not be retrieved.`,
             alertSeverityId: arg.alertSeverityId,
             autoResolveAlert: true,
             id: ObjectID.generate().toString(),
             onCallPolicyIds: [],
           },
         ],
-        name: `Check if ${arg.monitorName} domain is expired`,
-        description: `This criteria checks if the ${arg.monitorName} domain registration has expired`,
+        name: `Check if ${arg.monitorName} domain check failed`,
+        description: `This criteria checks if the ${arg.monitorName} domain registration has expired or could not be read`,
       };
     }
 

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -1144,8 +1144,17 @@ export default class MonitorStep extends DatabaseProperty {
       dnsMonitor: json["dnsMonitor"]
         ? (json["dnsMonitor"] as JSONObject)
         : undefined,
+      /*
+       * Normalized rather than passed through raw: steps saved before the
+       * lookupMethod option existed carry no such key, and the probe would
+       * otherwise receive a config that does not satisfy its own type.
+       */
       domainMonitor: json["domainMonitor"]
-        ? (json["domainMonitor"] as JSONObject)
+        ? MonitorStepDomainMonitorUtil.toJSON(
+            MonitorStepDomainMonitorUtil.fromJSON(
+              json["domainMonitor"] as JSONObject,
+            ),
+          )
         : undefined,
       dnssecMonitor: json["dnssecMonitor"]
         ? (json["dnssecMonitor"] as JSONObject)

--- a/Common/Types/Monitor/MonitorStepDomainMonitor.ts
+++ b/Common/Types/Monitor/MonitorStepDomainMonitor.ts
@@ -1,7 +1,9 @@
 import { JSONObject } from "../JSON";
+import DomainLookupMethod from "./DomainMonitor/DomainLookupMethod";
 
 export default interface MonitorStepDomainMonitor {
   domainName: string;
+  lookupMethod: DomainLookupMethod;
   timeout: number;
   retries: number;
 }
@@ -10,6 +12,7 @@ export class MonitorStepDomainMonitorUtil {
   public static getDefault(): MonitorStepDomainMonitor {
     return {
       domainName: "",
+      lookupMethod: DomainLookupMethod.Auto,
       timeout: 10000,
       retries: 3,
     };
@@ -18,6 +21,13 @@ export class MonitorStepDomainMonitorUtil {
   public static fromJSON(json: JSONObject): MonitorStepDomainMonitor {
     return {
       domainName: (json["domainName"] as string) || "",
+      /*
+       * Monitors saved before RDAP support existed carry no lookupMethod at
+       * all, and Auto is the behaviour they should get.
+       */
+      lookupMethod: MonitorStepDomainMonitorUtil.parseLookupMethod(
+        json["lookupMethod"],
+      ),
       timeout: (json["timeout"] as number) || 10000,
       retries: (json["retries"] as number) || 3,
     };
@@ -26,8 +36,19 @@ export class MonitorStepDomainMonitorUtil {
   public static toJSON(monitor: MonitorStepDomainMonitor): JSONObject {
     return {
       domainName: monitor.domainName,
+      lookupMethod: monitor.lookupMethod,
       timeout: monitor.timeout,
       retries: monitor.retries,
     };
+  }
+
+  public static parseLookupMethod(value: unknown): DomainLookupMethod {
+    const values: Array<string> = Object.values(DomainLookupMethod);
+
+    if (typeof value === "string" && values.includes(value)) {
+      return value as DomainLookupMethod;
+    }
+
+    return DomainLookupMethod.Auto;
   }
 }

--- a/Common/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.ts
+++ b/Common/UI/Components/MonitorTemplateVariables/TemplateVariablesCatalog.ts
@@ -463,11 +463,21 @@ export default class TemplateVariablesCatalog {
         return {
           title: "Domain",
           variables: [
-            { key: "isOnline", description: "True if WHOIS lookup succeeded." },
+            {
+              key: "isOnline",
+              description: "True if the registration lookup succeeded.",
+            },
             { key: "domainName", description: "Domain queried." },
+            {
+              key: "lookupMethod",
+              description: "Protocol that answered - RDAP or WHOIS.",
+            },
             { key: "registrar", description: "Registrar name." },
             { key: "createdDate", description: "Domain registration date." },
-            { key: "updatedDate", description: "Last WHOIS update." },
+            {
+              key: "updatedDate",
+              description: "Last change to the registration.",
+            },
             { key: "expiresDate", description: "Expiration date." },
             { key: "nameServers", description: "Array of nameservers." },
             { key: "domainStatus", description: "EPP status codes." },

--- a/Probe/Tests/Utils/Domain/DomainName.test.ts
+++ b/Probe/Tests/Utils/Domain/DomainName.test.ts
@@ -1,0 +1,142 @@
+import DomainNameUtil from "../../../Utils/Domain/DomainName";
+import { describe, expect, it } from "@jest/globals";
+
+describe("DomainNameUtil", () => {
+  describe("normalize", () => {
+    it("lowercases and trims", () => {
+      expect(DomainNameUtil.normalize("  ExAmPle.COM  ")).toBe("example.com");
+    });
+
+    it("strips a scheme that was pasted along with the name", () => {
+      expect(DomainNameUtil.normalize("https://example.com")).toBe(
+        "example.com",
+      );
+      expect(DomainNameUtil.normalize("http://example.com")).toBe(
+        "example.com",
+      );
+    });
+
+    it("strips path, query and fragment", () => {
+      expect(DomainNameUtil.normalize("https://example.com/pricing")).toBe(
+        "example.com",
+      );
+      expect(DomainNameUtil.normalize("example.com/a/b?c=d#e")).toBe(
+        "example.com",
+      );
+    });
+
+    it("strips a port", () => {
+      expect(DomainNameUtil.normalize("example.com:8080")).toBe("example.com");
+    });
+
+    it("strips credentials", () => {
+      expect(DomainNameUtil.normalize("https://user:pass@example.com")).toBe(
+        "example.com",
+      );
+    });
+
+    it("strips the root label's trailing dot", () => {
+      expect(DomainNameUtil.normalize("example.com.")).toBe("example.com");
+    });
+
+    it("returns an empty string for empty input", () => {
+      expect(DomainNameUtil.normalize("")).toBe("");
+      expect(DomainNameUtil.normalize("   ")).toBe("");
+    });
+
+    it("keeps an '@' that belongs to the path out of the host", () => {
+      expect(DomainNameUtil.normalize("https://example.com/u/@handle")).toBe(
+        "example.com",
+      );
+    });
+
+    /*
+     * Registries, the IANA bootstrap registry and WHOIS servers all key on
+     * A-labels. whois-json used to punycode the name itself, so skipping the
+     * conversion here would reject every IDN monitor before any lookup.
+     */
+    it("converts an IDN to its A-label form", () => {
+      expect(DomainNameUtil.normalize("münchen.de")).toBe("xn--mnchen-3ya.de");
+      expect(DomainNameUtil.normalize("CAFÉ.fr")).toBe("xn--caf-dma.fr");
+    });
+
+    it("leaves an already-punycoded name alone", () => {
+      expect(DomainNameUtil.normalize("xn--mnchen-3ya.de")).toBe(
+        "xn--mnchen-3ya.de",
+      );
+    });
+
+    it("keeps the original value when it cannot be mapped, so errors can name it", () => {
+      expect(DomainNameUtil.normalize("not a domain")).toBe("not a domain");
+    });
+  });
+
+  describe("isValid", () => {
+    it("accepts ordinary names", () => {
+      expect(DomainNameUtil.isValid("example.com")).toBe(true);
+      expect(DomainNameUtil.isValid("identity.digital")).toBe(true);
+      expect(DomainNameUtil.isValid("a-b.co.uk")).toBe(true);
+      expect(DomainNameUtil.isValid("xn--80ak6aa92e.com")).toBe(true);
+    });
+
+    it("rejects a single label", () => {
+      expect(DomainNameUtil.isValid("localhost")).toBe(false);
+      expect(DomainNameUtil.isValid("com")).toBe(false);
+    });
+
+    it("rejects empty and over-long names", () => {
+      expect(DomainNameUtil.isValid("")).toBe(false);
+      expect(
+        DomainNameUtil.isValid(`${"a".repeat(250)}.${"b".repeat(10)}.com`),
+      ).toBe(false);
+    });
+
+    it("rejects labels with invalid characters or edge hyphens", () => {
+      expect(DomainNameUtil.isValid("exa_mple.com")).toBe(false);
+      expect(DomainNameUtil.isValid("-example.com")).toBe(false);
+      expect(DomainNameUtil.isValid("example-.com")).toBe(false);
+      expect(DomainNameUtil.isValid("example..com")).toBe(false);
+      expect(DomainNameUtil.isValid("exam ple.com")).toBe(false);
+    });
+
+    it("rejects an IP address", () => {
+      expect(DomainNameUtil.isValid("192.0.2.1")).toBe(false);
+    });
+
+    it("rejects a label longer than 63 characters", () => {
+      expect(DomainNameUtil.isValid(`${"a".repeat(64)}.com`)).toBe(false);
+      expect(DomainNameUtil.isValid(`${"a".repeat(63)}.com`)).toBe(true);
+    });
+  });
+
+  describe("getTld", () => {
+    it("returns the rightmost label", () => {
+      expect(DomainNameUtil.getTld("identity.digital")).toBe("digital");
+      expect(DomainNameUtil.getTld("a.b.example.co.uk")).toBe("uk");
+    });
+  });
+
+  describe("getSuffixCandidates", () => {
+    it("returns every trailing run of labels, longest first", () => {
+      expect(DomainNameUtil.getSuffixCandidates("a.b.example.com")).toEqual([
+        "a.b.example.com",
+        "b.example.com",
+        "example.com",
+        "com",
+      ]);
+    });
+
+    it("ignores empty labels", () => {
+      expect(DomainNameUtil.getSuffixCandidates("example.com.")).toEqual([
+        "example.com",
+        "com",
+      ]);
+    });
+
+    it("handles a single label", () => {
+      expect(DomainNameUtil.getSuffixCandidates("digital")).toEqual([
+        "digital",
+      ]);
+    });
+  });
+});

--- a/Probe/Tests/Utils/Domain/DomainRecord.test.ts
+++ b/Probe/Tests/Utils/Domain/DomainRecord.test.ts
@@ -1,0 +1,358 @@
+import {
+  DomainRecord,
+  DomainRecordUtil,
+} from "../../../Utils/Domain/DomainRecord";
+import { describe, expect, it } from "@jest/globals";
+
+describe("DomainRecordUtil", () => {
+  describe("hasRegistrationData", () => {
+    it("rejects an empty record", () => {
+      expect(DomainRecordUtil.hasRegistrationData({})).toBe(false);
+    });
+
+    it("rejects empty collections", () => {
+      expect(
+        DomainRecordUtil.hasRegistrationData({
+          nameServers: [],
+          domainStatus: [],
+        }),
+      ).toBe(false);
+    });
+
+    const singleFieldRecords: Array<[string, DomainRecord]> = [
+      ["domainName", { domainName: "example.com" }],
+      ["registrar", { registrar: "Example Registrar" }],
+      ["createdDate", { createdDate: "2014-09-10T16:00:01.000Z" }],
+      ["updatedDate", { updatedDate: "2026-01-01T00:00:00.000Z" }],
+      ["expiresDate", { expiresDate: "2030-01-01T00:00:00.000Z" }],
+      ["nameServers", { nameServers: ["ns1.example.com"] }],
+      ["domainStatus", { domainStatus: ["ok"] }],
+    ];
+
+    for (const [fieldName, record] of singleFieldRecords) {
+      it(`accepts a record carrying only ${fieldName}`, () => {
+        expect(DomainRecordUtil.hasRegistrationData(record)).toBe(true);
+      });
+    }
+
+    /*
+     * DENIC answers an unregistered name with the name echoed back plus
+     * "Status: free". Those are fields, but they are the opposite of a
+     * registration - accepting them would report a domain that has actually
+     * been lost as healthy, which is the same failure mode as issue #3046.
+     */
+    it("rejects a DENIC-style 'this domain is free' answer", () => {
+      expect(
+        DomainRecordUtil.hasRegistrationData({
+          domainName: "nichtregistriert.de",
+          domainStatus: ["free"],
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects other registries' not-registered statuses", () => {
+      for (const status of [
+        "available",
+        "AVAILABLE",
+        "notFound",
+        "no match",
+        "nonexistent",
+      ]) {
+        expect(
+          DomainRecordUtil.hasRegistrationData({
+            domainName: "example.test",
+            domainStatus: DomainRecordUtil.parseWhoisDomainStatus(status),
+          }),
+        ).toBe(false);
+      }
+    });
+
+    it("does not mistake a registered domain's status for availability", () => {
+      expect(
+        DomainRecordUtil.hasRegistrationData({
+          domainName: "example.de",
+          domainStatus: ["connect"],
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("isNotRegisteredStatus", () => {
+    it("recognises statuses split into separate tokens", () => {
+      expect(
+        DomainRecordUtil.isNotRegisteredStatus(["No", "Object", "Found"]),
+      ).toBe(true);
+    });
+
+    it("is false for a missing or ordinary status", () => {
+      expect(DomainRecordUtil.isNotRegisteredStatus(undefined)).toBe(false);
+      expect(DomainRecordUtil.isNotRegisteredStatus([])).toBe(false);
+      expect(
+        DomainRecordUtil.isNotRegisteredStatus(["clientTransferProhibited"]),
+      ).toBe(false);
+    });
+  });
+
+  describe("normalizeDate", () => {
+    it("normalizes RFC 3339 to ISO 8601", () => {
+      expect(DomainRecordUtil.normalizeDate("2026-09-10T16:00:01.587Z")).toBe(
+        "2026-09-10T16:00:01.587Z",
+      );
+    });
+
+    it("normalizes a WHOIS timestamp without milliseconds", () => {
+      expect(DomainRecordUtil.normalizeDate("2031-11-10T20:55:40Z")).toBe(
+        "2031-11-10T20:55:40.000Z",
+      );
+    });
+
+    it("accepts a Date instance", () => {
+      expect(
+        DomainRecordUtil.normalizeDate(new Date("2030-01-02T03:04:05Z")),
+      ).toBe("2030-01-02T03:04:05.000Z");
+    });
+
+    it("returns undefined for an invalid Date instance", () => {
+      expect(DomainRecordUtil.normalizeDate(new Date("nope"))).toBeUndefined();
+    });
+
+    /*
+     * Dropping beats passing through: the expiry criteria call
+     * `new Date(...)` on this, and an Invalid Date makes every comparison
+     * false - "expires in under 30 days" would never fire and "is expired"
+     * would answer "no" forever on a domain that had already lapsed.
+     */
+    it("drops an unparseable value rather than handing it to the criteria", () => {
+      expect(
+        DomainRecordUtil.normalizeDate("REDACTED FOR PRIVACY"),
+      ).toBeUndefined();
+    });
+
+    it("parses registro.br's compact YYYYMMDD form", () => {
+      expect(DomainRecordUtil.normalizeDate("20260313")).toBe(
+        "2026-03-13T00:00:00.000Z",
+      );
+    });
+
+    it("strips registro.br's trailing record id", () => {
+      expect(DomainRecordUtil.normalizeDate("19960424 #7137")).toBe(
+        "1996-04-24T00:00:00.000Z",
+      );
+    });
+
+    it("parses day-first dates with a four digit year", () => {
+      expect(DomainRecordUtil.normalizeDate("16-11-2035")).toBe(
+        "2035-11-16T00:00:00.000Z",
+      );
+      expect(DomainRecordUtil.normalizeDate("31.8.2027 00:00:00")).toBe(
+        "2027-08-31T00:00:00.000Z",
+      );
+    });
+
+    it("rejects an impossible day rather than rolling it over", () => {
+      expect(DomainRecordUtil.normalizeDate("20260231")).toBeUndefined();
+      expect(DomainRecordUtil.normalizeDate("31-02-2026")).toBeUndefined();
+    });
+
+    it("returns undefined for empty or non-string input", () => {
+      expect(DomainRecordUtil.normalizeDate("")).toBeUndefined();
+      expect(DomainRecordUtil.normalizeDate("   ")).toBeUndefined();
+      expect(DomainRecordUtil.normalizeDate(undefined)).toBeUndefined();
+      expect(DomainRecordUtil.normalizeDate(null)).toBeUndefined();
+      expect(DomainRecordUtil.normalizeDate(12345)).toBeUndefined();
+    });
+  });
+
+  describe("normalizeNameServers", () => {
+    it("lowercases, trims and de-duplicates", () => {
+      expect(
+        DomainRecordUtil.normalizeNameServers([
+          " NS1.Example.COM ",
+          "ns1.example.com",
+          "NS2.EXAMPLE.COM.",
+        ]),
+      ).toEqual(["ns1.example.com", "ns2.example.com"]);
+    });
+
+    it("drops glue addresses", () => {
+      expect(
+        DomainRecordUtil.normalizeNameServers([
+          "ns1.example.com",
+          "192.0.2.1",
+          "2a01:8840:16::36",
+        ]),
+      ).toEqual(["ns1.example.com"]);
+    });
+
+    it("ignores empty entries", () => {
+      expect(
+        DomainRecordUtil.normalizeNameServers(["", undefined, "  "]),
+      ).toEqual([]);
+    });
+  });
+
+  describe("normalizeDomainStatus", () => {
+    it("folds an RDAP spelled-out status to its EPP name", () => {
+      expect(
+        DomainRecordUtil.normalizeDomainStatus("client transfer prohibited"),
+      ).toBe("clientTransferProhibited");
+    });
+
+    it("leaves an EPP name untouched", () => {
+      expect(
+        DomainRecordUtil.normalizeDomainStatus("clientTransferProhibited"),
+      ).toBe("clientTransferProhibited");
+    });
+
+    it("strips a trailing EPP status URL", () => {
+      expect(
+        DomainRecordUtil.normalizeDomainStatus(
+          "clientTransferProhibited https://icann.org/epp#clientTransferProhibited",
+        ),
+      ).toBe("clientTransferProhibited");
+    });
+
+    it("returns an empty string when nothing is left", () => {
+      expect(
+        DomainRecordUtil.normalizeDomainStatus("https://icann.org/epp#ok"),
+      ).toBe("");
+      expect(DomainRecordUtil.normalizeDomainStatus("   ")).toBe("");
+    });
+  });
+
+  describe("parseWhoisDomainStatus", () => {
+    /*
+     * whois-json joins every repeated "Domain Status:" line with a space, so
+     * a normal gTLD answer arrives as one long string. Before this was
+     * handled the whole blob became a single bogus status value.
+     */
+    it("splits the space-joined blob whois-json produces", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus(
+          "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited clientTransferProhibited https://icann.org/epp#clientTransferProhibited",
+        ),
+      ).toEqual(["clientDeleteProhibited", "clientTransferProhibited"]);
+    });
+
+    it("keeps a lowercase spelled-out status as one phrase", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus("client transfer prohibited"),
+      ).toEqual(["clientTransferProhibited"]);
+    });
+
+    it("handles single-word ccTLD statuses", () => {
+      expect(DomainRecordUtil.parseWhoisDomainStatus("connect")).toEqual([
+        "connect",
+      ]);
+      expect(DomainRecordUtil.parseWhoisDomainStatus("ok")).toEqual(["ok"]);
+    });
+
+    it("splits on newlines, commas and semicolons", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus("ok\nserverHold, clientHold"),
+      ).toEqual(["ok", "serverHold", "clientHold"]);
+    });
+
+    it("de-duplicates", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus(
+          "clientHold clientHold clientHold",
+        ),
+      ).toEqual(["clientHold"]);
+    });
+
+    it("accepts an array", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus([
+          "client transfer prohibited",
+          "client delete prohibited",
+        ]),
+      ).toEqual(["clientTransferProhibited", "clientDeleteProhibited"]);
+    });
+
+    it("returns an empty array for missing input", () => {
+      expect(DomainRecordUtil.parseWhoisDomainStatus(undefined)).toEqual([]);
+      expect(DomainRecordUtil.parseWhoisDomainStatus("")).toEqual([]);
+    });
+
+    /*
+     * whois-json joins repeated status lines with a space, so a segment can
+     * hold several spelled-out statuses. Splitting on whitespace would
+     * shred them and treating the segment as one phrase would fuse them -
+     * hence the phrase table. CZ.NIC emits exactly this pair.
+     */
+    it("separates two spelled-out statuses joined into one segment", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus(
+          "paid and in zone server delete prohibited",
+        ),
+      ).toEqual(["paidAndInZone", "serverDeleteProhibited"]);
+    });
+
+    it("does not fuse two single-word statuses", () => {
+      expect(DomainRecordUtil.parseWhoisDomainStatus("ok active")).toEqual([
+        "ok",
+        "active",
+      ]);
+    });
+
+    it("treats a parenthesised status as its own value", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus("ok (paid and in zone)"),
+      ).toEqual(["ok", "paidAndInZone"]);
+    });
+
+    it("folds a mixed-case spelled-out status", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus(
+          "Sponsoring registrar change forbidden",
+        ),
+      ).toEqual(["sponsoringRegistrarChangeForbidden"]);
+    });
+
+    it("still splits the gTLD blob at its EPP status URLs", () => {
+      expect(
+        DomainRecordUtil.parseWhoisDomainStatus(
+          "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited clientTransferProhibited https://icann.org/epp#clientTransferProhibited",
+        ),
+      ).toEqual(["clientDeleteProhibited", "clientTransferProhibited"]);
+    });
+  });
+
+  describe("parseWhoisNameServers", () => {
+    it("splits the space-joined blob whois-json produces", () => {
+      expect(
+        DomainRecordUtil.parseWhoisNameServers(
+          "NS1.EXAMPLE.COM NS2.EXAMPLE.COM",
+        ),
+      ).toEqual(["ns1.example.com", "ns2.example.com"]);
+    });
+
+    it("drops inline glue addresses", () => {
+      expect(
+        DomainRecordUtil.parseWhoisNameServers("ns1.example.com 192.0.2.1"),
+      ).toEqual(["ns1.example.com"]);
+    });
+
+    it("splits on commas", () => {
+      expect(
+        DomainRecordUtil.parseWhoisNameServers(
+          "ns1.example.com,ns2.example.com",
+        ),
+      ).toEqual(["ns1.example.com", "ns2.example.com"]);
+    });
+
+    it("accepts an array and de-duplicates", () => {
+      expect(
+        DomainRecordUtil.parseWhoisNameServers([
+          "NS1.EXAMPLE.COM.",
+          "ns1.example.com",
+        ]),
+      ).toEqual(["ns1.example.com"]);
+    });
+
+    it("returns an empty array for missing input", () => {
+      expect(DomainRecordUtil.parseWhoisNameServers(undefined)).toEqual([]);
+    });
+  });
+});

--- a/Probe/Tests/Utils/Domain/RdapBootstrap.test.ts
+++ b/Probe/Tests/Utils/Domain/RdapBootstrap.test.ts
@@ -1,0 +1,383 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { JSONObject } from "Common/Types/JSON";
+import RdapBootstrap, {
+  BOOTSTRAP_CACHE_TTL_IN_MS,
+  BOOTSTRAP_FAILURE_CACHE_TTL_IN_MS,
+  BOOTSTRAP_FETCH_TIMEOUT_IN_MS,
+  IANA_RDAP_BOOTSTRAP_URL,
+  RdapBootstrapResult,
+} from "../../../Utils/Domain/RdapBootstrap";
+import RdapHttp, { RdapHttpResponse } from "../../../Utils/Domain/RdapHttp";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * A trimmed copy of https://data.iana.org/rdap/dns.json. ".digital" really is
+ * served by Identity Digital's RDAP endpoint, and ".io" really is absent from
+ * the registry - which is why Auto has to fall back to WHOIS for it.
+ */
+const BOOTSTRAP_DOCUMENT: JSONObject = {
+  version: "1.0",
+  publication: "2026-07-23T02:00:03Z",
+  services: [
+    [
+      ["digital", "email", "life", "zone"],
+      ["https://rdap.identitydigital.services/rdap/"],
+    ],
+    [["com", "net"], ["https://rdap.verisign.com/com/v1/"]],
+    [["example"], ["http://rdap-legacy.example/", "https://rdap.example/"]],
+    [["noslash"], ["https://rdap.noslash.example/rdap"]],
+  ],
+};
+
+const okResponse: (body: JSONObject) => RdapHttpResponse = (
+  body: JSONObject,
+): RdapHttpResponse => {
+  return { statusCode: 200, body: body };
+};
+
+describe("RdapBootstrap", () => {
+  // eslint-disable-next-line @typescript-eslint/typedef
+  let getJsonSpy = jest.spyOn(RdapHttp, "getJson");
+  let nowInMs: number = 1_700_000_000_000;
+
+  beforeEach(() => {
+    RdapBootstrap.clearCache();
+
+    nowInMs = 1_700_000_000_000;
+    jest.spyOn(Date, "now").mockImplementation((): number => {
+      return nowInMs;
+    });
+
+    getJsonSpy = jest
+      .spyOn(RdapHttp, "getJson")
+      .mockResolvedValue(okResponse(BOOTSTRAP_DOCUMENT) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    RdapBootstrap.clearCache();
+  });
+
+  describe("parseBootstrapDocument", () => {
+    it("maps every suffix in a service entry to its base URLs", () => {
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument(BOOTSTRAP_DOCUMENT);
+
+      expect(registry.get("digital")).toEqual([
+        "https://rdap.identitydigital.services/rdap/",
+      ]);
+      expect(registry.get("zone")).toEqual([
+        "https://rdap.identitydigital.services/rdap/",
+      ]);
+      expect(registry.get("com")).toEqual([
+        "https://rdap.verisign.com/com/v1/",
+      ]);
+    });
+
+    it("prefers HTTPS endpoints over plain HTTP", () => {
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument(BOOTSTRAP_DOCUMENT);
+
+      expect(registry.get("example")).toEqual([
+        "https://rdap.example/",
+        "http://rdap-legacy.example/",
+      ]);
+    });
+
+    it("appends the trailing slash the base URL is supposed to have", () => {
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument(BOOTSTRAP_DOCUMENT);
+
+      expect(registry.get("noslash")).toEqual([
+        "https://rdap.noslash.example/rdap/",
+      ]);
+    });
+
+    it("normalizes suffix casing and stray dots", () => {
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument({
+        services: [[[".DIGITAL."], ["https://rdap.example/"]]],
+      });
+
+      expect(registry.get("digital")).toEqual(["https://rdap.example/"]);
+    });
+
+    it("merges entries that claim the same suffix", () => {
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument({
+        services: [
+          [["test"], ["https://a.example/"]],
+          [["test"], ["https://b.example/"]],
+        ],
+      });
+
+      expect(registry.get("test")).toEqual([
+        "https://a.example/",
+        "https://b.example/",
+      ]);
+    });
+
+    it("skips malformed service entries instead of throwing", () => {
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument({
+        services: [
+          "not-an-entry",
+          [["onlysuffixes"]],
+          [["bad"], "not-an-array"],
+          [["nourls"], []],
+          [["skipped"], ["ftp://rdap.example/"]],
+          [[42], ["https://rdap.example/"]],
+          [["good"], ["https://rdap.example/"]],
+        ],
+      } as unknown as JSONObject);
+
+      expect(registry.get("good")).toEqual(["https://rdap.example/"]);
+      expect(registry.get("onlysuffixes")).toBeUndefined();
+      expect(registry.get("bad")).toBeUndefined();
+      expect(registry.get("nourls")).toBeUndefined();
+      expect(registry.get("skipped")).toBeUndefined();
+      expect(registry.size).toBe(1);
+    });
+
+    it("returns an empty registry for a document with no services", () => {
+      expect(RdapBootstrap.parseBootstrapDocument({}).size).toBe(0);
+      expect(RdapBootstrap.parseBootstrapDocument(null).size).toBe(0);
+    });
+  });
+
+  describe("getServiceUrlsForDomain", () => {
+    it("fetches the IANA bootstrap registry", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+
+      expect(getJsonSpy).toHaveBeenCalledTimes(1);
+      expect(getJsonSpy.mock.calls[0]![0]).toBe(IANA_RDAP_BOOTSTRAP_URL);
+    });
+
+    // The regression for issue #3046: .digital does have an RDAP service.
+    it("resolves the RDAP service for .digital", async () => {
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("identity.digital"),
+      ).resolves.toEqual({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://rdap.identitydigital.services/rdap/"],
+      });
+    });
+
+    it("matches on the TLD regardless of how many labels precede it", async () => {
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("a.b.c.example.com"),
+      ).resolves.toEqual({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://rdap.verisign.com/com/v1/"],
+      });
+    });
+
+    it("prefers the longest matching suffix", async () => {
+      getJsonSpy.mockResolvedValue(
+        okResponse({
+          services: [
+            [["uk"], ["https://rdap.nominet.example/"]],
+            [["co.uk"], ["https://rdap.couk.example/"]],
+          ],
+        }) as never,
+      );
+
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("example.co.uk"),
+      ).resolves.toEqual({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://rdap.couk.example/"],
+      });
+    });
+
+    it("is case insensitive", async () => {
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("IDENTITY.DIGITAL"),
+      ).resolves.toEqual({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://rdap.identitydigital.services/rdap/"],
+      });
+    });
+
+    /*
+     * Roughly half the ccTLDs publish no RDAP service. That is not an error -
+     * it is the signal that tells Auto to use WHOIS.
+     */
+    it("reports the registry as available but empty for a TLD with no RDAP service", async () => {
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("example.io"),
+      ).resolves.toEqual({ isRegistryAvailable: true, serviceUrls: [] });
+    });
+  });
+
+  describe("caching", () => {
+    it("fetches once and serves later lookups from cache", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("a.com");
+      await RdapBootstrap.getServiceUrlsForDomain("b.digital");
+      await RdapBootstrap.getServiceUrlsForDomain("c.net");
+
+      expect(getJsonSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("shares one in-flight fetch between concurrent lookups", async () => {
+      await Promise.all([
+        RdapBootstrap.getServiceUrlsForDomain("a.com"),
+        RdapBootstrap.getServiceUrlsForDomain("b.digital"),
+        RdapBootstrap.getServiceUrlsForDomain("c.net"),
+      ]);
+
+      expect(getJsonSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("refetches once the cache TTL has passed", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("a.com");
+
+      nowInMs += BOOTSTRAP_CACHE_TTL_IN_MS + 1;
+
+      await RdapBootstrap.getServiceUrlsForDomain("a.com");
+
+      expect(getJsonSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("clearCache forces a refetch", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("a.com");
+      RdapBootstrap.clearCache();
+      await RdapBootstrap.getServiceUrlsForDomain("a.com");
+
+      expect(getJsonSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("when the bootstrap registry cannot be read", () => {
+    /*
+     * The distinction that matters: "unavailable" must never be reported as
+     * "this TLD has no RDAP service". The latter is permanent, and a
+     * permanent verdict skips retries and the probe-connectivity gate - so a
+     * data.iana.org outage would open an incident on every domain monitor.
+     */
+    it("reports the registry as unavailable rather than as an empty answer", async () => {
+      getJsonSpy.mockRejectedValue(new Error("getaddrinfo ENOTFOUND") as never);
+
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("identity.digital"),
+      ).resolves.toEqual({ isRegistryAvailable: false, serviceUrls: [] });
+    });
+
+    it("treats a non-2xx response as unavailable", async () => {
+      getJsonSpy.mockResolvedValue({ statusCode: 503, body: null } as never);
+
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("identity.digital"),
+      ).resolves.toEqual({ isRegistryAvailable: false, serviceUrls: [] });
+    });
+
+    it("treats a document listing no services as unavailable", async () => {
+      getJsonSpy.mockResolvedValue(okResponse({ services: [] }) as never);
+
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("identity.digital"),
+      ).resolves.toEqual({ isRegistryAvailable: false, serviceUrls: [] });
+    });
+
+    it("does not retry on every check while the failure is cached", async () => {
+      getJsonSpy.mockRejectedValue(new Error("network down") as never);
+
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+
+      expect(getJsonSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries once the failure cache expires", async () => {
+      getJsonSpy.mockRejectedValue(new Error("network down") as never);
+
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+
+      nowInMs += BOOTSTRAP_FAILURE_CACHE_TTL_IN_MS + 1;
+
+      getJsonSpy.mockResolvedValue(okResponse(BOOTSTRAP_DOCUMENT) as never);
+
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("identity.digital"),
+      ).resolves.toEqual({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://rdap.identitydigital.services/rdap/"],
+      });
+      expect(getJsonSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps serving a stale registry rather than nothing", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+
+      nowInMs += BOOTSTRAP_CACHE_TTL_IN_MS + 1;
+      getJsonSpy.mockRejectedValue(new Error("network down") as never);
+
+      await expect(
+        RdapBootstrap.getServiceUrlsForDomain("identity.digital"),
+      ).resolves.toEqual({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://rdap.identitydigital.services/rdap/"],
+      });
+    });
+  });
+
+  describe("the shared fetch's timeout", () => {
+    /*
+     * The bootstrap document is fetched once for the whole probe, so it must
+     * not inherit the timeout of whichever monitor happened to trigger it -
+     * one monitor set to 2s would otherwise abort the ~200KB fetch for every
+     * other monitor and poison the 5-minute failure cache.
+     */
+    it("is not shortened by a monitor with a small timeout", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital", {
+        timeoutInMs: 2000,
+      });
+
+      expect(getJsonSpy.mock.calls[0]![1]).toEqual({
+        timeoutInMs: BOOTSTRAP_FETCH_TIMEOUT_IN_MS,
+      });
+    });
+
+    it("is extended by a monitor with a longer timeout", async () => {
+      await RdapBootstrap.getServiceUrlsForDomain("identity.digital", {
+        timeoutInMs: BOOTSTRAP_FETCH_TIMEOUT_IN_MS + 5000,
+      });
+
+      expect(getJsonSpy.mock.calls[0]![1]).toEqual({
+        timeoutInMs: BOOTSTRAP_FETCH_TIMEOUT_IN_MS + 5000,
+      });
+    });
+  });
+
+  describe("result typing", () => {
+    it("always reports both fields", async () => {
+      const result: RdapBootstrapResult =
+        await RdapBootstrap.getServiceUrlsForDomain("identity.digital");
+
+      expect(result.isRegistryAvailable).toBe(true);
+      expect(result.serviceUrls).toHaveLength(1);
+    });
+  });
+});

--- a/Probe/Tests/Utils/Domain/RdapDomainParser.test.ts
+++ b/Probe/Tests/Utils/Domain/RdapDomainParser.test.ts
@@ -1,0 +1,312 @@
+import { JSONObject } from "Common/Types/JSON";
+import { DomainRecord } from "../../../Utils/Domain/DomainRecord";
+import RdapDomainParser from "../../../Utils/Domain/RdapDomainParser";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Captured from https://rdap.identitydigital.services/rdap/domain/identity.digital
+ * - the exact TLD from issue #3046, whose WHOIS server answers
+ * "TLD is not supported." and whose RDAP service answers properly.
+ */
+const IDENTITY_DIGITAL_RESPONSE: JSONObject = {
+  rdapConformance: ["rdap_level_0"],
+  objectClassName: "domain",
+  handle: "DOMAIN-ID",
+  ldhName: "identity.digital",
+  status: ["client transfer prohibited"],
+  events: [
+    { eventAction: "transfer", eventDate: "2022-05-12T08:30:49.664Z" },
+    { eventAction: "expiration", eventDate: "2026-09-10T16:00:01.587Z" },
+    { eventAction: "registration", eventDate: "2014-09-10T16:00:01.587Z" },
+    { eventAction: "last changed", eventDate: "2026-07-23T00:05:29.72Z" },
+    {
+      eventAction: "last update of RDAP database",
+      eventDate: "2026-08-07T07:42:57.036Z",
+    },
+  ],
+  secureDNS: { delegationSigned: false, maxSigLife: 1 },
+  nameservers: [
+    { objectClassName: "nameserver", ldhName: "ns-525.awsdns-01.net" },
+    { objectClassName: "nameserver", ldhName: "ns-1272.awsdns-31.org" },
+    { objectClassName: "nameserver", ldhName: "ns-1583.awsdns-05.co.uk" },
+    { objectClassName: "nameserver", ldhName: "ns-341.awsdns-42.com" },
+  ],
+  entities: [
+    {
+      objectClassName: "entity",
+      handle: "625",
+      roles: ["registrar"],
+      vcardArray: [
+        "vcard",
+        [
+          ["version", {}, "text", "4.0"],
+          ["fn", {}, "text", "Name.com, Inc."],
+        ],
+      ],
+      links: [
+        {
+          rel: "self",
+          href: "https://rdap.identitydigital.services/rdap/entity/625",
+        },
+        { rel: "about", href: "https://namerdap.systems/" },
+      ],
+    },
+  ],
+};
+
+// Captured from Verisign's RDAP service, which returns the name in uppercase.
+const VERISIGN_RESPONSE: JSONObject = {
+  objectClassName: "domain",
+  ldhName: "ONEUPTIME.COM",
+  status: ["client transfer prohibited", "server delete prohibited"],
+  events: [
+    { eventAction: "registration", eventDate: "2021-11-10T20:55:40Z" },
+    { eventAction: "expiration", eventDate: "2031-11-10T20:55:40Z" },
+    { eventAction: "last changed", eventDate: "2022-03-28T07:35:06Z" },
+  ],
+  secureDNS: {
+    delegationSigned: true,
+    dsData: [{ keyTag: 2371, algorithm: 13, digestType: 2, digest: "9203BC" }],
+  },
+  nameservers: [
+    { ldhName: "ALLA.NS.CLOUDFLARE.COM" },
+    { ldhName: "BILL.NS.CLOUDFLARE.COM" },
+  ],
+  entities: [
+    {
+      roles: ["registrar"],
+      vcardArray: [
+        "vcard",
+        [
+          ["version", {}, "text", "4.0"],
+          ["fn", {}, "text", "Cloudflare, Inc."],
+        ],
+      ],
+      links: [{ rel: "about", href: "http://www.cloudflare.com" }],
+    },
+  ],
+};
+
+describe("RdapDomainParser", () => {
+  describe("a real Identity Digital (.digital) response", () => {
+    const record: DomainRecord = RdapDomainParser.parse(
+      IDENTITY_DIGITAL_RESPONSE,
+    );
+
+    it("reads the domain name", () => {
+      expect(record.domainName).toBe("identity.digital");
+    });
+
+    it("reads the expiration event as the expiry date", () => {
+      expect(record.expiresDate).toBe("2026-09-10T16:00:01.587Z");
+    });
+
+    it("reads the registration event as the created date", () => {
+      expect(record.createdDate).toBe("2014-09-10T16:00:01.587Z");
+    });
+
+    it("reads 'last changed' as the updated date, not the RDAP database timestamp", () => {
+      expect(record.updatedDate).toBe("2026-07-23T00:05:29.720Z");
+    });
+
+    it("folds the spelled-out RDAP status to its EPP name", () => {
+      expect(record.domainStatus).toEqual(["clientTransferProhibited"]);
+    });
+
+    it("lowercases the name servers", () => {
+      expect(record.nameServers).toEqual([
+        "ns-525.awsdns-01.net",
+        "ns-1272.awsdns-31.org",
+        "ns-1583.awsdns-05.co.uk",
+        "ns-341.awsdns-42.com",
+      ]);
+    });
+
+    it("reports an unsigned delegation using WHOIS vocabulary", () => {
+      expect(record.dnssec).toBe("unsigned");
+    });
+
+    it("reads the registrar name from the entity's jCard", () => {
+      expect(record.registrar).toBe("Name.com, Inc.");
+    });
+
+    it("reads the registrar URL from the 'about' link, not 'self'", () => {
+      expect(record.registrarUrl).toBe("https://namerdap.systems/");
+    });
+  });
+
+  describe("a real Verisign (.com) response", () => {
+    const record: DomainRecord = RdapDomainParser.parse(VERISIGN_RESPONSE);
+
+    it("lowercases an uppercase ldhName", () => {
+      expect(record.domainName).toBe("oneuptime.com");
+    });
+
+    it("reports a signed delegation using WHOIS vocabulary", () => {
+      expect(record.dnssec).toBe("signedDelegation");
+    });
+
+    it("folds every status", () => {
+      expect(record.domainStatus).toEqual([
+        "clientTransferProhibited",
+        "serverDeleteProhibited",
+      ]);
+    });
+
+    it("normalizes dates without milliseconds", () => {
+      expect(record.expiresDate).toBe("2031-11-10T20:55:40.000Z");
+    });
+  });
+
+  describe("registrar extraction", () => {
+    it("finds a registrar nested inside another entity", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        entities: [
+          {
+            roles: ["registrant"],
+            entities: [
+              {
+                roles: ["registrar"],
+                vcardArray: [
+                  "vcard",
+                  [["fn", {}, "text", "Nested Registrar Ltd"]],
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(record.registrar).toBe("Nested Registrar Ltd");
+    });
+
+    it("falls back to the org property when there is no fn", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        entities: [
+          {
+            roles: ["Registrar"],
+            vcardArray: ["vcard", [["org", {}, "text", "Org Only Registrar"]]],
+          },
+        ],
+      });
+
+      expect(record.registrar).toBe("Org Only Registrar");
+    });
+
+    it("falls back to the first link when none is rel=about", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        entities: [
+          {
+            roles: ["registrar"],
+            links: [{ rel: "self", href: "https://registry.example/entity/1" }],
+          },
+        ],
+      });
+
+      expect(record.registrarUrl).toBe("https://registry.example/entity/1");
+    });
+
+    it("ignores entities that carry no registrar role", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        entities: [
+          {
+            roles: ["technical"],
+            vcardArray: ["vcard", [["fn", {}, "text", "Tech Contact"]]],
+          },
+        ],
+      });
+
+      expect(record.registrar).toBeUndefined();
+    });
+  });
+
+  describe("tolerance for shapes registries actually send", () => {
+    it("accepts a status given as a bare string", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        status: "active",
+      });
+
+      expect(record.domainStatus).toEqual(["active"]);
+    });
+
+    it("accepts name servers given as bare strings", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        nameservers: ["NS1.EXAMPLE.COM"],
+      });
+
+      expect(record.nameServers).toEqual(["ns1.example.com"]);
+    });
+
+    it("falls back to unicodeName when there is no ldhName", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        unicodeName: "münchen.de",
+      });
+
+      expect(record.domainName).toBe("münchen.de");
+    });
+
+    it("skips events with a missing action or an unusable date", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        events: [
+          { eventDate: "2030-01-01T00:00:00Z" },
+          { eventAction: "expiration" },
+          { eventAction: "registration", eventDate: "2020-01-01T00:00:00Z" },
+          "not-an-event",
+        ],
+      });
+
+      expect(record.expiresDate).toBeUndefined();
+      expect(record.createdDate).toBe("2020-01-01T00:00:00.000Z");
+    });
+
+    it("keeps the first occurrence when an action repeats", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        events: [
+          { eventAction: "expiration", eventDate: "2030-01-01T00:00:00Z" },
+          { eventAction: "expiration", eventDate: "2040-01-01T00:00:00Z" },
+        ],
+      });
+
+      expect(record.expiresDate).toBe("2030-01-01T00:00:00.000Z");
+    });
+
+    it("omits secureDNS when delegationSigned is absent", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: "example.com",
+        secureDNS: { maxSigLife: 1 },
+      });
+
+      expect(record.dnssec).toBeUndefined();
+    });
+  });
+
+  describe("degenerate input", () => {
+    it("returns an empty record for null", () => {
+      expect(RdapDomainParser.parse(null)).toEqual({});
+    });
+
+    it("returns an empty record for an empty object", () => {
+      expect(RdapDomainParser.parse({})).toEqual({});
+    });
+
+    it("does not throw on wrongly typed members", () => {
+      const record: DomainRecord = RdapDomainParser.parse({
+        ldhName: 42,
+        status: 7,
+        events: "nope",
+        nameservers: { not: "an array" },
+        entities: "nope",
+        secureDNS: "nope",
+      } as unknown as JSONObject);
+
+      expect(record).toEqual({});
+    });
+  });
+});

--- a/Probe/Tests/Utils/Domain/RdapHttp.test.ts
+++ b/Probe/Tests/Utils/Domain/RdapHttp.test.ts
@@ -1,0 +1,154 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import URL from "Common/Types/API/URL";
+import { JSONObject } from "Common/Types/JSON";
+import API, { APIRequestOptions } from "Common/Utils/API";
+import ProxyConfig from "../../../Utils/ProxyConfig";
+import RdapHttp, { RdapHttpResponse } from "../../../Utils/Domain/RdapHttp";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * Every other RDAP test stubs this module out, so without these the media
+ * type and the proxy wiring - the two things it exists for - are never
+ * exercised. RDAP is the one probe protocol that CAN honour a proxy (WHOIS
+ * is a raw socket), so silently dropping the agents would break every
+ * proxied deployment.
+ */
+describe("RdapHttp.getJson", () => {
+  // eslint-disable-next-line @typescript-eslint/typedef
+  let getSpy = jest.spyOn(API, "get");
+
+  beforeEach(() => {
+    getSpy = jest
+      .spyOn(API, "get")
+      .mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, { ldhName: "example.com" }, {}),
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function requestOptions(): APIRequestOptions {
+    return getSpy.mock.calls[0]![0] as APIRequestOptions;
+  }
+
+  it("requests the URL it was given", async () => {
+    await RdapHttp.getJson("https://rdap.example/rdap/domain/example.com", {
+      timeoutInMs: 5000,
+    });
+
+    expect((requestOptions().url as URL).toString()).toBe(
+      "https://rdap.example/rdap/domain/example.com",
+    );
+  });
+
+  it("asks for the RDAP media type ahead of plain JSON", async () => {
+    await RdapHttp.getJson("https://rdap.example/rdap/domain/example.com", {
+      timeoutInMs: 5000,
+    });
+
+    expect(requestOptions().headers?.["Accept"]).toBe(
+      "application/rdap+json, application/json",
+    );
+  });
+
+  it("passes the timeout through", async () => {
+    await RdapHttp.getJson("https://rdap.example/domain/x.com", {
+      timeoutInMs: 1234,
+    });
+
+    expect(requestOptions().options?.timeout).toBe(1234);
+  });
+
+  it("attaches the probe's proxy agents", async () => {
+    const httpsAgent: Record<string, unknown> = { marker: "https-agent" };
+
+    jest
+      .spyOn(ProxyConfig, "getRequestProxyAgents")
+      .mockReturnValue({ httpsAgent } as never);
+
+    await RdapHttp.getJson("https://rdap.example/domain/x.com", {
+      timeoutInMs: 5000,
+    });
+
+    expect(requestOptions().options?.httpsAgent).toBe(httpsAgent);
+  });
+
+  it("returns the status and body of a successful response", async () => {
+    const response: RdapHttpResponse = await RdapHttp.getJson(
+      "https://rdap.example/domain/x.com",
+      { timeoutInMs: 5000 },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ldhName: "example.com" });
+  });
+
+  /*
+   * API.get returns rather than throws for a response that arrived, which is
+   * how a 404 ("not registered") reaches the caller as data.
+   */
+  it("returns the status of an error response instead of throwing", async () => {
+    getSpy.mockResolvedValue(
+      new HTTPErrorResponse(404, { message: "not found" }, {}),
+    );
+
+    const response: RdapHttpResponse = await RdapHttp.getJson(
+      "https://rdap.example/domain/x.com",
+      { timeoutInMs: 5000 },
+    );
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  /*
+   * An array body is not an RDAP domain object; handing it to the parser as
+   * one would let `["a","b"]` masquerade as a record.
+   */
+  it("reports an array body as null", async () => {
+    getSpy.mockResolvedValue({
+      statusCode: 200,
+      data: ["not", "a", "domain"],
+    } as never);
+
+    const response: RdapHttpResponse = await RdapHttp.getJson(
+      "https://rdap.example/domain/x.com",
+      { timeoutInMs: 5000 },
+    );
+
+    expect(response.body).toBeNull();
+  });
+
+  it("reports an absent body as null", async () => {
+    getSpy.mockResolvedValue({ statusCode: 204, data: undefined } as never);
+
+    const response: RdapHttpResponse = await RdapHttp.getJson(
+      "https://rdap.example/domain/x.com",
+      { timeoutInMs: 5000 },
+    );
+
+    expect(response.body).toBeNull();
+  });
+
+  it("propagates a connection-level failure to the caller", async () => {
+    getSpy.mockRejectedValue(new Error("connect ECONNREFUSED") as never);
+
+    await expect(
+      RdapHttp.getJson("https://rdap.example/domain/x.com", {
+        timeoutInMs: 5000,
+      }),
+    ).rejects.toThrow("connect ECONNREFUSED");
+  });
+});

--- a/Probe/Tests/Utils/Domain/RdapLookup.test.ts
+++ b/Probe/Tests/Utils/Domain/RdapLookup.test.ts
@@ -1,0 +1,278 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { JSONObject } from "Common/Types/JSON";
+import {
+  DomainLookupError,
+  DomainLookupErrorUtil,
+  DomainLookupUnsupportedError,
+  DomainNotFoundError,
+} from "../../../Utils/Domain/DomainLookupError";
+import RdapBootstrap from "../../../Utils/Domain/RdapBootstrap";
+import RdapHttp from "../../../Utils/Domain/RdapHttp";
+import RdapLookup, { RdapLookupResult } from "../../../Utils/Domain/RdapLookup";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const IDENTITY_DIGITAL_RDAP: JSONObject = {
+  ldhName: "identity.digital",
+  status: ["client transfer prohibited"],
+  events: [
+    { eventAction: "registration", eventDate: "2014-09-10T16:00:01.587Z" },
+    { eventAction: "expiration", eventDate: "2026-09-10T16:00:01.587Z" },
+  ],
+  nameservers: [{ ldhName: "ns-525.awsdns-01.net" }],
+  entities: [
+    {
+      roles: ["registrar"],
+      vcardArray: ["vcard", [["fn", {}, "text", "Name.com, Inc."]]],
+    },
+  ],
+};
+
+const IDENTITY_DIGITAL_BASE_URL: string =
+  "https://rdap.identitydigital.services/rdap/";
+
+describe("RdapLookup", () => {
+  // eslint-disable-next-line @typescript-eslint/typedef
+  let getJsonSpy = jest.spyOn(RdapHttp, "getJson");
+  // eslint-disable-next-line @typescript-eslint/typedef
+  let bootstrapSpy = jest.spyOn(RdapBootstrap, "getServiceUrlsForDomain");
+
+  beforeEach(() => {
+    bootstrapSpy = jest
+      .spyOn(RdapBootstrap, "getServiceUrlsForDomain")
+      .mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [IDENTITY_DIGITAL_BASE_URL],
+      } as never);
+
+    getJsonSpy = jest.spyOn(RdapHttp, "getJson").mockResolvedValue({
+      statusCode: 200,
+      body: IDENTITY_DIGITAL_RDAP,
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The whole point of issue #3046: .digital's WHOIS host answers "TLD is not
+   * supported.", while its RDAP service returns a complete record.
+   */
+  it("reads a full record for a TLD whose WHOIS server is dead", async () => {
+    const result: RdapLookupResult = await RdapLookup.lookup(
+      "identity.digital",
+      { timeoutInMs: 5000 },
+    );
+
+    expect(result.record.domainName).toBe("identity.digital");
+    expect(result.record.expiresDate).toBe("2026-09-10T16:00:01.587Z");
+    expect(result.record.registrar).toBe("Name.com, Inc.");
+    expect(result.rdapServerUrl).toBe(IDENTITY_DIGITAL_BASE_URL);
+  });
+
+  it("queries {baseUrl}domain/{name}", async () => {
+    await RdapLookup.lookup("identity.digital", { timeoutInMs: 5000 });
+
+    expect(getJsonSpy.mock.calls[0]![0]).toBe(
+      "https://rdap.identitydigital.services/rdap/domain/identity.digital",
+    );
+  });
+
+  it("passes the configured timeout down to the request", async () => {
+    await RdapLookup.lookup("identity.digital", { timeoutInMs: 1234 });
+
+    expect(getJsonSpy.mock.calls[0]![1]).toEqual({ timeoutInMs: 1234 });
+    expect(bootstrapSpy.mock.calls[0]![1]).toEqual({ timeoutInMs: 1234 });
+  });
+
+  describe("when the TLD publishes no RDAP service", () => {
+    beforeEach(() => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+    });
+
+    it("throws DomainLookupUnsupportedError", async () => {
+      await expect(
+        RdapLookup.lookup("example.io", { timeoutInMs: 5000 }),
+      ).rejects.toBeInstanceOf(DomainLookupUnsupportedError);
+    });
+
+    it("names the TLD and points at the other lookup methods", async () => {
+      await expect(
+        RdapLookup.lookup("example.io", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/\.io/);
+      await expect(
+        RdapLookup.lookup("example.io", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/WHOIS or Auto/);
+    });
+
+    it("does not make an RDAP request", async () => {
+      await RdapLookup.lookup("example.io", { timeoutInMs: 5000 }).catch(
+        (): void => {},
+      );
+
+      expect(getJsonSpy).not.toHaveBeenCalled();
+    });
+
+    it("is not retryable - a missing RDAP service will not appear on a retry", async () => {
+      const err: unknown = await RdapLookup.lookup("example.io", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(false);
+    });
+  });
+
+  /*
+   * Not reaching IANA is a fact about the network, not about the TLD.
+   * Reporting it as "no RDAP service" would be untrue AND permanent, and a
+   * permanent verdict skips retries and the probe-connectivity gate - so one
+   * data.iana.org outage would fire an incident on every domain monitor on
+   * the probe.
+   */
+  describe("when the IANA bootstrap registry is unreachable", () => {
+    beforeEach(() => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: false,
+        serviceUrls: [],
+      } as never);
+    });
+
+    it("is retryable, unlike a TLD that genuinely has no RDAP service", async () => {
+      const err: unknown = await RdapLookup.lookup("example.com", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(true);
+      expect(err).not.toBeInstanceOf(DomainLookupUnsupportedError);
+    });
+
+    it("does not claim the TLD publishes no RDAP service", async () => {
+      await expect(
+        RdapLookup.lookup("example.com", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/bootstrap registry/);
+      await expect(
+        RdapLookup.lookup("example.com", { timeoutInMs: 5000 }),
+      ).rejects.not.toThrow(/No RDAP service is published/);
+    });
+  });
+
+  describe("HTTP status handling", () => {
+    it("treats 404 as an authoritative 'not registered'", async () => {
+      getJsonSpy.mockResolvedValue({ statusCode: 404, body: null } as never);
+
+      await expect(
+        RdapLookup.lookup("not-registered.digital", { timeoutInMs: 5000 }),
+      ).rejects.toBeInstanceOf(DomainNotFoundError);
+    });
+
+    it("does not retry a 404 - the answer will not change", async () => {
+      getJsonSpy.mockResolvedValue({ statusCode: 404, body: null } as never);
+
+      const err: unknown = await RdapLookup.lookup("not-registered.digital", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(false);
+    });
+
+    it("treats a 5xx as a retryable failure", async () => {
+      getJsonSpy.mockResolvedValue({ statusCode: 503, body: null } as never);
+
+      const err: unknown = await RdapLookup.lookup("identity.digital", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(err).toBeInstanceOf(DomainLookupError);
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(true);
+      expect(DomainLookupErrorUtil.getMessage(err)).toContain("503");
+    });
+
+    it("treats a rate-limit response as a retryable failure", async () => {
+      getJsonSpy.mockResolvedValue({ statusCode: 429, body: null } as never);
+
+      const err: unknown = await RdapLookup.lookup("identity.digital", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(true);
+    });
+
+    it("rejects a 200 that carries no registration data", async () => {
+      getJsonSpy.mockResolvedValue({
+        statusCode: 200,
+        body: { rdapConformance: ["rdap_level_0"], notices: [] },
+      } as never);
+
+      await expect(
+        RdapLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/without any registration data/);
+    });
+  });
+
+  describe("when a TLD publishes more than one RDAP server", () => {
+    beforeEach(() => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: ["https://primary.example/", "https://secondary.example/"],
+      } as never);
+    });
+
+    it("falls through to the next server when the first one fails", async () => {
+      getJsonSpy
+        .mockRejectedValueOnce(new Error("connect ECONNREFUSED") as never)
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: IDENTITY_DIGITAL_RDAP,
+        } as never);
+
+      const result: RdapLookupResult = await RdapLookup.lookup(
+        "identity.digital",
+        { timeoutInMs: 5000 },
+      );
+
+      expect(result.rdapServerUrl).toBe("https://secondary.example/");
+      expect(getJsonSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops at a 404 instead of asking the next server", async () => {
+      getJsonSpy.mockResolvedValue({ statusCode: 404, body: null } as never);
+
+      await expect(
+        RdapLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toBeInstanceOf(DomainNotFoundError);
+      expect(getJsonSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the last failure when every server fails", async () => {
+      getJsonSpy
+        .mockRejectedValueOnce(new Error("first server down") as never)
+        .mockRejectedValueOnce(new Error("second server down") as never);
+
+      await expect(
+        RdapLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toThrow("second server down");
+    });
+  });
+});

--- a/Probe/Tests/Utils/Domain/WhoisLookup.test.ts
+++ b/Probe/Tests/Utils/Domain/WhoisLookup.test.ts
@@ -1,0 +1,365 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  DomainLookupErrorUtil,
+  DomainLookupUnsupportedError,
+  DomainNotFoundError,
+} from "../../../Utils/Domain/DomainLookupError";
+import { DomainRecord } from "../../../Utils/Domain/DomainRecord";
+import WhoisLookup from "../../../Utils/Domain/WhoisLookup";
+import {
+  WhoisMockCall,
+  __getWhoisCalls,
+  __resetWhoisMock,
+  __setWhoisError,
+  __setWhoisResponse,
+} from "../../__mocks__/whois-json";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Captured verbatim from `whois-json("oneuptime.com")`. Two things about it
+ * matter: whois-json joins repeated "Name Server:" lines into one
+ * space-separated string, and the expiry arrives under the registrar's key
+ * (registrarRegistrationExpirationDate) rather than the registry's.
+ */
+const WORKING_COM_RESPONSE: Record<string, unknown> = {
+  domainName: "ONEUPTIME.COM",
+  registryDomainId: "2654109619_DOMAIN_COM-VRSN",
+  registrarWhoisServer: "whois.cloudflare.com",
+  registrar: "Cloudflare, Inc.",
+  registrarUrl: "https://www.cloudflare.com",
+  updatedDate: "2022-03-18T13:27:06Z",
+  creationDate: "2021-11-10T20:55:40Z",
+  registrarRegistrationExpirationDate: "2031-11-10T20:55:40Z",
+  domainStatus:
+    "clienttransferprohibited https://icann.org/epp#clienttransferprohibited",
+  nameServer: "alla.ns.cloudflare.com bill.ns.cloudflare.com",
+  dnssec: "signedDelegation",
+  registrantName: "DATA REDACTED",
+};
+
+/*
+ * Captured verbatim from `whois-json("identity.digital")`. This is issue
+ * #3046: whois.donuts.co - still the mapped WHOIS host for .digital and
+ * every other Identity Digital TLD - replies "TLD is not supported." plus a
+ * terms-of-use blob. Neither line parses into a registration field, so the
+ * call resolves with an object that says nothing about the domain.
+ */
+const TLD_NOT_SUPPORTED_RESPONSE: Record<string, unknown> = {
+  lastUpdateOfWhoisDatabase: "2026-08-07T07:45:25Z <<<",
+  termsOfUse:
+    "Access to WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the registry database.",
+};
+
+describe("WhoisLookup", () => {
+  beforeEach(() => {
+    __resetWhoisMock();
+  });
+
+  afterEach(() => {
+    __resetWhoisMock();
+  });
+
+  describe("a working gTLD response", () => {
+    beforeEach(() => {
+      __setWhoisResponse(WORKING_COM_RESPONSE);
+    });
+
+    it("lowercases the domain name", async () => {
+      const record: DomainRecord = await WhoisLookup.lookup("oneuptime.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.domainName).toBe("oneuptime.com");
+    });
+
+    it("reads the registrar and its URL", async () => {
+      const record: DomainRecord = await WhoisLookup.lookup("oneuptime.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.registrar).toBe("Cloudflare, Inc.");
+      expect(record.registrarUrl).toBe("https://www.cloudflare.com");
+    });
+
+    it("normalizes the dates to ISO 8601", async () => {
+      const record: DomainRecord = await WhoisLookup.lookup("oneuptime.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.createdDate).toBe("2021-11-10T20:55:40.000Z");
+      expect(record.updatedDate).toBe("2022-03-18T13:27:06.000Z");
+      expect(record.expiresDate).toBe("2031-11-10T20:55:40.000Z");
+    });
+
+    it("splits the space-joined name server blob", async () => {
+      const record: DomainRecord = await WhoisLookup.lookup("oneuptime.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.nameServers).toEqual([
+        "alla.ns.cloudflare.com",
+        "bill.ns.cloudflare.com",
+      ]);
+    });
+
+    it("drops the EPP status URL", async () => {
+      const record: DomainRecord = await WhoisLookup.lookup("oneuptime.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.domainStatus).toEqual(["clienttransferprohibited"]);
+    });
+
+    it("reads DNSSEC", async () => {
+      const record: DomainRecord = await WhoisLookup.lookup("oneuptime.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.dnssec).toBe("signedDelegation");
+    });
+  });
+
+  describe("a retired WHOIS server that answers without a record", () => {
+    beforeEach(() => {
+      __setWhoisResponse(TLD_NOT_SUPPORTED_RESPONSE);
+    });
+
+    // Regression for issue #3046 - this used to resolve as a healthy monitor.
+    it("fails instead of reporting an empty record as a success", async () => {
+      await expect(
+        WhoisLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/without any registration data/);
+    });
+
+    it("explains what happened and what to do about it", async () => {
+      await expect(
+        WhoisLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/RDAP or Auto/);
+    });
+
+    /*
+     * A content-less reply is also what a registrar sends while rate
+     * limiting or briefly broken, and those cases are indistinguishable
+     * here. Classifying it permanent would open an incident on the first
+     * blip without even a retry, so it stays retryable; a genuinely dead TLD
+     * simply exhausts its attempts and is reported then.
+     */
+    it("is retryable, because a rate-limited registrar looks the same", async () => {
+      const err: unknown = await WhoisLookup.lookup("identity.digital", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(true);
+      expect(err).not.toBeInstanceOf(DomainLookupUnsupportedError);
+    });
+
+    it("also fails on a completely empty response", async () => {
+      __setWhoisResponse({});
+
+      await expect(
+        WhoisLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/without any registration data/);
+    });
+
+    it("also fails when the library resolves with null", async () => {
+      __setWhoisResponse(null);
+
+      await expect(
+        WhoisLookup.lookup("identity.digital", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/without any registration data/);
+    });
+  });
+
+  /*
+   * The other half of what a domain monitor exists to detect. DENIC echoes
+   * the name back with "Status: free" for an unregistered domain, which has
+   * fields and would otherwise read as a healthy registration.
+   */
+  describe("a domain that is not registered", () => {
+    it("reports DENIC's 'free' answer as not registered", async () => {
+      __setWhoisResponse({ domain: "nichtregistriert.de", status: "free" });
+
+      await expect(
+        WhoisLookup.lookup("nichtregistriert.de", { timeoutInMs: 5000 }),
+      ).rejects.toBeInstanceOf(DomainNotFoundError);
+    });
+
+    it("says so plainly", async () => {
+      __setWhoisResponse({ domain: "nichtregistriert.de", status: "free" });
+
+      await expect(
+        WhoisLookup.lookup("nichtregistriert.de", { timeoutInMs: 5000 }),
+      ).rejects.toThrow(/not registered/);
+    });
+
+    it("does not retry - the answer will not change", async () => {
+      __setWhoisResponse({ domain: "example.test", status: "AVAILABLE" });
+
+      const err: unknown = await WhoisLookup.lookup("example.test", {
+        timeoutInMs: 5000,
+      }).catch((caught: unknown): unknown => {
+        return caught;
+      });
+
+      expect(DomainLookupErrorUtil.isRetryable(err)).toBe(false);
+    });
+  });
+
+  describe("options passed to whois-json", () => {
+    beforeEach(() => {
+      __setWhoisResponse(WORKING_COM_RESPONSE);
+    });
+
+    /*
+     * The monitor's Timeout setting used to be dropped on the floor, leaving
+     * a WHOIS socket with no deadline at all.
+     */
+    it("passes the configured timeout through", async () => {
+      await WhoisLookup.lookup("oneuptime.com", { timeoutInMs: 4321 });
+
+      const calls: Array<WhoisMockCall> = __getWhoisCalls();
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.domain).toBe("oneuptime.com");
+      expect(calls[0]!.options).toEqual({ timeout: 4321, follow: 2 });
+    });
+  });
+
+  describe("registry-specific field names", () => {
+    it("reads the registry expiry key", async () => {
+      __setWhoisResponse({
+        domainName: "example.com",
+        registryExpiryDate: "2030-05-06T07:08:09Z",
+      });
+
+      const record: DomainRecord = await WhoisLookup.lookup("example.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.expiresDate).toBe("2030-05-06T07:08:09.000Z");
+    });
+
+    it("reads the .ru/.su style paid-till key", async () => {
+      __setWhoisResponse({
+        domain: "EXAMPLE.RU",
+        paidTill: "2030-01-01T21:00:00Z",
+        nserver: "ns1.example.ru ns2.example.ru",
+        state: "REGISTERED, DELEGATED, VERIFIED",
+      });
+
+      const record: DomainRecord = await WhoisLookup.lookup("example.ru", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.domainName).toBe("example.ru");
+      expect(record.expiresDate).toBe("2030-01-01T21:00:00.000Z");
+      expect(record.nameServers).toEqual(["ns1.example.ru", "ns2.example.ru"]);
+      expect(record.domainStatus).toEqual([
+        "REGISTERED",
+        "DELEGATED",
+        "VERIFIED",
+      ]);
+    });
+
+    it("accepts a DENIC style record with no expiry at all", async () => {
+      __setWhoisResponse({
+        domain: "example.de",
+        status: "connect",
+        changed: "2024-02-03T10:11:12Z",
+      });
+
+      const record: DomainRecord = await WhoisLookup.lookup("example.de", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.expiresDate).toBeUndefined();
+      expect(record.domainStatus).toEqual(["connect"]);
+      expect(record.updatedDate).toBe("2024-02-03T10:11:12.000Z");
+    });
+  });
+
+  describe("a followed referral chain", () => {
+    /*
+     * Precedence has to be asserted on a key both hops carry and disagree
+     * on, otherwise the test passes whichever way the merge runs.
+     */
+    it("lets the earlier (registry) hop win a key both hops set", async () => {
+      __setWhoisResponse([
+        {
+          server: "whois.verisign-grs.com",
+          data: {
+            domainName: "EXAMPLE.COM",
+            registrar: "Registry Says This",
+            registryExpiryDate: "2030-01-01T00:00:00Z",
+          },
+        },
+        {
+          server: "whois.registrar.example",
+          data: {
+            domainName: "example.com",
+            registrar: "Registrar Says That",
+            registryExpiryDate: "2999-01-01T00:00:00Z",
+            nameServer: "ns1.example.com",
+          },
+        },
+      ]);
+
+      const record: DomainRecord = await WhoisLookup.lookup("example.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.registrar).toBe("Registry Says This");
+      expect(record.expiresDate).toBe("2030-01-01T00:00:00.000Z");
+    });
+
+    it("lets a later hop fill a key the earlier one left out", async () => {
+      __setWhoisResponse([
+        {
+          server: "whois.verisign-grs.com",
+          data: { domainName: "EXAMPLE.COM" },
+        },
+        {
+          server: "whois.registrar.example",
+          data: {
+            registrar: "Only The Registrar Knows",
+            nameServer: "ns1.example.com",
+          },
+        },
+      ]);
+
+      const record: DomainRecord = await WhoisLookup.lookup("example.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.domainName).toBe("example.com");
+      expect(record.registrar).toBe("Only The Registrar Knows");
+      expect(record.nameServers).toEqual(["ns1.example.com"]);
+    });
+
+    it("handles array entries that are plain records", async () => {
+      __setWhoisResponse([
+        { domainName: "example.com", registrar: "Flat Array Registrar" },
+      ]);
+
+      const record: DomainRecord = await WhoisLookup.lookup("example.com", {
+        timeoutInMs: 5000,
+      });
+
+      expect(record.registrar).toBe("Flat Array Registrar");
+    });
+  });
+
+  describe("transport failures", () => {
+    it("propagates the error so the caller can retry it", async () => {
+      __setWhoisError(new Error("connect ETIMEDOUT 192.0.2.1:43"));
+
+      await expect(
+        WhoisLookup.lookup("example.com", { timeoutInMs: 5000 }),
+      ).rejects.toThrow("connect ETIMEDOUT 192.0.2.1:43");
+    });
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/DomainMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/DomainMonitor.test.ts
@@ -1,0 +1,657 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
+import DomainMonitorResponse from "Common/Types/Monitor/DomainMonitor/DomainMonitorResponse";
+import MonitorStepDomainMonitor from "Common/Types/Monitor/MonitorStepDomainMonitor";
+import { JSONObject } from "Common/Types/JSON";
+import Sleep from "Common/Types/Sleep";
+import logger from "Common/Server/Utils/Logger";
+import OnlineCheck from "../../../../Utils/OnlineCheck";
+import RdapBootstrap from "../../../../Utils/Domain/RdapBootstrap";
+import RdapHttp from "../../../../Utils/Domain/RdapHttp";
+import DomainMonitorUtil from "../../../../Utils/Monitors/MonitorTypes/DomainMonitor";
+import {
+  WhoisMockCall,
+  __getWhoisCalls,
+  __resetWhoisMock,
+  __setWhoisError,
+  __setWhoisResponse,
+} from "../../../__mocks__/whois-json";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const RDAP_BASE_URL: string = "https://rdap.identitydigital.services/rdap/";
+
+const RDAP_RESPONSE: JSONObject = {
+  ldhName: "identity.digital",
+  status: ["client transfer prohibited"],
+  events: [
+    { eventAction: "registration", eventDate: "2014-09-10T16:00:01.587Z" },
+    { eventAction: "expiration", eventDate: "2026-09-10T16:00:01.587Z" },
+  ],
+  nameservers: [{ ldhName: "NS-525.AWSDNS-01.NET" }],
+  secureDNS: { delegationSigned: false },
+  entities: [
+    {
+      roles: ["registrar"],
+      vcardArray: ["vcard", [["fn", {}, "text", "Name.com, Inc."]]],
+    },
+  ],
+};
+
+/*
+ * What whois.donuts.co actually returns for any .digital domain: a database
+ * timestamp and a terms-of-use blob, with the "TLD is not supported." line
+ * dropped by the parser because it has no colon. Issue #3046.
+ */
+const TLD_NOT_SUPPORTED_WHOIS: Record<string, unknown> = {
+  lastUpdateOfWhoisDatabase: "2026-08-07T07:45:25Z <<<",
+  termsOfUse: "Access to WHOIS information is provided to assist persons.",
+};
+
+const WORKING_WHOIS: Record<string, unknown> = {
+  domainName: "EXAMPLE.IO",
+  registrar: "Example Registrar Ltd",
+  creationDate: "2015-01-02T03:04:05Z",
+  registryExpiryDate: "2030-01-02T03:04:05Z",
+  nameServer: "ns1.example.io ns2.example.io",
+  domainStatus: "clientTransferProhibited https://icann.org/epp#x",
+};
+
+function buildConfig(input?: {
+  domainName?: string;
+  lookupMethod?: DomainLookupMethod;
+  timeout?: number;
+  retries?: number;
+}): MonitorStepDomainMonitor {
+  return {
+    domainName: input?.domainName ?? "identity.digital",
+    lookupMethod: input?.lookupMethod ?? DomainLookupMethod.Auto,
+    timeout: input?.timeout ?? 5000,
+    retries: input?.retries ?? 3,
+  };
+}
+
+describe("DomainMonitorUtil.query", () => {
+  // eslint-disable-next-line @typescript-eslint/typedef
+  let bootstrapSpy = jest.spyOn(RdapBootstrap, "getServiceUrlsForDomain");
+  // eslint-disable-next-line @typescript-eslint/typedef
+  let getJsonSpy = jest.spyOn(RdapHttp, "getJson");
+
+  beforeEach(() => {
+    __resetWhoisMock();
+
+    // The retry backoff is real seconds otherwise.
+    jest.spyOn(Sleep, "sleep").mockResolvedValue(undefined as never);
+
+    // Every failure path logs; keep the suite output readable.
+    jest.spyOn(logger, "error").mockImplementation((): void => {});
+    jest.spyOn(logger, "debug").mockImplementation((): void => {});
+
+    bootstrapSpy = jest
+      .spyOn(RdapBootstrap, "getServiceUrlsForDomain")
+      .mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [RDAP_BASE_URL],
+      } as never);
+
+    getJsonSpy = jest
+      .spyOn(RdapHttp, "getJson")
+      .mockResolvedValue({ statusCode: 200, body: RDAP_RESPONSE } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    __resetWhoisMock();
+  });
+
+  describe("Auto on a TLD whose WHOIS server is retired (issue #3046)", () => {
+    beforeEach(() => {
+      // WHOIS for .digital answers with no registration data at all.
+      __setWhoisResponse(TLD_NOT_SUPPORTED_WHOIS);
+    });
+
+    it("reads the record over RDAP instead of reporting an empty success", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(true);
+      expect(response!.lookupMethod).toBe(DomainLookupMethod.RDAP);
+      expect(response!.expiresDate).toBe("2026-09-10T16:00:01.587Z");
+      expect(response!.registrar).toBe("Name.com, Inc.");
+      expect(response!.nameServers).toEqual(["ns-525.awsdns-01.net"]);
+      expect(response!.domainStatus).toEqual(["clientTransferProhibited"]);
+      expect(response!.failureCause).toBe("");
+      /*
+       * Explicitly false, not undefined: criteria compare booleans, so an
+       * unset value makes "Is Request Timeout / False" undecidable and, under
+       * FilterCondition.All, stops the monitor ever going back online.
+       */
+      expect(response!.isTimeout).toBe(false);
+    });
+
+    it("never has to ask WHOIS", async () => {
+      await DomainMonitorUtil.query(buildConfig(), {
+        isOnlineCheckRequest: true,
+      });
+
+      expect(__getWhoisCalls()).toHaveLength(0);
+    });
+  });
+
+  describe("Auto on a TLD with no RDAP service", () => {
+    beforeEach(() => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisResponse(WORKING_WHOIS);
+    });
+
+    it("falls back to WHOIS and succeeds", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({ domainName: "example.io" }),
+          { isOnlineCheckRequest: true },
+        );
+
+      expect(response!.isOnline).toBe(true);
+      expect(response!.lookupMethod).toBe(DomainLookupMethod.WHOIS);
+      expect(response!.expiresDate).toBe("2030-01-02T03:04:05.000Z");
+      expect(response!.registrar).toBe("Example Registrar Ltd");
+      expect(response!.isTimeout).toBe(false);
+    });
+
+    it("does not issue an RDAP request", async () => {
+      await DomainMonitorUtil.query(buildConfig({ domainName: "example.io" }), {
+        isOnlineCheckRequest: true,
+      });
+
+      expect(getJsonSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Auto when the RDAP server is unreachable", () => {
+    it("falls back to WHOIS within the same attempt", async () => {
+      getJsonSpy.mockRejectedValue(new Error("connect ECONNREFUSED") as never);
+      __setWhoisResponse(WORKING_WHOIS);
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(true);
+      expect(response!.lookupMethod).toBe(DomainLookupMethod.WHOIS);
+      expect(response!.totalAttempts).toBe(1);
+    });
+  });
+
+  describe("Auto when the registry says the domain is not registered", () => {
+    beforeEach(() => {
+      getJsonSpy.mockResolvedValue({ statusCode: 404, body: null } as never);
+      __setWhoisResponse(WORKING_WHOIS);
+    });
+
+    it("reports the failure rather than second-guessing the registry", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.failureCause).toContain("not registered");
+    });
+
+    it("does not fall back to WHOIS", async () => {
+      await DomainMonitorUtil.query(buildConfig(), {
+        isOnlineCheckRequest: true,
+      });
+
+      expect(__getWhoisCalls()).toHaveLength(0);
+    });
+
+    it("does not retry", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig({ retries: 3 }), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.totalAttempts).toBe(1);
+      expect(getJsonSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Auto when both protocols fail", () => {
+    beforeEach(() => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisResponse(TLD_NOT_SUPPORTED_WHOIS);
+    });
+
+    it("reports offline", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.isTimeout).toBe(false);
+    });
+
+    it("explains both failures so the operator can tell them apart", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.failureCause).toContain("RDAP:");
+      expect(response!.failureCause).toContain("WHOIS:");
+      expect(response!.failureCause).toContain("No RDAP service is published");
+      expect(response!.failureCause).toContain("without any registration data");
+    });
+
+    /*
+     * A content-less WHOIS reply is indistinguishable from a rate-limited or
+     * briefly broken registrar, so it stays retryable even though the RDAP
+     * half is settled. A dead TLD simply exhausts its attempts.
+     */
+    it("still retries while one of the two failures could be transient", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig({ retries: 3 }), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.totalAttempts).toBe(3);
+      expect(response!.isOnline).toBe(false);
+    });
+
+    it("does not retry when both answers are genuinely settled", async () => {
+      __setWhoisResponse({ domain: "gone.digital", status: "free" });
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig({ retries: 3 }), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.totalAttempts).toBe(1);
+      expect(__getWhoisCalls()).toHaveLength(1);
+    });
+  });
+
+  describe("the WHOIS lookup method", () => {
+    it("reports a failure when the WHOIS server returns no record", async () => {
+      __setWhoisResponse(TLD_NOT_SUPPORTED_WHOIS);
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({ lookupMethod: DomainLookupMethod.WHOIS }),
+          { isOnlineCheckRequest: true },
+        );
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.failureCause).toContain("without any registration data");
+      expect(response!.expiresDate).toBeUndefined();
+    });
+
+    it("never reaches for RDAP", async () => {
+      __setWhoisResponse(WORKING_WHOIS);
+
+      await DomainMonitorUtil.query(
+        buildConfig({ lookupMethod: DomainLookupMethod.WHOIS }),
+        { isOnlineCheckRequest: true },
+      );
+
+      expect(bootstrapSpy).not.toHaveBeenCalled();
+      expect(getJsonSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the RDAP lookup method", () => {
+    it("fails with an actionable message when the TLD has no RDAP service", async () => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisResponse(WORKING_WHOIS);
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({
+            domainName: "example.io",
+            lookupMethod: DomainLookupMethod.RDAP,
+          }),
+          { isOnlineCheckRequest: true },
+        );
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.failureCause).toContain("No RDAP service is published");
+      expect(__getWhoisCalls()).toHaveLength(0);
+    });
+  });
+
+  describe("retries", () => {
+    it("retries a transient failure up to the configured limit", async () => {
+      getJsonSpy.mockRejectedValue(new Error("socket hang up") as never);
+      __setWhoisError(new Error("socket hang up"));
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          retry: 3,
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.totalAttempts).toBe(3);
+      expect(response!.probeAttempts).toHaveLength(3);
+      expect(response!.probeAttempts![0]!.isOnline).toBe(false);
+      expect(response!.probeAttempts![2]!.attemptNumber).toBe(3);
+    });
+
+    it("stops as soon as an attempt succeeds", async () => {
+      getJsonSpy
+        .mockRejectedValueOnce(new Error("socket hang up") as never)
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: RDAP_RESPONSE,
+        } as never);
+      __setWhoisError(new Error("socket hang up"));
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          retry: 3,
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(true);
+      expect(response!.totalAttempts).toBe(2);
+    });
+  });
+
+  describe("timeouts", () => {
+    it("classifies a WHOIS socket timeout as a timeout", async () => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisError(new Error("connect ETIMEDOUT 192.0.2.1:43"));
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          retry: 2,
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.isTimeout).toBe(true);
+      expect(response!.failureCause).toBe(
+        "Request was tried 2 times and it timed out.",
+      );
+    });
+
+    /*
+     * axios reports its own deadline as ECONNABORTED, which the old
+     * substring check did not recognise as a timeout.
+     */
+    it("classifies an axios ECONNABORTED as a timeout", async () => {
+      getJsonSpy.mockRejectedValue(
+        new Error("timeout of 5000ms exceeded (ECONNABORTED)") as never,
+      );
+      __setWhoisError(new Error("ECONNABORTED"));
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          retry: 1,
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isTimeout).toBe(true);
+    });
+  });
+
+  describe("the domain name field", () => {
+    it("rejects a malformed name without touching the network", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({ domainName: "not a domain" }),
+          { isOnlineCheckRequest: true },
+        );
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.failureCause).toContain("is not a valid domain name");
+      expect(bootstrapSpy).not.toHaveBeenCalled();
+      expect(__getWhoisCalls()).toHaveLength(0);
+    });
+
+    it("accepts a URL pasted into the field", async () => {
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({ domainName: "  HTTPS://Identity.Digital/pricing  " }),
+          { isOnlineCheckRequest: true },
+        );
+
+      expect(response!.isOnline).toBe(true);
+      expect(bootstrapSpy.mock.calls[0]![0]).toBe("identity.digital");
+      expect(getJsonSpy.mock.calls[0]![0]).toBe(
+        `${RDAP_BASE_URL}domain/identity.digital`,
+      );
+    });
+  });
+
+  describe("configuration handed to the lookups", () => {
+    it("uses the step's timeout", async () => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisResponse(WORKING_WHOIS);
+
+      await DomainMonitorUtil.query(buildConfig({ timeout: 7500 }), {
+        isOnlineCheckRequest: true,
+      });
+
+      const calls: Array<WhoisMockCall> = __getWhoisCalls();
+      expect(calls[0]!.options).toEqual({ timeout: 7500, follow: 2 });
+    });
+
+    it("lets the caller's timeout win over the step's", async () => {
+      await DomainMonitorUtil.query(buildConfig({ timeout: 7500 }), {
+        timeout: 2500,
+        isOnlineCheckRequest: true,
+      });
+
+      expect(getJsonSpy.mock.calls[0]![1]).toEqual({ timeoutInMs: 2500 });
+    });
+
+    /*
+     * Monitors saved before RDAP support existed carry no lookupMethod at
+     * all; they must behave as Auto rather than crash or skip the lookup.
+     */
+    it("treats a config with no lookupMethod as Auto", async () => {
+      const legacyConfig: MonitorStepDomainMonitor = {
+        domainName: "identity.digital",
+        timeout: 5000,
+        retries: 3,
+      } as MonitorStepDomainMonitor;
+
+      expect(DomainMonitorUtil.getLookupMethod(legacyConfig)).toBe(
+        DomainLookupMethod.Auto,
+      );
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(legacyConfig, {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(true);
+      expect(response!.lookupMethod).toBe(DomainLookupMethod.RDAP);
+    });
+
+    it("treats an unrecognised lookupMethod as Auto", async () => {
+      expect(
+        DomainMonitorUtil.getLookupMethod({
+          domainName: "example.com",
+          lookupMethod: "Telepathy" as DomainLookupMethod,
+          timeout: 5000,
+          retries: 3,
+        }),
+      ).toBe(DomainLookupMethod.Auto);
+    });
+  });
+
+  /*
+   * A data.iana.org outage says nothing about any TLD. If it were reported
+   * as "this TLD has no RDAP service" - permanent - it would skip the
+   * retries AND the probe-connectivity gate, and open an incident on every
+   * domain monitor on the probe at once.
+   */
+  describe("when the IANA bootstrap registry is unreachable", () => {
+    beforeEach(() => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: false,
+        serviceUrls: [],
+      } as never);
+    });
+
+    it("falls back to WHOIS under Auto and still succeeds", async () => {
+      __setWhoisResponse(WORKING_WHOIS);
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.isOnline).toBe(true);
+      expect(response!.lookupMethod).toBe(DomainLookupMethod.WHOIS);
+    });
+
+    it("retries rather than declaring the TLD unsupported", async () => {
+      __setWhoisResponse(TLD_NOT_SUPPORTED_WHOIS);
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), {
+          retry: 3,
+          isOnlineCheckRequest: true,
+        });
+
+      expect(response!.totalAttempts).toBe(3);
+      expect(response!.failureCause).not.toContain(
+        "No RDAP service is published",
+      );
+    });
+
+    it("is dropped by the connectivity gate instead of firing an incident", async () => {
+      jest
+        .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+        .mockResolvedValue(false as never);
+      __setWhoisResponse(TLD_NOT_SUPPORTED_WHOIS);
+
+      await expect(
+        DomainMonitorUtil.query(buildConfig(), { retry: 1 }),
+      ).resolves.toBeNull();
+    });
+
+    it("does the same under the explicit RDAP method", async () => {
+      jest
+        .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+        .mockResolvedValue(false as never);
+
+      await expect(
+        DomainMonitorUtil.query(
+          buildConfig({ lookupMethod: DomainLookupMethod.RDAP }),
+          { retry: 1 },
+        ),
+      ).resolves.toBeNull();
+    });
+  });
+
+  describe("when WHOIS says the domain is not registered", () => {
+    it("reports it plainly and does not retry", async () => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisResponse({ domain: "gone.de", status: "free" });
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({ domainName: "gone.de", retries: 3 }),
+          { isOnlineCheckRequest: true },
+        );
+
+      expect(response!.isOnline).toBe(false);
+      expect(response!.failureCause).toContain("not registered");
+      expect(response!.totalAttempts).toBe(1);
+    });
+  });
+
+  describe("the probe-connectivity gate", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+        .mockResolvedValue(false as never);
+    });
+
+    it("drops a transient failure when the probe itself is offline", async () => {
+      getJsonSpy.mockRejectedValue(new Error("socket hang up") as never);
+      __setWhoisError(new Error("socket hang up"));
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig(), { retry: 1 });
+
+      expect(response).toBeNull();
+    });
+
+    /*
+     * A registry that answered "no such domain" has already proved the
+     * network works. Routing that through the connectivity gate would throw
+     * away the very failure the monitor exists to report.
+     */
+    it("still reports a settled failure when the probe reports itself offline", async () => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+      __setWhoisResponse({ domain: "gone.de", status: "free" });
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(buildConfig({ domainName: "gone.de" }), {
+          retry: 1,
+        });
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(false);
+      expect(response!.failureCause).toContain("not registered");
+    });
+
+    it("still reports an unsupported TLD under the explicit RDAP method", async () => {
+      bootstrapSpy.mockResolvedValue({
+        isRegistryAvailable: true,
+        serviceUrls: [],
+      } as never);
+
+      const response: DomainMonitorResponse | null =
+        await DomainMonitorUtil.query(
+          buildConfig({
+            domainName: "example.io",
+            lookupMethod: DomainLookupMethod.RDAP,
+          }),
+          { retry: 1 },
+        );
+
+      expect(response).not.toBeNull();
+      expect(response!.failureCause).toContain("No RDAP service is published");
+    });
+  });
+});

--- a/Probe/Tests/__mocks__/whois-json.ts
+++ b/Probe/Tests/__mocks__/whois-json.ts
@@ -1,8 +1,62 @@
-// Mock for whois-json ESM module (not parseable by Jest)
-const whoisJson: (_domain: string) => Promise<Record<string, unknown>> = async (
-  _domain: string,
-): Promise<Record<string, unknown>> => {
-  return {};
+/*
+ * Mock for the whois-json ESM module (not parseable by Jest). Wired in by
+ * moduleNameMapper in Probe/jest.config.json, so `jest.mock("whois-json")`
+ * is never involved and tests drive it through the helpers below.
+ */
+
+export type WhoisMockOptions = Record<string, unknown> | undefined;
+
+export type WhoisMockImplementation = (
+  domain: string,
+  options?: WhoisMockOptions,
+) => Promise<unknown>;
+
+export interface WhoisMockCall {
+  domain: string;
+  options?: WhoisMockOptions;
+}
+
+const defaultImplementation: WhoisMockImplementation =
+  async (): Promise<unknown> => {
+    return {};
+  };
+
+let implementation: WhoisMockImplementation = defaultImplementation;
+
+const calls: Array<WhoisMockCall> = [];
+
+const whoisJson: WhoisMockImplementation = async (
+  domain: string,
+  options?: WhoisMockOptions,
+): Promise<unknown> => {
+  calls.push({ domain, options });
+
+  return await implementation(domain, options);
 };
+
+export function __setWhoisImplementation(impl: WhoisMockImplementation): void {
+  implementation = impl;
+}
+
+export function __setWhoisResponse(response: unknown): void {
+  implementation = async (): Promise<unknown> => {
+    return response;
+  };
+}
+
+export function __setWhoisError(error: Error): void {
+  implementation = async (): Promise<unknown> => {
+    throw error;
+  };
+}
+
+export function __getWhoisCalls(): Array<WhoisMockCall> {
+  return calls;
+}
+
+export function __resetWhoisMock(): void {
+  implementation = defaultImplementation;
+  calls.length = 0;
+}
 
 export default whoisJson;

--- a/Probe/Utils/Domain/DomainLookupError.ts
+++ b/Probe/Utils/Domain/DomainLookupError.ts
@@ -1,0 +1,72 @@
+/*
+ * Lookup failures split into two kinds, and the split is what decides
+ * whether DomainMonitorUtil.query retries.
+ *
+ * A retryable failure is a transient one - the registry timed out, rate
+ * limited us, or answered 5xx. A permanent failure is a fact about the
+ * domain or the TLD: the domain is not registered, or the TLD publishes no
+ * usable registration service. Retrying those three more times with a
+ * one-second sleep in between only delays the (identical) answer.
+ */
+export class DomainLookupError extends Error {
+  public readonly isRetryable: boolean;
+
+  public constructor(message: string, options?: { isRetryable?: boolean }) {
+    super(message);
+    this.name = "DomainLookupError";
+    this.isRetryable = options?.isRetryable ?? true;
+  }
+}
+
+// The registry answered authoritatively that the domain does not exist.
+export class DomainNotFoundError extends DomainLookupError {
+  public constructor(message: string) {
+    super(message, { isRetryable: false });
+    this.name = "DomainNotFoundError";
+  }
+}
+
+/*
+ * No usable registration service for this name - no RDAP entry in the IANA
+ * bootstrap, or a WHOIS server that answered without a record.
+ */
+export class DomainLookupUnsupportedError extends DomainLookupError {
+  public constructor(message: string) {
+    super(message, { isRetryable: false });
+    this.name = "DomainLookupUnsupportedError";
+  }
+}
+
+export class DomainLookupErrorUtil {
+  public static isRetryable(err: unknown): boolean {
+    if (err instanceof DomainLookupError) {
+      return err.isRetryable;
+    }
+
+    return true;
+  }
+
+  public static getMessage(err: unknown): string {
+    if (err instanceof Error) {
+      return err.message || err.toString();
+    }
+
+    return String(err);
+  }
+
+  /*
+   * WHOIS runs over a raw socket and RDAP over axios, so a deadline being
+   * hit shows up under several different names.
+   */
+  public static isTimeout(err: unknown): boolean {
+    const message: string = DomainLookupErrorUtil.getMessage(err).toLowerCase();
+
+    return (
+      message.includes("timeout") ||
+      message.includes("timed out") ||
+      message.includes("etimeout") ||
+      message.includes("etimedout") ||
+      message.includes("econnaborted")
+    );
+  }
+}

--- a/Probe/Utils/Domain/DomainName.ts
+++ b/Probe/Utils/Domain/DomainName.ts
@@ -1,0 +1,95 @@
+import { domainToASCII } from "node:url";
+
+const LABEL_PATTERN: RegExp = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const ALL_DIGITS_PATTERN: RegExp = /^[0-9]+$/;
+
+/*
+ * People paste "https://example.com/pricing" into a field labelled "Domain
+ * Name" often enough that it is worth accepting. Everything here is about
+ * getting from what was pasted to the registrable name a WHOIS or RDAP
+ * server will answer for.
+ */
+export default class DomainNameUtil {
+  public static normalize(domainName: string): string {
+    let normalized: string = (domainName || "").trim().toLowerCase();
+
+    // Strip a scheme, if one was pasted along with the name.
+    normalized = normalized.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
+
+    /*
+     * Path, query and fragment go first: an "@" can legitimately appear in a
+     * path, and stripping credentials before the path would take the wrong
+     * side of it.
+     */
+    normalized = normalized.split("/")[0] || "";
+    normalized = normalized.split("?")[0] || "";
+    normalized = normalized.split("#")[0] || "";
+
+    // Strip credentials.
+    normalized = normalized.split("@").pop() || "";
+
+    // Strip a port.
+    normalized = normalized.split(":")[0] || "";
+
+    // Strip the root label's trailing dot.
+    normalized = normalized.replace(/\.+$/, "");
+
+    /*
+     * Registries, the IANA bootstrap registry and WHOIS servers all key on
+     * A-labels ("xn--mnchen-3ya.de"), never the U-label an operator types.
+     * whois-json used to do this conversion itself, so skipping it here
+     * would break every IDN monitor. domainToASCII returns "" for input it
+     * cannot map, in which case the original value is kept so the failure
+     * message can name what was actually entered.
+     */
+    return domainToASCII(normalized) || normalized;
+  }
+
+  public static isValid(domainName: string): boolean {
+    if (!domainName || domainName.length > 253) {
+      return false;
+    }
+
+    const labels: Array<string> = domainName.split(".");
+
+    if (labels.length < 2) {
+      return false;
+    }
+
+    for (const label of labels) {
+      if (!LABEL_PATTERN.test(label)) {
+        return false;
+      }
+    }
+
+    // The last label (the TLD) is never all-numeric - that would be an IP.
+    return !ALL_DIGITS_PATTERN.test(labels[labels.length - 1] || "");
+  }
+
+  public static getTld(domainName: string): string {
+    const labels: Array<string> = domainName.split(".");
+
+    return labels[labels.length - 1] || "";
+  }
+
+  /*
+   * RFC 9224 matches a bootstrap entry against the longest run of trailing
+   * labels, so candidates are produced longest-first: "a.b.example.com" ->
+   * ["a.b.example.com", "b.example.com", "example.com", "com"].
+   */
+  public static getSuffixCandidates(domainName: string): Array<string> {
+    const labels: Array<string> = domainName
+      .split(".")
+      .filter((label: string) => {
+        return label.length > 0;
+      });
+
+    const candidates: Array<string> = [];
+
+    for (let i: number = 0; i < labels.length; i++) {
+      candidates.push(labels.slice(i).join("."));
+    }
+
+    return candidates;
+  }
+}

--- a/Probe/Utils/Domain/DomainRecord.ts
+++ b/Probe/Utils/Domain/DomainRecord.ts
@@ -1,0 +1,458 @@
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
+
+const WHITESPACE_PATTERN: RegExp = /\s/;
+const LOWERCASE_WORD_PATTERN: RegExp = /^[a-z]+$/;
+const IPV4_PATTERN: RegExp = /^[0-9.]+$/;
+const URL_PATTERN: RegExp = /\bhttps?:\/\/\S+/gi;
+const COMPACT_DATE_PATTERN: RegExp = /^(\d{4})(\d{2})(\d{2})$/;
+const DAY_FIRST_DATE_PATTERN: RegExp =
+  /^(\d{1,2})[-/.](\d{1,2})[-/.](\d{4})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?)?$/;
+
+const NOT_REGISTERED_STATUSES: Set<string> = new Set<string>([
+  "free",
+  "available",
+  "notregistered",
+  "noobjectfound",
+  "nomatch",
+  "notfound",
+  "nonexistent",
+]);
+
+/*
+ * EPP statuses (RFC 5731) and the registry-specific phrases seen in the wild,
+ * spelled out the way RDAP and the phrase-emitting WHOIS servers write them.
+ * Longest first so a greedy scan consumes the most specific match.
+ */
+const SPELLED_OUT_STATUS_PHRASES: Array<string> = [
+  "client delete prohibited",
+  "client hold",
+  "client renew prohibited",
+  "client transfer prohibited",
+  "client update prohibited",
+  "server delete prohibited",
+  "server hold",
+  "server renew prohibited",
+  "server transfer prohibited",
+  "server update prohibited",
+  "pending create",
+  "pending delete",
+  "pending renew",
+  "pending restore",
+  "pending transfer",
+  "pending update",
+  "add period",
+  "auto renew period",
+  "redemption period",
+  "renew period",
+  "transfer period",
+  "associated",
+  "paid and in zone",
+  "sponsoring registrar change forbidden",
+  "delete candidate",
+  "not delegated",
+  "no object found",
+  "in transit",
+  "outzone",
+  "expired",
+  "inactive",
+  "active",
+  "connect",
+  "ok",
+  "free",
+]
+  .slice()
+  .sort((a: string, b: string) => {
+    return b.length - a.length;
+  });
+
+/*
+ * The registration facts a domain monitor cares about, normalized away from
+ * whichever protocol produced them. RDAP and WHOIS both reduce to this shape
+ * so that a monitor's criteria keep matching when Auto flips between the two
+ * (which it does per-TLD, and on fallback).
+ */
+export interface DomainRecord {
+  domainName?: string | undefined;
+  registrar?: string | undefined;
+  registrarUrl?: string | undefined;
+  createdDate?: string | undefined;
+  updatedDate?: string | undefined;
+  expiresDate?: string | undefined;
+  nameServers?: Array<string> | undefined;
+  dnssec?: string | undefined;
+  domainStatus?: Array<string> | undefined;
+}
+
+export interface DomainLookupResult {
+  record: DomainRecord;
+  lookupMethod: DomainLookupMethod;
+  // Only set when RDAP answered - which registry endpoint served the record.
+  rdapServerUrl?: string | undefined;
+}
+
+export class DomainRecordUtil {
+  /*
+   * A WHOIS server that has been retired but is still listening answers with
+   * boilerplate - "TLD is not supported.", a terms-of-use blob - and no
+   * registration fields at all. That parses without throwing, which is how an
+   * unmonitorable domain used to be reported as a healthy one. A response
+   * carrying none of these fields is not a registration record.
+   */
+  public static hasRegistrationData(record: DomainRecord): boolean {
+    /*
+     * DENIC and friends answer an unregistered name with the name echoed
+     * back plus "Status: free". That has fields, but it is the opposite of a
+     * registration - reporting it as healthy would reproduce the very bug
+     * this guard exists to catch, on a domain that has actually been lost.
+     */
+    if (DomainRecordUtil.isNotRegisteredStatus(record.domainStatus)) {
+      return false;
+    }
+
+    return Boolean(
+      record.domainName ||
+        record.registrar ||
+        record.createdDate ||
+        record.updatedDate ||
+        record.expiresDate ||
+        (record.nameServers && record.nameServers.length > 0) ||
+        (record.domainStatus && record.domainStatus.length > 0),
+    );
+  }
+
+  /*
+   * Statuses that mean "there is no registration here". Registries word this
+   * differently - DENIC "free", others "available", "No Object Found" - and
+   * whois-json may hand any of them over as separate tokens, so the joined
+   * form is checked too.
+   */
+  public static isNotRegisteredStatus(
+    statuses: Array<string> | undefined,
+  ): boolean {
+    if (!statuses || statuses.length === 0) {
+      return false;
+    }
+
+    const joined: string = statuses.join("").toLowerCase();
+
+    if (NOT_REGISTERED_STATUSES.has(joined)) {
+      return true;
+    }
+
+    return statuses.some((status: string) => {
+      return NOT_REGISTERED_STATUSES.has(status.toLowerCase());
+    });
+  }
+
+  /*
+   * Dates are stored as strings and read back with `new Date(...)` by the
+   * expiry criteria. WHOIS emits a dozen formats and RDAP emits RFC 3339, so
+   * everything is normalized to ISO 8601 here.
+   *
+   * A value that cannot be parsed is DROPPED rather than passed through.
+   * Handing the criteria a string they turn into an Invalid Date is worse
+   * than having no date at all: NaN comparisons are all false, so
+   * "expires in less than 30 days" would never fire and "is expired = false"
+   * would answer "not expired" forever, on a domain that had already lapsed.
+   */
+  public static normalizeDate(value: unknown): string | undefined {
+    if (value instanceof Date) {
+      return isNaN(value.getTime()) ? undefined : value.toISOString();
+    }
+
+    if (typeof value !== "string") {
+      return undefined;
+    }
+
+    const trimmed: string = value.trim();
+
+    if (!trimmed) {
+      return undefined;
+    }
+
+    // registro.br appends a record id: "19960424 #7137".
+    const cleaned: string = trimmed.replace(/\s+#\S+$/, "");
+
+    const parsed: Date = new Date(cleaned);
+
+    if (!isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+
+    const fallback: Date | null = DomainRecordUtil.parseRegistryDate(cleaned);
+
+    return fallback ? fallback.toISOString() : undefined;
+  }
+
+  /*
+   * Only reached for strings the built-in parser already rejected, so these
+   * patterns cannot change the meaning of anything it accepts. Both are
+   * unambiguous: YYYYMMDD (registro.br) and day-first with a 4-digit year
+   * (.hk "16-11-2035", .fi "31.8.2027 00:00:00").
+   */
+  private static parseRegistryDate(value: string): Date | null {
+    const compact: RegExpExecArray | null = COMPACT_DATE_PATTERN.exec(value);
+
+    if (compact) {
+      return DomainRecordUtil.buildUtcDate({
+        year: Number(compact[1]),
+        month: Number(compact[2]),
+        day: Number(compact[3]),
+      });
+    }
+
+    const dayFirst: RegExpExecArray | null = DAY_FIRST_DATE_PATTERN.exec(value);
+
+    if (dayFirst) {
+      return DomainRecordUtil.buildUtcDate({
+        year: Number(dayFirst[3]),
+        month: Number(dayFirst[2]),
+        day: Number(dayFirst[1]),
+        hour: dayFirst[4] ? Number(dayFirst[4]) : 0,
+        minute: dayFirst[5] ? Number(dayFirst[5]) : 0,
+        second: dayFirst[6] ? Number(dayFirst[6]) : 0,
+      });
+    }
+
+    return null;
+  }
+
+  private static buildUtcDate(parts: {
+    year: number;
+    month: number;
+    day: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
+  }): Date | null {
+    if (
+      parts.month < 1 ||
+      parts.month > 12 ||
+      parts.day < 1 ||
+      parts.day > 31
+    ) {
+      return null;
+    }
+
+    const date: Date = new Date(
+      Date.UTC(
+        parts.year,
+        parts.month - 1,
+        parts.day,
+        parts.hour || 0,
+        parts.minute || 0,
+        parts.second || 0,
+      ),
+    );
+
+    // Date.UTC rolls over out-of-range days (Feb 31 -> Mar 3); reject those.
+    if (
+      date.getUTCFullYear() !== parts.year ||
+      date.getUTCMonth() !== parts.month - 1 ||
+      date.getUTCDate() !== parts.day
+    ) {
+      return null;
+    }
+
+    return date;
+  }
+
+  public static normalizeNameServers(
+    values: Array<string | undefined>,
+  ): Array<string> {
+    const hosts: Set<string> = new Set<string>();
+
+    for (const value of values) {
+      if (!value) {
+        continue;
+      }
+
+      const host: string = value.trim().toLowerCase().replace(/\.$/, "");
+
+      // Registries pad the host with its glue addresses on the same line.
+      if (!host || DomainRecordUtil.looksLikeIpAddress(host)) {
+        continue;
+      }
+
+      hosts.add(host);
+    }
+
+    return Array.from(hosts);
+  }
+
+  /*
+   * RDAP publishes EPP statuses spelled out with spaces ("client transfer
+   * prohibited") while WHOIS emits the EPP name itself
+   * ("clientTransferProhibited https://icann.org/epp#..."). Criteria are plain
+   * string comparisons, so both are folded to the EPP name - otherwise the
+   * same monitor would stop matching the moment Auto picked the other
+   * protocol.
+   */
+  public static normalizeDomainStatus(value: string): string {
+    // Drop the EPP status URL that registries append.
+    const withoutUrl: string = value.replace(/\bhttps?:\/\/\S+/gi, "").trim();
+
+    if (!withoutUrl) {
+      return "";
+    }
+
+    if (!WHITESPACE_PATTERN.test(withoutUrl)) {
+      return withoutUrl;
+    }
+
+    return withoutUrl
+      .split(/\s+/)
+      .map((word: string, index: number) => {
+        const lower: string = word.toLowerCase();
+
+        if (index === 0) {
+          return lower;
+        }
+
+        return lower.charAt(0).toUpperCase() + lower.slice(1);
+      })
+      .join("");
+  }
+
+  public static normalizeDomainStatuses(
+    values: Array<string | undefined>,
+  ): Array<string> {
+    const statuses: Set<string> = new Set<string>();
+
+    for (const value of values) {
+      if (!value) {
+        continue;
+      }
+
+      const normalized: string = DomainRecordUtil.normalizeDomainStatus(value);
+
+      if (normalized) {
+        statuses.add(normalized);
+      }
+    }
+
+    return Array.from(statuses);
+  }
+
+  /*
+   * WHOIS status arrives as one blob: whois-json joins every repeated
+   * "Domain Status:" line with a space, so several statuses share a segment.
+   * Two shapes have to come out of that correctly:
+   *
+   *   gTLD    "clientDeleteProhibited https://... clientTransferProhibited https://..."
+   *   ccTLD   "paid and in zone server delete prohibited"   (two CZ.NIC lines)
+   *
+   * The first is recovered by cutting at the EPP status URLs that separate
+   * the entries. The second cannot be cut on whitespace - that would fuse or
+   * shred it - so spelled-out statuses are matched greedily against a table
+   * of the phrases registries actually emit.
+   */
+  public static parseWhoisDomainStatus(
+    value: string | Array<string> | undefined,
+  ): Array<string> {
+    if (!value) {
+      return [];
+    }
+
+    const segments: Array<string> = Array.isArray(value)
+      ? value
+      : value.split(/[\n,;]+/);
+
+    const phrases: Array<string> = [];
+
+    for (const segment of segments) {
+      /*
+       * Parentheses hold a separate status (".ee: ok (paid and in zone)"),
+       * and every EPP URL marks the end of the entry before it.
+       */
+      const pieces: Array<string> = segment
+        .replace(URL_PATTERN, " ")
+        .replace(/[()[\]]/g, " ")
+        .split(" ");
+
+      for (const piece of pieces) {
+        phrases.push(...DomainRecordUtil.splitStatusPiece(piece));
+      }
+    }
+
+    return DomainRecordUtil.normalizeDomainStatuses(phrases);
+  }
+
+  private static splitStatusPiece(piece: string): Array<string> {
+    let remaining: string = piece.trim().replace(/\s+/g, " ");
+
+    if (!remaining) {
+      return [];
+    }
+
+    const found: Array<string> = [];
+
+    /*
+     * Consume known spelled-out phrases from the front, longest first, so
+     * "paid and in zone server delete prohibited" yields two statuses rather
+     * than one nonsense value.
+     */
+    let matchedSomething: boolean = true;
+
+    while (remaining && matchedSomething) {
+      matchedSomething = false;
+
+      for (const phrase of SPELLED_OUT_STATUS_PHRASES) {
+        const lower: string = remaining.toLowerCase();
+
+        if (lower === phrase || lower.startsWith(`${phrase} `)) {
+          found.push(remaining.slice(0, phrase.length));
+          remaining = remaining.slice(phrase.length).trim();
+          matchedSomething = true;
+          break;
+        }
+      }
+    }
+
+    if (!remaining) {
+      return found;
+    }
+
+    const tokens: Array<string> = remaining.split(" ");
+
+    /*
+     * Whatever is left is either a run of EPP names ("clientDeleteProhibited
+     * clientTransferProhibited") or one unknown lowercase phrase. Keep the
+     * old heuristic for that tail.
+     */
+    const isSpelledOutPhrase: boolean =
+      tokens.length > 1 &&
+      tokens.every((token: string) => {
+        return LOWERCASE_WORD_PATTERN.test(token);
+      });
+
+    if (isSpelledOutPhrase) {
+      found.push(remaining);
+    } else {
+      found.push(...tokens);
+    }
+
+    return found;
+  }
+
+  public static parseWhoisNameServers(
+    value: string | Array<string> | undefined,
+  ): Array<string> {
+    if (!value) {
+      return [];
+    }
+
+    const tokens: Array<string> = Array.isArray(value)
+      ? value.flatMap((entry: string) => {
+          return entry.split(/[\s,]+/);
+        })
+      : value.split(/[\s,]+/);
+
+    return DomainRecordUtil.normalizeNameServers(tokens);
+  }
+
+  private static looksLikeIpAddress(value: string): boolean {
+    // IPv4, or anything with a colon (IPv6 / host:port), is glue, not a host.
+    return IPV4_PATTERN.test(value) || value.includes(":");
+  }
+}

--- a/Probe/Utils/Domain/RdapBootstrap.ts
+++ b/Probe/Utils/Domain/RdapBootstrap.ts
@@ -1,0 +1,257 @@
+import { JSONObject } from "Common/Types/JSON";
+import logger from "Common/Server/Utils/Logger";
+import DomainNameUtil from "./DomainName";
+import RdapHttp, { RdapHttpResponse } from "./RdapHttp";
+
+/*
+ * RFC 9224. IANA publishes which RDAP service is authoritative for which
+ * TLD; it is the only way to find a registry's RDAP base URL that does not
+ * go stale the way a hardcoded WHOIS server map does.
+ */
+export const IANA_RDAP_BOOTSTRAP_URL: string =
+  "https://data.iana.org/rdap/dns.json";
+
+// The document changes a handful of times a year.
+export const BOOTSTRAP_CACHE_TTL_IN_MS: number = 24 * 60 * 60 * 1000;
+
+/*
+ * A probe that cannot reach data.iana.org should degrade to WHOIS quickly
+ * rather than pay the fetch timeout on every single check, but it should
+ * also start using RDAP again on its own once the network recovers.
+ */
+export const BOOTSTRAP_FAILURE_CACHE_TTL_IN_MS: number = 5 * 60 * 1000;
+
+export const BOOTSTRAP_FETCH_TIMEOUT_IN_MS: number = 15000;
+
+export interface RdapBootstrapResult {
+  // False only when the IANA registry could not be read at all.
+  isRegistryAvailable: boolean;
+  serviceUrls: Array<string>;
+}
+
+export default class RdapBootstrap {
+  private static serviceUrlsBySuffix: Map<string, Array<string>> | null = null;
+  private static cachedAtInMs: number = 0;
+  private static lastFailedAtInMs: number = 0;
+  private static inFlightLoad: Promise<Map<
+    string,
+    Array<string>
+  > | null> | null = null;
+
+  public static clearCache(): void {
+    RdapBootstrap.serviceUrlsBySuffix = null;
+    RdapBootstrap.cachedAtInMs = 0;
+    RdapBootstrap.lastFailedAtInMs = 0;
+    RdapBootstrap.inFlightLoad = null;
+  }
+
+  /*
+   * Every RDAP base URL that claims the longest matching suffix of this
+   * domain, most-preferred first.
+   *
+   * isRegistryAvailable is the load-bearing part of the result. An empty
+   * serviceUrls with the registry AVAILABLE means "this TLD publishes no
+   * RDAP service", which is the normal state of affairs for .io, .co, .de
+   * and most other ccTLDs and is permanent. An empty serviceUrls with the
+   * registry UNAVAILABLE means we could not reach IANA, which is transient
+   * and must not be reported as a fact about the TLD.
+   */
+  public static async getServiceUrlsForDomain(
+    domainName: string,
+    options?: { timeoutInMs?: number | undefined },
+  ): Promise<RdapBootstrapResult> {
+    const registry: Map<string, Array<string>> | null =
+      await RdapBootstrap.getRegistry(options);
+
+    if (!registry) {
+      return { isRegistryAvailable: false, serviceUrls: [] };
+    }
+
+    for (const candidate of DomainNameUtil.getSuffixCandidates(
+      domainName.toLowerCase(),
+    )) {
+      const urls: Array<string> | undefined = registry.get(candidate);
+
+      if (urls && urls.length > 0) {
+        return { isRegistryAvailable: true, serviceUrls: urls };
+      }
+    }
+
+    return { isRegistryAvailable: true, serviceUrls: [] };
+  }
+
+  public static parseBootstrapDocument(
+    json: JSONObject | null,
+  ): Map<string, Array<string>> {
+    const registry: Map<string, Array<string>> = new Map<
+      string,
+      Array<string>
+    >();
+
+    const services: unknown = json ? json["services"] : null;
+
+    if (!Array.isArray(services)) {
+      return registry;
+    }
+
+    for (const service of services) {
+      if (!Array.isArray(service) || service.length < 2) {
+        continue;
+      }
+
+      const suffixes: unknown = service[0];
+      const urls: unknown = service[1];
+
+      if (!Array.isArray(suffixes) || !Array.isArray(urls)) {
+        continue;
+      }
+
+      const baseUrls: Array<string> = RdapBootstrap.normalizeServiceUrls(urls);
+
+      if (baseUrls.length === 0) {
+        continue;
+      }
+
+      for (const suffix of suffixes) {
+        if (typeof suffix !== "string") {
+          continue;
+        }
+
+        const key: string = suffix
+          .trim()
+          .toLowerCase()
+          .replace(/^\.+|\.+$/g, "");
+
+        if (!key) {
+          continue;
+        }
+
+        const existing: Array<string> = registry.get(key) || [];
+
+        registry.set(key, [...existing, ...baseUrls]);
+      }
+    }
+
+    return registry;
+  }
+
+  /*
+   * Base URLs are documented to end in "/" but not every entry does, and a
+   * few entries are plain HTTP. HTTPS is preferred and the trailing slash is
+   * made uniform so callers can just append "domain/<name>".
+   */
+  private static normalizeServiceUrls(urls: Array<unknown>): Array<string> {
+    const httpsUrls: Array<string> = [];
+    const otherUrls: Array<string> = [];
+
+    for (const url of urls) {
+      if (typeof url !== "string") {
+        continue;
+      }
+
+      const trimmed: string = url.trim();
+
+      if (!trimmed) {
+        continue;
+      }
+
+      const withSlash: string = trimmed.endsWith("/") ? trimmed : `${trimmed}/`;
+
+      if (withSlash.toLowerCase().startsWith("https://")) {
+        httpsUrls.push(withSlash);
+      } else if (withSlash.toLowerCase().startsWith("http://")) {
+        otherUrls.push(withSlash);
+      }
+    }
+
+    return [...httpsUrls, ...otherUrls];
+  }
+
+  private static async getRegistry(options?: {
+    timeoutInMs?: number | undefined;
+  }): Promise<Map<string, Array<string>> | null> {
+    const now: number = Date.now();
+
+    if (
+      RdapBootstrap.serviceUrlsBySuffix &&
+      now - RdapBootstrap.cachedAtInMs < BOOTSTRAP_CACHE_TTL_IN_MS
+    ) {
+      return RdapBootstrap.serviceUrlsBySuffix;
+    }
+
+    if (
+      RdapBootstrap.lastFailedAtInMs &&
+      now - RdapBootstrap.lastFailedAtInMs < BOOTSTRAP_FAILURE_CACHE_TTL_IN_MS
+    ) {
+      // Serve a stale copy if there is one; otherwise let the caller use WHOIS.
+      return RdapBootstrap.serviceUrlsBySuffix;
+    }
+
+    // Many monitors run at once - one fetch serves all of them.
+    if (!RdapBootstrap.inFlightLoad) {
+      RdapBootstrap.inFlightLoad = RdapBootstrap.load(options).finally(() => {
+        RdapBootstrap.inFlightLoad = null;
+      });
+    }
+
+    return RdapBootstrap.inFlightLoad;
+  }
+
+  private static async load(options?: {
+    timeoutInMs?: number | undefined;
+  }): Promise<Map<string, Array<string>> | null> {
+    try {
+      const response: RdapHttpResponse = await RdapHttp.getJson(
+        IANA_RDAP_BOOTSTRAP_URL,
+        {
+          /*
+           * This fetch is shared by every domain monitor on the probe, so it
+           * must not inherit whichever monitor happened to trigger it. A
+           * monitor with a 2s timeout would otherwise abort the ~200KB
+           * document for everybody and poison the failure cache.
+           */
+          timeoutInMs: Math.max(
+            options?.timeoutInMs || 0,
+            BOOTSTRAP_FETCH_TIMEOUT_IN_MS,
+          ),
+        },
+      );
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw new Error(
+          `IANA RDAP bootstrap returned HTTP ${response.statusCode}`,
+        );
+      }
+
+      const registry: Map<
+        string,
+        Array<string>
+      > = RdapBootstrap.parseBootstrapDocument(response.body);
+
+      if (registry.size === 0) {
+        throw new Error("IANA RDAP bootstrap document listed no services");
+      }
+
+      RdapBootstrap.serviceUrlsBySuffix = registry;
+      RdapBootstrap.cachedAtInMs = Date.now();
+      RdapBootstrap.lastFailedAtInMs = 0;
+
+      logger.debug(
+        `RDAP bootstrap loaded: ${registry.size} suffixes from ${IANA_RDAP_BOOTSTRAP_URL}`,
+      );
+
+      return registry;
+    } catch (err: unknown) {
+      RdapBootstrap.lastFailedAtInMs = Date.now();
+
+      logger.debug(
+        `RDAP bootstrap fetch failed, domain lookups will fall back to WHOIS: ${
+          (err as Error)?.message || String(err)
+        }`,
+      );
+
+      // A stale registry still beats no registry.
+      return RdapBootstrap.serviceUrlsBySuffix;
+    }
+  }
+}

--- a/Probe/Utils/Domain/RdapDomainParser.ts
+++ b/Probe/Utils/Domain/RdapDomainParser.ts
@@ -1,0 +1,369 @@
+import { JSONObject } from "Common/Types/JSON";
+import { DomainRecord, DomainRecordUtil } from "./DomainRecord";
+
+/*
+ * RDAP event actions this parser cares about (RFC 9083 section 10.2.3).
+ * "last update of RDAP database" is deliberately not mapped to updatedDate -
+ * it describes the registry's database, not the registration.
+ */
+const EVENT_REGISTRATION: string = "registration";
+const EVENT_EXPIRATION: string = "expiration";
+const EVENT_LAST_CHANGED: string = "last changed";
+
+/*
+ * Turns an RFC 9083 domain object into the flat record a domain monitor
+ * evaluates. Pure - no I/O - so every registry response shape encountered in
+ * the wild can be covered by a test.
+ */
+export default class RdapDomainParser {
+  public static parse(json: JSONObject | null): DomainRecord {
+    if (!json) {
+      return {};
+    }
+
+    const record: DomainRecord = {};
+
+    const domainName: string | undefined =
+      RdapDomainParser.asString(json["ldhName"]) ||
+      RdapDomainParser.asString(json["unicodeName"]);
+
+    if (domainName) {
+      record.domainName = domainName.toLowerCase().replace(/\.$/, "");
+    }
+
+    const eventDates: Map<string, string> = RdapDomainParser.parseEvents(
+      json["events"],
+    );
+
+    const createdDate: string | undefined = eventDates.get(EVENT_REGISTRATION);
+    const expiresDate: string | undefined = eventDates.get(EVENT_EXPIRATION);
+    const updatedDate: string | undefined = eventDates.get(EVENT_LAST_CHANGED);
+
+    if (createdDate) {
+      record.createdDate = createdDate;
+    }
+
+    if (expiresDate) {
+      record.expiresDate = expiresDate;
+    }
+
+    if (updatedDate) {
+      record.updatedDate = updatedDate;
+    }
+
+    const domainStatus: Array<string> =
+      DomainRecordUtil.normalizeDomainStatuses(
+        RdapDomainParser.asStringArray(json["status"]),
+      );
+
+    if (domainStatus.length > 0) {
+      record.domainStatus = domainStatus;
+    }
+
+    const nameServers: Array<string> = RdapDomainParser.parseNameServers(
+      json["nameservers"],
+    );
+
+    if (nameServers.length > 0) {
+      record.nameServers = nameServers;
+    }
+
+    const dnssec: string | undefined = RdapDomainParser.parseSecureDNS(
+      json["secureDNS"],
+    );
+
+    if (dnssec) {
+      record.dnssec = dnssec;
+    }
+
+    const registrar: { name?: string; url?: string } =
+      RdapDomainParser.parseRegistrar(json["entities"]);
+
+    if (registrar.name) {
+      record.registrar = registrar.name;
+    }
+
+    if (registrar.url) {
+      record.registrarUrl = registrar.url;
+    }
+
+    return record;
+  }
+
+  private static parseEvents(events: unknown): Map<string, string> {
+    const dates: Map<string, string> = new Map<string, string>();
+
+    if (!Array.isArray(events)) {
+      return dates;
+    }
+
+    for (const event of events) {
+      if (!event || typeof event !== "object" || Array.isArray(event)) {
+        continue;
+      }
+
+      const action: string | undefined = RdapDomainParser.asString(
+        (event as JSONObject)["eventAction"],
+      );
+      const date: string | undefined = DomainRecordUtil.normalizeDate(
+        (event as JSONObject)["eventDate"],
+      );
+
+      if (!action || !date) {
+        continue;
+      }
+
+      const key: string = action.trim().toLowerCase();
+
+      // First occurrence wins; registries do not repeat these actions.
+      if (!dates.has(key)) {
+        dates.set(key, date);
+      }
+    }
+
+    return dates;
+  }
+
+  private static parseNameServers(nameservers: unknown): Array<string> {
+    if (!Array.isArray(nameservers)) {
+      return [];
+    }
+
+    const hosts: Array<string | undefined> = nameservers.map(
+      (nameserver: unknown): string | undefined => {
+        if (typeof nameserver === "string") {
+          return nameserver;
+        }
+
+        if (
+          !nameserver ||
+          typeof nameserver !== "object" ||
+          Array.isArray(nameserver)
+        ) {
+          return undefined;
+        }
+
+        return (
+          RdapDomainParser.asString((nameserver as JSONObject)["ldhName"]) ||
+          RdapDomainParser.asString((nameserver as JSONObject)["unicodeName"])
+        );
+      },
+    );
+
+    return DomainRecordUtil.normalizeNameServers(hosts);
+  }
+
+  /*
+   * Reported with the same vocabulary WHOIS uses ("signedDelegation" /
+   * "unsigned") so a criterion written against one lookup method keeps
+   * matching under the other.
+   */
+  private static parseSecureDNS(secureDNS: unknown): string | undefined {
+    if (
+      !secureDNS ||
+      typeof secureDNS !== "object" ||
+      Array.isArray(secureDNS)
+    ) {
+      return undefined;
+    }
+
+    const delegationSigned: unknown = (secureDNS as JSONObject)[
+      "delegationSigned"
+    ];
+
+    if (delegationSigned === true) {
+      return "signedDelegation";
+    }
+
+    if (delegationSigned === false) {
+      return "unsigned";
+    }
+
+    return undefined;
+  }
+
+  /*
+   * The registrar is the entity carrying the "registrar" role. Registries
+   * nest it inconsistently - sometimes at the top level, sometimes inside
+   * another entity - so the whole tree is searched.
+   */
+  private static parseRegistrar(entities: unknown): {
+    name?: string;
+    url?: string;
+  } {
+    const entity: JSONObject | null = RdapDomainParser.findEntityWithRole(
+      entities,
+      "registrar",
+      0,
+    );
+
+    if (!entity) {
+      return {};
+    }
+
+    const result: { name?: string; url?: string } = {};
+
+    const name: string | undefined = RdapDomainParser.parseVCardName(
+      entity["vcardArray"],
+    );
+
+    if (name) {
+      result.name = name;
+    }
+
+    const url: string | undefined = RdapDomainParser.parseAboutLink(
+      entity["links"],
+    );
+
+    if (url) {
+      result.url = url;
+    }
+
+    return result;
+  }
+
+  private static findEntityWithRole(
+    entities: unknown,
+    role: string,
+    depth: number,
+  ): JSONObject | null {
+    // Guards against a registry echoing a cyclic-looking entity tree back.
+    if (!Array.isArray(entities) || depth > 4) {
+      return null;
+    }
+
+    for (const entity of entities) {
+      if (!entity || typeof entity !== "object" || Array.isArray(entity)) {
+        continue;
+      }
+
+      const roles: Array<string> = RdapDomainParser.asStringArray(
+        (entity as JSONObject)["roles"],
+      ).map((value: string) => {
+        return value.trim().toLowerCase();
+      });
+
+      if (roles.includes(role)) {
+        return entity as JSONObject;
+      }
+    }
+
+    for (const entity of entities) {
+      if (!entity || typeof entity !== "object" || Array.isArray(entity)) {
+        continue;
+      }
+
+      const nested: JSONObject | null = RdapDomainParser.findEntityWithRole(
+        (entity as JSONObject)["entities"],
+        role,
+        depth + 1,
+      );
+
+      if (nested) {
+        return nested;
+      }
+    }
+
+    return null;
+  }
+
+  /*
+   * jCard (RFC 7095): ["vcard", [["version", {}, "text", "4.0"],
+   * ["fn", {}, "text", "Example Registrar, Inc."], ...]].
+   */
+  private static parseVCardName(vcardArray: unknown): string | undefined {
+    if (!Array.isArray(vcardArray) || vcardArray.length < 2) {
+      return undefined;
+    }
+
+    const properties: unknown = vcardArray[1];
+
+    if (!Array.isArray(properties)) {
+      return undefined;
+    }
+
+    let organization: string | undefined = undefined;
+
+    for (const property of properties) {
+      if (!Array.isArray(property) || property.length < 4) {
+        continue;
+      }
+
+      const name: string | undefined = RdapDomainParser.asString(property[0]);
+      const value: string | undefined = RdapDomainParser.asString(property[3]);
+
+      if (!name || !value) {
+        continue;
+      }
+
+      if (name.toLowerCase() === "fn") {
+        return value.trim();
+      }
+
+      if (name.toLowerCase() === "org" && !organization) {
+        organization = value.trim();
+      }
+    }
+
+    return organization;
+  }
+
+  private static parseAboutLink(links: unknown): string | undefined {
+    if (!Array.isArray(links)) {
+      return undefined;
+    }
+
+    let firstHref: string | undefined = undefined;
+
+    for (const link of links) {
+      if (!link || typeof link !== "object" || Array.isArray(link)) {
+        continue;
+      }
+
+      const rel: string | undefined = RdapDomainParser.asString(
+        (link as JSONObject)["rel"],
+      );
+      const href: string | undefined = RdapDomainParser.asString(
+        (link as JSONObject)["href"],
+      );
+
+      if (!href) {
+        continue;
+      }
+
+      if (rel && rel.trim().toLowerCase() === "about") {
+        return href.trim();
+      }
+
+      if (!firstHref) {
+        firstHref = href.trim();
+      }
+    }
+
+    return firstHref;
+  }
+
+  private static asString(value: unknown): string | undefined {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+
+    const trimmed: string = value.trim();
+
+    return trimmed || undefined;
+  }
+
+  private static asStringArray(value: unknown): Array<string> {
+    if (typeof value === "string") {
+      return [value];
+    }
+
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.filter((item: unknown): item is string => {
+      return typeof item === "string";
+    });
+  }
+}

--- a/Probe/Utils/Domain/RdapHttp.ts
+++ b/Probe/Utils/Domain/RdapHttp.ts
@@ -1,0 +1,56 @@
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import URL from "Common/Types/API/URL";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import ProxyConfig, { ProxyAgents } from "../ProxyConfig";
+
+export interface RdapHttpResponse {
+  statusCode: number;
+  body: JSONObject | null;
+}
+
+/*
+ * The one place RDAP talks HTTP. Both the IANA bootstrap fetch and the
+ * per-domain query go through here so they share the probe's proxy config
+ * and the RDAP media type.
+ */
+export default class RdapHttp {
+  public static async getJson(
+    urlString: string,
+    options: { timeoutInMs: number },
+  ): Promise<RdapHttpResponse> {
+    const url: URL = URL.fromString(urlString);
+
+    const proxyAgents: ProxyAgents = ProxyConfig.getRequestProxyAgents(url);
+
+    const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await API.get<JSONObject>({
+        url: url,
+        headers: {
+          /*
+           * RFC 9083 media type. Some registries content-negotiate on it and
+           * a few reject application/json outright, so it goes first.
+           */
+          Accept: "application/rdap+json, application/json",
+        },
+        options: {
+          timeout: options.timeoutInMs,
+          ...proxyAgents,
+        },
+      });
+
+    return {
+      statusCode: response.statusCode,
+      body: RdapHttp.toJSONObject(response.data),
+    };
+  }
+
+  private static toJSONObject(data: unknown): JSONObject | null {
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      return null;
+    }
+
+    return data as JSONObject;
+  }
+}

--- a/Probe/Utils/Domain/RdapLookup.ts
+++ b/Probe/Utils/Domain/RdapLookup.ts
@@ -1,0 +1,132 @@
+import logger from "Common/Server/Utils/Logger";
+import DomainNameUtil from "./DomainName";
+import {
+  DomainLookupError,
+  DomainLookupErrorUtil,
+  DomainLookupUnsupportedError,
+  DomainNotFoundError,
+} from "./DomainLookupError";
+import { DomainRecord, DomainRecordUtil } from "./DomainRecord";
+import RdapBootstrap, {
+  IANA_RDAP_BOOTSTRAP_URL,
+  RdapBootstrapResult,
+} from "./RdapBootstrap";
+import RdapDomainParser from "./RdapDomainParser";
+import RdapHttp, { RdapHttpResponse } from "./RdapHttp";
+
+export interface RdapLookupResult {
+  record: DomainRecord;
+  rdapServerUrl: string;
+}
+
+export default class RdapLookup {
+  /*
+   * Reads a domain's registration record over RDAP (RFC 9083), using the
+   * IANA bootstrap registry (RFC 9224) to find the authoritative server.
+   *
+   * Throws DomainLookupUnsupportedError when the TLD publishes no RDAP
+   * service - that is the normal state for .io, .co, .de and most other
+   * ccTLDs, and the caller is expected to fall back to WHOIS rather than
+   * treat it as an outage.
+   */
+  public static async lookup(
+    domainName: string,
+    options: { timeoutInMs: number },
+  ): Promise<RdapLookupResult> {
+    const bootstrap: RdapBootstrapResult =
+      await RdapBootstrap.getServiceUrlsForDomain(domainName, {
+        timeoutInMs: options.timeoutInMs,
+      });
+
+    /*
+     * Not reaching IANA says nothing about the TLD. Reporting it as "this TLD
+     * has no RDAP service" would be both untrue and permanent, which would
+     * skip the retries and the probe-connectivity gate and open an incident
+     * on every domain monitor on the probe during a data.iana.org outage.
+     */
+    if (!bootstrap.isRegistryAvailable) {
+      throw new DomainLookupError(
+        `Could not read the IANA RDAP bootstrap registry at ${IANA_RDAP_BOOTSTRAP_URL}, so the RDAP service for .${DomainNameUtil.getTld(
+          domainName,
+        )} is unknown.`,
+      );
+    }
+
+    const baseUrls: Array<string> = bootstrap.serviceUrls;
+
+    if (baseUrls.length === 0) {
+      throw new DomainLookupUnsupportedError(
+        `No RDAP service is published for .${DomainNameUtil.getTld(
+          domainName,
+        )} in the IANA RDAP bootstrap registry. Use the WHOIS or Auto lookup method for this domain.`,
+      );
+    }
+
+    let lastError: unknown = null;
+
+    /*
+     * A TLD can list more than one RDAP endpoint. Try each in turn so one
+     * mirror being down does not fail the check.
+     */
+    for (const baseUrl of baseUrls) {
+      const url: string = `${baseUrl}domain/${encodeURIComponent(domainName)}`;
+
+      try {
+        return {
+          record: await RdapLookup.queryServer(url, options),
+          rdapServerUrl: baseUrl,
+        };
+      } catch (err: unknown) {
+        // "Not registered" is an answer, not a reason to try the next mirror.
+        if (err instanceof DomainNotFoundError) {
+          throw err;
+        }
+
+        logger.debug(
+          `RDAP query failed against ${url}: ${DomainLookupErrorUtil.getMessage(
+            err,
+          )}`,
+        );
+
+        lastError = err;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new DomainLookupError(
+          `RDAP lookup for ${domainName} failed against every server published for its TLD.`,
+        );
+  }
+
+  private static async queryServer(
+    url: string,
+    options: { timeoutInMs: number },
+  ): Promise<DomainRecord> {
+    const response: RdapHttpResponse = await RdapHttp.getJson(url, {
+      timeoutInMs: options.timeoutInMs,
+    });
+
+    if (response.statusCode === 404) {
+      throw new DomainNotFoundError(
+        `The registry's RDAP service reports that this domain is not registered (HTTP 404 from ${url}).`,
+      );
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new DomainLookupError(
+        `RDAP server returned HTTP ${response.statusCode} for ${url}.`,
+      );
+    }
+
+    const record: DomainRecord = RdapDomainParser.parse(response.body);
+
+    if (!DomainRecordUtil.hasRegistrationData(record)) {
+      throw new DomainLookupError(
+        `RDAP server at ${url} answered without any registration data.`,
+      );
+    }
+
+    return record;
+  }
+}

--- a/Probe/Utils/Domain/WhoisLookup.ts
+++ b/Probe/Utils/Domain/WhoisLookup.ts
@@ -1,0 +1,293 @@
+import whoisJson from "whois-json";
+import { DomainLookupError, DomainNotFoundError } from "./DomainLookupError";
+import { DomainRecord, DomainRecordUtil } from "./DomainRecord";
+
+type WhoisData = Record<string, unknown>;
+
+/*
+ * whois-json camel-cases every "Key: value" line it can find and throws the
+ * rest away, so the same fact arrives under a different key per registry.
+ * These are the aliases seen in practice, most specific first.
+ */
+const DOMAIN_NAME_KEYS: Array<string> = ["domainName", "domain"];
+
+const REGISTRAR_KEYS: Array<string> = [
+  "registrar",
+  "registrarName",
+  "sponsoringRegistrar",
+];
+
+const REGISTRAR_URL_KEYS: Array<string> = [
+  "registrarUrl",
+  "registrarURL",
+  "referralUrl",
+];
+
+const CREATED_DATE_KEYS: Array<string> = [
+  "creationDate",
+  "createdDate",
+  "created",
+  "registered",
+  "registrationTime",
+  "domainRegistrationDate",
+];
+
+const UPDATED_DATE_KEYS: Array<string> = [
+  "updatedDate",
+  "lastUpdated",
+  "lastModified",
+  "changed",
+];
+
+const EXPIRES_DATE_KEYS: Array<string> = [
+  "registrarRegistrationExpirationDate",
+  "registryExpiryDate",
+  "expirationDate",
+  "expiresDate",
+  "expires",
+  "expiryDate",
+  "expirationTime",
+  "paidTill",
+  "renewalDate",
+  "validUntil",
+];
+
+const NAME_SERVER_KEYS: Array<string> = [
+  "nameServer",
+  "nameServers",
+  "nameservers",
+  "nserver",
+];
+
+const DNSSEC_KEYS: Array<string> = ["dnssec", "DNSSEC"];
+
+const DOMAIN_STATUS_KEYS: Array<string> = ["domainStatus", "status", "state"];
+
+export default class WhoisLookup {
+  public static async lookup(
+    domainName: string,
+    options: { timeoutInMs: number },
+  ): Promise<DomainRecord> {
+    /*
+     * The timeout used to be dropped on the floor here, which left the
+     * monitor's Timeout setting doing nothing at all and a hung WHOIS socket
+     * with no deadline. `follow` walks the registry -> registrar referral so
+     * the detailed record is the one that gets parsed.
+     */
+    const result: unknown = await whoisJson(domainName, {
+      timeout: options.timeoutInMs,
+      follow: 2,
+    });
+
+    const record: DomainRecord = WhoisLookup.toDomainRecord(result);
+
+    /*
+     * An explicit "there is nothing registered here" - DENIC's "Status: free"
+     * and friends. That is a settled answer about the domain, so it is
+     * permanent and worth saying plainly.
+     */
+    if (DomainRecordUtil.isNotRegisteredStatus(record.domainStatus)) {
+      throw new DomainNotFoundError(
+        `The WHOIS server for ${domainName} reports that this domain is not registered (status: ${record.domainStatus?.join(
+          ", ",
+        )}).`,
+      );
+    }
+
+    /*
+     * The bug this guards against: retired WHOIS hosts that are still
+     * listening. whois.donuts.co - still the mapped server for .digital and
+     * every other Identity Digital TLD - answers "TLD is not supported."
+     * plus a terms-of-use blob. None of that parses into a registration
+     * field, so the lookup "succeeded" with an empty record and the monitor
+     * was reported healthy with a blank expiry date.
+     *
+     * This stays RETRYABLE. The same content-less shape is what a registrar
+     * returns when it rate-limits ("Query rate exceeded") or is briefly
+     * broken, and treating those as permanent would open an incident on the
+     * first blip without so much as a retry. A genuinely dead TLD simply
+     * fails all its attempts and is reported then.
+     */
+    if (!DomainRecordUtil.hasRegistrationData(record)) {
+      throw new DomainLookupError(
+        `The WHOIS server for ${domainName} answered without any registration data. The TLD's WHOIS service may be unavailable, rate limiting, or no longer supported - try the RDAP or Auto lookup method.`,
+      );
+    }
+
+    return record;
+  }
+
+  public static toDomainRecord(result: unknown): DomainRecord {
+    const merged: WhoisData = WhoisLookup.mergeResponses(result);
+
+    const record: DomainRecord = {};
+
+    const domainName: string | undefined = WhoisLookup.firstString(
+      merged,
+      DOMAIN_NAME_KEYS,
+    );
+
+    if (domainName) {
+      record.domainName = domainName.toLowerCase().replace(/\.$/, "");
+    }
+
+    const registrar: string | undefined = WhoisLookup.firstString(
+      merged,
+      REGISTRAR_KEYS,
+    );
+
+    if (registrar) {
+      record.registrar = registrar;
+    }
+
+    const registrarUrl: string | undefined = WhoisLookup.firstString(
+      merged,
+      REGISTRAR_URL_KEYS,
+    );
+
+    if (registrarUrl) {
+      record.registrarUrl = registrarUrl;
+    }
+
+    const createdDate: string | undefined = DomainRecordUtil.normalizeDate(
+      WhoisLookup.firstString(merged, CREATED_DATE_KEYS),
+    );
+
+    if (createdDate) {
+      record.createdDate = createdDate;
+    }
+
+    const updatedDate: string | undefined = DomainRecordUtil.normalizeDate(
+      WhoisLookup.firstString(merged, UPDATED_DATE_KEYS),
+    );
+
+    if (updatedDate) {
+      record.updatedDate = updatedDate;
+    }
+
+    const expiresDate: string | undefined = DomainRecordUtil.normalizeDate(
+      WhoisLookup.firstString(merged, EXPIRES_DATE_KEYS),
+    );
+
+    if (expiresDate) {
+      record.expiresDate = expiresDate;
+    }
+
+    const nameServers: Array<string> = DomainRecordUtil.parseWhoisNameServers(
+      WhoisLookup.firstValue(merged, NAME_SERVER_KEYS),
+    );
+
+    if (nameServers.length > 0) {
+      record.nameServers = nameServers;
+    }
+
+    const dnssec: string | undefined = WhoisLookup.firstString(
+      merged,
+      DNSSEC_KEYS,
+    );
+
+    if (dnssec) {
+      record.dnssec = dnssec;
+    }
+
+    const domainStatus: Array<string> = DomainRecordUtil.parseWhoisDomainStatus(
+      WhoisLookup.firstValue(merged, DOMAIN_STATUS_KEYS),
+    );
+
+    if (domainStatus.length > 0) {
+      record.domainStatus = domainStatus;
+    }
+
+    return record;
+  }
+
+  /*
+   * A followed referral chain comes back as an array. Earlier entries are
+   * the registry's answer and later ones the registrar's; earlier wins on
+   * conflict, later fills the gaps.
+   */
+  private static mergeResponses(result: unknown): WhoisData {
+    if (!result) {
+      return {};
+    }
+
+    if (!Array.isArray(result)) {
+      return WhoisLookup.unwrap(result);
+    }
+
+    const merged: WhoisData = {};
+
+    for (const entry of result) {
+      const data: WhoisData = WhoisLookup.unwrap(entry);
+
+      for (const key of Object.keys(data)) {
+        const existing: unknown = merged[key];
+
+        if (existing === undefined || existing === null || existing === "") {
+          merged[key] = data[key];
+        }
+      }
+    }
+
+    return merged;
+  }
+
+  // whois-json's verbose shape is { server, data: { ...fields } }.
+  private static unwrap(entry: unknown): WhoisData {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return {};
+    }
+
+    const record: WhoisData = entry as WhoisData;
+    const data: unknown = record["data"];
+
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      return data as WhoisData;
+    }
+
+    return record;
+  }
+
+  private static firstValue(
+    data: WhoisData,
+    keys: Array<string>,
+  ): string | Array<string> | undefined {
+    for (const key of keys) {
+      const value: unknown = data[key];
+
+      if (typeof value === "string" && value.trim()) {
+        return value;
+      }
+
+      if (Array.isArray(value)) {
+        const strings: Array<string> = value.filter(
+          (item: unknown): item is string => {
+            return typeof item === "string" && item.trim().length > 0;
+          },
+        );
+
+        if (strings.length > 0) {
+          return strings;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  private static firstString(
+    data: WhoisData,
+    keys: Array<string>,
+  ): string | undefined {
+    const value: string | Array<string> | undefined = WhoisLookup.firstValue(
+      data,
+      keys,
+    );
+
+    if (Array.isArray(value)) {
+      return value[0]?.trim();
+    }
+
+    return value?.trim();
+  }
+}

--- a/Probe/Utils/Monitors/MonitorTypes/DomainMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DomainMonitor.ts
@@ -4,8 +4,17 @@ import ObjectID from "Common/Types/ObjectID";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
 import Sleep from "Common/Types/Sleep";
 import MonitorStepDomainMonitor from "Common/Types/Monitor/MonitorStepDomainMonitor";
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
 import DomainMonitorResponse from "Common/Types/Monitor/DomainMonitor/DomainMonitorResponse";
-import whoisJson from "whois-json";
+import DomainNameUtil from "../../Domain/DomainName";
+import {
+  DomainLookupErrorUtil,
+  DomainLookupUnsupportedError,
+  DomainNotFoundError,
+} from "../../Domain/DomainLookupError";
+import { DomainLookupResult, DomainRecord } from "../../Domain/DomainRecord";
+import RdapLookup, { RdapLookupResult } from "../../Domain/RdapLookup";
+import WhoisLookup from "../../Domain/WhoisLookup";
 
 export interface DomainQueryOptions {
   timeout?: number | undefined;
@@ -16,6 +25,8 @@ export interface DomainQueryOptions {
   attempts?: Array<ProbeAttempt> | undefined;
 }
 
+export const DEFAULT_DOMAIN_QUERY_TIMEOUT_IN_MS: number = 10000;
+
 export default class DomainMonitorUtil {
   public static async query(
     config: MonitorStepDomainMonitor,
@@ -25,7 +36,7 @@ export default class DomainMonitorUtil {
       options = {};
     }
 
-    if (options?.currentRetryCount === undefined) {
+    if (options.currentRetryCount === undefined) {
       options.currentRetryCount = 1;
     }
 
@@ -33,213 +44,290 @@ export default class DomainMonitorUtil {
       options.attempts = [];
     }
 
+    const lookupMethod: DomainLookupMethod =
+      DomainMonitorUtil.getLookupMethod(config);
+
+    const domainName: string = DomainNameUtil.normalize(config.domainName);
+
     logger.debug(
-      `Domain Query: ${options?.monitorId?.toString()} ${config.domainName} - Retry: ${options?.currentRetryCount}`,
+      `Domain Query: ${options.monitorId?.toString()} ${domainName} - Method: ${lookupMethod} - Retry: ${options.currentRetryCount}`,
     );
 
     const startTime: [number, number] = process.hrtime();
     const attemptedAt: Date = new Date();
 
-    try {
-      const result: any = await whoisJson(config.domainName);
+    /*
+     * A malformed name is a configuration mistake. Reporting it straight away
+     * beats spending three network round trips discovering the same thing.
+     */
+    if (!DomainNameUtil.isValid(domainName)) {
+      return {
+        isOnline: false,
+        isTimeout: false,
+        responseTimeInMs: 0,
+        failureCause: `"${config.domainName}" is not a valid domain name.`,
+        domainName: domainName || config.domainName,
+        lookupMethod: lookupMethod,
+        probeAttempts: options.attempts,
+        totalAttempts: options.attempts.length,
+      };
+    }
 
-      const endTime: [number, number] = process.hrtime(startTime);
-      const responseTimeInMs: number = Math.ceil(
-        (endTime[0] * 1000000000 + endTime[1]) / 1000000,
-      );
-      const responseReceivedAt: Date = new Date();
+    try {
+      const lookupResult: DomainLookupResult = await DomainMonitorUtil.lookup({
+        domainName: domainName,
+        lookupMethod: lookupMethod,
+        timeoutInMs:
+          options.timeout ||
+          config.timeout ||
+          DEFAULT_DOMAIN_QUERY_TIMEOUT_IN_MS,
+      });
+
+      const responseTimeInMs: number =
+        DomainMonitorUtil.getElapsedInMs(startTime);
+
       options.attempts.push({
         attemptNumber: options.currentRetryCount,
         attemptedAt,
-        responseReceivedAt,
+        responseReceivedAt: new Date(),
         responseTimeInMs,
         isOnline: true,
       });
 
-      // Parse WHOIS response
-      const whoisData: any = Array.isArray(result) ? result[0] : result;
-
-      const nameServers: Array<string> = DomainMonitorUtil.parseNameServers(
-        whoisData?.nameServer || whoisData?.nameServers,
-      );
-
-      const domainStatus: Array<string> = DomainMonitorUtil.parseDomainStatus(
-        whoisData?.domainStatus || whoisData?.status,
-      );
-
       logger.debug(
-        `Domain Query success: ${options?.monitorId?.toString()} ${config.domainName} - Response Time: ${responseTimeInMs}ms`,
+        `Domain Query success: ${options.monitorId?.toString()} ${domainName} - Method: ${lookupResult.lookupMethod}${
+          lookupResult.rdapServerUrl ? ` (${lookupResult.rdapServerUrl})` : ""
+        } - Response Time: ${responseTimeInMs}ms`,
       );
+
+      const record: DomainRecord = lookupResult.record;
 
       return {
         isOnline: true,
+        /*
+         * Explicitly false, not absent: criteria compare booleans, and an
+         * undefined isTimeout makes an "Is Request Timeout / False" filter
+         * undecidable, which under FilterCondition.All would stop the
+         * monitor ever going back online.
+         */
+        isTimeout: false,
         responseTimeInMs: responseTimeInMs,
         failureCause: "",
-        domainName: config.domainName,
-        registrar:
-          whoisData?.registrar || whoisData?.registrarName || undefined,
-        registrarUrl:
-          whoisData?.registrarUrl ||
-          whoisData?.registrarURL ||
-          whoisData?.referralUrl ||
-          undefined,
-        createdDate:
-          whoisData?.creationDate ||
-          whoisData?.createdDate ||
-          whoisData?.created ||
-          undefined,
-        updatedDate:
-          whoisData?.updatedDate ||
-          whoisData?.lastUpdated ||
-          whoisData?.changed ||
-          undefined,
-        expiresDate:
-          whoisData?.registrarRegistrationExpirationDate ||
-          whoisData?.registryExpiryDate ||
-          whoisData?.expirationDate ||
-          whoisData?.expiresDate ||
-          whoisData?.expires ||
-          whoisData?.expiryDate ||
-          undefined,
-        nameServers: nameServers.length > 0 ? nameServers : undefined,
-        dnssec: whoisData?.dnssec || whoisData?.DNSSEC || undefined,
-        domainStatus: domainStatus.length > 0 ? domainStatus : undefined,
+        domainName: record.domainName || domainName,
+        registrar: record.registrar,
+        registrarUrl: record.registrarUrl,
+        createdDate: record.createdDate,
+        updatedDate: record.updatedDate,
+        expiresDate: record.expiresDate,
+        nameServers: record.nameServers,
+        dnssec: record.dnssec,
+        domainStatus: record.domainStatus,
+        lookupMethod: lookupResult.lookupMethod,
         probeAttempts: options.attempts,
         totalAttempts: options.attempts.length,
       };
     } catch (err: unknown) {
+      const responseTimeInMs: number =
+        DomainMonitorUtil.getElapsedInMs(startTime);
+
+      const failureCause: string = DomainLookupErrorUtil.getMessage(err);
+      const isTimeout: boolean = DomainLookupErrorUtil.isTimeout(err);
+      const isRetryable: boolean = DomainLookupErrorUtil.isRetryable(err);
+
       logger.debug(
-        `Domain Query error: ${options?.monitorId?.toString()} ${config.domainName}`,
-      );
-      logger.debug(err);
-
-      if (!options) {
-        options = {};
-      }
-
-      if (!options.currentRetryCount) {
-        options.currentRetryCount = 0;
-      }
-
-      if (!options.attempts) {
-        options.attempts = [];
-      }
-
-      const endTime: [number, number] = process.hrtime(startTime);
-      const responseTimeInMs: number = Math.ceil(
-        (endTime[0] * 1000000000 + endTime[1]) / 1000000,
+        `Domain Query error: ${options.monitorId?.toString()} ${domainName} - ${failureCause}`,
       );
 
-      const responseReceivedAt: Date = new Date();
       options.attempts.push({
         attemptNumber: options.currentRetryCount || 1,
         attemptedAt,
-        responseReceivedAt,
+        responseReceivedAt: new Date(),
         responseTimeInMs,
         isOnline: false,
-        failureCause: (err as Error).message || (err as Error).toString(),
+        failureCause: failureCause,
       });
 
-      if (options.currentRetryCount < (options.retry || config.retries || 3)) {
+      const maxRetries: number = options.retry || config.retries || 3;
+
+      /*
+       * "This domain is not registered" and "this TLD has no usable
+       * registration service" are settled answers. Retrying them just adds
+       * one second of sleep per attempt before reporting the same thing.
+       */
+      if (isRetryable && options.currentRetryCount < maxRetries) {
         options.currentRetryCount++;
         await Sleep.sleep(1000);
         return await DomainMonitorUtil.query(config, options);
       }
 
-      // Check if the probe is online
-      if (!options.isOnlineCheckRequest) {
+      /*
+       * The probe-connectivity gate only applies to failures that could have
+       * been caused by the probe's own network. A registry that answered
+       * "not registered" has already proved the network works, and dropping
+       * that result would hide the very failure we are trying to report.
+       */
+      if (isRetryable && !options.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
           logger.error(
-            `DomainMonitor - Probe is not online. Cannot query ${options?.monitorId?.toString()} ${config.domainName} - ERROR: ${err}`,
+            `DomainMonitor - Probe is not online. Cannot query ${options.monitorId?.toString()} ${domainName} - ERROR: ${failureCause}`,
           );
           return null;
         }
       }
 
-      // Check if timeout
-      const isTimeout: boolean =
-        (err as Error).message?.toLowerCase().includes("timeout") ||
-        (err as Error).message?.toLowerCase().includes("timed out") ||
-        (err as Error).message?.toLowerCase().includes("etimeout");
-
-      if (isTimeout) {
-        return {
-          isOnline: false,
-          isTimeout: true,
-          responseTimeInMs: responseTimeInMs,
-          failureCause:
-            "Request was tried " +
-            options.currentRetryCount +
-            " times and it timed out.",
-          domainName: config.domainName,
-          probeAttempts: options.attempts,
-          totalAttempts: options.attempts.length,
-        };
-      }
-
       return {
         isOnline: false,
-        isTimeout: false,
+        isTimeout: isTimeout,
         responseTimeInMs: responseTimeInMs,
-        failureCause: (err as Error).message || (err as Error).toString(),
-        domainName: config.domainName,
+        failureCause: isTimeout
+          ? `Request was tried ${options.currentRetryCount} times and it timed out.`
+          : failureCause,
+        domainName: domainName,
+        lookupMethod: lookupMethod,
         probeAttempts: options.attempts,
         totalAttempts: options.attempts.length,
       };
     }
   }
 
-  private static parseNameServers(
-    value: string | Array<string> | undefined,
-  ): Array<string> {
-    if (!value) {
-      return [];
+  public static getLookupMethod(
+    config: MonitorStepDomainMonitor,
+  ): DomainLookupMethod {
+    const values: Array<string> = Object.values(DomainLookupMethod);
+
+    /*
+     * Monitors created before RDAP support existed carry no lookupMethod,
+     * and MonitorStep deserialization has historically handed the probe the
+     * raw JSON - so this cannot assume the field is populated.
+     */
+    if (config.lookupMethod && values.includes(config.lookupMethod)) {
+      return config.lookupMethod;
     }
 
-    if (Array.isArray(value)) {
-      return value.map((ns: string) => {
-        return ns.trim().toLowerCase();
-      });
-    }
-
-    if (typeof value === "string") {
-      return value
-        .split(/[\s,]+/)
-        .map((ns: string) => {
-          return ns.trim().toLowerCase();
-        })
-        .filter((ns: string) => {
-          return ns.length > 0;
-        });
-    }
-
-    return [];
+    return DomainLookupMethod.Auto;
   }
 
-  private static parseDomainStatus(
-    value: string | Array<string> | undefined,
-  ): Array<string> {
-    if (!value) {
-      return [];
+  private static async lookup(input: {
+    domainName: string;
+    lookupMethod: DomainLookupMethod;
+    timeoutInMs: number;
+  }): Promise<DomainLookupResult> {
+    const { domainName, lookupMethod, timeoutInMs } = input;
+
+    if (lookupMethod === DomainLookupMethod.WHOIS) {
+      return {
+        record: await WhoisLookup.lookup(domainName, {
+          timeoutInMs: timeoutInMs,
+        }),
+        lookupMethod: DomainLookupMethod.WHOIS,
+      };
     }
 
-    if (Array.isArray(value)) {
-      return value.map((status: string) => {
-        return status.trim();
+    if (lookupMethod === DomainLookupMethod.RDAP) {
+      const result: RdapLookupResult = await RdapLookup.lookup(domainName, {
+        timeoutInMs: timeoutInMs,
+      });
+
+      return {
+        record: result.record,
+        lookupMethod: DomainLookupMethod.RDAP,
+        rdapServerUrl: result.rdapServerUrl,
+      };
+    }
+
+    return await DomainMonitorUtil.lookupAuto(domainName, timeoutInMs);
+  }
+
+  /*
+   * RDAP first, WHOIS second. RDAP is discovered from IANA so it stays
+   * correct as registries move, but roughly half the ccTLDs publish no RDAP
+   * service at all - for those the bootstrap lookup returns nothing and
+   * WHOIS is the only option. Both are tried inside a single attempt so the
+   * retry budget is not doubled.
+   */
+  private static async lookupAuto(
+    domainName: string,
+    timeoutInMs: number,
+  ): Promise<DomainLookupResult> {
+    let rdapError: unknown = null;
+
+    try {
+      const result: RdapLookupResult = await RdapLookup.lookup(domainName, {
+        timeoutInMs: timeoutInMs,
+      });
+
+      return {
+        record: result.record,
+        lookupMethod: DomainLookupMethod.RDAP,
+        rdapServerUrl: result.rdapServerUrl,
+      };
+    } catch (err: unknown) {
+      /*
+       * The registry's own RDAP service is authoritative about whether a
+       * domain exists. Asking WHOIS for a second opinion would only turn a
+       * clear answer into a vague one.
+       */
+      if (err instanceof DomainNotFoundError) {
+        throw err;
+      }
+
+      rdapError = err;
+
+      logger.debug(
+        `RDAP lookup for ${domainName} did not produce a record, falling back to WHOIS: ${DomainLookupErrorUtil.getMessage(
+          err,
+        )}`,
+      );
+    }
+
+    try {
+      return {
+        record: await WhoisLookup.lookup(domainName, {
+          timeoutInMs: timeoutInMs,
+        }),
+        lookupMethod: DomainLookupMethod.WHOIS,
+      };
+    } catch (whoisError: unknown) {
+      throw DomainMonitorUtil.combineAutoFailures({
+        domainName,
+        rdapError,
+        whoisError,
       });
     }
+  }
 
-    if (typeof value === "string") {
-      return value
-        .split(/[\n,]+/)
-        .map((status: string) => {
-          return status.trim();
-        })
-        .filter((status: string) => {
-          return status.length > 0;
-        });
+  /*
+   * When both protocols fail the operator needs to see both reasons - "WHOIS
+   * returned nothing" on its own does not explain why RDAP was not used.
+   */
+  private static combineAutoFailures(input: {
+    domainName: string;
+    rdapError: unknown;
+    whoisError: unknown;
+  }): Error {
+    const rdapMessage: string = DomainLookupErrorUtil.getMessage(
+      input.rdapError,
+    );
+    const whoisMessage: string = DomainLookupErrorUtil.getMessage(
+      input.whoisError,
+    );
+
+    const message: string = `Could not read registration data for ${input.domainName}. RDAP: ${rdapMessage} WHOIS: ${whoisMessage}`;
+
+    const bothPermanent: boolean =
+      !DomainLookupErrorUtil.isRetryable(input.rdapError) &&
+      !DomainLookupErrorUtil.isRetryable(input.whoisError);
+
+    if (bothPermanent) {
+      return new DomainLookupUnsupportedError(message);
     }
 
-    return [];
+    return new Error(message);
+  }
+
+  private static getElapsedInMs(startTime: [number, number]): number {
+    const endTime: [number, number] = process.hrtime(startTime);
+
+    return Math.ceil((endTime[0] * 1000000000 + endTime[1]) / 1000000);
   }
 }

--- a/Scripts/TerraformProvider/StaticFiles/monitorsteps.go
+++ b/Scripts/TerraformProvider/StaticFiles/monitorsteps.go
@@ -899,7 +899,7 @@ func monitorStepsStepSchema() schema.NestedAttributeObject {
 		"profile_monitor":              "Raw JSON escape hatch for the Profiles monitor query config.",
 		"network_device_monitor":       "Raw JSON escape hatch for the Network Device monitor config (networkDeviceId).",
 		"dns_monitor":                  "Raw JSON escape hatch for the DNS monitor config (queryName, recordType, ...).",
-		"domain_monitor":               "Raw JSON escape hatch for the Domain monitor config (domainName).",
+		"domain_monitor":               "Raw JSON escape hatch for the Domain monitor config (domainName, lookupMethod, timeout, retries). lookupMethod is one of Auto, RDAP, WHOIS and defaults to Auto.",
 		"dnssec_monitor":               "Raw JSON escape hatch for the DNSSEC monitor config (domainName, resolvers).",
 		"sql_monitor":                  "Raw JSON escape hatch for the SQL Query monitor config (databaseType, host, port, databaseName, query, ...).",
 		"external_status_page_monitor": "Raw JSON escape hatch for the External Status Page monitor config (statusPageUrl, providerType).",


### PR DESCRIPTION
Fixes #3046.

## The bug

Adding a domain monitor for `identity.digital` (or any `.digital`, `.email`, `.life`, `.today`, `.zone`, … domain) produced a monitor that looked **healthy with a blank expiry date** and reported no failure anywhere in the UI.

Reproduced directly:

```
$ node -e "require('whois')('identity.digital', ...)"
TLD is not supported.
>>> Last update of WHOIS database: 2026-08-07T07:45:38Z <<<
Terms of Use: Access to WHOIS information is provided …
```

Two things combine:

1. `whois-json` ships a static TLD → WHOIS-host map that has gone stale. `.digital` is mapped to `whois.donuts.co`, Identity Digital's retired host, which now answers **every** query with the literal text `TLD is not supported.` The same mapping covers ~290 other Identity Digital TLDs.
2. `whois-json`'s parser keeps only `Key: value` lines and drops the rest, so that reply *resolves successfully* as `{lastUpdateOfWhoisDatabase, termsOfUse}` — no error is thrown. `DomainMonitor.query` then pushed an `isOnline: true` probe attempt **before looking at the data** and returned `isOnline: true` with every registration field `undefined`.

And even had it reported `isOnline: false`, nothing would have surfaced: `CheckOn.IsOnline` was not evaluatable for `MonitorType.Domain`, and both default criteria seeds keyed off `DomainIsExpired`, which returns "undecidable" when there is no expiry date. The monitor kept its previous status silently.

## The fix

**RDAP (RFC 9083), discovered from IANA (RFC 9224).** `.digital` publishes a perfectly good RDAP service — WHOIS is simply the wrong protocol for it. The authoritative endpoint per TLD is read from `https://data.iana.org/rdap/dns.json` (cached 24 h, 5 min negative cache, one shared in-flight fetch) rather than a hardcoded map, so it stays correct as registries move.

**A `Lookup Method` option** on the domain monitor step:

| Method | Behaviour |
| --- | --- |
| **Auto** (default) | RDAP when the TLD publishes one, WHOIS otherwise. Falls back to WHOIS inside the *same* attempt if RDAP fails, so the retry budget is not doubled. |
| **RDAP** | RDAP only; clear error if the TLD has no RDAP service. |
| **WHOIS** | WHOIS only. |

Auto rather than RDAP-only because roughly half the ccTLDs (`.io`, `.co`, `.de`, `.ch`, `.jp`, …) publish no RDAP service at all.

**A response with no registration data is now a failure.** Both lookups validate that something identifying came back; if not, the monitor goes offline with an actionable cause ("The WHOIS server for identity.digital answered without any registration data … try the RDAP or Auto lookup method"). Settled failures — domain not registered (RDAP 404), TLD with no usable service, malformed domain name — are reported immediately instead of burning three retries, and they bypass the probe-connectivity gate that would otherwise discard the result.

**`CheckOn.IsOnline` / `IsRequestTimeout` now work for Domain monitors** — evaluator, UI dropdown, and the default criteria seeds. New domain monitors get `IsOnline` in both their online and offline criteria.

**Failure classification**

A failure is only treated as *permanent* — skipping retries and the probe-connectivity gate — when it is genuinely settled:

| Condition | Classification |
| --- | --- |
| RDAP 404 from the registry, or WHOIS `Status: free` | permanent — the domain is not registered |
| TLD absent from the IANA registry, under `RDAP` mode | permanent — no RDAP service exists |
| IANA registry unreachable | **transient** — says nothing about the TLD |
| WHOIS answers with no record | **transient** — indistinguishable from a rate-limited registrar |

That distinction matters: a permanent verdict bypasses the `OnlineCheck` gate, so misclassifying a `data.iana.org` outage would open an incident on every domain monitor on the probe at once.

**Also fixed along the way**

- The step's `Timeout` setting was passed to `DomainMonitor.query` and then never used — WHOIS ran with no deadline at all. It is now honoured by both protocols.
- `whois-json` joins repeated `Domain Status:` lines with a space, so a normal gTLD answer became **one** bogus status value like `clientDeleteProhibited https://icann.org/epp#… clientTransferProhibited https://icann.org/epp#…`. Statuses are now split, stripped of their EPP URLs, and folded to the EPP name (`clientTransferProhibited`) whichever protocol answered — so a criterion keeps matching when Auto switches protocol.
- `MonitorStep.fromJSON` raw-cast `domainMonitor` straight through, so `MonitorStepDomainMonitorUtil.fromJSON` never ran in production. It does now, which is what lets monitors saved before this change default to `Auto`.
- Dates from both protocols are normalized to ISO 8601; name servers drop inline glue addresses; a URL pasted into the Domain Name field is accepted.
- IDNs are converted to their A-label (`münchen.de` → `xn--mnchen-3ya.de`) before the lookup — `whois-json` used to do this itself, so validating the U-label would have broken every IDN monitor.
- A date a registry publishes in an unparseable form is now dropped rather than stored. An Invalid Date makes every criteria comparison false, so `registro.br`'s `20260313` would have made "expires within 30 days" never fire and "is expired" answer "no" forever. Compact `YYYYMMDD` and day-first forms are parsed instead.
- The success path now sets `isTimeout: false` explicitly. Left unset, an `Is Request Timeout / False` filter is undecidable on every healthy check and, under `FilterCondition.All`, the monitor could never go back online.
- The shared IANA fetch no longer adopts the timeout of whichever monitor triggered it — one monitor set to 2s would otherwise abort the ~200 KB document for every other monitor and poison the 5-minute failure cache.

## Compatibility

Existing monitors keep working: a missing `lookupMethod` is treated as `Auto` at deserialization *and* defensively in the probe. The default-criteria change only affects **newly created** monitors — monitors created earlier keep their persisted criteria and need an `Is Online / False` filter added by hand to alert on a failed lookup. This is called out in the docs.

## Behaviour changes worth knowing about

- **Status codes are reshaped.** `whois-json` joins repeated `Domain Status:` lines into one string, so a normal gTLD answer used to land as a single value like `clientDeleteProhibited https://icann.org/epp#… clientTransferProhibited https://icann.org/epp#…`. It is now split into individual statuses with the URLs stripped. `Contains` criteria keep matching; an `Equal To` criterion written against the whole blob will not.
- **Registrar names can differ between protocols.** RDAP reads it from the entity's jCard, WHOIS from the `Registrar:` field. They usually agree but are not guaranteed to, so prefer `Contains` over `Equal To`. Noted in the docs.

## Tests

225 new tests across 8 files:

- `Probe/Tests/Utils/Domain/DomainName.test.ts` — normalization, validation, IDN A-label conversion
- `Probe/Tests/Utils/Domain/DomainRecord.test.ts` — date formats, status splitting, the not-registered guard
- `Probe/Tests/Utils/Domain/RdapBootstrap.test.ts` — bootstrap parsing, longest-suffix match, TTL, failure cache, stale-serving, in-flight sharing, the shared-timeout floor
- `Probe/Tests/Utils/Domain/RdapDomainParser.test.ts` — against RDAP responses captured verbatim from Identity Digital and Verisign
- `Probe/Tests/Utils/Domain/RdapHttp.test.ts` — media type, proxy agents, status handling
- `Probe/Tests/Utils/Domain/RdapLookup.test.ts` — including registry-unreachable vs no-RDAP-service
- `Probe/Tests/Utils/Domain/WhoisLookup.test.ts` — including the exact `.digital` reply from the bug report
- `Probe/Tests/Utils/Monitors/MonitorTypes/DomainMonitor.test.ts` — end-to-end per lookup method, fallback, retries, timeouts, the connectivity gate
- `Common/Tests/Server/Utils/Monitor/Criteria/DomainMonitorCriteria.test.ts`
- plus updates to `MonitorStepDomainMonitor`, `MonitorStep` and `MonitorCriteriaInstance` tests

`Probe`: 758 tests pass. `Common`: 1,838 monitor tests pass, and the full suite is green apart from three wall-clock/timing tests and seven pre-existing jest-dom typing failures, none of which this change touches. `npm run fix`, `npm run i18n:validate`, `npm run docs:check-anchors` and `tsc` on Common/Probe/App all clean.

A multi-agent adversarial review of this diff produced 28 confirmed findings, several verified by execution rather than reading. Every correctness and regression finding is fixed above, each with a regression test.

## Network requirements

Probes need outbound HTTPS to `data.iana.org` and to registry RDAP endpoints. RDAP honours the probe's `HTTP_PROXY_URL` / `HTTPS_PROXY_URL` / `NO_PROXY`; WHOIS (raw TCP 43) does not. If `data.iana.org` is unreachable, Auto degrades to WHOIS and retries the registry periodically.
