### PR TITLE
feat(monitor): add labels to create form

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
@@ -745,6 +745,23 @@ const MonitorCreate: FunctionComponent<
 
                   placeholder: "Select Monitoring Interval",
                 },
+                {
+                  field: {
+                    labels: true,
+                  },
+                  title: "Labels",
+                  stepId: "labels",
+                  description:
+                    "Team members with access to these labels will only be able to access this resource. This is optional and an advanced feature.",
+                  fieldType: FormFieldSchemaType.MultiSelectDropdown,
+                  dropdownModal: {
+                    type: Label,
+                    labelField: "name",
+                    valueField: "_id",
+                  },
+                  required: false,
+                  placeholder: "Labels",
+                },
               ]}
               steps={[
                 {
@@ -772,6 +789,10 @@ const MonitorCreate: FunctionComponent<
                       values.monitorType as MonitorType,
                     );
                   },
+                },
+                {
+                  title: "Labels",
+                  id: "labels",
                 },
               ]}
               onBeforeCreate={async (item: Monitor): Promise<Monitor> => {

--- a/App/Tests/Dashboard/MonitorCreateLabels.test.ts
+++ b/App/Tests/Dashboard/MonitorCreateLabels.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The monitor-create form is declared inline in a page component, while the
+ * App test suite runs in a plain Node environment with no renderer. These
+ * source invariants cover the load-bearing form wiring in the same style as
+ * MonitorProbeSelectionPages.test.ts. Whitespace is squashed first so prettier
+ * re-wrapping cannot turn a real regression check into a formatting failure.
+ *
+ * Labels must be a real Monitor relation rather than misc form data, and the
+ * dedicated step must remain last for every monitor type. The latter matters
+ * especially for Manual monitors, which skip both conditional middle steps.
+ */
+
+const MONITOR_CREATE_SOURCE_PATH: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Pages",
+  "Monitor",
+  "Create.tsx",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+const source: string = squash(
+  fs.readFileSync(MONITOR_CREATE_SOURCE_PATH, "utf8"),
+);
+
+function sourceBetween(startMarker: string, endMarker: string): string {
+  const start: number = source.indexOf(startMarker);
+  const end: number = source.indexOf(endMarker, start + startMarker.length);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return source.slice(start + startMarker.length, end);
+}
+
+describe("Monitor create labels", () => {
+  test("submits labels as the real Monitor.labels relation", () => {
+    expect(source).toContain(squash("field: { labels: true, },"));
+
+    /*
+     * An override field is removed from the Monitor payload and sent through
+     * miscDataProps instead. That is correct for probes, but would silently
+     * prevent ModelForm from persisting the MonitorLabel join rows.
+     */
+    expect(source).not.toContain(squash("overrideField: { labels: true, },"));
+    expect(source).not.toContain('overrideFieldKey: "labels"');
+  });
+
+  test("renders an optional Label-backed multi-select", () => {
+    expect(source).toContain(
+      squash(`
+        field: {
+          labels: true,
+        },
+        title: "Labels",
+        stepId: "labels",
+        description:
+          "Team members with access to these labels will only be able to access this resource. This is optional and an advanced feature.",
+        fieldType: FormFieldSchemaType.MultiSelectDropdown,
+        dropdownModal: {
+          type: Label,
+          labelField: "name",
+          valueField: "_id",
+        },
+        required: false,
+        placeholder: "Labels",
+      `),
+    );
+  });
+
+  test("keeps Labels as a dedicated unconditional final step", () => {
+    const steps: string = sourceBetween("steps={[", "]} onBeforeCreate=");
+    const intervalStepStart: number = steps.indexOf(
+      squash(`
+        title: "Probes & Interval",
+        id: "monitoring-interval",
+      `),
+    );
+    const labelsStep: string = squash(`
+      {
+        title: "Labels",
+        id: "labels",
+      },
+    `);
+    const labelsStepStart: number = steps.indexOf(labelsStep);
+
+    expect(intervalStepStart).toBeGreaterThanOrEqual(0);
+    expect(steps).toContain(
+      squash(`
+        showIf: (values: FormValues<Monitor>) => {
+          return MonitorTypeHelper.doesMonitorTypeHaveInterval(
+            values.monitorType as MonitorType,
+          );
+        },
+      `),
+    );
+    expect(labelsStepStart).toBeGreaterThan(intervalStepStart);
+
+    /*
+     * An exact, showIf-free block at the end keeps Labels visible to Manual,
+     * criteria-only, and probeable monitor types alike.
+     */
+    expect(steps.trim().endsWith(labelsStep)).toBe(true);
+  });
+
+  test("loads template labels and maps them into initial form values", () => {
+    const templateLoader: string = sourceBetween(
+      "const fetchMonitorTemplate:",
+      "return (",
+    );
+
+    expect(templateLoader).toContain(
+      squash(`
+        monitoringInterval: true,
+        labels: true,
+      `),
+    );
+    expect(templateLoader).toContain(
+      squash(`
+        labels: template.labels?.map((label: Label) => {
+          return label.id!.toString();
+        }),
+      `),
+    );
+    expect(templateLoader).toContain("setInitialValues(values);");
+  });
+
+  test("explains the labels' access-control effect and optional nature", () => {
+    expect(source).toContain(
+      "Team members with access to these labels will only be able to access this resource.",
+    );
+    expect(source).toContain("This is optional and an advanced feature.");
+  });
+});

--- a/E2E/Tests/Dashboard/CreateMonitors.spec.ts
+++ b/E2E/Tests/Dashboard/CreateMonitors.spec.ts
@@ -1,4 +1,4 @@
-import { Browser, Page, test, Locator } from "@playwright/test";
+import { Browser, expect, Locator, Page, test } from "@playwright/test";
 import Faker from "Common/Utils/Faker";
 import { IS_BILLING_ENABLED } from "../../Config";
 import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
@@ -11,14 +11,15 @@ import {
   InfraMonitorRecipe,
   MonitorTypeRecipe,
 } from "./Helpers/Monitors";
+import { createItem, getItem, JSONish, toId } from "./Helpers/MonitorAlerting";
 
 /*
- * Monitor creation end-to-end coverage for every monitor type offered by the
- * dashboard "Create Monitor" form.
+ * Broad monitor creation end-to-end coverage across each wizard shape offered
+ * by the dashboard "Create Monitor" form.
  *
- * One project is created up front (serial mode + shared page) and every
- * monitor type is then created as its own test, so a failure is isolated to a
- * single type instead of failing the whole suite.
+ * One project is created up front (serial mode + shared page) and each
+ * representative monitor type is then created as its own test, so a failure
+ * is isolated to a single type instead of failing the whole suite.
  *
  * To run locally against a full stack:
  *
@@ -28,12 +29,12 @@ import {
 test.describe.configure({ mode: "serial" });
 
 const recipes: Array<MonitorTypeRecipe> = [
-  // Single-step: name + type only.
+  // Manual skips criteria and interval, then lands on the final Labels step.
   {
     label: "Manual",
     cardValue: "Manual",
     hasInterval: false,
-    singleStep: true,
+    skipsCriteria: true,
   },
   {
     /*
@@ -170,8 +171,8 @@ const recipes: Array<MonitorTypeRecipe> = [
    * The standalone "SNMP" monitor type was retired and replaced by the
    * "Network Device" monitor type, which references a registered
    * NetworkDevice resource (see MonitorType.NetworkDevice). There is no
-   * longer an SNMP card in the create form, so this recipe was removed —
-   * Network Device monitoring is covered by the NetworkDevice E2E flow.
+   * longer an SNMP card in the create form. Network Device creation needs a
+   * separately configured device and is outside this general recipe table.
    */
 
   // Code-based probeable types: fill the Monaco editor + interval.
@@ -267,12 +268,16 @@ const infraRecipes: Array<InfraMonitorRecipe> = [
 interface SharedContext {
   page: Page;
   projectId: string;
+  labelIds: Array<string>;
+  labelNames: Array<string>;
 }
 
-test.describe("Monitor Creation - All Types", () => {
+test.describe("Monitor Creation - Representative Types", () => {
   const ctx: SharedContext = {
     page: undefined as unknown as Page,
     projectId: "",
+    labelIds: [],
+    labelNames: [],
   };
 
   test.beforeAll(async ({ browser }: { browser: Browser }) => {
@@ -293,10 +298,73 @@ test.describe("Monitor Creation - All Types", () => {
        */
       preferredPlanName: IS_BILLING_ENABLED ? "Growth" : undefined,
     });
+
+    for (const color of ["#3b82f6", "#22c55e"]) {
+      const labelName: string = `E2E Monitor Label ${Faker.generateName().toString()}`;
+      const label: JSONish = await createItem({
+        page: ctx.page,
+        projectId: ctx.projectId,
+        path: "/api/label",
+        item: {
+          name: labelName,
+          projectId: ctx.projectId,
+          color: { _type: "Color", value: color },
+        },
+      });
+
+      const labelId: string = toId(label["_id"]);
+      expect(labelId, `seeded label "${labelName}" should have an id`).not.toBe(
+        "",
+      );
+      ctx.labelIds.push(labelId);
+      ctx.labelNames.push(labelName);
+    }
   });
 
   test.afterAll(async () => {
     await ctx.page.close();
+  });
+
+  test("should create a Manual monitor with multiple labels", async () => {
+    test.setTimeout(120000);
+
+    const monitorId: string = await createMonitor({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      monitorName: `E2E Labelled Manual ${Faker.generateName().toString()}`,
+      recipe: recipes[0]!,
+      labelNames: ctx.labelNames,
+    });
+
+    expect(monitorId, "the labelled monitor should have an id").not.toBe("");
+
+    const monitor: JSONish = await getItem({
+      page: ctx.page,
+      projectId: ctx.projectId,
+      path: "/api/monitor",
+      id: monitorId,
+      select: {
+        _id: true,
+        labels: { _id: true, name: true },
+      },
+    });
+    const labels: Array<JSONish> =
+      (monitor["labels"] as Array<JSONish> | undefined) || [];
+
+    expect(
+      labels
+        .map((label: JSONish) => {
+          return toId(label["_id"]);
+        })
+        .sort(),
+    ).toEqual([...ctx.labelIds].sort());
+    expect(
+      labels
+        .map((label: JSONish) => {
+          return String(label["name"] || "");
+        })
+        .sort(),
+    ).toEqual([...ctx.labelNames].sort());
   });
 
   for (const recipe of recipes) {

--- a/E2E/Tests/Dashboard/Helpers/Monitors.ts
+++ b/E2E/Tests/Dashboard/Helpers/Monitors.ts
@@ -14,6 +14,7 @@ import { gotoProjectPage } from "./ProductOnboarding";
  *                      pre-populated, so only the type-specific destination /
  *                      config fields need filling.
  *   3. interval      — monitoring interval Dropdown (only for probeable types)
+ *   4. labels        — optional monitor labels (always the final step)
  *
  * The submit button keeps the test id "Create Monitor" on every step; on a
  * non-final step its visible text is "Next".
@@ -30,10 +31,10 @@ export interface MonitorTypeRecipe {
   // true for probeable types that show the extra interval step.
   hasInterval: boolean;
   /*
-   * true for Manual + inbound documentation types that skip the criteria step
-   * entirely (single submit click creates the monitor).
+   * true for monitor types that skip criteria and interval. The always-visible
+   * Labels step still follows Monitor Info.
    */
-  singleStep?: boolean;
+  skipsCriteria?: boolean;
   /*
    * Fills the criteria step's required fields. Omit for types whose defaults
    * already satisfy validation (Manual, telemetry types, ...).
@@ -150,6 +151,42 @@ const selectMonitoringInterval: (data: {
 };
 
 /*
+ * Selects zero or more monitor labels on the wizard's final step. Waiting for
+ * the combobox even when no labels are requested makes every create recipe
+ * prove that the unconditional final step is reachable.
+ */
+const selectMonitorLabels: (data: {
+  page: Page;
+  labelNames?: Array<string> | undefined;
+}) => Promise<void> = async (data: {
+  page: Page;
+  labelNames?: Array<string> | undefined;
+}): Promise<void> => {
+  const combo: Locator = data.page
+    .locator(monitorCreateFormSelector)
+    .getByRole("combobox", { name: "Labels", exact: true });
+  await combo.waitFor({ state: "visible", timeout: 30000 });
+
+  for (const labelName of data.labelNames || []) {
+    await combo.click();
+    await combo.fill(labelName);
+    await data.page
+      .getByRole("option", { name: labelName, exact: true })
+      .click({ timeout: 30000 });
+    await expect(
+      data.page.getByRole("button", { name: `Remove ${labelName}` }),
+    ).toBeVisible({ timeout: 30000 });
+  }
+
+  /*
+   * EntityDropdown's multi-select menu stays open after a selection and can
+   * cover the submit button. A mousedown outside it closes only the dropdown.
+   */
+  await data.page.locator(monitorCreateFormSelector).dispatchEvent("mousedown");
+  await expect(data.page.getByTestId("entity-dropdown-menu")).toHaveCount(0);
+};
+
+/*
  * Waits for the criteria step to finish loading before it is submitted.
  *
  * The criteria step's MonitorSteps component fetches monitor statuses,
@@ -183,6 +220,7 @@ type CreateMonitorFunction = (data: {
   projectId: string;
   monitorName: string;
   recipe: MonitorTypeRecipe;
+  labelNames?: Array<string> | undefined;
 }) => Promise<string>;
 
 export const createMonitor: CreateMonitorFunction = async (data: {
@@ -190,6 +228,7 @@ export const createMonitor: CreateMonitorFunction = async (data: {
   projectId: string;
   monitorName: string;
   recipe: MonitorTypeRecipe;
+  labelNames?: Array<string> | undefined;
 }): Promise<string> => {
   const page: Page = data.page;
 
@@ -211,28 +250,27 @@ export const createMonitor: CreateMonitorFunction = async (data: {
   );
   await expect(card).toBeVisible({ timeout: 30000 });
   await card.click();
+  await page.getByTestId(submitButtonTestId).click();
 
-  if (data.recipe.singleStep) {
-    // The one submit both creates the monitor and navigates to it.
-    await clickCreateUntilMonitorView({ page, projectId: data.projectId });
-  } else {
-    // Advance to the criteria step, then wait for its async defaults.
-    await page.getByTestId(submitButtonTestId).click();
+  if (!data.recipe.skipsCriteria) {
+    // Wait for the criteria step's async defaults, then fill any required data.
     await waitForCriteriaStepReady({ page });
     if (data.recipe.fillCriteria) {
       await data.recipe.fillCriteria({ page });
     }
 
+    // Advance from Criteria to either Probes & Interval or Labels.
+    await page.getByTestId(submitButtonTestId).click();
+
     if (data.recipe.hasInterval) {
-      // Advance to the interval step, choose an interval, then create.
-      await page.getByTestId(submitButtonTestId).click();
+      // Choose an interval, then advance to the always-final Labels step.
       await selectMonitoringInterval({ page });
-      await clickCreateUntilMonitorView({ page, projectId: data.projectId });
-    } else {
-      // No interval step: this submit creates the monitor.
-      await clickCreateUntilMonitorView({ page, projectId: data.projectId });
+      await page.getByTestId(submitButtonTestId).click();
     }
   }
+
+  await selectMonitorLabels({ page, labelNames: data.labelNames });
+  await clickCreateUntilMonitorView({ page, projectId: data.projectId });
 
   const match: RegExpMatchArray | null = page.url().match(monitorIdInUrlRegex);
   return match ? match[1]! : "";
@@ -439,7 +477,9 @@ export const createInfraMonitor: CreateInfraMonitorFunction = async (data: {
     .click();
   await page.waitForTimeout(1500);
 
-  // This submit creates the infra monitor; retry it until it navigates.
+  // Advance from Criteria to Labels, then submit the final step.
+  await page.getByTestId(submitButtonTestId).click();
+  await selectMonitorLabels({ page });
   await clickCreateUntilMonitorView({ page, projectId: data.projectId });
 
   const match: RegExpMatchArray | null = page.url().match(monitorIdInUrlRegex);

--- a/E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts
@@ -244,6 +244,11 @@ test.describe("Monitor probe selection", () => {
       .getByRole("option", { name: "Every 5 Minutes", exact: true })
       .click();
 
+    // Step 4: Labels is always the final step; leave it empty here.
+    await page.getByTestId(submitButtonTestId).click();
+    await expect(
+      page.getByRole("combobox", { name: "Labels", exact: true }),
+    ).toBeVisible({ timeout: 30000 });
     await page.getByTestId(submitButtonTestId).click();
 
     await page.waitForURL(

--- a/E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts
@@ -253,6 +253,11 @@ test.describe("Monitor summary probe picker", () => {
       .getByRole("option", { name: "Every 5 Minutes", exact: true })
       .click();
 
+    // Step 4: Labels is always the final step; leave it empty here.
+    await page.getByTestId(submitButtonTestId).click();
+    await expect(
+      page.getByRole("combobox", { name: "Labels", exact: true }),
+    ).toBeVisible({ timeout: 30000 });
     await page.getByTestId(submitButtonTestId).click();
 
     await page.waitForURL(

--- a/E2E/Tests/Dashboard/Slo.spec.ts
+++ b/E2E/Tests/Dashboard/Slo.spec.ts
@@ -39,15 +39,15 @@ import { createMonitor, MonitorTypeRecipe } from "./Helpers/Monitors";
 test.describe.configure({ mode: "serial" });
 
 /*
- * A Manual monitor is the cheapest monitor to create (single wizard step, no
- * criteria and no interval) and is enough for an SLO to reference — the SLO
- * only needs monitors to attach, it does not need them to have reported yet.
+ * A Manual monitor is the cheapest monitor to create (no criteria or interval)
+ * and is enough for an SLO to reference — the SLO only needs monitors to
+ * attach, it does not need them to have reported yet.
  */
 const manualMonitorRecipe: MonitorTypeRecipe = {
   label: "Manual",
   cardValue: "Manual",
   hasInterval: false,
-  singleStep: true,
+  skipsCriteria: true,
 };
 
 const uuidPattern: string =


### PR DESCRIPTION
## What changed

- Added an always-visible final **Labels** step to the monitor creation wizard.
- Reused the existing `Monitor.labels` relation and Label-backed multi-select, including monitor-template label defaults.
- Updated Manual, criteria-only, probeable, and infrastructure monitor E2E navigation for the new final step.
- Added a browser test that selects two labels and verifies both persisted on the created monitor.
- Added five focused regression tests for field wiring, unconditional step placement, template defaults, persistence-safe model binding, and access-control copy.

## Why

Monitor creation did not declare a labels field or step, even though monitors already support persisted labels and monitor templates already load label defaults. Users therefore had to create a monitor first and assign its labels afterward.

## Impact

Every monitor type can now receive optional labels during creation, including Manual monitors and types that do not show the Probes & Interval step. Existing unlabeled creation remains supported.

## Root cause

The create form omitted the existing `Monitor.labels` relation. Its wizard also had conditional final steps, so labels needed a dedicated unconditional last step rather than being attached to Criteria or Probes & Interval.

## Validation

- `npm run fix` — passed
- App focused regression suites — 3 suites, 37 tests passed
- `npm run compile` in `E2E` — passed
- `npm run compile` in `App` — passed
- Independent final diff review — no blocking findings
- Added Playwright coverage for selecting multiple labels and reading them back from the Monitor API

## Local environment notes

- The live Playwright persistence test could not be executed locally because the shared Docker API was not listening after hot reload; CI can run the committed test against a healthy stack.
- The Dashboard full type-check was retried after restoring its locked `rrweb` dependency, but the shared host remained heavily CPU-saturated and the diagnostic-free run was stopped after 20 minutes. The changed E2E project and App checks above completed successfully.