### PR TITLE
Add optional phoneClaimName for Global OIDC / Project OIDC SSO

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/Index.tsx
@@ -251,6 +251,19 @@ const Settings: FunctionComponent = (): ReactElement => {
           },
           {
             field: {
+              phoneClaimName: true,
+            },
+            title: "Phone Claim Name",
+            description:
+              "Claim name in the ID token (or userinfo response) that contains the user's phone number. Optional - leave blank to skip syncing phone numbers.",
+            fieldType: FormFieldSchemaType.Text,
+            required: false,
+            placeholder: "phone_number",
+            stepId: "claims",
+            disableSpellCheck: true,
+          },
+          {
+            field: {
               disableSignUpWithSso: true,
             },
             title: "Disable Sign Up with SSO",

--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/View.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/GlobalOIDC/View.tsx
@@ -248,6 +248,15 @@ const GlobalOIDCView: FunctionComponent = (): ReactElement => {
             },
             {
               field: {
+                phoneClaimName: true,
+              },
+              title: "Phone Claim Name",
+              fieldType: FormFieldSchemaType.Text,
+              required: false,
+              placeholder: "phone_number",
+            },
+            {
+              field: {
                 disableSignUpWithSso: true,
               },
               title: "Disable Sign Up with SSO",
@@ -319,6 +328,13 @@ const GlobalOIDCView: FunctionComponent = (): ReactElement => {
                   nameClaimName: true,
                 },
                 title: "Name Claim Name",
+                fieldType: FieldType.Text,
+              },
+              {
+                field: {
+                  phoneClaimName: true,
+                },
+                title: "Phone Claim Name",
                 fieldType: FieldType.Text,
               },
               {

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/OIDC.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/OIDC.tsx
@@ -204,6 +204,16 @@ const OIDCPage: FunctionComponent<PageComponentProps> = (
               defaultValue: "name",
             },
             {
+              field: { phoneClaimName: true },
+              title: "Phone Claim Name",
+              fieldType: FormFieldSchemaType.Text,
+              required: false,
+              description:
+                "Name of the ID token / userinfo claim that contains the user's phone number. Optional - leave blank to skip syncing phone numbers.",
+              placeholder: "phone_number",
+              stepId: "more",
+            },
+            {
               field: { isEnabled: true },
               description:
                 "You can test this first, before enabling it. To test, please save the config.",

--- a/App/FeatureSet/Identity/API/GlobalOIDC.ts
+++ b/App/FeatureSet/Identity/API/GlobalOIDC.ts
@@ -298,6 +298,7 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
         scopes: true,
         emailClaimName: true,
         nameClaimName: true,
+        phoneClaimName: true,
         disableSignUpWithSso: true,
       },
       props: { isRoot: true },
@@ -355,6 +356,7 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
         callbackParams,
         emailClaimName: globalOidc.emailClaimName || "email",
         nameClaimName: globalOidc.nameClaimName || "name",
+        phoneClaimName: globalOidc.phoneClaimName || undefined,
       });
     } catch (err: unknown) {
       logger.error(err, getLogAttributesFromRequest(req as RequestLike));
@@ -394,6 +396,7 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
         isEmailVerified: true,
         profilePictureId: true,
         timezone: true,
+        companyPhoneNumber: true,
       },
       props: { isRoot: true },
     });
@@ -470,6 +473,25 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
     }
 
     alreadySavedUser.email = result.email;
+
+    /*
+     * Phone claim is optional and only synced when the admin configured a
+     * phoneClaimName. Written to companyPhoneNumber (general contact info),
+     * never to the verified call/SMS on-call channels - those require their
+     * own explicit verification step and must not be bypassed by an IdP claim.
+     */
+    if (
+      result.phone &&
+      result.phone.toString() !==
+        alreadySavedUser.companyPhoneNumber?.toString()
+    ) {
+      await UserService.updateOneById({
+        id: alreadySavedUser.id!,
+        data: { companyPhoneNumber: result.phone },
+        props: { isRoot: true },
+      });
+      alreadySavedUser.companyPhoneNumber = result.phone;
+    }
 
     await AccessTokenService.refreshUserAllPermissions(alreadySavedUser.id!);
 

--- a/App/FeatureSet/Identity/API/OIDC.ts
+++ b/App/FeatureSet/Identity/API/OIDC.ts
@@ -380,6 +380,7 @@ const handleOidcCallback: HandleOidcCallbackFunction = async (
         scopes: true,
         emailClaimName: true,
         nameClaimName: true,
+        phoneClaimName: true,
         teams: { _id: true },
       },
       props: { isRoot: true },
@@ -437,6 +438,7 @@ const handleOidcCallback: HandleOidcCallbackFunction = async (
         callbackParams,
         emailClaimName: projectOidc.emailClaimName || "email",
         nameClaimName: projectOidc.nameClaimName || "name",
+        phoneClaimName: projectOidc.phoneClaimName || undefined,
       });
     } catch (err: unknown) {
       logger.error(err, getLogAttributesFromRequest(req as RequestLike));
@@ -463,6 +465,7 @@ const handleOidcCallback: HandleOidcCallbackFunction = async (
         isEmailVerified: true,
         profilePictureId: true,
         timezone: true,
+        companyPhoneNumber: true,
       },
       props: { isRoot: true },
     });
@@ -536,6 +539,25 @@ const handleOidcCallback: HandleOidcCallbackFunction = async (
     const projectId: ObjectID = new ObjectID(req.params["projectId"] as string);
 
     alreadySavedUser.email = result.email;
+
+    /*
+     * Phone claim is optional and only synced when the admin configured a
+     * phoneClaimName. Written to companyPhoneNumber (general contact info),
+     * never to the verified call/SMS on-call channels - those require their
+     * own explicit verification step and must not be bypassed by an IdP claim.
+     */
+    if (
+      result.phone &&
+      result.phone.toString() !==
+        alreadySavedUser.companyPhoneNumber?.toString()
+    ) {
+      await UserService.updateOneById({
+        id: alreadySavedUser.id!,
+        data: { companyPhoneNumber: result.phone },
+        props: { isRoot: true },
+      });
+      alreadySavedUser.companyPhoneNumber = result.phone;
+    }
 
     await AccessTokenService.refreshUserAllPermissions(alreadySavedUser.id!);
 

--- a/App/FeatureSet/Identity/Utils/OIDC.ts
+++ b/App/FeatureSet/Identity/Utils/OIDC.ts
@@ -1,6 +1,7 @@
 import URL from "Common/Types/API/URL";
 import Email from "Common/Types/Email";
 import Name from "Common/Types/Name";
+import Phone from "Common/Types/Phone";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import { JSONObject } from "Common/Types/JSON";
 import { Issuer, Client, generators, TokenSet } from "openid-client";
@@ -16,6 +17,7 @@ export interface OidcClientConfig {
 export interface OidcCallbackResult {
   email: Email;
   name: Name | null;
+  phone: Phone | null;
   issuer: string;
   rawClaims: JSONObject;
 }
@@ -78,6 +80,7 @@ export default class OIDCUtil {
     callbackParams: Record<string, string>;
     emailClaimName: string;
     nameClaimName: string;
+    phoneClaimName?: string | undefined;
   }): Promise<OidcCallbackResult> {
     const tokenSet: TokenSet = await data.client.callback(
       data.redirectUri.toString(),
@@ -99,9 +102,12 @@ export default class OIDCUtil {
 
     let emailValue: unknown = claims[data.emailClaimName];
     let nameValue: unknown = claims[data.nameClaimName];
+    let phoneValue: unknown = data.phoneClaimName
+      ? claims[data.phoneClaimName]
+      : undefined;
 
-    // If email/name not in ID token claims, fall back to userinfo endpoint.
-    if (!emailValue || !nameValue) {
+    // If email/name/phone not in ID token claims, fall back to userinfo endpoint.
+    if (!emailValue || !nameValue || (data.phoneClaimName && !phoneValue)) {
       try {
         const userInfo: JSONObject = (await data.client.userinfo(
           tokenSet.access_token!,
@@ -113,6 +119,10 @@ export default class OIDCUtil {
 
         if (!nameValue) {
           nameValue = userInfo[data.nameClaimName];
+        }
+
+        if (data.phoneClaimName && !phoneValue) {
+          phoneValue = userInfo[data.phoneClaimName];
         }
       } catch {
         // userinfo failure is non-fatal if claims already present in ID token
@@ -132,9 +142,23 @@ export default class OIDCUtil {
       name = new Name(nameValue);
     }
 
+    let phone: Phone | null = null;
+    if (phoneValue && typeof phoneValue === "string") {
+      try {
+        phone = new Phone(phoneValue);
+      } catch {
+        /*
+         * Claim present but not in a format Phone accepts. Non-fatal: skip syncing
+         * rather than failing the whole login over an optional field.
+         */
+        phone = null;
+      }
+    }
+
     return {
       email,
       name,
+      phone,
       issuer: claims["iss"] as string,
       rawClaims: claims,
     };

--- a/App/Tests/Identity/OIDC.test.ts
+++ b/App/Tests/Identity/OIDC.test.ts
@@ -89,6 +89,7 @@ interface CallbackOverrides {
   callbackParams?: Record<string, string> | undefined;
   emailClaimName?: string | undefined;
   nameClaimName?: string | undefined;
+  phoneClaimName?: string | undefined;
 }
 
 /*
@@ -116,6 +117,7 @@ async function runCallback(
     },
     emailClaimName: overrides.emailClaimName ?? "email",
     nameClaimName: overrides.nameClaimName ?? "name",
+    phoneClaimName: overrides.phoneClaimName,
   });
 }
 
@@ -801,6 +803,56 @@ describe("OIDCUtil - claim extraction", () => {
     expect(result.email.toString()).toBe("sam.carter@example.com");
     expect(result.name?.toString()).toBe("Sam Carter");
   });
+
+  test("returns a null phone when no phoneClaimName is configured", async () => {
+    const idp: TestIdp = await startIdp({
+      idTokenClaims: {
+        nonce: NONCE,
+        email: "alice@example.com",
+        phone_number: "+15551234567",
+      },
+      omitUserInfoEndpoint: true,
+    });
+
+    const result: OidcCallbackResult = await runCallback(idp);
+
+    expect(result.phone).toBeNull();
+  });
+
+  test("reads the phone number from the configured claim name", async () => {
+    const idp: TestIdp = await startIdp({
+      idTokenClaims: {
+        nonce: NONCE,
+        email: "alice@example.com",
+        phone_number: "+15551234567",
+      },
+      omitUserInfoEndpoint: true,
+    });
+
+    const result: OidcCallbackResult = await runCallback(idp, {
+      phoneClaimName: "phone_number",
+    });
+
+    expect(result.phone?.toString()).toBe("+15551234567");
+  });
+
+  test("returns a null phone, without failing the login, when the claim is not in a format Phone accepts", async () => {
+    const idp: TestIdp = await startIdp({
+      idTokenClaims: {
+        nonce: NONCE,
+        email: "alice@example.com",
+        phone_number: "not-a-phone-number",
+      },
+      omitUserInfoEndpoint: true,
+    });
+
+    const result: OidcCallbackResult = await runCallback(idp, {
+      phoneClaimName: "phone_number",
+    });
+
+    expect(result.phone).toBeNull();
+    expect(result.email.toString()).toBe("alice@example.com");
+  });
 });
 
 describe("OIDCUtil - userinfo fallback", () => {
@@ -846,6 +898,22 @@ describe("OIDCUtil - userinfo fallback", () => {
 
     expect(result.email.toString()).toBe("bob@example.com");
     expect(result.name?.toString()).toBe("Bob Brown");
+  });
+
+  test("falls back to userinfo for the phone number when a phoneClaimName is configured", async () => {
+    const idp: TestIdp = await startIdp({
+      idTokenClaims: { nonce: NONCE, email: "alice@example.com" },
+      userInfo: {
+        sub: "00u1a2b3c4D5E6F7g8h9",
+        phone_number: "+15551234567",
+      },
+    });
+
+    const result: OidcCallbackResult = await runCallback(idp, {
+      phoneClaimName: "phone_number",
+    });
+
+    expect(result.phone?.toString()).toBe("+15551234567");
   });
 
   /*

--- a/Common/Models/DatabaseModels/GlobalOidc.ts
+++ b/Common/Models/DatabaseModels/GlobalOidc.ts
@@ -221,6 +221,26 @@ export default class GlobalOIDC extends BaseModel {
     update: [],
   })
   @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Phone Claim Name",
+    description:
+      "Claim name in the ID token (or userinfo response) that contains the user's phone number. Optional - leave blank to skip syncing phone numbers. Synced into the user's company phone number, not into any verified call/SMS notification channel.",
+    example: "phone_number",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public phoneClaimName?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
     isDefaultValueColumn: true,
     type: TableColumnType.Boolean,
     title: "Disable Sign Up with SSO",

--- a/Common/Models/DatabaseModels/ProjectOidc.ts
+++ b/Common/Models/DatabaseModels/ProjectOidc.ts
@@ -468,6 +468,38 @@ export default class ProjectOIDC extends BaseModel {
     read: [
       Permission.ProjectOwner,
       Permission.ProjectAdmin,
+      Permission.ReadProjectOIDC,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.EditProjectOIDC,
+    ],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    description:
+      "Claim name in the ID token (or userinfo response) that contains the user's phone number. Optional - leave blank to skip syncing phone numbers. Synced into the user's company phone number, not into any verified call/SMS notification channel.",
+    example: "phone_number",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public phoneClaimName?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.CreateProjectOIDC,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
       Permission.ProjectMember,
       Permission.Viewer,
       Permission.SettingsAdmin,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786107524687-AddPhoneClaimNameToOidc.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786107524687-AddPhoneClaimNameToOidc.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPhoneClaimNameToOidc1786107524687
+  implements MigrationInterface
+{
+  public name = "AddPhoneClaimNameToOidc1786107524687";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ProjectOIDC" ADD "phoneClaimName" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "GlobalOIDC" ADD "phoneClaimName" character varying(100)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "GlobalOIDC" DROP COLUMN "phoneClaimName"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProjectOIDC" DROP COLUMN "phoneClaimName"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -512,6 +512,7 @@ import { AddInvestigationCodeFixRecommendation1786500000000 } from "./1786500000
 import { AddInvestigationAnalysisTldr1786600000000 } from "./1786600000000-AddInvestigationAnalysisTldr";
 import { DropProjectCallSMSConfigCredentialUniques1786700000000 } from "./1786700000000-DropProjectCallSMSConfigCredentialUniques";
 import { AddDataSourceTable1786303472848 } from "./1786303472848-AddDataSourceTable";
+import { AddPhoneClaimNameToOidc1786107524687 } from "./1786107524687-AddPhoneClaimNameToOidc";
 
 export default [
   InitialMigration,
@@ -1028,4 +1029,5 @@ export default [
   AddInvestigationAnalysisTldr1786600000000,
   DropProjectCallSMSConfigCredentialUniques1786700000000,
   AddDataSourceTable1786303472848,
+  AddPhoneClaimNameToOidc1786107524687,
 ];


### PR DESCRIPTION
## What

Closes #3056.

Global OIDC and Project OIDC only ever extracted `email` and `name` from the ID token/userinfo response (`OIDCUtil.exchangeCodeAndValidate` -> `OidcCallbackResult`), configurable via `emailClaimName`/`nameClaimName`. This adds an optional `phoneClaimName` on the same two models, following the exact same pattern, so admins whose IdP emits a phone claim (Entra ID, Okta, etc.) can sync it too.

## Design decision (see #3056 for the tradeoff)

The synced value is written to `User.companyPhoneNumber` — the general contact field already collected at signup — **not** to `UserCall`/`UserSMS`, which back the actual on-call call/SMS delivery channels and appear to require an explicit verification step (`alertPhoneVerificationCode`/`tempAlertPhoneNumber` on `User`). Auto-populating those straight from an unverified IdP claim would bypass that step, so this PR deliberately does not do that. Happy to adjust if maintainers see it differently.

`StatusPageOIDC` (subscriber SSO on public status pages) is intentionally left untouched — subscribers aren't `User` rows with a `companyPhoneNumber`, so this doesn't apply there. `phoneClaimName` is optional on `OIDCUtil.exchangeCodeAndValidate`, so `StatusPageOIDC.ts` needed no changes.

## Behavior

- If `phoneClaimName` is not set (default, existing behavior unchanged): no phone claim is looked up, `result.phone` is always `null`, nothing is synced.
- If set: read from the ID token, falling back to the userinfo endpoint the same way email/name already do.
- If the claim is present but not in a format `Phone` accepts, the login still succeeds — the phone is just not synced (non-fatal, same philosophy as the existing name handling).
- On every successful login (both new-user creation and existing-user login) where a valid phone claim is present and differs from what's stored, `User.companyPhoneNumber` is updated.

## Changes

- `Common/Models/DatabaseModels/GlobalOidc.ts`, `ProjectOidc.ts`: new optional `phoneClaimName` column (same access control as `nameClaimName`).
- `Common/Server/Infrastructure/Postgres/SchemaMigrations/`: generated migration (`npm run generate-postgres-migration` against a database migrated with every existing migration, per AGENTS.md), registered in `Index.ts`. `npm run check-postgres-schema-drift` passes clean.
- `App/FeatureSet/Identity/Utils/OIDC.ts`: `OidcCallbackResult.phone`, `exchangeCodeAndValidate` accepts optional `phoneClaimName`.
- `App/FeatureSet/Identity/API/GlobalOIDC.ts`, `OIDC.ts`: pass `phoneClaimName` through, sync `companyPhoneNumber` alongside the existing email sync.
- `App/FeatureSet/AdminDashboard/.../GlobalOIDC/{Index,View}.tsx`, `App/FeatureSet/Dashboard/.../Settings/OIDC.tsx`: optional "Phone Claim Name" form field, mirroring "Name Claim Name".
- `App/Tests/Identity/OIDC.test.ts`: claim-extraction and userinfo-fallback tests for the phone claim (invalid-format claim is non-fatal, missing `phoneClaimName` yields `null`, etc).

## Test plan

- [x] `npm run check-postgres-schema-drift` — clean, no drift.
- [x] `Common` and `App` both `tsc --noEmit` clean.
- [x] `npx eslint` clean on all changed files (via `npm run fix`).
- [x] `Tests/Identity/OIDC.test.ts` — 49/49 passing, including the new phone-claim cases.
- [ ] Not manually tested end-to-end against a real IdP (Entra ID, Okta) in a running dev stack — only the `OIDCUtil` unit tests against the local test IdP.