### PR TITLE
fix(kubernetes-agent): pin every workload to Linux nodes so Windows pools don't ImagePullBackOff

### DIFF
--- a/HelmChart/Public/kubernetes-agent/README.md
+++ b/HelmChart/Public/kubernetes-agent/README.md
@@ -539,6 +539,10 @@ To validate a key by hand (`200` = valid, `401` = unknown/revoked):
 curl -i -H "x-oneuptime-token: <YOUR_API_KEY>" "$ONEUPTIME_URL/otlp/v1/validate"
 ```
 
+### Mixed-OS clusters (Windows node pools)
+
+All agent images are Linux-only, so every workload in the chart pins itself to Linux nodes with a `kubernetes.io/os: linux` nodeSelector. On clusters with Windows node pools (e.g. AKS), Windows nodes are simply not monitored — the DaemonSets skip them instead of sitting in `ImagePullBackOff` there. If you're upgrading from a chart version without the pin and see agent pods stuck in `ImagePullBackOff` on Windows nodes, `helm upgrade` to the current version; the stuck pods are removed automatically once the pin applies.
+
 ### Application pods crash with SIGSEGV after enabling log ↔ trace correlation
 
 If you enabled `ebpf.logToTraceCorrelation` (off by default) and **.NET application pods start crashing with `Exit Code: 139`** (SIGSEGV) within seconds of the eBPF DaemonSet starting, the cause is almost always a conflict with an `LD_PRELOAD`-based APM agent in the same pods.

--- a/HelmChart/Public/kubernetes-agent/templates/_helpers.tpl
+++ b/HelmChart/Public/kubernetes-agent/templates/_helpers.tpl
@@ -59,6 +59,32 @@ Service account name
 {{- end }}
 
 {{/*
+Pod nodeSelector with the Linux-only pin merged in.
+
+Every image this chart deploys — the OTel collectors, OBI, the profiler,
+OpenCost, Prometheus, kube-state-metrics, the cost and log agents — is built
+for linux only. On mixed-OS clusters (e.g. AKS with Windows node pools) an
+unpinned pod spec can be scheduled onto a Windows node, where the image pull
+can never succeed and the pod sits in ImagePullBackOff forever; the
+DaemonSets are guaranteed to hit this because they tolerate every taint.
+The kubelet labels every node with kubernetes.io/os (stable since
+Kubernetes 1.14), so requiring "linux" is always safe.
+
+Takes the workload's user-configured nodeSelector map (or an empty dict when
+the workload has no such knob). User-supplied keys win on conflict.
+
+Usage (the include is nindent-ed under the `nodeSelector:` key):
+  nodeSelector:
+    {{`{{- include "kubernetes-agent.nodeSelector" .Values.ebpf.nodeSelector | nindent 8 }}`}}
+*/}}
+{{- define "kubernetes-agent.nodeSelector" -}}
+{{- /* mergeOverwrite, not merge: sprig merge won't let a zero value ("")
+     in the user map displace the pin, breaking last-writer-wins. The
+     dest dict is a fresh literal, so .Values is never mutated. */ -}}
+{{- toYaml (mergeOverwrite (dict "kubernetes.io/os" "linux") (. | default dict)) -}}
+{{- end }}
+
+{{/*
 Build the OTEL_EBPF_METRICS_FEATURES env var value from .Values.ebpf.features
 toggles. Returns a comma-separated string of the OBI feature names that are
 currently enabled. Empty list -> empty string (OBI then exports no metrics).

--- a/HelmChart/Public/kubernetes-agent/templates/daemonset-ebpf.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/daemonset-ebpf.yaml
@@ -20,10 +20,12 @@ spec:
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
       hostPID: true
-      {{- with .Values.ebpf.nodeSelector }}
+      # kubernetes.io/os=linux is always merged in (user keys win): the
+      # image is linux-only and eBPF needs a Linux kernel, and the blanket
+      # toleration below would otherwise land pods on Windows nodes in
+      # permanent ImagePullBackOff.
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "kubernetes-agent.nodeSelector" .Values.ebpf.nodeSelector | nindent 8 }}
       {{- with .Values.ebpf.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/kubernetes-agent/templates/daemonset-profiling.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/daemonset-profiling.yaml
@@ -22,6 +22,11 @@ spec:
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
       hostPID: true
+      # Linux nodes only — the profiler is eBPF-based and its image is
+      # linux-only; the blanket toleration below would otherwise land
+      # pods on Windows nodes in permanent ImagePullBackOff.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       tolerations:
         - operator: Exists
       containers:

--- a/HelmChart/Public/kubernetes-agent/templates/daemonset.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/daemonset.yaml
@@ -34,6 +34,11 @@ spec:
       # Lets the debug sidecar see the collector's processes (ps, /proc, strace).
       shareProcessNamespace: true
       {{- end }}
+      # Linux nodes only — the collector image is linux-only, and the
+      # blanket toleration below would otherwise land pods on Windows
+      # nodes in permanent ImagePullBackOff.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       tolerations:
         - operator: Exists
       containers:

--- a/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-cost-agent.yaml
@@ -23,6 +23,10 @@ spec:
         component: cost-agent
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux nodes only — the image is linux-only, and Windows pools
+      # (e.g. on AKS) are not tainted by default.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       # No privileged containers, no hostPath, no hostNetwork — GKE Autopilot
       # compatible. The poller only talks HTTP to the cost engine's Service
       # and to OneUptime.

--- a/HelmChart/Public/kubernetes-agent/templates/deployment-logs-api.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment-logs-api.yaml
@@ -20,6 +20,10 @@ spec:
         component: log-collector
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux nodes only — the image is linux-only, and Windows pools
+      # (e.g. on AKS) are not tainted by default.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       # No privileged containers, no hostPath, no hostNetwork — GKE Autopilot
       # compatible. The tailer only needs the ServiceAccount's API access.
       securityContext:

--- a/HelmChart/Public/kubernetes-agent/templates/deployment.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-deployment.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux nodes only — the collector image is linux-only, and Windows
+      # pools (e.g. on AKS) are not tainted by default.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       {{- if and .Values.debug.enabled .Values.debug.shareProcessNamespace }}
       # Lets the debug sidecar see the collector's processes (ps, /proc, strace).
       shareProcessNamespace: true

--- a/HelmChart/Public/kubernetes-agent/templates/kube-state-metrics.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/kube-state-metrics.yaml
@@ -87,6 +87,10 @@ spec:
     spec:
       serviceAccountName: {{ include "kubernetes-agent.fullname" . }}-kube-state-metrics
       automountServiceAccountToken: true
+      # Linux nodes only — the image is linux-only, and Windows pools
+      # (e.g. on AKS) are not tainted by default.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/HelmChart/Public/kubernetes-agent/templates/opencost.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/opencost.yaml
@@ -52,6 +52,10 @@ spec:
         component: opencost
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux nodes only — the image is linux-only, and Windows pools
+      # (e.g. on AKS) are not tainted by default.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       # No privileged containers, no hostPath, no hostNetwork — GKE
       # Autopilot compatible. OpenCost only needs API reads (RBAC) and
       # HTTP to its Prometheus.

--- a/HelmChart/Public/kubernetes-agent/templates/prometheus-cost.yaml
+++ b/HelmChart/Public/kubernetes-agent/templates/prometheus-cost.yaml
@@ -104,6 +104,10 @@ spec:
         checksum/config: {{ toYaml .Values.cost.prometheus | sha256sum | trunc 32 }}
     spec:
       serviceAccountName: {{ include "kubernetes-agent.serviceAccountName" . }}
+      # Linux nodes only — the image is linux-only, and Windows pools
+      # (e.g. on AKS) are not tainted by default.
+      nodeSelector:
+        {{- include "kubernetes-agent.nodeSelector" (dict) | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/HelmChart/Public/kubernetes-agent/troubleshoot.sh
+++ b/HelmChart/Public/kubernetes-agent/troubleshoot.sh
@@ -147,9 +147,13 @@ EOF
     raw=$(kubectl exec "$SIDECAR_POD" -n "$NS" -c debug -- sh -c "$snippet" 2>&1)
   else
     local pod="oub-curl-${RANDOM}"
+    # Pin to a Linux node — the curl image is linux-only, and on clusters
+    # with untainted Windows pools the probe could otherwise land there and
+    # report a launch failure instead of an egress verdict.
     raw=$(kubectl run "$pod" -n "$NS" --rm -i --restart=Never \
             --image="$CURL_IMAGE" \
             --labels="oneuptime-doctor=true" \
+            --overrides='{"apiVersion":"v1","spec":{"nodeSelector":{"kubernetes.io/os":"linux"}}}' \
             --command -- sh -c "$snippet" 2>&1)
   fi
 

--- a/HelmChart/Public/kubernetes-agent/values.schema.json
+++ b/HelmChart/Public/kubernetes-agent/values.schema.json
@@ -756,7 +756,7 @@
         },
         "nodeSelector": {
           "type": "object",
-          "description": "nodeSelector for the eBPF agent DaemonSet pods."
+          "description": "nodeSelector for the eBPF agent DaemonSet pods. The chart always merges in `kubernetes.io/os: linux` (keys set here win on conflict) so agent pods never schedule onto Windows nodes."
         },
         "tolerations": {
           "type": "array",

--- a/HelmChart/Public/kubernetes-agent/values.yaml
+++ b/HelmChart/Public/kubernetes-agent/values.yaml
@@ -774,6 +774,9 @@ ebpf:
   # Exists) so the DaemonSet covers all nodes. To keep it OFF a tainted DB-only
   # pool — so it doesn't compete with or instrument the database tier — override
   # `tolerations` with a narrower list and/or set `nodeSelector` / `affinity`.
+  # `kubernetes.io/os: linux` is always merged into the nodeSelector (keys set
+  # here win on conflict) — eBPF needs a Linux kernel and the image is
+  # linux-only, so Windows nodes (e.g. AKS Windows pools) are never scheduled.
   nodeSelector: {}
   tolerations:
     - operator: Exists


### PR DESCRIPTION
## Problem

On clusters with Windows node pools (reported on AKS, `akswin*` nodes), the kubernetes-agent DaemonSets schedule onto Windows nodes and sit in permanent `ImagePullBackOff`:

- The `kubernetes-agent-ebpf` and `kubernetes-agent-logs` DaemonSets tolerate every taint (`operator: Exists`) and had no OS constraint, so they were placed on all 12 nodes of the reporter's cluster — but only the 4 Linux nodes could pull `otel/ebpf-instrument` / `otel/opentelemetry-collector-contrib`, which are linux-only images.
- The chart's Deployments (metrics collector, cost agent, log tailer, kube-state-metrics, OpenCost, cost Prometheus) had the same exposure, since Windows pools are not tainted by default on AKS.

## Fix

Add a `kubernetes-agent.nodeSelector` helper that merges `kubernetes.io/os: linux` into the pod spec of **every** workload in the chart (3 DaemonSets + 6 Deployments). Windows nodes are simply skipped instead of accumulating stuck pods — which is the correct end state, since the agent's images (and eBPF itself) are Linux-only. The `kubernetes.io/os` label is set by the kubelet on every node since Kubernetes 1.14, so requiring it is always safe.

- For the eBPF DaemonSet, the pin is merged **under** any user-supplied `ebpf.nodeSelector` via `mergeOverwrite`, so explicitly set keys (including zero values) win on conflict. `.Values` is never mutated.
- The ad-hoc egress probe pod in `troubleshoot.sh` (`kubectl run`) gets the same pin via `--overrides`, so the connectivity check can't false-fail by landing on a Windows node.
- Documented the mixed-OS behavior in the README (Troubleshooting) plus the `values.yaml` / `values.schema.json` descriptions.

On upgrade, the DaemonSet controller automatically deletes the stuck pods on Windows nodes once the pod template no longer matches them; healthy Linux pods roll normally.

## Verification

- `helm lint` passes (same check CI runs).
- Rendered the chart under 6 scenarios (defaults; all optional features on — profiling, cost, kube-state-metrics; `logs.mode=api`; `preset=gke-autopilot`; user `ebpf.nodeSelector` extra keys; user override of `kubernetes.io/os` itself) and asserted every rendered Deployment/DaemonSet pod spec carries the pin, user keys merge in, and explicit user overrides win with no duplicate YAML keys.
- Exhaustively enumerated the chart for other pod-creating specs (Jobs, CronJobs, StatefulSets, hooks, embedded manifests): none exist; all 9 workloads are covered. `preset=eks-fargate` renders 8/8 pinned (node DaemonSet correctly absent there).
- `bash -n troubleshoot.sh` passes.

Fixes agent deployment on mixed-OS clusters: `kubernetes-agent-ebpf` / `kubernetes-agent-logs` now show Desired = number of *Linux* nodes, all Available.